### PR TITLE
[github] GitHub Actions workflows changes

### DIFF
--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -6,7 +6,6 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
@@ -15,7 +14,6 @@ on:
       - '.github/workflows/llvm-project-tests.yml'
       - '!llvm/**'
   pull_request:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:

--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -55,9 +55,9 @@ jobs:
 
       - name: Backport Commits
         run: |
-          printf "$COMMENT_BODY" |
+          printf "%s" "$COMMENT_BODY" |
           ./llvm/utils/git/github-automation.py \
-          --repo $GITHUB_REPOSITORY \
+          --repo "$GITHUB_REPOSITORY" \
           --token ${{ secrets.RELEASE_WORKFLOW_PUSH_SECRET }} \
           release-workflow \
           --issue-number ${{ github.event.issue.number }} \
@@ -84,9 +84,9 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          printf "$COMMENT_BODY" |
+          printf "%s" "$COMMENT_BODY" |
           ./llvm/utils/git/github-automation.py \
-          --repo $GITHUB_REPOSITORY \
+          --repo "$GITHUB_REPOSITORY" \
           --token ${{ secrets.RELEASE_WORKFLOW_PUSH_SECRET }} \
           release-workflow \
           --issue-number ${{ github.event.issue.number }} \

--- a/.github/workflows/issue-subscriber.yml
+++ b/.github/workflows/issue-subscriber.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Setup Automation Script
         run: |
-          curl -O -L https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_SHA/llvm/utils/git/github-automation.py
-          curl -O -L https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$GITHUB_SHA/llvm/utils/git/requirements.txt
+          curl -O -L https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/"$GITHUB_SHA"/llvm/utils/git/github-automation.py
+          curl -O -L https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/"$GITHUB_SHA"/llvm/utils/git/requirements.txt
           chmod a+x github-automation.py
           pip install -r requirements.txt
 

--- a/.github/workflows/libclang-abi-tests.yml
+++ b/.github/workflows/libclang-abi-tests.yml
@@ -6,14 +6,12 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
       - 'clang/**'
       - '.github/workflows/libclang-abi-tests.yml'
   pull_request:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
@@ -52,32 +50,35 @@ jobs:
       - name: Setup Variables
         id: vars
         run: |
-          minor_version=0
           remote_repo='https://github.com/llvm/llvm-project'
-          if [ ${{ steps.version.outputs.LLVM_VERSION_MINOR }} -ne 0 -o ${{ steps.version.outputs.LLVM_VERSION_PATCH }} -eq 0 ]; then
+          if [ ${{ steps.version.outputs.LLVM_VERSION_MINOR }} -ne 0 ] || [ ${{ steps.version.outputs.LLVM_VERSION_PATCH }} -eq 0 ]; then
             major_version=$(( ${{ steps.version.outputs.LLVM_VERSION_MAJOR }} - 1))
             baseline_ref="llvmorg-$major_version.0.0"
 
             # If there is a minor release, we want to use that as the base line.
-            minor_ref=$(git ls-remote --refs -t $remote_repo llvmorg-$major_version.[1-9].[0-9] | tail -n1 | grep -o 'llvmorg-.\+' || true)
+            minor_ref=$(git ls-remote --refs -t "$remote_repo" llvmorg-"$major_version".[1-9].[0-9] | tail -n1 | grep -o 'llvmorg-.\+' || true)
             if [ -n "$minor_ref" ]; then
-               baseline_ref=$minor_ref
+               baseline_ref="$minor_ref"
             else
               # Check if we have a release candidate
-              rc_ref=$(git ls-remote --refs -t $remote_repo llvmorg-$major_version.[1-9].[0-9]-rc* | tail -n1 | grep -o 'llvmorg-.\+' || true)
+              rc_ref=$(git ls-remote --refs -t "$remote_repo" llvmorg-"$major_version".[1-9].[0-9]-rc* | tail -n1 | grep -o 'llvmorg-.\+' || true)
               if [ -n "$rc_ref" ]; then
-                baseline_ref=$rc_ref
+                baseline_ref="$rc_ref"
               fi
             fi
