### PR TITLE
[MLIR][Presburger] Disambiguate call to floor

### DIFF
--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -45,7 +45,7 @@ static void normalizeDivisionByGCD(SmallVectorImpl<int64_t> &dividend,
 
   // Normalize the dividend and the denominator.
   std::transform(dividend.begin(), dividend.end(), dividend.begin(),
-                 [gcd](int64_t &n) { return floor(n / gcd); });
+                 [gcd](int64_t &n) { return floor((double)(n / gcd)); });
   divisor /= gcd;
 }
 


### PR DESCRIPTION
While testing LLVM 14.0.0 rc1 on Solaris, compilation of `FAIL`ed with

  /var/llvm/llvm-14.0.0-rc1/rc1/llvm-project/mlir/lib/Analysis/Presburger/Utils.cpp: In lambda function:
  /var/llvm/llvm-14.0.0-rc1/rc1/llvm-project/mlir/lib/Analysis/Presburger/Utils.cpp:48:58: error: call of overloaded ‘floor(int64_t)’ is ambiguous
     48 |                  [gcd](int64_t &n) { return floor(n / gcd); });
        |                                                          ^
  ...
  /usr/gcc/10/lib/gcc/sparcv9-sun-solaris2.11/10.3.0/include-fixed/iso/math_iso.h:201:21:
note: candidate: ‘long double std::floor(long double)’
    201 |  inline long double floor(long double __X) { return __floorl(__X); }
        |                     ^~~~~
  /usr/gcc/10/lib/gcc/sparcv9-sun-solaris2.11/10.3.0/include-fixed/iso/math_iso.h:165:15:
note: candidate: ‘float std::floor(float)’
    165 |  inline float floor(float __X) { return __floorf(__X); }
        |               ^~~~~
  /usr/gcc/10/lib/gcc/sparcv9-sun-solaris2.11/10.3.0/include-fixed/iso/math_iso.h:78:15:
note: candidate: ‘double std::floor(double)’
     78 | extern double floor __P((double));
        |               ^~~~~

The same issue had already occured in the past, cf. D108750
<https://reviews.llvm.org/D108750>, and the solution is the same: cast the
`floor` arg to `double`.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`.

Differential Revision: https://reviews.llvm.org/D119324

(cherry picked from commit 91596755359e29c677bfa84d86edcaa1e70df955)

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
