### PR TITLE
[flang] Lower PRIVATE component names safely

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -250,6 +250,11 @@ public:
   mangleName(const Fortran::semantics::DerivedTypeSpec &) = 0;
   /// Unique a compiler generated name (add a containing scope specific prefix)
   virtual std::string mangleName(std::string &) = 0;
+  /// Return the field name for a derived type component inside a fir.record
+  /// type.
+  virtual std::string
+  getRecordTypeFieldName(const Fortran::semantics::Symbol &component) = 0;
+
   /// Get the KindMap.
   virtual const fir::KindMapping &getKindMap() = 0;
 

--- a/flang/include/flang/Lower/Mangler.h
+++ b/flang/include/flang/Lower/Mangler.h
@@ -96,6 +96,13 @@ inline std::string mangleArrayLiteral(
 /// Return the compiler-generated name of a static namelist variable descriptor.
 std::string globalNamelistDescriptorName(const Fortran::semantics::Symbol &sym);
 
+/// Return the field name for a derived type component inside a fir.record type.
+/// It is the component name if the component is not private. Otherwise it is
+/// mangled with the component parent type to avoid any name clashes in type
+/// extensions.
+std::string getRecordTypeFieldName(const Fortran::semantics::Symbol &component,
+                                   ScopeBlockIdMap &);
+
 } // namespace lower::mangle
 } // namespace Fortran
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -856,6 +856,11 @@ public:
     return Fortran::lower::mangle::mangleName(name, getCurrentScope(),
                                               scopeBlockIdMap);
   }
+  std::string getRecordTypeFieldName(
+      const Fortran::semantics::Symbol &component) override final {
+    return Fortran::lower::mangle::getRecordTypeFieldName(component,
+                                                          scopeBlockIdMap);
+  }
   const fir::KindMapping &getKindMap() override final {
     return bridge.getKindMap();
   }

