### PR TITLE
[clang][deps] Implement move-conversion for `CowCompilerInvocation`

### DIFF
--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -354,6 +354,9 @@ public:
     deep_copy_assign(X);
   }
 
+  CowCompilerInvocation(CompilerInvocation &&X)
+      : CompilerInvocationBase(std::move(X)) {}
+
   // Const getters are inherited from the base class.
 
   /// Mutable getters.


### PR DESCRIPTION
This avoids making copies at the end of `makeCommonInvocationForModuleBuild()` (in `ModuleDepCollector.cpp`).