### PR TITLE
Add missing comma causing implicit string concat

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
@@ -56,7 +56,7 @@ static const std::string DefaultIgnoredParameterTypeSuffixes =
                                    "reverse_const_iterator",
                                    "ConstReverseIterator",
                                    "Const_Reverse_Iterator",
-                                   "const_reverse_iterator"
+                                   "const_reverse_iterator",
                                    "Constreverseiterator",
                                    "constreverseiterator"});
 


### PR DESCRIPTION
This is very likely a bug and and unwanted implicit string concatenation caused by a missing comma.

The entry would be "Const_Reverse_Iteratorconst_reverse_iterator" which basically breaks matching against both entries.