### PR TITLE
avoid sign-conversion-error in erase

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -764,7 +764,7 @@ public:
     iterator I = std::move(E, this->end(), S);
     // Drop the last elts.
     this->destroy_range(I, this->end());
-    this->set_size(I - this->begin());
+    this->set_size(static_cast<size_type>(I - this->begin()));
     return(N);
   }
 


### PR DESCRIPTION
without the cast i ran into:
  `error: conversion to 'std::size_t' {aka 'long long unsigned int'} from 'long long int' may change the sign of the result [-Werror=sign-conversion]`