-            echo "BASELINE_VERSION_MAJOR=$major_version" >> $GITHUB_OUTPUT
-            echo "BASELINE_REF=$baseline_ref" >> $GITHUB_OUTPUT
-            echo "ABI_HEADERS=clang-c" >> $GITHUB_OUTPUT
-            echo "ABI_LIBS=libclang.so" >> $GITHUB_OUTPUT
+            {
+              echo "BASELINE_VERSION_MAJOR=$major_version"
+              echo "BASELINE_REF=$baseline_ref"
+              echo "ABI_HEADERS=clang-c"
+              echo "ABI_LIBS=libclang.so"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.LLVM_VERSION_MAJOR }}" >> $GITHUB_OUTPUT
-            echo "BASELINE_REF=llvmorg-${{ steps.version.outputs.LLVM_VERSION_MAJOR }}.0.0" >> $GITHUB_OUTPUT
-            echo "ABI_HEADERS=." >> $GITHUB_OUTPUT
-            echo "ABI_LIBS=libclang.so libclang-cpp.so" >> $GITHUB_OUTPUT
+            {
+              echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.LLVM_VERSION_MAJOR }}"
+              echo "BASELINE_REF=llvmorg-${{ steps.version.outputs.LLVM_VERSION_MAJOR }}.0.0"
+              echo "ABI_HEADERS=."
+              echo "ABI_LIBS=libclang.so libclang-cpp.so"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   abi-dump:
@@ -119,7 +120,7 @@ jobs:
       - name: Configure
         run: |
           mkdir install
-          cmake -B build -S llvm -G Ninja -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD="" -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_C_FLAGS_DEBUG="-g1 -Og" -DCMAKE_CXX_FLAGS_DEBUG="-g1 -Og" -DCMAKE_INSTALL_PREFIX=$(pwd)/install llvm
+          cmake -B build -S llvm -G Ninja -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD="" -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_C_FLAGS_DEBUG="-g1 -Og" -DCMAKE_CXX_FLAGS_DEBUG="-g1 -Og" -DCMAKE_INSTALL_PREFIX="$(pwd)"/install llvm
       - name: Build
         run: ninja -C build/ ${{ needs.abi-dump-setup.outputs.ABI_LIBS }} install-clang-headers
       - name: Dump ABI

--- a/.github/workflows/libclc-tests.yml
+++ b/.github/workflows/libclc-tests.yml
@@ -6,7 +6,6 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
@@ -16,7 +15,6 @@ on:
       - '!clang/**'
       - '!llvm/**'
   pull_request:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:

--- a/.github/workflows/lld-tests.yml
+++ b/.github/workflows/lld-tests.yml
@@ -6,7 +6,6 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
@@ -15,7 +14,6 @@ on:
       - '.github/workflows/llvm-project-tests.yml'
       - '!llvm/**'
   pull_request:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:

--- a/.github/workflows/lldb-tests.yml
+++ b/.github/workflows/lldb-tests.yml
@@ -6,7 +6,6 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
@@ -16,7 +15,6 @@ on:
       - '!clang/**'
       - '!llvm/**'
   pull_request:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -93,6 +93,6 @@ jobs:
         run: |
           # Make sure all of LLVM libraries that llvm-config needs are built.
           ninja -C build
-          cmake -G Ninja -S libclc -B libclc-build -DLLVM_DIR=$(pwd)/build/lib/cmake/llvm -DLIBCLC_TARGETS_TO_BUILD="amdgcn--;amdgcn--amdhsa;r600--;nvptx--;nvptx64--;nvptx--nvidiacl;nvptx64--nvidiacl"
+          cmake -G Ninja -S libclc -B libclc-build -DLLVM_DIR="$(pwd)"/build/lib/cmake/llvm -DLIBCLC_TARGETS_TO_BUILD="amdgcn--;amdgcn--amdhsa;r600--;nvptx--;nvptx64--;nvptx--nvidiacl;nvptx64--nvidiacl"
           ninja -C libclc-build
           ninja -C libclc-build test

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -6,7 +6,6 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
@@ -14,7 +13,6 @@ on:
       - '.github/workflows/llvm-tests.yml'
       - '.github/workflows/llvm-project-tests.yml'
   pull_request:
-    ignore-forks: true
     branches:
       - 'release/**'
     paths:
@@ -78,12 +76,16 @@ jobs:
       - name: Setup Variables
         id: vars
         run: |
-          if [ ${{ steps.version.outputs.LLVM_VERSION_MINOR }} -ne 0 -o ${{ steps.version.outputs.LLVM_VERSION_PATCH }} -eq 0 ]; then
-            echo "BASELINE_VERSION_MAJOR=$(( ${{ steps.version.outputs.LLVM_VERSION_MAJOR }} - 1))" >> $GITHUB_OUTPUT
-            echo "ABI_HEADERS=llvm-c" >> $GITHUB_OUTPUT
+          if [ ${{ steps.version.outputs.LLVM_VERSION_MINOR }} -ne 0 ] || [ ${{ steps.version.outputs.LLVM_VERSION_PATCH }} -eq 0 ]; then
+            {
+              echo "BASELINE_VERSION_MAJOR=$(( ${{ steps.version.outputs.LLVM_VERSION_MAJOR }} - 1))"
+              echo "ABI_HEADERS=llvm-c"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.LLVM_VERSION_MAJOR }}" >> $GITHUB_OUTPUT
-            echo "ABI_HEADERS=." >> $GITHUB_OUTPUT
+            {
+              echo "BASELINE_VERSION_MAJOR=${{ steps.version.outputs.LLVM_VERSION_MAJOR }}"
+              echo "ABI_HEADERS=."
+            } >> "$GITHUB_OUTPUT"
           fi
 
   abi-dump:
@@ -125,7 +127,7 @@ jobs:
       - name: Configure
         run: |
           mkdir install
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD="" -DLLVM_BUILD_LLVM_DYLIB=ON -DCMAKE_C_FLAGS_DEBUG="-g1 -Og" -DCMAKE_CXX_FLAGS_DEBUG="-g1 -Og" -DCMAKE_INSTALL_PREFIX=$(pwd)/install llvm
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD="" -DLLVM_BUILD_LLVM_DYLIB=ON -DCMAKE_C_FLAGS_DEBUG="-g1 -Og" -DCMAKE_CXX_FLAGS_DEBUG="-g1 -Og" -DCMAKE_INSTALL_PREFIX="$(pwd)"/install llvm
       - name: Build
         # Need to run install-LLVM twice to ensure the symlink is installed (this is a bug).
         run: |
@@ -141,7 +143,7 @@ jobs:
           else
             touch llvm.symbols
           fi
-          abi-dumper $EXTRA_ARGS -lver ${{ matrix.ref }} -skip-cxx -public-headers ./install/include/${{ needs.abi-dump-setup.outputs.ABI_HEADERS }} -o ${{ matrix.ref }}.abi ./install/lib/libLLVM.so
+          abi-dumper "$EXTRA_ARGS" -lver ${{ matrix.ref }} -skip-cxx -public-headers ./install/include/${{ needs.abi-dump-setup.outputs.ABI_HEADERS }} -o ${{ matrix.ref }}.abi ./install/lib/libLLVM.so
           # Remove symbol versioning from dumps, so we can compare across major versions.
           sed -i 's/LLVM_${{ matrix.llvm_version_major }}/LLVM_NOVERSION/' ${{ matrix.ref }}.abi
       - name: Upload ABI file
@@ -188,7 +190,7 @@ jobs:
           # FIXME: Reading of gzip'd abi files on the GitHub runners stop
           # working some time in March of 2021, likely due to a change in the
           # runner's environment.
