### PR TITLE
[mlir][llvm] Use attributes to store access groups.

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -206,7 +206,7 @@ def LoopAnnotationAttr : LLVM_Attr<"LoopAnnotation", "loop_annotation"> {
     OptionalParameter<"LoopUnswitchAttr">:$unswitch,
     OptionalParameter<"BoolAttr">:$mustProgress,
     OptionalParameter<"BoolAttr">:$isVectorized,
-    OptionalArrayRefParameter<"SymbolRefAttr">:$parallelAccesses
+    OptionalArrayRefParameter<"AccessGroupAttr">:$parallelAccesses
   );
 
   let assemblyFormat = "`<` struct(params) `>`";
@@ -500,11 +500,37 @@ def LLVM_DISubroutineTypeAttr : LLVM_Attr<"DISubroutineType", "di_subroutine_typ
     OptionalArrayRefParameter<"DITypeAttr">:$types
   );
   let builders = [
-    TypeBuilder<(ins "ArrayRef<DITypeAttr>":$types), [{
+    AttrBuilder<(ins "ArrayRef<DITypeAttr>":$types), [{
       return $_get($_ctxt, /*callingConvention=*/0, types);
     }]>
   ];
   let assemblyFormat = "`<` struct(params) `>`";
+}
+
+//===----------------------------------------------------------------------===//
+// AccessGroupAttr
+//===----------------------------------------------------------------------===//
+
+def LLVM_AccessGroupAttr : LLVM_Attr<"AccessGroup", "access_group"> {
+  let parameters = (ins
+    "int64_t":$id,
+    "DistinctSequenceAttr":$elem_of
+  );
+  let builders = [
+    AttrBuilder<(ins "DistinctSequenceAttr":$sequence), [{
+      return $_get($_ctxt, sequence.getNextID(), sequence);
+    }]>
+  ];
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+//===----------------------------------------------------------------------===//
+// AccessGroupArrayAttr
+//===----------------------------------------------------------------------===//
+
+def AccessGroupArrayAttr :
+  TypedArrayAttrBase<LLVM_AccessGroupAttr, "access group array attribute"> {
+  let constBuilderCall = ?;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
@@ -60,6 +60,57 @@ public:
   static bool classof(Attribute attr);
 };
 
+namespace detail {
+class DistinctSequenceAttrStorage;
+} // namespace detail
+
+/// This class is a helper attribute to generate a sequence of unique
+/// identifiers that can be used to model distinct metadata nodes. The
+/// attribute has a scope that limits the validity of the generated sequence to
+/// a function since generating unique identifiers at the module level could
+/// lead to non determinism due to the parallel processing of functions. A
+/// mutable state can be incremented to generate the next unique identifier.
+///
+/// Example:
+/// ```
+/// #distinct_sequence = #llvm.distinct_sequence<scope = @foo, state = 2>
+/// #access_group = #llvm.access_group<id = 0, elem_of = #sequence>
+/// #access_group1 = #llvm.access_group<id = 1, elem_of = #sequence>
+///
+/// llvm.func @foo(%arg0: !llvm.ptr) {
+///   %0 = llvm.load %arg0 {access_groups = [#access_group, #access_group1]}
+/// }
+/// ```
+class DistinctSequenceAttr
+    : public Attribute::AttrBase<DistinctSequenceAttr, Attribute,
+                                 detail::DistinctSequenceAttrStorage,
+                                 AttributeTrait::IsMutable> {
+public:
+  // Inherit Base constructors.
+  using Base::Base;
+
+  /// Returns a distinct sequences attribute for the given scope.
+  static DistinctSequenceAttr get(SymbolRefAttr scope);
+
+  /// Returns the keyword used when printing and parsing the attribute.
+  static constexpr StringLiteral getMnemonic() { return {"distinct_sequence"}; }
+
+  /// Returns the symbol that limits the scope of the sequence.
+  SymbolRefAttr getScope() const;
+
+  /// Returns the next identifier without incrementing the mutable state.
+  int64_t getState() const;
+
+  /// Returns the next identifier and increments the mutable state.
+  int64_t getNextID();
+
+  /// Parses an instance of this attribute.
+  static Attribute parse(AsmParser &parser, Type type);
+
+  /// Prints this attribute.
+  void print(AsmPrinter &os) const;
+};
+
 // Inline the LLVM generated Linkage enum and utility.
 // This is only necessary to isolate the "enum generated code" from the
 // attribute definition itself.
@@ -72,5 +123,13 @@ using linkage::Linkage;
 
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.h.inc"
+
+namespace mlir {
+namespace LLVM {
+/// Verifies the access groups attached to the given operation.
+LogicalResult verifyAccessGroups(Operation *op,
+                                 ArrayRef<AccessGroupAttr> accessGroups);
+} // namespace LLVM
+} // namespace mlir
 
 #endif // MLIR_DIALECT_LLVMIR_LLVMATTRS_H_

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
@@ -15,7 +15,6 @@ def LLVM_Dialect : Dialect {
   let name = "llvm";
   let cppNamespace = "::mlir::LLVM";
 
-  let useDefaultAttributePrinterParser = 1;
   let hasRegionArgAttrVerify = 1;
   let hasRegionResultAttrVerify = 1;
   let hasOperationAttrVerify = 1;
@@ -76,6 +75,8 @@ def LLVM_Dialect : Dialect {
 
     Type parseType(DialectAsmParser &p) const override;
     void printType(Type, DialectAsmPrinter &p) const override;
+    Attribute parseAttribute(DialectAsmParser &parser, Type type) const override;
+    void printAttribute(Attribute attr, DialectAsmPrinter &os) const override;
 
   private:
     /// Verifies a parameter attribute attached to a parameter of type

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.h
@@ -19,8 +19,8 @@ namespace mlir {
 namespace LLVM {
 namespace detail {
 
-/// Verifies the access groups attribute of memory operations that implement the
-/// access group interface.
+/// Verifies the access group attributes of memory operations that implement
+/// the access group interface.
 LogicalResult verifyAccessGroupOpInterface(Operation *op);
 
 /// Verifies the alias analysis attributes of memory operations that implement

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -53,7 +53,7 @@ def AccessGroupOpInterface : OpInterface<"AccessGroupOpInterface"> {
     An interface for memory operations that can carry access groups metadata.
     It provides setters and getters for the operation's access groups attribute.
     The default implementations of the interface methods expect the operation
-    to have an attribute of type ArrayAttr named access_groups.
+    to have an array attribute named access_groups.
   }];
 
   let cppNamespace = "::mlir::LLVM";

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOpBase.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOpBase.td
@@ -263,7 +263,7 @@ class LLVM_MemAccessOpBase<string mnemonic, list<Trait> traits = []> :
       DeclareOpInterfaceMethods<AccessGroupOpInterface>,
       DeclareOpInterfaceMethods<AliasAnalysisOpInterface>], traits)>,
     LLVM_MemOpPatterns {
-  dag aliasAttrs = (ins OptionalAttr<SymbolRefArrayAttr>:$access_groups,
+  dag aliasAttrs = (ins OptionalAttr<AccessGroupArrayAttr>:$access_groups,
                     OptionalAttr<SymbolRefArrayAttr>:$alias_scopes,
                     OptionalAttr<SymbolRefArrayAttr>:$noalias_scopes,
                     OptionalAttr<SymbolRefArrayAttr>:$tbaa);
@@ -306,7 +306,7 @@ class LLVM_IntrOpBase<Dialect dialect, string opName, string enumName,
       Results<!if(!gt(numResults, 0), (outs LLVM_Type:$res), (outs))> {
   dag aliasAttrs = !con(
         !if(!gt(requiresAccessGroup, 0),
-            (ins OptionalAttr<SymbolRefArrayAttr>:$access_groups),
+            (ins OptionalAttr<AccessGroupArrayAttr>:$access_groups),
             (ins )),
         !if(!gt(requiresAccessGroup, 0),
             (ins OptionalAttr<SymbolRefArrayAttr>:$alias_scopes,

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1126,26 +1126,6 @@ def LLVM_AliasScopeMetadataOp : LLVM_Op<"alias_scope", [
   let hasVerifier = 1;
 }
 
-def LLVM_AccessGroupMetadataOp : LLVM_Op<"access_group", [
-  HasParent<"MetadataOp">, Symbol
-]> {
-  let arguments = (ins
-    SymbolNameAttr:$sym_name
-  );
-  let summary = "LLVM dialect access group metadata.";
-  let description = [{
-    Defines an access group metadata that can be attached to any instruction
-    that potentially accesses memory. The access group may be attached to a
-    memory accessing instruction via the `llvm.access.group` metadata and
-    a branch instruction in the loop latch block via the
-    `llvm.loop.parallel_accesses` metadata.
-
-    See the following link for more details:
-    https://llvm.org/docs/LangRef.html#llvm-access-group-metadata
-  }];
-  let assemblyFormat = "$sym_name attr-dict";
-}
-
 def LLVM_TBAARootMetadataOp : LLVM_Op<"tbaa_root", [
   HasParent<"MetadataOp">, Symbol
 ]> {

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -14,6 +14,7 @@
 #ifndef MLIR_TARGET_LLVMIR_MODULEIMPORT_H
 #define MLIR_TARGET_LLVMIR_MODULEIMPORT_H
 
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Target/LLVMIR/Import.h"
@@ -180,10 +181,10 @@ public:
     return tbaaMapping.lookup(node);
   }
 
-  /// Returns the symbol references pointing to the access group operations that
-  /// map to the access group nodes starting from the access group metadata
-  /// `node`. Returns failure, if any of the symbol references cannot be found.
-  FailureOr<SmallVector<SymbolRefAttr>>
+  /// Returns the access group attributes that map to the access group nodes
+  /// starting from the access group metadata `node`. Returns failure if the
+  /// lookup fails for any of the access groups.
+  FailureOr<SmallVector<AccessGroupAttr>>
   lookupAccessGroupAttrs(const llvm::MDNode *node) const;
 
   /// Returns the loop annotation attribute that corresponds to the given LLVM
@@ -285,10 +286,13 @@ private:
   /// invocation of this function).
   LogicalResult processTBAAMetadata(const llvm::MDNode *node);
   /// Converts all LLVM access groups starting from `node` to MLIR access group
-  /// operations and stores a mapping from every nested access group node to the
-  /// symbol pointing to the translated operation. Returns success if all
-  /// conversions succeed and failure otherwise.
-  LogicalResult processAccessGroupMetadata(const llvm::MDNode *node);
+  /// operations and stores a mapping from every nested access group to the
+  /// translated attribute. Uses `distinctSequence` to generate the function
+  /// specific access group identifiers. Returns success if all conversions
+  /// succeed and failure otherwise.
+  LogicalResult
+  processAccessGroupMetadata(const llvm::MDNode *node,
+                             DistinctSequenceAttr distinctSequence);
   /// Converts all LLVM alias scopes and domains starting from `node` to MLIR
   /// alias scope and domain operations and stores a mapping from every nested
   /// alias scope or alias domain node to the symbol pointing to the translated

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -280,10 +280,6 @@ private:
   LogicalResult convertGlobals();
   LogicalResult convertOneFunction(LLVMFuncOp func);
 
-  /// Process access_group LLVM Metadata operations and create LLVM
-  /// metadata nodes.
-  LogicalResult createAccessGroupMetadata();
-
   /// Process alias.scope LLVM Metadata operations and create LLVM
   /// metadata nodes for them and their domains.
   LogicalResult createAliasScopeMetadata();

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -27,14 +27,40 @@ using namespace mlir::LLVM;
 #include "mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.cpp.inc"
 
 //===----------------------------------------------------------------------===//
-// LLVMDialect registration
+// LLVMDialect
 //===----------------------------------------------------------------------===//
 
 void LLVMDialect::registerAttributes() {
+  addAttributes<DistinctSequenceAttr>();
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.cpp.inc"
       >();
+}
+
+Attribute LLVMDialect::parseAttribute(DialectAsmParser &parser,
+                                      Type type) const {
+  StringRef mnemonic;
+  Attribute attr;
+  OptionalParseResult result =
+      generatedAttributeParser(parser, &mnemonic, type, attr);
+  if (result.has_value())
+    return attr;
+
+  if (mnemonic == DistinctSequenceAttr::getMnemonic())
+    return DistinctSequenceAttr::parse(parser, type);
+
+  llvm_unreachable("unhandled LLVM attribute kind");
+}
+
+void LLVMDialect::printAttribute(Attribute attr, DialectAsmPrinter &os) const {
+  if (succeeded(generatedAttributePrinter(attr, os)))
+    return;
+
+  if (auto composite = dyn_cast<DistinctSequenceAttr>(attr))
+    composite.print(os);
+  else
+    llvm_unreachable("unhandled LLVM attribute kind");
 }
 
 //===----------------------------------------------------------------------===//
@@ -99,4 +125,182 @@ bool MemoryEffectsAttr::isReadWrite() {
   if (this->getOther() != ModRefInfo::ModRef)
     return false;
   return true;
+}
+
+//===----------------------------------------------------------------------===//
+// DistinctSequenceAttr
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace LLVM {
+namespace detail {
+/// Attribute storage class of the distinct sequence attribute that stores the
+/// sequence scope and a mutable state that is used to get the next identifier.
+class DistinctSequenceAttrStorage : public AttributeStorage {
+public:
+  using KeyTy = SymbolRefAttr;
+
+  DistinctSequenceAttrStorage(SymbolRefAttr scope) : scope(scope) {}
+
+  static DistinctSequenceAttrStorage *
+  construct(AttributeStorageAllocator &allocator, const KeyTy &key) {
+    return new (allocator.allocate<DistinctSequenceAttrStorage>())
+        DistinctSequenceAttrStorage(key);
+  }
+
+  /// Stores the next identifier value that matches the state variable to
+  /// `nextID` and post increments the state (incrementing is thread safe since
+  /// the storage uniquer acquires a mutex before calling the mutate method).
+  LogicalResult mutate(AttributeStorageAllocator &allocator, int64_t *nextID) {
+    *nextID = state++;
+    return success();
+  }
+
+  /// Sets the state to `state` after parsing an attribute instance (setting
+  /// the state is thread safe since the storage uniquer acquires a mutex before
+  /// calling the mutate method).
+  LogicalResult mutate(AttributeStorageAllocator &allocator, int64_t state) {
+    this->state = state;
+    return success();
+  }
+
+  /// Returns the scope of the sequence.
+  SymbolRefAttr getScope() const { return scope; }
+
+  /// Returns the state of the sequence.
+  int64_t getState() const { return state; }
+
+  /// Compares the non-mutable part of the attribute.
+  bool operator==(const KeyTy &other) const { return scope == other; }
+
+private:
+  SymbolRefAttr scope;
+  int64_t state = 0;
+};
+} // namespace detail
+} // namespace LLVM
+} // namespace mlir
+
+DistinctSequenceAttr DistinctSequenceAttr::get(SymbolRefAttr scope) {
+  return Base::get(scope.getContext(), scope);
+}
+
+SymbolRefAttr DistinctSequenceAttr::getScope() const {
+  return getImpl()->getScope();
+}
+
+int64_t DistinctSequenceAttr::getState() const { return getImpl()->getState(); }
+
+int64_t DistinctSequenceAttr::getNextID() {
+  int64_t nextID;
+  (void)Base::mutate(&nextID);
+  return nextID;
+}
+
+Attribute DistinctSequenceAttr::parse(AsmParser &parser, Type type) {
+  if (parser.parseLess())
+    return {};
+
+  // A helper function to parse a struct parameter.
+  auto parseParameter =
+      [&](StringRef name, StringRef type, bool &seen,
+          function_ref<ParseResult()> parseFn) -> ParseResult {
+    if (seen) {
+      return parser.emitError(parser.getCurrentLocation())
+             << "struct has duplicate parameter '" << name << "'";
+    }
+    if (failed(parseFn())) {
+      return parser.emitError(parser.getCurrentLocation())
+             << "failed to parse DistinctSequenceAttr parameter '" << name
+             << "' which is to be a '" << type << "'";
+    }
+    seen = true;
+    return success();
+  };
+
+  std::pair<SymbolRefAttr, bool> scope = {nullptr, false};
+  std::pair<int64_t, bool> state = {0, false};
+  do {
+    std::string keyword;
+    if (failed(parser.parseKeywordOrString(&keyword))) {
+      parser.emitError(parser.getCurrentLocation())
+          << "expected a parameter name in struct";
+      return {};
+    }
+    if (parser.parseEqual())
+      return {};
+
+    if (keyword == "scope") {
+      if (failed(parseParameter(keyword, "SymbolRefAttr", scope.second, [&]() {
+            return parser.parseAttribute<SymbolRefAttr>(scope.first);
+          })))
+        return {};
+    } else if (keyword == "state") {
+      if (failed(parseParameter(keyword, "int64_t", state.second, [&]() {
+            return parser.parseInteger(state.first);
+          })))
+        return {};
+    } else {
+      parser.emitError(parser.getCurrentLocation())
+          << "expected a parameter name in struct";
+      return {};
+    }
+  } while (succeeded(parser.parseOptionalComma()));
+
+  if (!scope.second) {
+    parser.emitError(parser.getCurrentLocation())
+        << "struct is missing required parameter 'scope'";
+    return {};
+  }
+  if (!state.second) {
+    parser.emitError(parser.getCurrentLocation())
+        << "struct is missing required parameter 'state'";
+    return {};
+  }
+
+  if (parser.parseGreater())
+    return {};
+
+  DistinctSequenceAttr distinctSeqAttr = get(scope.first);
+  (void)distinctSeqAttr.mutate(state.first);
+  return distinctSeqAttr;
+}
+
+void DistinctSequenceAttr::print(AsmPrinter &os) const {
+  os << DistinctSequenceAttr::getMnemonic() << "<";
+  os << "scope = ";
+  os.printAttribute(getImpl()->getScope());
+  os << ", state = " << getImpl()->getState();
+  os << ">";
+}
+
+LogicalResult
+mlir::LLVM::verifyAccessGroups(Operation *op,
+                               ArrayRef<AccessGroupAttr> accessGroups) {
+  // Search the top-level symbol table.
+  Operation *topLevelSymbolTable = SymbolTable::getNearestSymbolTable(op);
+  Operation *parentOp = topLevelSymbolTable->getParentOp();
+  while (parentOp && parentOp->hasTrait<OpTrait::SymbolTable>()) {
+    topLevelSymbolTable = parentOp;
+    parentOp = parentOp->getParentOp();
+  }
+
+  // Verify the access group sequence scope matches the parent operation and the
+  // unique identifiers are smaller than the sequence state.
+  for (AccessGroupAttr group : accessGroups) {
+    DistinctSequenceAttr sequence = group.getElemOf();
+    Operation *scopeOp = SymbolTable::lookupNearestSymbolFrom(
+        topLevelSymbolTable, sequence.getScope());
+    if (scopeOp != op->getParentOp()) {
+      return op->emitOpError()
+             << "expected distinct sequence scope '" << sequence.getScope()
+             << "' to resolve to the parent operation";
+    }
+    if (group.getId() >= sequence.getState()) {
+      return op->emitOpError() << "expected access group id '" << group.getId()
+                               << "' to be lower than the sequence state '"
+                               << sequence.getState() << "'";
+    }
+  }
+  return success();
 }

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMInterfaces.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMInterfaces.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/LLVMIR/LLVMInterfaces.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 using namespace mlir;
@@ -82,18 +83,6 @@ LogicalResult verifySymbolRefsPointTo(Operation *op, StringRef name,
 }
 
 //===----------------------------------------------------------------------===//
-// AccessGroupOpInterface
-//===----------------------------------------------------------------------===//
-
-LogicalResult mlir::LLVM::detail::verifyAccessGroupOpInterface(Operation *op) {
-  auto iface = cast<AccessGroupOpInterface>(op);
-  if (failed(verifySymbolRefsPointTo<LLVM::AccessGroupMetadataOp>(
-          iface, "access groups", iface.getAccessGroupsOrNull())))
-    return failure();
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // AliasAnalysisOpInterface
 //===----------------------------------------------------------------------===//
 
@@ -109,6 +98,18 @@ mlir::LLVM::detail::verifyAliasAnalysisOpInterface(Operation *op) {
   if (failed(verifySymbolRefsPointTo<LLVM::TBAATagOp>(
           iface, "tbaa tags", iface.getTBAATagsOrNull())))
     return failure();
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// AccessGroupOpInterface
+//===----------------------------------------------------------------------===//
+
+LogicalResult mlir::LLVM::detail::verifyAccessGroupOpInterface(Operation *op) {
+  auto iface = cast<AccessGroupOpInterface>(op);
+  if (ArrayAttr groups = iface.getAccessGroupsOrNull())
+    return verifyAccessGroups(
+        op, llvm::to_vector(groups.getAsRange<AccessGroupAttr>()));
   return success();
 }
 

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMIRToLLVMTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMIRToLLVMTranslation.cpp
@@ -158,18 +158,18 @@ static LogicalResult setTBAAAttr(const llvm::MDNode *node, Operation *op,
 static LogicalResult setAccessGroupsAttr(const llvm::MDNode *node,
                                          Operation *op,
                                          LLVM::ModuleImport &moduleImport) {
-  FailureOr<SmallVector<SymbolRefAttr>> accessGroups =
+  FailureOr<SmallVector<AccessGroupAttr>> groups =
       moduleImport.lookupAccessGroupAttrs(node);
-  if (failed(accessGroups))
+  if (failed(groups))
     return failure();
 
   auto iface = dyn_cast<AccessGroupOpInterface>(op);
   if (!iface)
     return failure();
 
-  iface.setAccessGroups(ArrayAttr::get(
-      iface.getContext(),
-      SmallVector<Attribute>{accessGroups->begin(), accessGroups->end()}));
+  iface.setAccessGroups(
+      ArrayAttr::get(iface->getContext(),
+                     SmallVector<Attribute>{groups->begin(), groups->end()}));
   return success();
 }
 

--- a/mlir/lib/Target/LLVMIR/LoopAnnotationImporter.h
+++ b/mlir/lib/Target/LLVMIR/LoopAnnotationImporter.h
@@ -14,6 +14,7 @@
 #ifndef MLIR_LIB_TARGET_LLVMIR_LOOPANNOTATIONIMPORTER_H_
 #define MLIR_LIB_TARGET_LLVMIR_LOOPANNOTATIONIMPORTER_H_
 
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Target/LLVMIR/ModuleImport.h"
 
@@ -26,23 +27,23 @@ namespace detail {
 /// AccessGroupMetadataOps.
 class LoopAnnotationImporter {
 public:
-  explicit LoopAnnotationImporter(OpBuilder &builder) : builder(builder) {}
+  explicit LoopAnnotationImporter(MLIRContext *context) : context(context) {}
   LoopAnnotationAttr translateLoopAnnotation(const llvm::MDNode *node,
                                              Location loc);
 
-  /// Converts all LLVM access groups starting from node to MLIR access group
-  /// operations mested in the region of metadataOp. It stores a mapping from
-  /// every nested access group nod to the symbol pointing to the translated
-  /// operation. Returns success if all conversions succeed and failure
-  /// otherwise.
+  /// Converts all LLVM access groups starting from `node` to MLIR access group
+  /// attributes. Uses `distinctSequence` to generate the function specific
+  /// access group identifiers. It stores a mapping from every nested access
+  /// group node to the translated access group attribute. Returns success if
+  /// all conversions succeed and failure otherwise.
   LogicalResult translateAccessGroup(const llvm::MDNode *node, Location loc,
-                                     MetadataOp metadataOp);
+                                     DistinctSequenceAttr distinctSequence);
 
-  /// Returns the symbol references pointing to the access group operations that
-  /// map to the access group nodes starting from the access group metadata
-  /// node. Returns failure, if any of the symbol references cannot be found.
-  FailureOr<SmallVector<SymbolRefAttr>>
-  lookupAccessGroupAttrs(const llvm::MDNode *node) const;
+  /// Returns the access group attributes that map to the access group nodes
+  /// starting from the access group metadata `node`. Returns failure if the
+  /// lookup fails for any of the access groups.
+  FailureOr<SmallVector<AccessGroupAttr>>
+  lookupAccessGroupsAttr(const llvm::MDNode *node) const;
 
 private:
   /// Returns the LLVM metadata corresponding to a llvm loop metadata attribute.
@@ -57,11 +58,11 @@ private:
            "attempting to map loop options that was already mapped");
   }
 
-  OpBuilder &builder;
+  MLIRContext *context;
   DenseMap<const llvm::MDNode *, LoopAnnotationAttr> loopMetadataMapping;
-  /// Mapping between original LLVM access group metadata nodes and the symbol
-  /// references pointing to the imported MLIR access group operations.
-  DenseMap<const llvm::MDNode *, SymbolRefAttr> accessGroupMapping;
+  /// Mapping between original LLVM access group metadata nodes and the
+  /// corresponding MLIR access group attribute.
+  DenseMap<const llvm::MDNode *, AccessGroupAttr> accessGroupMapping;
 };
 
 } // namespace detail

--- a/mlir/lib/Target/LLVMIR/LoopAnnotationTranslation.h
+++ b/mlir/lib/Target/LLVMIR/LoopAnnotationTranslation.h
@@ -25,23 +25,17 @@ namespace detail {
 /// into a corresponding llvm::MDNodes.
 class LoopAnnotationTranslation {
 public:
-  LoopAnnotationTranslation(Operation *mlirModule, llvm::Module &llvmModule)
-      : mlirModule(mlirModule), llvmModule(llvmModule) {}
+  LoopAnnotationTranslation(llvm::Module &llvmModule)
+      : llvmModule(llvmModule) {}
 
   llvm::MDNode *translateLoopAnnotation(LoopAnnotationAttr attr, Operation *op);
 
-  /// Traverses the global access group metadata operation in the `mlirModule`
-  /// and creates corresponding LLVM metadata nodes.
-  LogicalResult createAccessGroupMetadata();
-
-  /// Returns the LLVM metadata corresponding to a symbol reference to an mlir
-  /// LLVM dialect access group operation.
-  llvm::MDNode *getAccessGroup(Operation *op,
-                               SymbolRefAttr accessGroupRef) const;
+  /// Returns the LLVM metadata corresponding to an MLIR access group attribute.
+  llvm::MDNode *getAccessGroup(AccessGroupAttr group);
 
   /// Returns the LLVM metadata corresponding to the access group operations
   /// referenced by the AccessGroupOpInterface or null if there are none.
-  llvm::MDNode *getAccessGroups(AccessGroupOpInterface op) const;
+  llvm::MDNode *getAccessGroups(AccessGroupOpInterface op);
 
 private:
   /// Returns the LLVM metadata corresponding to a llvm loop metadata attribute.
@@ -60,12 +54,11 @@ private:
   /// The metadata is attached to Latch block branches with this attribute.
   DenseMap<Attribute, llvm::MDNode *> loopMetadataMapping;
 
-  /// Mapping from an access group metadata operation to its LLVM metadata.
-  /// This map is populated on module entry and is used to annotate loops (as
-  /// identified via their branches) and contained memory accesses.
-  DenseMap<Operation *, llvm::MDNode *> accessGroupMetadataMapping;
+  /// Mapping from an access group attributes to the corresponding LLVM metadata
+  /// nodes. This map is populated on module entry and is used to annotate loops
+  /// (as identified via their branches) and contained memory accesses.
+  DenseMap<AccessGroupAttr, llvm::MDNode *> accessGroupMetadataMapping;
 
-  Operation *mlirModule;
   llvm::Module &llvmModule;
 };
 

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -442,8 +442,8 @@ ModuleTranslation::ModuleTranslation(Operation *module,
     : mlirModule(module), llvmModule(std::move(llvmModule)),
       debugTranslation(
           std::make_unique<DebugTranslation>(module, *this->llvmModule)),
-      loopAnnotationTranslation(std::make_unique<LoopAnnotationTranslation>(
-          module, *this->llvmModule)),
+      loopAnnotationTranslation(
+          std::make_unique<LoopAnnotationTranslation>(*this->llvmModule)),
       typeTranslator(this->llvmModule->getContext()),
       iface(module->getContext()) {
   assert(satisfiesLLVMModule(mlirModule) &&
@@ -1017,10 +1017,6 @@ LogicalResult ModuleTranslation::convertFunctions() {
   return success();
 }
 
-LogicalResult ModuleTranslation::createAccessGroupMetadata() {
-  return loopAnnotationTranslation->createAccessGroupMetadata();
-}
-
 void ModuleTranslation::setAccessGroupsMetadata(AccessGroupOpInterface op,
                                                 llvm::Instruction *inst) {
   if (llvm::MDNode *node = loopAnnotationTranslation->getAccessGroups(op))
@@ -1325,8 +1321,6 @@ mlir::translateModuleToLLVMIR(Operation *module, llvm::LLVMContext &llvmContext,
   if (failed(translator.convertFunctionSignatures()))
     return nullptr;
   if (failed(translator.convertGlobals()))
-    return nullptr;
-  if (failed(translator.createAccessGroupMetadata()))
     return nullptr;
   if (failed(translator.createAliasScopeMetadata()))
     return nullptr;

--- a/mlir/test/Dialect/LLVMIR/inlining.mlir
+++ b/mlir/test/Dialect/LLVMIR/inlining.mlir
@@ -59,16 +59,14 @@ func.func @test_not_inline() -> i32 {
 
 // -----
 
-llvm.metadata @metadata {
-  llvm.access_group @group
-  llvm.return
-}
+#distinct_sequence = #llvm.distinct_sequence<scope = @with_mem_attr, state = 1>
+#access_group = #llvm.access_group<id = 0, elem_of = #distinct_sequence>
 
 func.func private @with_mem_attr(%ptr : !llvm.ptr) {
   %0 = llvm.mlir.constant(42 : i32) : i32
   // Do not inline load/store operations that carry attributes requiring
   // handling while inlining, until this is supported by the inliner.
-  llvm.store %0, %ptr { access_groups = [@metadata::@group] }: i32, !llvm.ptr
+  llvm.store %0, %ptr { access_groups = [#access_group] }: i32, !llvm.ptr
   return
 }
 

--- a/mlir/test/Dialect/LLVMIR/loop-metadata.mlir
+++ b/mlir/test/Dialect/LLVMIR/loop-metadata.mlir
@@ -42,6 +42,14 @@
 // CHECK-DAG: #[[UNSWITCH:.*]] = #llvm.loop_unswitch<partialDisable = true>
 #unswitch = #llvm.loop_unswitch<partialDisable = true>
 
+// CHECK-DAG: #[[DISTINCT:.*]] = #llvm.distinct_sequence<scope = @loop_annotation, state = 2>
+#distinct_sequence = #llvm.distinct_sequence<scope = @loop_annotation, state = 2>
+
+// CHECK-DAG: #[[GROUP0:.*]] = #llvm.access_group<id = 0, elem_of = #[[DISTINCT]]>
+#access_group0 = #llvm.access_group<id = 0, elem_of = #distinct_sequence>
+// CHECK-DAG: #[[GROUP1:.*]] = #llvm.access_group<id = 1, elem_of = #[[DISTINCT]]>
+#access_group1 = #llvm.access_group<id = 1, elem_of = #distinct_sequence>
+
 // CHECK: #[[LOOP_ANNOT:.*]] = #llvm.loop_annotation<
 // CHECK-DAG: disableNonforced = false
 // CHECK-DAG: mustProgress = true
@@ -53,7 +61,7 @@
 // CHECK-DAG: peeled = #[[PEELED]]
 // CHECK-DAG: unswitch = #[[UNSWITCH]]
 // CHECK-DAG: isVectorized = false
-// CHECK-DAG: parallelAccesses = @metadata::@group1, @metadata::@group2>
+// CHECK-DAG: parallelAccesses =  #[[GROUP0]], #[[GROUP1]]>
 #loopMD = #llvm.loop_annotation<disableNonforced = false,
         mustProgress = true,
         vectorize = #vectorize,
@@ -66,7 +74,7 @@
         peeled = #peeled,
         unswitch = #unswitch,
         isVectorized = false,
-        parallelAccesses = @metadata::@group1, @metadata::@group2>
+        parallelAccesses = #access_group0, #access_group1>
 
 // CHECK: llvm.func @loop_annotation
 llvm.func @loop_annotation() {
@@ -74,9 +82,4 @@ llvm.func @loop_annotation() {
   llvm.br ^bb1 {llvm.loop = #loopMD}
 ^bb1:
   llvm.return
-}
-
-llvm.metadata @metadata {
-  llvm.access_group @group1
-  llvm.access_group @group2
 }

--- a/mlir/test/Dialect/LLVMIR/tbaa-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/tbaa-invalid.mlir
@@ -27,12 +27,12 @@ llvm.func @tbaa(%arg0: !llvm.ptr) {
 module {
   llvm.func @tbaa(%arg0: !llvm.ptr) {
     %0 = llvm.mlir.constant(1 : i8) : i8
-    // expected-error@below {{expected '@metadata::@group1' to resolve to a llvm.tbaa_tag}}
-    llvm.store %0, %arg0 {tbaa = [@metadata::@group1]} : i8, !llvm.ptr
+    // expected-error@below {{expected '@metadata::@domain' to resolve to a llvm.tbaa_tag}}
+    llvm.store %0, %arg0 {tbaa = [@metadata::@domain]} : i8, !llvm.ptr
     llvm.return
   }
   llvm.metadata @metadata {
-    llvm.access_group @group1
+    llvm.alias_scope_domain @domain
   }
 }
 

--- a/mlir/test/mlir-tblgen/llvm-intrinsics.td
+++ b/mlir/test/mlir-tblgen/llvm-intrinsics.td
@@ -50,7 +50,7 @@
 // It does not implement the alias analysis interface.
 // GROUPS: 0>
 // It has an access group attribute.
-// GROUPS: OptionalAttr<SymbolRefArrayAttr>:$access_groups
+// GROUPS: OptionalAttr<AccessGroupArrayAttr>:$access_groups
 
 //---------------------------------------------------------------------------//
 

--- a/mlir/tools/mlir-tblgen/LLVMIRIntrinsicGen.cpp
+++ b/mlir/tools/mlir-tblgen/LLVMIRIntrinsicGen.cpp
@@ -217,7 +217,7 @@ static bool emitIntrinsic(const llvm::Record &record, llvm::raw_ostream &os) {
   llvm::SmallVector<llvm::StringRef, 8> operands(intr.getNumOperands(),
                                                  "LLVM_Type");
   if (requiresAccessGroup)
-    operands.push_back("OptionalAttr<SymbolRefArrayAttr>:$access_groups");
+    operands.push_back("OptionalAttr<AccessGroupArrayAttr>:$access_groups");
   if (requiresAliasAnalysis) {
     operands.push_back("OptionalAttr<SymbolRefArrayAttr>:$alias_scopes");
     operands.push_back("OptionalAttr<SymbolRefArrayAttr>:$noalias_scopes");


### PR DESCRIPTION
The revision replaces the existing access group operations by attributes. The access group operations are currently stored in a global metadata operation. This solution is problematic when inlining since the access groups cannot be modified in parallel - the inliner splits the call graph into strongly connected components and inlines them in parallel - resulting in possible race conditions.

The revision introduces an access group attribute that uses an integer identifier to model the semantics of distinct metadata. A distinct sequence attribute is used to generate the unique identifiers for a specific function. Having a sequence generator per function ensures deterministic identifiers can be generated even if functions are manipulated in parallel.

Example:

 llvm.metadata @metadata {
   llvm.access_group @group
   llvm.return
 }

 llvm.store %0, %ptr { access_groups = [@metadata::@group] }

translates to:

 #sequence = #llvm.distinct_sequence<scope = @foo, state = 1>
 #group = #llvm.access_group<id = 0, elem_of = #sequence>

 llvm.store %0, %ptr { access_groups = [#group] }

Depends on D148007

Differential Revision: https://reviews.llvm.org/D148106

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
