### PR TITLE
[clang][Diagnostics] Fix wrong line number display

### DIFF
--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -1160,8 +1160,7 @@ void TextDiagnostic::emitSnippetAndCaret(
   // Find the set of lines to include.
   const unsigned MaxLines = DiagOpts->SnippetLineLimit;
   std::pair<unsigned, unsigned> Lines = {CaretLineNo, CaretLineNo};
-  unsigned DisplayLineNo =
-      Ranges.empty() ? Loc.getPresumedLoc().getLine() : ~0u;
+  unsigned DisplayLineNo = Loc.getPresumedLoc().getLine();
   for (const auto &I : Ranges) {
     if (auto OptionalRange = findLinesForRange(I, FID, SM))
       Lines = maybeAddRange(Lines, *OptionalRange, MaxLines);

--- a/clang/test/Misc/diag-style.cpp
+++ b/clang/test/Misc/diag-style.cpp
@@ -24,3 +24,20 @@ void f(int x) {
 // CHECK-NEXT: {{^}}      |
 // CHECK-NEXT: {{^}}      |
 // CHECK-NEXT: {{^}}   12 |
+
+#line 10
+int func(
+  int a, int b,
+  int&
+  r);
+
+void test() {
+  func(3, 4, 5);
+}
+// CHECK: 10:5: note: candidate function not viable
+// CHECK-NEXT: {{^}}   10 |
+// CHECK-NEXT: {{^}}      |
+// CHECK-NEXT: {{^}}   11 |
+// CHECK-NEXT: {{^}}   12 |
+// CHECK-NEXT: {{^}}      |
+// CHECK-NEXT: {{^}}   13 |

--- a/clang/test/Misc/diag-style.cpp
+++ b/clang/test/Misc/diag-style.cpp
@@ -41,3 +41,5 @@ void test() {
 // CHECK-NEXT: {{^}}   12 |
 // CHECK-NEXT: {{^}}      |
 // CHECK-NEXT: {{^}}   13 |
+// CHECK-NEXT: {{^}}      |
+


### PR DESCRIPTION
When the caret location is lower than the lowest source range, clang is printing wrong line numbers. The first line number should consider caret location line even when there are source ranges provided.

Current wrong line example: https://godbolt.org/z/aj4qEjzs4