### PR TITLE
[Github][OpenMP] Adding rule for OpenMP label

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -794,3 +794,35 @@ llvm:binary-utilities:
   - llvm/tools/llvm-size/**
   - llvm/tools/llvm-strings/**
   - llvm/tools/llvm-symbolizer/**
+
+clang:openmp:
+  - clang/include/clang/Basic/OpenMP*
+  - clang/include/clang/AST/OpenMPClause.h
+  - clang/include/clang/AST/DeclOpenMP.h
+  - clang/include/clang/AST/ExprOpenMP.h
+  - clang/include/clang/AST/StmtOpenMP.h
+  - clang/lib/AST/DeclOpenMP.cpp
+  - clang/lib/AST/OpenMPClause.cpp
+  - clang/lib/AST/StmtOpenMP.cpp
+  - clang/lib/Headers/openmp_wrappers/**
+  - clang/lib/Parse/ParseOpenMP.cpp
+  - clang/lib/Basic/OpenMPKinds.cpp
+  - clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
+  - clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+  - clang/lib/CodeGen/CgStmtOpenMP.cpp
+  - clang/lib/CodeGen/CGOpenMP*
+  - clang/lib/Sema/SemaOpenMP.cpp
+  - clang/test/OpenMP/**
+  - clang/test/AST/ast-dump-openmp-*
+  - llvm/lib/Frontend/OpenMP/**
+  - llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+  - llvm/include/llvm/Frontend/OpenMP/**
+  - llvm/include/llvm/Transforms/IPO/OpenMPOpt.h
+  - llvm/unittests/Frontend/OpenMP*
+  - llvm/test/Transforms/OpenMP/**
+
+openmp:libomp:
+  - any: ['openmp/**', '!openmp/libomptarget/**']
+
+openmp:libomptarget:
+  - any: ['openmp/**', '!openmp/runtime/**']


### PR DESCRIPTION
The intention is to add the paths: top-level OpenMP and MLIR/Dialect/OpenMP
I'm sure there are other paths missing here.