### PR TITLE
[llvm-nm] Fix heap-use-after-free while executing 'llvm-nm -n --export-symbols'

### DIFF
--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -237,10 +237,8 @@ struct NMSymbol {
   std::string IndirectName;
 
   bool isDefined() const {
-    if (Sym.getRawDataRefImpl().p) {
-      uint32_t Flags = cantFail(Sym.getFlags());
-      return !(Flags & SymbolRef::SF_Undefined);
-    }
+    if (Sym.getRawDataRefImpl().p)
+      return !(SymFlags & SymbolRef::SF_Undefined);
     return TypeChar != 'U';
   }
 


### PR DESCRIPTION
Use symbol's flags saved in `NMSymbol::SymFlags` inside `NMSymbol::isDefined()` since `BasicSymbolRef::getFlags()` requires the symbol's containing entity object to exist (which doesn't, causing llvm-nm to crash).

Here is the AddressSanitizer report:

```
==3324663==ERROR: AddressSanitizer: heap-use-after-free on address 0x60e000000200 READ of size 8 at 0x60e000000200 thread T0
    #0 0x55c6536785d8 in llvm::object::BasicSymbolRef::getFlags() const llvm-project/llvm/include/llvm/Object/SymbolicFile.h:207:24
    #1 0x55c6536785d8 in (anonymous namespace)::NMSymbol::isDefined() const llvm-project/llvm/tools/llvm-nm/llvm-nm.cpp:241:37
```