### PR TITLE
[flang] Improve length information in character transformational

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -2093,7 +2093,15 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       CHECK(sameArg);
       if (std::optional<DynamicType> aType{sameArg->GetType()}) {
         if (result.categorySet.test(aType->category())) {
-          resultType = *aType;
+          if (const auto *sameChar{UnwrapExpr<Expr<SomeCharacter>>(*sameArg)}) {
+            if (auto len{ToInt64(Fold(context, sameChar->LEN()))}) {
+              resultType = DynamicType{aType->kind(), *len};
+            } else {
+              resultType = *aType;
+            }
+          } else {
+            resultType = *aType;
+          }
         } else {
           resultType = DynamicType{*category, aType->kind()};
         }

--- a/flang/test/Evaluate/fold-substr.f90
+++ b/flang/test/Evaluate/fold-substr.f90
@@ -20,3 +20,11 @@ module m
   logical, parameter :: test_07d = ca(1)(5:) == ""
   logical, parameter :: test_07e = ca(1)(:) == "abcd"
 end module
+
+subroutine foo(x)
+  character(4) :: x(:, :)
+  logical, parameter :: test_01 = len(transpose(x(:, :)(:))) == 4
+  logical, parameter :: test_02 = len(transpose(x(:, :)(1:2))) == 2
+  logical, parameter :: test_03 = len(maxval(x(:, :)(:))) == 4
+  logical, parameter :: test_04 = len(maxval(x(:, :)(1:2))) == 2
+end subroutine


### PR DESCRIPTION
Intrinsic resolution currently does not resolve constant length information for character transformational  (with "sameChar") where the argument has constant length but is not a variable or a constant expression.

It is not required to fold those expressions (only inquiry on constant expression or variable with constant length is required to be a constant expression).

But constant length information for character is valuable for lowering, so I think this is a nice and easy to have.

Addresses my comment in https://github.com/llvm/llvm-project/pull/65705#discussion_r1319902912 where the patch is adding code to in lowering manually get constant length info into FIR type system for maxval intrinsic result instead of relying on what LEN() is able to provide.