### PR TITLE
Fix objc_clsopt_v16_t in AppleObjCRuntimeV2.cpp

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -292,6 +292,7 @@ struct objc_clsopt_v16_t {
    uint32_t occupied;
    uint32_t shift;
    uint32_t mask;
+   uint32_t zero;
    uint64_t salt;
    uint32_t scramble[256];
    uint8_t  tab[0]; // tab[mask+1]


### PR DESCRIPTION
I'm not sure if you all actually use this file for anything, but I've been using it to understand the NEW macOS/iOS15 dyld_shared_cache ObjC runtime structures and noticed this was wrong when I tried to actually use it.

