### PR TITLE
[APINotes] Remove unused OS-availability feature

### DIFF
--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -28,8 +28,6 @@ using namespace api_notes;
 namespace {
 enum class APIAvailability {
   Available = 0,
-  OSX,
-  IOS,
   None,
   NonSwift,
 };
@@ -39,8 +37,6 @@ namespace llvm {
 namespace yaml {
 template <> struct ScalarEnumerationTraits<APIAvailability> {
   static void enumeration(IO &IO, APIAvailability &AA) {
-    IO.enumCase(AA, "OSX", APIAvailability::OSX);
-    IO.enumCase(AA, "iOS", APIAvailability::IOS);
     IO.enumCase(AA, "none", APIAvailability::None);
     IO.enumCase(AA, "nonswift", APIAvailability::NonSwift);
     IO.enumCase(AA, "available", APIAvailability::Available);


### PR DESCRIPTION
iOS/OSX-specific availability is a legacy of compiled API Notes which are not supported and were removed from Apple Clang in 2019 (see https://github.com/apple/llvm-project/commit/30fc70f349277a42e02550779b464b92a2f06c1c).