### PR TITLE
[flang] Foil attempts to put automatic objects in COMMON

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -419,11 +419,16 @@ void CheckHelper::Check(const Symbol &symbol) {
     }
     CheckBindCFunctionResult(symbol);
   }
-  if (symbol.owner().IsModule() && IsAutomatic(symbol)) {
-    messages_.Say(
-        "Automatic data object '%s' may not appear in the specification part"
-        " of a module"_err_en_US,
-        symbol.name());
+  if (IsAutomatic(symbol)) {
+    if (const Symbol * common{FindCommonBlockContaining(symbol)}) {
+      messages_.Say(
+          "Automatic data object '%s' may not appear in COMMON block /%s/"_err_en_US,
+          symbol.name(), common->name());
+    } else if (symbol.owner().IsModule()) {
+      messages_.Say(
+          "Automatic data object '%s' may not appear in a module"_err_en_US,
+          symbol.name());
+    }
   }
   if (IsProcedure(symbol) && !symbol.HasExplicitInterface()) {
     if (IsAllocatable(symbol)) {

--- a/flang/test/Semantics/resolve77.f90
+++ b/flang/test/Semantics/resolve77.f90
@@ -8,10 +8,16 @@ module m
   interface ifn3
     module procedure if3
   end interface
-  !ERROR: Automatic data object 'a' may not appear in the specification part of a module
+  !ERROR: Automatic data object 'a' may not appear in a module
   real :: a(if1(1))
-  !ERROR: Automatic data object 'b' may not appear in the specification part of a module
+  !ERROR: Automatic data object 'b' may not appear in a module
   real :: b(ifn2(1))
+  !ERROR: Automatic data object 'c' may not appear in COMMON block /blk/
+  real :: c(if1(1))
+  !ERROR: Automatic data object 'd' may not appear in COMMON block //
+  real :: d(ifn2(1))
+  common /blk/c
+  common d
  contains
   subroutine t1(n)
     integer :: iarr(if1(n))


### PR DESCRIPTION
We were catching automatic objects in modules and SAVE, but not in COMMON blocks.

Fixes https://github.com/llvm/llvm-project/issues/65003.