### PR TITLE
[NFC] Set a variable in the mlir data formatter

### DIFF
--- a/mlir/utils/lldb-scripts/mlirDataFormatters.py
+++ b/mlir/utils/lldb-scripts/mlirDataFormatters.py
@@ -5,6 +5,7 @@ Load into LLDB with 'command script import /path/to/mlirDataFormatters.py'
 """
 
 import re
+
 import lldb
 
 
@@ -196,6 +197,7 @@ class AttrTypeSynthProvider:
             valobj, self.abstractVal, internal_dict
         )
         if not self.type:
+            self.impl_type = None
             return
 
         # Grab the ImplTy from the resolved type. This is the 3rd template

--- a/mlir/utils/lldb-scripts/mlirDataFormatters.py
+++ b/mlir/utils/lldb-scripts/mlirDataFormatters.py
@@ -5,7 +5,6 @@ Load into LLDB with 'command script import /path/to/mlirDataFormatters.py'
 """
 
 import re
-
 import lldb
 
 


### PR DESCRIPTION
The formatter fails when num_children is invoked and self.impl_type is not set.
