### PR TITLE
[Driver] Always use gas with -fno-integrated-as on Solaris

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -700,6 +700,10 @@ void tools::gnutools::Assembler::ConstructJob(Compilation &C,
   unsigned PICLevel;
   bool IsPIE;
   const char *DefaultAssembler = "as";
+  // Enforce GNU as on Solaris; the native assembler's input syntax isn't fully
+  // compatible.
+  if (getToolChain().getTriple().isOSSolaris())
+    DefaultAssembler = "gas";
   std::tie(RelocationModel, PICLevel, IsPIE) =
       ParsePICArgs(getToolChain(), Args);
 

--- a/clang/lib/Driver/ToolChains/Solaris.cpp
+++ b/clang/lib/Driver/ToolChains/Solaris.cpp
@@ -8,6 +8,7 @@
 
 #include "Solaris.h"
 #include "CommonArgs.h"
+#include "Gnu.h"
 #include "clang/Basic/LangStandard.h"
 #include "clang/Config/config.h"
 #include "clang/Driver/Compilation.h"
@@ -32,20 +33,8 @@ void solaris::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
                                       const InputInfoList &Inputs,
                                       const ArgList &Args,
                                       const char *LinkingOutput) const {
-  claimNoWarnArgs(Args);
-  ArgStringList CmdArgs;
-
-  Args.AddAllArgValues(CmdArgs, options::OPT_Wa_COMMA, options::OPT_Xassembler);
-
-  CmdArgs.push_back("-o");
-  CmdArgs.push_back(Output.getFilename());
-
-  for (const auto &II : Inputs)
-    CmdArgs.push_back(II.getFilename());
-
-  const char *Exec = Args.MakeArgString(getToolChain().GetProgramPath("as"));
-  C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
-                                         Exec, CmdArgs, Inputs, Output));
+  // Just call the Gnu version, which enforces gas on Solaris.
+  gnutools::Assembler::ConstructJob(C, JA, Output, Inputs, Args, LinkingOutput);
 }
 
 bool solaris::isLinkerGnuLd(const ToolChain &TC, const ArgList &Args) {

--- a/clang/lib/Driver/ToolChains/Solaris.h
+++ b/clang/lib/Driver/ToolChains/Solaris.h
@@ -19,10 +19,9 @@ namespace tools {
 
 /// solaris -- Directly call Solaris assembler and linker
 namespace solaris {
-class LLVM_LIBRARY_VISIBILITY Assembler : public Tool {
+class LLVM_LIBRARY_VISIBILITY Assembler : public gnutools::Assembler {
 public:
-  Assembler(const ToolChain &TC)
-      : Tool("solaris::Assembler", "assembler", TC) {}
+  Assembler(const ToolChain &TC) : gnutools::Assembler(TC) {}
 
   bool hasIntegratedCPP() const override { return false; }
 

--- a/clang/test/Driver/compress-noias.c
+++ b/clang/test/Driver/compress-noias.c
@@ -7,6 +7,12 @@
 // RUN: %clang -### -target i686-unknown-linux-gnu -fno-integrated-as -Wa,--compress-debug-sections -c %s 2>&1 | FileCheck -check-prefix CHECK-__COMPRESS_DEBUG_SECTIONS %s
 // CHECK-__COMPRESS_DEBUG_SECTIONS: "--compress-debug-sections"
 
+// RUN: %clang -### --target=i386-pc-solaris2.11 -fno-integrated-as -Wa,-compress-debug-sections=zlib -c %s 2>&1 | FileCheck -check-prefix CHECK-_COMPRESS_DEBUG_SECTIONS-ZLIB %s
+// CHECK-_COMPRESS_DEBUG_SECTIONS-ZLIB: "-compress-debug-sections=zlib"
+
+// RUN: %clang -### --target=i386-pc-solaris2.11 -fno-integrated-as -Wa,--compress-debug-sections=zlib -c %s 2>&1 | FileCheck -check-prefix CHECK-__COMPRESS_DEBUG_SECTIONS-ZLIB %s
+// CHECK-__COMPRESS_DEBUG_SECTIONS-ZLIB: "--compress-debug-sections=zlib"
+
 // RUN: %clang -### -target i686-unknown-linux-gnu -fno-integrated-as -Wa,--compress-debug-sections -Wa,--nocompress-debug-sections -c %s 2>&1 | FileCheck -check-prefix CHECK-POSNEG %s
 // CHECK-POSNEG: "--compress-debug-sections"
 // CHECK-POSNEG: "--nocompress-debug-sections"

--- a/clang/test/Driver/solaris-as.c
+++ b/clang/test/Driver/solaris-as.c
@@ -1,0 +1,11 @@
+/// General tests for assembler invocations on Solaris.
+
+/// Test that clang uses gas on Solaris.
+// RUN: %clang -x assembler %s -### -c -fno-integrated-as \
+// RUN:         --target=sparc-sun-solaris2.11 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-GAS %s
+// RUN: %clang -x assembler %s -### -c -fno-integrated-as \
+// RUN:         --target=sparc-sun-solaris2.11 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-GAS %s
+/// Allow for both "/usr/bin/gas" (native) and "gas" (cross) forms.
+// CHECK-GAS: gas"


### PR DESCRIPTION
`clang -fno-integrated-as` doesn't currently work on Solaris: it doesn't even select between 32 and 64-bit objects.  Besides, Solaris has both the native assembler (`/usr/bin/as`) and the GNU assembler (`/usr/bin/gas` resp. `/usr/gnu/bin/as`).  The native sparc and x86 assemblers aren't compatible with `clang`'s assembler syntax to varying degrees, and the command line options for `as` and `gas` are completely different.

Therefore this patch chooses to always use `gas` on Solaris, using `gnutools::Assembler::ConstructJob` to pass the correct options.

Tested on `amd64-pc-solaris2.11`, `sparcv9-sun-solaris2.11`, and `x86_64-pc-linux-gnu`.