### PR TITLE
[IRSymtab] Replace linear time lookup with DenseSet

### DIFF
--- a/llvm/lib/Object/IRSymtab.cpp
+++ b/llvm/lib/Object/IRSymtab.cpp
@@ -215,6 +215,11 @@ Expected<int> Builder::getComdatIndex(const Comdat *C, const Module *M) {
   return P.first->second;
 }
 
+static DenseSet<StringRef> buildPreservedSymbolsSet() {
+  return DenseSet<StringRef>(std::begin(PreservedSymbols),
+                             std::end(PreservedSymbols));
+}
+
 Error Builder::addSymbol(const ModuleSymbolTable &Msymtab,
                          const SmallPtrSet<GlobalValue *, 4> &Used,
                          ModuleSymbolTable::Symbol Msym) {
@@ -270,7 +275,9 @@ Error Builder::addSymbol(const ModuleSymbolTable &Msymtab,
 
   setStr(Sym.IRName, GV->getName());
 
-  bool IsPreservedSymbol = llvm::is_contained(PreservedSymbols, GV->getName());
+  static const DenseSet<StringRef> PreservedSymbolsSet =
+      buildPreservedSymbolsSet();
+  bool IsPreservedSymbol = PreservedSymbolsSet.count(GV->getName());
 
   if (Used.count(GV) || IsPreservedSymbol)
     Sym.Flags |= 1 << storage::Symbol::FB_used;

--- a/llvm/lib/Object/IRSymtab.cpp
+++ b/llvm/lib/Object/IRSymtab.cpp
@@ -277,7 +277,7 @@ Error Builder::addSymbol(const ModuleSymbolTable &Msymtab,
 
   static const DenseSet<StringRef> PreservedSymbolsSet =
       buildPreservedSymbolsSet();
-  bool IsPreservedSymbol = PreservedSymbolsSet.count(GV->getName());
+  bool IsPreservedSymbol = PreservedSymbolsSet.contains(GV->getName());
 
   if (Used.count(GV) || IsPreservedSymbol)
     Sym.Flags |= 1 << storage::Symbol::FB_used;


### PR DESCRIPTION
There is an inefficiency in the IRSymtab Builder where it does a lookup of PreservedSymbols when calling addSymbol. This lookup is linear in time, so it tends to be quite slow. Replacing it with DenseSet gives a 0.1% speedup:
https://llvm-compile-time-tracker.com/compare.php?from=02d27eac0f3f470a93635fc98ae990bf2a9809ed&to=62b09786fff4d53aa0c75b64aea48de241e4a856&stat=instructions:u

This change is quite similar to https://reviews.llvm.org/D157951.