### PR TITLE
[lldb] Accept optional module in Value::ResolveValue

### DIFF
--- a/lldb/include/lldb/Core/Value.h
+++ b/lldb/include/lldb/Core/Value.h
@@ -107,7 +107,7 @@ public:
 
   Type *GetType();
 
-  Scalar &ResolveValue(ExecutionContext *exe_ctx);
+  Scalar &ResolveValue(ExecutionContext *exe_ctx, Module *module = nullptr);
 
   const Scalar &GetScalar() const { return m_value; }
 

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -572,7 +572,7 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
   return error;
 }
 
-Scalar &Value::ResolveValue(ExecutionContext *exe_ctx) {
+Scalar &Value::ResolveValue(ExecutionContext *exe_ctx, Module *module) {
   const CompilerType &compiler_type = GetCompilerType();
   if (compiler_type.IsValid()) {
     switch (m_value_type) {
@@ -587,7 +587,7 @@ Scalar &Value::ResolveValue(ExecutionContext *exe_ctx) {
     {
       DataExtractor data;
       lldb::addr_t addr = m_value.ULongLong(LLDB_INVALID_ADDRESS);
-      Status error(GetValueAsData(exe_ctx, data, nullptr));
+      Status error(GetValueAsData(exe_ctx, data, module));
       if (error.Success()) {
         Scalar scalar;
         if (compiler_type.GetValueAsScalar(

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -334,7 +334,7 @@ bool ValueObject::ResolveValue(Scalar &scalar) {
   {
     ExecutionContext exe_ctx(GetExecutionContextRef());
     Value tmp_value(m_value);
-    scalar = tmp_value.ResolveValue(&exe_ctx);
+    scalar = tmp_value.ResolveValue(&exe_ctx, GetModule().get());
     if (scalar.IsValid()) {
       const uint32_t bitfield_bit_size = GetBitfieldBitSize();
       if (bitfield_bit_size)


### PR DESCRIPTION
Value::ResolveValue calls Value::GetValueAsData as part of its implementation. The latter can receive an optional Module pointer, which is always null when called from the former. Allow threading in the Module in Value::ResolveValue.

rdar://115021869