### PR TITLE
[clang-tidy] Exclude bitwise operators in bugprone-non-zero-enum-to-bool-conversion

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
@@ -49,6 +49,8 @@ bool NonZeroEnumToBoolConversionCheck::isLanguageVersionSupported(
 }
 
 void NonZeroEnumToBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
+  // Excluding bitwise operators (binary and overload) to avoid false-positives
+  // in code like this 'if (e & SUCCESS) {'.
   auto ExcludedOperators = binaryOperation(hasAnyOperatorName(
       "|", "&", "^", "<<", ">>", "~", "|=", "&=", "^=", "<<=", ">>="));
 

--- a/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
@@ -49,6 +49,9 @@ bool NonZeroEnumToBoolConversionCheck::isLanguageVersionSupported(
 }
 
 void NonZeroEnumToBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
+  auto ExcludedOperators = binaryOperation(hasAnyOperatorName(
+      "|", "&", "^", "<<", ">>", "~", "|=", "&=", "^=", "<<=", ">>="));
+
   Finder->addMatcher(
       castExpr(hasCastKind(CK_IntegralToBoolean),
                unless(isExpansionInSystemHeader()), hasType(booleanType()),
@@ -58,7 +61,8 @@ void NonZeroEnumToBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
                                      unless(matchers::matchesAnyListedName(
                                          EnumIgnoreList)))
                                 .bind("enum"))))),
-                        unless(declRefExpr(to(enumConstantDecl()))))),
+                        unless(declRefExpr(to(enumConstantDecl()))),
+                        unless(ignoringImplicit(ExcludedOperators)))),
                unless(hasAncestor(staticAssertDecl())))
           .bind("cast"),
       this);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -183,6 +183,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/lambda-function-name>` check by adding option
   `IgnoreMacros` to ignore warnings in macros.
 
+- Improved :doc:`bugprone-non-zero-enum-to-bool-conversion
+  <clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion>` check by
+  eliminating false positives resulting from direct usage of bitwise operators.
+
 - Improved :doc:`bugprone-reserved-identifier
   <clang-tidy/checks/bugprone/reserved-identifier>` check, so that it does not
   warn on macros starting with underscore and lowercase letter.
@@ -227,7 +231,7 @@ Changes in existing checks
   `DeduplicateFindings` to output one finding per symbol occurrence.
 
 - Improved :doc:`misc-include-cleaner
-  <clang-tidy/checks/misc/include-cleaner>` check to avoid fixes insert 
+  <clang-tidy/checks/misc/include-cleaner>` check to avoid fixes insert
   same include header multiple times.
 
 - Improved :doc:`misc-redundant-expression

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/non-zero-enum-to-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/non-zero-enum-to-bool-conversion.cpp
@@ -82,6 +82,14 @@ bool explicitCompare(EStatus value) {
   return value == SUCCESS;
 }
 
+bool explicitBitUsage1(EStatus value) {
+  return (value & SUCCESS);
+}
+
+bool explicitBitUsage2(EStatus value) {
+  return (value | SUCCESS);
+}
+
 bool testEnumeratorCompare() {
   return SUCCESS;
 }
@@ -102,6 +110,18 @@ bool testIgnored(IgnoredEnum value) {
 
 bool testIgnored(IgnoredSecondEnum value) {
   return value;
+}
+
+enum CustomOperatorEnum {
+    E0 = 0x1,
+    E1 = 0x2,
+    E2 = 0x4
+};
+
+CustomOperatorEnum operator&(CustomOperatorEnum a, CustomOperatorEnum b) { return static_cast<CustomOperatorEnum>(a & b); }
+
+void testCustomOperator(CustomOperatorEnum e) {
+    if (e & E1) {}
 }
 
 }


### PR DESCRIPTION
Improved bugprone-non-zero-enum-to-bool-conversion check by eliminating false positives resulting from direct usage of bitwise operators.