### PR TITLE
[clang][ExtractAPI] Add support for Objective-C categories

### DIFF
--- a/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
+++ b/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
@@ -484,9 +484,13 @@ bool ExtractAPIVisitorBase<Derived>::VisitObjCCategoryDecl(
   SymbolReference Interface(InterfaceDecl->getName(),
                             API.recordUSR(InterfaceDecl));
 
+  if (isInSystemHeader(InterfaceDecl))
+    API.addObjCCategoryModule(InterfaceDecl->getName(),
+                              API.recordUSR(InterfaceDecl));
+
   ObjCCategoryRecord *ObjCCategoryRecord = API.addObjCCategory(
       Name, USR, Loc, AvailabilitySet(Decl), Comment, Declaration, SubHeading,
-      Interface, isInSystemHeader(Decl));
+      Interface, isInSystemHeader(Decl), isInSystemHeader(InterfaceDecl));
 
   getDerivedExtractAPIVisitor().recordObjCMethods(ObjCCategoryRecord,
                                                   Decl->methods());

--- a/clang/include/clang/ExtractAPI/Serialization/SerializerBase.h
+++ b/clang/include/clang/ExtractAPI/Serialization/SerializerBase.h
@@ -35,6 +35,10 @@ public:
 
     getDerived()->traverseObjCProtocols();
 
+    getDerived()->traverseObjCCategories();
+
+    getDerived()->traverseObjCCategoryModule();
+
     getDerived()->traverseMacroDefinitionRecords();
 
     getDerived()->traverseTypedefRecords();
@@ -70,6 +74,16 @@ public:
       getDerived()->visitObjCContainerRecord(*Protocol.second);
   }
 
+  void traverseObjCCategories() {
+    for (const auto &Category : API.getObjCCategories())
+      getDerived()->visitObjCCategoryRecord(*Category.second);
+  }
+
+  void traverseObjCCategoryModule() {
+    for (const auto &CategoryModule : API.getObjCCategoryModule())
+      getDerived()->visitObjCCategoryModuleRecord(*CategoryModule.second);
+  }
+
   void traverseMacroDefinitionRecords() {
     for (const auto &Macro : API.getMacros())
       getDerived()->visitMacroDefinitionRecord(*Macro.second);
@@ -94,6 +108,12 @@ public:
 
   /// Visit an Objective-C container record.
   void visitObjCContainerRecord(const ObjCContainerRecord &Record){};
+
+  /// Visit an Objective-C category record.
+  void visitObjCCategoryRecord(const ObjCCategoryRecord &Record){};
+
+  /// Visit an Objective-C category module record.
+  void visitObjCCategoryModuleRecord(const ObjCCategoryModuleRecord &Record){};
 
   /// Visit a macro definition record.
   void visitMacroDefinitionRecord(const MacroDefinitionRecord &Record){};

--- a/clang/include/clang/ExtractAPI/Serialization/SymbolGraphSerializer.h
+++ b/clang/include/clang/ExtractAPI/Serialization/SymbolGraphSerializer.h
@@ -163,6 +163,12 @@ public:
   /// Visit an Objective-C container record.
   void visitObjCContainerRecord(const ObjCContainerRecord &Record);
 
+  /// Visit an Objective-C category record.
+  void visitObjCCategoryRecord(const ObjCCategoryRecord &Record);
+
+  /// Visit an Objective-C category module record.
+  void visitObjCCategoryModuleRecord(const ObjCCategoryModuleRecord &Record);
+
   /// Visit a macro definition record.
   void visitMacroDefinitionRecord(const MacroDefinitionRecord &Record);
 

--- a/clang/lib/ExtractAPI/API.cpp
+++ b/clang/lib/ExtractAPI/API.cpp
@@ -120,22 +120,34 @@ StructRecord *APISet::addStruct(StringRef Name, StringRef USR, PresumedLoc Loc,
                            SubHeading, IsFromSystemHeader);
 }
 
