### PR TITLE
[libc] Fix some warnings

### DIFF
--- a/libc/src/__support/CPP/limits.h
+++ b/libc/src/__support/CPP/limits.h
@@ -17,8 +17,8 @@ namespace cpp {
 // Some older gcc distributions don't define these for 32 bit targets.
 #ifndef LLONG_MAX
 constexpr size_t LLONG_BIT_WIDTH = sizeof(long long) * 8;
-constexpr long long LLONG_MAX = ~0LL ^ (1LL << LLONG_BIT_WIDTH - 1);
-constexpr long long LLONG_MIN = 1LL << LLONG_BIT_WIDTH - 1;
+constexpr long long LLONG_MAX = ~0LL ^ (1LL << (LLONG_BIT_WIDTH - 1));
+constexpr long long LLONG_MIN = 1LL << (LLONG_BIT_WIDTH - 1);
 constexpr unsigned long long ULLONG_MAX = ~0ULL;
 #endif
 

--- a/libc/test/src/ctype/isprint_test.cpp
+++ b/libc/test/src/ctype/isprint_test.cpp
@@ -11,9 +11,10 @@
 
 TEST(LlvmLibcIsPrint, DefaultLocale) {
   for (int ch = -255; ch < 255; ++ch) {
-    if (' ' <= ch && ch <= '~') // A-Z, a-z, 0-9, punctuation, space.
+    if (' ' <= ch && ch <= '~') { // A-Z, a-z, 0-9, punctuation, space.
       EXPECT_NE(__llvm_libc::isprint(ch), 0);
-    else
+    } else {
       EXPECT_EQ(__llvm_libc::isprint(ch), 0);
+    }
   }
 }


### PR DESCRIPTION
Some compilers will warn about dangling else and missleading lack of parentheses.