### PR TITLE
[openmp][amdgpu] Add DynamicLdsSize to AMDGPUImplicitArgsTy

### DIFF
--- a/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -3203,6 +3203,7 @@ Error AMDGPUKernelTy::launchImpl(GenericDeviceTy &GenericDevice,
     ImplArgs->GroupSizeY = 1;
     ImplArgs->GroupSizeZ = 1;
     ImplArgs->GridDims = 1;
+    ImplArgs->DynamicLdsSize = KernelArgs.DynCGroupMem;
   }
 
   // Push the kernel launch into the stream.

--- a/openmp/libomptarget/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
@@ -45,7 +45,9 @@ struct AMDGPUImplicitArgsTy {
   uint16_t GroupSizeZ;
   uint8_t Unused0[46]; // 46 byte offset.
   uint16_t GridDims;
-  uint8_t Unused1[190]; // 190 byte offset.
+  uint8_t Unused1[54]; // 54 byte offset.
+  uint32_t DynamicLdsSize;
+  uint8_t Unused2[132]; // 132 byte offset.
 };
 
 // Dummy struct for COV4 implicitargs.


### PR DESCRIPTION
#65273 "hidden_dynamic_lds_size" argument will be added in the reserved section at offset 120 of the implicit argument layout
Add DynamicLdsSize to AMDGPUImplicitArgsTy struct at offset 120 and fill the dynamic LDS size before kernel launch.