### PR TITLE
[clang][dataflow] Model the fields that are accessed via inline accessors

### DIFF
--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -1481,10 +1481,8 @@ TEST(TransferTest, StructModeledFieldsWithAccessor) {
               getEnvironmentAtAnnotation(Results, "p");
         auto &SLoc = getLocForDecl<RecordStorageLocation>(ASTCtx, Env, "s");
         std::vector<const ValueDecl*> Fields;
-        for (auto [Field, _] : SLoc.children()) {
+        for (auto [Field, _] : SLoc.children())
           Fields.push_back(Field);
-          llvm::dbgs() << Field->getNameAsString() << "\n";
-        }
         // Only the fields that have simple accessor methods (that have a
         // single statement body that returns the member variable) should be modeled.
         ASSERT_THAT(Fields, UnorderedElementsAre(

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -1449,27 +1449,30 @@ TEST(TransferTest, BaseClassInitializer) {
 TEST(TransferTest, StructModeledFieldsWithAccessor) {
   std::string Code = R"(
     class S {
-      int *P;
-      int *Q;
-      int X;
-      int Y;
-      int Z;
+      int *Ptr;
+      int *PtrNonConst;
+      int Int;
+      int IntWithInc;
+      int IntNotAccessed;
+      int IntRef;
     public:
-      int *getPtr() const { return P; }
-      int *getPtrNonConst() { return Q; }
-      int getInt(int i) const { return X; }
-      int getWithOtherWork(int i) { Y += i; return Y; }
-      int getIntNotCalled() const { return Z; }
+      int *getPtr() const { return Ptr; }
+      int *getPtrNonConst() { return PtrNonConst; }
+      int getInt(int i) const { return Int; }
+      int getWithInc(int i) { IntWithInc += i; return IntWithInc; }
+      int getIntNotAccessed() const { return IntNotAccessed; }
       int getIntNoDefinition() const;
+      int &getIntRef() { return IntRef; }
     };
 
     void target() {
       S s;
-      int *p = s.getPtr();
-      int *q = s.getPtrNonConst();
-      int x = s.getInt(1);
-      int y = s.getWithOtherWork(1);
-      int w = s.getIntNoDefinition();
+      int *p1 = s.getPtr();
+      int *p2 = s.getPtrNonConst();
+      int i1 = s.getInt(1);
+      int i2 = s.getWithInc(1);
+      int i3 = s.getIntNoDefinition();
+      int &iref = s.getIntRef();
       // [[p]]
     }
   )";
@@ -1484,10 +1487,11 @@ TEST(TransferTest, StructModeledFieldsWithAccessor) {
         for (auto [Field, _] : SLoc.children())
           Fields.push_back(Field);
         // Only the fields that have simple accessor methods (that have a
-        // single statement body that returns the member variable) should be modeled.
+        // single statement body that returns the member variable) should be
+        // modeled.
         ASSERT_THAT(Fields, UnorderedElementsAre(
-            findValueDecl(ASTCtx, "P"), findValueDecl(ASTCtx, "Q"),
-            findValueDecl(ASTCtx, "X")));
+            findValueDecl(ASTCtx, "Ptr"), findValueDecl(ASTCtx, "PtrNonConst"),
+            findValueDecl(ASTCtx, "Int"), findValueDecl(ASTCtx, "IntRef")));
       });
 }
 


### PR DESCRIPTION
So that the values that are accessed via such accessors can be analyzed as a limited version of context-sensitive analysis. We can potentially do this only when some option is set, but doing additional modeling like this won't be expensive and intrusive, so we do it by default for now.