### PR TITLE
[compiler-rt] Check for and use -lunwind when linking with -nodefaultlibs

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -63,6 +63,12 @@ if (C_SUPPORTS_NODEFAULTLIBS_FLAG)
                         moldname mingwex msvcrt)
     list(APPEND CMAKE_REQUIRED_LIBRARIES ${MINGW_LIBRARIES})
   endif()
+  check_library_exists(unwind _Unwind_RaiseException "" COMPILER_RT_HAS_LIBUNWIND)
+  if (COMPILER_RT_HAS_LIBUNWIND)
+    # If we're omitting default libraries, we might need to manually link in libunwind.
+    # This can affect whether we detect a statically linked libc++ correctly.
+    list(APPEND CMAKE_REQUIRED_LIBRARIES unwind)
+  endif()
 endif ()
 
 # CodeGen options.


### PR DESCRIPTION
If libc++ is available and should be used as the ubsan C++ ABI library, the check for libc++ might fail if libc++ is a static library, as the -nodefaultlibs flag inhibits a potential compiler default -lunwind.

Just like the -nodefaultlibs configuration tests for and manually adds a bunch of compiler default libraries, look for -lunwind too.