### PR TITLE
[llvm][ADT] Implement `IntrusiveRefCntPtr::useCount()`

### DIFF
--- a/llvm/unittests/ADT/IntrusiveRefCntPtrTest.cpp
+++ b/llvm/unittests/ADT/IntrusiveRefCntPtrTest.cpp
@@ -140,4 +140,17 @@ TEST(IntrusiveRefCntPtr, InteropsWithConvertible) {
   EXPECT_EQ(P4, X4.get());
 }
 
+TEST(IntrusiveRefCntPtrTest, Unique) {
+  IntrusiveRefCntPtr<X> X1;
+  EXPECT_EQ(X1.useCount(), 0);
+  X1 = new X();
+  EXPECT_EQ(X1.useCount(), 1);
+  {
+    IntrusiveRefCntPtr<X> X2 = X1;
+    EXPECT_EQ(X1.useCount(), 2);
+    EXPECT_EQ(X2.useCount(), 2);
+  }
+  EXPECT_EQ(X1.useCount(), 1);
+}
+
 } // end namespace llvm


### PR DESCRIPTION
This function has the same semantics as `std::shared_ptr<T>::use_count()`, and enables implementing copy-on-write semantics.