### PR TITLE
[clang] Add error note when if clause is used on teams before 5.2.

### DIFF
--- a/clang/test/OpenMP/teams_default_messages.cpp
+++ b/clang/test/OpenMP/teams_default_messages.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -verify -fopenmp -DOMP51 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-version=51 -fopenmp -DOMP51 -o - %s -Wuninitialized
 
-// RUN: %clang_cc1 -verify -fopenmp-simd -DOMP51 -o - %s -Wuninitialized
+// RUN: %clang_cc1 -verify -fopenmp-version=51 -fopenmp-simd -DOMP51 -o - %s -Wuninitialized
 
 // RUN: %clang_cc1 -verify -fopenmp-version=50 -fopenmp -o - %s -Wuninitialized
 
@@ -42,6 +42,9 @@ int main(int argc, char **argv) {
   #pragma omp parallel default(shared)
   ++argc; // expected-error {{variable 'argc' must have explicitly specified data sharing attributes}}
 
+  #pragma omp teams if(x) // expected-error {{unexpected OpenMP clause 'if' in directive '#pragma omp teams'}}
+  foo();
+
 #ifdef OMP51
 #pragma omp target
 #pragma omp teams default(firstprivate) // expected-note 2 {{explicit data sharing attribute requested here}}
@@ -55,6 +58,9 @@ int main(int argc, char **argv) {
     ++x; // expected-error {{variable 'x' must have explicitly specified data sharing attributes}}
     ++y; // expected-error {{variable 'y' must have explicitly specified data sharing attributes}}
   }
+#pragma omp teams if(x) // expected-error {{unexpected OpenMP clause 'if' in directive '#pragma omp teams'}}
+  foo();
+
 #endif
   return 0;
 }

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -672,7 +672,7 @@ def OMP_Teams : Directive<"teams"> {
   ];
   let allowedOnceClauses = [
     VersionedClause<OMPC_Default>,
-    VersionedClause<OMPC_If>,
+    VersionedClause<OMPC_If, 52>,
     VersionedClause<OMPC_NumTeams>,
     VersionedClause<OMPC_ThreadLimit>
   ];


### PR DESCRIPTION
`if` clause is valid with openmp >= 5.2. It is not supported yet.