### PR TITLE
[flang] Fix crash under -fdebug-dump-all

### DIFF
--- a/flang/lib/Semantics/runtime-type-info.cpp
+++ b/flang/lib/Semantics/runtime-type-info.cpp
@@ -310,8 +310,11 @@ static SomeExpr StructureExpr(evaluate::StructureConstructor &&x) {
 
 static int GetIntegerKind(const Symbol &symbol) {
   auto dyType{evaluate::DynamicType::From(symbol)};
-  CHECK(dyType && dyType->category() == TypeCategory::Integer);
-  return dyType->kind();
+  CHECK((dyType && dyType->category() == TypeCategory::Integer) ||
+      symbol.owner().context().HasError(symbol));
+  return dyType && dyType->category() == TypeCategory::Integer
+      ? dyType->kind()
+      : symbol.owner().context().GetDefaultKind(TypeCategory::Integer);
 }
 
 // Save a rank-1 array constant of some numeric type as an

--- a/flang/test/Driver/dump-all-bad.f90
+++ b/flang/test/Driver/dump-all-bad.f90
@@ -10,6 +10,8 @@
 ! CHECK: Flang: symbols dump
 
 program bad
-  real,pointer :: x
-  x = null()      ! Error - must be pointer assignment
+  type dt(k)
+    integer(kind=16) :: k
+    integer(kind=16) :: comp
+  end type dt
 end


### PR DESCRIPTION
The -fdebug-dump-all flag invokes runtime type information generation even for a program with fatal semantic errors. This could cause a crash on a failed CHECK(), since the type information table generator assumes a correct program. Make it more resilient for a known fatal case.  (But if we hit many more of these, we should look into not generating the runtime type information tables under this flag.)