### PR TITLE
[flang] Extension: accept NULL([MOLD=]) for ALLOCATABLE INTENT(IN) du…

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -298,6 +298,8 @@ end
 * Unrestricted `INTRINSIC` functions are accepted for use in
   `PROCEDURE` statements in generic interfaces, as in some other
   compilers.
+* A `NULL()` pointer is treated as an unallocated allocatable
+  when associated with an `INTENT(IN)` allocatable dummy argument.
 
 ### Extensions supported when enabled by options
 

--- a/flang/include/flang/Common/Fortran-features.h
+++ b/flang/include/flang/Common/Fortran-features.h
@@ -37,7 +37,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     DistinguishableSpecifics, DefaultSave, PointerInSeqType, NonCharacterFormat,
     SaveMainProgram, SaveBigMainProgramVariables,
     DistinctArrayConstructorLengths, PPCVector, RelaxedIntentInChecking,
-    ForwardRefImplicitNoneData)
+    ForwardRefImplicitNoneData, NullActualForAllocatable)
 
 // Portability and suspicious usage warnings for conforming code
 ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,

--- a/flang/test/Semantics/call27.f90
+++ b/flang/test/Semantics/call27.f90
@@ -1,10 +1,10 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! Catch NULL() actual argument association with allocatable dummy argument
 program test
-  !ERROR: Null actual argument 'NULL()' may not be associated with allocatable dummy argument 'a='
+  !ERROR: NULL() actual argument 'NULL()' may not be associated with allocatable dummy argument 'a=' without INTENT(IN)
   call foo1(null())
-  !ERROR: Null actual argument 'NULL()' may not be associated with allocatable dummy argument 'a='
-  call foo2(null()) ! perhaps permissible later on user request
+  !PORTABILITY: Allocatable dummy argument 'a=' is associated with NULL()
+  call foo2(null())
   call foo3(null()) ! ok
  contains
   subroutine foo1(a)


### PR DESCRIPTION
…mmy argument

Several compilers accept a null pointer (with or without a MOLD=) as an actual argument for association with an INTENT(IN) allocatable dummy argument. At runtime, the allocatable dummy argument appears to be in the unallocated state.  This seems useful, unambiguous, unlikely to invalidate conforming code, and works with Intel, NAG, & XLF, so it should be supported with an optional portability warning in this compiler as well.