### PR TITLE
[AMDGPU] Erase ShaderFunctions in AMDGPUPALMetadata::reset()

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUPALMetadata.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUPALMetadata.cpp
@@ -908,6 +908,7 @@ void AMDGPUPALMetadata::reset() {
   MsgPackDoc.clear();
   Registers = MsgPackDoc.getEmptyNode();
   HwStages = MsgPackDoc.getEmptyNode();
+  ShaderFunctions = MsgPackDoc.getEmptyNode();
 }
 
 unsigned AMDGPUPALMetadata::getPALVersion(unsigned idx) {


### PR DESCRIPTION
**Issue**
Before this pull request, ShaderFunctions was never get erased when the pal metadata were reset. As a result, when the same ELF streamer was reused for another compilation, the ShaderFunctions was dirty so that the .Shader_Function section could not be generated properly.

**Fix**
Erase ShaderFunctions in AMDGPUPALMetadata::reset()