### PR TITLE
[Driver] Fix linking with -lm on Solaris

### DIFF
--- a/clang/test/Driver/solaris-ld.c
+++ b/clang/test/Driver/solaris-ld.c
@@ -26,7 +26,6 @@
 // CHECK-GLD: "--as-needed" "-lgcc_s" "--no-as-needed"
 // CHECK-LD-SPARC32-SAME: "-lc"
 // CHECK-LD-SPARC32-SAME: "-lgcc"
-// CHECK-LD-SPARC32-SAME: "-lm"
 // CHECK-LD-SPARC32-SAME: "[[SYSROOT]]/usr/gcc/4.8/lib/gcc/sparc-sun-solaris2.11/4.8.2{{/|\\\\}}crtend.o"
 // CHECK-LD-SPARC32-SAME: "[[SYSROOT]]/usr/lib{{/|\\\\}}crtn.o"
 
@@ -49,7 +48,6 @@
 // CHECK-LD-SPARC64-SAME: "-lgcc_s"
 // CHECK-LD-SPARC64-SAME: "-lc"
 // CHECK-LD-SPARC64-SAME: "-lgcc"
-// CHECK-LD-SPARC64-SAME: "-lm"
 // CHECK-LD-SPARC64-SAME: "[[SYSROOT]]/usr/gcc/4.8/lib/gcc/sparc-sun-solaris2.11/4.8.2/sparcv9{{/|\\\\}}crtend.o"
 // CHECK-LD-SPARC64-SAME: "[[SYSROOT]]/usr/lib/sparcv9{{/|\\\\}}crtn.o"
 
@@ -72,7 +70,6 @@
 // CHECK-LD-X32-SAME: "-lgcc_s"
 // CHECK-LD-X32-SAME: "-lc"
 // CHECK-LD-X32-SAME: "-lgcc"
-// CHECK-LD-X32-SAME: "-lm"
 // CHECK-LD-X32-SAME: "[[SYSROOT]]/usr/gcc/4.9/lib/gcc/i386-pc-solaris2.11/4.9.4{{/|\\\\}}crtend.o"
 // CHECK-LD-X32-SAME: "[[SYSROOT]]/usr/lib{{/|\\\\}}crtn.o"
 
@@ -96,7 +93,6 @@
 // CHECK-LD-X64-SAME: "-lgcc_s"
 // CHECK-LD-X64-SAME: "-lc"
 // CHECK-LD-X64-SAME: "-lgcc"
-// CHECK-LD-X64-SAME: "-lm"
 // CHECK-LD-X64-SAME: "[[SYSROOT]]/usr/gcc/4.9/lib/gcc/i386-pc-solaris2.11/4.9.4/amd64{{/|\\\\}}crtend.o"
 // CHECK-LD-X64-SAME: "[[SYSROOT]]/usr/lib/amd64{{/|\\\\}}crtn.o"
 
@@ -110,7 +106,22 @@
 // CHECK-SPARC32-SHARED-SAME: "-lgcc_s"
 // CHECK-SPARC32-SHARED-SAME: "-lc"
 // CHECK-SPARC32-SHARED-NOT: "-lgcc"
-// CHECK-SPARC32-SHARED-NOT: "-lm"
+
+// Check that libm is only linked with clang++.
+// RUN: %clang -### %s --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOLIBM %s
+// RUN: %clang -### %s -shared --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOLIBM %s
+// RUN: %clangxx -### %s --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-LIBM %s
+// RUN: %clangxx -### %s -shared --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-LIBM %s
+// CHECK-LIBM: "-lm"
+// CHECK-NOLIBM-NOT: "-lm"
 
 // Check the right ld flags are present with -pie.
 // RUN: %clang --target=sparc-sun-solaris2.11 -### %s -pie -fuse-ld= \


### PR DESCRIPTION
As noticed in D158846, the Solaris driver deviates from other targets in that it links every executable with `-lm`, but doesn't for shared objects. For C code, this is unnecessary, while for C++ `libm` is always needed, even for shared objects.

This patch fixes this by following the `Gnu.cpp` precedent.  It adjusts the `solaris-ld.c` test accordingly, adding some more tests.

Tested on `amd64-pc-solaris2.11`, `sparcv9-sun-solaris2.11`, and `x86_64-pc-linux-gnu`.