### PR TITLE
[compiler-rt] Allow to build on CYGWIN

### DIFF
--- a/compiler-rt/lib/builtins/int_lib.h
+++ b/compiler-rt/lib/builtins/int_lib.h
@@ -49,7 +49,7 @@
 #define SYMBOL_NAME(name) XSTR(__USER_LABEL_PREFIX__) #name
 
 #if defined(__ELF__) || defined(__MINGW32__) || defined(__wasm__) ||           \
-    defined(_AIX)
+    defined(_AIX)    || defined(__CYGWIN__)
 #define COMPILER_RT_ALIAS(name, aliasname) \
   COMPILER_RT_ABI __typeof(name) aliasname __attribute__((__alias__(#name)));
 #elif defined(__APPLE__)


### PR DESCRIPTION
If you try to build `compiler-rt` on CYGWIN, you will get message:
```
error: Unsupported target
```
Adding support for this platform. just needs to add testing if `__CYGWIN__` is defined into `lib\builtins\int_lib.h`.