### PR TITLE
[LIT] Print discovered tests and percentages

### DIFF
--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -310,6 +310,7 @@ def print_histogram(tests):
 
 def print_results(tests, elapsed, opts):
     tests_by_code = {code: [] for code in lit.Test.ResultCode.all_codes()}
+    total_tests = len(tests)
     for test in tests:
         tests_by_code[test.result.code].append(test)
 
@@ -320,7 +321,7 @@ def print_results(tests, elapsed, opts):
             opts.shown_codes,
         )
 
-    print_summary(tests_by_code, opts.quiet, elapsed)
+    print_summary(total_tests, tests_by_code, opts.quiet, elapsed)
 
 
 def print_group(tests, code, shown_codes):
@@ -335,10 +336,11 @@ def print_group(tests, code, shown_codes):
     sys.stdout.write("\n")
 
 
-def print_summary(tests_by_code, quiet, elapsed):
+def print_summary(total_tests, tests_by_code, quiet, elapsed):
     if not quiet:
         print("\nTesting Time: %.2fs" % elapsed)
 
+    print("\nTotal Discovered Tests: %s" % (total_tests))
     codes = [c for c in lit.Test.ResultCode.all_codes() if not quiet or c.isFailure]
     groups = [(c.label, len(tests_by_code[c])) for c in codes]
     groups = [(label, count) for label, count in groups if count]
@@ -351,4 +353,4 @@ def print_summary(tests_by_code, quiet, elapsed):
     for (label, count) in groups:
         label = label.ljust(max_label_len)
         count = str(count).rjust(max_count_len)
-        print("  %s: %s" % (label, count))
+        print("  %s: %s (%.2f%%)" % (label, count, float(count) / total_tests * 100))

--- a/llvm/utils/lit/tests/discovery.py
+++ b/llvm/utils/lit/tests/discovery.py
@@ -28,6 +28,13 @@
 # CHECK-BASIC-OUT: top-level-suite :: test-one
 # CHECK-BASIC-OUT: top-level-suite :: test-two
 
+# RUN: %{lit} %{inputs}/discovery \
+# RUN:   -v > %t.out 2> %t.err
+# RUN: FileCheck --check-prefix=CHECK-PERCENTAGES-OUT < %/t.out %s
+#
+# CHECK-PERCENTAGES-OUT:  Total Discovered Tests: {{[0-9]*}}
+# CHECK-PERCENTAGES-OUT:  Passed: {{[0-9]*}} {{\([0-9]*\.[0-9]*%\)}}
+
 # Check discovery when providing the special builtin 'config_map'
 # RUN: %{python} %{inputs}/config-map-discovery/driver.py \
 # RUN:           %{inputs}/config-map-discovery/main-config/lit.cfg \


### PR DESCRIPTION
This patch adds "nice-to-have" feature in lit.
it prints the total number of discovered tests at the beginning. It is covenient to see the total number of tests and avoid scrolling up to the beginning of log.

Further, this patch also prints %ge of tests.

Differential Revision: https://reviews.llvm.org/D159081