### PR TITLE
[Flang][OpenMP] Seek over an HLFIR declare to check for threadprivate

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -3666,12 +3666,18 @@ void Fortran::lower::genThreadprivateOp(
         currentLocation, symValue.getType(), symValue);
   } else {
     mlir::Value symValue = converter.getSymbolAddress(sym);
-    mlir::Operation *op = symValue.getDefiningOp();
+
     // The symbol may be use-associated multiple times, and nothing needs to be
     // done after the original symbol is mapped to the threadprivatized value
     // for the first time. Use the threadprivatized value directly.
+    mlir::Operation *op;
+    if (auto declOp = symValue.getDefiningOp<hlfir::DeclareOp>())
+      op = declOp.getMemref().getDefiningOp();
+    else
+      op = symValue.getDefiningOp();
     if (mlir::isa<mlir::omp::ThreadprivateOp>(op))
       return;
+
     symThreadprivateValue = firOpBuilder.create<mlir::omp::ThreadprivateOp>(
         currentLocation, symValue.getType(), symValue);
   }

--- a/flang/test/Lower/OpenMP/threadprivate-use-association-2-hlfir.f90
+++ b/flang/test/Lower/OpenMP/threadprivate-use-association-2-hlfir.f90
@@ -1,0 +1,43 @@
+! This test checks lowering of OpenMP Threadprivate Directive.
+! Test for threadprivate variable double use in use association.
+
+!RUN: %flang_fc1 -emit-hlfir -flang-experimental-hlfir -fopenmp %s -o - | FileCheck %s
+!RUN: bbc -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+! CHECK-LABEL: fir.global @_QMmEx : i32
+module m
+  integer :: x
+  !$omp threadprivate(x)
+end
+
+! CHECK-LABEL: func.func @_QMm2Ptest() {
+! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QMmEx) : !fir.ref<i32>
+! CHECK:         %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "_QMmEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:         %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<i32> -> !fir.ref<i32>
+! CHECK:         %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QMmEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:         fir.call @_QPbar(%[[VAL_3]]#1) {{.*}}: (!fir.ref<i32>) -> ()
+! CHECK:         return
+! CHECK:       }
+
+! CHECK-LABEL: func.func @_QMm2FtestPinternal_test() {
+! CHECK:         %[[VAL_0:.*]] = fir.address_of(@_QMmEx) : !fir.ref<i32>
+! CHECK:         %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "_QMmEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:         %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<i32> -> !fir.ref<i32>
+! CHECK:         %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QMmEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:         fir.call @_QPbar(%[[VAL_3]]#1) {{.*}}: (!fir.ref<i32>) -> ()
+! CHECK:         return
+! CHECK:       }
+
+module m2
+  use m
+ contains
+  subroutine test()
+    use m
+    call bar(x)
+   contains
+    subroutine internal_test()
+      use m
+      call bar(x)
+    end
+  end
+end


### PR DESCRIPTION
To check whether we have already generated a threadprivate operation, we have to seek over the HLFIR declare in the HLFIR flow.