### PR TITLE
[flang][runtime] zero size allocation in source allocation

### DIFF
--- a/flang/runtime/allocatable.cpp
+++ b/flang/runtime/allocatable.cpp
@@ -168,9 +168,6 @@ int RTNAME(AllocatableAllocate)(Descriptor &descriptor, bool hasStat,
 int RTNAME(AllocatableAllocateSource)(Descriptor &alloc,
     const Descriptor &source, bool hasStat, const Descriptor *errMsg,
     const char *sourceFile, int sourceLine) {
-  if (alloc.Elements() == 0) {
-    return StatOk;
-  }
   int stat{RTNAME(AllocatableAllocate)(
       alloc, hasStat, errMsg, sourceFile, sourceLine)};
   if (stat == StatOk) {

--- a/flang/runtime/descriptor.cpp
+++ b/flang/runtime/descriptor.cpp
@@ -142,8 +142,11 @@ std::size_t Descriptor::Elements() const {
 
 int Descriptor::Allocate() {
   std::size_t byteSize{Elements() * ElementBytes()};
-  void *p{std::malloc(byteSize)};
-  if (!p && byteSize) {
+  // Zero size allocation is possible in Fortran and the resulting
+  // descriptor must be allocated/associated. Since std::malloc(0)
+  // result is implementation defined, always allocate at least one byte.
+  void *p{byteSize ? std::malloc(byteSize) : std::malloc(1)};
+  if (!p) {
     return CFI_ERROR_MEM_ALLOCATION;
   }
   // TODO: image synchronization

--- a/flang/runtime/pointer.cpp
+++ b/flang/runtime/pointer.cpp
@@ -154,9 +154,6 @@ int RTNAME(PointerAllocate)(Descriptor &pointer, bool hasStat,
 int RTNAME(PointerAllocateSource)(Descriptor &pointer, const Descriptor &source,
     bool hasStat, const Descriptor *errMsg, const char *sourceFile,
     int sourceLine) {
-  if (pointer.Elements() == 0) {
-    return StatOk;
-  }
   int stat{RTNAME(PointerAllocate)(
       pointer, hasStat, errMsg, sourceFile, sourceLine)};
   if (stat == StatOk) {


### PR DESCRIPTION
Source allocation with a zero sized array is legal, and the resulting allocatable/pointer should be allocated/associated.

The current code skipped the actual allocation, leading the allocatable or pointer to look unallocated/disassociated.