### PR TITLE
Added support of Windows XP for the files generated by clang.

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -247,9 +247,9 @@ struct Configuration {
   uint32_t minorImageVersion = 0;
   // If changing the default os/subsys version here, update the default in
   // the MinGW driver accordingly.
-  uint32_t majorOSVersion = 6;
+  uint32_t majorOSVersion = 4;
   uint32_t minorOSVersion = 0;
-  uint32_t majorSubsystemVersion = 6;
+  uint32_t majorSubsystemVersion = 4;
   uint32_t minorSubsystemVersion = 0;
   uint32_t timestamp = 0;
   uint32_t functionPadMin = 0;

--- a/lldb/test/Shell/ObjectFile/PECOFF/basic-info-arm.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/basic-info-arm.yaml
@@ -16,11 +16,11 @@ OptionalHeader:
   ImageBase:       4194304
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/basic-info-arm64.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/basic-info-arm64.yaml
@@ -16,11 +16,11 @@ OptionalHeader:
   ImageBase:       1073741824
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/basic-info.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/basic-info.yaml
@@ -16,11 +16,11 @@ OptionalHeader:
   ImageBase:       290816
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/disassemble-thumb.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/disassemble-thumb.yaml
@@ -12,11 +12,11 @@ OptionalHeader:
   ImageBase:       4194304
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/invalid-export-table.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/invalid-export-table.yaml
@@ -11,11 +11,11 @@ OptionalHeader:
   ImageBase:       1073741824
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/section-types.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/section-types.yaml
@@ -12,11 +12,11 @@ OptionalHeader:
   ImageBase:       4194304
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_NO_SEH, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/sections-names.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/sections-names.yaml
@@ -12,11 +12,11 @@ OptionalHeader:
   ImageBase:       1073741824
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/sections.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/sections.yaml
@@ -40,11 +40,11 @@ OptionalHeader:
   ImageBase:       1073741824
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/symbol.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/symbol.yaml
@@ -14,11 +14,11 @@ OptionalHeader:
   ImageBase:       1073741824
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]

--- a/lldb/test/Shell/ObjectFile/PECOFF/uuid.yaml
+++ b/lldb/test/Shell/ObjectFile/PECOFF/uuid.yaml
@@ -10,11 +10,11 @@ OptionalHeader:
   ImageBase:       2147483648
   SectionAlignment: 4096
   FileAlignment:   512
-  MajorOperatingSystemVersion: 6
+  MajorOperatingSystemVersion: 4
   MinorOperatingSystemVersion: 0
   MajorImageVersion: 0
   MinorImageVersion: 0
-  MajorSubsystemVersion: 6
+  MajorSubsystemVersion: 4
   MinorSubsystemVersion: 0
   Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_GUI
   DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT ]


### PR DESCRIPTION
In fact I set the versions to 4.0 (Windows NT 4.0) because MinGW-w64 libs have them set so, but I haven't tested the binaries (the binaries, built against MinGW-w64 runtime) on anything other than XP and ReactOS.