### PR TITLE
Support: allow building with non-C/C++ language linkers

### DIFF
--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -79,7 +79,11 @@ endif( MSVC OR MINGW )
 # Delay load shell32.dll if possible to speed up process startup.
 set (delayload_flags)
 if (MSVC)
-  set (delayload_flags delayimp -delayload:shell32.dll -delayload:ole32.dll)
+  # When linking with Swift, `swiftc.exe` is used as the linker drive rather
+  # than invoking `link.exe` directly.  In such a case, the flags should be
+  # marked as `-Xlinker` to pass them directly to the linker.  As a temporary
+  # workaround simply elide the delay loading.
+  set (delayload_flags $<$<NOT:$<LINK_LANGUAGE:Swift>>:delayimp -delayload:shell32.dll -delayload:ole32.dll>)
 endif()
 
 # Link Z3 if the user wants to build it.


### PR DESCRIPTION
When building with Swift as the linker language, CMake will use the Swift driver to perform the link oepration.  The flags here are not marked to be interpreted by the linker as the default behaviour with MSVC is to use `link` directly rather than through a linker driver. For simplicity's sake and as an immediate solution to these flags being passed to the driver, avoid the delay load with Swift.  A more comprehensive solution would be to pass these flags via `-Xlinker` when building with Swift.