### PR TITLE
Add socialpoint checks group

### DIFF
--- a/clang-tools-extra/clang-tidy/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/CMakeLists.txt
@@ -73,6 +73,7 @@ add_subdirectory(openmp)
 add_subdirectory(performance)
 add_subdirectory(portability)
 add_subdirectory(readability)
+add_subdirectory(socialpoint)
 add_subdirectory(zircon)
 set(ALL_CLANG_TIDY_CHECKS
   clangTidyAndroidModule
@@ -96,6 +97,7 @@ set(ALL_CLANG_TIDY_CHECKS
   clangTidyPerformanceModule
   clangTidyPortabilityModule
   clangTidyReadabilityModule
+  clangTidySocialpointModule
   clangTidyZirconModule
   )
 if(CLANG_TIDY_ENABLE_STATIC_ANALYZER)

--- a/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
@@ -128,6 +128,11 @@ extern volatile int ReadabilityModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED ReadabilityModuleAnchorDestination =
     ReadabilityModuleAnchorSource;
 
+// This anchor is used to force the linker to link the SocialpointModule.
+extern volatile int SocialpointModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED SocialpointModuleAnchorDestination =
+SocialpointModuleAnchorSource;
+
 // This anchor is used to force the linker to link the ZirconModule.
 extern volatile int ZirconModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED ZirconModuleAnchorDestination =

--- a/clang-tools-extra/clang-tidy/socialpoint/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/socialpoint/CMakeLists.txt
@@ -1,0 +1,33 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  )
+
+add_clang_library(clangTidySocialpointModule
+  DefinitionsInHeadersCheck.cpp
+  SocialpointTidyModule.cpp
+  SortConstructorInitializersCheck.cpp
+
+  LINK_LIBS
+  clangTidy
+  clangTidyReadabilityModule
+  clangTidyUtils
+
+  DEPENDS
+  omp_gen
+  )
+
+clang_target_link_libraries(clangTidySocialpointModule
+  PRIVATE
+  clangAnalysis
+  clangAST
+  clangASTMatchers
+  clangBasic
+  clangLex
+  clangSerialization
+  clangTooling
+  )
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  )

