### PR TITLE
github-automation: Use a single comment for team mentions on pull requests

### DIFF
--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -9,6 +9,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Ideally, we would use the PR number in the concurrency group, but we don't
+  # have access to it here.  We need to ensure only one job is running for
+  # each PR at a time, because there is a potential race condition when
+  # updating the issue comment.
+  group: "PR Subscriber"
+  cancel-in-progress: false
+
 jobs:
   auto-subscribe:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will reduce the number of notifications created when a pull request label is added.  Each team will only get a notification when their team's label is added and not when other teams' labels are added.