### PR TITLE
[Driver] Remove duplicate -e on DragonFly

### DIFF
--- a/clang/lib/Driver/ToolChains/DragonFly.cpp
+++ b/clang/lib/Driver/ToolChains/DragonFly.cpp
@@ -117,7 +117,7 @@ void dragonfly::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   Args.AddAllArgs(CmdArgs,
-                  {options::OPT_L, options::OPT_T_Group, options::OPT_e});
+                  {options::OPT_L, options::OPT_T_Group});
 
   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
 


### PR DESCRIPTION
62281227bf7ca48d0101e4c9d11f71600208c7df was commited, but I noticed one spot was missed in the DragonFly Driver.