### PR TITLE
[libc] Add missing deps for header libraries.

### DIFF
--- a/libc/cmake/modules/LLVMLibCHeaderRules.cmake
+++ b/libc/cmake/modules/LLVMLibCHeaderRules.cmake
@@ -55,6 +55,8 @@ function(add_header target_name)
     ${target_name}
     HDRS
       ${dest_file}
+    DEPENDS
+      ${copied_hdr_target}
   )
   set_target_properties(
     ${fq_target_name}
@@ -175,6 +177,8 @@ function(add_gen_header target_name)
     ${target_name}
     HDRS
       ${out_file}
+    DEPENDS
+      ${generated_hdr_target}
   )
 
   set_target_properties(

--- a/libc/cmake/modules/LLVMLibCLibraryRules.cmake
+++ b/libc/cmake/modules/LLVMLibCLibraryRules.cmake
@@ -160,13 +160,6 @@ function(create_header_library fq_target_name)
     message(FATAL_ERROR "'add_header_library' target requires a HDRS list of .h files.")
   endif()
 
-  set(FULL_HDR_PATHS "")
-  # TODO: Remove this foreach block when we can switch to the new
-  # version of the CMake policy CMP0076.
-  foreach(hdr IN LISTS ADD_HEADER_HDRS)
-    list(APPEND FULL_HDR_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/${hdr})
-  endforeach()
-
   if(SHOW_INTERMEDIATE_OBJECTS)
     message(STATUS "Adding header library ${fq_target_name}")
     if(${SHOW_INTERMEDIATE_OBJECTS} STREQUAL "DEPS")
@@ -177,7 +170,7 @@ function(create_header_library fq_target_name)
   endif()
 
   add_library(${fq_target_name} INTERFACE)
-  target_sources(${fq_target_name} INTERFACE ${FULL_HDR_PATHS})
+  target_sources(${fq_target_name} INTERFACE ${ADD_HEADER_HDRS})
   if(ADD_HEADER_DEPENDS)
     add_dependencies(${fq_target_name} ${ADD_HEADER_DEPENDS})
   endif()


### PR DESCRIPTION
Also, we removed CMP0076 exception sometime back but did not adjust the
build rules. The adjustment in the build rules is also done in this
patch.
