### PR TITLE
added not-tested LinalgTilingToParallelLoops pass

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/Passes.h
+++ b/mlir/include/mlir/Dialect/Linalg/Passes.h
@@ -21,6 +21,7 @@ std::unique_ptr<OperationPass<FuncOp>> createConvertElementwiseToLinalgPass();
 std::unique_ptr<OperationPass<FuncOp>> createLinalgFoldUnitExtentDimsPass();
 
 std::unique_ptr<Pass> createLinalgElementwiseOpFusionPass();
+
 std::unique_ptr<Pass> createFoldReshapeOpsByLinearizationPass();
 
 std::unique_ptr<OperationPass<FuncOp>>
@@ -34,7 +35,14 @@ createLinalgTilingToTiledLoopPass(ArrayRef<int64_t> tileSizes = {},
                                   ArrayRef<StringRef> distributionTypes = {});
 
 std::unique_ptr<OperationPass<FuncOp>>
+createMemoryFootPrintReducePass(int64_t maxFootprint = 0);
+
+std::unique_ptr<OperationPass<FuncOp>>
+createLinalgMemoryFootprintReductionPass(int64_t maxFootprint = 0);
+
+std::unique_ptr<OperationPass<FuncOp>>
 createLinalgPromotionPass(bool dynamicBuffers, bool useAlloca);
+
 std::unique_ptr<OperationPass<FuncOp>> createLinalgPromotionPass();
 
 std::unique_ptr<OperationPass<FuncOp>> createLinalgInlineScalarOperandsPass();

--- a/mlir/include/mlir/Dialect/Linalg/Passes.td
+++ b/mlir/include/mlir/Dialect/Linalg/Passes.td
@@ -174,6 +174,21 @@ def LinalgTiling : FunctionPass<"linalg-tile"> {
   ];
 }
 
+def LinalgMemoryFootprintReduction : FunctionPass<"linalg-memory-footprint-reduce"> {
+  let summary = "Brings the LinalgOps memory footprint below maxMemFootprint";
+  let constructor = "mlir::createLinalgMemoryFootprintReductionPass()";
+  let options = [
+    ListOption<"maxMemFootprint", "linalg-max-memory-footprint", "int64_t", 
+               "Max memory footprint in bytes", "llvm::cl::Optional">
+  ];
+  let dependentDialects = [
+    "AffineDialect",
+    "linalg::LinalgDialect",
+    "memref::MemRefDialect",
+    "scf::SCFDialect"
+  ];
+}
+
 def LinalgTilingToParallelLoops
     : FunctionPass<"linalg-tile-to-parallel-loops"> {
   let summary = "Tile operations in the linalg dialect to parallel loops";


### PR DESCRIPTION
I have not tested this yet, but added a pass for registration in the table gen files. We can't use the createTilingPass within our pass, because that runs on functions and will tile every linalg op in the function with the same tiling parameters. this is not what we want. I will be using the rewrite patters that TilingPass uses to rewrite each linalg op individually.