### PR TITLE
[lld][MachO] Add option to suppress mismatch profile errors

### DIFF
--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -208,6 +208,7 @@ struct Configuration {
   bool ltoDebugPassManager = false;
   bool csProfileGenerate = false;
   llvm::StringRef csProfilePath;
+  bool pgoWarnMismatch;
 
   bool callGraphProfileSort = false;
   llvm::StringRef printSymbolOrder;

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1670,6 +1670,8 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   config->ltoDebugPassManager = args.hasArg(OPT_lto_debug_pass_manager);
   config->csProfileGenerate = args.hasArg(OPT_cs_profile_generate);
   config->csProfilePath = args.getLastArgValue(OPT_cs_profile_path);
+  config->pgoWarnMismatch =
+      args.hasFlag(OPT_pgo_warn_mismatch, OPT_no_pgo_warn_mismatch, true);
   config->generateUuid = !args.hasArg(OPT_no_uuid);
 
   for (const Arg *arg : args.filtered(OPT_alias)) {

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -71,6 +71,7 @@ static lto::Config createConfig() {
   c.DebugPassManager = config->ltoDebugPassManager;
   c.CSIRProfile = std::string(config->csProfilePath);
   c.RunCSIRInstr = config->csProfileGenerate;
+  c.PGOWarnMismatch = config->pgoWarnMismatch;
   c.OptLevel = config->ltoo;
   c.CGOptLevel = config->ltoCgo;
   if (config->saveTemps)

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -1,5 +1,10 @@
 include "llvm/Option/OptParser.td"
 
+multiclass BB<string name, string help1, string help2> {
+  def NAME: Flag<["--"], name>, HelpText<help1>;
+  def no_ # NAME: Flag<["--"], "no-" # name>, HelpText<help2>;
+}
+
 // Flags that lld/MachO understands but ld64 doesn't. These take
 // '--' instead of '-' and use dashes instead of underscores, so
 // they don't collide with the ld64 compat options.
@@ -130,6 +135,9 @@ def cs_profile_generate: Flag<["--"], "cs-profile-generate">,
     HelpText<"Perform context senstive PGO instrumentation">, Group<grp_lld>;
 def cs_profile_path: Joined<["--"], "cs-profile-path=">,
     HelpText<"Context sensitive profile file path">, Group<grp_lld>;
+defm pgo_warn_mismatch: BB<"pgo-warn-mismatch",
+  "turn on warnings about profile cfg mismatch (default)",
+  "turn off warnings about profile cfg mismatch">, Group<grp_lld>;
 
 // This is a complete Options.td compiled from Apple's ld(1) manpage
 // dated 2018-03-07 and cross checked with ld64 source code in repo

--- a/lld/test/MachO/pgo-warn-mismatch.ll
+++ b/lld/test/MachO/pgo-warn-mismatch.ll
@@ -1,0 +1,34 @@
+; REQUIRES: x86
+
+; RUN: rm -rf %t && split-file %s %t
+; RUN: llvm-as %t/a.ll -o %t/a.o
+; RUN: llvm-profdata merge %t/cs.proftext -o %t/cs.profdata
+
+;; Ensure lld generates warnings for profile cfg mismatch.
+; RUN: not %lld -dylib --cs-profile-path=%t/cs.profdata %t/a.o -o /dev/null 2>&1 | FileCheck %s
+; RUN: not %lld -dylib --cs-profile-path=%t/cs.profdata --pgo-warn-mismatch %t/a.o -o /dev/null 2>&1 | FileCheck %s
+
+;; Ensure lld will not generate warnings for profile cfg mismatch.
+; RUN: %lld -dylib --cs-profile-path=%t/cs.profdata --no-pgo-warn-mismatch %t/a.o -o /dev/null
+
+; CHECK: function control flow change detected (hash mismatch) foo Hash = [[#]]
+
+;--- a.ll
+target triple = "x86_64-apple-darwin"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define i32 @foo() {
+entry:
+  ret i32 0
+}
+
+;--- cs.proftext
+:csir
+_foo
+# Func Hash:
+2277602155505015273
+# Num Counters:
+2
+# Counter Values:
+1
+0


### PR DESCRIPTION
Both ELF and COFF support `--no-lto-pgo-warn-mismatch` in https://reviews.llvm.org/D104431 to suppress warnings due to mismatching profile hashes. As profiles go stale, it becomes likely that some function's CFGs will change so that their profiles can no longer be used. This commit adds the linker option `--no-pgo-warn-mismatch` to suppress these warnings.

Note that we do have the LLVM backend flag `no-pgo-warn-mismatch` (https://github.com/llvm/llvm-project/blob/3df1a64ebad8f31231ba05cf6ff43a985fea9235/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp#L210) but that is set to true by default during LTO (https://github.com/llvm/llvm-project/blob/3df1a64ebad8f31231ba05cf6ff43a985fea9235/llvm/include/llvm/LTO/Config.h#L76-L77).