### PR TITLE
[CMake] [compiler-rt] fix architecture checks in runtime builds

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -1,5 +1,6 @@
 include(CMakePushCheckState)
 include(CheckSymbolExists)
+include(CheckCXXSourceCompiles)
 
 # Because compiler-rt spends a lot of time setting up custom compile flags,
 # define a handy helper function for it. The compile flags setting in CMake
@@ -124,15 +125,9 @@ macro(test_target_arch arch def)
                        SOURCE "#include <limits.h>\nint foo(int x, int y) { return x + y; }\n"
                        FLAGS ${TARGET_${arch}_CFLAGS})
     else()
-      set(FLAG_NO_EXCEPTIONS "")
-      if(COMPILER_RT_HAS_FNO_EXCEPTIONS_FLAG)
-        set(FLAG_NO_EXCEPTIONS " -fno-exceptions ")
-      endif()
       set(SAVED_CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${argstring}")
-      try_compile(CAN_TARGET_${arch} ${CMAKE_BINARY_DIR} ${SIMPLE_SOURCE}
-                  COMPILE_DEFINITIONS "${TARGET_${arch}_CFLAGS} ${FLAG_NO_EXCEPTIONS}"
-                  OUTPUT_VARIABLE TARGET_${arch}_OUTPUT)
+      check_cxx_source_compiles("${SIMPLE_SOURCE}" CAN_TARGET_${arch})
       set(CMAKE_EXE_LINKER_FLAGS ${SAVED_CMAKE_EXE_LINKER_FLAGS})
     endif()
   endif()

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -226,8 +226,7 @@ set(COMPILER_RT_SUPPORTED_ARCH)
 # platform. We use the results of these tests to build only the various target
 # runtime libraries supported by our current compilers cross-compiling
 # abilities.
-set(SIMPLE_SOURCE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/simple.cc)
-file(WRITE ${SIMPLE_SOURCE} "#include <stdlib.h>\n#include <stdio.h>\nint main(void) { printf(\"hello, world\"); }\n")
+set(SIMPLE_SOURCE "#include <stdlib.h>\n#include <stdio.h>\nint main(void) { printf(\"hello, world\"); }\n")
 
 # Detect whether the current target platform is 32-bit or 64-bit, and setup
 # the correct commandline flags needed to attempt to target 32-bit and 64-bit.


### PR DESCRIPTION
When Clang is built with libunwind as the default unwinder, the architecture support checks in compiler-rt fail during the runtime build because Clang can't link before libunwind is built. This commit fixes the checks by making them respect CMAKE_REQUIRED_FLAGS, a variable that contains linker arguments to disable the unwinder if necessary.