### PR TITLE
[mlir] Support null interface to base conversion

### DIFF
--- a/mlir/tools/mlir-tblgen/OpInterfacesGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpInterfacesGen.cpp
@@ -571,6 +571,7 @@ void InterfaceGenerator::emitInterfaceDecl(const Interface &interface) {
 
     // Allow implicit conversion to the base interface.
     os << "  operator " << baseQualName << " () const {\n"
+       << "    if (!*this) return nullptr;\n"
        << "    return " << baseQualName << "(*this, getImpl()->impl"
        << base.getName() << ");\n"
        << "  }\n\n";

--- a/mlir/unittests/IR/InterfaceTest.cpp
+++ b/mlir/unittests/IR/InterfaceTest.cpp
@@ -70,3 +70,16 @@ TEST(InterfaceTest, TestCustomClassOf) {
   EXPECT_FALSE(isa<TestOptionallyImplementedOpInterface>(*op));
   op.erase();
 }
+
+TEST(InterfaceTest, TestImplicitConversion) {
+  MLIRContext context;
+  context.loadDialect<test::TestDialect>();
+
+  TestBaseTypeInterfacePrintTypeB typeB;
+  TestBaseTypeInterfacePrintTypeA typeA = typeB;
+  EXPECT_EQ(typeA, nullptr);
+
+  typeB = TestType::get(&context);
+  typeA = typeB;
+  EXPECT_EQ(typeA, typeB);
+}


### PR DESCRIPTION
The current implicit conversion operator from an interface to a "base interface" of the interface unconditionally calls `this->getImpl()` which leads to accessing a null pointer if the interface instance is a null instance.

This PR changes the ODS generated interface instance to explicitly check and then return a null interface instance if the `this` instance is a null instance.