### PR TITLE
[flang][openacc] Support labeled DO loop after acc combined directive

### DIFF
--- a/flang/lib/Parser/openacc-parsers.cpp
+++ b/flang/lib/Parser/openacc-parsers.cpp
@@ -257,8 +257,7 @@ TYPE_PARSER(startAccLine >>
 
 TYPE_PARSER(construct<OpenACCCombinedConstruct>(
     sourced(Parser<AccBeginCombinedDirective>{} / endAccLine),
-    withMessage("A DO loop must follow the combined construct"_err_en_US,
-        Parser<DoConstruct>{}),
+    maybe(Parser<DoConstruct>{}),
     maybe(Parser<AccEndCombinedDirective>{} / endAccLine)))
 
 } // namespace Fortran::parser

--- a/flang/lib/Semantics/canonicalize-acc.cpp
+++ b/flang/lib/Semantics/canonicalize-acc.cpp
@@ -132,14 +132,24 @@ private:
     parser::Block::iterator nextIt;
     auto &beginDir{std::get<parser::AccBeginCombinedDirective>(x.t)};
     auto &dir{std::get<parser::AccCombinedDirective>(beginDir.t)};
-    const auto &doConstruct{std::get<std::optional<parser::DoConstruct>>(x.t)};
+    auto &nestedDo{std::get<std::optional<parser::DoConstruct>>(x.t)};
 
-    if (doConstruct) {
+    if (!nestedDo) {
+      nextIt = it;
+      if (++nextIt != block.end()) {
+        if (auto *doCons{parser::Unwrap<parser::DoConstruct>(*nextIt)}) {
+          nestedDo = std::move(*doCons);
+          nextIt = block.erase(nextIt);
+        }
+      }
+    }
+
+    if (nestedDo) {
       CheckDoConcurrentClauseRestriction<parser::OpenACCCombinedConstruct,
-          parser::AccBeginCombinedDirective>(x, *doConstruct);
+          parser::AccBeginCombinedDirective>(x, *nestedDo);
       CheckTileClauseRestriction<parser::OpenACCCombinedConstruct,
-          parser::AccBeginCombinedDirective>(x, *doConstruct);
-      if (!doConstruct->GetLoopControl()) {
+          parser::AccBeginCombinedDirective>(x, *nestedDo);
+      if (!nestedDo->GetLoopControl()) {
         messages_.Say(dir.source,
             "DO loop after the %s directive must have loop control"_err_en_US,
             parser::ToUpperCaseLetters(dir.source.ToString()));

--- a/flang/test/Lower/OpenACC/acc-parallel-loop.f90
+++ b/flang/test/Lower/OpenACC/acc-parallel-loop.f90
@@ -803,4 +803,11 @@ subroutine acc_parallel_loop
 ! CHECK:        acc.yield
 ! CHECK-NEXT: }{{$}}
 
+  !$acc parallel loop
+  do 10 i=0, n
+  10 continue
+! CHECK: acc.parallel
+! CHECK: acc.loop
+! CHECK: fir.do_loop
+
 end subroutine acc_parallel_loop

--- a/flang/test/Semantics/OpenACC/acc-combined-loop.f90
+++ b/flang/test/Semantics/OpenACC/acc-combined-loop.f90
@@ -6,16 +6,28 @@ program openacc_combined_loop
 
   i = 1
 
+  !ERROR: A DO loop must follow the PARALLEL LOOP directive
   !$acc parallel loop
-  !ERROR: A DO loop must follow the combined construct
   i = 1
+
+  !ERROR: A DO loop must follow the KERNELS LOOP directive
+  !$acc kernels loop
+  i = 1
+
+  !ERROR: A DO loop must follow the SERIAL LOOP directive
+  !$acc serial loop
+  i = 1
+
+  !$acc parallel loop
+  do 10 i=0, n
+  10 continue
 
   !$acc kernels loop
-  !ERROR: A DO loop must follow the combined construct
-  i = 1
+  do 20 i=0, n
+  20 continue
 
   !$acc serial loop
-  !ERROR: A DO loop must follow the combined construct
-  i = 1
+  do 30 i=0, n
+  30 continue
 
 end


### PR DESCRIPTION
This patch adds support for labeled do loop after combined directive. It relaxes the initial parser and canonicalize labeled do loop into the OpenACCCombinedConstruct.