### PR TITLE
[LiveRegUnits] Remove use of std::function from phys_regs_and_masks

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveRegUnits.h
+++ b/llvm/include/llvm/CodeGen/LiveRegUnits.h
@@ -161,15 +161,15 @@ private:
 
 /// Returns an iterator range over all physical register and mask operands for
 /// \p MI and bundled instructions. This also skips any debug operands.
-inline iterator_range<filter_iterator<
-    ConstMIBundleOperands, std::function<bool(const MachineOperand &)>>>
+inline iterator_range<
+    filter_iterator<ConstMIBundleOperands, bool (*)(const MachineOperand &)>>
 phys_regs_and_masks(const MachineInstr &MI) {
-  std::function<bool(const MachineOperand &)> Pred =
-      [](const MachineOperand &MOP) {
-        return MOP.isRegMask() ||
-               (MOP.isReg() && !MOP.isDebug() && MOP.getReg().isPhysical());
-      };
-  return make_filter_range(const_mi_bundle_ops(MI), Pred);
+  auto Pred = [](const MachineOperand &MOP) {
+    return MOP.isRegMask() ||
+           (MOP.isReg() && !MOP.isDebug() && MOP.getReg().isPhysical());
+  };
+  return make_filter_range(const_mi_bundle_ops(MI),
+                           static_cast<bool (*)(const MachineOperand &)>(Pred));
 }
 
 } // end namespace llvm


### PR DESCRIPTION
This removes some std::function boilerplate from my profile of the
most frequently called functions in llc. The geomean speed up of 0.01%
just barely shows up on https://llvm-compile-time-tracker.com/
