### PR TITLE
Fix gcc-9.3 compile errors (-Werror=format-security)

### DIFF
--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -57,7 +57,7 @@ llvm::Error SystemInitializerFull::Initialize() {
 
 void SystemInitializerFull::Terminate() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   Debugger::SettingsTerminate();
 

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -927,7 +927,7 @@ void Module::FindTypes_Impl(
     llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
     TypeMap &types) {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
   if (SymbolFile *symbols = GetSymbolFile())
     symbols->FindTypes(name, parent_decl_ctx, max_matches,
                        searched_symbol_files, types);
@@ -1015,7 +1015,7 @@ void Module::FindTypes(
     llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
     TypeMap &types) {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
   if (SymbolFile *symbols = GetSymbolFile())
     symbols->FindTypes(pattern, languages, searched_symbol_files, types);
 }
@@ -1027,7 +1027,7 @@ SymbolFile *Module::GetSymbolFile(bool can_create, Stream *feedback_strm) {
       ObjectFile *obj_file = GetObjectFile();
       if (obj_file != nullptr) {
         static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-        Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+        Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
         m_symfile_up.reset(
             SymbolVendor::FindPlugin(shared_from_this(), feedback_strm));
         m_did_load_symfile = true;

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -106,7 +106,7 @@ llvm::Error SystemInitializerCommon::Initialize() {
     return error;
 
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   process_gdb_remote::ProcessGDBRemoteLog::Initialize();
 
@@ -122,7 +122,7 @@ llvm::Error SystemInitializerCommon::Initialize() {
 
 void SystemInitializerCommon::Terminate() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
 #if defined(_WIN32)
   ProcessWindowsLog::Terminate();

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -207,7 +207,7 @@ bool CommandInterpreter::GetSpaceReplPrompts() const {
 
 void CommandInterpreter::Initialize() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   CommandReturnObject result;
 
@@ -452,7 +452,7 @@ const char *CommandInterpreter::ProcessEmbeddedScriptCommands(const char *arg) {
 
 void CommandInterpreter::LoadCommandDictionary() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   lldb::ScriptLanguage script_language = m_debugger.GetScriptLanguage();
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1892,7 +1892,7 @@ void AppleObjCRuntimeV2::UpdateISAToDescriptorMapIfNeeded() {
   Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_PROCESS | LIBLLDB_LOG_TYPES));
 
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   // Else we need to check with our process to see when the map was updated.
   Process *process = GetProcess();

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
@@ -68,7 +68,7 @@ bool ScriptInterpreterLua::ExecuteOneLine(llvm::StringRef command,
 
 void ScriptInterpreterLua::ExecuteInterpreterLoop() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   Debugger &debugger = m_debugger;
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -1067,7 +1067,7 @@ bool ScriptInterpreterPythonImpl::ExecuteOneLine(
 
 void ScriptInterpreterPythonImpl::ExecuteInterpreterLoop() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   Debugger &debugger = m_debugger;
 
@@ -2238,7 +2238,7 @@ bool ScriptInterpreterPythonImpl::GetScriptedSummary(
     const TypeSummaryOptions &options, std::string &retval) {
 
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   if (!valobj.get()) {
     retval.assign("<no object>");
@@ -3237,7 +3237,7 @@ void ScriptInterpreterPythonImpl::InitializePrivate() {
   g_initialized = true;
 
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   // RAII-based initialization which correctly handles multiple-initialization,
   // version- specific differences among Python 2 and Python 3, and saving and

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -568,7 +568,7 @@ void Symtab::SortSymbolIndexesByValue(std::vector<uint32_t> &indexes,
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
   // No need to sort if we have zero or one items...
   if (indexes.size() <= 1)
     return;

--- a/lldb/tools/lldb-test/SystemInitializerTest.cpp
+++ b/lldb/tools/lldb-test/SystemInitializerTest.cpp
@@ -55,7 +55,7 @@ llvm::Error SystemInitializerTest::Initialize() {
 
 void SystemInitializerTest::Terminate() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
-  Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat, "%s", LLVM_PRETTY_FUNCTION);
 
   Debugger::SettingsTerminate();
 


### PR DESCRIPTION
Fixes a bunch of error when compiling with gcc-9.3, like below:
```
/home/ggreif/llvm-project/lldb/source/Core/Module.cpp: In member function ‘void lldb_private::Module::FindTypes_Impl(lldb_private::ConstString, const lldb_private::CompilerDeclContext&, size_t, llvm::DenseSet<lldb_private::SymbolFile*>&, lldb_private::TypeMap&)’:
/home/ggreif/llvm-project/lldb/source/Core/Module.cpp:930:52: error: format not a string literal and no format arguments [-Werror=format-security]
  930 |   Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
      |                                                    ^
/home/ggreif/llvm-project/lldb/source/Core/Module.cpp: In member function ‘void lldb_private::Module::FindTypes(llvm::ArrayRef<lldb_private::CompilerContext>, lldb_private::LanguageSet, llvm::DenseSet<lldb_private::SymbolFile*>&, lldb_private::TypeMap&)’:
/home/ggreif/llvm-project/lldb/source/Core/Module.cpp:1018:52: error: format not a string literal and no format arguments [-Werror=format-security]
 1018 |   Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
      |                                                    ^
/home/ggreif/llvm-project/lldb/source/Core/Module.cpp: In member function ‘virtual lldb_private::SymbolFile* lldb_private::Module::GetSymbolFile(bool, lldb_private::Stream*)’:
/home/ggreif/llvm-project/lldb/source/Core/Module.cpp:1030:58: error: format not a string literal and no format arguments [-Werror=format-security]
 1030 |         Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
      |                                                          ^
```
These are unsafe uses of format strings, worth fixing.