### PR TITLE
adding `<limits>` to fix a g++ error

### DIFF
--- a/llvm/utils/benchmark/src/benchmark_register.h
+++ b/llvm/utils/benchmark/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
there was a missing header error appearing with `gnu` compiler. I think it doesn't appear with clang because it' included in any other header.