### PR TITLE
[Fuzzer] Update build.sh to fix build errors

### DIFF
--- a/compiler-rt/lib/fuzzer/build.sh
+++ b/compiler-rt/lib/fuzzer/build.sh
@@ -2,10 +2,10 @@
 LIBFUZZER_SRC_DIR=$(dirname $0)
 CXX="${CXX:-clang}"
 for f in $LIBFUZZER_SRC_DIR/*.cpp; do
-  $CXX -g -O2 -fno-omit-frame-pointer -std=c++11 $f -c &
+  $CXX -g -O2 -fno-omit-frame-pointer -std=c++14 $f -c &
 done
 wait
 rm -f libFuzzer.a
-ar ru libFuzzer.a Fuzzer*.o
+ar r libFuzzer.a Fuzzer*.o
 rm -f Fuzzer*.o
 


### PR DESCRIPTION
Switch from C++11 to C++14 as fuzzer requires std::chrono and stdlibc++ doesn't provide chrono literals when using -std=c++11.

Also remove 'u' from ar command to fix this warning: ar: `u' modifier ignored since `D' is the default (see `U')