### PR TITLE
[flang][runtime] Enforce proper termination of list-directed input va…

### DIFF
--- a/flang/include/flang/Runtime/iostat.h
+++ b/flang/include/flang/Runtime/iostat.h
@@ -84,6 +84,7 @@ enum Iostat {
   IostatBadFlushUnit,
   IostatBadOpOnChildUnit,
   IostatBadNewUnit,
+  IostatBadListDirectedInputSeparator,
 };
 
 const char *IostatErrorString(int);

--- a/flang/runtime/iostat.cpp
+++ b/flang/runtime/iostat.cpp
@@ -113,6 +113,8 @@ const char *IostatErrorString(int iostat) {
     return "Impermissible I/O statement on child I/O unit";
   case IostatBadNewUnit:
     return "NEWUNIT= without FILE= or STATUS='SCRATCH'";
+  case IostatBadListDirectedInputSeparator:
+    return "List-directed input value has trailing unused characters";
   default:
     return nullptr;
   }


### PR DESCRIPTION
…lues

Emit an error at runtime when a list-directed input value is not followed by a value separator or end of record.  Previously, the runtime I/O library was consuming as many input characters that were valid for the type of the value, and leaving any remaining characters for the next input edit, if any.