### PR TITLE
[libc++] Simplify overload sets where C::iterator == C::const_iterator

### DIFF
--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -742,23 +742,13 @@ public:
     }
 
     _LIBCPP_INLINE_VISIBILITY
-          iterator begin() _NOEXCEPT       {return __tree_.begin();}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator begin() const _NOEXCEPT {return __tree_.begin();}
-    _LIBCPP_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT         {return __tree_.end();}
     _LIBCPP_INLINE_VISIBILITY
     const_iterator end()   const _NOEXCEPT {return __tree_.end();}
 
     _LIBCPP_INLINE_VISIBILITY
-          reverse_iterator rbegin() _NOEXCEPT
-            {return reverse_iterator(end());}
-    _LIBCPP_INLINE_VISIBILITY
     const_reverse_iterator rbegin() const _NOEXCEPT
         {return const_reverse_iterator(end());}
-    _LIBCPP_INLINE_VISIBILITY
-          reverse_iterator rend() _NOEXCEPT
-            {return reverse_iterator(begin());}
     _LIBCPP_INLINE_VISIBILITY
     const_reverse_iterator rend() const _NOEXCEPT
         {return const_reverse_iterator(begin());}
@@ -916,14 +906,8 @@ public:
 
     // set operations:
     _LIBCPP_INLINE_VISIBILITY
