### PR TITLE
[clang-tidy] Avoid checking magic numbers if _BitInt

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
@@ -191,6 +191,9 @@ bool MagicNumbersCheck::isConstant(const MatchFinder::MatchResult &Result,
 }
 
 bool MagicNumbersCheck::isIgnoredValue(const IntegerLiteral *Literal) const {
+  if (Literal->getType()->isBitIntType()) {
+    return true;
+  }
   const llvm::APInt IntValue = Literal->getValue();
   const int64_t Value = IntValue.getZExtValue();
   if (Value == 0)

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/bitint-no-crash.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/bitint-no-crash.c
@@ -1,0 +1,6 @@
+// RUN: %check_clang_tidy %s readability-magic-numbers %t --
+
+// Don't crash
+
+_BitInt(128) A = 4533629751480627964421wb;
+// CHECK-MESSAGES: warning


### PR DESCRIPTION
Recent changes to add _BitInt support have caused our internal random testing to fail. This change just avoids a readability magic numbers check for now if a _BitInt. The crash seen (edited for clarity) is shown below.

<src-root>/llvm/include/llvm/ADT/APInt.h:1488:
  uint64_t llvm::APInt::getZExtValue() const: Assertion `getActiveBits()
  <= 64 && "Too many bits for uint64_t"' failed.

...
 #9 <address> llvm::APInt::getZExtValue() const
      <src-root>/llvm/include/llvm/ADT/APInt.h:1488:5
      clang::IntegerLiteral const*) const
      <src-root>/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp:198:47
      <clang::IntegerLiteral>(clang::ast_matchers::MatchFinder::MatchResult
      const&, char const*)
      <src-root>/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.h:67:5
      clang::ast_matchers::MatchFinder::MatchResult const&)
      <src-root>/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp:152:35
...

Reviewed By: donat.nagy