### PR TITLE
[mlir][ProofOfConcept] Support scalable dimensions in ShapedTypes

### DIFF
--- a/mlir/include/mlir/Dialect/ArmSME/IR/ArmSME.td
+++ b/mlir/include/mlir/Dialect/ArmSME/IR/ArmSME.td
@@ -44,20 +44,25 @@ def ArmSME_Dialect : Dialect {
 
 class SMETileType<Type datatype, list<int> dims, string description>
   : ShapedContainerType<[datatype],
-      And<[IsVectorOfRankPred<[2]>, allDimsScalableVectorTypePred,
-           IsVectorOfShape<dims>]>,
+      And<[IsVectorOfRankPred<[2]>, IsVectorOfShape<dims>]>,
   description>;
 
-def nxnxv16i8  : SMETileType<I8,   [16, 16], "vector<[16]x[16]xi8>">;
-def nxnxv8i16  : SMETileType<I16,  [8,  8 ], "vector<[8]x[8]xi16>">;
-def nxnxv4i32  : SMETileType<I32,  [4,  4 ], "vector<[4]x[4]xi32>">;
-def nxnxv2i64  : SMETileType<I64,  [2,  2 ], "vector<[2]x[2]xi64>">;
-def nxnxv1i128 : SMETileType<I128, [1,  1 ], "vector<[1]x[1]xi128>">;
 
-def nxnxv8f16  : SMETileType<F16,  [8,  8 ], "vector<[8]x[8]xf16>">;
-def nxnxv8bf16 : SMETileType<BF16, [8,  8 ], "vector<[8]x[8]xbf16>">;
-def nxnxv4f32  : SMETileType<F32,  [4,  4 ], "vector<[4]x[4]xf32>">;
-def nxnxv2f64  : SMETileType<F64,  [2,  2 ], "vector<[2]x[2]xf64>">;
+class DimOfSize<int size> {
+  int scalable = !sub(0, size);
+  int fixed = size;
+}
+
+def nxnxv16i8  : SMETileType<I8,   [DimOfSize<16>.scalable, DimOfSize<16>.scalable], "vector<[16]x[16]xi8>">;
+def nxnxv8i16  : SMETileType<I16,  [DimOfSize<8>.scalable, DimOfSize<8>.scalable], "vector<[8]x[8]xi16>">;
+def nxnxv4i32  : SMETileType<I32,  [DimOfSize<4>.scalable, DimOfSize<4>.scalable], "vector<[4]x[4]xi32>">;
+def nxnxv2i64  : SMETileType<I64,  [DimOfSize<2>.scalable, DimOfSize<2>.scalable], "vector<[2]x[2]xi64>">;
+def nxnxv1i128 : SMETileType<I128, [DimOfSize<1>.scalable, DimOfSize<1>.scalable], "vector<[1]x[1]xi128>">;
+
+def nxnxv8f16  : SMETileType<F16,  [DimOfSize<8>.scalable, DimOfSize<8>.scalable], "vector<[8]x[8]xf16>">;
+def nxnxv8bf16 : SMETileType<BF16, [DimOfSize<8>.scalable, DimOfSize<8>.scalable], "vector<[8]x[8]xbf16>">;
+def nxnxv4f32  : SMETileType<F32,  [DimOfSize<4>.scalable, DimOfSize<4>.scalable], "vector<[4]x[4]xf32>">;
+def nxnxv2f64  : SMETileType<F64,  [DimOfSize<2>.scalable, DimOfSize<2>.scalable], "vector<[2]x[2]xf64>">;
 
 def SMETile : AnyTypeOf<[nxnxv16i8, nxnxv8i16, nxnxv4i32, nxnxv2i64, nxnxv1i128,
                          nxnxv8f16, nxnxv8bf16, nxnxv4f32, nxnxv2f64]>;
@@ -421,8 +426,7 @@ def MoveVectorToTileSliceOp : ArmSME_Op<"move_vector_to_tile_slice", [
       "tile", "vector",
       "VectorType::get("
         "::llvm::cast<mlir::VectorType>($_self).getShape().drop_front(),"
-        "::llvm::cast<mlir::VectorType>($_self).getElementType(),"
-        "/*scalableDims=*/{true})">,
+        "::llvm::cast<mlir::VectorType>($_self).getElementType())">,
 ]> {
   let summary = "Move 1-D scalable vector to slice of 2-D tile";
   let description = [{

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -730,7 +730,7 @@ def Vector_ScalableInsertOp :
        AllTypesMatch<["dest", "res"]>,
        PredOpTrait<"position is a multiple of the source length.",
         CPred<
-          "(getPos() % getSourceVectorType().getNumElements()) == 0"
+          "(getPos() % getSourceVectorType().getMinNumElements()) == 0"
         >>]>,
      Arguments<(ins VectorOfRank<[1]>:$source,
                     ScalableVectorOfRank<[1]>:$dest,
@@ -786,7 +786,7 @@ def Vector_ScalableExtractOp :
        AllElementTypesMatch<["source", "res"]>,
        PredOpTrait<"position is a multiple of the result length.",
         CPred<
-          "(getPos() % getResultVectorType().getNumElements()) == 0"
+          "(getPos() % getResultVectorType().getMinNumElements()) == 0"
         >>]>,
      Arguments<(ins ScalableVectorOfRank<[1]>:$source,
                     I64Attr:$pos)>,

--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -850,7 +850,7 @@ def Builtin_SparseElementsAttr : Builtin_Attr<
              "expected sparse indices to be 64-bit integer values");
       assert((::llvm::isa<RankedTensorType, VectorType>(type)) &&
              "type must be ranked tensor or vector");
-      assert(type.hasStaticShape() && "type must have static shape");
+      assert(!type.hasDynamicShape() && "type cannot have dynamic shape");
       return $_get(type.getContext(), type,
                    ::llvm::cast<DenseIntElementsAttr>(indices), values);
     }]>,

