### PR TITLE
[lldb][Commands] Check that modules reports that they're loaded

### DIFF
--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -13,7 +13,6 @@
 
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBPlatform.h"
-#include "lldb/API/SBStructuredData.h"
 
 namespace lldb_private {
 class CommandPluginInterfaceImplementation;
@@ -47,7 +46,6 @@ public:
       eBroadcastBitProgress = (1 << 0),
       eBroadcastBitWarning = (1 << 1),
       eBroadcastBitError = (1 << 2),
-      eBroadcastBitSymbolChange = (1 << 3),
   };
 
   SBDebugger();

--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -13,6 +13,7 @@
 
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBPlatform.h"
+#include "lldb/API/SBStructuredData.h"
 
 namespace lldb_private {
 class CommandPluginInterfaceImplementation;
@@ -46,6 +47,7 @@ public:
       eBroadcastBitProgress = (1 << 0),
       eBroadcastBitWarning = (1 << 1),
       eBroadcastBitError = (1 << 2),
+      eBroadcastBitSymbolChange = (1 << 3),
   };
 
   SBDebugger();

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -40,7 +40,8 @@ public:
     eBroadcastBitModulesLoaded = (1 << 1),
     eBroadcastBitModulesUnloaded = (1 << 2),
     eBroadcastBitWatchpointChanged = (1 << 3),
-    eBroadcastBitSymbolsLoaded = (1 << 4)
+    eBroadcastBitSymbolsLoaded = (1 << 4),
+    eBroadcastBitSymbolsChanged = (1 << 5),
   };
 
   // Constructors

--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -83,7 +83,7 @@ public:
     eBroadcastBitProgress = (1 << 0),
     eBroadcastBitWarning = (1 << 1),
     eBroadcastBitError = (1 << 2),
-    eBroadcastBitSymbolChange = (1 << 3),
+    eBroadcastBitSymbolFileChange = (1 << 3),
   };
 
   using DebuggerList = std::vector<lldb::DebuggerSP>;

--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -83,7 +83,7 @@ public:
     eBroadcastBitProgress = (1 << 0),
     eBroadcastBitWarning = (1 << 1),
     eBroadcastBitError = (1 << 2),
-    eBroadcastSymbolChange = (1 << 3),
+    eBroadcastBitSymbolChange = (1 << 3),
   };
 
   using DebuggerList = std::vector<lldb::DebuggerSP>;

--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -83,7 +83,7 @@ public:
     eBroadcastBitProgress = (1 << 0),
     eBroadcastBitWarning = (1 << 1),
     eBroadcastBitError = (1 << 2),
-    eBroadcastBitSymbolFileChange = (1 << 3),
+    eBroadcastBitSymbolFileChanged = (1 << 3),
   };
 
   using DebuggerList = std::vector<lldb::DebuggerSP>;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_TARGET_TARGET_H
 #define LLDB_TARGET_TARGET_H
 
+#include <_types/_uint32_t.h>
 #include <list>
 #include <map>
 #include <memory>
@@ -875,7 +876,7 @@ public:
 
   void ModulesDidUnload(ModuleList &module_list, bool delete_locations);
 
-  void SymbolsDidLoad(ModuleList &module_list);
+  void SymbolsDidLoad(ModuleList &module_list, uint32_t load_or_change_broadcast_bit);
 
   void ClearModules(bool delete_locations);
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -9,7 +9,6 @@
 #ifndef LLDB_TARGET_TARGET_H
 #define LLDB_TARGET_TARGET_H
 
-#include <_types/_uint32_t.h>
 #include <list>
 #include <map>
 #include <memory>

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -4212,7 +4212,7 @@ protected:
           // currently loaded
           ModuleList module_list;
           module_list.Append(module_sp);
-          target->SymbolsDidLoad(module_list);
+          target->SymbolsDidLoad(module_list, Target::eBroadcastBitSymbolsLoaded);
 
           // Make sure we load any scripting resources that may be embedded
           // in the debug info files in case the platform supports that.

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -4504,6 +4504,10 @@ protected:
       if (process)
         process->Flush();
     }
