### PR TITLE
[flang] handle indirect module variable use in internal procedure

### DIFF
--- a/flang/test/Lower/HLFIR/internal-procedures-2.f90
+++ b/flang/test/Lower/HLFIR/internal-procedures-2.f90
@@ -1,0 +1,29 @@
+! Test instantiation of module variables inside an internal subprogram
+! where the use statement is inside the host program.
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
+
+module module_used_by_host
+ implicit none
+ integer :: indexed_by_var(2)
+ integer :: ref_in_implied_do
+ integer :: ref_in_forall(2)
+end module
+
+subroutine host_procedure
+ use module_used_by_host
+ implicit none
+contains
+ subroutine internal_procedure(i, mask)
+  integer :: i
+  logical :: mask(2)
+  indexed_by_var(i) = 0
+  print *, (/(ref_in_implied_do, integer::j=1,10)/)
+  forall (integer::k = 1:2)
+    ref_in_forall(k) = 0
+  end forall
+ end subroutine
+end subroutine
+! CHECK-LABEL: func.func @_QFhost_procedurePinternal_procedure(
+! CHECK:    fir.address_of(@_QMmodule_used_by_hostEindexed_by_var) : !fir.ref<!fir.array<2xi32>>
+! CHECK:    fir.address_of(@_QMmodule_used_by_hostEref_in_forall) : !fir.ref<!fir.array<2xi32>>
+! CHECK:    fir.address_of(@_QMmodule_used_by_hostEref_in_implied_do) : !fir.ref<i32>

--- a/flang/test/Lower/explicit-interface-results-2.f90
+++ b/flang/test/Lower/explicit-interface-results-2.f90
@@ -94,7 +94,7 @@ subroutine host5()
   implicit none
   call internal_proc_a()
 contains
-! CHECK-LABEL: func @_QFhost5Pinternal_proc_a() {
+! CHECK-LABEL: func @_QFhost5Pinternal_proc_a() attributes {fir.internal_proc} {
   subroutine internal_proc_a()
     call takes_array(return_array())
 ! CHECK:  %[[VAL_0:.*]] = fir.address_of(@_QMsome_moduleEn_module) : !fir.ref<i32>


### PR DESCRIPTION
When a module variable is referenced inside an internal procedure, but the use statement for the module is inside the host, semantics may not create any symbols with HostAssocDetails directly under the internal procedure scope.
So pft::getScopeVariableList, that is called in the bridge when lowering the internal procedure scope, failed to instantiate the module variables. This lead to "symbol is not mapped to any IR value" compile time errors.

This patch fixes the issue by adding the variables to the list of "captured" global variables from the host program, so that they are instantiated as part of the `internalProcedureBindings` in the bridge.

The rational of doing it that way instead of changing `getScopeVariableList` is that `getScopeVariableList` would have to import all the module variables used inside the host since it cannot know which ones are referenced inside the internal procedure from the semantics::Scope information. The fix in this patch only instantiates the module variables from the host that are actually referenced inside the internal procedure.