### PR TITLE
LLDB Expression unittest: fix bogus expressions

### DIFF
--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -204,12 +204,12 @@ TEST(DWARFExpression, DW_OP_convert) {
       llvm::HasValue(GetScalar(64, 0xffffffffffeeddcc, is_signed)));
 
   // Truncate to 8 bits.
-  EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 'A', 'B', 'C', 'D', 0xee, 0xff, //
+  EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 'A', 'B', 'C', 'D', //
                                DW_OP_convert, offs_uchar}),
                        llvm::HasValue(GetScalar(8, 'A', not_signed)));
 
   // Also truncate to 8 bits.
-  EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 'A', 'B', 'C', 'D', 0xee, 0xff, //
+  EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 'A', 'B', 'C', 'D', //
                                DW_OP_convert, offs_schar}),
                        llvm::HasValue(GetScalar(8, 'A', is_signed)));
 


### PR DESCRIPTION
Remove erroneous bytes, which seem to be
leftover from copy&paste.

Fixes https://bugs.llvm.org/show_bug.cgi?id=45853

Maybe it would be a good idea to warn about bogus instructions in the unit test context. Left as future work...