### PR TITLE
[CMake] Pass doc-related LLVM variables to external projects

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -344,6 +344,8 @@ function(llvm_ExternalProject_Add name source_dir)
                -DPACKAGE_VERSION=${PACKAGE_VERSION}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+               -DLLVM_ENABLE_SPHINX=${LLVM_ENABLE_SPHINX}
+               -DLLVM_BUILD_DOCS=${LLVM_BUILD_DOCS}
                -DCMAKE_EXPORT_COMPILE_COMMANDS=1
                ${cmake_args}
                ${PASSTHROUGH_VARIABLES}


### PR DESCRIPTION
When generating the configuration arguments for external projects, some of the external-project-specific CMake variables only work in combination with CMake variables from LLVM itself. In particular, the some of the doc-related CMake variables in libcxx depend on LLVM_ENABLE_SPHINX. Pass

LLVM_ENABLE_SPHINX
LLVM_BUILD_DOCS

to external projects.

Differential Revision: https://reviews.llvm.org/D158483