### PR TITLE
[libc] customizable namespace 2/4

### DIFF
--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_SUPPORT_COMMON_H
 #define LLVM_LIBC_SUPPORT_COMMON_H
 
+#ifndef LIBC_NAMESPACE
+#error "LIBC_NAMESPACE macro is not defined."
+#endif
+
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/properties/architectures.h"
 


### PR DESCRIPTION
This implements the second step of https://discourse.llvm.org/t/rfc-customizable-namespace-to-allow-testing-the-libc-when-the-system-libc-is-also-llvms-libc/73079

Namely "Add a guard in `src/__support/common.h`"