### PR TITLE
[clang][dataflow] Rename test target function to `target()`.

### DIFF
--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -5860,7 +5860,7 @@ TEST(TransferTest, EvaluateBlockWithUnreachablePreds) {
   // is marked unreachable). Trying to get the analysis state via
   // `getEnvironment` for the subexpression still should not crash.
   std::string Code = R"(
-    int cast(int i) {
+    int target(int i) {
       if ((i < 0 && true) || false) {
         return 0;
       }


### PR DESCRIPTION
Otherwise, the test doesn't actually do anything.