+
+    if (result.Succeeded())
+      Debugger::ReportSymbolChange(module_spec);
+
     return result.Succeeded();
   }
 

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1536,7 +1536,7 @@ void Debugger::ReportSymbolChange(const ModuleSpec &module_spec) {
     std::lock_guard<std::recursive_mutex> guard(*g_debugger_list_mutex_ptr);
     for (DebuggerSP debugger_sp : *g_debugger_list_ptr) {
       EventSP event_sp = std::make_shared<Event>(
-          Debugger::eBroadcastBitSymbolChange,
+          Debugger::eBroadcastBitSymbolFileChange,
           new SymbolChangeEventData(debugger_sp, module_spec));
       debugger_sp->GetBroadcaster().BroadcastEvent(event_sp);
     }
@@ -1844,7 +1844,7 @@ lldb::thread_result_t Debugger::DefaultEventHandler() {
 
   listener_sp->StartListeningForEvents(
       &m_broadcaster, eBroadcastBitProgress | eBroadcastBitWarning |
-                          eBroadcastBitError | eBroadcastBitSymbolChange);
+                          eBroadcastBitError | eBroadcastBitSymbolFileChange);
 
   // Let the thread that spawned us know that we have started up and that we
   // are now listening to all required events so no events get missed

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1536,7 +1536,7 @@ void Debugger::ReportSymbolChange(const ModuleSpec &module_spec) {
     std::lock_guard<std::recursive_mutex> guard(*g_debugger_list_mutex_ptr);
     for (DebuggerSP debugger_sp : *g_debugger_list_ptr) {
       EventSP event_sp = std::make_shared<Event>(
-          Debugger::eBroadcastSymbolChange,
+          Debugger::eBroadcastBitSymbolChange,
           new SymbolChangeEventData(debugger_sp, module_spec));
       debugger_sp->GetBroadcaster().BroadcastEvent(event_sp);
     }
@@ -1844,7 +1844,7 @@ lldb::thread_result_t Debugger::DefaultEventHandler() {
 
   listener_sp->StartListeningForEvents(
       &m_broadcaster, eBroadcastBitProgress | eBroadcastBitWarning |
-                          eBroadcastBitError | eBroadcastSymbolChange);
+                          eBroadcastBitError | eBroadcastBitSymbolChange);
 
   // Let the thread that spawned us know that we have started up and that we
   // are now listening to all required events so no events get missed

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1536,7 +1536,7 @@ void Debugger::ReportSymbolChange(const ModuleSpec &module_spec) {
     std::lock_guard<std::recursive_mutex> guard(*g_debugger_list_mutex_ptr);
     for (DebuggerSP debugger_sp : *g_debugger_list_ptr) {
       EventSP event_sp = std::make_shared<Event>(
-          Debugger::eBroadcastBitSymbolFileChange,
+          Debugger::eBroadcastBitSymbolFileChanged,
           new SymbolChangeEventData(debugger_sp, module_spec));
       debugger_sp->GetBroadcaster().BroadcastEvent(event_sp);
     }
@@ -1844,7 +1844,7 @@ lldb::thread_result_t Debugger::DefaultEventHandler() {
 
   listener_sp->StartListeningForEvents(
       &m_broadcaster, eBroadcastBitProgress | eBroadcastBitWarning |
-                          eBroadcastBitError | eBroadcastBitSymbolFileChange);
+                          eBroadcastBitError | eBroadcastBitSymbolFileChanged);
 
   // Let the thread that spawned us know that we have started up and that we
   // are now listening to all required events so no events get missed

--- a/lldb/source/Core/DebuggerEvents.cpp
+++ b/lldb/source/Core/DebuggerEvents.cpp
@@ -148,9 +148,12 @@ void SymbolChangeEventData::DoOnRemoval(Event *event_ptr) {
         if (!module_sp->GetSymbolFileFileSpec())
           module_sp->SetSymbolFileFileSpec(m_module_spec.GetSymbolFileSpec());
       }
+
+      // This method is only calling SymbolsDidLoad to indicate that the symbol
+      // file in question has changed, so indicate that to SymbolsDidLoad
       ModuleList module_list;
       module_list.Append(module_sp);
-      target_sp->SymbolsDidLoad(module_list);
+      target_sp->SymbolsDidLoad(module_list, Target::eBroadcastBitSymbolsChanged);
     }
   }
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -66,7 +66,6 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 
-#include <_types/_uint32_t.h>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -66,6 +66,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 
+#include <_types/_uint32_t.h>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -1662,7 +1663,7 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
   }
 }
 
