### PR TITLE
[AMDGPU] Incorrect error message regarding SCC modifier

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -4477,11 +4477,17 @@ bool AMDGPUAsmParser::validateCoherencyBits(const MCInst &Inst,
   }
 
   if (isGFX90A() && !isGFX940() && (CPol & CPol::SCC)) {
-    SMLoc S = getImmLoc(AMDGPUOperand::ImmTyCPol, Operands);
-    StringRef CStr(S.getPointer());
-    S = SMLoc::getFromPointer(&CStr.data()[CStr.find("scc")]);
-    Error(S, "scc is not supported on this GPU");
-    return false;
+    const uint64_t AllowSCCModifier = SIInstrFlags::MUBUF |
+                                      SIInstrFlags::MTBUF | SIInstrFlags::MIMG |
+                                      SIInstrFlags::FLAT;
+    if (!(TSFlags & AllowSCCModifier)) {
+      SMLoc S = getImmLoc(AMDGPUOperand::ImmTyCPol, Operands);
+      StringRef CStr(S.getPointer());
+      S = SMLoc::getFromPointer(&CStr.data()[CStr.find("scc")]);
+      Error(S,
+            "scc modifier is not supported for this instruction on this GPU");
+      return false;
+    }
   }
 
   if (!(TSFlags & (SIInstrFlags::IsAtomicNoRet | SIInstrFlags::IsAtomicRet)))

