### PR TITLE
Add GitHub workflow for check Python file formatting

### DIFF
--- a/.github/workflows/pr-python-format.yml
+++ b/.github/workflows/pr-python-format.yml
@@ -1,0 +1,39 @@
+name: "Check Python Formatting"
+on:
+  pull_request:
+    # run on .py
+    paths:
+      - '**.py'
+
+jobs:
+  python_formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch LLVM sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+        with:
+          files: '**/*.py'
+
+      - name: "Listed files"
+        run: |
+          echo "Formatting files:"
+          echo "${{ steps.changed-files.outputs.all_changed_files }}"
+
+      - name: Setup Python env
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Python Formatting
+        uses: akaihola/darker@1.7.2
+        with:
+          options: "--check --diff --color"
+          version: "~=1.7.2"
+          src: "${{ steps.changed-files.outputs.all_changed_files }}"


### PR DESCRIPTION
Using darker which is doing black on diffs, similar to git-clang-format.