### PR TITLE
|libc++] __search: check regex with an empty string at last

### DIFF
--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -6176,6 +6176,19 @@ basic_regex<_CharT, _Traits>::__search(
             __m.__matches_.assign(__m.size(), __m.__unmatched_);
         }
     }
+    if (!(__flags & regex_constants::match_not_null || __flags & regex_constants::match_continuous))
+    {
+        __m.__matches_.assign(__m.size(), __m.__unmatched_);
+        if (__match_at_start(__last, __last, __m, __flags, false))
+        {
+            __m.__prefix_.second = __m[0].first;
+            __m.__prefix_.matched = __m.__prefix_.first != __m.__prefix_.second;
+            __m.__suffix_.first = __m[0].second;
+            __m.__suffix_.matched = __m.__suffix_.first != __m.__suffix_.second;
+            return true;
+        }
+        __m.__matches_.assign(__m.size(), __m.__unmatched_);
+    }
     __m.__matches_.clear();
     return false;
 }

--- a/libcxx/test/std/re/re.alg/re.alg.search/extended.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/extended.pass.cpp
@@ -221,6 +221,21 @@ int main(int, char**)
     }
     {
         std::cmatch m;
+        const char s[] = "efabc";
+        assert(std::regex_search(s, m, std::regex("$", std::regex_constants::extended)));
+        assert(m.size() == 1);
+        assert(m.prefix().matched);
+        assert(m.prefix().first == s);
+        assert(m.prefix().second == m[0].first);
+        assert(!m.suffix().matched);
+        assert(m.suffix().first == m[0].second);
+        assert(m.suffix().second == s+5);
+        assert(m.length(0) == 0);
+        assert(m.position(0) == 5);
+        assert(m.str(0) == s+5);
+    }
+    {
+        std::cmatch m;
         const char s[] = "efabcg";
         assert(!std::regex_search(s, m, std::regex("abc$", std::regex_constants::extended)));
         assert(m.size() == 0);


### PR DESCRIPTION
Let's try github pull request as it will be the new standard soon (as I understood). I create a account an phabrikator and was not able to understand how create a pull request.

Description of the patch:
/!\ This is a kind of WIP, as my first patch and inside the regex engine I'm not quite sure of what I'm doing. Review it carefully (btw I ran all the tests). /!\

If the pattern is able to match an empty string we should try it.

We try only if match_not_null is not set.