### PR TITLE
[flang] Lower BIND(C) assumed length to CFI descriptor

### DIFF
--- a/flang/lib/Optimizer/Builder/BoxValue.cpp
+++ b/flang/lib/Optimizer/Builder/BoxValue.cpp
@@ -214,11 +214,6 @@ bool fir::BoxValue::verify() const {
     return false;
   if (!lbounds.empty() && lbounds.size() != rank())
     return false;
-  // Explicit extents are here to cover cases where an explicit-shape dummy
-  // argument comes as a fir.box. This can only happen with derived types and
-  // unlimited polymorphic.
-  if (!extents.empty() && !(isDerived() || isUnlimitedPolymorphic()))
-    return false;
   if (!extents.empty() && extents.size() != rank())
     return false;
   if (isCharacter() && explicitParams.size() > 1)

--- a/flang/test/Lower/HLFIR/bindc-assumed-length.f90
+++ b/flang/test/Lower/HLFIR/bindc-assumed-length.f90
@@ -1,0 +1,18 @@
+! Test that assumed length character scalars and explicit shape arrays are passed via
+! CFI descriptor (fir.box) in BIND(C) procedures. They are passed only by address
+! and length  in non BIND(C) procedures. See Fortran 2018 standard 18.3.6 point 2(5).
+! RUN: bbc -emit-hlfir -o - %s 2>&1 | FileCheck %s
+
+! CHECK: func.func @foo(
+! CHECK-SAME: %{{[^:]*}}: !fir.box<!fir.char<1,?>>
+! CHECK-SAME: %{{[^:]*}}: !fir.box<!fir.array<100x!fir.char<1,?>>>
+subroutine foo(c1, c3) bind(c)
+  character(*) :: c1,  c3(100)
+end subroutine
+
+! CHECK: func.func @_QPnot_bindc(
+! CHECK-SAME: %{{[^:]*}}: !fir.boxchar<1>
+! CHECK-SAME: %{{[^:]*}}: !fir.boxchar<1>
+subroutine not_bindc(c1, c3)
+  character(*) :: c1,  c3(100)
+end subroutine

--- a/flang/test/Lower/HLFIR/bindc-assumed-length.f90
+++ b/flang/test/Lower/HLFIR/bindc-assumed-length.f90
@@ -1,18 +1,41 @@
 ! Test that assumed length character scalars and explicit shape arrays are passed via
 ! CFI descriptor (fir.box) in BIND(C) procedures. They are passed only by address
 ! and length  in non BIND(C) procedures. See Fortran 2018 standard 18.3.6 point 2(5).
-! RUN: bbc -emit-hlfir -o - %s 2>&1 | FileCheck %s
+! RUN: bbc -hlfir -emit-fir -o - %s 2>&1 | FileCheck %s
 
-! CHECK: func.func @foo(
+module bindcchar
+contains
+! CHECK-LABEL: func.func @bindc(
 ! CHECK-SAME: %{{[^:]*}}: !fir.box<!fir.char<1,?>>
 ! CHECK-SAME: %{{[^:]*}}: !fir.box<!fir.array<100x!fir.char<1,?>>>
-subroutine foo(c1, c3) bind(c)
-  character(*) :: c1,  c3(100)
+subroutine bindc(c1, c3) bind(c)
+  character(*) ::  c1, c3(100)
+ print *, c1(1:3), c3(5)(1:3)
 end subroutine
 
-! CHECK: func.func @_QPnot_bindc(
+! CHECK-LABEL:  func.func @bindc_optional(
+! CHECK-SAME: %{{[^:]*}}: !fir.box<!fir.char<1,?>>
+! CHECK-SAME: %{{[^:]*}}: !fir.box<!fir.array<100x!fir.char<1,?>>>
+subroutine bindc_optional(c1, c3) bind(c)
+  character(*), optional ::  c1, c3(100)
+ print *, c1(1:3), c3(5)(1:3)
+end subroutine
+
+! CHECK-LABEL:  func.func @_QMbindccharPnot_bindc(
 ! CHECK-SAME: %{{[^:]*}}: !fir.boxchar<1>
 ! CHECK-SAME: %{{[^:]*}}: !fir.boxchar<1>
 subroutine not_bindc(c1, c3)
   character(*) :: c1,  c3(100)
+  call bindc(c1, c3)
+  call bindc_optional(c1, c3)
 end subroutine
+
+! CHECK-LABEL:  func.func @_QMbindccharPnot_bindc_optional(
+! CHECK-SAME: %{{[^:]*}}: !fir.boxchar<1>
+! CHECK-SAME: %{{[^:]*}}: !fir.boxchar<1>
+subroutine not_bindc_optional(c1, c3)
+  character(*), optional :: c1,  c3(100)
+  call bindc(c1, c3)
+  call bindc_optional(c1, c3)
+end subroutine
+end module


### PR DESCRIPTION
Outside of BIND(C), assumed length character scalar and explicit shape are passed by address + an extra length argument (fir.boxchar in FIR).

The standard mandates that they be passed via CFI descriptor in BIND(C) interface (fir.box in FIR). This patch fix the handling for this case.