### PR TITLE
workflows/pr-receive: Ignore pull requests with 10 or more commits

### DIFF
--- a/.github/workflows/pr-receive.yml
+++ b/.github/workflows/pr-receive.yml
@@ -10,7 +10,12 @@ permissions:
 jobs:
   pr-target:
     runs-on: ubuntu-latest
-    if: github.repository == 'llvm/llvm-project'
+    # Ignore PRs with more than 10 commits.  Pull requests with a lot of
+    # commits tend to be accidents usually when somone made a mistake while trying
+    # to rebase.  We want to ignore these pull requests to avoid excessive
+    # notifications.
+    if: github.repository == 'llvm/llvm-project' &&
+        github.event.pull_request.commits < 10
     steps:
       - name: Store PR Information
         run: |

--- a/.github/workflows/pr-receive.yml
+++ b/.github/workflows/pr-receive.yml
@@ -11,7 +11,7 @@ jobs:
   pr-target:
     runs-on: ubuntu-latest
     # Ignore PRs with more than 10 commits.  Pull requests with a lot of
-    # commits tend to be accidents usually when somone made a mistake while trying
+    # commits tend to be accidents usually when someone made a mistake while trying
     # to rebase.  We want to ignore these pull requests to avoid excessive
     # notifications.
     if: github.repository == 'llvm/llvm-project' &&


### PR DESCRIPTION
This will cause the auto-labeler not to run on pull requests with more than 10 commits.  Usually larger pull requests like this are mistakes and we want to avoid generating an excessive amount of notifications.

It may be possible for legitimate pull requests to have 10 or more commits from people pushing fixup commits to addresss review comments. However, these pull requests should already have the correct labels by the time they grow to 10 commits.