### PR TITLE
[test] Use host platform specific error message substitution in lit tests

### DIFF
--- a/llvm/test/tools/llvm-symbolizer/get-input-file.test
+++ b/llvm/test/tools/llvm-symbolizer/get-input-file.test
@@ -11,7 +11,7 @@ RUN: FileCheck --input-file=%t.2.err --check-prefix=NOADDR %s
 
 # Two items specified, check if the first one is an existing file.
 RUN: llvm-symbolizer "foo 400" 2>%t.3.err | FileCheck %s --check-prefix=NOSOURCE
-RUN: FileCheck --input-file=%t.3.err --check-prefix=NOTFOUND %s
+RUN: FileCheck --input-file=%t.3.err --check-prefix=NOTFOUND -DMSG=%errc_ENOENT %s
 
 # FILE: must be followed by a file name.
 RUN: llvm-symbolizer "FILE:" 2>%t.4.err | FileCheck %s --check-prefix=NOSOURCE
@@ -36,7 +36,7 @@ NOFILE: error: no input filename has been specified
 
 NOADDR: error: 'foo': no module offset has been specified
 
-NOTFOUND:  error: 'foo': {{[nN]}}o such file or directory
+NOTFOUND:  error: 'foo': [[MSG]]
 
 MISSING-FILE: error: 'FILE:': must be followed by an input file
 


### PR DESCRIPTION
On z/OS, the following error message is not matched correctly in lit tests.

`EDC5129I No such file or directory.`
This patch uses a lit config substitution to check for platform specific error messages.