### PR TITLE
Use kevent queue for waiting for file unlocking

### DIFF
--- a/llvm/include/llvm/Support/LockFileManager.h
+++ b/llvm/include/llvm/Support/LockFileManager.h
@@ -64,6 +64,8 @@ private:
   static Optional<std::pair<std::string, int> >
   readLockFile(StringRef LockFileName);
 
+  bool waitForUnlockUsingSystemEvents(WaitForUnlockResult *);
+
   static bool processStillExecuting(StringRef Hostname, int PID);
 
 public:


### PR DESCRIPTION
## What
- LockFileManager now using File system events in order to check whether the file was deleted
- Additional timing between operations added to prevent potential race condition case, when file was deleted right before event queue was set up

## Why
Exponential waiting can dramatically decrease compilation performance. For example, if module A is dependent on Module B, and Module B is performing long compilation, The compilation of module A wiill be delayed on additional deltaT time, which is about the same time as the last waiting interval .