--- a/llvm/test/MC/AMDGPU/gfx90a_asm_features.s
+++ b/llvm/test/MC/AMDGPU/gfx90a_asm_features.s
@@ -1024,3 +1024,78 @@ global_atomic_add_f32 v1, v0, v2, s[0:1] glc ; encoding: [0x00,0x80,0x35,0xdd,0x
 // GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
 // GFX90A: global_atomic_pk_add_f16  v0, v[0:1], v2, off glc ; encoding: [0x00,0x80,0x39,0xdd,0x00,0x02,0x7f,0x00]
 global_atomic_pk_add_f16 v0, v[0:1], v2, off glc
+
+// GFX908: :[[@LINE+3]]:{{[0-9]+}}: error: scc modifier is not supported on this GPU
+// GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_add_f32 v0, v[0:1], v2, off glc scc
+global_atomic_add_f32 v0, v[0:1], v2, off glc scc
+
+// GFX908: :[[@LINE+3]]:{{[0-9]+}}: error: scc modifier is not supported on this GPU
+// GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_add_f32 v[0:1], v2, off scc
+global_atomic_add_f32 v[0:1], v2, off scc
+
+// GFX908: :[[@LINE+3]]:{{[0-9]+}}: error: scc modifier is not supported on this GPU
+// GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_add_f32 v0, v2, s[0:1] scc
+global_atomic_add_f32 v0, v2, s[0:1] scc
+
+// GFX908: :[[@LINE+3]]:{{[0-9]+}}: error: scc modifier is not supported on this GPU
+// GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_add_f32 v1, v0, v2, s[0:1] glc scc
+global_atomic_add_f32 v1, v0, v2, s[0:1] glc scc
+
+// GFX908: :[[@LINE+3]]:{{[0-9]+}}: error: scc modifier is not supported on this GPU
+// GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_pk_add_f16 v0, v[0:1], v2, off glc scc
+global_atomic_pk_add_f16 v0, v[0:1], v2, off glc scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: flat_atomic_add_f64 v[0:1], v[0:1], v[2:3] glc scc
+flat_atomic_add_f64 v[0:1], v[0:1], v[2:3] glc scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: flat_atomic_add_f64 v[0:1], v[2:3] scc
+flat_atomic_add_f64 v[0:1], v[2:3] scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: flat_atomic_min_f64 v[0:1], v[2:3] scc
+flat_atomic_min_f64 v[0:1], v[2:3] scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: flat_atomic_max_f64 v[0:1], v[2:3] scc
+flat_atomic_max_f64 v[0:1], v[2:3] scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_add_f64 v[0:1], v[2:3], off scc
+global_atomic_add_f64 v[0:1], v[2:3], off scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_min_f64 v[0:1], v[2:3], off scc
+global_atomic_min_f64 v[0:1], v[2:3], off scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: global_atomic_max_f64 v[0:1], v[2:3], off scc
+global_atomic_max_f64 v[0:1], v[2:3], off scc
+
+// GFX908: :[[@LINE+3]]:{{[0-9]+}}: error: scc modifier is not supported on this GPU
+// GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: buffer_atomic_add_f32 v4, off, s[8:11], s3 scc
+buffer_atomic_add_f32 v4, off, s[8:11], s3 scc
+
+// GFX908: :[[@LINE+3]]:{{[0-9]+}}: error: scc modifier is not supported on this GPU
+// GFX1010: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: buffer_atomic_pk_add_f16 v4, off, s[8:11], s3 scc
+buffer_atomic_pk_add_f16 v4, off, s[8:11], s3 scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: buffer_atomic_add_f64 v[4:5], off, s[8:11], s3 scc
+buffer_atomic_add_f64 v[4:5], off, s[8:11], s3 scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: buffer_atomic_max_f64 v[4:5], off, s[8:11], s3 scc
+buffer_atomic_max_f64 v[4:5], off, s[8:11], s3 scc
+
+// NOT-GFX90A: :[[@LINE+2]]:{{[0-9]+}}: error: instruction not supported on this GPU
+// GFX90A: buffer_atomic_min_f64 v[4:5], off, s[8:11], s3 scc
+buffer_atomic_min_f64 v[4:5], off, s[8:11], s3 scc

--- a/llvm/test/MC/AMDGPU/gfx90a_err.s
+++ b/llvm/test/MC/AMDGPU/gfx90a_err.s
@@ -195,57 +195,6 @@ image_sample_cd v[0:3], v[0:1], s[4:11], s[16:19] dmask:0xf
 image_sample_b v[0:3], v[0:1], s[4:11], s[16:19] dmask:0xf
 // GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
 
-global_atomic_add_f32 v0, v[0:1], v2, off glc scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-global_atomic_add_f32 v[0:1], v2, off scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-global_atomic_add_f32 v0, v2, s[0:1] scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-global_atomic_add_f32 v1, v0, v2, s[0:1] glc scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-global_atomic_pk_add_f16 v0, v[0:1], v2, off glc scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-flat_atomic_add_f64 v[0:1], v[0:1], v[2:3] glc scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-flat_atomic_add_f64 v[0:1], v[2:3] scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-flat_atomic_min_f64 v[0:1], v[2:3] scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-flat_atomic_max_f64 v[0:1], v[2:3] scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-global_atomic_add_f64 v[0:1], v[2:3], off scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-global_atomic_min_f64 v[0:1], v[2:3], off scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-global_atomic_max_f64 v[0:1], v[2:3], off scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-buffer_atomic_add_f32 v4, off, s[8:11], s3 scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-buffer_atomic_pk_add_f16 v4, off, s[8:11], s3 scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-buffer_atomic_add_f64 v[4:5], off, s[8:11], s3 scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-buffer_atomic_max_f64 v[4:5], off, s[8:11], s3 scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
-buffer_atomic_min_f64 v[4:5], off, s[8:11], s3 scc
-// GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: scc is not supported on this GPU
-
 v_mov_b32_sdwa v1, src_lds_direct dst_sel:DWORD
 // GFX90A: :[[@LINE-1]]:{{[0-9]+}}: error: lds_direct is not supported on this GPU
 


### PR DESCRIPTION
For the AMD GFX90A GPU, the SCC instruction modifier is allowed for certain classes of instructions. However, the current assembler generates an error message, "scc is not supported on this GPU", regardless of the instruciton. This fix modifies the message as well as the logic for generating the message. Related tests are moved from gfx90a_err.s to gfx90a_asm_features.s.