### PR TITLE
fix dupe word typos

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
@@ -357,7 +357,7 @@ bool ExceptionAnalyzer::ExceptionInfo::filterByCatch(
       else if (isFunctionPointerConvertible(ExceptionCanTy, HandlerCanTy)) {
         TypesToDelete.push_back(ExceptionTy);
       }
-      // A a qualification conversion ...
+      // A qualification conversion ...
       else if (isQualificationConvertiblePointer(ExceptionCanTy, HandlerCanTy,
                                                  Context.getLangOpts())) {
         TypesToDelete.push_back(ExceptionTy);

--- a/clang/lib/Format/MacroCallReconstructor.cpp
+++ b/clang/lib/Format/MacroCallReconstructor.cpp
@@ -466,7 +466,7 @@ void MacroCallReconstructor::finalize() {
 #endif
 
   // We created corresponding unwrapped lines for each incoming line as children
-  // the the toplevel null token.
+  // of the toplevel null token.
   assert(Result.Tokens.size() == 1 && !Result.Tokens.front()->Children.empty());
   LLVM_DEBUG({
     llvm::dbgs() << "Finalizing reconstructed lines:\n";

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -912,7 +912,7 @@ ExprResult Sema::DefaultArgumentPromotion(Expr *E) {
   //     of type T from the glvalue and the result of the conversion
   //     is a prvalue for the temporary.
   // FIXME: add some way to gate this entire thing for correctness in
-  // potentially potentially evaluated contexts.
+  // potentially evaluated contexts.
   if (getLangOpts().CPlusPlus && E->isGLValue() && !isUnevaluatedContext()) {
     ExprResult Temp = PerformCopyInitialization(
                        InitializedEntity::InitializeTemporary(E->getType()),

--- a/clang/test/PCH/cxx-templates.h
+++ b/clang/test/PCH/cxx-templates.h
@@ -466,7 +466,7 @@ namespace ClassTemplateCycle {
   T t;
 
   // Create a cycle: the variable M refers to A<1, 1>, whose template argument
-  // list list refers back to M.
+  // list refers back to M.
   template<int, int> struct A;
   const decltype(sizeof(A<1, 1>*)) M = 1;
   template<int N> struct A<N, M> {};

--- a/lldb/source/Breakpoint/BreakpointSiteList.cpp
+++ b/lldb/source/Breakpoint/BreakpointSiteList.cpp
@@ -175,7 +175,7 @@ bool BreakpointSiteList::FindInRange(lldb::addr_t lower_bound,
 
   // This is one tricky bit.  The breakpoint might overlap the bottom end of
   // the range.  So we grab the breakpoint prior to the lower bound, and check
-  // that that + its byte size isn't in our range.
+  // that + its byte size isn't in our range.
   if (lower != m_bp_site_list.begin()) {
     collection::const_iterator prev_pos = lower;
     prev_pos--;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -53,7 +53,7 @@ class ClangPersistentVariables;
 /// struct so that it can be passed to the JITted version of the IR.
 ///
 /// Fourth and finally, it "dematerializes" the struct after the JITted code
-/// has has executed, placing the new values back where it found the old ones.
+/// has executed, placing the new values back where it found the old ones.
 class ClangExpressionDeclMap : public ClangASTSource {
 public:
   /// Constructor

--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleLoader.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleLoader.cpp
@@ -285,7 +285,7 @@ StringRef TraceIntelPTBundleLoader::GetSchema() {
   "tscPerfZeroConversion"?: {
     // Values used to convert between TSCs and nanoseconds. See the time_zero
     // section in https://man7.org/linux/man-pages/man2/perf_event_open.2.html
-    // for for information.
+    // for information.
 
     "timeMult": integer,
     "timeShift": integer,

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -2777,7 +2777,7 @@ bool isKnownNonZero(const Value *V, const APInt &DemandedElts, unsigned Depth,
 
     // If there exists any subset of X (sX) and subset of Y (sY) s.t sX * sY is
     // non-zero, then X * Y is non-zero. We can find sX and sY by just taking
-    // the the lowest known One of X and Y. If they are non-zero, the result
+    // the lowest known One of X and Y. If they are non-zero, the result
     // must be non-zero. We can check if LSB(X) * LSB(Y) != 0 by doing
     // X.CountLeadingZeros + Y.CountLeadingZeros < BitWidth.
     return (XKnown.countMaxTrailingZeros() + YKnown.countMaxTrailingZeros()) <

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5113,7 +5113,7 @@ bool SelectionDAG::isEqualTo(SDValue A, SDValue B) const {
   // Check the obvious case.
   if (A == B) return true;
 
-  // For for negative and positive zero.
+  // For negative and positive zero.
   if (const ConstantFPSDNode *CA = dyn_cast<ConstantFPSDNode>(A))
     if (const ConstantFPSDNode *CB = dyn_cast<ConstantFPSDNode>(B))
       if (CA->isZero() && CB->isZero()) return true;

--- a/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
@@ -1249,7 +1249,7 @@ void SelectionDAGBuilder::visitGCRelocate(const GCRelocateInst &Relocate) {
 
     // All the reloads are independent and are reading memory only modified by
     // statepoints (i.e. no other aliasing stores); informing SelectionDAG of
-    // this this let's CSE kick in for free and allows reordering of
+    // this let's CSE kick in for free and allows reordering of
     // instructions if possible.  The lowering for statepoint sets the root,
     // so this is ordering all reloads with the either
     // a) the statepoint node itself, or

--- a/mlir/lib/Analysis/Presburger/PWMAFunction.cpp
+++ b/mlir/lib/Analysis/Presburger/PWMAFunction.cpp
@@ -334,7 +334,7 @@ PWMAFunction PWMAFunction::unionFunction(
     // defined.
     //
     // `dom` here is guranteed to be disjoint from already added pieces
-    // because because the pieces added before are either:
+    // because the pieces added before are either:
     // - Subsets of the domain of other MAFs in `this`, which are guranteed
     //   to be disjoint from `dom`, or
     // - They are one of the pieces added for `pieceB`, and we have been

--- a/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
+++ b/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
@@ -536,7 +536,7 @@ LogicalResult mlir::detail::verifyDataLayoutSpec(DataLayoutSpecInterface spec,
       return failure();
 
   // Second, dispatch verifications of entry groups to types or dialects they
-  // are are associated with.
+  // are associated with.
   DenseMap<TypeID, DataLayoutEntryList> types;
   DenseMap<StringAttr, DataLayoutEntryInterface> ids;
   spec.bucketEntriesByType(types, ids);


### PR DESCRIPTION
Fix typos with duplicated words in comments. 100+ matches were found with a regex search, then all of them manually searched. I only committed the 12 where I am confident it's a mistake.