### PR TITLE
[scudo] Enable "Delayed release to OS" feature for Android

### DIFF
--- a/compiler-rt/lib/scudo/standalone/flags.inc
+++ b/compiler-rt/lib/scudo/standalone/flags.inc
@@ -42,7 +42,7 @@ SCUDO_FLAG(bool, may_return_null, true,
            "returning NULL in otherwise non-fatal error scenarios, eg: OOM, "
            "invalid allocation alignments, etc.")
 
-SCUDO_FLAG(int, release_to_os_interval_ms, SCUDO_ANDROID ? INT32_MIN : 5000,
+SCUDO_FLAG(int, release_to_os_interval_ms, 5000,
            "Interval (in milliseconds) at which to attempt release of unused "
            "memory to the OS. Negative values disable the feature.")
 


### PR DESCRIPTION
Instead of immediately releasing any mapped memory back to the OS (via overlapping mmaps when MTE is enabled, madvise when not), the memory is retained and only given back after a configurable interval (5000 ms for now)

This change gives a slight performance increase in two ways:
* When MTE is enabled, mappings are made non-accessible with one mprotect instead of two mmaps
* If the mapping is reused within the specified time interval, the contents are retained. This reduces the number of page faults.