### PR TITLE
Remove rank 0 affine.parallel when canonicalizing

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
@@ -587,6 +587,8 @@ def AffineParallelOp : Affine_Op<"parallel", [ImplicitAffineTerminator]> {
     static StringRef getUpperBoundsMapAttrName() { return "upperBoundsMap"; }
     static StringRef getStepsAttrName() { return "steps"; }
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def AffinePrefetchOp : Affine_Op<"prefetch"> {

--- a/mlir/test/Dialect/Affine/canonicalize.mlir
+++ b/mlir/test/Dialect/Affine/canonicalize.mlir
@@ -604,3 +604,18 @@ func @drop_duplicate_bounds(%N : index) {
   }
   return
 }
+
+// -----
+
+// CHECK: func @remove_rank0_affine_parallel(%[[OUT:.*]]: memref<f32>)
+func @remove_rank0_affine_parallel(%out: memref<f32>) {
+  // CHECK-NEXT: %[[CST:.*]] = constant
+  %cst = constant 0.0 : f32
+  // CHECK-NEXT: affine.store %[[CST]], %[[OUT]][] : memref<f32>
+  affine.parallel () = () to () {
+    affine.parallel () = () to () {
+      affine.store %cst, %out[] : memref<f32>
+    }
+  }
+  return
+}


### PR DESCRIPTION
AffineParallelOps of rank 0 (i.e., those with no induction variables) are superfluous. This adds a canonicalizer for AffineParallelOps that removes them if they are rank 0.

Submitting here for verification that this correctly enables the changes we want on the PlaidML side before submitting upstream. We can also land this and point PlaidML here if we decide we want to move faster than the LLVM/MLIR review process. We probably shouldn't land until we've rebased this on top of #5 and landed https://github.com/plaidml/plaidml/pull/1062 on the PlaidML side, as there are some minor conflicts that will need to be resolved.