### PR TITLE
LLVM_DEFINITIONS is a string and not a list

### DIFF
--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -967,7 +967,7 @@ include
   LLVMConfig.cmake).
 
 ``LLVM_DEFINITIONS``
-  A list of preprocessor defines that should be used when building against LLVM.
+  A single string argument containing preprocessor defines (with `-D` prefix) that should be used when building against LLVM. Users must convert it to list before use (eg. `separate_arguments()`).
 
 ``LLVM_ENABLE_ASSERTIONS``
   This is set to ON if LLVM was built with assertions, otherwise OFF.


### PR DESCRIPTION
A user may be tempted to just do:

```
target_compile_definitions(foo PRIVATE ${LLVM_DEFINITIONS})
```

which would fails. The ${LLVM_DEFINITIONS} expands to a single argument since the value of the variable is not ;-separated.  The result is that CMake thinks user is trying to specify a single definition whose name is the entire string value minus a leading `-D`.

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
