### PR TITLE
[MC][NFC] Allow MCInstrAnalysis to store state

### DIFF
--- a/llvm/include/llvm/MC/MCInstrAnalysis.h
+++ b/llvm/include/llvm/MC/MCInstrAnalysis.h
@@ -42,7 +42,7 @@ public:
 
   /// Update internal state with \p Inst at \p Addr.
   ///
-  /// For some types a analyses, inspecting a single instruction is not
+  /// For some types of analyses, inspecting a single instruction is not
   /// sufficient. Some examples are auipc/jalr pairs on RISC-V or adrp/ldr pairs
   /// on AArch64. To support inspecting multiple instructions, targets may keep
   /// track of an internal state while analysing instructions. Clients should

--- a/llvm/include/llvm/MC/MCInstrAnalysis.h
+++ b/llvm/include/llvm/MC/MCInstrAnalysis.h
@@ -37,6 +37,21 @@ public:
   MCInstrAnalysis(const MCInstrInfo *Info) : Info(Info) {}
   virtual ~MCInstrAnalysis() = default;
 
+  /// Clear the internal state. See updateState for more information.
+  virtual void resetState() {}
+
+  /// Update internal state with \p Inst at \p Addr.
+  ///
+  /// For some types a analyses, inspecting a single instruction is not
+  /// sufficient. Some examples are auipc/jalr pairs on RISC-V or adrp/ldr pairs
+  /// on AArch64. To support inspecting multiple instructions, targets may keep
+  /// track of an internal state while analysing instructions. Clients should
+  /// call updateState for every instruction which allows later calls to one of
+  /// the analysis functions to take previous instructions into account.
+  /// Whenever state becomes irrelevant (e.g., when starting to disassemble a
+  /// new function), clients should call resetState to clear it.
+  virtual void updateState(const MCInst &Inst, uint64_t Addr) {}
+
   virtual bool isBranch(const MCInst &Inst) const {
     return Info->get(Inst.getOpcode()).isBranch();
   }


### PR DESCRIPTION
Currently, all the analysis functions provided by `MCInstrAnalysis` work on a single instruction. On some targets, this limits the kind of instructions that can be successfully analyzed as common constructs may need multiple instructions.

For example, a typical call sequence on RISC-V uses a auipc+jalr pair. In order to analyse the jalr inside `evaluateBranch`, information about the corresponding auipc is needed. Similarly, AArch64 uses adrp+ldr pairs to access globals.

This patch proposes to add state to `MCInstrAnalysis` to support these use cases. Two new virtual methods are added:
- `updateState`: takes an instruction and its address. This methods should be called by clients on every instruction and allows targets to store whatever information they need to analyse future instructions.
- `resetState`: clears the state whenever it becomes irrelevant. Clients could call this, for example, when starting to disassemble a new function.

Note that the default implementations do nothing so this patch is NFC. No actual state is stored inside `MCInstrAnalysis`; deciding the structure of the state is left to the targets.

This patch also modifies llvm-objdump to use the new interface.

This patch is an alternative to [D116677](https://reviews.llvm.org/D116677) and the idea of storing state in `MCInstrAnalysis` was first discussed there.