### PR TITLE
[OpenMP][test][VE] Limit the number of threads to create

### DIFF
--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -1153,7 +1153,14 @@ extern void __kmp_init_target_task();
 #if defined(PTHREAD_THREADS_MAX) && PTHREAD_THREADS_MAX < INT_MAX
 #define KMP_MAX_NTH PTHREAD_THREADS_MAX
 #else
+#ifdef __ve__
+// VE's pthread supports only up to 64 threads per a VE process.
+//   https://sxauroratsubasa.sakura.ne.jp/documents/veos/en/VEOS_high_level_design.pdf
+//   p. 14 Maximum number of threads per VE process is 64.
+#define KMP_MAX_NTH 64
+#else
 #define KMP_MAX_NTH INT_MAX
+#endif
 #endif
 #endif /* KMP_MAX_NTH */
 

--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -1894,6 +1894,13 @@ void __kmp_runtime_initialize(void) {
 
     /* Query the maximum number of threads */
     __kmp_type_convert(sysconf(_SC_THREAD_THREADS_MAX), &(__kmp_sys_max_nth));
+#ifdef __ve__
+    if (__kmp_sys_max_nth == -1) {
+      // VE's pthread supports only up to 64 threads per a VE process.
+      // So we use that KMP_MAX_NTH (predefined as 64) here.
+      __kmp_sys_max_nth = KMP_MAX_NTH;
+    }
+#else
     if (__kmp_sys_max_nth == -1) {
       /* Unlimited threads for NPTL */
       __kmp_sys_max_nth = INT_MAX;
@@ -1901,6 +1908,7 @@ void __kmp_runtime_initialize(void) {
       /* Can't tell, just use PTHREAD_THREADS_MAX */
       __kmp_sys_max_nth = KMP_MAX_NTH;
     }
+#endif
 
     /* Query the minimum stack size */
     __kmp_sys_min_stksize = sysconf(_SC_THREAD_STACK_MIN);

--- a/openmp/runtime/test/atomic/omp-atomic-compare-signedness.c
+++ b/openmp/runtime/test/atomic/omp-atomic-compare-signedness.c
@@ -11,7 +11,12 @@
 // UNSUPPORTED: gcc
 
 // High parallelism increases our chances of detecting a lack of atomicity.
+#ifdef __ve__
+// VE's pthread_create supports 64 threads at a maximum.
+#define NUM_THREADS_TRY 64
+#else
 #define NUM_THREADS_TRY 256
+#endif
 
 #include <limits.h>
 #include <omp.h>


### PR DESCRIPTION
VE supports up to 64 threads per a VE process.  So, we limit the number of threads defined by KMP_MAX_NTH.  We also modify the __kmp_sys_max_nth initialization to use KMP_MAX_NTH as a limit.  We also modify a test program itself.