### PR TITLE
Fix buggy numerics of tanh(complex) at inf

### DIFF
--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -1269,8 +1269,8 @@ tanh(const complex<_Tp>& __x)
     if (__libcpp_isinf_or_builtin(__x.real()))
     {
         if (!__libcpp_isfinite_or_builtin(__x.imag()))
-            return complex<_Tp>(_Tp(1), _Tp(0));
-        return complex<_Tp>(_Tp(1), copysign(_Tp(0), sin(_Tp(2) * __x.imag())));
+            return complex<_Tp>(copysign(_Tp(1), __x.real()), _Tp(0));
+        return complex<_Tp>(copysign(_Tp(1), __x.real()), copysign(_Tp(0), sin(_Tp(2) * __x.imag())));
     }
     if (__libcpp_isnan_or_builtin(__x.real()) && __x.imag() == 0)
         return __x;

--- a/libcxx/test/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
@@ -57,18 +57,18 @@ void test_edges()
         }
         else if (std::isinf(testcases[i].real()) && std::isfinite(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
             assert(std::signbit(r.imag()) == std::signbit(sin(2*testcases[i].imag())));
         }
         else if (std::isinf(testcases[i].real()) && std::isinf(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
         }
         else if (std::isinf(testcases[i].real()) && std::isnan(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
         }
         else if (std::isnan(testcases[i].real()) && testcases[i].imag() == 0)


### PR DESCRIPTION
Because:
lim[x->inf, tanh(x+iy)] = 1
lim[x->-inf, tanh(x+iy)] = -1

See also:
https://github.com/NVIDIA/libcudacxx/pull/210

cc: @wmaxey @ngimel @mruberry