### PR TITLE
[libc] customizable namespace 1/4

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -44,9 +44,22 @@ if(("libc" IN_LIST LLVM_ENABLE_RUNTIMES AND NOT LLVM_RUNTIMES_BUILD) OR
 endif()
 
 option(LIBC_CMAKE_VERBOSE_LOGGING
-       "Log details warnings and notifications during CMake configuration." OFF)
+  "Log details warnings and notifications during CMake configuration." OFF)
+
 # Path libc/scripts directory.
 set(LIBC_BUILD_SCRIPTS_DIR "${LIBC_SOURCE_DIR}/utils/build_scripts")
+
+# Defining a global namespace to enclose all libc functions.
+set(LIBC_NAMESPACE "__llvm_libc_${LLVM_VERSION_MAJOR}_${LLVM_VERSION_MINOR}_${LLVM_VERSION_PATCH}_${LLVM_VERSION_SUFFIX}"
+  CACHE STRING "The namespace to use to enclose internal implementations. Must start with '__llvm_libc'."
+)
+
+if(NOT LIBC_NAMESPACE MATCHES "^__llvm_libc")
+  message(FATAL_ERROR "Invalid LIBC_NAMESPACE. Must start with '__llvm_libc' was '${LIBC_NAMESPACE}'")
+endif()
+
+message(STATUS "Setting LIBC_NAMESPACE namespace to '${LIBC_NAMESPACE}'")
+add_compile_definitions(LIBC_NAMESPACE=${LIBC_NAMESPACE})
 
 # Flags to pass down to the compiler while building the libc functions.
 set(LIBC_COMPILE_OPTIONS_DEFAULT "" CACHE STRING "Architecture to tell clang to optimize for (e.g. -march=... or -mcpu=...)")
@@ -137,7 +150,8 @@ if(LLVM_LIBC_ENABLE_LINTING)
                       OUTPUT_VARIABLE CLANG_TIDY_OUTPUT)
       string(REGEX MATCH "[0-9]+" CLANG_TIDY_VERSION "${CLANG_TIDY_OUTPUT}")
       string(REGEX MATCH "[0-9]+" CLANG_MAJOR_VERSION
-             "${CMAKE_CXX_COMPILER_VERSION}")
+        "${CMAKE_CXX_COMPILER_VERSION}")
+
       if(NOT CLANG_TIDY_VERSION EQUAL CLANG_MAJOR_VERSION)
         set(LLVM_LIBC_ENABLE_LINTING OFF)
         message(WARNING "

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -12,6 +12,7 @@ load(
 load(":platforms.bzl", "PLATFORM_CPU_ARM64", "PLATFORM_CPU_X86_64")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("//:vars.bzl", "LLVM_VERSION_MAJOR", "LLVM_VERSION_MINOR", "LLVM_VERSION_PATCH")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -33,6 +34,8 @@ MEMORY_COPTS = [
     # "LIBC_COPT_MEMCPY_X86_USE_REPMOVSB_FROM_SIZE=0",
     # "LIBC_COPT_MEMCPY_X86_USE_SOFTWARE_PREFETCHING",
 ]
+
+llvm_libc_namespace = "__llvm_libc_{}_{}_{}_git".format(LLVM_VERSION_MAJOR, LLVM_VERSION_MINOR, LLVM_VERSION_PATCH)
 
 # A flag to pick which `mpfr` to use for math tests.
 # Usage: `--@llvm-project//libc:mpfr=<disable|external|system>`.
@@ -69,6 +72,7 @@ config_setting(
 # paths of the kind "../../" to other libc targets.
 cc_library(
     name = "libc_root",
+    defines = ["LIBC_NAMESPACE=" + llvm_libc_namespace],
     includes = ["."],
 )
 


### PR DESCRIPTION
This implements the first step of https://discourse.llvm.org/t/rfc-customizable-namespace-to-allow-testing-the-libc-when-the-system-libc-is-also-llvms-libc/73079

Make required Bazel and CMake preparatory changes which define the var for the customizable namespace and use it (pass it as a compile option -DLIBC_NAMESPACE=<...>).

Differential Revision: https://reviews.llvm.org/D159112