### PR TITLE
raw_ostream colors are uppercase

### DIFF
--- a/llvm/include/llvm/Support/WithColor.h
+++ b/llvm/include/llvm/Support/WithColor.h
@@ -60,7 +60,7 @@ public:
   /// @param Mode Enable, disable or compute whether to use colors.
   WithColor(raw_ostream &OS, HighlightColor S,
             ColorMode Mode = ColorMode::Auto);
-  /// To be used like this: WithColor(OS, raw_ostream::Black) << "text";
+  /// To be used like this: WithColor(OS, raw_ostream::BLACK) << "text";
   /// @param OS The output stream
   /// @param Color ANSI color to use, the special SAVEDCOLOR can be used to
   /// change only the bold attribute, and keep colors untouched


### PR DESCRIPTION
Fix a small but misleading/confusing typo in the comments (which shows up in the doxygen documentation):

`Black` -> `BLACK` (the enumeration is case-sensitive).