### PR TITLE
[MachineBasicBlock] Fix use after free in SplitCriticalEdge

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -688,11 +688,13 @@ public:
   }
 
   /// Update the terminator instructions in block to account for changes to
-  /// block layout which may have been made. PreviousLayoutSuccessor should be
-  /// set to the block which may have been used as fallthrough before the block
-  /// layout was modified.  If the block previously fell through to that block,
-  /// it may now need a branch. If it previously branched to another block, it
-  /// may now be able to fallthrough to the current layout successor.
+  /// block layout which may have been made. \p PreviousLayoutSuccessor should
+  /// be set to the block which may have been used as fallthrough before the
+  /// block layout was modified.  If the block previously fell through to that
+  /// block, it may now need a branch. If it previously branched to another
+  /// block, it may now be able to fallthrough to the current layout successor.
+  /// SlotIndexes provided by \p Indexes will be updated to reflect any
+  /// instructions inserted or removed.
   void updateTerminator(MachineBasicBlock *PreviousLayoutSuccessor,
                         SlotIndexes *Indexes = nullptr);
 

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -693,7 +693,8 @@ public:
   /// layout was modified.  If the block previously fell through to that block,
   /// it may now need a branch. If it previously branched to another block, it
   /// may now be able to fallthrough to the current layout successor.
-  void updateTerminator(MachineBasicBlock *PreviousLayoutSuccessor);
+  void updateTerminator(MachineBasicBlock *PreviousLayoutSuccessor,
+                        SlotIndexes *Indexes = nullptr);
 
   // Machine-CFG mutators
 

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -680,19 +680,24 @@ public:
   /// Remove the branching code at the end of the specific MBB.
   /// This is only invoked in cases where analyzeBranch returns success. It
   /// returns the number of instructions that were removed.
+  /// If \p Indexes is non-null, then instructions will also be removed from
+  /// SlotIndexes.
   /// If \p BytesRemoved is non-null, report the change in code size from the
   /// removed instructions.
   virtual unsigned removeBranch(MachineBasicBlock &MBB,
-                                int *BytesRemoved = nullptr,
-                                SlotIndexes *Indexes = nullptr) const {
+                                SlotIndexes *Indexes = nullptr,
+                                int *BytesRemoved = nullptr) const {
     llvm_unreachable("Target didn't implement TargetInstrInfo::removeBranch!");
   }
 
   /// Insert branch code into the end of the specified MachineBasicBlock. The
   /// operands to this method are the same as those returned by analyzeBranch.
   /// This is only invoked in cases where analyzeBranch returns success. It
-  /// returns the number of instructions inserted. If \p BytesAdded is non-null,
-  /// report the change in code size from the added instructions.
+  /// returns the number of instructions inserted.
+  /// If \p Indexes is non-null, then added instructions will be inserted into
+  /// SlotIndexes.
+  /// If \p BytesAdded is non-null, report the change in code size from the
+  /// added instructions.
   ///
   /// It is also invoked by tail merging to add unconditional branches in
   /// cases where analyzeBranch doesn't apply because there was no original
@@ -704,18 +709,19 @@ public:
   virtual unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                                 MachineBasicBlock *FBB,
                                 ArrayRef<MachineOperand> Cond,
-                                const DebugLoc &DL, int *BytesAdded = nullptr,
-                                SlotIndexes *Indexes = nullptr) const {
+                                const DebugLoc &DL,
+                                SlotIndexes *Indexes = nullptr,
+                                int *BytesAdded = nullptr) const {
     llvm_unreachable("Target didn't implement TargetInstrInfo::insertBranch!");
   }
 
   unsigned insertUnconditionalBranch(MachineBasicBlock &MBB,
                                      MachineBasicBlock *DestBB,
                                      const DebugLoc &DL,
-                                     int *BytesAdded = nullptr,
-                                     SlotIndexes *Indexes = nullptr) const {
+                                     SlotIndexes *Indexes = nullptr,
+                                     int *BytesAdded = nullptr) const {
     return insertBranch(MBB, DestBB, nullptr, ArrayRef<MachineOperand>(), DL,
-                        BytesAdded, Indexes);
+                        Indexes, BytesAdded);
   }
 
   /// Object returned by analyzeLoopForPipelining. Allows software pipelining

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -53,6 +53,7 @@ class ScheduleDAGMI;
 class ScheduleHazardRecognizer;
 class SDNode;
 class SelectionDAG;
+class SlotIndexes;
 class SMSchedule;
 class SwingSchedulerDAG;
 class RegScavenger;
@@ -682,7 +683,8 @@ public:
   /// If \p BytesRemoved is non-null, report the change in code size from the
   /// removed instructions.
   virtual unsigned removeBranch(MachineBasicBlock &MBB,
-                                int *BytesRemoved = nullptr) const {
+                                int *BytesRemoved = nullptr,
+                                SlotIndexes *Indexes = nullptr) const {
     llvm_unreachable("Target didn't implement TargetInstrInfo::removeBranch!");
   }
 
@@ -702,17 +704,18 @@ public:
   virtual unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                                 MachineBasicBlock *FBB,
                                 ArrayRef<MachineOperand> Cond,
-                                const DebugLoc &DL,
-                                int *BytesAdded = nullptr) const {
+                                const DebugLoc &DL, int *BytesAdded = nullptr,
+                                SlotIndexes *Indexes = nullptr) const {
     llvm_unreachable("Target didn't implement TargetInstrInfo::insertBranch!");
   }
 
   unsigned insertUnconditionalBranch(MachineBasicBlock &MBB,
                                      MachineBasicBlock *DestBB,
                                      const DebugLoc &DL,
-                                     int *BytesAdded = nullptr) const {
+                                     int *BytesAdded = nullptr,
+                                     SlotIndexes *Indexes = nullptr) const {
     return insertBranch(MBB, DestBB, nullptr, ArrayRef<MachineOperand>(), DL,
-                        BytesAdded);
+                        BytesAdded, Indexes);
   }
 
   /// Object returned by analyzeLoopForPipelining. Allows software pipelining

