### PR TITLE
[NFC][Clang][RISCV] Remove trailing whitespaces in riscv_vector.td

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -577,7 +577,7 @@ multiclass RVVIndexedLoad<string op> {
       foreach eew_list = EEWList[0-2] in {
         defvar eew = eew_list[0];
         defvar eew_type = eew_list[1];
-        let Name = op # eew # "_v", IRName = op, MaskedIRName = op # "_mask", 
+        let Name = op # eew # "_v", IRName = op, MaskedIRName = op # "_mask",
             RequiredFeatures = !if(!eq(type, "x"), ["ZvfhminOrZvfh"],
                                                    []<string>) in {
           def: RVVOutOp1Builtin<"v", "vPCe" # eew_type # "Uv", type>;
@@ -1783,7 +1783,7 @@ let HasMasked = false,
                                    [["v", "Uv", "UvUv"]]>;
     defm vmv_v : RVVOutBuiltinSet<"vmv_v_v", "csilfd",
                                    [["v", "v", "vv"]]>;
-    let RequiredFeatures = ["ZvfhminOrZvfh"] in                               
+    let RequiredFeatures = ["ZvfhminOrZvfh"] in
       defm vmv_v : RVVOutBuiltinSet<"vmv_v_v", "x",
                                     [["v", "v", "vv"]]>;
   let SupportOverloading = false in


### PR DESCRIPTION
This whitespaces breaking `Format` CI.
```
$ trap 'kill -- $$' INT TERM QUIT; clang/utils/ci/run-buildbot check-format
+ set -o pipefail
+ unset LANG
+ unset LC_ALL
+ unset LC_COLLATE
++ basename clang/utils/ci/run-buildbot
+ PROGNAME=run-buildbot
+ [[ 1 == 0 ]]
+ [[ 1 -gt 0 ]]
+ case ${1} in
+ BUILDER=check-format
+ shift
+ [[ 0 -gt 0 ]]
++ git rev-parse --show-toplevel
+ MONOREPO_ROOT=/var/lib/buildkite-agent/builds/linux-56-fdf668759-vtv88-1/llvm-project/clang-ci
+ BUILD_DIR=/var/lib/buildkite-agent/builds/linux-56-fdf668759-vtv88-1/llvm-project/clang-ci/build/check-format
+ INSTALL_DIR=/var/lib/buildkite-agent/builds/linux-56-fdf668759-vtv88-1/llvm-project/clang-ci/build/check-format/install
+ cmake --version
cmake version 3.23.3
CMake suite maintained and supported by Kitware (kitware.com/cmake).
+ ninja --version
1.10.1
+ case "${BUILDER}" in
+ grep -rnI '[[:blank:]]$' clang/lib clang/include clang/docs
clang/include/clang/Basic/riscv_vector.td:580:        let Name = op # eew # "_v", IRName = op, MaskedIRName = op # "_mask",
clang/include/clang/Basic/riscv_vector.td:1786:    let RequiredFeatures = ["ZvfhminOrZvfh"] in
```