### PR TITLE
[LiveRegUnits] Enhanced the register liveness check

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveRegUnits.h
+++ b/llvm/include/llvm/CodeGen/LiveRegUnits.h
@@ -112,13 +112,13 @@ public:
   /// The regmask has the same format as the one in the RegMask machine operand.
   void addRegsInMask(const uint32_t *RegMask);
 
-  /// Returns true if no part of physical register \p Reg is live.
-  bool available(MCPhysReg Reg) const {
-    for (MCRegUnit Unit : TRI->regunits(Reg)) {
-      if (Units.test(Unit))
-        return false;
-    }
-    return true;
+  /// Returns true if no part of physical register \p Reg is live or reserved.
+  bool available(const MachineRegisterInfo &MRI, MCPhysReg Reg) const;
+
+  /// Returns true if any part of physical register \p Reg is live
+  bool contains(MCPhysReg Reg) const {
+    return llvm::any_of(TRI->regunits(Reg),
+                        [&](MCRegUnit Unit) { return Units.test(Unit); });
   }
 
   /// Updates liveness when stepping backwards over the instruction \p MI.

--- a/llvm/include/llvm/CodeGen/MachineOutliner.h
+++ b/llvm/include/llvm/CodeGen/MachineOutliner.h
@@ -156,7 +156,7 @@ public:
                                     const TargetRegisterInfo &TRI) {
     if (!FromEndOfBlockToStartOfSeqWasSet)
       initFromEndOfBlockToStartOfSeq(TRI);
-    return FromEndOfBlockToStartOfSeq.available(Reg);
+    return !FromEndOfBlockToStartOfSeq.contains(Reg);
   }
 
   /// \returns True if `isAvailableAcrossAndOutOfSeq` fails for any register
@@ -166,7 +166,7 @@ public:
     if (!FromEndOfBlockToStartOfSeqWasSet)
       initFromEndOfBlockToStartOfSeq(TRI);
     return any_of(Regs, [&](Register Reg) {
-      return !FromEndOfBlockToStartOfSeq.available(Reg);
+      return FromEndOfBlockToStartOfSeq.contains(Reg);
     });
   }
 
@@ -181,7 +181,7 @@ public:
   bool isAvailableInsideSeq(Register Reg, const TargetRegisterInfo &TRI) {
     if (!InSeqWasSet)
       initInSeq(TRI);
-    return InSeq.available(Reg);
+    return !InSeq.contains(Reg);
   }
 
   /// The number of instructions that would be saved by outlining every

