### PR TITLE
[InlineAsm] Add constraint A to getMemConstraintName

### DIFF
--- a/llvm/include/llvm/IR/InlineAsm.h
+++ b/llvm/include/llvm/IR/InlineAsm.h
@@ -443,6 +443,8 @@ public:
       return "m";
     case InlineAsm::Constraint_o:
       return "o";
+    case InlineAsm::Constraint_A:
+      return "A";
     case InlineAsm::Constraint_v:
       return "v";
     case InlineAsm::Constraint_Q:

--- a/llvm/include/llvm/IR/InlineAsm.h
+++ b/llvm/include/llvm/IR/InlineAsm.h
@@ -443,10 +443,10 @@ public:
       return "m";
     case InlineAsm::Constraint_o:
       return "o";
-    case InlineAsm::Constraint_A:
-      return "A";
     case InlineAsm::Constraint_v:
       return "v";
+    case InlineAsm::Constraint_A:
+      return "A";
     case InlineAsm::Constraint_Q:
       return "Q";
     case InlineAsm::Constraint_R:


### PR DESCRIPTION
We will get an assertion of 'Unknown memory constraint' when we dump
`MachineOperand` with constraint A.
