### PR TITLE
[mlir] transform.structured.match loop-like flag

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformEnums.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformEnums.td
@@ -3,7 +3,8 @@ include "mlir/IR/EnumAttr.td"
 def MatchInterfaceEnum : I32EnumAttr<"MatchInterfaceEnum", "An interface to match",
     [
       I32EnumAttrCase<"LinalgOp", 0>,
-      I32EnumAttrCase<"TilingInterface", 1>
+      I32EnumAttrCase<"TilingInterface", 1>,
+      I32EnumAttrCase<"LoopLikeInterface", 2>,
     ]>{
   let cppNamespace = "mlir::transform";
 }

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -1147,6 +1147,9 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
       if (iface == transform::MatchInterfaceEnum::TilingInterface &&
           isa<TilingInterface>(op))
         return;
+      if (iface == transform::MatchInterfaceEnum::LoopLikeInterface &&
+          !isa<LoopLikeOpInterface>(op))
+        return;
     }
 
     // Check if all specified attributes match.


### PR DESCRIPTION
Add an enum option to `transform.structured.match` operation to match payload operations implementing LoopLikeOpInterface.