### PR TITLE
[Haiku] Don't assume clang was build with libstdc++ as default

### DIFF
--- a/clang/test/Driver/haiku.cpp
+++ b/clang/test/Driver/haiku.cpp
@@ -1,5 +1,5 @@
 // Check the C++ header path (libstdc++)
-// RUN: %clangxx --target=x86_64-unknown-haiku -### %s 2>&1 \
+// RUN: %clangxx --target=x86_64-unknown-haiku --stdlib=libstdc++ -### %s 2>&1 \
 // RUN:   --sysroot=%S/Inputs/haiku_x86_64_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-LIBSTDCXX-HEADER-PATH %s
 // CHECK-LIBSTDCXX-HEADER-PATH: "-internal-isystem" "[[SYSROOT:[^"]+]]/boot/system/develop/headers/c++"


### PR DESCRIPTION
This test fails with `CLANG_DEFAULT_CXX_STDLIB=libc++`