### PR TITLE
Fixed bug using string stream by including missing header

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/impl/system.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/impl/system.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <set>
 #include <string>
+#include <sstream> 
 
 #include "internal.h"
 #include "machine.h"


### PR DESCRIPTION
This fixes the amdgpu libomptarget offloading. The sstream header was missing and has now been included. Without this header an error will occur compiling openmp for the AMDGPU target. 