### PR TITLE
Minor fix help message git clang-format

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -45,7 +45,7 @@ second <commit> that differ from the first <commit>.
 The following git-config settings set the default of the corresponding option:
   clangFormat.binary
   clangFormat.commit
-  clangFormat.extension
+  clangFormat.extensions
   clangFormat.style
 '''
 


### PR DESCRIPTION
Close #123 

The option name for `clangFormat.extensions` was reported in the singular form in the help message.