### PR TITLE
[clang] Allow MCTargetOptions to be parseable by -mllvm.

### DIFF
--- a/clang/test/Misc/cc1as-mllvm-mc-options.s
+++ b/clang/test/Misc/cc1as-mllvm-mc-options.s
@@ -1,0 +1,12 @@
+// Ensure MCTargetOptionsCommandFlags are parsable under -mllvm
+// RUN: %clang -cc1as -mllvm --help %s | FileCheck %s
+// CHECK: --asm-show-inst
+// CHECK: --dwarf-version
+// CHECK: --dwarf64
+// CHECK: --emit-dwarf-unwind
+// CHECK: --fatal-warnings
+// CHECK: --incremental-linker-compatible
+// CHECK: --mc-relax-all
+// CHECK: --no-deprecated-warn
+// CHECK: --no-type-check
+// CHECK: --no-warn

--- a/clang/test/Misc/compiler-mllvm-mc-options.c
+++ b/clang/test/Misc/compiler-mllvm-mc-options.c
@@ -1,0 +1,12 @@
+// Ensure MCTargetOptionsCommandFlags are parsable under -mllvm
+// RUN: %clang -mllvm --help -c %s -o /dev/null | FileCheck %s
+// CHECK: --asm-show-inst
+// CHECK: --dwarf-version
+// CHECK: --dwarf64
+// CHECK: --emit-dwarf-unwind
+// CHECK: --fatal-warnings
+// CHECK: --incremental-linker-compatible
+// CHECK: --mc-relax-all
+// CHECK: --no-deprecated-warn
+// CHECK: --no-type-check
+// CHECK: --no-warn

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/LinkAllPasses.h"
+#include "llvm/MC/MCTargetOptionsCommandFlags.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
@@ -52,6 +53,9 @@
 
 using namespace clang;
 using namespace llvm::opt;
+
+// Initialize MC Target option flags (for -mllvm)
+static llvm::mc::RegisterMCTargetOptionsFlags MOF;
 
 //===----------------------------------------------------------------------===//
 // Main driver

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -36,6 +36,7 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/MCTargetOptionsCommandFlags.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
@@ -408,7 +409,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
   std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(Opts.Triple));
   assert(MRI && "Unable to create target register info!");
 
-  MCTargetOptions MCOptions;
+  MCTargetOptions MCOptions = llvm::mc::InitMCTargetOptionsFromFlags();
   MCOptions.EmitDwarfUnwind = Opts.EmitDwarfUnwind;
   MCOptions.EmitCompactUnwindNonCanonical = Opts.EmitCompactUnwindNonCanonical;
   MCOptions.AsSecureLogFile = Opts.AsSecureLogFile;


### PR DESCRIPTION
The cl::opt used by MCTargetOptions are not created until RegisterMCTargetOptionsFlags is instantiated. Due to this deferral the compiler driver -mllvm path is unable to parse flags such as --no-deprecated-warn which work properly in llvm-mc.

Move the instantiation into the frontend and cc1as and propagate the results into MCTargetOptions.