### PR TITLE
[Github] Add test directories to IR/Transforms/Analysis teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -429,14 +429,19 @@ utils/bazel/llvm-project-overlay/libc/** @llvm/pr-subscribers-libc
 /llvm/lib/IR/ @llvm/pr-subscribers-llvm-ir
 /llvm/include/llvm/IR/ @llvm/pr-subscribers-llvm-ir
 /llvm/docs/LangRef.rst @llvm/pr-subscribers-llvm-ir
+/llvm/unittests/IR/ @llvm/pr-subscribers-llvm-ir
 
 # llvm-analysis
 /llvm/lib/Analysis/ @llvm/pr-subscribers-llvm-analysis
 /llvm/include/llvm/Analysis/ @llvm/pr-subscribers-llvm-analysis
+/llvm/test/Analysis/ @llvm/pr-subscribers-llvm-analysis
+/llvm/unittests/Analysis/ @llvm/pr-subscribers-llvm-analysis
 
 # llvm-transforms
 /llvm/lib/Transforms/ @llvm/pr-subscribers-llvm-transforms
 /llvm/include/llvm/Transforms/ @llvm/pr-subscribers-llvm-transforms
+/llvm/test/Transforms/ @llvm/pr-subscribers-llvm-transforms
+/llvm/unittests/Transforms/ @llvm/pr-subscribers-llvm-transforms
 
 # clangd
 /clang-tools-extra/clangd/ @llvm/pr-subscribers-clangd


### PR DESCRIPTION
Having test directories included for notifications sent out to these teams seems like a decent idea. I don't think it should produce much churn and it catches a couple cases like separately reviewed pre-committed tests that aren't frequent but do exist.