### PR TITLE
Detect Objective-C based on macros used in otherwise C-like headers

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -2687,6 +2687,7 @@ private:
         "CGSizeMake",
         "CGVector",
         "CGVectorMake",
+        "FOUNDATION_EXPORT",
         "NSAffineTransform",
         "NSArray",
         "NSAttributedString",
@@ -2743,6 +2744,7 @@ private:
         "NSURLQueryItem",
         "NSUUID",
         "NSValue",
+        "NS_ASSUME_NONNULL_BEGIN",
         "UIImage",
         "UIView",
     };


### PR DESCRIPTION
Prevents the classification of Objective-C headers containing only C functions with primitive arguments and return types from being classified as C/C++ and potentially having different formatting rules applied to them as a result.