### PR TITLE
[clang-format] Fix a serious bug in git-clang-format

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -606,7 +606,7 @@ def apply_changes(old_tree, new_tree, force=False, patch_mode=False):
     index_tree = old_tree
   else:
     with temporary_index_file(new_tree):
-      run('git', 'checkout-index', '-a', '-f')
+      run('git', 'checkout-index', '-f', '--', *changed_files)
   return changed_files
 
 


### PR DESCRIPTION
When applying format changes to staged files, git-clang-format erroneously checks out all files in the index and thus may overwrite unstaged changes.

Fixes #65643.