### PR TITLE
[flang] Assume unknown target of procedure pointer assignment is a pr…

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -8108,6 +8108,15 @@ bool ResolveNamesVisitor::Pre(const parser::PointerAssignmentStmt &x) {
         return false;
       }
     }
+    if (IsProcedurePointer(parser::GetLastName(dataRef).symbol) &&
+        !FindSymbol(*name)) {
+      // Unknown target of procedure pointer must be an external procedure
+      Symbol &symbol{MakeSymbol(
+          context().globalScope(), name->source, Attrs{Attr::EXTERNAL})};
+      Resolve(*name, symbol);
+      ConvertToProcEntity(symbol);
+      return false;
+    }
   }
   Walk(expr);
   return false;

--- a/flang/test/Semantics/symbol31.f90
+++ b/flang/test/Semantics/symbol31.f90
@@ -1,0 +1,7 @@
+! RUN: %python %S/test_symbols.py %s %flang_fc1
+ !DEF: /MainProgram1/pptr EXTERNAL, POINTER ProcEntity
+ procedure(), pointer :: pptr
+ !REF: /MainProgram1/pptr
+ !DEF: /mustbeexternal EXTERNAL ProcEntity
+ pptr => mustbeexternal
+end program


### PR DESCRIPTION
…ocedure

When an previously unknown name appears as the target of an assignment to a known procedure pointer, create an external symbol for it rather than an implicitly-typed object symbol.