### PR TITLE
[libc++] Improve the verbosity of configuration errors when a compiler flag is not supported

### DIFF
--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -203,6 +203,19 @@ def programSucceeds(config, program, args=None):
 
 
 @_memoizeExpensiveOperation(lambda c, f: (c.substitutions, c.environment, f))
+def tryCompileFlag(config, flag):
+    """
+    Try using the given compiler flag and return the exit code along with stdout and stderr.
+    """
+    # fmt: off
+    with _makeConfigTest(config) as test:
+        out, err, exitCode, timeoutInfo, _ = _executeWithFakeConfig(test, [
+            "%{{cxx}} -xc++ {} -Werror -fsyntax-only %{{flags}} %{{compile_flags}} {}".format(os.devnull, flag)
+        ])
+        return exitCode, out, err
+    # fmt: on
+
+
 def hasCompileFlag(config, flag):
     """
     Return whether the compiler in the configuration supports a given compiler flag.
@@ -210,16 +223,8 @@ def hasCompileFlag(config, flag):
     This is done by executing the %{cxx} substitution with the given flag and
     checking whether that succeeds.
     """
-    with _makeConfigTest(config) as test:
-        out, err, exitCode, timeoutInfo, _ = _executeWithFakeConfig(
-            test,
-            [
-                "%{{cxx}} -xc++ {} -Werror -fsyntax-only %{{flags}} %{{compile_flags}} {}".format(
-                    os.devnull, flag
-                )
-            ],
-        )
-        return exitCode == 0
+    (exitCode, _, _) = tryCompileFlag(config, flag)
+    return exitCode == 0
 
 
 @_memoizeExpensiveOperation(lambda c, s: (c.substitutions, c.environment, s))
@@ -348,9 +353,14 @@ def _getSubstitution(substitution, config):
 def _appendToSubstitution(substitutions, key, value):
     return [(k, v + " " + value) if k == key else (k, v) for (k, v) in substitutions]
 
-
 def _prependToSubstitution(substitutions, key, value):
     return [(k, value + " " + v) if k == key else (k, v) for (k, v) in substitutions]
+
+def _ensureFlagIsSupported(config, flag):
+    (exitCode, out, err) = tryCompileFlag(config, flag)
+    assert (
+        exitCode == 0
+    ), f"Trying to enable compiler flag {flag}, which is not supported. stdout was:\n{out}\n\nstderr was:\n{err}"
 
 
 class ConfigAction(object):
@@ -427,9 +437,7 @@ class AddFlag(ConfigAction):
 
     def applyTo(self, config):
         flag = self._getFlag(config)
-        assert hasCompileFlag(
-            config, flag
-        ), "Trying to enable flag {}, which is not supported".format(flag)
+        _ensureFlagIsSupported(config, flag)
         config.substitutions = _appendToSubstitution(
             config.substitutions, "%{flags}", flag
         )
@@ -473,9 +481,7 @@ class AddCompileFlag(ConfigAction):
 
     def applyTo(self, config):
         flag = self._getFlag(config)
-        assert hasCompileFlag(
-            config, flag
-        ), "Trying to enable compile flag {}, which is not supported".format(flag)
+        _ensureFlagIsSupported(config, flag)
         config.substitutions = _appendToSubstitution(
             config.substitutions, "%{compile_flags}", flag
         )
@@ -497,9 +503,7 @@ class AddLinkFlag(ConfigAction):
 
     def applyTo(self, config):
         flag = self._getFlag(config)
-        assert hasCompileFlag(
-            config, flag
-        ), "Trying to enable link flag {}, which is not supported".format(flag)
+        _ensureFlagIsSupported(config, flag)
         config.substitutions = _appendToSubstitution(
             config.substitutions, "%{link_flags}", flag
         )
@@ -521,9 +525,7 @@ class PrependLinkFlag(ConfigAction):
 
     def applyTo(self, config):
         flag = self._getFlag(config)
-        assert hasCompileFlag(
-            config, flag
-        ), "Trying to enable link flag {}, which is not supported".format(flag)
+        _ensureFlagIsSupported(config, flag)
         config.substitutions = _prependToSubstitution(
             config.substitutions, "%{link_flags}", flag
         )


### PR DESCRIPTION
If an assertion fails during the configuration of the test suite because the compiler doesn't support a flag (or the compiler configuration is borked entirely), we will now print additional context to help debug the issue instead of just saying "The compiler doesn't support the flag" and bailing.