### PR TITLE
[dataflow] Add global condition to DataflowAnalysisContext

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysisContext.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysisContext.h
@@ -110,13 +110,12 @@ public:
 
   /// Adds `Constraint` to current and future flow conditions in this context.
   ///
-  /// The common condition must contain only flow-insensitive information, i.e.
-  /// facts that are true on all paths through the program.
+  /// Invariants must contain only flow-insensitive information, i.e. facts that
+  /// are true on all paths through the program.
   /// Information can be added eagerly (when analysis begins), or lazily (e.g.
   /// when values are first used). The analysis must be careful that the same
-  /// information is added to the common condition regardless of which order
-  /// blocks are analyzed in.
-  void addCommonConstraint(const Formula &Constraint);
+  /// information is added regardless of which order blocks are analyzed in.
+  void addInvariant(const Formula &Constraint);
 
   /// Adds `Constraint` to the flow condition identified by `Token`.
   void addFlowConditionConstraint(Atom Token, const Formula &Constraint);
@@ -233,7 +232,7 @@ private:
   // dependencies is stored in the `FlowConditionDeps` map.
   llvm::DenseMap<Atom, llvm::DenseSet<Atom>> FlowConditionDeps;
   llvm::DenseMap<Atom, const Formula *> FlowConditionConstraints;
-  const Formula *GlobalConstraints = nullptr;
+  const Formula *Invariant = nullptr;
 
   llvm::DenseMap<const FunctionDecl *, ControlFlowContext> FunctionContexts;
 

--- a/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysisContext.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysisContext.h
@@ -110,10 +110,12 @@ public:
 
   /// Adds `Constraint` to current and future flow conditions in this context.
   ///
-  /// This must be used with care: the constraint must be truly global across
-  /// the analysis, and should not invalidate the result of past logic.
-  ///
-  /// Adding constraints on freshly created boolean variables is generally safe.
+  /// The global condition must contain only flow-insensitive information, i.e.
+  /// facts that are true on all paths through the program.
+  /// Information can be added eagerly (when analysis begins), or lazily (e.g.
+  /// when values are first used). The analysis must be careful that the same
+  /// information is added to the global condition regardless of which order
+  /// blocks are analyzed in.
   void addGlobalConstraint(const Formula &Constraint);
 
   /// Adds `Constraint` to the flow condition identified by `Token`.

--- a/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysisContext.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysisContext.h
@@ -110,13 +110,13 @@ public:
 
   /// Adds `Constraint` to current and future flow conditions in this context.
   ///
-  /// The global condition must contain only flow-insensitive information, i.e.
+  /// The common condition must contain only flow-insensitive information, i.e.
   /// facts that are true on all paths through the program.
   /// Information can be added eagerly (when analysis begins), or lazily (e.g.
   /// when values are first used). The analysis must be careful that the same
-  /// information is added to the global condition regardless of which order
+  /// information is added to the common condition regardless of which order
   /// blocks are analyzed in.
-  void addGlobalConstraint(const Formula &Constraint);
+  void addCommonConstraint(const Formula &Constraint);
 
   /// Adds `Constraint` to the flow condition identified by `Token`.
   void addFlowConditionConstraint(Atom Token, const Formula &Constraint);

--- a/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
@@ -104,11 +104,11 @@ DataflowAnalysisContext::getOrCreateNullPointerValue(QualType PointeeType) {
   return *Res.first->second;
 }
 
