### PR TITLE
[mlir] Make `extraClassOf` compile with attribute and type interfaces

### DIFF
--- a/mlir/include/mlir/IR/Attributes.h
+++ b/mlir/include/mlir/IR/Attributes.h
@@ -291,7 +291,7 @@ public:
                                           Attribute, AttributeTrait::TraitBase>;
   using InterfaceBase::InterfaceBase;
 
-private:
+protected:
   /// Returns the impl interface instance for the given type.
   static typename InterfaceBase::Concept *getInterfaceFor(Attribute attr) {
 #ifndef NDEBUG

--- a/mlir/include/mlir/IR/Types.h
+++ b/mlir/include/mlir/IR/Types.h
@@ -276,7 +276,7 @@ public:
       detail::Interface<ConcreteType, Type, Traits, Type, TypeTrait::TraitBase>;
   using InterfaceBase::InterfaceBase;
 
-private:
+protected:
   /// Returns the impl interface instance for the given type.
   static typename InterfaceBase::Concept *getInterfaceFor(Type type) {
 #ifndef NDEBUG

--- a/mlir/test/lib/Dialect/Test/TestInterfaces.td
+++ b/mlir/test/lib/Dialect/Test/TestInterfaces.td
@@ -147,4 +147,30 @@ def TestOptionallyImplementedOpInterface
   }];
 }
 
+def TestOptionallyImplementedAttrInterface
+    : AttrInterface<"TestOptionallyImplementedAttrInterface"> {
+  let cppNamespace = "::mlir";
+
+  let methods = [
+    InterfaceMethod<"", "bool", "getImplementsInterface", (ins)>,
+  ];
+
+  let extraClassOf = [{
+    return $_attr.getImplementsInterface();
+  }];
+}
+
+def TestOptionallyImplementedTypeInterface
+    : TypeInterface<"TestOptionallyImplementedTypeInterface"> {
+  let cppNamespace = "::mlir";
+
+  let methods = [
+    InterfaceMethod<"", "bool", "getImplementsInterface", (ins)>,
+  ];
+
+  let extraClassOf = [{
+    return $_type.getImplementsInterface();
+  }];
+}
+
 #endif // MLIR_TEST_DIALECT_TEST_INTERFACES


### PR DESCRIPTION
Using `extraClassOf` currently does not work with attribute or type interfaces as the generated code calls `getInterfaceFor`, a private method of `AttributeInterface` and `TypeInterface` respectively.

This PR fixes this by applying the same change that has been done to `OpInterface` in the past: Make `getInterfaceFor` a protected member of the class, allowing the generated code in subclasses to use it.

An attribute and type interface with `extraClassOf` have been added as interfaces in the test dialect to ensure it compiles without errors.