### PR TITLE
[llvm-exegesis] Add error handling for fork failures

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -260,6 +260,12 @@ private:
       return AddMemDefError;
 
     pid_t ParentOrChildPID = fork();
+
+    if (ParentOrChildPID == -1) {
+      return make_error<Failure>("Failed to create child process: " +
+                                 Twine(strerror(errno)));
+    }
+
     if (ParentOrChildPID == 0) {
       // We are in the child process, close the write end of the pipe
       close(PipeFiles[1]);


### PR DESCRIPTION
There are still some transient failures on the clang-avx512 builder on the new subprocess memory tests. Some of them seem to be related to an inability to fork, but it's hard to debug currently as there is no explicit error handling for a failed fork call, and nice error reporting for a failed fork is something that we should have regardless.