### PR TITLE
get DiagnosticEngine as a reference

### DIFF
--- a/mlir/docs/Diagnostics.md
+++ b/mlir/docs/Diagnostics.md
@@ -26,7 +26,7 @@ the diagnostic should be propagated to any previously registered handlers. It
 can be interfaced with via an `MLIRContext` instance.
 
 ```c++
-DiagnosticEngine engine = ctx->getDiagEngine();
+DiagnosticEngine& engine = ctx->getDiagEngine();
 
 /// Handle the reported diagnostic.
 // Return success to signal that the diagnostic has either been fully processed,


### PR DESCRIPTION
‘mlir::DiagnosticEngine::DiagnosticEngine(const mlir::DiagnosticEngine&)’ is implicitly deleted because the default definition would be ill-formed: