### PR TITLE
[Clang][OpenMP] Emit unroll directive w/o captured stmt

### DIFF
--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -8064,7 +8064,8 @@ void CodeGenFunction::EmitSimpleOMPExecutableDirective(
       D.getDirectiveKind() == OMPD_critical ||
       D.getDirectiveKind() == OMPD_section ||
       D.getDirectiveKind() == OMPD_master ||
-      D.getDirectiveKind() == OMPD_masked) {
+      D.getDirectiveKind() == OMPD_masked ||
+      D.getDirectiveKind() == OMPD_unroll) {
     EmitStmt(D.getAssociatedStmt());
   } else {
     auto LPCRegion =

--- a/clang/test/OpenMP/bug63570.c
+++ b/clang/test/OpenMP/bug63570.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -verify -fopenmp -x c -triple x86_64-apple-darwin10 %s
+// RUN: %clang_cc1 -verify -fopenmp-simd -x c -triple x86_64-apple-darwin10 %s
+// expected-no-diagnostics
+
+void f(float *a, float *b) {
+#pragma omp unroll
+  for (int i = 0; i < 128; i++) {
+    a[i] = b[i];
+  }
+}


### PR DESCRIPTION
The front end doesn't create captured stmt for unroll directive. This leads to
a crash when `-fopenmp-simd` is used, as reported in #63570.

Fix #63570.
