### PR TITLE
[lldb] Add test to document alias tab completion behaviour

### DIFF
--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -622,6 +622,25 @@ class CommandLineCompletionTestCase(TestBase):
     def test_command_unalias(self):
         self.complete_from_to("command unalias ima", "command unalias image")
 
+    def test_command_aliases(self):
+        self.runCmd("command alias brkpt breakpoint")
+        # If there is an unambiguous completion from the built-in commands,
+        # we choose that.
+        self.complete_from_to("br", "breakpoint")
+        # Only if there is not, do we then look for an unambiguous completion
+        # from the user defined aliases.
+        self.complete_from_to("brk", "brkpt")
+
+        # Aliases are included when there's no exact match.
+        self.runCmd("command alias play breakpoint")
+        self.complete_from_to("pl", ["plugin", "platform", "play"])
+
+        # That list can also contain only aliases if there's no built-ins to
+        # match.
+        self.runCmd("command alias test_1 breakpoint")
+        self.runCmd("command alias test_2 breakpoint")
+        self.complete_from_to("test_", ["test_1", "test_2"])
+
     def test_completion_description_commands(self):
         """Test descriptions of top-level command completions"""
         self.check_completion_with_desc(


### PR DESCRIPTION
While looking at https://github.com/llvm/llvm-project/issues/49528 I found that, happily, aliases can now be tab completed.

However, if there is a built-in match that will always be taken. Which is a bit surprising, though logical if we don't want people really messing up their commands I guess.

Meaning "b" tab completes to our built-in breakpoint alias, before it looks at any of the aliases. "bf" doesn't match "b", so it looks through the aliases.

I didn't find any tests for this in the obvious places, so this adds some.