### PR TITLE
[ADT] Add detection utility for incomplete types

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2476,6 +2476,16 @@ bool hasNItemsOrLess(ContainerTy &&C, unsigned N) {
 template <class Ptr> auto to_address(const Ptr &P) { return P.operator->(); }
 template <class T> constexpr T *to_address(T *P) { return P; }
 
+// Detect incomplete types, relying on the fact that their size is unknown.
+namespace detail {
+template <typename T> using has_sizeof = decltype(sizeof(T));
+} // namespace detail
+
+/// Detects when type `T` is incomplete. This is true for forward declarations
+/// and false for types with a full definition.
+template <typename T>
+constexpr bool is_incomplete_v = !is_detected<detail::has_sizeof, T>::value;
+
 } // end namespace llvm
 
 namespace std {

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1300,4 +1300,10 @@ TEST(STLExtrasTest, LessSecond) {
   }
 }
 
+struct Foo;
+struct Bar {};
+
+static_assert(is_incomplete_v<Foo>, "Foo is incomplete");
+static_assert(!is_incomplete_v<Bar>, "Bar is defined");
+
 } // namespace


### PR DESCRIPTION
This allows us to produce better error messages for types that were only forward-declared, but where a full definition was expected.

The first user will be https://reviews.llvm.org/D159013; this change is sent to review separately to reduce the scope of the other patch.