+ObjCCategoryModuleRecord *APISet::addObjCCategoryModule(StringRef Name,
+                                                        StringRef USR) {
+  // Create the category record.
+  auto *Record =
+      addTopLevelRecord(USRBasedLookupTable, ObjCCategoryModule, USR, Name);
+
+  return Record;
+}
+
 ObjCCategoryRecord *APISet::addObjCCategory(
     StringRef Name, StringRef USR, PresumedLoc Loc,
     AvailabilitySet Availabilities, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
-    SymbolReference Interface, bool IsFromSystemHeader) {
+    SymbolReference Interface, bool IsFromSystemHeader,
+    bool IsFromExternalModule) {
   // Create the category record.
   auto *Record =
       addTopLevelRecord(USRBasedLookupTable, ObjCCategories, USR, Name, Loc,
                         std::move(Availabilities), Comment, Declaration,
                         SubHeading, Interface, IsFromSystemHeader);
 
-  // If this category is extending a known interface, associate it with the
-  // ObjCInterfaceRecord.
-  auto It = ObjCInterfaces.find(Interface.USR);
-  if (It != ObjCInterfaces.end())
-    It->second->Categories.push_back(Record);
+  // If this category is extending an external module, associate it with that
+  // module.
+  if (IsFromExternalModule) {
+    auto It = ObjCCategoryModule.find(Interface.USR);
+    if (It != ObjCCategoryModule.end())
+      It->second->Categories.push_back(Record);
+  }
 
   return Record;
 }
@@ -295,6 +307,7 @@ void ObjCInstanceVariableRecord::anchor() {}
 void ObjCInstanceMethodRecord::anchor() {}
 void ObjCClassMethodRecord::anchor() {}
 void ObjCCategoryRecord::anchor() {}
