### PR TITLE
[unittests] Add missing includes

### DIFF
--- a/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
+++ b/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
@@ -20,9 +20,9 @@
 
 using namespace llvm;
 using testing::_;
+using testing::DoAll;
 using testing::InSequence;
 using testing::SaveArg;
-using testing::DoAll;
 
 namespace {
 

--- a/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
+++ b/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
@@ -22,6 +22,7 @@ using namespace llvm;
 using testing::_;
 using testing::InSequence;
 using testing::SaveArg;
+using testing::DoAll;
 
 namespace {
 

--- a/llvm/unittests/TextAPI/TextStubHelpers.h
+++ b/llvm/unittests/TextAPI/TextStubHelpers.h
@@ -6,6 +6,7 @@
 //
 //===-----------------------------------------------------------------------===/
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/TextAPI/InterfaceFile.h"
 #include <algorithm>


### PR DESCRIPTION
There are missing include and using in TextStubTests and AsmPrinterDwarfTest and they causes build failures when using vanilla GoogleTest v1.14.0. This patch fixes this issue.
