### PR TITLE
[libc] Fix test passing negative value in timespec passed to nanosleep

### DIFF
--- a/libc/test/src/time/gettimeofday_test.cpp
+++ b/libc/test/src/time/gettimeofday_test.cpp
@@ -25,7 +25,7 @@ TEST(LlvmLibcGettimeofday, SmokeTest) {
     int ret = __llvm_libc::gettimeofday(&tv, tz);
     ASSERT_EQ(ret, 0);
 
-    int sleep_time = -sleep_times[i];
+    int sleep_time = sleep_times[i];
     // Sleep for {sleep_time} microsceconds.
     struct timespec tim = {0, sleep_time * 1000};
     struct timespec tim2 = {0, 0};


### PR DESCRIPTION
This test was setting tv_nsec to a negative value, which as per the standard this is an EINVAL:

The value in the tv_nsec field was not in the range [0, 999999999] or tv_sec was negative.

https://man7.org/linux/man-pages/man2/nanosleep.2.html