### PR TITLE
[OpenMP] Use the more appropriate function to retrieve the thread id on OpenBSD

### DIFF
--- a/openmp/runtime/src/kmp_wrapper_getpid.h
+++ b/openmp/runtime/src/kmp_wrapper_getpid.h
@@ -30,7 +30,7 @@
 #include <lwp.h>
 #define __kmp_gettid() _lwp_self()
 #elif KMP_OS_OPENBSD
-#define __kmp_gettid() syscall(SYS_getthrid)
+#define __kmp_gettid() getthrid()
 #elif defined(SYS_gettid)
 // Hopefully other Unix systems define SYS_gettid syscall for getting os thread
 // id


### PR DESCRIPTION
Use the getthrid() function instead of a syscall.