### PR TITLE
[mlir] Add UnitParameter to indicate the presence of a flag

### DIFF
--- a/mlir/include/mlir/IR/AttrTypeBase.td
+++ b/mlir/include/mlir/IR/AttrTypeBase.td
@@ -424,6 +424,14 @@ class AttributeSelfTypeParameter<string desc,
                          "::mlir::NoneType::get($_ctxt)", typeBuilder);
 }
 
+// Used to indicate the presence of a keyword in asm. Should be used within
+// optional parens in the declarative assembly format.
+def UnitParameter : AttrOrTypeParameter<"::mlir::UnitAttr", "boolean flag"> {
+  let printer = "";
+  let parser = "::mlir::UnitAttr::get($_parser.getContext())";
+  let defaultValue = "::mlir::UnitAttr()";
+}
+
 //===----------------------------------------------------------------------===//
 // ArrayOfAttr
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
A type or attribute parameter which wraps UnitAttr with no printing. Helpful in conjunction with the declarative assembly format's optional parens.
