### PR TITLE
[lldb] Support Unicode in the prompt

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -248,9 +248,8 @@ private:
   void SetCurrentLine(int line_index);
 
   /// Determines the width of the prompt in characters.  The width is guaranteed
-  /// to be the same for
-  /// all lines of the current multi-line session.
-  int GetPromptWidth();
+  /// to be the same for all lines of the current multi-line session.
+  size_t GetPromptWidth();
 
   /// Returns true if the underlying EditLine session's keybindings are
   /// Emacs-based, or false if

--- a/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -26,6 +26,7 @@ class PExpectTest(TestBase):
         dimensions=None,
         run_under=None,
         post_spawn=None,
+        encoding=None,
         use_colors=False,
     ):
         logfile = getattr(sys.stdout, "buffer", sys.stdout) if self.TraceOn() else None
@@ -58,6 +59,7 @@ class PExpectTest(TestBase):
             timeout=timeout,
             dimensions=dimensions,
             env=env,
+            encoding=encoding,
         )
         self.child.ptyproc.delayafterclose = timeout / 10
         self.child.ptyproc.delayafterterminate = timeout / 10

--- a/lldb/test/API/terminal/TestEditline.py
+++ b/lldb/test/API/terminal/TestEditline.py
@@ -44,3 +44,14 @@ class EditlineTest(PExpectTest):
             )
 
         self.quit()
+
+    @skipIfAsan
+    @skipIfEditlineSupportMissing
+    def test_prompt_unicode(self):
+        """Test that we can use Unicode in the LLDB prompt."""
+        self.launch(use_colors=True, encoding="utf-8")
+        self.child.send('settings set prompt "🐛 "\n')
+        # Check that the cursor is at position 4 ([4G)
+        # Prompt: 🐛 _
+        # Column: 1..4
+        self.child.expect(re.escape("🐛 \x1b[0m\x1b[4G"))


### PR DESCRIPTION
Account for Unicode when computing the prompt column width. Previously, the string length (i.e. number of bytes) rather than the width of the Glyph was used to compute the cursor position. The result was that the cursor would be offset to the right when using a prompt containing Unicode.