### PR TITLE
[clang][AArch64] Add --print-supported-extensions support

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5260,7 +5260,7 @@ def print_supported_cpus : Flag<["-", "--"], "print-supported-cpus">,
   MarshallingInfoFlag<FrontendOpts<"PrintSupportedCPUs">>;
 def print_supported_extensions : Flag<["-", "--"], "print-supported-extensions">,
   Visibility<[ClangOption, CC1Option, CLOption]>,
-  HelpText<"Print supported extensions for RISC-V">,
+  HelpText<"Print supported -march extensions (RISC-V and AArch64 only)">,
   MarshallingInfoFlag<FrontendOpts<"PrintSupportedExtensions">>;
 def : Flag<["-"], "mcpu=help">, Alias<print_supported_cpus>;
 def : Flag<["-"], "mtune=help">, Alias<print_supported_cpus>;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4284,7 +4284,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     // and quits.
     if (Arg *A = Args.getLastArg(Opt)) {
       if (Opt == options::OPT_print_supported_extensions &&
-          !C.getDefaultToolChain().getTriple().isRISCV()) {
+          !C.getDefaultToolChain().getTriple().isRISCV() &&
+          !C.getDefaultToolChain().getTriple().isAArch64()) {
         C.getDriver().Diag(diag::err_opt_not_valid_on_target)
             << "--print-supported-extensions";
         return;

--- a/clang/test/Driver/print-supported-extensions.c
+++ b/clang/test/Driver/print-supported-extensions.c
@@ -1,0 +1,14 @@
+// Test that --print-supported-extensions lists supported -march extensions
+// on supported architectures, and errors on unsupported architectures.
+
+// RUN: %if aarch64-registered-target %{ %clang --target=aarch64-linux-gnu \
+// RUN:   --print-supported-extensions 2>&1 | FileCheck %s --check-prefix AARCH64 %}
+// AARCH64: All available -march extensions for AArch64
+
+// RUN: %if aarch64-registered-target %{ %clang --target=riscv64-linux-gnu \
+// RUN:   --print-supported-extensions 2>&1 | FileCheck %s --check-prefix RISCV %}
+// RISCV: All available -march extensions for RISC-V
+
+// RUN: %if x86-registered-target %{ not %clang --target=x86_64-linux-gnu \
+// RUN:   --print-supported-extensions 2>&1 | FileCheck %s --check-prefix X86 %}
+// X86: error: option '--print-supported-extensions' cannot be specified on this target

--- a/llvm/include/llvm/TargetParser/AArch64TargetParser.h
+++ b/llvm/include/llvm/TargetParser/AArch64TargetParser.h
@@ -576,6 +576,8 @@ bool isX18ReservedByDefault(const Triple &TT);
 // themselves, they are sequential (0, 1, 2, 3, ...).
 uint64_t getCpuSupportsMask(ArrayRef<StringRef> FeatureStrs);
 
+void PrintSupportedExtensions();
+
 } // namespace AArch64
 } // namespace llvm
 

--- a/llvm/lib/TargetParser/AArch64TargetParser.cpp
+++ b/llvm/lib/TargetParser/AArch64TargetParser.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TargetParser/AArch64TargetParser.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/ARMTargetParserCommon.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cctype>
@@ -131,4 +132,13 @@ std::optional<AArch64::CpuInfo> AArch64::parseCpu(StringRef Name) {
       return C;
 
   return {};
+}
+
+void AArch64::PrintSupportedExtensions() {
+  outs() << "All available -march extensions for AArch64\n\n";
+  for (const auto &Ext : Extensions) {
+    // Extensions without a feature cannot be used with -march.
+    if (!Ext.Feature.empty())
+      outs() << '\t' << Ext.Name << "\n";
+  }
 }

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1805,7 +1805,7 @@ TEST(TargetParserTest, AArch64ArchExtFeature) {
   }
 }
 
-TEST(TargetParserTest, PrintSupportedExtensions) {
+TEST(TargetParserTest, AArch64PrintSupportedExtensions) {
   std::string expected = "All available -march extensions for AArch64\n\n"
                          "\taes\n\tb16b16\n\tbf16";
 

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1805,4 +1805,26 @@ TEST(TargetParserTest, AArch64ArchExtFeature) {
   }
 }
 
+TEST(TargetParserTest, PrintSupportedExtensions) {
+  std::string expected = "All available -march extensions for AArch64\n\n"
+                         "\taes\n\tb16b16\n\tbf16";
+
+  outs().flush();
+  testing::internal::CaptureStdout();
+  AArch64::PrintSupportedExtensions();
+  outs().flush();
+  std::string captured = testing::internal::GetCapturedStdout();
+
+  // Check that the start of the output is as expected.
+  EXPECT_EQ(0ULL, captured.find(expected));
+
+  // Should not include "none".
+  EXPECT_EQ(std::string::npos, captured.find("none"));
+  // Should not include anything that lacks a feature name. Checking a few here
+  // but not all as if one is hidden correctly the rest should be.
+  EXPECT_EQ(std::string::npos, captured.find("memtag3"));
+  EXPECT_EQ(std::string::npos, captured.find("sha1"));
+  EXPECT_EQ(std::string::npos, captured.find("ssbs2"));
+}
+
 } // namespace


### PR DESCRIPTION
This follows the RISC-V work done in 4b40ced4e5ba10b841516b3970e7699ba8ded572.

This uses AArch64's target parser instead. We just list the names, without the "+" on them, which matches RISC-V's format.

```
$ ./bin/clang -target aarch64-linux-gnu --print-supported-extensions
clang version 18.0.0 (https://github.com/llvm/llvm-project.git 154da8aec20719c82235a6957aa6e461f5a5e030)
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: <...>
All available -march extensions for AArch64

        aes
        b16b16
        bf16
        brbe
        crc
        crypto
        cssc
        <...>
```

Since our extensions don't have versions in the same way there's just one column with the name in.

Any extension without a feature name (including the special "none") is not listed as those cannot be passed to -march, they're just for the backend. For example the MTE extension can be added with "+memtag" but MTE2 and MTE3 do not have feature names so they cannot be added to -march.

This does not attempt to tackle the fact that clang allows invalid combinations of AArch64 extensions, it simply lists the possible options. It's still up to the user to ask for something sensible.

Equally, this has no context of what CPU is being selected. Neither does the RISC-V option, the user has to be aware of that.

I've added a target parser test, and a high level clang test that checks RISC-V and AArch64 work and that Intel, that doesn't support this, shows the correct error.