--- a/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
+++ b/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
@@ -79,7 +79,7 @@ bool DeadMachineInstructionElim::isDead(const MachineInstr *MI) const {
     Register Reg = MO.getReg();
     if (Reg.isPhysical()) {
       // Don't delete live physreg defs, or any reserved register defs.
-      if (!LivePhysRegs.available(Reg) || MRI->isReserved(Reg))
+      if (!LivePhysRegs.available(*MRI, Reg))
         return false;
     } else {
       if (MO.isDead()) {

--- a/llvm/lib/CodeGen/LiveRegUnits.cpp
+++ b/llvm/lib/CodeGen/LiveRegUnits.cpp
@@ -41,6 +41,11 @@ void LiveRegUnits::addRegsInMask(const uint32_t *RegMask) {
   }
 }
 
+bool LiveRegUnits::available(const MachineRegisterInfo &MRI,
+                             MCPhysReg Reg) const {
+  return !MRI.isReserved(Reg) && !contains(Reg);
+}
+
 void LiveRegUnits::stepBackward(const MachineInstr &MI) {
   // Remove defined registers and regmask kills from the set.
   for (const MachineOperand &MOP : MI.operands()) {

--- a/llvm/lib/CodeGen/MachineSink.cpp
+++ b/llvm/lib/CodeGen/MachineSink.cpp
@@ -1627,7 +1627,7 @@ static bool aliasWithRegsInLiveIn(MachineBasicBlock &MBB, unsigned Reg,
                                   const TargetRegisterInfo *TRI) {
   LiveRegUnits LiveInRegUnits(*TRI);
   LiveInRegUnits.addLiveIns(MBB);
-  return !LiveInRegUnits.available(Reg);
+  return LiveInRegUnits.contains(Reg);
 }
 
 static MachineBasicBlock *
@@ -1680,7 +1680,7 @@ static void clearKillFlags(MachineInstr *MI, MachineBasicBlock &CurBB,
   for (auto U : UsedOpsInCopy) {
     MachineOperand &MO = MI->getOperand(U);
     Register SrcReg = MO.getReg();
-    if (!UsedRegUnits.available(SrcReg)) {
+    if (UsedRegUnits.contains(SrcReg)) {
       MachineBasicBlock::iterator NI = std::next(MI->getIterator());
       for (MachineInstr &UI : make_range(NI, CurBB.end())) {
         if (UI.killsRegister(SrcReg, TRI)) {
@@ -1725,7 +1725,7 @@ static bool hasRegisterDependency(MachineInstr *MI,
     if (!Reg)
       continue;
     if (MO.isDef()) {
-      if (!ModifiedRegUnits.available(Reg) || !UsedRegUnits.available(Reg)) {
+      if (ModifiedRegUnits.contains(Reg) || UsedRegUnits.contains(Reg)) {
         HasRegDependency = true;
         break;
       }
@@ -1736,7 +1736,7 @@ static bool hasRegisterDependency(MachineInstr *MI,
       // it's not perfectly clear if skipping the internal read is safe in all
       // other targets.
     } else if (MO.isUse()) {
-      if (!ModifiedRegUnits.available(Reg)) {
+      if (ModifiedRegUnits.contains(Reg)) {
         HasRegDependency = true;
         break;
       }

--- a/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
+++ b/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
@@ -518,7 +518,7 @@ int AArch64A57FPLoadBalancing::scavengeRegister(Chain *G, Color C,
   unsigned RegClassID = ChainBegin->getDesc().operands()[0].RegClass;
   auto Ord = RCI.getOrder(TRI->getRegClass(RegClassID));
   for (auto Reg : Ord) {
-    if (!Units.available(Reg))
+    if (Units.contains(Reg))
       continue;
     if (C == getColor(Reg))
       return Reg;

--- a/llvm/lib/Target/AArch64/AArch64FalkorHWPFFix.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FalkorHWPFFix.cpp
@@ -748,7 +748,7 @@ void FalkorHWPFFix::runOnLoop(MachineLoop &L, MachineFunction &Fn) {
       }
 
       for (unsigned ScratchReg : AArch64::GPR64RegClass) {
-        if (!LR.available(ScratchReg) || MRI.isReserved(ScratchReg))
+        if (!LR.available(MRI, ScratchReg))
           continue;
 
         LoadInfo NewLdI(LdI);

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -7838,8 +7838,8 @@ AArch64InstrInfo::getOutlinableRanges(MachineBasicBlock &MBB,
   // where these registers are dead. We will only outline from those ranges.
   LiveRegUnits LRU(getRegisterInfo());
   auto AreAllUnsafeRegsDead = [&LRU]() {
-    return LRU.available(AArch64::W16) && LRU.available(AArch64::W17) &&
-           LRU.available(AArch64::NZCV);
+    return !LRU.contains(AArch64::W16) && !LRU.contains(AArch64::W17) &&
+           !LRU.contains(AArch64::NZCV);
   };
 
   // We need to know if LR is live across an outlining boundary later on in
@@ -7909,7 +7909,7 @@ AArch64InstrInfo::getOutlinableRanges(MachineBasicBlock &MBB,
       CreateNewRangeStartingAt(MI.getIterator());
       continue;
     }
-    LRAvailableEverywhere &= LRU.available(AArch64::LR);
+    LRAvailableEverywhere &= !LRU.contains(AArch64::LR);
     RangeBegin = MI.getIterator();
     ++RangeLen;
   }

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostSelectOptimize.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostSelectOptimize.cpp
@@ -198,7 +198,7 @@ bool AArch64PostSelectOptimize::optimizeNZCVDefs(MachineBasicBlock &MBB) {
   LRU.addLiveOuts(MBB);
 
   for (auto &II : instructionsWithoutDebug(MBB.rbegin(), MBB.rend())) {
-    bool NZCVDead = LRU.available(AArch64::NZCV);
+    bool NZCVDead = !LRU.contains(AArch64::NZCV);
     if (NZCVDead && II.definesRegister(AArch64::NZCV)) {
       // The instruction defines NZCV, but NZCV is dead.
       unsigned NewOpc = getNonFlagSettingVariant(II.getOpcode());

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6259,8 +6259,8 @@ bool ARMBaseInstrInfo::isMBBSafeToOutlineFrom(MachineBasicBlock &MBB,
     LRU.accumulate(MI);
 
   // Check if each of the unsafe registers are available...
-  bool R12AvailableInBlock = LRU.available(ARM::R12);
-  bool CPSRAvailableInBlock = LRU.available(ARM::CPSR);
+  bool R12AvailableInBlock = !LRU.contains(ARM::R12);
+  bool CPSRAvailableInBlock = !LRU.contains(ARM::CPSR);
 
   // If all of these are dead (and not live out), we know we don't have to check
   // them later.
@@ -6272,9 +6272,9 @@ bool ARMBaseInstrInfo::isMBBSafeToOutlineFrom(MachineBasicBlock &MBB,
 
   // If any of these registers is available in the MBB, but also a live out of
   // the block, then we know outlining is unsafe.
-  if (R12AvailableInBlock && !LRU.available(ARM::R12))
+  if (R12AvailableInBlock && LRU.contains(ARM::R12))
     return false;
-  if (CPSRAvailableInBlock && !LRU.available(ARM::CPSR))
+  if (CPSRAvailableInBlock && LRU.contains(ARM::CPSR))
     return false;
 
   // Check if there's a call inside this MachineBasicBlock.  If there is, then
@@ -6287,7 +6287,7 @@ bool ARMBaseInstrInfo::isMBBSafeToOutlineFrom(MachineBasicBlock &MBB,
   bool LRIsAvailable =
       MBB.isReturnBlock() && !MBB.back().isCall()
           ? isLRAvailable(getRegisterInfo(), MBB.rbegin(), MBB.rend())
-          : LRU.available(ARM::LR);
+          : !LRU.contains(ARM::LR);
   if (!LRIsAvailable)
     Flags |= MachineOutlinerMBBFlags::LRUnavailableSomewhere;
 

--- a/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
@@ -316,7 +316,7 @@ bool HexagonRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
 
         Register R = BI.getOperand(0).getReg();
         if (R.isPhysical()) {
-          if (Defs.available(R))
+          if (!Defs.contains(R))
             ReuseBP = R;
         } else if (R.isVirtual()) {
           // Extending a range of a virtual register can be dangerous,

--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -150,9 +150,9 @@ RISCVMoveMerge::findMatchingInst(MachineBasicBlock::iterator &MBBI,
         //  If paired destination register was modified or used, the source reg
         //  was modified, there is no possibility of finding matching
         //  instruction so exit early.
-        if (!ModifiedRegUnits.available(DestReg) ||
-            !UsedRegUnits.available(DestReg) ||
-            !ModifiedRegUnits.available(SourceReg))
+        if (ModifiedRegUnits.contains(DestReg) ||
+            UsedRegUnits.contains(DestReg) ||
+            ModifiedRegUnits.contains(SourceReg))
           return E;
 
         return I;
@@ -162,9 +162,9 @@ RISCVMoveMerge::findMatchingInst(MachineBasicBlock::iterator &MBBI,
             (RegPair.Destination->getReg() == DestReg))
           return E;
 
-        if (!ModifiedRegUnits.available(DestReg) ||
-            !UsedRegUnits.available(DestReg) ||
-            !ModifiedRegUnits.available(SourceReg))
+        if (ModifiedRegUnits.contains(DestReg) ||
+            UsedRegUnits.contains(DestReg) ||
+            ModifiedRegUnits.contains(SourceReg))
           return E;
 
         return I;

--- a/llvm/lib/Target/RISCV/RISCVPushPopOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVPushPopOptimizer.cpp
@@ -100,8 +100,8 @@ bool RISCVPushPopOpt::adjustRetVal(MachineBasicBlock::iterator &MBBI) {
     LiveRegUnits::accumulateUsedDefed(MI, ModifiedRegUnits, UsedRegUnits, TRI);
     // If a0 was modified or used, there is no possibility
     // of using ret_val slot of POP instruction.
-    if (!ModifiedRegUnits.available(RISCV::X10) ||
-        !UsedRegUnits.available(RISCV::X10))
+    if (ModifiedRegUnits.contains(RISCV::X10) ||
+        UsedRegUnits.contains(RISCV::X10))
       return false;
   }
   return false;


### PR DESCRIPTION
Currently there's only a provision to check whether a register is contained in the LiveRegUnits BitVector. Introducing the method which is available in LivePhysRegs to check whether the register is not reserved as well. The naming convention has been retained like in LivePhysRegs.

The motivation for this PR is [[AMDGPU] [SIFrameLowering] Use LiveRegUnits instead of LivePhysRegs](https://github.com/llvm/llvm-project/pull/65962)