### PR TITLE
[ci] builkite don't escape windows targets

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -52,4 +52,5 @@ cmake -S ${MONOREPO_ROOT}/llvm -B ${BUILD_DIR} \
       -D LLVM_CCACHE_BUILD=ON
 
 echo "--- ninja"
-ninja -C ${BUILD_DIR} ${targets}
+# Targets are not escaped as they are passed as separate arguments.
+ninja -C "${BUILD_DIR}" ${targets}

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -51,4 +51,5 @@ cmake -S ${MONOREPO_ROOT}/llvm -B ${BUILD_DIR} \
       -D CMAKE_CXX_COMPILER_LAUNCHER=sccache
 
 echo "--- ninja"
-ninja -C "${BUILD_DIR}" "${targets}"
+# Targets are not escaped as they are passed as separate arguments.
+ninja -C "${BUILD_DIR}" ${targets}


### PR DESCRIPTION
ninja takes every target as a separate argument