### PR TITLE
[libc++] Switch FreeBSD CI job to Clang 16

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -1119,8 +1119,8 @@ steps:
         - "**/test-results.xml"
         - "**/*.abilist"
       env:
-          CC: "clang15"
-          CXX: "clang++15"
+          CC: "clang16"
+          CXX: "clang++16"
           ENABLE_STD_MODULES: "Off"
       agents:
         queue: "libcxx-builders"


### PR DESCRIPTION
libc++ will drop support for Clang 15 before long.