### PR TITLE
[flang][openacc] Add check for acc cache directive

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -335,6 +335,10 @@ void AccStructureChecker::Enter(const parser::OpenACCCacheConstruct &x) {
   const auto &verbatim = std::get<parser::Verbatim>(x.t);
   PushContextAndClauseSets(verbatim.source, llvm::acc::Directive::ACCD_cache);
   SetContextDirectiveSource(verbatim.source);
+  if (loopNestLevel == 0) {
+    context_.Say(verbatim.source,
+          "The CACHE directive must be inside a loop"_err_en_US);
+  }
 }
 void AccStructureChecker::Leave(const parser::OpenACCCacheConstruct &x) {
   dirContext_.pop_back();
@@ -653,6 +657,14 @@ void AccStructureChecker::Enter(const parser::SubroutineSubprogram &) {
 
 void AccStructureChecker::Enter(const parser::SeparateModuleSubprogram &) {
   declareSymbols.clear();
+}
+
+void AccStructureChecker::Enter(const parser::DoConstruct &) {
+  ++loopNestLevel;
+}
+
+void AccStructureChecker::Leave(const parser::DoConstruct &) {
+  --loopNestLevel;
 }
 
 llvm::StringRef AccStructureChecker::getDirectiveName(

--- a/flang/lib/Semantics/check-acc-structure.h
+++ b/flang/lib/Semantics/check-acc-structure.h
@@ -71,6 +71,8 @@ public:
   void Enter(const parser::SubroutineSubprogram &);
   void Enter(const parser::FunctionSubprogram &);
   void Enter(const parser::SeparateModuleSubprogram &);
+  void Enter(const parser::DoConstruct &);
+  void Leave(const parser::DoConstruct &);
 
 #define GEN_FLANG_CLAUSE_CHECK_ENTER
 #include "llvm/Frontend/OpenACC/ACC.inc"
@@ -88,6 +90,7 @@ private:
   llvm::StringRef getDirectiveName(llvm::acc::Directive directive) override;
 
   llvm::SmallDenseSet<Symbol *> declareSymbols;
+  unsigned loopNestLevel = 0;
 };
 
 } // namespace Fortran::semantics

--- a/flang/test/Semantics/OpenACC/acc-cache-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-cache-validity.f90
@@ -19,6 +19,8 @@ program openacc_cache_validity
   type(atype), dimension(10) :: ta
   real(8), dimension(N) :: a
 
+  do i = 1, N
+
   !$acc cache(a(i))
   !$acc cache(a(1:2,3:4))
   !$acc cache(a)
@@ -39,5 +41,10 @@ program openacc_cache_validity
 
   !ERROR: Only array element or subarray are allowed in CACHE directive
   !$acc cache(/i/)
+
+  end do
+
+  !ERROR: The CACHE directive must be inside a loop
+  !$acc cache(a)
 
 end program openacc_cache_validity


### PR DESCRIPTION
OpenACC 3.3 - 2.10 The cache directive may appear at the top of (inside of) a loop.

This patch adds a semantic check to ensure the cache directive is inside a loop.