### PR TITLE
allow urls in the `/cherry-pick` command

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -395,7 +395,8 @@ class ReleaseWorkflow:
             args = m.group(2)
 
             if command == 'cherry-pick':
-                return self.create_branch(args.split())
+                args=[arg.rsplit('/')[-1] for arg in args] # extract commit hash from URL if one was provided
+                return self.create_branch(args)
 
             if command == 'branch':
                 m = re.match('([^/]+)/([^/]+)/(.+)', args)


### PR DESCRIPTION
e.g. `/cherry-pick https://github.com/llvm/llvm-project/commit/80f444646c62ccc8b2399d60ac91e62e6e576da6` on the ui looks legit:

/cherry-pick https://github.com/llvm/llvm-project/commit/80f444646c62ccc8b2399d60ac91e62e6e576da6

it was failing with a cryptic message:
Failed to cherry-pick: https://github.com/llvm/llvm-project/commit/80f444646c62ccc8b2399d60ac91e62e6e576da6

now it will allow us to do things like

```
/cherry-pick 123def https://github.com/llvm/llvm-project/321fed abcdef
```
and the script will cherry-pick `123def`, `321fed` and `abcdef`.