-void Target::SymbolsDidLoad(ModuleList &module_list) {
+void Target::SymbolsDidLoad(ModuleList &module_list, uint32_t load_or_change_broadcast_bit) {
   if (m_valid && module_list.GetSize()) {
     if (m_process_sp) {
       for (LanguageRuntime *runtime : m_process_sp->GetLanguageRuntimes()) {
@@ -1672,7 +1673,7 @@ void Target::SymbolsDidLoad(ModuleList &module_list) {
 
     m_breakpoint_list.UpdateBreakpoints(module_list, true, false);
     m_internal_breakpoint_list.UpdateBreakpoints(module_list, true, false);
-    BroadcastEvent(eBroadcastBitSymbolsLoaded,
+    BroadcastEvent(load_or_change_broadcast_bit,
                    new TargetEventData(this->shared_from_this(), module_list));
   }
 }

--- a/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
+++ b/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
@@ -71,6 +71,7 @@ class AddDsymCommandCase(TestBase):
         )
 
         # Add the dSYM
+        self.exe_name = "a.out"
         self.do_add_dsym_with_success(self.exe_name)
 
         # Get the next event
@@ -79,6 +80,20 @@ class AddDsymCommandCase(TestBase):
 
         # Check that the event is valid
         self.assertTrue(event.IsValid(), "Got a valid eBroadcastBitSymbolsLoaded event.")
+
+        # Check that there were modules reported with the event
+        num_modules = lldb.SBTarget.GetNumModulesFromEvent(event)
+        self.assertTrue(
+            num_modules > 0, "At least one module was reported with the eBroadcastBitSymbolsLoaded event"
+        )
+
+        # Check that all modules are valid
+        for x in range(num_modules):
+            current_module = lldb.SBTarget.GetModuleAtIndexFromEvent(x, event)
+            self.assertTrue(
+                current_module.IsValid(),
+                "Module %s from event eBroadcastBitSymbolsLoaded is valid." % current_module.GetFileSpec().GetFilename()
+            )
 
     def generate_main_cpp(self, version=0):
         """Generate main.cpp from main.cpp.template."""

--- a/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
+++ b/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
@@ -70,20 +70,15 @@ class AddDsymCommandCase(TestBase):
             lldb.SBTarget.eBroadcastBitSymbolsLoaded,
         )
 
-
-        self.exe_name = "a.out"
-
         # Add the dSYM
         self.do_add_dsym_with_success(self.exe_name)
 
         # Get the next event
-        # event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
         event = lldb.SBEvent()
         listener.WaitForEvent(1, event)
 
         # Check that the event is valid
         self.assertTrue(event.IsValid(), "Got a valid eBroadcastBitSymbolsLoaded event.")
-
 
     def generate_main_cpp(self, version=0):
         """Generate main.cpp from main.cpp.template."""


### PR DESCRIPTION
This provides a test to ensure that when modules are loaded via the `add-dsym` command that they're loaded properly and broadcast the `Target::eBroadcastBitSymbolsLoaded` bit.

Also refactors `Debugger::eBroadcastSymbolChange` to `Debugger::eBroadcastBitSymbolChanged` to match the naming convention for other event bits used in the debugger.