--- a/mlir/include/mlir/IR/BuiltinDialectBytecode.td
+++ b/mlir/include/mlir/IR/BuiltinDialectBytecode.td
@@ -283,13 +283,12 @@ def VectorType : DialectType<(type
 }
 
 def VectorTypeWithScalableDims : DialectType<(type
-  Array<BoolList>:$scalableDims,
   Array<SignedVarIntList>:$shape,
   Type:$elementType
 )> {
   let printerPredicate = "$_val.isScalable()";
   // Note: order of serialization does not match order of builder.
-  let cBuilder = "get<$_resultType>(context, shape, elementType, scalableDims)";
+  let cBuilder = "get<$_resultType>(context, shape, elementType)";
 }
 }
 

--- a/mlir/include/mlir/IR/BuiltinTypeInterfaces.h
+++ b/mlir/include/mlir/IR/BuiltinTypeInterfaces.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_IR_BUILTINTYPEINTERFACES_H
 #define MLIR_IR_BUILTINTYPEINTERFACES_H
 
+#include "mlir/IR/ShapeDim.h"
 #include "mlir/IR/Types.h"
 
 #include "mlir/IR/BuiltinTypeInterfaces.h.inc"

--- a/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
+++ b/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
@@ -54,8 +54,8 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
     A shape is a list of sizes corresponding to the dimensions of the container.
     If the number of dimensions in the shape is unknown, the shape is "unranked".
     If the number of dimensions is known, the shape "ranked". The sizes of the
