### PR TITLE
[clang-format][NFC] Fix broken dump_format_help.py and sync RST file

### DIFF
--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -69,8 +69,7 @@ to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.
     --ferror-limit=<uint>          - Set the maximum number of clang-format errors to emit
                                      before stopping (0 = no limit).
                                      Used only with --dry-run or -n
-    --files=<filename>             - A file containing a list of files to process, one
-                                     per line.
+    --files=<filename>             - A file containing a list of files to process, one per line.
     -i                             - Inplace edit <file>s, if specified.
     --length=<uint>                - Format a range of this length (in bytes).
                                      Multiple ranges can be formatted by specifying

--- a/clang/docs/tools/dump_format_help.py
+++ b/clang/docs/tools/dump_format_help.py
@@ -7,14 +7,14 @@ import re
 import subprocess
 import sys
 
-CLANG_DIR = os.path.join(os.path.dirname(__file__), "../..")
-DOC_FILE = os.path.join(CLANG_DIR, "docs/ClangFormat.rst")
+PARENT_DIR = os.path.join(os.path.dirname(__file__), "..")
+DOC_FILE = os.path.join(PARENT_DIR, "ClangFormat.rst")
 
 
 def substitute(text, tag, contents):
     replacement = "\n.. START_%s\n\n%s\n\n.. END_%s\n" % (tag, contents, tag)
     pattern = r"\n\.\. START_%s\n.*\n\.\. END_%s\n" % (tag, tag)
-    return re.sub(pattern, "%s", text, flags=re.S) % replacement
+    return re.sub(pattern, replacement, text, flags=re.S)
 
 
 def indent(text, columns, indent_first_line=True):
@@ -40,7 +40,7 @@ def get_help_text():
     out = (
         """.. code-block:: console
 
-$ clang-format -help
+$ clang-format --help
 """
         + out
     )
@@ -55,7 +55,7 @@ def validate(text, columns):
 
 
 help_text = get_help_text()
-validate(help_text, 95)
+validate(help_text, 100)
 
 with open(DOC_FILE) as f:
     contents = f.read()

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -200,7 +200,8 @@ static cl::opt<bool>
                           "whether or not to print diagnostics in color"),
                  cl::init(false), cl::cat(ClangFormatCategory), cl::Hidden);
 
-static cl::list<std::string> FileNames(cl::Positional, cl::desc("[<file> ...]"),
+static cl::list<std::string> FileNames(cl::Positional,
+                                       cl::desc("[@<file>] [<file> ...]"),
                                        cl::cat(ClangFormatCategory));
 
 namespace clang {


### PR DESCRIPTION
Running `dump_format_help.py` in `clang/docs/tools`:
```
warning: line too long:
                                      relative to the current working directory when reading stdin.
warning: line too long:
     --files=<filename>             - A file containing a list of files to process, one per line.
warning: line too long:
     --help-list                    - Display list of available options (--help-list-hidden for more)
Traceback (most recent call last):
  File "/Users/Owen/remove-braces/clang/docs/tools/./dump_format_help.py", line 63, in <module>
    contents = substitute(contents, "FORMAT_HELP", help_text)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Owen/remove-braces/clang/docs/tools/./dump_format_help.py", line 17, in substitute
    return re.sub(pattern, "%s", text, flags=re.S) % replacement
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
TypeError: not enough arguments for format string
```