### PR TITLE
[PseudoProbe] Use probe id as the base dwarf discriminator for callsites

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -22,6 +22,7 @@
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Metadata.h"
+#include "llvm/IR/PseudoProbe.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Discriminator.h"
@@ -2075,6 +2076,14 @@ public:
   static unsigned
   getBaseDiscriminatorFromDiscriminator(unsigned D,
                                         bool IsFSDiscriminator = false) {
+    // Return the probe id instead of zero for a pseudo probe discriminator.
+    // This should help differenciate callsites with same line numbers to
+    // achieve a decent AutoFDO profile under -fpseudo-probe-for-profiling,
+    // where the original callsite dwarf discriminator is overwritten by
+    // callsite probe information.
+    if (isPseudoProbeDiscriminator(D))
+      return PseudoProbeDwarfDiscriminator::extractProbeIndex(D);
+
     if (IsFSDiscriminator)
       return getMaskedDiscriminator(D, getBaseDiscriminatorBits());
     return getUnsignedFromPrefixEncoding(D);

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-inline.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-inline.ll
@@ -106,6 +106,8 @@ if.end:
 ;YAML-NEXT:    - Line:            '1'
 ;YAML-NEXT:    - String:          ':'
 ;YAML-NEXT:    - Column:          '11'
+;YAML-NEXT:    - String:          .
+;YAML-NEXT:    - Disc:            '2'
 ;YAML-NEXT:    - String:          ';'
 ;YAML-NEXT:  ...
 ;YAML:  --- !Analysis

--- a/llvm/test/tools/llvm-profgen/inline-probe-afdo.test
+++ b/llvm/test/tools/llvm-profgen/inline-probe-afdo.test
@@ -1,0 +1,82 @@
+; RUN: llvm-profgen --format=text --use-dwarf-correlation --ignore-stack-samples --perfscript=%S/Inputs/cs-preinline-cost.perfscript --binary=%S/Inputs/cs-preinline-cost.perfbin --output %t
+; RUN: FileCheck %s --input-file %t
+
+; CHECK:     main:947937:0
+; CHECK-NEXT:  2: 545
+; CHECK-NEXT:  3: 545
+; CHECK-NEXT:  5: 545
+; CHECK-NEXT:  7: 0
+; CHECK-NEXT:  65496: 545
+; CHECK-NEXT:  3.7: _Z3fooi:915794
+; CHECK-NEXT:   1: 545
+; CHECK-NEXT:   5: 545
+; CHECK-NEXT:   6: 272
+; CHECK-NEXT:   10: 273
+; CHECK-NEXT:   11: 180
+; CHECK-NEXT:   12: 6965
+; CHECK-NEXT:   13: 6965
+; CHECK-NEXT:   14: 6965
+; CHECK-NEXT:   15: 6965
+; CHECK-NEXT:   20: 182
+; CHECK-NEXT:   21: 6958
+; CHECK-NEXT:   22: 6958
+; CHECK-NEXT:   23: 6958
+; CHECK-NEXT:   24: 6958
+; CHECK-NEXT:   29: 272
+; CHECK-NEXT:   65529: 182
+; CHECK-NEXT:  4.8: _Z3fooi:16338
+; CHECK-NEXT:   1: 272
+; CHECK-NEXT:   6: 545
+
+
+
+
+; binary is built with the source below using the following command line:
+;   clang -O3 -g -fpseudo-probe-for-profiling test.cpp
+;
+;#include <stdio.h>
+;
+;volatile int state = 9000;
+;
+;int foo(int x) {
+;    if (x == 0) {
+;        return 7;
+;    }
+;
+;    if ((x & 1) == 0) {
+;        state--;
+;        return 9;
+;    }
+;
+;    if (state > 5000) {
+;        while (state > 5000) {
+;               for (int i = 50; i >= 0; i--) {
+;                state *= 6;
+;                state /= 7;
+;                state -= 1;
+;            }
+;        }
+;    }
+;    else {
+;        while (state < 5000) {
+;            for (int i = 50; i >= 0; i--) {
+;                state *= 6;
+;                state /= 5;
+;                state += 1;
+;            }
+;        }
+;    }
+;
+;    return state;
+;}
+;
+;volatile int cnt = 10000000;//10000000;
+;int main() {
+;    int r = 0;
+;    for (int i = 0; i < cnt; i++) {
+;      r += foo(i);
+;      r -= foo(i & (~1));
+;      r += foo(0);
+;    }
+;    return r;
+;}


### PR DESCRIPTION
With `-fpseudo-probe-for-profiling`, the dwarf discriminator for a callsite will be overwritten to pseudo probe related information for that callsite. The probe information is encoded in a special format (i.e., with all lowest three digits be one) in order to be distinguished from regular dwarf discriminator. The special encoding format will be decoded to zero by the regular discriminator logic. This means all callsites would have a zero discriminator in both the sample profile and the compiler, for classic AutoFDO. This is inconvenient in that no decent classic AutoFDO can be generated from a pseudo probe build. I'm mitigating the issue by allowing callsite probe id to be used as the base dwarf discriminator for classic AutoFDO, since probe id is also unique and can be used to differentiate callsites on the same source line.



