### PR TITLE
[libc++][C++20 modules] Fixes CMake include paths.

### DIFF
--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -122,7 +122,16 @@ set(LIBCXX_MODULE_STD_SOURCES
 # When that is removed the configured file can use the substitution
 # LIBCXX_GENERATED_INCLUDE_TARGET_DIR avoiding this set.
 # Also clean up the parts needed to generate the install version.
-set(LIBCXX_CONFIGURED_INCLUDE_DIR ${LIBCXX_GENERATED_INCLUDE_TARGET_DIR})
+# - LIBCXX_GENERATED_INCLUDE_DIR contains the libc++ headers
+# - LIBCXX_GENERATED_INCLUDE_TARGET_DIR contains the libc++ site config
+if ("${LIBCXX_GENERATED_INCLUDE_DIR}" STREQUAL "${LIBCXX_GENERATED_INCLUDE_TARGET_DIR}")
+  # This typically happens when the target is not installed.
+  set(LIBCXX_CONFIGURED_INCLUDE_DIRS "${LIBCXX_GENERATED_INCLUDE_DIR}")
+else()
+  set(LIBCXX_CONFIGURED_INCLUDE_DIRS
+    "${LIBCXX_GENERATED_INCLUDE_DIR};${LIBCXX_GENERATED_INCLUDE_TARGET_DIR}"
+  )
+endif()
 configure_file(
   "CMakeLists.txt.in"
   "${LIBCXX_GENERATED_MODULE_DIR}/CMakeLists.txt"

--- a/libcxx/modules/CMakeLists.txt.in
+++ b/libcxx/modules/CMakeLists.txt.in
@@ -40,7 +40,7 @@ target_sources(std
 )
 
 target_compile_definitions(std PRIVATE _LIBCPP_ENABLE_EXPERIMENTAL)
-target_include_directories(std SYSTEM PRIVATE @LIBCXX_CONFIGURED_INCLUDE_DIR@)
+target_include_directories(std SYSTEM PRIVATE @LIBCXX_CONFIGURED_INCLUDE_DIRS@)
 
 target_compile_options(std
   PUBLIC


### PR DESCRIPTION
When the modules are used in a bootstrap build the paths ${LIBCXX_GENERATED_INCLUDE_DIR} and ${LIBCXX_GENERATED_INCLUDE_TARGET_DIR} have a different value and both are needed to build modules.

This issue has been reported on Slack.