### PR TITLE
[clang] Avoid evaluating the BitWidth expression over and over again

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4471,6 +4471,14 @@ void FieldDecl::setLazyInClassInitializer(LazyDeclStmtPtr NewInit) {
 
 unsigned FieldDecl::getBitWidthValue(const ASTContext &Ctx) const {
   assert(isBitField() && "not a bitfield");
+
+  // Try to avoid evaluating the expression in the overwhelmingly
+  // common case that we have a ConstantExpr.
+  if (const auto *CE = dyn_cast<ConstantExpr>(getBitWidth())) {
+    assert(CE->hasAPValueResult());
+    return CE->getResultAsAPSInt().getZExtValue();
+  }
+
   return getBitWidth()->EvaluateKnownConstInt(Ctx).getZExtValue();
 }
 


### PR DESCRIPTION
It's usually a ConstantExpr with a saved constant integer anyway, so we can just return that.