### PR TITLE
[flang] Fold NORM2()

### DIFF
--- a/flang/lib/Evaluate/fold-logical.cpp
+++ b/flang/lib/Evaluate/fold-logical.cpp
@@ -28,14 +28,11 @@ static Expr<T> FoldAllAnyParity(FoldingContext &context, FunctionRef<T> &&ref,
     Scalar<T> (Scalar<T>::*operation)(const Scalar<T> &) const,
     Scalar<T> identity) {
   static_assert(T::category == TypeCategory::Logical);
-  using Element = Scalar<T>;
   std::optional<int> dim;
   if (std::optional<Constant<T>> array{
           ProcessReductionArgs<T>(context, ref.arguments(), dim, identity,
               /*ARRAY(MASK)=*/0, /*DIM=*/1)}) {
-    auto accumulator{[&](Element &element, const ConstantSubscripts &at) {
-      element = (element.*operation)(array->At(at));
-    }};
+    OperationAccumulator accumulator{*array, operation};
     return Expr<T>{DoReduction<T>(*array, dim, identity, accumulator)};
   }
   return Expr<T>{std::move(ref)};

--- a/flang/lib/Evaluate/fold-real.cpp
+++ b/flang/lib/Evaluate/fold-real.cpp
@@ -43,6 +43,80 @@ static Expr<T> FoldTransformationalBessel(
   return Expr<T>{std::move(funcRef)};
 }
 
+// NORM2
+template <int KIND> class Norm2Accumulator {
+  using T = Type<TypeCategory::Real, KIND>;
+
+public:
+  Norm2Accumulator(
+      const Constant<T> &array, const Constant<T> &maxAbs, Rounding rounding)
+      : array_{array}, maxAbs_{maxAbs}, rounding_{rounding} {};
+  void operator()(Scalar<T> &element, const ConstantSubscripts &at) {
+    // Kahan summation of scaled elements
+    auto scale{maxAbs_.At(maxAbsAt_)};
+    if (scale.IsZero()) {
+      // If maxAbs is zero, so are all elements, and result
+      element = scale;
+    } else {
+      auto item{array_.At(at)};
+      auto scaled{item.Divide(scale).value};
+      auto square{item.Multiply(scaled).value};
+      auto next{square.Add(correction_, rounding_)};
+      overflow_ |= next.flags.test(RealFlag::Overflow);
+      auto sum{element.Add(next.value, rounding_)};
+      overflow_ |= sum.flags.test(RealFlag::Overflow);
+      correction_ = sum.value.Subtract(element, rounding_)
+                        .value.Subtract(next.value, rounding_)
+                        .value;
+      element = sum.value;
+    }
+  }
+  bool overflow() const { return overflow_; }
+  void Done(Scalar<T> &result) {
+    auto corrected{result.Add(correction_, rounding_)};
+    overflow_ |= corrected.flags.test(RealFlag::Overflow);
+    correction_ = Scalar<T>{};
+    auto rescaled{corrected.value.Multiply(maxAbs_.At(maxAbsAt_))};
+    maxAbs_.IncrementSubscripts(maxAbsAt_);
+    overflow_ |= rescaled.flags.test(RealFlag::Overflow);
+    result = rescaled.value.SQRT().value;
+  }
+
+private:
+  const Constant<T> &array_;
+  const Constant<T> &maxAbs_;
+  const Rounding rounding_;
+  bool overflow_{false};
+  Scalar<T> correction_{};
+  ConstantSubscripts maxAbsAt_{maxAbs_.lbounds()};
+};
+
+template <int KIND>
+static Expr<Type<TypeCategory::Real, KIND>> FoldNorm2(FoldingContext &context,
+    FunctionRef<Type<TypeCategory::Real, KIND>> &&funcRef) {
+  using T = Type<TypeCategory::Real, KIND>;
+  using Element = typename Constant<T>::Element;
+  std::optional<int> dim;
+  const Element identity{};
+  if (std::optional<Constant<T>> array{
+          ProcessReductionArgs<T>(context, funcRef.arguments(), dim, identity,
+              /*X=*/0, /*DIM=*/1)}) {
+    MaxvalMinvalAccumulator<T, /*ABS=*/true> maxAbsAccumulator{
+        RelationalOperator::GT, context, *array};
+    Constant<T> maxAbs{
+        DoReduction<T>(*array, dim, identity, maxAbsAccumulator)};
+    Norm2Accumulator norm2Accumulator{
+        *array, maxAbs, context.targetCharacteristics().roundingMode()};
+    Constant<T> result{DoReduction<T>(*array, dim, identity, norm2Accumulator)};
+    if (norm2Accumulator.overflow()) {
+      context.messages().Say(
+          "NORM2() of REAL(%d) data overflowed"_warn_en_US, KIND);
+    }
+    return Expr<T>{std::move(result)};
+  }
+  return Expr<T>{std::move(funcRef)};
+}
+
 template <int KIND>
 Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
     FoldingContext &context,
@@ -238,6 +312,8 @@ Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
           },
           sExpr->u);
     }
