### PR TITLE
[libc++] Add a utility for checking the output of commands

### DIFF
--- a/libcxx/test/configs/cmake-bridge.cfg.in
+++ b/libcxx/test/configs/cmake-bridge.cfg.in
@@ -31,3 +31,4 @@ config.substitutions.append(('%{lib-dir}', '@LIBCXX_TESTING_INSTALL_PREFIX@/@LIB
 config.substitutions.append(('%{module-dir}', '@LIBCXX_TESTING_INSTALL_PREFIX@/@LIBCXX_INSTALL_MODULES_DIR@'))
 config.substitutions.append(('%{test-tools-dir}', '@LIBCXX_TEST_TOOLS_PATH@'))
 config.substitutions.append(('%{benchmark_flags}', '-I @LIBCXX_BINARY_DIR@/test/benchmarks/google-benchmark/include -L @LIBCXX_BINARY_DIR@/test/benchmarks/google-benchmark/lib -L @LIBCXX_BINARY_DIR@/test/benchmarks/google-benchmark/lib64 -l benchmark'))
+config.substitutions.append(('%{check-output}', os.path.join('@LIBCXX_BINARY_DIR@', 'bin/check_output') + " %s"))

--- a/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_codegen.sh.cpp
+++ b/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_codegen.sh.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// This test is checking the LLVM IR
+// REQUIRES: clang
+
+// UNSUPPORTED: asan, tsan, ubsan, msan
+
+// RUN: %{cxx} %s %{flags} %{compile_flags} -O3 -c -S -emit-llvm -o - | %{check-output}
+
+#include <algorithm>
+
+int* test1(int* first, int* last, int* out) {
+  // CHECK:      define
+  // CHECK-SAME: test1
+  // CHECK:      tail call void @llvm.memmove
+  return std::copy(first, last, out);
+}

--- a/libcxx/test/libcxx/selftest/clang_tidy/proper_version_checks.sh.cpp
+++ b/libcxx/test/libcxx/selftest/clang_tidy/proper_version_checks.sh.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: has-clang-tidy
+
+// RUN: %{clang-tidy} %s -header-filter=.* --checks='-*,libcpp-cpp-version-check' --load=%{test-tools-dir}/clang_tidy_checks/libcxx-tidy.plugin -- %{compile_flags} -fno-modules 2>&1 | %{check-output}
+
+#include <__config>
+
+// CHECK: warning: _LIBCPP_STD_VER >= version should be used instead of _LIBCPP_STD_VER > prev_version
+#if _LIBCPP_STD_VER > 14
+#endif
+
+// CHECK: warning: Use _LIBCPP_STD_VER instead of __cplusplus to constrain based on the C++ version
+#if __cplusplus >= 201103L
+#endif
+
+// CHECK: warning: _LIBCPP_STD_VER >= 11 is always true. Did you mean '#ifndef _LIBCPP_CXX03_LANG'?
+#if _LIBCPP_STD_VER >= 11
+#endif
+
+// CHECK: warning: Not a valid value for _LIBCPP_STD_VER. Use 14, 17, 20, 23, or 26
+#if _LIBCPP_STD_VER >= 12
+#endif

--- a/libcxx/test/libcxx/utilities/utility/unreachable.codegen.sh.cpp
+++ b/libcxx/test/libcxx/utilities/utility/unreachable.codegen.sh.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// This test is checking the LLVM IR
+// REQUIRES: clang
+
+// UNSUPPORTED: asan, tsan, ubsan, msan
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+
+// RUN: %{cxx} %s %{flags} %{compile_flags} -Wno-missing-noreturn -O3 -c -S -emit-llvm -o - | %{check-output}
+
+// This is an assert instead in debug mode
+// UNSUPPORTED: libcpp-hardening-mode=debug
+
+#include <utility>
+
+void test() {
+  // CHECK:      define dso_local void
+  // CHECK-SAME: test
+  // CHECK-NEXT: unreachable
+  // CHECK-NEXT: }
+  std::unreachable();
+}

--- a/libcxx/test/tools/CMakeLists.txt
+++ b/libcxx/test/tools/CMakeLists.txt
@@ -3,6 +3,8 @@ set(LIBCXX_TEST_TOOLS_PATH ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Clang-tidy tests are disabled due to non-clang based compiler.")
-  return()
+else()
+  add_subdirectory(clang_tidy_checks)
 endif()
-add_subdirectory(clang_tidy_checks)
+
+add_subdirectory(check_output)

--- a/libcxx/test/tools/check_output/CMakeLists.txt
+++ b/libcxx/test/tools/check_output/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+add_executable(check_output check_output.cpp)
+
+# put the binary into <build>/bin
+set_target_properties(check_output PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${LIBCXX_BINARY_DIR}/bin")
+
+# set the language mode
+set_target_properties(check_output PROPERTIES
+                      CXX_STANDARD 23
+                      CXX_STANDARD_REQUIRED YES
+                      CXX_EXTENSIONS NO)
+
+# The standard library we link against is most likely not built against MSan, so we have to disable it.
+target_compile_options(check_output PRIVATE -Werror=missing-prototypes -fno-sanitize=memory)
+target_link_options(check_output PRIVATE -fno-sanitize=memory)
+
+add_dependencies(cxx-test-depends check_output)

--- a/libcxx/test/tools/check_output/check_output.cpp
+++ b/libcxx/test/tools/check_output/check_output.cpp
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <algorithm>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <ranges>
+#include <string>
+
+using namespace std::string_view_literals;
+
+enum class Result {
+  success,
+  mismatch,
+  no_match_found,
+  unknown_matcher,
+  invalid_use,
+};
+
+namespace co {
+namespace {
+[[noreturn]] void exit(Result result) { std::exit(static_cast<int>(result)); }
+
+[[noreturn]] void print_failure(int line, std::string_view stdin_content, std::string_view matcher) {
+  std::cout << "Failed to match: `" << matcher << "`\nRemaining data:\n" << stdin_content << '\n';
+  co::exit(Result::mismatch);
+}
+
+bool is_newline(char c) { return c == '\n'; }
+
+bool isblank(char c) { return std::isblank(c); }
+
+bool consume_front(std::string_view& sv, std::string_view start) {
+  if (!sv.starts_with(start))
+    return false;
+  sv.remove_prefix(start.size());
+  return true;
+}
+} // namespace
+} // namespace co
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    std::cerr << "check_output has to be used as `<command> | ./check_output %s`\n";
+    co::exit(Result::invalid_use);
+  }
+
+  std::string file_content_data = [&] {
+    std::ifstream file(argv[1]);
+    if (!file) {
+      std::cerr << "Failed to open file: " << argv[1] << '\n';
+      co::exit(Result::invalid_use);
+    }
+    return std::string{std::istreambuf_iterator<char>{file}, {}};
+  }();
+  std::string_view file_content = file_content_data; // Don't copy the data around all the time
+
+  std::string stdin_content_data = [&] {
+    std::cin >> std::noskipws;
+    return std::string{std::istream_iterator<char>{std::cin}, {}};
+  }();
+  std::string_view stdin_content = stdin_content_data; // Don't copy the data around all the time
+
+  size_t match_count = 0;
+  auto drop_blanks   = std::views::drop_while(co::isblank);
+
+  while (!file_content.empty()) {
+    auto marker = std::ranges::search(file_content, "// CHECK"sv);
+    if (marker.empty()) {
+      if (match_count == 0) {
+        std::cerr << "No matcher found!\n";
+        co::exit(Result::no_match_found);
+      }
+      co::exit(Result::success);
+    }
+    file_content.remove_prefix(marker.end() - file_content.begin());
+
+    const auto get_match = [&]() {
+      return std::string_view(file_content.begin(), std::ranges::find(file_content, '\n'));
+    };
+
+    if (co::consume_front(file_content, ":")) {
+      auto match = get_match();
+      auto found = std::ranges::search(
+          stdin_content | std::views::drop_while(std::not_fn(co::is_newline)) | std::views::drop(1),
+          match | drop_blanks);
+      if (found.empty()) {
+        co::print_failure(1, stdin_content, match);
+      }
+      ++match_count;
+      stdin_content.remove_prefix(found.end() - stdin_content.begin());
+    } else if (co::consume_front(file_content, "-SAME:")) {
+      auto match    = get_match();
+      auto haystack = std::string_view(stdin_content.begin(), std::ranges::find(stdin_content, '\n'));
+      auto found    = std::ranges::search(haystack, match | drop_blanks);
+      if (found.empty()) {
+        co::print_failure(1, stdin_content, match);
+      }
+      stdin_content.remove_prefix(found.end() - stdin_content.begin());
+    } else if (co::consume_front(file_content, "-NEXT:")) {
+      auto match    = get_match();
+      auto haystack = [&] {
+        auto begin = std::ranges::find(stdin_content, '\n');
+        if (begin == stdin_content.end()) {
+          co::print_failure(1, stdin_content, match);
+        }
+        ++begin;
+        return std::string_view(begin, std::ranges::find(begin, stdin_content.end(), '\n'));
+      }();
+      auto found = std::ranges::search(haystack, match | drop_blanks);
+      if (found.empty())
+        co::print_failure(1, stdin_content, match);
+      stdin_content.remove_prefix(found.end() - stdin_content.begin());
+    } else {
+      std::cerr << "Unkown matcher type "
+                << std::string_view(file_content.begin(), std::ranges::find(file_content, ':')) << " found\n";
+      co::exit(Result::unknown_matcher);
+    }
+  }
+
+  co::exit(Result::success);
+}

--- a/libcxx/test/tools/clang_tidy_checks/proper_version_checks.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/proper_version_checks.cpp
@@ -36,8 +36,6 @@ private:
         clang::CharSourceRange::getTokenRange(condition_range),
         preprocessor_.getSourceManager(),
         preprocessor_.getLangOpts());
-    if (preprocessor_.getSourceManager().isInMainFile(location))
-      return;
 
     if (condition == "__cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)")
       return;


### PR DESCRIPTION
This allows us to check the output of any tools.
For example, we can
- check for codegen properties - e.g. make sure `std::copy` with trivial types always calls `__builtin_memmove`
- we can ensure that clang-tidy checks actually diagnose the things they should

These kinds of tests are more likely to break because of external tool changes, so they shouldn't be used if there is a different way to test things.

This tool is a strict subset of `FileCheck`in terms of it's functionality. I didn't just make that a dependency because it has quite heavy dependencies itself, which would make it by far the most costly part of building libc++. If we find that we extend this tool a lot (or FileCheck becomes less heavy) we should reconsider whether we should take the dependency hit.