--- a/clang-tools-extra/clang-tidy/socialpoint/DefinitionsInHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/socialpoint/DefinitionsInHeadersCheck.cpp
@@ -1,0 +1,218 @@
+//===--- DefinitionsInHeadersCheck.cpp - clang-tidy------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DefinitionsInHeadersCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Lex/Lexer.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace socialpoint {
+
+namespace {
+
+AST_MATCHER_P(NamedDecl, usesHeaderFileExtension, utils::FileExtensionsSet,
+              HeaderFileExtensions) {
+  return utils::isExpansionLocInHeaderFile(
+      Node.getBeginLoc(), Finder->getASTContext().getSourceManager(),
+      HeaderFileExtensions);
+}
+
+llvm::Optional<SourceLocation> findStaticKeywordLocation(const DeclaratorDecl* Decl,
+                                                         SourceManager *SM,
+                                                         const LangOptions& LangOpts)
+{
+    llvm::Optional<SourceLocation> loc = Decl->getInnerLocStart();
+    while(loc && loc <= Decl->getEndLoc())
+    {
+        auto Range = CharSourceRange::getTokenRange(*loc);
+        if(Lexer::getSourceText(Range, *SM, LangOpts) == "static")
+        {
+            return loc;
+        }
+        auto Next = Lexer::findNextToken(*loc, *SM, LangOpts);
+        loc = Next.map([](const auto& token) {
+            return token.getLocation();
+            });
+    }
+    return llvm::None;
+}
+
+} // namespace
+
+DefinitionsInHeadersCheck::DefinitionsInHeadersCheck(StringRef Name,
+                                                     ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+    IncludeInternalLinkage(Options.get("IncludeInternalLinkage", false)),
+    UseHeaderFileExtension(Options.get("UseHeaderFileExtension", true)),
+      RawStringHeaderFileExtensions(Options.getLocalOrGlobal(
+          "HeaderFileExtensions", utils::defaultHeaderFileExtensions()))
+{
+  if (!utils::parseFileExtensions(RawStringHeaderFileExtensions,
+                                  HeaderFileExtensions,
+                                  utils::defaultFileExtensionDelimiters())) {
+    // FIXME: Find a more suitable way to handle invalid configuration
+    // options.
+    llvm::errs() << "Invalid header file extension: "
+                 << RawStringHeaderFileExtensions << "\n";
+  }
+}
+
+void DefinitionsInHeadersCheck::storeOptions(
+    ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "UseHeaderFileExtension", UseHeaderFileExtension);
+  Options.store(Opts, "HeaderFileExtensions", RawStringHeaderFileExtensions);
+  Options.store(Opts, "IncludeInternalLinkage", IncludeInternalLinkage);
+}
+
+void DefinitionsInHeadersCheck::registerMatchers(MatchFinder *Finder) {
+  auto DefinitionMatcher =
+      anyOf(functionDecl(isDefinition(), unless(isDeleted())),
+            varDecl(isDefinition()));
+  if (UseHeaderFileExtension) {
+    Finder->addMatcher(namedDecl(DefinitionMatcher,
+                                 usesHeaderFileExtension(HeaderFileExtensions))
+                           .bind("name-decl"),
+                       this);
+  } else {
+    Finder->addMatcher(
+        namedDecl(DefinitionMatcher,
+                  anyOf(usesHeaderFileExtension(HeaderFileExtensions),
+                        unless(isExpansionInMainFile())))
+            .bind("name-decl"),
+        this);
+  }
+}
+
+template <typename T>
+void DefinitionsInHeadersCheck::Fix(const T* decl,  SourceManager *SM, 
+                                    const LangOptions& LangOpts)
+{
+  if(decl->getStorageClass() == SC_Static)
+  {
+    if(auto loc = findStaticKeywordLocation(decl, SM, LangOpts)) {
+      diag(*loc, /*FixDescription=*/"replace 'static' by 'inline'",
+           DiagnosticIDs::Note)
+           << FixItHint::CreateReplacement(*loc, "inline");
+    } else {
+      diag(decl->getInnerLocStart(), "replace 'static' by 'inline'",
+           DiagnosticIDs::Note);
+    }
+  }
+  else
+  {
+    auto TokenCharRange = CharSourceRange::getTokenRange(decl->getInnerLocStart());
+    llvm::StringRef Token = Lexer::getSourceText(TokenCharRange, *SM, LangOpts);
+    std::string Replacement = ("inline " + Token).str();
+    diag(decl->getInnerLocStart(), "make as 'inline'",
+         DiagnosticIDs::Note)
+         << FixItHint::CreateReplacement(decl->getInnerLocStart(), Replacement);
+    }
+}
+
+void DefinitionsInHeadersCheck::check(const MatchFinder::MatchResult &Result) {
+  // Don't run the check in failing TUs.
+  if (Result.Context->getDiagnostics().hasUncompilableErrorOccurred())
+    return;
+
+  // C++ [basic.def.odr] p6:
+  // There can be more than one definition of a class type, enumeration type,
+  // inline function with external linkage, class template, non-static function
+  // template, static data member of a class template, member function of a
+  // class template, or template specialization for which some template
+  // parameters are not specifiedin a program provided that each definition
+  // appears in a different translation unit, and provided the definitions
+  // satisfy the following requirements.
+  const auto *ND = Result.Nodes.getNodeAs<NamedDecl>("name-decl");
+  assert(ND);
+  if (ND->isInvalidDecl())
+    return;
+
+  // Internal linkage variable definitions are ignored if IncludeInternalLinkage
+  // is not set:
+  //   const int a = 1;
+  //   static int b = 1;
+  //
+  // Although these might also cause ODR violations, we can be less certain and
+  // should try to keep the false-positive rate down.
+  //
+  // FIXME: Should declarations in anonymous namespaces get the same treatment
+  // as static / const declarations?
+  if (!IncludeInternalLinkage && 
+      !ND->hasExternalFormalLinkage() && !ND->isInAnonymousNamespace())
+    return;
+
+  SourceManager *SourceManager = Result.SourceManager;
+  const LangOptions& LangOpts = Result.Context->getLangOpts();
+
+  if (const auto *FD = dyn_cast<FunctionDecl>(ND)) {
+    // Inline functions are allowed.
+    if (FD->isInlined() || FD->hasAttr<AlwaysInlineAttr>())
+      return;
+    // Function templates are allowed.
+    if (FD->getTemplatedKind() == FunctionDecl::TK_FunctionTemplate)
+      return;
+    // Ignore instantiated functions.
+    if (FD->isTemplateInstantiation())
+      return;
+    // Member function of a class template and member function of a nested class
+    // in a class template are allowed.
+    if (const auto *MD = dyn_cast<CXXMethodDecl>(FD)) {
+      const auto *DC = MD->getDeclContext();
+      while (DC->isRecord()) {
+        if (const auto *RD = dyn_cast<CXXRecordDecl>(DC)) {
+          if (isa<ClassTemplatePartialSpecializationDecl>(RD))
+            return;
+          if (RD->getDescribedClassTemplate())
+            return;
+        }
+        DC = DC->getParent();
+      }
+    }
+
+    bool IsFullSpec = FD->getTemplateSpecializationKind() != TSK_Undeclared;
+    diag(FD->getLocation(),
+         "%select{function|full function template specialization}0 %1 defined "
+         "in a header file; function definitions in header files can lead to "
+         "ODR violations")
+        << IsFullSpec << FD;
+    Fix(FD, SourceManager, LangOpts);
+  } else if (const auto *VD = dyn_cast<VarDecl>(ND)) {
+    // C++14 variable templates are allowed.
+    if (VD->getDescribedVarTemplate())
+      return;
+    // Static data members of a class template are allowed.
+    if (VD->getDeclContext()->isDependentContext() && VD->isStaticDataMember())
+      return;
+    // Ignore instantiated static data members of classes.
+    if (isTemplateInstantiation(VD->getTemplateSpecializationKind()))
+      return;
+    // Ignore variable definition within function scope.
+    if (VD->hasLocalStorage() || VD->isStaticLocal())
+      return;
+    // Ignore inline variables.
+    if (VD->isInline())
+      return;
+    // Ignore constexpr variables.
+    if(VD->isConstexpr())
+        return;
+
+    diag(VD->getLocation(),
+         "variable %0 defined in a header file; "
+         "variable definitions in header files can lead to ODR violations")
+        << VD;
+    Fix(VD, SourceManager, LangOpts);
+  }
+}
+
+} // namespace socialpoint
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/socialpoint/DefinitionsInHeadersCheck.h
+++ b/clang-tools-extra/clang-tidy/socialpoint/DefinitionsInHeadersCheck.h
@@ -1,0 +1,58 @@
+//===--- DefinitionsInHeadersCheck.h - clang-tidy----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_SOCIALPOINT_DEFINITIONS_IN_HEADERS_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_SOCIALPOINT_DEFINITIONS_IN_HEADERS_H
+
+#include "../ClangTidyCheck.h"
+#include "../utils/FileExtensionsUtils.h"
+
+namespace clang {
+namespace tidy {
+namespace socialpoint {
+
+/// Finds non-extern non-inline function and variable definitions in header
+/// files, which can lead to potential ODR violations.
+///
+/// The check supports these options:
+///   - `UseHeaderFileExtension`: Whether to use file extension to distinguish
+///     header files. True by default.
+///   - `HeaderFileExtensions`: a semicolon-separated list of filename
+///     extensions of header files (The filename extension should not contain
+///     "." prefix). ";h;hh;hpp;hxx" by default.
+///
+///     For extension-less header files, using an empty string or leaving an
+///     empty string between ";" if there are other filename extensions.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/misc-definitions-in-headers.html
+class DefinitionsInHeadersCheck : public ClangTidyCheck {
+public:
+  DefinitionsInHeadersCheck(StringRef Name, ClangTidyContext *Context);
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus11;
+  }
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+private:
+  const bool IncludeInternalLinkage;
+  const bool UseHeaderFileExtension;
+  const std::string RawStringHeaderFileExtensions;
+  utils::FileExtensionsSet HeaderFileExtensions;
+
+  template <typename T>
+  void Fix(const T* decl, SourceManager *SourceManager, const LangOptions& LangOpts);
+};
+
+} // namespace socialpoint
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_SOCIALPOINT_DEFINITIONS_IN_HEADERS_H

--- a/clang-tools-extra/clang-tidy/socialpoint/SocialpointTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/socialpoint/SocialpointTidyModule.cpp
@@ -1,0 +1,50 @@
+//===--- GoogleTidyModule.cpp - clang-tidy --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../ClangTidy.h"
+#include "../ClangTidyModule.h"
+#include "../ClangTidyModuleRegistry.h"
+#include "DefinitionsInHeadersCheck.h"
+#include "SortConstructorInitializersCheck.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace socialpoint {
+
+class SocialpointModule : public ClangTidyModule {
+ public:
+  void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<DefinitionsInHeadersCheck>(
+        "socialpoint-definitions-in-headers");
+    CheckFactories.registerCheck<SortConstructorInitializersCheck>(
+        "socialpoint-sort-constructor-initializers");
+  }
+
+  ClangTidyOptions getModuleOptions() override {
+    ClangTidyOptions Options;
+    auto &Opts = Options.CheckOptions;
+    Opts["socialpoint-definitions-in-headers.IncludeInternalLinkage"] =
+        "1";
+    return Options;
+  }
+};
+
+// Register the GoogleTidyModule using this statically initialized variable.
+static ClangTidyModuleRegistry::Add<SocialpointModule> X("socialpoint-module",
+                                                         "Adds Socialpoint lint checks.");
+
+}  // namespace socialpoint
+
+// This anchor is used to force the linker to link in the generated object file
+// and thus register the SocialpointModule.
+volatile int SocialpointModuleAnchorSource = 0;
+
+}  // namespace tidy
+}  // namespace clang

