### PR TITLE
[clang] Fix wrong warning about missing init for flexible array members

### DIFF
--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -2395,7 +2395,8 @@ void InitListChecker::CheckStructUnionTypes(
       if (HasDesignatedInit && InitializedFields.count(*it))
         continue;
 
-      if (!it->isUnnamedBitfield() && !it->hasInClassInitializer()) {
+      if (!it->isUnnamedBitfield() && !it->hasInClassInitializer() &&
+          !it->getType()->isIncompleteArrayType()) {
         SemaRef.Diag(IList->getSourceRange().getEnd(),
                      diag::warn_missing_field_initializers)
             << *it;

--- a/clang/test/Sema/missing-field-initializers.c
+++ b/clang/test/Sema/missing-field-initializers.c
@@ -50,3 +50,11 @@ struct { int:5; int a; int:5; int b; int:5; } noNamedImplicit[] = {
   { 1, 2 },
   { 1 } // expected-warning {{missing field 'b' initializer}}
 };
+
+// GH66300
+struct S {
+  int f0;
+  int f1[];
+};
+
+struct S s = {1, {1, 2}}; // No warning

--- a/clang/test/Sema/missing-field-initializers.c
+++ b/clang/test/Sema/missing-field-initializers.c
@@ -57,4 +57,7 @@ struct S {
   int f1[];
 };
 
-struct S s = {1, {1, 2}}; // No warning
+// We previously would accidentally diagnose missing a field initializer for
+// f1, now we no longer issue that warning (note, this code is still unsafe
+// because of the buffer overrun).
+struct S s = {1, {1, 2}};


### PR DESCRIPTION
91088978d712cd7b33610c59f69d87d5a39e3113 shouldn't have removed an additional check that field has incomplete array type.

Fixes https://github.com/llvm/llvm-project/issues/66300