### PR TITLE
Update paths for `debuginfo` labeling

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -313,13 +313,30 @@ testing-tools:
   - llvm/utils/update*_test_checks.py
 
 debuginfo:
-  - clang/lib/CodeGen/CGDebugInfo.cpp
+  - clang/lib/CodeGen/CGDebugInfo.*
   - llvm/include/llvm/BinaryFormat/Dwarf.*
+  - llvm/include/llvm/CodeGen/*Debug*.*
   - llvm/include/llvm/DebugInfo/**
-  - llvm/include/llvm/IR/Debug*.h
-  - llvm/lib/CodeGen/AsmPrinter/**
+  - llvm/include/llvm/Debuginfod/**
+  - llvm/include/llvm/Frontend/Debug/**
+  - llvm/include/llvm/IR/Debug*.*
+  - llvm/include/llvm/Object/*Debug*.*
+  - llvm/include/llvm/ObjectYAML/*Debug*.*
+  - llvm/include/llvm/Transforms/Utils/*Debug*.*
+  - llvm/include/llvm-c/DebugInfo.h
+  - llvm/lib/BinaryFormat/Dwarf.cpp
+  - llvm/lib/CodeGen/AsmPrinter/*Debug*.*
+  - llvm/lib/CodeGen/AsmPrinter/Dwarf*.*
+  - llvm/lib/CodeGen/AsmPrinter/DIE*.*
+  - llvm/lib/CodeGen/LiveDebugValues/**
+  - llvm/lib/CodeGen/*Debug*.*
+  - llvm/lib/CodeGen/DwarfEHPrepare.cpp
   - llvm/lib/DebugInfo/**
+  - llvm/lib/Debuginfod/**
+  - llvm/lib/DWARFLinkerParallel/**
   - llvm/lib/IR/Debug*.cpp
+  - llvm/lib/MC/MCDwarf.cpp
+  - llvm/lib/Transforms/Utils/*Debug*.*
   - llvm/test/DebugInfo/**
   - llvm/test/tools/dsymutil/**
   - llvm/test/tools/llvm-debuginfo-analyzer/**


### PR DESCRIPTION
Adds a bunch of stuff overlooked in the original setup. Steps back a little on the llvm/lib/CodeGen/AsmPrinter paths.