### PR TITLE
[mlir][TOSA] Fix interpretation of --tosa-validate='profile=undefined'

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -101,7 +101,7 @@ def TosaValidation : Pass<"tosa-validate", "func::FuncOp"> {
                 "Use Main Inference profile."),
                clEnumValN(mlir::tosa::TosaProfileEnum::MainTraining, "mt",
                 "Use Main Training profile."),
-               clEnumValN(mlir::tosa::TosaProfileEnum::MainTraining, "undefined",
+               clEnumValN(mlir::tosa::TosaProfileEnum::Undefined, "undefined",
                 "Do not define a profile.")
               )}]>,
       Option<"StrictOperationSpecAlignment", "strict-op-spec-alignment", "bool",


### PR DESCRIPTION
Due to a copy-paste error in 32b7c1ff this was incorrectly mapped to `TosaProfileEnum::MainTraining` rather than `TosaProfileEnum::Undefined`.