### PR TITLE
[libc] Implement 'qsort' and 'bsearch' on the GPU

### DIFF
--- a/clang/lib/Headers/llvm_libc_wrappers/stdlib.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/stdlib.h
@@ -23,8 +23,11 @@
 
 #pragma omp begin declare target
 
-// The LLVM C library uses this type so we forward declare it.
+// The LLVM C library uses these named types so we forward declare them.
 typedef void (*__atexithandler_t)(void);
+typedef int (*__bsearchcompare_t)(const void *, const void *);
+typedef int (*__qsortcompare_t)(const void *, const void *);
+typedef int (*__qsortrcompare_t)(const void *, const void *, void *);
 
 // Enforce ABI compatibility with the structs used by the LLVM C library.
 _Static_assert(__builtin_offsetof(div_t, quot) == 0, "ABI mismatch!");

--- a/libc/config/gpu/api.td
+++ b/libc/config/gpu/api.td
@@ -46,6 +46,9 @@ def StdlibAPI : PublicAPI<"stdlib.h"> {
     "ldiv_t",
     "lldiv_t",
     "size_t",
+    "__bsearchcompare_t",
+    "__qsortcompare_t",
+    "__qsortrcompare_t",
     "__atexithandler_t",
   ];
 }

--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -58,9 +58,12 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.atoll
     libc.src.stdlib.div
     libc.src.stdlib.labs
+    libc.src.stdlib.bsearch
     libc.src.stdlib.ldiv
     libc.src.stdlib.llabs
     libc.src.stdlib.lldiv
+    libc.src.stdlib.qsort
+    libc.src.stdlib.qsort_r
     libc.src.stdlib.strtod
     libc.src.stdlib.strtof
     libc.src.stdlib.strtol

--- a/libc/docs/gpu/support.rst
+++ b/libc/docs/gpu/support.rst
@@ -96,6 +96,9 @@ llabs          |check|
 div            |check|
 ldiv           |check|
 lldiv          |check|
+bsearch        |check|
+qsort          |check|
+qsort_r        |check|
 strtod         |check|
 strtof         |check|
 strtol         |check|


### PR DESCRIPTION
Summary:
This patch simply adds the necessary config to enable qsort and bsearch
on the GPU. It is *highly* unlikely that anyone will use these, as they
are single threaded, but we may as well support all entrypoints that we
can.
