### PR TITLE
Add check for matching HeaderFilter before emitting Diagnostic

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
@@ -449,8 +449,13 @@ void ClangTidyDiagnosticConsumer::HandleDiagnostic(
   FullSourceLoc Loc;
   if (Info.getLocation().isValid() && Info.hasSourceManager())
     Loc = FullSourceLoc(Info.getLocation(), Info.getSourceManager());
-  Converter.emitDiagnostic(Loc, DiagLevel, Message, Info.getRanges(),
+
+  StringRef FileName(Loc.printToString(Loc.getManager()));
+  if(getHeaderFilter()->match(FileName)) // only emit if FileName is matching
+  {
+    Converter.emitDiagnostic(Loc, DiagLevel, Message, Info.getRanges(),
                            Info.getFixItHints());
+  }
 
   if (Info.hasSourceManager())
     checkFilters(Info.getLocation(), Info.getSourceManager());


### PR DESCRIPTION
Hello,
we were facing issue that HeaderFilter is not working properly. We get some false positive warning although HeaderFilter is set. In our case rapidjson is emitting some warnings.

Same issue is also described here in another project: https://fuchsia.googlesource.com/peridot/+/HEAD/docs/lint.md


 