### PR TITLE
[lld/ELF,gold] Remove transitionary opaque pointer flags

### DIFF
--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -673,8 +673,6 @@ def: J<"plugin-opt=cs-profile-path=">,
 def: J<"plugin-opt=obj-path=">,
   Alias<lto_obj_path_eq>,
   HelpText<"Alias for --lto-obj-path=">;
-def plugin_opt_opaque_pointers: F<"plugin-opt=opaque-pointers">,
-  HelpText<"Use opaque pointers in IR during LTO (default)">;
 def: J<"plugin-opt=opt-remarks-filename=">,
   Alias<opt_remarks_filename>,
   HelpText<"Alias for --opt-remarks-filename">;

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -308,8 +308,6 @@ namespace options {
       RemarksFormat = std::string(opt);
     } else if (opt.consume_front("stats-file=")) {
       stats_file = std::string(opt);
-    } else if (opt == "opaque-pointers") {
-      // We always use opaque pointers.
     } else {
       // Save this option to pass to the code generator.
       // ParseCommandLineOptions() expects argv[0] to be program name. Lazily


### PR DESCRIPTION
This was only useful during the transition when mixing non-opaque-pointer and opaque-pointer IR,
now everything uses opaque pointers.
