### PR TITLE
[lldb][NFCI] Remove typedef for TypeCategoryMap::ValueSP

### DIFF
--- a/lldb/include/lldb/DataFormatters/FormatManager.h
+++ b/lldb/include/lldb/DataFormatters/FormatManager.h
@@ -57,7 +57,7 @@ public:
 
   void EnableCategory(ConstString category_name,
                       TypeCategoryMap::Position pos, lldb::LanguageType lang) {
-    TypeCategoryMap::ValueSP category_sp;
+    lldb::TypeCategoryImplSP category_sp;
     if (m_categories_map.Get(category_name, category_sp) && category_sp) {
       m_categories_map.Enable(category_sp, pos);
       category_sp->AddLanguage(lang);

--- a/lldb/include/lldb/DataFormatters/TypeCategoryMap.h
+++ b/lldb/include/lldb/DataFormatters/TypeCategoryMap.h
@@ -29,11 +29,9 @@ private:
 
 public:
   typedef ConstString KeyType;
-  typedef TypeCategoryImpl ValueType;
-  typedef ValueType::SharedPointer ValueSP;
-  typedef std::map<KeyType, ValueSP> MapType;
+  typedef std::map<KeyType, lldb::TypeCategoryImplSP> MapType;
   typedef MapType::iterator MapIterator;
-  typedef std::function<bool(const ValueSP &)> ForEachCallback;
+  typedef std::function<bool(const lldb::TypeCategoryImplSP &)> ForEachCallback;
 
   typedef uint32_t Position;
 
@@ -43,7 +41,7 @@ public:
 
   TypeCategoryMap(IFormatChangeListener *lst);
 
-  void Add(KeyType name, const ValueSP &entry);
+  void Add(KeyType name, const lldb::TypeCategoryImplSP &entry);
 
   bool Delete(KeyType name);
 
@@ -51,9 +49,9 @@ public:
 
   bool Disable(KeyType category_name);
 
-  bool Enable(ValueSP category, Position pos = Default);
+  bool Enable(lldb::TypeCategoryImplSP category, Position pos = Default);
 
-  bool Disable(ValueSP category);
+  bool Disable(lldb::TypeCategoryImplSP category);
 
   void EnableAllCategories();
 
@@ -61,7 +59,7 @@ public:
 
   void Clear();
 
-  bool Get(KeyType name, ValueSP &entry);
+  bool Get(KeyType name, lldb::TypeCategoryImplSP &entry);
 
   void ForEach(ForEachCallback callback);
 

--- a/lldb/source/DataFormatters/TypeCategoryMap.cpp
+++ b/lldb/source/DataFormatters/TypeCategoryMap.cpp
@@ -24,7 +24,7 @@ TypeCategoryMap::TypeCategoryMap(IFormatChangeListener *lst)
   Enable(default_cs, First);
 }
 
-void TypeCategoryMap::Add(KeyType name, const ValueSP &entry) {
+void TypeCategoryMap::Add(KeyType name, const TypeCategoryImplSP &entry) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
   m_map[name] = entry;
   if (listener)
@@ -45,7 +45,7 @@ bool TypeCategoryMap::Delete(KeyType name) {
 
 bool TypeCategoryMap::Enable(KeyType category_name, Position pos) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
-  ValueSP category;
+  TypeCategoryImplSP category;
   if (!Get(category_name, category))
     return false;
   return Enable(category, pos);
@@ -53,13 +53,13 @@ bool TypeCategoryMap::Enable(KeyType category_name, Position pos) {
 
 bool TypeCategoryMap::Disable(KeyType category_name) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
-  ValueSP category;
+  TypeCategoryImplSP category;
   if (!Get(category_name, category))
     return false;
   return Disable(category);
 }
 
-bool TypeCategoryMap::Enable(ValueSP category, Position pos) {
+bool TypeCategoryMap::Enable(TypeCategoryImplSP category, Position pos) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
   if (category.get()) {
     Position pos_w = pos;
@@ -81,7 +81,7 @@ bool TypeCategoryMap::Enable(ValueSP category, Position pos) {
   return false;
 }
 
-bool TypeCategoryMap::Disable(ValueSP category) {
+bool TypeCategoryMap::Disable(TypeCategoryImplSP category) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
   if (category.get()) {
     m_active_categories.remove_if(delete_matching_categories(category));
@@ -93,7 +93,7 @@ bool TypeCategoryMap::Disable(ValueSP category) {
 
 void TypeCategoryMap::EnableAllCategories() {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
-  std::vector<ValueSP> sorted_categories(m_map.size(), ValueSP());
+  std::vector<TypeCategoryImplSP> sorted_categories(m_map.size(), TypeCategoryImplSP());
   MapType::iterator iter = m_map.begin(), end = m_map.end();
   for (; iter != end; ++iter) {
     if (iter->second->IsEnabled())
@@ -102,7 +102,7 @@ void TypeCategoryMap::EnableAllCategories() {
     if (pos >= sorted_categories.size()) {
       auto iter = std::find_if(
           sorted_categories.begin(), sorted_categories.end(),
-          [](const ValueSP &sp) -> bool { return sp.get() == nullptr; });
+          [](const TypeCategoryImplSP &sp) -> bool { return sp.get() == nullptr; });
       pos = std::distance(sorted_categories.begin(), iter);
     }
     sorted_categories.at(pos) = iter->second;
@@ -130,7 +130,7 @@ void TypeCategoryMap::Clear() {
     listener->Changed();
 }
 
-bool TypeCategoryMap::Get(KeyType name, ValueSP &entry) {
+bool TypeCategoryMap::Get(KeyType name, TypeCategoryImplSP &entry) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
   MapIterator iter = m_map.find(name);
   if (iter == m_map.end())


### PR DESCRIPTION
lldb already has a `ValueSP` type. This was confusing to me when reading TypeCategoryMap, especially when `ValueSP` is not qualified. From first glance it looks like it's referring to a `std::shared_ptr<lldb_private::Value>` when it's really referring to a `std::shared_ptr<lldb_private::TypeCategoryImpl>`.