### PR TITLE
[libc] Fix gmtime test on systems with sizeof(time_t) == 4

### DIFF
--- a/libc/test/src/time/gmtime_test.cpp
+++ b/libc/test/src/time/gmtime_test.cpp
@@ -20,7 +20,7 @@ using __llvm_libc::testing::ErrnoSetterMatcher::Succeeds;
 using __llvm_libc::time_utils::TimeConstants;
 
 TEST(LlvmLibcGmTime, OutOfRange) {
-  if(sizeof(time_t) == 4)
+  if (sizeof(time_t) < sizeof(int64_t))
     return;
   time_t seconds =
       1 + INT_MAX * static_cast<int64_t>(

--- a/libc/test/src/time/gmtime_test.cpp
+++ b/libc/test/src/time/gmtime_test.cpp
@@ -20,6 +20,8 @@ using __llvm_libc::testing::ErrnoSetterMatcher::Succeeds;
 using __llvm_libc::time_utils::TimeConstants;
 
 TEST(LlvmLibcGmTime, OutOfRange) {
+  if(sizeof(time_t) == 4)
+    return;
   time_t seconds =
       1 + INT_MAX * static_cast<int64_t>(
                         TimeConstants::NUMBER_OF_SECONDS_IN_LEAP_YEAR);


### PR DESCRIPTION
This test creates a time_t variable and assigns 0xfffffffffe1d7b01 which overflows the maximum time_t value for 64-bit time_t, then checks if the syscall fails and errno was set.

In systems with sizeof(time_t) == 4, the value is narrowed down to 0xfe1d7b01 and doesn't overflow, causing the test to fail.

This patch then disables the test on systems with 32 bits long time_t.