### PR TITLE
[mlir][bytecode] Check that bytecode source buffer is sufficiently aligned.

### DIFF
--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -11,10 +11,8 @@
 #include "mlir/Bytecode/BytecodeImplementation.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Bytecode/Encoding.h"
-#include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/IR/Visitors.h"
@@ -25,19 +23,14 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Endian.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/SourceMgr.h"
 
-#include <cassert>
 #include <cstddef>
-#include <cstdint>
-#include <cstring>
 #include <list>
 #include <memory>
 #include <numeric>
 #include <optional>
-#include <string>
 
 #define DEBUG_TYPE "mlir-bytecode-reader"
 

--- a/mlir/unittests/Bytecode/BytecodeTest.cpp
+++ b/mlir/unittests/Bytecode/BytecodeTest.cpp
@@ -18,14 +18,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include <algorithm>
-#include <cstdlib>
-#include <memory>
-
 using namespace llvm;
 using namespace mlir;
 
-using testing::ElementsAre;
+using ::testing::StartsWith;
 
 StringLiteral IRWithResources = R"(
 module @TestDialectResources attributes {
@@ -34,7 +30,7 @@ module @TestDialectResources attributes {
 {-#
   dialect_resources: {
     builtin: {
-      resource: "0x1000000001000000020000000300000004000000"
+      resource: "0x2000000001000000020000000300000004000000"
     }
   }
 #-}
@@ -52,19 +48,19 @@ TEST(Bytecode, MultiModuleWithResource) {
   std::string buffer;
   llvm::raw_string_ostream ostream(buffer);
   ASSERT_TRUE(succeeded(writeBytecodeToFile(module.get(), ostream)));
-
-  // Make a sufficiently aligned copy of the buffer for reading it back.
   ostream.flush();
-  constexpr std::size_t kAlignment = 16; // AsmResourceBlob alignment.
-  auto deleter = [](char *ptr) { std::free(ptr); };
-  std::unique_ptr<char, decltype(deleter)> aligned_buffer(
-      static_cast<char *>(std::aligned_alloc(kAlignment, buffer.size())),
-      deleter);
-  std::copy(buffer.begin(), buffer.end(), aligned_buffer.get());
+
+  // Create copy of buffer which is aligned to requested resource alignment.
+  constexpr size_t kAlignment = 0x20;
+  size_t buffer_size = buffer.size();
+  buffer.reserve(buffer_size + kAlignment - 1);
+  size_t pad = ~(uintptr_t)buffer.data() + 1 & kAlignment - 1;
+  buffer.insert(0, pad, ' ');
+  StringRef aligned_buffer(buffer.data() + pad, buffer_size);
 
   // Parse it back
-  OwningOpRef<Operation *> roundTripModule = parseSourceString<Operation *>(
-      {aligned_buffer.get(), buffer.size()}, parseConfig);
+  OwningOpRef<Operation *> roundTripModule =
+      parseSourceString<Operation *>(aligned_buffer, parseConfig);
   ASSERT_TRUE(roundTripModule);
 
   // FIXME: Parsing external resources does not work on big-endian
@@ -91,4 +87,40 @@ TEST(Bytecode, MultiModuleWithResource) {
 
   checkResourceAttribute(*module);
   checkResourceAttribute(*roundTripModule);
+}
+
+TEST(Bytecode, InsufficientAlignmentFailure) {
+  MLIRContext context;
+  Builder builder(&context);
+  ParserConfig parseConfig(&context);
+  OwningOpRef<Operation *> module =
+      parseSourceString<Operation *>(IRWithResources, parseConfig);
+  ASSERT_TRUE(module);
+
+  // Write the module to bytecode
+  std::string buffer;
+  llvm::raw_string_ostream ostream(buffer);
+  ASSERT_TRUE(succeeded(writeBytecodeToFile(module.get(), ostream)));
+  ostream.flush();
+
+  // Create copy of buffer which is insufficiently aligned.
+  constexpr size_t kAlignment = 0x20;
+  size_t buffer_size = buffer.size();
+  buffer.reserve(buffer_size + kAlignment - 1);
+  size_t pad = ~(uintptr_t)buffer.data() + kAlignment / 2 + 1 & kAlignment - 1;
+  buffer.insert(0, pad, ' ');
+  StringRef misaligned_buffer(buffer.data() + pad, buffer_size);
+
+  std::unique_ptr<Diagnostic> diagnostic;
+  context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+    diagnostic = std::make_unique<Diagnostic>(std::move(diag));
+  });
+
+  // Try to parse it back and check for alignment error.
+  OwningOpRef<Operation *> roundTripModule =
+      parseSourceString<Operation *>(misaligned_buffer, parseConfig);
+  EXPECT_FALSE(roundTripModule);
+  ASSERT_TRUE(diagnostic);
+  EXPECT_THAT(diagnostic->str(),
+              StartsWith("expected bytecode buffer to be aligned to 32"));
 }

--- a/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
@@ -360,6 +360,27 @@ cc_test(
 )
 
 cc_test(
+    name = "bytecode_tests",
+    size = "small",
+    srcs = glob([
+        "Bytecode/*.cpp",
+        "Bytecode/*.h",
+        "Bytecode/*/*.cpp",
+        "Bytecode/*/*.h",
+    ]),
+    deps = [
+        "//llvm:Support",
+        "//mlir:BytecodeReader",
+        "//mlir:BytecodeWriter",
+        "//mlir:IR",
+        "//mlir:Parser",
+        "//third-party/unittest:gmock",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
     name = "conversion_tests",
     size = "small",
     srcs = glob([


### PR DESCRIPTION
Before this change, the `ByteCode` test failed on CentOS 7 with devtoolset-9, because strings happen to be only 8 byte aligned. In general though, strings have no alignment guarantee.

Increase resource alignment in test. 
Adjust test to make a copy of the buffer that is sufficiently aligned.
Add test to check error when buffer is insufficiently aligned.