### PR TITLE
[libc][bazel] Fix missing dependencies for `lseek`

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2530,9 +2530,13 @@ libc_function(
 libc_function(
     name = "lseek",
     srcs = ["src/unistd/linux/lseek.cpp"],
-    hdrs = ["src/unistd/lseek.h"],
+    hdrs = [
+        "src/__support/File/linux/lseekImpl.h",
+        "src/unistd/lseek.h",
+    ],
     deps = [
         ":__support_common",
+        ":__support_error_or",
         ":__support_osutil_syscall",
         ":errno",
     ],


### PR DESCRIPTION
Failure introduced in 8cd4ecfa6001eed7486fa3618bbd6bde47a0b075