### PR TITLE
[Dexter] Replace clang with clang++ in various cross project tests

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 //
-// RUN: %clang -std=gnu++11 -O0 -g -lstdc++ %s -o %t
+// RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
 // Radar 8945514

--- a/cross-project-tests/debuginfo-tests/dexter-tests/asan-deque.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/asan-deque.cpp
@@ -8,7 +8,7 @@
 // lldb-8, even outside of dexter, will sometimes trigger an asan fault in
 // the debugged process and generally freak out.
 
-// RUN: %clang -std=gnu++11 -O1 -glldb -fsanitize=address -arch x86_64 %s -o %t
+// RUN: %clang++ -std=gnu++11 -O1 -glldb -fsanitize=address -arch x86_64 %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
 #include <deque>

--- a/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 //
-// RUN: %clang -std=gnu++11 -O0 -glldb %s -o %t
+// RUN: %clang++ -std=gnu++11 -O0 -glldb %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
@@ -4,7 +4,7 @@
 
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// RUN: %clang -std=gnu++11 -O0 -g %s -o %t
+// RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary  %t --debugger 'lldb' -v -- %s
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
@@ -5,7 +5,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 
-// RUN: %clang -g -O0 %s -o %t
+// RUN: %clang++ -g -O0 %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -v -- %s
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/nrvo-string.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/nrvo-string.cpp
@@ -7,11 +7,11 @@
 //           Zorg configures the ASAN stage2 bots to not build the asan
 //           compiler-rt. Only run this test on non-asanified configurations.
 //
-// RUN: %clang -std=gnu++11 -O0 -glldb -fno-exceptions %s -o %t
+// RUN: %clang++ -std=gnu++11 -O0 -glldb -fno-exceptions %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
 //
-// RUN: %clang -std=gnu++11 -O1 -glldb -fno-exceptions %s -o %t
+// RUN: %clang++ -std=gnu++11 -O1 -glldb -fno-exceptions %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
 //

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-fastmath.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-fastmath.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang -std=gnu++11 -O2 -ffast-math -g %s -o %t
+// RUN: %clang++ -std=gnu++11 -O2 -ffast-math -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
-// RUN: %clang -std=gnu++11 -O0 -ffast-math -g %s -o %t
+// RUN: %clang++ -std=gnu++11 -O0 -ffast-math -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-loops.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-loops.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-windows
 // UNSUPPORTED: system-darwin
 
-// RUN: %clang -std=gnu++11 -O2 -g %s -o %t
+// RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t --debugger 'lldb' -- %s
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/dex_declare_file.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/dex_declare_file.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: dex_declare_file.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_program_state.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_program_state.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_program_state.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_kinds.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_kinds.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_step_kinds.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_order.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_order.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_step_order.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_type.cpp
@@ -9,7 +9,7 @@
 // TODO: Reduce this test's coverage and be more specific about
 // expected behaviour.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_type.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_value.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_value.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_out_range.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_out_range.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: float_range_out_range.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_zero_nonmatch.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_zero_nonmatch.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: float_range_zero_nonmatch.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/missing_dex_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/missing_dex_address.cpp
@@ -5,7 +5,7 @@
 // The dbgeng driver doesn't support \DexDeclareAddress yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: missing_dex_address.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unreachable.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_line_range.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_line_range.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_line_range.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_on_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_on_line.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_on_line.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
@@ -1,7 +1,7 @@
 // The dbgeng driver doesn't support \DexCommandLine yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_c_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: command_line.c:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
@@ -2,7 +2,7 @@
 //      Test that a \DexDeclareAddress value can have its value defined after
 //      the first reference to that value.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: address_after_ref.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
@@ -4,7 +4,7 @@
 //      expression after the target line has been stepped on a given number of
 //      times.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: address_hit_count.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
@@ -2,7 +2,7 @@
 //      Test that a \DexDeclareAddress value can be used to compare the
 //      addresses of two local variables that refer to the same address.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expression_address.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
@@ -2,7 +2,7 @@
 //      Test that a \DexDeclareAddress value can be used to compare two equal
 //      pointer variables.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: identical_address.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
@@ -2,7 +2,7 @@
 //      Test that multiple \DexDeclareAddress references that point to different
 //      addresses can be used within a single \DexExpectWatchValue.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: multiple_address.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
@@ -2,7 +2,7 @@
 //      Test that a \DexDeclareAddress value can be used to compare two pointer
 //      variables that have a fixed offset between them.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: offset_address.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
@@ -2,7 +2,7 @@
 //      Test that a \DexDeclareAddress value can be used to check the change in
 //      value of a variable over time, relative to its initial value.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: self_comparison.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/dex_and_source/test.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/dex_and_source/test.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 //
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: dex_and_source
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
@@ -6,7 +6,7 @@
 //      condition (x == 5) is satisfied.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_conditional.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
@@ -7,7 +7,7 @@
 //      given number of times.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_conditional_hit_count.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
@@ -4,7 +4,7 @@
 //      specific number of times.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_hit_count.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
