### PR TITLE
IRBuilder: avoid crash when seeking to start of a BasicBlock with only DebugInfo

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -887,7 +887,8 @@ Instruction::getPrevNonDebugInstruction(bool SkipPseudoOp) const {
 
 const DebugLoc &Instruction::getStableDebugLoc() const {
   if (isa<DbgInfoIntrinsic>(this))
-    return getNextNonDebugInstruction()->getDebugLoc();
+    if (const Instruction *Next = getNextNonDebugInstruction())
+      return Next->getDebugLoc();
   return getDebugLoc();
 }
 

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -566,6 +566,19 @@ TEST(AssignmentTrackingTest, Utils) {
   EXPECT_FALSE(at::getAssignmentMarkers(&Fun2Alloca).empty());
 }
 
+TEST(IRBuilder, GetSetInsertionPointWithEmptyBasicBlock) {
+  LLVMContext C;
+  std::unique_ptr<BasicBlock> BB(BasicBlock::Create(C, "start"));
+  Module *M = new Module("module", C);
+  IRBuilder<> Builder(BB.get());
+  Function *DbgDeclare = Intrinsic::getDeclaration(M, Intrinsic::dbg_declare);
+  Value *DIV = MetadataAsValue::get(C, (Metadata *)nullptr);
+  SmallVector<Value *, 3> Args = {DIV, DIV, DIV};
+  Builder.CreateCall(DbgDeclare, Args);
+  auto IP = BB->getFirstInsertionPt();
+  Builder.SetInsertPoint(BB.get(), IP);
+}
+
 TEST(AssignmentTrackingTest, InstrMethods) {
   // Test the assignment tracking Instruction methods.
   // This includes:


### PR DESCRIPTION
This fixes a crash in `rustc` that was triggered by
https://reviews.llvm.org/D159485 (aka
llvm/llvm-project@1ce1732f82aec29ec27d6de58153d516bca1d633).

This was more or less pair-programmed with @krasimirgg - I can't claim
full credit.