-          abi-compliance-checker $EXTRA_ARGS -l libLLVM.so -old build-baseline/*.abi -new build-latest/*.abi || test "${{ needs.abi-dump-setup.outputs.ABI_HEADERS }}" = "llvm-c"
+          abi-compliance-checker "$EXTRA_ARGS" -l libLLVM.so -old build-baseline/*.abi -new build-latest/*.abi || test "${{ needs.abi-dump-setup.outputs.ABI_HEADERS }}" = "llvm-c"
       - name: Upload ABI Comparison
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -23,29 +23,29 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+               run_id: context.payload.workflow_run.id
             });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr"
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
+            const matchArtifact = artifacts.data.artifacts.find((artifact) =>
+              artifact.name === 'pr'
+            );
+            const download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+               archive_format: 'zip'
             });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            const { writeFileSync } = require('node:fs');
+            writeFileSync('${{ github.workspace }}/pr.zip', Buffer.from(download.data));
 
       - run: unzip pr.zip
 
       - name: "Get PR Number"
         id: vars
         run:
-          echo "pr-number=`cat NR`" >> $GITHUB_OUTPUT
+          echo "pr-number=$(cat NR)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/labeler@v4
         with:
@@ -53,4 +53,4 @@ jobs:
           # workaround for https://github.com/actions/labeler/issues/112
           sync-labels: ''
           repo-token: ${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}
-          pr-number: ${{steps.vars.outputs.pr-number}}
+          pr-number: ${{ steps.vars.outputs.pr-number }}

--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -23,37 +23,37 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+               run_id: context.payload.workflow_run.id
             });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr"
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
+            const matchArtifact = artifacts.data.artifacts.find((artifact) =>
+              artifact.name === 'pr'
+            );
+            const download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+               archive_format: 'zip'
             });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            const { writeFileSync } = require('node:fs');
+            writeFileSync('${{ github.workspace }}/pr.zip', Buffer.from(download.data));
 
       - run: unzip pr.zip
 
       - name: Setup Automation Script
         run: |
-          curl -O -L https://raw.githubusercontent.com/$GITHUB_REPOSITORY/main/llvm/utils/git/github-automation.py
-          curl -O -L https://raw.githubusercontent.com/$GITHUB_REPOSITORY/main/llvm/utils/git/requirements.txt
+          curl -O -L https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/main/llvm/utils/git/github-automation.py
+          curl -O -L https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/main/llvm/utils/git/requirements.txt
           chmod a+x github-automation.py
           pip install -r requirements.txt
 
       - name: Update watchers
         # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
         run: |
-          PR_NUMBER=`cat NR`
-          LABEL_NAME=`cat LABEL`
+          PR_NUMBER=$(cat NR)
+          LABEL_NAME=$(cat LABEL)
           ./github-automation.py \
             --token '${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}' \
             pr-subscriber \

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -48,7 +48,7 @@ jobs:
       # | X.Y.Z     | -final
       run: |
         tag="${{ github.ref_name }}"
-        trimmed=`echo ${{ inputs.tag }} | xargs`
+        trimmed=$(echo ${{ inputs.tag }} | xargs)
         [[ "$trimmed" != "" ]] && tag="$trimmed"
         if [ -n "${{ inputs.upload }}" ]; then
           upload="${{ inputs.upload }}"
@@ -92,7 +92,7 @@ jobs:
     - name: Set macOS build env variables
       if: runner.os == 'macOS'
       run: |
-        echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> $GITHUB_ENV
+        echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> "$GITHUB_ENV"
 
     - name: Build and test release
       run: |

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -22,7 +22,7 @@ jobs:
           test "${{ github.actor }}" = "tstellar" || test "${{ github.actor }}" = "tru"
           echo "${{ github.ref_name }}" | grep -e '^llvmorg-[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\)\?$'
           release_version=$(echo "${{ github.ref_name }}" | sed 's/llvmorg-//g')
-          echo "release-version=$release_version" >> $GITHUB_OUTPUT
+          echo "release-version=$release_version" >> "$GITHUB_OUTPUT"
 
       - name: Install Dependencies
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: Build Documentation
         run: |
           ./llvm/utils/release/build-docs.sh -release ${{ steps.validate-tag.outputs.release-version }}
-          ./llvm/utils/release/github-upload-release.py --token ${{ github.token }} --release ${{ steps.validate-tag.outputs.release-version }} upload --files *doxygen*.tar.xz
+          ./llvm/utils/release/github-upload-release.py --token ${{ github.token }} --release ${{ steps.validate-tag.outputs.release-version }} upload --files ./*doxygen*.tar.xz
 
       - name: Create Release Notes Artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Version Check
         run: |
           version=$(grep -o 'LLVM_VERSION_\(MAJOR\|MINOR\|PATCH\) [0-9]\+' llvm/CMakeLists.txt  | cut -d ' ' -f 2 | tr "\n" "." | sed 's/.$//g')
-          .github/workflows/version-check.py $version
+          .github/workflows/version-check.py "$version"


### PR DESCRIPTION
- Remove usages of the non-existent `ignore-forks` field, conditions in jobs already exist to prevent the jobs from running in forks.
- Don't use variables in the `printf` format string. Use `printf "..%s.." "$foo"`. ([SC2059](https://www.shellcheck.net/wiki/SC2059))
- Double quote variable expansion to prevent globbing and word splitting. ([SC2086](https://www.shellcheck.net/wiki/SC2086))
- Prefer `[ p ] || [ q ]` as `[ p -o q ]` is not well defined. ([SC2166](https://www.shellcheck.net/wiki/SC2166))
- Consider `{ cmd1; cmd2; } >> file` instead of individual redirects. ([SC2129](https://www.shellcheck.net/wiki/SC2129))
- Use `$(...)` notation instead of legacy notation `...`. ([SC2006](https://www.shellcheck.net/wiki/SC2006))
- Use `./*glob*` or `-- *glob*` so names with dashes won't become options. ([SC2035](https://www.shellcheck.net/wiki/SC2035))
- Refactor JavaScript code in certain workflows.
- Change workflow variable substitution style of some workflows to be consistent with others.