### PR TITLE
[Driver] Change default PCH extension name from .gch to .pch

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -41,6 +41,9 @@ code bases.
 C/C++ Language Potentially Breaking Changes
 -------------------------------------------
 
+- The default extension name for PCH generation (``-c -xc-header`` and ``-c
+  -xc++-header``) is now ``.pch`` instead of ``.gch``.
+
 C++ Specific Potentially Breaking Changes
 -----------------------------------------
 

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -98,7 +98,7 @@ TYPE("plist",                    Plist,        INVALID,         "plist",  phases
 TYPE("rewritten-objc",           RewrittenObjC,INVALID,         "cpp",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("rewritten-legacy-objc",    RewrittenLegacyObjC,INVALID,   "cpp",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("remap",                    Remap,        INVALID,         "remap",  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
-TYPE("precompiled-header",       PCH,          INVALID,         "gch",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("precompiled-header",       PCH,          INVALID,         "pch",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("object",                   Object,       INVALID,         "o",      phases::Link)
 TYPE("treelang",                 Treelang,     INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("image",                    Image,        INVALID,         "out",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)

--- a/clang/test/Driver/pch-codegen.cpp
+++ b/clang/test/Driver/pch-codegen.cpp
@@ -2,10 +2,12 @@
 // RUN: mkdir -p %t
 
 // Create PCH without codegen.
-// RUN: %clang -x c++-header %S/../Modules/Inputs/codegen-flags/foo.h -o %t/foo-cg.pch -### 2>&1 | FileCheck %s -check-prefix=CHECK-PCH-CREATE
+// RUN: %clang -x c++-header %S/../Modules/Inputs/codegen-flags/foo.h -### 2>&1 | FileCheck %s -check-prefix=CHECK-PCH-CREATE
 // CHECK-PCH-CREATE: -emit-pch
 // CHECK-PCH-CREATE-NOT: -fmodules-codegen
 // CHECK-PCH-CREATE-NOT: -fmodules-debuginfo
+/// Also test that the default extension name is .pch instead of .gch
+// CHECK-PCH-CREATE: "-o" "{{[^"]+.pch}}"
 
 // Create PCH with -fpch-codegen.
 // RUN: %clang -x c++-header -fpch-codegen %S/../Modules/Inputs/codegen-flags/foo.h -o %t/foo-cg.pch -### 2>&1 | FileCheck %s -check-prefix=CHECK-PCH-CODEGEN-CREATE


### PR DESCRIPTION
For `c-header` and `c++-header` inputs, Clang driver selects the
`-emit-pch` frontend action and defaults the output suffix name to
`.gch` (except clang-cl, which uses `.pch`) to follow GCC.
```
clang -c a.h               # a.h.gch
clang -xc++-header -c a.h  # a.h.gch
```

In every other place we prefer `.pch` to `.gch`. E.g. `-include a.h`
probes `a.h.pch` before `a.h.gch`, and we have `-include-pch` instead of
`-include-gch`. (Clang and GCC use different extension names for C++ modules as well.)

This change isn't disruptive because:

* Most newer build systems specify explicit output filenames and are unaffected
* Implicit output name users almost assuredly use something like
  `-include a.h`, which probes both `a.h.pch` and `a.h.gch`[^1]

[^1]: In the future, we shall stop probing `a.h.gch` for `-include a.h` as the
compatibility intended behavior actually gets in the way
(https://discourse.llvm.org/t/how-to-have-clang-ignore-gch-directories/51835).
This patch is a prerequisite.
