### PR TITLE
[flang][runtime] Handle type code synonyms in CFI_... runtime

### DIFF
--- a/flang/include/flang/Runtime/type-code.h
+++ b/flang/include/flang/Runtime/type-code.h
@@ -53,10 +53,19 @@ public:
   RT_API_ATTRS std::optional<std::pair<TypeCategory, int>>
   GetCategoryAndKind() const;
 
-  RT_API_ATTRS bool operator==(const TypeCode &that) const {
-    return raw_ == that.raw_;
+  RT_API_ATTRS bool operator==(TypeCode that) const {
+    if (raw_ == that.raw_) { // fast path
+      return true;
+    } else {
+      // Multiple raw CFI_type_... codes can represent the same Fortran
+      // type category + kind type parameter, e.g. CFI_type_int and
+      // CFI_type_int32_t.
+      auto thisCK{GetCategoryAndKind()};
+      auto thatCK{that.GetCategoryAndKind()};
+      return thisCK && thatCK && *thisCK == *thatCK;
+    }
   }
-  bool operator!=(const TypeCode &that) const { return raw_ != that.raw_; }
+  bool operator!=(TypeCode that) const { return !(*this == that); }
 
 private:
   ISO::CFI_type_t raw_{CFI_type_other};

--- a/flang/runtime/ISO_Fortran_binding.cpp
+++ b/flang/runtime/ISO_Fortran_binding.cpp
@@ -148,9 +148,11 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   if (IsAssumedSize(source) && !upper_bounds) {
     return CFI_INVALID_DESCRIPTOR;
   }
-  if ((result->type != source->type) ||
-      (result->elem_len != source->elem_len)) {
-    return CFI_INVALID_DESCRIPTOR;
+  if (runtime::TypeCode{result->type} != runtime::TypeCode{source->type}) {
+    return CFI_INVALID_TYPE;
+  }
+  if (source->elem_len != result->elem_len) {
+    return CFI_INVALID_ELEM_LEN;
   }
   if (result->attribute == CFI_attribute_allocatable) {
     return CFI_INVALID_ATTRIBUTE;
@@ -256,7 +258,7 @@ int CFI_setpointer(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   if (source->rank != result->rank) {
     return CFI_INVALID_RANK;
   }
-  if (source->type != result->type) {
+  if (runtime::TypeCode{source->type} != runtime::TypeCode{result->type}) {
     return CFI_INVALID_TYPE;
   }
   if (source->elem_len != result->elem_len) {


### PR DESCRIPTION
Some CFI_type_... type codes are synonyms; ensure that they are treated as equivalent when validating inputs to CFI_... runtime routines.