### PR TITLE
[libc][bazel] Add CPP tests

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/src/__support/CPP/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/__support/CPP/BUILD.bazel
@@ -1,0 +1,112 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc CPP functions.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+cc_test(
+    name = "atomic_test",
+    srcs = ["atomic_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_atomic",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "bitset_test",
+    srcs = ["bitset_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_bitset",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "cstddef_test",
+    srcs = ["cstddef_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_cstddef",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "integer_sequence_test",
+    srcs = ["integer_sequence_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_utility",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "limits_test",
+    srcs = ["limits_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_limits",
+        "//libc:__support_uint",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "optional_test",
+    srcs = ["optional_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_optional",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "span_test",
+    srcs = ["span_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_array",
+        "//libc:__support_cpp_span",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "stringstream_test",
+    srcs = ["stringstream_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:__support_cpp_stringstream",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "string_test",
+    srcs = ["string_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_string",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+cc_test(
+    name = "stringview_test",
+    srcs = ["stringview_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_string_view",
+        "//libc:libc_root",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)


### PR DESCRIPTION
This PR adds tests for the `src/__support/CPP` folder to the bazel build system.
