### PR TITLE
[www] Fix Ninja build instructions on Windows

### DIFF
--- a/clang/www/get_started.html
+++ b/clang/www/get_started.html
@@ -206,7 +206,7 @@ second build directory next to it for running the tests with these steps:</p>
   <li><tt>set CC=cl</tt> (necessary to force CMake to choose MSVC over mingw GCC
     if you have it installed)</li>
   <li><tt>set CXX=cl</tt></li>
-  <li><tt>cmake -GNinja ..\llvm</tt></li>
+  <li><tt>cmake -GNinja -DLLVM_ENABLE_PROJECTS=clang ..\llvm</tt></li>
   <li><tt>ninja clang</tt> This will build just clang.</li>
   <li><tt>ninja check-clang</tt> This will run the clang tests.</li>
 </ol>


### PR DESCRIPTION
The `clang` target used in the line below is only generated with `LLVM_ENABLE_PROJECTS=clang`.

Without this change, running `ninja clang` will fail with:
```
ninja: error: unknown target 'clang', did you mean 'clean'?
```