### PR TITLE
[llvm-objdump] Add initial --chained_fixups option support

### DIFF
--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -369,6 +369,23 @@ struct dyld_chained_import_addend64
   uint64_t    addend;
 };
 
+// values for dyld_chained_starts_in_segment.pointer_format
+enum {
+  DYLD_CHAINED_PTR_ARM64E                 =  1,    // stride 8, unauth target is vmaddr
+  DYLD_CHAINED_PTR_64                     =  2,    // target is vmaddr
+  DYLD_CHAINED_PTR_32                     =  3,
+  DYLD_CHAINED_PTR_32_CACHE               =  4,
+  DYLD_CHAINED_PTR_32_FIRMWARE            =  5,
+  DYLD_CHAINED_PTR_64_OFFSET              =  6,    // target is vm offset
+  DYLD_CHAINED_PTR_ARM64E_OFFSET          =  7,    // old name
+  DYLD_CHAINED_PTR_ARM64E_KERNEL          =  7,    // stride 4, unauth target is vm offset
+  DYLD_CHAINED_PTR_64_KERNEL_CACHE        =  8,
+  DYLD_CHAINED_PTR_ARM64E_USERLAND        =  9,    // stride 8, unauth target is vm offset
+  DYLD_CHAINED_PTR_ARM64E_FIRMWARE        = 10,    // stride 4, unauth target is vmaddr
+  DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE    = 11,    // stride 1, x86_64 kernel caches
+  DYLD_CHAINED_PTR_ARM64E_USERLAND24      = 12,    // stride 8, unauth target is vm offset, 24-bit bind
+};
+
 enum {
   // Constant masks for the "n_type" field in llvm::MachO::nlist and
   // llvm::MachO::nlist_64

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -342,6 +342,33 @@ struct dyld_chained_starts_in_segment
                               // the last of which has the high bit set
 };
 
