### PR TITLE
[OpenMP] Remove optimization skipping reduction struct initialization

### DIFF
--- a/openmp/libomptarget/test/offloading/task_in_reduction_target.c
+++ b/openmp/libomptarget/test/offloading/task_in_reduction_target.c
@@ -1,0 +1,31 @@
+// RUN: %libomptarget-compile-generic && \
+// RUN: %libomptarget-run-generic
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+
+  int num_devices = omp_get_num_devices();
+
+  // No target devices, just return
+  if (num_devices == 0) {
+    printf("PASS\n");
+    return 0;
+  }
+
+  double sum = 999;
+  double A = 311;
+
+#pragma omp taskgroup task_reduction(+ : sum)
+  {
+#pragma omp target map(to : A) in_reduction(+ : sum) device(0) nowait
+    { sum += A; }
+  }
+
+  printf("PASS\n");
+  return EXIT_SUCCESS;
+}
+
+// CHECK: PASS


### PR DESCRIPTION
This commit removes an optimization that skips the initialization of the
reduction struct if the number of threads in a team is 1. This optimization
caused a bug with Hidden Helper Threads. When the task group is initially
initialized by the master thread but a Hidden Helper Thread executes a target
nowait region, it requires the reduction struct initialization to properly
accumulate the data.

This commit also adds a LIT test for issue #57522 to ensure that the issue is
properly addressed and that the optimization removal does not introduce any
regressions.

Fixes: #57522
