### PR TITLE
[Docs] Add example of making a PR with git and GitHub web interface

### DIFF
--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -291,7 +291,7 @@ checks:
   ninja check
 
   # Push the rebased changes to your fork.
-  git push origin my_change
+  git push origin my_change -f
 
 Once your PR is approved, rebased, and tests are passing, click `Squash and
 Merge` on your PR in the GitHub web interface.

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -246,8 +246,8 @@ Once you've cloned your forked repository,
   # fork and upstream to llvm/llvm-project
   git push origin my_change
 
-Now back on the GitHub web interface, navigate to your fork and create a pull
-request from your branch to llvm::main.
+Navigate to the URL printed to the console from the git push command in the last step.
+Create a pull request from your branch to llvm::main.
 
 ::
 
@@ -258,6 +258,12 @@ request from your branch to llvm::main.
 
   # Commit your changes
   git commit file.cpp -m "Code Review adjustments"
+
+  # Format changes
+  git clang-format HEAD~
+
+  # Recommit if any formatting changes
+  git commit -a --amend
 
   # Push your changes to your fork branch, be mindful of
   # your remotes here, if you don't remember what points to your

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -265,20 +265,28 @@ Create a pull request from your branch to llvm::main.
   # Recommit if any formatting changes
   git commit -a --amend
 
+  # Re-run tests and make sure nothing broke.
+  ninja check-llvm
+
   # Push your changes to your fork branch, be mindful of
   # your remotes here, if you don't remember what points to your
   # fork, use git remote -v to see. Usually origin points to your
   # fork and upstream to llvm/llvm-project
   git push origin my_change
 
-  # When your PR is accepted, you can now rebase it and make sure
-  # you have all the latest changes.
+Before merging the PR, it is reccomended that you rebase locally and re-run test
+checks:
+
+::
+
+  # Make sure you have all the latest changes
   git rebase -i origin/main
 
-  # If this PR is older and you get a lot of new commits with the
-  # rebase, you might want to re-run tests and make sure nothing
-  # broke.
+  # Make sure tests pass with latest changes and your change
   ninja check-llvm
+
+  # Push the rebased changes to your fork.
+  git push origin my_change
 
 Once your PR is approved, rebased, and tests are passing, click `Squash and
 Merge` on your PR in the GitHub web interface.

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -268,7 +268,7 @@ Create a pull request from your branch to llvm::main.
   git commit -a --amend
 
   # Re-run tests and make sure nothing broke.
-  ninja check-llvm
+  ninja check
 
   # Push your changes to your fork branch, be mindful of
   # your remotes here, if you don't remember what points to your

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -207,6 +207,76 @@ See more in-depth information about how to contribute in the following documenta
 * :doc:`Contributing`
 * :doc:`MyFirstTypoFix`
 
+Example Pull Request with git
+====================================
+
+Instead of using the GitHub CLI to create a PR, you can push your code to a
+remote branch on your fork and create the PR to upstream using the GitHub web
+interface.
+
+Here is an example of making a PR using git and the GitHub web interface:
+
+First follow the instructions to [fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo?tool=webui#forking-a-repository).
+
+Next follow the instructions to [clone your forked repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo?tool=webui#cloning-your-forked-repository).
+
+Once you've cloned your forked repository,
+
+::
+
+  # Switch to the forked repo and create a new branch
+  cd llvm-project
+  git switch -c my_change
+
+  # Create your changes
+  $EDITOR file.cpp
+
+  # Don't forget clang-format
+  git clang-format
+
+  # and don't forget running your tests
+  ninja check-llvm
+
+  # Commit, use a good commit message
+  git commit file.cpp
+
+  # Push your changes to your fork branch, be mindful of
+  # your remotes here, if you don't remember what points to your
+  # fork, use git remote -v to see. Usually origin points to your
+  # fork and upstream to llvm/llvm-project
+  git push origin my_change
+
+Now back on the GitHub web interface, navigate to your fork and create a pull
+request from your branch to llvm::main.
+
+::
+
+  # If you get any review comments, come back to the branch and
+  # adjust them.
+  git switch my_change
+  $EDITOR file.cpp
+
+  # Commit your changes
+  git commit file.cpp -m "Code Review adjustments"
+
+  # Push your changes to your fork branch, be mindful of
+  # your remotes here, if you don't remember what points to your
+  # fork, use git remote -v to see. Usually origin points to your
+  # fork and upstream to llvm/llvm-project
+  git push origin my_change
+
+  # When your PR is accepted, you can now rebase it and make sure
+  # you have all the latest changes.
+  git rebase -i origin/main
+
+  # If this PR is older and you get a lot of new commits with the
+  # rebase, you might want to re-run tests and make sure nothing
+  # broke.
+  ninja check-llvm
+
+Once your PR is approved, rebased, and tests are passing, click `Squash and
+Merge` on your PR in the GitHub web interface.
+
 Releases
 ========
 

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -227,9 +227,6 @@ Once you've cloned your forked repository,
   # Switch to the forked repo
   cd llvm-project
 
-  # Add upstream as a remote
-  git remote add upstream https://github.com/llvm/llvm-project.git
-
   # Create a new branch
   git switch -c my_change
 
@@ -283,6 +280,9 @@ Before merging the PR, it is recommended that you rebase locally and re-run test
 checks:
 
 ::
+
+  # Add upstream as a remote
+  git remote add upstream https://github.com/llvm/llvm-project.git
 
   # Make sure you have all the latest changes
   git fetch upstream && git rebase -i upstream/main

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -224,8 +224,13 @@ Once you've cloned your forked repository,
 
 ::
 
-  # Switch to the forked repo and create a new branch
+  # Switch to the forked repo
   cd llvm-project
+
+  # Add upstream as a remote
+  git remote add upstream https://github.com/llvm/llvm-project.git
+
+  # Create a new branch
   git switch -c my_change
 
   # Create your changes
@@ -274,16 +279,16 @@ Create a pull request from your branch to llvm::main.
   # fork and upstream to llvm/llvm-project
   git push origin my_change
 
-Before merging the PR, it is reccomended that you rebase locally and re-run test
+Before merging the PR, it is recommended that you rebase locally and re-run test
 checks:
 
 ::
 
   # Make sure you have all the latest changes
-  git rebase -i origin/main
+  git fetch upstream && git rebase -i upstream/main
 
   # Make sure tests pass with latest changes and your change
-  ninja check-llvm
+  ninja check
 
   # Push the rebased changes to your fork.
   git push origin my_change


### PR DESCRIPTION
Some people may not have access to `gh` or may prefer to use `git` and the GitHub web interface to make a PR. This patch adds an example of making a PR using this approach.