### PR TITLE
[llvm][IR] Rvalue to non-const lvalue reference

### DIFF
--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -559,7 +559,7 @@ operator<<(RemarkT &&R,
                StringRef>
                S) {
   R.insert(S);
-  return R;
+  return *(&R);
 }
 
 template <class RemarkT>
@@ -581,7 +581,7 @@ operator<<(RemarkT &&R,
                DiagnosticInfoOptimizationBase::Argument>
                A) {
   R.insert(A);
-  return R;
+  return *(&R);
 }
 
 template <class RemarkT>


### PR DESCRIPTION
This fix explicitly casts rvalue remarks to non-const lvalue reference for returning. Compilations with `-std=c++2b` enabled complains on this.

#53750

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
