### PR TITLE
[libc] Add is_scalar

### DIFF
--- a/libc/src/__support/CPP/type_traits.h
+++ b/libc/src/__support/CPP/type_traits.h
@@ -36,6 +36,7 @@
 #include "src/__support/CPP/type_traits/is_reference.h"
 #include "src/__support/CPP/type_traits/is_rvalue_reference.h"
 #include "src/__support/CPP/type_traits/is_same.h"
+#include "src/__support/CPP/type_traits/is_scalar.h"
 #include "src/__support/CPP/type_traits/is_signed.h"
 #include "src/__support/CPP/type_traits/is_trivially_constructible.h"
 #include "src/__support/CPP/type_traits/is_trivially_copyable.h"

--- a/libc/src/__support/CPP/type_traits/is_scalar.h
+++ b/libc/src/__support/CPP/type_traits/is_scalar.h
@@ -1,0 +1,32 @@
+//===-- is_scalar type_traits -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_IS_SCALAR_H
+#define LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_IS_SCALAR_H
+
+#include "src/__support/CPP/type_traits/bool_constant.h"
+#include "src/__support/CPP/type_traits/is_arithmetic.h"
+#include "src/__support/CPP/type_traits/is_enum.h"
+#include "src/__support/CPP/type_traits/is_member_pointer.h"
+#include "src/__support/CPP/type_traits/is_null_pointer.h"
+#include "src/__support/CPP/type_traits/is_pointer.h"
+#include "src/__support/macros/attributes.h"
+
+namespace __llvm_libc::cpp {
+
+// is_scalar
+template <class T>
+struct is_scalar
+    : cpp::bool_constant<cpp::is_arithmetic_v<T> || cpp::is_enum_v<T> ||
+                         cpp::is_pointer_v<T> || cpp::is_member_pointer_v<T> ||
+                         cpp::is_null_pointer_v<T>> {};
+template <class T>
+LIBC_INLINE_VAR constexpr bool is_scalar_v = is_scalar<T>::value;
+
+} // namespace __llvm_libc::cpp
+
+#endif // LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_IS_SCALAR_H

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -313,6 +313,7 @@ libc_support_library(
         "src/__support/CPP/type_traits/is_reference.h",
         "src/__support/CPP/type_traits/is_rvalue_reference.h",
         "src/__support/CPP/type_traits/is_same.h",
+        "src/__support/CPP/type_traits/is_scalar.h",
         "src/__support/CPP/type_traits/is_signed.h",
         "src/__support/CPP/type_traits/is_trivially_constructible.h",
         "src/__support/CPP/type_traits/is_trivially_copyable.h",


### PR DESCRIPTION
Adds the is_scalar traits based on implementation in https://en.cppreference.com/w/cpp/types/is_scalar
