### PR TITLE
[ARM] Change CRC predicated to just HasCRC

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -4854,7 +4854,7 @@ class AI_crc32<bit C, bits<2> sz, string suffix, SDPatternOperator builtin>
   : AInoP<(outs GPRnopc:$Rd), (ins GPRnopc:$Rn, GPRnopc:$Rm), MiscFrm, NoItinerary,
                !strconcat("crc32", suffix), "\t$Rd, $Rn, $Rm",
                [(set GPRnopc:$Rd, (builtin GPRnopc:$Rn, GPRnopc:$Rm))]>,
-               Requires<[IsARM, HasV8, HasCRC]> {
+               Requires<[IsARM, HasCRC]> {
   bits<4> Rd;
   bits<4> Rn;
   bits<4> Rm;

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -3448,7 +3448,7 @@ class T2I_crc32<bit C, bits<2> sz, string suffix, SDPatternOperator builtin>
   : T2ThreeRegNoP<(outs rGPR:$Rd), (ins rGPR:$Rn, rGPR:$Rm), NoItinerary,
                !strconcat("crc32", suffix, "\t$Rd, $Rn, $Rm"),
                [(set rGPR:$Rd, (builtin rGPR:$Rn, rGPR:$Rm))]>,
-               Requires<[IsThumb2, HasV8, HasCRC]> {
+               Requires<[IsThumb2, HasCRC]> {
   let Inst{31-27} = 0b11111;
   let Inst{26-21} = 0b010110;
   let Inst{20}    = C;

--- a/llvm/test/CodeGen/ARM/crc32.ll
+++ b/llvm/test/CodeGen/ARM/crc32.ll
@@ -1,4 +1,7 @@
+; RUN: llc -mtriple=thumbv7 -mattr=+crc -o - %s | FileCheck %s
 ; RUN: llc -mtriple=thumbv8 -o - %s | FileCheck %s
+; RUN: llc -mtriple=armv7 -mattr=+crc -o - %s | FileCheck %s
+; RUN: llc -mtriple=armv8 -o - %s | FileCheck %s
 
 define i32 @test_crc32b(i32 %cur, i8 %next) {
 ; CHECK-LABEL: test_crc32b:

--- a/llvm/test/MC/ARM/crc32-thumb.s
+++ b/llvm/test/MC/ARM/crc32-thumb.s
@@ -8,9 +8,9 @@
 @ CHECK:  crc32b    r0, r1, r2              @ encoding: [0xc1,0xfa,0x82,0xf0]
 @ CHECK:  crc32h    r0, r1, r2              @ encoding: [0xc1,0xfa,0x92,0xf0]
 @ CHECK:  crc32w    r0, r1, r2              @ encoding: [0xc1,0xfa,0xa2,0xf0]
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
@@ -22,9 +22,9 @@
 @ CHECK:  crc32cb   r0, r1, r2              @ encoding: [0xd1,0xfa,0x82,0xf0]
 @ CHECK:  crc32ch   r0, r1, r2              @ encoding: [0xd1,0xfa,0x92,0xf0]
 @ CHECK:  crc32cw   r0, r1, r2              @ encoding: [0xd1,0xfa,0xa2,0xf0]
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc

--- a/llvm/test/MC/ARM/crc32.s
+++ b/llvm/test/MC/ARM/crc32.s
@@ -8,9 +8,9 @@
 @ CHECK:  crc32b    r0, r1, r2              @ encoding: [0x42,0x00,0x01,0xe1]
 @ CHECK:  crc32h    r0, r1, r2              @ encoding: [0x42,0x00,0x21,0xe1]
 @ CHECK:  crc32w    r0, r1, r2              @ encoding: [0x42,0x00,0x41,0xe1]
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
@@ -22,9 +22,9 @@
 @ CHECK:  crc32cb   r0, r1, r2              @ encoding: [0x42,0x02,0x01,0xe1]
 @ CHECK:  crc32ch   r0, r1, r2              @ encoding: [0x42,0x02,0x21,0xe1]
 @ CHECK:  crc32cw   r0, r1, r2              @ encoding: [0x42,0x02,0x41,0xe1]
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc
 @ CHECK-NOCRC: error: instruction requires: crc

--- a/llvm/test/MC/ARM/directive-arch_extension-crc.s
+++ b/llvm/test/MC/ARM/directive-arch_extension-crc.s
@@ -15,18 +15,18 @@
 	.type crc,%function
 crc:
 	crc32b r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 	crc32h r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 	crc32w r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 
 	crc32cb r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 	crc32ch r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 	crc32cw r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 
 	.arch_extension nocrc
 @ CHECK-V7: error: architectural extension 'crc' is not allowed for the current base architecture
@@ -36,22 +36,22 @@ crc:
 	.type nocrc,%function
 nocrc:
 	crc32b r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-V8: error: instruction requires: crc
 	crc32h r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-V8: error: instruction requires: crc
 	crc32w r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-V8: error: instruction requires: crc
 
 	crc32cb r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-V8: error: instruction requires: crc
 	crc32ch r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-V8: error: instruction requires: crc
 	crc32cw r0, r1, r2
-@ CHECK-V7: error: instruction requires: crc armv8
+@ CHECK-V7: error: instruction requires: crc
 @ CHECK-V8: error: instruction requires: crc
 


### PR DESCRIPTION
This removes the backend requirement for crc instructions on HasV8, relying on just HasCRC instead. This should allow them to be selected with ArmV7 + crc, making them more usable whilst hopefully not making them incorrectly generated (they only come from intrinsics, and HasCRC usually requires HasV8). This is how most other instructions are specified.