@@ -4,7 +4,7 @@
 //      is stepped on.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_simple.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
@@ -7,7 +7,7 @@
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_conditional.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
@@ -8,7 +8,7 @@
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_conditional_hit_count.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
@@ -7,7 +7,7 @@
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_hit_count.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
@@ -7,7 +7,7 @@
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows, system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_simple.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_program_state.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_program_state.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_program_state.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
@@ -10,7 +10,7 @@
 // TODO: The dbgeng debugger does not support column step reporting at present.
 // XFAIL: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: direction.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func.cpp
@@ -5,7 +5,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: func.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func_external.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func_external.cpp
@@ -8,7 +8,7 @@
 // This fails right now on my linux and windows machine, needs examining as to
 // why.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: func_external.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/recursive.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/recursive.cpp
@@ -5,7 +5,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: recursive.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/small_loop.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/small_loop.cpp
@@ -5,7 +5,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: small_loop.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_order.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_order.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_step_order.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_type.cpp
@@ -8,7 +8,7 @@
 // in the same manner as LLDB.
 // XFAIL: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_type.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_value.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_value.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_multiple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_multiple.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: float_range_multiple.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_no_arg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_no_arg.cpp
@@ -7,7 +7,7 @@
 // work for both dbgeng and lldb, which output floats differently.
 // UNSUPPORTED: system-darwin, system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: float_range_no_arg.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_small.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_small.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: float_range_small.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_zero_match.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_zero_match.cpp
@@ -3,7 +3,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: float_range_zero_match.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
@@ -2,7 +2,7 @@
 //      Test that \DexLimitSteps keyword argument hit_count correctly limits
 //      the number of times the command can trigger.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: hit_count.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Check number of step lines are correctly reported in json output.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --verbose -- %s | FileCheck %s
 // CHECK: limit_steps_check_json_step_count.cpp
 // CHECK: ## BEGIN ##

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
@@ -2,7 +2,7 @@
 //      Check the DexLimit steps only gathers step info for 2 iterations of a
 //      for loop.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_expect_loop.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Ensure that limited stepping breaks for all expected values.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_expect_value.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
@@ -3,7 +3,7 @@
 //      doesn't exist. This can happen due to optimisations or label is on an
 //      empty line.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_line_mismatch.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Ensure that multiple overlapping \DexLimitSteps ranges do not interfere.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_overlapping_ranges.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Test that LimitStep commands can exist on the same from line.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_same_line_conditional.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
@@ -2,7 +2,7 @@
 //      Test that \DexLimitSteps can be used without a condition (i.e. the
 //      breakpoint range is set any time from_line is stepped on).
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unconditional.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unreachable.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_not_cmd_lineno.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_not_cmd_lineno.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_not_cmd_lineno.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_on_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_on_line.cpp
@@ -4,7 +4,7 @@
 //
 // UNSUPPORTED: system-darwin
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_on_line.cpp:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
@@ -11,7 +11,7 @@
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
 
 // CHECK: Resolved Addresses:

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_bad_label_ref.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_bad_label_ref.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Check that referencing an undefined label gives a useful error message.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
 //
 // CHECK: parser error:{{.*}}err_bad_label_ref.cpp(15): Unresolved label: 'label_does_not_exist'

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_address.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Check that declaring duplicate addresses gives a useful error message.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
 
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_label.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_label.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Check that defining duplicate labels gives a useful error message.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
 //
 // CHECK: parser error:{{.*}}err_duplicate_label.cpp(12): Found duplicate line label: 'oops'

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
@@ -7,7 +7,7 @@
 // Note: Despite using 'lldb' as the debugger, lldb is not actually required
 //       as the test should finish before lldb would be invoked.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t --debugger 'lldb' \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
@@ -7,7 +7,7 @@
 // Note: Despite using 'lldb' as the debugger, lldb is not actually required
 //       as the test should finish before lldb would be invoked.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t --debugger "lldb" \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
@@ -7,7 +7,7 @@
 // Note: Despite using 'lldb' as the debugger, lldb is not actually required
 //       as the test should finish before lldb would be invoked.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t --debugger "lldb" \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
@@ -7,7 +7,7 @@
 // Note: Despite using 'lldb' as the debugger, lldb is not actually required
 //       as the test should finish before lldb would be invoked.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t --debugger "lldb" \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
@@ -7,7 +7,7 @@
 // Note: Despite using 'lldb' as the debugger, lldb is not actually required
 //       as the test should finish before lldb would be invoked.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t --debugger "lldb" \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
@@ -7,7 +7,7 @@
 // Note: Despite using 'lldb' as the debugger, lldb is not actually required
 //       as the test should finish before lldb would be invoked.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t --debugger "lldb" \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_undeclared_addr.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_undeclared_addr.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Check that using an undeclared address gives a useful error message.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
 
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
@@ -2,7 +2,7 @@
 //    Check that the optional keyword argument 'on_line' makes a \DexLabel label
 //    that line instead of the line the command is found on.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: label_another_line.cpp: (1.0000)
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Check that we can use label-relative line numbers.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
 //
 // CHECK: label_offset.cpp: (1.0000)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/source-root-dir.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/source-root-dir.cpp
