### PR TITLE
[Sparc] Don't emit __multi3 on 32-bit SPARC

### DIFF
--- a/llvm/lib/Target/Sparc/SparcISelLowering.cpp
+++ b/llvm/lib/Target/Sparc/SparcISelLowering.cpp
@@ -1748,6 +1748,7 @@ SparcTargetLowering::SparcTargetLowering(const TargetMachine &TM,
   if (!Subtarget->is64Bit()) {
     // These libcalls are not available in 32-bit.
     setLibcallName(RTLIB::MULO_I64, nullptr);
+    setLibcallName(RTLIB::MUL_I128, nullptr);
     setLibcallName(RTLIB::SHL_I128, nullptr);
     setLibcallName(RTLIB::SRL_I128, nullptr);
     setLibcallName(RTLIB::SRA_I128, nullptr);

--- a/llvm/test/CodeGen/SPARC/smulo-128-legalisation-lowering.ll
+++ b/llvm/test/CodeGen/SPARC/smulo-128-legalisation-lowering.ll
@@ -6,125 +6,159 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
 ; SPARC-LABEL: muloti_test:
 ; SPARC:         .cfi_startproc
 ; SPARC-NEXT:  ! %bb.0: ! %start
-; SPARC-NEXT:    save %sp, -136, %sp
+; SPARC-NEXT:    save %sp, -96, %sp
 ; SPARC-NEXT:    .cfi_def_cfa_register %fp
 ; SPARC-NEXT:    .cfi_window_save
 ; SPARC-NEXT:    .cfi_register %o7, %i7
-; SPARC-NEXT:    ld [%fp+92], %l1
-; SPARC-NEXT:    ld [%fp+96], %l2
-; SPARC-NEXT:    mov %i3, %l6
-; SPARC-NEXT:    mov %i2, %l4
-; SPARC-NEXT:    mov %i1, %i3
-; SPARC-NEXT:    mov %i0, %l3
-; SPARC-NEXT:    sra %i0, 31, %o4
-; SPARC-NEXT:    st %o4, [%sp+96]
-; SPARC-NEXT:    st %o4, [%sp+92]
-; SPARC-NEXT:    mov %i4, %o0
-; SPARC-NEXT:    mov %i5, %o1
-; SPARC-NEXT:    mov %l1, %o2
-; SPARC-NEXT:    mov %l2, %o3
-; SPARC-NEXT:    call __multi3
-; SPARC-NEXT:    mov %o4, %o5
-; SPARC-NEXT:    st %o0, [%fp+-12] ! 4-byte Folded Spill
-; SPARC-NEXT:    st %o1, [%fp+-16] ! 4-byte Folded Spill
-; SPARC-NEXT:    st %o2, [%fp+-20] ! 4-byte Folded Spill
-; SPARC-NEXT:    st %o3, [%fp+-24] ! 4-byte Folded Spill
-; SPARC-NEXT:    st %i5, [%sp+96]
-; SPARC-NEXT:    st %i4, [%sp+92]
-; SPARC-NEXT:    mov %g0, %o0
-; SPARC-NEXT:    mov %g0, %o1
-; SPARC-NEXT:    mov %i2, %o2
-; SPARC-NEXT:    mov %l6, %o3
-; SPARC-NEXT:    mov %g0, %o4
-; SPARC-NEXT:    call __multi3
-; SPARC-NEXT:    mov %g0, %o5
-; SPARC-NEXT:    st %o0, [%fp+-28] ! 4-byte Folded Spill
-; SPARC-NEXT:    st %o1, [%fp+-32] ! 4-byte Folded Spill
-; SPARC-NEXT:    mov %o2, %l0
-; SPARC-NEXT:    mov %o3, %i2
-; SPARC-NEXT:    st %l2, [%sp+96]
-; SPARC-NEXT:    st %l1, [%sp+92]
-; SPARC-NEXT:    mov %g0, %o0
-; SPARC-NEXT:    mov %g0, %o1
-; SPARC-NEXT:    mov %l4, %o2
-; SPARC-NEXT:    mov %l6, %o3
-; SPARC-NEXT:    mov %g0, %o4
-; SPARC-NEXT:    call __multi3
-; SPARC-NEXT:    mov %g0, %o5
-; SPARC-NEXT:    mov %o0, %i1
-; SPARC-NEXT:    mov %o1, %i0
-; SPARC-NEXT:    st %o2, [%fp+-4] ! 4-byte Folded Spill
-; SPARC-NEXT:    st %o3, [%fp+-8] ! 4-byte Folded Spill
-; SPARC-NEXT:    st %l2, [%sp+96]
-; SPARC-NEXT:    st %l1, [%sp+92]
-; SPARC-NEXT:    mov %g0, %o0
-; SPARC-NEXT:    mov %g0, %o1
-; SPARC-NEXT:    mov %l3, %o2
-; SPARC-NEXT:    mov %i3, %o3
-; SPARC-NEXT:    mov %g0, %o4
-; SPARC-NEXT:    call __multi3
-; SPARC-NEXT:    mov %g0, %o5
-; SPARC-NEXT:    mov %o0, %l1
-; SPARC-NEXT:    mov %o1, %l2
-; SPARC-NEXT:    mov %o2, %l5
-; SPARC-NEXT:    mov %o3, %l7
-; SPARC-NEXT:    st %l6, [%sp+96]
-; SPARC-NEXT:    sra %i4, 31, %o0
-; SPARC-NEXT:    st %l4, [%sp+92]
-; SPARC-NEXT:    mov %o0, %o1
-; SPARC-NEXT:    mov %o0, %o2
-; SPARC-NEXT:    mov %o0, %o3
-; SPARC-NEXT:    mov %l3, %o4
-; SPARC-NEXT:    call __multi3
-; SPARC-NEXT:    mov %i3, %o5
-; SPARC-NEXT:    st %i5, [%sp+96]
-; SPARC-NEXT:    st %i4, [%sp+92]
-; SPARC-NEXT:    ld [%fp+-24], %i4 ! 4-byte Folded Reload
-; SPARC-NEXT:    addcc %o3, %i4, %i4
-; SPARC-NEXT:    ld [%fp+-20], %i5 ! 4-byte Folded Reload
-; SPARC-NEXT:    addxcc %o2, %i5, %i5
-; SPARC-NEXT:    ld [%fp+-16], %g2 ! 4-byte Folded Reload
-; SPARC-NEXT:    addxcc %o1, %g2, %l4
-; SPARC-NEXT:    ld [%fp+-12], %g2 ! 4-byte Folded Reload
-; SPARC-NEXT:    addxcc %o0, %g2, %l6
-; SPARC-NEXT:    addcc %l7, %i0, %i0
-; SPARC-NEXT:    addxcc %l5, %i1, %g2
-; SPARC-NEXT:    addxcc %l2, 0, %g3
-; SPARC-NEXT:    addxcc %l1, 0, %g4
-; SPARC-NEXT:    addcc %i2, %i0, %i1
-; SPARC-NEXT:    addxcc %l0, %g2, %i0
-; SPARC-NEXT:    ld [%fp+-32], %i2 ! 4-byte Folded Reload
-; SPARC-NEXT:    addxcc %i2, 0, %i2
-; SPARC-NEXT:    ld [%fp+-28], %g2 ! 4-byte Folded Reload
-; SPARC-NEXT:    addxcc %g2, 0, %g2
+; SPARC-NEXT:    ld [%fp+96], %l1
+; SPARC-NEXT:    mov %i3, %l0
+; SPARC-NEXT:    mov %i2, %g2
+; SPARC-NEXT:    umul %i3, %l1, %i3
+; SPARC-NEXT:    rd %y, %i2
+; SPARC-NEXT:    ld [%fp+92], %l2
+; SPARC-NEXT:    umul %g2, %l1, %g3
+; SPARC-NEXT:    rd %y, %g4
 ; SPARC-NEXT:    addcc %g3, %i2, %i2
-; SPARC-NEXT:    addxcc %g4, %g2, %l0
-; SPARC-NEXT:    addxcc %g0, 0, %l1
-; SPARC-NEXT:    addxcc %g0, 0, %l2
-; SPARC-NEXT:    mov %g0, %o0
-; SPARC-NEXT:    mov %g0, %o1
-; SPARC-NEXT:    mov %l3, %o2
-; SPARC-NEXT:    mov %i3, %o3
-; SPARC-NEXT:    mov %g0, %o4
-; SPARC-NEXT:    call __multi3
-; SPARC-NEXT:    mov %g0, %o5
-; SPARC-NEXT:    addcc %o3, %i2, %i2
-; SPARC-NEXT:    addxcc %o2, %l0, %i3
-; SPARC-NEXT:    addxcc %o1, %l1, %g2
-; SPARC-NEXT:    addxcc %o0, %l2, %g3
-; SPARC-NEXT:    addcc %i2, %i4, %i2
-; SPARC-NEXT:    addxcc %i3, %i5, %i3
-; SPARC-NEXT:    addxcc %g2, %l4, %i4
-; SPARC-NEXT:    addxcc %g3, %l6, %i5
-; SPARC-NEXT:    sra %i0, 31, %g2
-; SPARC-NEXT:    xor %i5, %g2, %i5
-; SPARC-NEXT:    xor %i3, %g2, %i3
-; SPARC-NEXT:    or %i3, %i5, %i3
-; SPARC-NEXT:    xor %i4, %g2, %i4
-; SPARC-NEXT:    xor %i2, %g2, %i2
-; SPARC-NEXT:    or %i2, %i4, %i2
-; SPARC-NEXT:    or %i2, %i3, %i2
-; SPARC-NEXT:    cmp %i2, 0
+; SPARC-NEXT:    addxcc %g4, 0, %g3
+; SPARC-NEXT:    umul %l0, %l2, %g4
+; SPARC-NEXT:    rd %y, %l3
+; SPARC-NEXT:    addcc %g4, %i2, %i2
+; SPARC-NEXT:    addxcc %l3, 0, %g4
+; SPARC-NEXT:    addcc %g3, %g4, %g3
+; SPARC-NEXT:    addxcc %g0, 0, %g4
+; SPARC-NEXT:    umul %g2, %l2, %l3
+; SPARC-NEXT:    rd %y, %l4
+; SPARC-NEXT:    addcc %l3, %g3, %g3
+; SPARC-NEXT:    umul %i1, %l1, %l3
+; SPARC-NEXT:    rd %y, %l5
+; SPARC-NEXT:    addxcc %l4, %g4, %g4
+; SPARC-NEXT:    umul %i0, %l1, %l4
+; SPARC-NEXT:    rd %y, %l6
+; SPARC-NEXT:    addcc %l4, %l5, %l4
+; SPARC-NEXT:    addxcc %l6, 0, %l5
+; SPARC-NEXT:    umul %i1, %l2, %l6
+; SPARC-NEXT:    rd %y, %l7
+; SPARC-NEXT:    addcc %l6, %l4, %l4
+; SPARC-NEXT:    addxcc %l7, 0, %l6
+; SPARC-NEXT:    addcc %l5, %l6, %l5
+; SPARC-NEXT:    addxcc %g0, 0, %l6
+; SPARC-NEXT:    umul %i0, %l2, %l7
+; SPARC-NEXT:    rd %y, %o0
+; SPARC-NEXT:    addcc %l7, %l5, %l5
+; SPARC-NEXT:    addxcc %o0, %l6, %l6
+; SPARC-NEXT:    addcc %l3, %g3, %g3
+; SPARC-NEXT:    addxcc %l4, %g4, %g4
+; SPARC-NEXT:    addxcc %l5, 0, %l3
+; SPARC-NEXT:    umul %l0, %i5, %l4
+; SPARC-NEXT:    rd %y, %l5
+; SPARC-NEXT:    addxcc %l6, 0, %l6
+; SPARC-NEXT:    umul %g2, %i5, %l7
+; SPARC-NEXT:    rd %y, %o0
+; SPARC-NEXT:    addcc %l7, %l5, %l5
+; SPARC-NEXT:    addxcc %o0, 0, %l7
+; SPARC-NEXT:    umul %l0, %i4, %o0
+; SPARC-NEXT:    rd %y, %o1
+; SPARC-NEXT:    addcc %o0, %l5, %l5
+; SPARC-NEXT:    addxcc %o1, 0, %o0
+; SPARC-NEXT:    addcc %l7, %o0, %l7
+; SPARC-NEXT:    addxcc %g0, 0, %o0
+; SPARC-NEXT:    umul %g2, %i4, %o1
+; SPARC-NEXT:    rd %y, %o2
+; SPARC-NEXT:    addcc %o1, %l7, %l7
+; SPARC-NEXT:    addxcc %o2, %o0, %o0
+; SPARC-NEXT:    addcc %l4, %g3, %g3
+; SPARC-NEXT:    addxcc %l5, %g4, %g4
+; SPARC-NEXT:    addxcc %l7, 0, %l4
+; SPARC-NEXT:    addxcc %o0, 0, %l5
+; SPARC-NEXT:    addcc %l3, %l4, %l3
+; SPARC-NEXT:    addxcc %l6, %l5, %l4
+; SPARC-NEXT:    addxcc %g0, 0, %l5
+; SPARC-NEXT:    umul %i1, %i5, %l6
+; SPARC-NEXT:    rd %y, %l7
+; SPARC-NEXT:    addxcc %g0, 0, %o0
+; SPARC-NEXT:    umul %i0, %i5, %o1
+; SPARC-NEXT:    rd %y, %o2
+; SPARC-NEXT:    addcc %o1, %l7, %l7
+; SPARC-NEXT:    addxcc %o2, 0, %o1
+; SPARC-NEXT:    umul %i1, %i4, %o2
+; SPARC-NEXT:    rd %y, %o3
+; SPARC-NEXT:    addcc %o2, %l7, %l7
+; SPARC-NEXT:    addxcc %o3, 0, %o2
+; SPARC-NEXT:    addcc %o1, %o2, %o1
+; SPARC-NEXT:    addxcc %g0, 0, %o2
+; SPARC-NEXT:    umul %i0, %i4, %o3
+; SPARC-NEXT:    rd %y, %o4
+; SPARC-NEXT:    addcc %o3, %o1, %o1
+; SPARC-NEXT:    addxcc %o4, %o2, %o2
+; SPARC-NEXT:    addcc %l6, %l3, %l3
+; SPARC-NEXT:    addxcc %l7, %l4, %l4
+; SPARC-NEXT:    addxcc %o1, %l5, %l5
+; SPARC-NEXT:    sra %i0, 31, %l6
+; SPARC-NEXT:    smul %l6, %i4, %l7
+; SPARC-NEXT:    umul %l6, %i5, %o1
+; SPARC-NEXT:    rd %y, %o3
+; SPARC-NEXT:    addxcc %o2, %o0, %i5
+; SPARC-NEXT:    umul %l2, %l6, %l2
+; SPARC-NEXT:    rd %y, %o0
+; SPARC-NEXT:    add %o3, %l7, %l7
+; SPARC-NEXT:    umul %l1, %l6, %l1
+; SPARC-NEXT:    rd %y, %l6
+; SPARC-NEXT:    add %l7, %o1, %l7
+; SPARC-NEXT:    add %l6, %l2, %o2
+; SPARC-NEXT:    add %o2, %l1, %o2
+; SPARC-NEXT:    addcc %l1, %o1, %o1
+; SPARC-NEXT:    addxcc %o2, %l7, %l7
+; SPARC-NEXT:    addcc %l2, %l6, %o2
+; SPARC-NEXT:    addxcc %o0, 0, %o3
+; SPARC-NEXT:    addcc %l1, %o2, %o2
+; SPARC-NEXT:    addxcc %l6, 0, %l6
+; SPARC-NEXT:    addcc %o3, %l6, %l6
+; SPARC-NEXT:    addxcc %g0, 0, %o3
+; SPARC-NEXT:    addcc %l2, %l6, %l2
+; SPARC-NEXT:    addxcc %o0, %o3, %l6
+; SPARC-NEXT:    addcc %l2, %o1, %l2
+; SPARC-NEXT:    sra %i4, 31, %i4
+; SPARC-NEXT:    umul %l0, %i4, %l0
+; SPARC-NEXT:    rd %y, %o0
+; SPARC-NEXT:    addxcc %l6, %l7, %l6
+; SPARC-NEXT:    umul %i4, %g2, %g2
+; SPARC-NEXT:    rd %y, %l7
+; SPARC-NEXT:    add %o0, %l0, %o1
+; SPARC-NEXT:    smul %i0, %i4, %i0
+; SPARC-NEXT:    umul %i1, %i4, %i1
+; SPARC-NEXT:    rd %y, %i4
+; SPARC-NEXT:    add %o1, %g2, %o1
+; SPARC-NEXT:    add %i4, %i1, %i4
+; SPARC-NEXT:    add %i4, %i0, %i0
+; SPARC-NEXT:    addcc %i1, %l0, %i1
+; SPARC-NEXT:    addxcc %i0, %o1, %i0
+; SPARC-NEXT:    addcc %l0, %o0, %i4
+; SPARC-NEXT:    addxcc %o0, 0, %o0
+; SPARC-NEXT:    addcc %g2, %i4, %i4
+; SPARC-NEXT:    addxcc %l7, 0, %o1
+; SPARC-NEXT:    addcc %o0, %o1, %o0
+; SPARC-NEXT:    addxcc %g0, 0, %o1
+; SPARC-NEXT:    addcc %g2, %o0, %g2
+; SPARC-NEXT:    addxcc %l7, %o1, %l7
+; SPARC-NEXT:    addcc %g2, %i1, %i1
+; SPARC-NEXT:    addxcc %l7, %i0, %i0
+; SPARC-NEXT:    addcc %l0, %l1, %g2
+; SPARC-NEXT:    addxcc %i4, %o2, %i4
+; SPARC-NEXT:    addxcc %i1, %l2, %i1
+; SPARC-NEXT:    addxcc %i0, %l6, %i0
+; SPARC-NEXT:    addcc %l3, %g2, %g2
+; SPARC-NEXT:    addxcc %l4, %i4, %i4
+; SPARC-NEXT:    addxcc %l5, %i1, %i1
+; SPARC-NEXT:    addxcc %i5, %i0, %i0
+; SPARC-NEXT:    sra %g4, 31, %i5
+; SPARC-NEXT:    xor %i0, %i5, %i0
+; SPARC-NEXT:    xor %i4, %i5, %i4
+; SPARC-NEXT:    or %i4, %i0, %i0
+; SPARC-NEXT:    xor %i1, %i5, %i1
+; SPARC-NEXT:    xor %g2, %i5, %i4
+; SPARC-NEXT:    or %i4, %i1, %i1
+; SPARC-NEXT:    or %i1, %i0, %i0
+; SPARC-NEXT:    cmp %i0, 0
 ; SPARC-NEXT:    bne .LBB0_2
 ; SPARC-NEXT:    nop
 ; SPARC-NEXT:  ! %bb.1: ! %start
@@ -133,10 +167,9 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
 ; SPARC-NEXT:  .LBB0_2:
 ; SPARC-NEXT:    mov 1, %i4
 ; SPARC-NEXT:  .LBB0_3: ! %start
-; SPARC-NEXT:    ld [%fp+-4], %i2 ! 4-byte Folded Reload
-; SPARC-NEXT:    ld [%fp+-8], %i3 ! 4-byte Folded Reload
+; SPARC-NEXT:    mov %g4, %i0
 ; SPARC-NEXT:    ret
-; SPARC-NEXT:    restore
+; SPARC-NEXT:    restore %g0, %g3, %o1
 ;
 ; SPARC64-LABEL: muloti_test:
 ; SPARC64:         .cfi_startproc

--- a/llvm/test/CodeGen/SPARC/umulo-128-legalisation-lowering.ll
+++ b/llvm/test/CodeGen/SPARC/umulo-128-legalisation-lowering.ll
@@ -6,157 +6,158 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
 ; SPARC-LABEL: muloti_test:
 ; SPARC:         .cfi_startproc
 ; SPARC-NEXT:  ! %bb.0: ! %start
-; SPARC-NEXT:    save %sp, -112, %sp
+; SPARC-NEXT:    save %sp, -96, %sp
 ; SPARC-NEXT:    .cfi_def_cfa_register %fp
 ; SPARC-NEXT:    .cfi_window_save
 ; SPARC-NEXT:    .cfi_register %o7, %i7
-; SPARC-NEXT:    ld [%fp+92], %l4
-; SPARC-NEXT:    ld [%fp+96], %g2
-; SPARC-NEXT:    umul %i2, %i5, %g3
-; SPARC-NEXT:    rd %y, %g4
-; SPARC-NEXT:    st %g4, [%fp+-12] ! 4-byte Folded Spill
-; SPARC-NEXT:    umul %i4, %i3, %g4
+; SPARC-NEXT:    mov %i3, %g2
+; SPARC-NEXT:    mov %i2, %g4
+; SPARC-NEXT:    umul %i2, %i5, %i2
+; SPARC-NEXT:    rd %y, %o0
+; SPARC-NEXT:    ld [%fp+92], %l6
+; SPARC-NEXT:    umul %i4, %i3, %i3
+; SPARC-NEXT:    rd %y, %o2
+; SPARC-NEXT:    ld [%fp+96], %g3
+; SPARC-NEXT:    umul %i5, %g2, %l0
+; SPARC-NEXT:    rd %y, %l7
+; SPARC-NEXT:    umul %l6, %i1, %l2
+; SPARC-NEXT:    rd %y, %l3
+; SPARC-NEXT:    add %i3, %i2, %i2
+; SPARC-NEXT:    umul %i0, %g3, %i3
 ; SPARC-NEXT:    rd %y, %l5
-; SPARC-NEXT:    st %g2, [%sp+96]
-; SPARC-NEXT:    umul %i5, %i3, %l1
-; SPARC-NEXT:    rd %y, %l6
-; SPARC-NEXT:    st %l4, [%sp+92]
-; SPARC-NEXT:    umul %l4, %i1, %l2
-; SPARC-NEXT:    rd %y, %l0
-; SPARC-NEXT:    st %l0, [%fp+-4] ! 4-byte Folded Spill
-; SPARC-NEXT:    add %g4, %g3, %g3
-; SPARC-NEXT:    umul %i0, %g2, %g4
-; SPARC-NEXT:    rd %y, %l0
-; SPARC-NEXT:    st %l0, [%fp+-8] ! 4-byte Folded Spill
-; SPARC-NEXT:    add %l6, %g3, %l3
-; SPARC-NEXT:    umul %i1, %g2, %g2
-; SPARC-NEXT:    rd %y, %l0
-; SPARC-NEXT:    add %g4, %l2, %g3
-; SPARC-NEXT:    add %l0, %g3, %l2
-; SPARC-NEXT:    addcc %g2, %l1, %l1
-; SPARC-NEXT:    addxcc %l2, %l3, %l7
-; SPARC-NEXT:    mov %g0, %o0
-; SPARC-NEXT:    mov %g0, %o1
-; SPARC-NEXT:    mov %i2, %o2
-; SPARC-NEXT:    mov %i3, %o3
-; SPARC-NEXT:    mov %g0, %o4
-; SPARC-NEXT:    call __multi3
-; SPARC-NEXT:    mov %g0, %o5
-; SPARC-NEXT:    addcc %o1, %l1, %g3
-; SPARC-NEXT:    addxcc %o0, %l7, %g2
-; SPARC-NEXT:    mov 1, %g4
-; SPARC-NEXT:    cmp %g2, %o0
-; SPARC-NEXT:    mov %o3, %i3
+; SPARC-NEXT:    add %l7, %i2, %o1
+; SPARC-NEXT:    umul %i1, %g3, %i2
+; SPARC-NEXT:    rd %y, %l1
+; SPARC-NEXT:    add %i3, %l2, %i3
+; SPARC-NEXT:    add %l1, %i3, %l2
+; SPARC-NEXT:    addcc %i2, %l0, %l0
+; SPARC-NEXT:    umul %g2, %g3, %i3
+; SPARC-NEXT:    rd %y, %i2
+; SPARC-NEXT:    addxcc %l2, %o1, %o4
+; SPARC-NEXT:    umul %g4, %g3, %g3
+; SPARC-NEXT:    rd %y, %l4
+; SPARC-NEXT:    addcc %g3, %i2, %i2
+; SPARC-NEXT:    addxcc %l4, 0, %g3
+; SPARC-NEXT:    umul %g2, %l6, %g2
+; SPARC-NEXT:    rd %y, %l4
+; SPARC-NEXT:    addcc %g2, %i2, %i2
+; SPARC-NEXT:    addxcc %l4, 0, %g2
+; SPARC-NEXT:    addcc %g3, %g2, %g2
+; SPARC-NEXT:    addxcc %g0, 0, %g3
+; SPARC-NEXT:    umul %g4, %l6, %l4
+; SPARC-NEXT:    rd %y, %o3
+; SPARC-NEXT:    addcc %l4, %g2, %l4
+; SPARC-NEXT:    addxcc %o3, %g3, %o3
+; SPARC-NEXT:    addcc %l4, %l0, %g2
+; SPARC-NEXT:    addxcc %o3, %o4, %g3
+; SPARC-NEXT:    mov 1, %l0
+; SPARC-NEXT:    cmp %g3, %o3
 ; SPARC-NEXT:    bcs .LBB0_2
-; SPARC-NEXT:    mov %g4, %o3
+; SPARC-NEXT:    mov %l0, %o4
 ; SPARC-NEXT:  ! %bb.1: ! %start
-; SPARC-NEXT:    mov %g0, %o3
+; SPARC-NEXT:    mov %g0, %o4
 ; SPARC-NEXT:  .LBB0_2: ! %start
-; SPARC-NEXT:    cmp %g3, %o1
+; SPARC-NEXT:    cmp %g2, %l4
 ; SPARC-NEXT:    bcs .LBB0_4
-; SPARC-NEXT:    mov %g4, %l1
+; SPARC-NEXT:    mov %l0, %l4
 ; SPARC-NEXT:  ! %bb.3: ! %start
-; SPARC-NEXT:    mov %g0, %l1
+; SPARC-NEXT:    mov %g0, %l4
 ; SPARC-NEXT:  .LBB0_4: ! %start
-; SPARC-NEXT:    cmp %g2, %o0
+; SPARC-NEXT:    cmp %g3, %o3
 ; SPARC-NEXT:    be .LBB0_6
 ; SPARC-NEXT:    nop
 ; SPARC-NEXT:  ! %bb.5: ! %start
-; SPARC-NEXT:    mov %o3, %l1
+; SPARC-NEXT:    mov %o4, %l4
 ; SPARC-NEXT:  .LBB0_6: ! %start
-; SPARC-NEXT:    cmp %i2, 0
+; SPARC-NEXT:    cmp %g4, 0
 ; SPARC-NEXT:    bne .LBB0_8
-; SPARC-NEXT:    mov %g4, %i2
+; SPARC-NEXT:    mov %l0, %g4
 ; SPARC-NEXT:  ! %bb.7: ! %start
-; SPARC-NEXT:    mov %g0, %i2
+; SPARC-NEXT:    mov %g0, %g4
 ; SPARC-NEXT:  .LBB0_8: ! %start
 ; SPARC-NEXT:    cmp %i4, 0
 ; SPARC-NEXT:    bne .LBB0_10
-; SPARC-NEXT:    mov %g4, %o1
+; SPARC-NEXT:    mov %l0, %o3
 ; SPARC-NEXT:  ! %bb.9: ! %start
-; SPARC-NEXT:    mov %g0, %o1
+; SPARC-NEXT:    mov %g0, %o3
 ; SPARC-NEXT:  .LBB0_10: ! %start
-; SPARC-NEXT:    cmp %l5, 0
+; SPARC-NEXT:    cmp %o2, 0
 ; SPARC-NEXT:    bne .LBB0_12
-; SPARC-NEXT:    mov %g4, %o0
+; SPARC-NEXT:    mov %l0, %o2
 ; SPARC-NEXT:  ! %bb.11: ! %start
-; SPARC-NEXT:    mov %g0, %o0
+; SPARC-NEXT:    mov %g0, %o2
 ; SPARC-NEXT:  .LBB0_12: ! %start
-; SPARC-NEXT:    ld [%fp+-12], %l5 ! 4-byte Folded Reload
-; SPARC-NEXT:    cmp %l5, 0
+; SPARC-NEXT:    cmp %o0, 0
 ; SPARC-NEXT:    bne .LBB0_14
-; SPARC-NEXT:    mov %g4, %l5
+; SPARC-NEXT:    mov %l0, %o0
 ; SPARC-NEXT:  ! %bb.13: ! %start
-; SPARC-NEXT:    mov %g0, %l5
+; SPARC-NEXT:    mov %g0, %o0
 ; SPARC-NEXT:  .LBB0_14: ! %start
-; SPARC-NEXT:    cmp %l3, %l6
+; SPARC-NEXT:    cmp %o1, %l7
 ; SPARC-NEXT:    bcs .LBB0_16
-; SPARC-NEXT:    mov %g4, %l3
+; SPARC-NEXT:    mov %l0, %l7
 ; SPARC-NEXT:  ! %bb.15: ! %start
-; SPARC-NEXT:    mov %g0, %l3
+; SPARC-NEXT:    mov %g0, %l7
 ; SPARC-NEXT:  .LBB0_16: ! %start
-; SPARC-NEXT:    cmp %l4, 0
+; SPARC-NEXT:    cmp %l6, 0
 ; SPARC-NEXT:    bne .LBB0_18
-; SPARC-NEXT:    mov %g4, %l4
+; SPARC-NEXT:    mov %l0, %l6
 ; SPARC-NEXT:  ! %bb.17: ! %start
-; SPARC-NEXT:    mov %g0, %l4
+; SPARC-NEXT:    mov %g0, %l6
 ; SPARC-NEXT:  .LBB0_18: ! %start
 ; SPARC-NEXT:    cmp %i0, 0
 ; SPARC-NEXT:    bne .LBB0_20
-; SPARC-NEXT:    mov %g4, %l7
+; SPARC-NEXT:    mov %l0, %o1
 ; SPARC-NEXT:  ! %bb.19: ! %start
-; SPARC-NEXT:    mov %g0, %l7
+; SPARC-NEXT:    mov %g0, %o1
 ; SPARC-NEXT:  .LBB0_20: ! %start
-; SPARC-NEXT:    ld [%fp+-8], %l6 ! 4-byte Folded Reload
-; SPARC-NEXT:    cmp %l6, 0
+; SPARC-NEXT:    cmp %l5, 0
 ; SPARC-NEXT:    bne .LBB0_22
-; SPARC-NEXT:    mov %g4, %l6
+; SPARC-NEXT:    mov %l0, %l5
 ; SPARC-NEXT:  ! %bb.21: ! %start
-; SPARC-NEXT:    mov %g0, %l6
+; SPARC-NEXT:    mov %g0, %l5
 ; SPARC-NEXT:  .LBB0_22: ! %start
-; SPARC-NEXT:    and %o1, %i2, %i2
-; SPARC-NEXT:    ld [%fp+-4], %o1 ! 4-byte Folded Reload
-; SPARC-NEXT:    cmp %o1, 0
-; SPARC-NEXT:    and %l7, %l4, %o1
+; SPARC-NEXT:    and %o3, %g4, %g4
+; SPARC-NEXT:    cmp %l3, 0
+; SPARC-NEXT:    and %o1, %l6, %o1
 ; SPARC-NEXT:    bne .LBB0_24
-; SPARC-NEXT:    mov %g4, %l4
+; SPARC-NEXT:    mov %l0, %l3
 ; SPARC-NEXT:  ! %bb.23: ! %start
-; SPARC-NEXT:    mov %g0, %l4
+; SPARC-NEXT:    mov %g0, %l3
 ; SPARC-NEXT:  .LBB0_24: ! %start
-; SPARC-NEXT:    or %i2, %o0, %l7
-; SPARC-NEXT:    cmp %l2, %l0
-; SPARC-NEXT:    or %o1, %l6, %l2
+; SPARC-NEXT:    or %g4, %o2, %l6
+; SPARC-NEXT:    cmp %l2, %l1
+; SPARC-NEXT:    or %o1, %l5, %l2
 ; SPARC-NEXT:    bcs .LBB0_26
-; SPARC-NEXT:    mov %g4, %i2
+; SPARC-NEXT:    mov %l0, %g4
 ; SPARC-NEXT:  ! %bb.25: ! %start
-; SPARC-NEXT:    mov %g0, %i2
+; SPARC-NEXT:    mov %g0, %g4
 ; SPARC-NEXT:  .LBB0_26: ! %start
-; SPARC-NEXT:    or %l7, %l5, %l0
+; SPARC-NEXT:    or %l6, %o0, %l1
 ; SPARC-NEXT:    or %i5, %i4, %i4
 ; SPARC-NEXT:    cmp %i4, 0
-; SPARC-NEXT:    or %l2, %l4, %l2
+; SPARC-NEXT:    or %l2, %l3, %l2
 ; SPARC-NEXT:    bne .LBB0_28
-; SPARC-NEXT:    mov %g4, %i4
+; SPARC-NEXT:    mov %l0, %i4
 ; SPARC-NEXT:  ! %bb.27: ! %start
 ; SPARC-NEXT:    mov %g0, %i4
 ; SPARC-NEXT:  .LBB0_28: ! %start
-; SPARC-NEXT:    or %l0, %l3, %i5
+; SPARC-NEXT:    or %l1, %l7, %i5
 ; SPARC-NEXT:    or %i1, %i0, %i0
 ; SPARC-NEXT:    cmp %i0, 0
 ; SPARC-NEXT:    bne .LBB0_30
-; SPARC-NEXT:    or %l2, %i2, %i0
+; SPARC-NEXT:    or %l2, %g4, %i0
 ; SPARC-NEXT:  ! %bb.29: ! %start
-; SPARC-NEXT:    mov %g0, %g4
+; SPARC-NEXT:    mov %g0, %l0
 ; SPARC-NEXT:  .LBB0_30: ! %start
-; SPARC-NEXT:    and %g4, %i4, %i1
+; SPARC-NEXT:    and %l0, %i4, %i1
 ; SPARC-NEXT:    or %i1, %i0, %i0
 ; SPARC-NEXT:    or %i0, %i5, %i0
-; SPARC-NEXT:    or %i0, %l1, %i0
+; SPARC-NEXT:    or %i0, %l4, %i0
 ; SPARC-NEXT:    and %i0, 1, %i4
-; SPARC-NEXT:    mov %g2, %i0
-; SPARC-NEXT:    mov %g3, %i1
+; SPARC-NEXT:    mov %g3, %i0
 ; SPARC-NEXT:    ret
-; SPARC-NEXT:    restore %g0, %o2, %o2
+; SPARC-NEXT:    restore %g0, %g2, %o1
 ;
 ; SPARC64-LABEL: muloti_test:
 ; SPARC64:         .cfi_startproc


### PR DESCRIPTION
LLVM fails to build on 32-bit Solaris/SPARC: several programs fail to link due to undefined references to `__multi3`.  This reference is from `lib/libLLVMScalarOpts.a(LoopStrengthReduce.cpp.o)`.  However, This function exists neither in the 32-bit `libgcc.a` nor in `libclang_rt.builtins-sparc.a`.  It's only defined in their 64-bit counterparts.

The same issue affects several 32-bit targets, e.g. 32-bit PowerPC as described in Issue #54460.  The fix is the same: inhibit the libcall for 32-bit compilations.  This patch does just that, regenerating the affected testcases.  It allows the build to complete.

Tested on `sparc-sun-solaris2.11`.