### PR TITLE
[flang] Fix SIZEOF() expression rewriting

### DIFF
--- a/flang/include/flang/Evaluate/characteristics.h
+++ b/flang/include/flang/Evaluate/characteristics.h
@@ -88,11 +88,11 @@ public:
   static std::optional<TypeAndShape> Characterize(
       const ActualArgument &, FoldingContext &, bool invariantOnly = false);
 
-  // General case for Expr<T>, ActualArgument, &c.
+  // General case for Expr<T>, &c.
   template <typename A>
   static std::optional<TypeAndShape> Characterize(
       const A &x, FoldingContext &context, bool invariantOnly = false) {
-    if (const auto *symbol{UnwrapWholeSymbolOrComponentDataRef(x)}) {
+    if (const auto *symbol{UnwrapWholeSymbolDataRef(x)}) {
       if (auto result{Characterize(*symbol, context, invariantOnly)}) {
         return result;
       }
@@ -116,7 +116,7 @@ public:
   static std::optional<TypeAndShape> Characterize(
       const Designator<Type<TypeCategory::Character, KIND>> &x,
       FoldingContext &context, bool invariantOnly = true) {
-    if (const auto *symbol{UnwrapWholeSymbolOrComponentDataRef(x)}) {
+    if (const auto *symbol{UnwrapWholeSymbolDataRef(x)}) {
       if (auto result{Characterize(*symbol, context, invariantOnly)}) {
         return result;
       }
@@ -184,8 +184,6 @@ private:
   static std::optional<TypeAndShape> Characterize(
       const semantics::AssocEntityDetails &, FoldingContext &,
       bool invariantOnly = true);
-  static std::optional<TypeAndShape> Characterize(
-      const semantics::ProcEntityDetails &, FoldingContext &);
   void AcquireAttrs(const semantics::Symbol &);
   void AcquireLEN();
   void AcquireLEN(const semantics::Symbol &);

--- a/flang/test/Evaluate/rewrite05.f90
+++ b/flang/test/Evaluate/rewrite05.f90
@@ -1,0 +1,34 @@
+! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+program main
+  type t
+    integer, allocatable :: component(:)
+  end type
+  type(t) :: x
+  call init(10)
+  !CHECK: PRINT *, [INTEGER(4)::int(lbound(x%component,dim=1,kind=8),kind=4)]
+  print *, lbound(x%component)
+  !CHECK: PRINT *, [INTEGER(4)::int(size(x%component,dim=1,kind=8)+lbound(x%component,dim=1,kind=8)-1_8,kind=4)]
+  print *, ubound(x%component)
+  !CHECK: PRINT *, int(size(x%component,dim=1,kind=8),kind=4)
+  print *, size(x%component)
+  !CHECK: PRINT *, 4_8*size(x%component,dim=1,kind=8)
+  print *, sizeof(x%component)
+  !CHECK: PRINT *, 1_4
+  print *, lbound(iota(10), 1)
+  !CHECK: PRINT *, ubound(iota(10_4),1_4)
+  print *, ubound(iota(10), 1)
+  !CHECK: PRINT *, size(iota(10_4))
+  print *, size(iota(10))
+  !CHECK: PRINT *, sizeof(iota(10_4))
+  print *, sizeof(iota(10))
+ contains
+  function iota(n) result(result)
+    integer, intent(in) :: n
+    integer, allocatable :: result(:)
+    result = [(j,j=1,n)]
+  end
+  subroutine init(n)
+    integer, intent(in) :: n
+    allocate(x%component(0:n-1))
+  end
+end


### PR DESCRIPTION
The rewriting of the extension intrinsic function SIZEOF was producing results that would reference symbols that were not available in the current scope, leading to crashes in lowering. The symbols could be function result variables, for SIZEOF(func()), or bare derived type component names, for SIZEOF(array(n)%component). Fixing this without regressing on a current test case involved careful threading of some state through the TypeAndShape characterization code and the shape/bounds analyzer, and some clean-up was done along the way.