### PR TITLE
Fix gcc 7.5 incompatibility in GlobPattern.cpp

### DIFF
--- a/llvm/lib/Support/GlobPattern.cpp
+++ b/llvm/lib/Support/GlobPattern.cpp
@@ -59,7 +59,7 @@ static Expected<SmallVector<std::string, 1>>
 parseBraceExpansions(StringRef S, std::optional<size_t> MaxSubPatterns) {
   SmallVector<std::string> SubPatterns = {S.str()};
   if (!MaxSubPatterns || !S.contains('{'))
-    return SubPatterns;
+    return std::move(SubPatterns);
 
   struct BraceExpansion {
     size_t Start;
@@ -129,7 +129,7 @@ parseBraceExpansions(StringRef S, std::optional<size_t> MaxSubPatterns) {
       for (StringRef Orig : OrigSubPatterns)
         SubPatterns.emplace_back(Orig).replace(BE.Start, BE.Length, Term);
   }
-  return SubPatterns;
+  return std::move(SubPatterns);
 }
 
 Expected<GlobPattern>


### PR DESCRIPTION
rG8daace8b2d89 injected a build break in an older-but-still-supported version of gcc (at least, I think it's supported): `arm-linux-gnueabihf-gcc (Ubuntu/Linaro 7.5.0-3ubuntu1~18.04) 7.5.0`, in which we get failures on lines 62 and 132 of the form

`GlobPattern.cpp: In function ‘llvm::Expected<llvm::SmallVector<std::__cxx11::basic_string<char>, 1> > parseBraceExpansions(llvm::StringRef, std::optional<unsigned int>)’:
GlobPattern.cpp:62:12: error: could not convert ‘SubPatterns’ from ‘llvm::SmallVector<std::__cxx11::basic_string<char> >’ to ‘llvm::Expected<llvm::SmallVector<std::__cxx11::basic_string<char>, 1> >’`

In both cases, replacing the `return SubPatterns;` with `return std::move(SubPatterns);` heals the misbehavior.

(Yes, gcc7.5 is probably getting a bit long in the tooth here, and we're looking to upgrade; unfortunately, we are temporarily hamstrung by some ancient build infrastructure that is essentially incapable of being easily upgraded to newer builds, and it will take us a little time to figure out good replacements, unfortunately.)