### PR TITLE
[MLIR][Linalg] Bail out if the tiles provided are more than the number

### DIFF
--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -2534,6 +2534,12 @@ transform::TileOp::apply(transform::TransformRewriter &rewriter,
       diag.attachNote(op->getLoc()) << "target op";
       return diag;
     }
+    if (tileSizes.size() > tilingInterface.getLoopIteratorTypes().size()) {
+      DiagnosedSilenceableFailure diag = emitSilenceableError()
+                                         << "too many tiles for";
+      diag.attachNote(op->getLoc()) << "target op";
+      return diag;
+    }
 
     scf::SCFTilingOptions tilingOptions;
     if (!tileSizes.empty()) {

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -2535,8 +2535,11 @@ transform::TileOp::apply(transform::TransformRewriter &rewriter,
       return diag;
     }
     if (tileSizes.size() > tilingInterface.getLoopIteratorTypes().size()) {
-      DiagnosedSilenceableFailure diag = emitSilenceableError()
-                                         << "too many tiles for";
+      DiagnosedSilenceableFailure diag =
+          emitSilenceableError()
+          << "too many tiles provided, expected at most "
+          << tilingInterface.getLoopIteratorTypes().size() << " found "
+          << tileSizes.size();
       diag.attachNote(op->getLoc()) << "target op";
       return diag;
     }

--- a/mlir/test/Dialect/Linalg/transform-op-tile.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-tile.mlir
@@ -220,3 +220,20 @@ transform.sequence failures(propagate) {
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
   %1, %loops:3 = transform.structured.tile %0 [4, 4, [4]] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
 }
+
+// -----
+
+func.func @matmul(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>,
+                    %arg2: tensor<128x128xf32>) ->  tensor<128x128xf32> {
+  // expected-note @below {{target op}}
+  %0 = linalg.matmul ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2: tensor<128x128xf32>) -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+transform.sequence failures(propagate) {
+^bb0(%arg1: !transform.any_op):
+  %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+  // expected-error @below {{too many tiles for}}
+  %1, %loops = transform.structured.tile %0 [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+}

--- a/mlir/test/Dialect/Linalg/transform-op-tile.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-tile.mlir
@@ -223,8 +223,8 @@ transform.sequence failures(propagate) {
 
 // -----
 
-func.func @matmul(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>,
-                    %arg2: tensor<128x128xf32>) ->  tensor<128x128xf32> {
+func.func @too_many_tiles(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>,
+                          %arg2: tensor<128x128xf32>) ->  tensor<128x128xf32> {
   // expected-note @below {{target op}}
   %0 = linalg.matmul ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>) -> tensor<128x128xf32>
@@ -234,6 +234,6 @@ func.func @matmul(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>,
 transform.sequence failures(propagate) {
 ^bb0(%arg1: !transform.any_op):
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-  // expected-error @below {{too many tiles for}}
+  // expected-error @below {{too many tiles provided, expected at most 3 found 4}}
   %1, %loops = transform.structured.tile %0 [1, 0, 0, 0] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 }


### PR DESCRIPTION
Currently, the compiler crashes if the number of tiles provided exceeds the number of loops.