### PR TITLE
Fix out of line Concept-comparisons of NestedNameSpecifiers

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -218,6 +218,9 @@ Bug Fixes in This Version
   (`#65156 <https://github.com/llvm/llvm-project/issues/65156>`_`)
 - Clang no longer considers the loss of ``__unaligned`` qualifier from objects as
   an invalid conversion during method function overload resolution.
+- Clang now properly handles out of line template specializations when there is
+  a non-template inner-class between the function and the class template
+  (`#65810 <https://github.com/llvm/llvm-project/issues/65810>`_).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -218,9 +218,6 @@ Bug Fixes in This Version
   (`#65156 <https://github.com/llvm/llvm-project/issues/65156>`_`)
 - Clang no longer considers the loss of ``__unaligned`` qualifier from objects as
   an invalid conversion during method function overload resolution.
-- Clang now properly handles out of line template specializations when there is
-  a non-template inner-class between the function and the class template
-  (`#65810 <https://github.com/llvm/llvm-project/issues/65810>`_).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,6 +274,10 @@ Bug Fixes to C++ Support
   lambda refers to an init-capture.
   (`#65067 <https://github.com/llvm/llvm-project/issues/65067>`_` and
   `#63675 <https://github.com/llvm/llvm-project/issues/63675>`_`)
+
+- Clang now properly handles out of line template specializations when there is
+  a non-template inner-class between the function and the class template.
+  (`#65810 <https://github.com/llvm/llvm-project/issues/65810>`_)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -230,6 +230,11 @@ Response HandleFunction(const FunctionDecl *Function,
 Response HandleFunctionTemplateDecl(const FunctionTemplateDecl *FTD,
                                     MultiLevelTemplateArgumentList &Result) {
   if (!isa<ClassTemplateSpecializationDecl>(FTD->getDeclContext())) {
+    Result.addOuterTemplateArguments(
+        const_cast<FunctionTemplateDecl *>(FTD),
+        const_cast<FunctionTemplateDecl *>(FTD)->getInjectedTemplateArgs(),
+        /*Final=*/false);
+
     NestedNameSpecifier *NNS = FTD->getTemplatedDecl()->getQualifier();
 
     while (const Type *Ty = NNS ? NNS->getAsType() : nullptr) {

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -238,11 +238,12 @@ Response HandleFunctionTemplateDecl(const FunctionTemplateDecl *FTD,
     NestedNameSpecifier *NNS = FTD->getTemplatedDecl()->getQualifier();
 
     while (const Type *Ty = NNS ? NNS->getAsType() : nullptr) {
-
-      if (const auto *TSTy = Ty->getAs<TemplateSpecializationType>())
-        Result.addOuterTemplateArguments(
-            const_cast<FunctionTemplateDecl *>(FTD), TSTy->template_arguments(),
-            /*Final=*/false);
+      if (NNS->isInstantiationDependent()) {
+        if (const auto *TSTy = Ty->getAs<TemplateSpecializationType>())
+          Result.addOuterTemplateArguments(
+              const_cast<FunctionTemplateDecl *>(FTD), TSTy->template_arguments(),
+              /*Final=*/false);
+      }
 
       NNS = NNS->getPrefix();
     }

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -231,14 +231,18 @@ Response HandleFunctionTemplateDecl(const FunctionTemplateDecl *FTD,
                                     MultiLevelTemplateArgumentList &Result) {
   if (!isa<ClassTemplateSpecializationDecl>(FTD->getDeclContext())) {
     NestedNameSpecifier *NNS = FTD->getTemplatedDecl()->getQualifier();
-    const Type *Ty;
-    const TemplateSpecializationType *TSTy;
-    if (NNS && (Ty = NNS->getAsType()) &&
-        (TSTy = Ty->getAs<TemplateSpecializationType>()))
-      Result.addOuterTemplateArguments(const_cast<FunctionTemplateDecl *>(FTD),
-                                       TSTy->template_arguments(),
-                                       /*Final=*/false);
+
+    while (const Type *Ty = NNS ? NNS->getAsType() : nullptr) {
+
+      if (const auto *TSTy = Ty->getAs<TemplateSpecializationType>())
+        Result.addOuterTemplateArguments(
+            const_cast<FunctionTemplateDecl *>(FTD), TSTy->template_arguments(),
+            /*Final=*/false);
+
+      NNS = NNS->getPrefix();
+    }
   }
+
   return Response::ChangeDecl(FTD->getLexicalDeclContext());
 }
 

--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -418,3 +418,51 @@ template<typename T> concept A = true;
 template<typename T> struct X { A<T> auto f(); };
 template<typename T> A<T> auto X<T>::f() {}
 }
+
+namespace GH65810 {
+template<typename Param>
+concept TrivialConcept =
+requires(Param param) {
+  (void)param;
+};
+
+template <typename T>
+struct Base {
+  class InnerClass;
+};
+
+template <typename T>
+class Base<T>::InnerClass {
+  template <typename Param>
+    requires TrivialConcept<Param>
+    int func(Param param) const;
+};
+
+template <typename T>
+template <typename Param>
+requires TrivialConcept<Param>
+int Base<T>::InnerClass::func(Param param) const {
+  return 0;
+}
+
+template<typename T>
+struct Outermost {
+  struct Middle {
+    template<typename U>
+    struct Innermost {
+      template <typename Param>
+        requires TrivialConcept<Param>
+        int func(Param param) const;
+    };
+  };
+};
+
+template <typename T>
+template <typename U>
+template <typename Param>
+requires TrivialConcept<Param>
+int Outermost<T>::Middle::Innermost<U>::func(Param param) const {
+  return 0;
+}
+
+} // namespace GH65810


### PR DESCRIPTION
As reported in GH65810, we don't properly collect ALL of the template parameters in a nested name specifier, and were only doing the 'inner level'.

This patch makes sure we collect from all levels.

Fixes: #65810