### PR TITLE
[libc] move in_place_t in utility

### DIFF
--- a/libc/src/__support/CPP/optional.h
+++ b/libc/src/__support/CPP/optional.h
@@ -16,11 +16,6 @@
 namespace __llvm_libc {
 namespace cpp {
 
-// Trivial in_place_t struct.
-struct in_place_t {
-  LIBC_INLINE constexpr explicit in_place_t() = default;
-};
-
 // Trivial nullopt_t struct.
 struct nullopt_t {
   LIBC_INLINE constexpr explicit nullopt_t() = default;
@@ -28,9 +23,6 @@ struct nullopt_t {
 
 // nullopt that can be used and returned.
 LIBC_INLINE_VAR constexpr nullopt_t nullopt{};
-
-// in_place that can be used in the constructor.
-LIBC_INLINE_VAR constexpr in_place_t in_place{};
 
 // This is very simple implementation of the std::optional class. It makes
 // several assumptions that the underlying type is trivially constructable,

--- a/libc/src/__support/CPP/utility.h
+++ b/libc/src/__support/CPP/utility.h
@@ -11,6 +11,7 @@
 
 #include "src/__support/CPP/utility/declval.h"
 #include "src/__support/CPP/utility/forward.h"
+#include "src/__support/CPP/utility/in_place.h"
 #include "src/__support/CPP/utility/integer_sequence.h"
 #include "src/__support/CPP/utility/move.h"
 

--- a/libc/src/__support/CPP/utility/in_place.h
+++ b/libc/src/__support/CPP/utility/in_place.h
@@ -1,0 +1,36 @@
+//===-- in_place utility ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_SUPPORT_CPP_UTILITY_IN_PLACE_H
+#define LLVM_LIBC_SRC_SUPPORT_CPP_UTILITY_IN_PLACE_H
+
+#include "src/__support/macros/attributes.h"
+
+#include <stddef.h> // size_t
+
+namespace __llvm_libc::cpp {
+
+// in_place
+struct in_place_t {
+  explicit in_place_t() = default;
+};
+LIBC_INLINE_VAR constexpr in_place_t in_place{};
+
+template <class T> struct in_place_type_t {
+  explicit in_place_type_t() = default;
+};
+template <class T> LIBC_INLINE_VAR constexpr in_place_type_t<T> in_place_type{};
+
+template <size_t I> struct in_place_index_t {
+  explicit in_place_index_t() = default;
+};
+template <size_t I>
+LIBC_INLINE_VAR constexpr in_place_index_t<I> in_place_index{};
+
+} // namespace __llvm_libc::cpp
+
+#endif // LLVM_LIBC_SRC_SUPPORT_CPP_UTILITY_IN_PLACE_H

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -344,6 +344,7 @@ libc_support_library(
         "src/__support/CPP/utility.h",
         "src/__support/CPP/utility/declval.h",
         "src/__support/CPP/utility/forward.h",
+        "src/__support/CPP/utility/in_place.h",
         "src/__support/CPP/utility/integer_sequence.h",
         "src/__support/CPP/utility/move.h",
     ],


### PR DESCRIPTION
This is needed because `cpp::in_place_t` is also used by `cpp::expected`
https://en.cppreference.com/w/cpp/utility/in_place