### PR TITLE
[polly] Link polly-isl-test with LLVMSupport

### DIFF
--- a/polly/lib/External/CMakeLists.txt
+++ b/polly/lib/External/CMakeLists.txt
@@ -306,6 +306,7 @@ if (POLLY_BUNDLED_ISL)
 
   target_link_libraries(polly-isl-test PRIVATE
     PollyISL
+    LLVMSupport
     )
 
   # ISL requires at least C99 to compile. gcc < 5.0 use -std=gnu89 as default.


### PR DESCRIPTION
Otherwise link may fail if user provided additional library to link with via CMAKE_EXE_LINKER_FLAGS.

Concrete example is using custom allocator, LLVMSupport provides needed `-lpthread` in that case. Note that `-lpthread` cannot be passed via CMAKE_EXE_LINKER_FLAGS by user because it breaks pthread detection in LLVM CMakeLists, LLVM_PTHREAD_LIB becomes empty.