### PR TITLE
Bugfix for clang-tidy readability-redundant-declaration

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantDeclarationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantDeclarationCheck.cpp
@@ -32,7 +32,9 @@ void RedundantDeclarationCheck::registerMatchers(MatchFinder *Finder) {
                       functionDecl(unless(anyOf(
                           isDefinition(), isDefaulted(),
                           doesDeclarationForceExternallyVisibleDefinition(),
-                          hasParent(friendDecl()))))))
+                          hasParent(friendDecl()),
+                          hasParent(functionTemplateDecl(hasParent(friendDecl())))
+                      )))))
           .bind("Decl"),
       this);
 }


### PR DESCRIPTION
Rule readability-redundant-declaration does not count that friend declaration that is not redundant could be template.

Minimum sample code: https://godbolt.org/z/_XzwfD