### PR TITLE
[AST] Only dump desugared type when visibly different

### DIFF
--- a/clang/docs/HowToSetupToolingForLLVM.rst
+++ b/clang/docs/HowToSetupToolingForLLVM.rst
@@ -172,7 +172,7 @@ Examples:
   clang::ASTConsumer *newASTConsumer() (CompoundStmt 0x44da290 </home/alexfh/local/llvm/tools/clang/tools/clang-check/ClangCheck.cpp:64:40, line:72:3>
     (IfStmt 0x44d97c8 <line:65:5, line:66:45>
       <<<NULL>>>
-        (ImplicitCastExpr 0x44d96d0 <line:65:9> '_Bool':'_Bool' <UserDefinedConversion>
+        (ImplicitCastExpr 0x44d96d0 <line:65:9> '_Bool' <UserDefinedConversion>
   ...
   $ clang-check tools/clang/tools/clang-check/ClangCheck.cpp -ast-print -ast-dump-filter ActionFactory::newASTConsumer
   Processing: tools/clang/tools/clang-check/ClangCheck.cpp.

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -113,6 +113,28 @@ ABI Changes in This Version
 - Following the SystemV ABI for x86-64, ``__int128`` arguments will no longer
   be split between a register and a stack slot.
 
+AST Dumping Potentially Breaking Changes
+----------------------------------------
+- When dumping a sugared type, Clang will no longer print the desugared type if
+  its textual representation is the same as the sugared one. This applies to
+  both text dumps of the form ``'foo':'foo'`` which will now be dumped as just
+  ``'foo'``, and JSON dumps of the form:
+
+  .. code-block:: json
+
+    "type": {
+      "qualType": "foo",
+      "desugaredQualType": "foo"
+    }
+
+  which will now be dumped as just:
+
+  .. code-block:: json
+
+    "type": {
+      "qualType": "foo"
+    }
+
 What's New in Clang |release|?
 ==============================
 Some of the major new features and improvements to Clang are listed

--- a/clang/lib/AST/JSONNodeDumper.cpp
+++ b/clang/lib/AST/JSONNodeDumper.cpp
@@ -315,12 +315,16 @@ std::string JSONNodeDumper::createPointerRepresentation(const void *Ptr) {
 
 llvm::json::Object JSONNodeDumper::createQualType(QualType QT, bool Desugar) {
   SplitQualType SQT = QT.split();
-  llvm::json::Object Ret{{"qualType", QualType::getAsString(SQT, PrintPolicy)}};
+  std::string SQTS = QualType::getAsString(SQT, PrintPolicy);
+  llvm::json::Object Ret{{"qualType", SQTS}};
 
   if (Desugar && !QT.isNull()) {
     SplitQualType DSQT = QT.getSplitDesugaredType();
-    if (DSQT != SQT)
-      Ret["desugaredQualType"] = QualType::getAsString(DSQT, PrintPolicy);
+    if (DSQT != SQT) {
+      std::string DSQTS = QualType::getAsString(DSQT, PrintPolicy);
+      if (DSQTS != SQTS)
+        Ret["desugaredQualType"] = DSQTS;
+    }
     if (const auto *TT = QT->getAs<TypedefType>())
       Ret["typeAliasDeclId"] = createPointerRepresentation(TT->getDecl());
   }

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -692,13 +692,18 @@ void TextNodeDumper::dumpBareType(QualType T, bool Desugar) {
   ColorScope Color(OS, ShowColors, TypeColor);
 
   SplitQualType T_split = T.split();
-  OS << "'" << QualType::getAsString(T_split, PrintPolicy) << "'";
+  std::string T_str = QualType::getAsString(T_split, PrintPolicy);
+  OS << "'" << T_str << "'";
 
   if (Desugar && !T.isNull()) {
-    // If the type is sugared, also dump a (shallow) desugared type.
+    // If the type is sugared, also dump a (shallow) desugared type when
+    // it is visibly different.
     SplitQualType D_split = T.getSplitDesugaredType();
-    if (T_split != D_split)
-      OS << ":'" << QualType::getAsString(D_split, PrintPolicy) << "'";
+    if (T_split != D_split) {
+      std::string D_str = QualType::getAsString(D_split, PrintPolicy);
+      if (T_str != D_str)
+        OS << ":'" << QualType::getAsString(D_split, PrintPolicy) << "'";
+    }
   }
 }
 

--- a/clang/test/AST/HLSL/this-reference-template.hlsl
+++ b/clang/test/AST/HLSL/this-reference-template.hlsl
@@ -35,12 +35,12 @@ void main() {
 // CHECK:     -CXXMethodDecl 0x{{[0-9A-Fa-f]+}} <line:8:3, line:10:3> line:8:5 used getFirst 'int ()' implicit_instantiation implicit-inline
 // CHECK-NEXT:-CompoundStmt 0x{{[0-9A-Fa-f]+}} <col:16, line:10:3>
 // CHECK-NEXT:-ReturnStmt 0x{{[0-9A-Fa-f]+}} <line:9:4, col:16>
-// CHECK-NEXT:-ImplicitCastExpr 0x{{[0-9A-Fa-f]+}} <col:11, col:16> 'int':'int' <LValueToRValue>
-// CHECK-NEXT:-MemberExpr 0x{{[0-9A-Fa-f]+}} <col:11, col:16> 'int':'int' lvalue .First 0x{{[0-9A-Fa-f]+}}
+// CHECK-NEXT:-ImplicitCastExpr 0x{{[0-9A-Fa-f]+}} <col:11, col:16> 'int' <LValueToRValue>
+// CHECK-NEXT:-MemberExpr 0x{{[0-9A-Fa-f]+}} <col:11, col:16> 'int' lvalue .First 0x{{[0-9A-Fa-f]+}}
 // CHECK-NEXT:-CXXThisExpr 0x{{[0-9A-Fa-f]+}} <col:11> 'Pair<int, float>' lvalue this
 // CHECK-NEXT:-CXXMethodDecl 0x{{[0-9A-Fa-f]+}} <line:12:3, line:14:3> line:12:5 used getSecond 'float ()' implicit_instantiation implicit-inline
 // CHECK-NEXT:-CompoundStmt 0x{{[0-9A-Fa-f]+}} <col:17, line:14:3>
 // CHECK-NEXT:-ReturnStmt 0x{{[0-9A-Fa-f]+}} <line:13:5, col:12>
-// CHECK-NEXT:-ImplicitCastExpr 0x{{[0-9A-Fa-f]+}} <col:12> 'float':'float' <LValueToRValue>
-// CHECK-NEXT:-MemberExpr 0x{{[0-9A-Fa-f]+}} <col:12> 'float':'float' lvalue .Second 0x{{[0-9A-Fa-f]+}}
+// CHECK-NEXT:-ImplicitCastExpr 0x{{[0-9A-Fa-f]+}} <col:12> 'float' <LValueToRValue>
+// CHECK-NEXT:-MemberExpr 0x{{[0-9A-Fa-f]+}} <col:12> 'float' lvalue .Second 0x{{[0-9A-Fa-f]+}}
 // CHECK-NEXT:-CXXThisExpr 0x{{[0-9A-Fa-f]+}} <col:12> 'Pair<int, float>' lvalue implicit this

--- a/clang/test/AST/ast-dump-APValue-anon-union.cpp
+++ b/clang/test/AST/ast-dump-APValue-anon-union.cpp
@@ -30,23 +30,23 @@ union U1 {
 
 void Test() {
   constexpr S0 s0{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s0 'const S0':'const S0' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s0 'const S0' constexpr listinit
   // CHECK-NEXT:  |   |-value: Struct
   // CHECK-NEXT:  |   | `-field: Union .i Int 42
 
   constexpr U0 u0a{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u0a 'const U0':'const U0' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u0a 'const U0' constexpr listinit
   // CHECK-NEXT:  |   |-value: Union None
 
   constexpr U0 u0b{3.1415f};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u0b 'const U0':'const U0' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u0b 'const U0' constexpr listinit
   // CHECK-NEXT:  |   |-value: Union .U0::(anonymous union at {{.*}}) Union .f Float 3.141500e+00
 
   constexpr U1 u1a{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u1a 'const U1':'const U1' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u1a 'const U1' constexpr listinit
   // CHECK-NEXT:  |   |-value: Union .U1::(anonymous union at {{.*}}) Union .f Float 0.000000e+00
 
   constexpr U1 u1b{3.1415f};
-  // CHECK:    `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u1b 'const U1':'const U1' constexpr listinit
+  // CHECK:    `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u1b 'const U1' constexpr listinit
   // CHECK-NEXT:      |-value: Union .U1::(anonymous union at {{.*}}) Union .f Float 3.141500e+00
 }

--- a/clang/test/AST/ast-dump-APValue-struct.cpp
+++ b/clang/test/AST/ast-dump-APValue-struct.cpp
@@ -60,12 +60,12 @@ struct S5 : S4 {
 
 void Test() {
   constexpr S0 s0{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s0 'const S0':'const S0' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s0 'const S0' constexpr listinit
   // CHECK-NEXT:  |   |-value: Struct
   // CHECK-NEXT:  |   | `-fields: Int 0, Union .j Int 0
 
   constexpr S1 s1{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s1 'const S1':'const S1' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s1 'const S1' constexpr listinit
   // CHECK-NEXT:  |   |-value: Struct
   // CHECK-NEXT:  |   | |-field: Int 0
   // CHECK-NEXT:  |   | `-field: Union .s
@@ -73,12 +73,12 @@ void Test() {
   // CHECK-NEXT:  |   |     `-field: Int 0
 
   constexpr S2 s2{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s2 'const S2':'const S2' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s2 'const S2' constexpr listinit
   // CHECK-NEXT:  |   |-value: Struct
   // CHECK-NEXT:  |   | `-fields: Int 0, Union .u Union .j Int 0
 
   constexpr S3 s3{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s3 'const S3':'const S3' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s3 'const S3' constexpr listinit
   // CHECK-NEXT:  |   |-value: Struct
   // CHECK-NEXT:  |   | |-field: Int 0
   // CHECK-NEXT:  |   | `-field: Union .u
@@ -87,7 +87,7 @@ void Test() {
   // CHECK-NEXT:  |   |       `-field: Int 0
 
   constexpr S4 s4{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s4 'const S4':'const S4' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s4 'const S4' constexpr listinit
   // CHECK-NEXT:  |   |-value: Struct
   // CHECK-NEXT:  |   | |-base: Struct
   // CHECK-NEXT:  |   | | `-fields: Int 0, Union .j Int 0
@@ -96,7 +96,7 @@ void Test() {
   // CHECK-NEXT:  |   | `-fields: Int 4, Int 5, Int 6
 
   constexpr S5 s5{};
-  // CHECK:    `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s5 'const S5':'const S5' constexpr listinit
+  // CHECK:    `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} s5 'const S5' constexpr listinit
   // CHECK-NEXT:      |-value: Struct
   // CHECK-NEXT:      | |-base: Struct
   // CHECK-NEXT:      | | |-base: Struct

--- a/clang/test/AST/ast-dump-APValue-union.cpp
+++ b/clang/test/AST/ast-dump-APValue-union.cpp
@@ -39,25 +39,25 @@ union U3 {
 
 void Test() {
   constexpr U0 u0{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u0 'const U0':'const U0' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u0 'const U0' constexpr listinit
   // CHECK-NEXT:  |   |-value: Union .i Int 42
 
   constexpr U1 u1{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u1 'const U1':'const U1' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u1 'const U1' constexpr listinit
   // CHECK-NEXT:  |   |-value: Union .uinner Union .f Float 3.141500e+00
 
   constexpr U2 u2{};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u2 'const U2':'const U2' constexpr listinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u2 'const U2' constexpr listinit
   // CHECK-NEXT:  |   |-value: Union .uinner
   // CHECK-NEXT:  |   | `-Union .arr
   // CHECK-NEXT:  |   |   `-Array size=2
   // CHECK-NEXT:  |   |     `-elements: Int 1, Int 2
 
   constexpr U3 u3a = {.f = 3.1415};
-  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u3a 'const U3':'const U3' constexpr cinit
+  // CHECK:  | `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u3a 'const U3' constexpr cinit
   // CHECK-NEXT:  |   |-value: Union .f Float 3.141500e+00
 
   constexpr U3 u3b = {.uinner = {}};
-  // CHECK:    `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u3b 'const U3':'const U3' constexpr cinit
+  // CHECK:    `-VarDecl {{.*}} <col:{{.*}}, col:{{.*}}> col:{{.*}} u3b 'const U3' constexpr cinit
   // CHECK-NEXT:      |-value: Union .uinner Union .d Float 3.141500e+00
 }

--- a/clang/test/AST/ast-dump-attr.cpp
+++ b/clang/test/AST/ast-dump-attr.cpp
@@ -146,17 +146,17 @@ struct C { char a[16]; };
 // CHECK: ClassTemplateSpecializationDecl {{.*}} struct my_union
 // CHECK: CXXRecordDecl {{.*}} implicit struct my_union
 // CHECK: FieldDecl {{.*}} buffer 'char[1024]'
-// CHECK-NEXT: AlignedAttr {{.*}} alignas 'TestAligns::A':'TestAligns::A'
-// CHECK-NEXT: AlignedAttr {{.*}} alignas 'TestAligns::B':'TestAligns::B'
-// CHECK-NEXT: AlignedAttr {{.*}} alignas 'TestAligns::C':'TestAligns::C'
+// CHECK-NEXT: AlignedAttr {{.*}} alignas 'TestAligns::A'
+// CHECK-NEXT: AlignedAttr {{.*}} alignas 'TestAligns::B'
+// CHECK-NEXT: AlignedAttr {{.*}} alignas 'TestAligns::C'
 my_union<A, B, C> my_union_val;
 
 // CHECK: ClassTemplateSpecializationDecl {{.*}} struct my_union2
 // CHECK: CXXRecordDecl {{.*}} implicit struct my_union2
 // CHECK: FieldDecl {{.*}} buffer 'char[1024]'
-// CHECK-NEXT: AlignedAttr {{.*}} _Alignas 'TestAligns::A':'TestAligns::A'
-// CHECK-NEXT: AlignedAttr {{.*}} _Alignas 'TestAligns::B':'TestAligns::B'
-// CHECK-NEXT: AlignedAttr {{.*}} _Alignas 'TestAligns::C':'TestAligns::C'
+// CHECK-NEXT: AlignedAttr {{.*}} _Alignas 'TestAligns::A'
+// CHECK-NEXT: AlignedAttr {{.*}} _Alignas 'TestAligns::B'
+// CHECK-NEXT: AlignedAttr {{.*}} _Alignas 'TestAligns::C'
 my_union2<A, B, C> my_union2_val;
 
 } // namespace TestAligns

--- a/clang/test/AST/ast-dump-decl-json.c
+++ b/clang/test/AST/ast-dump-decl-json.c
@@ -1351,7 +1351,6 @@ void testParmVarDecl(int TestParmVarDecl);
 // CHECK-NEXT:    "isUsed": true,
 // CHECK-NEXT:    "name": "x",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "enum Enum",
 // CHECK-NEXT:     "qualType": "enum Enum"
 // CHECK-NEXT:    }
 // CHECK-NEXT:   },
@@ -1424,7 +1423,6 @@ void testParmVarDecl(int TestParmVarDecl);
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "enum Enum",
 // CHECK-NEXT:           "qualType": "enum Enum"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -1446,7 +1444,6 @@ void testParmVarDecl(int TestParmVarDecl);
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "enum Enum",
 // CHECK-NEXT:             "qualType": "enum Enum"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -1455,7 +1452,6 @@ void testParmVarDecl(int TestParmVarDecl);
 // CHECK-NEXT:             "kind": "ParmVarDecl",
 // CHECK-NEXT:             "name": "x",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "enum Enum",
 // CHECK-NEXT:              "qualType": "enum Enum"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }

--- a/clang/test/AST/ast-dump-decl-json.m
+++ b/clang/test/AST/ast-dump-decl-json.m
@@ -911,7 +911,6 @@ void f(void) {
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "name": "T",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "id",
 // CHECK-NEXT:     "qualType": "id",
 // CHECK-NEXT:     "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:    }

--- a/clang/test/AST/ast-dump-decl.cpp
+++ b/clang/test/AST/ast-dump-decl.cpp
@@ -248,19 +248,19 @@ namespace testFunctionTemplateDecl {
   // CHECK-NEXT:  | |-TemplateArgument type 'testFunctionTemplateDecl::A'
   // CHECK-NEXT:  | | `-RecordType 0{{.+}} 'testFunctionTemplateDecl::A'
   // CHECK-NEXT:  | |   `-CXXRecord 0x{{.+}} 'A'
-  // CHECK-NEXT:  | |-ParmVarDecl 0x{{.+}} <col:50> col:51 'testFunctionTemplateDecl::A':'testFunctionTemplateDecl::A'
+  // CHECK-NEXT:  | |-ParmVarDecl 0x{{.+}} <col:50> col:51 'testFunctionTemplateDecl::A'
   // CHECK-NEXT:  | `-CompoundStmt 0x{{.+}} <col:53, col:55>
   // CHECK-NEXT:  |-Function 0x{{.+}} 'TestFunctionTemplate' 'void (B)'
   // CHECK-NEXT:  |-FunctionDecl 0x{{.+}} <col:24, col:55> col:29 TestFunctionTemplate 'void (testFunctionTemplateDecl::C)'
   // CHECK-NEXT:  | |-TemplateArgument type 'testFunctionTemplateDecl::C'
   // CHECK-NEXT:  | | `-RecordType 0{{.+}} 'testFunctionTemplateDecl::C'
   // CHECK-NEXT:  | |   `-CXXRecord 0x{{.+}} 'C'
-  // CHECK-NEXT:  | `-ParmVarDecl 0x{{.+}} <col:50> col:51 'testFunctionTemplateDecl::C':'testFunctionTemplateDecl::C'
+  // CHECK-NEXT:  | `-ParmVarDecl 0x{{.+}} <col:50> col:51 'testFunctionTemplateDecl::C'
   // CHECK-NEXT:  `-FunctionDecl 0x{{.+}} <col:24, col:55> col:29 TestFunctionTemplate 'void (testFunctionTemplateDecl::D)'
   // CHECK-NEXT:    |-TemplateArgument type 'testFunctionTemplateDecl::D'
   // CHECK-NEXT:    | `-RecordType 0{{.+}} 'testFunctionTemplateDecl::D'
   // CHECK-NEXT:    |   `-CXXRecord 0x{{.+}} 'D'
-  // CHECK-NEXT:    |-ParmVarDecl 0x{{.+}} <col:50> col:51 'testFunctionTemplateDecl::D':'testFunctionTemplateDecl::D'
+  // CHECK-NEXT:    |-ParmVarDecl 0x{{.+}} <col:50> col:51 'testFunctionTemplateDecl::D'
   // CHECK-NEXT:    `-CompoundStmt 0x{{.+}} <col:53, col:55>
 
   // CHECK:       FunctionDecl 0x{{.+}} prev 0x{{.+}} <{{.+}}:[[@LINE-32]]:3, col:41> col:19 TestFunctionTemplate 'void (B)'
@@ -500,7 +500,7 @@ namespace testCanonicalTemplate {
   // CHECK-NEXT:     |-TemplateArgument type 'testCanonicalTemplate::A'{{$}}
   // CHECK-NEXT:     | `-RecordType 0x{{.+}} 'testCanonicalTemplate::A'{{$}}
   // CHECK-NEXT:     |   `-CXXRecord 0x{{.+}} 'A'{{$}}
-  // CHECK-NEXT:     `-ParmVarDecl 0x{{.*}} <col:50> col:51 'testCanonicalTemplate::A':'testCanonicalTemplate::A'{{$}}
+  // CHECK-NEXT:     `-ParmVarDecl 0x{{.*}} <col:50> col:51 'testCanonicalTemplate::A'{{$}}
 
   // CHECK:      FunctionTemplateDecl 0x{{.+}} prev 0x{{.+}} <{{.+}}:[[@LINE-12]]:3, col:51> col:29 TestFunctionTemplate{{$}}
   // CHECK-NEXT:   |-TemplateTypeParmDecl 0x{{.+}} <col:12, col:21> col:21 referenced typename depth 0 index 0 T{{$}}
@@ -613,15 +613,15 @@ namespace testCanonicalTemplate {
   // CHECK:      VarTemplateDecl 0x{{.+}} <{{.+}}:[[@LINE-11]]:7, col:43> col:43 TestVarTemplate{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <col:16, col:25> col:25 referenced typename depth 0 index 0 T{{$}}
   // CHECK-NEXT: |-VarDecl 0x{{.+}} <col:28, col:43> col:43 TestVarTemplate 'const T' static{{$}}
-  // CHECK-NEXT: |-VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <line:[[@LINE-11]]:3, col:34> col:14 referenced TestVarTemplate 'const int':'const int' implicit_instantiation cinit{{$}}
+  // CHECK-NEXT: |-VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <line:[[@LINE-11]]:3, col:34> col:14 referenced TestVarTemplate 'const int' implicit_instantiation cinit{{$}}
   // CHECK-NEXT: | |-NestedNameSpecifier TypeSpec 'testCanonicalTemplate::S'{{$}}
   // CHECK-NEXT: | |-TemplateArgument type 'int'{{$}}
   // CHECK-NEXT: | | `-BuiltinType 0x{{.+}} 'int'{{$}}
-  // CHECK-NEXT: | `-InitListExpr 0x{{.+}} <col:32, col:34> 'int':'int'{{$}}
-  // CHECK-NEXT: `-VarTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-19]]:28, col:43> col:43 referenced TestVarTemplate 'const int':'const int' implicit_instantiation static{{$}}
+  // CHECK-NEXT: | `-InitListExpr 0x{{.+}} <col:32, col:34> 'int'{{$}}
+  // CHECK-NEXT: `-VarTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-19]]:28, col:43> col:43 referenced TestVarTemplate 'const int' implicit_instantiation static{{$}}
   // CHECK-NEXT:   `-TemplateArgument type 'int'{{$}}
 
-  // CHECK:     VarTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-22]]:28, col:43> col:43 referenced TestVarTemplate 'const int':'const int' implicit_instantiation static{{$}}
+  // CHECK:     VarTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-22]]:28, col:43> col:43 referenced TestVarTemplate 'const int' implicit_instantiation static{{$}}
   // CHECK-NEXT:`-TemplateArgument type 'int'{{$}}
   // CHECK-NEXT:  `-BuiltinType 0x{{.+}} 'int'{{$}}
 
@@ -630,14 +630,14 @@ namespace testCanonicalTemplate {
   // CHECK-NEXT: |-VarDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <line:[[@LINE-25]]:3, col:34> col:14 TestVarTemplate 'const T' cinit{{$}}
   // CHECK-NEXT: | |-NestedNameSpecifier TypeSpec 'testCanonicalTemplate::S'{{$}}
   // CHECK-NEXT: | `-InitListExpr 0x{{.+}} <col:32, col:34> 'void'{{$}}
-  // CHECK-NEXT: |-VarTemplateSpecialization 0x{{.+}} 'TestVarTemplate' 'const int':'const int'{{$}}
-  // CHECK-NEXT: `-VarTemplateSpecialization 0x{{.+}} 'TestVarTemplate' 'const int':'const int'{{$}}
+  // CHECK-NEXT: |-VarTemplateSpecialization 0x{{.+}} 'TestVarTemplate' 'const int'{{$}}
+  // CHECK-NEXT: `-VarTemplateSpecialization 0x{{.+}} 'TestVarTemplate' 'const int'{{$}}
     
-  // CHECK:      VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <{{.+}}:[[@LINE-31]]:3, col:34> col:14 referenced TestVarTemplate 'const int':'const int' implicit_instantiation cinit{{$}}
+  // CHECK:      VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <{{.+}}:[[@LINE-31]]:3, col:34> col:14 referenced TestVarTemplate 'const int' implicit_instantiation cinit{{$}}
   // CHECK-NEXT: |-NestedNameSpecifier TypeSpec 'testCanonicalTemplate::S'{{$}}
   // CHECK-NEXT: |-TemplateArgument type 'int'{{$}}
   // CHECK-NEXT: | `-BuiltinType 0x{{.+}} 'int'{{$}}
-  // CHECK-NEXT: `-InitListExpr 0x{{.+}} <col:32, col:34> 'int':'int'{{$}}
+  // CHECK-NEXT: `-InitListExpr 0x{{.+}} <col:32, col:34> 'int'{{$}}
 } 
 
 template <class T>
@@ -856,7 +856,7 @@ namespace TestConstexprVariableTemplateWithInitializer {
   inline constexpr in_place_type_t<_Tp> in_place_type{};
   // CHECK:     -VarTemplateDecl 0x{{.+}} <line:[[@LINE-2]]:3, line:[[@LINE-1]]:55> col:41 in_place_type{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <line:[[@LINE-3]]:13, col:22> col:22 referenced typename depth 0 index 0 _Tp{{$}}
-  // CHECK-NEXT: `-VarDecl 0x{{.+}} <line:[[@LINE-3]]:3, col:55> col:41 in_place_type 'const in_place_type_t<_Tp>':'const in_place_type_t<_Tp>' inline constexpr listinit{{$}}
+  // CHECK-NEXT: `-VarDecl 0x{{.+}} <line:[[@LINE-3]]:3, col:55> col:41 in_place_type 'const in_place_type_t<_Tp>' inline constexpr listinit{{$}}
   // CHECK-NEXT:  `-InitListExpr 0x{{.+}} <col:54, col:55> 'void'{{$}}
 
   template <typename T> constexpr T call_init(0);

--- a/clang/test/AST/ast-dump-decl.m
+++ b/clang/test/AST/ast-dump-decl.m
@@ -94,7 +94,7 @@
 // CHECK:      ObjCInterfaceDecl{{.*}} TestGenericInterface
 // CHECK-NEXT:   -super ObjCInterface {{.+}} 'A'
 // CHECK-NEXT:   -ObjCProtocol {{.+}} 'P'
-// CHECK-NEXT:   -ObjCTypeParamDecl {{.+}} <col:33> col:33 T 'id':'id'
+// CHECK-NEXT:   -ObjCTypeParamDecl {{.+}} <col:33> col:33 T 'id'
 
 @implementation TestObjCClass (TestObjCCategoryDecl)
 - (void) bar {

--- a/clang/test/AST/ast-dump-expr-json.c
+++ b/clang/test/AST/ast-dump-expr-json.c
@@ -4080,7 +4080,6 @@ void PrimaryExpressions(int a) {
 // CHECK-NEXT:    "isUsed": true,
 // CHECK-NEXT:    "name": "b",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "struct S",
 // CHECK-NEXT:     "qualType": "struct S"
 // CHECK-NEXT:    }
 // CHECK-NEXT:   },
@@ -4530,7 +4529,6 @@ void PrimaryExpressions(int a) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "struct S",
 // CHECK-NEXT:           "qualType": "struct S"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -4539,7 +4537,6 @@ void PrimaryExpressions(int a) {
 // CHECK-NEXT:           "kind": "ParmVarDecl",
 // CHECK-NEXT:           "name": "b",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "struct S",
 // CHECK-NEXT:            "qualType": "struct S"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -4817,7 +4814,6 @@ void PrimaryExpressions(int a) {
 // CHECK-NEXT:       }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "struct S",
 // CHECK-NEXT:       "qualType": "struct S"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "valueCategory": "prvalue",
@@ -4839,7 +4835,6 @@ void PrimaryExpressions(int a) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "struct S",
 // CHECK-NEXT:         "qualType": "struct S"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "lvalue",
@@ -4860,7 +4855,6 @@ void PrimaryExpressions(int a) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "struct S",
 // CHECK-NEXT:           "qualType": "struct S"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",

--- a/clang/test/AST/ast-dump-expr-json.cpp
+++ b/clang/test/AST/ast-dump-expr-json.cpp
@@ -325,7 +325,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:    "isUsed": true,
 // CHECK-NEXT:    "name": "obj1",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "S",
 // CHECK-NEXT:     "qualType": "S"
 // CHECK-NEXT:    }
 // CHECK-NEXT:   },
@@ -462,7 +461,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "S",
 // CHECK-NEXT:         "qualType": "S"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "lvalue",
@@ -471,7 +469,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:         "kind": "ParmVarDecl",
 // CHECK-NEXT:         "name": "obj1",
 // CHECK-NEXT:         "type": {
-// CHECK-NEXT:          "desugaredQualType": "S",
 // CHECK-NEXT:          "qualType": "S"
 // CHECK-NEXT:         }
 // CHECK-NEXT:        }
@@ -733,7 +730,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "S",
 // CHECK-NEXT:             "qualType": "S"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -742,7 +738,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             "kind": "ParmVarDecl",
 // CHECK-NEXT:             "name": "obj1",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "S",
 // CHECK-NEXT:              "qualType": "S"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -2539,7 +2534,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:    "isUsed": true,
 // CHECK-NEXT:    "name": "a",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "S",
 // CHECK-NEXT:     "qualType": "S"
 // CHECK-NEXT:    }
 // CHECK-NEXT:   },
@@ -2672,7 +2666,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "S",
 // CHECK-NEXT:           "qualType": "S"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -2681,7 +2674,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           "kind": "ParmVarDecl",
 // CHECK-NEXT:           "name": "a",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "S",
 // CHECK-NEXT:            "qualType": "S"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -2848,7 +2840,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:       }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "int",
 // CHECK-NEXT:       "qualType": "int"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "valueCategory": "prvalue",
@@ -2948,7 +2939,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:       }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "float",
 // CHECK-NEXT:       "qualType": "float"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "valueCategory": "prvalue",
@@ -2992,7 +2982,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "S",
 // CHECK-NEXT:           "qualType": "S"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -3001,7 +2990,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           "kind": "ParmVarDecl",
 // CHECK-NEXT:           "name": "a",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "S",
 // CHECK-NEXT:            "qualType": "S"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -3169,7 +3157,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "S",
 // CHECK-NEXT:           "qualType": "S"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -3178,7 +3165,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           "kind": "ParmVarDecl",
 // CHECK-NEXT:           "name": "a",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "S",
 // CHECK-NEXT:            "qualType": "S"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -3247,7 +3233,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "S",
 // CHECK-NEXT:           "qualType": "S"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -3256,7 +3241,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           "kind": "ParmVarDecl",
 // CHECK-NEXT:           "name": "a",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "S",
 // CHECK-NEXT:            "qualType": "S"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -3500,7 +3484,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "S",
 // CHECK-NEXT:         "qualType": "S"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "lvalue",
@@ -3509,7 +3492,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:         "kind": "ParmVarDecl",
 // CHECK-NEXT:         "name": "a",
 // CHECK-NEXT:         "type": {
-// CHECK-NEXT:          "desugaredQualType": "S",
 // CHECK-NEXT:          "qualType": "S"
 // CHECK-NEXT:         }
 // CHECK-NEXT:        }
@@ -3537,7 +3519,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "valueCategory": "lvalue",
 // CHECK-NEXT:      "typeArg": {
-// CHECK-NEXT:       "desugaredQualType": "S",
 // CHECK-NEXT:       "qualType": "S"
 // CHECK-NEXT:      }
 // CHECK-NEXT:     },
@@ -3562,11 +3543,9 @@ void TestNonADLCall3() {
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "valueCategory": "lvalue",
 // CHECK-NEXT:      "typeArg": {
-// CHECK-NEXT:       "desugaredQualType": "const volatile S",
 // CHECK-NEXT:       "qualType": "const volatile S"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "adjustedTypeArg": {
-// CHECK-NEXT:       "desugaredQualType": "S",
 // CHECK-NEXT:       "qualType": "S"
 // CHECK-NEXT:      }
 // CHECK-NEXT:     }
@@ -6591,7 +6570,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "isImplicit": true,
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "int",
 // CHECK-NEXT:             "qualType": "int"
 // CHECK-NEXT:            }
 // CHECK-NEXT:           }
@@ -7858,7 +7836,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:        "isUsed": true,
 // CHECK-NEXT:        "name": "x",
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "NS::X",
 // CHECK-NEXT:         "qualType": "NS::X"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "init": "call",
@@ -7879,7 +7856,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "NS::X",
 // CHECK-NEXT:           "qualType": "NS::X"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -8030,7 +8006,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "NS::X",
 // CHECK-NEXT:             "qualType": "NS::X"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -8039,7 +8014,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "x",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "NS::X",
 // CHECK-NEXT:              "qualType": "NS::X"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -8139,7 +8113,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "NS::X",
 // CHECK-NEXT:         "qualType": "NS::X"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "prvalue",
@@ -8187,7 +8160,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "NS::X",
 // CHECK-NEXT:             "qualType": "NS::X"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -8196,7 +8168,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "x",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "NS::X",
 // CHECK-NEXT:              "qualType": "NS::X"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -8299,7 +8270,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:        "isUsed": true,
 // CHECK-NEXT:        "name": "x",
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "NS::X",
 // CHECK-NEXT:         "qualType": "NS::X"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "init": "call",
@@ -8320,7 +8290,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "NS::X",
 // CHECK-NEXT:           "qualType": "NS::X"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -8470,7 +8439,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "NS::X",
 // CHECK-NEXT:             "qualType": "NS::X"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -8479,7 +8447,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "x",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "NS::X",
 // CHECK-NEXT:              "qualType": "NS::X"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -8582,7 +8549,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:        "isUsed": true,
 // CHECK-NEXT:        "name": "x",
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "NS::X",
 // CHECK-NEXT:         "qualType": "NS::X"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "init": "call",
@@ -8603,7 +8569,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "NS::X",
 // CHECK-NEXT:           "qualType": "NS::X"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -8799,7 +8764,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "NS::X",
 // CHECK-NEXT:             "qualType": "NS::X"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -8808,7 +8772,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "x",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "NS::X",
 // CHECK-NEXT:              "qualType": "NS::X"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -8908,7 +8871,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "NS::X",
 // CHECK-NEXT:         "qualType": "NS::X"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "prvalue",
@@ -8956,7 +8918,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "NS::X",
 // CHECK-NEXT:             "qualType": "NS::X"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -8965,7 +8926,6 @@ void TestNonADLCall3() {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "x",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "NS::X",
 // CHECK-NEXT:              "qualType": "NS::X"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }

--- a/clang/test/AST/ast-dump-expr-json.m
+++ b/clang/test/AST/ast-dump-expr-json.m
@@ -764,7 +764,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:    "isUsed": true,
 // CHECK-NEXT:    "name": "Obj",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "id",
 // CHECK-NEXT:     "qualType": "id",
 // CHECK-NEXT:     "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:    }
@@ -825,7 +824,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "id",
 // CHECK-NEXT:         "qualType": "id",
 // CHECK-NEXT:         "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:        },
@@ -848,7 +846,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -858,7 +855,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           "kind": "ParmVarDecl",
 // CHECK-NEXT:           "name": "Obj",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "id",
 // CHECK-NEXT:            "qualType": "id",
 // CHECK-NEXT:            "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:           }
@@ -2036,7 +2032,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:       }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "id",
 // CHECK-NEXT:       "qualType": "id",
 // CHECK-NEXT:       "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:      },
@@ -2468,7 +2463,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "id",
 // CHECK-NEXT:         "qualType": "id",
 // CHECK-NEXT:         "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:        },
@@ -2490,7 +2484,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -2678,7 +2671,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -2700,7 +2692,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "id",
 // CHECK-NEXT:             "qualType": "id",
 // CHECK-NEXT:             "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:            },
@@ -2864,7 +2855,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:        "isUsed": true,
 // CHECK-NEXT:        "name": "i",
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "id",
 // CHECK-NEXT:         "qualType": "id",
 // CHECK-NEXT:         "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:        },
@@ -2886,7 +2876,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -3163,7 +3152,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "id",
 // CHECK-NEXT:             "qualType": "id",
 // CHECK-NEXT:             "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:            },
@@ -3312,7 +3300,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:       }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "id",
 // CHECK-NEXT:       "qualType": "id",
 // CHECK-NEXT:       "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:      },
@@ -3788,7 +3775,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "id",
 // CHECK-NEXT:         "qualType": "id",
 // CHECK-NEXT:         "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:        },
@@ -3810,7 +3796,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -3998,7 +3983,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -4020,7 +4004,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "id",
 // CHECK-NEXT:             "qualType": "id",
 // CHECK-NEXT:             "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:            },
@@ -4113,7 +4096,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -4208,7 +4190,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:       }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "id",
 // CHECK-NEXT:       "qualType": "id",
 // CHECK-NEXT:       "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:      },
@@ -4231,7 +4212,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "id",
 // CHECK-NEXT:         "qualType": "id",
 // CHECK-NEXT:         "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:        },
@@ -4241,7 +4221,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:         "kind": "VarDecl",
 // CHECK-NEXT:         "name": "i",
 // CHECK-NEXT:         "type": {
-// CHECK-NEXT:          "desugaredQualType": "id",
 // CHECK-NEXT:          "qualType": "id",
 // CHECK-NEXT:          "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:         }
@@ -4263,7 +4242,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "id",
 // CHECK-NEXT:         "qualType": "id",
 // CHECK-NEXT:         "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:        },
@@ -4584,7 +4562,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "id",
 // CHECK-NEXT:           "qualType": "id",
 // CHECK-NEXT:           "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:          },
@@ -4681,7 +4658,6 @@ void TestObjCBoolLiteral(void) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "id",
 // CHECK-NEXT:             "qualType": "id",
 // CHECK-NEXT:             "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:            },

--- a/clang/test/AST/ast-dump-expr.c
+++ b/clang/test/AST/ast-dump-expr.c
@@ -259,7 +259,7 @@ void PostfixOperators(int *a, struct S b, struct S *c) {
   b.a;
   // CHECK: ImplicitCastExpr
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:3, col:5> 'int' lvalue .a 0x{{[^ ]*}}
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'struct S':'struct S' lvalue ParmVar 0x{{[^ ]*}} 'b' 'struct S':'struct S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'struct S' lvalue ParmVar 0x{{[^ ]*}} 'b' 'struct S'
 
   c->a;
   // CHECK: ImplicitCastExpr
@@ -280,8 +280,8 @@ void PostfixOperators(int *a, struct S b, struct S *c) {
 
   (struct S){1};
   // CHECK: ImplicitCastExpr
-  // CHECK-NEXT: CompoundLiteralExpr 0x{{[^ ]*}} <col:3, col:15> 'struct S':'struct S' lvalue
-  // CHECK-NEXT: InitListExpr 0x{{[^ ]*}} <col:13, col:15> 'struct S':'struct S'
+  // CHECK-NEXT: CompoundLiteralExpr 0x{{[^ ]*}} <col:3, col:15> 'struct S' lvalue
+  // CHECK-NEXT: InitListExpr 0x{{[^ ]*}} <col:13, col:15> 'struct S'
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:14> 'int' 1
 }
 

--- a/clang/test/AST/ast-dump-expr.cpp
+++ b/clang/test/AST/ast-dump-expr.cpp
@@ -59,7 +59,7 @@ void Throw() {
 void PointerToMember(S obj1, S *obj2, int S::* data, void (S::*call)(int)) {
   obj1.*data;
   // CHECK: BinaryOperator 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:9> 'int' lvalue '.*'
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S':'S' lvalue ParmVar 0x{{[^ ]*}} 'obj1' 'S':'S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S' lvalue ParmVar 0x{{[^ ]*}} 'obj1' 'S'
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:9> 'int S::*' lvalue ParmVar 0x{{[^ ]*}} 'data' 'int S::*'
 
@@ -74,7 +74,7 @@ void PointerToMember(S obj1, S *obj2, int S::* data, void (S::*call)(int)) {
   // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:18> 'void'
   // CHECK-NEXT: ParenExpr 0x{{[^ ]*}} <col:3, col:14> '<bound member function type>'
   // CHECK-NEXT: BinaryOperator 0x{{[^ ]*}} <col:4, col:10> '<bound member function type>' '.*'
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:4> 'S':'S' lvalue ParmVar 0x{{[^ ]*}} 'obj1' 'S':'S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:4> 'S' lvalue ParmVar 0x{{[^ ]*}} 'obj1' 'S'
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:10> 'void (S::*)(int)' lvalue ParmVar 0x{{[^ ]*}} 'call' 'void (S::*)(int)'
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:16> 'int' 12
@@ -178,7 +178,7 @@ void PostfixExpressions(S a, S *p, U<int> *r) {
   a.func(0);
   // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:11> 'void'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:3, col:5> '<bound member function type>' .func 0x{{[^ ]*}}
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S':'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S':'S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S'
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:10> 'int' 0
 
   p->func(0);
@@ -190,16 +190,16 @@ void PostfixExpressions(S a, S *p, U<int> *r) {
 
   // FIXME: there is no mention that this used the template keyword.
   p->template foo<int>();
-  // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:24> 'int':'int'
+  // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:24> 'int'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:3, col:22> '<bound member function type>' ->foo 0x{{[^ ]*}}
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S *' lvalue ParmVar 0x{{[^ ]*}} 'p' 'S *'
 
   // FIXME: there is no mention that this used the template keyword.
   a.template foo<float>();
-  // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:25> 'float':'float'
+  // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:25> 'float'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:3, col:23> '<bound member function type>' .foo 0x{{[^ ]*}}
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S':'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S':'S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S'
 
   p->~S();
   // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:9> 'void'
@@ -210,14 +210,14 @@ void PostfixExpressions(S a, S *p, U<int> *r) {
   a.~S();
   // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:8> 'void'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:3, col:6> '<bound member function type>' .~S 0x{{[^ ]*}}
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S':'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S':'S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S'
 
   // FIXME: there seems to be no way to distinguish the construct below from
   // the construct above.
   a.~decltype(a)();
   // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:18> 'void'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:3, col:5> '<bound member function type>' .~S 0x{{[^ ]*}}
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S':'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S':'S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S'
 
   // FIXME: similarly, there is no way to distinguish the construct below from
   // the p->~S() case.
@@ -233,13 +233,13 @@ void PostfixExpressions(S a, S *p, U<int> *r) {
   r->template U<int>::~U();
   // CHECK: CXXMemberCallExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:26> 'void'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:3, col:24> '<bound member function type>' ->~U 0x{{[^ ]*}}
-  // CHECK-NEXT: NestedNameSpecifier TypeSpecWithTemplate 'U<int>':'U<int>'
+  // CHECK-NEXT: NestedNameSpecifier TypeSpecWithTemplate 'U<int>'
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:3> 'U<int> *' lvalue ParmVar 0x{{[^ ]*}} 'r' 'U<int> *'
 
   typeid(a);
   // CHECK: CXXTypeidExpr 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:11> 'const std::type_info' lvalue
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:10> 'S':'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S':'S'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:10> 'S' lvalue ParmVar 0x{{[^ ]*}} 'a' 'S'
 
   // FIXME: no type information is printed for the argument.
   typeid(S);
@@ -448,7 +448,7 @@ void PrimaryExpressions(Ts... a) {
   // CHECK-NEXT: CXXMethodDecl 0x{{[^ ]*}} <col:16, col:18> col:3 operator() 'auto () const -> auto' inline
   // CHECK-NEXT: CompoundStmt
   // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <col:4> col:4 implicit 'Ts...'
-  // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <col:10> col:10 implicit 'int':'int'
+  // CHECK-NEXT: FieldDecl 0x{{[^ ]*}} <col:10> col:10 implicit 'int'
   // CHECK-NEXT: ParenListExpr 0x{{[^ ]*}} <col:4> 'NULL TYPE'
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:4> 'Ts' lvalue ParmVar 0x{{[^ ]*}} 'a' 'Ts...'
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:14> 'int' 12

--- a/clang/test/AST/ast-dump-fpfeatures.cpp
+++ b/clang/test/AST/ast-dump-fpfeatures.cpp
@@ -140,7 +140,7 @@ float func_15(float x, float y) {
 // CHECK:         FunctionDecl {{.*}} func_14 'float (float, float)'
 // CHECK:           CompoundStmt
 // CHECK-NEXT:        ReturnStmt
-// CHECK-NEXT:          BinaryOperator {{.*}} 'float':'float' '+' ConstRoundingMode=towardzero
+// CHECK-NEXT:          BinaryOperator {{.*}} 'float' '+' ConstRoundingMode=towardzero
 
 float func_16(float x, float y) {
 #pragma STDC FENV_ROUND FE_TOWARDZERO

--- a/clang/test/AST/ast-dump-funcs.cpp
+++ b/clang/test/AST/ast-dump-funcs.cpp
@@ -32,7 +32,7 @@ struct S {
   // CHECK-NEXT: CXXCtorInitializer Field 0x{{[^ ]*}} 'j' 'int'
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:17> 'int' 0
   // CHECK-NEXT: CXXCtorInitializer Field 0x{{[^ ]*}} 'r' 'R'
-  // CHECK-NEXT: CXXConstructExpr 0x{{[^ ]*}} <col:3> 'R':'R' 'void () noexcept'
+  // CHECK-NEXT: CXXConstructExpr 0x{{[^ ]*}} <col:3> 'R' 'void () noexcept'
   // CHECK-NEXT: CompoundStmt 0x{{[^ ]*}} <col:20, col:21>
 
   void a();

--- a/clang/test/AST/ast-dump-functionprototype.cpp
+++ b/clang/test/AST/ast-dump-functionprototype.cpp
@@ -5,7 +5,7 @@ struct B {};
 
 typedef void (type1)() noexcept(10 > 5);
 
-// CHECK:      TypedefDecl {{.*}} type1 'void () noexcept(10 > 5)':'void () noexcept(10 > 5)'
+// CHECK:      TypedefDecl {{.*}} type1 'void () noexcept(10 > 5)'
 // CHECK-NEXT: `-ParenType {{.*}}
 // CHECK-NEXT:   `-FunctionProtoType {{.*}} 'void () noexcept(10 > 5)' exceptionspec_noexcept_true cdecl
 // CHECK-NEXT:     |-NoexceptExpr: ConstantExpr {{.*}} 'bool'
@@ -14,9 +14,9 @@ typedef void (type1)() noexcept(10 > 5);
 
 typedef void (type2)() throw(A, B);
 
-// CHECK:      TypedefDecl {{.*}} type2 'void () throw(A, B)':'void () throw(A, B)'
+// CHECK:      TypedefDecl {{.*}} type2 'void () throw(A, B)'
 // CHECK-NEXT: `-ParenType {{.*}}
 // CHECK-NEXT:   `-FunctionProtoType {{.*}} 'void () throw(A, B)' exceptionspec_dynamic cdecl
-// CHECK-NEXT:     |-Exceptions: 'A':'A', 'B':'B'
+// CHECK-NEXT:     |-Exceptions: 'A', 'B'
 // CHECK-NEXT:     `-BuiltinType {{.*}} 'void'
 

--- a/clang/test/AST/ast-dump-lambda.cpp
+++ b/clang/test/AST/ast-dump-lambda.cpp
@@ -229,7 +229,7 @@ template <typename... Ts> void test(Ts... a) {
 // CHECK-NEXT:    | | |-CXXMethodDecl {{.*}} <col:16, col:19> col:3{{( imported)?}} operator() 'auto () const -> auto' inline
 // CHECK-NEXT:    | | | `-CompoundStmt {{.*}} <col:18, col:19>
 // CHECK-NEXT:    | | |-FieldDecl {{.*}} <col:4> col:4{{( imported)?}} implicit 'Ts...'
-// CHECK-NEXT:    | | `-FieldDecl {{.*}} <col:10> col:10{{( imported)?}} implicit 'int':'int'
+// CHECK-NEXT:    | | `-FieldDecl {{.*}} <col:10> col:10{{( imported)?}} implicit 'int'
 // CHECK-NEXT:    | |-ParenListExpr {{.*}} <col:4> 'NULL TYPE'
 // CHECK-NEXT:    | | `-DeclRefExpr {{.*}} <col:4> 'Ts' lvalue ParmVar {{.*}} 'a' 'Ts...'
 // CHECK-NEXT:    | |-IntegerLiteral {{.*}} <col:14> 'int' 12

--- a/clang/test/AST/ast-dump-objc-arc-json.m
+++ b/clang/test/AST/ast-dump-objc-arc-json.m
@@ -22,7 +22,6 @@ id TestCompoundLiteral(id a) {
 // CHECK-NEXT:   }
 // CHECK-NEXT:  },
 // CHECK-NEXT:  "type": {
-// CHECK-NEXT:   "desugaredQualType": "id",
 // CHECK-NEXT:   "qualType": "id",
 // CHECK-NEXT:   "typeAliasDeclId": "0x{{.*}}"
 // CHECK-NEXT:  },

--- a/clang/test/AST/ast-dump-openmp-begin-declare-variant_reference.cpp
+++ b/clang/test/AST/ast-dump-openmp-begin-declare-variant_reference.cpp
@@ -121,7 +121,7 @@ int test(float &&f, short &&s) {
 // CHECK-NEXT: | | | `-LValueReferenceType [[ADDR_7:0x[a-z0-9]*]] 'float &'
 // CHECK-NEXT: | | |   `-BuiltinType [[ADDR_8:0x[a-z0-9]*]] 'float'
 // CHECK-NEXT: | | |-CXXRecordDecl [[ADDR_9:0x[a-z0-9]*]] <col:22, col:29> col:29 implicit struct remove_reference
-// CHECK-NEXT: | | `-TypedefDecl [[ADDR_10:0x[a-z0-9]*]] <col:55, col:67> col:67 referenced type 'float':'float'
+// CHECK-NEXT: | | `-TypedefDecl [[ADDR_10:0x[a-z0-9]*]] <col:55, col:67> col:67 referenced type 'float'
 // CHECK-NEXT: | |   `-SubstTemplateTypeParmType [[ADDR_11:0x[a-z0-9]*]] 'float' sugar class depth 0 index 0 _Tp
 // CHECK-NEXT: | |     |-ClassTemplateSpecialization [[ADDR_6]] 'remove_reference'
 // CHECK-NEXT: | |     `-BuiltinType [[ADDR_8]] 'float'
@@ -137,7 +137,7 @@ int test(float &&f, short &&s) {
 // CHECK-NEXT: |   | `-LValueReferenceType [[ADDR_15:0x[a-z0-9]*]] 'short &'
 // CHECK-NEXT: |   |   `-BuiltinType [[ADDR_16:0x[a-z0-9]*]] 'short'
 // CHECK-NEXT: |   |-CXXRecordDecl [[ADDR_17:0x[a-z0-9]*]] <col:22, col:29> col:29 implicit struct remove_reference
-// CHECK-NEXT: |   `-TypedefDecl [[ADDR_18:0x[a-z0-9]*]] <col:55, col:67> col:67 referenced type 'short':'short'
+// CHECK-NEXT: |   `-TypedefDecl [[ADDR_18:0x[a-z0-9]*]] <col:55, col:67> col:67 referenced type 'short'
 // CHECK-NEXT: |     `-SubstTemplateTypeParmType [[ADDR_19:0x[a-z0-9]*]] 'short' sugar class depth 0 index 0 _Tp
 // CHECK-NEXT: |       |-ClassTemplateSpecialization [[ADDR_14]] 'remove_reference'
 // CHECK-NEXT: |       `-BuiltinType [[ADDR_16]] 'short'

--- a/clang/test/AST/ast-dump-openmp-begin-declare-variant_template_1.cpp
+++ b/clang/test/AST/ast-dump-openmp-begin-declare-variant_template_1.cpp
@@ -124,14 +124,14 @@ int test() {
 // CHECK-NEXT: |         |-CallExpr [[ADDR_63:0x[a-z0-9]*]] <col:10, col:25> 'int'
 // CHECK-NEXT: |         | |-ImplicitCastExpr [[ADDR_64:0x[a-z0-9]*]] <col:10> 'int (*)(double)' <FunctionToPointerDecay>
 // CHECK-NEXT: |         | | `-DeclRefExpr [[ADDR_65:0x[a-z0-9]*]] <col:10> 'int (double)' {{.*}}Function [[ADDR_44]] 'also_after' 'int (double)'
-// CHECK-NEXT: |         | `-CXXFunctionalCastExpr [[ADDR_66:0x[a-z0-9]*]] <col:21, col:24> 'double':'double' functional cast to double <NoOp>
-// CHECK-NEXT: |         |   `-ImplicitCastExpr [[ADDR_67:0x[a-z0-9]*]] <col:23> 'double':'double' <IntegralToFloating> part_of_explicit_cast
+// CHECK-NEXT: |         | `-CXXFunctionalCastExpr [[ADDR_66:0x[a-z0-9]*]] <col:21, col:24> 'double' functional cast to double <NoOp>
+// CHECK-NEXT: |         |   `-ImplicitCastExpr [[ADDR_67:0x[a-z0-9]*]] <col:23> 'double' <IntegralToFloating> part_of_explicit_cast
 // CHECK-NEXT: |         |     `-IntegerLiteral [[ADDR_58]] <col:23> 'int' 0
 // CHECK-NEXT: |         `-CallExpr [[ADDR_68:0x[a-z0-9]*]] <line:16:1, line:39:25> 'int'
 // CHECK-NEXT: |           |-ImplicitCastExpr [[ADDR_69:0x[a-z0-9]*]] <line:16:1> 'int (*)(double)' <FunctionToPointerDecay>
 // CHECK-NEXT: |           | `-DeclRefExpr [[ADDR_25]] <col:1> 'int (double)' Function [[ADDR_26]] 'also_after[implementation={vendor(llvm)}]' 'int (double)'
-// CHECK-NEXT: |           `-CXXFunctionalCastExpr [[ADDR_66]] <line:39:21, col:24> 'double':'double' functional cast to double <NoOp>
-// CHECK-NEXT: |             `-ImplicitCastExpr [[ADDR_67]] <col:23> 'double':'double' <IntegralToFloating> part_of_explicit_cast
+// CHECK-NEXT: |           `-CXXFunctionalCastExpr [[ADDR_66]] <line:39:21, col:24> 'double' functional cast to double <NoOp>
+// CHECK-NEXT: |             `-ImplicitCastExpr [[ADDR_67]] <col:23> 'double' <IntegralToFloating> part_of_explicit_cast
 // CHECK-NEXT: |               `-IntegerLiteral [[ADDR_58]] <col:23> 'int' 0
 // CHECK-NEXT: |-TypedefDecl [[ADDR_70:0x[a-z0-9]*]] <line:42:1, col:18> col:14 referenced Ty 'int (*)({{.*}})'
 // CHECK-NEXT: | `-PointerType [[ADDR_71:0x[a-z0-9]*]] 'int (*)({{.*}})'

--- a/clang/test/AST/ast-dump-openmp-begin-declare-variant_template_2.cpp
+++ b/clang/test/AST/ast-dump-openmp-begin-declare-variant_template_2.cpp
@@ -66,7 +66,7 @@ int test() {
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_10:0x[a-z0-9]*]] <line:5:1, line:7:1> line:5:5 used also_before 'int (double)'
 // CHECK-NEXT: |   |-TemplateArgument type 'double'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_11:0x[a-z0-9]*]] 'double'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_12:0x[a-z0-9]*]] <col:17> col:18 'double':'double'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_12:0x[a-z0-9]*]] <col:17> col:18 'double'
 // CHECK-NEXT: |   |-CompoundStmt [[ADDR_13:0x[a-z0-9]*]] <col:20, line:7:1>
 // CHECK-NEXT: |   | `-ReturnStmt [[ADDR_14:0x[a-z0-9]*]] <line:6:3, col:10>
 // CHECK-NEXT: |   |   `-IntegerLiteral [[ADDR_6]] <col:10> 'int' 1
@@ -97,7 +97,7 @@ int test() {
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_17]] <line:18:1, line:20:1> line:18:1 also_before[implementation={extension(allow_templates)}] 'int (double)'
 // CHECK-NEXT: |   |-TemplateArgument type 'double'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_11]] 'double'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_37:0x[a-z0-9]*]] <col:17> col:18 'double':'double'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_37:0x[a-z0-9]*]] <col:17> col:18 'double'
 // CHECK-NEXT: |   `-CompoundStmt [[ADDR_38:0x[a-z0-9]*]] <col:20, line:20:1>
 // CHECK-NEXT: |     `-ReturnStmt [[ADDR_39:0x[a-z0-9]*]] <line:19:3, col:10>
 // CHECK-NEXT: |       `-IntegerLiteral [[ADDR_36]] <col:10> 'int' 0
@@ -110,7 +110,7 @@ int test() {
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_47:0x[a-z0-9]*]] <line:44:1, line:46:1> line:44:5 used also_after 'int (char)'
 // CHECK-NEXT: |   |-TemplateArgument type 'char'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_48:0x[a-z0-9]*]] 'char'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_49:0x[a-z0-9]*]] <col:16> col:17 'char':'char'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_49:0x[a-z0-9]*]] <col:16> col:17 'char'
 // CHECK-NEXT: |   |-CompoundStmt [[ADDR_50:0x[a-z0-9]*]] <col:19, line:46:1>
 // CHECK-NEXT: |   | `-ReturnStmt [[ADDR_51:0x[a-z0-9]*]] <line:45:3, col:10>
 // CHECK-NEXT: |   |   `-IntegerLiteral [[ADDR_52:0x[a-z0-9]*]] <col:10> 'int' 6
@@ -126,7 +126,7 @@ int test() {
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_55]] <line:22:1, line:24:1> line:22:1 also_after[implementation={extension(allow_templates)}] 'int (char)'
 // CHECK-NEXT: |   |-TemplateArgument type 'char'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_48]] 'char'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_60:0x[a-z0-9]*]] <col:16> col:17 'char':'char'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_60:0x[a-z0-9]*]] <col:16> col:17 'char'
 // CHECK-NEXT: |   `-CompoundStmt [[ADDR_61:0x[a-z0-9]*]] <col:19, line:24:1>
 // CHECK-NEXT: |     `-ReturnStmt [[ADDR_62:0x[a-z0-9]*]] <line:23:3, col:10>
 // CHECK-NEXT: |       `-IntegerLiteral [[ADDR_59]] <col:10> 'int' 0
@@ -213,7 +213,7 @@ int test() {
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_128:0x[a-z0-9]*]] <line:48:1, line:50:1> line:48:5 used also_after_mismatch 'int (int)'
 // CHECK-NEXT: |   |-TemplateArgument type 'int'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_129:0x[a-z0-9]*]] 'int'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_130:0x[a-z0-9]*]] <col:25> col:26 'int':'int'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_130:0x[a-z0-9]*]] <col:25> col:26 'int'
 // CHECK-NEXT: |   `-CompoundStmt [[ADDR_131:0x[a-z0-9]*]] <col:28, line:50:1>
 // CHECK-NEXT: |     `-ReturnStmt [[ADDR_132:0x[a-z0-9]*]] <line:49:3, col:10>
 // CHECK-NEXT: |       `-IntegerLiteral [[ADDR_127]] <col:10> 'int' 0
@@ -244,12 +244,12 @@ int test() {
 // CHECK-NEXT:         | |   |-CallExpr [[ADDR_155:0x[a-z0-9]*]] <col:85, col:103> 'int'
 // CHECK-NEXT:         | |   | |-ImplicitCastExpr [[ADDR_156:0x[a-z0-9]*]] <col:85, col:100> 'int (*)(char)' <FunctionToPointerDecay>
 // CHECK-NEXT:         | |   | | `-DeclRefExpr [[ADDR_157:0x[a-z0-9]*]] <col:85, col:100> 'int (char)' {{.*}}Function [[ADDR_47]] 'also_after' 'int (char)' (FunctionTemplate [[ADDR_114]] 'also_after')
-// CHECK-NEXT:         | |   | `-ImplicitCastExpr [[ADDR_158:0x[a-z0-9]*]] <col:102> 'char':'char' <IntegralCast>
+// CHECK-NEXT:         | |   | `-ImplicitCastExpr [[ADDR_158:0x[a-z0-9]*]] <col:102> 'char' <IntegralCast>
 // CHECK-NEXT:         | |   |   `-IntegerLiteral [[ADDR_159:0x[a-z0-9]*]] <col:102> 'int' 0
 // CHECK-NEXT:         | |   `-CallExpr [[ADDR_160:0x[a-z0-9]*]] <line:22:1, line:54:103> 'int'
 // CHECK-NEXT:         | |     |-ImplicitCastExpr [[ADDR_161:0x[a-z0-9]*]] <line:22:1> 'int (*)(char)' <FunctionToPointerDecay>
 // CHECK-NEXT:         | |     | `-DeclRefExpr [[ADDR_54]] <col:1> 'int (char)' {{.*}}Function [[ADDR_55]] 'also_after[implementation={extension(allow_templates)}]' 'int (char)'
-// CHECK-NEXT:         | |     `-ImplicitCastExpr [[ADDR_162:0x[a-z0-9]*]] <line:54:102> 'char':'char' <IntegralCast>
+// CHECK-NEXT:         | |     `-ImplicitCastExpr [[ADDR_162:0x[a-z0-9]*]] <line:54:102> 'char' <IntegralCast>
 // CHECK-NEXT:         | |       `-IntegerLiteral [[ADDR_159]] <col:102> 'int' 0
 // CHECK-NEXT:         | `-CallExpr [[ADDR_163:0x[a-z0-9]*]] <col:107, col:128> 'int'
 // CHECK-NEXT:         |   |-ImplicitCastExpr [[ADDR_164:0x[a-z0-9]*]] <col:107> 'int (*)(int)' <FunctionToPointerDecay>

--- a/clang/test/AST/ast-dump-openmp-begin-declare-variant_template_3.cpp
+++ b/clang/test/AST/ast-dump-openmp-begin-declare-variant_template_3.cpp
@@ -97,14 +97,14 @@ int test() {
 // CHECK-NEXT: | |-FunctionDecl [[ADDR_32:0x[a-z0-9]*]] <line:10:1, line:12:1> line:10:5 used also_before 'int (int)'
 // CHECK-NEXT: | | |-TemplateArgument type 'int'
 // CHECK-NEXT: | | | `-BuiltinType [[ADDR_9]] 'int'
-// CHECK-NEXT: | | |-ParmVarDecl [[ADDR_33:0x[a-z0-9]*]] <col:17, col:19> col:19 s 'int':'int'
+// CHECK-NEXT: | | |-ParmVarDecl [[ADDR_33:0x[a-z0-9]*]] <col:17, col:19> col:19 s 'int'
 // CHECK-NEXT: | | `-CompoundStmt [[ADDR_34:0x[a-z0-9]*]] <col:22, line:12:1>
 // CHECK-NEXT: | |   `-ReturnStmt [[ADDR_35:0x[a-z0-9]*]] <line:11:3, col:10>
 // CHECK-NEXT: | |     `-IntegerLiteral [[ADDR_28]] <col:10> 'int' 0
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_36:0x[a-z0-9]*]] <line:10:1, line:12:1> line:10:5 used also_before 'int (double)'
 // CHECK-NEXT: |   |-TemplateArgument type 'double'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_21]] 'double'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_37:0x[a-z0-9]*]] <col:17, col:19> col:19 s 'double':'double'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_37:0x[a-z0-9]*]] <col:17, col:19> col:19 s 'double'
 // CHECK-NEXT: |   `-CompoundStmt [[ADDR_38:0x[a-z0-9]*]] <col:22, line:12:1>
 // CHECK-NEXT: |     `-ReturnStmt [[ADDR_39:0x[a-z0-9]*]] <line:11:3, col:10>
 // CHECK-NEXT: |       `-IntegerLiteral [[ADDR_28]] <col:10> 'int' 0
@@ -116,7 +116,7 @@ int test() {
 // CHECK-NEXT: | |   |-DeclStmt [[ADDR_44:0x[a-z0-9]*]] <line:18:3, col:11>
 // CHECK-NEXT: | |   | `-VarDecl [[ADDR_45:0x[a-z0-9]*]] <col:3, col:10> col:10 referenced t 'double'
 // CHECK-NEXT: | |   |-DeclStmt [[ADDR_46:0x[a-z0-9]*]] <line:19:3, col:16>
-// CHECK-NEXT: | |   | `-VarDecl [[ADDR_47:0x[a-z0-9]*]] <col:3, col:15> col:8 q 'S<T>':'S<T>' callinit
+// CHECK-NEXT: | |   | `-VarDecl [[ADDR_47:0x[a-z0-9]*]] <col:3, col:15> col:8 q 'S<T>' callinit
 // CHECK-NEXT: | |   |   `-ParenListExpr [[ADDR_48:0x[a-z0-9]*]] <col:9, col:15> 'NULL TYPE'
 // CHECK-NEXT: | |   |     |-IntegerLiteral [[ADDR_49:0x[a-z0-9]*]] <col:10> 'int' 1
 // CHECK-NEXT: | |   |     `-UnaryOperator [[ADDR_50:0x[a-z0-9]*]] <col:13, col:14> 'double *' prefix '&' cannot overflow
@@ -126,11 +126,11 @@ int test() {
 // CHECK-NEXT: | |-FunctionDecl [[ADDR_54:0x[a-z0-9]*]] <line:16:1, line:21:1> line:16:1 also_before[implementation={extension(allow_templates)}] 'int (S<int>)'
 // CHECK-NEXT: | | |-TemplateArgument type 'int'
 // CHECK-NEXT: | | | `-BuiltinType [[ADDR_9]] 'int'
-// CHECK-NEXT: | | `-ParmVarDecl [[ADDR_55:0x[a-z0-9]*]] <col:17, col:22> col:22 s 'S<int>':'S<int>'
+// CHECK-NEXT: | | `-ParmVarDecl [[ADDR_55:0x[a-z0-9]*]] <col:17, col:22> col:22 s 'S<int>'
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_56:0x[a-z0-9]*]] <col:1, line:21:1> line:16:1 also_before[implementation={extension(allow_templates)}] 'int (S<double>)'
 // CHECK-NEXT: |   |-TemplateArgument type 'double'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_21]] 'double'
-// CHECK-NEXT: |   `-ParmVarDecl [[ADDR_57:0x[a-z0-9]*]] <col:17, col:22> col:22 s 'S<double>':'S<double>'
+// CHECK-NEXT: |   `-ParmVarDecl [[ADDR_57:0x[a-z0-9]*]] <col:17, col:22> col:22 s 'S<double>'
 // CHECK-NEXT: |-FunctionTemplateDecl [[ADDR_58:0x[a-z0-9]*]] <line:22:1, line:23:19> col:5 implicit special
 // CHECK-NEXT: | |-TemplateTypeParmDecl [[ADDR_59:0x[a-z0-9]*]] <line:22:11, col:20> col:20 referenced typename depth 0 index 0 T
 // CHECK-NEXT: | |-FunctionDecl [[ADDR_60:0x[a-z0-9]*]] <line:23:1, col:19> col:5 special 'int (S<T>)'
@@ -140,7 +140,7 @@ int test() {
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_65:0x[a-z0-9]*]] <col:1, col:19> col:5 used special 'int (S<int>)'
 // CHECK-NEXT: |   |-TemplateArgument type 'int'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_9]] 'int'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_66:0x[a-z0-9]*]] <col:13, col:18> col:18 s 'S<int>':'S<int>'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_66:0x[a-z0-9]*]] <col:13, col:18> col:18 s 'S<int>'
 // CHECK-NEXT: |   `-OMPDeclareVariantAttr [[ADDR_67:0x[a-z0-9]*]] <<invalid sloc>> Implicit implementation={extension(allow_templates)}
 // CHECK-NEXT: |     `-DeclRefExpr [[ADDR_68:0x[a-z0-9]*]] <col:1> 'int (S<int>)' {{.*}}Function [[ADDR_69:0x[a-z0-9]*]] 'special[implementation={extension(allow_templates)}]' 'int (S<int>)'
 // CHECK-NEXT: |-FunctionTemplateDecl [[ADDR_70:0x[a-z0-9]*]] <line:22:1, line:27:1> line:23:1 special[implementation={extension(allow_templates)}]
@@ -151,7 +151,7 @@ int test() {
 // CHECK-NEXT: | |   |-DeclStmt [[ADDR_72:0x[a-z0-9]*]] <line:24:3, col:6>
 // CHECK-NEXT: | |   | `-VarDecl [[ADDR_73:0x[a-z0-9]*]] <col:3, col:5> col:5 referenced t 'T'
 // CHECK-NEXT: | |   |-DeclStmt [[ADDR_74:0x[a-z0-9]*]] <line:25:3, col:16>
-// CHECK-NEXT: | |   | `-VarDecl [[ADDR_75:0x[a-z0-9]*]] <col:3, col:15> col:8 q 'S<T>':'S<T>' callinit
+// CHECK-NEXT: | |   | `-VarDecl [[ADDR_75:0x[a-z0-9]*]] <col:3, col:15> col:8 q 'S<T>' callinit
 // CHECK-NEXT: | |   |   `-ParenListExpr [[ADDR_76:0x[a-z0-9]*]] <col:9, col:15> 'NULL TYPE'
 // CHECK-NEXT: | |   |     |-IntegerLiteral [[ADDR_77:0x[a-z0-9]*]] <col:10> 'int' 0
 // CHECK-NEXT: | |   |     `-UnaryOperator [[ADDR_78:0x[a-z0-9]*]] <col:13, col:14> '<dependent type>' prefix '&' cannot overflow
@@ -161,16 +161,16 @@ int test() {
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_69]] <line:23:1, line:27:1> line:23:1 special[implementation={extension(allow_templates)}] 'int (S<int>)'
 // CHECK-NEXT: |   |-TemplateArgument type 'int'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_9]] 'int'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_82:0x[a-z0-9]*]] <col:13, col:18> col:18 s 'S<int>':'S<int>'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_82:0x[a-z0-9]*]] <col:13, col:18> col:18 s 'S<int>'
 // CHECK-NEXT: |   `-CompoundStmt [[ADDR_83:0x[a-z0-9]*]] <col:21, line:27:1>
 // CHECK-NEXT: |     |-DeclStmt [[ADDR_84:0x[a-z0-9]*]] <line:24:3, col:6>
-// CHECK-NEXT: |     | `-VarDecl [[ADDR_85:0x[a-z0-9]*]] <col:3, col:5> col:5 used t 'int':'int'
+// CHECK-NEXT: |     | `-VarDecl [[ADDR_85:0x[a-z0-9]*]] <col:3, col:5> col:5 used t 'int'
 // CHECK-NEXT: |     |-DeclStmt [[ADDR_86:0x[a-z0-9]*]] <line:25:3, col:16>
-// CHECK-NEXT: |     | `-VarDecl [[ADDR_87:0x[a-z0-9]*]] <col:3, col:15> col:8 q 'S<int>':'S<int>' callinit
-// CHECK-NEXT: |     |   `-CXXConstructExpr [[ADDR_88:0x[a-z0-9]*]] <col:8, col:15> 'S<int>':'S<int>' 'void (int, int *)'
+// CHECK-NEXT: |     | `-VarDecl [[ADDR_87:0x[a-z0-9]*]] <col:3, col:15> col:8 q 'S<int>' callinit
+// CHECK-NEXT: |     |   `-CXXConstructExpr [[ADDR_88:0x[a-z0-9]*]] <col:8, col:15> 'S<int>' 'void (int, int *)'
 // CHECK-NEXT: |     |     |-IntegerLiteral [[ADDR_77]] <col:10> 'int' 0
 // CHECK-NEXT: |     |     `-UnaryOperator [[ADDR_89:0x[a-z0-9]*]] <col:13, col:14> 'int *' prefix '&' cannot overflow
-// CHECK-NEXT: |     |       `-DeclRefExpr [[ADDR_90:0x[a-z0-9]*]] <col:14> 'int':'int' {{.*}}Var [[ADDR_85]] 't' 'int':'int'
+// CHECK-NEXT: |     |       `-DeclRefExpr [[ADDR_90:0x[a-z0-9]*]] <col:14> 'int' {{.*}}Var [[ADDR_85]] 't' 'int'
 // CHECK-NEXT: |     `-ReturnStmt [[ADDR_91:0x[a-z0-9]*]] <line:26:3, col:10>
 // CHECK-NEXT: |       `-IntegerLiteral [[ADDR_81]] <col:10> 'int' 0
 // CHECK-NEXT: |-FunctionTemplateDecl [[ADDR_92:0x[a-z0-9]*]] <line:28:1, line:29:22> col:5 implicit also_after
@@ -187,7 +187,7 @@ int test() {
 // CHECK-NEXT: |     |-DeclStmt [[ADDR_101:0x[a-z0-9]*]] <line:31:3, col:11>
 // CHECK-NEXT: |     | `-VarDecl [[ADDR_102:0x[a-z0-9]*]] <col:3, col:10> col:10 referenced t 'double'
 // CHECK-NEXT: |     |-DeclStmt [[ADDR_103:0x[a-z0-9]*]] <line:32:3, col:18>
-// CHECK-NEXT: |     | `-VarDecl [[ADDR_104:0x[a-z0-9]*]] <col:3, col:17> col:8 q 'S<T>':'S<T>' callinit
+// CHECK-NEXT: |     | `-VarDecl [[ADDR_104:0x[a-z0-9]*]] <col:3, col:17> col:8 q 'S<T>' callinit
 // CHECK-NEXT: |     |   `-ParenListExpr [[ADDR_105:0x[a-z0-9]*]] <col:9, col:17> 'NULL TYPE'
 // CHECK-NEXT: |     |     |-FloatingLiteral [[ADDR_106:0x[a-z0-9]*]] <col:10> 'double' 2.000000e+00
 // CHECK-NEXT: |     |     `-UnaryOperator [[ADDR_107:0x[a-z0-9]*]] <col:15, col:16> 'double *' prefix '&' cannot overflow
@@ -204,14 +204,14 @@ int test() {
 // CHECK-NEXT: | |-FunctionDecl [[ADDR_118:0x[a-z0-9]*]] <line:38:1, line:40:1> line:38:5 used also_after 'int (int)'
 // CHECK-NEXT: | | |-TemplateArgument type 'int'
 // CHECK-NEXT: | | | `-BuiltinType [[ADDR_9]] 'int'
-// CHECK-NEXT: | | |-ParmVarDecl [[ADDR_119:0x[a-z0-9]*]] <col:16, col:18> col:18 s 'int':'int'
+// CHECK-NEXT: | | |-ParmVarDecl [[ADDR_119:0x[a-z0-9]*]] <col:16, col:18> col:18 s 'int'
 // CHECK-NEXT: | | `-CompoundStmt [[ADDR_120:0x[a-z0-9]*]] <col:21, line:40:1>
 // CHECK-NEXT: | |   `-ReturnStmt [[ADDR_121:0x[a-z0-9]*]] <line:39:3, col:10>
 // CHECK-NEXT: | |     `-IntegerLiteral [[ADDR_117]] <col:10> 'int' 0
 // CHECK-NEXT: | `-FunctionDecl [[ADDR_122:0x[a-z0-9]*]] <line:38:1, line:40:1> line:38:5 used also_after 'int (double)'
 // CHECK-NEXT: |   |-TemplateArgument type 'double'
 // CHECK-NEXT: |   | `-BuiltinType [[ADDR_21]] 'double'
-// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_123:0x[a-z0-9]*]] <col:16, col:18> col:18 s 'double':'double'
+// CHECK-NEXT: |   |-ParmVarDecl [[ADDR_123:0x[a-z0-9]*]] <col:16, col:18> col:18 s 'double'
 // CHECK-NEXT: |   `-CompoundStmt [[ADDR_124:0x[a-z0-9]*]] <col:21, line:40:1>
 // CHECK-NEXT: |     `-ReturnStmt [[ADDR_125:0x[a-z0-9]*]] <line:39:3, col:10>
 // CHECK-NEXT: |       `-IntegerLiteral [[ADDR_117]] <col:10> 'int' 0
@@ -243,19 +243,19 @@ int test() {
 // CHECK-NEXT:             |-CallExpr [[ADDR_151:0x[a-z0-9]*]] <col:78, col:98> 'int'
 // CHECK-NEXT:             | |-ImplicitCastExpr [[ADDR_152:0x[a-z0-9]*]] <col:78> 'int (*)(S<int>)' <FunctionToPointerDecay>
 // CHECK-NEXT:             | | `-DeclRefExpr [[ADDR_153:0x[a-z0-9]*]] <col:78> 'int (S<int>)' {{.*}}Function [[ADDR_65]] 'special' 'int (S<int>)' (FunctionTemplate [[ADDR_58]] 'special')
-// CXX11-NEXT:             | `-CXXConstructExpr [[ADDR_154:0x[a-z0-9]*]] <col:86, col:97> 'S<int>':'S<int>' 'void (S<int> &&) noexcept' elidable
-// CXX11-NEXT:             |   `-MaterializeTemporaryExpr [[ADDR_155:0x[a-z0-9]*]] <col:86, col:97> 'S<int>':'S<int>' xvalue
-// CHECK-NEXT:             |     `-CXXTemporaryObjectExpr [[ADDR_156:0x[a-z0-9]*]] <col:86, col:97> 'S<int>':'S<int>' 'void (int, int *)'
+// CXX11-NEXT:             | `-CXXConstructExpr [[ADDR_154:0x[a-z0-9]*]] <col:86, col:97> 'S<int>' 'void (S<int> &&) noexcept' elidable
+// CXX11-NEXT:             |   `-MaterializeTemporaryExpr [[ADDR_155:0x[a-z0-9]*]] <col:86, col:97> 'S<int>' xvalue
+// CHECK-NEXT:             |     `-CXXTemporaryObjectExpr [[ADDR_156:0x[a-z0-9]*]] <col:86, col:97> 'S<int>' 'void (int, int *)'
 // CHECK-NEXT:             |       |-IntegerLiteral [[ADDR_157:0x[a-z0-9]*]] <col:93> 'int' 0
 // CHECK-NEXT:             |       `-ImplicitCastExpr [[ADDR_158:0x[a-z0-9]*]] <col:96> 'int *' <NullToPointer>
 // CHECK-NEXT:             |         `-IntegerLiteral [[ADDR_159:0x[a-z0-9]*]] <col:96> 'int' 0
 // CHECK-NEXT:             `-CallExpr [[ADDR_160:0x[a-z0-9]*]] <line:23:1, line:44:98> 'int'
 // CHECK-NEXT:               |-ImplicitCastExpr [[ADDR_161:0x[a-z0-9]*]] <line:23:1> 'int (*)(S<int>)' <FunctionToPointerDecay>
 // CHECK-NEXT:               | `-DeclRefExpr [[ADDR_68]] <col:1> 'int (S<int>)' {{.*}}Function [[ADDR_69]] 'special[implementation={extension(allow_templates)}]' 'int (S<int>)'
-// CXX11-NEXT:               `-CXXConstructExpr [[ADDR_162:0x[a-z0-9]*]] <line:44:86, col:97> 'S<int>':'S<int>' 'void (S<int> &&) noexcept' elidable
-// CXX11-NEXT:                 `-MaterializeTemporaryExpr [[ADDR_163:0x[a-z0-9]*]] <col:86, col:97> 'S<int>':'S<int>' xvalue
-// CXX11-NEXT:                   `-CXXTemporaryObjectExpr [[ADDR_156]] <col:86, col:97> 'S<int>':'S<int>' 'void (int, int *)'
-// CXX17-NEXT:                   `-CXXTemporaryObjectExpr [[ADDR_156]] <line:[[#]]:86, col:97> 'S<int>':'S<int>' 'void (int, int *)'
+// CXX11-NEXT:               `-CXXConstructExpr [[ADDR_162:0x[a-z0-9]*]] <line:44:86, col:97> 'S<int>' 'void (S<int> &&) noexcept' elidable
+// CXX11-NEXT:                 `-MaterializeTemporaryExpr [[ADDR_163:0x[a-z0-9]*]] <col:86, col:97> 'S<int>' xvalue
+// CXX11-NEXT:                   `-CXXTemporaryObjectExpr [[ADDR_156]] <col:86, col:97> 'S<int>' 'void (int, int *)'
+// CXX17-NEXT:                   `-CXXTemporaryObjectExpr [[ADDR_156]] <line:[[#]]:86, col:97> 'S<int>' 'void (int, int *)'
 // CHECK-NEXT:                     |-IntegerLiteral [[ADDR_157]] <col:93> 'int' 0
 // CHECK-NEXT:                     `-ImplicitCastExpr [[ADDR_158]] <col:96> 'int *' <NullToPointer>
 // CHECK-NEXT:                       `-IntegerLiteral [[ADDR_159]] <col:96> 'int' 0

--- a/clang/test/AST/ast-dump-overloaded-operators.cpp
+++ b/clang/test/AST/ast-dump-overloaded-operators.cpp
@@ -31,14 +31,14 @@ void test() {
 // CHECK-NEXT:     |-CXXOperatorCallExpr {{.*}} <line:16:3, col:7> 'void' '+'
 // CHECK-NEXT:     | |-ImplicitCastExpr {{.*}} <col:5> 'void (*)(E, E)' <FunctionToPointerDecay>
 // CHECK-NEXT:     | | `-DeclRefExpr {{.*}} <col:5> 'void (E, E)' lvalue Function {{.*}} 'operator+' 'void (E, E)'
-// CHECK-NEXT:     | |-ImplicitCastExpr {{.*}} <col:3> 'E':'E' <LValueToRValue>
-// CHECK-NEXT:     | | `-DeclRefExpr {{.*}} <col:3> 'E':'E' lvalue Var {{.*}} 'e' 'E'
-// CHECK-NEXT:     | `-ImplicitCastExpr {{.*}} <col:7> 'E':'E' <LValueToRValue>
-// CHECK-NEXT:     |   `-DeclRefExpr {{.*}} <col:7> 'E':'E' lvalue Var {{.*}} 'e' 'E'
+// CHECK-NEXT:     | |-ImplicitCastExpr {{.*}} <col:3> 'E' <LValueToRValue>
+// CHECK-NEXT:     | | `-DeclRefExpr {{.*}} <col:3> 'E' lvalue Var {{.*}} 'e' 'E'
+// CHECK-NEXT:     | `-ImplicitCastExpr {{.*}} <col:7> 'E' <LValueToRValue>
+// CHECK-NEXT:     |   `-DeclRefExpr {{.*}} <col:7> 'E' lvalue Var {{.*}} 'e' 'E'
 // CHECK-NEXT:     `-CXXOperatorCallExpr {{.*}} <line:17:3, col:7> 'void' ','
 // CHECK-NEXT:       |-ImplicitCastExpr {{.*}} <col:5> 'void (*)(E, E)' <FunctionToPointerDecay>
 // CHECK-NEXT:       | `-DeclRefExpr {{.*}} <col:5> 'void (E, E)' lvalue Function {{.*}} 'operator,' 'void (E, E)'
-// CHECK-NEXT:       |-ImplicitCastExpr {{.*}} <col:3> 'E':'E' <LValueToRValue>
-// CHECK-NEXT:       | `-DeclRefExpr {{.*}} <col:3> 'E':'E' lvalue Var {{.*}} 'e' 'E'
-// CHECK-NEXT:       `-ImplicitCastExpr {{.*}} <col:7> 'E':'E' <LValueToRValue>
-// CHECK-NEXT:         `-DeclRefExpr {{.*}} <col:7> 'E':'E' lvalue Var {{.*}} 'e' 'E'
+// CHECK-NEXT:       |-ImplicitCastExpr {{.*}} <col:3> 'E' <LValueToRValue>
+// CHECK-NEXT:       | `-DeclRefExpr {{.*}} <col:3> 'E' lvalue Var {{.*}} 'e' 'E'
+// CHECK-NEXT:       `-ImplicitCastExpr {{.*}} <col:7> 'E' <LValueToRValue>
+// CHECK-NEXT:         `-DeclRefExpr {{.*}} <col:7> 'E' lvalue Var {{.*}} 'e' 'E'

--- a/clang/test/AST/ast-dump-records-json.cpp
+++ b/clang/test/AST/ast-dump-records-json.cpp
@@ -3266,7 +3266,6 @@ struct Derived6 : virtual public Bases... {
 // CHECK-NEXT:   {
 // CHECK-NEXT:    "access": "public",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "Base1",
 // CHECK-NEXT:     "qualType": "Base1"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "writtenAccess": "none"
@@ -3378,7 +3377,6 @@ struct Derived6 : virtual public Bases... {
 // CHECK-NEXT:   {
 // CHECK-NEXT:    "access": "private",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "Base1",
 // CHECK-NEXT:     "qualType": "Base1"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "writtenAccess": "private"
@@ -3479,7 +3477,6 @@ struct Derived6 : virtual public Bases... {
 // CHECK-NEXT:    "access": "public",
 // CHECK-NEXT:    "isVirtual": true,
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "Base1",
 // CHECK-NEXT:     "qualType": "Base1"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "writtenAccess": "none"
@@ -3718,7 +3715,6 @@ struct Derived6 : virtual public Bases... {
 // CHECK-NEXT:   {
 // CHECK-NEXT:    "access": "public",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "Base1",
 // CHECK-NEXT:     "qualType": "Base1"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "writtenAccess": "none"
@@ -3727,7 +3723,6 @@ struct Derived6 : virtual public Bases... {
 // CHECK-NEXT:    "access": "public",
 // CHECK-NEXT:    "isVirtual": true,
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "Base2",
 // CHECK-NEXT:     "qualType": "Base2"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "writtenAccess": "none"
@@ -3735,7 +3730,6 @@ struct Derived6 : virtual public Bases... {
 // CHECK-NEXT:   {
 // CHECK-NEXT:    "access": "protected",
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "Base3",
 // CHECK-NEXT:     "qualType": "Base3"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "writtenAccess": "protected"
@@ -3975,7 +3969,6 @@ struct Derived6 : virtual public Bases... {
 // CHECK-NEXT:    "access": "protected",
 // CHECK-NEXT:    "isVirtual": true,
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "Base1",
 // CHECK-NEXT:     "qualType": "Base1"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "writtenAccess": "protected"

--- a/clang/test/AST/ast-dump-records.cpp
+++ b/clang/test/AST/ast-dump-records.cpp
@@ -301,10 +301,10 @@ class NonTrivial {
 struct CheckFullExpression {
 // CHECK: |-CXXRecordDecl {{.*}} struct CheckFullExpression definition
   NonTrivial value = NonTrivial();
-// CHECK: | |-FieldDecl {{.*}} value 'NonTrivial':'NonTrivial'
-// CHECK-NEXT: | | `-ExprWithCleanups {{.*}} 'NonTrivial':'NonTrivial'
-// CHECK-NEXT: | |   `-CXXBindTemporaryExpr {{.*}} 'NonTrivial':'NonTrivial' (CXXTemporary{{.*}})
-// CHECK-NEXT: | |     `-CXXTemporaryObjectExpr {{.*}} 'NonTrivial':'NonTrivial' 'void ()'
+// CHECK: | |-FieldDecl {{.*}} value 'NonTrivial'
+// CHECK-NEXT: | | `-ExprWithCleanups {{.*}} 'NonTrivial'
+// CHECK-NEXT: | |   `-CXXBindTemporaryExpr {{.*}} 'NonTrivial' (CXXTemporary{{.*}})
+// CHECK-NEXT: | |     `-CXXTemporaryObjectExpr {{.*}} 'NonTrivial' 'void ()'
 };
 
 struct CheckNoCleanup {

--- a/clang/test/AST/ast-dump-recovery.cpp
+++ b/clang/test/AST/ast-dump-recovery.cpp
@@ -202,27 +202,27 @@ void InvalidInitalizer(int x) {
   // CHECK-NEXT:  `-InitListExpr
   Bar b2 = {1};
   // CHECK:     `-VarDecl {{.*}} b3 'Bar'
-  // CHECK-NEXT:  `-RecoveryExpr {{.*}} 'Bar':'Bar' contains-errors
+  // CHECK-NEXT:  `-RecoveryExpr {{.*}} 'Bar' contains-errors
   // CHECK-NEXT:    `-DeclRefExpr {{.*}} 'x' 'int'
   Bar b3 = Bar(x);
   // CHECK:     `-VarDecl {{.*}} b4 'Bar'
-  // CHECK-NEXT:  `-RecoveryExpr {{.*}} 'Bar':'Bar' contains-errors
+  // CHECK-NEXT:  `-RecoveryExpr {{.*}} 'Bar' contains-errors
   // CHECK-NEXT:    `-InitListExpr {{.*}} 'void'
   // CHECK-NEXT:      `-DeclRefExpr {{.*}} 'x' 'int'
   Bar b4 = Bar{x};
   // CHECK:     `-VarDecl {{.*}} b5 'Bar'
-  // CHECK-NEXT: `-CXXUnresolvedConstructExpr {{.*}} 'Bar':'Bar' contains-errors 'Bar'
+  // CHECK-NEXT: `-CXXUnresolvedConstructExpr {{.*}} 'Bar' contains-errors 'Bar'
   // CHECK-NEXT:   `-RecoveryExpr {{.*}} contains-errors
   // CHECK-NEXT:     `-UnresolvedLookupExpr {{.*}} 'invalid'
   Bar b5 = Bar(invalid());
   // CHECK:     `-VarDecl {{.*}} b6 'Bar'
-  // CHECK-NEXT: `-CXXUnresolvedConstructExpr {{.*}} 'Bar':'Bar' contains-errors 'Bar'
+  // CHECK-NEXT: `-CXXUnresolvedConstructExpr {{.*}} 'Bar' contains-errors 'Bar'
   // CHECK-NEXT:  `-InitListExpr {{.*}} contains-errors
   // CHECK-NEXT:   `-RecoveryExpr {{.*}} contains-errors
   // CHECK-NEXT:     `-UnresolvedLookupExpr {{.*}} 'invalid'
   Bar b6 = Bar{invalid()};
 
-  // CHECK:     RecoveryExpr {{.*}} 'Bar':'Bar' contains-errors
+  // CHECK:     RecoveryExpr {{.*}} 'Bar' contains-errors
   // CHECK-NEXT:  `-IntegerLiteral {{.*}} 'int' 1
   Bar(1);
 
@@ -326,7 +326,7 @@ void CtorInitializer() {
     // CHECK-NEXT: |   `-RecoveryExpr {{.*}} '<dependent type>'
     // CHECK-NEXT: |     `-UnresolvedLookupExpr {{.*}} '<overloaded function type>'
     // CHECK-NEXT: |-CXXCtorInitializer Field {{.*}} 's' 'S'
-    // CHECK-NEXT: | `-RecoveryExpr {{.*}} 'S':'S' contains-errors
+    // CHECK-NEXT: | `-RecoveryExpr {{.*}} 'S' contains-errors
     // CHECK-NEXT: |   |-IntegerLiteral {{.*}} 1
     // CHECK-NEXT: |   `-IntegerLiteral {{.*}} 2
   };

--- a/clang/test/AST/ast-dump-stmt-json.cpp
+++ b/clang/test/AST/ast-dump-stmt-json.cpp
@@ -2265,7 +2265,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isReferenced": true,
 // CHECK-NEXT:          "name": "obj",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "DependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:           "qualType": "DependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:          }
 // CHECK-NEXT:         }
@@ -2331,7 +2330,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "DependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:             "qualType": "DependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -2340,7 +2338,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "obj",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "DependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:              "qualType": "DependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -2429,7 +2426,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "DependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:             "qualType": "DependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -2438,7 +2434,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "obj",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "DependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:              "qualType": "DependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -2593,7 +2588,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "type": {
-// CHECK-NEXT:                 "desugaredQualType": "DependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:                 "qualType": "DependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "valueCategory": "lvalue",
@@ -2602,7 +2596,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                 "kind": "VarDecl",
 // CHECK-NEXT:                 "name": "obj",
 // CHECK-NEXT:                 "type": {
-// CHECK-NEXT:                  "desugaredQualType": "DependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:                  "qualType": "DependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                }
@@ -2779,7 +2772,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isReferenced": true,
 // CHECK-NEXT:          "name": "obj",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "OtherDependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:           "qualType": "OtherDependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:          }
 // CHECK-NEXT:         }
@@ -2867,7 +2859,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "OtherDependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:             "qualType": "OtherDependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -2876,7 +2867,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "obj",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "OtherDependentScopeMemberExprWrapper<T>",
 // CHECK-NEXT:              "qualType": "OtherDependentScopeMemberExprWrapper<T>"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -3037,7 +3027,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "U",
 // CHECK-NEXT:             "qualType": "U"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "prvalue",
@@ -3066,7 +3055,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "U",
 // CHECK-NEXT:             "qualType": "U"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "prvalue",
@@ -4563,7 +4551,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isUsed": true,
 // CHECK-NEXT:          "name": "__begin1",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "init": "c",
@@ -4663,7 +4650,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isUsed": true,
 // CHECK-NEXT:          "name": "__end1",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "init": "c",
@@ -4804,7 +4790,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -4826,7 +4811,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "int *",
 // CHECK-NEXT:             "qualType": "int *"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -4835,7 +4819,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "__begin1",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "int *",
 // CHECK-NEXT:              "qualType": "int *"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -4858,7 +4841,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -4880,7 +4862,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "int *",
 // CHECK-NEXT:             "qualType": "int *"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -4889,7 +4870,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "__end1",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "int *",
 // CHECK-NEXT:              "qualType": "int *"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -4914,7 +4894,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "int *",
 // CHECK-NEXT:         "qualType": "int *"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "lvalue",
@@ -4937,7 +4916,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -4946,7 +4924,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           "kind": "VarDecl",
 // CHECK-NEXT:           "name": "__begin1",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "int *",
 // CHECK-NEXT:            "qualType": "int *"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -5055,7 +5032,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "type": {
-// CHECK-NEXT:                 "desugaredQualType": "int *",
 // CHECK-NEXT:                 "qualType": "int *"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "valueCategory": "prvalue",
@@ -5077,7 +5053,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "type": {
-// CHECK-NEXT:                   "desugaredQualType": "int *",
 // CHECK-NEXT:                   "qualType": "int *"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "valueCategory": "lvalue",
@@ -5086,7 +5061,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   "kind": "VarDecl",
 // CHECK-NEXT:                   "name": "__begin1",
 // CHECK-NEXT:                   "type": {
-// CHECK-NEXT:                    "desugaredQualType": "int *",
 // CHECK-NEXT:                    "qualType": "int *"
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  }
@@ -5160,7 +5134,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:        "isUsed": true,
 // CHECK-NEXT:        "name": "C",
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "Container",
 // CHECK-NEXT:         "qualType": "Container"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "init": "call",
@@ -5181,7 +5154,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "Container",
 // CHECK-NEXT:           "qualType": "Container"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -5275,7 +5247,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "Container",
 // CHECK-NEXT:             "qualType": "Container"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -5284,7 +5255,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "C",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "Container",
 // CHECK-NEXT:              "qualType": "Container"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -5333,7 +5303,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isUsed": true,
 // CHECK-NEXT:          "name": "__begin1",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "init": "c",
@@ -5418,7 +5387,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "type": {
-// CHECK-NEXT:                   "desugaredQualType": "Container",
 // CHECK-NEXT:                   "qualType": "Container"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "valueCategory": "lvalue",
@@ -5481,7 +5449,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isUsed": true,
 // CHECK-NEXT:          "name": "__end1",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "init": "c",
@@ -5566,7 +5533,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "type": {
-// CHECK-NEXT:                   "desugaredQualType": "Container",
 // CHECK-NEXT:                   "qualType": "Container"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "valueCategory": "lvalue",
@@ -5626,7 +5592,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -5648,7 +5613,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "int *",
 // CHECK-NEXT:             "qualType": "int *"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -5657,7 +5621,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "__begin1",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "int *",
 // CHECK-NEXT:              "qualType": "int *"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -5680,7 +5643,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -5702,7 +5664,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "int *",
 // CHECK-NEXT:             "qualType": "int *"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -5711,7 +5672,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "__end1",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "int *",
 // CHECK-NEXT:              "qualType": "int *"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -5736,7 +5696,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "int *",
 // CHECK-NEXT:         "qualType": "int *"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "lvalue",
@@ -5759,7 +5718,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -5768,7 +5726,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           "kind": "VarDecl",
 // CHECK-NEXT:           "name": "__begin1",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "int *",
 // CHECK-NEXT:            "qualType": "int *"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -5877,7 +5834,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "type": {
-// CHECK-NEXT:                 "desugaredQualType": "int *",
 // CHECK-NEXT:                 "qualType": "int *"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "valueCategory": "prvalue",
@@ -5899,7 +5855,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "type": {
-// CHECK-NEXT:                   "desugaredQualType": "int *",
 // CHECK-NEXT:                   "qualType": "int *"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "valueCategory": "lvalue",
@@ -5908,7 +5863,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   "kind": "VarDecl",
 // CHECK-NEXT:                   "name": "__begin1",
 // CHECK-NEXT:                   "type": {
-// CHECK-NEXT:                    "desugaredQualType": "int *",
 // CHECK-NEXT:                    "qualType": "int *"
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  }
@@ -6120,7 +6074,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isUsed": true,
 // CHECK-NEXT:          "name": "__begin1",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "init": "c",
@@ -6220,7 +6173,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:          "isUsed": true,
 // CHECK-NEXT:          "name": "__end1",
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "init": "c",
@@ -6361,7 +6313,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -6383,7 +6334,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "int *",
 // CHECK-NEXT:             "qualType": "int *"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -6392,7 +6342,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "__begin1",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "int *",
 // CHECK-NEXT:              "qualType": "int *"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -6415,7 +6364,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",
@@ -6437,7 +6385,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "type": {
-// CHECK-NEXT:             "desugaredQualType": "int *",
 // CHECK-NEXT:             "qualType": "int *"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            "valueCategory": "lvalue",
@@ -6446,7 +6393,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:             "kind": "VarDecl",
 // CHECK-NEXT:             "name": "__end1",
 // CHECK-NEXT:             "type": {
-// CHECK-NEXT:              "desugaredQualType": "int *",
 // CHECK-NEXT:              "qualType": "int *"
 // CHECK-NEXT:             }
 // CHECK-NEXT:            }
@@ -6471,7 +6417,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "int *",
 // CHECK-NEXT:         "qualType": "int *"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "lvalue",
@@ -6494,7 +6439,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "int *",
 // CHECK-NEXT:           "qualType": "int *"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "lvalue",
@@ -6503,7 +6447,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:           "kind": "VarDecl",
 // CHECK-NEXT:           "name": "__begin1",
 // CHECK-NEXT:           "type": {
-// CHECK-NEXT:            "desugaredQualType": "int *",
 // CHECK-NEXT:            "qualType": "int *"
 // CHECK-NEXT:           }
 // CHECK-NEXT:          }
@@ -6612,7 +6555,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "type": {
-// CHECK-NEXT:                 "desugaredQualType": "int *",
 // CHECK-NEXT:                 "qualType": "int *"
 // CHECK-NEXT:                },
 // CHECK-NEXT:                "valueCategory": "prvalue",
@@ -6634,7 +6576,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "type": {
-// CHECK-NEXT:                   "desugaredQualType": "int *",
 // CHECK-NEXT:                   "qualType": "int *"
 // CHECK-NEXT:                  },
 // CHECK-NEXT:                  "valueCategory": "lvalue",
@@ -6643,7 +6584,6 @@ void TestDependentGenericSelectionExpr(Ty T) {
 // CHECK-NEXT:                   "kind": "VarDecl",
 // CHECK-NEXT:                   "name": "__begin1",
 // CHECK-NEXT:                   "type": {
-// CHECK-NEXT:                    "desugaredQualType": "int *",
 // CHECK-NEXT:                    "qualType": "int *"
 // CHECK-NEXT:                   }
 // CHECK-NEXT:                  }

--- a/clang/test/AST/ast-dump-stmt.cpp
+++ b/clang/test/AST/ast-dump-stmt.cpp
@@ -99,8 +99,8 @@ void TestUnionInitList()
   U us[3] = {1};
 // CHECK: VarDecl {{.+}} <col:3, col:15> col:5 us 'U[3]' cinit
 // CHECK-NEXT: `-InitListExpr {{.+}} <col:13, col:15> 'U[3]'
-// CHECK-NEXT:   |-array_filler: InitListExpr {{.+}} <col:15> 'U':'U' field Field {{.+}} 'i' 'int'
-// CHECK-NEXT:   `-InitListExpr {{.+}} <col:14> 'U':'U' field Field {{.+}} 'i' 'int'
+// CHECK-NEXT:   |-array_filler: InitListExpr {{.+}} <col:15> 'U' field Field {{.+}} 'i' 'int'
+// CHECK-NEXT:   `-InitListExpr {{.+}} <col:14> 'U' field Field {{.+}} 'i' 'int'
 // CHECK-NEXT:     `-IntegerLiteral {{.+}} <col:14> 'int' 1
 }
 
@@ -198,28 +198,28 @@ void TestIteration() {
   // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:16> col:16 implicit used __range1 'int (&)[10]' cinit
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:16> 'int[10]' lvalue Var 0x{{[^ ]*}} 'vals' 'int[10]'
   // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14> col:14 implicit used __begin1 'int *':'int *' cinit
+  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14> col:14 implicit used __begin1 'int *' cinit
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int[10]' lvalue Var 0x{{[^ ]*}} '__range1' 'int (&)[10]'
   // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14, col:16> col:14 implicit used __end1 'int *':'int *' cinit
+  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14, col:16> col:14 implicit used __end1 'int *' cinit
   // CHECK-NEXT: BinaryOperator 0x{{[^ ]*}} <col:14, col:16> 'int *' '+'
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int[10]' lvalue Var 0x{{[^ ]*}} '__range1' 'int (&)[10]'
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:16> 'long' 10
   // CHECK-NEXT: BinaryOperator 0x{{[^ ]*}} <col:14> 'bool' '!='
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__end1' 'int *':'int *'
-  // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue prefix '++'
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__end1' 'int *'
+  // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:14> 'int *' lvalue prefix '++'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: DeclStmt
   // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:8, col:14> col:12 v 'int' cinit
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:14> 'int' lvalue prefix '*' cannot overflow
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: NullStmt
 
   Container C;
@@ -229,32 +229,32 @@ void TestIteration() {
   // CHECK-NEXT: <<<NULL>>>
   // CHECK-NEXT: DeclStmt
   // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:16> col:16 implicit used __range1 'Container &' cinit
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:16> 'Container':'Container' lvalue Var 0x{{[^ ]*}} 'C' 'Container':'Container'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:16> 'Container' lvalue Var 0x{{[^ ]*}} 'C' 'Container'
   // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14> col:14 implicit used __begin1 'int *':'int *' cinit
+  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14> col:14 implicit used __begin1 'int *' cinit
   // CHECK-NEXT: CXXMemberCallExpr 0x{{[^ ]*}} <col:14> 'int *'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:14> '<bound member function type>' .begin 0x{{[^ ]*}}
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'Container':'Container' lvalue Var 0x{{[^ ]*}} '__range1' 'Container &'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'Container' lvalue Var 0x{{[^ ]*}} '__range1' 'Container &'
   // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14> col:14 implicit used __end1 'int *':'int *' cinit
+  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:14> col:14 implicit used __end1 'int *' cinit
   // CHECK-NEXT: CXXMemberCallExpr 0x{{[^ ]*}} <col:14> 'int *'
   // CHECK-NEXT: MemberExpr 0x{{[^ ]*}} <col:14> '<bound member function type>' .end 0x{{[^ ]*}}
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'Container':'Container' lvalue Var 0x{{[^ ]*}} '__range1' 'Container &'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'Container' lvalue Var 0x{{[^ ]*}} '__range1' 'Container &'
   // CHECK-NEXT: BinaryOperator 0x{{[^ ]*}} <col:14> 'bool' '!='
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__end1' 'int *':'int *'
-  // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue prefix '++'
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__end1' 'int *'
+  // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:14> 'int *' lvalue prefix '++'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: DeclStmt
   // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:8, col:14> col:12 v 'int' cinit
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:14> 'int' lvalue prefix '*' cannot overflow
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:14> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: NullStmt
 
   for (int a; int v : vals)
@@ -266,27 +266,27 @@ void TestIteration() {
   // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:23> col:23 implicit used __range1 'int (&)[10]' cinit
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:23> 'int[10]' lvalue Var 0x{{[^ ]*}} 'vals' 'int[10]'
   // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:21> col:21 implicit used __begin1 'int *':'int *' cinit
+  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:21> col:21 implicit used __begin1 'int *' cinit
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int[10]' lvalue Var 0x{{[^ ]*}} '__range1' 'int (&)[10]'
   // CHECK-NEXT: DeclStmt
-  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:21, col:23> col:21 implicit used __end1 'int *':'int *' cinit
+  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:21, col:23> col:21 implicit used __end1 'int *' cinit
   // CHECK-NEXT: BinaryOperator 0x{{[^ ]*}} <col:21, col:23> 'int *' '+'
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int[10]' lvalue Var 0x{{[^ ]*}} '__range1' 'int (&)[10]'
   // CHECK-NEXT: IntegerLiteral 0x{{[^ ]*}} <col:23> 'long' 10
   // CHECK-NEXT: BinaryOperator 0x{{[^ ]*}} <col:21> 'bool' '!='
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__end1' 'int *':'int *'
-  // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:21> 'int *':'int *' lvalue prefix '++'
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *' lvalue Var 0x{{[^ ]*}} '__end1' 'int *'
+  // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:21> 'int *' lvalue prefix '++'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: DeclStmt
   // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:15, col:21> col:19 v 'int' cinit
   // CHECK-NEXT: ImplicitCastExpr
   // CHECK-NEXT: UnaryOperator 0x{{[^ ]*}} <col:21> 'int' lvalue prefix '*' cannot overflow
   // CHECK-NEXT: ImplicitCastExpr
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *':'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *':'int *'
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:21> 'int *' lvalue Var 0x{{[^ ]*}} '__begin1' 'int *'
   // CHECK-NEXT: NullStmt
 }

--- a/clang/test/AST/ast-dump-stmt.m
+++ b/clang/test/AST/ast-dump-stmt.m
@@ -55,4 +55,4 @@ id TestCompoundLiteral(id a) {
 // CHECK:     FunctionDecl{{.*}}TestCompoundLiteral
 // CHECK:       ExprWithCleanups
 // CHECK-NEXT:    cleanup CompoundLiteralExpr
-// CHECK:           CompoundLiteralExpr{{.*}}'S':'S' lvalue
+// CHECK:           CompoundLiteralExpr{{.*}}'S' lvalue

--- a/clang/test/AST/ast-dump-template-decls-json.cpp
+++ b/clang/test/AST/ast-dump-template-decls-json.cpp
@@ -826,7 +826,6 @@ void i();
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "Uy<Ty>",
 // CHECK-NEXT:         "qualType": "Uy<Ty>"
 // CHECK-NEXT:        }
 // CHECK-NEXT:       }

--- a/clang/test/AST/ast-dump-template-decls.cpp
+++ b/clang/test/AST/ast-dump-template-decls.cpp
@@ -171,7 +171,7 @@ template<class E1, class E2> class E {};
 using test1 = D<E, int>;
 // CHECK:      TypeAliasDecl 0x{{[^ ]*}} <line:{{[1-9]+}}:1, col:23> col:7 test1 'D<subst_default_argument::E, int>':'subst_default_argument::E<int, subst_default_argument::A<int>>'
 // CHECK:      TemplateSpecializationType 0x{{[^ ]*}} 'A<int>' sugar A
-// CHECK-NEXT: |-TemplateArgument type 'int':'int'
+// CHECK-NEXT: |-TemplateArgument type 'int'
 // CHECK-NEXT: | `-SubstTemplateTypeParmType 0x{{[^ ]*}} 'int' sugar class depth 0 index 1 D2
 // CHECK-NEXT: |   |-TypeAliasTemplate 0x{{[^ ]*}} 'D'
 // CHECK-NEXT: |   `-BuiltinType 0x{{[^ ]*}} 'int'

--- a/clang/test/AST/ast-dump-template-json-win32-mangler-crash.cpp
+++ b/clang/test/AST/ast-dump-template-json-win32-mangler-crash.cpp
@@ -532,7 +532,6 @@ int main()
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "name": "type",
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "integral_constant<_Ty, _Val>",
 // CHECK-NEXT:         "qualType": "integral_constant<_Ty, _Val>"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "inner": [
@@ -872,7 +871,6 @@ int main()
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "name": "bool_constant",
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "integral_constant<bool, _Val>",
 // CHECK-NEXT:       "qualType": "integral_constant<bool, _Val>"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "inner": [

--- a/clang/test/AST/ast-dump-temporaries-json.cpp
+++ b/clang/test/AST/ast-dump-temporaries-json.cpp
@@ -36,7 +36,6 @@ void MaterializeTemp() {
 // CHECK-NEXT:   }
 // CHECK-NEXT:  },
 // CHECK-NEXT:  "type": {
-// CHECK-NEXT:   "desugaredQualType": "const S",
 // CHECK-NEXT:   "qualType": "const S"
 // CHECK-NEXT:  },
 // CHECK-NEXT:  "valueCategory": "lvalue",
@@ -58,7 +57,6 @@ void MaterializeTemp() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "type": {
-// CHECK-NEXT:     "desugaredQualType": "const S",
 // CHECK-NEXT:     "qualType": "const S"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    "valueCategory": "lvalue",
@@ -89,7 +87,6 @@ void MaterializeTemp() {
 // CHECK-NEXT:       }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "type": {
-// CHECK-NEXT:       "desugaredQualType": "const S",
 // CHECK-NEXT:       "qualType": "const S"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      "valueCategory": "prvalue",
@@ -111,7 +108,6 @@ void MaterializeTemp() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "type": {
-// CHECK-NEXT:         "desugaredQualType": "S",
 // CHECK-NEXT:         "qualType": "S"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "valueCategory": "prvalue",
@@ -141,7 +137,6 @@ void MaterializeTemp() {
 // CHECK-NEXT:           }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "type": {
-// CHECK-NEXT:           "desugaredQualType": "S",
 // CHECK-NEXT:           "qualType": "S"
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "valueCategory": "prvalue",

--- a/clang/test/AST/ast-dump-types-json.cpp
+++ b/clang/test/AST/ast-dump-types-json.cpp
@@ -101,7 +101,6 @@ using ::TestUsingShadowDeclType;
 // CHECK-NEXT:  },
 // CHECK-NEXT:  "name": "TestElaboratedType2",
 // CHECK-NEXT:  "type": {
-// CHECK-NEXT:   "desugaredQualType": "NS::S",
 // CHECK-NEXT:   "qualType": "NS::S"
 // CHECK-NEXT:  },
 // CHECK-NEXT:  "inner": [

--- a/clang/test/AST/coroutine-locals-cleanup.cpp
+++ b/clang/test/AST/coroutine-locals-cleanup.cpp
@@ -85,7 +85,7 @@ Task bar() {
 // CHECK:           CaseStmt
 // CHECK:             ExprWithCleanups {{.*}} 'void'
 // CHECK-NEXT:          CoawaitExpr
-// CHECK-NEXT:            CXXBindTemporaryExpr {{.*}} 'Task':'Task' (CXXTemporary {{.*}})
+// CHECK-NEXT:            CXXBindTemporaryExpr {{.*}} 'Task' (CXXTemporary {{.*}})
 // CHECK:                 MaterializeTemporaryExpr {{.*}} 'Awaiter':'Task::Awaiter'
 // CHECK:                 ExprWithCleanups {{.*}} 'bool'
 // CHECK-NEXT:              CXXMemberCallExpr {{.*}} 'bool'
@@ -98,7 +98,7 @@ Task bar() {
 // CHECK:           CaseStmt
 // CHECK:             ExprWithCleanups {{.*}} 'void'
 // CHECK-NEXT:          CoawaitExpr
-// CHECK-NEXT:            CXXBindTemporaryExpr {{.*}} 'Task':'Task' (CXXTemporary {{.*}})
+// CHECK-NEXT:            CXXBindTemporaryExpr {{.*}} 'Task' (CXXTemporary {{.*}})
 // CHECK:                 MaterializeTemporaryExpr {{.*}} 'Awaiter':'Task::Awaiter'
 // CHECK:                 ExprWithCleanups {{.*}} 'bool'
 // CHECK-NEXT:              CXXMemberCallExpr {{.*}} 'bool'

--- a/clang/test/AST/float16.cpp
+++ b/clang/test/AST/float16.cpp
@@ -85,7 +85,7 @@ auto C = -1.0f16 + B;
 //CHECK-NEXT: | `-ImplicitCastExpr {{.*}} '__fp16' <FloatingCast>
 //CHECK-NEXT: |   `-UnaryOperator {{.*}} 'double' prefix '-'
 //CHECK-NEXT: |     `-FloatingLiteral {{.*}} 'double' 1.000000e-01
-//CHECK-NEXT: |-VarDecl {{.*}} C 'float':'float' cinit
+//CHECK-NEXT: |-VarDecl {{.*}} C 'float' cinit
 //CHECK-NEXT: | `-BinaryOperator {{.*}} 'float' '+'
 //CHECK-NEXT: |   |-ImplicitCastExpr {{.*}} 'float' <FloatingCast>
 //CHECK-NEXT: |   | `-UnaryOperator {{.*}} '_Float16' prefix '-'
@@ -100,7 +100,7 @@ auto C = -1.0f16 + B;
 //CHECK-NATIVE: | `-ImplicitCastExpr {{.*}} '__fp16' <FloatingCast>
 //CHECK-NATIVE: |   `-UnaryOperator {{.*}} 'double' prefix '-'
 //CHECK-NATIVE: |     `-FloatingLiteral {{.*}} 'double' 1.000000e-01
-//CHECK-NATIVE: |-VarDecl {{.*}} C '__fp16':'__fp16' cinit
+//CHECK-NATIVE: |-VarDecl {{.*}} C '__fp16' cinit
 //CHECK-NATIVE: | `-BinaryOperator {{.*}} '__fp16' '+'
 //CHECK-NATIVE: |   |-ImplicitCastExpr {{.*}} '__fp16' <FloatingCast>
 //CHECK-NATIVE: |   | `-UnaryOperator {{.*}} '_Float16' prefix '-'
@@ -178,12 +178,12 @@ template <class C> C func1t(C arg) {
 //CHECK-NEXT: | |       `-FloatingLiteral {{.*}} '_Float16' 2.000000e+00
 //CHECK-NEXT: | `-FunctionDecl {{.*}} used func1t '_Float16 (_Float16)'
 //CHECK-NEXT: |   |-TemplateArgument type '_Float16'
-//CHECK:      |   |-ParmVarDecl {{.*}} used arg '_Float16':'_Float16'
+//CHECK:      |   |-ParmVarDecl {{.*}} used arg '_Float16'
 //CHECK-NEXT: |   `-CompoundStmt
 //CHECK-NEXT: |     `-ReturnStmt
 //CHECK-NEXT: |       `-BinaryOperator {{.*}} '_Float16' '*'
-//CHECK-NEXT: |         |-ImplicitCastExpr {{.*}} '_Float16':'_Float16' <LValueToRValue>
-//CHECK-NEXT: |         | `-DeclRefExpr {{.*}} '_Float16':'_Float16' lvalue ParmVar {{.*}} 'arg' '_Float16':'_Float16'
+//CHECK-NEXT: |         |-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
+//CHECK-NEXT: |         | `-DeclRefExpr {{.*}} '_Float16' lvalue ParmVar {{.*}} 'arg' '_Float16'
 //CHECK-NEXT: |         `-FloatingLiteral {{.*}} '_Float16' 2.000000e+00
 
 
@@ -223,14 +223,14 @@ int main(void) {
 //CHECK-NEXT:  |     `-FloatingLiteral {{.*}} 'double' 1.000977e+00
 
   C1 c1(f1l);
-//CHECK:       | `-VarDecl{{.*}} used c1 'C1':'C1' callinit
-//CHECK-NEXT:  |   `-CXXConstructExpr {{.*}} 'C1':'C1' 'void (_Float16)
+//CHECK:       | `-VarDecl{{.*}} used c1 'C1' callinit
+//CHECK-NEXT:  |   `-CXXConstructExpr {{.*}} 'C1' 'void (_Float16)
 //CHECK-NEXT:  |     `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
 //CHECK-NEXT:  |       `-DeclRefExpr {{.*}} '_Float16' lvalue Var 0x{{.*}} 'f1l' '_Float16'
 
   S1<_Float16> s1 = { 132.f16 };
-//CHECK:       | `-VarDecl {{.*}} used s1 'S1<_Float16>':'S1<_Float16>' cinit
-//CHECK-NEXT:  |   `-InitListExpr {{.*}} 'S1<_Float16>':'S1<_Float16>'
+//CHECK:       | `-VarDecl {{.*}} used s1 'S1<_Float16>' cinit
+//CHECK-NEXT:  |   `-InitListExpr {{.*}} 'S1<_Float16>'
 //CHECK-NEXT:  |     `-FloatingLiteral {{.*}} '_Float16' 1.320000e+02
 
   _Float16 f4l = func1n(f1l)  + func1f(f2l) + c1.func1c(f3l) + c1.func2c(f1l) +
@@ -255,37 +255,37 @@ int main(void) {
 //CHECK-NEXT:  |     | | | | | |     `-DeclRefExpr {{.*}} '_Float16' lvalue Var {{.*}} 'f2l' '_Float16'
 //CHECK-NEXT:  |     | | | | | `-CXXMemberCallExpr {{.*}} '_Float16'
 //CHECK-NEXT:  |     | | | | |   |-MemberExpr {{.*}} '<bound member function type>' .func1c {{.*}}
-//CHECK-NEXT:  |     | | | | |   | `-DeclRefExpr {{.*}} 'C1':'C1' lvalue Var {{.*}} 'c1' 'C1':'C1'
+//CHECK-NEXT:  |     | | | | |   | `-DeclRefExpr {{.*}} 'C1' lvalue Var {{.*}} 'c1' 'C1'
 //CHECK-NEXT:  |     | | | | |   `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
 //CHECK-NEXT:  |     | | | | |     `-DeclRefExpr {{.*}} '_Float16' lvalue Var {{.*}} 'f3l' '_Float16'
 //CHECK-NEXT:  |     | | | | `-CallExpr {{.*}} '_Float16'
 //CHECK-NEXT:  |     | | | |   |-ImplicitCastExpr {{.*}} '_Float16 (*)(_Float16)' <FunctionToPointerDecay>
 //CHECK-NEXT:  |     | | | |   | `-MemberExpr {{.*}} '_Float16 (_Float16)' lvalue .func2c {{.*}}
-//CHECK-NEXT:  |     | | | |   |   `-DeclRefExpr {{.*}} 'C1':'C1' lvalue Var {{.*}} 'c1' 'C1':'C1'
+//CHECK-NEXT:  |     | | | |   |   `-DeclRefExpr {{.*}} 'C1' lvalue Var {{.*}} 'c1' 'C1'
 //CHECK-NEXT:  |     | | | |   `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
 //CHECK-NEXT:  |     | | | |     `-DeclRefExpr {{.*}} '_Float16' lvalue Var {{.*}} 'f1l' '_Float16'
-//CHECK-NEXT:  |     | | | `-CallExpr {{.*}} '_Float16':'_Float16'
+//CHECK-NEXT:  |     | | | `-CallExpr {{.*}} '_Float16'
 //CHECK-NEXT:  |     | | |   |-ImplicitCastExpr {{.*}} '_Float16 (*)(_Float16)' <FunctionToPointerDecay>
 //CHECK-NEXT:  |     | | |   | `-DeclRefExpr {{.*}} '_Float16 (_Float16)' lvalue Function {{.*}} 'func1t' '_Float16 (_Float16)' (FunctionTemplate {{.*}} 'func1t')
 //CHECK-NEXT:  |     | | |   `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
 //CHECK-NEXT:  |     | | |     `-DeclRefExpr {{.*}} '_Float16' lvalue Var {{.*}} 'f1l' '_Float16'
 //CHECK-NEXT:  |     | | `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
 //CHECK-NEXT:  |     | |   `-MemberExpr {{.*}} '_Float16' lvalue .mem2 {{.*}}
-//CHECK-NEXT:  |     | |     `-DeclRefExpr {{.*}} 'S1<_Float16>':'S1<_Float16>' lvalue Var {{.*}} 's1' 'S1<_Float16>':'S1<_Float16>'
+//CHECK-NEXT:  |     | |     `-DeclRefExpr {{.*}} 'S1<_Float16>' lvalue Var {{.*}} 's1' 'S1<_Float16>'
 //CHECK-NEXT:  |     | `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
 //CHECK-NEXT:  |     |   `-DeclRefExpr {{.*}} '_Float16' lvalue Var {{.*}} 'f1n' '_Float16'
 //CHECK-NEXT:  |     `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>
 //CHECK-NEXT:  |       `-DeclRefExpr {{.*}} '_Float16' lvalue Var {{.*}} 'f2n' '_Float16'
 
   auto f5l = -1.f16, *f6l = &f2l, f7l = func1t(f3l);
-//CHECK:       | |-VarDecl {{.*}} f5l '_Float16':'_Float16' cinit
+//CHECK:       | |-VarDecl {{.*}} f5l '_Float16' cinit
 //CHECK-NEXT:  | | `-UnaryOperator {{.*}} '_Float16' prefix '-'
 //CHECK-NEXT:  | |   `-FloatingLiteral {{.*}} '_Float16' 1.000000e+00
 //CHECK-NEXT:  | |-VarDecl {{.*}} f6l '_Float16 *' cinit
 //CHECK-NEXT:  | | `-UnaryOperator {{.*}} '_Float16 *' prefix '&'
 //CHECK-NEXT:  | |   `-DeclRefExpr {{.*}} '_Float16' lvalue Var {{.*}} 'f2l' '_Float16'
-//CHECK-NEXT:  | `-VarDecl {{.*}} f7l '_Float16':'_Float16' cinit
-//CHECK-NEXT:  |   `-CallExpr {{.*}} '_Float16':'_Float16'
+//CHECK-NEXT:  | `-VarDecl {{.*}} f7l '_Float16' cinit
+//CHECK-NEXT:  |   `-CallExpr {{.*}} '_Float16'
 //CHECK-NEXT:  |     |-ImplicitCastExpr {{.*}} '_Float16 (*)(_Float16)' <FunctionToPointerDecay>
 //CHECK-NEXT:  |     | `-DeclRefExpr {{.*}} '_Float16 (_Float16)' lvalue Function {{.*}} 'func1t' '_Float16 (_Float16)' (FunctionTemplate {{.*}} 'func1t')
 //CHECK-NEXT:  |     `-ImplicitCastExpr {{.*}} '_Float16' <LValueToRValue>

--- a/clang/test/AST/nrvo.c
+++ b/clang/test/AST/nrvo.c
@@ -7,11 +7,11 @@ struct A f1(void) {
   // CHECK-NEXT: CompoundStmt 0x{{[^ ]*}} <col:19, line:{{[^:]*}}:1>
   struct A a;
   // CHECK-NEXT: DeclStmt 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:13>
-  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:3, col:12> col:12 used a 'struct A':'struct A' nrvo
+  // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:3, col:12> col:12 used a 'struct A' nrvo
   return a;
   // CHECK-NEXT: ReturnStmt 0x{{[^ ]*}} <line:[[@LINE-1]]:3, col:10>
-  // CHECK-NEXT: ImplicitCastExpr 0x{{[^ ]*}} <col:10> 'struct A':'struct A' <LValueToRValue>
-  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:10> 'struct A':'struct A' lvalue Var 0x{{[^ ]*}} 'a' 'struct A':'struct A'
+  // CHECK-NEXT: ImplicitCastExpr 0x{{[^ ]*}} <col:10> 'struct A' <LValueToRValue>
+  // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:10> 'struct A' lvalue Var 0x{{[^ ]*}} 'a' 'struct A'
 }
 
 void f2(void) {
@@ -20,10 +20,10 @@ void f2(void) {
     // CHECK-NEXT: CompoundStmt 0x{{[^ ]*}} <col:10, line:{{[^:]*}}:3>
     struct A a;
     // CHECK-NEXT: DeclStmt 0x{{[^ ]*}} <line:[[@LINE-1]]:5, col:15>
-    // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:5, col:14> col:14 used a 'struct A':'struct A' nrvo
+    // CHECK-NEXT: VarDecl 0x{{[^ ]*}} <col:5, col:14> col:14 used a 'struct A' nrvo
     return a;
     // CHECK-NEXT: ReturnStmt 0x{{[^ ]*}} <line:[[@LINE-1]]:5, col:12>
-    // CHECK-NEXT: ImplicitCastExpr 0x{{[^ ]*}} <col:12> 'struct A':'struct A' <LValueToRValue>
-    // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:12> 'struct A':'struct A' lvalue Var 0x{{[^ ]*}} 'a' 'struct A':'struct A'
+    // CHECK-NEXT: ImplicitCastExpr 0x{{[^ ]*}} <col:12> 'struct A' <LValueToRValue>
+    // CHECK-NEXT: DeclRefExpr 0x{{[^ ]*}} <col:12> 'struct A' lvalue Var 0x{{[^ ]*}} 'a' 'struct A'
   }();
 }

--- a/clang/test/AST/sourceranges.cpp
+++ b/clang/test/AST/sourceranges.cpp
@@ -49,14 +49,14 @@ void construct() {
   A a = A(12);
   // CHECK: CXXConstructExpr {{0x[0-9a-fA-F]+}} <col:9, col:13> 'A':'foo::A' 'void (int){{( __attribute__\(\(thiscall\)\))?}}'
   D d = D(12);
-  // CHECK: CXXConstructExpr {{0x[0-9a-fA-F]+}} <col:9, col:13> 'D':'D' 'void (int){{( __attribute__\(\(thiscall\)\))?}}'
+  // CHECK: CXXConstructExpr {{0x[0-9a-fA-F]+}} <col:9, col:13> 'D' 'void (int){{( __attribute__\(\(thiscall\)\))?}}'
 }
 
 namespace PR38987 {
 struct A { A(); };
 template <class T> void f() { T{}; }
 template void f<A>();
-// CHECK: CXXTemporaryObjectExpr {{.*}} <col:31, col:33> 'PR38987::A':'PR38987::A'
+// CHECK: CXXTemporaryObjectExpr {{.*}} <col:31, col:33> 'PR38987::A'
 }
 
 void abort() __attribute__((noreturn));

--- a/clang/test/C/drs/dr253.c
+++ b/clang/test/C/drs/dr253.c
@@ -19,7 +19,7 @@ struct fred y [] = { { { "abc" }, 1 }, [0] = { .s[0] = 'q' } };
 
 // CHECK: VarDecl 0x{{.*}} <line:16:1, col:62> col:13 y 'struct fred[1]' cinit
 // CHECK-NEXT: InitListExpr 0x{{.*}} <col:20, col:62> 'struct fred[1]'
-// CHECK-NEXT: InitListExpr 0x{{.*}} <col:46, col:60> 'struct fred':'struct fred'
+// CHECK-NEXT: InitListExpr 0x{{.*}} <col:46, col:60> 'struct fred'
 // CHECK-NEXT: InitListExpr 0x{{.*}} <col:50, col:56> 'char[6]'
 // CHECK-NEXT: array_filler
 // CHECK-NEXT: ImplicitCastExpr

--- a/clang/test/CXX/dcl.decl/dcl.init/dcl.init.ref/p4-ast.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.init/dcl.init.ref/p4-ast.cpp
@@ -3,7 +3,7 @@
 void f() noexcept;
 
 // CHECK: VarDecl {{.*}} ref 'void (&)()' cinit
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'void ()':'void ()' lvalue <NoOp>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'void ()' lvalue <NoOp>
 // CHECK-NEXT: DeclRefExpr {{.*}} 'void () noexcept' lvalue Function {{.*}} 'f' 'void () noexcept'
 void (&ref)() = f;
 
@@ -13,6 +13,6 @@ struct X {
 } x;
 
 // CHECK: VarDecl {{.*}} xp 'void (&)()' cinit
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'void ()':'void ()' lvalue <NoOp>
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'void () noexcept':'void () noexcept' lvalue <UserDefinedConversion>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'void ()' lvalue <NoOp>
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'void () noexcept' lvalue <UserDefinedConversion>
 void (&xp)() = x;

--- a/clang/test/Import/objc-param-decl/test.m
+++ b/clang/test/Import/objc-param-decl/test.m
@@ -5,7 +5,7 @@
 // CHECK-SAME: FirstParam
 // CHECK-SAME: 'id<NSString>'
 // CHECK-NEXT: ObjCTypeParamDecl
-// CHECK-SAME: 'id':'id'
+// CHECK-SAME: 'id'
 
 void expr() {
   Dictionary *d;

--- a/clang/test/OpenMP/align_clause_ast_print.cpp
+++ b/clang/test/OpenMP/align_clause_ast_print.cpp
@@ -122,7 +122,7 @@ int template_test() {
 // DUMP: NonTypeTemplateParmDecl {{.*}}'unsigned int' depth 0 index 1 size
 // DUMP: IntegerLiteral {{.*}}'unsigned int' 1
 // DUMP: OMPAllocateDecl {{.*}}
-// DUMP: DeclRefExpr {{.*}}'double':'double' lvalue Var {{.*}} 'foo' 'double':'double'
+// DUMP: DeclRefExpr {{.*}}'double' lvalue Var {{.*}} 'foo' 'double'
 // DUMP: OMPAlignClause {{.*}}
 // DUMP: ConstantExpr {{.*}}'unsigned int'
 // DUMP: value: Int 1

--- a/clang/test/OpenMP/generic_loop_ast_print.cpp
+++ b/clang/test/OpenMP/generic_loop_ast_print.cpp
@@ -51,15 +51,15 @@
 //DUMP: FunctionDecl{{.*}}templ_foo 'void (int)'
 //DUMP: TemplateArgument type 'int'
 //DUMP: TemplateArgument integral 2
-//DUMP: ParmVarDecl{{.*}}'int':'int'
+//DUMP: ParmVarDecl{{.*}}'int'
 //DUMP: OMPSimdDirective
 //DUMP: OMPCollapseClause
 //DUMP: ConstantExpr{{.*}}'int'
 //DUMP: value: Int 2
 //DUMP: OMPReductionClause
-//DUMP: DeclRefExpr{{.*}}'z' 'int':'int'
+//DUMP: DeclRefExpr{{.*}}'z' 'int'
 //DUMP: OMPLastprivateClause
-//DUMP: DeclRefExpr{{.*}}'j' 'int':'int'
+//DUMP: DeclRefExpr{{.*}}'j' 'int'
 //DUMP: ForStmt
 template <typename T, int C>
 void templ_foo(T t) {

--- a/clang/test/OpenMP/scope_ast_print.cpp
+++ b/clang/test/OpenMP/scope_ast_print.cpp
@@ -81,8 +81,8 @@ int template_test() {
 //DUMP: BuiltinType {{.*}}'double'
 //DUMP: OMPScopeDirective
 //DUMP: OMPPrivateClause
-//DUMP: DeclRefExpr {{.*}}'double':'double' lvalue Var {{.*}} 'a' 'double':'double'
+//DUMP: DeclRefExpr {{.*}}'double' lvalue Var {{.*}} 'a' 'double'
 //DUMP: OMPReductionClause
-//DUMP: DeclRefExpr {{.*}}'double':'double' lvalue Var {{.*}} 'b' 'double':'double'
+//DUMP: DeclRefExpr {{.*}}'double' lvalue Var {{.*}} 'b' 'double'
 //PRINT: #pragma omp scope private(a) reduction(*: b)
 #endif // HEADER

--- a/clang/test/SemaCXX/co_await-ast.cpp
+++ b/clang/test/SemaCXX/co_await-ast.cpp
@@ -47,13 +47,13 @@ awaitable foo() {
 // CHECK:   |-CompoundStmt {{.*}}
 // CHECK:   | `-ExprWithCleanups {{.*}} 'void'
 // CHECK:   |   `-CoawaitExpr {{.*}} 'void'
-// CHECK:   |     |-CXXTemporaryObjectExpr {{.*}} 'executor':'executor' 'void (){{.*}} noexcept' zeroing
+// CHECK:   |     |-CXXTemporaryObjectExpr {{.*}} 'executor' 'void (){{.*}} noexcept' zeroing
 // CHECK:   |     |-MaterializeTemporaryExpr {{.*}} 'result_t':'awaitable_frame::result_t' lvalue
 // CHECK:   |     | `-CXXBindTemporaryExpr {{.*}} 'result_t':'awaitable_frame::result_t' (CXXTemporary {{.*}})
 // CHECK:   |     |   `-CXXMemberCallExpr {{.*}} 'result_t':'awaitable_frame::result_t'
 // CHECK:   |     |     |-MemberExpr {{.*}} '<bound member function type>' .await_transform {{.*}}
 // CHECK:   |     |     | `-DeclRefExpr {{.*}} 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame' lvalue Var {{.*}} '__promise' 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame'
-// CHECK:   |     |     `-CXXTemporaryObjectExpr {{.*}} 'executor':'executor' 'void (){{.*}} noexcept' zeroing
+// CHECK:   |     |     `-CXXTemporaryObjectExpr {{.*}} 'executor' 'void (){{.*}} noexcept' zeroing
 // CHECK:   |     |-ExprWithCleanups {{.*}} 'bool'
 // CHECK:   |     | `-CXXMemberCallExpr {{.*}} 'bool'
 // CHECK:   |     |   `-MemberExpr {{.*}} '<bound member function type>' .await_ready {{.*}}
@@ -64,7 +64,7 @@ awaitable foo() {
 // CHECK:   |     |             `-CXXMemberCallExpr {{.*}} 'result_t':'awaitable_frame::result_t'
 // CHECK:   |     |               |-MemberExpr {{.*}} '<bound member function type>' .await_transform {{.*}}
 // CHECK:   |     |               | `-DeclRefExpr {{.*}} 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame' lvalue Var {{.*}} '__promise' 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame'
-// CHECK:   |     |               `-CXXTemporaryObjectExpr {{.*}} 'executor':'executor' 'void (){{.*}} noexcept' zeroing
+// CHECK:   |     |               `-CXXTemporaryObjectExpr {{.*}} 'executor' 'void (){{.*}} noexcept' zeroing
 // CHECK:   |     |-ExprWithCleanups {{.*}} 'void'
 // CHECK:   |     | `-CXXMemberCallExpr {{.*}} 'void'
 // CHECK:   |     |   |-MemberExpr {{.*}} '<bound member function type>' .await_suspend {{.*}}
@@ -74,9 +74,9 @@ awaitable foo() {
 // CHECK:   |     |   |       `-CXXMemberCallExpr {{.*}} 'result_t':'awaitable_frame::result_t'
 // CHECK:   |     |   |         |-MemberExpr {{.*}} '<bound member function type>' .await_transform {{.*}}
 // CHECK:   |     |   |         | `-DeclRefExpr {{.*}} 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame' lvalue Var {{.*}} '__promise' 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame'
-// CHECK:   |     |   |         `-CXXTemporaryObjectExpr {{.*}} 'executor':'executor' 'void (){{.*}} noexcept' zeroing
-// CHECK:   |     |   `-ImplicitCastExpr {{.*}} 'std::coroutine_handle<void>':'std::coroutine_handle<void>' <ConstructorConversion>
-// CHECK:   |     |     `-CXXConstructExpr {{.*}} 'std::coroutine_handle<void>':'std::coroutine_handle<void>' 'void (coroutine_handle<awaitable_frame> &&){{.*}} noexcept'
+// CHECK:   |     |   |         `-CXXTemporaryObjectExpr {{.*}} 'executor' 'void (){{.*}} noexcept' zeroing
+// CHECK:   |     |   `-ImplicitCastExpr {{.*}} 'std::coroutine_handle<void>' <ConstructorConversion>
+// CHECK:   |     |     `-CXXConstructExpr {{.*}} 'std::coroutine_handle<void>' 'void (coroutine_handle<awaitable_frame> &&){{.*}} noexcept'
 // CHECK:   |     |       `-MaterializeTemporaryExpr {{.*}} 'coroutine_handle<awaitable_frame>':'std::coroutine_handle<awaitable_frame>' xvalue
 // CHECK:   |     |         `-CallExpr {{.*}} 'coroutine_handle<awaitable_frame>':'std::coroutine_handle<awaitable_frame>'
 // CHECK:   |     |           |-ImplicitCastExpr {{.*}} 'coroutine_handle<awaitable_frame> (*)(void *) noexcept' <FunctionToPointerDecay>
@@ -93,6 +93,6 @@ awaitable foo() {
 // CHECK:   |                 `-CXXMemberCallExpr {{.*}} 'result_t':'awaitable_frame::result_t'
 // CHECK:   |                   |-MemberExpr {{.*}} '<bound member function type>' .await_transform {{.*}}
 // CHECK:   |                   | `-DeclRefExpr {{.*}} 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame' lvalue Var {{.*}} '__promise' 'std::coroutine_traits<awaitable>::promise_type':'awaitable_frame'
-// CHECK:   |                   `-CXXTemporaryObjectExpr {{.*}} <col:12, col:21> 'executor':'executor' 'void (){{.*}} noexcept' zeroing
+// CHECK:   |                   `-CXXTemporaryObjectExpr {{.*}} <col:12, col:21> 'executor' 'void (){{.*}} noexcept' zeroing
 
 // Rest of the generated coroutine statements omitted.

--- a/clang/test/SemaCXX/consteval-cleanup.cpp
+++ b/clang/test/SemaCXX/consteval-cleanup.cpp
@@ -21,11 +21,11 @@ void foo() {
   // CHECK: foo
   // CHECK: ExprWithCleanups
   // CHECK-NEXT: BinaryOperator {{.*}} 'bool' ','
-  // CHECK-NEXT: BinaryOperator {{.*}} 'P':'P' ','
-  // CHECK-NEXT: CXXFunctionalCastExpr {{.*}} 'A':'A'
-  // CHECK-NEXT: CXXBindTemporaryExpr {{.*}} 'A':'A'
-  // CHECK-NEXT: CXXConstructExpr {{.*}} 'A':'A'
-  // CHECK: ConstantExpr {{.*}} 'P':'P'
+  // CHECK-NEXT: BinaryOperator {{.*}} 'P' ','
+  // CHECK-NEXT: CXXFunctionalCastExpr {{.*}} 'A'
+  // CHECK-NEXT: CXXBindTemporaryExpr {{.*}} 'A'
+  // CHECK-NEXT: CXXConstructExpr {{.*}} 'A'
+  // CHECK: ConstantExpr {{.*}} 'P'
   // CHECK-NEXT: value:
   // CHECK-NEXT: ExprWithCleanups
 }
@@ -36,10 +36,10 @@ void foobar() {
   // CHECK: ExprWithCleanups
   // CHECK-NEXT: cleanup Block
   // CHECK-NEXT: BinaryOperator {{.*}} 'bool' ','
-  // CHECK-NEXT: BinaryOperator {{.*}} 'P':'P' ','
+  // CHECK-NEXT: BinaryOperator {{.*}} 'P' ','
   // CHECK-NEXT: CallExpr
   // CHECK-NEXT: BlockExpr
-  // CHECK: ConstantExpr {{.*}} 'P':'P'
+  // CHECK: ConstantExpr {{.*}} 'P'
   // CHECK-NEXT: value:
   // CHECK-NEXT: ExprWithCleanups
   // CHECK-NOT:  cleanup Block

--- a/clang/test/SemaOpenCLCXX/address-space-deduction.clcpp
+++ b/clang/test/SemaOpenCLCXX/address-space-deduction.clcpp
@@ -6,7 +6,7 @@
 constexpr int foo = 0;
 
 //CHECK: |-VarDecl {{.*}} foo1 'T' cinit
-//CHECK: `-VarTemplateSpecializationDecl {{.*}} used foo1 '__global long':'__global long' implicit_instantiation cinit
+//CHECK: `-VarTemplateSpecializationDecl {{.*}} used foo1 '__global long' implicit_instantiation cinit
 template <typename T>
 T foo1 = 0;
 

--- a/clang/test/SemaOpenCLCXX/addrspace-auto.clcpp
+++ b/clang/test/SemaOpenCLCXX/addrspace-auto.clcpp
@@ -1,18 +1,18 @@
 //RUN: %clang_cc1 %s -pedantic -ast-dump -verify | FileCheck %s
 
 __constant int i = 1;
-//CHECK: |-VarDecl {{.*}} ai '__global int':'__global int'
+//CHECK: |-VarDecl {{.*}} ai '__global int'
 auto ai = i;
 
 kernel void test() {
   int i;
-  //CHECK: VarDecl {{.*}} ai '__private int':'__private int'
+  //CHECK: VarDecl {{.*}} ai '__private int'
   auto ai = i;
 
   constexpr int c = 1;
-  //CHECK: VarDecl {{.*}} used cai '__constant int':'__constant int'
+  //CHECK: VarDecl {{.*}} used cai '__constant int'
   __constant auto cai = c;
-  //CHECK: VarDecl {{.*}} aii '__private int':'__private int'
+  //CHECK: VarDecl {{.*}} aii '__private int'
   auto aii = cai;
 
   //CHECK: VarDecl {{.*}} ref '__private int &__private'

--- a/clang/test/SemaTemplate/aggregate-deduction-candidate.cpp
+++ b/clang/test/SemaTemplate/aggregate-deduction-candidate.cpp
@@ -21,8 +21,8 @@ namespace Basic {
   // CHECK: `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for A> 'auto (double, double) -> Basic::A<double>'
   // CHECK:   |-TemplateArgument type 'double'
   // CHECK:   | `-BuiltinType {{.*}} 'double'
-  // CHECK:   |-ParmVarDecl {{.*}} 'double':'double'
-  // CHECK:   `-ParmVarDecl {{.*}} 'double':'double'
+  // CHECK:   |-ParmVarDecl {{.*}} 'double'
+  // CHECK:   `-ParmVarDecl {{.*}} 'double'
   // CHECK: FunctionProtoType {{.*}} 'auto (T, T) -> A<T>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'A<T>' dependent
   // CHECK: | `-CXXRecord {{.*}} 'A'
@@ -65,13 +65,13 @@ namespace Basic {
   // CHECK: FunctionTemplateDecl {{.*}} implicit <deduction guide for C>
   // CHECK: |-TemplateTypeParmDecl {{.*}} referenced typename depth 0 index 0 T
   // CHECK: |-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for C> 'auto (S<T>, T) -> C<T>'
-  // CHECK: | |-ParmVarDecl {{.*}} 'S<T>':'S<T>'
+  // CHECK: | |-ParmVarDecl {{.*}} 'S<T>'
   // CHECK: | `-ParmVarDecl {{.*}} 'T'
   // CHECK: `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for C> 'auto (S<int>, int) -> Basic::C<int>'
   // CHECK:   |-TemplateArgument type 'int'
   // CHECK:   | `-BuiltinType {{.*}} 'int'
   // CHECK:   |-ParmVarDecl {{.*}} 'S<int>':'Basic::S<int>'
-  // CHECK:   `-ParmVarDecl {{.*}} 'int':'int'
+  // CHECK:   `-ParmVarDecl {{.*}} 'int'
   // CHECK: FunctionProtoType {{.*}} 'auto (S<T>, T) -> C<T>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'C<T>' dependent
   // CHECK: | `-CXXRecord {{.*}} 'C'
@@ -87,8 +87,8 @@ namespace Basic {
   // CHECK: FunctionTemplateDecl {{.*}} implicit <deduction guide for D>
   // CHECK: |-TemplateTypeParmDecl {{.*}} referenced typename depth 0 index 0 T
   // CHECK: `-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for D> 'auto (int, int) -> D<T>'
-  // CHECK:   |-ParmVarDecl {{.*}} 'int':'int'
-  // CHECK:   `-ParmVarDecl {{.*}} 'int':'int'
+  // CHECK:   |-ParmVarDecl {{.*}} 'int'
+  // CHECK:   `-ParmVarDecl {{.*}} 'int'
   // CHECK: FunctionProtoType {{.*}} 'auto (int, int) -> D<T>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'D<T>' dependent
   // CHECK: | `-CXXRecord {{.*}} 'D'
@@ -117,7 +117,7 @@ namespace Basic {
   // CHECK: `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for E> 'auto (int, decltype(t)) -> Basic::E<int>'
   // CHECK:   |-TemplateArgument type 'int'
   // CHECK:   | `-BuiltinType {{.*}} 'int'
-  // CHECK:   |-ParmVarDecl {{.*}} 'int':'int'
+  // CHECK:   |-ParmVarDecl {{.*}} 'int'
   // CHECK:   `-ParmVarDecl {{.*}} 'decltype(t)':'int'
   // CHECK: FunctionProtoType {{.*}} 'auto (T, decltype(t)) -> E<T>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'E<T>' dependent
@@ -150,7 +150,7 @@ namespace Basic {
   // CHECK:   |-TemplateArgument type 'int'
   // CHECK:   | `-BuiltinType {{.*}} 'int'
   // CHECK:   |-ParmVarDecl {{.*}} 'typename I<int>::type':'int'
-  // CHECK:   `-ParmVarDecl {{.*}} 'int':'int'
+  // CHECK:   `-ParmVarDecl {{.*}} 'int'
   // CHECK: FunctionProtoType {{.*}} 'auto (typename I<T>::type, T) -> F<T>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'F<T>' dependent
   // CHECK: | `-CXXRecord {{.*}} 'F'
@@ -235,8 +235,8 @@ namespace BraceElision {
   // CHECK: `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for A> 'auto (int, int) -> BraceElision::A<int>'
   // CHECK:   |-TemplateArgument type 'int'
   // CHECK:   | `-BuiltinType {{.*}} 'int'
-  // CHECK:   |-ParmVarDecl {{.*}} 'int':'int'
-  // CHECK:   `-ParmVarDecl {{.*}} 'int':'int'
+  // CHECK:   |-ParmVarDecl {{.*}} 'int'
+  // CHECK:   `-ParmVarDecl {{.*}} 'int'
   // CHECK: FunctionProtoType {{.*}} 'auto (T, T) -> A<T>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'A<T>' dependent
   // CHECK: | `-CXXRecord {{.*}} 'A'
@@ -275,8 +275,8 @@ namespace TrailingPack {
   // CHECK: | `-TemplateArgument type 'TrailingPack::(lambda at {{.*}})'
   // CHECK: |   `-RecordType {{.*}} 'TrailingPack::(lambda at {{.*}})'
   // CHECK: |     `-CXXRecord {{.*}} ''
-  // CHECK: |-ParmVarDecl {{.*}} 'TrailingPack::(lambda at {{.*}})':'TrailingPack::(lambda at {{.*}})'
-  // CHECK: `-ParmVarDecl {{.*}} 'TrailingPack::(lambda at {{.*}})':'TrailingPack::(lambda at {{.*}})'
+  // CHECK: |-ParmVarDecl {{.*}} 'TrailingPack::(lambda at {{.*}})'
+  // CHECK: `-ParmVarDecl {{.*}} 'TrailingPack::(lambda at {{.*}})'
   // CHECK: FunctionProtoType {{.*}} 'auto (T...) -> A<T...>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'A<T...>' dependent
   // CHECK: | `-CXXRecord {{.*}} 'A'
@@ -324,7 +324,7 @@ namespace DeduceArity {
   // CHECK: FunctionTemplateDecl {{.*}} implicit <deduction guide for F>
   // CHECK: |-TemplateTypeParmDecl {{.*}} referenced typename depth 0 index 0 ... T
   // CHECK: |-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for F> 'auto (Types<T...>, T...) -> F<T...>'
-  // CHECK: | |-ParmVarDecl {{.*}} 'Types<T...>':'Types<T...>'
+  // CHECK: | |-ParmVarDecl {{.*}} 'Types<T...>'
   // CHECK: | `-ParmVarDecl {{.*}} 'T...' pack
   // CHECK: |-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for F> 
   // CHECK-SAME: 'auto (Types<X, Y, Z>, DeduceArity::X, DeduceArity::Y, DeduceArity::Z) -> 
@@ -340,16 +340,16 @@ namespace DeduceArity {
   // CHECK: | |   `-RecordType {{.*}} 'DeduceArity::Z'
   // CHECK: | |     `-CXXRecord {{.*}} 'Z'
   // CHECK: | |-ParmVarDecl {{.*}} 'Types<X, Y, Z>':'DeduceArity::Types<DeduceArity::X, DeduceArity::Y, DeduceArity::Z>'
-  // CHECK: | |-ParmVarDecl {{.*}} 'DeduceArity::X':'DeduceArity::X'
-  // CHECK: | |-ParmVarDecl {{.*}} 'DeduceArity::Y':'DeduceArity::Y'
-  // CHECK: | `-ParmVarDecl {{.*}} 'DeduceArity::Z':'DeduceArity::Z'
+  // CHECK: | |-ParmVarDecl {{.*}} 'DeduceArity::X'
+  // CHECK: | |-ParmVarDecl {{.*}} 'DeduceArity::Y'
+  // CHECK: | `-ParmVarDecl {{.*}} 'DeduceArity::Z'
   // CHECK: `-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for F> 'auto (Types<X>, DeduceArity::X) -> DeduceArity::F<DeduceArity::X>'
   // CHECK:   |-TemplateArgument pack
   // CHECK:   | `-TemplateArgument type 'DeduceArity::X'
   // CHECK:   |   `-RecordType {{.*}} 'DeduceArity::X'
   // CHECK:   |     `-CXXRecord {{.*}} 'X'
   // CHECK:   |-ParmVarDecl {{.*}} 'Types<X>':'DeduceArity::Types<DeduceArity::X>'
-  // CHECK:   `-ParmVarDecl {{.*}} 'DeduceArity::X':'DeduceArity::X'
+  // CHECK:   `-ParmVarDecl {{.*}} 'DeduceArity::X'
   // CHECK: FunctionProtoType {{.*}} 'auto (Types<T...>, T...) -> F<T...>' dependent trailing_return cdecl
   // CHECK: |-InjectedClassNameType {{.*}} 'F<T...>' dependent
   // CHECK: | `-CXXRecord {{.*}} 'F'

--- a/clang/test/SemaTemplate/deduction-guide.cpp
+++ b/clang/test/SemaTemplate/deduction-guide.cpp
@@ -37,7 +37,7 @@ using AT = A<int[3], int, int, short>;
 // CHECK:   | | `-Var {{.*}} 'arr1' 'int[3]'
 // CHECK:   | `-TemplateArgument decl
 // CHECK:   |   `-Var {{.*}} 'arr2' 'int[3]'
-// CHECK:   |-ParmVarDecl {{.*}} 'X<&arr1, &arr2>':'X<&arr1, &arr2>'
+// CHECK:   |-ParmVarDecl {{.*}} 'X<&arr1, &arr2>'
 // CHECK:   |-ParmVarDecl {{.*}} 'int (*)[3]'
 // CHECK:   |-ParmVarDecl {{.*}} 'int (*)[3]'
 // CHECK:   `-ParmVarDecl {{.*}} 'short (*)[4]'
@@ -76,7 +76,7 @@ using BT = B<char, 'x'>;
 // CHECK:   |-TemplateArgument integral 120
 // CHECK:   |-TemplateArgument type 'std::nullptr_t'
 // CHECK:   |-TemplateArgument nullptr
-// CHECK:   `-ParmVarDecl {{.*}} 'X<nullptr, 'x'>':'X<nullptr, 'x'>'
+// CHECK:   `-ParmVarDecl {{.*}} 'X<nullptr, 'x'>'
 // CHECK: FunctionProtoType {{.*}} 'auto (X<W, V>) -> B<T, V>' dependent trailing_return
 // CHECK: |-InjectedClassNameType {{.*}} 'B<T, V>' dependent
 // CHECK: `-TemplateSpecializationType {{.*}} 'X<W, V>' dependent X
@@ -111,9 +111,9 @@ using CT = C<int>;
 // CHECK:  |-TemplateArgument template B
 // CHECK:  |-TemplateArgument type 'int'
 // CHECK:  |-TemplateArgument integral 0
-// CHECK:  |-ParmVarDecl {{.*}} 'int':'int'
-// CHECK:  |-ParmVarDecl {{.*}} 'Y<B>':'Y<B>'
-// CHECK:  `-ParmVarDecl {{.*}} 'int':'int'
+// CHECK:  |-ParmVarDecl {{.*}} 'int'
+// CHECK:  |-ParmVarDecl {{.*}} 'Y<B>'
+// CHECK:  `-ParmVarDecl {{.*}} 'int'
 // CHECK: FunctionProtoType {{.*}} 'auto (A, Y<>, type-parameter-0-2) -> C<A>' dependent trailing_return cdecl
 // CHECK: |-InjectedClassNameType {{.*}} 'C<A>' dependent
 // CHECK: |-TemplateTypeParmType {{.*}} 'A' dependent depth 0 index 0
@@ -234,7 +234,7 @@ F s(0);
 // CHECK:   |-TemplateArgument integral 120
 // CHECK:   |-TemplateArgument type 'int'
 // CHECK:   | `-BuiltinType {{.*}} 'int'
-// CHECK:   `-ParmVarDecl {{.*}} 'int':'int'
+// CHECK:   `-ParmVarDecl {{.*}} 'int'
 // CHECK: FunctionProtoType {{.*}} 'auto (type-parameter-0-1) -> F<>' dependent trailing_return cdecl
 // CHECK: |-InjectedClassNameType {{.*}} 'F<>' dependent
 // CHECK: | `-CXXRecord {{.*}} 'F'

--- a/clang/test/SemaTemplate/default-expr-arguments-3.cpp
+++ b/clang/test/SemaTemplate/default-expr-arguments-3.cpp
@@ -4,7 +4,7 @@
 // CHECK: FunctionDecl {{.*}} used func 'void ()'
 // CHECK-NEXT: TemplateArgument type 'int'
 // CHECK: LambdaExpr {{.*}} '(lambda at
-// CHECK: ParmVarDecl {{.*}} used f 'foo':'foo' cinit
+// CHECK: ParmVarDecl {{.*}} used f 'foo' cinit
 // CHECK-NEXT: DeclRefExpr {{.*}} 'foo' EnumConstant {{.*}} 'a' 'foo'
 
 namespace PR28795 {
@@ -23,7 +23,7 @@ namespace PR28795 {
 // CHECK: ClassTemplateSpecializationDecl {{.*}} struct class2 definition
 // CHECK: TemplateArgument type 'int'
 // CHECK: LambdaExpr {{.*}} '(lambda at
-// CHECK: ParmVarDecl {{.*}} used f 'foo':'foo' cinit
+// CHECK: ParmVarDecl {{.*}} used f 'foo' cinit
 // CHECK-NEXT: DeclRefExpr {{.*}} 'foo' EnumConstant {{.*}} 'a' 'foo'
 
 // Template struct case:
@@ -41,7 +41,7 @@ template struct class2<int>;
 // CHECK-NEXT: FunctionDecl {{.*}} f1 'void ()'
 // CHECK: FunctionDecl {{.*}} f1 'void ()'
 // CHECK-NEXT: TemplateArgument type 'int'
-// CHECK: ParmVarDecl {{.*}} n 'foo':'foo' cinit
+// CHECK: ParmVarDecl {{.*}} n 'foo' cinit
 // CHECK-NEXT: DeclRefExpr {{.*}} 'foo' EnumConstant {{.*}} 'a' 'foo'
 
 template<typename T>

--- a/clang/test/SemaTemplate/make_integer_seq.cpp
+++ b/clang/test/SemaTemplate/make_integer_seq.cpp
@@ -37,7 +37,7 @@ using test2 = B<int, 1>;
 // CHECK-NEXT:       `-ElaboratedType 0x{{[0-9A-Fa-f]+}} '__make_integer_seq<A, int, 1>' sugar
 // CHECK-NEXT:         `-TemplateSpecializationType 0x{{[0-9A-Fa-f]+}} '__make_integer_seq<A, int, 1>' sugar alias __make_integer_seq
 // CHECK-NEXT:           |-TemplateArgument template A
-// CHECK-NEXT:           |-TemplateArgument type 'int':'int'
+// CHECK-NEXT:           |-TemplateArgument type 'int'
 // CHECK-NEXT:           | `-SubstTemplateTypeParmType 0x{{[0-9A-Fa-f]+}} 'int' sugar class depth 0 index 0 B1
 // CHECK-NEXT:           |   |-TypeAliasTemplate 0x{{[0-9A-Fa-f]+}} 'B'
 // CHECK-NEXT:           |   `-BuiltinType 0x{{[0-9A-Fa-f]+}} 'int'
@@ -48,14 +48,14 @@ using test2 = B<int, 1>;
 // CHECK-NEXT:           |     |-NonTypeTemplateParmDecl 0x{{[0-9A-Fa-f]+}} <col:21, col:24> col:24 referenced 'B1' depth 0 index 1 B2
 // CHECK-NEXT:           |     `-IntegerLiteral 0x{{[0-9A-Fa-f]+}} <col:64> 'int' 1
 // CHECK-NEXT:           `-TemplateSpecializationType 0x{{[0-9A-Fa-f]+}} 'A<int, 0>' sugar A
-// CHECK-NEXT:             |-TemplateArgument type 'int':'int'
+// CHECK-NEXT:             |-TemplateArgument type 'int'
 // CHECK-NEXT:             | `-SubstTemplateTypeParmType 0x{{[0-9A-Fa-f]+}} 'int' sugar class depth 0 index 0 B1
 // CHECK-NEXT:             |   |-TypeAliasTemplate 0x{{[0-9A-Fa-f]+}} 'B'
 // CHECK-NEXT:             |   `-BuiltinType 0x{{[0-9A-Fa-f]+}} 'int'
 // CHECK-NEXT:             |-TemplateArgument expr
 // CHECK-NEXT:             | `-ConstantExpr 0x{{[0-9A-Fa-f]+}} <col:64> 'int'
 // CHECK-NEXT:             |   |-value: Int 0
-// CHECK-NEXT:             |   `-IntegerLiteral 0x{{[0-9A-Fa-f]+}} <col:64> 'int':'int' 0
+// CHECK-NEXT:             |   `-IntegerLiteral 0x{{[0-9A-Fa-f]+}} <col:64> 'int' 0
 // CHECK-NEXT:             `-RecordType 0x{{[0-9A-Fa-f]+}} 'A<int, 0>'
 // CHECK-NEXT:               `-ClassTemplateSpecialization 0x{{[0-9A-Fa-f]+}} 'A'
 
@@ -99,7 +99,7 @@ template <template <class T, T...> class S, class T, int N> struct C {
 // CHECK-NEXT:             `-IntegerLiteral 0x{{[0-9A-Fa-f]+}} <col:42> 'int' 1
 
   using test5 = __make_integer_seq<A, int, N>;
-//      CHECK: `-TypeAliasDecl 0x{{[0-9A-Fa-f]+}} <line:101:3, col:45> col:9 test5 '__make_integer_seq<A, int, N>':'__make_integer_seq<A, int, N>'
+//      CHECK: `-TypeAliasDecl 0x{{[0-9A-Fa-f]+}} <line:101:3, col:45> col:9 test5 '__make_integer_seq<A, int, N>'
 // CHECK-NEXT:   `-ElaboratedType 0x{{[0-9A-Fa-f]+}} '__make_integer_seq<A, int, N>' sugar dependent
 // CHECK-NEXT:     `-TemplateSpecializationType 0x{{[0-9A-Fa-f]+}} '__make_integer_seq<A, int, N>' sugar dependent alias __make_integer_seq
 // CHECK-NEXT:       |-TemplateArgument template A

--- a/clang/test/SemaTemplate/pr47676.cpp
+++ b/clang/test/SemaTemplate/pr47676.cpp
@@ -34,5 +34,5 @@ void g(void) {
 
 //      CHECK: |       `-CStyleCastExpr {{.*}} '__vector int' <VectorSplat>
 // CHECK-NEXT: |         `-ImplicitCastExpr {{.*}} 'int' <FloatingToIntegral>
-// CHECK-NEXT: |           `-ImplicitCastExpr {{.*}}:'double' <LValueToRValue>
+// CHECK-NEXT: |           `-ImplicitCastExpr {{.*}}'double' <LValueToRValue>
 }

--- a/clang/test/SemaTemplate/type_pack_element.cpp
+++ b/clang/test/SemaTemplate/type_pack_element.cpp
@@ -55,7 +55,7 @@ template<int N, class ...Ts> struct A {
 // CHECK-NEXT:               `-TemplateTypeParmType 0x{{[0-9A-Fa-f]+}} 'type-parameter-0-1' dependent contains_unexpanded_pack depth 0 index 1 pack
 
   using test4 = __type_pack_element<N, int>;
-//      CHECK: `-TypeAliasDecl 0x{{[0-9A-Fa-f]+}} <line:57:3, col:43> col:9 test4 '__type_pack_element<N, int>':'__type_pack_element<N, int>'
+//      CHECK: `-TypeAliasDecl 0x{{[0-9A-Fa-f]+}} <line:57:3, col:43> col:9 test4 '__type_pack_element<N, int>'
 // CHECK-NEXT:   `-ElaboratedType 0x{{[0-9A-Fa-f]+}} '__type_pack_element<N, int>' sugar dependent
 // CHECK-NEXT:     `-TemplateSpecializationType 0x{{[0-9A-Fa-f]+}} '__type_pack_element<N, int>' sugar dependent alias __type_pack_element
 // CHECK-NEXT:       |-TemplateArgument expr

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -4941,7 +4941,7 @@ TEST_P(ASTImporterOptionSpecificTestBase,
 | `-CXXDeductionGuideDecl 0x20515d8 <col:9, col:12> col:9 implicit used <deduction guide for A> 'auto (int) -> A<int>'
 |   |-TemplateArgument type 'int'
 |   | `-BuiltinType 0x20587e0 'int'
-|   `-ParmVarDecl 0x2051388 <col:11> col:12 'int':'int'
+|   `-ParmVarDecl 0x2051388 <col:11> col:12 'int'
 `-FunctionTemplateDecl 0x1fe5a78 <line:2:7, col:36> col:36 implicit <deduction guide for A>
   |-TemplateTypeParmDecl 0x1fe4eb0 <col:17, col:26> col:26 referenced typename depth 0 index 0 T
   `-CXXDeductionGuideDecl 0x1fe59c0 <col:36> col:36 implicit <deduction guide for A> 'auto (A<T>) -> A<T>'


### PR DESCRIPTION
These are an artifact of how types are structured but serve little
purpose, merely showing that the type is sugared in some way. For
example, ElaboratedType's existence means struct S gets printed as
'struct S':'struct S' in the AST, which is unnecessary visual clutter.
Note that skipping the second print when the types have the same string
matches what we do for diagnostics, where the aka will be skipped.
