### PR TITLE
[flang] Accept intrinsic functions in DATA statement variables

### DIFF
--- a/flang/test/Semantics/data05.f90
+++ b/flang/test/Semantics/data05.f90
@@ -93,4 +93,8 @@ module m
     integer j(2)
     data j(2:1), j(1:2) /1,2/ ! CHECK: j (InDataStmt) size=8 offset=0: ObjectEntity type: INTEGER(4) shape: 1_8:2_8 init:[INTEGER(4)::1_4,2_4]
   end subroutine
+  subroutine s14
+    integer j(0:1)
+    data (j(modulo(k,2)),k=1,2) /3,4/ ! CHECK: j (InDataStmt) size=8 offset=0: ObjectEntity type: INTEGER(4) shape: 0_8:1_8 init:[INTEGER(4)::4_4,3_4]
+  end subroutine
 end module


### PR DESCRIPTION
Pure intrinsic functions are acceptable in constant expressions so long as their arguments are constant expressions.  Allow them to appear in subscripts in DATA statement variables.

Fixes https://github.com/llvm/llvm-project/issues/65046.