### PR TITLE
[NFC]Add assert to avoid possibly deref nullptr

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinterInlineAsm.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinterInlineAsm.cpp
@@ -400,6 +400,7 @@ void AsmPrinter::emitInlineAsm(const MachineInstr *MI) const {
         "Reserved registers on the clobber list may not be "
         "preserved across the asm statement, and clobbering them may "
         "lead to undefined behaviour.";
+    assert(MMI && "MMI can not be nullptr!");
     MMI->getModule()->getContext().diagnose(DiagnosticInfoInlineAsm(
         LocCookie, Msg, DiagnosticSeverity::DS_Warning));
     MMI->getModule()->getContext().diagnose(

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -769,6 +769,7 @@ void X86AsmPrinter::emitStartOfAsmFile(Module &M) {
       if (!TT.isArch32Bit() && !TT.isArch64Bit())
         llvm_unreachable("CFProtection used on invalid architecture!");
       MCSection *Cur = OutStreamer->getCurrentSectionOnly();
+      assert(MMI && "MMI can not be nullptr!");
       MCSection *Nt = MMI->getContext().getELFSection(
           ".note.gnu.property", ELF::SHT_NOTE, ELF::SHF_ALLOC);
       OutStreamer->switchSection(Nt);


### PR DESCRIPTION
These 2 functions could be called by AsmPrinter::doInitialization in AsmPrinter.cpp. doInitialization init MMI in the beginning`MMI = MMIWP ? &MMIWP->getMMI() : nullptr;`, MMI has the possibility to be nullptr, which could make the later deref crash. I think in most time MMI could not be nullptr, but from the view of function implementation, it could be, so I'd like to add assert to it, if this could be a problem, then we could avoid crash.