+void ObjCCategoryModuleRecord::anchor() {}
 void ObjCInterfaceRecord::anchor() {}
 void ObjCProtocolRecord::anchor() {}
 void MacroDefinitionRecord::anchor() {}

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -747,7 +747,6 @@ void SymbolGraphSerializer::visitObjCCategoryRecord(
     return;
 
   Symbols.emplace_back(std::move(*ObjCCategory));
-  serializeMembers(Record, Record.Ivars);
   serializeMembers(Record, Record.Methods);
   serializeMembers(Record, Record.Properties);
 

--- a/clang/test/ExtractAPI/objc_module_category.m
+++ b/clang/test/ExtractAPI/objc_module_category.m
@@ -14,15 +14,15 @@
 // CHECK-NOT: warning:
 
 //--- input.h
-@protocol Protocol;
-
-@interface Interface
+#import <Foundation/Foundation.h>
+/// Doc comment 1
+@interface NSString (Category1)
+-(void)method1;
 @end
 
-@interface Interface (Category) <Protocol>
-@property int Property;
-- (void)InstanceMethod;
-+ (void)ClassMethod;
+/// Doc comment 2
+@interface NSString (Category2)
+-(void)method2;
 @end
 
 //--- reference.output.json.in
@@ -53,27 +53,27 @@
   "relationships": [
     {
       "kind": "memberOf",
-      "source": "c:objc(cs)Interface(im)InstanceMethod",
-      "target": "c:objc(cy)Interface@Category",
-      "targetFallback": "Category"
+      "source": "c:objc(cs)NSString(im)method1",
+      "target": "c:objc(cy)NSString@Category1",
+      "targetFallback": "Category1"
     },
     {
       "kind": "memberOf",
-      "source": "c:objc(cs)Interface(cm)ClassMethod",
-      "target": "c:objc(cy)Interface@Category",
-      "targetFallback": "Category"
+      "source": "c:objc(cs)NSString(im)method2",
+      "target": "c:objc(cy)NSString@Category2",
+      "targetFallback": "Category2"
     },
     {
       "kind": "memberOf",
-      "source": "c:objc(cs)Interface(py)Property",
-      "target": "c:objc(cy)Interface@Category",
-      "targetFallback": "Category"
+      "source": "c:objc(cy)NSString@Category1",
+      "target": "c:objc(cs)NSString",
+      "targetFallback": "NSString"
     },
     {
-      "kind": "conformsTo",
-      "source": "c:objc(cy)Interface@Category",
-      "target": "c:objc(pl)Protocol",
-      "targetFallback": "Protocol"
+      "kind": "memberOf",
+      "source": "c:objc(cy)NSString@Category2",
+      "target": "c:objc(cs)NSString",
+      "targetFallback": "NSString"
     }
   ],
   "symbols": [
@@ -89,17 +89,47 @@
           "spelling": " "
         },
         {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSString",
+          "spelling": "NSString"
+        },
+        {
+          "kind": "text",
+          "spelling": " ("
+        },
+        {
           "kind": "identifier",
-          "spelling": "Interface"
+          "spelling": "Category1"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
         }
       ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 18,
+                "line": 2
+              },
+              "start": {
+                "character": 5,
+                "line": 2
+              }
+            },
+            "text": "Doc comment 1"
+          }
+        ]
+      },
       "identifier": {
         "interfaceLanguage": "objective-c",
-        "precise": "c:objc(cs)Interface"
+        "precise": "c:objc(cy)NSString@Category1"
       },
       "kind": {
-        "displayName": "Class",
-        "identifier": "objective-c.class"
+        "displayName": "Class Extension",
+        "identifier": "objective-c.class.extension"
       },
       "location": {
         "position": {
@@ -112,82 +142,19 @@
         "navigator": [
           {
             "kind": "identifier",
-            "spelling": "Interface"
+            "spelling": "Category1"
           }
         ],
         "subHeading": [
           {
             "kind": "identifier",
-            "spelling": "Interface"
+            "spelling": "Category1"
           }
         ],
-        "title": "Interface"
+        "title": "NSString (Category1)"
       },
       "pathComponents": [
-        "Interface"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "@interface"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "typeIdentifier",
-          "preciseIdentifier": "c:objc(cs)Interface",
-          "spelling": "Interface"
-        },
-        {
-          "kind": "text",
-          "spelling": " ("
-        },
-        {
-          "kind": "identifier",
-          "spelling": "Category"
-        },
-        {
-          "kind": "text",
-          "spelling": ")"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:objc(cy)Interface@Category"
-      },
-      "kind": {
-        "displayName": "Class Extension",
-        "identifier": "objective-c.class.extension"
-      },
-      "location": {
-        "position": {
-          "character": 12,
-          "line": 6
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "Category"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "Category"
-          }
-        ],
-        "title": "Interface (Category)"
-      },
-      "pathComponents": [
-        "Category"
+        "Category1"
       ]
     },
     {
@@ -208,7 +175,7 @@
         },
         {
           "kind": "identifier",
-          "spelling": "InstanceMethod"
+          "spelling": "method1"
         },
         {
           "kind": "text",
@@ -226,7 +193,7 @@
       },
       "identifier": {
         "interfaceLanguage": "objective-c",
-        "precise": "c:objc(cs)Interface(im)InstanceMethod"
+        "precise": "c:objc(cs)NSString(im)method1"
       },
       "kind": {
         "displayName": "Instance Method",
@@ -235,7 +202,7 @@
       "location": {
         "position": {
           "character": 1,
-          "line": 8
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -243,7 +210,7 @@
         "navigator": [
           {
             "kind": "identifier",
-            "spelling": "InstanceMethod"
+            "spelling": "method1"
           }
         ],
         "subHeading": [
@@ -253,14 +220,94 @@
           },
           {
             "kind": "identifier",
-            "spelling": "InstanceMethod"
+            "spelling": "method1"
           }
         ],
-        "title": "InstanceMethod"
+        "title": "method1"
       },
       "pathComponents": [
-        "Category",
-        "InstanceMethod"
+        "Category1",
+        "method1"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@interface"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)NSString",
+          "spelling": "NSString"
+        },
+        {
+          "kind": "text",
+          "spelling": " ("
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Category2"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "docComment": {
+        "lines": [
+          {
+            "range": {
+              "end": {
+                "character": 18,
+                "line": 7
+              },
+              "start": {
+                "character": 5,
+                "line": 7
+              }
+            },
+            "text": "Doc comment 2"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:objc(cy)NSString@Category2"
+      },
+      "kind": {
+        "displayName": "Class Extension",
+        "identifier": "objective-c.class.extension"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 8
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Category2"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "Category2"
+          }
+        ],
+        "title": "NSString (Category2)"
+      },
+      "pathComponents": [
+        "Category2"
       ]
     },
     {
@@ -268,7 +315,7 @@
       "declarationFragments": [
         {
           "kind": "text",
-          "spelling": "+ ("
+          "spelling": "- ("
         },
         {
           "kind": "typeIdentifier",
@@ -281,7 +328,7 @@
         },
         {
           "kind": "identifier",
-          "spelling": "ClassMethod"
+          "spelling": "method2"
         },
         {
           "kind": "text",
@@ -299,11 +346,11 @@
       },
       "identifier": {
         "interfaceLanguage": "objective-c",
-        "precise": "c:objc(cs)Interface(cm)ClassMethod"
+        "precise": "c:objc(cs)NSString(im)method2"
       },
       "kind": {
-        "displayName": "Type Method",
-        "identifier": "objective-c.type.method"
+        "displayName": "Instance Method",
+        "identifier": "objective-c.method"
       },
       "location": {
         "position": {
@@ -316,85 +363,36 @@
         "navigator": [
           {
             "kind": "identifier",
-            "spelling": "ClassMethod"
+            "spelling": "method2"
           }
         ],
         "subHeading": [
           {
             "kind": "text",
-            "spelling": "+ "
+            "spelling": "- "
           },
           {
             "kind": "identifier",
-            "spelling": "ClassMethod"
+            "spelling": "method2"
           }
         ],
-        "title": "ClassMethod"
+        "title": "method2"
       },
       "pathComponents": [
-        "Category",
-        "ClassMethod"
+        "Category2",
+        "method2"
       ]
     },
     {
       "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "@property"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "typeIdentifier",
-          "preciseIdentifier": "c:I",
-          "spelling": "int"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "Property"
-        }
-      ],
       "identifier": {
         "interfaceLanguage": "objective-c",
-        "precise": "c:objc(cs)Interface(py)Property"
+        "precise": "c:objc(cs)NSString"
       },
       "kind": {
-        "displayName": "Instance Property",
-        "identifier": "objective-c.property"
-      },
-      "location": {
-        "position": {
-          "character": 15,
-          "line": 7
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "Property"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "Property"
-          }
-        ],
-        "title": "Property"
-      },
-      "pathComponents": [
-        "Category",
-        "Property"
-      ]
+        "displayName": "Module Extension",
+        "identifier": "objective-c.module.extension"
+      }
     }
   ]
 }

