### PR TITLE
Update pr59999.cppm to reflect a reproducible state

### DIFF
--- a/clang/test/Modules/pr59999.cppm
+++ b/clang/test/Modules/pr59999.cppm
@@ -4,17 +4,31 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 //
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple %t/Module-Reflector.cppm \
+// RUN:     -emit-module-interface -o %t/Module-Reflector.pcm
 // RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple %t/Module.cppm \
 // RUN:     -emit-module-interface -o %t/Module.pcm
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple %t/Object-Reflector.cppm \
+// RUN:     -fmodule-file=Module=%t/Module.pcm -emit-module-interface \
+// RUN:     -o %t/Object-Reflector.pcm
 // RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple %t/Object.cppm \
 // RUN:     -fmodule-file=Module=%t/Module.pcm -emit-module-interface -o %t/Object.pcm
-// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple %t/Object.pcm \
-// RUN:     -fmodule-file=Module=%t/Module.pcm -S -emit-llvm -o - | FileCheck %t/Object.cppm
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple %t/World.cppm \
+// RUN:     -fmodule-file=Module=%t/Module.pcm -fmodule-file=Object=%t/Object.pcm \
+// RUN:     -o %t/World.pcm
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple %t/World.pcm \
+// RUN:     -fmodule-file=Module=%t/Module.pcm -fmodule-file=Object=%t/Object.pcm \
+// RUN:     -S -emit-llvm -o - | FileCheck %t/World.cppm
+
+//--- Module-Reflector.cppm
+export module Module:Reflector;
+
+export template <class ObjectType> bool ModuleRegister() { return true; };
 
 //--- Module.cppm
 export module Module;
 
-export template <class ObjectType> bool ModuleRegister() { return true; };
+export import :Reflector;
 
 export struct ModuleEntry {
   static const bool bRegistered;
@@ -22,12 +36,18 @@ export struct ModuleEntry {
 
 const bool ModuleEntry::bRegistered = ModuleRegister<ModuleEntry>();
 
+//--- Object-Reflector.cppm
+export module Object:Reflector;
+
+export template <class ObjectType> bool ObjectRegister() { return true; };
+
 //--- Object.cppm
 export module Object;
 
 import Module;
 
-export template <class ObjectType> bool ObjectRegister() { return true; }
+export import :Reflector;
+
 export struct NObject {
   static const bool bRegistered;
 };
@@ -39,6 +59,14 @@ export struct ObjectModuleEntry {
 const bool NObject::bRegistered = ObjectRegister<NObject>();
 // One another function, that helps clang crash
 const bool ObjectModuleEntry::bRegistered = ModuleRegister<ObjectModuleEntry>();
+
+//--- World.cppm
+
+export module World;
+
+import Object;
+
+export const bool NWorldRegistered = ModuleRegister<long>();
 
 // Check that the LLVM IR is generated correctly instead of crashing.
 // CHECK: define{{.*}}@_ZGIW6Object


### PR DESCRIPTION
This is a extension for #59999 tests in order to make them reproduce the issue reported.

From local tests, I found out the definition in a "part unit" being instantiated in a deeper dependency tree is fundamental to the failure. So, in the case of this issue, splitting the code with its parts and the `World` module are important.

Also, I noticed more symbols are also important to reproduce the issue.