### PR TITLE
[llvm] Add LLVM_CTOR_NODISCARD

### DIFF
--- a/llvm/include/llvm/MC/MCInstPrinter.h
+++ b/llvm/include/llvm/MC/MCInstPrinter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_MC_MCINSTPRINTER_H
 #define LLVM_MC_MCINSTPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Format.h"
 #include <cstdint>
 
@@ -97,8 +98,8 @@ public:
 
   class WithMarkup {
   public:
-    WithMarkup(raw_ostream &OS, Markup M, bool EnableMarkup,
-                             bool EnableColor);
+    LLVM_CTOR_NODISCARD WithMarkup(raw_ostream &OS, Markup M, bool EnableMarkup,
+                                   bool EnableColor);
     ~WithMarkup();
 
     template <typename T> WithMarkup &operator<<(T &O) {

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -307,6 +307,12 @@
 #define LLVM_GSL_POINTER
 #endif
 
+#if LLVM_HAS_CPP_ATTRIBUTE(nodiscard) >= 201907L
+#define LLVM_CTOR_NODISCARD [[nodiscard]]
+#else
+#define LLVM_CTOR_NODISCARD
+#endif
+
 /// LLVM_EXTENSION - Support compilers where we have a keyword to suppress
 /// pedantic diagnostics.
 #ifdef __GNUC__


### PR DESCRIPTION
[[nodiscard]] on constructors is a defect report against C++17. That means that it should be applied retroactively, though older compilers might not know about it and emit warnings. This adds a back-compatibility macro.