### PR TITLE
fix typos in comments

### DIFF
--- a/clang-tools-extra/clang-doc/ClangDoc.h
+++ b/clang-tools-extra/clang-doc/ClangDoc.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file exposes a method to craete the FrontendActionFactory for the
+// This file exposes a method to create the FrontendActionFactory for the
 // clang-doc tool. The factory runs the clang-doc mapper on a given set of
 // source code files, storing the results key-value pairs in its
 // ExecutionContext.

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
@@ -1301,7 +1301,7 @@ RuntimeDyldELF::processRelocationRef(
         MemMgr.allowStubAllocation()) {
       resolveAArch64Branch(SectionID, Value, RelI, Stubs);
     } else if (RelType == ELF::R_AARCH64_ADR_GOT_PAGE) {
-      // Craete new GOT entry or find existing one. If GOT entry is
+      // Create new GOT entry or find existing one. If GOT entry is
       // to be created, then we also emit ABS64 relocation for it.
       uint64_t GOTOffset = findOrAllocGOTEntry(Value, ELF::R_AARCH64_ABS64);
       resolveGOTOffsetRelocation(SectionID, Offset, GOTOffset + Addend,

--- a/llvm/test/tools/llvm-objcopy/ELF/Inputs/ihex-elf-sections.yaml
+++ b/llvm/test/tools/llvm-objcopy/ELF/Inputs/ihex-elf-sections.yaml
@@ -33,7 +33,7 @@ Sections:
   - Name:            .data3
 # The last section not only overlaps segment boundary, but
 # also has linear address which doesn't fit 20 bits. The 
-# following records should be craeted:
+# following records should be created:
 # 'SegmentAddr'(02) record with address 0x0
 # 'ExtendedAddr'(04) record with address 0x100000
 # 'Data'(00) record with 8 bytes of section data


### PR DESCRIPTION
Hi, LLVM developers

This PR fix typo in comments, change `craete` => `create`.