### PR TITLE
[include-mapping] Python fixes

### DIFF
--- a/clang/tools/include-mapping/cppreference_parser.py
+++ b/clang/tools/include-mapping/cppreference_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===- cppreference_parser.py -  ------------------------------*- python -*--===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/clang/tools/include-mapping/cppreference_parser.py
+++ b/clang/tools/include-mapping/cppreference_parser.py
@@ -176,6 +176,10 @@ def _GetSymbols(pool, root_dir, index_page_name, namespace, variants_to_accept):
     return symbols
 
 
+def signal_ignore_initializer():
+    return signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
 def GetSymbols(parse_pages):
     """Get all symbols by parsing the given pages.
 
@@ -192,9 +196,7 @@ def GetSymbols(parse_pages):
     symbols = []
     # Run many workers to process individual symbol pages under the symbol index.
     # Don't allow workers to capture Ctrl-C.
-    pool = multiprocessing.Pool(
-        initializer=lambda: signal.signal(signal.SIGINT, signal.SIG_IGN)
-    )
+    pool = multiprocessing.Pool(initializer=signal_ignore_initializer)
     try:
         for root_dir, page_name, namespace in parse_pages:
             symbols.extend(

--- a/clang/tools/include-mapping/gen_std.py
+++ b/clang/tools/include-mapping/gen_std.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===- gen_std.py -  ------------------------------------------*- python -*--===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
I had to regenerate the include mapping while resolving a downstream merge conflict, and ran into two issue on my machine. These shouldn't change anything, just make things work on my config.

- Move the `multiprocessing.Pool` initializer to a top-level function, it was previously causing a pickle failure with my machine's python, specifically complaining about having to pickle the lambda or a local function. Works fine with a top-level function.
- Change the `env python` to `env python3` for convenience. The interpreter is installed as python3 on macOS.

It looks like about 2/3 of the scripts in `clang/tools/` are using `env python3` over `env python` so the latter seems a reasonable change to make.