--- a/flang/lib/Lower/ConvertConstant.cpp
+++ b/flang/lib/Lower/ConvertConstant.cpp
@@ -362,8 +362,9 @@ static mlir::Value genInlinedStructureCtorLitImpl(
     if (sym->test(Fortran::semantics::Symbol::Flag::ParentComp))
       TODO(loc, "parent component in structure constructor");
 
-    llvm::StringRef name = toStringRef(sym->name());
+    std::string name = converter.getRecordTypeFieldName(sym);
     mlir::Type componentTy = recTy.getType(name);
+    assert(componentTy && "failed to retrieve component");
     // FIXME: type parameters must come from the derived-type-spec
     auto field = builder.create<fir::FieldIndexOp>(
         loc, fieldTy, name, type,

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -937,7 +937,7 @@ public:
       if (isDerivedTypeWithLenParameters(sym))
         TODO(loc, "component with length parameters in structure constructor");
 
-      llvm::StringRef name = toStringRef(sym.name());
+      std::string name = converter.getRecordTypeFieldName(sym);
       // FIXME: type parameters must come from the derived-type-spec
       mlir::Value field = builder.create<fir::FieldIndexOp>(
           loc, fieldTy, name, ty,
@@ -1476,7 +1476,7 @@ public:
     for (const Fortran::evaluate::Component *field : list) {
       auto recTy = ty.cast<fir::RecordType>();
       const Fortran::semantics::Symbol &sym = getLastSym(*field);
-      llvm::StringRef name = toStringRef(sym.name());
+      std::string name = converter.getRecordTypeFieldName(sym);
       coorArgs.push_back(builder.create<fir::FieldIndexOp>(
           loc, fldTy, name, recTy, fir::getTypeParams(obj)));
       ty = recTy.getType(name);
@@ -6745,7 +6745,8 @@ private:
               },
               [&](const Fortran::evaluate::Component *x) {
                 auto fieldTy = fir::FieldType::get(builder.getContext());
-                llvm::StringRef name = toStringRef(getLastSym(*x).name());
+                std::string name =
+                    converter.getRecordTypeFieldName(getLastSym(*x));
                 if (auto recTy = ty.dyn_cast<fir::RecordType>()) {
                   ty = recTy.getType(name);
                   auto fld = builder.create<fir::FieldIndexOp>(

--- a/flang/lib/Lower/ConvertExprToHLFIR.cpp
+++ b/flang/lib/Lower/ConvertExprToHLFIR.cpp
@@ -742,7 +742,7 @@ private:
     assert(
         !componentSym.test(Fortran::semantics::Symbol::Flag::ParentComp) &&
         "parent components are skipped and must not reach visitComponentImpl");
-    partInfo.componentName = componentSym.name().ToString();
+    partInfo.componentName = converter.getRecordTypeFieldName(componentSym);
     auto recordType =
         hlfir::getFortranElementType(baseType).cast<fir::RecordType>();
     if (recordType.isDependentType())
@@ -1721,7 +1721,7 @@ private:
     for (const auto &value : ctor.values()) {
       const Fortran::semantics::Symbol &sym = *value.first;
       const Fortran::lower::SomeExpr &expr = value.second.value();
-      llvm::StringRef name = toStringRef(sym.name());
+      std::string name = converter.getRecordTypeFieldName(sym);
       if (sym.test(Fortran::semantics::Symbol::Flag::ParentComp)) {
         const Fortran::semantics::DeclTypeSpec *declTypeSpec = sym.GetType();
         assert(declTypeSpec && declTypeSpec->AsDerived() &&

--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -382,23 +382,25 @@ struct TypeBuilderImpl {
 
     // Gather the record type fields.
     // (1) The data components.
-    for (const auto &field :
+    for (const auto &component :
          Fortran::semantics::OrderedComponentIterator(tySpec)) {
       // Lowering is assuming non deferred component lower bounds are always 1.
       // Catch any situations where this is not true for now.
       if (!converter.getLoweringOptions().getLowerToHighLevelFIR() &&
-          componentHasNonDefaultLowerBounds(field))
-        TODO(converter.genLocation(field.name()),
+          componentHasNonDefaultLowerBounds(component))
+        TODO(converter.genLocation(component.name()),
              "derived type components with non default lower bounds");
-      if (IsProcedure(field))
-        TODO(converter.genLocation(field.name()), "procedure components");
-      mlir::Type ty = genSymbolType(field);
+      if (IsProcedure(component))
+        TODO(converter.genLocation(component.name()), "procedure components");
+      mlir::Type ty = genSymbolType(component);
       // Do not add the parent component (component of the parents are
       // added and should be sufficient, the parent component would
-      // duplicate the fields).
-      if (field.test(Fortran::semantics::Symbol::Flag::ParentComp))
+      // duplicate the fields). Note that genSymbolType must be called above on
+      // it so that the dispatch table for the parent type still gets emitted
+      // as needed.
+      if (component.test(Fortran::semantics::Symbol::Flag::ParentComp))
         continue;
-      cs.emplace_back(field.name().ToString(), ty);
+      cs.emplace_back(converter.getRecordTypeFieldName(component), ty);
     }
 
     // (2) The LEN type parameters.

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -324,7 +324,7 @@ static mlir::Value genDefaultInitializerValue(
     if (component.test(Fortran::semantics::Symbol::Flag::ParentComp))
       continue;
     mlir::Value componentValue;
-    llvm::StringRef name = toStringRef(component.name());
+    std::string name = converter.getRecordTypeFieldName(component);
     mlir::Type componentTy = recTy.getType(name);
     assert(componentTy && "component not found in type");
     if (const auto *object{

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -230,6 +230,25 @@ std::string Fortran::lower::mangle::mangleName(
   return fir::NameUniquer::doType(modules, procs, blockId, symbolName, kinds);
 }
 
+std::string Fortran::lower::mangle::getRecordTypeFieldName(
+    const Fortran::semantics::Symbol &component,
+    ScopeBlockIdMap &scopeBlockIdMap) {
+  if (!component.attrs().test(Fortran::semantics::Attr::PRIVATE))
+    return component.name().ToString();
+  const Fortran::semantics::DerivedTypeSpec *componentParentType =
+      component.owner().derivedTypeSpec();
+  assert(componentParentType &&
+         "failed to retrieve private component parent type");
+  // Do not mangle Iso C C_PTR and C_FUNPTR components. This type cannot be
+  // extended as per Fortran 2018 7.5.7.1, mangling them makes the IR unreadable
+  // when using ISO C modules, and lowering needs to know the component way
+  // without access to semantics::Symbol.
+  if (Fortran::semantics::IsIsoCType(componentParentType))
+    return component.name().ToString();
+  return component.name().ToString() + "." +
+         mangleName(*componentParentType, scopeBlockIdMap);
+}
+
 std::string Fortran::lower::mangle::demangleName(llvm::StringRef name) {
   auto result = fir::NameUniquer::deconstruct(name);
   return result.second.name;

--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -245,8 +245,8 @@ std::string Fortran::lower::mangle::getRecordTypeFieldName(
   // without access to semantics::Symbol.
   if (Fortran::semantics::IsIsoCType(componentParentType))
     return component.name().ToString();
-  return component.name().ToString() + "." +
-         mangleName(*componentParentType, scopeBlockIdMap);
+  return mangleName(*componentParentType, scopeBlockIdMap) + "." +
+         component.name().ToString();
 }
 
 std::string Fortran::lower::mangle::demangleName(llvm::StringRef name) {

--- a/flang/test/Lower/HLFIR/private-components.f90
+++ b/flang/test/Lower/HLFIR/private-components.f90
@@ -1,0 +1,35 @@
+! Test that private component names are mangled inside fir.record
+! in a way that allow components with the same name to be added in
+! type extensions.
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
+
+module name_clash
+  type:: t
+    integer, private :: i
+  end type
+end module
+
+!CHECK-LABEL: func.func @_QPuser_clash(
+!CHECK-SAME: !fir.ref<!fir.type<_QFuser_clashTt2{i._QMname_clashTt:i32,i:i32}>>
+!CHECK-SAME: !fir.ref<!fir.type<_QMname_clashTt{i._QMname_clashTt:i32}>>
+subroutine user_clash(a, at)
+  use name_clash
+  type,extends(t) :: t2
+    integer :: i = 2
+  end type
+  type(t2) :: a, b
+  type(t) :: at
+  print *, a%i
+  print *, t2(t=at)
+  a = b
+end subroutine
+
+! CHECK-LABEL: func.func @_QPclash_with_intrinsic_module(
+! CHECK-SAME: !fir.ref<!fir.type<_QFclash_with_intrinsic_moduleTmy_class{which._QMieee_arithmeticTieee_class_type:i8,which:i8}>>
+subroutine clash_with_intrinsic_module(a)
+ use ieee_arithmetic
+ type, extends(ieee_class_type) :: my_class
+    integer(1) :: which
+ end type
+ type(my_class) :: a
+end subroutine

--- a/flang/test/Lower/HLFIR/private-components.f90
+++ b/flang/test/Lower/HLFIR/private-components.f90
@@ -11,8 +11,8 @@ module name_clash
 end module
 
 !CHECK-LABEL: func.func @_QPuser_clash(
-!CHECK-SAME: !fir.ref<!fir.type<_QFuser_clashTt2{i._QMname_clashTt:i32,i:i32}>>
-!CHECK-SAME: !fir.ref<!fir.type<_QMname_clashTt{i._QMname_clashTt:i32}>>
+!CHECK-SAME: !fir.ref<!fir.type<_QFuser_clashTt2{_QMname_clashTt.i:i32,i:i32}>>
+!CHECK-SAME: !fir.ref<!fir.type<_QMname_clashTt{_QMname_clashTt.i:i32}>>
 subroutine user_clash(a, at)
   use name_clash
   type,extends(t) :: t2
@@ -26,7 +26,7 @@ subroutine user_clash(a, at)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPclash_with_intrinsic_module(
-! CHECK-SAME: !fir.ref<!fir.type<_QFclash_with_intrinsic_moduleTmy_class{which._QMieee_arithmeticTieee_class_type:i8,which:i8}>>
+! CHECK-SAME: !fir.ref<!fir.type<_QFclash_with_intrinsic_moduleTmy_class{_QMieee_arithmeticTieee_class_type.which:i8,which:i8}>>
 subroutine clash_with_intrinsic_module(a)
  use ieee_arithmetic
  type, extends(ieee_class_type) :: my_class

--- a/flang/test/Lower/HLFIR/private-components.f90
+++ b/flang/test/Lower/HLFIR/private-components.f90
@@ -7,6 +7,7 @@ module name_clash
   type:: t
     integer, private :: i
   end type
+  type(t), parameter :: cst = t(42)
 end module
 
 !CHECK-LABEL: func.func @_QPuser_clash(

--- a/flang/test/Lower/Intrinsics/ieee_class.f90
+++ b/flang/test/Lower/Intrinsics/ieee_class.f90
@@ -41,8 +41,8 @@ subroutine classify(x)
   use m; use ieee_arithmetic
   real(k) :: x
   ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca i32 {adapt.valuebyref}
-  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}> {bindc_name = "r", uniq_name = "_QFclassifyEr"}
+  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}> {bindc_name = "r", uniq_name = "_QFclassifyEr"}
   type(ieee_class_type) :: r
 
   ! CHECK:     %[[V_8:[0-9]+]] = fir.load %arg0 : !fir.ref<f64>
@@ -64,24 +64,24 @@ subroutine classify(x)
   ! CHECK:     %[[V_24:[0-9]+]] = arith.andi %[[V_23]], %c1{{.*}} : i64
   ! CHECK:     %[[V_25:[0-9]+]] = arith.ori %[[V_22]], %[[V_24]] : i64
   ! CHECK:     %[[V_26:[0-9]+]] = fir.address_of(@_FortranAIeeeClassTable) : !fir.ref<!fir.array<32xi8>>
-  ! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_26]], %[[V_25]] : (!fir.ref<!fir.array<32xi8>>, i64) -> !fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>
-  ! CHECK:     %[[V_28:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_27]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
-  ! CHECK:     %[[V_30:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK:     %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_26]], %[[V_25]] : (!fir.ref<!fir.array<32xi8>>, i64) -> !fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>
+  ! CHECK:     %[[V_28:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_27]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_30:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK:     %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_32:[0-9]+]] = fir.load %[[V_29]] : !fir.ref<i8>
   ! CHECK:     fir.store %[[V_32]] to %[[V_31]] : !fir.ref<i8>
   r = ieee_class(x)
 
 ! if (r==ieee_signaling_nan)      call out(x, 1)
 ! if (r==ieee_quiet_nan)          call out(x, 2)
-  ! CHECK:     %[[V_38:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK:     %[[V_39:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_38]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_38:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK:     %[[V_39:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_38]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     fir.store %c3{{.*}} to %[[V_39]] : !fir.ref<i8>
-  ! CHECK:     %[[V_40:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK:     %[[V_41:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_40]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
-  ! CHECK:     %[[V_42:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK:     %[[V_43:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_42]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_40:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK:     %[[V_41:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_40]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_42:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK:     %[[V_43:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_42]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_44:[0-9]+]] = fir.load %[[V_41]] : !fir.ref<i8>
   ! CHECK:     %[[V_45:[0-9]+]] = fir.load %[[V_43]] : !fir.ref<i8>
   ! CHECK:     %[[V_46:[0-9]+]] = arith.cmpi eq, %[[V_44]], %[[V_45]] : i8
@@ -109,13 +109,13 @@ program p
 
 ! x(1)  = ieee_value(x(1), ieee_signaling_nan)
 ! x(2)  = ieee_value(x(1), ieee_quiet_nan)
-  ! CHECK:     %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
   ! CHECK:     %[[V_2:[0-9]+]] = fir.address_of(@_QFEx) : !fir.ref<!fir.array<10xf64>>
-  ! CHECK:     %[[V_8:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK:     %[[V_9:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_8]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_8:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK:     %[[V_9:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_8]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     fir.store %c3{{.*}} to %[[V_9]] : !fir.ref<i8>
-  ! CHECK:     %[[V_10:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-  ! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_10:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+  ! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_12:[0-9]+]] = fir.load %[[V_11]] : !fir.ref<i8>
   ! CHECK:     %[[V_13:[0-9]+]] = fir.address_of(@_FortranAIeeeValueTable_8) : !fir.ref<!fir.array<12xi64>>
   ! CHECK:     %[[V_14:[0-9]+]] = fir.coordinate_of %[[V_13]], %[[V_12]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>

--- a/flang/test/Lower/Intrinsics/ieee_class.f90
+++ b/flang/test/Lower/Intrinsics/ieee_class.f90
@@ -41,8 +41,8 @@ subroutine classify(x)
   use m; use ieee_arithmetic
   real(k) :: x
   ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca i32 {adapt.valuebyref}
-  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}> {bindc_name = "r", uniq_name = "_QFclassifyEr"}
+  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}> {bindc_name = "r", uniq_name = "_QFclassifyEr"}
   type(ieee_class_type) :: r
 
   ! CHECK:     %[[V_8:[0-9]+]] = fir.load %arg0 : !fir.ref<f64>
@@ -64,24 +64,24 @@ subroutine classify(x)
   ! CHECK:     %[[V_24:[0-9]+]] = arith.andi %[[V_23]], %c1{{.*}} : i64
   ! CHECK:     %[[V_25:[0-9]+]] = arith.ori %[[V_22]], %[[V_24]] : i64
   ! CHECK:     %[[V_26:[0-9]+]] = fir.address_of(@_FortranAIeeeClassTable) : !fir.ref<!fir.array<32xi8>>
-  ! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_26]], %[[V_25]] : (!fir.ref<!fir.array<32xi8>>, i64) -> !fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>
-  ! CHECK:     %[[V_28:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_27]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
-  ! CHECK:     %[[V_30:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK:     %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_26]], %[[V_25]] : (!fir.ref<!fir.array<32xi8>>, i64) -> !fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>
+  ! CHECK:     %[[V_28:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_27]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_30:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_32:[0-9]+]] = fir.load %[[V_29]] : !fir.ref<i8>
   ! CHECK:     fir.store %[[V_32]] to %[[V_31]] : !fir.ref<i8>
   r = ieee_class(x)
 
 ! if (r==ieee_signaling_nan)      call out(x, 1)
 ! if (r==ieee_quiet_nan)          call out(x, 2)
-  ! CHECK:     %[[V_38:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK:     %[[V_39:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_38]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_38:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_39:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_38]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     fir.store %c3{{.*}} to %[[V_39]] : !fir.ref<i8>
-  ! CHECK:     %[[V_40:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK:     %[[V_41:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_40]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
-  ! CHECK:     %[[V_42:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK:     %[[V_43:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_42]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_40:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_41:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_40]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_42:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_43:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_42]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_44:[0-9]+]] = fir.load %[[V_41]] : !fir.ref<i8>
   ! CHECK:     %[[V_45:[0-9]+]] = fir.load %[[V_43]] : !fir.ref<i8>
   ! CHECK:     %[[V_46:[0-9]+]] = arith.cmpi eq, %[[V_44]], %[[V_45]] : i8
@@ -109,13 +109,13 @@ program p
 
 ! x(1)  = ieee_value(x(1), ieee_signaling_nan)
 ! x(2)  = ieee_value(x(1), ieee_quiet_nan)
-  ! CHECK:     %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
+  ! CHECK:     %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
   ! CHECK:     %[[V_2:[0-9]+]] = fir.address_of(@_QFEx) : !fir.ref<!fir.array<10xf64>>
-  ! CHECK:     %[[V_8:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK:     %[[V_9:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_8]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_8:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_9:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_8]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     fir.store %c3{{.*}} to %[[V_9]] : !fir.ref<i8>
-  ! CHECK:     %[[V_10:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-  ! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_10:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+  ! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_12:[0-9]+]] = fir.load %[[V_11]] : !fir.ref<i8>
   ! CHECK:     %[[V_13:[0-9]+]] = fir.address_of(@_FortranAIeeeValueTable_8) : !fir.ref<!fir.array<12xi64>>
   ! CHECK:     %[[V_14:[0-9]+]] = fir.coordinate_of %[[V_13]], %[[V_12]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>

--- a/flang/test/Lower/Intrinsics/ieee_operator_eq.f90
+++ b/flang/test/Lower/Intrinsics/ieee_operator_eq.f90
@@ -4,10 +4,10 @@
 subroutine s(r1,r2)
   use ieee_arithmetic, only: ieee_round_type, operator(==)
   type(ieee_round_type) :: r1, r2
-  ! CHECK:   %[[V_3:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_4:[0-9]+]] = fir.coordinate_of %arg0, %[[V_3]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
-  ! CHECK:   %[[V_5:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_6:[0-9]+]] = fir.coordinate_of %arg1, %[[V_5]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_3:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_4:[0-9]+]] = fir.coordinate_of %arg0, %[[V_3]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_5:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_6:[0-9]+]] = fir.coordinate_of %arg1, %[[V_5]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   %[[V_7:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<i8>
   ! CHECK:   %[[V_8:[0-9]+]] = fir.load %[[V_6]] : !fir.ref<i8>
   ! CHECK:   %[[V_9:[0-9]+]] = arith.cmpi eq, %[[V_7]], %[[V_8]] : i8
@@ -26,26 +26,26 @@ end
     end
   end interface
 
-  ! CHECK:   %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_3:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_9:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_10:[0-9]+]] = fir.coordinate_of %[[V_3]], %[[V_9]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_3:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_9:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_10:[0-9]+]] = fir.coordinate_of %[[V_3]], %[[V_9]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c0{{.*}} to %[[V_10]] : !fir.ref<i8>
-  ! CHECK:   %[[V_16:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_17:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_16]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_16:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_17:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_16]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c1{{.*}} to %[[V_17]] : !fir.ref<i8>
-  ! CHECK:   fir.call @_QPs(%[[V_3]], %[[V_2]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>) -> ()
+  ! CHECK:   fir.call @_QPs(%[[V_3]], %[[V_2]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>) -> ()
   call s(ieee_to_zero, ieee_nearest)
 
-  ! CHECK:   %[[V_23:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_23:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c1{{.*}} to %[[V_24]] : !fir.ref<i8>
-  ! CHECK:   %[[V_30:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:   %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_30:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:   %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c1{{.*}} to %[[V_31]] : !fir.ref<i8>
-  ! CHECK:   fir.call @_QPs(%[[V_1]], %[[V_0]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>) -> ()
+  ! CHECK:   fir.call @_QPs(%[[V_1]], %[[V_0]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>) -> ()
   call s(ieee_nearest, ieee_nearest)
 end
 

--- a/flang/test/Lower/Intrinsics/ieee_operator_eq.f90
+++ b/flang/test/Lower/Intrinsics/ieee_operator_eq.f90
@@ -4,10 +4,10 @@
 subroutine s(r1,r2)
   use ieee_arithmetic, only: ieee_round_type, operator(==)
   type(ieee_round_type) :: r1, r2
-  ! CHECK:   %[[V_3:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_4:[0-9]+]] = fir.coordinate_of %arg0, %[[V_3]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
-  ! CHECK:   %[[V_5:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_6:[0-9]+]] = fir.coordinate_of %arg1, %[[V_5]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_3:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_4:[0-9]+]] = fir.coordinate_of %arg0, %[[V_3]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_5:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_6:[0-9]+]] = fir.coordinate_of %arg1, %[[V_5]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   %[[V_7:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<i8>
   ! CHECK:   %[[V_8:[0-9]+]] = fir.load %[[V_6]] : !fir.ref<i8>
   ! CHECK:   %[[V_9:[0-9]+]] = arith.cmpi eq, %[[V_7]], %[[V_8]] : i8
@@ -26,26 +26,26 @@ end
     end
   end interface
 
-  ! CHECK:   %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_3:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_9:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_10:[0-9]+]] = fir.coordinate_of %[[V_3]], %[[V_9]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_3:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_9:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_10:[0-9]+]] = fir.coordinate_of %[[V_3]], %[[V_9]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c0{{.*}} to %[[V_10]] : !fir.ref<i8>
-  ! CHECK:   %[[V_16:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_17:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_16]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_16:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_17:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_16]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c1{{.*}} to %[[V_17]] : !fir.ref<i8>
-  ! CHECK:   fir.call @_QPs(%[[V_3]], %[[V_2]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>) -> ()
+  ! CHECK:   fir.call @_QPs(%[[V_3]], %[[V_2]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>) -> ()
   call s(ieee_to_zero, ieee_nearest)
 
-  ! CHECK:   %[[V_23:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_23:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c1{{.*}} to %[[V_24]] : !fir.ref<i8>
-  ! CHECK:   %[[V_30:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:   %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:   %[[V_30:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:   %[[V_31:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_30]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:   fir.store %c1{{.*}} to %[[V_31]] : !fir.ref<i8>
-  ! CHECK:   fir.call @_QPs(%[[V_1]], %[[V_0]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>) -> ()
+  ! CHECK:   fir.call @_QPs(%[[V_1]], %[[V_0]]) {{.*}} : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>) -> ()
   call s(ieee_nearest, ieee_nearest)
 end
 

--- a/flang/test/Lower/Intrinsics/ieee_rounding.f90
+++ b/flang/test/Lower/Intrinsics/ieee_rounding.f90
@@ -3,16 +3,16 @@
 ! CHECK-LABEL: c.func @_QQmain
 program r
   use ieee_arithmetic
-  ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}> {bindc_name = "round_value", uniq_name = "_QFEround_value"}
+  ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}> {bindc_name = "round_value", uniq_name = "_QFEround_value"}
   type(ieee_round_type) :: round_value
 
-  ! CHECK:     %[[V_13:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:     %[[V_14:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_13]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_13:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:     %[[V_14:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_13]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     fir.store %c3{{.*}} to %[[V_14]] : !fir.ref<i8>
-  ! CHECK:     %[[V_15:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-  ! CHECK:     %[[V_16:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_15]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_15:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+  ! CHECK:     %[[V_16:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_15]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_17:[0-9]+]] = fir.load %[[V_16]] : !fir.ref<i8>
   ! CHECK:     %[[V_18:[0-9]+]] = arith.cmpi sge, %[[V_17]], %c0{{.*}} : i8
   ! CHECK:     %[[V_19:[0-9]+]] = arith.cmpi sle, %[[V_17]], %c3{{.*}} : i8
@@ -21,26 +21,26 @@ program r
   ! CHECK:     %[[V_22:[0-9]+]] = fir.convert %[[V_21]] : (!fir.logical<4>) -> i1
   ! CHECK:     fir.if %[[V_22]] {
   if (ieee_support_rounding(ieee_down)) then
-    ! CHECK:       %[[V_23:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-    ! CHECK:       %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_23:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+    ! CHECK:       %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       %[[V_25:[0-9]+]] = fir.call @llvm.get.rounding() {{.*}} : () -> i32
     ! CHECK:       %[[V_26:[0-9]+]] = fir.convert %[[V_25]] : (i32) -> i8
     ! CHECK:       fir.store %[[V_26]] to %[[V_24]] : !fir.ref<i8>
     call ieee_get_rounding_mode(round_value)
 
-    ! CHECK:       %[[V_32:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-    ! CHECK:       %[[V_33:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_32]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_32:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+    ! CHECK:       %[[V_33:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_32]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       fir.store %c3{{.*}} to %[[V_33]] : !fir.ref<i8>
-    ! CHECK:       %[[V_34:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-    ! CHECK:       %[[V_35:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_34]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_34:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+    ! CHECK:       %[[V_35:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_34]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       %[[V_36:[0-9]+]] = fir.load %[[V_35]] : !fir.ref<i8>
     ! CHECK:       %[[V_37:[0-9]+]] = fir.convert %[[V_36]] : (i8) -> i32
     ! CHECK:       fir.call @llvm.set.rounding(%[[V_37]]) {{.*}} : (i32) -> ()
     call ieee_set_rounding_mode(ieee_down)
     print*, 'ok'
 
-    ! CHECK:       %[[V_46:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
-    ! CHECK:       %[[V_47:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_46]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_46:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_round_type.mode, !fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>
+    ! CHECK:       %[[V_47:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_46]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{_QMieee_arithmeticTieee_round_type.mode:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       %[[V_48:[0-9]+]] = fir.load %[[V_47]] : !fir.ref<i8>
     ! CHECK:       %[[V_49:[0-9]+]] = fir.convert %[[V_48]] : (i8) -> i32
     ! CHECK:       fir.call @llvm.set.rounding(%[[V_49]]) {{.*}} : (i32) -> ()

--- a/flang/test/Lower/Intrinsics/ieee_rounding.f90
+++ b/flang/test/Lower/Intrinsics/ieee_rounding.f90
@@ -3,16 +3,16 @@
 ! CHECK-LABEL: c.func @_QQmain
 program r
   use ieee_arithmetic
-  ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}> {bindc_name = "round_value", uniq_name = "_QFEround_value"}
+  ! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}> {bindc_name = "round_value", uniq_name = "_QFEround_value"}
   type(ieee_round_type) :: round_value
 
-  ! CHECK:     %[[V_13:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:     %[[V_14:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_13]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_13:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:     %[[V_14:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_13]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     fir.store %c3{{.*}} to %[[V_14]] : !fir.ref<i8>
-  ! CHECK:     %[[V_15:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-  ! CHECK:     %[[V_16:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_15]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+  ! CHECK:     %[[V_15:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+  ! CHECK:     %[[V_16:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_15]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
   ! CHECK:     %[[V_17:[0-9]+]] = fir.load %[[V_16]] : !fir.ref<i8>
   ! CHECK:     %[[V_18:[0-9]+]] = arith.cmpi sge, %[[V_17]], %c0{{.*}} : i8
   ! CHECK:     %[[V_19:[0-9]+]] = arith.cmpi sle, %[[V_17]], %c3{{.*}} : i8
@@ -21,26 +21,26 @@ program r
   ! CHECK:     %[[V_22:[0-9]+]] = fir.convert %[[V_21]] : (!fir.logical<4>) -> i1
   ! CHECK:     fir.if %[[V_22]] {
   if (ieee_support_rounding(ieee_down)) then
-    ! CHECK:       %[[V_23:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-    ! CHECK:       %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_23:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+    ! CHECK:       %[[V_24:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_23]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       %[[V_25:[0-9]+]] = fir.call @llvm.get.rounding() {{.*}} : () -> i32
     ! CHECK:       %[[V_26:[0-9]+]] = fir.convert %[[V_25]] : (i32) -> i8
     ! CHECK:       fir.store %[[V_26]] to %[[V_24]] : !fir.ref<i8>
     call ieee_get_rounding_mode(round_value)
 
-    ! CHECK:       %[[V_32:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-    ! CHECK:       %[[V_33:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_32]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_32:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+    ! CHECK:       %[[V_33:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_32]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       fir.store %c3{{.*}} to %[[V_33]] : !fir.ref<i8>
-    ! CHECK:       %[[V_34:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-    ! CHECK:       %[[V_35:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_34]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_34:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+    ! CHECK:       %[[V_35:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_34]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       %[[V_36:[0-9]+]] = fir.load %[[V_35]] : !fir.ref<i8>
     ! CHECK:       %[[V_37:[0-9]+]] = fir.convert %[[V_36]] : (i8) -> i32
     ! CHECK:       fir.call @llvm.set.rounding(%[[V_37]]) {{.*}} : (i32) -> ()
     call ieee_set_rounding_mode(ieee_down)
     print*, 'ok'
 
-    ! CHECK:       %[[V_46:[0-9]+]] = fir.field_index mode, !fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>
-    ! CHECK:       %[[V_47:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_46]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode:i8}>>, !fir.field) -> !fir.ref<i8>
+    ! CHECK:       %[[V_46:[0-9]+]] = fir.field_index mode._QMieee_arithmeticTieee_round_type, !fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>
+    ! CHECK:       %[[V_47:[0-9]+]] = fir.coordinate_of %[[V_2]], %[[V_46]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_round_type{mode._QMieee_arithmeticTieee_round_type:i8}>>, !fir.field) -> !fir.ref<i8>
     ! CHECK:       %[[V_48:[0-9]+]] = fir.load %[[V_47]] : !fir.ref<i8>
     ! CHECK:       %[[V_49:[0-9]+]] = fir.convert %[[V_48]] : (i8) -> i32
     ! CHECK:       fir.call @llvm.set.rounding(%[[V_49]]) {{.*}} : (i32) -> ()

--- a/flang/test/Lower/Intrinsics/ieee_unordered.f90
+++ b/flang/test/Lower/Intrinsics/ieee_unordered.f90
@@ -2,8 +2,8 @@
 
 ! CHECK-LABEL: func @_QQmain
 use ieee_arithmetic
-! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
 ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca f128 {bindc_name = "x", uniq_name = "_QFEx"}
 ! CHECK-DAG: %[[V_3:[0-9]+]] = fir.alloca f128 {bindc_name = "y", uniq_name = "_QFEy"}
 ! CHECK-DAG: %[[V_4:[0-9]+]] = fir.alloca f128 {bindc_name = "z", uniq_name = "_QFEz"}
@@ -11,12 +11,12 @@ real(16) :: x, y, z
 
 x = -17.0
 
-! CHECK:     %[[V_10:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_10:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     fir.store %c3{{.*}} to %[[V_11]] : !fir.ref<i8>
 
-! CHECK:     %[[V_12:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-! CHECK:     %[[V_13:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_12]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_12:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+! CHECK:     %[[V_13:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_12]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     %[[V_14:[0-9]+]] = fir.load %[[V_13]] : !fir.ref<i8>
 ! CHECK:     %[[V_15:[0-9]+]] = fir.address_of(@_FortranAIeeeValueTable_16) : !fir.ref<!fir.array<12xi64>>
 ! CHECK:     %[[V_16:[0-9]+]] = fir.coordinate_of %[[V_15]], %[[V_14]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>
@@ -27,11 +27,11 @@ x = -17.0
 ! CHECK:     fir.store %[[V_20]] to %[[V_3]] : !fir.ref<f128>
 y = ieee_value(y, ieee_negative_inf)
 
-! CHECK:     %[[V_26:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_26]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_26:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_26]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     fir.store %c2{{.*}} to %[[V_27]] : !fir.ref<i8>
-! CHECK:     %[[V_28:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
-! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_28:[0-9]+]] = fir.field_index _QMieee_arithmeticTieee_class_type.which, !fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>
+! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{_QMieee_arithmeticTieee_class_type.which:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     %[[V_30:[0-9]+]] = fir.load %[[V_29]] : !fir.ref<i8>
 ! CHECK:     %[[V_31:[0-9]+]] = fir.address_of(@_FortranAIeeeValueTable_16) : !fir.ref<!fir.array<12xi64>>
 ! CHECK:     %[[V_32:[0-9]+]] = fir.coordinate_of %[[V_31]], %[[V_30]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>

--- a/flang/test/Lower/Intrinsics/ieee_unordered.f90
+++ b/flang/test/Lower/Intrinsics/ieee_unordered.f90
@@ -2,8 +2,8 @@
 
 ! CHECK-LABEL: func @_QQmain
 use ieee_arithmetic
-! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
+! CHECK-DAG: %[[V_0:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+! CHECK-DAG: %[[V_1:[0-9]+]] = fir.alloca !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
 ! CHECK-DAG: %[[V_2:[0-9]+]] = fir.alloca f128 {bindc_name = "x", uniq_name = "_QFEx"}
 ! CHECK-DAG: %[[V_3:[0-9]+]] = fir.alloca f128 {bindc_name = "y", uniq_name = "_QFEy"}
 ! CHECK-DAG: %[[V_4:[0-9]+]] = fir.alloca f128 {bindc_name = "z", uniq_name = "_QFEz"}
@@ -11,12 +11,12 @@ real(16) :: x, y, z
 
 x = -17.0
 
-! CHECK:     %[[V_10:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_10:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+! CHECK:     %[[V_11:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_10]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     fir.store %c3{{.*}} to %[[V_11]] : !fir.ref<i8>
 
-! CHECK:     %[[V_12:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-! CHECK:     %[[V_13:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_12]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_12:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+! CHECK:     %[[V_13:[0-9]+]] = fir.coordinate_of %[[V_1]], %[[V_12]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     %[[V_14:[0-9]+]] = fir.load %[[V_13]] : !fir.ref<i8>
 ! CHECK:     %[[V_15:[0-9]+]] = fir.address_of(@_FortranAIeeeValueTable_16) : !fir.ref<!fir.array<12xi64>>
 ! CHECK:     %[[V_16:[0-9]+]] = fir.coordinate_of %[[V_15]], %[[V_14]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>
@@ -27,11 +27,11 @@ x = -17.0
 ! CHECK:     fir.store %[[V_20]] to %[[V_3]] : !fir.ref<f128>
 y = ieee_value(y, ieee_negative_inf)
 
-! CHECK:     %[[V_26:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_26]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_26:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+! CHECK:     %[[V_27:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_26]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     fir.store %c2{{.*}} to %[[V_27]] : !fir.ref<i8>
-! CHECK:     %[[V_28:[0-9]+]] = fir.field_index which, !fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>
-! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which:i8}>>, !fir.field) -> !fir.ref<i8>
+! CHECK:     %[[V_28:[0-9]+]] = fir.field_index which._QMieee_arithmeticTieee_class_type, !fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>
+! CHECK:     %[[V_29:[0-9]+]] = fir.coordinate_of %[[V_0]], %[[V_28]] : (!fir.ref<!fir.type<_QMieee_arithmeticTieee_class_type{which._QMieee_arithmeticTieee_class_type:i8}>>, !fir.field) -> !fir.ref<i8>
 ! CHECK:     %[[V_30:[0-9]+]] = fir.load %[[V_29]] : !fir.ref<i8>
 ! CHECK:     %[[V_31:[0-9]+]] = fir.address_of(@_FortranAIeeeValueTable_16) : !fir.ref<!fir.array<12xi64>>
 ! CHECK:     %[[V_32:[0-9]+]] = fir.coordinate_of %[[V_31]], %[[V_30]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>


### PR DESCRIPTION
It is possible for a derived type extending a type with private components to define components with the same name as the private components.

This was not properly handled by lowering where several fir.record type component names could end-up being the same, leading to bad generated code (only the first component was accessed via fir.field_index, leading to bad generated code).

This patch handles the situation by adding the derived type mangled name to private component.