### PR TITLE
[flang][runtime] INQUIRE(UNIT=-666, EXIST=x) should be .FALSE.

### DIFF
--- a/flang/runtime/io-stmt.cpp
+++ b/flang/runtime/io-stmt.cpp
@@ -1271,7 +1271,7 @@ bool InquireNoUnitState::Inquire(
 bool InquireNoUnitState::Inquire(InquiryKeywordHash inquiry, bool &result) {
   switch (inquiry) {
   case HashInquiryKeyword("EXIST"):
-    result = true;
+    result = badUnitNumber() >= 0;
     return true;
   case HashInquiryKeyword("NAMED"):
   case HashInquiryKeyword("OPENED"):


### PR DESCRIPTION
The runtime implementation for INQUIRE(EXIST=x) is returning .TRUE. for all non-existent unit, which is incorrect for valid unit numbers.