### PR TITLE
[clang][doc] Don't escape _ in .rst files.

### DIFF
--- a/clang/utils/TableGen/ClangOptionDocEmitter.cpp
+++ b/clang/utils/TableGen/ClangOptionDocEmitter.cpp
@@ -194,7 +194,7 @@ unsigned getNumArgsForKind(Record *OptionKind, const Record *Option) {
 std::string escapeRST(StringRef Str) {
   std::string Out;
   for (auto K : Str) {
-    if (StringRef("`*|_[]\\").count(K))
+    if (StringRef("`*|[]\\").count(K))
       Out.push_back('\\');
     Out.push_back(K);
   }


### PR DESCRIPTION
The current generated ClangCommandLineReference.rst unconditionally escapes underscores. This leads odd output on the website https://clang.llvm.org/docs/ClangCommandLineReference.html

For example

   -fchar8\_t, -fno-char8\_t

Whether an underscore should be escaped depends on the state. Currently the escape routine doesn't keep track of the state and currently underscores are not used in places where they need to be escaped. Therefore remove the underscore from the list of escaped characters.