### PR TITLE
The use of find_package

### DIFF
--- a/llvm/lib/WindowsManifest/CMakeLists.txt
+++ b/llvm/lib/WindowsManifest/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GetLibraryName)
 
 if(LLVM_ENABLE_LIBXML2)
-  set(imported_libs LibXml2::LibXml2)
+  find_package(LibXml2 REQUIRED)
 endif()
 
 add_llvm_component_library(LLVMWindowsManifest


### PR DESCRIPTION
MacOS 10.15.7 camke fail because of "set(imported_libs", but works with find_package

The "set" cmake variable is trying to search at "/usr/include/libxml2" and it is unable to find at proper MacOS path = /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/libxml2

Output of "cmake ../"
....
-- Configuring done
CMake Error in lib/WindowsManifest/CMakeLists.txt:
  Imported target "LibXml2::LibXml2" includes non-existent path
    "/usr/include/libxml2"

To resolve the issue, we rather use find_package so cmake handles the library finding properly.