### PR TITLE
 [Dexter] Fix test failures on greendragon

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %clang -std=gnu++11 -O0 -g -lstdc++ %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \

--- a/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %clang -std=gnu++11 -O0 -glldb %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \

--- a/cross-project-tests/debuginfo-tests/dexter-tests/dbg-arg.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/dbg-arg.c
@@ -1,6 +1,5 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // This test case checks debug info during register moves for an argument.
 // RUN: %clang -std=gnu11 -m64 -mllvm -fast-isel=false -g %s -o %t

--- a/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
@@ -4,7 +4,6 @@
 
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 // RUN: %clang -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
 // RUN:     --binary  %t --debugger 'lldb' -v -- %s

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ctrl-flow.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ctrl-flow.c
@@ -1,6 +1,5 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining.c
@@ -1,6 +1,5 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
 //

--- a/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
@@ -4,7 +4,6 @@
 
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 
 // RUN: %clang -g -O0 %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \

--- a/cross-project-tests/debuginfo-tests/dexter-tests/stack-var.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/stack-var.c
@@ -1,6 +1,5 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %clang -std=gnu11 -O -glldb %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'lldb' -- %s

--- a/cross-project-tests/debuginfo-tests/dexter-tests/vla.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/vla.c
@@ -1,7 +1,6 @@
 // This test case verifies the debug location for variable-length arrays.
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %clang -std=gnu11 -O0 -glldb %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'lldb' -- %s

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/DefaultController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/DefaultController.py
@@ -87,11 +87,9 @@ class DefaultController(DebuggerControllerBase):
         self.step_collection.debugger = self.debugger.debugger_info
         self._break_point_all_lines()
         self.debugger.launch(cmdline)
-
         for command_obj in chain.from_iterable(self.step_collection.commands.values()):
             self.watches.update(command_obj.get_watches())
         early_exit_conditions = self._get_early_exit_conditions()
-
         timed_out = False
         total_timeout = Timeout(self.context.options.timeout_total)
         max_steps = self.context.options.max_steps

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/Debuggers.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/Debuggers.py
@@ -226,7 +226,6 @@ def run_debugger_subprocess(debugger_controller, working_dir_path):
 
     with open(controller_path, "rb") as fp:
         debugger_controller = pickle.load(fp)
-
     return debugger_controller
 
 

--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/Main.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/Main.py
@@ -193,7 +193,6 @@ class Context(object):
 
 def main() -> ReturnCode:
     context = Context()
-
     with PrettyOutput() as context.o:
         context.logger = Logger(context.o)
         try:

--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/test/Tool.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/test/Tool.py
@@ -11,6 +11,7 @@ import os
 import csv
 import pickle
 import shutil
+import platform
 
 from dex.command.ParseCommand import get_command_infos
 from dex.debugger.Debuggers import run_debugger_subprocess
