### PR TITLE
[libc] Add is_object

### DIFF
--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -118,6 +118,7 @@ add_header_library(
     type_traits/is_lvalue_reference.h
     type_traits/is_member_pointer.h
     type_traits/is_null_pointer.h
+    type_traits/is_object.h
     type_traits/is_pointer.h
     type_traits/is_reference.h
     type_traits/is_rvalue_reference.h

--- a/libc/src/__support/CPP/type_traits.h
+++ b/libc/src/__support/CPP/type_traits.h
@@ -32,6 +32,7 @@
 #include "src/__support/CPP/type_traits/is_lvalue_reference.h"
 #include "src/__support/CPP/type_traits/is_member_pointer.h"
 #include "src/__support/CPP/type_traits/is_null_pointer.h"
+#include "src/__support/CPP/type_traits/is_object.h"
 #include "src/__support/CPP/type_traits/is_pointer.h"
 #include "src/__support/CPP/type_traits/is_reference.h"
 #include "src/__support/CPP/type_traits/is_rvalue_reference.h"

--- a/libc/src/__support/CPP/type_traits/is_object.h
+++ b/libc/src/__support/CPP/type_traits/is_object.h
@@ -1,0 +1,30 @@
+//===-- is_object type_traits -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_IS_OBJECT_H
+#define LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_IS_OBJECT_H
+
+#include "src/__support/CPP/type_traits/bool_constant.h"
+#include "src/__support/CPP/type_traits/is_array.h"
+#include "src/__support/CPP/type_traits/is_class.h"
+#include "src/__support/CPP/type_traits/is_scalar.h"
+#include "src/__support/CPP/type_traits/is_union.h"
+#include "src/__support/macros/attributes.h"
+
+namespace __llvm_libc::cpp {
+
+// is_object
+template <class T>
+struct is_object
+    : cpp::bool_constant<cpp::is_scalar_v<T> || cpp::is_array_v<T> ||
+                         cpp::is_union_v<T> || cpp::is_class_v<T>> {};
+template <class T>
+LIBC_INLINE_VAR constexpr bool is_object_v = is_object<T>::value;
+
+} // namespace __llvm_libc::cpp
+
+#endif // LLVM_LIBC_SRC_SUPPORT_CPP_TYPE_TRAITS_IS_OBJECT_H

--- a/libc/test/src/__support/CPP/type_traits_test.cpp
+++ b/libc/test/src/__support/CPP/type_traits_test.cpp
@@ -253,6 +253,28 @@ TEST(LlvmLibcTypeTraitsTest, is_enum_enum) {
 
 // TODO is_null_pointer
 
+TEST(LlvmLibcTypeTraitsTest, is_object) {
+  EXPECT_TRUE((is_object_v<int>));      // scalar
+  EXPECT_TRUE((is_object_v<Struct[]>)); // array
+  EXPECT_TRUE((is_object_v<Union>));    // union
+  EXPECT_TRUE((is_object_v<Class>));    // class
+
+  // pointers are still objects
+  EXPECT_TRUE((is_object_v<int *>));       // scalar
+  EXPECT_TRUE((is_object_v<Struct(*)[]>)); // array
+  EXPECT_TRUE((is_object_v<Union *>));     // union
+  EXPECT_TRUE((is_object_v<Class *>));     // class
+
+  // reference are not objects
+  EXPECT_FALSE((is_object_v<int &>));       // scalar
+  EXPECT_FALSE((is_object_v<Struct(&)[]>)); // array
+  EXPECT_FALSE((is_object_v<Union &>));     // union
+  EXPECT_FALSE((is_object_v<Class &>));     // class
+
+  // not an object
+  EXPECT_FALSE((is_object_v<void>));
+}
+
 // TODO is_pointer
 
 // TODO is_reference

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -309,6 +309,7 @@ libc_support_library(
         "src/__support/CPP/type_traits/is_lvalue_reference.h",
         "src/__support/CPP/type_traits/is_member_pointer.h",
         "src/__support/CPP/type_traits/is_null_pointer.h",
+        "src/__support/CPP/type_traits/is_object.h",
         "src/__support/CPP/type_traits/is_pointer.h",
         "src/__support/CPP/type_traits/is_reference.h",
         "src/__support/CPP/type_traits/is_rvalue_reference.h",


### PR DESCRIPTION
Add the is_object type traits.
Implementation comes from https://en.cppreference.com/w/cpp/types/is_object
