### PR TITLE
Update documentation for MutableOperandRange

### DIFF
--- a/mlir/include/mlir/IR/ValueRange.h
+++ b/mlir/include/mlir/IR/ValueRange.h
@@ -112,6 +112,10 @@ private:
 
 /// This class provides a mutable adaptor for a range of operands. It allows for
 /// setting, inserting, and erasing operands from the given range.
+///
+/// (Note that when using AttrSizedOperandSegments, making changes to a
+/// MutableOperandRange invalidates other MutableOperandRange's in memory; you
+/// must get a new mutable adaptor for the other operand ranges).
 class MutableOperandRange {
 public:
   /// A pair of a named attribute corresponding to an operand segment attribute,


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/65829

Caching `MutableOperandRange`'s within an op with `AttrSizedOperandSegments`, then accidentally invalidating them by editing an operand range, seems like a common issue. Added some documentation to perhaps help with this.

Note: I'm not sure if this is the best place to document something like this, or if we even need this at all -- please feel free to reject if you think it's too much of an edge case. Thanks :)