### PR TITLE
[RISCV] Match prefetch address with offset

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -2469,23 +2469,6 @@ bool RISCVDAGToDAGISel::SelectAddrRegImmLsb00000(SDValue Addr, SDValue &Base,
     int64_t CVal = cast<ConstantSDNode>(Addr.getOperand(1))->getSExtValue();
     if (isInt<12>(CVal)) {
       Base = Addr.getOperand(0);
-      if (Base.getOpcode() == RISCVISD::ADD_LO) {
-        SDValue LoOperand = Base.getOperand(1);
-        if (auto *GA = dyn_cast<GlobalAddressSDNode>(LoOperand)) {
-          const DataLayout &DL = CurDAG->getDataLayout();
-          Align Alignment = commonAlignment(
-              GA->getGlobal()->getPointerAlignment(DL), GA->getOffset());
-          int64_t CombinedOffset = CVal + GA->getOffset();
-          if (((CombinedOffset & 0b11111) == 0) &&
-              (CVal == 0 || Alignment > CVal)) {
-            Base = Base.getOperand(0);
-            Offset = CurDAG->getTargetGlobalAddress(
-                GA->getGlobal(), SDLoc(LoOperand), LoOperand.getValueType(),
-                CombinedOffset, GA->getTargetFlags());
-            return true;
-          }
-        }
-      }
 
       // Early-out if not a valid offset.
       if ((CVal & 0b11111) != 0) {

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -2229,7 +2229,8 @@ bool RISCVDAGToDAGISel::SelectFrameAddrRegImm(SDValue Addr, SDValue &Base,
 // Fold constant addresses.
 static bool selectConstantAddr(SelectionDAG *CurDAG, const SDLoc &DL,
                                const MVT VT, const RISCVSubtarget *Subtarget,
-                               SDValue Addr, SDValue &Base, SDValue &Offset) {
+                               SDValue Addr, SDValue &Base, SDValue &Offset,
+                               bool IsPrefetch = false) {
   if (!isa<ConstantSDNode>(Addr))
     return false;
 
@@ -2241,6 +2242,9 @@ static bool selectConstantAddr(SelectionDAG *CurDAG, const SDLoc &DL,
   int64_t Lo12 = SignExtend64<12>(CVal);
   int64_t Hi = (uint64_t)CVal - (uint64_t)Lo12;
   if (!Subtarget->is64Bit() || isInt<32>(Hi)) {
+    if (IsPrefetch && (Lo12 & 0b11111) != 0)
+      return false;
+
     if (Hi) {
       int64_t Hi20 = (Hi >> 12) & 0xfffff;
       Base = SDValue(
@@ -2263,6 +2267,8 @@ static bool selectConstantAddr(SelectionDAG *CurDAG, const SDLoc &DL,
   if (Seq.back().getOpcode() != RISCV::ADDI)
     return false;
   Lo12 = Seq.back().getImm();
+  if (IsPrefetch && (Lo12 & 0b11111) != 0)
+    return false;
 
   // Drop the last instruction.
   Seq.pop_back();
@@ -2436,6 +2442,95 @@ bool RISCVDAGToDAGISel::SelectAddrRegImm(SDValue Addr, SDValue &Base,
   }
 
   if (selectConstantAddr(CurDAG, DL, VT, Subtarget, Addr, Base, Offset))
+    return true;
+
+  Base = Addr;
+  Offset = CurDAG->getTargetConstant(0, DL, VT);
+  return true;
+}
+
+/// Similar to SelectAddrRegImm, except that the least significant 5 bits of
+/// Offset shoule be all zeros.
+bool RISCVDAGToDAGISel::SelectAddrRegImmLsb00000(SDValue Addr, SDValue &Base,
+                                                 SDValue &Offset) {
+  if (SelectAddrFrameIndex(Addr, Base, Offset))
+    return true;
+
+  SDLoc DL(Addr);
+  MVT VT = Addr.getSimpleValueType();
+
+  if (Addr.getOpcode() == RISCVISD::ADD_LO) {
+    Base = Addr;
+    Offset = CurDAG->getTargetConstant(0, DL, VT);
+    return true;
+  }
+
+  if (CurDAG->isBaseWithConstantOffset(Addr)) {
+    int64_t CVal = cast<ConstantSDNode>(Addr.getOperand(1))->getSExtValue();
+    if (isInt<12>(CVal)) {
+      Base = Addr.getOperand(0);
+      if (Base.getOpcode() == RISCVISD::ADD_LO) {
+        SDValue LoOperand = Base.getOperand(1);
+        if (auto *GA = dyn_cast<GlobalAddressSDNode>(LoOperand)) {
+          const DataLayout &DL = CurDAG->getDataLayout();
+          Align Alignment = commonAlignment(
+              GA->getGlobal()->getPointerAlignment(DL), GA->getOffset());
+          int64_t CombinedOffset = CVal + GA->getOffset();
+          if (((CombinedOffset & 0b11111) == 0) &&
+              (CVal == 0 || Alignment > CVal)) {
+            Base = Base.getOperand(0);
+            Offset = CurDAG->getTargetGlobalAddress(
+                GA->getGlobal(), SDLoc(LoOperand), LoOperand.getValueType(),
+                CombinedOffset, GA->getTargetFlags());
+            return true;
+          }
+        }
+      }
+
+      // Early-out if not a valid offset.
+      if ((CVal & 0b11111) != 0) {
+        Base = Addr;
+        Offset = CurDAG->getTargetConstant(0, DL, VT);
+        return true;
+      }
+
+      if (auto *FIN = dyn_cast<FrameIndexSDNode>(Base))
+        Base = CurDAG->getTargetFrameIndex(FIN->getIndex(), VT);
+      Offset = CurDAG->getTargetConstant(CVal, DL, VT);
+      return true;
+    }
+  }
+
+  // Handle ADD with large immediates.
+  if (Addr.getOpcode() == ISD::ADD && isa<ConstantSDNode>(Addr.getOperand(1))) {
+    int64_t CVal = cast<ConstantSDNode>(Addr.getOperand(1))->getSExtValue();
+    assert(!(isInt<12>(CVal) && isInt<12>(CVal)) &&
+           "simm12 not already handled?");
+
+    // Handle immediates in the range [-4096,-2049] or [2017, 4065]. We can save
+    // one instruction by folding adjustment (-2048 or 2016) into the address.
+    if ((-2049 >= CVal && CVal >= -4096) || (4065 >= CVal && CVal >= 2017)) {
+      int64_t Adj = CVal < 0 ? -2048 : 2016;
+      int64_t AdjustedOffset = CVal - Adj;
+      Base = SDValue(CurDAG->getMachineNode(
+                         RISCV::ADDI, DL, VT, Addr.getOperand(0),
+                         CurDAG->getTargetConstant(AdjustedOffset, DL, VT)),
+                     0);
+      Offset = CurDAG->getTargetConstant(Adj, DL, VT);
+      return true;
+    }
+
+    if (selectConstantAddr(CurDAG, DL, VT, Subtarget, Addr.getOperand(1), Base,
+                           Offset, true)) {
+      // Insert an ADD instruction with the materialized Hi52 bits.
+      Base = SDValue(
+          CurDAG->getMachineNode(RISCV::ADD, DL, VT, Addr.getOperand(0), Base),
+          0);
+      return true;
+    }
+  }
+
+  if (selectConstantAddr(CurDAG, DL, VT, Subtarget, Addr, Base, Offset, true))
     return true;
 
   Base = Addr;

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -2459,12 +2459,6 @@ bool RISCVDAGToDAGISel::SelectAddrRegImmLsb00000(SDValue Addr, SDValue &Base,
   SDLoc DL(Addr);
   MVT VT = Addr.getSimpleValueType();
 
-  if (Addr.getOpcode() == RISCVISD::ADD_LO) {
-    Base = Addr;
-    Offset = CurDAG->getTargetConstant(0, DL, VT);
-    return true;
-  }
-
   if (CurDAG->isBaseWithConstantOffset(Addr)) {
     int64_t CVal = cast<ConstantSDNode>(Addr.getOperand(1))->getSExtValue();
     if (isInt<12>(CVal)) {

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -54,6 +54,7 @@ public:
   bool SelectAddrRegImmINX(SDValue Addr, SDValue &Base, SDValue &Offset) {
     return SelectAddrRegImm(Addr, Base, Offset, true);
   }
+  bool SelectAddrRegImmLsb00000(SDValue Addr, SDValue &Base, SDValue &Offset);
 
   bool SelectAddrRegRegScale(SDValue Addr, unsigned MaxShiftAmount,
                              SDValue &Base, SDValue &Index, SDValue &Scale);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
@@ -73,12 +73,16 @@ def PREFETCH_W : Prefetch_ri<0b00011, "prefetch.w">, Sched<[]>;
 // Patterns
 //===----------------------------------------------------------------------===//
 
+def AddrRegImmLsb00000 : ComplexPattern<iPTR, 2, "SelectAddrRegImmLsb00000">;
+
 let Predicates = [HasStdExtZicbop] in {
-  // FIXME: Match address with offset
-  def : Pat<(prefetch GPR:$rs1, timm, timm, (i32 0)),
-            (PREFETCH_I GPR:$rs1, 0)>;
-  def : Pat<(prefetch GPR:$rs1, (i32 0), timm, (i32 1)),
-            (PREFETCH_R GPR:$rs1, 0)>;
-  def : Pat<(prefetch GPR:$rs1, (i32 1), timm, (i32 1)),
-            (PREFETCH_W GPR:$rs1, 0)>;
+  def : Pat<(prefetch (AddrRegImmLsb00000 (XLenVT GPR:$rs1), simm12_lsb00000:$imm12),
+                      timm, timm, (i32 0)),
+            (PREFETCH_I GPR:$rs1, simm12_lsb00000:$imm12)>;
+  def : Pat<(prefetch (AddrRegImmLsb00000 (XLenVT GPR:$rs1), simm12_lsb00000:$imm12),
+                      (i32 0), timm, (i32 1)),
+            (PREFETCH_R GPR:$rs1, simm12_lsb00000:$imm12)>;
+  def : Pat<(prefetch (AddrRegImmLsb00000 (XLenVT GPR:$rs1), simm12_lsb00000:$imm12),
+                      (i32 1), timm, (i32 1)),
+            (PREFETCH_W GPR:$rs1, simm12_lsb00000:$imm12)>;
 }

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -436,9 +436,16 @@ bool RISCVRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
       // offset can by construction, at worst, a LUI and a ADD.
       int64_t Val = Offset.getFixed();
       int64_t Lo12 = SignExtend64<12>(Val);
-      MI.getOperand(FIOperandNum + 1).ChangeToImmediate(Lo12);
-      Offset = StackOffset::get((uint64_t)Val - (uint64_t)Lo12,
-                                Offset.getScalable());
+      if ((MI.getOpcode() == RISCV::PREFETCH_I ||
+           MI.getOpcode() == RISCV::PREFETCH_R ||
+           MI.getOpcode() == RISCV::PREFETCH_W) &&
+          (Lo12 & 0b11111) != 0)
+        MI.getOperand(FIOperandNum + 1).ChangeToImmediate(0);
+      else {
+        MI.getOperand(FIOperandNum + 1).ChangeToImmediate(Lo12);
+        Offset = StackOffset::get((uint64_t)Val - (uint64_t)Lo12,
+                                  Offset.getScalable());
+      }
     }
   }
 

--- a/llvm/test/CodeGen/RISCV/prefetch.ll
+++ b/llvm/test/CodeGen/RISCV/prefetch.ll
@@ -357,21 +357,18 @@ define void @test_prefetch_offsetable_0(ptr %a) nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_0:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    addi a0, a0, 2016
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 2016(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_0:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    addi a0, a0, 2016
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 2016(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_0:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, 2016
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 2016(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 2016
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -389,21 +386,18 @@ define void @test_prefetch_offsetable_1(ptr %a) nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_1:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    addi a0, a0, -2048
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_1:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    addi a0, a0, -2048
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_1:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, -2048
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 -2048
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -421,21 +415,18 @@ define void @test_prefetch_offsetable_2(ptr %a) nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_2:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    addi a0, a0, 32
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_2:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    addi a0, a0, 32
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_2:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, 32
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 32
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -453,21 +444,18 @@ define void @test_prefetch_offsetable_3(ptr %a) nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_3:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    addi a0, a0, -32
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r -32(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_3:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    addi a0, a0, -32
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r -32(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_3:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, -32
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -32(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 -32
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -485,24 +473,21 @@ define void @test_prefetch_offsetable_4(ptr %a) nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_4:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    addi a0, a0, 2047
-; RV32ZICBOP-NEXT:    addi a0, a0, 1
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    addi a0, a0, 32
+; RV32ZICBOP-NEXT:    prefetch.r 2016(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_4:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    addi a0, a0, 2047
-; RV64ZICBOP-NEXT:    addi a0, a0, 1
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    addi a0, a0, 32
+; RV64ZICBOP-NEXT:    prefetch.r 2016(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_4:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, 2047
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, 1
+; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, 32
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 2016(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 2048
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -520,24 +505,21 @@ define void @test_prefetch_offsetable_5(ptr %a) nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_5:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    addi a0, a0, -2048
 ; RV32ZICBOP-NEXT:    addi a0, a0, -1
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_5:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    addi a0, a0, -2048
 ; RV64ZICBOP-NEXT:    addi a0, a0, -1
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_5:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, -2048
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, -1
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 -2049
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -620,26 +602,23 @@ define void @test_prefetch_offsetable_9(ptr %a) nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_9:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    lui a1, 1
-; RV32ZICBOP-NEXT:    addi a1, a1, 64
 ; RV32ZICBOP-NEXT:    add a0, a0, a1
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 64(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_9:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    lui a1, 1
-; RV64ZICBOP-NEXT:    addiw a1, a1, 64
 ; RV64ZICBOP-NEXT:    add a0, a0, a1
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 64(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_9:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    lui a1, 1
-; RV64ZICBOPZIHINTNTL-NEXT:    addiw a1, a1, 64
 ; RV64ZICBOPZIHINTNTL-NEXT:    add a0, a0, a1
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 64(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 4160
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -658,26 +637,23 @@ define void @test_prefetch_offsetable_8(ptr %a) nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_offsetable_8:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    lui a1, 1048575
-; RV32ZICBOP-NEXT:    addi a1, a1, -64
 ; RV32ZICBOP-NEXT:    add a0, a0, a1
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r -64(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_offsetable_8:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    lui a1, 1048575
-; RV64ZICBOP-NEXT:    addiw a1, a1, -64
 ; RV64ZICBOP-NEXT:    add a0, a0, a1
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r -64(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_offsetable_8:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    lui a1, 1048575
-; RV64ZICBOPZIHINTNTL-NEXT:    addiw a1, a1, -64
 ; RV64ZICBOPZIHINTNTL-NEXT:    add a0, a0, a1
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -64(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %addr = getelementptr i8, ptr %a, i64 -4160
   call void @llvm.prefetch(ptr %addr, i32 0, i32 0, i32 1)
@@ -700,25 +676,22 @@ define void @test_prefetch_frameindex_0() nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_frameindex_0:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    addi sp, sp, -512
-; RV32ZICBOP-NEXT:    mv a0, sp
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 0(sp)
 ; RV32ZICBOP-NEXT:    addi sp, sp, 512
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_frameindex_0:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    addi sp, sp, -512
-; RV64ZICBOP-NEXT:    mv a0, sp
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 0(sp)
 ; RV64ZICBOP-NEXT:    addi sp, sp, 512
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_frameindex_0:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, -512
-; RV64ZICBOPZIHINTNTL-NEXT:    mv a0, sp
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(sp)
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, 512
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %data = alloca [128 x i32], align 4
@@ -895,25 +868,22 @@ define void @test_prefetch_frameindex_4() nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_frameindex_4:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    addi sp, sp, -512
-; RV32ZICBOP-NEXT:    addi a0, sp, 32
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 32(sp)
 ; RV32ZICBOP-NEXT:    addi sp, sp, 512
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_frameindex_4:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    addi sp, sp, -512
-; RV64ZICBOP-NEXT:    addi a0, sp, 32
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 32(sp)
 ; RV64ZICBOP-NEXT:    addi sp, sp, 512
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_frameindex_4:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, -512
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, sp, 32
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 32(sp)
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, 512
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %data = alloca [128 x i32], align 4
@@ -939,25 +909,22 @@ define void @test_prefetch_frameindex_5() nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_frameindex_5:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    addi sp, sp, -512
-; RV32ZICBOP-NEXT:    addi a0, sp, -32
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r -32(sp)
 ; RV32ZICBOP-NEXT:    addi sp, sp, 512
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_frameindex_5:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    addi sp, sp, -512
-; RV64ZICBOP-NEXT:    addi a0, sp, -32
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r -32(sp)
 ; RV64ZICBOP-NEXT:    addi sp, sp, 512
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_frameindex_5:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, -512
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, sp, -32
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -32(sp)
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, 512
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %data = alloca [128 x i32], align 4
@@ -983,25 +950,22 @@ define void @test_prefetch_frameindex_6() nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_frameindex_6:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    addi sp, sp, -512
-; RV32ZICBOP-NEXT:    addi a0, sp, 2016
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 2016(sp)
 ; RV32ZICBOP-NEXT:    addi sp, sp, 512
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_frameindex_6:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    addi sp, sp, -512
-; RV64ZICBOP-NEXT:    addi a0, sp, 2016
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 2016(sp)
 ; RV64ZICBOP-NEXT:    addi sp, sp, 512
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_frameindex_6:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, -512
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, sp, 2016
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 2016(sp)
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, 512
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %data = alloca [128 x i32], align 4
@@ -1027,25 +991,22 @@ define void @test_prefetch_frameindex_7() nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_frameindex_7:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    addi sp, sp, -512
-; RV32ZICBOP-NEXT:    addi a0, sp, -2048
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r -2048(sp)
 ; RV32ZICBOP-NEXT:    addi sp, sp, 512
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_frameindex_7:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    addi sp, sp, -512
-; RV64ZICBOP-NEXT:    addi a0, sp, -2048
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r -2048(sp)
 ; RV64ZICBOP-NEXT:    addi sp, sp, 512
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_frameindex_7:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, -512
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, sp, -2048
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -2048(sp)
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, 512
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %data = alloca [128 x i32], align 4
@@ -1116,9 +1077,8 @@ define void @test_prefetch_frameindex_9() nounwind {
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    addi sp, sp, -512
 ; RV32ZICBOP-NEXT:    mv a0, sp
-; RV32ZICBOP-NEXT:    addi a0, a0, -2048
 ; RV32ZICBOP-NEXT:    addi a0, a0, -4
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV32ZICBOP-NEXT:    addi sp, sp, 512
 ; RV32ZICBOP-NEXT:    ret
 ;
@@ -1126,9 +1086,8 @@ define void @test_prefetch_frameindex_9() nounwind {
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    addi sp, sp, -512
 ; RV64ZICBOP-NEXT:    mv a0, sp
-; RV64ZICBOP-NEXT:    addi a0, a0, -2048
 ; RV64ZICBOP-NEXT:    addi a0, a0, -4
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOP-NEXT:    addi sp, sp, 512
 ; RV64ZICBOP-NEXT:    ret
 ;
@@ -1136,10 +1095,9 @@ define void @test_prefetch_frameindex_9() nounwind {
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, -512
 ; RV64ZICBOPZIHINTNTL-NEXT:    mv a0, sp
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, -2048
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, -4
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    addi sp, sp, 512
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %data = alloca [128 x i32], align 4
@@ -1161,23 +1119,20 @@ define void @test_prefetch_constant_address_0() nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_constant_address_0:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    lui a0, 1
-; RV32ZICBOP-NEXT:    addi a0, a0, 32
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_constant_address_0:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    lui a0, 1
-; RV64ZICBOP-NEXT:    addiw a0, a0, 32
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_constant_address_0:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, 1
-; RV64ZICBOPZIHINTNTL-NEXT:    addiw a0, a0, 32
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %ptr = inttoptr i64 4128 to i8*
   call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 1)
@@ -1231,23 +1186,20 @@ define void @test_prefetch_constant_address_2() nounwind {
 ; RV32ZICBOP-LABEL: test_prefetch_constant_address_2:
 ; RV32ZICBOP:       # %bb.0:
 ; RV32ZICBOP-NEXT:    lui a0, 1048561
-; RV32ZICBOP-NEXT:    addi a0, a0, 32
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_constant_address_2:
 ; RV64ZICBOP:       # %bb.0:
 ; RV64ZICBOP-NEXT:    lui a0, 1048561
-; RV64ZICBOP-NEXT:    addiw a0, a0, 32
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_constant_address_2:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
 ; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, 1048561
-; RV64ZICBOPZIHINTNTL-NEXT:    addiw a0, a0, 32
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %ptr = inttoptr i64 18446744073709490208 to i8*
   call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 1)
@@ -1407,24 +1359,24 @@ define void @test_prefetch_global_3() nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_global_3:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    lui a0, %hi(g+32)
-; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g+32)
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    lui a0, %hi(g)
+; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV32ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_global_3:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    lui a0, %hi(g+32)
-; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g+32)
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    lui a0, %hi(g)
+; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV64ZICBOP-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_global_3:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g+32)
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g+32)
+; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g)
+; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 32(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %ptr = getelementptr [1024 x i32], ptr @g, i32 0, i32 8
   call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 1)
@@ -1442,24 +1394,24 @@ define void @test_prefetch_global_4() nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_global_4:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    lui a0, %hi(g-32)
-; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g-32)
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    lui a0, %hi(g)
+; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV32ZICBOP-NEXT:    prefetch.r -32(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_global_4:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    lui a0, %hi(g-32)
-; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g-32)
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    lui a0, %hi(g)
+; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV64ZICBOP-NEXT:    prefetch.r -32(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_global_4:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g-32)
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g-32)
+; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g)
+; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -32(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %ptr = getelementptr [1024 x i32], ptr @g, i32 0, i32 -8
   call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 1)
@@ -1477,24 +1429,24 @@ define void @test_prefetch_global_5() nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_global_5:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    lui a0, %hi(g+2016)
-; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g+2016)
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    lui a0, %hi(g)
+; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV32ZICBOP-NEXT:    prefetch.r 2016(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_global_5:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    lui a0, %hi(g+2016)
-; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g+2016)
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    lui a0, %hi(g)
+; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV64ZICBOP-NEXT:    prefetch.r 2016(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_global_5:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g+2016)
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g+2016)
+; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g)
+; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 2016(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %ptr = getelementptr [1024 x i32], ptr @g, i32 0, i32 504
   call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 1)
@@ -1512,24 +1464,24 @@ define void @test_prefetch_global_6() nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_global_6:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    lui a0, %hi(g-2048)
-; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g-2048)
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    lui a0, %hi(g)
+; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV32ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_global_6:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    lui a0, %hi(g-2048)
-; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g-2048)
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    lui a0, %hi(g)
+; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g)
+; RV64ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_global_6:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g-2048)
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g-2048)
+; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g)
+; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %ptr = getelementptr [1024 x i32], ptr @g, i32 0, i32 -512
   call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 1)
@@ -1582,24 +1534,24 @@ define void @test_prefetch_global_8() nounwind {
 ;
 ; RV32ZICBOP-LABEL: test_prefetch_global_8:
 ; RV32ZICBOP:       # %bb.0:
-; RV32ZICBOP-NEXT:    lui a0, %hi(g-2052)
-; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g-2052)
-; RV32ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV32ZICBOP-NEXT:    lui a0, %hi(g-4)
+; RV32ZICBOP-NEXT:    addi a0, a0, %lo(g-4)
+; RV32ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV32ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOP-LABEL: test_prefetch_global_8:
 ; RV64ZICBOP:       # %bb.0:
-; RV64ZICBOP-NEXT:    lui a0, %hi(g-2052)
-; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g-2052)
-; RV64ZICBOP-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOP-NEXT:    lui a0, %hi(g-4)
+; RV64ZICBOP-NEXT:    addi a0, a0, %lo(g-4)
+; RV64ZICBOP-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOP-NEXT:    ret
 ;
 ; RV64ZICBOPZIHINTNTL-LABEL: test_prefetch_global_8:
 ; RV64ZICBOPZIHINTNTL:       # %bb.0:
-; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g-2052)
-; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g-2052)
+; RV64ZICBOPZIHINTNTL-NEXT:    lui a0, %hi(g-4)
+; RV64ZICBOPZIHINTNTL-NEXT:    addi a0, a0, %lo(g-4)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ntl.all
-; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r 0(a0)
+; RV64ZICBOPZIHINTNTL-NEXT:    prefetch.r -2048(a0)
 ; RV64ZICBOPZIHINTNTL-NEXT:    ret
   %ptr = getelementptr [1024 x i32], ptr @g, i32 0, i32 -513
   call void @llvm.prefetch(ptr %ptr, i32 0, i32 0, i32 1)


### PR DESCRIPTION
A new ComplexPattern `AddrRegImmLsb00000` is added, which is like
`AddrRegImm` except that if the least significant 5 bits isn't all
zeros, we will fail back to offset 0.

This PR is stacked on #67644.