### PR TITLE
[mlir][IR] Insert operations before `SingleBlock`'s terminator 

### DIFF
--- a/mlir/include/mlir/IR/Block.h
+++ b/mlir/include/mlir/IR/Block.h
@@ -214,6 +214,9 @@ public:
   /// the block has a valid terminator operation.
   Operation *getTerminator();
 
+  /// Check whether this block has a terminator.
+  bool hasTerminator();
+
   //===--------------------------------------------------------------------===//
   // Predecessors and successors.
   //===--------------------------------------------------------------------===//

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -932,6 +932,10 @@ public:
   }
   template <typename OpT = ConcreteType>
   enable_if_single_region<OpT> insert(Block::iterator insertPt, Operation *op) {
+    Block *body = getBody();
+    // Insert op before the block's terminator if it has one
+    if (insertPt == body->end() && body->hasTerminator())
+      insertPt = Block::iterator(body->getTerminator());
     getBody()->getOperations().insert(insertPt, op);
   }
 };
@@ -995,37 +999,6 @@ struct SingleBlockImplicitTerminator {
                                  Location loc) {
       ::mlir::impl::ensureRegionTerminator(region, builder, loc,
                                            buildTerminator);
-    }
-
-    //===------------------------------------------------------------------===//
-    // Single Region Utilities
-    //===------------------------------------------------------------------===//
-
-    template <typename OpT, typename T = void>
-    using enable_if_single_region =
-        std::enable_if_t<OpT::template hasTrait<OneRegion>(), T>;
-
-    /// Insert the operation into the back of the body, before the terminator.
-    template <typename OpT = ConcreteType>
-    enable_if_single_region<OpT> push_back(Operation *op) {
-      Block *body = static_cast<SingleBlock<ConcreteType> *>(this)->getBody();
-      insert(Block::iterator(body->getTerminator()), op);
-    }
-
-    /// Insert the operation at the given insertion point. Note: The operation
-    /// is never inserted after the terminator, even if the insertion point is
-    /// end().
-    template <typename OpT = ConcreteType>
-    enable_if_single_region<OpT> insert(Operation *insertPt, Operation *op) {
-      insert(Block::iterator(insertPt), op);
-    }
-    template <typename OpT = ConcreteType>
-    enable_if_single_region<OpT> insert(Block::iterator insertPt,
-                                        Operation *op) {
-      Block *body = static_cast<SingleBlock<ConcreteType> *>(this)->getBody();
-      if (insertPt == body->end())
-        insertPt = Block::iterator(body->getTerminator());
-      body->getOperations().insert(insertPt, op);
     }
   };
 };

--- a/mlir/lib/IR/Block.cpp
+++ b/mlir/lib/IR/Block.cpp
@@ -236,8 +236,13 @@ void Block::eraseArguments(function_ref<bool(BlockArgument)> shouldEraseFn) {
 /// Get the terminator operation of this block. This function asserts that
 /// the block has a valid terminator operation.
 Operation *Block::getTerminator() {
-  assert(!empty() && back().mightHaveTrait<OpTrait::IsTerminator>());
+  assert(hasTerminator());
   return &back();
+}
+
+/// Check whether this block has a terminator.
+bool Block::hasTerminator() {
+  return !empty() && back().mightHaveTrait<OpTrait::IsTerminator>();
 }
 
 // Indexed successor access.


### PR DESCRIPTION
Change `SingleBlock::{insert,push_back}` to avoid inserting the argument operation after the block's terminator. This allows removing `SingleBlockImplicitTerminator`'s functions with the same name.

Define `Block::hasTerminator` checking whether the block has a terminator operation.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>