### PR TITLE
Increase the verbosity level needed to print Mutation sequence

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
@@ -644,7 +644,7 @@ void Fuzzer::PrintStatusForNewUnit(const Unit &U, const char *Text) {
   if (!Options.PrintNEW)
     return;
   PrintStats(Text, "");
-  if (Options.Verbosity) {
+  if (Options.Verbosity >= 2) {
     Printf(" L: %zd/%zd ", U.size(), Corpus.MaxInputSize());
     MD.PrintMutationSequence(Options.Verbosity >= 2);
     Printf("\n");


### PR DESCRIPTION
The mutation sequence is not that important and it populates most of the output for large corpus due to the high amount of mutations.
With this change the sequence will not be shown by default but the parameter `-verbosity=2` should be set.