### PR TITLE
[lldb] Treat user aliases the same as built-ins when tab completing

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1227,36 +1227,11 @@ CommandObject *
 CommandInterpreter::GetCommandObject(llvm::StringRef cmd_str,
                                      StringList *matches,
                                      StringList *descriptions) const {
-  CommandObject *command_obj =
-      GetCommandSP(cmd_str, false, true, matches, descriptions).get();
-
-  // If we didn't find an exact match to the command string in the commands,
-  // look in the aliases.
-
-  if (command_obj)
-    return command_obj;
-
-  command_obj = GetCommandSP(cmd_str, true, true, matches, descriptions).get();
-
-  if (command_obj)
-    return command_obj;
-
-  // If there wasn't an exact match then look for an inexact one in just the
-  // commands
-  command_obj = GetCommandSP(cmd_str, false, false, nullptr).get();
-
-  // Finally, if there wasn't an inexact match among the commands, look for an
-  // inexact match in both the commands and aliases.
-
-  if (command_obj) {
-    if (matches)
-      matches->AppendString(command_obj->GetCommandName());
-    if (descriptions)
-      descriptions->AppendString(command_obj->GetHelp());
-    return command_obj;
-  }
-
-  return GetCommandSP(cmd_str, true, false, matches, descriptions).get();
+  // Try to find a match among commands and aliases. Allowing inexact matches,
+  // but perferring exact matches.
+  return GetCommandSP(cmd_str, /*include_aliases=*/true, /*exact=*/false,
+                             matches, descriptions)
+                    .get();
 }
 
 CommandObject *CommandInterpreter::GetUserCommandObject(

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -508,6 +508,11 @@ void CommandInterpreter::Initialize() {
   if (cmd_obj_sp) {
     AddAlias("history", cmd_obj_sp);
   }
+
+  cmd_obj_sp = GetCommandSPExact("help");
+  if (cmd_obj_sp) {
+    AddAlias("h", cmd_obj_sp);
+  }
 }
 
 void CommandInterpreter::Clear() {

--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -20,6 +20,7 @@ class AbbreviationsTestCase(TestBase):
         self.assertTrue(result.Succeeded())
         self.assertEqual("apropos script", result.GetOutput())
 
+        # "h" could be "help" or "history", "he" can only be "help".
         command_interpreter.ResolveCommand("he", result)
         self.assertTrue(result.Succeeded())
         self.assertEqual("help", result.GetOutput())

--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -20,8 +20,7 @@ class AbbreviationsTestCase(TestBase):
         self.assertTrue(result.Succeeded())
         self.assertEqual("apropos script", result.GetOutput())
 
-        # "h" could be "help" or "history", "he" can only be "help".
-        command_interpreter.ResolveCommand("he", result)
+        command_interpreter.ResolveCommand("h", result)
         self.assertTrue(result.Succeeded())
         self.assertEqual("help", result.GetOutput())
 

--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -20,7 +20,7 @@ class AbbreviationsTestCase(TestBase):
         self.assertTrue(result.Succeeded())
         self.assertEqual("apropos script", result.GetOutput())
 
-        command_interpreter.ResolveCommand("h", result)
+        command_interpreter.ResolveCommand("he", result)
         self.assertTrue(result.Succeeded())
         self.assertEqual("help", result.GetOutput())
 

--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -618,19 +618,15 @@ class CommandLineCompletionTestCase(TestBase):
 
     def test_command_aliases(self):
         self.runCmd("command alias brkpt breakpoint")
-        # If there is an unambiguous completion from the built-in commands,
-        # we choose that.
-        self.complete_from_to("br", "breakpoint")
-        # Only if there is not, do we then look for an unambiguous completion
-        # from the user defined aliases.
+        # Exact matches are chosen if possible, even if there are longer
+        # completions we could use.
+        self.complete_from_to("b", "b ")
+        # Aliases are included in possible completions.
+        self.complete_from_to("br", ["breakpoint", "brkpt"])
+        # An alias can be the chosen completion.
         self.complete_from_to("brk", "brkpt")
 
-        # Aliases are included when there's no exact match.
-        self.runCmd("command alias play breakpoint")
-        self.complete_from_to("pl", ["plugin", "platform", "play"])
-
-        # That list can also contain only aliases if there's no built-ins to
-        # match.
+        # The list can contain only aliases if there's no built-ins to match.
         self.runCmd("command alias test_1 breakpoint")
         self.runCmd("command alias test_2 breakpoint")
         self.complete_from_to("test_", ["test_1", "test_2"])


### PR DESCRIPTION
Previously we would check all built-ins first for suggestions,
then check built-ins and aliases. This meant that if you had
an alias brkpt -> breakpoint, "br" would complete to "breakpoint".

Instead of giving you the choice of "brkpt" or "breakpoint".