### PR TITLE
[libc++] Update Apple CI jobs to run the C++23 configuration

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -908,7 +908,7 @@ steps:
   - group: ":mac: Apple"
     steps:
     - label: "MacOS x86_64"
-      command: "libcxx/utils/ci/run-buildbot generic-cxx20"
+      command: "libcxx/utils/ci/run-buildbot generic-cxx23"
       artifact_paths:
         - "**/test-results.xml"
         - "**/*.abilist"
@@ -923,7 +923,7 @@ steps:
       timeout_in_minutes: 120
 
     - label: "MacOS arm64"
-      command: "libcxx/utils/ci/run-buildbot generic-cxx20"
+      command: "libcxx/utils/ci/run-buildbot generic-cxx23"
       artifact_paths:
         - "**/test-results.xml"
         - "**/*.abilist"


### PR DESCRIPTION
We were running the test suite in C++20 mode, but we should really be tracking the latest supported version. We can't do C++26 because the latest stable AppleClang doesn't support it yet.