### PR TITLE
Fix compilation errors with -fforce-emit-vtables

### DIFF
--- a/lld/MachO/EhFrame.cpp
+++ b/lld/MachO/EhFrame.cpp
@@ -109,15 +109,15 @@ template <bool Invert = false>
 static void createSubtraction(PointerUnion<Symbol *, InputSection *> a,
                               PointerUnion<Symbol *, InputSection *> b,
                               uint64_t off, uint8_t length,
-                              SmallVectorImpl<Reloc> *newRelocs) {
+                              SmallVectorImpl<macho::Reloc> *newRelocs) {
   auto subtrahend = a;
   auto minuend = b;
   if (Invert)
     std::swap(subtrahend, minuend);
   assert(subtrahend.is<Symbol *>());
-  Reloc subtrahendReloc(target->subtractorRelocType, /*pcrel=*/false, length,
+  macho::Reloc subtrahendReloc(target->subtractorRelocType, /*pcrel=*/false, length,
                         off, /*addend=*/0, subtrahend);
-  Reloc minuendReloc(target->unsignedRelocType, /*pcrel=*/false, length, off,
+  macho::Reloc minuendReloc(target->unsignedRelocType, /*pcrel=*/false, length, off,
                      (Invert ? 1 : -1) * off, minuend);
   newRelocs->push_back(subtrahendReloc);
   newRelocs->push_back(minuendReloc);

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -105,7 +105,7 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
     return false;
   if (ia->relocs.size() != ib->relocs.size())
     return false;
-  auto f = [](const Reloc &ra, const Reloc &rb) {
+  auto f = [](const macho::Reloc &ra, const macho::Reloc &rb) {
     if (ra.type != rb.type)
       return false;
     if (ra.pcrel != rb.pcrel)
@@ -178,7 +178,7 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
   if (verboseDiagnostics)
     ++equalsVariableCount;
   assert(ia->relocs.size() == ib->relocs.size());
-  auto f = [this](const Reloc &ra, const Reloc &rb) {
+  auto f = [this](const macho::Reloc &ra, const macho::Reloc &rb) {
     // We already filtered out mismatching values/addends in equalsConstant.
     if (ra.referent == rb.referent)
       return true;
@@ -286,7 +286,7 @@ void ICF::run() {
   for (icfPass = 0; icfPass < 2; ++icfPass) {
     parallelForEach(icfInputs, [&](ConcatInputSection *isec) {
       uint32_t hash = isec->icfEqClass[icfPass % 2];
-      for (const Reloc &r : isec->relocs) {
+      for (const macho::Reloc &r : isec->relocs) {
         if (auto *sym = r.referent.dyn_cast<Symbol *>()) {
           if (auto *defined = dyn_cast<Defined>(sym)) {
             if (defined->isec) {

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/DebugInfo/DWARF/DWARFUnit.h"
+#include "llvm/LTO/LTO.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Threading.h"
@@ -28,9 +29,6 @@
 #include <vector>
 
 namespace llvm {
-namespace lto {
-class InputFile;
-} // namespace lto
 namespace MachO {
 class InterfaceFile;
 } // namespace MachO

--- a/lld/MachO/InputSection.cpp
+++ b/lld/MachO/InputSection.cpp
@@ -32,7 +32,7 @@ using namespace lld::macho;
 // can differ based on STL debug levels (e.g. iterator debugging on MSVC's STL),
 // so account for that.
 static_assert(sizeof(void *) != 8 ||
-                  sizeof(ConcatInputSection) == sizeof(std::vector<Reloc>) + 88,
+                  sizeof(ConcatInputSection) == sizeof(std::vector<macho::Reloc>) + 88,
               "Try to minimize ConcatInputSection's size, we create many "
               "instances of it");
 
@@ -135,7 +135,7 @@ std::string InputSection::getSourceLocation(uint64_t off) const {
   return {};
 }
 
-const Reloc *InputSection::getRelocAt(uint32_t off) const {
+const macho::Reloc *InputSection::getRelocAt(uint32_t off) const {
   auto it = llvm::find_if(
       relocs, [=](const macho::Reloc &r) { return r.offset == off; });
   if (it == relocs.end())

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -177,7 +177,7 @@ ObjcCategoryChecker::ObjcCategoryChecker()
       methodLayout(target->wordSize) {}
 
 // \p r must point to an offset within a cstring section.
-static StringRef getReferentString(const Reloc &r) {
+static StringRef getReferentString(const macho::Reloc &r) {
   if (auto *isec = r.referent.dyn_cast<InputSection *>())
     return cast<CStringInputSection>(isec)->getStringRefAtOffset(r.addend);
   auto *sym = cast<Defined>(r.referent.get<Symbol *>());
@@ -191,7 +191,7 @@ void ObjcCategoryChecker::parseMethods(const ConcatInputSection *methodsIsec,
                                        MethodContainerKind mcKind,
                                        MethodKind mKind) {
   ObjcClass &klass = classMap[methodContainerSym];
-  for (const Reloc &r : methodsIsec->relocs) {
+  for (const macho::Reloc &r : methodsIsec->relocs) {
     if ((r.offset - listHeaderLayout.totalSize) % methodLayout.totalSize !=
         methodLayout.nameOffset)
       continue;
@@ -219,7 +219,7 @@ void ObjcCategoryChecker::parseMethods(const ConcatInputSection *methodsIsec,
 
     // We have a duplicate; generate a warning message.
     const auto &mc = methodMap.lookup(methodName);
-    const Reloc *nameReloc = nullptr;
+    const macho::Reloc *nameReloc = nullptr;
     if (mc.kind == MCK_Category) {
       nameReloc = mc.isec->getRelocAt(catLayout.nameOffset);
     } else {

--- a/lld/MachO/Relocations.cpp
+++ b/lld/MachO/Relocations.cpp
@@ -18,10 +18,10 @@ using namespace llvm;
 using namespace lld;
 using namespace lld::macho;
 
-static_assert(sizeof(void *) != 8 || sizeof(Reloc) == 24,
+static_assert(sizeof(void *) != 8 || sizeof(macho::Reloc) == 24,
               "Try to minimize Reloc's size; we create many instances");
 
-InputSection *Reloc::getReferentInputSection() const {
+InputSection *macho::Reloc::getReferentInputSection() const {
   if (const auto *sym = referent.dyn_cast<Symbol *>()) {
     if (const auto *d = dyn_cast<Defined>(sym))
       return d->isec;

--- a/lld/MachO/UnwindInfoSection.cpp
+++ b/lld/MachO/UnwindInfoSection.cpp
@@ -234,7 +234,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
   // that are referenced from many places, at least some of them likely
   // live, it wouldn't reduce number of got entries.
   for (size_t i = 0; i < isec->relocs.size(); ++i) {
-    Reloc &r = isec->relocs[i];
+    macho::Reloc &r = isec->relocs[i];
     assert(target->hasAttr(r.type, RelocAttrBits::UNSIGNED));
     // Since compact unwind sections aren't part of the inputSections vector,
     // they don't get canonicalized by scanRelocations(), so we have to do the
@@ -375,7 +375,7 @@ void UnwindInfoSectionImpl::relocateCompactUnwind(
     cu.functionLength =
         support::endian::read32le(buf + cuLayout.functionLengthOffset);
     cu.encoding = support::endian::read32le(buf + cuLayout.encodingOffset);
-    for (const Reloc &r : d->unwindEntry->relocs) {
+    for (const macho::Reloc &r : d->unwindEntry->relocs) {
       if (r.offset == cuLayout.personalityOffset)
         cu.personality = r.referent.get<Symbol *>();
       else if (r.offset == cuLayout.lsdaOffset)

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFunc.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolFunc.h
@@ -10,6 +10,7 @@
 #define LLVM_DEBUGINFO_PDB_PDBSYMBOLFUNC_H
 
 #include "llvm/DebugInfo/PDB/IPDBRawSymbol.h"
+#include "llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h"
 
 #include "PDBSymbol.h"
 #include "PDBTypes.h"

--- a/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
+++ b/llvm/include/llvm/DebugInfo/PDB/UDTLayout.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/DebugInfo/PDB/PDBSymbol.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolData.h"
+#include "llvm/DebugInfo/PDB/PDBSymbolFunc.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeBaseClass.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeBuiltin.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h"


### PR DESCRIPTION
Currently some types are only declared but not defined in those headers, so with `-fforce-emit-vtables` compiler trips on them with "invalid application of ... to an incomplete type" errors.

Affects llvm/DebugInfo/PDB and lld/MachO

Fixes #55239