### PR TITLE
fix build on Alpine Linux

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -14,6 +14,7 @@ function(compiler_rt_check_linker_flag flag out_var)
 endfunction()
 
 check_library_exists(c fopen "" COMPILER_RT_HAS_LIBC)
+check_library_exists(execinfo backtrace "" COMPILER_RT_HAS_EXECINFO)
 if (COMPILER_RT_USE_BUILTINS_LIBRARY)
   include(HandleCompilerRT)
   find_compiler_rt_library(builtins "" COMPILER_RT_BUILTINS_LIBRARY)

--- a/compiler-rt/lib/scudo/CMakeLists.txt
+++ b/compiler-rt/lib/scudo/CMakeLists.txt
@@ -14,10 +14,12 @@ append_list_if(COMPILER_RT_HAS_LIBPTHREAD pthread SCUDO_MINIMAL_DYNAMIC_LIBS)
 append_list_if(COMPILER_RT_HAS_LIBLOG log SCUDO_MINIMAL_DYNAMIC_LIBS)
 append_list_if(COMPILER_RT_HAS_OMIT_FRAME_POINTER_FLAG -fno-omit-frame-pointer
                SCUDO_CFLAGS)
+append_list_if(COMPILER_RT_HAS_EXECINFO execinfo SCUDO_MINIMAL_DYNAMIC_LIBS)
 
 set(SCUDO_DYNAMIC_LINK_FLAGS ${SANITIZER_COMMON_LINK_FLAGS})
 # Use gc-sections by default to avoid unused code being pulled in.
 list(APPEND SCUDO_DYNAMIC_LINK_FLAGS -Wl,--gc-sections)
+
 
 if(ANDROID)
 # Put most Sanitizer shared libraries in the global group. For more details, see

--- a/compiler-rt/lib/scudo/standalone/CMakeLists.txt
+++ b/compiler-rt/lib/scudo/standalone/CMakeLists.txt
@@ -134,6 +134,7 @@ endif()
 set(SCUDO_LINK_LIBS)
 
 append_list_if(COMPILER_RT_HAS_LIBPTHREAD -pthread SCUDO_LINK_FLAGS)
+append_list_if(COMPILER_RT_HAS_EXECINFO execinfo SCUDO_LINK_LIBS)
 
 append_list_if(FUCHSIA zircon SCUDO_LINK_LIBS)
 


### PR DESCRIPTION
- make sure libexecinfo gets linked into compiler-rt when building
  against musl c library on Alpine Linux