### PR TITLE
[lldb-vscode] Display a more descriptive summary for containers and pointers

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/lldbvscode_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/lldbvscode_testcase.py
@@ -1,7 +1,8 @@
-from lldbsuite.test.lldbtest import *
 import os
-import vscode
 import time
+
+import vscode
+from lldbsuite.test.lldbtest import *
 
 
 class VSCodeTestCaseBase(TestBase):
@@ -267,7 +268,7 @@ class VSCodeTestCaseBase(TestBase):
 
         if memoryReference not in self.vscode.disassembled_instructions:
             self.vscode.request_disassemble(memoryReference=memoryReference)
-        
+
         return self.vscode.disassembled_instructions[memoryReference]
 
     def attach(

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/lldbvscode_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/lldbvscode_testcase.py
@@ -1,8 +1,7 @@
-import os
-import time
-
-import vscode
 from lldbsuite.test.lldbtest import *
+import os
+import vscode
+import time
 
 
 class VSCodeTestCaseBase(TestBase):
@@ -268,7 +267,7 @@ class VSCodeTestCaseBase(TestBase):
 
         if memoryReference not in self.vscode.disassembled_instructions:
             self.vscode.request_disassemble(memoryReference=memoryReference)
-
+        
         return self.vscode.disassembled_instructions[memoryReference]
 
     def attach(

--- a/lldb/test/API/tools/lldb-vscode/evaluate/TestVSCode_evaluate.py
+++ b/lldb/test/API/tools/lldb-vscode/evaluate/TestVSCode_evaluate.py
@@ -55,7 +55,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         self.assertEvaluate("var2", "21")
         self.assertEvaluate("static_int", "42")
         self.assertEvaluate("non_static_int", "43")
-        self.assertEvaluate("struct1", "my_struct @ 0x.*")
+        self.assertEvaluate("struct1", "{foo:15}")
         self.assertEvaluate("struct1.foo", "15")
         self.assertEvaluate("struct2->foo", "16")
 
@@ -85,7 +85,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         self.assertEvaluate(
             "non_static_int", "10"
         )  # different variable with the same name
-        self.assertEvaluate("struct1", "my_struct @ 0x.*")
+        self.assertEvaluate("struct1", "{foo:15}")
         self.assertEvaluate("struct1.foo", "15")
         self.assertEvaluate("struct2->foo", "16")
 

--- a/lldb/test/API/tools/lldb-vscode/variables/TestVSCode_variables.py
+++ b/lldb/test/API/tools/lldb-vscode/variables/TestVSCode_variables.py
@@ -2,12 +2,13 @@
 Test lldb-vscode setBreakpoints request
 """
 
+import os
+
+import lldbvscode_testcase
 import vscode
+from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import lldbutil
-import lldbvscode_testcase
-import os
 
 
 def make_buffer_verify_dict(start_idx, count, offset=0):
@@ -218,12 +219,12 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
             },
             "pt": {
                 "equals": {"type": "PointType"},
-                "startswith": {"result": "PointType @ 0x"},
+                "startswith": {"result": "{x:11, y:22}"},
                 "hasVariablesReference": True,
             },
             "pt.buffer": {
                 "equals": {"type": "int[32]"},
-                "startswith": {"result": "int[32] @ 0x"},
+                "startswith": {"result": "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...}"},
                 "hasVariablesReference": True,
             },
             "argv": {
@@ -409,7 +410,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
             "name": "pt",
             "response": {
                 "equals": {"type": "PointType"},
-                "startswith": {"result": "PointType @ 0x"},
+                "startswith": {"result": "{x:11, y:22}"},
                 "missing": ["indexedVariables"],
                 "hasVariablesReference": True,
             },


### PR DESCRIPTION
We've been displaying types and addresses for containers, but that's not very useful information. A better approach is to compose the summary of containers with the summary of a few of its children.

Not only that, we can dereference simple pointers and references to get the summary of the pointer variable, which is also better than just showing an anddress.

And in the rare case where the user wants to inspect the raw address, they can always use the debug console for that.

For the record, this is very similar to what the CodeLLDB extension does, and it seems to give a better experience.

An example of the new output:
<img width="494" alt="Screenshot 2023-09-06 at 2 24 27 PM" src="https://github.com/llvm/llvm-project/assets/1613874/588659b8-421a-4865-8d67-ce4b6182c4f9">

And this is the 
<img width="476" alt="Screenshot 2023-09-06 at 2 46 30 PM" src="https://github.com/llvm/llvm-project/assets/1613874/5768a52e-a773-449d-9aab-1b2fb2a98035">
old output:

