### PR TITLE
Fix ClangOpenCLBuiltinsImpl target not found

### DIFF
--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -72,4 +72,4 @@ clang_tablegen(OpenCLBuiltins.inc -gen-clang-opencl-builtins
   TARGET ClangOpenCLBuiltinsImpl
   )
 
-set_source_files_properties(SemaLookup.cpp OBJECT_DEPENDS ClangOpenCLBuiltinsImpl)
+add_dependencies(clangSema ClangOpenCLBuiltinsImpl)


### PR DESCRIPTION
set_source_files_properties OBJECT_DEPENDS for SemaLookup.cpp does not work as it's actually looking for a file target rather then a custom (clang_tablegen) target. The add_dependencies is going to fix the dependency error.

See also https://github.com/llvm-mirror/clang/pull/63 https://github.com/llvm-mirror/clang/pull/63/files