### PR TITLE
[mlir][bufferization] Allow returning allocs in empty tensor elimination

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/EmptyTensorElimination.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/EmptyTensorElimination.cpp
@@ -268,6 +268,7 @@ struct EmptyTensorElimination
 void EmptyTensorElimination::runOnOperation() {
   Operation *op = getOperation();
   OneShotBufferizationOptions options;
+  options.allowReturnAllocsFromLoops = true;
   OneShotAnalysisState state(op, options);
   if (failed(analyzeOp(op, state))) {
     signalPassFailure();


### PR DESCRIPTION
This flag was renamed in 6a91dfedeb956dfa092a6a3f411e8b02f0d5d289 and accidentally removed from the pass.