### PR TITLE
Windows Docker container

### DIFF
--- a/llvm/utils/docker/windows/.dockerignore
+++ b/llvm/utils/docker/windows/.dockerignore
@@ -1,0 +1,1 @@
+llvm-build-debug

--- a/llvm/utils/docker/windows/.gitignore
+++ b/llvm/utils/docker/windows/.gitignore
@@ -1,0 +1,1 @@
+llvm-build-debug

--- a/llvm/utils/docker/windows/Dockerfile
+++ b/llvm/utils/docker/windows/Dockerfile
@@ -1,0 +1,49 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+LABEL maintainer "LLVM Developers"
+
+# Set cmd as default shell
+SHELL ["cmd", "/S", "/C"]
+
+# Setup vs_buildtools.exe
+COPY Install.cmd C:\TEMP\
+ADD https://aka.ms/vscollect.exe C:\TEMP\collect.exe
+ADD https://aka.ms/vs/16/release/channel C:\TEMP\VisualStudio.chman
+ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+
+# Install VS2019 x86 x64 C++
+RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --installPath C:\BuildTools `
+    --channelUri C:\TEMP\VisualStudio.chman `
+    --installChannelUri C:\TEMP\VisualStudio.chman `
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+
+# Install Windows 10 SDK 19041 (apparently this is needed to let CMake detect MSVC??)
+RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --installPath C:\BuildTools `
+    --channelUri C:\TEMP\VisualStudio.chman `
+    --installChannelUri C:\TEMP\VisualStudio.chman `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.19041
+
+# Install VS CMake
+RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --installPath C:\BuildTools `
+    --channelUri C:\TEMP\VisualStudio.chman `
+    --installChannelUri C:\TEMP\VisualStudio.chman `
+    --add Microsoft.VisualStudio.Component.VC.CMake.Project
+
+# Add CMake to PATH
+RUN powershell setx /M PATH $($Env:PATH + ';C:\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin')
+
+
+# Install Chocolatey
+RUN powershell -Command `
+        iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); `
+        choco feature disable --name showDownloadProgress
+
+# To determine version
+RUN choco install -y git
+
+RUN choco install -y python --version=3.9.0

--- a/llvm/utils/docker/windows/Dockerfile
+++ b/llvm/utils/docker/windows/Dockerfile
@@ -46,4 +46,5 @@ RUN powershell -Command `
 # To determine version
 RUN choco install -y git
 
+# For the automated test suite
 RUN choco install -y python --version=3.9.0

--- a/llvm/utils/docker/windows/Install.cmd
+++ b/llvm/utils/docker/windows/Install.cmd
@@ -1,0 +1,14 @@
+@if not defined _echo echo off
+setlocal enabledelayedexpansion
+
+call %*
+if "%ERRORLEVEL%"=="3010" (
+    exit /b 0
+) else (
+    if not "%ERRORLEVEL%"=="0" (
+        set ERR=%ERRORLEVEL%
+        call C:\TEMP\collect.exe -zip:C:\vslogs.zip
+
+        exit /b !ERR!
+    )
+)

--- a/llvm/utils/docker/windows/README.md
+++ b/llvm/utils/docker/windows/README.md
@@ -1,0 +1,12 @@
+# How to build LLVM inside a Windows container
+
+## Problem
+
+Creating a Dockerfile that `ADD`s the source code inside is problematic, it works well only for Process Isolation machines and not Hyper-V ones.
+`docker build` on Windows with Hyper-V uses only 2 cores and that's the situation for almost everyone using Docker, LLVM would take ages to compile.
+
+## Solution
+
+1. Build Docker image that is ready to build LLVM
+2. Run it only to build LLVM by mounting inside the source code (`docker run` can use all cores when `NUMBER_OF_PROCESSORS` is specified)
+3. Get the artifacts out using a volume

--- a/llvm/utils/docker/windows/build-llvm-debug.bat
+++ b/llvm/utils/docker/windows/build-llvm-debug.bat
@@ -1,0 +1,3 @@
+@echo off
+mkdir llvm-build-debug
+docker-compose up --build --remove-orphans llvm-debug

--- a/llvm/utils/docker/windows/docker-compose.yml
+++ b/llvm/utils/docker/windows/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.4"
+
+services:
+
+
+  llvm-debug:
+    image: llvm-debug
+    # LLVM doesn't need Administrator to compile
+    user: ContainerUser
+    storage_opt:
+    # Default windows container C: drive max size is 20G, let's be safe here
+      size: '100G'
+    build:
+      context: "."
+    deploy:
+    # If you use Process Isolation you can remove these
+    # If you use Hyper-V and don't set a limit it will default to 
+    # something like 2 cores and ~1GB of RAM
+      resources:
+        limits:
+          cpus: ${NUMBER_OF_PROCESSORS}
+    # I tried with 8GB and it crashed
+          memory: 16GB
+    volumes:
+      # Mount the source code inside as readonly
+      - ../../../../:C:/llvm-project:ro
+      # Volume to get the artifacts out
+      - ./llvm-build-debug:C:/build/Debug
+    # Disable network access, not needed
+    networks:
+      - none
+    # https://llvm.org/docs/GettingStarted.html#local-llvm-configuration
+    # This for example will build llvm+clang+X86 target using x64 host build tools
+    command: >
+      cmd /c "echo [Creating LLVM CMake project]
+      && cd C:\build
+      && cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=X86 -G "Visual Studio 16 2019" -A x64 -Thost=x64 C:\llvm-project\llvm
+      && echo [Building LLVM]
+      && cmake --build ."
+
+networks:
+
+  none:
+    external: true

--- a/llvm/utils/docker/windows/docker-compose.yml
+++ b/llvm/utils/docker/windows/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       resources:
         limits:
           cpus: ${NUMBER_OF_PROCESSORS}
-    # I tried with 8GB and it crashed
+          # I tried with 8GB and it crashed
           memory: 16GB
     volumes:
       # Mount the source code inside as readonly


### PR DESCRIPTION
Path: `llvm/utils/docker/windows`

# How to build LLVM inside a Windows container

## Problem

Creating a Dockerfile that `ADD`s the source code inside is problematic, it works well only for Process Isolation machines and not Hyper-V ones.
`docker build` on Windows with Hyper-V uses only 2 cores and that's the situation for almost everyone using Docker, LLVM would take ages to compile.

## Solution

1. Build Docker image that is ready to build LLVM
2. Run it only to build LLVM by mounting inside the source code (`docker run` can use all cores when `NUMBER_OF_PROCESSORS` is specified)
3. Get the artifacts out using a volume


Wrote the same in the README included