-    dimensions of the shape must be positive, or kDynamic (in which case the
-    size of the dimension is dynamic, or not statically known).
+    fixed dimensions are positive, scalable dimensions are negative, and unknown
+    dimensions are kDynamic.
   }];
   let methods = [
     InterfaceMethod<[{
@@ -89,21 +89,53 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
   ];
 
   let extraClassDeclaration = [{
-    static constexpr int64_t kDynamic =
-        std::numeric_limits<int64_t>::min();
+    static constexpr int64_t kDynamic = ShapeDim::kDynamic();
 
     /// Whether the given dimension size indicates a dynamic dimension.
     static constexpr bool isDynamic(int64_t dValue) {
-      return dValue == kDynamic;
+      return ShapeDim(dValue).isDynamic();
+    }
+
+    /// Whether the given dimension is scalable (i.e. will be scaled a runtime
+    /// multiplier).
+    static constexpr bool isScalable(int64_t dValue) {
+      return ShapeDim(dValue).isScalable();
     }
 
     /// Whether the given shape has any size that indicates a dynamic dimension.
     static bool isDynamicShape(ArrayRef<int64_t> dSizes) {
-      return any_of(dSizes, [](int64_t dSize) { return isDynamic(dSize); });
+      return any_of(dSizes, [](ShapeDim dSize) { return dSize.isDynamic(); });
     }
 
+    /// Whether the given shape has any size that indicates a scalable dimension.
+    /// If any size is dynamic, the overall shape is considered dynamic, not
+    /// scalable.
+    static bool isScalableShape(ArrayRef<int64_t> dSizes) {
+      bool hasScalableDims = false;
+      for (ShapeDim dim: dSizes) {
+        if (dim.isDynamic()) return false;
+        hasScalableDims |= dim.isScalable();
+      }
+      return hasScalableDims;
+    }
+
+    /// Whether all dimensions of the shape have a static size (i.e.
+    /// not dynamic or scalable).
+    static bool isStaticShape(ArrayRef<int64_t> dSizes) {
+       return all_of(dSizes, [](ShapeDim dSize) { return dSize.isFixed(); });
+    }
+
+    /// Return the minimum number of elements a shape could hold. For dynamic
+    /// shapes this is always zero. For scalable shapes this is the number of
+    /// elements when the runtime multiplier is one.
+    static int64_t getMinNumElements(ArrayRef<int64_t> shape);
+
     /// Return the number of elements present in the given shape.
-    static int64_t getNumElements(ArrayRef<int64_t> shape);
+    /// Requires: isStaticShape.
+    static int64_t getNumElements(ArrayRef<int64_t> shape) {
+      assert(isStaticShape(shape));
+      return getMinNumElements(shape);
+    }
 
     /// Return a clone of this type with the given new shape and element type.
     /// The returned type is ranked, even if this type is unranked.
@@ -138,10 +170,18 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
       return $_type.getShape().size();
     }
 
+    /// Return the minimum number of elements this type can hold. If this has
+    /// a dynamic shape that will be zero. If this has a scalable this is the
+    /// number of elements when the runtime multiplier is one.
+    int64_t getMinNumElements() const {
+      return ::mlir::ShapedType::getMinNumElements($_type.getShape());
+    }
+
     /// If it has static shape, return the number of elements. Otherwise, abort.
     int64_t getNumElements() const {
-      assert(hasStaticShape() && "cannot get element count of dynamic shaped type");
-      return ::mlir::ShapedType::getNumElements($_type.getShape());
+      assert(hasStaticShape()
+        && "cannot get number of elements for scalable/dynamic size");
+      return getMinNumElements();
     }
 
     /// Returns true if this dimension has a dynamic size (for ranked types);
@@ -151,17 +191,32 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
       return ::mlir::ShapedType::isDynamic($_type.getShape()[idx]);
     }
 
-    /// Returns if this type has a static shape, i.e. if the type is ranked and
-    /// all dimensions have known size (>= 0).
-    bool hasStaticShape() const {
-      return $_type.hasRank() &&
-             !::mlir::ShapedType::isDynamicShape($_type.getShape());
+    /// Returns true if this dimension has a scalable size (for ranked types);
+    /// aborts for unranked types.
+    bool isScalableDim(unsigned idx) const {
+      assert(idx < getRank() && "invalid index for shaped type");
+      return ::mlir::ShapedType::isScalable($_type.getShape()[idx]);
     }
 
-    /// Returns if this type has a static shape and the shape is equal to
-    /// `shape` return true.
-    bool hasStaticShape(::llvm::ArrayRef<int64_t> shape) const {
-      return hasStaticShape() && $_type.getShape() == shape;
+    /// Returns if this type has a static shape, i.e. if the type is ranked and
+    /// all dimensions have known size at runtime.
+    bool hasStaticShape() const {
+      return $_type.hasRank() &&
+        ::mlir::ShapedType::isStaticShape($_type.getShape());
+    }
+
+    /// Returns if this type has a scalable shape, i.e. if the type is ranked
+    /// and any dimension is scalable (but not dynamic).
+    bool hasScalableShape() const {
+      return $_type.hasRank() &&
+        ::mlir::ShapedType::isScalableShape($_type.getShape());
+    }
+
+    /// Returns if this type has a dynamic shape, i.e. if the type is ranked
+    /// and any dimension is dynamic.
+    bool hasDynamicShape() const {
+      return $_type.hasRank() &&
+        ::mlir::ShapedType::isDynamicShape($_type.getShape());
     }
 
     /// If this is a ranked type, return the number of dimensions with dynamic
@@ -170,9 +225,28 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
       return llvm::count_if($_type.getShape(), ::mlir::ShapedType::isDynamic);
     }
 
-    /// If this is ranked type, return the size of the specified dimension.
-    /// Otherwise, abort.
+    /// If this is a ranked type, return the number of dimensions with scalable
+    /// size. Otherwise, abort.
+    int64_t getNumScalableDims() const {
+      return llvm::count_if($_type.getShape(), ::mlir::ShapedType::isScalable);
+    }
+
+    /// Deprecated. Using getDim() and explicitly querying for dim.fixedSize(),
+    /// dim.scalableSize(), dim.minSize(), or comparing with
+    /// ShapeDim::kDynamic() is preferred.
+    /// Gets the size of a dimension. For dynamic dimensions this returns
+    /// kDynamic, for scalable dimensions the min size, or the size for fixed
+    /// dimensions.
     int64_t getDimSize(unsigned idx) const {
+      ::mlir::ShapeDim dim = getDim(idx);
+      if (dim.isDynamic())
+        return dim;
+      return dim.minSize();
+    }
+
+    /// If this is a ranked type, return the specified dimension.
+    /// Otherwise, abort.
+    ShapeDim getDim(unsigned idx) const {
       assert(idx < getRank() && "invalid index for shaped type");
       return $_type.getShape()[idx];
     }
@@ -181,7 +255,7 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
     /// dimensions, given its `index` within the shape.
     unsigned getDynamicDimIndex(unsigned index) const {
       assert(index < getRank() && "invalid index");
-      assert(::mlir::ShapedType::isDynamic(getDimSize(index)) && "invalid index");
+      assert(::mlir::ShapedType::isDynamic(getDim(index)) && "invalid index");
       return llvm::count_if($_type.getShape().take_front(index),
                             ::mlir::ShapedType::isDynamic);
     }

--- a/mlir/include/mlir/IR/BuiltinTypes.h
+++ b/mlir/include/mlir/IR/BuiltinTypes.h
@@ -313,26 +313,13 @@ class VectorType::Builder {
 public:
   /// Build from another VectorType.
   explicit Builder(VectorType other)
-      : shape(other.getShape()), elementType(other.getElementType()),
-        scalableDims(other.getScalableDims()) {}
+      : shape(other.getShape()), elementType(other.getElementType()) {}
 
   /// Build from scratch.
-  Builder(ArrayRef<int64_t> shape, Type elementType,
-          unsigned numScalableDims = 0, ArrayRef<bool> scalableDims = {})
-      : shape(shape), elementType(elementType) {
-    if (scalableDims.empty())
-      scalableDims = SmallVector<bool>(shape.size(), false);
-    else
-      this->scalableDims = scalableDims;
-  }
+  Builder(ArrayRef<int64_t> shape, Type elementType)
+      : shape(shape), elementType(elementType) {}
 
-  Builder &setShape(ArrayRef<int64_t> newShape,
-                    ArrayRef<bool> newIsScalableDim = {}) {
-    if (newIsScalableDim.empty())
-      scalableDims = SmallVector<bool>(shape.size(), false);
-    else
-      scalableDims = newIsScalableDim;
-
+  Builder &setShape(ArrayRef<int64_t> newShape) {
     shape = newShape;
     return *this;
   }
@@ -347,28 +334,18 @@ public:
     assert(pos < shape.size() && "overflow");
     if (storage.empty())
       storage.append(shape.begin(), shape.end());
-    if (storageScalableDims.empty())
-      storageScalableDims.append(scalableDims.begin(), scalableDims.end());
     storage.erase(storage.begin() + pos);
-    storageScalableDims.erase(storageScalableDims.begin() + pos);
     shape = {storage.data(), storage.size()};
-    scalableDims =
-        ArrayRef<bool>(storageScalableDims.data(), storageScalableDims.size());
     return *this;
   }
 
-  operator VectorType() {
-    return VectorType::get(shape, elementType, scalableDims);
-  }
+  operator VectorType() { return VectorType::get(shape, elementType); }
 
 private:
   ArrayRef<int64_t> shape;
   // Owning shape data for copy-on-write operations.
   SmallVector<int64_t> storage;
   Type elementType;
-  ArrayRef<bool> scalableDims;
-  // Owning scalableDims data for copy-on-write operations.
-  SmallVector<bool> storageScalableDims;
 };
 
 /// Given an `originalShape` and a `reducedShape` assumed to be a subset of

--- a/mlir/include/mlir/IR/BuiltinTypes.td
+++ b/mlir/include/mlir/IR/BuiltinTypes.td
@@ -1072,22 +1072,13 @@ def Builtin_Vector : Builtin_Type<"Vector", [ShapedTypeInterface], "Type"> {
   }];
   let parameters = (ins
     ArrayRefParameter<"int64_t">:$shape,
-    "Type":$elementType,
-    ArrayRefParameter<"bool">:$scalableDims
+    "Type":$elementType
   );
   let builders = [
     TypeBuilderWithInferredContext<(ins
-      "ArrayRef<int64_t>":$shape, "Type":$elementType,
-      CArg<"ArrayRef<bool>", "{}">:$scalableDims
+      "ArrayRef<int64_t>":$shape, "Type":$elementType
     ), [{
-      // While `scalableDims` is optional, its default value should be
-      // `false` for every dim in `shape`.
-      SmallVector<bool> isScalableVec;
-      if (scalableDims.empty()) {
-        isScalableVec.resize(shape.size(), false);
-        scalableDims = isScalableVec;
-      }
-      return $_get(elementType.getContext(), shape, elementType, scalableDims);
+      return $_get(elementType.getContext(), shape, elementType);
     }]>
   ];
   let extraClassDeclaration = [{
@@ -1102,15 +1093,21 @@ def Builtin_Vector : Builtin_Type<"Vector", [ShapedTypeInterface], "Type"> {
       return ::llvm::isa<IntegerType, IndexType, FloatType>(t);
     }
 
+    /// Overload for VectorType::get() for ShapeDim. Cannot be called ::get
+    /// due to ambiguous overloads.
+    static VectorType create(ArrayRef<::mlir::ShapeDim> shape, Type elementType) {
+      SmallVector<int64_t> i64Shape(shape.size());
+      for (auto [i64dim, shapeDim] : llvm::zip(i64Shape, shape))
+        i64dim = shapeDim;
+      return get(i64Shape, elementType);
+    }
+
     /// Returns true if the vector contains scalable dimensions.
     bool isScalable() const {
-      return llvm::is_contained(getScalableDims(), true);
+      return hasScalableShape();
     }
     bool allDimsScalable() const {
-      // Treat 0-d vectors as fixed size.
-      if (getRank() == 0)
-        return false;
-      return !llvm::is_contained(getScalableDims(), false);
+      return llvm::all_of(getShape(), ShapedType::isScalable);
     }
 
     /// Get or create a new VectorType with the same shape as `this` and an

--- a/mlir/include/mlir/IR/CommonTypeConstraints.td
+++ b/mlir/include/mlir/IR/CommonTypeConstraints.td
@@ -459,7 +459,7 @@ class VectorOfRankAndType<list<int> allowedRanks,
 class IsVectorOfLengthPred<list<int> allowedLengths> :
   And<[IsVectorTypePred,
        Or<!foreach(allowedlength, allowedLengths,
-                   CPred<[{::llvm::cast<::mlir::VectorType>($_self).getNumElements()
+                   CPred<[{::llvm::cast<::mlir::VectorType>($_self).getMinNumElements()
                            == }]
                          # allowedlength>)>]>;
 
@@ -477,7 +477,7 @@ class IsFixedVectorOfLengthPred<list<int> allowedLengths> :
 class IsScalableVectorOfLengthPred<list<int> allowedLengths> :
   And<[IsScalableVectorTypePred,
        Or<!foreach(allowedlength, allowedLengths,
-                   CPred<[{::llvm::cast<::mlir::VectorType>($_self).getNumElements()
+                   CPred<[{::llvm::cast<::mlir::VectorType>($_self).getMinNumElements()
                            == }]
                          # allowedlength>)>]>;
 

--- a/mlir/include/mlir/IR/ShapeDim.h
+++ b/mlir/include/mlir/IR/ShapeDim.h
@@ -1,0 +1,85 @@
+//===- ShapeDim.h - MLIR ShapeDim Class --------------------------------------*-
+// C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ShapeDim class.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_IR_SHAPEDIM_H
+#define MLIR_IR_SHAPEDIM_H
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+namespace mlir {
+
+struct ShapeDim {
+  /// Deprecated. Use ShapeDim::fixed(), ShapeDim::scalable(), or
+  /// ShapeDim::kDynamic() instead.
+  constexpr ShapeDim(int64_t size) : size(size) {}
+
+  /// Deprecated. Use an explicit conversion instead.
+  constexpr operator int64_t() const { return size; }
+
+  /// Construct a scalable dimension.
+  constexpr static ShapeDim scalable(int64_t size) {
+    assert(size > 0);
+    return ShapeDim{-size};
+  }
+
+  /// Construct a fixed dimension.
+  constexpr static ShapeDim fixed(int64_t size) {
+    assert(size >= 0);
+    return ShapeDim{size};
+  }
+
+  /// Construct a dynamic dimension.
+  constexpr static ShapeDim kDynamic() { return ShapeDim{}; }
+
+  /// Returns whether this is a dynamic dimension.
+  constexpr bool isDynamic() const { return size == kDynamic(); }
+
+  /// Returns whether this is a scalable dimension.
+  constexpr bool isScalable() const { return size < 0 && !isDynamic(); }
+
+  /// Returns whether this is a fixed dimension.
+  constexpr bool isFixed() const { return size >= 0; }
+
+  /// Asserts a dimension is fixed and returns its size.
+  constexpr int64_t fixedSize() const {
+    assert(isFixed());
+    return size;
+  };
+
+  /// Asserts a dimension is scalable and returns its size.
+  constexpr int64_t scalableSize() const {
+    assert(isScalable());
+    return -size;
+  }
+
+  /// Returns the minimum (runtime) size for this dimension.
+  constexpr int64_t minSize() const {
+    if (isScalable())
+      return scalableSize();
+    if (isFixed())
+      return fixedSize();
+    return 0;
+  }
+
+private:
+  constexpr explicit ShapeDim()
+      : ShapeDim(std::numeric_limits<int64_t>::min()) {}
+
+  int64_t size;
+};
+
+} // namespace mlir
+
+#endif

--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -560,7 +560,7 @@ DenseElementsAttr TensorLiteralParser::getAttr(SMLoc loc, ShapedType type) {
   }
 
   // Handle the case where no elements were parsed.
-  if (!hexStorage && storage.empty() && type.getNumElements()) {
+  if (!hexStorage && storage.empty() && type.getMinNumElements()) {
     p.emitError(loc) << "parsed zero elements, but type (" << type
                      << ") expected at least 1";
     return nullptr;
@@ -1059,8 +1059,9 @@ ShapedType Parser::parseElementsLiteralType(Type type) {
     return nullptr;
   }
 
-  if (!sType.hasStaticShape())
-    return (emitError("elements literal type must have static shape"), nullptr);
+  if (sType.hasDynamicShape())
+    return (emitError("elements literal type cannot have dynamic dims"),
+            nullptr);
 
   return sType;
 }
@@ -1134,7 +1135,7 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
   auto valuesEltType = type.getElementType();
   ShapedType valuesType =
       valuesParser.getShape().empty()
-          ? RankedTensorType::get({indicesType.getDimSize(0)}, valuesEltType)
+          ? RankedTensorType::get({indicesType.getDim(0)}, valuesEltType)
           : RankedTensorType::get(valuesParser.getShape(), valuesEltType);
   auto values = valuesParser.getAttr(valuesLoc, valuesType);
 

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -210,8 +210,7 @@ public:
 
   /// Parse a vector type.
   VectorType parseVectorType();
-  ParseResult parseVectorDimensionList(SmallVectorImpl<int64_t> &dimensions,
-                                       SmallVectorImpl<bool> &scalableDims);
+  ParseResult parseVectorDimensionList(SmallVectorImpl<int64_t> &dimensions);
   ParseResult parseDimensionListRanked(SmallVectorImpl<int64_t> &dimensions,
                                        bool allowDynamic = true,
                                        bool withTrailingX = true);

--- a/mlir/lib/CAPI/IR/BuiltinTypes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinTypes.cpp
@@ -241,7 +241,7 @@ bool mlirShapedTypeIsDynamicDim(MlirType type, intptr_t dim) {
 
 int64_t mlirShapedTypeGetDimSize(MlirType type, intptr_t dim) {
   return llvm::cast<ShapedType>(unwrap(type))
-      .getDimSize(static_cast<unsigned>(dim));
+      .getDim(static_cast<unsigned>(dim));
 }
 
 int64_t mlirShapedTypeGetDynamicSize() { return ShapedType::kDynamic; }

--- a/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
@@ -498,9 +498,8 @@ Type LLVMTypeConverter::convertVectorType(VectorType type) const {
   if (!elementType)
     return {};
   if (type.getShape().empty())
-    return VectorType::get({1}, elementType);
-  Type vectorType = VectorType::get(type.getShape().back(), elementType,
-                                    type.getScalableDims().back());
+    return VectorType::get(1, elementType);
+  Type vectorType = VectorType::get(type.getShape().back(), elementType);
   assert(LLVM::isCompatibleVectorType(vectorType) &&
          "expected vector type compatible with the LLVM dialect");
   assert(

--- a/mlir/lib/Conversion/VectorToArmSME/VectorToArmSME.cpp
+++ b/mlir/lib/Conversion/VectorToArmSME/VectorToArmSME.cpp
@@ -148,8 +148,7 @@ struct ConstantOpToArmSMELowering : public OpRewritePattern<arith::ConstantOp> {
 
     // Unpack 1-d vector type from 2-d vector type.
     auto tileSliceType =
-        VectorType::get(tileType.getShape().drop_front(), tileElementType,
-                        /*scalableDims=*/{true});
+        VectorType::get(tileType.getShape().drop_front(), tileElementType);
     auto denseAttr1D = DenseElementsAttr::get(
         tileSliceType, denseAttr.getSplatValue<Attribute>());
     auto constantOp1D = rewriter.create<arith::ConstantOp>(loc, denseAttr1D);
@@ -209,8 +208,7 @@ struct BroadcastOpToArmSMELowering
         (srcVectorType && (srcVectorType.getRank() == 0))) {
       // Broadcast scalar or 0-d vector to 1-d vector.
       auto tileSliceType =
-          VectorType::get(tileType.getShape().drop_front(), tileElementType,
-                          /*scalableDims=*/{true});
+          VectorType::get(tileType.getShape().drop_front(), tileElementType);
       broadcastOp1D = rewriter.create<vector::BroadcastOp>(
           loc, tileSliceType, broadcastOp.getSource());
     } else if (srcVectorType && (srcVectorType.getRank() == 1))

--- a/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
+++ b/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
@@ -31,8 +31,7 @@ using namespace mlir::vector;
 // Helper to reduce vector type by *all* but one rank at back.
 static VectorType reducedVectorTypeBack(VectorType tp) {
   assert((tp.getRank() > 1) && "unlowerable vector type");
-  return VectorType::get(tp.getShape().take_back(), tp.getElementType(),
-                         tp.getScalableDims().take_back());
+  return VectorType::get(tp.getShape().take_back(), tp.getElementType());
 }
 
 // Helper that picks the proper sequence for inserting.
@@ -1390,7 +1389,7 @@ public:
         force32BitVectorIndices ? rewriter.getI32Type() : rewriter.getI64Type();
     auto loc = op->getLoc();
     Value indices = rewriter.create<LLVM::StepVectorOp>(
-        loc, LLVM::getVectorType(idxType, dstType.getShape()[0],
+        loc, LLVM::getVectorType(idxType, dstType.getDim(0).minSize(),
                                  /*isScalable=*/true));
     auto bound = getValueOrCreateCastToIndexLike(rewriter, loc, idxType,
                                                  op.getOperand(0));

--- a/mlir/lib/Dialect/ArmSME/Transforms/LegalizeForLLVMExport.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/LegalizeForLLVMExport.cpp
@@ -199,8 +199,7 @@ struct LoadTileSliceToArmSMELowering
     auto one = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getI1Type(),
         rewriter.getIntegerAttr(rewriter.getI1Type(), 1));
-    auto predTy = VectorType::get(tileType.getShape()[0], rewriter.getI1Type(),
-                                  /*scalableDims=*/{true});
+    auto predTy = VectorType::get(tileType.getShape()[0], rewriter.getI1Type());
     auto allActiveMask = rewriter.create<vector::SplatOp>(loc, predTy, one);
 
     auto tileI32 = castTileIDToI32(tile, loc, rewriter);
@@ -275,8 +274,7 @@ struct StoreTileSliceToArmSMELowering
     auto one = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getI1Type(),
         rewriter.getIntegerAttr(rewriter.getI1Type(), 1));
-    auto predTy = VectorType::get(tileType.getShape()[0], rewriter.getI1Type(),
-                                  /*scalableDims=*/{true});
+    auto predTy = VectorType::get(tileType.getShape()[0], rewriter.getI1Type());
     auto allActiveMask = rewriter.create<vector::SplatOp>(loc, predTy, one);
 
     Value tileI32 = castTileIDToI32(tile, loc, rewriter);
@@ -341,8 +339,7 @@ struct MoveVectorToTileSliceToArmSMELowering
     auto one = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getI1Type(),
         rewriter.getIntegerAttr(rewriter.getI1Type(), 1));
-    auto predTy = VectorType::get(tileType.getShape()[0], rewriter.getI1Type(),
-                                  /*scalableDims=*/{true});
+    auto predTy = VectorType::get(tileType.getShape()[0], rewriter.getI1Type());
     auto allActiveMask = rewriter.create<vector::SplatOp>(loc, predTy, one);
 
     auto tileI32 = castTileIDToI32(tile, loc, rewriter);

--- a/mlir/lib/Dialect/ArmSME/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/ArmSME/Utils/Utils.cpp
@@ -39,7 +39,8 @@ bool mlir::arm_sme::isValidSMETileVectorType(VectorType vType) {
     return false;
 
   unsigned minNumElts = arm_sme::getSMETileSliceMinNumElts(elemType);
-  if (vType.getShape() != ArrayRef<int64_t>({minNumElts, minNumElts}))
+  if (vType.getShape() != ArrayRef<int64_t>{ShapeDim::scalable(minNumElts),
+                                            ShapeDim::scalable(minNumElts)})
     return false;
 
   return true;

--- a/mlir/lib/Dialect/ArmSVE/IR/ArmSVEDialect.cpp
+++ b/mlir/lib/Dialect/ArmSVE/IR/ArmSVEDialect.cpp
@@ -29,8 +29,7 @@ using namespace mlir::arm_sve;
 static Type getI1SameShape(Type type) {
   auto i1Type = IntegerType::get(type.getContext(), 1);
   if (auto sVectorType = llvm::dyn_cast<VectorType>(type))
-    return VectorType::get(sVectorType.getShape(), i1Type,
-                           sVectorType.getScalableDims());
+    return VectorType::get(sVectorType.getShape(), i1Type);
   return nullptr;
 }
 

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseVectorization.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseVectorization.cpp
@@ -56,7 +56,10 @@ static bool isInvariantArg(BlockArgument arg, Block *block) {
 
 /// Constructs vector type for element type.
 static VectorType vectorType(VL vl, Type etp) {
-  return VectorType::get(vl.vectorLength, etp, vl.enableVLAVectorization);
+  return VectorType::create(vl.enableVLAVectorization
+                                ? ShapeDim::scalable(vl.vectorLength)
+                                : ShapeDim::fixed(vl.vectorLength),
+                            etp);
 }
 
 /// Constructs vector type from a memref value.

--- a/mlir/lib/Dialect/SparseTensor/Utils/Merger.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Utils/Merger.cpp
@@ -1215,7 +1215,7 @@ Type Merger::inferType(ExprId e, Value src) const {
   // Inspect source type. For vector types, apply the same
   // vectorization to the destination type.
   if (auto vtp = dyn_cast<VectorType>(src.getType()))
-    return VectorType::get(vtp.getNumElements(), dtp, vtp.getScalableDims());
+    return VectorType::get(vtp.getNumElements(), dtp);
   return dtp;
 }
 

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -154,8 +154,6 @@ public:
 
     auto srcRank = multiReductionOp.getSourceVectorType().getRank();
     auto srcShape = multiReductionOp.getSourceVectorType().getShape();
-    auto srcScalableDims =
-        multiReductionOp.getSourceVectorType().getScalableDims();
     auto loc = multiReductionOp.getLoc();
 
     // If rank less than 2, nothing to do.
@@ -164,7 +162,7 @@ public:
 
     // Allow only 1 scalable dimensions. Otherwise we could end-up with e.g.
     // `vscale * vscale` that's currently not modelled.
-    if (llvm::count(srcScalableDims, true) > 1)
+    if (multiReductionOp.getSourceVectorType().getNumScalableDims() > 1)
       return failure();
 
     // If already rank-2 ["parallel", "reduce"] or ["reduce", "parallel"] bail.
@@ -174,20 +172,16 @@ public:
 
     // 1. Separate reduction and parallel dims.
     SmallVector<int64_t, 4> parallelDims, parallelShapes;
-    SmallVector<bool, 4> parallelScalableDims;
     SmallVector<int64_t, 4> reductionDims, reductionShapes;
-    bool isReductionDimScalable = false;
     for (const auto &it : llvm::enumerate(reductionMask)) {
       int64_t i = it.index();
       bool isReduction = it.value();
       if (isReduction) {
         reductionDims.push_back(i);
         reductionShapes.push_back(srcShape[i]);
-        isReductionDimScalable |= srcScalableDims[i];
       } else {
         parallelDims.push_back(i);
         parallelShapes.push_back(srcShape[i]);
-        parallelScalableDims.push_back(srcScalableDims[i]);
       }
     }
 
@@ -196,13 +190,13 @@ public:
     int flattenedReductionDim = 0;
     if (!parallelShapes.empty()) {
       flattenedParallelDim = 1;
-      for (auto d : parallelShapes)
-        flattenedParallelDim *= d;
+      for (ShapeDim d : parallelShapes)
+        flattenedParallelDim *= d.minSize();
     }
     if (!reductionShapes.empty()) {
       flattenedReductionDim = 1;
-      for (auto d : reductionShapes)
-        flattenedReductionDim *= d;
+      for (ShapeDim d : reductionShapes)
+        flattenedReductionDim *= d.minSize();
     }
     // We must at least have some parallel or some reduction.
     assert((flattenedParallelDim || flattenedReductionDim) &&
@@ -223,23 +217,19 @@ public:
     // 4. Shape cast to collapse consecutive parallel (resp. reduction dim) into
     // a single parallel (resp. reduction) dim.
     SmallVector<bool, 2> mask;
-    SmallVector<bool, 2> scalableDims;
     SmallVector<int64_t, 2> vectorShape;
-    bool isParallelDimScalable = llvm::is_contained(parallelScalableDims, true);
+    bool isParallelDimScalable = ShapedType::isScalableShape(parallelShapes);
     if (flattenedParallelDim) {
       mask.push_back(false);
       vectorShape.push_back(flattenedParallelDim);
-      scalableDims.push_back(isParallelDimScalable);
     }
     if (flattenedReductionDim) {
       mask.push_back(true);
       vectorShape.push_back(flattenedReductionDim);
-      scalableDims.push_back(isReductionDimScalable);
     }
     if (!useInnerDimsForReduction && vectorShape.size() == 2) {
       std::swap(mask.front(), mask.back());
       std::swap(vectorShape.front(), vectorShape.back());
-      std::swap(scalableDims.front(), scalableDims.back());
     }
 
     Value newVectorMask;
@@ -253,17 +243,16 @@ public:
     }
 
     auto castedType = VectorType::get(
-        vectorShape, multiReductionOp.getSourceVectorType().getElementType(),
-        scalableDims);
+        vectorShape, multiReductionOp.getSourceVectorType().getElementType());
     Value cast = rewriter.create<vector::ShapeCastOp>(
         loc, castedType, multiReductionOp.getSource());
 
     Value acc = multiReductionOp.getAcc();
     if (flattenedParallelDim) {
-      auto accType = VectorType::get(
-          {flattenedParallelDim},
-          multiReductionOp.getSourceVectorType().getElementType(),
-          /*scalableDims=*/{isParallelDimScalable});
+      auto accType = VectorType::create(
+          {isParallelDimScalable ? ShapeDim::scalable(flattenedParallelDim)
+                                 : ShapeDim::fixed(flattenedParallelDim)},
+          multiReductionOp.getSourceVectorType().getElementType());
       acc = rewriter.create<vector::ShapeCastOp>(loc, accType, acc);
     }
     // 6. Creates the flattened form of vector.multi_reduction with inner/outer
@@ -282,8 +271,8 @@ public:
 
     // 8. Creates shape cast for the output n-D -> 2-D.
     VectorType outputCastedType = VectorType::get(
-        parallelShapes, multiReductionOp.getSourceVectorType().getElementType(),
-        parallelScalableDims);
+        parallelShapes,
+        multiReductionOp.getSourceVectorType().getElementType());
     rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(
         rootOp, outputCastedType, newMultiDimRedOp->getResult(0));
     return success();

--- a/mlir/lib/Dialect/Vector/Transforms/VectorDropLeadUnitDim.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDropLeadUnitDim.cpp
@@ -23,23 +23,14 @@ using namespace mlir::vector;
 // Returns `vector<1xT>` if `oldType` only has one element.
 static VectorType trimLeadingOneDims(VectorType oldType) {
   ArrayRef<int64_t> oldShape = oldType.getShape();
-  ArrayRef<int64_t> newShape = oldShape;
-
-  ArrayRef<bool> oldScalableDims = oldType.getScalableDims();
-  ArrayRef<bool> newScalableDims = oldScalableDims;
-
-  while (!newShape.empty() && newShape.front() == 1 &&
-         !newScalableDims.front()) {
-    newShape = newShape.drop_front(1);
-    newScalableDims = newScalableDims.drop_front(1);
-  }
+  ArrayRef<int64_t> newShape =
+      oldShape.drop_while([](uint64_t dim) { return dim == 1; });
 
   // Make sure we have at least 1 dimension per vector type requirements.
-  if (newShape.empty()) {
+  if (newShape.empty())
     newShape = oldShape.take_back();
-    newScalableDims = oldType.getScalableDims().take_back();
-  }
-  return VectorType::get(newShape, oldType.getElementType(), newScalableDims);
+
+  return VectorType::get(newShape, oldType.getElementType());
 }
 
 /// Return a smallVector of size `rank` containing all zeros.

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1017,10 +1017,7 @@ public:
         vector::createOrFoldDimOp(rewriter, loc, xferOp.getSource(), lastIndex);
     Value b = rewriter.create<arith::SubIOp>(loc, dim.getType(), dim, off);
     Value mask = rewriter.create<vector::CreateMaskOp>(
-        loc,
-        VectorType::get(vtp.getShape(), rewriter.getI1Type(),
-                        vtp.getScalableDims()),
-        b);
+        loc, VectorType::get(vtp.getShape(), rewriter.getI1Type()), b);
     if (xferOp.getMask()) {
       // Intersect the in-bounds with the mask specified as an op parameter.
       mask = rewriter.create<arith::AndIOp>(loc, mask, xferOp.getMask());

--- a/mlir/lib/IR/BuiltinAttributeInterfaces.cpp
+++ b/mlir/lib/IR/BuiltinAttributeInterfaces.cpp
@@ -29,7 +29,7 @@ Type ElementsAttr::getElementType(ElementsAttr elementsAttr) {
 }
 
 int64_t ElementsAttr::getNumElements(ElementsAttr elementsAttr) {
-  return elementsAttr.getShapedType().getNumElements();
+  return elementsAttr.getShapedType().getMinNumElements();
 }
 
 bool ElementsAttr::isValidIndex(ShapedType type, ArrayRef<uint64_t> index) {

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -1064,7 +1064,7 @@ bool DenseElementsAttr::isValidRawBuffer(ShapedType type,
                                          bool &detectedSplat) {
   size_t storageWidth = getDenseElementStorageWidth(type.getElementType());
   size_t rawBufferWidth = rawBuffer.size() * CHAR_BIT;
-  int64_t numElements = type.getNumElements();
+  int64_t numElements = type.getMinNumElements();
 
   // The initializer is always a splat if the result type has a single element.
   detectedSplat = numElements == 1;
@@ -1268,7 +1268,7 @@ Type DenseElementsAttr::getElementType() const {
 }
 
 int64_t DenseElementsAttr::getNumElements() const {
-  return getType().getNumElements();
+  return getType().getMinNumElements();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1318,7 +1318,7 @@ DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
 
 DenseElementsAttr DenseIntOrFPElementsAttr::getRaw(ShapedType type,
                                                    ArrayRef<char> data) {
-  assert(type.hasStaticShape() && "type must have static shape");
+  assert(!type.hasDynamicShape() && "type cannot have dynamic shape");
   bool isSplat = false;
   bool isValid = isValidRawBuffer(type, data, isSplat);
   assert(isValid);

--- a/mlir/lib/IR/BuiltinTypeInterfaces.cpp
+++ b/mlir/lib/IR/BuiltinTypeInterfaces.cpp
@@ -25,10 +25,10 @@ using namespace mlir::detail;
 
 constexpr int64_t ShapedType::kDynamic;
 
-int64_t ShapedType::getNumElements(ArrayRef<int64_t> shape) {
+int64_t ShapedType::getMinNumElements(ArrayRef<int64_t> shape) {
   int64_t num = 1;
-  for (int64_t dim : shape) {
-    num *= dim;
+  for (ShapeDim dim : shape) {
+    num *= dim.minSize();
     assert(num >= 0 && "integer overflow in element count computation");
   }
   return num;

--- a/mlir/lib/Target/LLVMIR/TypeToLLVM.cpp
+++ b/mlir/lib/Target/LLVMIR/TypeToLLVM.cpp
@@ -138,7 +138,7 @@ private:
            "expected compatible with LLVM vector type");
     if (type.isScalable())
       return llvm::ScalableVectorType::get(translateType(type.getElementType()),
-                                           type.getNumElements());
+                                           type.getMinNumElements());
     return llvm::FixedVectorType::get(translateType(type.getElementType()),
                                       type.getNumElements());
   }

--- a/mlir/test/IR/invalid-builtin-attributes.mlir
+++ b/mlir/test/IR/invalid-builtin-attributes.mlir
@@ -7,7 +7,7 @@ func.func @elementsattr_non_tensor_type() -> () {
 // -----
 
 func.func @elementsattr_non_ranked() -> () {
-  "foo"(){bar = dense<[4]> : tensor<?xi32>} : () -> () // expected-error {{elements literal type must have static shape}}
+  "foo"(){bar = dense<[4]> : tensor<?xi32>} : () -> () // expected-error {{elements literal type cannot have dynamic dims}}
 }
 
 // -----

--- a/mlir/test/IR/invalid-builtin-types.mlir
+++ b/mlir/test/IR/invalid-builtin-types.mlir
@@ -125,12 +125,12 @@ func.func @vectors(vector<1 x vector<1xi32>>, vector<2x4xf32>)
 
 // -----
 
-// expected-error @+1 {{vector types must have positive constant sizes}}
+// expected-error @+1 {{vector type must have non-zero sizes}}
 func.func @zero_vector_type() -> vector<0xi32>
 
 // -----
 
-// expected-error @+1 {{vector types must have positive constant sizes}}
+// expected-error @+1 {{vector type must have non-zero sizes}}
 func.func @zero_in_vector_type() -> vector<1x0xi32>
 
 // -----


### PR DESCRIPTION

This is a proof of concept for: https://discourse.llvm.org/t/rfc-support-scalable-dimensions-in-shapedtypes/73260

---

This patch adds support for scalable dims to ShapedTypes, it does this by making use of negative sizes for dims. With this:

- Fixed/static dimensions are positive values (>= 0)
- kDynamic stays the same (std::numeric_limits<int64_t>::min())
- Scalable dimensions are negative values (e.g. [8] is -8)

Associated methods/helpers to check for these dimensions have been added to ShapedType. So a shape is considered:

- Dynamic if any dimension is dynamic
- Scalable if any dimension is scalable (and no dimension is dynamic)
- Static/fixed if it is not dynamic or scalable

Treating these dimensions as integers or sizes could be error-prone, so instead, it is recommended to convert them to a ShapeDim before querying the size. Currently, int64_ts can be implicitly converted to/from an mlir::ShapeDim, however, it's hoped that it can eventually be made an explicit conversion with ShapeDim used everywhere.

The ShapeDim class (which simply wraps an int64_t) has methods to check for fixed, dynamic, or scalable dimensions with methods to query:

- The fixedSize(); if this dimension isFixed() return the size, abort otherwise
- The scalableSize(); if this dimension isScalable() return the minimum size (i.e. the size when the runtime multiplier is 1), abort otherwise
- The minSize(); the minimum size of a dimension, 0 for dynamic, scalableSize() for scalable, fixedSize() otherwise

With this, the array of booleans currently added to the VectorType to mark which dimensions are scalable can be removed. This makes the vector type act like any other ShapedType. This removes a lot of the special cases needed to handle scalable dims. Doing this, fixes several issues with misinterpreting or dropping scalable dims for vector types.

For example, now `vectorType.getDim(0) == 1` is only true if dim 0 is a unit dimension, and not a scalable dimension [1].

And:
```
  VectorType::get(
    vectorType.getShape().drop_front(), vectorType.getElementType())
```
will correctly drop the leading dimension and preserve all scalable dimensions.