### PR TITLE
Workflows: Allow pull request for clang-format changes

### DIFF
--- a/.github/workflows/repo-lockdown.yml
+++ b/.github/workflows/repo-lockdown.yml
@@ -9,6 +9,11 @@ on:
       - 'runtimes/**'
       - 'lldb/**'
       - '.github/**'
+      - 'clang/lib/Format/**'
+      - 'clang/include/clang/Format/**'
+      - 'clang/docs/**'
+      - 'clang/unitests/Format**'
+      - 'clang/tools/clang-format/**'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/repo-lockdown.yml
+++ b/.github/workflows/repo-lockdown.yml
@@ -12,7 +12,7 @@ on:
       - 'clang/lib/Format/**'
       - 'clang/include/clang/Format/**'
       - 'clang/docs/**'
-      - 'clang/unitests/Format**'
+      - 'clang/unitests/Format/**'
       - 'clang/tools/clang-format/**'
 
 permissions:


### PR DESCRIPTION
Remove repo lockdown on clang-format specific directories, this will allow the clang-format team to become familiar with the new PR process that is due to start Sept 1st.

