### PR TITLE
[vim] Fix regexp matching against syntax attribute

### DIFF
--- a/llvm/utils/vim/indent/llvm.vim
+++ b/llvm/utils/vim/indent/llvm.vim
@@ -52,7 +52,7 @@ function! GetLLVMIndent()
 
   " Find a non-blank not-completely commented line above the current line.
   let prev_lnum = prevnonblank(v:lnum - 1)
-  while prev_lnum > 0 && synIDattr(synID(prev_lnum, indent(prev_lnum)+1, 0), "name") =? "string\|comment"
+  while prev_lnum > 0 && synIDattr(synID(prev_lnum, indent(prev_lnum)+1, 0), 'name') =~? 'string\|comment'
     let prev_lnum = prevnonblank(prev_lnum-1)
   endwhile
   " Hit the start of the file, use zero indent.


### PR DESCRIPTION
- There is no operator =? in Vim. Use =~? for regexp matching ignoring case.
- Using double quote in rhs does not work with the pattern. Use single quote.