### PR TITLE
[lldb][NFCI] BreakpointResolverName ctor shouldn't unnecessarily copy data

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
@@ -38,7 +38,7 @@ public:
 
   // This one takes a C++ array of names.  It is always MatchType = Exact.
   BreakpointResolverName(const lldb::BreakpointSP &bkpt,
-                         std::vector<std::string> names,
+                         const std::vector<std::string> &names,
                          lldb::FunctionNameType name_type_mask,
                          lldb::LanguageType language, lldb::addr_t offset,
                          bool skip_prologue);

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -56,12 +56,10 @@ BreakpointResolverName::BreakpointResolverName(
   }
 }
 
-BreakpointResolverName::BreakpointResolverName(const BreakpointSP &bkpt,
-                                               std::vector<std::string> names,
-                                               FunctionNameType name_type_mask,
-                                               LanguageType language,
-                                               lldb::addr_t offset,
-                                               bool skip_prologue)
+BreakpointResolverName::BreakpointResolverName(
+    const BreakpointSP &bkpt, const std::vector<std::string> &names,
+    FunctionNameType name_type_mask, LanguageType language, lldb::addr_t offset,
+    bool skip_prologue)
     : BreakpointResolver(bkpt, BreakpointResolver::NameResolver, offset),
       m_match_type(Breakpoint::Exact), m_language(language),
       m_skip_prologue(skip_prologue) {


### PR DESCRIPTION
Instead of creating a copy of the vector, we should just pass a reference along. The only method that calls this Ctor also holds onto a non-mutable reference to the vector of strings so a copy should be unnecessary.