### PR TITLE
[mlir][tensor] Check the EmptyOp's dynamicSize to be non-negative

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -621,18 +621,6 @@ LogicalResult EmptyOp::verify() {
     return emitOpError("incorrect number of dynamic sizes, has ")
            << getDynamicSizes().size() << ", expected "
            << getType().getNumDynamicDims();
-
-  if (getDynamicSizes().size() > 0) {
-    if (llvm::any_of(getDynamicSizes(), [](Value operand) {
-          APInt constSizeArg;
-          if (!matchPattern(operand, m_ConstantInt(&constSizeArg))) {
-            return false;
-          }
-          return constSizeArg.isNegative();
-        }))
-      return emitOpError("dynamic size must be non-negative");
-  }
-
   return success();
 }
 

--- a/mlir/test/Dialect/Tensor/canonicalize.mlir
+++ b/mlir/test/Dialect/Tensor/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -split-input-file -canonicalize="test-convergence" | FileCheck %s
+// RUN: mlir-opt %s -split-input-file -canonicalize="test-convergence" -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: @tensor_bitcast_chain_ok
 // CHECK-SAME: %[[IN:.*]]: tensor<2xi32>
@@ -1847,4 +1847,15 @@ func.func @pack_unpack_dynamic_with_padding(%t: tensor<?x?x?x?xf32>, %dim1: inde
   %tensor_empty1 = tensor.empty(%dim3, %dim4, %dim5, %dim6) : tensor<?x?x?x?xf32>
   %packed = tensor.pack %unpacked padding_value(%pad: f32) inner_dims_pos = [0, 1] inner_tiles = [%tile1, %tile2] into %tensor_empty1 : tensor<?x?xf32> -> tensor<?x?x?x?xf32>
   return %packed : tensor<?x?x?x?xf32>
+}
+
+// -----
+
+func.func @invalid_empty_negative_size() -> (tensor<4x5x?xf32>) {
+  %c1 = arith.constant 1 : index
+  %cn2 = arith.constant 2 : index
+  %0 = index.sub %c1, %cn2
+  // expected-error@+1 {{dynamic size must be non-negative}}
+  %1 = tensor.empty(%0) : tensor<4x5x?xf32>
+  return %1 : tensor<4x5x?xf32>
 }

--- a/mlir/test/Dialect/Tensor/canonicalize.mlir
+++ b/mlir/test/Dialect/Tensor/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -split-input-file -canonicalize="test-convergence" -verify-diagnostics | FileCheck %s
+// RUN: mlir-opt %s -split-input-file -canonicalize="test-convergence" | FileCheck %s
 
 // CHECK-LABEL: @tensor_bitcast_chain_ok
 // CHECK-SAME: %[[IN:.*]]: tensor<2xi32>
@@ -1851,11 +1851,13 @@ func.func @pack_unpack_dynamic_with_padding(%t: tensor<?x?x?x?xf32>, %dim1: inde
 
 // -----
 
+// CHECK: func.func @invalid_empty_negative_size
+// CHECK: %[[IDX:.*]] = index.constant
+// CHECK: %[[T:.*]] = tensor.empty(%[[IDX]]) : tensor<4x5x?xf32>
 func.func @invalid_empty_negative_size() -> (tensor<4x5x?xf32>) {
   %c1 = arith.constant 1 : index
   %cn2 = arith.constant 2 : index
   %0 = index.sub %c1, %cn2
-  // expected-error@+1 {{dynamic size must be non-negative}}
   %1 = tensor.empty(%0) : tensor<4x5x?xf32>
   return %1 : tensor<4x5x?xf32>
 }

--- a/mlir/test/Dialect/Tensor/invalid.mlir
+++ b/mlir/test/Dialect/Tensor/invalid.mlir
@@ -553,6 +553,15 @@ func.func @empty_wrong_number_of_operands(%sz : index) {
 
 // -----
 
+func.func @empty_negative_size(%sz : index) {
+  %0 = arith.constant -1 : index
+  // expected-error@+1 {{dynamic size must be non-negative}}
+  %out = tensor.empty(%sz, %0) : tensor<2x?x?x5xf32>
+  return
+}
+
+// -----
+
 func.func @pack_invalid_no_padding_no_full_tiles(%input: tensor<256x128xf32>, %output: tensor<8x8x16x33xf32>) -> tensor<8x8x16x33xf32> {
   // expected-error@+1 {{invalid tile factor provided. Only full tiles are supported when padding_value is not set}}
   %0 = tensor.pack %input inner_dims_pos = [1, 0] inner_tiles = [16, 33] into %output : tensor<256x128xf32>  -> tensor<8x8x16x33xf32>

--- a/mlir/test/Dialect/Tensor/invalid.mlir
+++ b/mlir/test/Dialect/Tensor/invalid.mlir
@@ -553,15 +553,6 @@ func.func @empty_wrong_number_of_operands(%sz : index) {
 
 // -----
 
-func.func @empty_negative_size(%sz : index) {
-  %0 = arith.constant -1 : index
-  // expected-error@+1 {{dynamic size must be non-negative}}
-  %out = tensor.empty(%sz, %0) : tensor<2x?x?x5xf32>
-  return
-}
-
-// -----
-
 func.func @pack_invalid_no_padding_no_full_tiles(%input: tensor<256x128xf32>, %output: tensor<8x8x16x33xf32>) -> tensor<8x8x16x33xf32> {
   // expected-error@+1 {{invalid tile factor provided. Only full tiles are supported when padding_value is not set}}
   %0 = tensor.pack %input inner_dims_pos = [1, 0] inner_tiles = [16, 33] into %output : tensor<256x128xf32>  -> tensor<8x8x16x33xf32>


### PR DESCRIPTION
This patch addresses a crash that occurs when negative dynamic sizes are provided in tensor.emptyOp by adding a check to ensure that dynamic sizes are non-negative.

Fixes #64064