+  } else if (name == "norm2") {
+    return FoldNorm2<T::kind>(context, std::move(funcRef));
   } else if (name == "product") {
     auto one{Scalar<T>::FromInteger(value::Integer<8>{1}).value};
     return FoldProduct<T>(context, std::move(funcRef), one);
@@ -354,7 +430,7 @@ Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
           return result.value;
         }));
   }
-  // TODO: dot_product, matmul, norm2
+  // TODO: matmul
   return Expr<T>{std::move(funcRef)};
 }
 

--- a/flang/test/Evaluate/fold-norm2.f90
+++ b/flang/test/Evaluate/fold-norm2.f90
@@ -1,0 +1,29 @@
+! RUN: %python %S/test_folding.py %s %flang_fc1
+! Tests folding of NORM2(), F'2023 16.9.153
+module m
+  ! Examples from the standard
+  logical, parameter :: test_ex1 = norm2([3.,4.]) == 5.
+  real, parameter :: ex2(2,2) = reshape([1.,3.,2.,4.],[2,2])
+  real, parameter :: ex2_norm2_1(2) = norm2(ex2, dim=1)
+  real, parameter :: ex2_1(2) = [3.162277698516845703125,4.472136020660400390625]
+  logical, parameter :: test_ex2_1 = all(ex2_norm2_1 == ex2_1)
+  real, parameter :: ex2_norm2_2(2) = norm2(ex2, dim=2)
+  real, parameter :: ex2_2(2) = [2.2360680103302001953125,5.]
+  logical, parameter :: test_ex2_2 = all(ex2_norm2_2 == ex2_2)
+  !  0  3  6  9
+  !  1  4  7 10
+  !  2  5  8 11
+  integer, parameter :: dp = kind(0.d0)
+  real(dp), parameter :: a(3,4) = &
+    reshape([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], shape(a))
+  real(dp), parameter :: nAll = norm2(a)
+  real(dp), parameter :: check_nAll = sqrt(sum(a * a))
+  logical, parameter :: test_all = nAll == check_nAll
+  real(dp), parameter :: norms1(4) = norm2(a, dim=1)
+  real(dp), parameter :: check_norms1(4) = sqrt(sum(a * a, dim=1))
+  logical, parameter :: test_norms1 = all(norms1 == check_norms1)
+  real(dp), parameter :: norms2(3) = norm2(a, dim=2)
+  real(dp), parameter :: check_norms2(3) = sqrt(sum(a * a, dim=2))
+  logical, parameter :: test_norms2 = all(norms2 == check_norms2)
+  logical, parameter :: test_normZ = norm2([0.,0.,0.]) == 0.
+end


### PR DESCRIPTION
Fold references to the (relatively new) intrinsic function NORM2 at compilation time when the argument(s) are all constants. (Getting this done right involved some changes to the API of the accumulator function objects used by the DoReduction<> template, which rippled through some other reduction function folding code.)