-void DataflowAnalysisContext::addCommonConstraint(const Formula &Constraint) {
-  if (GlobalConstraints == nullptr)
-    GlobalConstraints = &Constraint;
+void DataflowAnalysisContext::addInvariant(const Formula &Constraint) {
+  if (Invariant == nullptr)
+    Invariant = &Constraint;
   else
-    GlobalConstraints = &arena().makeAnd(*GlobalConstraints, Constraint);
+    Invariant = &arena().makeAnd(*Invariant, Constraint);
 }
 
 void DataflowAnalysisContext::addFlowConditionConstraint(
@@ -181,8 +181,8 @@ void DataflowAnalysisContext::addTransitiveFlowConditionConstraints(
   llvm::DenseSet<Atom> AddedTokens;
   std::vector<Atom> Remaining = {Token};
 
-  if (GlobalConstraints)
-    Constraints.insert(GlobalConstraints);
+  if (Invariant)
+    Constraints.insert(Invariant);
   // Define all the flow conditions that might be referenced in constraints.
   while (!Remaining.empty()) {
     auto Token = Remaining.back();

--- a/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
@@ -104,7 +104,7 @@ DataflowAnalysisContext::getOrCreateNullPointerValue(QualType PointeeType) {
   return *Res.first->second;
 }
 
-void DataflowAnalysisContext::addGlobalConstraint(const Formula &Constraint) {
+void DataflowAnalysisContext::addCommonConstraint(const Formula &Constraint) {
   if (GlobalConstraints == nullptr)
     GlobalConstraints = &Constraint;
   else
@@ -156,7 +156,6 @@ bool DataflowAnalysisContext::flowConditionImplies(Atom Token,
   llvm::SetVector<const Formula *> Constraints;
   Constraints.insert(&arena().makeAtomRef(Token));
   Constraints.insert(&arena().makeNot(Val));
-  llvm::DenseSet<Atom> VisitedTokens;
   addTransitiveFlowConditionConstraints(Token, Constraints);
   return isUnsatisfiable(std::move(Constraints));
 }
@@ -166,7 +165,6 @@ bool DataflowAnalysisContext::flowConditionIsTautology(Atom Token) {
   // ever be false.
   llvm::SetVector<const Formula *> Constraints;
   Constraints.insert(&arena().makeNot(arena().makeAtomRef(Token)));
-  llvm::DenseSet<Atom> VisitedTokens;
   addTransitiveFlowConditionConstraints(Token, Constraints);
   return isUnsatisfiable(std::move(Constraints));
 }
@@ -203,10 +201,9 @@ void DataflowAnalysisContext::addTransitiveFlowConditionConstraints(
     }
 
     if (auto DepsIt = FlowConditionDeps.find(Token);
-        DepsIt != FlowConditionDeps.end()) {
+        DepsIt != FlowConditionDeps.end())
       for (Atom A : DepsIt->second)
         Remaining.push_back(A);
-    }
   }
 }
 

--- a/clang/unittests/Analysis/FlowSensitive/DataflowAnalysisContextTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DataflowAnalysisContextTest.cpp
@@ -46,18 +46,18 @@ TEST_F(DataflowAnalysisContextTest, AddFlowConditionConstraint) {
   EXPECT_TRUE(Context.flowConditionImplies(FC, C));
 }
 
-TEST_F(DataflowAnalysisContextTest, AddCommonConstraint) {
+TEST_F(DataflowAnalysisContextTest, AddInvariant) {
   Atom FC = A.makeFlowConditionToken();
   auto &C = A.makeAtomRef(A.makeAtom());
-  Context.addCommonConstraint(C);
+  Context.addInvariant(C);
   EXPECT_TRUE(Context.flowConditionImplies(FC, C));
 }
 
-TEST_F(DataflowAnalysisContextTest, CommonAndFCConstraintInteract) {
+TEST_F(DataflowAnalysisContextTest, InvariantAndFCConstraintInteract) {
   Atom FC = A.makeFlowConditionToken();
   auto &C = A.makeAtomRef(A.makeAtom());
   auto &D = A.makeAtomRef(A.makeAtom());
-  Context.addCommonConstraint(A.makeImplies(C, D));
+  Context.addInvariant(A.makeImplies(C, D));
   Context.addFlowConditionConstraint(FC, C);
   EXPECT_TRUE(Context.flowConditionImplies(FC, D));
 }

--- a/clang/unittests/Analysis/FlowSensitive/DataflowAnalysisContextTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DataflowAnalysisContextTest.cpp
@@ -46,18 +46,18 @@ TEST_F(DataflowAnalysisContextTest, AddFlowConditionConstraint) {
   EXPECT_TRUE(Context.flowConditionImplies(FC, C));
 }
 
-TEST_F(DataflowAnalysisContextTest, AddGlobalConstraint) {
+TEST_F(DataflowAnalysisContextTest, AddCommonConstraint) {
   Atom FC = A.makeFlowConditionToken();
   auto &C = A.makeAtomRef(A.makeAtom());
-  Context.addGlobalConstraint(C);
+  Context.addCommonConstraint(C);
   EXPECT_TRUE(Context.flowConditionImplies(FC, C));
 }
 
-TEST_F(DataflowAnalysisContextTest, GlobalAndFCConstraintInteract) {
+TEST_F(DataflowAnalysisContextTest, CommonAndFCConstraintInteract) {
   Atom FC = A.makeFlowConditionToken();
   auto &C = A.makeAtomRef(A.makeAtom());
   auto &D = A.makeAtomRef(A.makeAtom());
-  Context.addGlobalConstraint(A.makeImplies(C, D));
+  Context.addCommonConstraint(A.makeImplies(C, D));
   Context.addFlowConditionConstraint(FC, C);
   EXPECT_TRUE(Context.flowConditionImplies(FC, D));
 }

--- a/clang/unittests/Analysis/FlowSensitive/DataflowAnalysisContextTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DataflowAnalysisContextTest.cpp
@@ -46,6 +46,22 @@ TEST_F(DataflowAnalysisContextTest, AddFlowConditionConstraint) {
   EXPECT_TRUE(Context.flowConditionImplies(FC, C));
 }
 
+TEST_F(DataflowAnalysisContextTest, AddGlobalConstraint) {
+  Atom FC = A.makeFlowConditionToken();
+  auto &C = A.makeAtomRef(A.makeAtom());
+  Context.addGlobalConstraint(C);
+  EXPECT_TRUE(Context.flowConditionImplies(FC, C));
+}
+
+TEST_F(DataflowAnalysisContextTest, GlobalAndFCConstraintInteract) {
+  Atom FC = A.makeFlowConditionToken();
+  auto &C = A.makeAtomRef(A.makeAtom());
+  auto &D = A.makeAtomRef(A.makeAtom());
+  Context.addGlobalConstraint(A.makeImplies(C, D));
+  Context.addFlowConditionConstraint(FC, C);
+  EXPECT_TRUE(Context.flowConditionImplies(FC, D));
+}
+
 TEST_F(DataflowAnalysisContextTest, ForkFlowCondition) {
   Atom FC1 = A.makeFlowConditionToken();
   auto &C1 = A.makeAtomRef(A.makeAtom());


### PR DESCRIPTION
This records facts that are not sensitive to the current flow condition,
and should apply to all environments.

The motivating case is recording information about where a Value
originated, such as nullability:
 - we may see the same Value for multiple expressions (e.g. reads of the
   same field) in multiple environments (multiple blocks or iterations)
 - we want to record information only when we first see the Value
   (e.g. Nullability annotations on fields only add information if we
   don't know where the value came from)
 - this information should be expressible as a SAT condition
 - we must add this SAT condition to every environment where the
   Value may appear

We solve this by recording the information in the global condition.
This doesn't seem particularly elegant, but solves the problem and is
a fairly small and natural extension of the Environment.

Alternatives considered:
 - store the constraint directly as a property on the Value.
   But it's more composable for such properties to always be variables
   (AtomicBoolValue), and constrain them with SAT conditions.
 - add a hook whenever values are created, giving the analysis the
   chance to populate them.
   However the framework relies on/provides the ability to construct
   values in arbitrary places without providing the context such a hook
   would need, this would be a very invasive change.
