### PR TITLE
is_error_code_enum_v, is_error_condition_enum_v

### DIFF
--- a/libcxx/include/system_error
+++ b/libcxx/include/system_error
@@ -46,10 +46,10 @@ template <class T> struct is_error_condition_enum
     : public false_type {};
 
 template <class _Tp>
-inline constexpr size_t is_error_condition_enum_v = is_error_condition_enum<_Tp>::value; // C++17
+inline constexpr bool is_error_condition_enum_v = is_error_condition_enum<_Tp>::value; // C++17
 
 template <class _Tp>
-inline constexpr size_t is_error_code_enum_v = is_error_code_enum<_Tp>::value; // C++17
+inline constexpr bool is_error_code_enum_v = is_error_code_enum<_Tp>::value; // C++17
 
 class error_code
 {
@@ -164,7 +164,7 @@ struct _LIBCPP_TEMPLATE_VIS is_error_code_enum
 
 #if _LIBCPP_STD_VER > 14
 template <class _Tp>
-_LIBCPP_INLINE_VAR constexpr size_t is_error_code_enum_v = is_error_code_enum<_Tp>::value;
+_LIBCPP_INLINE_VAR constexpr bool is_error_code_enum_v = is_error_code_enum<_Tp>::value;
 #endif
 
 // is_error_condition_enum
@@ -175,7 +175,7 @@ struct _LIBCPP_TEMPLATE_VIS is_error_condition_enum
 
 #if _LIBCPP_STD_VER > 14
 template <class _Tp>
-_LIBCPP_INLINE_VAR constexpr size_t is_error_condition_enum_v = is_error_condition_enum<_Tp>::value;
+_LIBCPP_INLINE_VAR constexpr bool is_error_condition_enum_v = is_error_condition_enum<_Tp>::value;
 #endif
 
 template <>


### PR DESCRIPTION
should be bool, not size_t

https://bugs.llvm.org/show_bug.cgi?id=50755

Fixed by https://github.com/llvm/llvm-project/issues/50099

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
