### PR TITLE
[mlir][arith] Improve Lowering of `maxf`/`minf` ops

### DIFF
--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -55,14 +55,14 @@ using FPToSIOpLowering =
 using FPToUIOpLowering =
     VectorConvertToLLVMPattern<arith::FPToUIOp, LLVM::FPToUIOp>;
 using MaxFOpLowering =
-    VectorConvertToLLVMPattern<arith::MaxFOp, LLVM::MaxNumOp,
+    VectorConvertToLLVMPattern<arith::MaxFOp, LLVM::MaximumOp,
                                arith::AttrConvertFastMathToLLVM>;
 using MaxSIOpLowering =
     VectorConvertToLLVMPattern<arith::MaxSIOp, LLVM::SMaxOp>;
 using MaxUIOpLowering =
     VectorConvertToLLVMPattern<arith::MaxUIOp, LLVM::UMaxOp>;
 using MinFOpLowering =
-    VectorConvertToLLVMPattern<arith::MinFOp, LLVM::MinNumOp,
+    VectorConvertToLLVMPattern<arith::MinFOp, LLVM::MinimumOp,
                                arith::AttrConvertFastMathToLLVM>;
 using MinSIOpLowering =
     VectorConvertToLLVMPattern<arith::MinSIOp, LLVM::SMinOp>;

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -522,9 +522,9 @@ func.func @minmaxi(%arg0 : i32, %arg1 : i32) -> i32 {
 
 // CHECK-LABEL: @minmaxf
 func.func @minmaxf(%arg0 : f32, %arg1 : f32) -> f32 {
-  // CHECK: = llvm.intr.minnum(%arg0, %arg1) : (f32, f32) -> f32
+  // CHECK: = llvm.intr.minimum(%arg0, %arg1) : (f32, f32) -> f32
   %0 = arith.minf %arg0, %arg1 : f32
-  // CHECK: = llvm.intr.maxnum(%arg0, %arg1) : (f32, f32) -> f32
+  // CHECK: = llvm.intr.maximum(%arg0, %arg1) : (f32, f32) -> f32
   %1 = arith.maxf %arg0, %arg1 : f32
   return %0 : f32
 }
@@ -554,9 +554,9 @@ func.func @ops_supporting_fastmath(%arg0: f32, %arg1: f32, %arg2: i32) {
   %0 = arith.addf %arg0, %arg1 fastmath<fast> : f32
 // CHECK: llvm.fdiv %arg0, %arg1  {fastmathFlags = #llvm.fastmath<fast>} : f32
   %1 = arith.divf %arg0, %arg1 fastmath<fast> : f32
-// CHECK: llvm.intr.maxnum(%arg0, %arg1) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32) -> f32
+// CHECK: llvm.intr.maximum(%arg0, %arg1) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32) -> f32
   %2 = arith.maxf %arg0, %arg1 fastmath<fast> : f32
-// CHECK: llvm.intr.minnum(%arg0, %arg1) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32) -> f32
+// CHECK: llvm.intr.minimum(%arg0, %arg1) {fastmathFlags = #llvm.fastmath<fast>} : (f32, f32) -> f32
   %3 = arith.minf %arg0, %arg1 fastmath<fast> : f32
 // CHECK: llvm.fmul %arg0, %arg1  {fastmathFlags = #llvm.fastmath<fast>} : f32
   %4 = arith.mulf %arg0, %arg1 fastmath<fast> : f32


### PR DESCRIPTION
This patch is part of a larger initiative aimed at fixing floating-point `max` and `min` operations in MLIR: https://discourse.llvm.org/t/rfc-fix-floating-point-max-and-min-operations-in-mlir/72671.

This patch addresses task 1.1 from the plan. It involves modifying the lowering process for `arith.minf` and `arith.maxf` operations. Specifically, the change replaces the usage of `llvm.minnum` and `llvm.maxnum` with `llvm.minimum` and `llvm.maximum`, respectively. This adjustment is necessary because the `m**num` intrinsics are not suitable for the mentioned MLIR operations due to semantic discrepancies in handling NaNs, positive and negative floating-point zeros.
