### PR TITLE
[clang][dataflow] Emit an error if source code is not compiled as C++.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/ControlFlowContext.cpp
+++ b/clang/lib/Analysis/FlowSensitive/ControlFlowContext.cpp
@@ -84,6 +84,13 @@ ControlFlowContext::build(const Decl &D, Stmt &S, ASTContext &C) {
         std::make_error_code(std::errc::invalid_argument),
         "Cannot analyze templated declarations");
 
+  // The shape of certain elements of the AST can vary depending on the
+  // language. We currently only support C++.
+  if (!C.getLangOpts().CPlusPlus)
+    return llvm::createStringError(
+        std::make_error_code(std::errc::invalid_argument),
+        "Can only analyze C++");
+
   CFG::BuildOptions Options;
   Options.PruneTriviallyFalseEdges = true;
   Options.AddImplicitDtors = true;

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -70,6 +70,16 @@ const Formula &getFormula(const ValueDecl &D, const Environment &Env) {
   return cast<BoolValue>(Env.getValue(D))->formula();
 }
 
+TEST(TransferTest, CNotSupported) {
+  std::string Code = R"(
+    void target() {}
+  )";
+  ASSERT_THAT_ERROR(checkDataflowWithNoopAnalysis(
+                        Code, [](const auto &, auto &) {}, {BuiltinOptions{}},
+                        LangStandard::lang_c89),
+                    llvm::FailedWithMessage("Can only analyze C++"));
+}
+
 TEST(TransferTest, IntVarDeclNotTrackedWhenTransferDisabled) {
   std::string Code = R"(
     void target() {


### PR DESCRIPTION
The shape of certain elements of the AST can vary depending on the langugage.
We currently only support C++.
