### PR TITLE
[PowerPC] Optimize select_cc with VSX compare and xxsel

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.h
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.h
@@ -475,6 +475,9 @@ namespace llvm {
     /// XXMFACC = This corresponds to the xxmfacc instruction.
     XXMFACC,
 
+    /// VSX_CMPSEL = VSX compare gt/ge/eq instruction with selection.
+    VSX_CMPSEL,
+
     // Constrained conversion from floating point to int
     STRICT_FCTIDZ = ISD::FIRST_TARGET_STRICTFP_OPCODE,
     STRICT_FCTIWZ,

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -193,6 +193,8 @@ def PPCany_faddrtz: PatFrags<(ops node:$lhs, node:$rhs),
                              [(PPCfaddrtz node:$lhs, node:$rhs),
                               (PPCstrict_faddrtz node:$lhs, node:$rhs)]>;
 
+def PPCvsx_cmpsel : SDNode<"PPCISD::VSX_CMPSEL", SDTSelectCC, []>;
+
 def PPCfsel   : SDNode<"PPCISD::FSEL",
    // Type constraint for fsel.
    SDTypeProfile<1, 3, [SDTCisSameAs<0, 2>, SDTCisSameAs<0, 3>,

--- a/llvm/lib/Target/PowerPC/PPCInstrP10.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrP10.td
@@ -2067,6 +2067,19 @@ let AddedComplexity = 400, Predicates = [IsISA3_1, HasVSX] in {
             (v1i128 (VSRAQ v1i128:$VRA,
                      (XXPERMDI (COPY_TO_REGCLASS $VRB, VSRC),
                                (COPY_TO_REGCLASS $VRB, VSRC), 2)))>;
+
+def : Pat<(f128 (PPCvsx_cmpsel f128:$lhs, f128:$rhs, f128:$tval, f128:$fval, SETOEQ)),
+          (COPY_TO_REGCLASS (XXSEL (COPY_TO_REGCLASS $tval, VSRC),
+                                   (COPY_TO_REGCLASS $fval, VSRC),
+                                   (XSCMPEQQP $lhs, $rhs)), VSFRC)>;
+def : Pat<(f128 (PPCvsx_cmpsel f128:$lhs, f128:$rhs, f128:$tval, f128:$fval, SETOGE)),
+          (COPY_TO_REGCLASS (XXSEL (COPY_TO_REGCLASS $tval, VSRC),
+                                   (COPY_TO_REGCLASS $fval, VSRC),
+                                   (XSCMPGEQP $lhs, $rhs)), VSFRC)>;
+def : Pat<(f128 (PPCvsx_cmpsel f128:$lhs, f128:$rhs, f128:$tval, f128:$fval, SETOGT)),
+          (COPY_TO_REGCLASS (XXSEL (COPY_TO_REGCLASS $tval, VSRC),
+                                   (COPY_TO_REGCLASS $fval, VSRC),
+                                   (XSCMPGTQP $lhs, $rhs)), VSFRC)>;
 }
 
 class xxevalPattern <dag pattern, bits<8> imm> :

--- a/llvm/lib/Target/PowerPC/PPCInstrVSX.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrVSX.td
@@ -2918,6 +2918,39 @@ def : Pat<(PPCstore_scal_int_from_vsr f64:$src, XForm:$dst, 8),
           (STXSDX $src, XForm:$dst)>;
 def : Pat<(PPCstore_scal_int_from_vsr f128:$src, XForm:$dst, 8),
           (STXSDX (COPY_TO_REGCLASS $src, VSFRC), XForm:$dst)>;
+
+def : Pat<(f32 (PPCvsx_cmpsel f32:$lhs, f32:$rhs, f32:$tval, f32:$fval, SETOEQ)),
+          (COPY_TO_REGCLASS (XXSEL
+            (COPY_TO_REGCLASS $tval, VSRC), (COPY_TO_REGCLASS $fval, VSRC),
+            (XVCMPEQSP (COPY_TO_REGCLASS $lhs, VSRC),
+                       (COPY_TO_REGCLASS $rhs, VSRC))), VSSRC)>;
+def : Pat<(f32 (PPCvsx_cmpsel f32:$lhs, f32:$rhs, f32:$tval, f32:$fval, SETOGE)),
+          (COPY_TO_REGCLASS (XXSEL
+            (COPY_TO_REGCLASS $tval, VSRC), (COPY_TO_REGCLASS $fval, VSRC),
+            (XVCMPGESP (COPY_TO_REGCLASS $lhs, VSRC),
+                       (COPY_TO_REGCLASS $rhs, VSRC))), VSSRC)>;
+def : Pat<(f32 (PPCvsx_cmpsel f32:$lhs, f32:$rhs, f32:$tval, f32:$fval, SETOGT)),
+          (COPY_TO_REGCLASS (XXSEL
+            (COPY_TO_REGCLASS $tval, VSRC),
+            (COPY_TO_REGCLASS $fval, VSRC),
+            (XVCMPGTSP (COPY_TO_REGCLASS $lhs, VSRC),
+                       (COPY_TO_REGCLASS $rhs, VSRC))), VSSRC)>;
+def : Pat<(f64 (PPCvsx_cmpsel f64:$lhs, f64:$rhs, f64:$tval, f64:$fval, SETOEQ)),
+          (COPY_TO_REGCLASS (XXSEL
+            (COPY_TO_REGCLASS $tval, VSRC), (COPY_TO_REGCLASS $fval, VSRC),
+            (XVCMPEQDP (COPY_TO_REGCLASS $lhs, VSRC),
+                       (COPY_TO_REGCLASS $rhs, VSRC))), VSFRC)>;
+def : Pat<(f64 (PPCvsx_cmpsel f64:$lhs, f64:$rhs, f64:$tval, f64:$fval, SETOGE)),
+          (COPY_TO_REGCLASS (XXSEL
+            (COPY_TO_REGCLASS $tval, VSRC), (COPY_TO_REGCLASS $fval, VSRC),
+            (XVCMPGEDP (COPY_TO_REGCLASS $lhs, VSRC),
+                       (COPY_TO_REGCLASS $rhs, VSRC))), VSFRC)>;
+def : Pat<(f64 (PPCvsx_cmpsel f64:$lhs, f64:$rhs, f64:$tval, f64:$fval, SETOGT)),
+          (COPY_TO_REGCLASS (XXSEL
+            (COPY_TO_REGCLASS $tval, VSRC),
+            (COPY_TO_REGCLASS $fval, VSRC),
+            (XVCMPGTDP (COPY_TO_REGCLASS $lhs, VSRC),
+                       (COPY_TO_REGCLASS $rhs, VSRC))), VSFRC)>;
 } // HasVSX
 
 // Any big endian VSX subtarget.
@@ -3932,6 +3965,19 @@ foreach Ty = [v4i32, v4f32, v2i64, v2f64] in {
   def : Pat<(store Ty:$rS, DQForm:$dst), (STXV $rS, memrix16:$dst)>;
   def : Pat<(store Ty:$rS, XForm:$dst), (STXVX $rS, XForm:$dst)>;
 }
+
+def : Pat<(f64 (PPCvsx_cmpsel f64:$lhs, f64:$rhs, f64:$tval, f64:$fval, SETOEQ)),
+          (COPY_TO_REGCLASS (XXSEL (COPY_TO_REGCLASS $tval, VSRC),
+                                   (COPY_TO_REGCLASS $fval, VSRC),
+                                   (XSCMPEQDP $lhs, $rhs)), VSFRC)>;
+def : Pat<(f64 (PPCvsx_cmpsel f64:$lhs, f64:$rhs, f64:$tval, f64:$fval, SETOGE)),
+          (COPY_TO_REGCLASS (XXSEL (COPY_TO_REGCLASS $tval, VSRC),
+                                   (COPY_TO_REGCLASS $fval, VSRC),
+                                   (XSCMPGEDP $lhs, $rhs)), VSFRC)>;
+def : Pat<(f64 (PPCvsx_cmpsel f64:$lhs, f64:$rhs, f64:$tval, f64:$fval, SETOGT)),
+          (COPY_TO_REGCLASS (XXSEL (COPY_TO_REGCLASS $tval, VSRC),
+                                   (COPY_TO_REGCLASS $fval, VSRC),
+                                   (XSCMPGTDP $lhs, $rhs)), VSFRC)>;
 
 def : Pat<(f128 (load DQForm:$src)),
           (COPY_TO_REGCLASS (LXV memrix16:$src), VRRC)>;

--- a/llvm/test/CodeGen/PowerPC/cgp-select.ll
+++ b/llvm/test/CodeGen/PowerPC/cgp-select.ll
@@ -8,30 +8,32 @@ define dso_local void @wibble(ptr nocapture readonly %arg, i32 signext %arg1, pt
 ; CHECK-NEXT:    li 7, 7
 ; CHECK-NEXT:    cmpwi 4, 2
 ; CHECK-NEXT:    xsaddsp 0, 0, 0
-; CHECK-NEXT:    blt 0, .LBB0_5
+; CHECK-NEXT:    blt 0, .LBB0_4
 ; CHECK-NEXT:  # %bb.1: # %bb6
 ; CHECK-NEXT:    clrldi 4, 4, 32
 ; CHECK-NEXT:    addi 4, 4, -1
 ; CHECK-NEXT:    mtctr 4
 ; CHECK-NEXT:    li 4, 8
-; CHECK-NEXT:    b .LBB0_3
-; CHECK-NEXT:    .p2align 5
+; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_2: # %bb11
 ; CHECK-NEXT:    #
+; CHECK-NEXT:    lfsu 2, 4(3)
+; CHECK-NEXT:    xsaddsp 1, 2, 2
+; CHECK-NEXT:    xvcmpgtsp 3, 2, 0
+; CHECK-NEXT:    fcmpu 0, 2, 0
 ; CHECK-NEXT:    iselgt 7, 4, 7
 ; CHECK-NEXT:    addi 4, 4, 1
-; CHECK-NEXT:    bdz .LBB0_5
-; CHECK-NEXT:  .LBB0_3: # %bb11
-; CHECK-NEXT:    #
-; CHECK-NEXT:    lfsu 1, 4(3)
-; CHECK-NEXT:    fcmpu 0, 1, 0
-; CHECK-NEXT:    ble 0, .LBB0_2
-; CHECK-NEXT:  # %bb.4:
-; CHECK-NEXT:    xsaddsp 0, 1, 1
-; CHECK-NEXT:    b .LBB0_2
-; CHECK-NEXT:  .LBB0_5: # %bb8
+; CHECK-NEXT:    xxsel 1, 1, 0, 3
+; CHECK-NEXT:    fmr 0, 1
+; CHECK-NEXT:    bdnz .LBB0_2
+; CHECK-NEXT:  # %bb.3: # %bb8
 ; CHECK-NEXT:    stw 7, 0(5)
-; CHECK-NEXT:    stfs 0, 0(6)
+; CHECK-NEXT:    stfs 1, 0(6)
+; CHECK-NEXT:    blr
+; CHECK-NEXT:  .LBB0_4:
+; CHECK-NEXT:    fmr 1, 0
+; CHECK-NEXT:    stw 7, 0(5)
+; CHECK-NEXT:    stfs 1, 0(6)
 ; CHECK-NEXT:    blr
 bb:
   %tmp = load float, ptr %arg, align 4

--- a/llvm/test/CodeGen/PowerPC/fmf-propagation.ll
+++ b/llvm/test/CodeGen/PowerPC/fmf-propagation.ll
@@ -302,47 +302,43 @@ define float @fmul_fma_fast2(float %x) {
 define float @sqrt_afn_ieee(float %x) #0 {
 ; FMF-LABEL: sqrt_afn_ieee:
 ; FMF:       # %bb.0:
-; FMF-NEXT:    addis 3, 2, .LCPI11_1@toc@ha
-; FMF-NEXT:    xsabsdp 0, 1
-; FMF-NEXT:    lfs 2, .LCPI11_1@toc@l(3)
-; FMF-NEXT:    fcmpu 0, 0, 2
-; FMF-NEXT:    xxlxor 0, 0, 0
-; FMF-NEXT:    blt 0, .LBB11_2
-; FMF-NEXT:  # %bb.1:
 ; FMF-NEXT:    xsrsqrtesp 2, 1
 ; FMF-NEXT:    addis 3, 2, .LCPI11_0@toc@ha
 ; FMF-NEXT:    vspltisw 2, -3
 ; FMF-NEXT:    lfs 0, .LCPI11_0@toc@l(3)
-; FMF-NEXT:    xsmulsp 1, 1, 2
-; FMF-NEXT:    xsmulsp 0, 1, 0
-; FMF-NEXT:    xsmulsp 1, 1, 2
-; FMF-NEXT:    xvcvsxwdp 2, 34
-; FMF-NEXT:    xsaddsp 1, 1, 2
-; FMF-NEXT:    xsmulsp 0, 0, 1
-; FMF-NEXT:  .LBB11_2:
-; FMF-NEXT:    fmr 1, 0
+; FMF-NEXT:    addis 3, 2, .LCPI11_1@toc@ha
+; FMF-NEXT:    xsmulsp 3, 1, 2
+; FMF-NEXT:    xsabsdp 1, 1
+; FMF-NEXT:    xsmulsp 0, 3, 0
+; FMF-NEXT:    xsmulsp 2, 3, 2
+; FMF-NEXT:    xvcvsxwdp 3, 34
+; FMF-NEXT:    xsaddsp 2, 2, 3
+; FMF-NEXT:    xsmulsp 0, 0, 2
+; FMF-NEXT:    lfs 2, .LCPI11_1@toc@l(3)
+; FMF-NEXT:    xvcmpgesp 1, 2, 1
+; FMF-NEXT:    xxlxor 2, 2, 2
+; FMF-NEXT:    xxsel 1, 2, 0, 1
+; FMF-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; FMF-NEXT:    blr
 ;
 ; GLOBAL-LABEL: sqrt_afn_ieee:
 ; GLOBAL:       # %bb.0:
-; GLOBAL-NEXT:    addis 3, 2, .LCPI11_1@toc@ha
-; GLOBAL-NEXT:    xsabsdp 0, 1
-; GLOBAL-NEXT:    lfs 2, .LCPI11_1@toc@l(3)
-; GLOBAL-NEXT:    fcmpu 0, 0, 2
-; GLOBAL-NEXT:    xxlxor 0, 0, 0
-; GLOBAL-NEXT:    blt 0, .LBB11_2
-; GLOBAL-NEXT:  # %bb.1:
 ; GLOBAL-NEXT:    xsrsqrtesp 0, 1
 ; GLOBAL-NEXT:    vspltisw 2, -3
 ; GLOBAL-NEXT:    addis 3, 2, .LCPI11_0@toc@ha
-; GLOBAL-NEXT:    xvcvsxwdp 2, 34
-; GLOBAL-NEXT:    xsmulsp 1, 1, 0
-; GLOBAL-NEXT:    xsmaddasp 2, 1, 0
+; GLOBAL-NEXT:    xvcvsxwdp 3, 34
+; GLOBAL-NEXT:    xsmulsp 2, 1, 0
+; GLOBAL-NEXT:    xsabsdp 1, 1
+; GLOBAL-NEXT:    xsmaddasp 3, 2, 0
 ; GLOBAL-NEXT:    lfs 0, .LCPI11_0@toc@l(3)
-; GLOBAL-NEXT:    xsmulsp 0, 1, 0
-; GLOBAL-NEXT:    xsmulsp 0, 0, 2
-; GLOBAL-NEXT:  .LBB11_2:
-; GLOBAL-NEXT:    fmr 1, 0
+; GLOBAL-NEXT:    addis 3, 2, .LCPI11_1@toc@ha
+; GLOBAL-NEXT:    xsmulsp 0, 2, 0
+; GLOBAL-NEXT:    lfs 2, .LCPI11_1@toc@l(3)
+; GLOBAL-NEXT:    xvcmpgesp 1, 2, 1
+; GLOBAL-NEXT:    xxlxor 2, 2, 2
+; GLOBAL-NEXT:    xsmulsp 0, 0, 3
+; GLOBAL-NEXT:    xxsel 1, 2, 0, 1
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; GLOBAL-NEXT:    blr
   %rt = call afn ninf float @llvm.sqrt.f32(float %x)
   ret float %rt
@@ -373,41 +369,39 @@ define float @sqrt_afn_ieee_inf(float %x) #0 {
 define float @sqrt_afn_preserve_sign(float %x) #1 {
 ; FMF-LABEL: sqrt_afn_preserve_sign:
 ; FMF:       # %bb.0:
-; FMF-NEXT:    xxlxor 0, 0, 0
-; FMF-NEXT:    fcmpu 0, 1, 0
-; FMF-NEXT:    beq 0, .LBB13_2
-; FMF-NEXT:  # %bb.1:
-; FMF-NEXT:    xsrsqrtesp 0, 1
+; FMF-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; FMF-NEXT:    xsrsqrtesp 2, 1
 ; FMF-NEXT:    addis 3, 2, .LCPI13_0@toc@ha
 ; FMF-NEXT:    vspltisw 2, -3
-; FMF-NEXT:    lfs 2, .LCPI13_0@toc@l(3)
-; FMF-NEXT:    xsmulsp 1, 1, 0
-; FMF-NEXT:    xsmulsp 2, 1, 2
-; FMF-NEXT:    xsmulsp 0, 1, 0
-; FMF-NEXT:    xvcvsxwdp 1, 34
-; FMF-NEXT:    xsaddsp 0, 0, 1
-; FMF-NEXT:    xsmulsp 0, 2, 0
-; FMF-NEXT:  .LBB13_2:
-; FMF-NEXT:    fmr 1, 0
+; FMF-NEXT:    lfs 0, .LCPI13_0@toc@l(3)
+; FMF-NEXT:    xsmulsp 3, 1, 2
+; FMF-NEXT:    xsmulsp 0, 3, 0
+; FMF-NEXT:    xsmulsp 2, 3, 2
+; FMF-NEXT:    xvcvsxwdp 3, 34
+; FMF-NEXT:    xsaddsp 2, 2, 3
+; FMF-NEXT:    xsmulsp 0, 0, 2
+; FMF-NEXT:    xxlxor 2, 2, 2
+; FMF-NEXT:    xvcmpeqsp 1, 1, 2
+; FMF-NEXT:    xxsel 1, 2, 0, 1
+; FMF-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; FMF-NEXT:    blr
 ;
 ; GLOBAL-LABEL: sqrt_afn_preserve_sign:
 ; GLOBAL:       # %bb.0:
-; GLOBAL-NEXT:    xxlxor 0, 0, 0
-; GLOBAL-NEXT:    fcmpu 0, 1, 0
-; GLOBAL-NEXT:    beq 0, .LBB13_2
-; GLOBAL-NEXT:  # %bb.1:
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 def $vsl1
 ; GLOBAL-NEXT:    xsrsqrtesp 0, 1
 ; GLOBAL-NEXT:    vspltisw 2, -3
 ; GLOBAL-NEXT:    addis 3, 2, .LCPI13_0@toc@ha
-; GLOBAL-NEXT:    xvcvsxwdp 2, 34
-; GLOBAL-NEXT:    xsmulsp 1, 1, 0
-; GLOBAL-NEXT:    xsmaddasp 2, 1, 0
+; GLOBAL-NEXT:    xvcvsxwdp 3, 34
+; GLOBAL-NEXT:    xsmulsp 2, 1, 0
+; GLOBAL-NEXT:    xsmaddasp 3, 2, 0
 ; GLOBAL-NEXT:    lfs 0, .LCPI13_0@toc@l(3)
-; GLOBAL-NEXT:    xsmulsp 0, 1, 0
-; GLOBAL-NEXT:    xsmulsp 0, 0, 2
-; GLOBAL-NEXT:  .LBB13_2:
-; GLOBAL-NEXT:    fmr 1, 0
+; GLOBAL-NEXT:    xsmulsp 0, 2, 0
+; GLOBAL-NEXT:    xxlxor 2, 2, 2
+; GLOBAL-NEXT:    xvcmpeqsp 1, 1, 2
+; GLOBAL-NEXT:    xsmulsp 0, 0, 3
+; GLOBAL-NEXT:    xxsel 1, 2, 0, 1
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; GLOBAL-NEXT:    blr
   %rt = call afn ninf float @llvm.sqrt.f32(float %x)
   ret float %rt
@@ -440,46 +434,42 @@ define float @sqrt_afn_preserve_sign_inf(float %x) #1 {
 define float @sqrt_fast_ieee(float %x) #0 {
 ; FMF-LABEL: sqrt_fast_ieee:
 ; FMF:       # %bb.0:
-; FMF-NEXT:    addis 3, 2, .LCPI15_1@toc@ha
-; FMF-NEXT:    xsabsdp 0, 1
-; FMF-NEXT:    lfs 2, .LCPI15_1@toc@l(3)
-; FMF-NEXT:    fcmpu 0, 0, 2
-; FMF-NEXT:    xxlxor 0, 0, 0
-; FMF-NEXT:    blt 0, .LBB15_2
-; FMF-NEXT:  # %bb.1:
 ; FMF-NEXT:    xsrsqrtesp 0, 1
 ; FMF-NEXT:    vspltisw 2, -3
 ; FMF-NEXT:    addis 3, 2, .LCPI15_0@toc@ha
-; FMF-NEXT:    xvcvsxwdp 2, 34
-; FMF-NEXT:    xsmulsp 1, 1, 0
-; FMF-NEXT:    xsmaddasp 2, 1, 0
+; FMF-NEXT:    xvcvsxwdp 3, 34
+; FMF-NEXT:    xsmulsp 2, 1, 0
+; FMF-NEXT:    xsabsdp 1, 1
+; FMF-NEXT:    xsmaddasp 3, 2, 0
 ; FMF-NEXT:    lfs 0, .LCPI15_0@toc@l(3)
-; FMF-NEXT:    xsmulsp 0, 1, 0
-; FMF-NEXT:    xsmulsp 0, 0, 2
-; FMF-NEXT:  .LBB15_2:
-; FMF-NEXT:    fmr 1, 0
+; FMF-NEXT:    addis 3, 2, .LCPI15_1@toc@ha
+; FMF-NEXT:    xsmulsp 0, 2, 0
+; FMF-NEXT:    lfs 2, .LCPI15_1@toc@l(3)
+; FMF-NEXT:    xvcmpgesp 1, 2, 1
+; FMF-NEXT:    xxlxor 2, 2, 2
+; FMF-NEXT:    xsmulsp 0, 0, 3
+; FMF-NEXT:    xxsel 1, 2, 0, 1
+; FMF-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; FMF-NEXT:    blr
 ;
 ; GLOBAL-LABEL: sqrt_fast_ieee:
 ; GLOBAL:       # %bb.0:
-; GLOBAL-NEXT:    addis 3, 2, .LCPI15_1@toc@ha
-; GLOBAL-NEXT:    xsabsdp 0, 1
-; GLOBAL-NEXT:    lfs 2, .LCPI15_1@toc@l(3)
-; GLOBAL-NEXT:    fcmpu 0, 0, 2
-; GLOBAL-NEXT:    xxlxor 0, 0, 0
-; GLOBAL-NEXT:    blt 0, .LBB15_2
-; GLOBAL-NEXT:  # %bb.1:
 ; GLOBAL-NEXT:    xsrsqrtesp 0, 1
 ; GLOBAL-NEXT:    vspltisw 2, -3
 ; GLOBAL-NEXT:    addis 3, 2, .LCPI15_0@toc@ha
-; GLOBAL-NEXT:    xvcvsxwdp 2, 34
-; GLOBAL-NEXT:    xsmulsp 1, 1, 0
-; GLOBAL-NEXT:    xsmaddasp 2, 1, 0
+; GLOBAL-NEXT:    xvcvsxwdp 3, 34
+; GLOBAL-NEXT:    xsmulsp 2, 1, 0
+; GLOBAL-NEXT:    xsabsdp 1, 1
+; GLOBAL-NEXT:    xsmaddasp 3, 2, 0
 ; GLOBAL-NEXT:    lfs 0, .LCPI15_0@toc@l(3)
-; GLOBAL-NEXT:    xsmulsp 0, 1, 0
-; GLOBAL-NEXT:    xsmulsp 0, 0, 2
-; GLOBAL-NEXT:  .LBB15_2:
-; GLOBAL-NEXT:    fmr 1, 0
+; GLOBAL-NEXT:    addis 3, 2, .LCPI15_1@toc@ha
+; GLOBAL-NEXT:    xsmulsp 0, 2, 0
+; GLOBAL-NEXT:    lfs 2, .LCPI15_1@toc@l(3)
+; GLOBAL-NEXT:    xvcmpgesp 1, 2, 1
+; GLOBAL-NEXT:    xxlxor 2, 2, 2
+; GLOBAL-NEXT:    xsmulsp 0, 0, 3
+; GLOBAL-NEXT:    xxsel 1, 2, 0, 1
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; GLOBAL-NEXT:    blr
   %rt = call contract reassoc afn ninf float @llvm.sqrt.f32(float %x)
   ret float %rt
@@ -498,40 +488,38 @@ define float @sqrt_fast_ieee(float %x) #0 {
 define float @sqrt_fast_preserve_sign(float %x) #1 {
 ; FMF-LABEL: sqrt_fast_preserve_sign:
 ; FMF:       # %bb.0:
-; FMF-NEXT:    xxlxor 0, 0, 0
-; FMF-NEXT:    fcmpu 0, 1, 0
-; FMF-NEXT:    beq 0, .LBB16_2
-; FMF-NEXT:  # %bb.1:
+; FMF-NEXT:    # kill: def $f1 killed $f1 def $vsl1
 ; FMF-NEXT:    xsrsqrtesp 0, 1
 ; FMF-NEXT:    vspltisw 2, -3
 ; FMF-NEXT:    addis 3, 2, .LCPI16_0@toc@ha
-; FMF-NEXT:    xvcvsxwdp 2, 34
-; FMF-NEXT:    xsmulsp 1, 1, 0
-; FMF-NEXT:    xsmaddasp 2, 1, 0
+; FMF-NEXT:    xvcvsxwdp 3, 34
+; FMF-NEXT:    xsmulsp 2, 1, 0
+; FMF-NEXT:    xsmaddasp 3, 2, 0
 ; FMF-NEXT:    lfs 0, .LCPI16_0@toc@l(3)
-; FMF-NEXT:    xsmulsp 0, 1, 0
-; FMF-NEXT:    xsmulsp 0, 0, 2
-; FMF-NEXT:  .LBB16_2:
-; FMF-NEXT:    fmr 1, 0
+; FMF-NEXT:    xsmulsp 0, 2, 0
+; FMF-NEXT:    xxlxor 2, 2, 2
+; FMF-NEXT:    xvcmpeqsp 1, 1, 2
+; FMF-NEXT:    xsmulsp 0, 0, 3
+; FMF-NEXT:    xxsel 1, 2, 0, 1
+; FMF-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; FMF-NEXT:    blr
 ;
 ; GLOBAL-LABEL: sqrt_fast_preserve_sign:
 ; GLOBAL:       # %bb.0:
-; GLOBAL-NEXT:    xxlxor 0, 0, 0
-; GLOBAL-NEXT:    fcmpu 0, 1, 0
-; GLOBAL-NEXT:    beq 0, .LBB16_2
-; GLOBAL-NEXT:  # %bb.1:
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 def $vsl1
 ; GLOBAL-NEXT:    xsrsqrtesp 0, 1
 ; GLOBAL-NEXT:    vspltisw 2, -3
 ; GLOBAL-NEXT:    addis 3, 2, .LCPI16_0@toc@ha
-; GLOBAL-NEXT:    xvcvsxwdp 2, 34
-; GLOBAL-NEXT:    xsmulsp 1, 1, 0
-; GLOBAL-NEXT:    xsmaddasp 2, 1, 0
+; GLOBAL-NEXT:    xvcvsxwdp 3, 34
+; GLOBAL-NEXT:    xsmulsp 2, 1, 0
+; GLOBAL-NEXT:    xsmaddasp 3, 2, 0
 ; GLOBAL-NEXT:    lfs 0, .LCPI16_0@toc@l(3)
-; GLOBAL-NEXT:    xsmulsp 0, 1, 0
-; GLOBAL-NEXT:    xsmulsp 0, 0, 2
-; GLOBAL-NEXT:  .LBB16_2:
-; GLOBAL-NEXT:    fmr 1, 0
+; GLOBAL-NEXT:    xsmulsp 0, 2, 0
+; GLOBAL-NEXT:    xxlxor 2, 2, 2
+; GLOBAL-NEXT:    xvcmpeqsp 1, 1, 2
+; GLOBAL-NEXT:    xsmulsp 0, 0, 3
+; GLOBAL-NEXT:    xxsel 1, 2, 0, 1
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; GLOBAL-NEXT:    blr
   %rt = call contract reassoc ninf afn float @llvm.sqrt.f32(float %x)
   ret float %rt
@@ -540,34 +528,34 @@ define float @sqrt_fast_preserve_sign(float %x) #1 {
 ; fcmp can have fast-math-flags.
 
 ; FMFDEBUG-LABEL: Optimized lowered selection DAG: %bb.0 'fcmp_nnan:'
-; FMFDEBUG:         select_cc nnan {{t[0-9]+}}
+; FMFDEBUG:         PPCISD::VSX_CMPSEL
 ; FMFDEBUG:       Type-legalized selection DAG: %bb.0 'fcmp_nnan:'
 
 ; GLOBALDEBUG-LABEL: Optimized lowered selection DAG: %bb.0 'fcmp_nnan:'
-; GLOBALDEBUG:         select_cc nnan {{t[0-9]+}}
+; GLOBALDEBUG:      PPCISD::VSX_CMPSEL
 ; GLOBALDEBUG:       Type-legalized selection DAG: %bb.0 'fcmp_nnan:'
 
 define double @fcmp_nnan(double %a, double %y, double %z) {
 ; FMF-LABEL: fcmp_nnan:
 ; FMF:       # %bb.0:
 ; FMF-NEXT:    xxlxor 0, 0, 0
-; FMF-NEXT:    xscmpudp 0, 1, 0
-; FMF-NEXT:    blt 0, .LBB17_2
-; FMF-NEXT:  # %bb.1:
-; FMF-NEXT:    fmr 3, 2
-; FMF-NEXT:  .LBB17_2:
-; FMF-NEXT:    fmr 1, 3
+; FMF-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; FMF-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; FMF-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; FMF-NEXT:    xvcmpgedp 0, 0, 1
+; FMF-NEXT:    xxsel 1, 3, 2, 0
+; FMF-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; FMF-NEXT:    blr
 ;
 ; GLOBAL-LABEL: fcmp_nnan:
 ; GLOBAL:       # %bb.0:
 ; GLOBAL-NEXT:    xxlxor 0, 0, 0
-; GLOBAL-NEXT:    xscmpudp 0, 1, 0
-; GLOBAL-NEXT:    blt 0, .LBB17_2
-; GLOBAL-NEXT:  # %bb.1:
-; GLOBAL-NEXT:    fmr 3, 2
-; GLOBAL-NEXT:  .LBB17_2:
-; GLOBAL-NEXT:    fmr 1, 3
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; GLOBAL-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; GLOBAL-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; GLOBAL-NEXT:    xvcmpgedp 0, 0, 1
+; GLOBAL-NEXT:    xxsel 1, 3, 2, 0
+; GLOBAL-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; GLOBAL-NEXT:    blr
   %cmp = fcmp nnan ult double %a, 0.0
   %z.y = select i1 %cmp, double %z, double %y

--- a/llvm/test/CodeGen/PowerPC/recipest.ll
+++ b/llvm/test/CodeGen/PowerPC/recipest.ll
@@ -950,46 +950,42 @@ define float @goo3_fmf(float %a) nounwind {
 ;
 ; CHECK-P8-LABEL: goo3_fmf:
 ; CHECK-P8:       # %bb.0:
-; CHECK-P8-NEXT:    addis 3, 2, .LCPI23_1@toc@ha
-; CHECK-P8-NEXT:    xsabsdp 0, 1
-; CHECK-P8-NEXT:    lfs 2, .LCPI23_1@toc@l(3)
-; CHECK-P8-NEXT:    fcmpu 0, 0, 2
-; CHECK-P8-NEXT:    xxlxor 0, 0, 0
-; CHECK-P8-NEXT:    blt 0, .LBB23_2
-; CHECK-P8-NEXT:  # %bb.1:
 ; CHECK-P8-NEXT:    xsrsqrtesp 0, 1
 ; CHECK-P8-NEXT:    vspltisw 2, -3
 ; CHECK-P8-NEXT:    addis 3, 2, .LCPI23_0@toc@ha
-; CHECK-P8-NEXT:    xvcvsxwdp 2, 34
-; CHECK-P8-NEXT:    xsmulsp 1, 1, 0
-; CHECK-P8-NEXT:    xsmaddasp 2, 1, 0
+; CHECK-P8-NEXT:    xvcvsxwdp 3, 34
+; CHECK-P8-NEXT:    xsmulsp 2, 1, 0
+; CHECK-P8-NEXT:    xsabsdp 1, 1
+; CHECK-P8-NEXT:    xsmaddasp 3, 2, 0
 ; CHECK-P8-NEXT:    lfs 0, .LCPI23_0@toc@l(3)
-; CHECK-P8-NEXT:    xsmulsp 0, 1, 0
-; CHECK-P8-NEXT:    xsmulsp 0, 0, 2
-; CHECK-P8-NEXT:  .LBB23_2:
-; CHECK-P8-NEXT:    fmr 1, 0
+; CHECK-P8-NEXT:    addis 3, 2, .LCPI23_1@toc@ha
+; CHECK-P8-NEXT:    xsmulsp 0, 2, 0
+; CHECK-P8-NEXT:    lfs 2, .LCPI23_1@toc@l(3)
+; CHECK-P8-NEXT:    xvcmpgesp 1, 2, 1
+; CHECK-P8-NEXT:    xxlxor 2, 2, 2
+; CHECK-P8-NEXT:    xsmulsp 0, 0, 3
+; CHECK-P8-NEXT:    xxsel 1, 2, 0, 1
+; CHECK-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; CHECK-P8-NEXT:    blr
 ;
 ; CHECK-P9-LABEL: goo3_fmf:
 ; CHECK-P9:       # %bb.0:
-; CHECK-P9-NEXT:    addis 3, 2, .LCPI23_1@toc@ha
-; CHECK-P9-NEXT:    xsabsdp 0, 1
-; CHECK-P9-NEXT:    lfs 2, .LCPI23_1@toc@l(3)
-; CHECK-P9-NEXT:    fcmpu 0, 0, 2
-; CHECK-P9-NEXT:    xxlxor 0, 0, 0
-; CHECK-P9-NEXT:    blt 0, .LBB23_2
-; CHECK-P9-NEXT:  # %bb.1:
 ; CHECK-P9-NEXT:    xsrsqrtesp 0, 1
 ; CHECK-P9-NEXT:    vspltisw 2, -3
 ; CHECK-P9-NEXT:    addis 3, 2, .LCPI23_0@toc@ha
-; CHECK-P9-NEXT:    xsmulsp 1, 1, 0
-; CHECK-P9-NEXT:    xvcvsxwdp 2, 34
-; CHECK-P9-NEXT:    xsmaddasp 2, 1, 0
+; CHECK-P9-NEXT:    xsmulsp 2, 1, 0
+; CHECK-P9-NEXT:    xvcvsxwdp 3, 34
+; CHECK-P9-NEXT:    xsabsdp 1, 1
+; CHECK-P9-NEXT:    xsmaddasp 3, 2, 0
 ; CHECK-P9-NEXT:    lfs 0, .LCPI23_0@toc@l(3)
-; CHECK-P9-NEXT:    xsmulsp 0, 1, 0
-; CHECK-P9-NEXT:    xsmulsp 0, 0, 2
-; CHECK-P9-NEXT:  .LBB23_2:
-; CHECK-P9-NEXT:    fmr 1, 0
+; CHECK-P9-NEXT:    addis 3, 2, .LCPI23_1@toc@ha
+; CHECK-P9-NEXT:    xsmulsp 0, 2, 0
+; CHECK-P9-NEXT:    lfs 2, .LCPI23_1@toc@l(3)
+; CHECK-P9-NEXT:    xsmulsp 0, 0, 3
+; CHECK-P9-NEXT:    xvcmpgesp 1, 2, 1
+; CHECK-P9-NEXT:    xxlxor 2, 2, 2
+; CHECK-P9-NEXT:    xxsel 1, 2, 0, 1
+; CHECK-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; CHECK-P9-NEXT:    blr
   %r = call contract reassoc ninf afn float @llvm.sqrt.f32(float %a)
   ret float %r

--- a/llvm/test/CodeGen/PowerPC/scalar-equal.ll
+++ b/llvm/test/CodeGen/PowerPC/scalar-equal.ll
@@ -35,22 +35,22 @@ define double @testoeq(double %a, double %b, double %c, double %d) {
 ;
 ; NO-FAST-P9-LABEL: testoeq:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P9-NEXT:    beq cr0, .LBB0_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB0_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    xscmpeqdp vs0, f1, f2
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 ;
 ; NO-FAST-P8-LABEL: testoeq:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P8-NEXT:    beq cr0, .LBB0_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB0_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpeqdp vs0, vs1, vs2
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 entry:
   %cmp = fcmp oeq double %a, %b

--- a/llvm/test/CodeGen/PowerPC/scalar_cmp.ll
+++ b/llvm/test/CodeGen/PowerPC/scalar_cmp.ll
@@ -36,22 +36,24 @@ define float @select_oeq_float(float %a, float %b, float %c, float %d) {
 ;
 ; NO-FAST-P8-LABEL: select_oeq_float:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    beq cr0, .LBB0_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB0_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpeqsp vs0, vs1, vs2
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_oeq_float:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    beq cr0, .LBB0_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB0_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P9-NEXT:    xvcmpeqsp vs0, vs1, vs2
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp oeq float %a, %b
@@ -78,22 +80,22 @@ define double @select_oeq_double(double %a, double %b, double %c, double %d) {
 ;
 ; NO-FAST-P8-LABEL: select_oeq_double:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P8-NEXT:    beq cr0, .LBB1_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB1_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpeqdp vs0, vs1, vs2
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_oeq_double:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P9-NEXT:    beq cr0, .LBB1_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB1_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    xscmpeqdp vs0, f1, f2
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp oeq double %a, %b
@@ -198,24 +200,24 @@ define float @select_one_float(float %a, float %b, float %c, float %d) {
 ;
 ; NO-FAST-P8-LABEL: select_one_float:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    crnor 4*cr5+lt, un, eq
-; NO-FAST-P8-NEXT:    bc 12, 4*cr5+lt, .LBB4_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB4_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpeqsp vs0, vs2, vs1
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_one_float:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    crnor 4*cr5+lt, un, eq
-; NO-FAST-P9-NEXT:    bc 12, 4*cr5+lt, .LBB4_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB4_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P9-NEXT:    xvcmpeqsp vs0, vs2, vs1
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp one float %a, %b
@@ -242,24 +244,22 @@ define double @select_one_double(double %a, double %b, double %c, double %d) {
 ;
 ; NO-FAST-P8-LABEL: select_one_double:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    crnor 4*cr5+lt, un, eq
-; NO-FAST-P8-NEXT:    bc 12, 4*cr5+lt, .LBB5_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB5_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpeqdp vs0, vs2, vs1
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_one_double:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    crnor 4*cr5+lt, un, eq
-; NO-FAST-P9-NEXT:    bc 12, 4*cr5+lt, .LBB5_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB5_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    xscmpeqdp vs0, f2, f1
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp one double %a, %b
@@ -360,24 +360,24 @@ define float @select_oge_float(float %a, float %b, float %c, float %d) {
 ;
 ; NO-FAST-P8-LABEL: select_oge_float:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    crnor 4*cr5+lt, un, lt
-; NO-FAST-P8-NEXT:    bc 12, 4*cr5+lt, .LBB8_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB8_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgesp vs0, vs1, vs2
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_oge_float:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    crnor 4*cr5+lt, un, lt
-; NO-FAST-P9-NEXT:    bc 12, 4*cr5+lt, .LBB8_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB8_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P9-NEXT:    xvcmpgesp vs0, vs1, vs2
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp oge float %a, %b
@@ -400,24 +400,22 @@ define double @select_oge_double(double %a, double %b, double %c, double %d) {
 ;
 ; NO-FAST-P8-LABEL: select_oge_double:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    crnor 4*cr5+lt, un, lt
-; NO-FAST-P8-NEXT:    bc 12, 4*cr5+lt, .LBB9_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB9_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgedp vs0, vs1, vs2
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_oge_double:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    crnor 4*cr5+lt, un, lt
-; NO-FAST-P9-NEXT:    bc 12, 4*cr5+lt, .LBB9_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB9_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    xscmpgedp vs0, f1, f2
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp oge double %a, %b
@@ -502,22 +500,24 @@ define float @select_olt_float(float %a, float %b, float %c, float %d) {
 ;
 ; NO-FAST-P8-LABEL: select_olt_float:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    blt cr0, .LBB12_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB12_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgesp vs0, vs2, vs1
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_olt_float:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    blt cr0, .LBB12_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB12_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P9-NEXT:    xvcmpgesp vs0, vs2, vs1
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp olt float %a, %b
@@ -540,22 +540,22 @@ define double @select_olt_double(double %a, double %b, double %c, double %d) {
 ;
 ; NO-FAST-P8-LABEL: select_olt_double:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P8-NEXT:    blt cr0, .LBB13_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB13_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgedp vs0, vs2, vs1
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_olt_double:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P9-NEXT:    blt cr0, .LBB13_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB13_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    xscmpgedp vs0, f2, f1
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp olt double %a, %b
@@ -640,22 +640,24 @@ define float @select_ogt_float(float %a, float %b, float %c, float %d) {
 ;
 ; NO-FAST-P8-LABEL: select_ogt_float:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    bgt cr0, .LBB16_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB16_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgtsp vs0, vs1, vs2
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_ogt_float:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    bgt cr0, .LBB16_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB16_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P9-NEXT:    xvcmpgtsp vs0, vs1, vs2
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp ogt float %a, %b
@@ -678,22 +680,22 @@ define double @select_ogt_double(double %a, double %b, double %c, double %d) {
 ;
 ; NO-FAST-P8-LABEL: select_ogt_double:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P8-NEXT:    bgt cr0, .LBB17_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB17_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgtdp vs0, vs1, vs2
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_ogt_double:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    xscmpudp cr0, f1, f2
-; NO-FAST-P9-NEXT:    bgt cr0, .LBB17_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB17_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    xscmpgtdp vs0, f1, f2
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp ogt double %a, %b
@@ -778,24 +780,24 @@ define float @select_ole_float(float %a, float %b, float %c, float %d) {
 ;
 ; NO-FAST-P8-LABEL: select_ole_float:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    crnor 4*cr5+lt, un, gt
-; NO-FAST-P8-NEXT:    bc 12, 4*cr5+lt, .LBB20_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB20_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgtsp vs0, vs2, vs1
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_ole_float:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    crnor 4*cr5+lt, un, gt
-; NO-FAST-P9-NEXT:    bc 12, 4*cr5+lt, .LBB20_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB20_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P9-NEXT:    xvcmpgtsp vs0, vs2, vs1
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp ole float %a, %b
@@ -818,24 +820,22 @@ define double @select_ole_double(double %a, double %b, double %c, double %d) {
 ;
 ; NO-FAST-P8-LABEL: select_ole_double:
 ; NO-FAST-P8:       # %bb.0: # %entry
-; NO-FAST-P8-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P8-NEXT:    crnor 4*cr5+lt, un, gt
-; NO-FAST-P8-NEXT:    bc 12, 4*cr5+lt, .LBB21_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f3, f4
-; NO-FAST-P8-NEXT:  .LBB21_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    xvcmpgtdp vs0, vs2, vs1
+; NO-FAST-P8-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: select_ole_double:
 ; NO-FAST-P9:       # %bb.0: # %entry
-; NO-FAST-P9-NEXT:    fcmpu cr0, f1, f2
-; NO-FAST-P9-NEXT:    crnor 4*cr5+lt, un, gt
-; NO-FAST-P9-NEXT:    bc 12, 4*cr5+lt, .LBB21_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f3, f4
-; NO-FAST-P9-NEXT:  .LBB21_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f3
+; NO-FAST-P9-NEXT:    xscmpgtdp vs0, f2, f1
+; NO-FAST-P9-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    xxsel vs1, vs3, vs4, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp ole double %a, %b
@@ -976,25 +976,24 @@ define double @onecmp2(double %a, double %y, double %z) {
 ; NO-FAST-P8-LABEL: onecmp2:
 ; NO-FAST-P8:       # %bb.0: # %entry
 ; NO-FAST-P8-NEXT:    vspltisw v2, 1
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
 ; NO-FAST-P8-NEXT:    xvcvsxwdp vs0, vs34
-; NO-FAST-P8-NEXT:    xscmpudp cr0, f1, f0
-; NO-FAST-P8-NEXT:    bgt cr0, .LBB25_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f2, f3
-; NO-FAST-P8-NEXT:  .LBB25_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f2
+; NO-FAST-P8-NEXT:    xvcmpgtdp vs0, vs1, vs0
+; NO-FAST-P8-NEXT:    xxsel vs1, vs2, vs3, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: onecmp2:
 ; NO-FAST-P9:       # %bb.0: # %entry
 ; NO-FAST-P9-NEXT:    vspltisw v2, 1
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
 ; NO-FAST-P9-NEXT:    xvcvsxwdp vs0, vs34
-; NO-FAST-P9-NEXT:    xscmpudp cr0, f1, f0
-; NO-FAST-P9-NEXT:    bgt cr0, .LBB25_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f2, f3
-; NO-FAST-P9-NEXT:  .LBB25_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f2
+; NO-FAST-P9-NEXT:    xscmpgtdp vs0, f1, f0
+; NO-FAST-P9-NEXT:    xxsel vs1, vs2, vs3, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp ogt double %a, 1.000000e+00
@@ -1026,25 +1025,24 @@ define double @onecmp3(double %a, double %y, double %z) {
 ; NO-FAST-P8-LABEL: onecmp3:
 ; NO-FAST-P8:       # %bb.0: # %entry
 ; NO-FAST-P8-NEXT:    vspltisw v2, 1
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; NO-FAST-P8-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P8-NEXT:    # kill: def $f2 killed $f2 def $vsl2
 ; NO-FAST-P8-NEXT:    xvcvsxwdp vs0, vs34
-; NO-FAST-P8-NEXT:    xscmpudp cr0, f1, f0
-; NO-FAST-P8-NEXT:    beq cr0, .LBB26_2
-; NO-FAST-P8-NEXT:  # %bb.1: # %entry
-; NO-FAST-P8-NEXT:    fmr f2, f3
-; NO-FAST-P8-NEXT:  .LBB26_2: # %entry
-; NO-FAST-P8-NEXT:    fmr f1, f2
+; NO-FAST-P8-NEXT:    xvcmpeqdp vs0, vs1, vs0
+; NO-FAST-P8-NEXT:    xxsel vs1, vs2, vs3, vs0
+; NO-FAST-P8-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P8-NEXT:    blr
 ;
 ; NO-FAST-P9-LABEL: onecmp3:
 ; NO-FAST-P9:       # %bb.0: # %entry
 ; NO-FAST-P9-NEXT:    vspltisw v2, 1
+; NO-FAST-P9-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; NO-FAST-P9-NEXT:    # kill: def $f2 killed $f2 def $vsl2
 ; NO-FAST-P9-NEXT:    xvcvsxwdp vs0, vs34
-; NO-FAST-P9-NEXT:    xscmpudp cr0, f1, f0
-; NO-FAST-P9-NEXT:    beq cr0, .LBB26_2
-; NO-FAST-P9-NEXT:  # %bb.1: # %entry
-; NO-FAST-P9-NEXT:    fmr f2, f3
-; NO-FAST-P9-NEXT:  .LBB26_2: # %entry
-; NO-FAST-P9-NEXT:    fmr f1, f2
+; NO-FAST-P9-NEXT:    xscmpeqdp vs0, f1, f0
+; NO-FAST-P9-NEXT:    xxsel vs1, vs2, vs3, vs0
+; NO-FAST-P9-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; NO-FAST-P9-NEXT:    blr
 entry:
   %cmp = fcmp oeq double %a, 1.000000e+00

--- a/llvm/test/CodeGen/PowerPC/vsx.ll
+++ b/llvm/test/CodeGen/PowerPC/vsx.ll
@@ -2465,18 +2465,24 @@ define <2 x double> @test81(<4 x float> %b) {
 define double @test82(double %a, double %b, double %c, double %d) {
 ; CHECK-LABEL: test82:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xscmpudp cr0, f3, f4
-; CHECK-NEXT:    beqlr cr0
-; CHECK-NEXT:  # %bb.1: # %entry
-; CHECK-NEXT:    fmr f1, f2
+; CHECK-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; CHECK-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; CHECK-NEXT:    xvcmpeqdp vs0, vs3, vs4
+; CHECK-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; CHECK-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; CHECK-NEXT:    xxsel vs1, vs1, vs2, vs0
+; CHECK-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; CHECK-NEXT:    blr
 ;
 ; CHECK-REG-LABEL: test82:
 ; CHECK-REG:       # %bb.0: # %entry
-; CHECK-REG-NEXT:    xscmpudp cr0, f3, f4
-; CHECK-REG-NEXT:    beqlr cr0
-; CHECK-REG-NEXT:  # %bb.1: # %entry
-; CHECK-REG-NEXT:    fmr f1, f2
+; CHECK-REG-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; CHECK-REG-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; CHECK-REG-NEXT:    xvcmpeqdp vs0, vs3, vs4
+; CHECK-REG-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; CHECK-REG-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; CHECK-REG-NEXT:    xxsel vs1, vs1, vs2, vs0
+; CHECK-REG-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; CHECK-REG-NEXT:    blr
 ;
 ; CHECK-FISL-LABEL: test82:
@@ -2495,10 +2501,13 @@ define double @test82(double %a, double %b, double %c, double %d) {
 ;
 ; CHECK-LE-LABEL: test82:
 ; CHECK-LE:       # %bb.0: # %entry
-; CHECK-LE-NEXT:    xscmpudp cr0, f3, f4
-; CHECK-LE-NEXT:    beqlr cr0
-; CHECK-LE-NEXT:  # %bb.1: # %entry
-; CHECK-LE-NEXT:    fmr f1, f2
+; CHECK-LE-NEXT:    # kill: def $f4 killed $f4 def $vsl4
+; CHECK-LE-NEXT:    # kill: def $f3 killed $f3 def $vsl3
+; CHECK-LE-NEXT:    xvcmpeqdp vs0, vs3, vs4
+; CHECK-LE-NEXT:    # kill: def $f2 killed $f2 def $vsl2
+; CHECK-LE-NEXT:    # kill: def $f1 killed $f1 def $vsl1
+; CHECK-LE-NEXT:    xxsel vs1, vs1, vs2, vs0
+; CHECK-LE-NEXT:    # kill: def $f1 killed $f1 killed $vsl1
 ; CHECK-LE-NEXT:    blr
 entry:
   %m = fcmp oeq double %c, %d


### PR DESCRIPTION
VSX has 'Predicate Compare Instructions' to compare float values with specific predicates and save result into VSX register. They can be used to optimize select_cc of float types. For target CPUs without support for scalar comparisons, vector version will be used.