### PR TITLE
[Driver][NVPTX] Add a warning that device debug info does not work with optimizations

### DIFF
--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -413,13 +413,25 @@ void NVPTX::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
     // TODO: Perhaps we should map host -O2 to ptxas -O3. -O3 is ptxas's
     // default, so it may correspond more closely to the spirit of clang -O2.
 
+    bool noOptimization = A->getOption().matches(options::OPT_O0);
+    // Emit a driver diagnostic as warning if any -O option different from -O0,
+    // is passed since ptxas does not support optimized debugging.
+    if (!noOptimization) {
+      auto &Diags = TC.getDriver().getDiags();
+      unsigned DiagID = Diags.getCustomDiagID(
+          DiagnosticsEngine::Warning,
+          "ptxas cannot emit debug info with optimization "
+          "level ('%0') different than O0.");
+      Diags.Report(DiagID) << A->getAsString(Args);
+    }
+
     // -O3 seems like the least-bad option when -Osomething is specified to
     // clang but it isn't handled below.
     StringRef OOpt = "3";
     if (A->getOption().matches(options::OPT_O4) ||
         A->getOption().matches(options::OPT_Ofast))
       OOpt = "3";
-    else if (A->getOption().matches(options::OPT_O0))
+    else if (noOptimization)
       OOpt = "0";
     else if (A->getOption().matches(options::OPT_O)) {
       // -Os, -Oz, and -O(anything else) map to -O2, for lack of better options.

--- a/clang/test/Driver/cuda-external-tools.cu
+++ b/clang/test/Driver/cuda-external-tools.cu
@@ -28,6 +28,17 @@
 // RUN:   --offload-arch=sm_35 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
 // RUN: | FileCheck -check-prefixes=CHECK,ARCH64,SM35,RDC %s
 
+// Compiling -O{1,2,3,4,fast,s,z} with -g does not pass -g debug info to ptxas.
+// NOTE: This is because ptxas does not support optimized debugging.
+// RUN: %clang -### --target=x86_64-linux-gnu -O3 -g -c %s 2>&1 \
+// RUN:   --offload-arch=sm_35 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN: | FileCheck -check-prefixes=CHECK,ARCH64,SM35,OPT3-DBG %s
+
+// Compiling -O0 with -g passes -g debug info to ptxas.
+// RUN: %clang -### --target=x86_64-linux-gnu -O0 -g -c %s 2>&1 \
+// RUN:   --offload-arch=sm_35 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
+// RUN: | FileCheck -check-prefixes=CHECK,ARCH64,SM35,OPT0-DBG %s
+
 // With debugging enabled, ptxas should be run with with no ptxas optimizations.
 // RUN: %clang -### --target=x86_64-linux-gnu --cuda-noopt-device-debug -O2 -g -c %s 2>&1 \
 // RUN:   --offload-arch=sm_35 --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
@@ -134,6 +145,10 @@
 // OPT2-NOT: "-g"
 // OPT3-SAME: "-O3"
 // OPT3-NOT: "-g"
+// OPT3-DBG-SAME: "-O3" "-lineinfo"
+// OPT3-DBG-NOT: "-g"
+// OPT0-DBG-SAME: "-g" "--dont-merge-basicblocks" "--return-at-end"
+// OPT0-DBG-NOT: "-O0"
 // DBG-SAME: "-g" "--dont-merge-basicblocks" "--return-at-end"
 // SM35-SAME: "--gpu-name" "sm_35"
 // SM35-SAME: "--output-file" "[[CUBINFILE:[^"]*]]"


### PR DESCRIPTION
Passing `-g` to `ptxas` with any optimizations enabled is not allowed because, `ptxas` does not support optimized debugging.