### PR TITLE
[OpenMP][test][VE] Change to use VE_LD_LIBRARY_PATH for VE

### DIFF
--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -12,11 +12,15 @@ if 'PYLINT_IMPORT' in os.environ:
     lit_config = object()
 
 def prepend_dynamic_library_path(path):
+    target_arch = getattr(config, 'target_arch', None)
     if config.operating_system == 'Windows':
         name = 'PATH'
         sep = ';'
     elif config.operating_system == 'Darwin':
         name = 'DYLD_LIBRARY_PATH'
+        sep = ':'
+    elif target_arch == 've':
+        name = 'VE_LD_LIBRARY_PATH'
         sep = ':'
     else:
         name = 'LD_LIBRARY_PATH'


### PR DESCRIPTION
Change to use VE_LD_LIBRARY_PATH for VE instead of LD_LIBRARY_PATH. The VE is connected to the host, and compiled test programs for VE is invoked on the host and transferred to the VE.  If programs are compiled for the host, we use LD_LIBRARY_PATH.  Otherwise, we use VE_LD_LIBRARY_PATH.