### PR TITLE
[libc] Fix lseek in bazel

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -571,6 +571,18 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_file_linux_lseek_impl",
+    hdrs = ["src/__support/File/linux/lseekImpl.h"],
+    deps = [
+        ":__support_error_or",
+        ":__support_osutil_syscall",
+        ":__support_threads_mutex",
+        ":errno",
+        ":libc_root",
+    ],
+)
+
+libc_support_library(
     name = "__support_named_pair",
     hdrs = ["src/__support/named_pair.h"],
     deps = [":libc_root"],
@@ -2533,6 +2545,7 @@ libc_function(
     hdrs = ["src/unistd/lseek.h"],
     deps = [
         ":__support_common",
+        ":__support_file_linux_lseek_impl",
         ":__support_osutil_syscall",
         ":errno",
     ],


### PR DESCRIPTION
A previous patch moved the implementation of lseek to a new shared impl file but forgot to update the bazel. This patch fixes that.