### PR TITLE
[Github] Improve formating of PR diffs in bot notifications

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -49,7 +49,8 @@ def _get_curent_team(team_name, teams) -> Optional[github.Team.Team]:
 
 def escape_description(str):
     # https://github.com/github/markup/issues/1168#issuecomment-494946168
-    return html.escape(str.replace("@", "@<!-- -->"), False)
+    str = html.escape(str, False)
+    return str.replace("@", "@<!-- -->")
 
 class IssueSubscriber:
     @property

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -50,7 +50,11 @@ def _get_curent_team(team_name, teams) -> Optional[github.Team.Team]:
 def escape_description(str):
     # https://github.com/github/markup/issues/1168#issuecomment-494946168
     str = html.escape(str, False)
-    return str.replace("@", "@<!-- -->").replace("#", "#<!-- -->")
+    # '@' followed by alphanum is a user name
+    str = re.sub("@(?=\w+)","@<!-- -->", str)
+    # '#' followed by digits is considered an issue number
+    str = re.sub("#(?=\d+\s)", "#<!-- -->", str)
+    return str
 
 
 class IssueSubscriber:

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -51,7 +51,7 @@ def escape_description(str):
     # https://github.com/github/markup/issues/1168#issuecomment-494946168
     str = html.escape(str, False)
     # '@' followed by alphanum is a user name
-    str = re.sub("@(?=\w+)","@<!-- -->", str)
+    str = re.sub("@(?=\w+)", "@<!-- -->", str)
     # '#' followed by digits is considered an issue number
     str = re.sub("#(?=\d+\s)", "#<!-- -->", str)
     return str
@@ -60,6 +60,7 @@ def escape_description(str):
 def sanitize_markdown_code_block(str):
     # remove codeblocks terminators
     return re.sub("^\s*```\s*$", r"` ` `", str)
+
 
 class IssueSubscriber:
     @property

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -174,8 +174,9 @@ class PRSubscriber:
 
 <details>
 <summary>Changes</summary>
+
 {body}
---
+---
 {patch_link}
 
 {diff_stats}

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -56,6 +56,7 @@ def escape_description(str):
     str = re.sub("#(?=\d+\s)", "#<!-- -->", str)
     return str
 
+
 def sanitize_markdown_code_block(str):
     # remove codeblocks terminators
     return re.sub("^\s*```\s*$", r"` ` `", str)
@@ -164,8 +165,8 @@ class PRSubscriber:
         team_mention = "@llvm/{}".format(team.slug)
 
         body = escape_description(self.pr.body)
-# Note: the comment is in markdown and the code below
-# is sensible to line break
+        # Note: the comment is in markdown and the code below
+        # is sensible to line break
         comment = f"""
 {self.COMMENT_TAG}
 {team_mention}

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -47,10 +47,12 @@ def _get_curent_team(team_name, teams) -> Optional[github.Team.Team]:
             return team
     return None
 
+
 def escape_description(str):
     # https://github.com/github/markup/issues/1168#issuecomment-494946168
     str = html.escape(str, False)
     return str.replace("@", "@<!-- -->")
+
 
 class IssueSubscriber:
     @property
@@ -74,13 +76,13 @@ class IssueSubscriber:
 
         body = escape_description(self.issue.body)
 
-        comment = ( f"""
+        comment = f"""
 @llvm/{team.slug}
 
 <details>
 {body}
 </details>
-""" )
+"""
 
         self.issue.create_comment(comment)
         return True

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -12,6 +12,7 @@ import argparse
 from git import Repo  # type: ignore
 import html
 import github
+import html
 import os
 import re
 import requests
@@ -46,6 +47,9 @@ def _get_curent_team(team_name, teams) -> Optional[github.Team.Team]:
             return team
     return None
 
+def escape_description(str):
+    # https://github.com/github/markup/issues/1168#issuecomment-494946168
+    return html.escape(str.replace("@", "@<!-- -->"), False)
 
 class IssueSubscriber:
     @property
@@ -67,12 +71,15 @@ class IssueSubscriber:
         if team.slug == "issue-subscribers-good-first-issue":
             comment = "{}\n".format(beginner_comment)
 
-        comment = (
-            f"@llvm/{team.slug}"
-            + "\n\n<details>\n"
-            + f"{self.issue.body}\n"
-            + "</details>"
-        )
+        body = escape_description(self.issue.body)
+
+        comment = ( f"""
+@llvm/{team.slug}
+
+<details>
+{body}
+</details>
+""" )
 
         self.issue.create_comment(comment)
         return True

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -12,7 +12,6 @@ import argparse
 from git import Repo  # type: ignore
 import html
 import github
-import html
 import os
 import re
 import requests
@@ -123,8 +122,8 @@ class PRSubscriber:
             print(f"couldn't find team named {self.team_name}")
             return False
 
-         # GitHub limits comments to 65,536 characters, let's limit the diff
-         # and the file list to 20kB each.
+        # GitHub limits comments to 65,536 characters, let's limit the diff
+        # and the file list to 20kB each.
         STAT_LIMIT = 20 * 1024
         DIFF_LIMIT = 20 * 1024
 
@@ -138,9 +137,9 @@ class PRSubscriber:
                 diff_stats += f"-{file.deletions}"
             diff_stats += ") "
             if file.status == "renamed":
-                print(f"(from {file.previous_filename})"
+                print(f"(from {file.previous_filename})")
             diff_stats += "\n"
-            if len(diff_stats) > STAT_LIMIT)
+            if len(diff_stats) > STAT_LIMIT:
                 break
 
         # Get the diff

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -57,11 +57,6 @@ def escape_description(str):
     return str
 
 
-def sanitize_markdown_code_block(str):
-    # remove codeblocks terminators
-    return re.sub("^\s*```\s*$", r"` ` `", str)
-
-
 class IssueSubscriber:
     @property
     def team_name(self) -> str:
@@ -157,8 +152,6 @@ class PRSubscriber:
         except:
             patch = ""
 
-        patch = sanitize_markdown_code_block(patch)
-
         patch_link = f"Full diff: {self.pr.diff_url}\n"
         if len(patch) > DIFF_LIMIT:
             patch_link = f"\nPatch is {human_readable_size(len(patch))}, truncated to {human_readable_size(DIFF_LIMIT)} below, full version: {self.pr.diff_url}\n"
@@ -181,9 +174,9 @@ class PRSubscriber:
 
 {diff_stats}
 
-```diff
+``````````diff
 {patch}
-```
+``````````
 
 </details>
 """


### PR DESCRIPTION
* This avoid pinging folks on all issue when they got pinged on bugzilla eons ago
* Avoid formatting bugs when there is html in the issue description
* Truncate the list of files and the diff independently of each other. This avoids truncating cutting a file line in 2 and to cut in the middle of html markup. This is a fringe case but it does happen when people accidentally push weird branches conflicting on all the files.

Test: This is #66118 @cor3ntin 
