### PR TITLE
[AMDGPU] Fix some MIR tests

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/twoaddr-fma-f64.mir
+++ b/llvm/test/CodeGen/AMDGPU/twoaddr-fma-f64.mir
@@ -56,7 +56,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_fmaak_sgpr_src0_f64
-# GCN: V_FMA_F64_e64 0, killed %0, 0, %1, 0, %2:vreg_64_align2, 0, 0, implicit $mode, implicit $exec
+# GCN: V_FMA_F64_e64 0, killed %0, 0, %1, 0, %2, 0, 0, implicit $mode, implicit $exec
 
 ---
 name:            test_fmaak_sgpr_src0_f64
@@ -70,12 +70,13 @@ body:             |
 
     %0 = IMPLICIT_DEF
     %1 = V_MOV_B64_PSEUDO 4607182418800017408, implicit $exec
+    %2 = IMPLICIT_DEF
     %3 = V_FMAC_F64_e32 killed %0, %1, %2, implicit $mode, implicit $exec
 
 ...
 
 # GCN-LABEL: name: test_fmaak_inlineimm_src0_f64
-# GCN: V_FMA_F64_e64 0, 4611686018427387904, 0, %0, 0, %1:vreg_64_align2, 0, 0, implicit $mode, implicit $exec
+# GCN: V_FMA_F64_e64 0, 4611686018427387904, 0, %0, 0, %1, 0, 0, implicit $mode, implicit $exec
 
 ---
 name:            test_fmaak_inlineimm_src0_f64
@@ -87,6 +88,7 @@ body:             |
   bb.0:
 
     %0 = V_MOV_B64_PSEUDO 4607182418800017408, implicit $exec
+    %1 = IMPLICIT_DEF
     %2 = V_FMAC_F64_e32 4611686018427387904, %0, %1, implicit $mode, implicit $exec
 
 ...
@@ -104,6 +106,7 @@ body:             |
   bb.0:
 
     %0 = V_MOV_B64_PSEUDO 4607182418800017408, implicit $exec
+    %1 = IMPLICIT_DEF
     %2 = V_FMAC_F64_e32 4636737291354636288, %0, %1, implicit $mode, implicit $exec
 
 ...
@@ -124,6 +127,7 @@ body:             |
   bb.0:
 
     %0 = V_MOV_B64_PSEUDO 4607182418800017408, implicit $exec
+    %1 = IMPLICIT_DEF
     %2 = V_FMAC_F64_e32 %stack.0, %0, %1, implicit $mode, implicit $exec
 
 ...

--- a/llvm/test/CodeGen/AMDGPU/twoaddr-mad.mir
+++ b/llvm/test/CodeGen/AMDGPU/twoaddr-mad.mir
@@ -113,7 +113,7 @@ body:             |
 
 # GCN-LABEL: name: test_madak_sgpr_src0_f32
 # GCN: %1:vgpr_32 = V_MOV_B32_e32 1078523331, implicit $exec
-# GCN: %2:vgpr_32 = V_MAD_F32_e64 0, killed %0, 0, %1, 0, %3:vgpr_32, 0, 0, implicit $mode, implicit $exec
+# GCN: %3:vgpr_32 = V_MAD_F32_e64 0, killed %0, 0, %1, 0, %2, 0, 0, implicit $mode, implicit $exec
 
 ---
 name:            test_madak_sgpr_src0_f32
@@ -127,14 +127,15 @@ body:             |
 
     %0 = IMPLICIT_DEF
     %1 = V_MOV_B32_e32 1078523331, implicit $exec
-    %2 = V_MAC_F32_e32 killed %0, %1, %3, implicit $mode, implicit $exec
+    %2 = IMPLICIT_DEF
+    %3 = V_MAC_F32_e32 killed %0, %1, %2, implicit $mode, implicit $exec
 
 ...
 
 # This can still fold if this is an inline immediate.
 
 # GCN-LABEL: name: test_madak_inlineimm_src0_f32
-# GCN: %1:vgpr_32 = V_MADMK_F32 1073741824, 1078523331, %2:vgpr_32, implicit $mode, implicit $exec
+# GCN: %2:vgpr_32 = V_MADMK_F32 1073741824, 1078523331, %1, implicit $mode, implicit $exec
 
 ---
 name:            test_madak_inlineimm_src0_f32
@@ -146,13 +147,14 @@ body:             |
   bb.0:
 
     %0 = V_MOV_B32_e32 1078523331, implicit $exec
-    %1 = V_MAC_F32_e32 1073741824, %0, %2, implicit $mode, implicit $exec
+    %1 = IMPLICIT_DEF
+    %2 = V_MAC_F32_e32 1073741824, %0, %1, implicit $mode, implicit $exec
 
 ...
 # Non-inline immediate uses constant bus already.
 
 # GCN-LABEL: name: test_madak_otherimm_src0_f32
-# GCN: %1:vgpr_32 = V_MADMK_F32 %0, 1120403456, %2:vgpr_32, implicit $mode, implicit $exec
+# GCN: %2:vgpr_32 = V_MADMK_F32 %0, 1120403456, %1, implicit $mode, implicit $exec
 
 ---
 name:            test_madak_otherimm_src0_f32
@@ -164,13 +166,14 @@ body:             |
   bb.0:
 
     %0 = V_MOV_B32_e32 1078523331, implicit $exec
-    %1 = V_MAC_F32_e32 1120403456, %0, %2, implicit $mode, implicit $exec
+    %1 = IMPLICIT_DEF
+    %2 = V_MAC_F32_e32 1120403456, %0, %1, implicit $mode, implicit $exec
 
 ...
 # Non-inline immediate uses constant bus already.
 
 # GCN-LABEL: name: test_madak_other_constantlike_src0_f32
-# GCN: %1:vgpr_32 = V_MAC_F32_e32 %stack.0, %0, %1, implicit $mode, implicit $exec
+# GCN: %2:vgpr_32 = V_MAC_F32_e32 %stack.0, %0, %2, implicit $mode, implicit $exec
 ---
 name:            test_madak_other_constantlike_src0_f32
 registers:
@@ -185,7 +188,8 @@ body:             |
   bb.0:
 
     %0 = V_MOV_B32_e32 1078523331, implicit $exec
-    %1 = V_MAC_F32_e32 %stack.0, %0, %2, implicit $mode, implicit $exec
+    %1 = IMPLICIT_DEF
+    %2 = V_MAC_F32_e32 %stack.0, %0, %1, implicit $mode, implicit $exec
 
 ...
 
@@ -194,12 +198,8 @@ body:             |
 
 ---
 name:            test_madak_inline_literal_f16
-liveins:
-  - { reg: '$vgpr0', virtual-reg: '%3' }
 body:             |
   bb.0:
-    liveins: $vgpr0
-
     %3:vgpr_32 = COPY killed $vgpr0
 
     %26:vgpr_32 = V_MOV_B32_e32 49664, implicit $exec


### PR DESCRIPTION
Fix some problems in hand written MIR tests that only showed up when I
tried to run LiveIntervals on them, after which they failed machine
verification with "Use not jointly dominated by defs" errors.
