### PR TITLE
[Clang][AArch64] Define x86_64 macros for ARM64EC targets

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -336,7 +336,18 @@ void AArch64TargetInfo::getTargetDefinesARMV94A(const LangOptions &Opts,
 void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
                                          MacroBuilder &Builder) const {
   // Target identification.
-  Builder.defineMacro("__aarch64__");
+  if (getTriple().isWindowsArm64EC()) {
+    // Define the same set of macros as would be defined on x86_64 to ensure that
+    // ARM64EC datatype layouts match those of x86_64 compiled code
+    Builder.defineMacro("__amd64__");
+    Builder.defineMacro("__amd64");
+    Builder.defineMacro("__x86_64");
+    Builder.defineMacro("__x86_64__");
+    Builder.defineMacro("__arm64ec__");
+  } else {
+    Builder.defineMacro("__aarch64__");
+  }
+
   // Inline assembly supports AArch64 flag outputs.
   Builder.defineMacro("__GCC_ASM_FLAG_OUTPUTS__");
 
@@ -1466,7 +1477,13 @@ MicrosoftARM64TargetInfo::MicrosoftARM64TargetInfo(const llvm::Triple &Triple,
 void MicrosoftARM64TargetInfo::getTargetDefines(const LangOptions &Opts,
                                                 MacroBuilder &Builder) const {
   WindowsARM64TargetInfo::getTargetDefines(Opts, Builder);
-  Builder.defineMacro("_M_ARM64", "1");
+  if (getTriple().isWindowsArm64EC()) {
+    Builder.defineMacro("_M_X64", "100");
+    Builder.defineMacro("_M_AMD64", "100");
+    Builder.defineMacro("_M_ARM64EC", "1");
+  } else {
+    Builder.defineMacro("_M_ARM64", "1");
+  }
 }
 
 TargetInfo::CallingConvKind

--- a/clang/test/Preprocessor/predefined-win-macros.c
+++ b/clang/test/Preprocessor/predefined-win-macros.c
@@ -93,6 +93,19 @@
 // CHECK-ARM64-WIN: #define _WIN32 1
 // CHECK-ARM64-WIN: #define _WIN64 1
 
+// RUN: %clang_cc1 -triple arm64ec-windows %s -E -dM -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-ARM64EC-WIN
+
+// CHECK-ARM64EC-WIN-NOT: #define WIN32 1
+// CHECK-ARM64EC-WIN-NOT: #define WIN64 1
+// CHECK-ARM64EC-WIN-NOT: #define WINNT 1
+// CHECK-ARM64EC-WIN-NOT: #define _M_ARM64 1
+// CHECK-ARM64EC-WIN: #define _M_AMD64 100
+// CHECK-ARM64EC-WIN: #define _M_ARM64EC 1
+// CHECK-ARM64EC-WIN: #define _M_X64 100
+// CHECK-ARM64EC-WIN: #define _WIN32 1
+// CHECK-ARM64EC-WIN: #define _WIN64 1
+
 // RUN: %clang_cc1 -triple i686-windows-gnu %s -E -dM -o - \
 // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-X86-MINGW
 
@@ -131,3 +144,20 @@
 // CHECK-ARM64-MINGW: #define _WIN64 1
 // CHECK-ARM64-MINGW: #define __GCC_ASM_FLAG_OUTPUTS__ 1
 // CHECK-ARM64-MINGW: #define __aarch64__ 1
+
+// RUN: %clang_cc1 -triple arm64ec-windows-gnu %s -E -dM -o - \
+// RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-ARM64EC-MINGW
+
+// CHECK-ARM64EC-MINGW-NOT: #define _M_ARM64EC 1
+// CHECK-ARM64EC-MINGW: #define WIN32 1
+// CHECK-ARM64EC-MINGW: #define WIN64 1
+// CHECK-ARM64EC-MINGW: #define WINNT 1
+// CHECK-ARM64EC-MINGW: #define _WIN32 1
+// CHECK-ARM64EC-MINGW: #define _WIN64 1
+// CHECK-ARM64EC-MINGW: #define __GCC_ASM_FLAG_OUTPUTS__ 1
+// CHECK-ARM64EC-MINGW-NOT: #define __aarch64__ 1
+// CHECK-ARM64EC-MINGW: #define __amd64 1
+// CHECK-ARM64EC-MINGW: #define __amd64__ 1
+// CHECK-ARM64EC-MINGW: #define __arm64ec__ 1
+// CHECK-ARM64EC-MINGW: #define __x86_64 1
+// CHECK-ARM64EC-MINGW: #define __x86_64__ 1


### PR DESCRIPTION
The ARM64EC ABI requires that struct layouts match between regular x86_64 code and ARM64EC code. Ensure this is always the case by defining the same set of macros as are set when targeting x86_64 but with the addition of `__arm64ec__/_M_ARM64EC` macros that can be used for any ARM64EC specific code.

More details can be found here: https://techcommunity.microsoft.com/t5/windows-os-platform-blog/getting-to-know-arm64ec-defines-and-intrinsic-functions/ba-p/2957235