### PR TITLE
[BOLT] Switch BF::computeHash to xxh3

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -40,6 +40,7 @@
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/xxhash.h"
 #include <functional>
 #include <limits>
 #include <numeric>
@@ -3585,12 +3586,12 @@ size_t BinaryFunction::computeHash(bool UseDFS,
     llvm::copy(Layout.blocks(), std::back_inserter(Order));
 
   // The hash is computed by creating a string of all instruction opcodes and
-  // possibly their operands and then hashing that string with std::hash.
+  // possibly their operands and then hashing that string with xxh3.
   std::string HashString;
   for (const BinaryBasicBlock *BB : Order)
     HashString.append(hashBlock(BC, *BB, OperandHashFunc));
 
-  return Hash = std::hash<std::string>{}(HashString);
+  return Hash = llvm::xxh3_64bits(HashString);
 }
 
 void BinaryFunction::insertBasicBlocks(

--- a/bolt/test/X86/pre-aggregated-perf.test
+++ b/bolt/test/X86/pre-aggregated-perf.test
@@ -46,7 +46,7 @@ PERF2BOLT: 1 usqrt a 1 usqrt 10 0 22
 
 NEWFORMAT:  - name:            'frame_dummy/1'
 NEWFORMAT:    fid:             3
-NEWFORMAT:    hash:            0x24496F7F9594E89F
+NEWFORMAT:    hash:            0x28C72085C0BD8D37
 NEWFORMAT:    exec:            1
 
 NEWFORMAT:  - name:            usqrt


### PR DESCRIPTION
std::hash is C++ STL implementation-specific. Switch to xxh3 as the fast and
STL-independent alternative for basic block hashes which are exposed to users
in YAML profile.

Fixes #65241.
