### PR TITLE
Change begin of macro in translateSourceRange

### DIFF
--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -151,11 +151,13 @@ CXSourceRange cxloc::translateSourceRange(const SourceManager &SM,
                                           const CharSourceRange &R) {
   // We want the last character in this location, so we will adjust the
   // location accordingly.
+  SourceLocation BeginLoc = R.getBegin();
   SourceLocation EndLoc = R.getEnd();
   bool IsTokenRange = R.isTokenRange();
   if (EndLoc.isValid() && EndLoc.isMacroID() &&
       !SM.isMacroArgExpansion(EndLoc)) {
     CharSourceRange Expansion = SM.getExpansionRange(EndLoc);
+    BeginLoc = Expansion.getBegin();
     EndLoc = Expansion.getEnd();
     IsTokenRange = Expansion.isTokenRange();
   }
@@ -166,7 +168,7 @@ CXSourceRange cxloc::translateSourceRange(const SourceManager &SM,
   }
 
   CXSourceRange Result = {
-      {&SM, &LangOpts}, R.getBegin().getRawEncoding(), EndLoc.getRawEncoding()};
+      {&SM, &LangOpts}, BeginLoc.getRawEncoding(), EndLoc.getRawEncoding()};
   return Result;
 }
 


### PR DESCRIPTION
Currently translateSourceRange changes to end location in case of a macro. When getting the source location for a macro invocation it therefore returns the beginning of the macro definition with the end of the macro invocation (with everything inbetween). This change makes it to return the location of the macro invocation.