### PR TITLE
[clang-format] Correctly annotate designated initializer with PP if

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -618,16 +618,17 @@ void UnwrappedLineParser::calculateBraceTypes(bool ExpectClassBody) {
       if (Tok->isNot(TT_StatementMacro))
         break;
       [[fallthrough]];
+    case tok::kw_if:
+      if (PrevTok->is(tok::hash))
+        break;
+      [[fallthrough]];
     case tok::at:
     case tok::semi:
-    case tok::kw_if:
     case tok::kw_while:
     case tok::kw_for:
     case tok::kw_switch:
     case tok::kw_try:
     case tok::kw___try:
-      if (PrevTok->is(tok::hash))
-        break;
       if (!LBraceStack.empty() && LBraceStack.back().Tok->is(BK_Unknown))
         LBraceStack.back().Tok->setBlockKind(BK_Block);
       break;

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -626,6 +626,8 @@ void UnwrappedLineParser::calculateBraceTypes(bool ExpectClassBody) {
     case tok::kw_switch:
     case tok::kw_try:
     case tok::kw___try:
+      if (PrevTok->is(tok::hash))
+        break;
       if (!LBraceStack.empty() && LBraceStack.back().Tok->is(BK_Unknown))
         LBraceStack.back().Tok->setBlockKind(BK_Block);
       break;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2011,22 +2011,22 @@ TEST_F(TokenAnnotatorTest, UnderstandDesignatedInitializers) {
   EXPECT_TOKEN(Tokens[7], tok::period, TT_DesignatedInitializerPeriod);
 
   Tokens = annotate("SomeStruct {\n"
-  "#ifdef FOO\n"
-  "  .a = 1,\n"
-  "#endif\n"
-  "  .b = 2\n"
-  "};");
+                    "#ifdef FOO\n"
+                    "  .a = 1,\n"
+                    "#endif\n"
+                    "  .b = 2\n"
+                    "};");
   ASSERT_EQ(Tokens.size(), 19u) << Tokens;
   EXPECT_BRACE_KIND(Tokens[1], BK_BracedInit);
   EXPECT_TOKEN(Tokens[5], tok::period, TT_DesignatedInitializerPeriod);
   EXPECT_TOKEN(Tokens[12], tok::period, TT_DesignatedInitializerPeriod);
 
   Tokens = annotate("SomeStruct {\n"
-  "#if defined FOO\n"
-  "  .a = 1,\n"
-  "#endif\n"
-  "  .b = 2\n"
-  "};");
+                    "#if defined FOO\n"
+                    "  .a = 1,\n"
+                    "#endif\n"
+                    "  .b = 2\n"
+                    "};");
   ASSERT_EQ(Tokens.size(), 20u) << Tokens;
   EXPECT_BRACE_KIND(Tokens[1], BK_BracedInit);
   EXPECT_TOKEN(Tokens[6], tok::period, TT_DesignatedInitializerPeriod);

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1998,6 +1998,41 @@ TEST_F(TokenAnnotatorTest, UnderstandsNestedBlocks) {
   EXPECT_BRACE_KIND(Tokens[10], BK_Block);
 }
 
+TEST_F(TokenAnnotatorTest, UnderstandDesignatedInitializers) {
+  auto Tokens = annotate("SomeStruct { .a = 1 };");
+  ASSERT_EQ(Tokens.size(), 9u) << Tokens;
+  EXPECT_BRACE_KIND(Tokens[1], BK_BracedInit);
+  EXPECT_TOKEN(Tokens[2], tok::period, TT_DesignatedInitializerPeriod);
+
+  Tokens = annotate("SomeStruct { .a = 1, .b = 2 };");
+  ASSERT_EQ(Tokens.size(), 14u) << Tokens;
+  EXPECT_BRACE_KIND(Tokens[1], BK_BracedInit);
+  EXPECT_TOKEN(Tokens[2], tok::period, TT_DesignatedInitializerPeriod);
+  EXPECT_TOKEN(Tokens[7], tok::period, TT_DesignatedInitializerPeriod);
+
+  Tokens = annotate("SomeStruct {\n"
+  "#ifdef FOO\n"
+  "  .a = 1,\n"
+  "#endif\n"
+  "  .b = 2\n"
+  "};");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_BRACE_KIND(Tokens[1], BK_BracedInit);
+  EXPECT_TOKEN(Tokens[5], tok::period, TT_DesignatedInitializerPeriod);
+  EXPECT_TOKEN(Tokens[12], tok::period, TT_DesignatedInitializerPeriod);
+
+  Tokens = annotate("SomeStruct {\n"
+  "#if defined FOO\n"
+  "  .a = 1,\n"
+  "#endif\n"
+  "  .b = 2\n"
+  "};");
+  ASSERT_EQ(Tokens.size(), 20u) << Tokens;
+  EXPECT_BRACE_KIND(Tokens[1], BK_BracedInit);
+  EXPECT_TOKEN(Tokens[6], tok::period, TT_DesignatedInitializerPeriod);
+  EXPECT_TOKEN(Tokens[13], tok::period, TT_DesignatedInitializerPeriod);
+}
+
 } // namespace
 } // namespace format
 } // namespace clang


### PR DESCRIPTION
When encountering braces, such as those of a designated initializer, clang-format scans ahead to see what is contained within the braces. If it found a statement, like an if-statement of for-loop, it would deem the braces as not an initializer, but as a block instead.

However, this heuristic incorrectly included a preprocessor `#if` line as an if-statement. This manifested in strange results and discrepancies between `#ifdef` and `#if defined`.

With this patch, `if` is now ignored if it is preceeded by `#`.

Fixes most of https://github.com/llvm/llvm-project/issues/56685