### PR TITLE
[compiler-rt] Link atomic against builtins

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -878,7 +878,7 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
                               ARCHS ${arch}
                               SOURCES atomic.c
                               LINK_FLAGS ${COMPILER_RT_LIBATOMIC_LINK_FLAGS}
-                              DEPS builtins
+                              LINK_LIBS clang_rt.builtins-${arch}
                               PARENT_TARGET builtins-standalone-atomic)
     endif()
   endforeach()


### PR DESCRIPTION
The atomic shared library needs to be linked against builtins. The `add_compiler_rt_runtime` call already has `DEP builtins` but that only ensures that the `builtins` target is built before `clang_rt.atomic` but doesn't link against `clang_rt.builtins`, to do so we need to use `LINK_LIBS clang_rt.builtins`.