### PR TITLE
[AMDGPU] Fix V_MOV_B32_indirect inst size

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP1Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP1Instructions.td
@@ -1173,7 +1173,7 @@ defm V_CVT_NORM_U16_F16  : VOP1_Real_vi<0x4e>;
 
 defm V_ACCVGPR_MOV_B32   : VOP1Only_Real_vi<0x52>;
 
-let VOP1 = 1, SubtargetPredicate = isGFX8GFX9, Uses = [EXEC, M0] in {
+let VOP1 = 1, SubtargetPredicate = isGFX8GFX9, Uses = [EXEC, M0], Size = V_MOV_B32_e32.Size in {
 
 // Copy of v_mov_b32 with $vdst as a use operand for use with VGPR
 // indexing mode. vdst can't be treated as a def for codegen purposes,

--- a/llvm/test/CodeGen/AMDGPU/code-size-estimate.mir
+++ b/llvm/test/CodeGen/AMDGPU/code-size-estimate.mir
@@ -1,0 +1,20 @@
+# RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx90a -show-mc-encoding  -o - %s | FileCheck %s
+# RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx802 -show-mc-encoding  -o - %s | FileCheck %s
+
+
+# CHECK: indirect_mov:                           ; @indirect_mov
+# CHECK: s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0) ; encoding: [0x00,0x00,0x8c,0xbf]
+# CHECK: v_mov_b32_e32 v16, v1                   ; encoding: [0x01,0x03,0x20,0x7e]
+# CHECK: v_mov_b32_e32 v0, v3                    ; encoding: [0x03,0x03,0x00,0x7e]
+# CHECK: ; codeLenInByte = 12
+
+---
+name:            indirect_mov
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $vgpr1, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15
+
+  $vgpr16 = V_MOV_B32_indirect_read undef $vgpr1, implicit $exec, implicit $m0, implicit $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15
+  V_MOV_B32_indirect_write undef $vgpr0, undef $vgpr3, implicit $exec, implicit $m0, implicit-def $vgpr0_vgpr1_vgpr2_vgpr3, implicit killed $vgpr0_vgpr1_vgpr2_vgpr3(tied-def 4)
+...


### PR DESCRIPTION
This inst lowers to a normal v_mov_b32 so it's not zero-sized, but has a size of 4.

Solves SWDEV-416337