### PR TITLE
[libcxx][libcxxabi][libunwind] Support target-specific flags for tests

### DIFF
--- a/libcxx/test/CMakeLists.txt
+++ b/libcxx/test/CMakeLists.txt
@@ -32,6 +32,10 @@ else()
   serialize_lit_param(target_triple "\"${LLVM_DEFAULT_TARGET_TRIPLE}\"")
 endif()
 
+if (LIBCXX_TEST_TARGET_FLAGS)
+  serialize_lit_param(target_flags "\"${LIBCXX_TEST_TARGET_FLAGS}\"")
+endif()
+
 if (LLVM_USE_SANITIZER)
   serialize_lit_param(use_sanitizer "\"${LLVM_USE_SANITIZER}\"")
 endif()

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -111,6 +111,18 @@ DEFAULT_PARAMETERS = [
         ),
     ),
     Parameter(
+        name="target_flags",
+        type=str,
+        default=None,
+        help="Additional compile flags (e.g. -mabi=/-march=) to use when "
+        "compiling the test suite. This must be compatible with the target "
+        "that the tests will be run on.",
+        actions=lambda target_flags: [] if not target_flags else [
+            AddFlag(target_flags),
+            AddSubstitution("%{target_flags}", target_flags),
+        ],
+    ),
+    Parameter(
         name="std",
         choices=_allStandards,
         type=str,

--- a/libcxxabi/test/CMakeLists.txt
+++ b/libcxxabi/test/CMakeLists.txt
@@ -49,6 +49,10 @@ else()
   serialize_lit_param(target_triple "\"${LLVM_DEFAULT_TARGET_TRIPLE}\"")
 endif()
 
+if (LIBCXXABI_TEST_TARGET_FLAGS)
+  serialize_lit_param(target_flags "\"${LIBCXXABI_TEST_TARGET_FLAGS}\"")
+endif()
+
 foreach(param IN LISTS LIBCXXABI_TEST_PARAMS)
   string(REGEX REPLACE "(.+)=(.+)" "\\1" name "${param}")
   string(REGEX REPLACE "(.+)=(.+)" "\\2" value "${param}")

--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -32,6 +32,10 @@ else()
   serialize_lit_param(target_triple "\"${LLVM_DEFAULT_TARGET_TRIPLE}\"")
 endif()
 
+if (LIBUNWIND_TEST_TARGET_FLAGS)
+  serialize_lit_param(target_flags "\"${LIBUNWIND_TEST_TARGET_FLAGS}\"")
+endif()
+
 foreach(param IN LISTS LIBUNWIND_TEST_PARAMS)
   string(REGEX REPLACE "(.+)=(.+)" "\\1" name "${param}")
   string(REGEX REPLACE "(.+)=(.+)" "\\2" value "${param}")


### PR DESCRIPTION
There is currently only limited support for passing target-specific flags (e.g. `-mabi=` or `-march=`) to the testsuites if you don't have a compiler (or wrapper script) that defaults to the expected flags.

While there are parameters to pass `--target=` and
`-isysroot` (https://reviews.llvm.org/D151056 tries to extend that to `--sysroot=` so the linker can find libraries), building for some targets e.g. RISC-V may require additional flags when building with Clang.

This change adds a new target_flags parameter to the testsuite that appends the given flags to `%{flags}` and can be set from CMake using `{LIBUNWIND,LIBCXXABI_LIBCXX}_TEST_TARGET_FLAGS.`