--- a/clang-tools-extra/clang-tidy/socialpoint/SortConstructorInitializersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/socialpoint/SortConstructorInitializersCheck.cpp
@@ -1,0 +1,77 @@
+//===--- SortConstructorInitializersCheck.cpp - clang-tidy ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SortConstructorInitializersCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Lex/Lexer.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace socialpoint {
+
+void SortConstructorInitializersCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(cxxConstructorDecl(unless(isExpansionInSystemHeader()))
+                         .bind("constructor"),
+                     this);
+}
+
+void SortConstructorInitializersCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  if (auto *Decl = Result.Nodes.getNodeAs<CXXConstructorDecl>("constructor")) {
+    process(Decl, *Result.SourceManager, Result.Context->getLangOpts());
+  }
+}
+
+void SortConstructorInitializersCheck::process(const CXXConstructorDecl *Decl,
+                                               SourceManager &SourceMgr,
+                                               const LangOptions &LangOpts) {
+  if (Decl->getNumCtorInitializers()) {
+    bool AlreadySorted = true;
+    std::string fixStorage;
+    llvm::raw_string_ostream FixToApply(fixStorage);
+
+    SourceRange RangeToFix;
+    bool FirstInitializer = true;
+
+    for (const CXXCtorInitializer *Init : Decl->inits()) {
+      if (!Init->isMemberInitializer() || !Init->isWritten()) {
+        continue;
+      }
+      SourceRange InitRange = Init->getSourceRange();
+      if (FirstInitializer) {
+        RangeToFix = InitRange;
+      } else {
+        if (InitRange.getBegin() < RangeToFix.getBegin()) {
+          RangeToFix.setBegin(InitRange.getBegin());
+          AlreadySorted = false;
+        }
+        if (InitRange.getEnd() > RangeToFix.getEnd()) {
+          RangeToFix.setEnd(InitRange.getEnd());
+        }
+        FixToApply << ",";
+      }
+      FixToApply << Lexer::getSourceText(
+          CharSourceRange::getTokenRange(InitRange), SourceMgr, LangOpts);
+      FirstInitializer = false;
+    }
+
+    if (!AlreadySorted) {
+      auto CharRangeToFix = CharSourceRange::getTokenRange(RangeToFix);
+      diag(CharRangeToFix.getBegin(), "Member initializers are not sorted: %0")
+          << Lexer::getSourceText(CharRangeToFix, SourceMgr, LangOpts)
+          << FixItHint::CreateReplacement(CharRangeToFix, FixToApply.str());
+    }
+  }
+}
+
+} // namespace socialpoint
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/socialpoint/SortConstructorInitializersCheck.h
+++ b/clang-tools-extra/clang-tidy/socialpoint/SortConstructorInitializersCheck.h
@@ -1,0 +1,36 @@
+//===--- SortConstructorInitializersCheck.h - clang-tidy --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_SOCIALPOINT_SORTCONSTRUCTORINITIALIZERSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_SOCIALPOINT_SORTCONSTRUCTORINITIALIZERSCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace socialpoint {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/misc-sort-constructor-initializers.html
+class SortConstructorInitializersCheck : public ClangTidyCheck {
+public:
+  SortConstructorInitializersCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+private:
+    void process(const CXXConstructorDecl* Decl, SourceManager& SourceMgr, const LangOptions& LangOpts);
+};
+
+} // namespace socialpoint
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_SOCIALPOINT_SORTCONSTRUCTORINITIALIZERSCHECK_H

--- a/clang-tools-extra/clang-tidy/socialpoint/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/socialpoint/tool/run-clang-tidy.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+#
+#===- run-clang-tidy.py - Parallel clang-tidy runner --------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===#
+# FIXME: Integrate with clang-tidy-diff.py
+
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+from __future__ import print_function
+
+import argparse
+import fnmatch
+import glob
+import json
+import multiprocessing
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+import yaml
+
+try:
+  import yaml
+except ImportError:
+  yaml = None
+
+is_py2 = sys.version[0] == '2'
+
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
+
+
+def find_compilation_database(path):
+  """Adjusts the directory until a compilation database is found."""
+  result = './'
+  while not os.path.isfile(os.path.join(result, path)):
+    if os.path.realpath(result) == '/':
+      print('Error: could not find compilation database.')
+      sys.exit(1)
+    result += '../'
+  return os.path.realpath(result)
+
+
+def make_absolute(f, directory):
+  if os.path.isabs(f):
+    return f
+  return os.path.normpath(os.path.join(directory, f))
+
+
+def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
+                        header_filter, allow_enabling_alpha_checkers,
+                        extra_arg, extra_arg_before, quiet, config, system_headers):
+  """Gets a command line for clang-tidy."""
+  start = [clang_tidy_binary, '--use-color']
+  if allow_enabling_alpha_checkers:
+    start.append('-allow-enabling-analyzer-alpha-checkers')
+  if header_filter is not None:
+    start.append('-header-filter=' + header_filter)
+  if system_headers is True:
+    start.append('-system-headers')
+  if checks:
+    start.append('-checks=' + checks)
+  if tmpdir is not None:
+    start.append('-export-fixes')
+    # Get a temporary file. We immediately close the handle so clang-tidy can
+    # overwrite it.
+    (handle, name) = tempfile.mkstemp(suffix='.yaml', dir=tmpdir)
+    os.close(handle)
+    start.append(name)
+  for arg in extra_arg:
+      start.append('-extra-arg=%s' % arg)
+  for arg in extra_arg_before:
+      start.append('-extra-arg-before=%s' % arg)
+  start.append('-p=' + build_path)
+  if quiet:
+      start.append('-quiet')
+  if config:
+      start.append('-config=' + config)
+  start.append(f)
+  return start
+
+
+def merge_replacement_files(tmpdir, mergefile):
+  """Merge all replacement files in a directory into a single file"""
+  # The fixes suggested by clang-tidy >= 4.0.0 are given under
+  # the top level key 'Diagnostics' in the output yaml files
+  mergekey = "Diagnostics"
+  merged=[]
+  for replacefile in glob.iglob(os.path.join(tmpdir, '*.yaml')):
+    content = yaml.safe_load(open(replacefile, 'r'))
+    if not content:
+      continue # Skip empty files.
+    merged.extend(content.get(mergekey, []))
+
+  if merged:
+    # MainSourceFile: The key is required by the definition inside
+    # include/clang/Tooling/ReplacementsYaml.h, but the value
+    # is actually never used inside clang-apply-replacements,
+    # so we set it to '' here.
+    output = {'MainSourceFile': '', mergekey: merged}
+    with open(mergefile, 'w') as out:
+      yaml.safe_dump(output, out)
+  else:
+    # Empty the file:
+    open(mergefile, 'w').close()
+
+
+def check_clang_apply_replacements_binary(args):
+  """Checks if invoking supplied clang-apply-replacements binary works."""
+  try:
+    subprocess.check_call([args.clang_apply_replacements_binary, '--version'])
+  except:
+    print('Unable to run clang-apply-replacements. Is clang-apply-replacements '
+          'binary correctly specified?', file=sys.stderr)
+    traceback.print_exc()
+    sys.exit(1)
+
+
+def apply_fixes(args, tmpdir):
+  """Calls clang-apply-fixes on a given directory."""
+  invocation = [args.clang_apply_replacements_binary]
+  if args.format:
+    invocation.append('-format')
+  if args.style:
+    invocation.append('-style=' + args.style)
+  invocation.append(tmpdir)
+  subprocess.call(invocation)
+
+
+def run_tidy(args, tmpdir, build_path, queue, lock, failed_files):
+  """Takes filenames out of queue and runs clang-tidy on them."""
+  while True:
+    name = queue.get()
+    invocation = get_tidy_invocation(name, args.clang_tidy_binary, args.checks,
+                                     tmpdir, build_path, args.header_filter,
+                                     args.allow_enabling_alpha_checkers,
+                                     args.extra_arg, args.extra_arg_before,
+                                     args.quiet, args.config, args.system_headers)
+
+    proc = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = proc.communicate()
+    if proc.returncode != 0:
+      failed_files.append(name)
+    with lock:
+      sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
+      if len(err) > 0:
+        sys.stdout.flush()
+        sys.stderr.write(err.decode('utf-8'))
+    queue.task_done()
+
+def in_excluded_list(filename, excluded):
+  for pattern in excluded:
+     if fnmatch.fnmatch(filename, pattern):
+         return True
+  return False
+
+def main():
+  parser = argparse.ArgumentParser(description='Runs clang-tidy over all files '
+                                   'in a compilation database. Requires '
+                                   'clang-tidy and clang-apply-replacements in '
+                                   '$PATH.')
+  parser.add_argument('-allow-enabling-alpha-checkers',
+                      action='store_true', help='allow alpha checkers from '
+                                                'clang-analyzer.')
+  parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                      default='clang-tidy',
+                      help='path to clang-tidy binary')
+  parser.add_argument('-clang-apply-replacements-binary', metavar='PATH',
+                      default='clang-apply-replacements',
+                      help='path to clang-apply-replacements binary')
+  parser.add_argument('-checks', default=None,
+                      help='checks filter, when not specified, use clang-tidy '
+                      'default')
+  parser.add_argument('-config', default=None,
+                      help='Specifies a configuration in YAML/JSON format: '
+                      '  -config="{Checks: \'*\', '
+                      '                       CheckOptions: [{key: x, '
+                      '                                       value: y}]}" '
+                      'When the value is empty, clang-tidy will '
+                      'attempt to find a file named .clang-tidy for '
+                      'each source file in its parent directories.')
+  parser.add_argument('-header-filter', default=None,
+                      help='regular expression matching the names of the '
+                      'headers to output diagnostics from. Diagnostics from '
+                      'the main file of each translation unit are always '
+                      'displayed.')
+  parser.add_argument('-system-headers', action='store_true',
+                      help='show diagnostics from system headers.')
+  parser.add_argument('-exclude', default=None,
+                      help='List of files top exclude')
+  if yaml:
+    parser.add_argument('-export-fixes', metavar='filename', dest='export_fixes',
+                        help='Create a yaml file to store suggested fixes in, '
+                        'which can be applied with clang-apply-replacements.')
+  parser.add_argument('-j', type=int, default=0,
+                      help='number of tidy instances to be run in parallel.')
+  parser.add_argument('files', nargs='*', default=['.*'],
+                      help='files to be processed (regex on path)')
+  parser.add_argument('-fix', action='store_true', help='apply fix-its')
+  parser.add_argument('-format', action='store_true', help='Reformat code '
+                      'after applying fixes')
+  parser.add_argument('-style', default='file', help='The style of reformat '
+                      'code after applying fixes')
+  parser.add_argument('-p', dest='build_path',
+                      help='Path used to read a compile command database.')
+  parser.add_argument('-extra-arg', dest='extra_arg',
+                      action='append', default=[],
+                      help='Additional argument to append to the compiler '
+                      'command line.')
+  parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                      action='append', default=[],
+                      help='Additional argument to prepend to the compiler '
+                      'command line.')
+  parser.add_argument('-quiet', action='store_true',
+                      help='Run clang-tidy in quiet mode')
+  args = parser.parse_args()
+
+  db_path = 'compile_commands.json'
+
+  if args.build_path is not None:
+    build_path = args.build_path
+  else:
+    # Find our database
+    build_path = find_compilation_database(db_path)
+
+  try:
+    invocation = [args.clang_tidy_binary, '-list-checks']
+    if args.allow_enabling_alpha_checkers:
+      invocation.append('-allow-enabling-analyzer-alpha-checkers')
+    invocation.append('-p=' + build_path)
+    if args.checks:
+      invocation.append('-checks=' + args.checks)
+    invocation.append('-')
+    if args.quiet:
+      # Even with -quiet we still want to check if we can call clang-tidy.
+      with open(os.devnull, 'w') as dev_null:
+        subprocess.check_call(invocation, stdout=dev_null)
+    else:
+      subprocess.check_call(invocation)
+  except:
+    print("Unable to run clang-tidy.", file=sys.stderr)
+    sys.exit(1)
+
+  # Load the database and extract all files.
+  database = json.load(open(os.path.join(build_path, db_path)))
+  files = [make_absolute(entry['file'], entry['directory'])
+           for entry in database]
+  if args.exclude:
+    excluded = yaml.safe_load(args.exclude)
+
+  max_task = args.j
+  if max_task == 0:
+    max_task = multiprocessing.cpu_count()
+
+  tmpdir = None
+  if args.fix or (yaml and args.export_fixes):
+    check_clang_apply_replacements_binary(args)
+    tmpdir = tempfile.mkdtemp()
+
+  # Build up a big regexy filter from all command line arguments.
+  file_name_re = re.compile('|'.join(args.files))
+
+  return_code = 0
+  try:
+    # Spin up a bunch of tidy-launching threads.
+    task_queue = queue.Queue(max_task)
+    # List of files with a non-zero return code.
+    failed_files = []
+    lock = threading.Lock()
+    for _ in range(max_task):
+      t = threading.Thread(target=run_tidy,
+                           args=(args, tmpdir, build_path, task_queue, lock, failed_files))
+      t.daemon = True
+      t.start()
+
+    # Fill the queue with files.
+    for name in files:
+      if file_name_re.search(name):
+        if not in_excluded_list(name, excluded):
+          task_queue.put(name)
+
+    # Wait for all threads to be done.
+    task_queue.join()
+    if len(failed_files):
+      return_code = 1
+
+  except KeyboardInterrupt:
+    # This is a sad hack. Unfortunately subprocess goes
+    # bonkers with ctrl-c and we start forking merrily.
+    print('\nCtrl-C detected, goodbye.')
+    if tmpdir:
+      shutil.rmtree(tmpdir)
+    os.kill(0, 9)
+
+  if yaml and args.export_fixes:
+    print('Writing fixes to ' + args.export_fixes + ' ...')
+    try:
+      merge_replacement_files(tmpdir, args.export_fixes)
+    except:
+      print('Error exporting fixes.\n', file=sys.stderr)
+      traceback.print_exc()
+      return_code=1
+
+  os.chdir(build_path)
+  if args.fix:
+    print('Applying fixes ...')
+    try:
+      apply_fixes(args, tmpdir)
+    except:
+      print('Error applying fixes.\n', file=sys.stderr)
+      traceback.print_exc()
+      return_code = 1
+
+  if tmpdir:
+    shutil.rmtree(tmpdir)
+  sys.exit(return_code)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
- Create a socialpoint checks group: clang-tidy has its checks grouped. We can add any other interesting test to our group by aliasing it or implement any other needed test

- Added 2 checks:
  - 'socialpoint-definitions-in-headers' as a modified check of 'misc-definitions-in-headers' to suit our needs. That one was not detecting internal linkage variable definitions. Added a configuration option to allow for that. Also it was not handling properly __always_inline attribute
  - Added check 'socialpoint-sort-constructor-initializers' to fix out of order member initialization lists on constructors

 - Added a modified run-clang-tidy.py that allow to exclude files from checks. This may be useful to us to avoid applyinc changes to unwanted folders (like hydra/lib ones)

Example of invocation:
``run-clang-tidy.py -clang-tidy-binary path_to_custom_clang-tidy_binary -clang-apply-replacements-binary path_to_custom_clang-apply-replacements_binary -p path_to_compile_command_json -header-filter=.* -exclude="['*hydra/lib/format/format.cc','*/std_overrides/*.cpp']" -checks=-*,socialpoint-definitions-in-headers -config="{'CheckOptions': [{key: socialpoint-definitions-in-headers.IncludeInternalLinkage, value: 1}]}" -fix .``