-    iterator find(const key_type& __k)             {return __tree_.find(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator find(const key_type& __k) const {return __tree_.find(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator
-    find(const _K2& __k)                           {return __tree_.find(__k);}
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator
@@ -950,17 +934,9 @@ public:
 #endif // _LIBCPP_STD_VER >= 20
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator lower_bound(const key_type& __k)
-        {return __tree_.lower_bound(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator lower_bound(const key_type& __k) const
         {return __tree_.lower_bound(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator
-    lower_bound(const _K2& __k)       {return __tree_.lower_bound(__k);}
-
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator
@@ -968,16 +944,9 @@ public:
 #endif
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator upper_bound(const key_type& __k)
-        {return __tree_.upper_bound(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator upper_bound(const key_type& __k) const
         {return __tree_.upper_bound(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator
-    upper_bound(const _K2& __k)       {return __tree_.upper_bound(__k);}
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator
@@ -985,16 +954,9 @@ public:
 #endif
 
     _LIBCPP_INLINE_VISIBILITY
-    pair<iterator,iterator> equal_range(const key_type& __k)
-        {return __tree_.__equal_range_unique(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator,const_iterator> equal_range(const key_type& __k) const
         {return __tree_.__equal_range_unique(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    pair<iterator,iterator>
-    equal_range(const _K2& __k)       {return __tree_.__equal_range_multi(__k);}
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator,const_iterator>
@@ -1333,23 +1295,13 @@ public:
     }
 
     _LIBCPP_INLINE_VISIBILITY
-          iterator begin() _NOEXCEPT       {return __tree_.begin();}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator begin() const _NOEXCEPT {return __tree_.begin();}
-    _LIBCPP_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT         {return __tree_.end();}
     _LIBCPP_INLINE_VISIBILITY
     const_iterator end()   const _NOEXCEPT {return __tree_.end();}
 
     _LIBCPP_INLINE_VISIBILITY
-          reverse_iterator rbegin() _NOEXCEPT
-            {return reverse_iterator(end());}
-    _LIBCPP_INLINE_VISIBILITY
     const_reverse_iterator rbegin() const _NOEXCEPT
         {return const_reverse_iterator(end());}
-    _LIBCPP_INLINE_VISIBILITY
-          reverse_iterator rend() _NOEXCEPT
-            {return       reverse_iterator(begin());}
     _LIBCPP_INLINE_VISIBILITY
     const_reverse_iterator rend() const _NOEXCEPT
         {return const_reverse_iterator(begin());}
@@ -1507,14 +1459,8 @@ public:
 
     // set operations:
     _LIBCPP_INLINE_VISIBILITY
-    iterator find(const key_type& __k)             {return __tree_.find(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator find(const key_type& __k) const {return __tree_.find(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator
-    find(const _K2& __k)                           {return __tree_.find(__k);}
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator
@@ -1541,17 +1487,9 @@ public:
 #endif // _LIBCPP_STD_VER >= 20
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator lower_bound(const key_type& __k)
-        {return __tree_.lower_bound(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator lower_bound(const key_type& __k) const
             {return __tree_.lower_bound(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator
-    lower_bound(const _K2& __k)       {return __tree_.lower_bound(__k);}
-
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator
@@ -1559,16 +1497,9 @@ public:
 #endif
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator upper_bound(const key_type& __k)
-            {return __tree_.upper_bound(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator upper_bound(const key_type& __k) const
             {return __tree_.upper_bound(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator
-    upper_bound(const _K2& __k)       {return __tree_.upper_bound(__k);}
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator
@@ -1576,16 +1507,9 @@ public:
 #endif
 
     _LIBCPP_INLINE_VISIBILITY
-    pair<iterator,iterator>             equal_range(const key_type& __k)
-            {return __tree_.__equal_range_multi(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator,const_iterator> equal_range(const key_type& __k) const
             {return __tree_.__equal_range_multi(__k);}
 #if _LIBCPP_STD_VER >= 14
-    template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
-    _LIBCPP_INLINE_VISIBILITY
-    pair<iterator,iterator>
-    equal_range(const _K2& __k)       {return __tree_.__equal_range_multi(__k);}
     template <typename _K2, enable_if_t<__is_transparent<_Compare, _K2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator,const_iterator>

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -741,10 +741,6 @@ public:
     size_type max_size() const _NOEXCEPT {return __table_.max_size();}
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT        {return __table_.begin();}
-    _LIBCPP_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT          {return __table_.end();}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator begin()  const _NOEXCEPT {return __table_.begin();}
     _LIBCPP_INLINE_VISIBILITY
     const_iterator end()    const _NOEXCEPT {return __table_.end();}
@@ -881,13 +877,8 @@ public:
     key_equal key_eq() const {return __table_.key_eq();}
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator       find(const key_type& __k)       {return __table_.find(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator find(const key_type& __k) const {return __table_.find(__k);}
 #if _LIBCPP_STD_VER >= 20
-    template <class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator       find(const _K2& __k)            {return __table_.find(__k);}
     template <class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator find(const _K2& __k) const      {return __table_.find(__k);}
@@ -911,16 +902,9 @@ public:
 #endif // _LIBCPP_STD_VER >= 20
 
     _LIBCPP_INLINE_VISIBILITY
-    pair<iterator, iterator>             equal_range(const key_type& __k)
-        {return __table_.__equal_range_unique(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator, const_iterator> equal_range(const key_type& __k) const
         {return __table_.__equal_range_unique(__k);}
 #if _LIBCPP_STD_VER >= 20
-    template <class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
-    _LIBCPP_INLINE_VISIBILITY
-    pair<iterator, iterator>             equal_range(const _K2& __k)
-        {return __table_.__equal_range_unique(__k);}
     template <class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
     _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator, const_iterator> equal_range(const _K2& __k) const
@@ -937,10 +921,6 @@ public:
     _LIBCPP_INLINE_VISIBILITY
     size_type bucket(const key_type& __k) const {return __table_.bucket(__k);}
 
-    _LIBCPP_INLINE_VISIBILITY
-    local_iterator       begin(size_type __n)        {return __table_.begin(__n);}
-    _LIBCPP_INLINE_VISIBILITY
-    local_iterator       end(size_type __n)          {return __table_.end(__n);}
     _LIBCPP_INLINE_VISIBILITY
     const_local_iterator begin(size_type __n) const  {return __table_.cbegin(__n);}
     _LIBCPP_INLINE_VISIBILITY
@@ -1430,10 +1410,6 @@ public:
     size_type max_size() const _NOEXCEPT {return __table_.max_size();}
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT        {return __table_.begin();}
-    _LIBCPP_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT          {return __table_.end();}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator begin()  const _NOEXCEPT {return __table_.begin();}
     _LIBCPP_INLINE_VISIBILITY
     const_iterator end()    const _NOEXCEPT {return __table_.end();}
@@ -1567,13 +1543,8 @@ public:
     key_equal key_eq() const {return __table_.key_eq();}
 
     _LIBCPP_INLINE_VISIBILITY
-    iterator       find(const key_type& __k)       {return __table_.find(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     const_iterator find(const key_type& __k) const {return __table_.find(__k);}
 #if _LIBCPP_STD_VER >= 20
-    template<class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
-    _LIBCPP_INLINE_VISIBILITY
-    iterator       find(const _K2& __k)            {return __table_.find(__k);}
     template<class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
     _LIBCPP_INLINE_VISIBILITY
     const_iterator find(const _K2& __k) const      {return __table_.find(__k);}
@@ -1597,16 +1568,9 @@ public:
 #endif // _LIBCPP_STD_VER >= 20
 
     _LIBCPP_INLINE_VISIBILITY
-    pair<iterator, iterator>             equal_range(const key_type& __k)
-        {return __table_.__equal_range_multi(__k);}
-    _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator, const_iterator> equal_range(const key_type& __k) const
         {return __table_.__equal_range_multi(__k);}
 #if _LIBCPP_STD_VER >= 20
-    template<class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
-    _LIBCPP_INLINE_VISIBILITY
-    pair<iterator, iterator>             equal_range(const _K2& __k)
-        {return __table_.__equal_range_multi(__k);}
     template<class _K2, enable_if_t<__is_transparent<hasher, _K2>::value && __is_transparent<key_equal, _K2>::value>* = nullptr>
     _LIBCPP_INLINE_VISIBILITY
     pair<const_iterator, const_iterator> equal_range(const _K2& __k) const
@@ -1623,10 +1587,6 @@ public:
     _LIBCPP_INLINE_VISIBILITY
     size_type bucket(const key_type& __k) const {return __table_.bucket(__k);}
 
-    _LIBCPP_INLINE_VISIBILITY
-    local_iterator       begin(size_type __n)        {return __table_.begin(__n);}
-    _LIBCPP_INLINE_VISIBILITY
-    local_iterator       end(size_type __n)          {return __table_.end(__n);}
     _LIBCPP_INLINE_VISIBILITY
     const_local_iterator begin(size_type __n) const  {return __table_.cbegin(__n);}
     _LIBCPP_INLINE_VISIBILITY


### PR DESCRIPTION
No functional change intended, except to speed up overload resolution. The removed non-const overloads always do exactly the same thing as the const overloads, _including_ having the same return type, because for these `set`-like types the `iterator` and `const_iterator` types are identical by design. (And we'll never change this, because that would break existing user code that assumes they're identical.)