### PR TITLE
[MC][RISCV] Add assembly syntax highlighting for RISCV

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -282,7 +282,7 @@ void RISCVInstPrinter::printSpimm(const MCInst *MI, unsigned OpNo,
     Spimm = -Spimm;
 
   // RAII guard for ANSI color escape sequences
-  auto OS = markup(O, Markup::Immediate);
+  WithMarkup ScopedMarkup = markup(O, Markup::Immediate);
   RISCVZC::printSpimm(Spimm, O);
 }
 
@@ -295,7 +295,8 @@ void RISCVInstPrinter::printVMaskReg(const MCInst *MI, unsigned OpNo,
   if (MO.getReg() == RISCV::NoRegister)
     return;
   O << ", ";
-  markup(O, Markup::Register) << getRegisterName(MO.getReg()) << ".t";
+  printRegName(O, MO.getReg());
+  O << ".t";
 }
 
 const char *RISCVInstPrinter::getRegisterName(MCRegister Reg) {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -295,8 +295,7 @@ void RISCVInstPrinter::printVMaskReg(const MCInst *MI, unsigned OpNo,
   if (MO.getReg() == RISCV::NoRegister)
     return;
   O << ", ";
-  printRegName(O, MO.getReg());
-  markup(O, Markup::Register) << ".t";
+  markup(O, Markup::Register) << getRegisterName(MO.getReg()) << ".t";
 }
 
 const char *RISCVInstPrinter::getRegisterName(MCRegister Reg) {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -16,6 +16,7 @@
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCSymbol.h"
@@ -75,7 +76,7 @@ void RISCVInstPrinter::printInst(const MCInst *MI, uint64_t Address,
 }
 
 void RISCVInstPrinter::printRegName(raw_ostream &O, MCRegister Reg) const {
-  O << getRegisterName(Reg);
+  markup(O, Markup::Register) << getRegisterName(Reg);
 }
 
 void RISCVInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
@@ -90,7 +91,7 @@ void RISCVInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   }
 
   if (MO.isImm()) {
-    O << MO.getImm();
+    markup(O, Markup::Immediate) << MO.getImm();
     return;
   }
 
@@ -110,9 +111,9 @@ void RISCVInstPrinter::printBranchOperand(const MCInst *MI, uint64_t Address,
     uint64_t Target = Address + MO.getImm();
     if (!STI.hasFeature(RISCV::Feature64Bit))
       Target &= 0xffffffff;
-    O << formatHex(Target);
+    markup(O, Markup::Target) << formatHex(Target);
   } else {
-    O << MO.getImm();
+    markup(O, Markup::Target) << MO.getImm();
   }
 }
 
