### PR TITLE
Ensure regex substitution is a string

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1171,7 +1171,7 @@ def applySubstitutions(script, substitutions, recursion_limit=None):
             # short-lived, since the set of substitutions is fairly small, and
             # since thrashing has such bad consequences, not bounding the cache
             # seems reasonable.
-            ln = _caching_re_compile(a).sub(b, ln)
+            ln = _caching_re_compile(a).sub(str(b), ln)
 
         # Strip the trailing newline and any extra whitespace.
         return ln.strip()


### PR DESCRIPTION
The argument here is sometimes a `SubstituteCaptures` wrapper object containing a string, but Python3 seems to require that it be a real string of some sort.  The wrapper object supports `__str__` coercion, so it suffices to just coerce it to a real string.