### PR TITLE
Keep the shorten seed when Reduce an Input

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
@@ -551,6 +551,7 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
       II->U.size() > Size) {
     auto OldFeaturesFile = Sha1ToString(II->Sha1);
     Corpus.Replace(II, {Data, Data + Size}, TimeOfUnit);
+    WriteToOutputCorpus({Data, Data + Size}); 
     RenameFeatureSetFile(Options.FeaturesDir, OldFeaturesFile,
                          Sha1ToString(II->Sha1));
     return true;


### PR DESCRIPTION
This fixes the issue [#61990](https://github.com/llvm/llvm-project/issues/61990). It keeps the shortened seed in the RunOne function. Otherwise, we will lose the newfound interesting seeds under the fork mode. 

