### PR TITLE
[Interpreter] Add initialization of array members

### DIFF
--- a/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -618,7 +618,18 @@ GenericValue ExecutionEngine::getConstantValue(const Constant *C) {
       case Type::ScalableVectorTyID:
         report_fatal_error(
             "Scalable vector support not yet implemented in ExecutionEngine");
-      case Type::FixedVectorTyID:
+      case Type::ArrayTyID: {
+        auto *ArrTy = cast<ArrayType>(C->getType());
+        Type *ElemTy = ArrTy->getElementType();
+        unsigned int elemNum = ArrTy->getNumElements();
+        Result.AggregateVal.resize(elemNum);
+        if (ElemTy->isIntegerTy())
+          for (unsigned int i = 0; i < elemNum; ++i)
+            Result.AggregateVal[i].IntVal =
+                APInt(ElemTy->getPrimitiveSizeInBits(), 0);
+        break;
+      }
+      case Type::FixedVectorTyID: {
         // if the whole vector is 'undef' just reserve memory for the value.
         auto *VTy = cast<FixedVectorType>(C->getType());
         Type *ElemTy = VTy->getElementType();
@@ -629,6 +640,7 @@ GenericValue ExecutionEngine::getConstantValue(const Constant *C) {
             Result.AggregateVal[i].IntVal =
                 APInt(ElemTy->getPrimitiveSizeInBits(), 0);
         break;
+      }
     }
     return Result;
   }

--- a/llvm/test/ExecutionEngine/2010-01-15-UndefValue.ll
+++ b/llvm/test/ExecutionEngine/2010-01-15-UndefValue.ll
@@ -4,5 +4,6 @@ define i32 @main() {
        %a = add i32 0, undef
        %b = fadd float 0.0, undef
        %c = fadd double 0.0, undef
+       %d = insertvalue {i32, [4 x i32]} undef, i32 1, 1, 2
        ret i32 0
 }


### PR DESCRIPTION
Currently, the interpreter does not initialize `undef` constants of aggregate types correctly (with respect to arrays).
The initialization of the array elements is skipped although it is valid to directly write to them. Instructions like
`insertvalue {i32, [4 x i32]} undef, i32 1, 1, 2` therefore lead to a crash.
This is fixed by initializing array values just as fixed-size vectors or structs.