### PR TITLE
[clang-format] More on unbreakable strings in TypeScript

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -2242,8 +2242,10 @@ ContinuationIndenter::createBreakableToken(const FormatToken &Current,
       return nullptr;
 
     // Strings in TypeScript types and dictionary keys can not be broken.
-    if (Style.isJavaScript() && (Current.is(TT_SelectorName) ||
-                                 State.Line->startsWith(Keywords.kw_type))) {
+    if (Style.isJavaScript() &&
+        (Current.is(TT_SelectorName) ||
+         State.Line->startsWith(Keywords.kw_type) ||
+         State.Line->startsWith(tok::kw_export, Keywords.kw_type))) {
       return nullptr;
     }
 

--- a/clang/unittests/Format/FormatTestJS.cpp
+++ b/clang/unittests/Format/FormatTestJS.cpp
@@ -1604,6 +1604,9 @@ TEST_F(FormatTestJS, StringLiteralConcatenation) {
   verifyFormat("/* type */ type x =\n"
                "    'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';",
                getGoogleJSStyleWithColumns(20));
+  verifyFormat("export type x =\n"
+               "    'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';",
+               getGoogleJSStyleWithColumns(20));
   // Dictionary keys can't be broken. Values can be broken.
   verifyFormat("var w = {\n"
                "  'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx':\n"


### PR DESCRIPTION
Now. string literals in lines beginning with `export type` will not be broken.

The case was missed in 5db201fb75e6.  I don't know TypeScript.  And merging GitHub pull requests seems to be a little too easy.  So it got committed before the reviewers had a chance to find edge cases.