### PR TITLE
[mlir][IR] SingleBlockImplicitTerminator derives from TraitBase

### DIFF
--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -943,7 +943,8 @@ public:
 template <typename TerminatorOpType>
 struct SingleBlockImplicitTerminator {
   template <typename ConcreteType>
-  class Impl {
+  class Impl : public TraitBase<ConcreteType, SingleBlockImplicitTerminator<
+                                                  TerminatorOpType>::Impl> {
   private:
     /// Builds a terminator operation without relying on OpBuilder APIs to avoid
     /// cyclic header inclusion.


### PR DESCRIPTION
This was an oversight in 0ac21e654f194a0f7c9f5afe42e11924c546f89e.