### PR TITLE
[GitHub] Add main LLVM Dialect path to MLIR LLVM PR subscribers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,6 +120,7 @@
 
 # mlir-llvm
 /mlir/**/LLVM/ @llvm/pr-subscribers-mlir-llvm
+/mlir/**/LLVMIR/ @llvm/pr-subscribers-mlir-llvm
 
 # mlir-linalg
 /mlir/**/*Linalg @llvm/pr-subscribers-mlir-linalg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,8 +119,7 @@
 /mlir/**/Index/ @llvm/pr-subscribers-mlir-index
 
 # mlir-llvm
-/mlir/**/LLVM/ @llvm/pr-subscribers-mlir-llvm
-/mlir/**/LLVMIR/ @llvm/pr-subscribers-mlir-llvm
+/mlir/**/LLVM* @llvm/pr-subscribers-mlir-llvm
 
 # mlir-linalg
 /mlir/**/*Linalg @llvm/pr-subscribers-mlir-linalg


### PR DESCRIPTION
The LLVM Dialect in MLIR, which the `mlir-llvm` team is supposed to provide notifications for, is 98% not nested in a directory called LLVM but rather LLVMIR. The former only contains some tests.

This should make PRs such as https://github.com/llvm/llvm-project/pull/65508 add the team as codeowner.