### PR TITLE
[ADT] Remove any_isa (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/Any.h
+++ b/llvm/include/llvm/ADT/Any.h
@@ -135,12 +135,6 @@ private:
 // See also https://github.com/llvm/llvm-project/issues/62270
 template <typename T> char Any::TypeId<T>::Id = 1;
 
-template <typename T>
-LLVM_DEPRECATED("Use any_cast(Any*) != nullptr instead", "any_cast")
-bool any_isa(const Any &Value) {
-  return Value.isa<T>();
-}
-
 template <class T> T any_cast(const Any &Value) {
   assert(Value.isa<T>() && "Bad any cast!");
   return static_cast<T>(*any_cast<remove_cvref_t<T>>(&Value));


### PR DESCRIPTION
any_isa has been deprecated since:

  commit bb7940e25f6ca201ca57943544016390f1d2e504
  Author: Sebastian Neubauer <Sebastian.Neubauer@amd.com>
  Date:   Tue Dec 20 13:28:30 2022 +0100
