### PR TITLE
[mlir] Add option to cloning with different results

### DIFF
--- a/mlir/unittests/IR/OperationSupportTest.cpp
+++ b/mlir/unittests/IR/OperationSupportTest.cpp
@@ -312,4 +312,20 @@ TEST(OperationEquivalenceTest, HashWorksWithFlags) {
   op2->destroy();
 }
 
+TEST(OperationCloneTest, CloneWithDifferentResults) {
+  MLIRContext context;
+  Builder builder(&context);
+
+  Operation *useOp = createOp(&context, std::nullopt, builder.getI32Type());
+  IRMapping map;
+  Operation *cloneOp = useOp->clone(
+      map, Operation::CloneOptions::all().withResultTypes(
+               SmallVector<Type>{builder.getI32Type(), builder.getI16Type()}));
+
+  ASSERT_EQ(cloneOp->getNumResults(), 2u);
+  EXPECT_EQ(cloneOp->getResult(0).getType(), builder.getI32Type());
+  EXPECT_EQ(cloneOp->getResult(1).getType(), builder.getI16Type());
+  EXPECT_FALSE(map.contains(useOp->getResult(0)));
+}
+
 } // namespace


### PR DESCRIPTION
Since `Operation`s cannot change the results after creation, a clone is necessary to create new results. Doing such an operation generically has not been possible so far. This PR therefore adds a new option to the `CloneOptions` struct allowing adding changing the results of the created operation.

The caller is responsible to ensure that this is a valid operation and setting the `IRMapping` accordingly afterwards if required.