### PR TITLE
[clang][dataflow] Eliminate uses of `RecordValue::getChild()`.

### DIFF
--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -2860,11 +2860,11 @@ TEST(TransferTest, AggregateInitialization) {
 
           // Check that fields initialized in an initializer list are always
           // modeled in other instances of the same type.
-          const auto &OtherBVal =
-              getValueForDecl<RecordValue>(ASTCtx, Env, "OtherB");
-          EXPECT_THAT(OtherBVal.getChild(*BarDecl), NotNull());
-          EXPECT_THAT(OtherBVal.getChild(*BazDecl), NotNull());
-          EXPECT_THAT(OtherBVal.getChild(*QuxDecl), NotNull());
+          const auto &OtherBLoc =
+              getLocForDecl<RecordStorageLocation>(ASTCtx, Env, "OtherB");
+          EXPECT_THAT(OtherBLoc.getChild(*BarDecl), NotNull());
+          EXPECT_THAT(OtherBLoc.getChild(*BazDecl), NotNull());
+          EXPECT_THAT(OtherBLoc.getChild(*QuxDecl), NotNull());
         });
   }
 }


### PR DESCRIPTION
We want to work towards eliminating the `RecordStorageLocation` from
`RecordValue`. These particular uses of `RecordValue::getChild()` can simply
be replaced with `RecordStorageLocation::getChild()`.
