### PR TITLE
[clang][Diagnostics] Add source range to uninitialized diagnostics

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -3711,7 +3711,8 @@ findSubobject(EvalInfo &Info, const Expr *E, const CompleteObject &Obj,
          !isValidIndeterminateAccess(handler.AccessKind))) {
       if (!Info.checkingPotentialConstantExpression())
         Info.FFDiag(E, diag::note_constexpr_access_uninit)
-            << handler.AccessKind << O->isIndeterminate();
+            << handler.AccessKind << O->isIndeterminate()
+            << E->getSourceRange();
       return handler.failed();
     }
 
@@ -4443,7 +4444,8 @@ struct CompoundAssignSubobjectHandler {
       return foundVector(Subobj, SubobjType);
     case APValue::Indeterminate:
       Info.FFDiag(E, diag::note_constexpr_access_uninit)
-          << /*read of=*/0 << /*uninitialized object=*/1;
+          << /*read of=*/0 << /*uninitialized object=*/1
+          << E->getLHS()->getSourceRange();
       return false;
     default:
       // FIXME: can this happen?

--- a/clang/lib/AST/Interp/Interp.cpp
+++ b/clang/lib/AST/Interp/Interp.cpp
@@ -261,9 +261,8 @@ bool CheckInitialized(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
     return true;
 
   if (!S.checkingPotentialConstantExpression()) {
-    const SourceInfo &Loc = S.Current->getSource(OpPC);
-    S.FFDiag(Loc, diag::note_constexpr_access_uninit)
-        << AK << /*uninitialized=*/true;
+    S.FFDiag(S.Current->getSource(OpPC), diag::note_constexpr_access_uninit)
+        << AK << /*uninitialized=*/true << S.Current->getRange(OpPC);
   }
   return false;
 }

--- a/clang/lib/AST/Interp/InterpFrame.cpp
+++ b/clang/lib/AST/Interp/InterpFrame.cpp
@@ -230,5 +230,8 @@ SourceLocation InterpFrame::getLocation(CodePtr PC) const {
 }
 
 SourceRange InterpFrame::getRange(CodePtr PC) const {
+  if (Func && Func->getDecl()->isImplicit() && Caller)
+    return Caller->getRange(RetPC);
+
   return S.getRange(Func, PC);
 }

--- a/clang/test/Misc/constexpr-source-ranges.cpp
+++ b/clang/test/Misc/constexpr-source-ranges.cpp
@@ -41,3 +41,11 @@ int x = -1 + __INT_MAX__ + 2 + 3;
 // CHECK:      :{[[@LINE+1]]:9-[[@LINE+1]]:19}:
 int a = -(1 << 31) + 1;
 }
+
+
+constexpr int uninit() {
+  int aaa;
+  // CHECK: :{[[@LINE+1]]:10-[[@LINE+1]]:13}:
+  return aaa;
+}
+static_assert(uninit() == 0, "");


### PR DESCRIPTION
Before:

```
array.cpp:319:10: note: read of uninitialized object is not allowed in a constant expression
  319 |    return aaa;
      |           ^
```

After:

```
array.cpp:319:10: note: read of uninitialized object is not allowed in a constant expression
  319 |    return aaa;
      |           ^~~
```