### PR TITLE
Updates to the 'CLion Integration' section in ClangFormat docs

### DIFF
--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -176,13 +176,12 @@ CLion Integration
 =================
 
 :program:`clang-format` is integrated into `CLion <https://www.jetbrains
-.com/clion/>`_ as an alternative code formatter. It is disabled by default and
-can be turned on in Settings/Preferences | Editor | Code Style.
+.com/clion/>`_ as an alternative code formatter. CLion turns it on automatically when there is a .clang-format file
+under the project root. Code style rules are applied as you type, including indentation, auto-completion, code
+generation, and refactorings.
 
-If :program:`clang-format` support is enabled, CLion detects config files when
-opening a project and suggests overriding the current IDE settings. Code style
-rules from the ``.clang-format`` files are then applied automatically to all
-editor actions, including auto-completion, code generation, and refactorings.
+Clang-format can also be enabled without a .clang-format file. In this case, CLion prompts you to create one based
+on the current IDE settings or the default LLVM style.
 
 
 Visual Studio Integration


### PR DESCRIPTION
This commit updates the 'CLion Integration' section in ClangFormat docs. 
Key changes:
- clang-format is enabled automatically when there is a config file;
- formatting now works for indentations;
- if clang-format is enabled without a config file, CLion suggests creating it based on the IDE settings or uses the LLVM style by default.