### PR TITLE
[libc] libc-hdrgen, fixup link errors due to TableGen missing

### DIFF
--- a/libc/utils/LibcTableGenUtil/CMakeLists.txt
+++ b/libc/utils/LibcTableGenUtil/CMakeLists.txt
@@ -2,6 +2,6 @@ add_llvm_library(
   LibcTableGenUtil
   APIIndexer.cpp
   APIIndexer.h
-  LINK_COMPONENTS Support
+  LINK_COMPONENTS Support TableGen
 )
 target_include_directories(LibcTableGenUtil PUBLIC ${LIBC_SOURCE_DIR})


### PR DESCRIPTION
lib/libLLVMTableGen.so.12git  should be added when linking  bin/libc-hdrgen