### PR TITLE
[MLIR] Allow comparison of opaque properties

### DIFF
--- a/mlir/include/mlir/IR/ExtensibleDialect.h
+++ b/mlir/include/mlir/IR/ExtensibleDialect.h
@@ -495,6 +495,7 @@ public:
   }
   Attribute getPropertiesAsAttr(Operation *op) final { return {}; }
   void copyProperties(OpaqueProperties lhs, OpaqueProperties rhs) final {}
+  bool compareProperties(OpaqueProperties, OpaqueProperties) final { return false; }
   llvm::hash_code hashProperties(OpaqueProperties prop) final { return {}; }
 
 private:

--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -141,6 +141,7 @@ public:
                           function_ref<InFlightDiagnostic &()> getDiag) = 0;
     virtual Attribute getPropertiesAsAttr(Operation *) = 0;
     virtual void copyProperties(OpaqueProperties, OpaqueProperties) = 0;
+    virtual bool compareProperties(OpaqueProperties, OpaqueProperties) = 0;
     virtual llvm::hash_code hashProperties(OpaqueProperties) = 0;
   };
 
@@ -221,6 +222,7 @@ protected:
                           function_ref<InFlightDiagnostic &()> getDiag) final;
     Attribute getPropertiesAsAttr(Operation *) final;
     void copyProperties(OpaqueProperties, OpaqueProperties) final;
+    bool compareProperties(OpaqueProperties, OpaqueProperties) final;
     llvm::hash_code hashProperties(OpaqueProperties) final;
   };
 
@@ -445,6 +447,10 @@ public:
     return getImpl()->copyProperties(lhs, rhs);
   }
 
+  bool compareOpProperties(OpaqueProperties lhs, OpaqueProperties rhs) const {
+    return getImpl()->compareProperties(lhs, rhs);
+  }
+
   llvm::hash_code hashOpProperties(OpaqueProperties properties) const {
     return getImpl()->hashProperties(properties);
   }
@@ -645,6 +651,13 @@ public:
                                                concreteOp.getProperties());
       }
       return {};
+    }
+    bool compareProperties(OpaqueProperties lhs, OpaqueProperties rhs) final {
+      if constexpr (hasProperties) {
+        return *lhs.as<Properties *>() == *rhs.as<Properties *>();
+      } else {
+        return true;
+      }
     }
     void copyProperties(OpaqueProperties lhs, OpaqueProperties rhs) final {
       *lhs.as<Properties *>() = *rhs.as<Properties *>();

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -864,6 +864,10 @@ void OperationName::UnregisteredOpModel::copyProperties(OpaqueProperties lhs,
                                                         OpaqueProperties rhs) {
   *lhs.as<Attribute *>() = *rhs.as<Attribute *>();
 }
+bool OperationName::UnregisteredOpModel::compareProperties(OpaqueProperties lhs,
+                                                        OpaqueProperties rhs) {
+  return *lhs.as<Attribute *>() == *rhs.as<Attribute *>();
+}
 llvm::hash_code
 OperationName::UnregisteredOpModel::hashProperties(OpaqueProperties prop) {
   return llvm::hash_combine(*prop.as<Attribute *>());

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -768,7 +768,6 @@ OperationEquivalence::isRegionEquivalentTo(Region *lhs, Region *rhs,
       lhs->getNumSuccessors() != rhs->getNumSuccessors() ||
       lhs->getNumOperands() != rhs->getNumOperands() ||
       lhs->getNumResults() != rhs->getNumResults() ||
-      lhs->hashProperties() != rhs->hashProperties() ||
       !lhs->getName().compareOpProperties(lhs->getPropertiesStorage(),
                                         rhs->getPropertiesStorage()))
     return false;

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -768,7 +768,9 @@ OperationEquivalence::isRegionEquivalentTo(Region *lhs, Region *rhs,
       lhs->getNumSuccessors() != rhs->getNumSuccessors() ||
       lhs->getNumOperands() != rhs->getNumOperands() ||
       lhs->getNumResults() != rhs->getNumResults() ||
-      lhs->hashProperties() != rhs->hashProperties())
+      lhs->hashProperties() != rhs->hashProperties() ||
+      !lhs->getName().compareOpProperties(lhs->getPropertiesStorage(),
+                                        rhs->getPropertiesStorage()))
     return false;
   if (!(flags & IgnoreLocations) && lhs->getLoc() != rhs->getLoc())
     return false;

--- a/mlir/unittests/IR/OpPropertiesTest.cpp
+++ b/mlir/unittests/IR/OpPropertiesTest.cpp
@@ -28,6 +28,11 @@ struct TestProperties {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestProperties)
 };
 
+bool operator==(const TestProperties &lhs, TestProperties &rhs) {
+  return lhs.a == rhs.a && lhs.b == rhs.b && lhs.array == rhs.array &&
+         lhs.label == rhs.label;
+}
+
 /// Convert a DictionaryAttr to a TestProperties struct, optionally emit errors
 /// through the provided diagnostic if any. This is used for example during
 /// parsing with the generic format.


### PR DESCRIPTION
Add capabilities for comparing opaque properties. This is useful when dealing with arbitrary operations which can be compare based on their OperationName. Now you can furthermore compare their properties without the need to determine their actual type.