### PR TITLE
[libc] Fix failing mktime test case in 32-bit systems

### DIFF
--- a/libc/test/src/time/mktime_test.cpp
+++ b/libc/test/src/time/mktime_test.cpp
@@ -187,8 +187,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
       .tm_yday = 0
     };
-    EXPECT_THAT(__llvm_libc::mktime(&tm_data),
-                Succeeds(TimeConstants::OUT_OF_RANGE_RETURN_VALUE));
+    EXPECT_THAT(__llvm_libc::mktime(&tm_data), Fails(EOVERFLOW));
   }
 
   {
@@ -198,8 +197,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
       .tm_yday = 0
     };
-    EXPECT_THAT(__llvm_libc::mktime(&tm_data),
-                Succeeds(TimeConstants::OUT_OF_RANGE_RETURN_VALUE));
+    EXPECT_THAT(__llvm_libc::mktime(&tm_data), Fails(EOVERFLOW));
   }
 
   {
@@ -209,8 +207,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
       .tm_yday = 0
     };
-    EXPECT_THAT(__llvm_libc::mktime(&tm_data),
-                Succeeds(TimeConstants::OUT_OF_RANGE_RETURN_VALUE));
+    EXPECT_THAT(__llvm_libc::mktime(&tm_data), Fails(EOVERFLOW));
   }
 
   {
@@ -220,8 +217,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
       .tm_yday = 0
     };
-    EXPECT_THAT(__llvm_libc::mktime(&tm_data),
-                Succeeds(TimeConstants::OUT_OF_RANGE_RETURN_VALUE));
+    EXPECT_THAT(__llvm_libc::mktime(&tm_data), Fails(EOVERFLOW));
   }
 
   {
@@ -231,8 +227,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
       .tm_mon = Month::FEBRUARY, .tm_year = tm_year(2038), .tm_wday = 0,
       .tm_yday = 0
     };
-    EXPECT_THAT(__llvm_libc::mktime(&tm_data),
-                Succeeds(TimeConstants::OUT_OF_RANGE_RETURN_VALUE));
+    EXPECT_THAT(__llvm_libc::mktime(&tm_data), Fails(EOVERFLOW));
   }
 
   {
@@ -242,8 +237,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2039), .tm_wday = 0,
       .tm_yday = 0
     };
-    EXPECT_THAT(__llvm_libc::mktime(&tm_data),
-                Succeeds(TimeConstants::OUT_OF_RANGE_RETURN_VALUE));
+    EXPECT_THAT(__llvm_libc::mktime(&tm_data), Fails(EOVERFLOW));
   }
 }
 


### PR DESCRIPTION
Previously, these tests expected that calling mktime with a struct tm that caused overlow to succeed with return -1
(TimeConstants::OUT_OF_RANGE_RETURN_VALUE), however, the Succeeds call expects the errno to be zero (no failure).

This patch fixes the expected calls to fail with EOVERFLOW. These tests are only enabled to 32-bit systems, and are probably not being tested on the arm32 buildbot, that's why this was not a problem before.