### PR TITLE
[libc][libm][GPU ]Added `__builtin_logb` and `__builtin_logbf` to the GPU version of `libm`

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -157,6 +157,8 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.llrintf
     libc.src.math.llround
     libc.src.math.llroundf
+    libc.src.math.logb
+    libc.src.math.logbf
     libc.src.math.pow
     libc.src.math.powf
     libc.src.math.sin

--- a/libc/src/math/gpu/CMakeLists.txt
+++ b/libc/src/math/gpu/CMakeLists.txt
@@ -184,6 +184,26 @@ add_math_entrypoint_gpu_object(
 )
 
 add_math_entrypoint_gpu_object(
+  logb
+  SRCS
+    logb.cpp
+  HDRS
+    ../logb.h
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_math_entrypoint_gpu_object(
+  logbf
+  SRCS
+    logbf.cpp
+  HDRS
+    ../logbf.h
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_math_entrypoint_gpu_object(
   modf
   SRCS
     modf.cpp

--- a/libc/src/math/gpu/logb.cpp
+++ b/libc/src/math/gpu/logb.cpp
@@ -1,0 +1,16 @@
+//===-- Implementation of the GPU logb function ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/logb.h"
+#include "src/__support/common.h"
+
+namespace __llvm_libc {
+
+LLVM_LIBC_FUNCTION(double, logb, (double x)) { return __builtin_logb(x); }
+
+} // namespace __llvm_libc

--- a/libc/src/math/gpu/logbf.cpp
+++ b/libc/src/math/gpu/logbf.cpp
@@ -1,0 +1,17 @@
+//===-- Implementation of the GPU logbf function
+//---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/logbf.h"
+#include "src/__support/common.h"
+
+namespace __llvm_libc {
+
+LLVM_LIBC_FUNCTION(float, logbf, (float x)) { return __builtin_logbf(x); }
+
+} // namespace __llvm_libc


### PR DESCRIPTION
I found that the builtins for `logb` and `logbf` are correctly lowered on both AMD and NVIDIA GPUs, and therefore I think we should include them in the GPU version of `libm`.