### PR TITLE
[X86] Simplify the API of FixupBWInstPass::getSuperRegDestIfDead. NFC.

### DIFF
--- a/llvm/lib/Target/X86/X86FixupBWInsts.cpp
+++ b/llvm/lib/Target/X86/X86FixupBWInsts.cpp
@@ -79,11 +79,10 @@ class FixupBWInstPass : public MachineFunctionPass {
   /// byte or word instructions with better alternatives.
   void processBasicBlock(MachineFunction &MF, MachineBasicBlock &MBB);
 
-  /// This sets the \p SuperDestReg to the 32 bit super reg of the original
-  /// destination register of the MachineInstr passed in. It returns true if
-  /// that super register is dead just prior to \p OrigMI, and false if not.
-  bool getSuperRegDestIfDead(MachineInstr *OrigMI,
-                             Register &SuperDestReg) const;
+  /// This returns the 32 bit super reg of the original destination register of
+  /// the MachineInstr passed in, if that super register is dead just prior to
+  /// \p OrigMI. Otherwise it returns Register().
+  Register getSuperRegDestIfDead(MachineInstr *OrigMI) const;
 
   /// Change the MachineInstr \p MI into the equivalent extending load to 32 bit
   /// register if it is safe to do so.  Return the replacement instruction if
@@ -188,11 +187,10 @@ bool FixupBWInstPass::runOnMachineFunction(MachineFunction &MF) {
 /// destination register.
 ///
 /// If so, return that super register in \p SuperDestReg.
-bool FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI,
-                                            Register &SuperDestReg) const {
+Register FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI) const {
   const X86RegisterInfo *TRI = &TII->getRegisterInfo();
   Register OrigDestReg = OrigMI->getOperand(0).getReg();
-  SuperDestReg = getX86SubSuperRegister(OrigDestReg, 32);
+  Register SuperDestReg = getX86SubSuperRegister(OrigDestReg, 32);
   assert(SuperDestReg.isValid() && "Invalid Operand");
 
   const auto SubRegIdx = TRI->getSubRegIndex(SuperDestReg, OrigDestReg);
@@ -202,7 +200,7 @@ bool FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI,
   // If it isn't, then the register isn't really dead even if the
   // super-register is considered dead.
   if (SubRegIdx == X86::sub_8bit_hi)
-    return false;
+    return Register();
 
   // If neither the destination-super register nor any applicable subregisters
   // are live after this instruction, then the super register is safe to use.
@@ -210,14 +208,14 @@ bool FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI,
     // If the original destination register was not the low 8-bit subregister
     // then the super register check is sufficient.
     if (SubRegIdx != X86::sub_8bit)
-      return true;
+      return SuperDestReg;
     // If the original destination register was the low 8-bit subregister and
     // we also need to check the 16-bit subregister and the high 8-bit
     // subregister.
     MCRegister HighReg = getX86SubSuperRegister(SuperDestReg, 8, /*High=*/true);
     if (!LiveRegs.contains(getX86SubSuperRegister(OrigDestReg, 16)) &&
         (!HighReg.isValid() || !LiveRegs.contains(HighReg)))
-      return true;
+      return SuperDestReg;
     // Otherwise, we have a little more checking to do.
   }
 
@@ -257,7 +255,7 @@ bool FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI,
   // same properties.
   if (Opc != X86::MOV8rm && Opc != X86::MOV16rm && Opc != X86::MOV8rr &&
       Opc != X86::MOV16rr)
-    return false;
+    return Register();
 
   bool IsDefined = false;
   for (auto &MO: OrigMI->implicit_operands()) {
@@ -275,26 +273,25 @@ bool FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI,
     // %eax, or %rax will prevent us from using the %eax register.
     if (MO.isUse() && !TRI->isSubRegisterEq(OrigDestReg, MO.getReg()) &&
         TRI->regsOverlap(SuperDestReg, MO.getReg()))
-      return false;
+      return Register();
   }
   // Reg is not Imp-def'ed -> it's live both before/after the instruction.
   if (!IsDefined)
-    return false;
+    return Register();
 
   // Otherwise, the Reg is not live before the MI and the MOV can't
   // make it really live, so it's in fact dead even after the MI.
-  return true;
+  return SuperDestReg;
 }
 
 MachineInstr *FixupBWInstPass::tryReplaceLoad(unsigned New32BitOpcode,
                                               MachineInstr *MI) const {
-  Register NewDestReg;
-
   // We are going to try to rewrite this load to a larger zero-extending
   // load.  This is safe if all portions of the 32 bit super-register
   // of the original destination register, except for the original destination
   // register are dead. getSuperRegDestIfDead checks that.
-  if (!getSuperRegDestIfDead(MI, NewDestReg))
+  Register NewDestReg = getSuperRegDestIfDead(MI);
+  if (!NewDestReg)
     return nullptr;
 
   // Safe to change the instruction.
@@ -323,8 +320,8 @@ MachineInstr *FixupBWInstPass::tryReplaceCopy(MachineInstr *MI) const {
   auto &OldDest = MI->getOperand(0);
   auto &OldSrc = MI->getOperand(1);
 
-  Register NewDestReg;
-  if (!getSuperRegDestIfDead(MI, NewDestReg))
+  Register NewDestReg = getSuperRegDestIfDead(MI);
+  if (!NewDestReg)
     return nullptr;
 
   Register NewSrcReg = getX86SubSuperRegister(OldSrc.getReg(), 32);
@@ -357,8 +354,8 @@ MachineInstr *FixupBWInstPass::tryReplaceCopy(MachineInstr *MI) const {
 
 MachineInstr *FixupBWInstPass::tryReplaceExtend(unsigned New32BitOpcode,
                                                 MachineInstr *MI) const {
-  Register NewDestReg;
-  if (!getSuperRegDestIfDead(MI, NewDestReg))
+  Register NewDestReg = getSuperRegDestIfDead(MI);
+  if (!NewDestReg)
     return nullptr;
 
   // Don't interfere with formation of CBW instructions which should be a


### PR DESCRIPTION
It is easy to check the returned register for validity so there is no
need to return a separate boolean flag.
