### PR TITLE
[libc++] Mark static variables of locale::id as constinit

### DIFF
--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -688,7 +688,7 @@ locale::facet::__on_zero_shared() noexcept
 
 // locale::id
 
-int32_t locale::id::__next_id = 0;
+constinit int32_t locale::id::__next_id = 0;
 
 namespace
 {
@@ -836,7 +836,7 @@ const ctype_base::mask ctype_base::graph;
 // template <> class ctype<wchar_t>;
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-locale::id ctype<wchar_t>::id;
+constinit locale::id ctype<wchar_t>::id;
 
 ctype<wchar_t>::~ctype()
 {
@@ -969,7 +969,7 @@ ctype<wchar_t>::do_narrow(const char_type* low, const char_type* high, char dfau
 
 // template <> class ctype<char>;
 
-locale::id ctype<char>::id;
+constinit locale::id ctype<char>::id;
 
 const size_t ctype<char>::table_size;
 
@@ -1524,7 +1524,7 @@ ctype_byname<wchar_t>::do_narrow(const char_type* low, const char_type* high, ch
 
 // template <> class codecvt<char, char, mbstate_t>
 
-locale::id codecvt<char, char, mbstate_t>::id;
+constinit locale::id codecvt<char, char, mbstate_t>::id;
 
 codecvt<char, char, mbstate_t>::~codecvt()
 {
@@ -1586,7 +1586,7 @@ codecvt<char, char, mbstate_t>::do_max_length() const noexcept
 // template <> class codecvt<wchar_t, char, mbstate_t>
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-locale::id codecvt<wchar_t, char, mbstate_t>::id;
+constinit locale::id codecvt<wchar_t, char, mbstate_t>::id;
 
 codecvt<wchar_t, char, mbstate_t>::codecvt(size_t refs)
     : locale::facet(refs),
@@ -3192,7 +3192,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 
 // template <> class codecvt<char16_t, char, mbstate_t>
 
-locale::id codecvt<char16_t, char, mbstate_t>::id;
+constinit locale::id codecvt<char16_t, char, mbstate_t>::id;
 
 codecvt<char16_t, char, mbstate_t>::~codecvt()
 {
@@ -3271,7 +3271,7 @@ codecvt<char16_t, char, mbstate_t>::do_max_length() const noexcept
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>
 
-locale::id codecvt<char16_t, char8_t, mbstate_t>::id;
+constinit locale::id codecvt<char16_t, char8_t, mbstate_t>::id;
 
 codecvt<char16_t, char8_t, mbstate_t>::~codecvt()
 {
@@ -3350,7 +3350,7 @@ codecvt<char16_t, char8_t, mbstate_t>::do_max_length() const noexcept
 
 // template <> class codecvt<char32_t, char, mbstate_t>
 
-locale::id codecvt<char32_t, char, mbstate_t>::id;
+constinit locale::id codecvt<char32_t, char, mbstate_t>::id;
 
 codecvt<char32_t, char, mbstate_t>::~codecvt()
 {
@@ -3429,7 +3429,7 @@ codecvt<char32_t, char, mbstate_t>::do_max_length() const noexcept
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>
 
-locale::id codecvt<char32_t, char8_t, mbstate_t>::id;
+constinit locale::id codecvt<char32_t, char8_t, mbstate_t>::id;
 
 codecvt<char32_t, char8_t, mbstate_t>::~codecvt()
 {
@@ -4628,9 +4628,9 @@ static bool checked_string_to_char_convert(char& dest,
 
 // numpunct<char> && numpunct<wchar_t>
 
-locale::id numpunct< char  >::id;
+constinit locale::id numpunct<char>::id;
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-locale::id numpunct<wchar_t>::id;
+constinit locale::id numpunct<wchar_t>::id;
 #endif
 
 numpunct<char>::numpunct(size_t refs)


### PR DESCRIPTION
The dylib contains multiple global variables of type locale::id. Those can be marked as constinit to make it clear that static initialization is performed.