--- a/llvm/lib/CodeGen/BranchRelaxation.cpp
+++ b/llvm/lib/CodeGen/BranchRelaxation.cpp
@@ -364,7 +364,8 @@ bool BranchRelaxation::fixupConditionalBranch(MachineInstr &MI) {
                                 MachineBasicBlock *DestBB) {
     unsigned &BBSize = BlockInfo[MBB->getNumber()].Size;
     int NewBrSize = 0;
-    TII->insertUnconditionalBranch(*MBB, DestBB, DL, &NewBrSize);
+    TII->insertUnconditionalBranch(*MBB, DestBB, DL, /*Indexes=*/nullptr,
+                                   &NewBrSize);
     BBSize += NewBrSize;
   };
   auto insertBranch = [&](MachineBasicBlock *MBB, MachineBasicBlock *TBB,
@@ -372,13 +373,14 @@ bool BranchRelaxation::fixupConditionalBranch(MachineInstr &MI) {
                           SmallVectorImpl<MachineOperand>& Cond) {
     unsigned &BBSize = BlockInfo[MBB->getNumber()].Size;
     int NewBrSize = 0;
-    TII->insertBranch(*MBB, TBB, FBB, Cond, DL, &NewBrSize);
+    TII->insertBranch(*MBB, TBB, FBB, Cond, DL, /*Indexes=*/nullptr,
+                      &NewBrSize);
     BBSize += NewBrSize;
   };
   auto removeBranch = [&](MachineBasicBlock *MBB) {
     unsigned &BBSize = BlockInfo[MBB->getNumber()].Size;
     int RemovedSize = 0;
-    TII->removeBranch(*MBB, &RemovedSize);
+    TII->removeBranch(*MBB, /*Indexes=*/nullptr, &RemovedSize);
     BBSize -= RemovedSize;
   };
 

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -701,7 +701,7 @@ void MachineBasicBlock::updateTerminator(
       // The block has an unconditional branch. If its successor is now its
       // layout successor, delete the branch.
       if (isLayoutSuccessor(TBB))
-        TII->removeBranch(*this, nullptr, Indexes);
+        TII->removeBranch(*this, Indexes);
     } else {
       // The block has an unconditional fallthrough, or the end of the block is
       // unreachable.
@@ -718,7 +718,7 @@ void MachineBasicBlock::updateTerminator(
       // successor, insert a branch to jump to it.
       if (!isLayoutSuccessor(PreviousLayoutSuccessor))
         TII->insertBranch(*this, PreviousLayoutSuccessor, nullptr, Cond, DL,
-                          nullptr, Indexes);
+                          Indexes);
     }
     return;
   }
@@ -730,11 +730,11 @@ void MachineBasicBlock::updateTerminator(
     if (isLayoutSuccessor(TBB)) {
       if (TII->reverseBranchCondition(Cond))
         return;
-      TII->removeBranch(*this, nullptr, Indexes);
-      TII->insertBranch(*this, FBB, nullptr, Cond, DL, nullptr, Indexes);
+      TII->removeBranch(*this, Indexes);
+      TII->insertBranch(*this, FBB, nullptr, Cond, DL, Indexes);
     } else if (isLayoutSuccessor(FBB)) {
-      TII->removeBranch(*this, nullptr, Indexes);
-      TII->insertBranch(*this, TBB, nullptr, Cond, DL, nullptr, Indexes);
+      TII->removeBranch(*this, Indexes);
+      TII->insertBranch(*this, TBB, nullptr, Cond, DL, Indexes);
     }
     return;
   }
@@ -748,10 +748,10 @@ void MachineBasicBlock::updateTerminator(
     // We had a fallthrough to the same basic block as the conditional jump
     // targets.  Remove the conditional jump, leaving an unconditional
     // fallthrough or an unconditional jump.
-    TII->removeBranch(*this, nullptr, Indexes);
+    TII->removeBranch(*this, Indexes);
     if (!isLayoutSuccessor(TBB)) {
       Cond.clear();
-      TII->insertBranch(*this, TBB, nullptr, Cond, DL, nullptr, Indexes);
+      TII->insertBranch(*this, TBB, nullptr, Cond, DL, Indexes);
     }
     return;
   }
@@ -762,16 +762,15 @@ void MachineBasicBlock::updateTerminator(
       // We can't reverse the condition, add an unconditional branch.
       Cond.clear();
       TII->insertBranch(*this, PreviousLayoutSuccessor, nullptr, Cond, DL,
-                        nullptr, Indexes);
+                        Indexes);
       return;
     }
-    TII->removeBranch(*this, nullptr, Indexes);
+    TII->removeBranch(*this, Indexes);
     TII->insertBranch(*this, PreviousLayoutSuccessor, nullptr, Cond, DL,
-                      nullptr, Indexes);
-  } else if (!isLayoutSuccessor(PreviousLayoutSuccessor)) {
-    TII->removeBranch(*this, nullptr, Indexes);
-    TII->insertBranch(*this, TBB, PreviousLayoutSuccessor, Cond, DL, nullptr,
                       Indexes);
+  } else if (!isLayoutSuccessor(PreviousLayoutSuccessor)) {
+    TII->removeBranch(*this, Indexes);
+    TII->insertBranch(*this, TBB, PreviousLayoutSuccessor, Cond, DL, Indexes);
   }
 }
 
@@ -1183,7 +1182,7 @@ MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
   if (!NMBB->isLayoutSuccessor(Succ)) {
     SmallVector<MachineOperand, 4> Cond;
     const TargetInstrInfo *TII = getParent()->getSubtarget().getInstrInfo();
-    TII->insertBranch(*NMBB, Succ, nullptr, Cond, DL, nullptr, Indexes);
+    TII->insertBranch(*NMBB, Succ, nullptr, Cond, DL, Indexes);
   }
 
   // Fix PHI nodes in Succ so they refer to NMBB instead of this.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -535,8 +535,8 @@ bool AArch64InstrInfo::reverseBranchCondition(
 }
 
 unsigned AArch64InstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                        int *BytesRemoved,
-                                        SlotIndexes *Indexes) const {
+                                        SlotIndexes *Indexes,
+                                        int *BytesRemoved) const {
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
   if (I == MBB.end())
     return 0;
@@ -599,12 +599,10 @@ void AArch64InstrInfo::instantiateCondBranch(MachineBasicBlock &MBB,
   }
 }
 
