### PR TITLE
[clang-format][NFC] Skip remaining tests of the same case upon failure

### DIFF
--- a/clang/unittests/Format/FormatTestBase.h
+++ b/clang/unittests/Format/FormatTestBase.h
@@ -80,17 +80,22 @@ protected:
     return Style;
   }
 
-  void _verifyFormat(const char *File, int Line, llvm::StringRef Expected,
+  bool _verifyFormat(const char *File, int Line, llvm::StringRef Expected,
                      llvm::StringRef Code,
                      const std::optional<FormatStyle> &Style = {},
                      const std::vector<tooling::Range> &Ranges = {}) {
     testing::ScopedTrace t(File, Line, ::testing::Message() << Code.str());
+    const auto ExpectedCode{Expected.str()};
+    auto FormattedCode{format(Code, Style, SC_ExpectComplete, Ranges)};
+    EXPECT_EQ(ExpectedCode, FormattedCode);
+    if (ExpectedCode != FormattedCode)
+      return false;
     if (Expected != Code) {
-      EXPECT_EQ(Expected.str(),
-                format(Expected, Style, SC_ExpectComplete, Ranges))
-          << "Expected code is not stable";
+      FormattedCode = format(Expected, Style, SC_ExpectComplete, Ranges);
+      EXPECT_EQ(ExpectedCode, FormattedCode) << "Expected code is not stable";
+      if (ExpectedCode != FormattedCode)
+        return false;
     }
-    EXPECT_EQ(Expected.str(), format(Code, Style, SC_ExpectComplete, Ranges));
     auto UsedStyle = Style ? Style.value() : getDefaultStyle();
     if (UsedStyle.Language == FormatStyle::LK_Cpp) {
       // Objective-C++ is a superset of C++, so everything checked for C++
@@ -98,14 +103,18 @@ protected:
       FormatStyle ObjCStyle = UsedStyle;
       ObjCStyle.Language = FormatStyle::LK_ObjC;
       // FIXME: Additional messUp is superfluous.
-      EXPECT_EQ(Expected.str(),
-                format(Code, ObjCStyle, SC_ExpectComplete, Ranges));
+      FormattedCode = format(Code, ObjCStyle, SC_ExpectComplete, Ranges);
+      EXPECT_EQ(ExpectedCode, FormattedCode);
+      if (ExpectedCode != FormattedCode)
+        return false;
     }
+    return true;
   }
 
   void _verifyFormat(const char *File, int Line, llvm::StringRef Code,
                      const std::optional<FormatStyle> &Style = {}) {
-    _verifyFormat(File, Line, Code, Code, Style);
+    if (!_verifyFormat(File, Line, Code, Code, Style))
+      return;
     if (const auto MessedUpCode{messUp(Code)}; MessedUpCode != Code)
       _verifyFormat(File, Line, Code, MessedUpCode, Style);
   }


### PR DESCRIPTION
A typical test case goes through the format, stability, ObjC, and messUp tests. If any of theses tests fails, we should skip the remaining tests for the same test case.