@@ -1,6 +1,6 @@
 // This test started failing recently for unknown reasons.
 // XFAIL:*
-// RUN: %dexter_regression_test_build \
+// RUN: %dexter_regression_test_cxx_build \
 // RUN:     -fdebug-prefix-map=%S=/changed %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary %t \

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
@@ -1,7 +1,7 @@
 // The dbgeng driver doesn't support --target-run-args yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_c_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
 // CHECK: target_run_args.c:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
@@ -1,7 +1,7 @@
 // The dbgeng driver doesn't support --target-run-args yet.
 // UNSUPPORTED: system-windows
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_c_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
 // CHECK: target_run_args_with_command.c:
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
@@ -1,7 +1,7 @@
 // Purpose:
 //      Check the `view` subtool works with typical inputs.
 //
-// RUN: %dexter_regression_test_build %s -o %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --results %t.results -- %s
 //
 // RUN: %dexter_base view %t.results/view.cpp.dextIR | FileCheck %s

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -131,18 +131,31 @@ def configure_dexter_substitutions():
     if platform.system() == "Windows":
         # The Windows builder script uses lld.
         dependencies = ["clang", "lld-link"]
-        dexter_regression_test_builder = "clang-cl"
+        dexter_regression_test_c_builder = "clang-cl"
+        dexter_regression_test_cxx_builder = "clang-cl"
         dexter_regression_test_debugger = "dbgeng"
-        dexter_regression_test_flags = "/Zi /Od"
+        dexter_regression_test_c_flags = "/Zi /Od"
+        dexter_regression_test_cxx_flags = "/Zi /Od"
+        dexter_regression_test_additional_flags = ""
     else:
         # Use lldb as the debugger on non-Windows platforms.
         dependencies = ["clang", "lldb"]
-        dexter_regression_test_builder = "clang++"
+        dexter_regression_test_c_builder = "clang"
+        dexter_regression_test_cxx_builder = "clang++"
         dexter_regression_test_debugger = "lldb"
-        dexter_regression_test_flags = "-O0 -glldb -std=gnu++11"
+        dexter_regression_test_c_flags = "-O0 -glldb -std=gnu11"
+        dexter_regression_test_cxx_flags = "-O0 -glldb -std=gnu++11"
+        dexter_regression_test_additional_flags = '--lldb-executable "{}"'.format(
+            lldb_path
+        )
 
     tools.append(
-        ToolSubst("%dexter_regression_test_builder", dexter_regression_test_builder)
+        ToolSubst("%dexter_regression_test_c_builder", dexter_regression_test_c_builder)
+    )
+    tools.append(
+        ToolSubst(
+            "%dexter_regression_test_cxx_builder", dexter_regression_test_cxx_builder
+        )
     )
     tools.append(
         ToolSubst("%dexter_regression_test_debugger", dexter_regression_test_debugger)
@@ -151,7 +164,10 @@ def configure_dexter_substitutions():
     # regression tests we use clang to drive the linker, and so all flags will be
     # passed in a single command.
     tools.append(
-        ToolSubst("%dexter_regression_test_flags", dexter_regression_test_flags)
+        ToolSubst("%dexter_regression_test_c_flags", dexter_regression_test_c_flags)
+    )
+    tools.append(
+        ToolSubst("%dexter_regression_test_cxx_flags", dexter_regression_test_cxx_flags)
     )
 
     # Typical command would take the form:
@@ -165,18 +181,30 @@ def configure_dexter_substitutions():
             "--fail-lt 1.0 -w",
             "--debugger",
             dexter_regression_test_debugger,
+            dexter_regression_test_additional_flags,
         ]
     )
     tools.append(ToolSubst("%dexter_regression_test_run", dexter_regression_test_run))
 
     # Include build flags for %dexter_regression_test.
-    dexter_regression_test_build = " ".join(
+    dexter_regression_test_c_build = " ".join(
         [
-            dexter_regression_test_builder,
-            dexter_regression_test_flags,
+            dexter_regression_test_c_builder,
+            dexter_regression_test_c_flags,
         ]
     )
-    tools.append(ToolSubst("%dexter_regression_test_build", dexter_regression_test_build))
+    dexter_regression_test_cxx_build = " ".join(
+        [
+            dexter_regression_test_cxx_builder,
+            dexter_regression_test_cxx_flags,
+        ]
+    )
+    tools.append(
+        ToolSubst("%dexter_regression_test_c_build", dexter_regression_test_c_build)
+    )
+    tools.append(
+        ToolSubst("%dexter_regression_test_cxx_build", dexter_regression_test_cxx_build)
+    )
     return dependencies
 
 


### PR DESCRIPTION
This patch attempts to fixup a set of tests in the cross-project-tests directory by replacing invocations of clang with clang++ for a set of c++ files.

As a small additional change, this patch removes -lstdc++ from a test that did not appear to require it.