@@ -217,6 +218,9 @@ class Tool(TestToolBase):
         """
         try:
             if self.context.options.binary:
+                if platform.system() == 'Darwin' and os.path.exists(self.context.options.binary + '.dSYM'):
+                    # On Darwin, the debug info is in the .dSYM which might not be found by lldb, copy it into the tmp working directory
+                    shutil.copytree(self.context.options.binary + '.dSYM', self.context.options.executable + '.dSYM')
                 # Copy user's binary into the tmp working directory.
                 shutil.copy(
                     self.context.options.binary, self.context.options.executable

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
@@ -1,6 +1,5 @@
 // The dbgeng driver doesn't support \DexCommandLine yet.
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
@@ -2,7 +2,6 @@
 //      Test that a \DexDeclareAddress value can have its value defined after
 //      the first reference to that value.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: address_after_ref.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
@@ -4,7 +4,6 @@
 //      expression after the target line has been stepped on a given number of
 //      times.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: address_hit_count.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
@@ -2,7 +2,6 @@
 //      Test that a \DexDeclareAddress value can be used to compare the
 //      addresses of two local variables that refer to the same address.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expression_address.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
@@ -2,7 +2,6 @@
 //      Test that a \DexDeclareAddress value can be used to compare two equal
 //      pointer variables.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: identical_address.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
@@ -2,7 +2,6 @@
 //      Test that multiple \DexDeclareAddress references that point to different
 //      addresses can be used within a single \DexExpectWatchValue.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: multiple_address.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
@@ -2,7 +2,6 @@
 //      Test that a \DexDeclareAddress value can be used to compare two pointer
 //      variables that have a fixed offset between them.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: offset_address.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
@@ -2,7 +2,6 @@
 //      Test that a \DexDeclareAddress value can be used to check the change in
 //      value of a variable over time, relative to its initial value.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: self_comparison.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
@@ -6,7 +6,6 @@
 //      condition (x == 5) is satisfied.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_conditional.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
@@ -7,7 +7,6 @@
 //      given number of times.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_conditional_hit_count.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
@@ -4,7 +4,6 @@
 //      specific number of times.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_hit_count.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
@@ -4,7 +4,6 @@
 //      is stepped on.
 //      Tests using the default controller (no \DexLimitSteps).
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: default_simple.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
@@ -6,7 +6,6 @@
 //
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
@@ -7,7 +7,6 @@
 //
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
@@ -6,7 +6,6 @@
 //
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
-// XFAIL: system-darwin
 //
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
@@ -2,7 +2,6 @@
 //      Test that \DexLimitSteps keyword argument hit_count correctly limits
 //      the number of times the command can trigger.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: hit_count.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
@@ -1,7 +1,6 @@
 // Purpose:
 //      Check number of step lines are correctly reported in json output.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --verbose -- %s | FileCheck %s
 // CHECK: limit_steps_check_json_step_count.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
@@ -2,7 +2,6 @@
 //      Check the DexLimit steps only gathers step info for 2 iterations of a
 //      for loop.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_expect_loop.cpp:

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
@@ -1,7 +1,6 @@
 // Purpose:
 //      Ensure that limited stepping breaks for all expected values.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_expect_value.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
@@ -3,7 +3,6 @@
 //      doesn't exist. This can happen due to optimisations or label is on an
 //      empty line.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_line_mismatch.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
@@ -1,7 +1,6 @@
 // Purpose:
 //      Ensure that multiple overlapping \DexLimitSteps ranges do not interfere.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_overlapping_ranges.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
@@ -1,7 +1,6 @@
 // Purpose:
 //      Test that LimitStep commands can exist on the same from line.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_same_line_conditional.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
@@ -2,7 +2,6 @@
 //      Test that \DexLimitSteps can be used without a condition (i.e. the
 //      breakpoint range is set any time from_line is stepped on).
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: unconditional.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
@@ -11,7 +11,6 @@
 // The dbgeng driver doesn't support \DexLimitSteps yet.
 // UNSUPPORTED: system-windows
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
@@ -2,7 +2,6 @@
 //    Check that the optional keyword argument 'on_line' makes a \DexLabel label
 //    that line instead of the line the command is found on.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: label_another_line.cpp: (1.0000)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
@@ -1,7 +1,6 @@
 // Purpose:
 //      Check that we can use label-relative line numbers.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
@@ -1,7 +1,6 @@
 // The dbgeng driver doesn't support --target-run-args yet.
 // UNSUPPORTED: system-windows
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
 // CHECK: target_run_args.c:

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
@@ -1,7 +1,6 @@
 // The dbgeng driver doesn't support --target-run-args yet.
 // UNSUPPORTED: system-windows
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
 // CHECK: target_run_args_with_command.c:

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
@@ -1,7 +1,6 @@
 // Purpose:
 //      Check the `view` subtool works with typical inputs.
 //
-// XFAIL: system-darwin
 // RUN: %dexter_regression_test_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --results %t.results -- %s
 //


### PR DESCRIPTION
The issue with these test failures is that the dSYM was not being found by lldb, which is why setting breakpoints was failing and lldb quit without performing any steps. This change copies the dSYM to the same temp directory that the executable is copied to.