### PR TITLE
[flang][openacc] Use OpenACC terminator instead of fir.unreachable after Stop stmt

### DIFF
--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -103,6 +103,9 @@ void attachDeclarePreDeallocAction(AbstractConverter &, fir::FirOpBuilder &,
 void attachDeclarePostDeallocAction(AbstractConverter &, fir::FirOpBuilder &,
                                     const Fortran::semantics::Symbol &);
 
+void genOpenACCTerminator(fir::FirOpBuilder &, mlir::Operation *,
+                          mlir::Location);
+
 } // namespace lower
 } // namespace Fortran
 

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -3299,3 +3299,12 @@ void Fortran::lower::attachDeclarePostDeallocAction(
                  /*preAlloc=*/{}, /*postAlloc=*/{}, /*preDealloc=*/{},
                  /*postDealloc=*/builder.getSymbolRefAttr(fctName.str())));
 }
+
+void Fortran::lower::genOpenACCTerminator(fir::FirOpBuilder &builder,
+                                          mlir::Operation *op,
+                                          mlir::Location loc) {
+  if (mlir::isa<mlir::acc::ParallelOp, mlir::acc::LoopOp>(op))
+    builder.create<mlir::acc::YieldOp>(loc);
+  else
+    builder.create<mlir::acc::TerminatorOp>(loc);
+}

--- a/flang/lib/Lower/Runtime.cpp
+++ b/flang/lib/Lower/Runtime.cpp
@@ -8,6 +8,7 @@
 
 #include "flang/Lower/Runtime.h"
 #include "flang/Lower/Bridge.h"
+#include "flang/Lower/OpenACC.h"
 #include "flang/Lower/OpenMP.h"
 #include "flang/Lower/StatementContext.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
@@ -21,6 +22,7 @@
 #include "flang/Runtime/stop.h"
 #include "flang/Runtime/time-intrinsic.h"
 #include "flang/Semantics/tools.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "llvm/Support/Debug.h"
 #include <optional>
@@ -37,6 +39,9 @@ static void genUnreachable(fir::FirOpBuilder &builder, mlir::Location loc) {
   if (parentOp->getDialect()->getNamespace() ==
       mlir::omp::OpenMPDialect::getDialectNamespace())
     Fortran::lower::genOpenMPTerminator(builder, parentOp, loc);
+  else if (parentOp->getDialect()->getNamespace() ==
+           mlir::acc::OpenACCDialect::getDialectNamespace())
+    Fortran::lower::genOpenACCTerminator(builder, parentOp, loc);
   else
     builder.create<fir::UnreachableOp>(loc);
   mlir::Block *newBlock = curBlock->splitBlock(builder.getInsertionPoint());

--- a/flang/test/Lower/OpenACC/acc-unstructured.f90
+++ b/flang/test/Lower/OpenACC/acc-unstructured.f90
@@ -57,7 +57,7 @@ subroutine test_unstructured2(a, b, c)
 ! CHECK: acc.parallel
 ! CHECK: acc.loop
 ! CHECK: fir.call @_FortranAStopStatementText
-! CHECK: fir.unreachable
+! CHECK: acc.yield
 ! CHECK: acc.yield
 ! CHECK: acc.yield
 
@@ -80,7 +80,7 @@ subroutine test_unstructured3(a, b, c)
 ! CHECK-LABEL: func.func @_QPtest_unstructured3
 ! CHECK: acc.parallel
 ! CHECK: fir.call @_FortranAStopStatementText
-! CHECK: fir.unreachable
+! CHECK: acc.yield
 ! CHECK: acc.yield
 
 end subroutine

--- a/flang/test/Lower/OpenACC/stop-stmt-in-region.f90
+++ b/flang/test/Lower/OpenACC/stop-stmt-in-region.f90
@@ -29,7 +29,7 @@ end
 ! CHECK:           %[[VAL_2:.*]] = arith.constant false
 ! CHECK:           %[[VAL_3:.*]] = arith.constant false
 ! CHECK:           %[[VAL_4:.*]] = fir.call @_FortranAStopStatement(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]) {{.*}} : (i32, i1, i1) -> none
-! CHECK:           fir.unreachable
+! CHECK:           acc.yield
 ! CHECK:         }
 ! CHECK:         return
 ! CHECK:       }


### PR DESCRIPTION
This follow an update made on OpenMP https://reviews.llvm.org/D129969 and was not possible on OpenACC until the unstructured construct was supported.