### PR TITLE
[flang] Call finalization on empty type

### DIFF
--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -88,7 +88,7 @@ static bool hasDefaultInitialization(const Fortran::semantics::Symbol &sym) {
 
 // Does this variable have a finalization?
 static bool hasFinalization(const Fortran::semantics::Symbol &sym) {
-  if (sym.has<Fortran::semantics::ObjectEntityDetails>() && sym.size())
+  if (sym.has<Fortran::semantics::ObjectEntityDetails>())
     if (const Fortran::semantics::DeclTypeSpec *declTypeSpec = sym.GetType())
       if (const Fortran::semantics::DerivedTypeSpec *derivedTypeSpec =
               declTypeSpec->AsDerived())

--- a/flang/test/Lower/derived-type-finalization.f90
+++ b/flang/test/Lower/derived-type-finalization.f90
@@ -23,6 +23,11 @@ module derived_type_finalization
     type(t2) :: t
   end type
 
+  type t4
+  contains
+    final :: t4_final
+  end type
+
 contains
 
   subroutine t1_final(this)
@@ -226,6 +231,17 @@ contains
 ! CHECK-NOT: fir.freemem %{{.*}} : !fir.heap<!fir.array<?x!fir.type<_QMderived_type_finalizationTt1{a:i32}>>>
 ! CHECK: %[[RES_CONV:.*]] = fir.convert %[[RES]] : (!fir.ref<!fir.class<!fir.heap<!fir.array<?x!fir.type<_QMderived_type_finalizationTt1{a:i32}>>>>>) -> !fir.box<none>
 ! CHECK: %{{.*}} = fir.call @_FortranADestroy(%[[RES_CONV]]) {{.*}} : (!fir.box<none>) -> none
+
+  subroutine t4_final(this)
+    type(t4) :: this
+  end subroutine
+
+  subroutine local_t4()
+    type(t4) :: t
+  end subroutine
+
+! CHECK-LABEL: func.func @_QMderived_type_finalizationPlocal_t4()
+! CHECK: %{{.*}} = fir.call @_FortranADestroy(%2) fastmath<contract> : (!fir.box<none>) -> none
 
 end module
 


### PR DESCRIPTION
According to 7.5.6.3 point 3, finalization occurs when

> A nonpointer, nonallocatable object that is not a dummy argument or function result is finalized immediately before it would become undefined due to execution of a RETURN or END statement (19.6.6, item (3)).

We were not calling the finalization on empty derived-type. There is no such restriction so this patch updates the code so the finalization is called for empty type as well. 