### PR TITLE
[llvm-nm] Fix msan error in llvm-nm/wasm/weak-symbols.yaml.test

### DIFF
--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -1822,7 +1822,7 @@ static bool getSymbolNamesFromObject(SymbolicFile &Obj,
 
       if (const WasmObjectFile *WasmObj = dyn_cast<WasmObjectFile>(&Obj)) {
         const WasmSymbol &WasmSym = WasmObj->getWasmSymbol(Sym);
-        if (WasmSym.isTypeData())
+        if (WasmSym.isTypeData() && !WasmSym.isUndefined())
           S.Size = WasmSym.Info.DataRef.Size;
       }
 


### PR DESCRIPTION
This happened because we had a section

```
- Index:           3
         Kind:            DATA
         Name:            weak_import_data
         Flags:           [ BINDING_WEAK, UNDEFINED ]
```

Which does not have size. We managed to reproduce it by building llvm under msan with libcxx as a standard library and debug mode with -D_LIBCPP_DEBUG_STRICT_WEAK_ORDERING_CHECK. It called comp(a, a) and full tie detected uninitialized memory

This started to happen after https://reviews.llvm.org/D158799