### PR TITLE
[OpenMP] Align up the size when calling aligned_alloc

### DIFF
--- a/openmp/runtime/src/kmp_barrier.h
+++ b/openmp/runtime/src/kmp_barrier.h
@@ -21,7 +21,10 @@
 #define KMP_ALIGNED_ALLOCATE(size, alignment) _mm_malloc(size, alignment)
 #define KMP_ALIGNED_FREE(ptr) _mm_free(ptr)
 #elif KMP_HAVE_ALIGNED_ALLOC
-#define KMP_ALIGNED_ALLOCATE(size, alignment) aligned_alloc(alignment, size)
+#define KMP_ALGIN_UP(val, alignment)                                           \
+  (((val) + (alignment)-1) / (alignment) * (alignment))
+#define KMP_ALIGNED_ALLOCATE(size, alignment)                                  \
+  aligned_alloc(alignment, KMP_ALGIN_UP(size, alignment))
 #define KMP_ALIGNED_FREE(ptr) free(ptr)
 #elif KMP_HAVE_POSIX_MEMALIGN
 static inline void *KMP_ALIGNED_ALLOCATE(size_t size, size_t alignment) {


### PR DESCRIPTION
Based on https://en.cppreference.com/w/c/memory/aligned_alloc, the `size` is supposed
to be a multiple of `alignment`, and it is implementation defined behavior if not.
We have a non-conformant use in `kmp_barrier.h` when allocating distribute barrier.
The size of the barrier is 576 and the alignment is `4*CACHE_LINE`, which is 256
on most systems. Apparently it works perfectly fine for Linux and Intel-based Mac,
but not for Apple Silicon based Mac.

Fix #63194.
