### PR TITLE
[libc++][doc] Add warning about limitation of --fresh in boostrapping build

### DIFF
--- a/libcxx/docs/BuildingLibcxx.rst
+++ b/libcxx/docs/BuildingLibcxx.rst
@@ -79,7 +79,8 @@ CMake invocation at ``<monorepo>/llvm``:
   away from that terminology, which is too confusing.
 
 .. warning::
-  Adding the `--fresh` flag to the top-level cmake invocation in a bootstrapping build *will not* freshen the cmake cache of any of the enabled runtimes.
+  Adding the `--fresh` flag to the top-level cmake invocation in a bootstrapping build *will not*
+  freshen the cmake cache of any of the enabled runtimes.
 
 Support for Windows
 ===================

--- a/libcxx/docs/BuildingLibcxx.rst
+++ b/libcxx/docs/BuildingLibcxx.rst
@@ -78,6 +78,9 @@ CMake invocation at ``<monorepo>/llvm``:
   This type of build is also commonly called a "Runtimes build", but we would like to move
   away from that terminology, which is too confusing.
 
+.. warning::
+  Adding the `--fresh` flag to the top-level cmake invocation in a bootstrapping build *will not* freshen the cmake cache of any of the enabled runtimes.
+
 Support for Windows
 ===================
 


### PR DESCRIPTION
Add a warning to the `Building Libcxx` documentation about the limitations of the utility of `--fresh` at the top level.