### PR TITLE
[asan] Remove limitation on stack size poisoning

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -248,8 +248,7 @@ static void ClearShadowMemoryForContextStack(uptr stack, uptr ssize) {
   uptr bottom = stack & ~(PageSize - 1);
   ssize += stack - bottom;
   ssize = RoundUpTo(ssize, PageSize);
-  static const uptr kMaxSaneContextStackSize = 1 << 22;  // 4 Mb
-  if (AddrIsInMem(bottom) && ssize && ssize <= kMaxSaneContextStackSize) {
+  if (AddrIsInMem(bottom) && ssize) {
     PoisonShadow(bottom, ssize, 0);
   }
 }


### PR DESCRIPTION
Addresses the issue described in https://github.com/google/sanitizers/issues/1494 by @itrofimow:

> As far as i understand, intercepted `swapcontext` should unpoison shadow memory for `ucp`s stack, however it only does so if `ucp`s stack is [less than 4Mb](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/asan/asan_interceptors.cpp#L251). This behavior was introduced 9 years ago ([llvm/llvm-project@4f1885a](https://github.com/llvm/llvm-project/commit/4f1885a1096c3ac51cc0c0fa3d403aa21aa5d976)) and i couldn't find the exact reasoning behind these changes.
> 
> Recently we introduced stacks bigger than 4Mb (via boost.Coroutine2) and asan-ed builds started crashing left and right at seemingly random places - changing `kMaxSaneContextStackSize` to bigger numbers fixed that.
<...>

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
