### PR TITLE
[ADT] Fix an empty BitVector call getData assert `idx < size()' failed

### DIFF
--- a/llvm/include/llvm/ADT/BitVector.h
+++ b/llvm/include/llvm/ADT/BitVector.h
@@ -688,7 +688,7 @@ public:
   }
   bool isInvalid() const { return Size == (unsigned)-1; }
 
-  ArrayRef<BitWord> getData() const { return {&Bits[0], Bits.size()}; }
+  ArrayRef<BitWord> getData() const { return {Bits.data(), Bits.size()}; }
 
   //===--------------------------------------------------------------------===//
   // Portable bit mask operations.

--- a/llvm/unittests/ADT/BitVectorTest.cpp
+++ b/llvm/unittests/ADT/BitVectorTest.cpp
@@ -1134,6 +1134,14 @@ TYPED_TEST(BitVectorTest, EmptyVector) {
   testEmpty(E);
 }
 
+/// Make sure calling getData() is legal even on an empty BitVector
+TYPED_TEST(BitVectorTest, EmptyVectorGetData) {
+  BitVector A;
+  testEmpty(A);
+  auto B = A.getData();
+  EXPECT_TRUE(B.empty());
+}
+
 TYPED_TEST(BitVectorTest, Iterators) {
   TypeParam Filled(10, true);
   EXPECT_NE(Filled.set_bits_begin(), Filled.set_bits_end());


### PR DESCRIPTION
Fixes #65500