### PR TITLE
[llvm] Adopt WithMarkup in the MIPS backend

### DIFF
--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsInstPrinter.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsInstPrinter.cpp
@@ -73,8 +73,8 @@ const char* Mips::MipsFCCToString(Mips::CondCode CC) {
 }
 
 void MipsInstPrinter::printRegName(raw_ostream &OS, MCRegister Reg) const {
-  OS << markup("<reg:") << '$' << StringRef(getRegisterName(Reg)).lower()
-     << markup(">");
+  markup(OS, Markup::Register)
+      << '$' << StringRef(getRegisterName(Reg)).lower();
 }
 
 void MipsInstPrinter::printInst(const MCInst *MI, uint64_t Address,
@@ -134,7 +134,7 @@ void MipsInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   }
 
   if (Op.isImm()) {
-    O << markup("<imm:") << formatImm(Op.getImm()) << markup(">");
+    markup(O, Markup::Immediate) << formatImm(Op.getImm());
     return;
   }
 
@@ -150,9 +150,9 @@ void MipsInstPrinter::printJumpOperand(const MCInst *MI, unsigned OpNo,
     return printOperand(MI, OpNo, STI, O);
 
   if (PrintBranchImmAsAddress)
-    O << markup("<imm:") << formatHex(Op.getImm()) << markup(">");
+    markup(O, Markup::Immediate) << formatHex(Op.getImm());
   else
-    O << markup("<imm:") << formatImm(Op.getImm()) << markup(">");
+    markup(O, Markup::Immediate) << formatImm(Op.getImm());
 }
 
 void MipsInstPrinter::printBranchOperand(const MCInst *MI, uint64_t Address,
@@ -169,9 +169,9 @@ void MipsInstPrinter::printBranchOperand(const MCInst *MI, uint64_t Address,
       Target &= 0xffffffff;
     else if (STI.hasFeature(Mips::FeatureMips16))
       Target &= 0xffff;
-    O << markup("<imm:") << formatHex(Target) << markup(">");
+    markup(O, Markup::Immediate) << formatHex(Target);
   } else {
-    O << markup("<imm:") << formatImm(Op.getImm()) << markup(">");
+    markup(O, Markup::Immediate) << formatImm(Op.getImm());
   }
 }
 
@@ -184,7 +184,7 @@ void MipsInstPrinter::printUImm(const MCInst *MI, int opNum,
     Imm -= Offset;
     Imm &= (1 << Bits) - 1;
     Imm += Offset;
-    O << markup("<imm:") << formatImm(Imm) << markup(">");
+    markup(O, Markup::Immediate) << formatImm(Imm);
     return;
   }
 
@@ -213,12 +213,11 @@ void MipsInstPrinter::printMemOperand(const MCInst *MI, int opNum,
     break;
   }
 
-  O << markup("<mem:");
+  WithMarkup M = markup(O, Markup::Memory);
   printOperand(MI, opNum + 1, STI, O);
   O << "(";
   printOperand(MI, opNum, STI, O);
   O << ")";
-  O << markup(">");
 }
 
 void MipsInstPrinter::printMemOperandEA(const MCInst *MI, int opNum,


### PR DESCRIPTION
Adopt the new markup overload, introduced in 77d1032516e7, in the MIPS backend.