### PR TITLE
[Attributor] Only manifest pointer operand for `StoreInst` in `AAAddressSpace`

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -12544,8 +12544,13 @@ struct AAAddressSpaceImpl : public AAAddressSpace {
       // CGSCC if the AA is run on CGSCC instead of the entire module.
       if (!A.isRunOn(Inst->getFunction()))
         return true;
-      if (isa<LoadInst>(Inst) || isa<StoreInst>(Inst))
+      if (isa<LoadInst>(Inst))
         MakeChange(Inst, const_cast<Use &>(U));
+      if (auto *SI = dyn_cast<StoreInst>(Inst)) {
+        // We only make changes if the use is the pointer operand.
+        if (U.getOperandNo() == 1)
+          MakeChange(Inst, const_cast<Use &>(U));
+      }
       return true;
     };
 

--- a/llvm/test/Transforms/Attributor/address_space_info.ll
+++ b/llvm/test/Transforms/Attributor/address_space_info.ll
@@ -20,8 +20,7 @@ define internal void @_Z12global_writePi(ptr noundef %p) #0 {
 ; CHECK-SAME: (ptr nofree noundef nonnull writeonly align 4 dereferenceable(8) [[P:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = addrspacecast ptr [[P]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP1:%.*]] = addrspacecast ptr [[P]] to ptr addrspace(1)
-; CHECK-NEXT:    store ptr addrspace(1) [[TMP0]], ptr addrspace(1) [[TMP1]], align 4
+; CHECK-NEXT:    store ptr [[P]], ptr addrspace(1) [[TMP0]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:


### PR DESCRIPTION
`AAAddressSpace` currently only works for `LoadInst` and `StoreInst` currently. For `StoreInst`, the corresponding use can be the pointer operand, or value operand, or both. When it is used as value operand, it can prevent `AMDGPUPromoteAlloca` from optimization in certain cases. This patch changes the manifest method such that only pointer operand will be rewritten.