### PR TITLE
[lldb-vscode] Show a fake child with the raw value of synthetic types

### DIFF
--- a/lldb/test/API/tools/lldb-vscode/variables/TestVSCode_variables.py
+++ b/lldb/test/API/tools/lldb-vscode/variables/TestVSCode_variables.py
@@ -517,6 +517,20 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         }
         self.verify_variables(verify_locals, locals)
 
+        # We also verify that we produce a "[raw]" fake child with the real
+        # SBValue for the synthetic type.
+        verify_children = {
+            "[0]": {"equals": {"type": "int", "value": "0"}},
+            "[1]": {"equals": {"type": "int", "value": "0"}},
+            "[2]": {"equals": {"type": "int", "value": "0"}},
+            "[3]": {"equals": {"type": "int", "value": "0"}},
+            "[4]": {"equals": {"type": "int", "value": "0"}},
+            "[raw]": {"contains": {"type": ["vector"]}},
+        }
+        children = self.vscode.request_variables(locals[2]["variablesReference"])["body"]["variables"]
+        self.verify_variables(verify_children, children)
+
+
     @skipIfWindows
     @skipIfRemote
     def test_registers(self):

--- a/lldb/tools/lldb-vscode/JSONUtils.h
+++ b/lldb/tools/lldb-vscode/JSONUtils.h
@@ -440,12 +440,17 @@ std::string CreateUniqueVariableNameForDisplay(lldb::SBValue v,
 ///     As VSCode doesn't render two of more variables with the same name, we
 ///     apply a suffix to distinguish duplicated variables.
 ///
+/// \param[in] custom_name
+///     A provided custom name that is used instead of the SBValue's when
+///     creating the JSON representation.
+///
 /// \return
 ///     A "Variable" JSON object with that follows the formal JSON
 ///     definition outlined by Microsoft.
 llvm::json::Value CreateVariable(lldb::SBValue v, int64_t variablesReference,
                                  int64_t varID, bool format_hex,
-                                 bool is_name_duplicated = false);
+                                 bool is_name_duplicated = false,
+                                 std::optional<std::string> custom_name = {});
 
 llvm::json::Value CreateCompileUnit(lldb::SBCompileUnit unit);
 


### PR DESCRIPTION
Currently, if the user wants to inspect the raw version of a synthetic variable, they have to go to the debug console and type `frame var <variable>`, which is not a great experience. Taking inspiration from CodeLLDB, this adds a `[raw]` child to every synthetic variable so that this kind of inspection can be done visually.

Some examples:

<img width="500" alt="Screenshot 2023-09-06 at 7 56 25 PM" src="https://github.com/llvm/llvm-project/assets/1613874/7fefb7c5-0da7-49c7-968b-78ac88348fea">
<img width="479" alt="Screenshot 2023-09-06 at 6 58 25 PM" src="https://github.com/llvm/llvm-project/assets/1613874/6e650567-16e1-462f-9bf5-4a3a605cf6fc">


