### PR TITLE
[llvm] Adopt WithMarkup in the ARM backend

### DIFF
--- a/llvm/include/llvm/MC/MCInstPrinter.h
+++ b/llvm/include/llvm/MC/MCInstPrinter.h
@@ -154,9 +154,6 @@ public:
 
   WithMarkup markup(raw_ostream &OS, Markup M) const;
 
-  /// Utility functions to make adding mark ups simpler.
-  StringRef markup(StringRef s) const;
-
   bool getPrintImmHex() const { return PrintImmHex; }
   void setPrintImmHex(bool Value) { PrintImmHex = Value; }
 

--- a/llvm/lib/MC/MCInstPrinter.cpp
+++ b/llvm/lib/MC/MCInstPrinter.cpp
@@ -170,14 +170,6 @@ const char *MCInstPrinter::matchAliasPatterns(const MCInst *MI,
   return M.AsmStrings.data() + AsmStrOffset;
 }
 
-/// Utility functions to make adding mark ups simpler.
-StringRef MCInstPrinter::markup(StringRef s) const {
-  if (getUseMarkup())
-    return s;
-  else
-    return "";
-}
-
 // For asm-style hex (e.g. 0ffh) the first digit always has to be a number.
 static bool needsLeadingZero(uint64_t Value)
 {

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMInstPrinter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMInstPrinter.cpp
@@ -49,9 +49,8 @@ static unsigned translateShiftImm(unsigned imm) {
   return imm;
 }
 
-/// Prints the shift value with an immediate value.
 static void printRegImmShift(raw_ostream &O, ARM_AM::ShiftOpc ShOpc,
-                             unsigned ShImm, bool UseMarkup) {
+                             unsigned ShImm, const ARMInstPrinter &printer) {
   if (ShOpc == ARM_AM::no_shift || (ShOpc == ARM_AM::lsl && !ShImm))
     return;
   O << ", ";
@@ -61,11 +60,8 @@ static void printRegImmShift(raw_ostream &O, ARM_AM::ShiftOpc ShOpc,
 
   if (ShOpc != ARM_AM::rrx) {
     O << " ";
-    if (UseMarkup)
-      O << "<imm:";
-    O << "#" << translateShiftImm(ShImm);
-    if (UseMarkup)
-      O << ">";
+    printer.markup(O, llvm::MCInstPrinter::Markup::Immediate)
+        << "#" << translateShiftImm(ShImm);
   }
 }
 
@@ -86,7 +82,7 @@ bool ARMInstPrinter::applyTargetSpecificCLOption(StringRef Opt) {
 }
 
 void ARMInstPrinter::printRegName(raw_ostream &OS, MCRegister Reg) const {
-  OS << markup("<reg:") << getRegisterName(Reg, DefaultAltIdx) << markup(">");
+  markup(OS, Markup::Register) << getRegisterName(Reg, DefaultAltIdx);
 }
 
 void ARMInstPrinter::printInst(const MCInst *MI, uint64_t Address,
@@ -139,8 +135,9 @@ void ARMInstPrinter::printInst(const MCInst *MI, uint64_t Address,
       return;
     }
 
-    O << ", " << markup("<imm:") << "#"
-      << translateShiftImm(ARM_AM::getSORegOffset(MO2.getImm())) << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate)
+        << "#" << translateShiftImm(ARM_AM::getSORegOffset(MO2.getImm()));
     printAnnotation(O, Annot);
     return;
   }
@@ -316,7 +313,7 @@ void ARMInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
     unsigned Reg = Op.getReg();
     printRegName(O, Reg);
   } else if (Op.isImm()) {
-    O << markup("<imm:") << '#' << formatImm(Op.getImm()) << markup(">");
+    markup(O, Markup::Immediate) << '#' << formatImm(Op.getImm());
   } else {
     assert(Op.isExpr() && "unknown operand kind in printOperand");
     const MCExpr *Expr = Op.getExpr();
@@ -372,7 +369,8 @@ void ARMInstPrinter::printThumbLdrLabelOperand(const MCInst *MI, unsigned OpNum,
     return;
   }
 
-  O << markup("<mem:") << "[pc, ";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[pc, ";
 
   int32_t OffImm = (int32_t)MO1.getImm();
   bool isSub = OffImm < 0;
@@ -381,11 +379,11 @@ void ARMInstPrinter::printThumbLdrLabelOperand(const MCInst *MI, unsigned OpNum,
   if (OffImm == INT32_MIN)
     OffImm = 0;
   if (isSub) {
-    O << markup("<imm:") << "#-" << formatImm(-OffImm) << markup(">");
+    markup(O, Markup::Immediate) << "#-" << formatImm(-OffImm);
   } else {
-    O << markup("<imm:") << "#" << formatImm(OffImm) << markup(">");
+    markup(O, Markup::Immediate) << "#" << formatImm(OffImm);
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 // so_reg is a 4-operand unit corresponding to register forms of the A5.1
@@ -423,7 +421,7 @@ void ARMInstPrinter::printSORegImmOperand(const MCInst *MI, unsigned OpNum,
 
   // Print the shift opc.
   printRegImmShift(O, ARM_AM::getSORegShOp(MO2.getImm()),
-                   ARM_AM::getSORegOffset(MO2.getImm()), UseMarkup);
+                   ARM_AM::getSORegOffset(MO2.getImm()), *this);
 }
 
 //===--------------------------------------------------------------------===//
@@ -437,16 +435,18 @@ void ARMInstPrinter::printAM2PreOrOffsetIndexOp(const MCInst *MI, unsigned Op,
   const MCOperand &MO2 = MI->getOperand(Op + 1);
   const MCOperand &MO3 = MI->getOperand(Op + 2);
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
 
   if (!MO2.getReg()) {
     if (ARM_AM::getAM2Offset(MO3.getImm())) { // Don't print +0.
-      O << ", " << markup("<imm:") << "#"
-        << ARM_AM::getAddrOpcStr(ARM_AM::getAM2Op(MO3.getImm()))
-        << ARM_AM::getAM2Offset(MO3.getImm()) << markup(">");
+      O << ", ";
+      markup(O, Markup::Immediate)
+          << "#" << ARM_AM::getAddrOpcStr(ARM_AM::getAM2Op(MO3.getImm()))
+          << ARM_AM::getAM2Offset(MO3.getImm());
     }
-    O << "]" << markup(">");
+    O << "]";
     return;
   }
 
@@ -455,8 +455,8 @@ void ARMInstPrinter::printAM2PreOrOffsetIndexOp(const MCInst *MI, unsigned Op,
   printRegName(O, MO2.getReg());
 
   printRegImmShift(O, ARM_AM::getAM2ShiftOpc(MO3.getImm()),
-                   ARM_AM::getAM2Offset(MO3.getImm()), UseMarkup);
-  O << "]" << markup(">");
+                   ARM_AM::getAM2Offset(MO3.getImm()), *this);
+  O << "]";
 }
 
 void ARMInstPrinter::printAddrModeTBB(const MCInst *MI, unsigned Op,
@@ -464,11 +464,13 @@ void ARMInstPrinter::printAddrModeTBB(const MCInst *MI, unsigned Op,
                                       raw_ostream &O) {
   const MCOperand &MO1 = MI->getOperand(Op);
   const MCOperand &MO2 = MI->getOperand(Op + 1);
-  O << markup("<mem:") << "[";
+
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
   O << ", ";
   printRegName(O, MO2.getReg());
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printAddrModeTBH(const MCInst *MI, unsigned Op,
@@ -476,11 +478,14 @@ void ARMInstPrinter::printAddrModeTBH(const MCInst *MI, unsigned Op,
                                       raw_ostream &O) {
   const MCOperand &MO1 = MI->getOperand(Op);
   const MCOperand &MO2 = MI->getOperand(Op + 1);
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
   O << ", ";
   printRegName(O, MO2.getReg());
-  O << ", lsl " << markup("<imm:") << "#1" << markup(">") << "]" << markup(">");
+  O << ", lsl ";
+  markup(O, Markup::Immediate) << "#1";
+  O << "]";
 }
 
 void ARMInstPrinter::printAddrMode2Operand(const MCInst *MI, unsigned Op,
@@ -511,9 +516,9 @@ void ARMInstPrinter::printAddrMode2OffsetOperand(const MCInst *MI,
 
   if (!MO1.getReg()) {
     unsigned ImmOffs = ARM_AM::getAM2Offset(MO2.getImm());
-    O << markup("<imm:") << '#'
-      << ARM_AM::getAddrOpcStr(ARM_AM::getAM2Op(MO2.getImm())) << ImmOffs
-      << markup(">");
+    markup(O, Markup::Immediate)
+        << '#' << ARM_AM::getAddrOpcStr(ARM_AM::getAM2Op(MO2.getImm()))
+        << ImmOffs;
     return;
   }
 
@@ -521,7 +526,7 @@ void ARMInstPrinter::printAddrMode2OffsetOperand(const MCInst *MI,
   printRegName(O, MO1.getReg());
 
   printRegImmShift(O, ARM_AM::getAM2ShiftOpc(MO2.getImm()),
-                   ARM_AM::getAM2Offset(MO2.getImm()), UseMarkup);
+                   ARM_AM::getAM2Offset(MO2.getImm()), *this);
 }
 
 //===--------------------------------------------------------------------===//
@@ -535,13 +540,14 @@ void ARMInstPrinter::printAM3PreOrOffsetIndexOp(const MCInst *MI, unsigned Op,
   const MCOperand &MO2 = MI->getOperand(Op + 1);
   const MCOperand &MO3 = MI->getOperand(Op + 2);
 
-  O << markup("<mem:") << '[';
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << '[';
   printRegName(O, MO1.getReg());
 
   if (MO2.getReg()) {
     O << ", " << getAddrOpcStr(ARM_AM::getAM3Op(MO3.getImm()));
     printRegName(O, MO2.getReg());
-    O << ']' << markup(">");
+    O << ']';
     return;
   }
 
@@ -550,10 +556,10 @@ void ARMInstPrinter::printAM3PreOrOffsetIndexOp(const MCInst *MI, unsigned Op,
   ARM_AM::AddrOpc op = ARM_AM::getAM3Op(MO3.getImm());
 
   if (AlwaysPrintImm0 || ImmOffs || (op == ARM_AM::sub)) {
-    O << ", " << markup("<imm:") << "#" << ARM_AM::getAddrOpcStr(op) << ImmOffs
-      << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#" << ARM_AM::getAddrOpcStr(op) << ImmOffs;
   }
-  O << ']' << markup(">");
+  O << ']';
 }
 
 template <bool AlwaysPrintImm0>
@@ -586,9 +592,9 @@ void ARMInstPrinter::printAddrMode3OffsetOperand(const MCInst *MI,
   }
 
   unsigned ImmOffs = ARM_AM::getAM3Offset(MO2.getImm());
-  O << markup("<imm:") << '#'
-    << ARM_AM::getAddrOpcStr(ARM_AM::getAM3Op(MO2.getImm())) << ImmOffs
-    << markup(">");
+  markup(O, Markup::Immediate)
+      << '#' << ARM_AM::getAddrOpcStr(ARM_AM::getAM3Op(MO2.getImm()))
+      << ImmOffs;
 }
 
 void ARMInstPrinter::printPostIdxImm8Operand(const MCInst *MI, unsigned OpNum,
@@ -596,8 +602,8 @@ void ARMInstPrinter::printPostIdxImm8Operand(const MCInst *MI, unsigned OpNum,
                                              raw_ostream &O) {
   const MCOperand &MO = MI->getOperand(OpNum);
   unsigned Imm = MO.getImm();
-  O << markup("<imm:") << '#' << ((Imm & 256) ? "" : "-") << (Imm & 0xff)
-    << markup(">");
+  markup(O, Markup::Immediate)
+      << '#' << ((Imm & 256) ? "" : "-") << (Imm & 0xff);
 }
 
 void ARMInstPrinter::printPostIdxRegOperand(const MCInst *MI, unsigned OpNum,
@@ -615,8 +621,8 @@ void ARMInstPrinter::printPostIdxImm8s4Operand(const MCInst *MI, unsigned OpNum,
                                                raw_ostream &O) {
   const MCOperand &MO = MI->getOperand(OpNum);
   unsigned Imm = MO.getImm();
-  O << markup("<imm:") << '#' << ((Imm & 256) ? "" : "-") << ((Imm & 0xff) << 2)
-    << markup(">");
+  markup(O, Markup::Immediate)
+      << '#' << ((Imm & 256) ? "" : "-") << ((Imm & 0xff) << 2);
 }
 
 template<int shift>
@@ -626,15 +632,16 @@ void ARMInstPrinter::printMveAddrModeRQOperand(const MCInst *MI, unsigned OpNum,
   const MCOperand &MO1 = MI->getOperand(OpNum);
   const MCOperand &MO2 = MI->getOperand(OpNum + 1);
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
   O << ", ";
   printRegName(O, MO2.getReg());
 
   if (shift > 0)
-    printRegImmShift(O, ARM_AM::uxtw, shift, UseMarkup);
+    printRegImmShift(O, ARM_AM::uxtw, shift, *this);
 
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printLdStmModeOperand(const MCInst *MI, unsigned OpNum,
@@ -657,16 +664,18 @@ void ARMInstPrinter::printAddrMode5Operand(const MCInst *MI, unsigned OpNum,
     return;
   }
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
 
   unsigned ImmOffs = ARM_AM::getAM5Offset(MO2.getImm());
   ARM_AM::AddrOpc Op = ARM_AM::getAM5Op(MO2.getImm());
   if (AlwaysPrintImm0 || ImmOffs || Op == ARM_AM::sub) {
-    O << ", " << markup("<imm:") << "#" << ARM_AM::getAddrOpcStr(Op)
-      << ImmOffs * 4 << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate)
+        << "#" << ARM_AM::getAddrOpcStr(Op) << ImmOffs * 4;
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 template <bool AlwaysPrintImm0>
@@ -681,20 +690,19 @@ void ARMInstPrinter::printAddrMode5FP16Operand(const MCInst *MI, unsigned OpNum,
     return;
   }
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
 
   unsigned ImmOffs = ARM_AM::getAM5FP16Offset(MO2.getImm());
   unsigned Op = ARM_AM::getAM5FP16Op(MO2.getImm());
   if (AlwaysPrintImm0 || ImmOffs || Op == ARM_AM::sub) {
-    O << ", "
-      << markup("<imm:")
-      << "#"
-      << ARM_AM::getAddrOpcStr(ARM_AM::getAM5FP16Op(MO2.getImm()))
-      << ImmOffs * 2
-      << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate)
+        << "#" << ARM_AM::getAddrOpcStr(ARM_AM::getAM5FP16Op(MO2.getImm()))
+        << ImmOffs * 2;
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printAddrMode6Operand(const MCInst *MI, unsigned OpNum,
@@ -703,21 +711,23 @@ void ARMInstPrinter::printAddrMode6Operand(const MCInst *MI, unsigned OpNum,
   const MCOperand &MO1 = MI->getOperand(OpNum);
   const MCOperand &MO2 = MI->getOperand(OpNum + 1);
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
   if (MO2.getImm()) {
     O << ":" << (MO2.getImm() << 3);
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printAddrMode7Operand(const MCInst *MI, unsigned OpNum,
                                            const MCSubtargetInfo &STI,
                                            raw_ostream &O) {
   const MCOperand &MO1 = MI->getOperand(OpNum);
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printAddrMode6OffsetOperand(const MCInst *MI,
@@ -742,8 +752,9 @@ void ARMInstPrinter::printBitfieldInvMaskImmOperand(const MCInst *MI,
   int32_t lsb = llvm::countr_zero(v);
   int32_t width = llvm::bit_width(v) - lsb;
   assert(MO.isImm() && "Not a valid bf_inv_mask_imm value!");
-  O << markup("<imm:") << '#' << lsb << markup(">") << ", " << markup("<imm:")
-    << '#' << width << markup(">");
+  markup(O, Markup::Immediate) << '#' << lsb;
+  O << ", ";
+  markup(O, Markup::Immediate) << '#' << width;
 }
 
 void ARMInstPrinter::printMemBOption(const MCInst *MI, unsigned OpNum,
@@ -774,10 +785,11 @@ void ARMInstPrinter::printShiftImmOperand(const MCInst *MI, unsigned OpNum,
   bool isASR = (ShiftOp & (1 << 5)) != 0;
   unsigned Amt = ShiftOp & 0x1f;
   if (isASR) {
-    O << ", asr " << markup("<imm:") << "#" << (Amt == 0 ? 32 : Amt)
-      << markup(">");
+    O << ", asr ";
+    markup(O, Markup::Immediate) << "#" << (Amt == 0 ? 32 : Amt);
   } else if (Amt) {
-    O << ", lsl " << markup("<imm:") << "#" << Amt << markup(">");
+    O << ", lsl ";
+    markup(O, Markup::Immediate) << "#" << Amt;
   }
 }
 
@@ -788,7 +800,8 @@ void ARMInstPrinter::printPKHLSLShiftImm(const MCInst *MI, unsigned OpNum,
   if (Imm == 0)
     return;
   assert(Imm > 0 && Imm < 32 && "Invalid PKH shift immediate value!");
-  O << ", lsl " << markup("<imm:") << "#" << Imm << markup(">");
+  O << ", lsl ";
+  markup(O, Markup::Immediate) << "#" << Imm;
 }
 
 void ARMInstPrinter::printPKHASRShiftImm(const MCInst *MI, unsigned OpNum,
@@ -799,7 +812,8 @@ void ARMInstPrinter::printPKHASRShiftImm(const MCInst *MI, unsigned OpNum,
   if (Imm == 0)
     Imm = 32;
   assert(Imm > 0 && Imm <= 32 && "Invalid PKH shift immediate value!");
-  O << ", asr " << markup("<imm:") << "#" << Imm << markup(">");
+  O << ", asr ";
+  markup(O, Markup::Immediate) << "#" << Imm;
 }
 
 void ARMInstPrinter::printRegisterList(const MCInst *MI, unsigned OpNum,
@@ -1043,29 +1057,27 @@ void ARMInstPrinter::printAdrLabelOperand(const MCInst *MI, unsigned OpNum,
 
   int32_t OffImm = (int32_t)MO.getImm() << scale;
 
-  O << markup("<imm:");
+  WithMarkup ScopedMarkup = markup(O, Markup::Immediate);
   if (OffImm == INT32_MIN)
     O << "#-0";
   else if (OffImm < 0)
     O << "#-" << -OffImm;
   else
     O << "#" << OffImm;
-  O << markup(">");
 }
 
 void ARMInstPrinter::printThumbS4ImmOperand(const MCInst *MI, unsigned OpNum,
                                             const MCSubtargetInfo &STI,
                                             raw_ostream &O) {
-  O << markup("<imm:") << "#" << formatImm(MI->getOperand(OpNum).getImm() * 4)
-    << markup(">");
+  markup(O, Markup::Immediate)
+      << "#" << formatImm(MI->getOperand(OpNum).getImm() * 4);
 }
 
 void ARMInstPrinter::printThumbSRImm(const MCInst *MI, unsigned OpNum,
                                      const MCSubtargetInfo &STI,
                                      raw_ostream &O) {
   unsigned Imm = MI->getOperand(OpNum).getImm();
-  O << markup("<imm:") << "#" << formatImm((Imm == 0 ? 32 : Imm))
-    << markup(">");
+  markup(O, Markup::Immediate) << "#" << formatImm((Imm == 0 ? 32 : Imm));
 }
 
 void ARMInstPrinter::printThumbITMask(const MCInst *MI, unsigned OpNum,
@@ -1094,13 +1106,14 @@ void ARMInstPrinter::printThumbAddrModeRROperand(const MCInst *MI, unsigned Op,
     return;
   }
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
   if (unsigned RegNum = MO2.getReg()) {
     O << ", ";
     printRegName(O, RegNum);
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printThumbAddrModeImm5SOperand(const MCInst *MI,
@@ -1116,13 +1129,14 @@ void ARMInstPrinter::printThumbAddrModeImm5SOperand(const MCInst *MI,
     return;
   }
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
   if (unsigned ImmOffs = MO2.getImm()) {
-    O << ", " << markup("<imm:") << "#" << formatImm(ImmOffs * Scale)
-      << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#" << formatImm(ImmOffs * Scale);
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printThumbAddrModeImm5S1Operand(const MCInst *MI,
@@ -1168,7 +1182,7 @@ void ARMInstPrinter::printT2SOOperand(const MCInst *MI, unsigned OpNum,
   // Print the shift opc.
   assert(MO2.isImm() && "Not a valid t2_so_reg value!");
   printRegImmShift(O, ARM_AM::getSORegShOp(MO2.getImm()),
-                   ARM_AM::getSORegOffset(MO2.getImm()), UseMarkup);
+                   ARM_AM::getSORegOffset(MO2.getImm()), *this);
 }
 
 template <bool AlwaysPrintImm0>
@@ -1183,7 +1197,8 @@ void ARMInstPrinter::printAddrModeImm12Operand(const MCInst *MI, unsigned OpNum,
     return;
   }
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
 
   int32_t OffImm = (int32_t)MO2.getImm();
@@ -1192,11 +1207,13 @@ void ARMInstPrinter::printAddrModeImm12Operand(const MCInst *MI, unsigned OpNum,
   if (OffImm == INT32_MIN)
     OffImm = 0;
   if (isSub) {
-    O << ", " << markup("<imm:") << "#-" << formatImm(-OffImm) << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#-" << formatImm(-OffImm);
   } else if (AlwaysPrintImm0 || OffImm > 0) {
-    O << ", " << markup("<imm:") << "#" << formatImm(OffImm) << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#" << formatImm(OffImm);
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 template <bool AlwaysPrintImm0>
@@ -1207,7 +1224,8 @@ void ARMInstPrinter::printT2AddrModeImm8Operand(const MCInst *MI,
   const MCOperand &MO1 = MI->getOperand(OpNum);
   const MCOperand &MO2 = MI->getOperand(OpNum + 1);
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
 
   int32_t OffImm = (int32_t)MO2.getImm();
@@ -1216,11 +1234,13 @@ void ARMInstPrinter::printT2AddrModeImm8Operand(const MCInst *MI,
   if (OffImm == INT32_MIN)
     OffImm = 0;
   if (isSub) {
-    O << ", " << markup("<imm:") << "#-" << -OffImm << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#-" << -OffImm;
   } else if (AlwaysPrintImm0 || OffImm > 0) {
-    O << ", " << markup("<imm:") << "#" << OffImm << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#" << OffImm;
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 template <bool AlwaysPrintImm0>
@@ -1236,7 +1256,8 @@ void ARMInstPrinter::printT2AddrModeImm8s4Operand(const MCInst *MI,
     return;
   }
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
 
   int32_t OffImm = (int32_t)MO2.getImm();
@@ -1248,11 +1269,13 @@ void ARMInstPrinter::printT2AddrModeImm8s4Operand(const MCInst *MI,
   if (OffImm == INT32_MIN)
     OffImm = 0;
   if (isSub) {
-    O << ", " << markup("<imm:") << "#-" << -OffImm << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#-" << -OffImm;
   } else if (AlwaysPrintImm0 || OffImm > 0) {
-    O << ", " << markup("<imm:") << "#" << OffImm << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#" << OffImm;
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printT2AddrModeImm0_1020s4Operand(
@@ -1261,13 +1284,14 @@ void ARMInstPrinter::printT2AddrModeImm0_1020s4Operand(
   const MCOperand &MO1 = MI->getOperand(OpNum);
   const MCOperand &MO2 = MI->getOperand(OpNum + 1);
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
   if (MO2.getImm()) {
-    O << ", " << markup("<imm:") << "#" << formatImm(MO2.getImm() * 4)
-      << markup(">");
+    O << ", ";
+    markup(O, Markup::Immediate) << "#" << formatImm(MO2.getImm() * 4);
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printT2AddrModeImm8OffsetOperand(
@@ -1275,14 +1299,14 @@ void ARMInstPrinter::printT2AddrModeImm8OffsetOperand(
     raw_ostream &O) {
   const MCOperand &MO1 = MI->getOperand(OpNum);
   int32_t OffImm = (int32_t)MO1.getImm();
-  O << ", " << markup("<imm:");
+  O << ", ";
+  WithMarkup ScopedMarkup = markup(O, Markup::Immediate);
   if (OffImm == INT32_MIN)
     O << "#-0";
   else if (OffImm < 0)
     O << "#-" << -OffImm;
   else
     O << "#" << OffImm;
-  O << markup(">");
 }
 
 void ARMInstPrinter::printT2AddrModeImm8s4OffsetOperand(
@@ -1293,14 +1317,14 @@ void ARMInstPrinter::printT2AddrModeImm8s4OffsetOperand(
 
   assert(((OffImm & 0x3) == 0) && "Not a valid immediate!");
 
-  O << ", " << markup("<imm:");
+  O << ", ";
+  WithMarkup ScopedMarkup = markup(O, Markup::Immediate);
   if (OffImm == INT32_MIN)
     O << "#-0";
   else if (OffImm < 0)
     O << "#-" << -OffImm;
   else
     O << "#" << OffImm;
-  O << markup(">");
 }
 
 void ARMInstPrinter::printT2AddrModeSoRegOperand(const MCInst *MI,
@@ -1311,7 +1335,8 @@ void ARMInstPrinter::printT2AddrModeSoRegOperand(const MCInst *MI,
   const MCOperand &MO2 = MI->getOperand(OpNum + 1);
   const MCOperand &MO3 = MI->getOperand(OpNum + 2);
 
-  O << markup("<mem:") << "[";
+  WithMarkup ScopedMarkup = markup(O, Markup::Memory);
+  O << "[";
   printRegName(O, MO1.getReg());
 
   assert(MO2.getReg() && "Invalid so_reg load / store address!");
@@ -1321,17 +1346,17 @@ void ARMInstPrinter::printT2AddrModeSoRegOperand(const MCInst *MI,
   unsigned ShAmt = MO3.getImm();
   if (ShAmt) {
     assert(ShAmt <= 3 && "Not a valid Thumb2 addressing mode!");
-    O << ", lsl " << markup("<imm:") << "#" << ShAmt << markup(">");
+    O << ", lsl ";
+    markup(O, Markup::Immediate) << "#" << ShAmt;
   }
-  O << "]" << markup(">");
+  O << "]";
 }
 
 void ARMInstPrinter::printFPImmOperand(const MCInst *MI, unsigned OpNum,
                                        const MCSubtargetInfo &STI,
                                        raw_ostream &O) {
   const MCOperand &MO = MI->getOperand(OpNum);
-  O << markup("<imm:") << '#' << ARM_AM::getFPImmFloat(MO.getImm())
-    << markup(">");
+  markup(O, Markup::Immediate) << '#' << ARM_AM::getFPImmFloat(MO.getImm());
 }
 
 void ARMInstPrinter::printVMOVModImmOperand(const MCInst *MI, unsigned OpNum,
@@ -1340,16 +1365,17 @@ void ARMInstPrinter::printVMOVModImmOperand(const MCInst *MI, unsigned OpNum,
   unsigned EncodedImm = MI->getOperand(OpNum).getImm();
   unsigned EltBits;
   uint64_t Val = ARM_AM::decodeVMOVModImm(EncodedImm, EltBits);
-  O << markup("<imm:") << "#0x";
+
+  WithMarkup ScopedMarkup = markup(O, Markup::Immediate);
+  O << "#0x";
   O.write_hex(Val);
-  O << markup(">");
 }
 
 void ARMInstPrinter::printImmPlusOneOperand(const MCInst *MI, unsigned OpNum,
                                             const MCSubtargetInfo &STI,
                                             raw_ostream &O) {
   unsigned Imm = MI->getOperand(OpNum).getImm();
-  O << markup("<imm:") << "#" << formatImm(Imm + 1) << markup(">");
+  markup(O, Markup::Immediate) << "#" << formatImm(Imm + 1);
 }
 
 void ARMInstPrinter::printRotImmOperand(const MCInst *MI, unsigned OpNum,
@@ -1359,7 +1385,8 @@ void ARMInstPrinter::printRotImmOperand(const MCInst *MI, unsigned OpNum,
   if (Imm == 0)
     return;
   assert(Imm <= 3 && "illegal ror immediate!");
-  O << ", ror " << markup("<imm:") << "#" << 8 * Imm << markup(">");
+  O << ", ror ";
+  markup(O, Markup::Immediate) << "#" << 8 * Imm;
 }
 
 void ARMInstPrinter::printModImmOperand(const MCInst *MI, unsigned OpNum,
@@ -1389,30 +1416,29 @@ void ARMInstPrinter::printModImmOperand(const MCInst *MI, unsigned OpNum,
   int32_t Rotated = llvm::rotr<uint32_t>(Bits, Rot);
   if (ARM_AM::getSOImmVal(Rotated) == Op.getImm()) {
     // #rot has the least possible value
-    O << "#" << markup("<imm:");
+    O << "#";
     if (PrintUnsigned)
-      O << static_cast<uint32_t>(Rotated);
+      markup(O, Markup::Immediate) << static_cast<uint32_t>(Rotated);
     else
-      O << Rotated;
-    O << markup(">");
+      markup(O, Markup::Immediate) << Rotated;
     return;
   }
 
   // Explicit #bits, #rot implied
-  O << "#" << markup("<imm:") << Bits << markup(">") << ", #" << markup("<imm:")
-    << Rot << markup(">");
+  O << "#";
+  markup(O, Markup::Immediate) << Bits;
+  O << ", #";
+  markup(O, Markup::Immediate) << Rot;
 }
 
 void ARMInstPrinter::printFBits16(const MCInst *MI, unsigned OpNum,
                                   const MCSubtargetInfo &STI, raw_ostream &O) {
-  O << markup("<imm:") << "#" << 16 - MI->getOperand(OpNum).getImm()
-    << markup(">");
+  markup(O, Markup::Immediate) << "#" << 16 - MI->getOperand(OpNum).getImm();
 }
 
 void ARMInstPrinter::printFBits32(const MCInst *MI, unsigned OpNum,
                                   const MCSubtargetInfo &STI, raw_ostream &O) {
-  O << markup("<imm:") << "#" << 32 - MI->getOperand(OpNum).getImm()
-    << markup(">");
+  markup(O, Markup::Immediate) << "#" << 32 - MI->getOperand(OpNum).getImm();
 }
 
 void ARMInstPrinter::printVectorIndex(const MCInst *MI, unsigned OpNum,


### PR DESCRIPTION
Adopt the new markup overload, introduced in 77d1032, in the ARM backend. This commit completes the migration and removes the old overload.