### PR TITLE
[clang-format] Add BreakBeforeInlineASMColon and BreakBeforeStructInitialization configurations

### DIFF
--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1160,6 +1160,19 @@ struct FormatStyle {
   /// \endcode
   BraceWrappingFlags BraceWrapping;
 
+  /// If ``true``, colons in ASM parameters will be placed after line breaks.
+  /// \code
+  ///    true:
+  ///    asm volatile("loooooooooooooooooooooooooooooooooooooooooooooong",
+  ///                 :
+  ///                 : val);
+  ///
+  ///    false:
+  ///    asm volatile("loooooooooooooooooooooooooooooooooooooooooooooong",
+  ///                 : : val);
+  /// \endcode
+  bool BreakBeforeInlineASMColon;
+
   /// If ``true``, struct left brace will be placed after line breaks.
   /// \code
   ///    true:
@@ -2448,6 +2461,7 @@ struct FormatStyle {
            BinPackParameters == R.BinPackParameters &&
            BreakBeforeBinaryOperators == R.BreakBeforeBinaryOperators &&
            BreakBeforeBraces == R.BreakBeforeBraces &&
+           BreakBeforeInlineASMColon == R.BreakBeforeInlineASMColon &&
            BreakBeforeStructInitialization == R.BreakBeforeStructInitialization &&
            BreakBeforeTernaryOperators == R.BreakBeforeTernaryOperators &&
            BreakConstructorInitializers == R.BreakConstructorInitializers &&

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -1160,6 +1160,23 @@ struct FormatStyle {
   /// \endcode
   BraceWrappingFlags BraceWrapping;
 
+  /// If ``true``, struct left brace will be placed after line breaks.
+  /// \code
+  ///    true:
+  ///    struct new_struct struct_name =
+  ///    {
+  ///        a = 1,
+  ///        b = 2,
+  ///    };
+  ///
+  ///    false:
+  ///    struct new_struct struct_name = {
+  ///        a = 1,
+  ///        b = 2,
+  ///    };
+  /// \endcode
+  bool BreakBeforeStructInitialization;
+
   /// If ``true``, ternary operators will be placed after line breaks.
   /// \code
   ///    true:
@@ -2431,6 +2448,7 @@ struct FormatStyle {
            BinPackParameters == R.BinPackParameters &&
            BreakBeforeBinaryOperators == R.BreakBeforeBinaryOperators &&
            BreakBeforeBraces == R.BreakBeforeBraces &&
+           BreakBeforeStructInitialization == R.BreakBeforeStructInitialization &&
            BreakBeforeTernaryOperators == R.BreakBeforeTernaryOperators &&
            BreakConstructorInitializers == R.BreakConstructorInitializers &&
            CompactNamespaces == R.CompactNamespaces &&

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -334,7 +334,7 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
     auto LambdaBodyLength = getLengthToMatchingParen(Current, State.Stack);
     return (LambdaBodyLength > getColumnLimit(State));
   }
-  if (Current.MustBreakBefore || Current.is(TT_InlineASMColon))
+  if (Current.MustBreakBefore || (Current.is(TT_InlineASMColon) && Style.BreakBeforeInlineASMColon))
     return true;
   if (State.Stack.back().BreakBeforeClosingBrace &&
       Current.closesBlockOrBlockTypeList(Style))

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -953,6 +953,8 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
 
   const FormatToken &Previous = *Current.Previous;
   // If we are continuing an expression, we want to use the continuation indent.
+  if (Style.BreakBeforeStructInitialization)
+      Style.ContinuationIndentWidth = 0;
   unsigned ContinuationIndent =
       std::max(State.Stack.back().LastSpace, State.Stack.back().Indent) +
       Style.ContinuationIndentWidth;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -513,6 +513,9 @@ template <> struct MappingTraits<FormatStyle> {
         Style.BreakInheritanceList == FormatStyle::BILS_BeforeColon)
       Style.BreakInheritanceList = FormatStyle::BILS_BeforeComma;
 
+    IO.mapOptional("BreakBeforeInlineASMColon",
+                   Style.BreakBeforeInlineASMColon);
+
     IO.mapOptional("BreakBeforeStructInitialization",
                    Style.BreakBeforeStructInitialization);
 

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -513,6 +513,9 @@ template <> struct MappingTraits<FormatStyle> {
         Style.BreakInheritanceList == FormatStyle::BILS_BeforeColon)
       Style.BreakInheritanceList = FormatStyle::BILS_BeforeComma;
 
+    IO.mapOptional("BreakBeforeStructInitialization",
+                   Style.BreakBeforeStructInitialization);
+
     IO.mapOptional("BreakBeforeTernaryOperators",
                    Style.BreakBeforeTernaryOperators);
 

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3489,6 +3489,9 @@ static bool isAllmanBraceIncludedBreakableLambda(
 bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
                                      const FormatToken &Right) {
   const FormatToken &Left = *Right.Previous;
+   if (Style.BreakBeforeStructInitialization && Right.is(tok::l_brace) &&
+       (Right.is(BK_BracedInit) || Left.is(tok::equal)))
+    return true;
   if (Right.NewlinesBefore > 1 && Style.MaxEmptyLinesToKeep > 0)
     return true;
 


### PR DESCRIPTION
We are trying to use the clang-format approach as a base for Xen [1] style formatting.
During the state of testing clang-format with different configurations, we found that some points regarding the Xen coding style are not configurable. Therefore, we decided to add them to be able to make a choice in different cases.

[1] - https://xenproject.org/