### PR TITLE
clang/AMDGPU: Fix accidental behavior change for __builtin_amdgcn_ldexph

### DIFF
--- a/clang/test/CodeGenOpenCL/builtins-amdgcn-vi.cl
+++ b/clang/test/CodeGenOpenCL/builtins-amdgcn-vi.cl
@@ -52,7 +52,8 @@ void test_cos_f16(global half* out, half a)
 }
 
 // CHECK-LABEL: @test_ldexp_f16
-// CHECK: call half @llvm.ldexp.f16.i32
+// CHECK: [[TRUNC:%[0-9a-z]+]] = trunc i32
+// CHECK: call half @llvm.ldexp.f16.i16(half %a, i16 [[TRUNC]])
 void test_ldexp_f16(global half* out, half a, int b)
 {
   *out = __builtin_amdgcn_ldexph(a, b);


### PR DESCRIPTION
eece6ba283bd763e6d7109ae9e155e81cfee0651 swapped this to use the generic intrinsic which doesn't have the same behavior for exponent values outside of the range of short. The instruction will implicitly truncate, but the generic instruction clamps the value. The builtin should probably have used a short argument type to begin with.