### PR TITLE
Updating path of Tutorials Documentation

### DIFF
--- a/mlir/examples/toy/README.md
+++ b/mlir/examples/toy/README.md
@@ -3,5 +3,5 @@
 This contains sample code to support the tutorial on using MLIR for
 building a compiler for a simple Toy language.
 
-See [g3doc/Tutorials/Toy](../../g3doc/Tutorials/Toy) at the root of
+See [docs/Tutorials/Toy](../../docs/Tutorials/Toy) at the root of
 the repository for more informations.


### PR DESCRIPTION
This update is necessary due to the renaming of "g3doc" to "docs"