### PR TITLE
[clang][dataflow] Don't crash when BlockToState is called from unreachable path

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -43,7 +43,20 @@ const Environment *StmtToEnvMap::getEnvironment(const Stmt &S) const {
   if (!CFCtx.isBlockReachable(*BlockIt->getSecond()))
     return nullptr;
   const auto &State = BlockToState[BlockIt->getSecond()->getBlockID()];
-  assert(State);
+  if (!(State)) {
+    LLVM_DEBUG({
+      // State can be null when this block is unreachable from the block that
+      // called this method.
+      bool hasUnreachableEdgeFromPred = false;
+      for (auto B : BlockIt->getSecond()->preds())
+        if (!B) {
+          hasUnreachableEdgeFromPred = true;
+          break;
+        }
+      assert(hasUnreachableEdgeFromPred);
+    });
+    return nullptr;
+  }
   return &State->Env;
 }
 

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -5853,4 +5853,24 @@ TEST(TransferTest, AnonymousStructWithReferenceField) {
       });
 }
 
+TEST(TransferTest, EvaluateBlockWithUnreachablePreds) {
+  // This is a crash repro.
+  // `false` block may not have been processed when we try to evalute the `||`
+  // after visiting `true`, because it is not necessary (and therefore the edge
+  // is marked unreachable). Trying to get the analysis state via
+  // `getEnvironment` for the subexpression should still not crash.
+  std::string Code = R"(
+    int cast(int i) {
+      if ((i < 0 && true) || false) {
+        return 0;
+      }
+      return 0;
+    }
+  )";
+  runDataflow(
+      Code,
+      [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &Results,
+         ASTContext &ASTCtx) {});
+}
+
 } // namespace

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -5858,7 +5858,7 @@ TEST(TransferTest, EvaluateBlockWithUnreachablePreds) {
   // `false` block may not have been processed when we try to evalute the `||`
   // after visiting `true`, because it is not necessary (and therefore the edge
   // is marked unreachable). Trying to get the analysis state via
-  // `getEnvironment` for the subexpression should still not crash.
+  // `getEnvironment` for the subexpression still should not crash.
   std::string Code = R"(
     int cast(int i) {
       if ((i < 0 && true) || false) {


### PR DESCRIPTION
When we call `getEnvironment`, `BlockToState[BlockId]` for the block can return null even if CFCtx.isBlockReachable(B) returns true if it is called from a particular block that is marked unreachable to the block.