### PR TITLE
[clang-tidy] Fix bug in modernize-use-emplace

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseEmplaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseEmplaceCheck.cpp
@@ -13,8 +13,8 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::modernize {
 
 namespace {
-AST_MATCHER_P(InitListExpr, initCountIs, unsigned, N) {
-  return Node.getNumInits() == N;
+AST_MATCHER_P(InitListExpr, initCountLeq, unsigned, N) {
+  return Node.getNumInits() <= N;
 }
 
 // Identical to hasAnyName, except it does not take template specifiers into
@@ -212,7 +212,7 @@ void UseEmplaceCheck::registerMatchers(MatchFinder *Finder) {
 
   // allow for T{} to be replaced, even if no CTOR is declared
   auto HasConstructInitListExpr =
-      has(initListExpr(anyOf(initCountIs(0), initCountIs(1)),
+      has(initListExpr(initCountLeq(1),
                        anyOf(allOf(has(SoughtConstructExpr),
                                    has(cxxConstructExpr(argumentCountIs(0)))),
                              has(cxxBindTemporaryExpr(

--- a/clang-tools-extra/clang-tidy/modernize/UseEmplaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseEmplaceCheck.cpp
@@ -13,6 +13,10 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::modernize {
 
 namespace {
+AST_MATCHER_P(InitListExpr, initCountIs, unsigned, N) {
+  return Node.getNumInits() == N;
+}
+
 // Identical to hasAnyName, except it does not take template specifiers into
 // account. This is used to match the functions names as in
 // DefaultEmplacyFunctions below without caring about the template types of the
@@ -207,11 +211,13 @@ void UseEmplaceCheck::registerMatchers(MatchFinder *Finder) {
   auto HasConstructExpr = has(ignoringImplicit(SoughtConstructExpr));
 
   // allow for T{} to be replaced, even if no CTOR is declared
-  auto HasConstructInitListExpr = has(initListExpr(anyOf(
-      allOf(has(SoughtConstructExpr),
-            has(cxxConstructExpr(argumentCountIs(0)))),
-      has(cxxBindTemporaryExpr(has(SoughtConstructExpr),
-                               has(cxxConstructExpr(argumentCountIs(0))))))));
+  auto HasConstructInitListExpr =
+      has(initListExpr(anyOf(initCountIs(0), initCountIs(1)),
+                       anyOf(allOf(has(SoughtConstructExpr),
+                                   has(cxxConstructExpr(argumentCountIs(0)))),
+                             has(cxxBindTemporaryExpr(
+                                 has(SoughtConstructExpr),
+                                 has(cxxConstructExpr(argumentCountIs(0))))))));
   auto HasBracedInitListExpr =
       anyOf(has(cxxBindTemporaryExpr(HasConstructInitListExpr)),
             HasConstructInitListExpr);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -249,7 +249,7 @@ Changes in existing checks
 
 - Improved :doc:`modernize-use-emplace
   <clang-tidy/checks/modernize/use-emplace>` to not replace aggregates that
-  ``emplace_back`` cannot construct with aggregate initialization.
+  ``emplace`` cannot construct with aggregate initialization.
 
 - Improved :doc:`modernize-use-equals-delete
   <clang-tidy/checks/modernize/use-equals-delete>` check to ignore

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -247,6 +247,10 @@ Changes in existing checks
   <clang-tidy/checks/modernize/loop-convert>` to support for-loops with
   iterators initialized by free functions like ``begin``, ``end``, or ``size``.
 
+- Improved :doc:`modernize-use-emplace
+  <clang-tidy/checks/modernize/use-emplace>` to not replace aggregates that
+  ``emplace_back`` cannot construct with aggregate initialization.
+
 - Improved :doc:`modernize-use-equals-delete
   <clang-tidy/checks/modernize/use-equals-delete>` check to ignore
   false-positives when special member function is actually used or implicit.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-emplace.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-emplace.cpp
@@ -1343,11 +1343,8 @@ void testBracedInitTemporaries() {
   // These should not be noticed or fixed; after the correction, the code won't
   // compile.
   v4.push_back(NonTrivialWithIntAndVector{1, {}});
-  // CHECK-FIXES: v4.push_back(NonTrivialWithIntAndVector{1, {}});
   v4.push_back(NonTrivialWithIntAndVector{});
-  // CHECK-FIXES: v4.push_back(NonTrivialWithIntAndVector{});
   v4.push_back({});
-  // CHECK-FIXES: v4.push_back({});
 }
 
 void testWithPointerTypes() {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-emplace.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-emplace.cpp
@@ -1183,6 +1183,11 @@ struct NonTrivialWithVector {
   std::vector<int> it;
 };
 
+struct NonTrivialWithIntAndVector {
+  int x;
+  std::vector<int> it;
+};
+
 struct NonTrivialWithCtor {
   NonTrivialWithCtor();
   NonTrivialWithCtor(std::vector<int> const&);
@@ -1332,6 +1337,17 @@ void testBracedInitTemporaries() {
   v3.push_back(NonTrivialWithCtor{{}});
   v3.push_back({{0}});
   v3.push_back({{}});
+
+  std::vector<NonTrivialWithIntAndVector> v4;
+
+  // These should not be noticed or fixed; after the correction, the code won't
+  // compile.
+  v4.push_back(NonTrivialWithIntAndVector{1, {}});
+  // CHECK-FIXES: v4.push_back(NonTrivialWithIntAndVector{1, {}});
+  v4.push_back(NonTrivialWithIntAndVector{});
+  // CHECK-FIXES: v4.push_back(NonTrivialWithIntAndVector{});
+  v4.push_back({});
+  // CHECK-FIXES: v4.push_back({});
 }
 
 void testWithPointerTypes() {


### PR DESCRIPTION
emplace_back cannot construct an aggregate with arguments used to initialize the aggregate.
Closes #62387

Test plan: Added test test from #62387 which contains code that should not be replaced by the check.