### PR TITLE
Add a GitHub team to subscribe to WebAssembly backend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -588,3 +588,28 @@ utils/bazel/llvm-project-overlay/libc/** @llvm/pr-subscribers-libc
 /llvm/tools/llvm-exegesis/ @llvm/pr-subscribers-exegesis
 /llvm/test/tools/llvm-exegesis/ @llvm/pr-subscribers-exegesis
 /llvm/unittests/tools/llvm-exegesis/ @llvm/pr-subscribers-exegesis
+
+# WebAssembly
+/llvm/include/llvm/BinaryFormat/Wasm.h
+/llvm/include/llvm/IR/IntinsicsWebAssembly.td
+/llvm/include/llvm/Object/Wasm*
+/llvm/lib/CodeGen/Wasm*
+/llvm/lib/CodeGen/AsmPrinter/Wasm*
+/llvm/lib/MC/MCParser/Wasm*
+/llvm/lib/MC/Wasm*
+/llvm/lib/ObjCopy/wasm/
+/llvm/lib/Object/Wasm*
+/llvm/lib/Target/WebAssembly/
+/llvm/test/CodeGen/WebAssembly/
+/llvm/test/DebugInfo/WebAssembly/
+/llvm/test/MC/WebAssembly/
+/llvm/unittests/Target/WebAssembly/
+/clang/include/clang/Basic/BuiltinsWebAssembly.def
+/clang/include/clang/Basic/WebAssemblyReferenceTypes.def
+/clang/lib/Basic/Targets/WebAssembly*
+/clang/lib/Driver/Toolchains/WebAssembly*
+/clang/lib/CodeGen/Targets/WebAssembly*
+/clang/lib/Headers/wasm_simd128.h
+/clang/test/CodeGen/WebAssembly/
+/clang/test/Sema/*wasm*
+/clang/test/SemaCXX/*wasm*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -590,26 +590,26 @@ utils/bazel/llvm-project-overlay/libc/** @llvm/pr-subscribers-libc
 /llvm/unittests/tools/llvm-exegesis/ @llvm/pr-subscribers-exegesis
 
 # WebAssembly
-/llvm/include/llvm/BinaryFormat/Wasm.h
-/llvm/include/llvm/IR/IntinsicsWebAssembly.td
-/llvm/include/llvm/Object/Wasm*
-/llvm/lib/CodeGen/Wasm*
-/llvm/lib/CodeGen/AsmPrinter/Wasm*
-/llvm/lib/MC/MCParser/Wasm*
-/llvm/lib/MC/Wasm*
-/llvm/lib/ObjCopy/wasm/
-/llvm/lib/Object/Wasm*
-/llvm/lib/Target/WebAssembly/
-/llvm/test/CodeGen/WebAssembly/
-/llvm/test/DebugInfo/WebAssembly/
-/llvm/test/MC/WebAssembly/
-/llvm/unittests/Target/WebAssembly/
-/clang/include/clang/Basic/BuiltinsWebAssembly.def
-/clang/include/clang/Basic/WebAssemblyReferenceTypes.def
-/clang/lib/Basic/Targets/WebAssembly*
-/clang/lib/Driver/Toolchains/WebAssembly*
-/clang/lib/CodeGen/Targets/WebAssembly*
-/clang/lib/Headers/wasm_simd128.h
-/clang/test/CodeGen/WebAssembly/
-/clang/test/Sema/*wasm*
-/clang/test/SemaCXX/*wasm*
+/llvm/include/llvm/BinaryFormat/Wasm.h @llvm/pr-subscribers-webassembly
+/llvm/include/llvm/IR/IntinsicsWebAssembly.td @llvm/pr-subscribers-webassembly
+/llvm/include/llvm/Object/Wasm* @llvm/pr-subscribers-webassembly
+/llvm/lib/CodeGen/Wasm* @llvm/pr-subscribers-webassembly
+/llvm/lib/CodeGen/AsmPrinter/Wasm* @llvm/pr-subscribers-webassembly
+/llvm/lib/MC/MCParser/Wasm* @llvm/pr-subscribers-webassembly
+/llvm/lib/MC/Wasm* @llvm/pr-subscribers-webassembly
+/llvm/lib/ObjCopy/wasm/ @llvm/pr-subscribers-webassembly
+/llvm/lib/Object/Wasm* @llvm/pr-subscribers-webassembly
+/llvm/lib/Target/WebAssembly/ @llvm/pr-subscribers-webassembly
+/llvm/test/CodeGen/WebAssembly/ @llvm/pr-subscribers-webassembly
+/llvm/test/DebugInfo/WebAssembly/ @llvm/pr-subscribers-webassembly
+/llvm/test/MC/WebAssembly/ @llvm/pr-subscribers-webassembly
+/llvm/unittests/Target/WebAssembly/ @llvm/pr-subscribers-webassembly
+/clang/include/clang/Basic/BuiltinsWebAssembly.def @llvm/pr-subscribers-webassembly
+/clang/include/clang/Basic/WebAssemblyReferenceTypes.def @llvm/pr-subscribers-webassembly
+/clang/lib/Basic/Targets/WebAssembly* @llvm/pr-subscribers-webassembly
+/clang/lib/Driver/Toolchains/WebAssembly* @llvm/pr-subscribers-webassembly
+/clang/lib/CodeGen/Targets/WebAssembly* @llvm/pr-subscribers-webassembly
+/clang/lib/Headers/wasm_simd128.h @llvm/pr-subscribers-webassembly
+/clang/test/CodeGen/WebAssembly/ @llvm/pr-subscribers-webassembly
+/clang/test/Sema/*wasm* @llvm/pr-subscribers-webassembly
+/clang/test/SemaCXX/*wasm* @llvm/pr-subscribers-webassembly


### PR DESCRIPTION
This also includes some files related to the Wasm binary and object file format (which is technically distinct from the WebAssembly architecture, but practically inseparable).