### PR TITLE
[mlir][Vector] Make `vector.contract` work with scalable vectors

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -820,7 +820,8 @@ static LogicalResult verifyOutputShape(
           return e.cast<AffineConstantExpr>().getValue();
         }));
     auto expected =
-        VectorType::get(expectedShape, resVectorType.getElementType());
+        VectorType::get(expectedShape, resVectorType.getElementType(),
+                        resVectorType.getScalableDims());
     if (resVectorType != expected || accVectorType != expected)
       return op.emitOpError(
                  "invalid accumulator/result vector shape, expected: ")


### PR DESCRIPTION
This is just a small fix that makes sure that `vector.contract` works with scalable vectors.

Rather than duplicating all the roundtrip tests for vector.contract, I'm treating scalable vectors as an edge case and just adding a couple to verify that this works.