### PR TITLE
[llvm] Use llvm::any_cast instead of any_cast (NFC)

### DIFF
--- a/llvm/lib/CodeGen/MachinePassManager.cpp
+++ b/llvm/lib/CodeGen/MachinePassManager.cpp
@@ -41,8 +41,8 @@ Error MachineFunctionPassManager::run(Module &M,
     // current pipeline is the top-level pipeline. Callbacks are not used after
     // current pipeline.
     PI.pushBeforeNonSkippedPassCallback([&MFAM](StringRef PassID, Any IR) {
-      assert(any_cast<const MachineFunction *>(&IR));
-      const MachineFunction *MF = any_cast<const MachineFunction *>(IR);
+      assert(llvm::any_cast<const MachineFunction *>(&IR));
+      const MachineFunction *MF = llvm::any_cast<const MachineFunction *>(IR);
       assert(MF && "Machine function should be valid for printing");
       std::string Banner = std::string("After ") + std::string(PassID);
       verifyMachineFunction(&MFAM, Banner, *MF);

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -137,17 +137,17 @@ static cl::opt<std::string>
 /// Extract Module out of \p IR unit. May return nullptr if \p IR does not match
 /// certain global filters. Will never return nullptr if \p Force is true.
 const Module *unwrapModule(Any IR, bool Force = false) {
-  if (const auto **M = any_cast<const Module *>(&IR))
+  if (const auto **M = llvm::any_cast<const Module *>(&IR))
     return *M;
 
-  if (const auto **F = any_cast<const Function *>(&IR)) {
+  if (const auto **F = llvm::any_cast<const Function *>(&IR)) {
     if (!Force && !isFunctionInPrintList((*F)->getName()))
       return nullptr;
 
     return (*F)->getParent();
   }
 
-  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR)) {
+  if (const auto **C = llvm::any_cast<const LazyCallGraph::SCC *>(&IR)) {
     for (const LazyCallGraph::Node &N : **C) {
       const Function &F = N.getFunction();
       if (Force || (!F.isDeclaration() && isFunctionInPrintList(F.getName()))) {
@@ -158,7 +158,7 @@ const Module *unwrapModule(Any IR, bool Force = false) {
     return nullptr;
   }
 
-  if (const auto **L = any_cast<const Loop *>(&IR)) {
+  if (const auto **L = llvm::any_cast<const Loop *>(&IR)) {
     const Function *F = (*L)->getHeader()->getParent();
     if (!Force && !isFunctionInPrintList(F->getName()))
       return nullptr;
@@ -201,16 +201,16 @@ void printIR(raw_ostream &OS, const Loop *L) {
 }
 
 std::string getIRName(Any IR) {
-  if (any_cast<const Module *>(&IR))
+  if (llvm::any_cast<const Module *>(&IR))
     return "[module]";
 
-  if (const auto **F = any_cast<const Function *>(&IR))
+  if (const auto **F = llvm::any_cast<const Function *>(&IR))
     return (*F)->getName().str();
 
-  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+  if (const auto **C = llvm::any_cast<const LazyCallGraph::SCC *>(&IR))
     return (*C)->getName();
 
-  if (const auto **L = any_cast<const Loop *>(&IR))
+  if (const auto **L = llvm::any_cast<const Loop *>(&IR))
     return (*L)->getName().str();
 
   llvm_unreachable("Unknown wrapped IR type");
@@ -233,16 +233,16 @@ bool sccContainsFilterPrintFunc(const LazyCallGraph::SCC &C) {
 }
 
 bool shouldPrintIR(Any IR) {
-  if (const auto **M = any_cast<const Module *>(&IR))
+  if (const auto **M = llvm::any_cast<const Module *>(&IR))
     return moduleContainsFilterPrintFunc(**M);
 
-  if (const auto **F = any_cast<const Function *>(&IR))
+  if (const auto **F = llvm::any_cast<const Function *>(&IR))
     return isFunctionInPrintList((*F)->getName());
 
-  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+  if (const auto **C = llvm::any_cast<const LazyCallGraph::SCC *>(&IR))
     return sccContainsFilterPrintFunc(**C);
 
-  if (const auto **L = any_cast<const Loop *>(&IR))
+  if (const auto **L = llvm::any_cast<const Loop *>(&IR))
     return isFunctionInPrintList((*L)->getHeader()->getParent()->getName());
   llvm_unreachable("Unknown wrapped IR type");
 }
@@ -260,22 +260,22 @@ void unwrapAndPrint(raw_ostream &OS, Any IR) {
     return;
   }
 
-  if (const auto **M = any_cast<const Module *>(&IR)) {
+  if (const auto **M = llvm::any_cast<const Module *>(&IR)) {
     printIR(OS, *M);
     return;
   }
 
-  if (const auto **F = any_cast<const Function *>(&IR)) {
+  if (const auto **F = llvm::any_cast<const Function *>(&IR)) {
     printIR(OS, *F);
     return;
   }
 
-  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR)) {
+  if (const auto **C = llvm::any_cast<const LazyCallGraph::SCC *>(&IR)) {
     printIR(OS, *C);
     return;
   }
 
-  if (const auto **L = any_cast<const Loop *>(&IR)) {
+  if (const auto **L = llvm::any_cast<const Loop *>(&IR)) {
     printIR(OS, *L);
     return;
   }
@@ -306,9 +306,9 @@ std::string makeHTMLReady(StringRef SR) {
 
 // Return the module when that is the appropriate level of comparison for \p IR.
 const Module *getModuleForComparison(Any IR) {
-  if (const auto **M = any_cast<const Module *>(&IR))
+  if (const auto **M = llvm::any_cast<const Module *>(&IR))
     return *M;
-  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+  if (const auto **C = llvm::any_cast<const LazyCallGraph::SCC *>(&IR))
     return (*C)
         ->begin()
         ->getFunction()
@@ -325,7 +325,7 @@ bool isInterestingFunction(const Function &F) {
 bool isInteresting(Any IR, StringRef PassID, StringRef PassName) {
   if (isIgnored(PassID) || !isPassInPrintList(PassName))
     return false;
-  if (const auto **F = any_cast<const Function *>(&IR))
+  if (const auto **F = llvm::any_cast<const Function *>(&IR))
     return isInterestingFunction(**F);
   return true;
 }
@@ -648,10 +648,10 @@ template <typename T> void IRComparer<T>::analyzeIR(Any IR, IRDataT<T> &Data) {
     return;
   }
 
-  const Function **FPtr = any_cast<const Function *>(&IR);
+  const Function **FPtr = llvm::any_cast<const Function *>(&IR);
   const Function *F = FPtr ? *FPtr : nullptr;
   if (!F) {
-    const Loop **L = any_cast<const Loop *>(&IR);
+    const Loop **L = llvm::any_cast<const Loop *>(&IR);
     assert(L && "Unknown IR unit.");
     F = (*L)->getHeader()->getParent();
   }
@@ -837,10 +837,10 @@ void OptNoneInstrumentation::registerCallbacks(
 }
 
 bool OptNoneInstrumentation::shouldRun(StringRef PassID, Any IR) {
-  const Function **FPtr = any_cast<const Function *>(&IR);
+  const Function **FPtr = llvm::any_cast<const Function *>(&IR);
   const Function *F = FPtr ? *FPtr : nullptr;
   if (!F) {
-    if (const auto **L = any_cast<const Loop *>(&IR))
+    if (const auto **L = llvm::any_cast<const Loop *>(&IR))
       F = (*L)->getHeader()->getParent();
   }
   bool ShouldRun = !(F && F->hasOptNone());
@@ -916,13 +916,14 @@ void PrintPassInstrumentation::registerCallbacks(
 
     auto &OS = print();
     OS << "Running pass: " << PassID << " on " << getIRName(IR);
-    if (const auto **F = any_cast<const Function *>(&IR)) {
+    if (const auto **F = llvm::any_cast<const Function *>(&IR)) {
       unsigned Count = (*F)->getInstructionCount();
       OS << " (" << Count << " instruction";
       if (Count != 1)
         OS << 's';
       OS << ')';
-    } else if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR)) {
+    } else if (const auto **C =
+                   llvm::any_cast<const LazyCallGraph::SCC *>(&IR)) {
       int Count = (*C)->size();
       OS << " (" << Count << " node";
       if (Count != 1)
@@ -1138,9 +1139,9 @@ bool PreservedCFGCheckerInstrumentation::CFG::invalidate(
 static SmallVector<Function *, 1> GetFunctions(Any IR) {
   SmallVector<Function *, 1> Functions;
 
-  if (const auto **MaybeF = any_cast<const Function *>(&IR)) {
+  if (const auto **MaybeF = llvm::any_cast<const Function *>(&IR)) {
     Functions.push_back(*const_cast<Function **>(MaybeF));
-  } else if (const auto **MaybeM = any_cast<const Module *>(&IR)) {
+  } else if (const auto **MaybeM = llvm::any_cast<const Module *>(&IR)) {
     for (Function &F : **const_cast<Module **>(MaybeM))
       Functions.push_back(&F);
   }
@@ -1176,7 +1177,7 @@ void PreservedCFGCheckerInstrumentation::registerCallbacks(
       FAM.getResult<PreservedFunctionHashAnalysis>(*F);
     }
 
-    if (auto *MaybeM = any_cast<const Module *>(&IR)) {
+    if (auto *MaybeM = llvm::any_cast<const Module *>(&IR)) {
       Module &M = **const_cast<Module **>(MaybeM);
       MAM.getResult<PreservedModuleHashAnalysis>(M);
     }
@@ -1235,7 +1236,7 @@ void PreservedCFGCheckerInstrumentation::registerCallbacks(
         CheckCFG(P, F->getName(), *GraphBefore,
                  CFG(F, /* TrackBBLifetime */ false));
     }
-    if (auto *MaybeM = any_cast<const Module *>(&IR)) {
+    if (auto *MaybeM = llvm::any_cast<const Module *>(&IR)) {
       Module &M = **const_cast<Module **>(MaybeM);
       if (auto *HashBefore =
               MAM.getCachedResult<PreservedModuleHashAnalysis>(M)) {
@@ -1254,10 +1255,10 @@ void VerifyInstrumentation::registerCallbacks(
       [this](StringRef P, Any IR, const PreservedAnalyses &PassPA) {
         if (isIgnored(P) || P == "VerifierPass")
           return;
-        const Function **FPtr = any_cast<const Function *>(&IR);
+        const Function **FPtr = llvm::any_cast<const Function *>(&IR);
         const Function *F = FPtr ? *FPtr : nullptr;
         if (!F) {
-          if (const auto **L = any_cast<const Loop *>(&IR))
+          if (const auto **L = llvm::any_cast<const Loop *>(&IR))
             F = (*L)->getHeader()->getParent();
         }
 
@@ -1268,10 +1269,11 @@ void VerifyInstrumentation::registerCallbacks(
           if (verifyFunction(*F, &errs()))
             report_fatal_error("Broken function found, compilation aborted!");
         } else {
-          const Module **MPtr = any_cast<const Module *>(&IR);
+          const Module **MPtr = llvm::any_cast<const Module *>(&IR);
           const Module *M = MPtr ? *MPtr : nullptr;
           if (!M) {
-            if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+            if (const auto **C =
+                    llvm::any_cast<const LazyCallGraph::SCC *>(&IR))
               M = (*C)->begin()->getFunction().getParent();
           }
 

--- a/llvm/lib/Transforms/IPO/SampleProfileProbe.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileProbe.cpp
@@ -95,13 +95,13 @@ void PseudoProbeVerifier::runAfterPass(StringRef PassID, Any IR) {
   std::string Banner =
       "\n*** Pseudo Probe Verification After " + PassID.str() + " ***\n";
   dbgs() << Banner;
-  if (const auto **M = any_cast<const Module *>(&IR))
+  if (const auto **M = llvm::any_cast<const Module *>(&IR))
     runAfterPass(*M);
-  else if (const auto **F = any_cast<const Function *>(&IR))
+  else if (const auto **F = llvm::any_cast<const Function *>(&IR))
     runAfterPass(*F);
-  else if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+  else if (const auto **C = llvm::any_cast<const LazyCallGraph::SCC *>(&IR))
     runAfterPass(*C);
-  else if (const auto **L = any_cast<const Loop *>(&IR))
+  else if (const auto **L = llvm::any_cast<const Loop *>(&IR))
     runAfterPass(*L);
   else
     llvm_unreachable("Unknown IR unit");

--- a/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopPassManager.cpp
@@ -269,11 +269,12 @@ PreservedAnalyses FunctionToLoopPassAdaptor::run(Function &F,
   PI.pushBeforeNonSkippedPassCallback([&LAR, &LI](StringRef PassID, Any IR) {
     if (isSpecialPass(PassID, {"PassManager"}))
       return;
-    assert(any_cast<const Loop *>(&IR) || any_cast<const LoopNest *>(&IR));
-    const Loop **LPtr = any_cast<const Loop *>(&IR);
+    assert(llvm::any_cast<const Loop *>(&IR) ||
+           llvm::any_cast<const LoopNest *>(&IR));
+    const Loop **LPtr = llvm::any_cast<const Loop *>(&IR);
     const Loop *L = LPtr ? *LPtr : nullptr;
     if (!L)
-      L = &any_cast<const LoopNest *>(IR)->getOutermostLoop();
+      L = &llvm::any_cast<const LoopNest *>(IR)->getOutermostLoop();
     assert(L && "Loop should be valid for printing");
 
     // Verify the loop structure and LCSSA form before visiting the loop.

--- a/llvm/lib/Transforms/Utils/Debugify.cpp
+++ b/llvm/lib/Transforms/Utils/Debugify.cpp
@@ -1035,13 +1035,13 @@ void DebugifyEachInstrumentation::registerCallbacks(
       return;
     PreservedAnalyses PA;
     PA.preserveSet<CFGAnalyses>();
-    if (const auto **CF = any_cast<const Function *>(&IR)) {
+    if (const auto **CF = llvm::any_cast<const Function *>(&IR)) {
       Function &F = *const_cast<Function *>(*CF);
       applyDebugify(F, Mode, DebugInfoBeforePass, P);
       MAM.getResult<FunctionAnalysisManagerModuleProxy>(*F.getParent())
           .getManager()
           .invalidate(F, PA);
-    } else if (const auto **CM = any_cast<const Module *>(&IR)) {
+    } else if (const auto **CM = llvm::any_cast<const Module *>(&IR)) {
       Module &M = *const_cast<Module *>(*CM);
       applyDebugify(M, Mode, DebugInfoBeforePass, P);
       MAM.invalidate(M, PA);
@@ -1053,7 +1053,7 @@ void DebugifyEachInstrumentation::registerCallbacks(
           return;
         PreservedAnalyses PA;
         PA.preserveSet<CFGAnalyses>();
-        if (const auto **CF = any_cast<const Function *>(&IR)) {
+        if (const auto **CF = llvm::any_cast<const Function *>(&IR)) {
           auto &F = *const_cast<Function *>(*CF);
           Module &M = *F.getParent();
           auto It = F.getIterator();
@@ -1069,7 +1069,7 @@ void DebugifyEachInstrumentation::registerCallbacks(
           MAM.getResult<FunctionAnalysisManagerModuleProxy>(*F.getParent())
               .getManager()
               .invalidate(F, PA);
-        } else if (const auto **CM = any_cast<const Module *>(&IR)) {
+        } else if (const auto **CM = llvm::any_cast<const Module *>(&IR)) {
           Module &M = *const_cast<Module *>(*CM);
           if (Mode == DebugifyMode::SyntheticDebugInfo)
             checkDebugifyMetadata(M, M.functions(), P, "CheckModuleDebugify",

--- a/llvm/unittests/ADT/AnyTest.cpp
+++ b/llvm/unittests/ADT/AnyTest.cpp
@@ -24,55 +24,55 @@ TEST(AnyTest, ConstructionAndAssignment) {
 
   // An empty Any is not anything.
   EXPECT_FALSE(A.has_value());
-  EXPECT_FALSE(any_cast<int>(&A));
+  EXPECT_FALSE(llvm::any_cast<int>(&A));
 
   // An int is an int but not something else.
   EXPECT_TRUE(B.has_value());
-  EXPECT_TRUE(any_cast<int>(&B));
-  EXPECT_FALSE(any_cast<float>(&B));
+  EXPECT_TRUE(llvm::any_cast<int>(&B));
+  EXPECT_FALSE(llvm::any_cast<float>(&B));
 
   EXPECT_TRUE(C.has_value());
-  EXPECT_TRUE(any_cast<int>(&C));
+  EXPECT_TRUE(llvm::any_cast<int>(&C));
 
   // A const char * is a const char * but not an int.
   EXPECT_TRUE(D.has_value());
-  EXPECT_TRUE(any_cast<const char *>(&D));
-  EXPECT_FALSE(any_cast<int>(&D));
+  EXPECT_TRUE(llvm::any_cast<const char *>(&D));
+  EXPECT_FALSE(llvm::any_cast<int>(&D));
 
   // A double is a double but not a float.
   EXPECT_TRUE(E.has_value());
-  EXPECT_TRUE(any_cast<double>(&E));
-  EXPECT_FALSE(any_cast<float>(&E));
+  EXPECT_TRUE(llvm::any_cast<double>(&E));
+  EXPECT_FALSE(llvm::any_cast<float>(&E));
 
   // After copy constructing from an int, the new item and old item are both
   // ints.
   llvm::Any F(B);
   EXPECT_TRUE(B.has_value());
   EXPECT_TRUE(F.has_value());
-  EXPECT_TRUE(any_cast<int>(&F));
-  EXPECT_TRUE(any_cast<int>(&B));
+  EXPECT_TRUE(llvm::any_cast<int>(&F));
+  EXPECT_TRUE(llvm::any_cast<int>(&B));
 
   // After move constructing from an int, the new item is an int and the old one
   // isn't.
   llvm::Any G(std::move(C));
   EXPECT_FALSE(C.has_value());
   EXPECT_TRUE(G.has_value());
-  EXPECT_TRUE(any_cast<int>(&G));
-  EXPECT_FALSE(any_cast<int>(&C));
+  EXPECT_TRUE(llvm::any_cast<int>(&G));
+  EXPECT_FALSE(llvm::any_cast<int>(&C));
 
   // After copy-assigning from an int, the new item and old item are both ints.
   A = F;
   EXPECT_TRUE(A.has_value());
   EXPECT_TRUE(F.has_value());
-  EXPECT_TRUE(any_cast<int>(&A));
-  EXPECT_TRUE(any_cast<int>(&F));
+  EXPECT_TRUE(llvm::any_cast<int>(&A));
+  EXPECT_TRUE(llvm::any_cast<int>(&F));
 
   // After move-assigning from an int, the new item and old item are both ints.
   B = std::move(G);
   EXPECT_TRUE(B.has_value());
   EXPECT_FALSE(G.has_value());
-  EXPECT_TRUE(any_cast<int>(&B));
-  EXPECT_FALSE(any_cast<int>(&G));
+  EXPECT_TRUE(llvm::any_cast<int>(&B));
+  EXPECT_FALSE(llvm::any_cast<int>(&G));
 }
 
 TEST(AnyTest, GoodAnyCast) {

--- a/llvm/unittests/IR/PassBuilderCallbacksTest.cpp
+++ b/llvm/unittests/IR/PassBuilderCallbacksTest.cpp
@@ -291,15 +291,16 @@ template <> std::string getName(const StringRef &name) {
 }
 
 template <> std::string getName(const Any &WrappedIR) {
-  if (const auto *const *M = any_cast<const Module *>(&WrappedIR))
+  if (const auto *const *M = llvm::any_cast<const Module *>(&WrappedIR))
     return (*M)->getName().str();
-  if (const auto *const *F = any_cast<const Function *>(&WrappedIR))
+  if (const auto *const *F = llvm::any_cast<const Function *>(&WrappedIR))
     return (*F)->getName().str();
-  if (const auto *const *L = any_cast<const Loop *>(&WrappedIR))
+  if (const auto *const *L = llvm::any_cast<const Loop *>(&WrappedIR))
     return (*L)->getName().str();
-  if (const auto *const *L = any_cast<const LoopNest *>(&WrappedIR))
+  if (const auto *const *L = llvm::any_cast<const LoopNest *>(&WrappedIR))
     return (*L)->getName().str();
-  if (const auto *const *C = any_cast<const LazyCallGraph::SCC *>(&WrappedIR))
+  if (const auto *const *C =
+          llvm::any_cast<const LazyCallGraph::SCC *>(&WrappedIR))
     return (*C)->getName();
   return "<UNKNOWN>";
 }


### PR DESCRIPTION
This patch replaces any_cast with llvm::any_cast.  This in turn allows us to gracefully switch to std::any in future by forwarding llvm::Any and llvm::any_cast to:

  using Any = std::any;

  template <class T> T *any_cast(Any *Value) {
    return std::any_cast<T>(Value);
  }

respectively.

Without this patch, it's ambiguous whether any_cast refers to std::any_cast or llvm::any_cast.

As an added bonus, this patch makes it easier to mechanically replace llvm::any_cast with std::any_cast without affecting other occurrences of any_cast (e.g. in libcxx).