### PR TITLE
[clang-tidy][NFC][doc] Improve documentation for modernize-use-equals…

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseEqualsDeleteCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseEqualsDeleteCheck.h
@@ -14,8 +14,8 @@
 namespace clang::tidy::modernize {
 
 /// Identifies unimplemented private special member functions, and recommends
-/// using ``= delete`` for them, as well as relocating them from the ``private``
-/// to the ``public`` section.
+/// using ``= delete`` for them. Additionally, it recommends relocating any
+/// deleted member function from the ``private`` to the ``public`` section.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-delete.html

--- a/clang-tools-extra/clang-tidy/modernize/UseEqualsDeleteCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseEqualsDeleteCheck.h
@@ -13,22 +13,9 @@
 
 namespace clang::tidy::modernize {
 
-/// Mark unimplemented private special member functions with '= delete'.
-/// \code
-///   struct A {
-///   private:
-///     A(const A&);
-///     A& operator=(const A&);
-///   };
-/// \endcode
-/// Is converted to:
-/// \code
-///   struct A {
-///   private:
-///     A(const A&) = delete;
-///     A& operator=(const A&) = delete;
-///   };
-/// \endcode
+/// Identifies unimplemented private special member functions, and recommends
+/// using ``= delete`` for them, as well as relocating them from the ``private``
+/// to the ``public`` section.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-delete.html

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
@@ -3,20 +3,26 @@
 modernize-use-equals-delete
 ===========================
 
-Prior to C++11, the only way to "delete" a given function was to make it
-``private`` and without definition, to generate a compiler error (calling
-private function) or a linker error (undefined reference).
+Identifies unimplemented private special member functions, and recommends using
+``= delete`` for them, as well as relocating them from the ``private`` to the
+``public`` section.
 
-After C++11, the more idiomatic way to achieve this is by marking the functions
-as ``= delete``, and keeping them in the ``public`` section.
+Before the introduction of C11, the primary method to effectively "erase" a
+particular function involved declaring it as ``private`` without providing a
+definition. This approach would result in either a compiler error (when
+attempting to call a private function) or a linker error (due to an undefined
+reference).
 
-This check warns only on unimplemented private **special member functions**.
-To avoid false-positives, this check only applies in a translation unit that has
-all other member functions implemented. The check will generate partial fixes
-by adding ``= delete``, but the move the ``public`` section needs to be done
-manually.
+However, subsequent to the advent of C11, a more conventional approach emerged
+for achieving this purpose. It involves flagging functions as ``= delete`` and
+keeping them in the ``public`` section of the class.
 
-.. code-block:: c++
+To prevent false positives, this check is only active within a translation
+unit where all other member functions have been implemented. The check will
+generate partial fixes by introducing ``= delete``, but the user is responsible
+for manually relocating functions to the ``public`` section.
+
+.. code-block:: c
 
   // Example: bad
   class A {

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
@@ -7,13 +7,13 @@ Identifies unimplemented private special member functions, and recommends using
 ``= delete`` for them, as well as relocating them from the ``private`` to the
 ``public`` section.
 
-Before the introduction of C11, the primary method to effectively "erase" a
+Before the introduction of C++11, the primary method to effectively "erase" a
 particular function involved declaring it as ``private`` without providing a
 definition. This approach would result in either a compiler error (when
 attempting to call a private function) or a linker error (due to an undefined
 reference).
 
-However, subsequent to the advent of C11, a more conventional approach emerged
+However, subsequent to the advent of C++11, a more conventional approach emerged
 for achieving this purpose. It involves flagging functions as ``= delete`` and
 keeping them in the ``public`` section of the class.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
@@ -10,14 +10,11 @@ private function) or a linker error (undefined reference).
 After C++11, the more idiomatic way to achieve this is by marking the functions
 as ``= delete``, and keeping them in the ``public`` section.
 
-This check marks unimplemented private special member functions with ``= delete``.
-Additionally, it warns about ``delete``'d functions still kept in the ``private``
-section, that should be moved to the ``public`` one instead.
-
+This check warns only on unimplemented private **special member functions**.
 To avoid false-positives, this check only applies in a translation unit that has
 all other member functions implemented. The check will generate partial fixes
-by adding ``= delete``, but the user must manually move it to the ``public``
-section.
+by adding ``= delete``, but the move the ``public`` section needs to be done
+manually.
 
 .. code-block:: c++
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
@@ -4,8 +4,8 @@ modernize-use-equals-delete
 ===========================
 
 Identifies unimplemented private special member functions, and recommends using
-``= delete`` for them, as well as relocating them from the ``private`` to the
-``public`` section.
+``= delete`` for them. Additionally, it recommends relocating any deleted
+member function from the ``private`` to the ``public`` section.
 
 Before the introduction of C++11, the primary method to effectively "erase" a
 particular function involved declaring it as ``private`` without providing a

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
@@ -3,22 +3,34 @@
 modernize-use-equals-delete
 ===========================
 
+Prior to C++11, the only way to "delete" a given function was to make it
+``private`` and without definition, to generate a compiler error (calling
+private function) or a linker error (undefined reference).
+
+After C++11, the more idiomatic way to achieve this is by marking the functions
+as ``= delete``, and keeping them in the ``public`` section.
+
 This check marks unimplemented private special member functions with ``= delete``.
+Additionally, it warns about ``delete``'d functions still kept in the ``private``
+section, that should be moved to the ``public`` one instead.
+
 To avoid false-positives, this check only applies in a translation unit that has
-all other member functions implemented.
+all other member functions implemented. The check will generate partial fixes
+by adding ``= delete``, but the user must manually move it to the ``public``
+section.
 
 .. code-block:: c++
 
-  struct A {
-  private:
+  // Example: bad
+  class A {
+   private:
     A(const A&);
     A& operator=(const A&);
   };
 
-  // becomes
-
-  struct A {
-  private:
+  // Example: good
+  class A {
+   public:
     A(const A&) = delete;
     A& operator=(const A&) = delete;
   };

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-equals-delete.rst
@@ -22,7 +22,7 @@ unit where all other member functions have been implemented. The check will
 generate partial fixes by introducing ``= delete``, but the user is responsible
 for manually relocating functions to the ``public`` section.
 
-.. code-block:: c
+.. code-block:: c++
 
   // Example: bad
   class A {


### PR DESCRIPTION
…-delete

So the purpose of the check is more clear. Update examples code to show compliant code.

Fixes #65221 