### PR TITLE
[lldb] Format more Python files with black

### DIFF
--- a/lldb/bindings/python/createPythonInit.py
+++ b/lldb/bindings/python/createPythonInit.py
@@ -5,7 +5,7 @@ pkgRelDir = sys.argv[1]
 pkgFiles = sys.argv[2:]
 
 getFileName = lambda f: os.path.splitext(os.path.basename(f))[0]
-importNames = ', '.join('"{}"'.format(getFileName(f)) for f in pkgFiles)
+importNames = ", ".join('"{}"'.format(getFileName(f)) for f in pkgFiles)
 
 script = """__all__ = [{import_names}]
 for x in __all__:
@@ -18,7 +18,9 @@ def __lldb_init_module(debugger, internal_dict):
     lldb_init = getattr(submodule, '__lldb_init_module', None)
     if lldb_init:
       lldb_init(debugger, internal_dict)
-""".format(import_names=importNames, pkg_name=pkgRelDir.replace("/", "."))
+""".format(
+    import_names=importNames, pkg_name=pkgRelDir.replace("/", ".")
+)
 
 pkgIniFile = os.path.normpath(os.path.join(pkgRelDir, "__init__.py"))
 with open(pkgIniFile, "w") as f:

--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -10,9 +10,10 @@ def relpath_nodots(path, base):
     rel = os.path.normpath(os.path.relpath(path, base))
     assert not os.path.isabs(rel)
     parts = rel.split(os.path.sep)
-    if parts and parts[0] == '..':
+    if parts and parts[0] == "..":
         raise ValueError(f"{path} is not under {base}")
     return rel
+
 
 def main():
     parser = argparse.ArgumentParser(description="extract cmake variables from python")
@@ -35,10 +36,10 @@ def main():
         except ValueError:
             # Try to fall back to something reasonable if sysconfig's platlib
             # is outside of sys.prefix
-            if os.name == 'posix':
-                print('lib/python%d.%d/site-packages' % sys.version_info[:2])
-            elif os.name == 'nt':
-                print('Lib\\site-packages')
+            if os.name == "posix":
+                print("lib/python%d.%d/site-packages" % sys.version_info[:2])
+            elif os.name == "nt":
+                print("Lib\\site-packages")
             else:
                 raise
     elif args.variable_name == "LLDB_PYTHON_EXE_RELATIVE_PATH":
@@ -57,16 +58,20 @@ def main():
                     exe = os.path.realpath(exe)
                     continue
                 else:
-                    print("Could not find a relative path to sys.executable under sys.prefix", file=sys.stderr)
+                    print(
+                        "Could not find a relative path to sys.executable under sys.prefix",
+                        file=sys.stderr,
+                    )
                     for e in tried:
                         print("tried:", e, file=sys.stderr)
                     print("realpath(sys.prefix):", prefix, file=sys.stderr)
                     print("sys.prefix:", sys.prefix, file=sys.stderr)
                     sys.exit(1)
     elif args.variable_name == "LLDB_PYTHON_EXT_SUFFIX":
-        print(sysconfig.get_config_var('EXT_SUFFIX'))
+        print(sysconfig.get_config_var("EXT_SUFFIX"))
     else:
         parser.error(f"unknown variable {args.variable_name}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -42,9 +42,7 @@ automodapi_toctreedirnm = "python_api"
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ["sphinx.ext.todo", "sphinx.ext.mathjax", "sphinx.ext.intersphinx"]
 
-autodoc_default_options = {
-    "special-members": True
-}
+autodoc_default_options = {"special-members": True}
 
 # Unless we only generate the basic manpage we need the plugin for generating
 # the Python API documentation.
@@ -60,9 +58,7 @@ if not building_man_page:
     try:
         import furo
     except ModuleNotFoundError:
-        print(
-            f"install sphinx furo theme with {sys.executable} -m pip install furo"
-        )
+        print(f"install sphinx furo theme with {sys.executable} -m pip install furo")
     # The theme to use for HTML and HTML Help pages.  See the documentation for
     # a list of builtin themes.
     html_theme = "furo"

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2604,15 +2604,16 @@ FileCheck output:
         if not obj.Success():
             error = obj.GetCString()
             self.fail(self._formatMessage(msg, "'{}' is not success".format(error)))
+
     """Assert that an lldb.SBError is in the "failure" state."""
 
-    def assertFailure(self, obj, error_str = None, msg=None):
+    def assertFailure(self, obj, error_str=None, msg=None):
         if obj.Success():
             self.fail(self._formatMessage(msg, "Error not in a fail state"))
 
         if error_str == None:
             return
-                      
+
         error = obj.GetCString()
         self.assertEqual(error, error_str, msg)
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-vscode/vscode.py
@@ -649,12 +649,14 @@ class DebugCommunication(object):
         }
         return self.send_recv(command_dict)
 
-    def request_disassemble(self, memoryReference, offset=-50, instructionCount=200, resolveSymbols=True):
+    def request_disassemble(
+        self, memoryReference, offset=-50, instructionCount=200, resolveSymbols=True
+    ):
         args_dict = {
             "memoryReference": memoryReference,
             "offset": offset,
             "instructionCount": instructionCount,
-            "resolveSymbols": resolveSymbols
+            "resolveSymbols": resolveSymbols,
         }
         command_dict = {
             "command": "disassemble",

--- a/lldb/source/Interpreter/embedded_interpreter.py
+++ b/lldb/source/Interpreter/embedded_interpreter.py
@@ -1,4 +1,5 @@
 import sys
+
 if sys.version_info[0] < 3:
     import __builtin__ as builtins
 else:
@@ -18,10 +19,10 @@ except AttributeError:
     have_readline = False
 else:
     have_readline = True
-    if 'libedit' in readline.__doc__:
-        readline.parse_and_bind('bind ^I rl_complete')
+    if "libedit" in readline.__doc__:
+        readline.parse_and_bind("bind ^I rl_complete")
     else:
-        readline.parse_and_bind('tab: complete')
+        readline.parse_and_bind("tab: complete")
 
 # When running one line, we might place the string to run in this string
 # in case it would be hard to correctly escape a string's contents
@@ -34,7 +35,8 @@ def get_terminal_size(fd):
         import fcntl
         import termios
         import struct
-        hw = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
+
+        hw = struct.unpack("hh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234"))
     except:
         hw = (0, 0)
     return hw
@@ -46,7 +48,7 @@ class LLDBExit(SystemExit):
 
 def strip_and_check_exit(line):
     line = line.rstrip()
-    if line in ('exit', 'quit'):
+    if line in ("exit", "quit"):
         raise LLDBExit
     return line
 
@@ -75,6 +77,7 @@ def run_python_interpreter(local_dict):
         if get_terminal_size(fd)[1] == 0:
             try:
                 import termios
+
                 old = termios.tcgetattr(fd)
                 if old[3] & termios.ECHO:
                     # Need to turn off echoing and restore
@@ -86,7 +89,8 @@ def run_python_interpreter(local_dict):
                         code.interact(
                             banner="Python Interactive Interpreter. To exit, type 'quit()', 'exit()'.",
                             readfunc=readfunc_stdio,
-                            local=local_dict)
+                            local=local_dict,
+                        )
                     finally:
                         termios.tcsetattr(fd, termios.TCSADRAIN, old)
             except:
@@ -96,18 +100,20 @@ def run_python_interpreter(local_dict):
                 code.interact(
                     banner="Python Interactive Interpreter. To exit, type 'quit()', 'exit()' or Ctrl-D.",
                     readfunc=readfunc_stdio,
-                    local=local_dict)
+                    local=local_dict,
+                )
         else:
             # We have a real interactive terminal
             code.interact(
                 banner="Python Interactive Interpreter. To exit, type 'quit()', 'exit()' or Ctrl-D.",
                 readfunc=readfunc,
-                local=local_dict)
+                local=local_dict,
+            )
     except LLDBExit:
         pass
     except SystemExit as e:
         if e.code:
-            print('Script exited with code %s' % e.code)
+            print("Script exited with code %s" % e.code)
 
 
 def run_one_line(local_dict, input_string):
@@ -127,4 +133,4 @@ def run_one_line(local_dict, input_string):
         pass
     except SystemExit as e:
         if e.code:
-            print('Script exited with code %s' % e.code)
+            print("Script exited with code %s" % e.code)

--- a/lldb/tools/intel-features/intel-mpx/test/TestMPXTable.py
+++ b/lldb/tools/intel-features/intel-mpx/test/TestMPXTable.py
@@ -12,20 +12,21 @@ from lldbsuite.test import lldbutil
 
 
 class TestMPXTable(TestBase):
-
     def setUp(self):
         TestBase.setUp(self)
 
     @skipIf(compiler="clang")
-    @skipIf(oslist=no_match(['linux']))
-    @skipIf(archs=no_match(['i386', 'x86_64']))
-    @skipIf(compiler="gcc", compiler_version=["<", "5"]) #GCC version >= 5 supports
-    #Intel(R) Memory Protection Extensions (Intel(R) MPX).
+    @skipIf(oslist=no_match(["linux"]))
+    @skipIf(archs=no_match(["i386", "x86_64"]))
+    @skipIf(compiler="gcc", compiler_version=["<", "5"])  # GCC version >= 5 supports
+    # Intel(R) Memory Protection Extensions (Intel(R) MPX).
     def test_show_command(self):
         """Test 'mpx-table show' command"""
         self.build()
 
-        plugin_file = os.path.join(configuration.lldb_libs_dir, "liblldbIntelFeatures.so")
+        plugin_file = os.path.join(
+            configuration.lldb_libs_dir, "liblldbIntelFeatures.so"
+        )
         if not os.path.isfile(plugin_file):
             self.skipTest("features plugin missing.")
         plugin_command = " "
@@ -36,86 +37,120 @@ class TestMPXTable(TestBase):
         exe = os.path.join(os.getcwd(), "a.out")
         self.runCmd("file " + exe, CURRENT_EXECUTABLE_SET)
 
-        self.b1 = line_number('main.cpp', '// Break 1.')
-        self.b2 = line_number('main.cpp', '// Break 2.')
-        self.b3 = line_number('main.cpp', '// Break 3.')
-        self.b4 = line_number('main.cpp', '// Break 4.')
-        lldbutil.run_break_set_by_file_and_line(self, "main.cpp", self.b1, num_expected_locations=1)
-        lldbutil.run_break_set_by_file_and_line(self, "main.cpp", self.b2, num_expected_locations=1)
-        lldbutil.run_break_set_by_file_and_line(self, "main.cpp", self.b3, num_expected_locations=1)
-        lldbutil.run_break_set_by_file_and_line(self, "main.cpp", self.b4, num_expected_locations=1)
+        self.b1 = line_number("main.cpp", "// Break 1.")
+        self.b2 = line_number("main.cpp", "// Break 2.")
+        self.b3 = line_number("main.cpp", "// Break 3.")
+        self.b4 = line_number("main.cpp", "// Break 4.")
+        lldbutil.run_break_set_by_file_and_line(
+            self, "main.cpp", self.b1, num_expected_locations=1
+        )
+        lldbutil.run_break_set_by_file_and_line(
+            self, "main.cpp", self.b2, num_expected_locations=1
+        )
+        lldbutil.run_break_set_by_file_and_line(
+            self, "main.cpp", self.b3, num_expected_locations=1
+        )
+        lldbutil.run_break_set_by_file_and_line(
+            self, "main.cpp", self.b4, num_expected_locations=1
+        )
         self.runCmd("run", RUN_SUCCEEDED)
 
         target = self.dbg.GetSelectedTarget()
         process = target.GetProcess()
 
-        if (process.GetState() == lldb.eStateExited):
+        if process.GetState() == lldb.eStateExited:
             self.skipTest("Intel(R) MPX is not supported.")
         else:
-            self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT,
-                        substrs = ["stop reason = breakpoint 1."])
+            self.expect(
+                "thread backtrace",
+                STOPPED_DUE_TO_BREAKPOINT,
+                substrs=["stop reason = breakpoint 1."],
+            )
 
-        self.expect("mpx-table show a",
-                     substrs = ['lbound = 0x',
-                                ', ubound = 0x',
-                                '(pointer value = 0x',
-                                ', metadata = 0x',
-                                ')'],
-                     error = False)
+        self.expect(
+            "mpx-table show a",
+            substrs=[
+                "lbound = 0x",
+                ", ubound = 0x",
+                "(pointer value = 0x",
+                ", metadata = 0x",
+                ")",
+            ],
+            error=False,
+        )
 
-        self.expect("continue", STOPPED_DUE_TO_BREAKPOINT,
-                     substrs = ["stop reason = breakpoint 2."])
+        self.expect(
+            "continue",
+            STOPPED_DUE_TO_BREAKPOINT,
+            substrs=["stop reason = breakpoint 2."],
+        )
 
         # Check that out of scope pointer cannot be reached.
         #
-        self.expect("mpx-table show a",
-                     substrs = ['Invalid pointer.'],
-                     error = True)
+        self.expect("mpx-table show a", substrs=["Invalid pointer."], error=True)
 
-        self.expect("mpx-table show tmp",
-                     substrs = ['lbound = 0x',
-                                ', ubound = 0x',
-                                '(pointer value = 0x',
-                                ', metadata = 0x',
-                                ')'],
-                     error = False)
+        self.expect(
+            "mpx-table show tmp",
+            substrs=[
+                "lbound = 0x",
+                ", ubound = 0x",
+                "(pointer value = 0x",
+                ", metadata = 0x",
+                ")",
+            ],
+            error=False,
+        )
 
-        self.expect("continue", STOPPED_DUE_TO_BREAKPOINT,
-                     substrs = ["stop reason = breakpoint 3."])
+        self.expect(
+            "continue",
+            STOPPED_DUE_TO_BREAKPOINT,
+            substrs=["stop reason = breakpoint 3."],
+        )
 
         # Check that the pointer value is correctly updated.
         #
-        self.expect("mpx-table show tmp",
-                     substrs = ['lbound = 0x',
-                                ', ubound = 0x',
-                                '(pointer value = 0x2',
-                                ', metadata = 0x',
-                                ')'],
-                     error = False)
+        self.expect(
+            "mpx-table show tmp",
+            substrs=[
+                "lbound = 0x",
+                ", ubound = 0x",
+                "(pointer value = 0x2",
+                ", metadata = 0x",
+                ")",
+            ],
+            error=False,
+        )
 
-        self.expect("continue", STOPPED_DUE_TO_BREAKPOINT,
-                     substrs = ["stop reason = breakpoint 4."])
+        self.expect(
+            "continue",
+            STOPPED_DUE_TO_BREAKPOINT,
+            substrs=["stop reason = breakpoint 4."],
+        )
 
         # After going back to main(), check that out of scope pointer cannot be
         # reached.
         #
-        self.expect("mpx-table show tmp",
-                     substrs = ['Invalid pointer.'],
-                     error = True)
+        self.expect("mpx-table show tmp", substrs=["Invalid pointer."], error=True)
 
-        self.expect("mpx-table show a",
-                     substrs = ['lbound = 0x',
-                                ', ubound = 0x',
-                                '(pointer value = 0x',
-                                ', metadata = 0x',
-                                ')'],
-                     error = False)
+        self.expect(
+            "mpx-table show a",
+            substrs=[
+                "lbound = 0x",
+                ", ubound = 0x",
+                "(pointer value = 0x",
+                ", metadata = 0x",
+                ")",
+            ],
+            error=False,
+        )
 
     def test_set_command(self):
         """Test 'mpx-table set' command"""
         self.build()
 
-        plugin_file = os.path.join(configuration.lldb_libs_dir, "liblldbIntelFeatures.so")
+        plugin_file = os.path.join(
+            configuration.lldb_libs_dir, "liblldbIntelFeatures.so"
+        )
         if not os.path.isfile(plugin_file):
             self.skipTest("features plugin missing.")
         plugin_command = " "
@@ -126,35 +161,41 @@ class TestMPXTable(TestBase):
         exe = os.path.join(os.getcwd(), "a.out")
         self.runCmd("file " + exe, CURRENT_EXECUTABLE_SET)
 
-        self.b1 = line_number('main.cpp', '// Break 1.')
-        lldbutil.run_break_set_by_file_and_line(self, "main.cpp", self.b1, num_expected_locations=1)
+        self.b1 = line_number("main.cpp", "// Break 1.")
+        lldbutil.run_break_set_by_file_and_line(
+            self, "main.cpp", self.b1, num_expected_locations=1
+        )
         self.runCmd("run", RUN_SUCCEEDED)
 
         target = self.dbg.GetSelectedTarget()
         process = target.GetProcess()
 
-        if (process.GetState() == lldb.eStateExited):
+        if process.GetState() == lldb.eStateExited:
             self.skipTest("Intel(R) MPX is not supported.")
         else:
-            self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT,
-                        substrs = ["stop reason = breakpoint 1."])
+            self.expect(
+                "thread backtrace",
+                STOPPED_DUE_TO_BREAKPOINT,
+                substrs=["stop reason = breakpoint 1."],
+            )
 
         # Check that the BT Entry doesn't already contain the test values.
         #
-        self.expect("mpx-table show a", matching=False,
-                     substrs = ['lbound = 0xcafecafe',
-                                ', ubound = 0xbeefbeef'])
+        self.expect(
+            "mpx-table show a",
+            matching=False,
+            substrs=["lbound = 0xcafecafe", ", ubound = 0xbeefbeef"],
+        )
 
         # Set the test values.
         #
-        self.expect("mpx-table set a 0xcafecafe 0xbeefbeef", error = False)
+        self.expect("mpx-table set a 0xcafecafe 0xbeefbeef", error=False)
 
         # Verify that the test values have been correctly written in the BT
         # entry.
         #
-        self.expect("mpx-table show a",
-                     substrs = ['lbound = 0xcafecafe',
-                                ', ubound = 0xbeefbeef'],
-                     error = False)
-
-
+        self.expect(
+            "mpx-table show a",
+            substrs=["lbound = 0xcafecafe", ", ubound = 0xbeefbeef"],
+            error=False,
+        )

--- a/lldb/use_lldb_suite_root.py
+++ b/lldb/use_lldb_suite_root.py
@@ -4,8 +4,7 @@ import sys
 
 
 def add_third_party_module_dirs(lldb_root):
-    third_party_modules_dir = os.path.join(
-        lldb_root, "third_party", "Python", "module")
+    third_party_modules_dir = os.path.join(lldb_root, "third_party", "Python", "module")
     if not os.path.isdir(third_party_modules_dir):
         return
 
@@ -18,6 +17,7 @@ def add_third_party_module_dirs(lldb_root):
 def add_lldbsuite_packages_dir(lldb_root):
     packages_dir = os.path.join(lldb_root, "packages", "Python")
     sys.path.insert(0, packages_dir)
+
 
 lldb_root = os.path.dirname(inspect.getfile(inspect.currentframe()))
 


### PR DESCRIPTION
By running this from lldb/

$ black --exclude "third_party/|scripts/|utils/" ./