### PR TITLE
Correct typos in the dms_wait syntax and specs

### DIFF
--- a/mlir/docs/Dialects/Affine.md
+++ b/mlir/docs/Dialects/Affine.md
@@ -412,10 +412,10 @@ space 1 at indices [%k + 7, %l], would be specified as follows:
 Syntax:
 
 ```
-operation ::= `affine.dma_Start` ssa-use `[` multi-dim-affine-map-of-ssa-ids `]`, `[` multi-dim-affine-map-of-ssa-ids `]`, `[` multi-dim-affine-map-of-ssa-ids `]`, ssa-use `:` memref-type
+operation ::= `affine.dma_wait` ssa-use `[` multi-dim-affine-map-of-ssa-ids `]`, ssa-use `:` memref-type
 ```
 
-The `affine.dma_start` op blocks until the completion of a DMA operation
+The `affine.dma_wait` op blocks until the completion of a DMA operation
 associated with the tag element '%tag[%index]'. %tag is a memref, and %index
 has to be an index with the same restrictions as any load/store index.
 In particular, index for each memref dimension must be an affine expression of


### PR DESCRIPTION
The syntax and spec in affine.dma_wait should match the dma_wait heading instead of dma_start