### PR TITLE
[AST] Fix nested name specifiers printing as NamespaceNamespace

### DIFF
--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -16,6 +16,7 @@
 #include "clang/AST/DeclOpenMP.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/LocInfoType.h"
+#include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/SourceManager.h"
@@ -792,11 +793,11 @@ void clang::TextNodeDumper::dumpNestedNameSpecifier(const NestedNameSpecifier *N
       OS << " '" << NNS->getAsIdentifier()->getName() << "'";
       break;
     case NestedNameSpecifier::Namespace:
-      OS << " Namespace";
+      OS << " "; // "Namespace" is printed as the decl kind.
       dumpBareDeclRef(NNS->getAsNamespace());
       break;
     case NestedNameSpecifier::NamespaceAlias:
-      OS << " NamespaceAlias";
+      OS << " "; // "NamespaceAlias" is printed as the decl kind.
       dumpBareDeclRef(NNS->getAsNamespaceAlias());
       break;
     case NestedNameSpecifier::TypeSpec:

--- a/clang/test/AST/ast-dump-decl.cpp
+++ b/clang/test/AST/ast-dump-decl.cpp
@@ -740,7 +740,7 @@ namespace TestUsingDecl {
 }
 // CHECK:      NamespaceDecl{{.*}} TestUsingDecl
 // CHECK-NEXT:   UsingDecl{{.*}} testUsingDecl::i
-// CHECK-NEXT:   | `-NestedNameSpecifier NamespaceNamespace 0x{{.*}} 'testUsingDecl
+// CHECK-NEXT:   | `-NestedNameSpecifier Namespace 0x{{.*}} 'testUsingDecl
 // CHECK-NEXT:   UsingShadowDecl{{.*}} Var{{.*}} 'i' 'int'
 
 namespace testUnresolvedUsing {

--- a/clang/test/AST/ast-dump-openmp-begin-declare-variant_namespace_1.cpp
+++ b/clang/test/AST/ast-dump-openmp-begin-declare-variant_namespace_1.cpp
@@ -114,12 +114,12 @@ int main() {
 // CHECK-NEXT: |       | |-CallExpr [[ADDR_47:0x[a-z0-9]*]] <col:10, col:17> 'int'
 // CHECK-NEXT: |       | | `-ImplicitCastExpr [[ADDR_48:0x[a-z0-9]*]] <col:10, col:13> 'int (*)({{.*}})' <FunctionToPointerDecay>
 // CHECK-NEXT: |       | |   `-DeclRefExpr [[ADDR_49:0x[a-z0-9]*]] <col:10, col:13> 'int ({{.*}})' {{.*}}Function [[ADDR_1]] 'foo' 'int ({{.*}})'
-// CHECK-NEXT: |       | |   `-NestedNameSpecifier NamespaceNamespace [[ADDR_0]] 'A'
+// CHECK-NEXT: |       | |   `-NestedNameSpecifier Namespace [[ADDR_0]] 'A'
 // CHECK-NEXT: |       | `-PseudoObjectExpr [[ADDR_50:0x[a-z0-9]*]] <col:21, col:28> 'int'
 // CHECK-NEXT: |       |   |-CallExpr [[ADDR_51:0x[a-z0-9]*]] <col:21, col:28> 'int'
 // CHECK-NEXT: |       |   | `-ImplicitCastExpr [[ADDR_52:0x[a-z0-9]*]] <col:21, col:24> 'int (*)({{.*}})' <FunctionToPointerDecay>
 // CHECK-NEXT: |       |   |   `-DeclRefExpr [[ADDR_53:0x[a-z0-9]*]] <col:21, col:24> 'int ({{.*}})' {{.*}}Function [[ADDR_6]] 'bar' 'int ({{.*}})'
-// CHECK-NEXT: |       |   |   `-NestedNameSpecifier NamespaceNamespace [[ADDR_31]] 'B'
+// CHECK-NEXT: |       |   |   `-NestedNameSpecifier Namespace [[ADDR_31]] 'B'
 // CHECK-NEXT: |       |   `-CallExpr [[ADDR_54:0x[a-z0-9]*]] <line:34:1, line:50:28> 'int'
 // CHECK-NEXT: |       |     `-ImplicitCastExpr [[ADDR_55:0x[a-z0-9]*]] <line:34:1> 'int (*)({{.*}})' <FunctionToPointerDecay>
 // CHECK-NEXT: |       |       `-DeclRefExpr [[ADDR_11]] <col:1> 'int ({{.*}})' Function [[ADDR_12]] 'bar[implementation={vendor(llvm)}]' 'int ({{.*}})'
@@ -127,7 +127,7 @@ int main() {
 // CHECK-NEXT: |         |-CallExpr [[ADDR_57:0x[a-z0-9]*]] <col:32, col:39> 'int'
 // CHECK-NEXT: |         | `-ImplicitCastExpr [[ADDR_58:0x[a-z0-9]*]] <col:32, col:35> 'int (*)({{.*}})' <FunctionToPointerDecay>
 // CHECK-NEXT: |         |   `-DeclRefExpr [[ADDR_59:0x[a-z0-9]*]] <col:32, col:35> 'int ({{.*}})' {{.*}}Function [[ADDR_14]] 'baz' 'int ({{.*}})'
-// CHECK-NEXT: |         |   `-NestedNameSpecifier NamespaceNamespace [[ADDR_13]] 'C'
+// CHECK-NEXT: |         |   `-NestedNameSpecifier Namespace [[ADDR_13]] 'C'
 // CHECK-NEXT: |         `-CallExpr [[ADDR_60:0x[a-z0-9]*]] <line:42:1, line:50:39> 'int'
 // CHECK-NEXT: |           `-ImplicitCastExpr [[ADDR_61:0x[a-z0-9]*]] <line:42:1> 'int (*)({{.*}})' <FunctionToPointerDecay>
 // CHECK-NEXT: |             `-DeclRefExpr [[ADDR_19]] <col:1> 'int ({{.*}})' Function [[ADDR_20]] 'baz[implementation={vendor(llvm)}]' 'int ({{.*}})'

--- a/clang/test/AST/ast-dump-using.cpp
+++ b/clang/test/AST/ast-dump-using.cpp
@@ -6,7 +6,7 @@ struct S;
 namespace b {
 using a::S;
 // CHECK:      UsingDecl {{.*}} a::S
-// CHECK-NEXT: | `-NestedNameSpecifier NamespaceNamespace {{.*}} 'a'
+// CHECK-NEXT: | `-NestedNameSpecifier Namespace {{.*}} 'a'
 // CHECK-NEXT: UsingShadowDecl {{.*}} implicit CXXRecord {{.*}} 'S'
 // CHECK-NEXT: `-RecordType {{.*}} 'a::S'
 typedef S f; // to dump the introduced type


### PR DESCRIPTION
This happens because we print both the kind of the NNS and the kind of
decl (when it refers to one). These are always the same string.
