### PR TITLE
LLVM: fix compilation with -std=c++20

### DIFF
--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -362,7 +362,7 @@ llvm::cl::OptionValue<OpPassManager>::operator=(
   return *this;
 }
 
-llvm::cl::OptionValue<OpPassManager>::~OptionValue<OpPassManager>() = default;
+llvm::cl::OptionValue<OpPassManager>::~OptionValue() = default;
 
 void llvm::cl::OptionValue<OpPassManager>::setValue(
     const OpPassManager &newValue) {


### PR DESCRIPTION
C++20 made it invalid to use simple-template-ids for constructors and destructors: https://eel.is/c++draft/diff.cpp17.class#2 . GCC 11 and later throw an error on this. This PR fixes the problem.