### PR TITLE
WIP lifetime categories

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2766,6 +2766,20 @@ def TypeTagForDatatype : InheritableAttr {
   let Documentation = [TypeTagForDatatypeDocs];
 }
 
+def Owner : InheritableAttr {
+  let Spellings = [CXX11<"gsl", "Owner">];
+  let Subjects = SubjectList<[CXXRecord]>;
+  let Args = [TypeArgument<"DerefType">];
+  let Documentation = [Undocumented]; // FIXME
+}
+
+def Pointer : InheritableAttr {
+  let Subjects = SubjectList<[CXXRecord]>;
+  let Spellings = [CXX11<"gsl", "Pointer">];
+  let Args = [TypeArgument<"DerefType">];
+  let Documentation = [Undocumented]; // FIXME
+}
+
 // Microsoft-related attributes
 
 def MSNoVTable : InheritableAttr, TargetSpecificAttr<TargetMicrosoftCXXABI> {

--- a/clang/test/AST/ast-dump-attr.cpp
+++ b/clang/test/AST/ast-dump-attr.cpp
@@ -211,6 +211,15 @@ namespace TestSuppress {
     }
 }
 
+namespace TestLifetimeCategories {
+  class [[gsl::Owner(int)]] AOwner {};
+  // CHECK: CXXRecordDecl{{.*}} struct AOwner
+  // CHECK-NEXT: ObjCBridgeRelatedAttr{{.*}} NSParagraphStyle
+  class [[gsl::Pointer(int)]] APointer {};
+  // CHECK: CXXRecordDecl{{.*}} struct APointer
+  // CHECK-NEXT: ObjCBridgeRelatedAttr{{.*}} NSParagraphStyle
+}
+
 // Verify the order of attributes in the Ast. It must reflect the order
 // in the parsed source.
 int mergeAttrTest() __attribute__((deprecated)) __attribute__((warn_unused_result));

--- a/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp
+++ b/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+int [[gsl::Owner]] i;
+//expected-error@-1 {{'Owner' attribute cannot be applied to types}}
+void [[gsl::Owner]] f();
+//expected-error@-1 {{'Owner' attribute cannot be applied to types}}
+
+struct S {
+};
+
+S [[gsl::Owner]] Instance;
+//expected-error@-1 {{'Owner' attribute cannot be applied to types}}
+
+class [[gsl::Owner]] OwnerMissingParameter {};
+//expected-error@-1 {{'Owner' attribute takes one argument}}
+class [[gsl::Pointer]] PointerMissingParameter {};
+//expected-error@-1 {{'Pointer' attribute takes one argument}}
+
+
+class [[gsl::Owner(7)]] OwnerDerefNoType {};
+class [[gsl::Pointer("int")]] PointerDerefNoType {};
+
+
+class [[gsl::Owner(int)]] [[gsl::Pointer(int)]] BothOwnerPointer {};
+
+class [[gsl::Owner(int)]] [[gsl::Owner(int)]] DuplicateOwner {};
+class [[gsl::Pointer(int)]] [[gsl::Pointer(int)]] DuplicatePointer {};
+
+class [[gsl::Owner(int)]] [[gsl::Owner(char)]] OwnerDifferentTypes {};
+class [[gsl::Pointer(int)]] [[gsl::Pointer(char)]] PointerDifferentTypes {};
+
+class [[gsl::Owner(void)]] OwnerVoidDerefType {};
+class [[gsl::Pointer(void)]] PointerVoidDerefType {};
+
+class [[gsl::Owner(int)]] AnOwner {};
+class [[gsl::Pointer(S)]] APointer {};


### PR DESCRIPTION
The test currently fails with
```
error: 'error' diagnostics seen but not expected:
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 20: 'Owner' attribute takes one argument
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 21: 'Pointer' attribute takes one argument
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 24: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 24: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 26: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 26: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 27: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 27: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 29: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 29: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 30: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 30: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 32: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 33: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 35: expected '(' for function-style cast or type construction
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 36: 'S' does not refer to a value
error: 'note' diagnostics seen but not expected:
  File /home/gehre/llvm-project/clang/test/SemaCXX/attr-gsl-owner-pointer.cpp Line 8: declared here
```