### PR TITLE
Fix usage example for "CommonOptionsParser.h"

### DIFF
--- a/clang/include/clang/Tooling/CommonOptionsParser.h
+++ b/clang/include/clang/Tooling/CommonOptionsParser.h
@@ -56,9 +56,9 @@ namespace tooling {
 /// ...
 ///
 /// int main(int argc, const char **argv) {
-///   CommonOptionsParser OptionsParser(argc, argv, MyToolCategory);
-///   ClangTool Tool(OptionsParser.getCompilations(),
-///                  OptionsParser.getSourcePathList());
+///   Expected<CommonOptionsParser> OptionsParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
+///   ClangTool Tool(OptionsParser->getCompilations(),
+///                  OptionsParser->getSourcePathList());
 ///   return Tool.run(newFrontendActionFactory<SyntaxOnlyAction>().get());
 /// }
 /// \endcode


### PR DESCRIPTION
The current usage example suggests using `CommonOptionsParser::CommonOptionsParser()`, which is `protected` and throws:
```ps1
Error (active)    E0330
"clang::tooling::CommonOptionsParser::CommonOptionsParser(int &argc, const char **argv, llvm::cl::OptionCategory &Category, llvm::cl::NumOccurrencesFlag OccurrencesFlag = llvm::cl::OneOrMore, const char *Overview = (const char *)nullptr)"
(declared at line 76 of "llvm-project\llvm-13.0.0-msbuild-vs2019-x64-rel\include\clang\Tooling\CommonOptionsParser.h")
is inaccessible
```

The only way it compiles for me is as:
```cpp
Expected<CommonOptionsParser> OptionsParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
```

Feel free to close this if this is incorrect! =)