### PR TITLE
[GlobalISel] Check for unsupported Windows features on invoke

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2482,7 +2482,8 @@ bool IRTranslator::translateCall(const User &U, MachineIRBuilder &MIRBuilder) {
   auto TII = MF->getTarget().getIntrinsicInfo();
   const Function *F = CI.getCalledFunction();
 
-  // FIXME: support Windows dllimport function calls.
+  // FIXME: support Windows dllimport function calls and calls through
+  // weak symbols.
   if (F && (F->hasDLLImportStorageClass() ||
             (MF->getTarget().getTargetTriple().isOSWindows() &&
              F->hasExternalWeakLinkage())))
@@ -2662,6 +2663,13 @@ bool IRTranslator::translateInvoke(const User &U,
 
   // FIXME: support Windows exception handling.
   if (!isa<LandingPadInst>(EHPadBB->getFirstNonPHI()))
+    return false;
+
+  // FIXME: support Windows dllimport function calls and calls through
+  // weak symbols.
+  if (Fn && (Fn->hasDLLImportStorageClass() ||
+            (MF->getTarget().getTargetTriple().isOSWindows() &&
+             Fn->hasExternalWeakLinkage())))
     return false;
 
   bool LowerInlineAsm = I.isInlineAsm();

--- a/llvm/test/CodeGen/AArch64/dllimport.ll
+++ b/llvm/test/CodeGen/AArch64/dllimport.ll
@@ -59,3 +59,45 @@ define i32 @call_internal() {
 ; DAG-ISEL: b internal
 ; FAST-ISEL: b internal
 ; GLOBAL-ISEL: b internal
+
+define void @call_try_catch() personality ptr @__gxx_personality_seh0 {
+entry:
+  invoke void @myFunc()
+          to label %try.cont unwind label %lpad
+
+lpad:                                             ; preds = %entry
+  %0 = landingpad { ptr, i32 }
+          catch ptr @_ZTIi
+  %1 = extractvalue { ptr, i32 } %0, 1
+  %2 = tail call i32 @llvm.eh.typeid.for(ptr nonnull @_ZTIi) #1
+  %matches = icmp eq i32 %1, %2
+  br i1 %matches, label %catch, label %eh.resume
+
+catch:                                            ; preds = %lpad
+  %3 = extractvalue { ptr, i32 } %0, 0
+  %4 = tail call ptr @__cxa_begin_catch(ptr %3) #1
+  tail call void @__cxa_end_catch() #1
+  br label %try.cont
+
+try.cont:                                         ; preds = %entry, %catch
+  ret void
+
+eh.resume:                                        ; preds = %lpad
+  resume { ptr, i32 } %0
+}
+
+; CHECK-LABEL: call_try_catch
+; CHECK: adrp x8, __imp_myFunc
+; CHECK: ldr x8, [x8, :lo12:__imp_myFunc]
+; CHECK: blr x8
+
+declare dllimport void @myFunc()
+
+@_ZTIi = external constant ptr
+declare dso_local i32 @__gxx_personality_seh0(...)
+declare i32 @llvm.eh.typeid.for(ptr) #0
+declare dso_local ptr @__cxa_begin_catch(ptr)
+declare dso_local void @__cxa_end_catch()
+
+attributes #0 = { nounwind memory(none) }
+attributes #1 = { nounwind }


### PR DESCRIPTION
This matches what is done on calls, since
cc981d285d1aa33df201605b9a3e22dd2311ead2 (extended for another case in 5a751e747dbf2c267e944aa961e21de7a815e7eb).

Apply both those cases on invoke just like is done for call.

Also update the preexisting comment which was left without update in 5a751e747dbf2c267e944aa961e21de7a815e7eb.

This fixes github issue #61941.