### PR TITLE
[libc++] Fix enable_if in chrono::duration

### DIFF
--- a/libcxx/include/__chrono/duration.h
+++ b/libcxx/include/__chrono/duration.h
@@ -251,7 +251,7 @@ public:
         explicit duration(const _Rep2& __r,
             typename enable_if
             <
-               is_convertible<_Rep2, rep>::value &&
+               is_convertible<const _Rep2&, rep>::value &&
                (treat_as_floating_point<rep>::value ||
                !treat_as_floating_point<_Rep2>::value)
             >::type* = nullptr)


### PR DESCRIPTION
The duration(const meow&) constructor has a is_convertible<meow, rep> constraint which should be is_convertible<const meow&, rep>

Repro of the issue:

https://godbolt.org/z/c7fPrcTYM
#include <chrono>

struct S{
operator int() const&& noexcept = delete;
operator int() const& noexcept;
};

const S &fun();

auto k = std::chrono::microseconds{fun()};

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