@@ -123,11 +124,11 @@ void RISCVInstPrinter::printCSRSystemRegister(const MCInst *MI, unsigned OpNo,
   auto SiFiveReg = RISCVSysReg::lookupSiFiveRegByEncoding(Imm);
   auto SysReg = RISCVSysReg::lookupSysRegByEncoding(Imm);
   if (SiFiveReg && SiFiveReg->haveVendorRequiredFeatures(STI.getFeatureBits()))
-    O << SiFiveReg->Name;
+    markup(O, Markup::Register) << SiFiveReg->Name;
   else if (SysReg && SysReg->haveRequiredFeatures(STI.getFeatureBits()))
-    O << SysReg->Name;
+    markup(O, Markup::Register) << SysReg->Name;
   else
-    O << Imm;
+    markup(O, Markup::Register) << Imm;
 }
 
 void RISCVInstPrinter::printFenceArg(const MCInst *MI, unsigned OpNo,
@@ -162,11 +163,11 @@ void RISCVInstPrinter::printFPImmOperand(const MCInst *MI, unsigned OpNo,
                                          raw_ostream &O) {
   unsigned Imm = MI->getOperand(OpNo).getImm();
   if (Imm == 1) {
-    O << "min";
+    markup(O, Markup::Immediate) << "min";
   } else if (Imm == 30) {
-    O << "inf";
+    markup(O, Markup::Immediate) << "inf";
   } else if (Imm == 31) {
-    O << "nan";
+    markup(O, Markup::Immediate) << "nan";
   } else {
     float FPVal = RISCVLoadFPImm::getFPImm(Imm);
     // If the value is an integer, print a .0 fraction. Otherwise, use %g to
@@ -174,9 +175,9 @@ void RISCVInstPrinter::printFPImmOperand(const MCInst *MI, unsigned OpNo,
     // if it is shorter than printing as a decimal. The smallest value requires
     // 12 digits of precision including the decimal.
     if (FPVal == (int)(FPVal))
-      O << format("%.1f", FPVal);
+      markup(O, Markup::Immediate) << format("%.1f", FPVal);
     else
-      O << format("%.12g", FPVal);
+      markup(O, Markup::Immediate) << format("%.12g", FPVal);
   }
 }
 
@@ -208,19 +209,20 @@ void RISCVInstPrinter::printVTypeI(const MCInst *MI, unsigned OpNo,
 void RISCVInstPrinter::printRlist(const MCInst *MI, unsigned OpNo,
                                   const MCSubtargetInfo &STI, raw_ostream &O) {
   unsigned Imm = MI->getOperand(OpNo).getImm();
-  O << "{";
+  auto OS = markup(O, Markup::Register);
+  OS << "{";
   switch (Imm) {
   case RISCVZC::RLISTENCODE::RA:
-    O << (ArchRegNames ? "x1" : "ra");
+    OS << (ArchRegNames ? "x1" : "ra");
     break;
   case RISCVZC::RLISTENCODE::RA_S0:
-    O << (ArchRegNames ? "x1, x8" : "ra, s0");
+    OS << (ArchRegNames ? "x1, x8" : "ra, s0");
     break;
   case RISCVZC::RLISTENCODE::RA_S0_S1:
-    O << (ArchRegNames ? "x1, x8-x9" : "ra, s0-s1");
+    OS << (ArchRegNames ? "x1, x8-x9" : "ra, s0-s1");
     break;
   case RISCVZC::RLISTENCODE::RA_S0_S2:
-    O << (ArchRegNames ? "x1, x8-x9, x18" : "ra, s0-s2");
+    OS << (ArchRegNames ? "x1, x8-x9, x18" : "ra, s0-s2");
     break;
   case RISCVZC::RLISTENCODE::RA_S0_S3:
   case RISCVZC::RLISTENCODE::RA_S0_S4:
@@ -229,16 +231,16 @@ void RISCVInstPrinter::printRlist(const MCInst *MI, unsigned OpNo,
   case RISCVZC::RLISTENCODE::RA_S0_S7:
   case RISCVZC::RLISTENCODE::RA_S0_S8:
   case RISCVZC::RLISTENCODE::RA_S0_S9:
-    O << (ArchRegNames ? "x1, x8-x9, x18-" : "ra, s0-")
-      << getRegisterName(RISCV::X19 + (Imm - RISCVZC::RLISTENCODE::RA_S0_S3));
+    OS << (ArchRegNames ? "x1, x8-x9, x18-" : "ra, s0-")
+       << getRegisterName(RISCV::X19 + (Imm - RISCVZC::RLISTENCODE::RA_S0_S3));
     break;
   case RISCVZC::RLISTENCODE::RA_S0_S11:
-    O << (ArchRegNames ? "x1, x8-x9, x18-x27" : "ra, s0-s11");
+    OS << (ArchRegNames ? "x1, x8-x9, x18-x27" : "ra, s0-s11");
     break;
   default:
     llvm_unreachable("invalid register list");
   }
-  O << "}";
+  OS << "}";
 }
 
 void RISCVInstPrinter::printSpimm(const MCInst *MI, unsigned OpNo,
@@ -256,6 +258,7 @@ void RISCVInstPrinter::printSpimm(const MCInst *MI, unsigned OpNo,
   if (Opcode == RISCV::CM_PUSH)
     Spimm = -Spimm;
 
+  auto OS = markup(O, Markup::Immediate);
   RISCVZC::printSpimm(Spimm, O);
 }
 

--- a/llvm/test/MC/Disassembler/RISCV/colored.txt
+++ b/llvm/test/MC/Disassembler/RISCV/colored.txt
@@ -1,0 +1,23 @@
+# RUN: llvm-mc -triple=riscv64 -mattr=+zcmp,+experimental-zfa --cdis %s | FileCheck %s --strict-whitespace --match-full-lines
+
+# Registers and immediates
+0x03 0xe0 0x40 0x00
+# CHECK:	lwu	[0;36mzero[0m, [0;31m4[0m([0;36mra[0m)
+
+# Branch targets
+0x63 0x00 0xb5 0x04
+# CHECK-NEXT:	beq	[0;36ma0[0m, [0;36ma1[0m, [0;33m64[0m
+
+# CSRs
+0xf3 0x23 0x10 0xf1
+# CHECK-NEXT:	csrr	[0;36mt2[0m, [0;36mmvendorid[0m
+
+# FP immediates
+0xd3 0x00 0x1f 0xf0
+# CHECK-NEXT:	fli.s	[0;36mft1[0m, [0;31minf[0m
+0xd3 0x80 0x1e 0xf0
+# CHECK-NEXT:	fli.s	[0;36mft1[0m, [0;31m65536.0[0m
+
+# Rlist and spimm
+0x62 0xbe
+# CHECK-NEXT:	cm.popret	[0;36m{ra, s0-s1}[0m, [0;31m32[0m

--- a/llvm/test/MC/Disassembler/RISCV/colored.txt
+++ b/llvm/test/MC/Disassembler/RISCV/colored.txt
@@ -1,23 +1,48 @@
-# RUN: llvm-mc -triple=riscv64 -mattr=+zcmp,+experimental-zfa --cdis %s | FileCheck %s --strict-whitespace --match-full-lines
+# UNSUPPORTED: system-windows
+# RUN: llvm-mc -triple=riscv64 -mattr=+zcmp,+experimental-zfa,+v --cdis %s | FileCheck %s --strict-whitespace --match-full-lines -check-prefixes=CHECK,ASM,ABINAME
+# RUN: llvm-mc -triple=riscv64 -mattr=+zcmp,+experimental-zfa,+v -M numeric --cdis %s | FileCheck %s --strict-whitespace --match-full-lines -check-prefixes=CHECK,ASM,ARCHNAME
 
+# CHECK:	.text
 # Registers and immediates
 0x03 0xe0 0x40 0x00
-# CHECK:	lwu	[0;36mzero[0m, [0;31m4[0m([0;36mra[0m)
+# ABINAME-NEXT:	lwu	[0;36mzero[0m, [0;31m4[0m([0;36mra[0m)
+# ARCHNAME-NEXT:	lwu	[0;36mx0[0m, [0;31m4[0m([0;36mx1[0m)
 
 # Branch targets
 0x63 0x00 0xb5 0x04
-# CHECK-NEXT:	beq	[0;36ma0[0m, [0;36ma1[0m, [0;33m64[0m
+# ABINAME-NEXT:	beq	[0;36ma0[0m, [0;36ma1[0m, [0;33m64[0m
+# ARCHNAME-NEXT:	beq	[0;36mx10[0m, [0;36mx11[0m, [0;33m64[0m
 
 # CSRs
 0xf3 0x23 0x10 0xf1
-# CHECK-NEXT:	csrr	[0;36mt2[0m, [0;36mmvendorid[0m
+# ABINAME-NEXT:	csrr	[0;36mt2[0m, [0;36mmvendorid[0m
+# ARCHNAME-NEXT:	csrr	[0;36mx7[0m, [0;36mmvendorid[0m
 
 # FP immediates
 0xd3 0x00 0x1f 0xf0
-# CHECK-NEXT:	fli.s	[0;36mft1[0m, [0;31minf[0m
+# ABINAME-NEXT:	fli.s	[0;36mft1[0m, [0;31minf[0m
+# ARCHNAME-NEXT:	fli.s	[0;36mf1[0m, [0;31minf[0m
 0xd3 0x80 0x1e 0xf0
-# CHECK-NEXT:	fli.s	[0;36mft1[0m, [0;31m65536.0[0m
+# ABINAME-NEXT:	fli.s	[0;36mft1[0m, [0;31m65536.0[0m
+# ARCHNAME-NEXT:	fli.s	[0;36mf1[0m, [0;31m65536.0[0m
 
 # Rlist and spimm
+0x42 0xbe
+# ABINAME-NEXT:	cm.popret	{[0;36mra[0m}, [0;31m16[0m
+# ARCHNAME-NEXT:	cm.popret	{[0;36mx1[0m}, [0;31m16[0m
+0x5e 0xbe
+# ABINAME-NEXT:	cm.popret	{[0;36mra[0m, [0;36ms0[0m}, [0;31m64[0m
+# ARCHNAME-NEXT:	cm.popret	{[0;36mx1[0m, [0;36mx8[0m}, [0;31m64[0m
 0x62 0xbe
-# CHECK-NEXT:	cm.popret	[0;36m{ra, s0-s1}[0m, [0;31m32[0m
+# ABINAME-NEXT:	cm.popret	{[0;36mra[0m, [0;36ms0[0m-[0;36ms1[0m}, [0;31m32[0m
+# ARCHNAME-NEXT:	cm.popret	{[0;36mx1[0m, [0;36mx8[0m-[0;36mx9[0m}, [0;31m32[0m
+0x76 0xbe
+# ABINAME-NEXT:	cm.popret	{[0;36mra[0m, [0;36ms0[0m-[0;36ms2[0m}, [0;31m48[0m
+# ARCHNAME-NEXT:	cm.popret	{[0;36mx1[0m, [0;36mx8[0m-[0;36mx9[0m, [0;36mx18[0m}, [0;31m48[0m
+0xfe 0xbe
+# ABINAME-NEXT:	cm.popret	{[0;36mra[0m, [0;36ms0[0m-[0;36ms11[0m}, [0;31m160[0m
+# ARCHNAME-NEXT:	cm.popret	{[0;36mx1[0m, [0;36mx8[0m-[0;36mx9[0m, [0;36mx18[0m-[0;36mx27[0m}, [0;31m160[0m
+
+# mask registers
+0x57 0x04 0x4a 0x00
+# ASM-NEXT:	vadd.vv	[0;36mv8[0m, [0;36mv4[0m, [0;36mv20[0m, [0;36mv0[0m[0;36m.t[0m

--- a/llvm/test/MC/Disassembler/RISCV/colored.txt
+++ b/llvm/test/MC/Disassembler/RISCV/colored.txt
@@ -45,4 +45,4 @@
 
 # mask registers
 0x57 0x04 0x4a 0x00
-# ASM-NEXT:	vadd.vv	[0;36mv8[0m, [0;36mv4[0m, [0;36mv20[0m, [0;36mv0.t[0m
+# ASM-NEXT:	vadd.vv	[0;36mv8[0m, [0;36mv4[0m, [0;36mv20[0m, [0;36mv0[0m.t

--- a/llvm/test/MC/Disassembler/RISCV/colored.txt
+++ b/llvm/test/MC/Disassembler/RISCV/colored.txt
@@ -45,4 +45,4 @@
 
 # mask registers
 0x57 0x04 0x4a 0x00
-# ASM-NEXT:	vadd.vv	[0;36mv8[0m, [0;36mv4[0m, [0;36mv20[0m, [0;36mv0[0m[0;36m.t[0m
+# ASM-NEXT:	vadd.vv	[0;36mv8[0m, [0;36mv4[0m, [0;36mv20[0m, [0;36mv0.t[0m


### PR DESCRIPTION
This patch adds support for syntax highlighting RISC-V assembly.
Related patch:
AArch64: https://reviews.llvm.org/D159162
X86: https://reviews.llvm.org/D159241
