### PR TITLE
[libc++] Simplify how we select modules flavors in the test suite

### DIFF
--- a/libcxx/cmake/caches/Generic-modules-lsv.cmake
+++ b/libcxx/cmake/caches/Generic-modules-lsv.cmake
@@ -1,2 +1,2 @@
-set(LIBCXX_TEST_PARAMS "enable_modules=clang;enable_modules_lsv=True" CACHE STRING "")
+set(LIBCXX_TEST_PARAMS "enable_modules=clang-lsv" CACHE STRING "")
 set(LIBCXXABI_TEST_PARAMS "${LIBCXX_TEST_PARAMS}" CACHE STRING "")


### PR DESCRIPTION
This gets rid of the separate parameter enable_modules_lsv in favor of adding a named option to the enable_modules parameter. The patch also removes the getModuleFlag helper, which was just a really complicated way of hardcoding "none".