### PR TITLE
[InferAddressSpaces] Register pass.

### DIFF
--- a/llvm/lib/Transforms/Scalar/InferAddressSpaces.cpp
+++ b/llvm/lib/Transforms/Scalar/InferAddressSpaces.cpp
@@ -165,8 +165,12 @@ public:
   static char ID;
 
   InferAddressSpaces()
-      : FunctionPass(ID), FlatAddrSpace(UninitializedAddressSpace) {}
-  InferAddressSpaces(unsigned AS) : FunctionPass(ID), FlatAddrSpace(AS) {}
+      : FunctionPass(ID), FlatAddrSpace(UninitializedAddressSpace) {
+    initializeInferAddressSpacesPass(*PassRegistry::getPassRegistry());
+  }
+  InferAddressSpaces(unsigned AS) : FunctionPass(ID), FlatAddrSpace(AS) {
+    initializeInferAddressSpacesPass(*PassRegistry::getPassRegistry());
+  }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesCFG();


### PR DESCRIPTION
InferAddressSpaces failed to call its initialization function. It was still called through initializeScalarOpts in llc and opt, but it was skipped entirely in clang. When the initialization function is not called, this results in confusing behavior where the pass appears to run, but not entirely as it should, e.g. the pass is excluded from -print-before-all and -print-after-all.