### PR TITLE
[flang] Fix compile-time infinite loop

### DIFF
--- a/flang/test/Semantics/equivalence01.f90
+++ b/flang/test/Semantics/equivalence01.f90
@@ -230,3 +230,17 @@ contains
     equivalence (dupName, y)
   end function f17b
 end module m17
+
+module m18
+  ! Regression test: don't loop when checking mutually-referencing types
+  type t1
+    sequence
+    type (t2), pointer :: p
+  end type
+  type t2
+    sequence
+    type (t1), pointer :: p
+  end type
+  type(t1) x
+  common x
+end


### PR DESCRIPTION
When a COMMON block object has a derived type that is part of a set of mutually-dependent types with other members, the compiler loops.

Fixes https://github.com/llvm/llvm-project/issues/65572.