### PR TITLE
[X86] Convert X86FixupBWInsts from LivePhysRegs to LiveRegUnits. NFCI.

### DIFF
--- a/llvm/lib/Target/X86/X86FixupBWInsts.cpp
+++ b/llvm/lib/Target/X86/X86FixupBWInsts.cpp
@@ -209,8 +209,7 @@ Register FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI) const {
   auto Range = TRI->regunits(OrigDestReg);
   MCRegUnitIterator I = Range.begin(), E = Range.end();
   for (MCRegUnit S : TRI->regunits(SuperDestReg)) {
-    while (I != E && *I < S)
-      ++I;
+    I = std::lower_bound(I, E, S);
     if ((I == E || *I > S) && LiveUnits.getBitVector().test(S)) {
       SuperIsLive = true;
       break;

--- a/llvm/lib/Target/X86/X86FixupBWInsts.cpp
+++ b/llvm/lib/Target/X86/X86FixupBWInsts.cpp
@@ -50,7 +50,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/ProfileSummaryInfo.h"
 #include "llvm/CodeGen/LazyMachineBlockFrequencyInfo.h"
-#include "llvm/CodeGen/LivePhysRegs.h"
+#include "llvm/CodeGen/LiveRegUnits.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
@@ -145,7 +145,7 @@ private:
   MachineLoopInfo *MLI = nullptr;
 
   /// Register Liveness information after the current instruction.
-  LivePhysRegs LiveRegs;
+  LiveRegUnits LiveUnits;
 
   ProfileSummaryInfo *PSI = nullptr;
   MachineBlockFrequencyInfo *MBFI = nullptr;
@@ -169,7 +169,7 @@ bool FixupBWInstPass::runOnMachineFunction(MachineFunction &MF) {
   MBFI = (PSI && PSI->hasProfileSummary()) ?
          &getAnalysis<LazyMachineBlockFrequencyInfoPass>().getBFI() :
          nullptr;
-  LiveRegs.init(TII->getRegisterInfo());
+  LiveUnits.init(TII->getRegisterInfo());
 
   LLVM_DEBUG(dbgs() << "Start X86FixupBWInsts\n";);
 
@@ -202,22 +202,22 @@ Register FixupBWInstPass::getSuperRegDestIfDead(MachineInstr *OrigMI) const {
   if (SubRegIdx == X86::sub_8bit_hi)
     return Register();
 
-  // If neither the destination-super register nor any applicable subregisters
-  // are live after this instruction, then the super register is safe to use.
-  if (!LiveRegs.contains(SuperDestReg)) {
-    // If the original destination register was not the low 8-bit subregister
-    // then the super register check is sufficient.
-    if (SubRegIdx != X86::sub_8bit)
-      return SuperDestReg;
-    // If the original destination register was the low 8-bit subregister and
-    // we also need to check the 16-bit subregister and the high 8-bit
-    // subregister.
-    MCRegister HighReg = getX86SubSuperRegister(SuperDestReg, 8, /*High=*/true);
-    if (!LiveRegs.contains(getX86SubSuperRegister(OrigDestReg, 16)) &&
-        (!HighReg.isValid() || !LiveRegs.contains(HighReg)))
-      return SuperDestReg;
-    // Otherwise, we have a little more checking to do.
+  // Test all regunits of the super register that are not part of the
+  // sub register. If none of them are live then the super register is safe to
+  // use.
+  bool SuperIsLive = false;
+  auto Range = TRI->regunits(OrigDestReg);
+  MCRegUnitIterator I = Range.begin(), E = Range.end();
+  for (MCRegUnit S : TRI->regunits(SuperDestReg)) {
+    while (I != E && *I < S)
+      ++I;
+    if ((I == E || *I > S) && LiveUnits.getBitVector().test(S)) {
+      SuperIsLive = true;
+      break;
+    }
   }
+  if (!SuperIsLive)
+    return SuperDestReg;
 
   // If we get here, the super-register destination (or some part of it) is
   // marked as live after the original instruction.
@@ -449,9 +449,9 @@ void FixupBWInstPass::processBasicBlock(MachineFunction &MF,
 
   // Start computing liveness for this block. We iterate from the end to be able
   // to update this for each instruction.
-  LiveRegs.clear();
+  LiveUnits.clear();
   // We run after PEI, so we need to AddPristinesAndCSRs.
-  LiveRegs.addLiveOuts(MBB);
+  LiveUnits.addLiveOuts(MBB);
 
   OptForSize = MF.getFunction().hasOptSize() ||
                llvm::shouldOptimizeForSize(&MBB, PSI, MBFI);
@@ -461,7 +461,7 @@ void FixupBWInstPass::processBasicBlock(MachineFunction &MF,
       MIReplacements.push_back(std::make_pair(&MI, NewMI));
 
     // We're done with this instruction, update liveness for the next one.
-    LiveRegs.stepBackward(MI);
+    LiveUnits.stepBackward(MI);
   }
 
   while (!MIReplacements.empty()) {


### PR DESCRIPTION
This gives a geomean 0.50% speed up according to
https://llvm-compile-time-tracker.com/
