### PR TITLE
[LLD] [MinGW] Ignore --sort-common option

### DIFF
--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -223,6 +223,7 @@ def: F<"no-undefined">;
 def: F<"pic-executable">;
 defm: EqNoHelp<"plugin">;
 defm: EqNoHelp<"sysroot">;
+def: F<"sort-common">;
 def: F<"start-group">;
 
 // Ignore GCC collect2 LTO plugin related options. Note that we don't support


### PR DESCRIPTION
like done in the ELF side
this would allow to use archlinux default mingw flags: `-Wl,-O1,--sort-common,--as-needed -fstack-protector`
(on archlinux packages use the GNU linker by default)

cc @mstorsjo 