### PR TITLE
minor changes to MLIR CAPI

### DIFF
--- a/mlir/include/mlir-c/BuiltinTypes.h
+++ b/mlir/include/mlir-c/BuiltinTypes.h
@@ -225,7 +225,7 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAUnrankedMemRef(MlirType type);
  * same context as element type. The type is owned by the context. */
 MLIR_CAPI_EXPORTED MlirType mlirMemRefTypeGet(
     MlirType elementType, intptr_t rank, const int64_t *shape, intptr_t numMaps,
-    MlirAttribute const *affineMaps, unsigned memorySpace);
+    MlirAffineMap const *affineMaps, unsigned memorySpace);
 
 /** Creates a MemRef type with the given rank, shape, memory space and element
  * type in the same context as the element type. The type has no affine maps,
@@ -263,7 +263,7 @@ MLIR_CAPI_EXPORTED MlirAffineMap mlirMemRefTypeGetAffineMap(MlirType type,
 MLIR_CAPI_EXPORTED unsigned mlirMemRefTypeGetMemorySpace(MlirType type);
 
 /// Returns the memory spcae of the given Unranked MemRef type.
-MLIR_CAPI_EXPORTED unsigned mlirUnrankedMemrefGetMemorySpace(MlirType type);
+MLIR_CAPI_EXPORTED unsigned mlirUnrankedMemRefGetMemorySpace(MlirType type);
 
 //===----------------------------------------------------------------------===//
 // Tuple type.

--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -504,7 +504,7 @@ mlirBlockPrint(MlirBlock block, MlirStringCallback callback, void *userData);
 static inline bool mlirValueIsNull(MlirValue value) { return !value.ptr; }
 
 /// Returns 1 if two values are equal, 0 otherwise.
-bool mlirValueEqual(MlirValue value1, MlirValue value2);
+MLIR_CAPI_EXPORTED bool mlirValueEqual(MlirValue value1, MlirValue value2);
 
 /// Returns 1 if the value is a block argument, 0 otherwise.
 MLIR_CAPI_EXPORTED bool mlirValueIsABlockArgument(MlirValue value);

--- a/mlir/lib/CAPI/IR/BuiltinTypes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinTypes.cpp
@@ -276,7 +276,7 @@ MlirType mlirUnrankedMemRefTypeGetChecked(MlirType elementType,
                                              unwrap(loc)));
 }
 
-unsigned mlirUnrankedMemrefGetMemorySpace(MlirType type) {
+unsigned mlirUnrankedMemRefGetMemorySpace(MlirType type) {
   return unwrap(type).cast<UnrankedMemRefType>().getMemorySpace();
 }
 

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -686,7 +686,7 @@ static int printBuiltinTypes(MlirContext ctx) {
   MlirType unrankedMemRef = mlirUnrankedMemRefTypeGet(f32, 4);
   if (!mlirTypeIsAUnrankedMemRef(unrankedMemRef) ||
       mlirTypeIsAMemRef(unrankedMemRef) ||
-      mlirUnrankedMemrefGetMemorySpace(unrankedMemRef) != 4)
+      mlirUnrankedMemRefGetMemorySpace(unrankedMemRef) != 4)
     return 19;
   mlirTypeDump(unrankedMemRef);
   fprintf(stderr, "\n");


### PR DESCRIPTION
1. There appears to be a bug in `BuiltinTypes.h` in the definition of `mlirMemRefTypeGet`. I believe it should be `MlirAffineMap` as opposed to `MlirAttribute` here as evidenced here:

https://github.com/llvm/llvm-project/blob/297c839e2d22f9bc37f5f8cca7eb5924b49716d2/mlir/lib/CAPI/IR/BuiltinTypes.cpp#L225

2. Currently, `mlirValueEqual` is not exported as a CAPI. I am not sure if this is by design. I've added `MLIR_CAPI_EXPORTED`.

3. In `BuiltinTypes`, we see consistently the use of `MemRef`, with the exception of `mlirUnrankedMemrefGetMemorySpace`. I have changed that for consistency.