### PR TITLE
workflows/release-tasks: Don't do a test upload to test.pypi.org

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -98,12 +98,6 @@ jobs:
           sed -i "s/ + 'dev'//g" lit/__init__.py
           python3 setup.py sdist
 
-      - name: Upload lit to test.pypi.org
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.LLVM_LIT_TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-
       - name: Upload lit to pypi.org
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
I'm unable to create an account here, so I can't get a token to do the upload.