### PR TITLE
[Github] add spirv backend team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -434,12 +434,6 @@ flang/**/CodeGen/ @llvm/pr-subscribers-flang-codegen
 /llvm/utils/TableGen/CodeGenDAG* @llvm/pr-subscribers-selectiondag
 /llvm/utils/TableGen/DAGISel* @llvm/pr-subscribers-selectiondag
 
-# spirv
-/clang/lib/Driver/ToolChains/SPIRV.* @llvm/pr-subscribers-spirv
-/llvm/lib/Target/SPIRV @llvm/pr-subscribers-spirv
-/llvm/test/CodeGen/SPIRV @llvm/pr-subscribers-spirv
-/llvm/docs/SPIRVUsage.rst @llvm/pr-subscribers-spirv
-
 # register allocation
 /llvm/**/*RegAlloc @llvm/pr-subscribers-regalloc
 /llvm/**/CodeGen/Register* @llvm/pr-subscribers-regalloc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -434,6 +434,12 @@ flang/**/CodeGen/ @llvm/pr-subscribers-flang-codegen
 /llvm/utils/TableGen/CodeGenDAG* @llvm/pr-subscribers-selectiondag
 /llvm/utils/TableGen/DAGISel* @llvm/pr-subscribers-selectiondag
 
+# spirv
+/clang/lib/Driver/ToolChains/SPIRV.* @llvm/pr-subscribers-spirv
+/llvm/lib/Target/SPIRV @llvm/pr-subscribers-spirv
+/llvm/test/CodeGen/SPIRV @llvm/pr-subscribers-spirv
+/llvm/docs/SPIRVUsage.rst @llvm/pr-subscribers-spirv
+
 # register allocation
 /llvm/**/*RegAlloc @llvm/pr-subscribers-regalloc
 /llvm/**/CodeGen/Register* @llvm/pr-subscribers-regalloc

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -523,6 +523,13 @@ backend:DirectX:
   - clang/lib/Basic/Targets/DirectX*
   - llvm/include/llvm/IR/IntrinsicsDirectX.td
 
+backend:SPIR-V:
+  - clang/lib/Driver/ToolChains/SPIRV.*
+  - llvm/lib/Target/SPIRV/**
+  - llvm/test/CodeGen/SPIRV/**
+  - llvm/test/Frontend/HLSL/**
+  - llvm/docs/SPIRVUsage.rst
+
 mlgo:
   - llvm/lib/Analysis/ML*
   - llvm/include/llvm/Analysis/ML*


### PR DESCRIPTION
This PR adds the paths the SPIR-V backend folks maintains. (Another distince SPIR-V team exists, but only for the MLIR part (mlir-spirv).

@tstellar : the team doesn't exist, I saw a message on the discourse asking people to create a PR and add you. Hope this is the correct process 😊