### PR TITLE
[clang][ExtractAPI] Create extractapi::RecordLocation

### DIFF
--- a/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
+++ b/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
@@ -29,6 +29,7 @@
 #include "clang/ExtractAPI/TypedefUnderlyingTypeResolver.h"
 #include "clang/Index/USRGeneration.h"
 #include "llvm/ADT/StringRef.h"
+#include <algorithm>
 #include <type_traits>
 
 namespace clang {
@@ -123,6 +124,8 @@ public:
   const RawComment *fetchRawCommentForDecl(const Decl *Decl) const;
 
 protected:
+  DocComment FetchDocCommentFromDecl(const Decl *Decl);
+
   /// Collect API information for the enum constants and associate with the
   /// parent enum.
   void recordEnumConstants(EnumRecord *EnumRecord,
@@ -224,6 +227,19 @@ static void modifyRecords(const T &Records, const StringRef &Name) {
 }
 
 template <typename Derived>
+DocComment ExtractAPIVisitorBase<Derived>::FetchDocCommentFromDecl(const Decl *Decl) {
+  DocComment Comment;
+  if (auto *RawComment =
+          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl)) {
+    auto RawCommentVec = RawComment->getFormattedLines(
+        Context.getSourceManager(), Context.getDiagnostics());
+    std::copy(RawCommentVec.begin(), RawCommentVec.end(),
+              std::back_inserter(Comment));
+  }
+  return Comment;
+}
+
+template <typename Derived>
 bool ExtractAPIVisitorBase<Derived>::VisitVarDecl(const VarDecl *Decl) {
   // skip function parameters.
   if (isa<ParmVarDecl>(Decl))
@@ -252,11 +268,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarDecl(const VarDecl *Decl) {
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the variable.
   DeclarationFragments Declaration =
@@ -322,11 +334,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitFunctionDecl(
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments, sub-heading, and signature of the function.
   DeclarationFragments SubHeading =
@@ -368,11 +376,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitEnumDecl(const EnumDecl *Decl) {
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the enum.
   DeclarationFragments Declaration =
@@ -484,11 +488,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitNamespaceDecl(
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the struct.
   DeclarationFragments Declaration =
@@ -516,11 +516,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitRecordDecl(const RecordDecl *Decl) {
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the struct.
   DeclarationFragments Declaration =
@@ -550,11 +546,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXRecordDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
   DeclarationFragments Declaration =
       DeclarationFragmentsBuilder::getFragmentsForCXXClass(Decl);
   DeclarationFragments SubHeading =
@@ -606,11 +598,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXMethodDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
   auto Access = DeclarationFragmentsBuilder::getAccessControl(Decl);
@@ -664,11 +652,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXConstructorDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments, sub-heading, and signature for the method.
   DeclarationFragments Declaration =
@@ -697,11 +681,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXDestructorDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments, sub-heading, and signature for the method.
   DeclarationFragments Declaration =
@@ -731,11 +711,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitConceptDecl(const ConceptDecl *Decl) {
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
   DeclarationFragments Declaration =
       DeclarationFragmentsBuilder::getFragmentsForConcept(Decl);
   DeclarationFragments SubHeading =
@@ -755,11 +731,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitClassTemplateSpecializationDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
   DeclarationFragments Declaration =
       DeclarationFragmentsBuilder::getFragmentsForClassTemplateSpecialization(
           Decl);
@@ -788,11 +760,7 @@ bool ExtractAPIVisitorBase<Derived>::
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
   DeclarationFragments Declaration = DeclarationFragmentsBuilder::
       getFragmentsForClassTemplatePartialSpecialization(Decl);
   DeclarationFragments SubHeading =
@@ -823,11 +791,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarTemplateDecl(
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the variable.
   DeclarationFragments Declaration;
@@ -868,11 +832,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarTemplateSpecializationDecl(
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the variable.
   DeclarationFragments Declaration =
@@ -899,11 +859,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitVarTemplatePartialSpecializationDecl(
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the variable.
   DeclarationFragments Declaration = DeclarationFragmentsBuilder::
@@ -931,11 +887,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitFunctionTemplateDecl(
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
@@ -963,11 +915,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitObjCInterfaceDecl(
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   LinkageInfo Linkage = Decl->getLinkageAndVisibility();
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the interface.
   DeclarationFragments Declaration =
@@ -1011,11 +959,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitObjCProtocolDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the protocol.
   DeclarationFragments Declaration =
@@ -1069,11 +1013,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitTypedefNameDecl(
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
   StringRef Name = Decl->getName();
   StringRef USR = API.recordUSR(Decl);
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   QualType Type = Decl->getUnderlyingType();
   SymbolReference SymRef =
@@ -1098,11 +1038,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitObjCCategoryDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
   // Build declaration fragments and sub-heading for the category.
   DeclarationFragments Declaration =
       DeclarationFragmentsBuilder::getFragmentsForObjCCategory(Decl);
@@ -1148,11 +1084,7 @@ void ExtractAPIVisitorBase<Derived>::recordEnumConstants(
     StringRef USR = API.recordUSR(Constant);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Constant->getLocation());
-    DocComment Comment;
-    if (auto *RawComment =
-            getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Constant))
-      Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                              Context.getDiagnostics());
+    DocComment Comment = FetchDocCommentFromDecl(Constant);
 
     // Build declaration fragments and sub-heading for the enum constant.
     DeclarationFragments Declaration =
@@ -1177,11 +1109,7 @@ void ExtractAPIVisitorBase<Derived>::recordStructFields(
     StringRef USR = API.recordUSR(Field);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Field->getLocation());
-    DocComment Comment;
-    if (auto *RawComment =
-            getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Field))
-      Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                              Context.getDiagnostics());
+    DocComment Comment = FetchDocCommentFromDecl(Field);
 
     // Build declaration fragments and sub-heading for the struct field.
     DeclarationFragments Declaration =
@@ -1206,11 +1134,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitFieldDecl(const FieldDecl *Decl) {
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments and sub-heading for the struct field.
   DeclarationFragments Declaration =
@@ -1235,11 +1159,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXConversionDecl(
   StringRef USR = API.recordUSR(Decl);
   PresumedLoc Loc =
       Context.getSourceManager().getPresumedLoc(Decl->getLocation());
-  DocComment Comment;
-  if (auto *RawComment =
-          getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Decl))
-    Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                            Context.getDiagnostics());
+  DocComment Comment = FetchDocCommentFromDecl(Decl);
 
   // Build declaration fragments, sub-heading, and signature for the method.
   DeclarationFragments Declaration =
@@ -1281,11 +1201,7 @@ void ExtractAPIVisitorBase<Derived>::recordObjCMethods(
     StringRef USR = API.recordUSR(Method);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Method->getLocation());
-    DocComment Comment;
-    if (auto *RawComment =
-            getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Method))
-      Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                              Context.getDiagnostics());
+    DocComment Comment = FetchDocCommentFromDecl(Method);
 
     // Build declaration fragments, sub-heading, and signature for the method.
     DeclarationFragments Declaration =
@@ -1310,11 +1226,7 @@ void ExtractAPIVisitorBase<Derived>::recordObjCProperties(
     StringRef USR = API.recordUSR(Property);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Property->getLocation());
-    DocComment Comment;
-    if (auto *RawComment =
-            getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Property))
-      Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                              Context.getDiagnostics());
+    DocComment Comment = FetchDocCommentFromDecl(Property);
 
     // Build declaration fragments and sub-heading for the property.
     DeclarationFragments Declaration =
@@ -1355,11 +1267,7 @@ void ExtractAPIVisitorBase<Derived>::recordObjCInstanceVariables(
     StringRef USR = API.recordUSR(Ivar);
     PresumedLoc Loc =
         Context.getSourceManager().getPresumedLoc(Ivar->getLocation());
-    DocComment Comment;
-    if (auto *RawComment =
-            getDerivedExtractAPIVisitor().fetchRawCommentForDecl(Ivar))
-      Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                              Context.getDiagnostics());
+    DocComment Comment = FetchDocCommentFromDecl(Ivar);
 
     // Build declaration fragments and sub-heading for the instance variable.
     DeclarationFragments Declaration =

--- a/clang/lib/ExtractAPI/API.cpp
+++ b/clang/lib/ExtractAPI/API.cpp
@@ -46,7 +46,7 @@ RecordTy *addTopLevelRecord(DenseMap<StringRef, APIRecord *> &USRLookupTable,
 
 NamespaceRecord *
 APISet::addNamespace(APIRecord *Parent, StringRef Name, StringRef USR,
-                     PresumedLoc Loc, AvailabilitySet Availability,
+                     RecordLocation Loc, AvailabilitySet Availability,
                      LinkageInfo Linkage, const DocComment &Comment,
                      DeclarationFragments Declaration,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader) {
@@ -61,7 +61,7 @@ APISet::addNamespace(APIRecord *Parent, StringRef Name, StringRef USR,
 }
 
 GlobalVariableRecord *
-APISet::addGlobalVar(StringRef Name, StringRef USR, PresumedLoc Loc,
+APISet::addGlobalVar(StringRef Name, StringRef USR, RecordLocation Loc,
                      AvailabilitySet Availabilities, LinkageInfo Linkage,
                      const DocComment &Comment, DeclarationFragments Fragments,
                      DeclarationFragments SubHeading, bool IsFromSystemHeader) {
@@ -71,7 +71,7 @@ APISet::addGlobalVar(StringRef Name, StringRef USR, PresumedLoc Loc,
 }
 
 GlobalVariableTemplateRecord *APISet::addGlobalVariableTemplate(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
+    StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, Template Template,
@@ -83,7 +83,7 @@ GlobalVariableTemplateRecord *APISet::addGlobalVariableTemplate(
 }
 
 GlobalFunctionRecord *APISet::addGlobalFunction(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
+    StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availabilities, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Fragments,
     DeclarationFragments SubHeading, FunctionSignature Signature,
@@ -95,7 +95,7 @@ GlobalFunctionRecord *APISet::addGlobalFunction(
 }
 
 GlobalFunctionTemplateRecord *APISet::addGlobalFunctionTemplate(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
+    StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, FunctionSignature Signature,
@@ -108,7 +108,7 @@ GlobalFunctionTemplateRecord *APISet::addGlobalFunctionTemplate(
 
 GlobalFunctionTemplateSpecializationRecord *
 APISet::addGlobalFunctionTemplateSpecialization(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
+    StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, FunctionSignature Signature,
@@ -120,7 +120,7 @@ APISet::addGlobalFunctionTemplateSpecialization(
 }
 
 EnumConstantRecord *APISet::addEnumConstant(EnumRecord *Enum, StringRef Name,
-                                            StringRef USR, PresumedLoc Loc,
+                                            StringRef USR, RecordLocation Loc,
                                             AvailabilitySet Availabilities,
                                             const DocComment &Comment,
                                             DeclarationFragments Declaration,
@@ -135,7 +135,7 @@ EnumConstantRecord *APISet::addEnumConstant(EnumRecord *Enum, StringRef Name,
   return Enum->Constants.emplace_back(std::move(Record)).get();
 }
 
-EnumRecord *APISet::addEnum(StringRef Name, StringRef USR, PresumedLoc Loc,
+EnumRecord *APISet::addEnum(StringRef Name, StringRef USR, RecordLocation Loc,
                             AvailabilitySet Availabilities,
                             const DocComment &Comment,
                             DeclarationFragments Declaration,
@@ -147,7 +147,7 @@ EnumRecord *APISet::addEnum(StringRef Name, StringRef USR, PresumedLoc Loc,
 }
 
 StructFieldRecord *APISet::addStructField(StructRecord *Struct, StringRef Name,
-                                          StringRef USR, PresumedLoc Loc,
+                                          StringRef USR, RecordLocation Loc,
                                           AvailabilitySet Availabilities,
                                           const DocComment &Comment,
                                           DeclarationFragments Declaration,
@@ -162,19 +162,18 @@ StructFieldRecord *APISet::addStructField(StructRecord *Struct, StringRef Name,
   return Struct->Fields.emplace_back(std::move(Record)).get();
 }
 
-StructRecord *APISet::addStruct(StringRef Name, StringRef USR, PresumedLoc Loc,
-                                AvailabilitySet Availabilities,
-                                const DocComment &Comment,
-                                DeclarationFragments Declaration,
-                                DeclarationFragments SubHeading,
-                                bool IsFromSystemHeader) {
+StructRecord *
+APISet::addStruct(StringRef Name, StringRef USR, RecordLocation Loc,
+                  AvailabilitySet Availabilities, const DocComment &Comment,
+                  DeclarationFragments Declaration,
+                  DeclarationFragments SubHeading, bool IsFromSystemHeader) {
   return addTopLevelRecord(USRBasedLookupTable, Structs, USR, Name, Loc,
                            std::move(Availabilities), Comment, Declaration,
                            SubHeading, IsFromSystemHeader);
 }
 
 StaticFieldRecord *
-APISet::addStaticField(StringRef Name, StringRef USR, PresumedLoc Loc,
+APISet::addStaticField(StringRef Name, StringRef USR, RecordLocation Loc,
                        AvailabilitySet Availabilities, LinkageInfo Linkage,
                        const DocComment &Comment,
                        DeclarationFragments Declaration,
@@ -188,7 +187,7 @@ APISet::addStaticField(StringRef Name, StringRef USR, PresumedLoc Loc,
 
 CXXFieldRecord *
 APISet::addCXXField(APIRecord *CXXClass, StringRef Name, StringRef USR,
-                    PresumedLoc Loc, AvailabilitySet Availabilities,
+                    RecordLocation Loc, AvailabilitySet Availabilities,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, AccessControl Access,
                     bool IsFromSystemHeader) {
@@ -201,7 +200,7 @@ APISet::addCXXField(APIRecord *CXXClass, StringRef Name, StringRef USR,
 }
 
 CXXFieldTemplateRecord *APISet::addCXXFieldTemplate(
-    APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
+    APIRecord *Parent, StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     AccessControl Access, Template Template, bool IsFromSystemHeader) {
@@ -217,7 +216,7 @@ CXXFieldTemplateRecord *APISet::addCXXFieldTemplate(
 
 CXXClassRecord *
 APISet::addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR,
-                    PresumedLoc Loc, AvailabilitySet Availabilities,
+                    RecordLocation Loc, AvailabilitySet Availabilities,
                     const DocComment &Comment, DeclarationFragments Declaration,
                     DeclarationFragments SubHeading, APIRecord::RecordKind Kind,
                     AccessControl Access, bool IsFromSystemHeader) {
@@ -232,7 +231,7 @@ APISet::addCXXClass(APIRecord *Parent, StringRef Name, StringRef USR,
 }
 
 ClassTemplateRecord *APISet::addClassTemplate(
-    APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
+    APIRecord *Parent, StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     Template Template, AccessControl Access, bool IsFromSystemHeader) {
@@ -247,7 +246,7 @@ ClassTemplateRecord *APISet::addClassTemplate(
 }
 
 ClassTemplateSpecializationRecord *APISet::addClassTemplateSpecialization(
-    APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
+    APIRecord *Parent, StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     AccessControl Access, bool IsFromSystemHeader) {
@@ -263,7 +262,7 @@ ClassTemplateSpecializationRecord *APISet::addClassTemplateSpecialization(
 
 ClassTemplatePartialSpecializationRecord *
 APISet::addClassTemplatePartialSpecialization(
-    APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
+    APIRecord *Parent, StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     Template Template, AccessControl Access, bool IsFromSystemHeader) {
@@ -279,7 +278,7 @@ APISet::addClassTemplatePartialSpecialization(
 
 GlobalVariableTemplateSpecializationRecord *
 APISet::addGlobalVariableTemplateSpecialization(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
+    StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, bool IsFromSystemHeader) {
@@ -291,7 +290,7 @@ APISet::addGlobalVariableTemplateSpecialization(
 
 GlobalVariableTemplatePartialSpecializationRecord *
 APISet::addGlobalVariableTemplatePartialSpecialization(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
+    StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, LinkageInfo Linkage,
     const DocComment &Comment, DeclarationFragments Declaration,
     DeclarationFragments SubHeading, Template Template,
@@ -303,7 +302,8 @@ APISet::addGlobalVariableTemplatePartialSpecialization(
 }
 
 ConceptRecord *APISet::addConcept(StringRef Name, StringRef USR,
-                                  PresumedLoc Loc, AvailabilitySet Availability,
+                                  RecordLocation Loc,
+                                  AvailabilitySet Availability,
                                   const DocComment &Comment,
                                   DeclarationFragments Declaration,
                                   DeclarationFragments SubHeading,
@@ -314,8 +314,8 @@ ConceptRecord *APISet::addConcept(StringRef Name, StringRef USR,
 }
 
 CXXMethodRecord *APISet::addCXXInstanceMethod(
-    APIRecord *CXXClassRecord, StringRef Name, StringRef USR, PresumedLoc Loc,
-    AvailabilitySet Availability, const DocComment &Comment,
+    APIRecord *CXXClassRecord, StringRef Name, StringRef USR,
+    RecordLocation Loc, AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access,
     bool IsFromSystemHeader) {
@@ -331,8 +331,8 @@ CXXMethodRecord *APISet::addCXXInstanceMethod(
 }
 
 CXXMethodRecord *APISet::addCXXStaticMethod(
-    APIRecord *CXXClassRecord, StringRef Name, StringRef USR, PresumedLoc Loc,
-    AvailabilitySet Availability, const DocComment &Comment,
+    APIRecord *CXXClassRecord, StringRef Name, StringRef USR,
+    RecordLocation Loc, AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access,
     bool IsFromSystemHeader) {
@@ -348,7 +348,7 @@ CXXMethodRecord *APISet::addCXXStaticMethod(
 }
 
 CXXMethodTemplateRecord *APISet::addCXXMethodTemplate(
-    APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
+    APIRecord *Parent, StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access, Template Template,
@@ -364,7 +364,7 @@ CXXMethodTemplateRecord *APISet::addCXXMethodTemplate(
 }
 
 CXXMethodTemplateSpecializationRecord *APISet::addCXXMethodTemplateSpec(
-    APIRecord *Parent, StringRef Name, StringRef USR, PresumedLoc Loc,
+    APIRecord *Parent, StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availability, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     FunctionSignature Signature, AccessControl Access,
@@ -381,7 +381,7 @@ CXXMethodTemplateSpecializationRecord *APISet::addCXXMethodTemplateSpec(
 }
 
 ObjCCategoryRecord *APISet::addObjCCategory(
-    StringRef Name, StringRef USR, PresumedLoc Loc,
+    StringRef Name, StringRef USR, RecordLocation Loc,
     AvailabilitySet Availabilities, const DocComment &Comment,
     DeclarationFragments Declaration, DeclarationFragments SubHeading,
     SymbolReference Interface, bool IsFromSystemHeader,
@@ -402,7 +402,7 @@ ObjCCategoryRecord *APISet::addObjCCategory(
 }
 
 ObjCInterfaceRecord *
-APISet::addObjCInterface(StringRef Name, StringRef USR, PresumedLoc Loc,
+APISet::addObjCInterface(StringRef Name, StringRef USR, RecordLocation Loc,
                          AvailabilitySet Availabilities, LinkageInfo Linkage,
                          const DocComment &Comment,
                          DeclarationFragments Declaration,
@@ -416,10 +416,10 @@ APISet::addObjCInterface(StringRef Name, StringRef USR, PresumedLoc Loc,
 
 ObjCMethodRecord *APISet::addObjCMethod(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, AvailabilitySet Availabilities, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading,
-    FunctionSignature Signature, bool IsInstanceMethod,
-    bool IsFromSystemHeader) {
+    RecordLocation Loc, AvailabilitySet Availabilities,
+    const DocComment &Comment, DeclarationFragments Declaration,
+    DeclarationFragments SubHeading, FunctionSignature Signature,
+    bool IsInstanceMethod, bool IsFromSystemHeader) {
   std::unique_ptr<ObjCMethodRecord> Record;
   if (IsInstanceMethod)
     Record = std::make_unique<ObjCInstanceMethodRecord>(
@@ -438,8 +438,9 @@ ObjCMethodRecord *APISet::addObjCMethod(
 
 ObjCPropertyRecord *APISet::addObjCProperty(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, AvailabilitySet Availabilities, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading,
+    RecordLocation Loc, AvailabilitySet Availabilities,
+    const DocComment &Comment, DeclarationFragments Declaration,
+    DeclarationFragments SubHeading,
     ObjCPropertyRecord::AttributeKind Attributes, StringRef GetterName,
     StringRef SetterName, bool IsOptional, bool IsInstanceProperty,
     bool IsFromSystemHeader) {
@@ -462,8 +463,9 @@ ObjCPropertyRecord *APISet::addObjCProperty(
 
 ObjCInstanceVariableRecord *APISet::addObjCInstanceVariable(
     ObjCContainerRecord *Container, StringRef Name, StringRef USR,
-    PresumedLoc Loc, AvailabilitySet Availabilities, const DocComment &Comment,
-    DeclarationFragments Declaration, DeclarationFragments SubHeading,
+    RecordLocation Loc, AvailabilitySet Availabilities,
+    const DocComment &Comment, DeclarationFragments Declaration,
+    DeclarationFragments SubHeading,
     ObjCInstanceVariableRecord::AccessControl Access, bool IsFromSystemHeader) {
   auto Record = std::make_unique<ObjCInstanceVariableRecord>(
       USR, Name, Loc, std::move(Availabilities), Comment, Declaration,
@@ -475,7 +477,7 @@ ObjCInstanceVariableRecord *APISet::addObjCInstanceVariable(
 }
 
 ObjCProtocolRecord *APISet::addObjCProtocol(StringRef Name, StringRef USR,
-                                            PresumedLoc Loc,
+                                            RecordLocation Loc,
                                             AvailabilitySet Availabilities,
                                             const DocComment &Comment,
                                             DeclarationFragments Declaration,
@@ -487,7 +489,7 @@ ObjCProtocolRecord *APISet::addObjCProtocol(StringRef Name, StringRef USR,
 }
 
 MacroDefinitionRecord *
-APISet::addMacroDefinition(StringRef Name, StringRef USR, PresumedLoc Loc,
+APISet::addMacroDefinition(StringRef Name, StringRef USR, RecordLocation Loc,
                            DeclarationFragments Declaration,
                            DeclarationFragments SubHeading,
                            bool IsFromSystemHeader) {
@@ -496,7 +498,7 @@ APISet::addMacroDefinition(StringRef Name, StringRef USR, PresumedLoc Loc,
 }
 
 TypedefRecord *
-APISet::addTypedef(StringRef Name, StringRef USR, PresumedLoc Loc,
+APISet::addTypedef(StringRef Name, StringRef USR, RecordLocation Loc,
                    AvailabilitySet Availabilities, const DocComment &Comment,
                    DeclarationFragments Declaration,
                    DeclarationFragments SubHeading,

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -14,6 +14,7 @@
 #include "clang/ExtractAPI/Serialization/SymbolGraphSerializer.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Version.h"
+#include "clang/ExtractAPI/API.h"
 #include "clang/ExtractAPI/DeclarationFragments.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -105,8 +106,7 @@ Object serializePlatform(const Triple &T) {
 }
 
 /// Serialize a source position.
-Object serializeSourcePosition(const PresumedLoc &Loc) {
-  assert(Loc.isValid() && "invalid source position");
+Object serializeSourcePosition(const RecordLocation &Loc) {
 
   Object SourcePosition;
   SourcePosition["line"] = Loc.getLine();
@@ -120,7 +120,7 @@ Object serializeSourcePosition(const PresumedLoc &Loc) {
 /// \param Loc The presumed location to serialize.
 /// \param IncludeFileURI If true, include the file path of \p Loc as a URI.
 /// Defaults to false.
-Object serializeSourceLocation(const PresumedLoc &Loc,
+Object serializeSourceLocation(const RecordLocation &Loc,
                                bool IncludeFileURI = false) {
   Object SourceLocation;
   serializeObject(SourceLocation, "position", serializeSourcePosition(Loc));
@@ -136,8 +136,8 @@ Object serializeSourceLocation(const PresumedLoc &Loc,
 }
 
 /// Serialize a source range with begin and end locations.
-Object serializeSourceRange(const PresumedLoc &BeginLoc,
-                            const PresumedLoc &EndLoc) {
+Object serializeSourceRange(const RecordLocation &BeginLoc,
+                            const RecordLocation &EndLoc) {
   Object SourceRange;
   serializeObject(SourceRange, "start", serializeSourcePosition(BeginLoc));
   serializeObject(SourceRange, "end", serializeSourcePosition(EndLoc));

--- a/clang/tools/libclang/CXExtractAPI.cpp
+++ b/clang/tools/libclang/CXExtractAPI.cpp
@@ -61,9 +61,12 @@ struct LibClangExtractAPIVisitor
         Context.getSourceManager().getPresumedLoc(Decl->getLocation());
     LinkageInfo Linkage = Decl->getLinkageAndVisibility();
     DocComment Comment;
-    if (auto *RawComment = fetchRawCommentForDecl(Interface))
-      Comment = RawComment->getFormattedLines(Context.getSourceManager(),
-                                              Context.getDiagnostics());
+    if (auto *RawComment = fetchRawCommentForDecl(Interface)) {
+      auto RawCommentVec = RawComment->getFormattedLines(
+          Context.getSourceManager(), Context.getDiagnostics());
+      std::copy(RawCommentVec.begin(), RawCommentVec.end(),
+                std::back_inserter(Comment));
+    }
 
     // Build declaration fragments and sub-heading by generating them for the
     // interface.


### PR DESCRIPTION
Create and use `extractapi::RecordLocation` instead of conventional `clang::PresumedLoc` to track the location of an APIRecord, this reduces the dependency of APISet on SourceManager and would help if someone wants to create APISet from JSON Serialized SymbolGraph.

These changes also add `extractapi::CommentLine` which is similar to RawComment::CommentLine but use RecordLocation instead of PresumedLoc.


This was initially being tracked on llvm Phabricator
Differential Revision: https://reviews.llvm.org/D157810