### PR TITLE
[llvm][Docs] Show how to format Python files changed in a commit

### DIFF
--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -120,6 +120,14 @@ For consistency and to limit churn, code should be automatically formatted with 
 rules based on major version. In order to avoid unnecessary churn in the formatting rules
 we currently use black version 23.x in LLVM.
 
+To format only the lines changed in a patch you can use
+`darker <https://pypi.org/project/darker/>`_. To format the changes in the most recent
+commit:
+
+::
+
+  darker --revision HEAD~1 $(git diff-tree --no-commit-id --name-only HEAD -r)
+
 Mechanical Source Issues
 ========================
 


### PR DESCRIPTION
black will always work on whole files and darker seems to be the only way to get it to work on chunks of files as you would with clang-format and https://clang.llvm.org/docs/ClangFormat.html#script-for-patch-reformatting.

This adds a one liner for the common use case. In theory you can not list files and use `.` as the path instead but it seems to find all python files, then see if they have changed. Instead of starting with the change list. So it takes ages on llvm-project/.