### PR TITLE
[AArch64] Relax binary format switch in AArch64MCInstLower::LowerSymbolOperand to allow non-Darwin Mach-O files

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MCInstLower.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MCInstLower.cpp
@@ -100,8 +100,8 @@ AArch64MCInstLower::GetExternalSymbolSymbol(const MachineOperand &MO) const {
   return Printer.GetExternalSymbolSymbol(MO.getSymbolName());
 }
 
-MCOperand AArch64MCInstLower::lowerSymbolOperandDarwin(const MachineOperand &MO,
-                                                       MCSymbol *Sym) const {
+MCOperand AArch64MCInstLower::lowerSymbolOperandMachO(const MachineOperand &MO,
+                                                      MCSymbol *Sym) const {
   // FIXME: We would like an efficient form for this, so we don't have to do a
   // lot of extra uniquing.
   MCSymbolRefExpr::VariantKind RefKind = MCSymbolRefExpr::VK_None;
@@ -270,8 +270,8 @@ MCOperand AArch64MCInstLower::lowerSymbolOperandCOFF(const MachineOperand &MO,
 
 MCOperand AArch64MCInstLower::LowerSymbolOperand(const MachineOperand &MO,
                                                  MCSymbol *Sym) const {
-  if (Printer.TM.getTargetTriple().isOSDarwin())
-    return lowerSymbolOperandDarwin(MO, Sym);
+  if (Printer.TM.getTargetTriple().isOSBinFormatMachO())
+    return lowerSymbolOperandMachO(MO, Sym);
   if (Printer.TM.getTargetTriple().isOSBinFormatCOFF())
     return lowerSymbolOperandCOFF(MO, Sym);
 

--- a/llvm/lib/Target/AArch64/AArch64MCInstLower.h
+++ b/llvm/lib/Target/AArch64/AArch64MCInstLower.h
@@ -34,8 +34,8 @@ public:
   bool lowerOperand(const MachineOperand &MO, MCOperand &MCOp) const;
   void Lower(const MachineInstr *MI, MCInst &OutMI) const;
 
-  MCOperand lowerSymbolOperandDarwin(const MachineOperand &MO,
-                                     MCSymbol *Sym) const;
+  MCOperand lowerSymbolOperandMachO(const MachineOperand &MO,
+                                    MCSymbol *Sym) const;
   MCOperand lowerSymbolOperandELF(const MachineOperand &MO,
                                   MCSymbol *Sym) const;
   MCOperand lowerSymbolOperandCOFF(const MachineOperand &MO,

--- a/llvm/test/CodeGen/AArch64/macho-none.ll
+++ b/llvm/test/CodeGen/AArch64/macho-none.ll
@@ -1,0 +1,16 @@
+; RUN: llc -mtriple=arm64-apple-none-elf %s -o - | FileCheck %s --check-prefix CHECK-ELF
+; RUN: llc -mtriple=arm64-apple-none-macho %s -o - | FileCheck %s --check-prefix CHECK-MACHO
+
+@var = global i8 0
+
+define i8 @foo() {
+  %x = load i8, ptr @var
+
+  ; CHECK-ELF: adrp x{{[0-9]+}}, :got:var
+  ; CHECK-ELF: ldr x{{[0-9]+}}, [x{{[0-9]+}}, :got_lo12:var]
+
+  ; CHECK-MACHO: adrp x{{[0-9]+}}, _var@PAGE
+  ; CHECK-MACHO: ldrb w{{[0-9]+}}, [x{{[0-9]+}}, _var@PAGEOFF]
+
+  ret i8 %x
+}


### PR DESCRIPTION
Trying to use a arm64-apple-none-macho target triple today crashes with an assertion, this patch fixes that.