+// DYLD_CHAINED_IMPORT
+struct dyld_chained_import
+{
+  uint32_t    lib_ordinal :  8,
+      weak_import :  1,
+      name_offset : 23;
+};
+
+// DYLD_CHAINED_IMPORT_ADDEND
+struct dyld_chained_import_addend
+{
+  uint32_t    lib_ordinal :  8,
+      weak_import :  1,
+      name_offset : 23;
+  int32_t     addend;
+};
+
+// DYLD_CHAINED_IMPORT_ADDEND64
+struct dyld_chained_import_addend64
+{
+  uint64_t    lib_ordinal : 16,
+      weak_import :  1,
+      reserved    : 15,
+      name_offset : 32;
+  uint64_t    addend;
+};
+
 enum {
   // Constant masks for the "n_type" field in llvm::MachO::nlist and
   // llvm::MachO::nlist_64

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -4662,6 +4662,8 @@ ArrayRef<uint8_t> MachOObjectFile::getDyldInfoExportsTrie() const {
   return makeArrayRef(Ptr, DyldInfo.export_size);
 }
 
+// TODO: add getDyldChainedFixupsHeader
+
 ArrayRef<uint8_t> MachOObjectFile::getUuid() const {
   if (!UuidLoadCmd)
     return None;

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -10537,7 +10537,7 @@ static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
     uint32_t SegOffset;
     memcpyAtOffset(ImageOffset+sizeof(uint32_t)*(SegIdx+1), SegOffset);
     SegOffsets.push_back(SegOffset);
-    outs() << "    seg_offset [" << SegIdx << "] = "
+    outs() << "    seg_offset[" << SegIdx << "] = "
            << SegOffset << " (" << segments[SegIdx].segname << ")\n";
   }
 
@@ -10547,11 +10547,57 @@ static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
     if (SegOffset == 0) continue;
     MachO::dyld_chained_starts_in_segment Seg;
     memcpyAtOffset(ImageOffset+SegOffset, Seg);
+    std::string PointerFormat;
+    switch (Seg.pointer_format) {
+    case MachO::DYLD_CHAINED_PTR_ARM64E:
+      PointerFormat = "DYLD_CHAINED_PTR_ARM64E";
+      break;
+    case MachO::DYLD_CHAINED_PTR_64:
+      PointerFormat = "DYLD_CHAINED_PTR_64";
+      break;
+    case MachO::DYLD_CHAINED_PTR_32:
+      PointerFormat = "DYLD_CHAINED_PTR_32";
+      break;
+    case MachO::DYLD_CHAINED_PTR_32_CACHE:
+      PointerFormat = "DYLD_CHAINED_PTR_32_CACHE";
+      break;
+    case MachO::DYLD_CHAINED_PTR_32_FIRMWARE:
+      PointerFormat = "DYLD_CHAINED_PTR_32_FIRMWARE";
+      break;
+    case MachO::DYLD_CHAINED_PTR_64_OFFSET:
+      PointerFormat = "DYLD_CHAINED_PTR_64_OFFSET";
+      break;
+    // TODO: handle DYLD_CHAINED_PTR_ARM64E_OFFSET
+//    case MachO::DYLD_CHAINED_PTR_ARM64E_OFFSET:
+//      PointerFormat = "DYLD_CHAINED_PTR_ARM64E_OFFSET";
+//      break;
+    case MachO::DYLD_CHAINED_PTR_ARM64E_KERNEL:
+      PointerFormat = "DYLD_CHAINED_PTR_ARM64E_KERNEL";
+      break;
+    case MachO::DYLD_CHAINED_PTR_64_KERNEL_CACHE:
+      PointerFormat = "DYLD_CHAINED_PTR_64_KERNEL_CACHE";
+      break;
+    case MachO::DYLD_CHAINED_PTR_ARM64E_USERLAND:
+      PointerFormat = "DYLD_CHAINED_PTR_ARM64E_USERLAND";
+      break;
+    case MachO::DYLD_CHAINED_PTR_ARM64E_FIRMWARE:
+      PointerFormat = "DYLD_CHAINED_PTR_ARM64E_FIRMWARE";
+      break;
+    case MachO::DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE:
+      PointerFormat = "DYLD_CHAINED_PTR_X86_64_KERNEL_CACHE";
+      break;
+    case MachO::DYLD_CHAINED_PTR_ARM64E_USERLAND24:
+      PointerFormat = "DYLD_CHAINED_PTR_ARM64E_USERLAND24";
+      break;
+    default:
+      PointerFormat = "UNKNOWN";
+      break;
+    }
     outs() << "chained starts in segment " << SegIdx << " (" << segments[SegIdx].segname << ")\n"
            << "  size = " << Seg.size << "\n"
-           << "  page_size = " << Seg.page_size << "\n" // TODO: show in hex
-           << "  pointer_format = " << Seg.pointer_format << "\n" // TODO: show in str
-           << "  segment_offset = " << Seg.segment_offset << "\n" // TODO: show in hex
+           << "  page_size = " << format("0x%016" PRIx64, Seg.page_size) << "\n"
+           << "  pointer_format = " << Seg.pointer_format << " (" << PointerFormat << ")\n"
+           << "  segment_offset = " << format("0x%016" PRIx64, Seg.segment_offset) << "\n"
            << "  max_valid_pointer = " << Seg.max_valid_pointer << "\n"
            << "  page_count = " << Seg.page_count << "\n";
      for (uint16_t PageIdx=0; PageIdx<Seg.page_count; PageIdx++){
@@ -10573,7 +10619,7 @@ static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
       MachO::dyld_chained_import Import;
       memcpyAtOffset(ImportsOffset+ImportIdx*sizeof(Import), Import);
       outs() << "  lib_ordinal = " << Import.lib_ordinal << "\n"
-             << "  weak_import =" << Import.weak_import << "\n"
+             << "  weak_import = " << Import.weak_import << "\n"
              << "  name_offset = " << Import.name_offset << " ("
              << StringRef(Obj->getData().data()+(SymbolOffset+Import.name_offset)) << ")" <<"\n";
       break;
@@ -10582,7 +10628,7 @@ static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
       MachO::dyld_chained_import_addend ImportAddend;
       memcpyAtOffset(ImportsOffset+ImportIdx*sizeof(ImportAddend), ImportAddend);
       outs() << "  lib_ordinal = " << ImportAddend.lib_ordinal << "\n"
-             << "  weak_import =" << ImportAddend.weak_import << "\n"
+             << "  weak_import = " << ImportAddend.weak_import << "\n"
              << "  name_offset = " << ImportAddend.name_offset << " ("
              << StringRef(Obj->getData().data()+(SymbolOffset+ImportAddend.name_offset)) << ")" <<"\n"
              << "  addend = " << ImportAddend.addend << "\n";
@@ -10592,7 +10638,7 @@ static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
       MachO::dyld_chained_import_addend64 ImportAddend64;
       memcpyAtOffset(ImportsOffset+ImportIdx*sizeof(ImportAddend64), ImportAddend64);
       outs() << "  lib_ordinal = " << ImportAddend64.lib_ordinal << "\n"
-             << "  weak_import =" << ImportAddend64.weak_import << "\n"
+             << "  weak_import = " << ImportAddend64.weak_import << "\n"
              << "  reserved =" << ImportAddend64.reserved << "\n"
              << "  name_offset = " << ImportAddend64.name_offset << " ("
              << StringRef(Obj->getData().data()+(SymbolOffset+ImportAddend64.name_offset)) << ")" <<"\n"

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -10618,29 +10618,38 @@ static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
   for (uint32_t ImportIdx=0; ImportIdx<Header.imports_count; ImportIdx++) {
     switch (Header.imports_format) {
     case MachO::DYLD_CHAINED_IMPORT:
-      outs() << "dyld_chained_import[" << ImportIdx << "]\n"; // TODO: add address
       MachO::dyld_chained_import Import;
       memcpyAtOffset(ImportsOffset+ImportIdx*sizeof(Import), Import);
-      outs() << "  lib_ordinal = " << Import.lib_ordinal << " (" << dylibName(Import.lib_ordinal) << ")\n"
+      uint32_t ImportValues[1];
+      memcpy(ImportValues, &Import, sizeof(Import));
+      outs() << "dyld chained import[" << ImportIdx << "] = "
+             << format("0x%08" PRIx64, ImportValues[0]) << "\n"
+             << "  lib_ordinal = " << Import.lib_ordinal << " (" << dylibName(Import.lib_ordinal) << ")\n"
              << "  weak_import = " << Import.weak_import << "\n"
              << "  name_offset = " << Import.name_offset << " ("
              << StringRef(Obj->getData().data()+(SymbolOffset+Import.name_offset)) << ")" <<"\n";
       break;
     case MachO::DYLD_CHAINED_IMPORT_ADDEND:
-      outs() << "dyld_chained_import_addend[" << ImportIdx << "]\n";
       MachO::dyld_chained_import_addend ImportAddend;
       memcpyAtOffset(ImportsOffset+ImportIdx*sizeof(ImportAddend), ImportAddend);
-      outs() << "  lib_ordinal = " << ImportAddend.lib_ordinal << " (" << dylibName(ImportAddend.lib_ordinal) << ")\n"
+      uint32_t ImportAddendValues[2];
+      memcpy(ImportAddendValues, &ImportAddend, sizeof(ImportAddend));
+      outs() << "dyld chained import addend[" << ImportIdx << "] = "
+             << format("0x%08" PRIx64, ImportAddendValues[0]) << format("0x%08" PRIx64, ImportAddendValues[1]) << "\n"
+             << "  lib_ordinal = " << ImportAddend.lib_ordinal << " (" << dylibName(ImportAddend.lib_ordinal) << ")\n"
              << "  weak_import = " << ImportAddend.weak_import << "\n"
              << "  name_offset = " << ImportAddend.name_offset << " ("
              << StringRef(Obj->getData().data()+(SymbolOffset+ImportAddend.name_offset)) << ")" <<"\n"
              << "  addend = " << ImportAddend.addend << "\n";
       break;
     case MachO::DYLD_CHAINED_IMPORT_ADDEND64:
-      outs() << "dyld_chained_import_addend64[" << ImportIdx << "]\n";
       MachO::dyld_chained_import_addend64 ImportAddend64;
       memcpyAtOffset(ImportsOffset+ImportIdx*sizeof(ImportAddend64), ImportAddend64);
-      outs() << "  lib_ordinal = " << ImportAddend64.lib_ordinal << " (" << dylibName(ImportAddend64.lib_ordinal) << ")\n"
+      uint64_t ImportAddend64Values[2];
+      memcpy(ImportAddend64Values, &ImportAddend64Values, sizeof(ImportAddend64));
+      outs() << "dyld chained import addend64[" << ImportIdx << "] = "
+             << format("0x%016" PRIx64, ImportAddend64Values[0]) << format("0x%016" PRIx64, ImportAddend64Values[1]) << "\n"
+             << "  lib_ordinal = " << ImportAddend64.lib_ordinal << " (" << dylibName(ImportAddend64.lib_ordinal) << ")\n"
              << "  weak_import = " << ImportAddend64.weak_import << "\n"
              << "  reserved =" << ImportAddend64.reserved << "\n"
              << "  name_offset = " << ImportAddend64.name_offset << " ("

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -10457,7 +10457,7 @@ static void printMachOWeakBindTable(object::MachOObjectFile *Obj) {
 //===----------------------------------------------------------------------===//
 
 static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
-  MachO::linkedit_data_command Ld;
+  MachO::linkedit_data_command Ld = MachO::linkedit_data_command{0, 0, 0, 0};
   Error Err = Error::success();
 
   // find LC_DYLD_CHAINED_FIXUPS Load Command & obtain loaded dylib info
@@ -10475,6 +10475,9 @@ static void printMachOChainedFixups(object::MachOObjectFile *Obj) {
   // no LC_DYLD_CHAINED_FIXUPS found
   if (Ld.dataoff == 0) {
     outs() << "no chained fixups\n";
+    if (Err){
+      reportError(std::move(Err), Obj->getFileName());
+    }
     return;
   }
 

--- a/llvm/tools/llvm-objdump/MachODump.h
+++ b/llvm/tools/llvm-objdump/MachODump.h
@@ -34,6 +34,7 @@ void parseMachOOptions(const llvm::opt::InputArgList &InputArgs);
 
 // MachO specific options
 extern bool Bind;
+extern bool Chained_fixups;
 extern bool DataInCode;
 extern std::string DisSymName;
 extern bool DylibId;
@@ -71,6 +72,8 @@ void printRebaseTable(object::ObjectFile *O);
 void printBindTable(object::ObjectFile *O);
 void printLazyBindTable(object::ObjectFile *O);
 void printWeakBindTable(object::ObjectFile *O);
+
+void printChainedFixups(object::ObjectFile *O);
 
 } // namespace objdump
 } // namespace llvm

--- a/llvm/tools/llvm-objdump/ObjdumpOpts.td
+++ b/llvm/tools/llvm-objdump/ObjdumpOpts.td
@@ -245,6 +245,10 @@ def weak_bind : Flag<["--"], "weak-bind">,
   HelpText<"Display mach-o weak binding info">,
   Group<grp_mach_o>;
 
+def chained_fixups : Flag<["--"], "chained_fixups">,
+  HelpText<"Print raw chained fixup data present in a final linked binary built with chained fixups.">,
+  Group<grp_mach_o>;
+
 def g : Flag<["-"], "g">,
   HelpText<"Print line information from debug info if available">,
   Group<grp_mach_o>;

--- a/llvm/tools/llvm-objdump/ObjdumpOpts.td
+++ b/llvm/tools/llvm-objdump/ObjdumpOpts.td
@@ -246,7 +246,7 @@ def weak_bind : Flag<["--"], "weak-bind">,
   Group<grp_mach_o>;
 
 def chained_fixups : Flag<["--"], "chained_fixups">,
-  HelpText<"Print raw chained fixup data present in a final linked binary built with chained fixups.">,
+  HelpText<"Print raw chained fixup data present in a final linked binary built with chained fixups. (requires --macho)">,
   Group<grp_mach_o>;
 
 def g : Flag<["-"], "g">,

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2761,7 +2761,7 @@ int main(int argc, char **argv) {
         (Bind || DataInCode || DylibId || DylibsUsed || ExportsTrie ||
          FirstPrivateHeader || FunctionStarts || IndirectSymbols || InfoPlist ||
          LazyBind || LinkOptHints || ObjcMetaData || Rebase || Rpaths ||
-         UniversalHeaders || WeakBind || !FilterSections.empty()))) {
+         UniversalHeaders || WeakBind || Chained_fixups || !FilterSections.empty()))) {
     T->printHelp(ToolName);
     return 2;
   }


### PR DESCRIPTION
iOS15 introduces fixup chain as a new format for rebase & binding in dynamic linking process; when building application targeting OS higher than iOS15 / macOS12, Mach-O uses fixup chain for dynamic linking, in replacement of rebase / binding information.
This option aims to behave like the -chained_fixups option of MacOS's otool-classic, which dumps information related to fixup chain in Mach-O object file, which dumps fixup chain related contents including dyld_chained_fixups_header, dyld_chained_starts_in_image, dyld_chained_starts_in_segment and dyld_chained_import[_addend][64].