### PR TITLE
Add use_default_shell_env = True to ctx.actions.run

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -169,6 +169,7 @@ def _gentbl_rule_impl(ctx):
         inputs = trans_srcs,
         executable = ctx.executable.tblgen,
         arguments = [args],
+        use_default_shell_env = True,
         mnemonic = "TdGenerate",
     )
 


### PR DESCRIPTION
When building a tool in a non-standard environment (e.g. custom compiler path -> LD_LIBRARY_PATH set) then `use_default_shell_env = True` is required to run that tool in the same environment or otherwise the build will fail due to missing symbols.
See https://github.com/google/jax/issues/7842 for this issue and https://github.com/tensorflow/tensorflow/pull/44549 for related fix in TF