### PR TITLE
[AST] Don't merge memory locations in AliasSetTracker

### DIFF
--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -184,10 +184,6 @@ class AliasSetTracker {
   // Map from pointers to their node
   PointerMapType PointerMap;
 
-  // Collection of alias sets that contain undef pointer values
-  DenseSet<AliasSet *> UndefPointerSets;
-  std::vector<AliasSet *> UndefPointerSetsVector;
-
 public:
   /// Create an empty collection of AliasSets, and use the specified alias
   /// analysis object to disambiguate load and store addresses.

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -54,7 +54,7 @@ class AliasSet : public ilist_node<AliasSet> {
   AliasSet *Forward = nullptr;
 
   /// Memory locations in this alias set.
-  std::vector<MemoryLocation> MemoryLocs;
+  SmallVector<MemoryLocation, 0> MemoryLocs;
 
   /// All instructions without a specific address in this alias set.
   std::vector<AssertingVH<Instruction>> UnknownInsts;
@@ -119,7 +119,7 @@ public:
 
   // Alias Set iteration - Allow access to all of the memory locations which are
   // part of this alias set.
-  using iterator = std::vector<MemoryLocation>::const_iterator;
+  using iterator = SmallVectorImpl<MemoryLocation>::const_iterator;
   iterator begin() const { return MemoryLocs.begin(); }
   iterator end() const { return MemoryLocs.end(); }
 

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -184,6 +184,10 @@ class AliasSetTracker {
   // Map from pointers to their node
   PointerMapType PointerMap;
 
+  // Collection of alias sets that contain undef pointer values
+  DenseSet<AliasSet *> UndefPointerSets;
+  std::vector<AliasSet *> UndefPointerSetsVector;
+
 public:
   /// Create an empty collection of AliasSets, and use the specified alias
   /// analysis object to disambiguate load and store addresses.

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -179,7 +179,7 @@ class AliasSetTracker {
   BatchAAResults &AA;
   ilist<AliasSet> AliasSets;
 
-  using PointerMapType = DenseMap<MemoryLocation, AliasSet *>;
+  using PointerMapType = DenseMap<AssertingVH<const Value>, AliasSet *>;
 
   // Map from pointers to their node
   PointerMapType PointerMap;

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -253,7 +253,7 @@ private:
 
   AliasSet &addPointer(MemoryLocation Loc, AliasSet::AccessLattice E);
   AliasSet *mergeAliasSetsForPointer(const MemoryLocation &MemLoc,
-                                     bool &MustAliasAll);
+                                     AliasSet *PtrAS, bool &MustAliasAll);
 
   /// Merge all alias sets into a single set that is considered to alias any
   /// pointer.

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -20,6 +20,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/ilist_node.h"
 #include "llvm/Analysis/MemoryLocation.h"
@@ -116,13 +117,19 @@ public:
   /// Merge the specified alias set into this alias set.
   void mergeSetIn(AliasSet &AS, AliasSetTracker &AST, BatchAAResults &BatchAA);
 
-  // Alias Set iteration - Allow access to all of the pointers which are part of
-  // this alias set.
+  // Alias Set iteration - Allow access to all of the memory locations which are
+  // part of this alias set.
   using iterator = std::vector<MemoryLocation>::const_iterator;
   iterator begin() const { return MemoryLocs.begin(); }
   iterator end() const { return MemoryLocs.end(); }
 
   unsigned size() { return MemoryLocs.size(); }
+
+  /// Retrieve the pointer values for the memory locations in this alias set.
+  /// The order matches that of the memory locations, but duplicate pointer
+  /// values are omitted.
+  using PointerVector = SmallVector<const Value *, 8>;
+  PointerVector getPointers() const;
 
   void print(raw_ostream &OS) const;
   void dump() const;

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -49,98 +49,11 @@ class Value;
 class AliasSet : public ilist_node<AliasSet> {
   friend class AliasSetTracker;
 
-  class PointerRec {
-    Value *Val;  // The pointer this record corresponds to.
-    PointerRec **PrevInList = nullptr;
-    PointerRec *NextInList = nullptr;
-    AliasSet *AS = nullptr;
-    LocationSize Size = LocationSize::mapEmpty();
-    AAMDNodes AAInfo;
-
-    // Whether the size for this record has been set at all. This makes no
-    // guarantees about the size being known.
-    bool isSizeSet() const { return Size != LocationSize::mapEmpty(); }
-
-  public:
-    PointerRec(Value *V)
-      : Val(V), AAInfo(DenseMapInfo<AAMDNodes>::getEmptyKey()) {}
-
-    Value *getValue() const { return Val; }
-
-    PointerRec *getNext() const { return NextInList; }
-    bool hasAliasSet() const { return AS != nullptr; }
-
-    PointerRec** setPrevInList(PointerRec **PIL) {
-      PrevInList = PIL;
-      return &NextInList;
-    }
-
-    bool updateSizeAndAAInfo(LocationSize NewSize, const AAMDNodes &NewAAInfo) {
-      bool SizeChanged = false;
-      if (NewSize != Size) {
-        LocationSize OldSize = Size;
-        Size = isSizeSet() ? Size.unionWith(NewSize) : NewSize;
-        SizeChanged = OldSize != Size;
-      }
-
-      if (AAInfo == DenseMapInfo<AAMDNodes>::getEmptyKey())
-        // We don't have a AAInfo yet. Set it to NewAAInfo.
-        AAInfo = NewAAInfo;
-      else {
-        AAMDNodes Intersection(AAInfo.intersect(NewAAInfo));
-        SizeChanged |= Intersection != AAInfo;
-        AAInfo = Intersection;
-      }
-      return SizeChanged;
-    }
-
-    LocationSize getSize() const {
-      assert(isSizeSet() && "Getting an unset size!");
-      return Size;
-    }
-
-    /// Return the AAInfo, or null if there is no information or conflicting
-    /// information.
-    AAMDNodes getAAInfo() const {
-      // If we have missing or conflicting AAInfo, return null.
-      if (AAInfo == DenseMapInfo<AAMDNodes>::getEmptyKey() ||
-          AAInfo == DenseMapInfo<AAMDNodes>::getTombstoneKey())
-        return AAMDNodes();
-      return AAInfo;
-    }
-
-    AliasSet *getAliasSet(AliasSetTracker &AST) {
-      assert(AS && "No AliasSet yet!");
-      if (AS->Forward) {
-        AliasSet *OldAS = AS;
-        AS = OldAS->getForwardedTarget(AST);
-        AS->addRef();
-        OldAS->dropRef(AST);
-      }
-      return AS;
-    }
-
-    void setAliasSet(AliasSet *as) {
-      assert(!AS && "Already have an alias set!");
-      AS = as;
-    }
-
-    void eraseFromList() {
-      if (NextInList) NextInList->PrevInList = PrevInList;
-      *PrevInList = NextInList;
-      if (AS->PtrListEnd == &NextInList) {
-        AS->PtrListEnd = PrevInList;
-        assert(*AS->PtrListEnd == nullptr && "List not terminated right!");
-      }
-      delete this;
-    }
-  };
-
-  // Doubly linked list of nodes.
-  PointerRec *PtrList = nullptr;
-  PointerRec **PtrListEnd;
   // Forwarding pointer.
   AliasSet *Forward = nullptr;
+
+  /// Memory locations in this alias set.
+  std::vector<MemoryLocation> MemoryLocs;
 
   /// All instructions without a specific address in this alias set.
   std::vector<AssertingVH<Instruction>> UnknownInsts;
@@ -178,8 +91,6 @@ class AliasSet : public ilist_node<AliasSet> {
   };
   unsigned Alias : 1;
 
-  unsigned SetSize = 0;
-
   void addRef() { ++RefCount; }
 
   void dropRef(AliasSetTracker &AST) {
@@ -207,65 +118,19 @@ public:
 
   // Alias Set iteration - Allow access to all of the pointers which are part of
   // this alias set.
-  class iterator;
-  iterator begin() const { return iterator(PtrList); }
-  iterator end()   const { return iterator(); }
-  bool empty() const { return PtrList == nullptr; }
+  using iterator = std::vector<MemoryLocation>::const_iterator;
+  iterator begin() const { return MemoryLocs.begin(); }
+  iterator end() const { return MemoryLocs.end(); }
 
-  // Unfortunately, ilist::size() is linear, so we have to add code to keep
-  // track of the list's exact size.
-  unsigned size() { return SetSize; }
+  unsigned size() { return MemoryLocs.size(); }
 
   void print(raw_ostream &OS) const;
   void dump() const;
 
-  /// Define an iterator for alias sets... this is just a forward iterator.
-  class iterator {
-    PointerRec *CurNode;
-
-  public:
-    using iterator_category = std::forward_iterator_tag;
-    using value_type = PointerRec;
-    using difference_type = std::ptrdiff_t;
-    using pointer = value_type *;
-    using reference = value_type &;
-
-    explicit iterator(PointerRec *CN = nullptr) : CurNode(CN) {}
-
-    bool operator==(const iterator& x) const {
-      return CurNode == x.CurNode;
-    }
-    bool operator!=(const iterator& x) const { return !operator==(x); }
-
-    value_type &operator*() const {
-      assert(CurNode && "Dereferencing AliasSet.end()!");
-      return *CurNode;
-    }
-    value_type *operator->() const { return &operator*(); }
-
-    Value *getPointer() const { return CurNode->getValue(); }
-    LocationSize getSize() const { return CurNode->getSize(); }
-    AAMDNodes getAAInfo() const { return CurNode->getAAInfo(); }
-
-    iterator& operator++() {                // Preincrement
-      assert(CurNode && "Advancing past AliasSet.end()!");
-      CurNode = CurNode->getNext();
-      return *this;
-    }
-    iterator operator++(int) { // Postincrement
-      iterator tmp = *this; ++*this; return tmp;
-    }
-  };
-
 private:
   // Can only be created by AliasSetTracker.
   AliasSet()
-      : PtrListEnd(&PtrList), RefCount(0),  AliasAny(false), Access(NoAccess),
-        Alias(SetMustAlias) {}
-
-  PointerRec *getSomePointer() const {
-    return PtrList;
-  }
+      : RefCount(0), AliasAny(false), Access(NoAccess), Alias(SetMustAlias) {}
 
   /// Return the real alias set this represents. If this has been merged with
   /// another set and is forwarding, return the ultimate destination set. This
@@ -284,16 +149,17 @@ private:
 
   void removeFromTracker(AliasSetTracker &AST);
 
-  void addPointer(AliasSetTracker &AST, PointerRec &Entry, LocationSize Size,
-                  const AAMDNodes &AAInfo, bool KnownMustAlias = false,
-                  bool SkipSizeUpdate = false);
+  bool isMustAliasMergeWith(AliasSet &AS, BatchAAResults &BatchAA) const;
+  void addPointer(AliasSetTracker &AST, const MemoryLocation &MemLoc,
+                  bool KnownMustAlias = false);
   void addUnknownInst(Instruction *I, BatchAAResults &AA);
 
 public:
   /// If the specified pointer "may" (or must) alias one of the members in the
   /// set return the appropriate AliasResult. Otherwise return NoAlias.
-  AliasResult aliasesPointer(const Value *Ptr, LocationSize Size,
-                             const AAMDNodes &AAInfo, BatchAAResults &AA) const;
+  AliasResult aliasesPointer(const MemoryLocation &MemLoc,
+                             BatchAAResults &AA) const;
+
   ModRefInfo aliasesUnknownInst(const Instruction *Inst,
                                 BatchAAResults &AA) const;
 };
@@ -307,7 +173,7 @@ class AliasSetTracker {
   BatchAAResults &AA;
   ilist<AliasSet> AliasSets;
 
-  using PointerMapType = DenseMap<AssertingVH<Value>, AliasSet::PointerRec *>;
+  using PointerMapType = DenseMap<MemoryLocation, AliasSet *>;
 
   // Map from pointers to their node
   PointerMapType PointerMap;
@@ -371,7 +237,7 @@ private:
   friend class AliasSet;
 
   // The total number of pointers contained in all "may" alias sets.
-  unsigned TotalMayAliasSetSize = 0;
+  unsigned TotalAliasSetSize = 0;
 
   // A non-null value signifies this AST is saturated. A saturated AST lumps
   // all pointers into a single "May" set.
@@ -379,18 +245,8 @@ private:
 
   void removeAliasSet(AliasSet *AS);
 
-  /// Just like operator[] on the map, except that it creates an entry for the
-  /// pointer if it doesn't already exist.
-  AliasSet::PointerRec &getEntryFor(Value *V) {
-    AliasSet::PointerRec *&Entry = PointerMap[V];
-    if (!Entry)
-      Entry = new AliasSet::PointerRec(V);
-    return *Entry;
-  }
-
   AliasSet &addPointer(MemoryLocation Loc, AliasSet::AccessLattice E);
-  AliasSet *mergeAliasSetsForPointer(const Value *Ptr, LocationSize Size,
-                                     const AAMDNodes &AAInfo,
+  AliasSet *mergeAliasSetsForPointer(const MemoryLocation &MemLoc,
                                      bool &MustAliasAll);
 
   /// Merge all alias sets into a single set that is considered to alias any

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -149,7 +149,6 @@ private:
 
   void removeFromTracker(AliasSetTracker &AST);
 
-  bool isMustAliasMergeWith(AliasSet &AS, BatchAAResults &BatchAA) const;
   void addPointer(AliasSetTracker &AST, const MemoryLocation &MemLoc,
                   bool KnownMustAlias = false);
   void addUnknownInst(Instruction *I, BatchAAResults &AA);

--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -19,7 +19,6 @@
 #define LLVM_ANALYSIS_ALIASSETTRACKER_H
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/ilist_node.h"
@@ -28,8 +27,6 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/ValueHandle.h"
 #include <cassert>
-#include <cstddef>
-#include <iterator>
 #include <vector>
 
 namespace llvm {

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -54,11 +54,10 @@ void AliasSet::mergeSetIn(AliasSet &AS, AliasSetTracker &AST,
   if (Alias == SetMustAlias) {
     // Check that these two merged sets really are must aliases. If we cannot
     // find a must-alias pair between them, this set becomes a may alias.
-    if (!llvm::any_of(MemoryLocs, [&](const MemoryLocation &MemLoc) {
-          return llvm::any_of(AS.MemoryLocs,
-                              [&](const MemoryLocation &ASMemLoc) {
-                                return BatchAA.isMustAlias(MemLoc, ASMemLoc);
-                              });
+    if (!any_of(MemoryLocs, [&](const MemoryLocation &MemLoc) {
+          return any_of(AS.MemoryLocs, [&](const MemoryLocation &ASMemLoc) {
+            return BatchAA.isMustAlias(MemLoc, ASMemLoc);
+          });
         }))
       Alias = SetMayAlias;
   }
@@ -67,7 +66,7 @@ void AliasSet::mergeSetIn(AliasSet &AS, AliasSetTracker &AST,
   if (MemoryLocs.empty()) {
     std::swap(MemoryLocs, AS.MemoryLocs);
   } else {
-    llvm::append_range(MemoryLocs, AS.MemoryLocs);
+    append_range(MemoryLocs, AS.MemoryLocs);
     AS.MemoryLocs.clear();
   }
 
@@ -115,7 +114,7 @@ void AliasSet::addPointer(AliasSetTracker &AST, const MemoryLocation &MemLoc,
   if (isMustAlias() && !KnownMustAlias) {
     // If we cannot find a must-alias with any of the existing MemoryLocs, we
     // must downgrade to may-alias.
-    if (!llvm::any_of(MemoryLocs, [&](const MemoryLocation &ASMemLoc) {
+    if (!any_of(MemoryLocs, [&](const MemoryLocation &ASMemLoc) {
           return AST.getAliasAnalysis().isMustAlias(MemLoc, ASMemLoc);
         }))
       Alias = SetMayAlias;
@@ -268,7 +267,7 @@ AliasSet &AliasSetTracker::getAliasSetFor(const MemoryLocation &MemLoc) {
   AliasSet *&MapEntry = PointerMap[MemLoc.Ptr];
   if (MapEntry) {
     AliasSet *AS = MapEntry->getForwardedTarget(*this);
-    if (llvm::is_contained(AS->MemoryLocs, MemLoc)) {
+    if (is_contained(AS->MemoryLocs, MemLoc)) {
       if (AS != MapEntry) {
         AS->addRef();
         MapEntry->dropRef(*this);

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -219,6 +219,7 @@ AliasSet::PointerVector AliasSet::getPointers() const {
   } else {
     Result.reserve(MemoryLocs.size());
     DenseSet<const Value *> Seen;
+    Seen.reserve(MemoryLocs.size());
     for (const MemoryLocation &MemLoc : MemoryLocs)
       if (Seen.insert(MemLoc.Ptr).second)
         Result.push_back(MemLoc.Ptr);

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -40,36 +40,38 @@ static cl::opt<unsigned>
                         cl::desc("The maximum number of pointers may-alias "
                                  "sets may contain before degradation"));
 
+bool AliasSet::isMustAliasMergeWith(AliasSet &AS,
+                                    BatchAAResults &BatchAA) const {
+  for (const MemoryLocation &MemLoc : MemoryLocs)
+    for (const MemoryLocation &ASMemLoc : AS.MemoryLocs)
+      if (!BatchAA.isMustAlias(MemLoc, ASMemLoc))
+        return false;
+  return true;
+}
+
 /// mergeSetIn - Merge the specified alias set into this alias set.
 void AliasSet::mergeSetIn(AliasSet &AS, AliasSetTracker &AST,
                           BatchAAResults &BatchAA) {
   assert(!AS.Forward && "Alias set is already forwarding!");
   assert(!Forward && "This set is a forwarding set!!");
 
-  bool WasMustAlias = (Alias == SetMustAlias);
   // Update the alias and access types of this set...
   Access |= AS.Access;
   Alias  |= AS.Alias;
 
   if (Alias == SetMustAlias) {
-    // Check that these two merged sets really are must aliases.  Since both
-    // used to be must-alias sets, we can just check any pointer from each set
-    // for aliasing.
-    PointerRec *L = getSomePointer();
-    PointerRec *R = AS.getSomePointer();
-
+    // Check that these two merged sets really are must aliases.
     // If the pointers are not a must-alias pair, this set becomes a may alias.
-    if (!BatchAA.isMustAlias(
-            MemoryLocation(L->getValue(), L->getSize(), L->getAAInfo()),
-            MemoryLocation(R->getValue(), R->getSize(), R->getAAInfo())))
+    if (!isMustAliasMergeWith(AS, BatchAA))
       Alias = SetMayAlias;
   }
 
-  if (Alias == SetMayAlias) {
-    if (WasMustAlias)
-      AST.TotalMayAliasSetSize += size();
-    if (AS.Alias == SetMustAlias)
-      AST.TotalMayAliasSetSize += AS.size();
+  // Merge the list of constituent pointers...
+  if (MemoryLocs.empty()) {
+    std::swap(MemoryLocs, AS.MemoryLocs);
+  } else {
+    llvm::append_range(MemoryLocs, AS.MemoryLocs);
+    AS.MemoryLocs.clear();
   }
 
   bool ASHadUnknownInsts = !AS.UnknownInsts.empty();
@@ -86,18 +88,6 @@ void AliasSet::mergeSetIn(AliasSet &AS, AliasSetTracker &AST,
   AS.Forward = this; // Forward across AS now...
   addRef();          // AS is now pointing to us...
 
-  // Merge the list of constituent pointers...
-  if (AS.PtrList) {
-    SetSize += AS.size();
-    AS.SetSize = 0;
-    *PtrListEnd = AS.PtrList;
-    AS.PtrList->setPrevInList(PtrListEnd);
-    PtrListEnd = AS.PtrListEnd;
-
-    AS.PtrList = nullptr;
-    AS.PtrListEnd = &AS.PtrList;
-    assert(*AS.PtrListEnd == nullptr && "End of list is not null?");
-  }
   if (ASHadUnknownInsts)
     AS.dropRef(AST);
 }
@@ -106,9 +96,8 @@ void AliasSetTracker::removeAliasSet(AliasSet *AS) {
   if (AliasSet *Fwd = AS->Forward) {
     Fwd->dropRef(*this);
     AS->Forward = nullptr;
-  } else // Update TotalMayAliasSetSize only if not forwarding.
-      if (AS->Alias == AliasSet::SetMayAlias)
-        TotalMayAliasSetSize -= AS->size();
+  } else // Update TotalAliasSetSize only if not forwarding.
+    TotalAliasSetSize -= AS->size();
 
   AliasSets.erase(AS);
   // If we've removed the saturated alias set, set saturated marker back to
@@ -124,42 +113,20 @@ void AliasSet::removeFromTracker(AliasSetTracker &AST) {
   AST.removeAliasSet(this);
 }
 
-void AliasSet::addPointer(AliasSetTracker &AST, PointerRec &Entry,
-                          LocationSize Size, const AAMDNodes &AAInfo,
-                          bool KnownMustAlias, bool SkipSizeUpdate) {
-  assert(!Entry.hasAliasSet() && "Entry already in set!");
-
+void AliasSet::addPointer(AliasSetTracker &AST, const MemoryLocation &MemLoc,
+                          bool KnownMustAlias) {
   // Check to see if we have to downgrade to _may_ alias.
-  if (isMustAlias())
-    if (PointerRec *P = getSomePointer()) {
-      if (!KnownMustAlias) {
-        BatchAAResults &AA = AST.getAliasAnalysis();
-        AliasResult Result = AA.alias(
-            MemoryLocation(P->getValue(), P->getSize(), P->getAAInfo()),
-            MemoryLocation(Entry.getValue(), Size, AAInfo));
-        if (Result != AliasResult::MustAlias) {
-          Alias = SetMayAlias;
-          AST.TotalMayAliasSetSize += size();
-        }
-        assert(Result != AliasResult::NoAlias && "Cannot be part of must set!");
-      } else if (!SkipSizeUpdate)
-        P->updateSizeAndAAInfo(Size, AAInfo);
-    }
-
-  Entry.setAliasSet(this);
-  Entry.updateSizeAndAAInfo(Size, AAInfo);
+  if (isMustAlias() && !KnownMustAlias)
+    for (const MemoryLocation &ASMemLoc : MemoryLocs)
+      if (!AST.getAliasAnalysis().isMustAlias(ASMemLoc, MemLoc)) {
+        Alias = SetMayAlias;
+        break;
+      }
 
   // Add it to the end of the list...
-  ++SetSize;
-  assert(*PtrListEnd == nullptr && "End of list is not null?");
-  *PtrListEnd = &Entry;
-  PtrListEnd = Entry.setPrevInList(PtrListEnd);
-  assert(*PtrListEnd == nullptr && "End of list is not null?");
-  // Entry points to alias set.
-  addRef();
+  MemoryLocs.push_back(MemLoc);
 
-  if (Alias == SetMayAlias)
-    AST.TotalMayAliasSetSize++;
+  AST.TotalAliasSetSize++;
 }
 
 void AliasSet::addUnknownInst(Instruction *I, BatchAAResults &AA) {
@@ -187,41 +154,22 @@ void AliasSet::addUnknownInst(Instruction *I, BatchAAResults &AA) {
 /// members in the set return the appropriate AliasResult. Otherwise return
 /// NoAlias.
 ///
-AliasResult AliasSet::aliasesPointer(const Value *Ptr, LocationSize Size,
-                                     const AAMDNodes &AAInfo,
+AliasResult AliasSet::aliasesPointer(const MemoryLocation &MemLoc,
                                      BatchAAResults &AA) const {
   if (AliasAny)
     return AliasResult::MayAlias;
 
-  if (Alias == SetMustAlias) {
-    assert(UnknownInsts.empty() && "Illegal must alias set!");
-
-    // If this is a set of MustAliases, only check to see if the pointer aliases
-    // SOME value in the set.
-    PointerRec *SomePtr = getSomePointer();
-    assert(SomePtr && "Empty must-alias set??");
-    return AA.alias(MemoryLocation(SomePtr->getValue(), SomePtr->getSize(),
-                                   SomePtr->getAAInfo()),
-                    MemoryLocation(Ptr, Size, AAInfo));
-  }
-
-  // If this is a may-alias set, we have to check all of the pointers in the set
-  // to be sure it doesn't alias the set...
-  for (iterator I = begin(), E = end(); I != E; ++I) {
-    AliasResult AR =
-        AA.alias(MemoryLocation(Ptr, Size, AAInfo),
-                 MemoryLocation(I.getPointer(), I.getSize(), I.getAAInfo()));
+  // Check all of the pointers in the set...
+  for (const auto &ASMemLoc : MemoryLocs) {
+    AliasResult AR = AA.alias(MemLoc, ASMemLoc);
     if (AR != AliasResult::NoAlias)
       return AR;
   }
 
   // Check the unknown instructions...
-  if (!UnknownInsts.empty()) {
-    for (Instruction *Inst : UnknownInsts)
-      if (isModOrRefSet(
-              AA.getModRefInfo(Inst, MemoryLocation(Ptr, Size, AAInfo))))
-        return AliasResult::MayAlias;
-  }
+  for (Instruction *Inst : UnknownInsts)
+    if (isModOrRefSet(AA.getModRefInfo(Inst, MemLoc)))
+      return AliasResult::MayAlias;
 
   return AliasResult::NoAlias;
 }
@@ -246,9 +194,8 @@ ModRefInfo AliasSet::aliasesUnknownInst(const Instruction *Inst,
   }
 
   ModRefInfo MR = ModRefInfo::NoModRef;
-  for (iterator I = begin(), E = end(); I != E; ++I) {
-    MR |= AA.getModRefInfo(
-        Inst, MemoryLocation(I.getPointer(), I.getSize(), I.getAAInfo()));
+  for (const auto &ASMemLoc : MemoryLocs) {
+    MR |= AA.getModRefInfo(Inst, ASMemLoc);
     if (isModAndRefSet(MR))
       return MR;
   }
@@ -257,13 +204,7 @@ ModRefInfo AliasSet::aliasesUnknownInst(const Instruction *Inst,
 }
 
 void AliasSetTracker::clear() {
-  // Delete all the PointerRec entries.
-  for (auto &I : PointerMap)
-    I.second->eraseFromList();
-
   PointerMap.clear();
-
-  // The alias sets should all be clear now.
   AliasSets.clear();
 }
 
@@ -271,17 +212,16 @@ void AliasSetTracker::clear() {
 /// alias the pointer. Return the unified set, or nullptr if no set that aliases
 /// the pointer was found. MustAliasAll is updated to true/false if the pointer
 /// is found to MustAlias all the sets it merged.
-AliasSet *AliasSetTracker::mergeAliasSetsForPointer(const Value *Ptr,
-                                                    LocationSize Size,
-                                                    const AAMDNodes &AAInfo,
-                                                    bool &MustAliasAll) {
+AliasSet *
+AliasSetTracker::mergeAliasSetsForPointer(const MemoryLocation &MemLoc,
+                                          bool &MustAliasAll) {
   AliasSet *FoundSet = nullptr;
   MustAliasAll = true;
   for (AliasSet &AS : llvm::make_early_inc_range(*this)) {
     if (AS.Forward)
       continue;
 
-    AliasResult AR = AS.aliasesPointer(Ptr, Size, AAInfo, AA);
+    AliasResult AR = AS.aliasesPointer(MemLoc, AA);
     if (AR == AliasResult::NoAlias)
       continue;
 
@@ -317,62 +257,42 @@ AliasSet *AliasSetTracker::findAliasSetForUnknownInst(Instruction *Inst) {
 }
 
 AliasSet &AliasSetTracker::getAliasSetFor(const MemoryLocation &MemLoc) {
+  // Check if this MemLoc is already registered
+  AliasSet *&AS = PointerMap[MemLoc];
+  if (AS) {
+    if (AS->Forward) {
+      // Update PointerMap entry to point to new target
+      AliasSet *OldAS = AS;
+      AS = OldAS->getForwardedTarget(*this);
+      AS->addRef();
+      OldAS->dropRef(*this);
+    }
+    return *AS;
+  }
 
-  Value * const Pointer = const_cast<Value*>(MemLoc.Ptr);
-  const LocationSize Size = MemLoc.Size;
-  const AAMDNodes &AAInfo = MemLoc.AATags;
-
-  AliasSet::PointerRec &Entry = getEntryFor(Pointer);
-
+  bool MustAliasAll = false;
   if (AliasAnyAS) {
     // At this point, the AST is saturated, so we only have one active alias
     // set. That means we already know which alias set we want to return, and
     // just need to add the pointer to that set to keep the data structure
     // consistent.
     // This, of course, means that we will never need a merge here.
-    if (Entry.hasAliasSet()) {
-      Entry.updateSizeAndAAInfo(Size, AAInfo);
-      assert(Entry.getAliasSet(*this) == AliasAnyAS &&
-             "Entry in saturated AST must belong to only alias set");
-    } else {
-      AliasAnyAS->addPointer(*this, Entry, Size, AAInfo);
-    }
-    return *AliasAnyAS;
-  }
-
-  bool MustAliasAll = false;
-  // Check to see if the pointer is already known.
-  if (Entry.hasAliasSet()) {
-    // If the size changed, we may need to merge several alias sets.
-    // Note that we can *not* return the result of mergeAliasSetsForPointer
-    // due to a quirk of alias analysis behavior. Since alias(undef, undef)
-    // is NoAlias, mergeAliasSetsForPointer(undef, ...) will not find the
-    // the right set for undef, even if it exists.
-    if (Entry.updateSizeAndAAInfo(Size, AAInfo)) {
-      mergeAliasSetsForPointer(Pointer, Size, AAInfo, MustAliasAll);
-
-      // For MustAlias sets, also update Size/AAInfo of the representative
-      // pointer.
-      AliasSet &AS = *Entry.getAliasSet(*this);
-      if (AS.isMustAlias())
-        if (AliasSet::PointerRec *P = AS.getSomePointer())
-          P->updateSizeAndAAInfo(Size, AAInfo);
-    }
-    // Return the set!
-    return *Entry.getAliasSet(*this)->getForwardedTarget(*this);
-  }
-
-  if (AliasSet *AS =
-          mergeAliasSetsForPointer(Pointer, Size, AAInfo, MustAliasAll)) {
+    AS = AliasAnyAS;
+  } else if (AliasSet *AliasAS =
+                 mergeAliasSetsForPointer(MemLoc, MustAliasAll)) {
     // Add it to the alias set it aliases.
-    AS->addPointer(*this, Entry, Size, AAInfo, MustAliasAll);
-    return *AS;
+    AS = AliasAS;
+  } else {
+    // Otherwise create a new alias set to hold the loaded pointer.
+    AS = new AliasSet();
+    AliasSets.push_back(AS);
+    MustAliasAll = true;
   }
-
-  // Otherwise create a new alias set to hold the loaded pointer.
-  AliasSets.push_back(new AliasSet());
-  AliasSets.back().addPointer(*this, Entry, Size, AAInfo, true);
-  return AliasSets.back();
+  // Register MemLoc in selected alias set
+  AS->addPointer(*this, MemLoc, MustAliasAll);
+  // PointerMap entry now points to the alias set
+  AS->addRef();
+  return *AS;
 }
 
 void AliasSetTracker::add(const MemoryLocation &Loc) {
@@ -509,15 +429,13 @@ void AliasSetTracker::add(const AliasSetTracker &AST) {
       add(Inst);
 
     // Loop over all of the pointers in this alias set.
-    for (AliasSet::iterator ASI = AS.begin(), E = AS.end(); ASI != E; ++ASI)
-      addPointer(
-          MemoryLocation(ASI.getPointer(), ASI.getSize(), ASI.getAAInfo()),
-          (AliasSet::AccessLattice)AS.Access);
+    for (const MemoryLocation &ASMemLoc : AS.MemoryLocs)
+      addPointer(ASMemLoc, (AliasSet::AccessLattice)AS.Access);
   }
 }
 
 AliasSet &AliasSetTracker::mergeAllAliasSets() {
-  assert(!AliasAnyAS && (TotalMayAliasSetSize > SaturationThreshold) &&
+  assert(!AliasAnyAS && (TotalAliasSetSize > SaturationThreshold) &&
          "Full merge should happen once, when the saturation threshold is "
          "reached");
 
@@ -558,7 +476,7 @@ AliasSet &AliasSetTracker::addPointer(MemoryLocation Loc,
   AliasSet &AS = getAliasSetFor(Loc);
   AS.Access |= E;
 
-  if (!AliasAnyAS && (TotalMayAliasSetSize > SaturationThreshold)) {
+  if (!AliasAnyAS && (TotalAliasSetSize > SaturationThreshold)) {
     // The AST is now saturated. From here on, we conservatively consider all
     // pointers to alias each-other.
     return mergeAllAliasSets();
@@ -584,17 +502,18 @@ void AliasSet::print(raw_ostream &OS) const {
   if (Forward)
     OS << " forwarding to " << (void*)Forward;
 
-  if (!empty()) {
+  if (!MemoryLocs.empty()) {
+    ListSeparator LS;
     OS << "Pointers: ";
-    for (iterator I = begin(), E = end(); I != E; ++I) {
-      if (I != begin()) OS << ", ";
-      I.getPointer()->printAsOperand(OS << "(");
-      if (I.getSize() == LocationSize::afterPointer())
+    for (const MemoryLocation &MemLoc : MemoryLocs) {
+      OS << LS;
+      MemLoc.Ptr->printAsOperand(OS << "(");
+      if (MemLoc.Size == LocationSize::afterPointer())
         OS << ", unknown after)";
-      else if (I.getSize() == LocationSize::beforeOrAfterPointer())
+      else if (MemLoc.Size == LocationSize::beforeOrAfterPointer())
         OS << ", unknown before-or-after)";
       else
-        OS << ", " << I.getSize() << ")";
+        OS << ", " << MemLoc.Size << ")";
     }
   }
   if (!UnknownInsts.empty()) {
@@ -615,7 +534,7 @@ void AliasSetTracker::print(raw_ostream &OS) const {
   OS << "Alias Set Tracker: " << AliasSets.size();
   if (AliasAnyAS)
     OS << " (Saturated)";
-  OS << " alias sets for " << PointerMap.size() << " pointer values.\n";
+  OS << " alias sets for " << PointerMap.size() << " memory locations.\n";
   for (const AliasSet &AS : *this)
     AS.print(OS);
   OS << "\n";

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -523,7 +523,7 @@ void AliasSet::print(raw_ostream &OS) const {
 
   if (!MemoryLocs.empty()) {
     ListSeparator LS;
-    OS << "Pointers: "; // FIXME: update output together with tests
+    OS << "Memory locations: ";
     for (const MemoryLocation &MemLoc : MemoryLocs) {
       OS << LS;
       MemLoc.Ptr->printAsOperand(OS << "(");

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1143,7 +1143,7 @@ bool AccessAnalysis::canCheckPtrAtRT(RuntimePointerChecking &RtCheck,
         (NumWritePtrChecks == 1 && NumReadPtrChecks == 0)) {
       assert((ASPointers.size() <= 1 ||
               all_of(ASPointers,
-                     [this](auto Ptr) {
+                     [this](const Value *Ptr) {
                        MemAccessInfo AccessWrite(const_cast<Value *>(Ptr),
                                                  true);
                        return DepCands.findValue(AccessWrite) == DepCands.end();

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1115,6 +1115,7 @@ bool AccessAnalysis::canCheckPtrAtRT(RuntimePointerChecking &RtCheck,
     int NumWritePtrChecks = 0;
     bool CanDoAliasSetRT = true;
     ++ASId;
+    auto ASPointers = AS.getPointers();
 
     // We assign consecutive id to access from different dependence sets.
     // Accesses within the same set don't need a runtime check.
@@ -1126,8 +1127,8 @@ bool AccessAnalysis::canCheckPtrAtRT(RuntimePointerChecking &RtCheck,
     // First, count how many write and read accesses are in the alias set. Also
     // collect MemAccessInfos for later.
     SmallVector<MemAccessInfo, 4> AccessInfos;
-    for (const auto &A : AS) {
-      Value *Ptr = const_cast<Value *>(A.Ptr);
+    for (const Value *Ptr_ : ASPointers) {
+      Value *Ptr = const_cast<Value *>(Ptr_);
       bool IsWrite = Accesses.count(MemAccessInfo(Ptr, true));
       if (IsWrite)
         ++NumWritePtrChecks;
@@ -1140,10 +1141,10 @@ bool AccessAnalysis::canCheckPtrAtRT(RuntimePointerChecking &RtCheck,
     // or a single write and no reads.
     if (NumWritePtrChecks == 0 ||
         (NumWritePtrChecks == 1 && NumReadPtrChecks == 0)) {
-      assert((AS.size() <= 1 ||
-              all_of(AS,
-                     [this](auto AC) {
-                       MemAccessInfo AccessWrite(const_cast<Value *>(AC.Ptr),
+      assert((ASPointers.size() <= 1 ||
+              all_of(ASPointers,
+                     [this](auto Ptr) {
+                       MemAccessInfo AccessWrite(const_cast<Value *>(Ptr),
                                                  true);
                        return DepCands.findValue(AccessWrite) == DepCands.end();
                      })) &&
@@ -1272,8 +1273,9 @@ void AccessAnalysis::processMemAccesses() {
   // set.
   for (const auto &AS : AST) {
     // Note that both the alias-set tracker and the alias sets themselves used
-    // linked lists internally and so the iteration order here is deterministic
-    // (matching the original instruction order within each set).
+    // ordered collections internally and so the iteration order here is
+    // deterministic.
+    auto ASPointers = AS.getPointers();
 
     bool SetHasWrite = false;
 
@@ -1290,8 +1292,8 @@ void AccessAnalysis::processMemAccesses() {
       bool UseDeferred = SetIteration > 0;
       PtrAccessMap &S = UseDeferred ? DeferredAccesses : Accesses;
 
-      for (const auto &AV : AS) {
-        Value *Ptr = const_cast<Value *>(AV.Ptr);
+      for (const Value *Ptr_ : ASPointers) {
+        Value *Ptr = const_cast<Value *>(Ptr_);
 
         // For a single memory access in AliasSetTracker, Accesses may contain
         // both read and write, and they both need to be handled for CheckDeps.

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1127,7 +1127,7 @@ bool AccessAnalysis::canCheckPtrAtRT(RuntimePointerChecking &RtCheck,
     // collect MemAccessInfos for later.
     SmallVector<MemAccessInfo, 4> AccessInfos;
     for (const auto &A : AS) {
-      Value *Ptr = A.getValue();
+      Value *Ptr = const_cast<Value *>(A.Ptr);
       bool IsWrite = Accesses.count(MemAccessInfo(Ptr, true));
       if (IsWrite)
         ++NumWritePtrChecks;
@@ -1143,7 +1143,8 @@ bool AccessAnalysis::canCheckPtrAtRT(RuntimePointerChecking &RtCheck,
       assert((AS.size() <= 1 ||
               all_of(AS,
                      [this](auto AC) {
-                       MemAccessInfo AccessWrite(AC.getValue(), true);
+                       MemAccessInfo AccessWrite(const_cast<Value *>(AC.Ptr),
+                                                 true);
                        return DepCands.findValue(AccessWrite) == DepCands.end();
                      })) &&
              "Can only skip updating CanDoRT below, if all entries in AS "
@@ -1290,7 +1291,7 @@ void AccessAnalysis::processMemAccesses() {
       PtrAccessMap &S = UseDeferred ? DeferredAccesses : Accesses;
 
       for (const auto &AV : AS) {
-        Value *Ptr = AV.getValue();
+        Value *Ptr = const_cast<Value *>(AV.Ptr);
 
         // For a single memory access in AliasSetTracker, Accesses may contain
         // both read and write, and they both need to be handled for CheckDeps.

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2323,8 +2323,8 @@ collectPromotionCandidates(MemorySSA *MSSA, AliasAnalysis *AA, Loop *L) {
   SmallVector<std::pair<SmallSetVector<Value *, 8>, bool>, 0> Result;
   for (auto [Set, HasReadsOutsideSet] : Sets) {
     SmallSetVector<Value *, 8> PointerMustAliases;
-    for (const auto &ASI : *Set)
-      PointerMustAliases.insert(const_cast<Value *>(ASI.Ptr));
+    for (const auto &MemLoc : *Set)
+      PointerMustAliases.insert(const_cast<Value *>(MemLoc.Ptr));
     Result.emplace_back(std::move(PointerMustAliases), HasReadsOutsideSet);
   }
 

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2324,7 +2324,7 @@ collectPromotionCandidates(MemorySSA *MSSA, AliasAnalysis *AA, Loop *L) {
   for (auto [Set, HasReadsOutsideSet] : Sets) {
     SmallSetVector<Value *, 8> PointerMustAliases;
     for (const auto &ASI : *Set)
-      PointerMustAliases.insert(ASI.getValue());
+      PointerMustAliases.insert(const_cast<Value *>(ASI.Ptr));
     Result.emplace_back(std::move(PointerMustAliases), HasReadsOutsideSet);
   }
 

--- a/llvm/lib/Transforms/Scalar/LoopVersioningLICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopVersioningLICM.cpp
@@ -263,8 +263,8 @@ bool LoopVersioningLICM::legalLoopMemoryAccesses() {
     // Check for Mod & MayAlias
     HasMayAlias |= AS.isMayAlias();
     HasMod |= AS.isMod();
-    for (const auto &A : AS) {
-      const Value *Ptr = A.Ptr;
+    for (const auto &MemLoc : AS) {
+      const Value *Ptr = MemLoc.Ptr;
       // Alias tracker should have pointers of same data type.
       //
       // FIXME: check no longer effective since opaque pointers?

--- a/llvm/lib/Transforms/Scalar/LoopVersioningLICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopVersioningLICM.cpp
@@ -258,13 +258,13 @@ bool LoopVersioningLICM::legalLoopMemoryAccesses() {
     // With MustAlias its not worth adding runtime bound check.
     if (AS.isMustAlias())
       return false;
-    Value *SomePtr = AS.begin()->getValue();
+    const Value *SomePtr = AS.begin()->Ptr;
     bool TypeCheck = true;
     // Check for Mod & MayAlias
     HasMayAlias |= AS.isMayAlias();
     HasMod |= AS.isMod();
     for (const auto &A : AS) {
-      Value *Ptr = A.getValue();
+      const Value *Ptr = A.Ptr;
       // Alias tracker should have pointers of same data type.
       //
       // FIXME: check no longer effective since opaque pointers?

--- a/llvm/test/Analysis/AliasSet/argmemonly.ll
+++ b/llvm/test/Analysis/AliasSet/argmemonly.ll
@@ -4,7 +4,7 @@
 @d = global i8 2, align 1
 
 ; CHECK: Alias sets for function 'test_alloca_argmemonly':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
 define void @test_alloca_argmemonly(ptr %s, ptr %d) {
@@ -16,9 +16,9 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_readonly_arg'
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Ref       Pointers: (ptr %s, unknown before-or-after), (ptr %s, LocationSize::precise(1))
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, unknown before-or-after), (ptr %s, LocationSize::precise(1))
 define i8 @test_readonly_arg(ptr noalias %s, ptr noalias %d) {
 entry:
   call void @my_memcpy(ptr %d, ptr %s, i64 1)
@@ -27,7 +27,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_noalias_argmemonly':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
 define void @test_noalias_argmemonly(ptr noalias %a, ptr %s, ptr %d) {
@@ -38,9 +38,9 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 4 memory locations.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
 define void @test5(ptr noalias %a, ptr noalias %b) {
 entry:
   store i8 1, ptr %a, align 1
@@ -50,9 +50,9 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_argcollapse':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 4 memory locations.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
 define void @test_argcollapse(ptr noalias %a, ptr noalias %b) {
 entry:
   store i8 1, ptr %a, align 1
@@ -62,7 +62,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memcpy1':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after)
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, unknown before-or-after)
 define void @test_memcpy1(ptr noalias %a, ptr noalias %b) {
@@ -73,7 +73,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memset1':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
 define void @test_memset1() {
 entry:
@@ -83,7 +83,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memset2':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
 define void @test_memset2(ptr %a) {
 entry:
@@ -92,7 +92,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memset3':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod Pointers: (ptr %a, unknown before-or-after), (ptr %b, unknown before-or-after)
 define void @test_memset3(ptr %a, ptr %b) {
 entry:
@@ -104,7 +104,7 @@ entry:
 ;; PICKUP HERE
 
 ; CHECK: Alias sets for function 'test_memset4':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %b, unknown before-or-after)
 define void @test_memset4(ptr noalias %a, ptr noalias %b) {
@@ -120,7 +120,7 @@ declare void @my_memmove(ptr nocapture, ptr nocapture readonly, i64) argmemonly
 
 
 ; CHECK: Alias sets for function 'test_attribute_intersect':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 memory locations.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 define i8 @test_attribute_intersect(ptr noalias %a) {
 entry:

--- a/llvm/test/Analysis/AliasSet/argmemonly.ll
+++ b/llvm/test/Analysis/AliasSet/argmemonly.ll
@@ -4,7 +4,7 @@
 @d = global i8 2, align 1
 
 ; CHECK: Alias sets for function 'test_alloca_argmemonly':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
 define void @test_alloca_argmemonly(ptr %s, ptr %d) {
@@ -16,9 +16,9 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_readonly_arg'
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Ref       Pointers: (ptr %s, unknown before-or-after), (ptr %s, LocationSize::precise(1))
 define i8 @test_readonly_arg(ptr noalias %s, ptr noalias %d) {
 entry:
   call void @my_memcpy(ptr %d, ptr %s, i64 1)
@@ -27,7 +27,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_noalias_argmemonly':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
 define void @test_noalias_argmemonly(ptr noalias %a, ptr %s, ptr %d) {
@@ -38,9 +38,9 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %b, unknown before-or-after)
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 4 memory locations.
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
 define void @test5(ptr noalias %a, ptr noalias %b) {
 entry:
   store i8 1, ptr %a, align 1
@@ -50,9 +50,9 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_argcollapse':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after)
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 4 memory locations.
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
 define void @test_argcollapse(ptr noalias %a, ptr noalias %b) {
 entry:
   store i8 1, ptr %a, align 1
@@ -62,7 +62,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memcpy1':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after)
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, unknown before-or-after)
 define void @test_memcpy1(ptr noalias %a, ptr noalias %b) {
@@ -73,7 +73,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memset1':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
 define void @test_memset1() {
 entry:
@@ -83,7 +83,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memset2':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
 define void @test_memset2(ptr %a) {
 entry:
@@ -92,7 +92,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_memset3':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod Pointers: (ptr %a, unknown before-or-after), (ptr %b, unknown before-or-after)
 define void @test_memset3(ptr %a, ptr %b) {
 entry:
@@ -104,7 +104,7 @@ entry:
 ;; PICKUP HERE
 
 ; CHECK: Alias sets for function 'test_memset4':
-; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %b, unknown before-or-after)
 define void @test_memset4(ptr noalias %a, ptr noalias %b) {
@@ -120,7 +120,7 @@ declare void @my_memmove(ptr nocapture, ptr nocapture readonly, i64) argmemonly
 
 
 ; CHECK: Alias sets for function 'test_attribute_intersect':
-; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
+; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 memory locations.
 ; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 define i8 @test_attribute_intersect(ptr noalias %a) {
 entry:

--- a/llvm/test/Analysis/AliasSet/argmemonly.ll
+++ b/llvm/test/Analysis/AliasSet/argmemonly.ll
@@ -5,8 +5,8 @@
 
 ; CHECK: Alias sets for function 'test_alloca_argmemonly':
 ; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Memory locations: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
 define void @test_alloca_argmemonly(ptr %s, ptr %d) {
 entry:
   %a = alloca i8, align 1
@@ -17,8 +17,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test_readonly_arg'
 ; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, unknown before-or-after), (ptr %s, LocationSize::precise(1))
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %s, unknown before-or-after), (ptr %s, LocationSize::precise(1))
 define i8 @test_readonly_arg(ptr noalias %s, ptr noalias %d) {
 entry:
   call void @my_memcpy(ptr %d, ptr %s, i64 1)
@@ -28,8 +28,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test_noalias_argmemonly':
 ; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Memory locations: (ptr %d, unknown before-or-after), (ptr %s, unknown before-or-after)
 define void @test_noalias_argmemonly(ptr noalias %a, ptr %s, ptr %d) {
 entry:
   store i8 1, ptr %a, align 1
@@ -39,8 +39,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test5':
 ; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Memory locations: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
 define void @test5(ptr noalias %a, ptr noalias %b) {
 entry:
   store i8 1, ptr %a, align 1
@@ -51,8 +51,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test_argcollapse':
 ; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Memory locations: (ptr %b, unknown before-or-after), (ptr %b, LocationSize::precise(1))
 define void @test_argcollapse(ptr noalias %a, ptr noalias %b) {
 entry:
   store i8 1, ptr %a, align 1
@@ -63,8 +63,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test_memcpy1':
 ; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %b, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Pointers: (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Memory locations: (ptr %b, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref Memory locations: (ptr %a, unknown before-or-after)
 define void @test_memcpy1(ptr noalias %a, ptr noalias %b) {
 entry:
   call void @my_memcpy(ptr %b, ptr %a, i64 1)
@@ -74,7 +74,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test_memset1':
 ; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Memory locations: (ptr %a, unknown before-or-after)
 define void @test_memset1() {
 entry:
   %a = alloca i8, align 1
@@ -84,7 +84,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test_memset2':
 ; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Memory locations: (ptr %a, unknown before-or-after)
 define void @test_memset2(ptr %a) {
 entry:
   call void @my_memset(ptr %a, i8 0, i64 1)
@@ -93,7 +93,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test_memset3':
 ; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod Pointers: (ptr %a, unknown before-or-after), (ptr %b, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod Memory locations: (ptr %a, unknown before-or-after), (ptr %b, unknown before-or-after)
 define void @test_memset3(ptr %a, ptr %b) {
 entry:
   call void @my_memset(ptr %a, i8 0, i64 1)
@@ -105,8 +105,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test_memset4':
 ; CHECK-NEXT: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %a, unknown before-or-after)
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Pointers: (ptr %b, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Memory locations: (ptr %a, unknown before-or-after)
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod Memory locations: (ptr %b, unknown before-or-after)
 define void @test_memset4(ptr noalias %a, ptr noalias %b) {
 entry:
   call void @my_memset(ptr %a, i8 0, i64 1)
@@ -121,7 +121,7 @@ declare void @my_memmove(ptr nocapture, ptr nocapture readonly, i64) argmemonly
 
 ; CHECK: Alias sets for function 'test_attribute_intersect':
 ; CHECK-NEXT: Alias Set Tracker: 1 alias sets for 1 pointer values.
-; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK-NEXT: AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define i8 @test_attribute_intersect(ptr noalias %a) {
 entry:
   ;; This call is effectively readnone since the argument is readonly

--- a/llvm/test/Analysis/AliasSet/guards.ll
+++ b/llvm/test/Analysis/AliasSet/guards.ll
@@ -3,10 +3,10 @@ declare void @llvm.experimental.guard(i1, ...)
 
 ; CHECK: Alias sets for function 'test0':
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test0(i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -19,10 +19,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test1':
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test1(i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -35,10 +35,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test2':
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test2(i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -51,10 +51,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test3':
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test3(i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -69,8 +69,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test4(i1 %cond_a) {
 entry:
   %a = alloca i8, align 1
@@ -85,8 +85,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test5(i1 %cond_a) {
 entry:
   %a = alloca i8, align 1
@@ -101,8 +101,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test6(i1 %cond_a) {
 entry:
   %a = alloca i8, align 1
@@ -117,8 +117,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test7(i1 %cond_a) {
 entry:
   %a = alloca i8, align 1
@@ -133,8 +133,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test8(i1 %cond_a, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -150,8 +150,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test9(i1 %cond_a, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -167,8 +167,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test10(i1 %cond_a, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -184,8 +184,8 @@ entry:
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test11(i1 %cond_a, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -199,8 +199,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test12':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test12(ptr %b, i1 %cond_b) {
 entry:
@@ -213,8 +213,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test13':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test13(ptr %b, i1 %cond_b) {
 entry:
@@ -227,8 +227,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test14':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test14(ptr %b, i1 %cond_b) {
 entry:
@@ -241,8 +241,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test15':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test15(ptr %b, i1 %cond_b) {
 entry:
@@ -255,9 +255,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test16':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test16(i1 %cond_a, ptr %b) {
 entry:
   %a = alloca i8, align 1
@@ -269,9 +269,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test17':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test17(i1 %cond_a, ptr %b) {
 entry:
   %a = alloca i8, align 1
@@ -283,9 +283,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test18':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test18(i1 %cond_a, ptr %b) {
 entry:
   %a = alloca i8, align 1
@@ -297,9 +297,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test19':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test19(i1 %cond_a, ptr %b) {
 entry:
   %a = alloca i8, align 1
@@ -311,9 +311,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test20':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test20(i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -326,9 +326,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test21':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test21(i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -341,9 +341,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test22':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test22(i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -356,9 +356,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test23':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test23(i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -371,9 +371,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test24':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test24(ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -386,9 +386,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test25':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test25(ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -401,9 +401,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test26':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test26(ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -416,9 +416,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test27':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test27(ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -431,9 +431,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test28':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test28(i1 %cond_a, ptr %ptr_b) {
 entry:
   %a = alloca i8, align 1
@@ -446,9 +446,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test29':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test29(i1 %cond_a, ptr %ptr_b) {
 entry:
   %a = alloca i8, align 1
@@ -461,9 +461,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test30':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test30(i1 %cond_a, ptr %ptr_b) {
 entry:
   %a = alloca i8, align 1
@@ -476,9 +476,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test31':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test31(i1 %cond_a, ptr %ptr_b) {
 entry:
   %a = alloca i8, align 1
@@ -491,9 +491,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test32':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test32(i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -507,9 +507,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test33':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test33(i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -523,9 +523,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test34':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test34(i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -539,9 +539,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test35':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 define void @test35(i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
   %a = alloca i8, align 1
@@ -555,9 +555,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test36':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test36(ptr %a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -569,9 +569,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test37':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test37(ptr %a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -583,9 +583,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test38':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test38(ptr %a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -597,9 +597,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test39':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test39(ptr %a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -611,9 +611,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test40':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test40(ptr %a, i1 %cond_a) {
 entry:
   %b = alloca i8, align 1
@@ -625,9 +625,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test41':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test41(ptr %a, i1 %cond_a) {
 entry:
   %b = alloca i8, align 1
@@ -639,9 +639,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test42':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test42(ptr %a, i1 %cond_a) {
 entry:
   %b = alloca i8, align 1
@@ -653,9 +653,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test43':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test43(ptr %a, i1 %cond_a) {
 entry:
   %b = alloca i8, align 1
@@ -667,9 +667,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test44':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test44(ptr %a, i1 %cond_a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -682,9 +682,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test45':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test45(ptr %a, i1 %cond_a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -697,9 +697,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test46':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test46(ptr %a, i1 %cond_a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -712,9 +712,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test47':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test47(ptr %a, i1 %cond_a, i1 %cond_b) {
 entry:
   %b = alloca i8, align 1
@@ -727,7 +727,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test48':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test48(ptr %a, ptr %b, i1 %cond_b) {
 entry:
@@ -739,7 +739,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test49':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test49(ptr %a, ptr %b, i1 %cond_b) {
 entry:
@@ -751,7 +751,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test50':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test50(ptr %a, ptr %b, i1 %cond_b) {
 entry:
@@ -763,7 +763,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test51':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test51(ptr %a, ptr %b, i1 %cond_b) {
 entry:
@@ -775,7 +775,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test52':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test52(ptr %a, i1 %cond_a, ptr %b) {
 entry:
@@ -787,7 +787,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test53':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test53(ptr %a, i1 %cond_a, ptr %b) {
 entry:
@@ -799,7 +799,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test54':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test54(ptr %a, i1 %cond_a, ptr %b) {
 entry:
@@ -811,7 +811,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test55':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test55(ptr %a, i1 %cond_a, ptr %b) {
 entry:
@@ -823,7 +823,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test56':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test56(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -836,7 +836,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test57':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test57(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -849,7 +849,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test58':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test58(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -862,7 +862,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test59':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test59(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -875,7 +875,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test60':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test60(ptr %a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -888,7 +888,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test61':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test61(ptr %a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -901,7 +901,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test62':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test62(ptr %a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -914,7 +914,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test63':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test63(ptr %a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -927,7 +927,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test64':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test64(ptr %a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -940,7 +940,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test65':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test65(ptr %a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -953,7 +953,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test66':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test66(ptr %a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -966,7 +966,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test67':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test67(ptr %a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -979,7 +979,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test68':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test68(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -993,7 +993,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test69':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test69(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1007,7 +1007,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test70':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test70(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1021,7 +1021,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test71':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test71(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1035,9 +1035,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test72':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test72(ptr %ptr_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1050,9 +1050,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test73':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test73(ptr %ptr_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1065,9 +1065,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test74':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test74(ptr %ptr_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1080,9 +1080,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test75':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test75(ptr %ptr_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1095,9 +1095,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test76':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test76(ptr %ptr_a, i1 %cond_a) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1110,9 +1110,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test77':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test77(ptr %ptr_a, i1 %cond_a) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1125,9 +1125,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test78':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test78(ptr %ptr_a, i1 %cond_a) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1140,9 +1140,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test79':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test79(ptr %ptr_a, i1 %cond_a) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1155,9 +1155,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test80':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test80(ptr %ptr_a, i1 %cond_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1171,9 +1171,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test81':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test81(ptr %ptr_a, i1 %cond_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1187,9 +1187,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test82':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test82(ptr %ptr_a, i1 %cond_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1203,9 +1203,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test83':
 ; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test83(ptr %ptr_a, i1 %cond_a, i1 %cond_b) {
 entry:
   %a = load ptr, ptr %ptr_a
@@ -1219,7 +1219,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test84':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test84(ptr %ptr_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1232,7 +1232,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test85':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test85(ptr %ptr_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1245,7 +1245,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test86':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test86(ptr %ptr_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1258,7 +1258,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test87':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test87(ptr %ptr_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1271,7 +1271,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test88':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test88(ptr %ptr_a, i1 %cond_a, ptr %b) {
 entry:
@@ -1284,7 +1284,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test89':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test89(ptr %ptr_a, i1 %cond_a, ptr %b) {
 entry:
@@ -1297,7 +1297,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test90':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test90(ptr %ptr_a, i1 %cond_a, ptr %b) {
 entry:
@@ -1310,7 +1310,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test91':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test91(ptr %ptr_a, i1 %cond_a, ptr %b) {
 entry:
@@ -1323,7 +1323,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test92':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test92(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1337,7 +1337,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test93':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test93(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1351,7 +1351,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test94':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test94(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1365,7 +1365,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test95':
 ; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test95(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
 entry:
@@ -1379,7 +1379,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test96':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test96(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1393,7 +1393,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test97':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test97(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1407,7 +1407,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test98':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test98(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1421,7 +1421,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test99':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test99(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1435,7 +1435,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test100':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test100(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -1449,7 +1449,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test101':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test101(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -1463,7 +1463,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test102':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test102(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -1477,7 +1477,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test103':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test103(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
 entry:
@@ -1491,7 +1491,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test104':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test104(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1506,7 +1506,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test105':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test105(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1521,7 +1521,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test106':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test106(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:
@@ -1536,7 +1536,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test107':
 ; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Memory locations: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test107(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
 entry:

--- a/llvm/test/Analysis/AliasSet/guards.ll
+++ b/llvm/test/Analysis/AliasSet/guards.ll
@@ -2,7 +2,7 @@
 declare void @llvm.experimental.guard(i1, ...)
 
 ; CHECK: Alias sets for function 'test0':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -18,7 +18,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test1':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -34,7 +34,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test2':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -50,7 +50,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -66,7 +66,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test4':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -82,7 +82,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -98,7 +98,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test6':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -114,7 +114,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test7':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -130,7 +130,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test8':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -147,7 +147,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test9':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -164,7 +164,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test10':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -181,7 +181,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test11':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -198,7 +198,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test12':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -212,7 +212,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test13':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -226,7 +226,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test14':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -240,7 +240,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test15':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -254,7 +254,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test16':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -268,7 +268,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test17':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -282,7 +282,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test18':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -296,7 +296,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test19':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -310,7 +310,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test20':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -325,7 +325,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test21':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -340,7 +340,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test22':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -355,7 +355,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test23':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -370,7 +370,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test24':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -385,7 +385,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test25':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -400,7 +400,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test26':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -415,7 +415,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test27':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -430,7 +430,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test28':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -445,7 +445,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test29':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -460,7 +460,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test30':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -475,7 +475,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test31':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -490,7 +490,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test32':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -506,7 +506,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test33':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -522,7 +522,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test34':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -538,7 +538,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test35':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -554,7 +554,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test36':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -568,7 +568,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test37':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -582,7 +582,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test38':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -596,7 +596,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test39':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -610,7 +610,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test40':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -624,7 +624,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test41':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -638,7 +638,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test42':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -652,7 +652,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test43':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -666,7 +666,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test44':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -681,7 +681,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test45':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -696,7 +696,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test46':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -711,7 +711,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test47':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -726,7 +726,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test48':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test48(ptr %a, ptr %b, i1 %cond_b) {
@@ -738,7 +738,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test49':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test49(ptr %a, ptr %b, i1 %cond_b) {
@@ -750,7 +750,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test50':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test50(ptr %a, ptr %b, i1 %cond_b) {
@@ -762,7 +762,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test51':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test51(ptr %a, ptr %b, i1 %cond_b) {
@@ -774,7 +774,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test52':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test52(ptr %a, i1 %cond_a, ptr %b) {
@@ -786,7 +786,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test53':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test53(ptr %a, i1 %cond_a, ptr %b) {
@@ -798,7 +798,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test54':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test54(ptr %a, i1 %cond_a, ptr %b) {
@@ -810,7 +810,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test55':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test55(ptr %a, i1 %cond_a, ptr %b) {
@@ -822,7 +822,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test56':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test56(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -835,7 +835,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test57':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test57(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -848,7 +848,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test58':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test58(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -861,7 +861,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test59':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test59(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -874,7 +874,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test60':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test60(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -887,7 +887,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test61':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test61(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -900,7 +900,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test62':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test62(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -913,7 +913,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test63':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test63(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -926,7 +926,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test64':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test64(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -939,7 +939,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test65':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test65(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -952,7 +952,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test66':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test66(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -965,7 +965,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test67':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test67(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -978,7 +978,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test68':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test68(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -992,7 +992,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test69':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test69(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1006,7 +1006,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test70':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test70(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1020,7 +1020,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test71':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test71(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1034,7 +1034,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test72':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1049,7 +1049,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test73':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1064,7 +1064,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test74':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1079,7 +1079,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test75':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1094,7 +1094,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test76':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1109,7 +1109,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test77':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1124,7 +1124,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test78':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1139,7 +1139,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test79':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1154,7 +1154,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test80':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1170,7 +1170,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test81':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1186,7 +1186,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test82':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1202,7 +1202,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test83':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1218,7 +1218,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test84':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test84(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1231,7 +1231,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test85':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test85(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1244,7 +1244,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test86':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test86(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1257,7 +1257,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test87':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test87(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1270,7 +1270,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test88':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test88(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1283,7 +1283,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test89':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test89(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1296,7 +1296,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test90':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test90(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1309,7 +1309,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test91':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test91(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1322,7 +1322,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test92':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test92(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1336,7 +1336,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test93':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test93(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1350,7 +1350,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test94':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test94(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1364,7 +1364,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test95':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test95(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1378,7 +1378,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test96':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test96(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1392,7 +1392,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test97':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test97(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1406,7 +1406,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test98':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test98(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1420,7 +1420,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test99':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test99(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1434,7 +1434,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test100':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test100(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1448,7 +1448,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test101':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test101(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1462,7 +1462,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test102':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test102(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1476,7 +1476,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test103':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test103(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1490,7 +1490,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test104':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test104(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1505,7 +1505,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test105':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test105(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1520,7 +1520,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test106':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test106(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1535,7 +1535,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test107':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test107(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {

--- a/llvm/test/Analysis/AliasSet/guards.ll
+++ b/llvm/test/Analysis/AliasSet/guards.ll
@@ -2,7 +2,7 @@
 declare void @llvm.experimental.guard(i1, ...)
 
 ; CHECK: Alias sets for function 'test0':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -18,7 +18,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test1':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -34,7 +34,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test2':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -50,7 +50,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -66,7 +66,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test4':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -82,7 +82,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -98,7 +98,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test6':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -114,7 +114,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test7':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -130,7 +130,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test8':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -147,7 +147,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test9':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -164,7 +164,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test10':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -181,7 +181,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test11':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -198,7 +198,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test12':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -212,7 +212,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test13':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -226,7 +226,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test14':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -240,7 +240,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test15':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
@@ -254,7 +254,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test16':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -268,7 +268,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test17':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -282,7 +282,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test18':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -296,7 +296,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test19':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -310,7 +310,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test20':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -325,7 +325,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test21':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -340,7 +340,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test22':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -355,7 +355,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test23':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -370,7 +370,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test24':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -385,7 +385,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test25':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -400,7 +400,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test26':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -415,7 +415,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test27':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -430,7 +430,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test28':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -445,7 +445,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test29':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -460,7 +460,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test30':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -475,7 +475,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test31':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -490,7 +490,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test32':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -506,7 +506,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test33':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
@@ -522,7 +522,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test34':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -538,7 +538,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test35':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
@@ -554,7 +554,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test36':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -568,7 +568,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test37':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -582,7 +582,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test38':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -596,7 +596,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test39':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -610,7 +610,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test40':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -624,7 +624,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test41':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -638,7 +638,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test42':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -652,7 +652,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test43':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -666,7 +666,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test44':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -681,7 +681,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test45':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -696,7 +696,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test46':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -711,7 +711,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test47':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -726,7 +726,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test48':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test48(ptr %a, ptr %b, i1 %cond_b) {
@@ -738,7 +738,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test49':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test49(ptr %a, ptr %b, i1 %cond_b) {
@@ -750,7 +750,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test50':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test50(ptr %a, ptr %b, i1 %cond_b) {
@@ -762,7 +762,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test51':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test51(ptr %a, ptr %b, i1 %cond_b) {
@@ -774,7 +774,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test52':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test52(ptr %a, i1 %cond_a, ptr %b) {
@@ -786,7 +786,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test53':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test53(ptr %a, i1 %cond_a, ptr %b) {
@@ -798,7 +798,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test54':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test54(ptr %a, i1 %cond_a, ptr %b) {
@@ -810,7 +810,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test55':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test55(ptr %a, i1 %cond_a, ptr %b) {
@@ -822,7 +822,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test56':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test56(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -835,7 +835,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test57':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test57(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -848,7 +848,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test58':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test58(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -861,7 +861,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test59':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test59(ptr %a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -874,7 +874,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test60':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test60(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -887,7 +887,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test61':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test61(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -900,7 +900,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test62':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test62(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -913,7 +913,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test63':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test63(ptr %a, ptr %ptr_b, i1 %cond_b) {
@@ -926,7 +926,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test64':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test64(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -939,7 +939,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test65':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test65(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -952,7 +952,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test66':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test66(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -965,7 +965,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test67':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test67(ptr %a, i1 %cond_a, ptr %ptr_b) {
@@ -978,7 +978,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test68':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test68(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -992,7 +992,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test69':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test69(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1006,7 +1006,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test70':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test70(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1020,7 +1020,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test71':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test71(ptr %a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1034,7 +1034,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test72':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1049,7 +1049,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test73':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1064,7 +1064,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test74':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1079,7 +1079,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test75':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1094,7 +1094,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test76':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1109,7 +1109,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test77':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1124,7 +1124,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test78':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1139,7 +1139,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test79':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1154,7 +1154,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test80':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1170,7 +1170,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test81':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1186,7 +1186,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test82':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1202,7 +1202,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test83':
-; CHECK: Alias Set Tracker: 2 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -1218,7 +1218,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test84':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test84(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1231,7 +1231,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test85':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test85(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1244,7 +1244,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test86':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test86(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1257,7 +1257,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test87':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test87(ptr %ptr_a, ptr %b, i1 %cond_b) {
@@ -1270,7 +1270,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test88':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test88(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1283,7 +1283,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test89':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test89(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1296,7 +1296,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test90':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test90(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1309,7 +1309,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test91':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test91(ptr %ptr_a, i1 %cond_a, ptr %b) {
@@ -1322,7 +1322,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test92':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test92(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1336,7 +1336,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test93':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test93(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1350,7 +1350,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test94':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test94(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1364,7 +1364,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test95':
-; CHECK: Alias Set Tracker: 1 alias sets for 3 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 3 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 4] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test95(ptr %ptr_a, i1 %cond_a, ptr %b, i1 %cond_b) {
@@ -1378,7 +1378,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test96':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test96(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1392,7 +1392,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test97':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test97(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1406,7 +1406,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test98':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test98(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1420,7 +1420,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test99':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test99(ptr %ptr_a, ptr %ptr_b, i1 %cond_b) {
@@ -1434,7 +1434,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test100':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test100(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1448,7 +1448,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test101':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test101(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1462,7 +1462,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test102':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test102(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1476,7 +1476,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test103':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ]
 define void @test103(ptr %ptr_a, i1 %cond_a, ptr %ptr_b) {
@@ -1490,7 +1490,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test104':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Ref       Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test104(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1505,7 +1505,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test105':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test105(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1520,7 +1520,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test106':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test106(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {
@@ -1535,7 +1535,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test107':
-; CHECK: Alias Set Tracker: 1 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 5] may alias, Mod/Ref   Pointers: (ptr %ptr_a, LocationSize::precise(8)), (ptr %ptr_b, LocationSize::precise(8)), (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     2 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond_a) [ "deopt"() ],   call void (i1, ...) @llvm.experimental.guard(i1 %cond_b) [ "deopt"() ]
 define void @test107(ptr %ptr_a, i1 %cond_a, ptr %ptr_b, i1 %cond_b) {

--- a/llvm/test/Analysis/AliasSet/intrinsics.ll
+++ b/llvm/test/Analysis/AliasSet/intrinsics.ll
@@ -2,9 +2,9 @@
 
 ; CHECK: Alias sets for function 'test1':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT: 1 Unknown instruction
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test1(i32 %c) {
 entry:
   %a = alloca i8, align 1
@@ -18,10 +18,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test2':
 ; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test2(i32 %c) {
 entry:
   %a = alloca i8, align 1
@@ -35,7 +35,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test3':
 ; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
 define void @test3(i32 %c, ptr %a, ptr %b) {
 entry:
@@ -48,9 +48,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test4':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test4(i32 %c, ptr %a) {
 entry:
   %b = alloca i8, align 1
@@ -63,9 +63,9 @@ entry:
 
 ; CHECK: Alias sets for function 'test5':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT: 1 Unknown instruction
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test5() {
 entry:
   %a = alloca i8, align 1

--- a/llvm/test/Analysis/AliasSet/intrinsics.ll
+++ b/llvm/test/Analysis/AliasSet/intrinsics.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -passes=print-alias-sets -S -o - < %s 2>&1 | FileCheck %s
 
 ; CHECK: Alias sets for function 'test1':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT: 1 Unknown instruction
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -17,7 +17,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test2':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
@@ -34,7 +34,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
 define void @test3(i32 %c, ptr %a, ptr %b) {
@@ -47,7 +47,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test4':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -62,7 +62,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT: 1 Unknown instruction
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))

--- a/llvm/test/Analysis/AliasSet/intrinsics.ll
+++ b/llvm/test/Analysis/AliasSet/intrinsics.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -passes=print-alias-sets -S -o - < %s 2>&1 | FileCheck %s
 
 ; CHECK: Alias sets for function 'test1':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT: 1 Unknown instruction
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -17,7 +17,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test2':
-; CHECK: Alias Set Tracker: 3 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] may alias, Ref
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
@@ -34,7 +34,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3':
-; CHECK: Alias Set Tracker: 1 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 3] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1)), (ptr %b, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
 define void @test3(i32 %c, ptr %a, ptr %b) {
@@ -47,7 +47,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test4':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:     1 Unknown instructions:   call void (i1, ...) @llvm.experimental.guard(i1 %cond1) [ "deopt"() ]
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
@@ -62,7 +62,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT: 1 Unknown instruction
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))

--- a/llvm/test/Analysis/AliasSet/memloc-vscale.ll
+++ b/llvm/test/Analysis/AliasSet/memloc-vscale.ll
@@ -2,7 +2,7 @@
 ; RUN: opt -S < %s -passes=print-alias-sets 2>&1 | FileCheck %s
 
 ; CHECK-LABEL: Alias sets for function 'sn'
-; CHECK: AliasSet[{{.*}}, 2] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(8))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(8))
 define void @sn(ptr %p) {;
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
   store i64 0, ptr %p, align 2
@@ -10,7 +10,7 @@ define void @sn(ptr %p) {;
 }
 
 ; CHECK-LABEL: Alias sets for function 'ns'
-; CHECK: AliasSet[{{.*}}, 2] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(8)), (ptr %p, LocationSize::precise(vscale x 16))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(8)), (ptr %p, LocationSize::precise(vscale x 16))
 define void @ns(ptr %p) {
   store i64 0, ptr %p, align 2
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
@@ -26,7 +26,7 @@ define void @ss(ptr %p) {
 }
 
 ; CHECK-LABEL: Alias sets for function 'ss2':
-; CHECK: AliasSet[{{.*}}, 2] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(vscale x 32))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(vscale x 32))
 define void @ss2(ptr %p) {
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2

--- a/llvm/test/Analysis/AliasSet/memloc-vscale.ll
+++ b/llvm/test/Analysis/AliasSet/memloc-vscale.ll
@@ -2,7 +2,7 @@
 ; RUN: opt -S < %s -passes=print-alias-sets 2>&1 | FileCheck %s
 
 ; CHECK-LABEL: Alias sets for function 'sn'
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %p, unknown after)
+; CHECK: AliasSet[{{.*}}, 2] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(8))
 define void @sn(ptr %p) {;
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
   store i64 0, ptr %p, align 2
@@ -10,7 +10,7 @@ define void @sn(ptr %p) {;
 }
 
 ; CHECK-LABEL: Alias sets for function 'ns'
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %p, unknown after)
+; CHECK: AliasSet[{{.*}}, 2] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(8)), (ptr %p, LocationSize::precise(vscale x 16))
 define void @ns(ptr %p) {
   store i64 0, ptr %p, align 2
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
@@ -26,7 +26,7 @@ define void @ss(ptr %p) {
 }
 
 ; CHECK-LABEL: Alias sets for function 'ss2':
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, unknown after)
+; CHECK: AliasSet[{{.*}}, 2] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(vscale x 32))
 define void @ss2(ptr %p) {
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2

--- a/llvm/test/Analysis/AliasSet/memloc-vscale.ll
+++ b/llvm/test/Analysis/AliasSet/memloc-vscale.ll
@@ -2,7 +2,7 @@
 ; RUN: opt -S < %s -passes=print-alias-sets 2>&1 | FileCheck %s
 
 ; CHECK-LABEL: Alias sets for function 'sn'
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(8))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Memory locations: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(8))
 define void @sn(ptr %p) {;
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
   store i64 0, ptr %p, align 2
@@ -10,7 +10,7 @@ define void @sn(ptr %p) {;
 }
 
 ; CHECK-LABEL: Alias sets for function 'ns'
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(8)), (ptr %p, LocationSize::precise(vscale x 16))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Memory locations: (ptr %p, LocationSize::precise(8)), (ptr %p, LocationSize::precise(vscale x 16))
 define void @ns(ptr %p) {
   store i64 0, ptr %p, align 2
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
@@ -18,7 +18,7 @@ define void @ns(ptr %p) {
 }
 
 ; CHECK-LABEL: Alias sets for function 'ss':
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Memory locations: (ptr %p, LocationSize::precise(vscale x 16))
 define void @ss(ptr %p) {
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
@@ -26,7 +26,7 @@ define void @ss(ptr %p) {
 }
 
 ; CHECK-LABEL: Alias sets for function 'ss2':
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(vscale x 32))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod       Memory locations: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(vscale x 32))
 define void @ss2(ptr %p) {
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2
@@ -34,7 +34,7 @@ define void @ss2(ptr %p) {
   ret void
 }
 ; CHECK-LABEL: Alias sets for function 'son':
-; CHECK: AliasSet[{{.*}}, 2] may alias, Mod       Pointers: (ptr %g, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(8))
+; CHECK: AliasSet[{{.*}}, 2] may alias, Mod       Memory locations: (ptr %g, LocationSize::precise(vscale x 16)), (ptr %p, LocationSize::precise(8))
 define void @son(ptr %p) {
   %g = getelementptr i8, ptr %p, i64 8
   store <vscale x 2 x i64> zeroinitializer, ptr %g, align 2
@@ -43,7 +43,7 @@ define void @son(ptr %p) {
 }
 
 ; CHECK-LABEL: Alias sets for function 'sno':
-; CHECK: AliasSet[{{.*}}, 2] may alias, Mod       Pointers: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %g, LocationSize::precise(8))
+; CHECK: AliasSet[{{.*}}, 2] may alias, Mod       Memory locations: (ptr %p, LocationSize::precise(vscale x 16)), (ptr %g, LocationSize::precise(8))
 define void @sno(ptr %p) {
   %g = getelementptr i8, ptr %p, i64 8
   store <vscale x 2 x i64> zeroinitializer, ptr %p, align 2

--- a/llvm/test/Analysis/AliasSet/memset.ll
+++ b/llvm/test/Analysis/AliasSet/memset.ll
@@ -5,7 +5,7 @@
 
 ; CHECK: Alias sets for function 'test_known_size':
 ; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, LocationSize::precise(1))
 define void @test_known_size(ptr noalias %d) {
 entry:
   call void @llvm.memset.p0.i64(ptr align 1 %d, i8 0, i64 1, i1 false)
@@ -14,7 +14,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test_unknown_size':
 ; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, unknown after)
 define void @test_unknown_size(ptr noalias %d, i64 %len) {
 entry:
   call void @llvm.memset.p0.i64(ptr align 1 %d, i8 0, i64 %len, i1 false)
@@ -24,7 +24,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test_atomic_known_size':
 ; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, LocationSize::precise(1))
 define void @test_atomic_known_size(ptr noalias %d) {
 entry:
   call void @llvm.memset.element.unordered.atomic.p0.i32(ptr align 1 %d, i8 0, i64 1, i32 1)
@@ -33,7 +33,7 @@ entry:
 
 ; CHECK: Alias sets for function 'test_atomic_unknown_size':
 ; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, unknown after)
 define void @test_atomic_unknown_size(ptr noalias %d, i64 %len) {
 entry:
   call void @llvm.memset.element.unordered.atomic.p0.i32(ptr align 1 %d, i8 0, i64 %len, i32 1)

--- a/llvm/test/Analysis/AliasSet/memset.ll
+++ b/llvm/test/Analysis/AliasSet/memset.ll
@@ -4,7 +4,7 @@
 @d = global i8 2, align 1
 
 ; CHECK: Alias sets for function 'test_known_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
 define void @test_known_size(ptr noalias %d) {
 entry:
@@ -13,7 +13,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_unknown_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
 define void @test_unknown_size(ptr noalias %d, i64 %len) {
 entry:
@@ -23,7 +23,7 @@ entry:
 
 
 ; CHECK: Alias sets for function 'test_atomic_known_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
 define void @test_atomic_known_size(ptr noalias %d) {
 entry:
@@ -32,7 +32,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_atomic_unknown_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
 define void @test_atomic_unknown_size(ptr noalias %d, i64 %len) {
 entry:

--- a/llvm/test/Analysis/AliasSet/memset.ll
+++ b/llvm/test/Analysis/AliasSet/memset.ll
@@ -4,7 +4,7 @@
 @d = global i8 2, align 1
 
 ; CHECK: Alias sets for function 'test_known_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
 define void @test_known_size(ptr noalias %d) {
 entry:
@@ -13,7 +13,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_unknown_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
 define void @test_unknown_size(ptr noalias %d, i64 %len) {
 entry:
@@ -23,7 +23,7 @@ entry:
 
 
 ; CHECK: Alias sets for function 'test_atomic_known_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
 define void @test_atomic_known_size(ptr noalias %d) {
 entry:
@@ -32,7 +32,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_atomic_unknown_size':
-; CHECK: Alias Set Tracker: 1 alias sets for 1 pointer values.
+; CHECK: Alias Set Tracker: 1 alias sets for 1 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
 define void @test_atomic_unknown_size(ptr noalias %d, i64 %len) {
 entry:

--- a/llvm/test/Analysis/AliasSet/memtransfer.ll
+++ b/llvm/test/Analysis/AliasSet/memtransfer.ll
@@ -6,8 +6,8 @@
 
 ; CHECK: Alias sets for function 'test_known_size':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %s, LocationSize::precise(1))
 define void @test_known_size(ptr noalias %s, ptr noalias %d) {
 entry:
   call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 1, i1 false)
@@ -16,8 +16,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test_unknown_size':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, unknown after)
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %d, unknown after)
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Memory locations: (ptr %s, unknown after)
 define void @test_unknown_size(ptr noalias %s, ptr noalias %d, i64 %len) {
 entry:
   call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 %len, i1 false)
@@ -27,10 +27,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test1':
 ; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test1(ptr %s, ptr %d) {
 entry:
   %a = alloca i8, align 1
@@ -43,10 +43,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test1_atomic':
 ; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test1_atomic(ptr %s, ptr %d) {
 entry:
   %a = alloca i8, align 1
@@ -59,10 +59,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test2':
 ; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Memory locations: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test2(ptr %s, ptr %d) {
 entry:
   %a = alloca i8, align 1
@@ -75,10 +75,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test3':
 ; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test3(ptr %s, ptr %d) {
 entry:
   %a = alloca i8, align 1
@@ -91,10 +91,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test3_atomic':
 ; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Memory locations: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test3_atomic(ptr %s, ptr %d) {
 entry:
   %a = alloca i8, align 1
@@ -107,10 +107,10 @@ entry:
 
 ; CHECK: Alias sets for function 'test4':
 ; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Memory locations: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test4(ptr %s, ptr %d) {
 entry:
   %a = alloca i8, align 1
@@ -123,8 +123,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test5':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test5() {
 entry:
   %a = alloca i8, align 1
@@ -137,8 +137,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test5_atomic':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test5_atomic() {
 entry:
   %a = alloca i8, align 1
@@ -151,8 +151,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test6':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test6() {
 entry:
   %a = alloca i8, align 1
@@ -165,8 +165,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test6_atomic':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test6_atomic() {
 entry:
   %a = alloca i8, align 1
@@ -179,8 +179,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test7':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test7() {
 entry:
   %a = alloca i8, align 1
@@ -194,8 +194,8 @@ entry:
 
 ; CHECK: Alias sets for function 'test7_atomic':
 ; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
-; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %a, LocationSize::precise(1))
+; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Memory locations: (ptr %b, LocationSize::precise(1))
 define void @test7_atomic() {
 entry:
   %a = alloca i8, align 1

--- a/llvm/test/Analysis/AliasSet/memtransfer.ll
+++ b/llvm/test/Analysis/AliasSet/memtransfer.ll
@@ -5,7 +5,7 @@
 
 
 ; CHECK: Alias sets for function 'test_known_size':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, LocationSize::precise(1))
 define void @test_known_size(ptr noalias %s, ptr noalias %d) {
@@ -15,7 +15,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_unknown_size':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, unknown after)
 define void @test_unknown_size(ptr noalias %s, ptr noalias %d, i64 %len) {
@@ -26,7 +26,7 @@ entry:
 
 
 ; CHECK: Alias sets for function 'test1':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -42,7 +42,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test1_atomic':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -58,7 +58,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test2':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -74,7 +74,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -90,7 +90,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3_atomic':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -106,7 +106,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test4':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -122,7 +122,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test5() {
@@ -136,7 +136,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5_atomic':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test5_atomic() {
@@ -150,7 +150,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test6':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test6() {
@@ -164,7 +164,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test6_atomic':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test6_atomic() {
@@ -178,7 +178,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test7':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 define void @test7() {
@@ -193,7 +193,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test7_atomic':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 define void @test7_atomic() {

--- a/llvm/test/Analysis/AliasSet/memtransfer.ll
+++ b/llvm/test/Analysis/AliasSet/memtransfer.ll
@@ -5,7 +5,7 @@
 
 
 ; CHECK: Alias sets for function 'test_known_size':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, LocationSize::precise(1))
 define void @test_known_size(ptr noalias %s, ptr noalias %d) {
@@ -15,7 +15,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test_unknown_size':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %d, unknown after)
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Ref       Pointers: (ptr %s, unknown after)
 define void @test_unknown_size(ptr noalias %s, ptr noalias %d, i64 %len) {
@@ -26,7 +26,7 @@ entry:
 
 
 ; CHECK: Alias sets for function 'test1':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -42,7 +42,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test1_atomic':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -58,7 +58,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test2':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -74,7 +74,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -90,7 +90,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test3_atomic':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref   Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -106,7 +106,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test4':
-; CHECK: Alias Set Tracker: 3 alias sets for 4 pointer values.
+; CHECK: Alias Set Tracker: 3 alias sets for 4 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK-NOT:    1 Unknown instructions
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 2] may alias, Mod/Ref    Pointers: (ptr %d, LocationSize::precise(1)), (ptr %s, LocationSize::precise(1))
@@ -122,7 +122,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test5() {
@@ -136,7 +136,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test5_atomic':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test5_atomic() {
@@ -150,7 +150,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test6':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test6() {
@@ -164,7 +164,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test6_atomic':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod       Pointers: (ptr %b, LocationSize::precise(1))
 define void @test6_atomic() {
@@ -178,7 +178,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test7':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 define void @test7() {
@@ -193,7 +193,7 @@ entry:
 }
 
 ; CHECK: Alias sets for function 'test7_atomic':
-; CHECK: Alias Set Tracker: 2 alias sets for 2 pointer values.
+; CHECK: Alias Set Tracker: 2 alias sets for 2 memory locations.
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %a, LocationSize::precise(1))
 ; CHECK:   AliasSet[0x{{[0-9a-f]+}}, 1] must alias, Mod/Ref   Pointers: (ptr %b, LocationSize::precise(1))
 define void @test7_atomic() {

--- a/llvm/test/Analysis/AliasSet/saturation.ll
+++ b/llvm/test/Analysis/AliasSet/saturation.ll
@@ -1,36 +1,34 @@
-; RUN: opt -passes=print-alias-sets -alias-set-saturation-threshold=2 -S -o - < %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=NOSAT
-; RUN: opt -passes=print-alias-sets -alias-set-saturation-threshold=1 -S -o - < %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=SAT
+; RUN: opt -passes=print-alias-sets -alias-set-saturation-threshold=4 -S -o - < %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=NOSAT
+; RUN: opt -passes=print-alias-sets -alias-set-saturation-threshold=3 -S -o - < %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=SAT
 
-; CHECK-LABEL: 'allmust'
+; CHECK-LABEL: 'nomerge'
 ; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %a, LocationSize::precise(4))
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %b, LocationSize::precise(4))
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %c, LocationSize::precise(4))
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %d, LocationSize::precise(4))
-define void @allmust() {
+; CHECK: AliasSet[{{.*}}, 2] may alias, Mod Pointers: (ptr %b, LocationSize::precise(4)), (ptr %b1, LocationSize::precise(4))
+define void @nomerge(i32 %k) {
   %a = alloca i32
-  %b = alloca i32
-  %c = alloca i32
-  %d = alloca i32
+  %b = alloca [10 x i32]
   store i32 1, ptr %a
   store i32 2, ptr %b
-  store i32 3, ptr %c
-  store i32 4, ptr %d
+  %b1 = getelementptr i32, ptr %b, i32 %k
+  store i32 3, ptr %b1
   ret void
 }
 
 ; CHECK-LABEL: 'mergemay'
-; NOSAT: AliasSet[{{.*}}, 2] may alias, Mod Pointers: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4))
+; NOSAT: AliasSet[{{.*}}, 3] may alias, Mod Pointers: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4)), (ptr %a2, LocationSize::precise(4))
 ; NOSAT: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %b, LocationSize::precise(4))
-; SAT: AliasSet[{{.*}}, 2] may alias, Mod forwarding to 0x[[FWD:[0-9a-f]*]]
+; SAT: AliasSet[{{.*}}, 3] may alias, Mod forwarding to 0x[[FWD:[0-9a-f]*]]
 ; SAT: AliasSet[{{.*}}, 1] must alias, Mod forwarding to 0x[[FWD]]
-; SAT: AliasSet[0x[[FWD]], 2] may alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4)), (ptr %b, LocationSize::precise(4))
-define void @mergemay(i32 %k) {
+; SAT: AliasSet[0x[[FWD]], 2] may alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4)), (ptr %a2, LocationSize::precise(4)), (ptr %b, LocationSize::precise(4))
+define void @mergemay(i32 %k, i32 %l) {
   %a = alloca i32
   %b = alloca i32
   store i32 1, ptr %a
   store i32 2, ptr %b
   %a1 = getelementptr i32, ptr %a, i32 %k
-  store i32 2, ptr %a1  
+  store i32 2, ptr %a1
+  %a2 = getelementptr i32, ptr %a, i32 %l
+  store i32 2, ptr %a2
   ret void
 }
 

--- a/llvm/test/Analysis/AliasSet/saturation.ll
+++ b/llvm/test/Analysis/AliasSet/saturation.ll
@@ -2,8 +2,8 @@
 ; RUN: opt -passes=print-alias-sets -alias-set-saturation-threshold=3 -S -o - < %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=SAT
 
 ; CHECK-LABEL: 'nomerge'
-; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %a, LocationSize::precise(4))
-; CHECK: AliasSet[{{.*}}, 2] may alias, Mod Pointers: (ptr %b, LocationSize::precise(4)), (ptr %b1, LocationSize::precise(4))
+; CHECK: AliasSet[{{.*}}, 1] must alias, Mod Memory locations: (ptr %a, LocationSize::precise(4))
+; CHECK: AliasSet[{{.*}}, 2] may alias, Mod Memory locations: (ptr %b, LocationSize::precise(4)), (ptr %b1, LocationSize::precise(4))
 define void @nomerge(i32 %k) {
   %a = alloca i32
   %b = alloca [10 x i32]
@@ -15,11 +15,11 @@ define void @nomerge(i32 %k) {
 }
 
 ; CHECK-LABEL: 'mergemay'
-; NOSAT: AliasSet[{{.*}}, 3] may alias, Mod Pointers: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4)), (ptr %a2, LocationSize::precise(4))
-; NOSAT: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %b, LocationSize::precise(4))
+; NOSAT: AliasSet[{{.*}}, 3] may alias, Mod Memory locations: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4)), (ptr %a2, LocationSize::precise(4))
+; NOSAT: AliasSet[{{.*}}, 1] must alias, Mod Memory locations: (ptr %b, LocationSize::precise(4))
 ; SAT: AliasSet[{{.*}}, 3] may alias, Mod forwarding to 0x[[FWD:[0-9a-f]*]]
 ; SAT: AliasSet[{{.*}}, 1] must alias, Mod forwarding to 0x[[FWD]]
-; SAT: AliasSet[0x[[FWD]], 2] may alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4)), (ptr %a2, LocationSize::precise(4)), (ptr %b, LocationSize::precise(4))
+; SAT: AliasSet[0x[[FWD]], 2] may alias, Mod/Ref Memory locations: (ptr %a, LocationSize::precise(4)), (ptr %a1, LocationSize::precise(4)), (ptr %a2, LocationSize::precise(4)), (ptr %b, LocationSize::precise(4))
 define void @mergemay(i32 %k, i32 %l) {
   %a = alloca i32
   %b = alloca i32
@@ -33,13 +33,13 @@ define void @mergemay(i32 %k, i32 %l) {
 }
 
 ; CHECK-LABEL: 'mergemust'
-; NOSAT: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %a, LocationSize::precise(4))
-; NOSAT: AliasSet[{{.*}}, 1] must alias, Mod Pointers: (ptr %b, LocationSize::precise(4))
-; NOSAT: AliasSet[{{.*}}, 2] may alias,  Mod Pointers: (ptr %c, LocationSize::precise(4)), (ptr %d, LocationSize::precise(4))
+; NOSAT: AliasSet[{{.*}}, 1] must alias, Mod Memory locations: (ptr %a, LocationSize::precise(4))
+; NOSAT: AliasSet[{{.*}}, 1] must alias, Mod Memory locations: (ptr %b, LocationSize::precise(4))
+; NOSAT: AliasSet[{{.*}}, 2] may alias,  Mod Memory locations: (ptr %c, LocationSize::precise(4)), (ptr %d, LocationSize::precise(4))
 ; SAT: AliasSet[{{.*}}, 1] must alias, Mod forwarding to 0x[[FWD:[0-9a-f]*]]
 ; SAT: AliasSet[{{.*}}, 1] must alias, Mod forwarding to 0x[[FWD]]
 ; SAT: AliasSet[{{.*}}, 2] may alias,  Mod forwarding to 0x[[FWD]]
-; SAT: AliasSet[0x[[FWD]], 3] may alias, Mod/Ref Pointers: (ptr %a, LocationSize::precise(4)), (ptr %b, LocationSize::precise(4)), (ptr %c, LocationSize::precise(4)), (ptr %d, LocationSize::precise(4))
+; SAT: AliasSet[0x[[FWD]], 3] may alias, Mod/Ref Memory locations: (ptr %a, LocationSize::precise(4)), (ptr %b, LocationSize::precise(4)), (ptr %c, LocationSize::precise(4)), (ptr %d, LocationSize::precise(4))
 define void @mergemust(ptr %c, ptr %d) {
   %a = alloca i32
   %b = alloca i32

--- a/llvm/test/Transforms/LICM/variant-aainfo.ll
+++ b/llvm/test/Transforms/LICM/variant-aainfo.ll
@@ -9,15 +9,17 @@ define void @_Z4testP1S(ptr %s) {
 ; CHECK-LABEL: define void @_Z4testP1S(
 ; CHECK-SAME: ptr [[S:%.*]]) {
 ; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[S_PROMOTED:%.*]] = load ptr, ptr [[S]], align 4, !tbaa [[TBAA0:![0-9]+]]
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]
 ; CHECK:       for.cond.cleanup:
+; CHECK-NEXT:    [[ADD_PTR_I_LCSSA:%.*]] = phi ptr [ [[ADD_PTR_I:%.*]], [[FOR_BODY]] ]
+; CHECK-NEXT:    store ptr [[ADD_PTR_I_LCSSA]], ptr [[S]], align 4, !tbaa [[TBAA0]]
 ; CHECK-NEXT:    ret void
 ; CHECK:       for.body:
-; CHECK-NEXT:    [[I_05:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC:%.*]], [[FOR_BODY]] ]
-; CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[S]], align 4, !tbaa [[TBAA0:![0-9]+]]
-; CHECK-NEXT:    store i32 [[I_05]], ptr [[TMP0]], align 4, !tbaa [[TBAA5:![0-9]+]]
-; CHECK-NEXT:    [[ADD_PTR_I:%.*]] = getelementptr inbounds i32, ptr [[TMP0]], i32 1
-; CHECK-NEXT:    store ptr [[ADD_PTR_I]], ptr [[S]], align 4, !tbaa [[TBAA7:![0-9]+]]
+; CHECK-NEXT:    [[ADD_PTR_I1:%.*]] = phi ptr [ [[S_PROMOTED]], [[ENTRY:%.*]] ], [ [[ADD_PTR_I]], [[FOR_BODY]] ]
+; CHECK-NEXT:    [[I_05:%.*]] = phi i32 [ 0, [[ENTRY]] ], [ [[INC:%.*]], [[FOR_BODY]] ]
+; CHECK-NEXT:    store i32 [[I_05]], ptr [[ADD_PTR_I1]], align 4, !tbaa [[TBAA4:![0-9]+]]
+; CHECK-NEXT:    [[ADD_PTR_I]] = getelementptr inbounds i32, ptr [[ADD_PTR_I1]], i32 1
 ; CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[I_05]], 1
 ; CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i32 [[INC]], 100
 ; CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP:%.*]], label [[FOR_BODY]]
@@ -48,12 +50,10 @@ for.body:                                         ; preds = %entry, %for.body
 !6 = !{!"int", !3, i64 0}
 !7 = !{!2, !2, i64 0}
 ;.
-; CHECK: [[TBAA0]] = !{[[META1:![0-9]+]], [[META2:![0-9]+]], i64 0}
-; CHECK: [[META1]] = !{!"_ZTS1S", [[META2]], i64 0}
-; CHECK: [[META2]] = !{!"any pointer", [[META3:![0-9]+]], i64 0}
-; CHECK: [[META3]] = !{!"omnipotent char", [[META4:![0-9]+]], i64 0}
-; CHECK: [[META4]] = !{!"Simple C++ TBAA"}
-; CHECK: [[TBAA5]] = !{[[META6:![0-9]+]], [[META6]], i64 0}
-; CHECK: [[META6]] = !{!"int", [[META3]], i64 0}
-; CHECK: [[TBAA7]] = !{[[META2]], [[META2]], i64 0}
+; CHECK: [[TBAA0]] = !{[[META1:![0-9]+]], [[META1]], i64 0}
+; CHECK: [[META1]] = !{!"any pointer", [[META2:![0-9]+]], i64 0}
+; CHECK: [[META2]] = !{!"omnipotent char", [[META3:![0-9]+]], i64 0}
+; CHECK: [[META3]] = !{!"Simple C++ TBAA"}
+; CHECK: [[TBAA4]] = !{[[META5:![0-9]+]], [[META5]], i64 0}
+; CHECK: [[META5]] = !{!"int", [[META2]], i64 0}
 ;.

--- a/polly/lib/Analysis/ScopBuilder.cpp
+++ b/polly/lib/Analysis/ScopBuilder.cpp
@@ -3255,8 +3255,10 @@ ScopBuilder::buildAliasGroupsForAccesses() {
     if (AS.isMustAlias() || AS.isForwardingAliasSet())
       continue;
     AliasGroupTy AG;
-    for (auto &PR : AS)
-      AG.push_back(PtrToAcc[PR.getValue()]);
+    llvm::SmallPtrSet<const Value *, 8> Seen;
+    for (auto &MemLoc : AS)
+      if (Seen.insert(MemLoc.Ptr).second)
+        AG.push_back(PtrToAcc[const_cast<Value *>(MemLoc.Ptr)]);
     if (AG.size() < 2)
       continue;
     AliasGroups.push_back(std::move(AG));

--- a/polly/lib/Analysis/ScopBuilder.cpp
+++ b/polly/lib/Analysis/ScopBuilder.cpp
@@ -3255,10 +3255,8 @@ ScopBuilder::buildAliasGroupsForAccesses() {
     if (AS.isMustAlias() || AS.isForwardingAliasSet())
       continue;
     AliasGroupTy AG;
-    llvm::SmallPtrSet<const Value *, 8> Seen;
-    for (auto &MemLoc : AS)
-      if (Seen.insert(MemLoc.Ptr).second)
-        AG.push_back(PtrToAcc[const_cast<Value *>(MemLoc.Ptr)]);
+    for (const Value *Ptr : AS.getPointers())
+      AG.push_back(PtrToAcc[const_cast<Value *>(Ptr)]);
     if (AG.size() < 2)
       continue;
     AliasGroups.push_back(std::move(AG));

--- a/polly/lib/Analysis/ScopDetection.cpp
+++ b/polly/lib/Analysis/ScopDetection.cpp
@@ -1158,8 +1158,9 @@ bool ScopDetection::isValidAccess(Instruction *Inst, const SCEV *AF,
         const unsigned int VariantSize = VariantLS.size(),
                            InvariantSize = InvariantLS.size();
 
-        for (const auto &Ptr : AS) {
-          Instruction *Inst = dyn_cast<Instruction>(Ptr.getValue());
+        for (const auto &MemLoc : AS) {
+          Instruction *Inst =
+              dyn_cast<Instruction>(const_cast<Value *>(MemLoc.Ptr));
           if (Inst && Context.CurRegion.contains(Inst)) {
             auto *Load = dyn_cast<LoadInst>(Inst);
             if (Load && InvariantLS.count(Load))

--- a/polly/lib/Analysis/ScopDetection.cpp
+++ b/polly/lib/Analysis/ScopDetection.cpp
@@ -1149,6 +1149,8 @@ bool ScopDetection::isValidAccess(Instruction *Inst, const SCEV *AF,
       // sure the base pointer is not an instruction defined inside the scop.
       // However, we can ignore loads that will be hoisted.
 
+      auto ASPointers = AS.getPointers();
+
       InvariantLoadsSetTy VariantLS, InvariantLS;
       // In order to detect loads which are dependent on other invariant loads
       // as invariant, we use fixed-point iteration method here i.e we iterate
@@ -1158,9 +1160,8 @@ bool ScopDetection::isValidAccess(Instruction *Inst, const SCEV *AF,
         const unsigned int VariantSize = VariantLS.size(),
                            InvariantSize = InvariantLS.size();
 
-        for (const auto &MemLoc : AS) {
-          Instruction *Inst =
-              dyn_cast<Instruction>(const_cast<Value *>(MemLoc.Ptr));
+        for (const Value *Ptr : ASPointers) {
+          Instruction *Inst = dyn_cast<Instruction>(const_cast<Value *>(Ptr));
           if (Inst && Context.CurRegion.contains(Inst)) {
             auto *Load = dyn_cast<LoadInst>(Inst);
             if (Load && InvariantLS.count(Load))

--- a/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
+++ b/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
@@ -638,7 +638,7 @@ bool ReportNonSimpleMemoryAccess::classof(const RejectReason *RR) {
 
 ReportAlias::ReportAlias(Instruction *Inst, AliasSet &AS)
     : RejectReason(RejectReasonKind::Alias), Inst(Inst) {
-  llvm::append_range(Pointers, AS.getPointers());
+  append_range(Pointers, AS.getPointers());
 }
 
 std::string ReportAlias::formatInvalidAlias(std::string Prefix,

--- a/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
+++ b/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
@@ -639,7 +639,8 @@ bool ReportNonSimpleMemoryAccess::classof(const RejectReason *RR) {
 ReportAlias::ReportAlias(Instruction *Inst, AliasSet &AS)
     : RejectReason(RejectReasonKind::Alias), Inst(Inst) {
   for (const auto &I : AS)
-    Pointers.push_back(I.getValue());
+    if (!llvm::is_contained(Pointers, I.Ptr))
+      Pointers.push_back(I.Ptr);
 }
 
 std::string ReportAlias::formatInvalidAlias(std::string Prefix,

--- a/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
+++ b/polly/lib/Analysis/ScopDetectionDiagnostic.cpp
@@ -638,9 +638,7 @@ bool ReportNonSimpleMemoryAccess::classof(const RejectReason *RR) {
 
 ReportAlias::ReportAlias(Instruction *Inst, AliasSet &AS)
     : RejectReason(RejectReasonKind::Alias), Inst(Inst) {
-  for (const auto &I : AS)
-    if (!llvm::is_contained(Pointers, I.Ptr))
-      Pointers.push_back(I.Ptr);
+  llvm::append_range(Pointers, AS.getPointers());
 }
 
 std::string ReportAlias::formatInvalidAlias(std::string Prefix,


### PR DESCRIPTION
This changes the AliasSetTracker to track memory locations instead of pointers in its alias sets. The motivation for this is outlined in [an RFC posted on LLVM discourse](https://discourse.llvm.org/t/rfc-dont-merge-memory-locations-in-aliassettracker/73336).

This commit does not yet change method names and code comments to refer to "memory location(s)" instead of "pointer(s)", to keep the changeset focused, and to first gain feedback on the idea. An additional commit can take care of this.

In the data structures of the AST implementation, I made the choice to replace the linked list of `PointerRec` entries (that had to go anyway) with a simple flat vector of `MemoryLocation` objects, but for the `AliasSet` objects referenced from a lookup table, I retained the mechanism of a linked list, reference counting, forwarding, etc. The data structures could be revised in a follow-up change.