--- a/clang/test/ExtractAPI/objc_property.m
+++ b/clang/test/ExtractAPI/objc_property.m
@@ -66,24 +66,6 @@
     },
     {
       "kind": "memberOf",
-      "source": "c:objc(cs)Interface(cpy)myCategoryTypeProp",
-      "target": "c:objc(cs)Interface",
-      "targetFallback": "Interface"
-    },
-    {
-      "kind": "memberOf",
-      "source": "c:objc(cs)Interface(py)myCategoryInstanceProp",
-      "target": "c:objc(cs)Interface",
-      "targetFallback": "Interface"
-    },
-    {
-      "kind": "conformsTo",
-      "source": "c:objc(cs)Interface",
-      "target": "c:objc(pl)Protocol",
-      "targetFallback": "Protocol"
-    },
-    {
-      "kind": "memberOf",
       "source": "c:objc(pl)Protocol(cpy)myProtocolTypeProp",
       "target": "c:objc(pl)Protocol",
       "targetFallback": "Protocol"
@@ -91,6 +73,24 @@
     {
       "kind": "memberOf",
       "source": "c:objc(pl)Protocol(py)myProtocolInstanceProp",
+      "target": "c:objc(pl)Protocol",
+      "targetFallback": "Protocol"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:objc(cs)Interface(cpy)myCategoryTypeProp",
+      "target": "c:objc(cy)Interface@Category",
+      "targetFallback": "Category"
+    },
+    {
+      "kind": "memberOf",
+      "source": "c:objc(cs)Interface(py)myCategoryInstanceProp",
+      "target": "c:objc(cy)Interface@Category",
+      "targetFallback": "Category"
+    },
+    {
+      "kind": "conformsTo",
+      "source": "c:objc(cy)Interface@Category",
       "target": "c:objc(pl)Protocol",
       "targetFallback": "Protocol"
     }
@@ -279,134 +279,6 @@
       "declarationFragments": [
         {
           "kind": "keyword",
-          "spelling": "@property"
-        },
-        {
-          "kind": "text",
-          "spelling": " ("
-        },
-        {
-          "kind": "keyword",
-          "spelling": "class"
-        },
-        {
-          "kind": "text",
-          "spelling": ") "
-        },
-        {
-          "kind": "typeIdentifier",
-          "preciseIdentifier": "c:I",
-          "spelling": "int"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "myCategoryTypeProp"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:objc(cs)Interface(cpy)myCategoryTypeProp"
-      },
-      "kind": {
-        "displayName": "Type Property",
-        "identifier": "objective-c.type.property"
-      },
-      "location": {
-        "position": {
-          "character": 22,
-          "line": 12
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "myCategoryTypeProp"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "myCategoryTypeProp"
-          }
-        ],
-        "title": "myCategoryTypeProp"
-      },
-      "pathComponents": [
-        "Interface",
-        "myCategoryTypeProp"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "@property"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "typeIdentifier",
-          "preciseIdentifier": "c:I",
-          "spelling": "int"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "myCategoryInstanceProp"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:objc(cs)Interface(py)myCategoryInstanceProp"
-      },
-      "kind": {
-        "displayName": "Instance Property",
-        "identifier": "objective-c.property"
-      },
-      "location": {
-        "position": {
-          "character": 15,
-          "line": 13
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "myCategoryInstanceProp"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "myCategoryInstanceProp"
-          }
-        ],
-        "title": "myCategoryInstanceProp"
-      },
-      "pathComponents": [
-        "Interface",
-        "myCategoryInstanceProp"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
           "spelling": "@protocol"
         },
         {
@@ -578,6 +450,197 @@
       "pathComponents": [
         "Protocol",
         "myProtocolInstanceProp"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@interface"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:objc(cs)Interface",
+          "spelling": "Interface"
+        },
+        {
+          "kind": "text",
+          "spelling": " ("
+        },
+        {
+          "kind": "identifier",
+          "spelling": "Category"
+        },
+        {
+          "kind": "text",
+          "spelling": ")"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:objc(cy)Interface@Category"
+      },
+      "kind": {
+        "displayName": "Class Extension",
+        "identifier": "objective-c.class.extension"
+      },
+      "location": {
+        "position": {
+          "character": 12,
+          "line": 11
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "Category"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "Category"
+          }
+        ],
+        "title": "Interface (Category)"
+      },
+      "pathComponents": [
+        "Category"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@property"
+        },
+        {
+          "kind": "text",
+          "spelling": " ("
+        },
+        {
+          "kind": "keyword",
+          "spelling": "class"
+        },
+        {
+          "kind": "text",
+          "spelling": ") "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:I",
+          "spelling": "int"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "myCategoryTypeProp"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:objc(cs)Interface(cpy)myCategoryTypeProp"
+      },
+      "kind": {
+        "displayName": "Type Property",
+        "identifier": "objective-c.type.property"
+      },
+      "location": {
+        "position": {
+          "character": 22,
+          "line": 12
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "myCategoryTypeProp"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "myCategoryTypeProp"
+          }
+        ],
+        "title": "myCategoryTypeProp"
+      },
+      "pathComponents": [
+        "Category",
+        "myCategoryTypeProp"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "keyword",
+          "spelling": "@property"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:I",
+          "spelling": "int"
+        },
+        {
+          "kind": "text",
+          "spelling": " "
+        },
+        {
+          "kind": "identifier",
+          "spelling": "myCategoryInstanceProp"
+        }
+      ],
+      "identifier": {
+        "interfaceLanguage": "objective-c",
+        "precise": "c:objc(cs)Interface(py)myCategoryInstanceProp"
+      },
+      "kind": {
+        "displayName": "Instance Property",
+        "identifier": "objective-c.property"
+      },
+      "location": {
+        "position": {
+          "character": 15,
+          "line": 13
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "myCategoryInstanceProp"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "myCategoryInstanceProp"
+          }
+        ],
+        "title": "myCategoryInstanceProp"
+      },
+      "pathComponents": [
+        "Category",
+        "myCategoryInstanceProp"
       ]
     }
   ]


### PR DESCRIPTION
Introducing support for Objective-C Categories for ExtractAPI. The suuport for Objective-C Categories is currently lacking
in terms of categories that extend a type defined in current module and categories that extend types that belong to external
modules such as NSString. Thus the objective of this patch is two fold, to fix former and the later.

This is achieved by introducing two new symbols ->

objective-c.module.extension.
objective-c.class.extension.
Note that the extension represents objective-c "category" (orienting well with Swift's Extension, which in spite that fact
that is different, however "broadly" serves similar purpose). The original idea is inspired by Max's @theMomax initial
post - https://forums.swift.org/t/symbol-graph-adaptions-for-documenting-extensions-to-external-types-in-docc/56684,
and Daniel's helpful comments and feedback. The implementation nonetheless is different serving purpose for this project.

The following diagram well represents the purpose ->

![llvm_categories](https://github.com/llvm/llvm-project/assets/17796905/7ca42257-439e-4fb2-86e8-82f532482893)
