### PR TITLE
[AssumptionCache] Track GlobalValues as affected values.

### DIFF
--- a/llvm/lib/Analysis/AssumptionCache.cpp
+++ b/llvm/lib/Analysis/AssumptionCache.cpp
@@ -62,7 +62,7 @@ findAffectedValues(CallBase *CI, TargetTransformInfo *TTI,
 
   auto AddAffected = [&Affected](Value *V, unsigned Idx =
                                                AssumptionCache::ExprResultIdx) {
-    if (isa<Argument>(V)) {
+    if (isa<Argument>(V) || isa<GlobalValue>(V)) {
       Affected.push_back({V, Idx});
     } else if (auto *I = dyn_cast<Instruction>(V)) {
       Affected.push_back({I, Idx});

--- a/llvm/test/Analysis/AssumptionCache/basic.ll
+++ b/llvm/test/Analysis/AssumptionCache/basic.ll
@@ -20,3 +20,14 @@ entry:
 
   ret void
 }
+
+@G = external global i32
+define void @test2() {
+; CHECK-LABEL: Cached assumptions for function: test2
+; CHECK-NEXT: icmp ne ptr @G, null
+
+entry:
+  %cond1 = icmp ne ptr @G, null
+  call void @llvm.assume(i1 %cond1)
+  ret void
+}

--- a/llvm/test/Analysis/ScalarEvolution/ranges.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ranges.ll
@@ -29,7 +29,7 @@ define i64 @ashr_global() {
 ; CHECK-LABEL: 'ashr_global'
 ; CHECK-NEXT:  Classifying expressions for: @ashr_global
 ; CHECK-NEXT:    %ashr = ashr i64 ptrtoint (ptr @G to i64), 63
-; CHECK-NEXT:    --> %ashr U: [-1,1) S: [-1,1)
+; CHECK-NEXT:    --> %ashr U: [0,1) S: [0,1)
 ; CHECK-NEXT:  Determining loop execution counts for: @ashr_global
 ;
   %ashr = ashr i64 ptrtoint (ptr @G to i64), 63


### PR DESCRIPTION
Fixes a corner case of the analysis: previously GlobalValues could be affected by assumptions, but were not tracked within AffectedValues. This patch allows assumptions which affect a given GlobalValue to be looked up via `assumptionsFor()`.

A small update to llvm/test/Analysis/ScalarEvolution/ranges.ll was necessary due to knowledge about a global value now being propagated from AssumptionCache -> ValueTracking -> ScalarEvolution.