### PR TITLE
[lldb-vscode] Make descriptive summaries and raw child for synthetics configurable

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/lldbvscode_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/lldbvscode_testcase.py
@@ -1,7 +1,8 @@
-from lldbsuite.test.lldbtest import *
 import os
-import vscode
 import time
+
+import vscode
+from lldbsuite.test.lldbtest import *
 
 
 class VSCodeTestCaseBase(TestBase):
@@ -267,7 +268,7 @@ class VSCodeTestCaseBase(TestBase):
 
         if memoryReference not in self.vscode.disassembled_instructions:
             self.vscode.request_disassemble(memoryReference=memoryReference)
-        
+
         return self.vscode.disassembled_instructions[memoryReference]
 
     def attach(
@@ -348,6 +349,8 @@ class VSCodeTestCaseBase(TestBase):
         runInTerminal=False,
         expectFailure=False,
         postRunCommands=None,
+        enableAutoVariableSummaries=False,
+        enableSyntheticChildDebugging=False,
     ):
         """Sending launch request to vscode"""
 
@@ -384,6 +387,8 @@ class VSCodeTestCaseBase(TestBase):
             sourceMap=sourceMap,
             runInTerminal=runInTerminal,
             postRunCommands=postRunCommands,
+            enableAutoVariableSummaries=enableAutoVariableSummaries,
+            enableSyntheticChildDebugging=enableSyntheticChildDebugging,
         )
 
         if expectFailure:
@@ -418,6 +423,8 @@ class VSCodeTestCaseBase(TestBase):
         disconnectAutomatically=True,
         postRunCommands=None,
         lldbVSCodeEnv=None,
