### PR TITLE
Typo: Sequnce

### DIFF
--- a/llvm/lib/Support/YAMLTraits.cpp
+++ b/llvm/lib/Support/YAMLTraits.cpp
@@ -738,7 +738,7 @@ bool Output::canElideEmptySequence() {
   // the whole key/value can be not written.  But, that produces wrong yaml
   // if the key/value is the only thing in the map and the map is used in
   // a sequence.  This detects if the this sequence is the first key/value
-  // in map that itself is embedded in a sequnce.
+  // in map that itself is embedded in a sequence.
   if (StateStack.size() < 2)
     return true;
   if (StateStack.back() != inMapFirstKey)

--- a/llvm/lib/Target/ARM/README-Thumb.txt
+++ b/llvm/lib/Target/ARM/README-Thumb.txt
@@ -185,7 +185,7 @@ ldr r2, [r2]
 
 These instructions preserve the condition code which is important if the spill
 is between a cmp and a bcc instruction. However, we can use the (potentially)
-cheaper sequnce if we know it's ok to clobber the condition register.
+cheaper sequence if we know it's ok to clobber the condition register.
 
 add r2, sp, #255 * 4
 add r2, #132


### PR DESCRIPTION
I spotted that typo accidentally, and it's unlikely that I will get involved in llvm anytime soon, so the regular process is quite a lot of overhead for a trivial change.
If anyone reads this at all:
Feel free to incorporate the change on your own, or simply discard it - I just can't leave an error without at least trying to fix it ;-)