### PR TITLE
[IRDL] Fix CMake to generate IRDL dialect docs

### DIFF
--- a/mlir/include/mlir/Dialect/IRDL/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/IRDL/IR/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect(IRDL irdl)
+add_mlir_doc(IRDL IRDL Dialects/ -gen-dialect-doc)
 
 # Add IRDL interfaces
 set(LLVM_TARGET_DEFINITIONS IRDLInterfaces.td)


### PR DESCRIPTION
The CMake file for IRDL was not generating documentation on the mlir website. This patch fixes this.