### PR TITLE
fix for gcc 8

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
@@ -713,7 +713,7 @@ private:
 
   uint32_t getTrampolineSize() const { return RemoteTrampolineSize; }
 
-  Expected<std::vector<char>> readMem(char *Dst, JITTargetAddress Src,
+  Expected<std::vector<uint8_t>> readMem(char *Dst, JITTargetAddress Src,
                                       uint64_t Size) {
     // Check for an 'out-of-band' error, e.g. from an MM destructor.
     if (ExistingError)


### PR DESCRIPTION
This patch is required to enable building LLVM 5.x with GCC 8.x

It is already part of the redhat-llvm:
https://bugzilla.redhat.com/show_bug.cgi?id=1540620