-unsigned AArch64InstrInfo::insertBranch(MachineBasicBlock &MBB,
-                                        MachineBasicBlock *TBB,
-                                        MachineBasicBlock *FBB,
-                                        ArrayRef<MachineOperand> Cond,
-                                        const DebugLoc &DL, int *BytesAdded,
-                                        SlotIndexes *Indexes) const {
+unsigned AArch64InstrInfo::insertBranch(
+    MachineBasicBlock &MBB, MachineBasicBlock *TBB, MachineBasicBlock *FBB,
+    ArrayRef<MachineOperand> Cond, const DebugLoc &DL, SlotIndexes *Indexes,
+    int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -225,12 +225,12 @@ public:
   bool analyzeBranchPredicate(MachineBasicBlock &MBB,
                               MachineBranchPredicate &MBP,
                               bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -225,12 +225,12 @@ public:
   bool analyzeBranchPredicate(MachineBasicBlock &MBB,
                               MachineBranchPredicate &MBP,
                               bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,
@@ -378,7 +378,8 @@ private:
 
   void instantiateCondBranch(MachineBasicBlock &MBB, const DebugLoc &DL,
                              MachineBasicBlock *TBB,
-                             ArrayRef<MachineOperand> Cond) const;
+                             ArrayRef<MachineOperand> Cond,
+                             SlotIndexes *Indexes) const;
   bool substituteCmpToZero(MachineInstr &CmpInstr, unsigned SrcReg,
                            const MachineRegisterInfo &MRI) const;
   bool removeCmpToZeroOrOne(MachineInstr &CmpInstr, unsigned SrcReg,

--- a/llvm/lib/Target/AMDGPU/R600InstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/R600InstrInfo.cpp
@@ -731,8 +731,8 @@ unsigned R600InstrInfo::insertBranch(MachineBasicBlock &MBB,
                                      MachineBasicBlock *TBB,
                                      MachineBasicBlock *FBB,
                                      ArrayRef<MachineOperand> Cond,
-                                     const DebugLoc &DL, int *BytesAdded,
-                                     SlotIndexes *Indexes) const {
+                                     const DebugLoc &DL, SlotIndexes *Indexes,
+                                     int *BytesAdded) const {
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert(!BytesAdded && "code size not handled");
 
@@ -782,8 +782,9 @@ unsigned R600InstrInfo::insertBranch(MachineBasicBlock &MBB,
   }
 }
 
-unsigned R600InstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                     SlotIndexes *Indexes) const {
+unsigned R600InstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                     SlotIndexes *Indexes,
+                                     int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   // Note : we leave PRED* instructions there.

--- a/llvm/lib/Target/AMDGPU/R600InstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/R600InstrInfo.h
@@ -170,11 +170,11 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   bool isPredicated(const MachineInstr &MI) const override;
 

--- a/llvm/lib/Target/AMDGPU/R600InstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/R600InstrInfo.h
@@ -170,11 +170,11 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool isPredicated(const MachineInstr &MI) const override;
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -2843,8 +2843,8 @@ bool SIInstrInfo::analyzeBranch(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
   return analyzeBranchImpl(MBB, I, TBB, FBB, Cond, AllowModify);
 }
 
-unsigned SIInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                   SlotIndexes *Indexes) const {
+unsigned SIInstrInfo::removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes,
+                                   int *BytesRemoved) const {
   unsigned Count = 0;
   unsigned RemovedSize = 0;
   for (MachineInstr &MI : llvm::make_early_inc_range(MBB.terminators())) {
@@ -2875,8 +2875,8 @@ unsigned SIInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                    MachineBasicBlock *TBB,
                                    MachineBasicBlock *FBB,
                                    ArrayRef<MachineOperand> Cond,
-                                   const DebugLoc &DL, int *BytesAdded,
-                                   SlotIndexes *Indexes) const {
+                                   const DebugLoc &DL, SlotIndexes *Indexes,
+                                   int *BytesAdded) const {
   if (!FBB && Cond.empty()) {
     MachineInstr *UncondBr =
         BuildMI(&MBB, DL, get(AMDGPU::S_BRANCH)).addMBB(TBB);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -331,13 +331,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   bool reverseBranchCondition(
     SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -331,13 +331,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool reverseBranchCondition(
     SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/ARC/ARCInstrInfo.cpp
+++ b/llvm/lib/Target/ARC/ARCInstrInfo.cpp
@@ -252,8 +252,9 @@ bool ARCInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
   return false;
 }
 
-unsigned ARCInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                    SlotIndexes *Indexes) const {
+unsigned ARCInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                    SlotIndexes *Indexes,
+                                    int *BytesRemoved) const {
   assert(!BytesRemoved && "Code size not handled");
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
   if (I == MBB.end())
@@ -375,8 +376,8 @@ unsigned ARCInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                     MachineBasicBlock *TBB,
                                     MachineBasicBlock *FBB,
                                     ArrayRef<MachineOperand> Cond,
-                                    const DebugLoc &DL, int *BytesAdded,
-                                    SlotIndexes *Indexes) const {
+                                    const DebugLoc &DL, SlotIndexes *Indexes,
+                                    int *BytesAdded) const {
   assert(!BytesAdded && "Code size not handled.");
 
   // Shouldn't be a fall through.

--- a/llvm/lib/Target/ARC/ARCInstrInfo.h
+++ b/llvm/lib/Target/ARC/ARCInstrInfo.h
@@ -57,11 +57,11 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                    const DebugLoc &, MCRegister DestReg, MCRegister SrcReg,

--- a/llvm/lib/Target/ARC/ARCInstrInfo.h
+++ b/llvm/lib/Target/ARC/ARCInstrInfo.h
@@ -57,11 +57,11 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                    const DebugLoc &, MCRegister DestReg, MCRegister SrcReg,

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -469,8 +469,8 @@ bool ARMBaseInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 }
 
 unsigned ARMBaseInstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                        int *BytesRemoved,
-                                        SlotIndexes *Indexes) const {
+                                        SlotIndexes *Indexes,
+                                        int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
@@ -500,12 +500,10 @@ unsigned ARMBaseInstrInfo::removeBranch(MachineBasicBlock &MBB,
   return 2;
 }
 
-unsigned ARMBaseInstrInfo::insertBranch(MachineBasicBlock &MBB,
-                                        MachineBasicBlock *TBB,
-                                        MachineBasicBlock *FBB,
-                                        ArrayRef<MachineOperand> Cond,
-                                        const DebugLoc &DL, int *BytesAdded,
-                                        SlotIndexes *Indexes) const {
+unsigned ARMBaseInstrInfo::insertBranch(
+    MachineBasicBlock &MBB, MachineBasicBlock *TBB, MachineBasicBlock *FBB,
+    ArrayRef<MachineOperand> Cond, const DebugLoc &DL, SlotIndexes *Indexes,
+    int *BytesAdded) const {
   assert(!BytesAdded && "code size not handled");
   ARMFunctionInfo *AFI = MBB.getParent()->getInfo<ARMFunctionInfo>();
   int BOpc   = !AFI->isThumbFunction()

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
@@ -143,12 +143,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
@@ -143,12 +143,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/AVR/AVRInstrInfo.cpp
+++ b/llvm/lib/Target/AVR/AVRInstrInfo.cpp
@@ -400,8 +400,8 @@ unsigned AVRInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                     MachineBasicBlock *TBB,
                                     MachineBasicBlock *FBB,
                                     ArrayRef<MachineOperand> Cond,
-                                    const DebugLoc &DL, int *BytesAdded,
-                                    SlotIndexes *Indexes) const {
+                                    const DebugLoc &DL, SlotIndexes *Indexes,
+                                    int *BytesAdded) const {
   if (BytesAdded)
     *BytesAdded = 0;
 
@@ -444,8 +444,9 @@ unsigned AVRInstrInfo::insertBranch(MachineBasicBlock &MBB,
   return Count;
 }
 
-unsigned AVRInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                    SlotIndexes *Indexes) const {
+unsigned AVRInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                    SlotIndexes *Indexes,
+                                    int *BytesRemoved) const {
   if (BytesRemoved)
     *BytesRemoved = 0;
 

--- a/llvm/lib/Target/AVR/AVRInstrInfo.h
+++ b/llvm/lib/Target/AVR/AVRInstrInfo.h
@@ -99,10 +99,10 @@ public:
                      bool AllowModify = false) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
 

--- a/llvm/lib/Target/AVR/AVRInstrInfo.h
+++ b/llvm/lib/Target/AVR/AVRInstrInfo.h
@@ -99,10 +99,10 @@ public:
                      bool AllowModify = false) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
 

--- a/llvm/lib/Target/BPF/BPFInstrInfo.cpp
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.cpp
@@ -222,8 +222,8 @@ unsigned BPFInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                     MachineBasicBlock *TBB,
                                     MachineBasicBlock *FBB,
                                     ArrayRef<MachineOperand> Cond,
-                                    const DebugLoc &DL, int *BytesAdded,
-                                    SlotIndexes *Indexes) const {
+                                    const DebugLoc &DL, SlotIndexes *Indexes,
+                                    int *BytesAdded) const {
   assert(!BytesAdded && "code size not handled");
 
   // Shouldn't be a fall through.
@@ -241,8 +241,9 @@ unsigned BPFInstrInfo::insertBranch(MachineBasicBlock &MBB,
   llvm_unreachable("Unexpected conditional branch");
 }
 
-unsigned BPFInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                    SlotIndexes *Indexes) const {
+unsigned BPFInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                    SlotIndexes *Indexes,
+                                    int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.end();

--- a/llvm/lib/Target/BPF/BPFInstrInfo.h
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.h
@@ -52,12 +52,12 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
 private:
   void expandMEMCPY(MachineBasicBlock::iterator) const;

--- a/llvm/lib/Target/BPF/BPFInstrInfo.h
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.h
@@ -52,12 +52,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
+
 private:
   void expandMEMCPY(MachineBasicBlock::iterator) const;
 

--- a/llvm/lib/Target/CSKY/CSKYInstrInfo.cpp
+++ b/llvm/lib/Target/CSKY/CSKYInstrInfo.cpp
@@ -111,8 +111,9 @@ bool CSKYInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
   return true;
 }
 
-unsigned CSKYInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                     SlotIndexes *Indexes) const {
+unsigned CSKYInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                     SlotIndexes *Indexes,
+                                     int *BytesRemoved) const {
   if (BytesRemoved)
     *BytesRemoved = 0;
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
@@ -160,8 +161,8 @@ unsigned CSKYInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                      MachineBasicBlock *TBB,
                                      MachineBasicBlock *FBB,
                                      ArrayRef<MachineOperand> Cond,
-                                     const DebugLoc &DL, int *BytesAdded,
-                                     SlotIndexes *Indexes) const {
+                                     const DebugLoc &DL, SlotIndexes *Indexes,
+                                     int *BytesAdded) const {
   if (BytesAdded)
     *BytesAdded = 0;
 

--- a/llvm/lib/Target/CSKY/CSKYInstrInfo.h
+++ b/llvm/lib/Target/CSKY/CSKYInstrInfo.h
@@ -59,16 +59,16 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   bool analyzeBranch(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/CSKY/CSKYInstrInfo.h
+++ b/llvm/lib/Target/CSKY/CSKYInstrInfo.h
@@ -59,16 +59,16 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool analyzeBranch(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -604,8 +604,8 @@ bool HexagonInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 }
 
 unsigned HexagonInstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                        int *BytesRemoved,
-                                        SlotIndexes *Indexes) const {
+                                        SlotIndexes *Indexes,
+                                        int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   LLVM_DEBUG(dbgs() << "\nRemoving branches out of " << printMBBReference(MBB));
@@ -629,12 +629,10 @@ unsigned HexagonInstrInfo::removeBranch(MachineBasicBlock &MBB,
   return Count;
 }
 
-unsigned HexagonInstrInfo::insertBranch(MachineBasicBlock &MBB,
-                                        MachineBasicBlock *TBB,
-                                        MachineBasicBlock *FBB,
-                                        ArrayRef<MachineOperand> Cond,
-                                        const DebugLoc &DL, int *BytesAdded,
-                                        SlotIndexes *Indexes) const {
+unsigned HexagonInstrInfo::insertBranch(
+    MachineBasicBlock &MBB, MachineBasicBlock *TBB, MachineBasicBlock *FBB,
+    ArrayRef<MachineOperand> Cond, const DebugLoc &DL, SlotIndexes *Indexes,
+    int *BytesAdded) const {
   unsigned BOpc   = Hexagon::J2_jump;
   unsigned BccOpc = Hexagon::J2_jumpt;
   assert(validateBranchCond(Cond) && "Invalid branching condition");
@@ -660,8 +658,8 @@ unsigned HexagonInstrInfo::insertBranch(MachineBasicBlock &MBB,
           !analyzeBranch(MBB, NewTBB, NewFBB, Cond, false) &&
           MachineFunction::iterator(NewTBB) == ++MBB.getIterator()) {
         reverseBranchCondition(Cond);
-        removeBranch(MBB, nullptr, Indexes);
-        return insertBranch(MBB, TBB, nullptr, Cond, DL, nullptr, Indexes);
+        removeBranch(MBB, Indexes);
+        return insertBranch(MBB, TBB, nullptr, Cond, DL, Indexes);
       }
       MachineInstr *MI = BuildMI(&MBB, DL, get(BOpc)).addMBB(TBB);
       if (Indexes)

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.h
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.h
@@ -111,8 +111,8 @@ public:
   /// Remove the branching code at the end of the specific MBB.
   /// This is only invoked in cases where analyzeBranch returns success. It
   /// returns the number of instructions that were removed.
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   /// Insert branch code into the end of the specified MachineBasicBlock.
   /// The operands to this method are the same as those
@@ -126,8 +126,8 @@ public:
   /// merging needs to be disabled.
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   /// Analyze loop L, which must be a single-basic-block loop, and if the
   /// conditions can be understood enough produce a PipelinerLoopInfo object.

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.h
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.h
@@ -111,8 +111,8 @@ public:
   /// Remove the branching code at the end of the specific MBB.
   /// This is only invoked in cases where analyzeBranch returns success. It
   /// returns the number of instructions that were removed.
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   /// Insert branch code into the end of the specified MachineBasicBlock.
   /// The operands to this method are the same as those
@@ -126,8 +126,8 @@ public:
   /// merging needs to be disabled.
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   /// Analyze loop L, which must be a single-basic-block loop, and if the
   /// conditions can be understood enough produce a PipelinerLoopInfo object.

--- a/llvm/lib/Target/Lanai/LanaiInstrInfo.cpp
+++ b/llvm/lib/Target/Lanai/LanaiInstrInfo.cpp
@@ -658,8 +658,8 @@ unsigned LanaiInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                       MachineBasicBlock *TrueBlock,
                                       MachineBasicBlock *FalseBlock,
                                       ArrayRef<MachineOperand> Condition,
-                                      const DebugLoc &DL, int *BytesAdded,
-                                      SlotIndexes *Indexes) const {
+                                      const DebugLoc &DL, SlotIndexes *Indexes,
+                                      int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TrueBlock && "insertBranch must not be told to insert a fallthrough");
   assert(!BytesAdded && "code size not handled");
@@ -694,8 +694,9 @@ unsigned LanaiInstrInfo::insertBranch(MachineBasicBlock &MBB,
   return 2;
 }
 
-unsigned LanaiInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                      SlotIndexes *Indexes) const {
+unsigned LanaiInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                      SlotIndexes *Indexes,
+                                      int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator Instruction = MBB.end();

--- a/llvm/lib/Target/Lanai/LanaiInstrInfo.h
+++ b/llvm/lib/Target/Lanai/LanaiInstrInfo.h
@@ -89,8 +89,8 @@ public:
                      SmallVectorImpl<MachineOperand> &Condition,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   // For a comparison instruction, return the source registers in SrcReg and
   // SrcReg2 if having two register operands, and the value it compares against
@@ -139,8 +139,8 @@ public:
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TrueBlock,
                         MachineBasicBlock *FalseBlock,
                         ArrayRef<MachineOperand> Condition, const DebugLoc &DL,
-                        int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 };
 
 static inline bool isSPLSOpcode(unsigned Opcode) {

--- a/llvm/lib/Target/Lanai/LanaiInstrInfo.h
+++ b/llvm/lib/Target/Lanai/LanaiInstrInfo.h
@@ -89,8 +89,8 @@ public:
                      SmallVectorImpl<MachineOperand> &Condition,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   // For a comparison instruction, return the source registers in SrcReg and
   // SrcReg2 if having two register operands, and the value it compares against
@@ -138,9 +138,9 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TrueBlock,
                         MachineBasicBlock *FalseBlock,
-                        ArrayRef<MachineOperand> Condition,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        ArrayRef<MachineOperand> Condition, const DebugLoc &DL,
+                        int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 };
 
 static inline bool isSPLSOpcode(unsigned Opcode) {

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.cpp
@@ -320,8 +320,8 @@ bool LoongArchInstrInfo::isBranchOffsetInRange(unsigned BranchOp,
 }
 
 unsigned LoongArchInstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                          int *BytesRemoved,
-                                          SlotIndexes *Indexes) const {
+                                          SlotIndexes *Indexes,
+                                          int *BytesRemoved) const {
   if (BytesRemoved)
     *BytesRemoved = 0;
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
@@ -357,12 +357,10 @@ unsigned LoongArchInstrInfo::removeBranch(MachineBasicBlock &MBB,
 
 // Inserts a branch into the end of the specific MachineBasicBlock, returning
 // the number of instructions inserted.
-unsigned LoongArchInstrInfo::insertBranch(MachineBasicBlock &MBB,
-                                          MachineBasicBlock *TBB,
-                                          MachineBasicBlock *FBB,
-                                          ArrayRef<MachineOperand> Cond,
-                                          const DebugLoc &DL, int *BytesAdded,
-                                          SlotIndexes *Indexes) const {
+unsigned LoongArchInstrInfo::insertBranch(
+    MachineBasicBlock &MBB, MachineBasicBlock *TBB, MachineBasicBlock *FBB,
+    ArrayRef<MachineOperand> Cond, const DebugLoc &DL, SlotIndexes *Indexes,
+    int *BytesAdded) const {
   if (BytesAdded)
     *BytesAdded = 0;
 

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.h
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.h
@@ -62,13 +62,13 @@ public:
   bool isBranchOffsetInRange(unsigned BranchOpc,
                              int64_t BrOffset) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &dl, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   void insertIndirectBranch(MachineBasicBlock &MBB,
                             MachineBasicBlock &NewDestBB,

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.h
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.h
@@ -62,13 +62,13 @@ public:
   bool isBranchOffsetInRange(unsigned BranchOpc,
                              int64_t BrOffset) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &dl,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &dl, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   void insertIndirectBranch(MachineBasicBlock &MBB,
                             MachineBasicBlock &NewDestBB,

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -255,8 +255,9 @@ bool M68kInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
   return AnalyzeBranchImpl(MBB, TBB, FBB, Cond, AllowModify);
 }
 
-unsigned M68kInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                     SlotIndexes *Indexes) const {
+unsigned M68kInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                     SlotIndexes *Indexes,
+                                     int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.end();
@@ -284,8 +285,8 @@ unsigned M68kInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                      MachineBasicBlock *TBB,
                                      MachineBasicBlock *FBB,
                                      ArrayRef<MachineOperand> Cond,
-                                     const DebugLoc &DL, int *BytesAdded,
-                                     SlotIndexes *Indexes) const {
+                                     const DebugLoc &DL, SlotIndexes *Indexes,
+                                     int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TBB && "InsertBranch must not be told to insert a fallthrough");
   assert((Cond.size() == 1 || Cond.size() == 0) &&

--- a/llvm/lib/Target/M68k/M68kInstrInfo.h
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.h
@@ -261,13 +261,13 @@ public:
                          SmallVectorImpl<MachineOperand> &Cond,
                          bool AllowModify) const;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
                    const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,

--- a/llvm/lib/Target/M68k/M68kInstrInfo.h
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.h
@@ -261,13 +261,13 @@ public:
                          SmallVectorImpl<MachineOperand> &Cond,
                          bool AllowModify) const;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
                    const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,

--- a/llvm/lib/Target/MSP430/MSP430InstrInfo.cpp
+++ b/llvm/lib/Target/MSP430/MSP430InstrInfo.cpp
@@ -105,8 +105,8 @@ void MSP430InstrInfo::copyPhysReg(MachineBasicBlock &MBB,
 }
 
 unsigned MSP430InstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                       int *BytesRemoved,
-                                       SlotIndexes *Indexes) const {
+                                       SlotIndexes *Indexes,
+                                       int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.end();
@@ -258,8 +258,8 @@ unsigned MSP430InstrInfo::insertBranch(MachineBasicBlock &MBB,
                                        MachineBasicBlock *TBB,
                                        MachineBasicBlock *FBB,
                                        ArrayRef<MachineOperand> Cond,
-                                       const DebugLoc &DL, int *BytesAdded,
-                                       SlotIndexes *Indexes) const {
+                                       const DebugLoc &DL, SlotIndexes *Indexes,
+                                       int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert((Cond.size() == 1 || Cond.size() == 0) &&

--- a/llvm/lib/Target/MSP430/MSP430InstrInfo.h
+++ b/llvm/lib/Target/MSP430/MSP430InstrInfo.h
@@ -61,12 +61,12 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   int64_t getFramePoppedByCallee(const MachineInstr &I) const {
     assert(isFrameInstr(I) && "Not a frame instruction");

--- a/llvm/lib/Target/MSP430/MSP430InstrInfo.h
+++ b/llvm/lib/Target/MSP430/MSP430InstrInfo.h
@@ -61,12 +61,12 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   int64_t getFramePoppedByCallee(const MachineInstr &I) const {
     assert(isFrameInstr(I) && "Not a frame instruction");

--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -139,8 +139,8 @@ unsigned MipsInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                      MachineBasicBlock *TBB,
                                      MachineBasicBlock *FBB,
                                      ArrayRef<MachineOperand> Cond,
-                                     const DebugLoc &DL, int *BytesAdded,
-                                     SlotIndexes *Indexes) const {
+                                     const DebugLoc &DL, SlotIndexes *Indexes,
+                                     int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert(!BytesAdded && "code size not handled");
@@ -173,8 +173,9 @@ unsigned MipsInstrInfo::insertBranch(MachineBasicBlock &MBB,
   return 1;
 }
 
-unsigned MipsInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                     SlotIndexes *Indexes) const {
+unsigned MipsInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                     SlotIndexes *Indexes,
+                                     int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::reverse_iterator I = MBB.rbegin(), REnd = MBB.rend();

--- a/llvm/lib/Target/Mips/MipsInstrInfo.h
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.h
@@ -65,13 +65,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/Mips/MipsInstrInfo.h
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.h
@@ -65,13 +65,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
@@ -206,7 +206,8 @@ private:
                      SmallVectorImpl<MachineOperand> &Cond) const;
 
   void BuildCondBr(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
-                   const DebugLoc &DL, ArrayRef<MachineOperand> Cond) const;
+                   const DebugLoc &DL, ArrayRef<MachineOperand> Cond,
+                   SlotIndexes *Indexes = nullptr) const;
 };
 
 /// Create MipsInstrInfo objects.

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.cpp
@@ -147,8 +147,9 @@ bool NVPTXInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
   return true;
 }
 
-unsigned NVPTXInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                      SlotIndexes *Indexes) const {
+unsigned NVPTXInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                      SlotIndexes *Indexes,
+                                      int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
   MachineBasicBlock::iterator I = MBB.end();
   if (I == MBB.begin())
@@ -181,8 +182,8 @@ unsigned NVPTXInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                       MachineBasicBlock *TBB,
                                       MachineBasicBlock *FBB,
                                       ArrayRef<MachineOperand> Cond,
-                                      const DebugLoc &DL, int *BytesAdded,
-                                      SlotIndexes *Indexes) const {
+                                      const DebugLoc &DL, SlotIndexes *Indexes,
+                                      int *BytesAdded) const {
   assert(!BytesAdded && "code size not handled");
 
   // Shouldn't be a fall through.

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.h
@@ -60,12 +60,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.h
@@ -60,12 +60,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -1440,8 +1440,9 @@ bool PPCInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
   return true;
 }
 
-unsigned PPCInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                    SlotIndexes *Indexes) const {
+unsigned PPCInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                    SlotIndexes *Indexes,
+                                    int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
@@ -1480,8 +1481,8 @@ unsigned PPCInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                     MachineBasicBlock *TBB,
                                     MachineBasicBlock *FBB,
                                     ArrayRef<MachineOperand> Cond,
-                                    const DebugLoc &DL, int *BytesAdded,
-                                    SlotIndexes *Indexes) const {
+                                    const DebugLoc &DL, SlotIndexes *Indexes,
+                                    int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert((Cond.size() == 2 || Cond.size() == 0) &&

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -395,12 +395,13 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   // Select analysis.
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -395,12 +395,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   // Select analysis.
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -923,8 +923,9 @@ bool RISCVInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
   return true;
 }
 
-unsigned RISCVInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                      SlotIndexes *Indexes) const {
+unsigned RISCVInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                      SlotIndexes *Indexes,
+                                      int *BytesRemoved) const {
   if (BytesRemoved)
     *BytesRemoved = 0;
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
@@ -965,8 +966,8 @@ unsigned RISCVInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                       MachineBasicBlock *TBB,
                                       MachineBasicBlock *FBB,
                                       ArrayRef<MachineOperand> Cond,
-                                      const DebugLoc &DL, int *BytesAdded,
-                                      SlotIndexes *Indexes) const {
+                                      const DebugLoc &DL, SlotIndexes *Indexes,
+                                      int *BytesAdded) const {
   if (BytesAdded)
     *BytesAdded = 0;
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -102,16 +102,16 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &dl, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   void insertIndirectBranch(MachineBasicBlock &MBB,
                             MachineBasicBlock &NewDestBB,
                             MachineBasicBlock &RestoreBB, const DebugLoc &DL,
                             int64_t BrOffset, RegScavenger *RS) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -102,16 +102,16 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &dl,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &dl, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   void insertIndirectBranch(MachineBasicBlock &MBB,
                             MachineBasicBlock &NewDestBB,
                             MachineBasicBlock &RestoreBB, const DebugLoc &DL,
                             int64_t BrOffset, RegScavenger *RS) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
@@ -200,8 +200,9 @@ bool SPIRVInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 // returns the number of instructions that were removed.
 // If \p BytesRemoved is non-null, report the change in code size from the
 // removed instructions.
-unsigned SPIRVInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                      SlotIndexes *Indexes) const {
+unsigned SPIRVInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                      SlotIndexes *Indexes,
+                                      int *BytesRemoved) const {
   report_fatal_error("Branch removal not supported, as MBB info not propagated"
                      " to OpPhi instructions. Try using -O0 instead.");
 }
@@ -223,8 +224,8 @@ unsigned SPIRVInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                       MachineBasicBlock *TBB,
                                       MachineBasicBlock *FBB,
                                       ArrayRef<MachineOperand> Cond,
-                                      const DebugLoc &DL, int *BytesAdded,
-                                      SlotIndexes *Indexes) const {
+                                      const DebugLoc &DL, SlotIndexes *Indexes,
+                                      int *BytesAdded) const {
   report_fatal_error("Branch insertion not supported, as MBB info not "
                      "propagated to OpPhi instructions. Try using "
                      "-O0 instead.");

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
@@ -200,8 +200,8 @@ bool SPIRVInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 // returns the number of instructions that were removed.
 // If \p BytesRemoved is non-null, report the change in code size from the
 // removed instructions.
-unsigned SPIRVInstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                      int *BytesRemoved) const {
+unsigned SPIRVInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
+                                      SlotIndexes *Indexes) const {
   report_fatal_error("Branch removal not supported, as MBB info not propagated"
                      " to OpPhi instructions. Try using -O0 instead.");
 }
@@ -219,9 +219,12 @@ unsigned SPIRVInstrInfo::removeBranch(MachineBasicBlock &MBB,
 //
 // The CFG information in MBB.Predecessors and MBB.Successors must be valid
 // before calling this function.
-unsigned SPIRVInstrInfo::insertBranch(
-    MachineBasicBlock &MBB, MachineBasicBlock *TBB, MachineBasicBlock *FBB,
-    ArrayRef<MachineOperand> Cond, const DebugLoc &DL, int *BytesAdded) const {
+unsigned SPIRVInstrInfo::insertBranch(MachineBasicBlock &MBB,
+                                      MachineBasicBlock *TBB,
+                                      MachineBasicBlock *FBB,
+                                      ArrayRef<MachineOperand> Cond,
+                                      const DebugLoc &DL, int *BytesAdded,
+                                      SlotIndexes *Indexes) const {
   report_fatal_error("Branch insertion not supported, as MBB info not "
                      "propagated to OpPhi instructions. Try using "
                      "-O0 instead.");

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
@@ -41,13 +41,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                    const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,
                    bool KillSrc) const override;

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
@@ -41,13 +41,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                    const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,
                    bool KillSrc) const override;

--- a/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.cpp
@@ -329,8 +329,8 @@ unsigned SparcInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                       MachineBasicBlock *TBB,
                                       MachineBasicBlock *FBB,
                                       ArrayRef<MachineOperand> Cond,
-                                      const DebugLoc &DL, int *BytesAdded,
-                                      SlotIndexes *Indexes) const {
+                                      const DebugLoc &DL, SlotIndexes *Indexes,
+                                      int *BytesAdded) const {
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert((Cond.size() <= 3) &&
          "Sparc branch conditions should have at most three components!");
@@ -373,8 +373,9 @@ unsigned SparcInstrInfo::insertBranch(MachineBasicBlock &MBB,
   return 2;
 }
 
-unsigned SparcInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                      SlotIndexes *Indexes) const {
+unsigned SparcInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                      SlotIndexes *Indexes,
+                                      int *BytesRemoved) const {
   MachineBasicBlock::iterator I = MBB.end();
   unsigned Count = 0;
   int Removed = 0;

--- a/llvm/lib/Target/Sparc/SparcInstrInfo.h
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.h
@@ -71,13 +71,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/Sparc/SparcInstrInfo.h
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.h
@@ -71,13 +71,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -447,8 +447,8 @@ bool SystemZInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 }
 
 unsigned SystemZInstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                        int *BytesRemoved,
-                                        SlotIndexes *Indexes) const {
+                                        SlotIndexes *Indexes,
+                                        int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   // Most of the code and comments here are boilerplate.
@@ -481,12 +481,10 @@ reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const {
   return false;
 }
 
-unsigned SystemZInstrInfo::insertBranch(MachineBasicBlock &MBB,
-                                        MachineBasicBlock *TBB,
-                                        MachineBasicBlock *FBB,
-                                        ArrayRef<MachineOperand> Cond,
-                                        const DebugLoc &DL, int *BytesAdded,
-                                        SlotIndexes *Indexes) const {
+unsigned SystemZInstrInfo::insertBranch(
+    MachineBasicBlock &MBB, MachineBasicBlock *TBB, MachineBasicBlock *FBB,
+    ArrayRef<MachineOperand> Cond, const DebugLoc &DL, SlotIndexes *Indexes,
+    int *BytesAdded) const {
   // In this function we output 32-bit branches, which should always
   // have enough range.  They can be shortened and relaxed by later code
   // in the pipeline, if desired.

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -238,12 +238,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
   bool analyzeCompare(const MachineInstr &MI, Register &SrcReg,
                       Register &SrcReg2, int64_t &Mask,
                       int64_t &Value) const override;

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -238,12 +238,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   bool analyzeCompare(const MachineInstr &MI, Register &SrcReg,
                       Register &SrcReg2, int64_t &Mask,
                       int64_t &Value) const override;

--- a/llvm/lib/Target/VE/VEInstrInfo.cpp
+++ b/llvm/lib/Target/VE/VEInstrInfo.cpp
@@ -228,8 +228,8 @@ unsigned VEInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                    MachineBasicBlock *TBB,
                                    MachineBasicBlock *FBB,
                                    ArrayRef<MachineOperand> Cond,
-                                   const DebugLoc &DL, int *BytesAdded,
-                                   SlotIndexes *Indexes) const {
+                                   const DebugLoc &DL, SlotIndexes *Indexes,
+                                   int *BytesAdded) const {
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert((Cond.size() == 3 || Cond.size() == 0) &&
          "VE branch conditions should have three component!");
@@ -296,8 +296,8 @@ unsigned VEInstrInfo::insertBranch(MachineBasicBlock &MBB,
   return 2;
 }
 
-unsigned VEInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                   SlotIndexes *Indexes) const {
+unsigned VEInstrInfo::removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes,
+                                   int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.end();

--- a/llvm/lib/Target/VE/VEInstrInfo.h
+++ b/llvm/lib/Target/VE/VEInstrInfo.h
@@ -67,13 +67,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/VE/VEInstrInfo.h
+++ b/llvm/lib/Target/VE/VEInstrInfo.h
@@ -67,13 +67,13 @@ public:
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
@@ -136,8 +136,8 @@ bool WebAssemblyInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
 }
 
 unsigned WebAssemblyInstrInfo::removeBranch(MachineBasicBlock &MBB,
-                                            int *BytesRemoved,
-                                            SlotIndexes *Indexes) const {
+                                            SlotIndexes *Indexes,
+                                            int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::instr_iterator I = MBB.instr_end();
@@ -160,12 +160,10 @@ unsigned WebAssemblyInstrInfo::removeBranch(MachineBasicBlock &MBB,
   return Count;
 }
 
-unsigned WebAssemblyInstrInfo::insertBranch(MachineBasicBlock &MBB,
-                                            MachineBasicBlock *TBB,
-                                            MachineBasicBlock *FBB,
-                                            ArrayRef<MachineOperand> Cond,
-                                            const DebugLoc &DL, int *BytesAdded,
-                                            SlotIndexes *Indexes) const {
+unsigned WebAssemblyInstrInfo::insertBranch(
+    MachineBasicBlock &MBB, MachineBasicBlock *TBB, MachineBasicBlock *FBB,
+    ArrayRef<MachineOperand> Cond, const DebugLoc &DL, SlotIndexes *Indexes,
+    int *BytesAdded) const {
   assert(!BytesAdded && "code size not handled");
 
   if (Cond.empty()) {

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
@@ -56,12 +56,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
@@ -56,12 +56,12 @@ public:
                      MachineBasicBlock *&FBB,
                      SmallVectorImpl<MachineOperand> &Cond,
                      bool AllowModify = false) const override;
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   bool
   reverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
 

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -3342,8 +3342,9 @@ bool X86InstrInfo::analyzeBranchPredicate(MachineBasicBlock &MBB,
   return true;
 }
 
-unsigned X86InstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                    SlotIndexes *Indexes) const {
+unsigned X86InstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                    SlotIndexes *Indexes,
+                                    int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.end();
@@ -3371,8 +3372,8 @@ unsigned X86InstrInfo::insertBranch(MachineBasicBlock &MBB,
                                     MachineBasicBlock *TBB,
                                     MachineBasicBlock *FBB,
                                     ArrayRef<MachineOperand> Cond,
-                                    const DebugLoc &DL, int *BytesAdded,
-                                    SlotIndexes *Indexes) const {
+                                    const DebugLoc &DL, SlotIndexes *Indexes,
+                                    int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert((Cond.size() == 1 || Cond.size() == 0) &&

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -349,12 +349,12 @@ public:
                               TargetInstrInfo::MachineBranchPredicate &MBP,
                               bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,
                        Register, Register, Register, int &, int &,
                        int &) const override;

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -349,12 +349,12 @@ public:
                               TargetInstrInfo::MachineBranchPredicate &MBP,
                               bool AllowModify = false) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
   bool canInsertSelect(const MachineBasicBlock &, ArrayRef<MachineOperand> Cond,
                        Register, Register, Register, int &, int &,
                        int &) const override;

--- a/llvm/lib/Target/XCore/XCoreInstrInfo.cpp
+++ b/llvm/lib/Target/XCore/XCoreInstrInfo.cpp
@@ -273,8 +273,8 @@ unsigned XCoreInstrInfo::insertBranch(MachineBasicBlock &MBB,
                                       MachineBasicBlock *TBB,
                                       MachineBasicBlock *FBB,
                                       ArrayRef<MachineOperand> Cond,
-                                      const DebugLoc &DL, int *BytesAdded,
-                                      SlotIndexes *Indexes) const {
+                                      const DebugLoc &DL, SlotIndexes *Indexes,
+                                      int *BytesAdded) const {
   // Shouldn't be a fall through.
   assert(TBB && "insertBranch must not be told to insert a fallthrough");
   assert((Cond.size() == 2 || Cond.size() == 0) &&
@@ -309,8 +309,9 @@ unsigned XCoreInstrInfo::insertBranch(MachineBasicBlock &MBB,
   return 2;
 }
 
-unsigned XCoreInstrInfo::removeBranch(MachineBasicBlock &MBB, int *BytesRemoved,
-                                      SlotIndexes *Indexes) const {
+unsigned XCoreInstrInfo::removeBranch(MachineBasicBlock &MBB,
+                                      SlotIndexes *Indexes,
+                                      int *BytesRemoved) const {
   assert(!BytesRemoved && "code size not handled");
 
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();

--- a/llvm/lib/Target/XCore/XCoreInstrInfo.h
+++ b/llvm/lib/Target/XCore/XCoreInstrInfo.h
@@ -56,11 +56,11 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL, int *BytesAdded = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+                        const DebugLoc &DL, SlotIndexes *Indexes = nullptr,
+                        int *BytesAdded = nullptr) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
-                        SlotIndexes *Indexes = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, SlotIndexes *Indexes = nullptr,
+                        int *BytesRemoved = nullptr) const override;
 
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                    const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,

--- a/llvm/lib/Target/XCore/XCoreInstrInfo.h
+++ b/llvm/lib/Target/XCore/XCoreInstrInfo.h
@@ -56,11 +56,11 @@ public:
 
   unsigned insertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-                        const DebugLoc &DL,
-                        int *BytesAdded = nullptr) const override;
+                        const DebugLoc &DL, int *BytesAdded = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
-  unsigned removeBranch(MachineBasicBlock &MBB,
-                        int *BytesRemoved = nullptr) const override;
+  unsigned removeBranch(MachineBasicBlock &MBB, int *BytesRemoved = nullptr,
+                        SlotIndexes *Indexes = nullptr) const override;
 
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                    const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,


### PR DESCRIPTION
Remove use after free when attempting to update SlotIndexes in MachineBasicBlock::SplitCriticalEdge.
Add support to targets for updating SlotIndexes when inserting or removing branches.