### PR TITLE
Fix type checking for qualified id block parameters.

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -8428,9 +8428,8 @@ bool ASTContext::canAssignObjCInterfacesInBlockPointer(
   }
 
   if (LHSOPT->isObjCQualifiedIdType() || RHSOPT->isObjCQualifiedIdType())
-    return finish(ObjCQualifiedIdTypesAreCompatible(
-        (BlockReturnType ? LHSOPT : RHSOPT),
-        (BlockReturnType ? RHSOPT : LHSOPT), false));
+    return finish(ObjCQualifiedIdTypesAreCompatible(LHSOPT,
+                                                    RHSOPT, false));
 
   const ObjCInterfaceType* LHS = LHSOPT->getInterfaceType();
   const ObjCInterfaceType* RHS = RHSOPT->getInterfaceType();


### PR DESCRIPTION
Hi:
we're in the process of testing with Clang 10 and noticed a behavior change caused by this commit.

Consider the following piece of code:
```
@protocol P
@end

@protocol Q
@end

@interface I <P,Q>
@end

void a() {
    void (^genericBlockWithParam)(id <P>);
    void (^blockWithParam)(I *);
    blockWithParam = genericBlockWithParam;
    genericBlockWithParam = blockWithParam;
}
```
when I use clang 9, it will be below error

```
incompatible block pointer types assigning to 'void (^__strong)(I *__strong)' from 'void (^__strong)(__strong id<P>)'
    blockWithParam = genericBlockWithParam;
                   ^ ~~~~~~~~~~~~~~~~~~~~~
```
but in clang 10, the error is that
```
incompatible block pointer types assigning to 'void (^__strong)(__strong id<P>)' from 'void (^__strong)(I *__strong)'
     genericBlockWithParam = blockWithParam;
                    ^ ~~~~~~~~~~~~~~~~~~~~~
```
I think clang 9 is reasonable.