### PR TITLE
[SPIRV] Add support for SPV_KHR_bit_instructions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -506,7 +506,7 @@ void SPIRV::RequirementHandler::checkSatisfiable(
   for (auto Ext : AllExtensions) {
     if (ST.canUseExtension(Ext))
       continue;
-    LLVM_DEBUG(dbgs() << "Extension not suported: "
+    LLVM_DEBUG(dbgs() << "Extension not supported: "
                       << getSymbolicOperandMnemonic(
                              OperandCategory::ExtensionOperand, Ext)
                       << "\n");
@@ -745,7 +745,12 @@ void addInstrRequirements(const MachineInstr &MI,
   case SPIRV::OpBitFieldInsert:
   case SPIRV::OpBitFieldSExtract:
   case SPIRV::OpBitFieldUExtract:
+    if (!ST.canUseExtension(SPIRV::Extension::SPV_KHR_bit_instructions)) {
+      Reqs.addCapability(SPIRV::Capability::Shader);
+      break;
+    }
     Reqs.addExtension(SPIRV::Extension::SPV_KHR_bit_instructions);
+    Reqs.addCapability(SPIRV::Capability::BitInstructions);
     break;
   case SPIRV::OpTypeRuntimeArray:
     Reqs.addCapability(SPIRV::Capability::Shader);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -526,7 +526,7 @@ void SPIRV::RequirementHandler::addAvailableCaps(const CapabilityList &ToAdd) {
 }
 
 void SPIRV::RequirementHandler::removeCapabilityIf(
-    const Capability::Capability ToRemove, 
+    const Capability::Capability ToRemove,
     const Capability::Capability IfPresent) {
   if (AvailableCaps.contains(IfPresent))
     AvailableCaps.erase(ToRemove);
@@ -910,7 +910,7 @@ void addInstrRequirements(const MachineInstr &MI,
   // If we require capability Shader, then we can remove the requirement for
   // the BitInstructions capability, since Shader is a superset capability
   // of BitInstructions.
-  Reqs.removeCapabilityIf(SPIRV::Capability::BitInstructions, 
+  Reqs.removeCapabilityIf(SPIRV::Capability::BitInstructions,
                           SPIRV::Capability::Shader);
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -525,8 +525,9 @@ void SPIRV::RequirementHandler::addAvailableCaps(const CapabilityList &ToAdd) {
           SPIRV::OperandCategory::CapabilityOperand, Cap));
 }
 
-void SPIRV::RequirementHandler::removeCapabilityIf(const Capability::Capability ToRemove, 
-                                                   const Capability::Capability IfPresent) {
+void SPIRV::RequirementHandler::removeCapabilityIf(
+    const Capability::Capability ToRemove, 
+    const Capability::Capability IfPresent) {
   if (AvailableCaps.contains(IfPresent))
     AvailableCaps.erase(ToRemove);
 }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -909,8 +909,7 @@ void addInstrRequirements(const MachineInstr &MI,
   // If we require capability Shader, then we can remove the requirement for
   // the BitInstructions capability, since Shader is a superset capability
   // of BitInstructions.
-  Reqs.removeCapabilityIf(SPIRV::Capability::Shader,
-                          SPIRV::Capability::BitInstructions);
+  Reqs.removeCapabilityIf(SPIRV::Capability::BitInstructions, SPIRV::Capability::Shader);
 }
 
 static void collectReqs(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -909,7 +909,8 @@ void addInstrRequirements(const MachineInstr &MI,
   // If we require capability Shader, then we can remove the requirement for
   // the BitInstructions capability, since Shader is a superset capability
   // of BitInstructions.
-  Reqs.removeCapabilityIf(SPIRV::Capability::BitInstructions, SPIRV::Capability::Shader);
+  Reqs.removeCapabilityIf(SPIRV::Capability::BitInstructions, 
+                          SPIRV::Capability::Shader);
 }
 
 static void collectReqs(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -113,6 +113,10 @@ public:
   bool isCapabilityAvailable(Capability::Capability Cap) const {
     return AvailableCaps.contains(Cap);
   }
+
+  // Remove capability ToRemove, but only if IfPresent is present.
+  void removeCapabilityIf(const Capability::Capability ToRemove,
+                          const Capability::Capability IfPresent);
 };
 
 using InstrList = SmallVector<MachineInstr *>;

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -45,7 +45,7 @@ cl::list<SPIRV::Extension::Extension> Extensions(
         clEnumValN(SPIRV::Extension::SPV_KHR_bit_instructions,
                    "SPV_KHR_bit_instructions",
                    "This enables bit instructions to be used by SPIR-V modules "
-                   "without the requiring the Shader capability")));
+                   "without requiring the Shader capability")));
 
 // Compare version numbers, but allow 0 to mean unspecified.
 static bool isAtLeastVer(uint32_t Target, uint32_t VerToCompareTo) {

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -41,7 +41,11 @@ cl::list<SPIRV::Extension::Extension> Extensions(
         clEnumValN(SPIRV::Extension::SPV_KHR_no_integer_wrap_decoration,
                    "SPV_KHR_no_integer_wrap_decoration",
                    "Adds decorations to indicate that a given instruction does "
-                   "not cause integer wrapping")));
+                   "not cause integer wrapping"),
+        clEnumValN(SPIRV::Extension::SPV_KHR_bit_instructions,
+                   "SPV_KHR_bit_instructions",
+                   "This enables bit instructions to be used by SPIR-V modules "
+                   "without the requiring the Shader capability")));
 
 // Compare version numbers, but allow 0 to mean unspecified.
 static bool isAtLeastVer(uint32_t Target, uint32_t VerToCompareTo) {

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVSubtarget.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRV.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVLegalizerInfo.h"

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -450,6 +450,7 @@ defm PhysicalStorageBufferAddressesEXT : CapabilityOperand<5347, 0, 0, [], [Shad
 defm CooperativeMatrixNV : CapabilityOperand<5357, 0, 0, [], [Shader]>;
 defm ArbitraryPrecisionIntegersINTEL : CapabilityOperand<5844, 0, 0, [SPV_INTEL_arbitrary_precision_integers], [Int8, Int16]>;
 defm OptNoneINTEL : CapabilityOperand<6094, 0, 0, [SPV_INTEL_optnone], []>;
+defm BitInstructions : CapabilityOperand<6025, 0, 0, [SPV_KHR_bit_instructions], []>;
 
 //===----------------------------------------------------------------------===//
 // Multiclass used to define SourceLanguage enum values and at the same time

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions.ll
@@ -1,0 +1,24 @@
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s --spirv-extensions=SPV_KHR_bit_instructions -o - | FileCheck %s --check-prefix=CHECK-EXTENSION
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-NO-EXTENSION
+
+; CHECK-EXTENSION:      OpCapability BitInstructions
+; CHECK-EXTENSION-NEXT: OpExtension "SPV_KHR_bit_instructions"
+; CHECK-EXTENSION-NOT:  OpCabilitity Shader
+; CHECK-NO-EXTENSION:     OpCapability Shader
+; CHECK-NO-EXTENSION-NOT: OpCabilitity BitInstructions
+; CHECK-NO-EXTENSION-NOT: OpExtension "SPV_KHR_bit_instructions"
+
+
+; CHECK-EXTENSION: %[[#int:]] = OpTypeInt 32
+; CHECK-EXTENSION: OpBitReverse %[[#int]]
+; CHECK-NO-EXTENSION: %[[#int:]] = OpTypeInt 32
+; CHECK-NO-EXTENSION: OpBitReverse %[[#int]]
+
+define spir_kernel void @testBitRev(i32 %a, i32 %b, i32 %c, i32 addrspace(1)* nocapture %res) local_unnamed_addr {
+entry:
+  %call = tail call i32 @llvm.bitreverse.i32(i32 %b)
+  store i32 %call, i32 addrspace(1)* %res, align 4
+  ret void
+}
+
+declare i32 @llvm.bitreverse.i32(i32)

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpBitReverse_i32.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpBitReverse_i32.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
+; CHECK-SPIRV:      OpCapability BitInstructions
+; CHECK-SPIRV-NEXT: OpExtension "SPV_KHR_bit_instructions"
+
 ; CHECK-SPIRV: %[[#int:]] = OpTypeInt 32
 ; CHECK-SPIRV: OpBitReverse %[[#int]]
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpBitReverse_i32.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpBitReverse_i32.ll
@@ -1,8 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; CHECK-SPIRV:      OpCapability BitInstructions
-; CHECK-SPIRV-NEXT: OpExtension "SPV_KHR_bit_instructions"
-
 ; CHECK-SPIRV: %[[#int:]] = OpTypeInt 32
 ; CHECK-SPIRV: OpBitReverse %[[#int]]
 


### PR DESCRIPTION
Draft version of patch to add support for SPV_KHR_bit_instructions.

Created revision so we can discuss how to proceed here.
SPV_KHR_bit_instructions (http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_bit_instructions.html),
adds support for instructions that we already support through
the Shader capability but without requiring the shader cap.

However we currently have no way to disable the shader cap afaiu.
On the other hand, SPV_KHR_bit_instructions was one of the
extensions @mpaszkowski listed that we need to implement.

So what does it mean at the moment the need to implement this?
Is it just the ability to issue the extension and capabilities
instructions without issuing the Shader capability? If so,
then I will need to add here a way to disable the Shader
capability. What do you think?

Previously https://reviews.llvm.org/D156661