### PR TITLE
[SimplifyCFG]  Skip merging return blocks if it would break a CallBr.

### DIFF
--- a/llvm/test/Transforms/SimplifyCFG/callbr-destinations.ll
+++ b/llvm/test/Transforms/SimplifyCFG/callbr-destinations.ll
@@ -1,0 +1,28 @@
+; RUN: opt < %s -simplifycfg -disable-output
+;
+; Test that SimplifyCFG does not cause CallBr instructions to have duplicate
+; destinations, which will cause the verifier to assert.
+
+define void @fun0() {
+entry:
+  callbr void asm sideeffect "", "X"(i8* blockaddress(@fun0, %bb1))
+          to label %bb2 [label %bb1]
+
+bb1:                                              ; preds = %bb
+  ret void
+
+bb2:                                             ; preds = %bb
+  ret void
+}
+
+define void @fun1() {
+entry:
+  callbr void asm sideeffect "", "X"(i8* blockaddress(@fun1, %bb1))
+          to label %bb2 [label %bb1]
+
+bb2:                                             ; preds = %bb
+  ret void
+
+bb1:                                              ; preds = %bb
+  ret void
+}


### PR DESCRIPTION
SimplifyCFG should not merge empty return blocks and leave a CallBr behind
with a duplicated destination since the verifier will then trigger an
assert. This patch checks for this case and avoids the transformation.

CodeGenPrepare has a similar check which also has a FIXME comment about why
this is needed. It seems perhaps better if these two passes would eventually
instead update the CallBr instruction instead of just checking and avoiding.

This fixes https://bugs.llvm.org/show_bug.cgi?id=45062.

Review: Craig Topper

Differential Revision: https://reviews.llvm.org/D75620

(cherry picked from commit c2dafe12dc24f7f1326f5c4c6a3b23f1485f1bd6)