### PR TITLE
Add missing switch case in getCursorKindForDecl

### DIFF
--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -3956,6 +3956,8 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
   switch (D->getKind()) {
   case Decl::Enum:
     return CXCursor_EnumDecl;
+  case Decl::LinkageSpec:  
+    return CXCursor_LinkageSpec;
   case Decl::EnumConstant:
     return CXCursor_EnumConstantDecl;
   case Decl::Field:


### PR DESCRIPTION
The omission of this case is causing extern C blocks to be parsed incorrectly.

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
