### PR TITLE
[flang] Fix characterization of result of function returning procedur…

### DIFF
--- a/flang/include/flang/Common/enum-class.h
+++ b/flang/include/flang/Common/enum-class.h
@@ -12,7 +12,7 @@
 //   enum class className { enum1, enum2, ... , enumN };
 // as well as the introspective utilities
 //   static constexpr std::size_t className_enumSize{N};
-//   static inline const std::string_view EnumToString(className);
+//   static inline std::string_view EnumToString(className);
 
 #ifndef FORTRAN_COMMON_ENUM_CLASS_H_
 #define FORTRAN_COMMON_ENUM_CLASS_H_

--- a/flang/lib/Semantics/pointer-assignment.cpp
+++ b/flang/lib/Semantics/pointer-assignment.cpp
@@ -10,6 +10,7 @@
 #include "definable.h"
 #include "flang/Common/idioms.h"
 #include "flang/Common/restorer.h"
+#include "flang/Common/template.h"
 #include "flang/Evaluate/characteristics.h"
 #include "flang/Evaluate/expression.h"
 #include "flang/Evaluate/fold.h"
@@ -389,16 +390,8 @@ bool PointerAssignmentChecker::Check(const evaluate::ProcedureDesignator &d) {
 }
 
 bool PointerAssignmentChecker::Check(const evaluate::ProcedureRef &ref) {
-  if (auto chars{Procedure::Characterize(ref, foldingContext_)}) {
-    if (chars->functionResult) {
-      if (const auto *proc{chars->functionResult->IsProcedurePointer()}) {
-        return Check(ref.proc().GetName(), true, proc);
-      }
-    }
-    return Check(ref.proc().GetName(), true, &*chars);
-  } else {
-    return Check(ref.proc().GetName(), true, nullptr);
-  }
+  auto chars{Procedure::Characterize(ref, foldingContext_)};
+  return Check(ref.proc().GetName(), true, common::GetPtrFromOptional(chars));
 }
 
 // The target can be unlimited polymorphic if the pointer is, or if it is


### PR DESCRIPTION
…e pointer

The procedure characterization package correctly characterizes the result of a reference to a function that returns a procedure pointer. In the event of a result that is a pointer to a function that itself is a procedure pointer, the code in pointer assignment semantics checking was mistakenly using that result's procedure characteristics as the characteristics of the original function reference.  This is just wrong; delete it.