### PR TITLE
[Github] Use our own issue labeler fork

### DIFF
--- a/.github/new-issues-labeler.yml
+++ b/.github/new-issues-labeler.yml
@@ -1,6 +1,3 @@
-'new issue':
-  - '/.*/'
-
 'clang':
   - '/\bclang(?!\-)\b/i'
 

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'llvm/llvm-project'
     steps:
-      - uses: github/issue-labeler@v3.2
+      - uses: llvm/actions/issue-labeler@main
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/new-issues-labeler.yml


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/issues/65701#issuecomment-1712803305
⚠️ https://github.com/llvm/actions/pull/6 must be merged first

- Only adds 'new issue' if no other label is added (https://github.com/llvm/llvm-project/issues/65701)

- No not add labels if labels were already set
- Only add `foo` if there are no `foo:bar` label being added (although, we don't use that yet)