### PR TITLE
[clang-tidy][modernize-use-using]fix function pointer typedef correctly

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
@@ -120,8 +120,10 @@ void UseUsingCheck::check(const MatchFinder::MatchResult &Result) {
         Type.substr(0, FirstTypedefType.size()) == FirstTypedefType)
       Type = FirstTypedefName + Type.substr(FirstTypedefType.size() + 1);
   }
-  if (!ReplaceRange.getEnd().isMacroID())
-    LastReplacementEnd = ReplaceRange.getEnd().getLocWithOffset(Name.size());
+  if (!ReplaceRange.getEnd().isMacroID()) {
+    const SourceLocation::IntTy Offset = MatchedDecl->getFunctionType() ? 0 : Name.size();
+    LastReplacementEnd = ReplaceRange.getEnd().getLocWithOffset(Offset);
+  }
 
   auto Diag = diag(ReplaceRange.getBegin(), UseUsingWarning);
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -246,8 +246,9 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-std-print>` check to accurately generate
   fixes for reordering arguments.
 
-- Improved :doc:`modernize-use-using<clang-tidy/checks/modernize/use-using>` 
-  check to fix function pointer ``typedef`` correctly.
+- Improved :doc:`modernize-use-using
+  <clang-tidy/checks/modernize/use-using>` check to fix function pointer
+  ``typedef`` correctly.
 
 - Improved :doc:`performance-faster-string-find
   <clang-tidy/checks/performance/faster-string-find>` check to properly escape

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -246,6 +246,9 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-std-print>` check to accurately generate
   fixes for reordering arguments.
 
+- Improved :doc:`modernize-use-using<clang-tidy/checks/modernize/use-using>` 
+  check to fix function pointer ``typedef`` correctly.
+
 - Improved :doc:`performance-faster-string-find
   <clang-tidy/checks/performance/faster-string-find>` check to properly escape
   single quotes.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -319,5 +319,5 @@ typedef void (*ISSUE_65055_1)(int);
 typedef bool (*ISSUE_65055_2)(int);
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
-// CHECK-FIXES: using ISSUE_65055_1 = void (*)(int)
-// CHECK-FIXES: using ISSUE_65055_2 = bool (*)(int)
+// CHECK-FIXES: using ISSUE_65055_1 = void (*)(int);
+// CHECK-FIXES: using ISSUE_65055_2 = bool (*)(int);

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -314,3 +314,10 @@ typedef struct { struct { int a; struct { struct { int b; } c; int d; } e; } f; 
 typedef struct { struct { int a; } b; union { int c; float d; struct { int e; }; }; struct { double f; } g; } PR50990_siblings;
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef'
 // CHECK-FIXES: using PR50990_siblings = struct { struct { int a; } b; union { int c; float d; struct { int e; }; }; struct { double f; } g; };
+
+typedef void (*ISSUE_65055_1)(int);
+typedef bool (*ISSUE_65055_2)(int);
+// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
+// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
+// CHECK-FIXES: using ISSUE_65055_1 = void (*)(int)
+// CHECK-FIXES: using ISSUE_65055_2 = bool (*)(int)

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -319,5 +319,5 @@ typedef void (*ISSUE_65055_1)(int);
 typedef bool (*ISSUE_65055_2)(int);
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
-// CHECK-FIXES: using ISSUE_65055_1 = void (*)(int);
-// CHECK-FIXES: using ISSUE_65055_2 = bool (*)(int);
+// CHECK-FIXES: {{^}}using ISSUE_65055_1 = void (*)(int);{{$}}
+// CHECK-FIXES: {{^}}using ISSUE_65055_2 = bool (*)(int);{{$}}


### PR DESCRIPTION
Fixed #65055
For normal type, typedef is from typedef to the end of original type, but for function pointer it is from typedef to the end.
So it needs to consider alias name length for normal type.