### PR TITLE
[DirectX backend] avoid generate redundant bitcast in DXILPrepareModule

### DIFF
--- a/llvm/lib/Target/DirectX/DXILPrepare.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrepare.cpp
@@ -154,7 +154,7 @@ public:
           if (auto GEP = dyn_cast<GetElementPtrInst>(&I)) {
             if (Value *NoOpBitcast = maybeGenerateBitcast(
                     Builder, PointerTypes, I, GEP->getPointerOperand(),
-                    GEP->getResultElementType()))
+                    GEP->getSourceElementType()))
               GEP->setOperand(0, NoOpBitcast);
             continue;
           }

--- a/llvm/test/CodeGen/DirectX/typed_ptr.ll
+++ b/llvm/test/CodeGen/DirectX/typed_ptr.ll
@@ -2,9 +2,16 @@
 target triple = "dxil-unknown-unknown"
 
 ; Make sure not crash when has typed ptr.
-; CHECK:@test
+; CHECK:define i64 @test(ptr %p)
+; Make sure no bitcast generated.
+; CHECK-NOT:bitcast
+
+@gs = external addrspace(3) global [20 x [6 x float]], align 4
 
 define i64 @test(i64* %p) {
+  %base = getelementptr inbounds [20 x [6 x float]], ptr addrspace(3) @gs, i64 0, i64 3
+  %addr = getelementptr inbounds [6 x float], ptr addrspace(3) %base, i64 0, i64 2
+  store float 1.000000e+00, ptr addrspace(3) %addr, align 4
   %v = load i64, i64* %p
   ret i64 %v
 }

--- a/llvm/test/CodeGen/DirectX/typed_ptr.ll
+++ b/llvm/test/CodeGen/DirectX/typed_ptr.ll
@@ -1,17 +1,29 @@
 ; RUN: opt -S -dxil-prepare < %s | FileCheck %s
 target triple = "dxil-unknown-unknown"
 
-; Make sure not crash when has typed ptr.
-; CHECK:define i64 @test(ptr %p)
-; Make sure no bitcast generated.
-; CHECK-NOT:bitcast
-
 @gs = external addrspace(3) global [20 x [6 x float]], align 4
 
+; Make sure not crash when has typed ptr.
 define i64 @test(i64* %p) {
+; CHECK-LABEL: define i64 @test(
+; CHECK-SAME: ptr [[P:%.*]]) {
+; CHECK-NEXT:    [[V:%.*]] = load i64, ptr [[P]], align 4
+; CHECK-NEXT:    ret i64 [[V]]
+;
+  %v = load i64, i64* %p
+  ret i64 %v
+}
+
+; Make sure no bitcast generated.
+define void @test_gep() {
+; CHECK-LABEL: define void @test_gep() {
+; CHECK-NEXT:    [[BASE:%.*]] = getelementptr inbounds [20 x [6 x float]], ptr addrspace(3) @gs, i64 0, i64 3
+; CHECK-NEXT:    [[ADDR:%.*]] = getelementptr inbounds [6 x float], ptr addrspace(3) [[BASE]], i64 0, i64 2
+; CHECK-NEXT:    store float 1.000000e+00, ptr addrspace(3) [[ADDR]], align 4
+; CHECK-NEXT:    ret void
+;
   %base = getelementptr inbounds [20 x [6 x float]], ptr addrspace(3) @gs, i64 0, i64 3
   %addr = getelementptr inbounds [6 x float], ptr addrspace(3) %base, i64 0, i64 2
   store float 1.000000e+00, ptr addrspace(3) %addr, align 4
-  %v = load i64, i64* %p
-  ret i64 %v
+  ret void
 }


### PR DESCRIPTION
When emit NoOp bitcast for GEP Ptr Operand, should use SourceElementType instead of ResultElementType.

**Behavior Before Change**
Redundant bitcast like 
   ` bitcast ptr addrspace(3) @gs to ptr addrspace(3)`
 will be generated for llvm/test/CodeGen/DirectX/typed_ptr.ll

**Behavior After Change**
  No bitcast will be generated.

Fixes https://github.com/llvm/llvm-project/issues/65183