### PR TITLE
[libc][NFC] Eliminate the internal header library target.

### DIFF
--- a/libc/cmake/modules/LLVMLibCLibraryRules.cmake
+++ b/libc/cmake/modules/LLVMLibCLibraryRules.cmake
@@ -175,27 +175,19 @@ function(create_header_library fq_target_name)
       endforeach()
     endif()
   endif()
-  set(interface_target_name "${fq_target_name}.__header_library__")
 
-  add_library(${interface_target_name} INTERFACE)
-  target_sources(${interface_target_name} INTERFACE ${FULL_HDR_PATHS})
+  add_library(${fq_target_name} INTERFACE)
+  target_sources(${fq_target_name} INTERFACE ${FULL_HDR_PATHS})
   if(ADD_HEADER_DEPENDS)
-    add_dependencies(${interface_target_name} ${ADD_HEADER_DEPENDS})
+    add_dependencies(${fq_target_name} ${ADD_HEADER_DEPENDS})
   endif()
-  set_target_properties(
-    ${interface_target_name}
-    PROPERTIES
-      INTERFACE_FLAGS "${ADD_HEADER_FLAGS}"
-  )
   if(ADD_HEADER_COMPILE_OPTIONS)
-    target_compile_options(${interface_target_name} INTERFACE ${ADD_HEADER_COMPILE_OPTIONS})
+    target_compile_options(${fq_target_name} INTERFACE ${ADD_HEADER_COMPILE_OPTIONS})
   endif()
-
-  add_custom_target(${fq_target_name})
-  add_dependencies(${fq_target_name} ${interface_target_name})
   set_target_properties(
     ${fq_target_name}
     PROPERTIES
+      INTERFACE_FLAGS "${ADD_HEADER_FLAGS}"
       TARGET_TYPE "${HDR_LIBRARY_TARGET_TYPE}"
       DEPS "${ADD_HEADER_DEPENDS}"
       FLAGS "${ADD_HEADER_FLAGS}"


### PR DESCRIPTION
The internal header library target with name suffix `.__header_library`
has been removed as it serves no purpose now. It was added to make older
versions of CMake happy.