+        enableAutoVariableSummaries=False,
+        enableSyntheticChildDebugging=False,
     ):
         """Build the default Makefile target, create the VSCode debug adaptor,
         and launch the process.
@@ -446,4 +453,6 @@ class VSCodeTestCaseBase(TestBase):
             runInTerminal=runInTerminal,
             disconnectAutomatically=disconnectAutomatically,
             postRunCommands=postRunCommands,
+            enableAutoVariableSummaries=enableAutoVariableSummaries,
+            enableSyntheticChildDebugging=enableSyntheticChildDebugging,
         )

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py
@@ -648,7 +648,7 @@ class DebugCommunication(object):
             "arguments": args_dict,
         }
         return self.send_recv(command_dict)
-    
+
     def request_disassemble(self, memoryReference, offset=-50, instructionCount=200, resolveSymbols=True):
         args_dict = {
             "memoryReference": memoryReference,
@@ -727,6 +727,8 @@ class DebugCommunication(object):
         sourceMap=None,
         runInTerminal=False,
         postRunCommands=None,
+        enableAutoVariableSummaries=False,
+        enableSyntheticChildDebugging=False,
     ):
         args_dict = {"program": program}
         if args:
@@ -768,6 +770,8 @@ class DebugCommunication(object):
             args_dict["runInTerminal"] = runInTerminal
         if postRunCommands:
             args_dict["postRunCommands"] = postRunCommands
+        args_dict["enableAutoVariableSummaries"] = enableAutoVariableSummaries
+        args_dict["enableSyntheticChildDebugging"] = enableSyntheticChildDebugging
         command_dict = {"command": "launch", "type": "request", "arguments": args_dict}
         response = self.send_recv(command_dict)
 

--- a/lldb/test/API/tools/lldb-vscode/evaluate/TestVSCode_evaluate.py
+++ b/lldb/test/API/tools/lldb-vscode/evaluate/TestVSCode_evaluate.py
@@ -28,13 +28,13 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
     def isExpressionParsedExpected(self):
         return self.context != "hover"
 
-    def run_test_evaluate_expressions(self, context=None):
+    def run_test_evaluate_expressions(self, context=None, enableAutoVariableSummaries=False):
         """
         Tests the evaluate expression request at different breakpoints
         """
         self.context = context
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
+        self.build_and_launch(program, enableAutoVariableSummaries=enableAutoVariableSummaries)
         source = "main.cpp"
         self.set_source_breakpoints(
             source,
@@ -55,7 +55,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         self.assertEvaluate("var2", "21")
         self.assertEvaluate("static_int", "42")
         self.assertEvaluate("non_static_int", "43")
-        self.assertEvaluate("struct1", "{foo:15}")
+        self.assertEvaluate("struct1", "{foo:15}" if enableAutoVariableSummaries else "my_struct @ 0x")
         self.assertEvaluate("struct1.foo", "15")
         self.assertEvaluate("struct2->foo", "16")
 
@@ -85,7 +85,7 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         self.assertEvaluate(
             "non_static_int", "10"
         )  # different variable with the same name
-        self.assertEvaluate("struct1", "{foo:15}")
+        self.assertEvaluate("struct1", "{foo:15}" if enableAutoVariableSummaries else "my_struct @ 0x")
         self.assertEvaluate("struct1.foo", "15")
         self.assertEvaluate("struct2->foo", "16")
 
@@ -146,22 +146,22 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
     @skipIfRemote
     def test_generic_evaluate_expressions(self):
         # Tests context-less expression evaluations
-        self.run_test_evaluate_expressions()
+        self.run_test_evaluate_expressions(enableAutoVariableSummaries=False)
 
     @skipIfWindows
     @skipIfRemote
     def test_repl_evaluate_expressions(self):
         # Tests expression evaluations that are triggered from the Debug Console
-        self.run_test_evaluate_expressions("repl")
+        self.run_test_evaluate_expressions("repl", enableAutoVariableSummaries=True)
 
     @skipIfWindows
     @skipIfRemote
     def test_watch_evaluate_expressions(self):
         # Tests expression evaluations that are triggered from a watch expression
-        self.run_test_evaluate_expressions("watch")
+        self.run_test_evaluate_expressions("watch", enableAutoVariableSummaries=False)
 
     @skipIfWindows
     @skipIfRemote
     def test_hover_evaluate_expressions(self):
         # Tests expression evaluations that are triggered when hovering on the editor
-        self.run_test_evaluate_expressions("hover")
+        self.run_test_evaluate_expressions("hover", enableAutoVariableSummaries=True)

--- a/lldb/test/API/tools/lldb-vscode/evaluate/TestVSCode_evaluate.py
+++ b/lldb/test/API/tools/lldb-vscode/evaluate/TestVSCode_evaluate.py
@@ -28,13 +28,17 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
     def isExpressionParsedExpected(self):
         return self.context != "hover"
 
-    def run_test_evaluate_expressions(self, context=None, enableAutoVariableSummaries=False):
+    def run_test_evaluate_expressions(
+        self, context=None, enableAutoVariableSummaries=False
+    ):
         """
         Tests the evaluate expression request at different breakpoints
         """
         self.context = context
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program, enableAutoVariableSummaries=enableAutoVariableSummaries)
+        self.build_and_launch(
+            program, enableAutoVariableSummaries=enableAutoVariableSummaries
+        )
         source = "main.cpp"
         self.set_source_breakpoints(
             source,
@@ -55,7 +59,9 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         self.assertEvaluate("var2", "21")
         self.assertEvaluate("static_int", "42")
         self.assertEvaluate("non_static_int", "43")
-        self.assertEvaluate("struct1", "{foo:15}" if enableAutoVariableSummaries else "my_struct @ 0x")
+        self.assertEvaluate(
+            "struct1", "{foo:15}" if enableAutoVariableSummaries else "my_struct @ 0x"
+        )
         self.assertEvaluate("struct1.foo", "15")
         self.assertEvaluate("struct2->foo", "16")
 
@@ -85,7 +91,9 @@ class TestVSCode_variables(lldbvscode_testcase.VSCodeTestCaseBase):
         self.assertEvaluate(
             "non_static_int", "10"
         )  # different variable with the same name
-        self.assertEvaluate("struct1", "{foo:15}" if enableAutoVariableSummaries else "my_struct @ 0x")
+        self.assertEvaluate(
+            "struct1", "{foo:15}" if enableAutoVariableSummaries else "my_struct @ 0x"
+        )
         self.assertEvaluate("struct1.foo", "15")
         self.assertEvaluate("struct2->foo", "16")
 

--- a/lldb/tools/lldb-vscode/VSCode.cpp
+++ b/lldb/tools/lldb-vscode/VSCode.cpp
@@ -41,6 +41,8 @@ VSCode::VSCode()
            {"swift_throw", "Swift Throw", lldb::eLanguageTypeSwift}}),
       focus_tid(LLDB_INVALID_THREAD_ID), sent_terminated_event(false),
       stop_at_entry(false), is_attach(false),
+      enable_auto_variable_summaries(false),
+      enable_synthetic_child_debugging(false),
       restarting_process_id(LLDB_INVALID_PROCESS_ID),
       configuration_done_sent(false), waiting_for_run_in_terminal(false),
       progress_event_reporter(

--- a/lldb/tools/lldb-vscode/VSCode.h
+++ b/lldb/tools/lldb-vscode/VSCode.h
@@ -167,6 +167,8 @@ struct VSCode {
   std::atomic<bool> sent_terminated_event;
   bool stop_at_entry;
   bool is_attach;
+  bool enable_auto_variable_summaries;
+  bool enable_synthetic_child_debugging;
   // The process event thread normally responds to process exited events by
   // shutting down the entire adapter. When we're restarting, we keep the id of
   // the old process here so we can detect this case and keep running.

--- a/lldb/tools/lldb-vscode/lldb-vscode.cpp
+++ b/lldb/tools/lldb-vscode/lldb-vscode.cpp
@@ -647,6 +647,10 @@ void request_attach(const llvm::json::Object &request) {
   std::vector<std::string> postRunCommands =
       GetStrings(arguments, "postRunCommands");
   const llvm::StringRef debuggerRoot = GetString(arguments, "debuggerRoot");
+  g_vsc.enable_auto_variable_summaries =
+      GetBoolean(arguments, "enableAutoVariableSummaries", false);
+  g_vsc.enable_synthetic_child_debugging =
+      GetBoolean(arguments, "enableSyntheticChildDebugging", false);
 
   // This is a hack for loading DWARF in .o files on Mac where the .o files
   // in the debug map of the main executable have relative paths which require
@@ -1794,6 +1798,10 @@ void request_launch(const llvm::json::Object &request) {
       GetStrings(arguments, "postRunCommands");
   g_vsc.stop_at_entry = GetBoolean(arguments, "stopOnEntry", false);
   const llvm::StringRef debuggerRoot = GetString(arguments, "debuggerRoot");
+  g_vsc.enable_auto_variable_summaries =
+      GetBoolean(arguments, "enableAutoVariableSummaries", false);
+  g_vsc.enable_synthetic_child_debugging =
+      GetBoolean(arguments, "enableSyntheticChildDebugging", false);
 
   // This is a hack for loading DWARF in .o files on Mac where the .o files
   // in the debug map of the main executable have relative paths which require
@@ -3292,7 +3300,8 @@ void request_variables(const llvm::json::Object &request) {
       // "[raw]" child that can be used to inspect the raw version of a
       // synthetic member. That eliminates the need for the user to go to the
       // debug console and type `frame var <variable> to get these values.
-      if (variable.IsSynthetic() && i == num_children)
+      if (g_vsc.enable_synthetic_child_debugging && variable.IsSynthetic() &&
+          i == num_children)
         addChild(variable.GetNonSyntheticValue(), "[raw]");
     }
   }

--- a/lldb/tools/lldb-vscode/package.json
+++ b/lldb/tools/lldb-vscode/package.json
@@ -240,6 +240,16 @@
 							"timeout": {
 								"type": "string",
 								"description": "The time in seconds to wait for a program to stop at entry point when launching with \"launchCommands\". Defaults to 30 seconds."
+							},
+							"enableAutoVariableSummaries": {
+								"type": "boolean",
+								"description": "Enable auto generated summaries for variables when no summaries exist for a given type. This feature can cause performance delays in large projects when viewing variables.",
+								"default": false
+							},
+							"enableSyntheticChildDebugging": {
+								"type": "boolean",
+								"description": "If a variable is displayed using a synthetic children, also display the actual contents of the variable at the end under a [raw] entry. This is useful when creating sythetic child plug-ins as it lets you see the actual contents of the variable.",
+								"default": false
 							}
 						}
 					},
@@ -319,6 +329,16 @@
 							"timeout": {
 								"type": "string",
 								"description": "The time in seconds to wait for a program to stop when attaching using \"attachCommands\". Defaults to 30 seconds."
+							},
+							"enableAutoVariableSummaries": {
+								"type": "boolean",
+								"description": "Enable auto generated summaries for variables when no summaries exist for a given type. This feature can cause performance delays in large projects when viewing variables.",
+								"default": false
+							},
+							"enableSyntheticChildDebugging": {
+								"type": "boolean",
+								"description": "If a variable is displayed using a synthetic children, also display the actual contents of the variable at the end under a [raw] entry. This is useful when creating sythetic child plug-ins as it lets you see the actual contents of the variable.",
+								"default": false
 							}
 						}
 					}


### PR DESCRIPTION
"descriptive summaries" should only be used for small to medium binaries because of the performance penalty the cause when completing types. I'm defaulting it to false.
Besides that, the "raw child" for synthetics should be optional as well. I'm defaulting it to false.

Both options can be set via a launch or attach config, following the pattern of most settings. javascript extension wrappers can set these settings on their own as well.
