### PR TITLE
[libc] continues header cleanup process

### DIFF
--- a/libc/src/__support/CPP/type_traits/is_rvalue_reference.h
+++ b/libc/src/__support/CPP/type_traits/is_rvalue_reference.h
@@ -25,7 +25,7 @@ template <typename T> struct is_rvalue_reference : public false_type {};
 template <typename T> struct is_rvalue_reference<T &&> : public true_type {};
 #endif
 template <class T>
-LIBC_INLINE constexpr is_rvalue_reference_v = is_rvalue_reference<T>::value;
+LIBC_INLINE constexpr bool is_rvalue_reference_v = is_rvalue_reference<T>::value;
 
 } // namespace __llvm_libc::cpp
 

--- a/libc/src/__support/CPP/type_traits/is_rvalue_reference.h
+++ b/libc/src/__support/CPP/type_traits/is_rvalue_reference.h
@@ -25,7 +25,7 @@ template <typename T> struct is_rvalue_reference : public false_type {};
 template <typename T> struct is_rvalue_reference<T &&> : public true_type {};
 #endif
 template <class T>
-using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
+LIBC_INLINE constexpr is_rvalue_reference_v = is_rvalue_reference<T>::value;
 
 } // namespace __llvm_libc::cpp
 

--- a/libc/src/__support/CPP/type_traits/is_rvalue_reference.h
+++ b/libc/src/__support/CPP/type_traits/is_rvalue_reference.h
@@ -25,7 +25,8 @@ template <typename T> struct is_rvalue_reference : public false_type {};
 template <typename T> struct is_rvalue_reference<T &&> : public true_type {};
 #endif
 template <class T>
-LIBC_INLINE constexpr bool is_rvalue_reference_v = is_rvalue_reference<T>::value;
+LIBC_INLINE_VAR constexpr bool is_rvalue_reference_v =
+    is_rvalue_reference<T>::value;
 
 } // namespace __llvm_libc::cpp
 

--- a/libc/src/__support/CPP/type_traits/remove_extent.h
+++ b/libc/src/__support/CPP/type_traits/remove_extent.h
@@ -9,6 +9,7 @@
 #define LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_REMOVE_EXTENT_H
 
 #include "src/__support/CPP/type_traits/type_identity.h"
+#include "stddef.h"
 
 namespace __llvm_libc::cpp {
 

--- a/libc/src/__support/CPP/type_traits/remove_extent.h
+++ b/libc/src/__support/CPP/type_traits/remove_extent.h
@@ -9,7 +9,7 @@
 #define LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_REMOVE_EXTENT_H
 
 #include "src/__support/CPP/type_traits/type_identity.h"
-#include "stddef.h"
+#include "stddef.h" // size_t
 
 namespace __llvm_libc::cpp {
 


### PR DESCRIPTION
* replaces `add_rvalue_reference_t` with `is_rvalue_reference_t`
* includes `"stddef.h"` for `size_t` include