### PR TITLE
[clang][deps] Load module map file from PCM

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1338,7 +1338,8 @@ static bool compileModule(CompilerInstance &ImportingInstance,
     Result = compileModuleImpl(
         ImportingInstance, ImportLoc, Module->getTopLevelModuleName(),
         FrontendInputFile(ModuleMapFilePath, IK, +Module->IsSystem),
-        ModMap.getModuleMapFileForUniquing(Module)->getName(), ModuleFileName);
+        ModMap.getModuleMapFileForUniquing(Module)->getNameAsRequested(),
+        ModuleFileName);
   } else {
     // FIXME: We only need to fake up an input file here as a way of
     // transporting the module's directory to the module map parser. We should
@@ -1355,7 +1356,7 @@ static bool compileModule(CompilerInstance &ImportingInstance,
     Result = compileModuleImpl(
         ImportingInstance, ImportLoc, Module->getTopLevelModuleName(),
         FrontendInputFile(FakeModuleMapFile, IK, +Module->IsSystem),
-        ModMap.getModuleMapFileForUniquing(Module)->getName(),
+        ModMap.getModuleMapFileForUniquing(Module)->getNameAsRequested(),
         ModuleFileName,
         [&](CompilerInstance &Instance) {
       std::unique_ptr<llvm::MemoryBuffer> ModuleMapBuffer =

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1307,6 +1307,9 @@ void ModuleMap::setInferredModuleAllowedBy(Module *M,
 
 std::error_code
 ModuleMap::canonicalizeModuleMapPath(SmallVectorImpl<char> &Path) {
+  FileManager &FM = SourceMgr.getFileManager();
+  FM.makeAbsolutePath(Path);
+
   StringRef Dir = llvm::sys::path::parent_path({Path.data(), Path.size()});
 
   // Do not canonicalize within the framework; the module map parser expects
@@ -1317,8 +1320,7 @@ ModuleMap::canonicalizeModuleMapPath(SmallVectorImpl<char> &Path) {
       Dir = Parent;
   }
 
-  FileManager &FM = SourceMgr.getFileManager();
-  auto DirEntry = FM.getDirectoryRef(Dir.empty() ? "." : Dir);
+  auto DirEntry = FM.getDirectoryRef(Dir);
   if (!DirEntry)
     return llvm::errorToErrorCode(DirEntry.takeError());
 

--- a/clang/test/ClangScanDeps/modules-inferred-vfs-mod-map.m
+++ b/clang/test/ClangScanDeps/modules-inferred-vfs-mod-map.m
@@ -1,0 +1,63 @@
+// This test checks that we report the module map that allowed inferring using
+// its on-disk path in file dependencies.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- frameworks/Inferred.framework/Headers/Inferred.h
+//--- frameworks/Inferred.framework/Frameworks/Sub.framework/Headers/Sub.h
+//--- real/module.modulemap
+framework module * {}
+//--- vfsoverlay.json.template
+{
+  "version": 0,
+  "case-sensitive": "false",
+  "use-external-names": true,
+  "roots": [
+    {
+      "contents": [
+        {
+           "external-contents": "DIR/real/module.modulemap",
+           "name": "module.modulemap",
+           "type": "file"
+        }
+      ],
+      "name": "DIR/frameworks",
+      "type": "directory"
+    }
+  ]
+}
+//--- tu.m
+#include <Inferred/Inferred.h>
+
+//--- cdb.json.template
+[{
+  "directory": "DIR",
+  "file": "DIR/tu.m",
+  "command": "clang -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -F DIR/frameworks -ivfsoverlay DIR/vfsoverlay.json -c DIR/tu.m -o DIR/tu.o"
+}]
+
+// RUN: sed "s|DIR|%/t|g" %t/vfsoverlay.json.template > %t/vfsoverlay.json
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full > %t/result.json
+// RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t
+
+// CHECK:      {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "clang-module-deps": [],
+// CHECK-NEXT:       "clang-modulemap-file": "[[PREFIX]]/frameworks/module.modulemap",
+// CHECK-NEXT:       "command-line": [
+// CHECK:            ],
+// CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/frameworks/Inferred.framework/Frameworks/Sub.framework/Headers/Sub.h",
+// CHECK-NEXT:         "[[PREFIX]]/frameworks/Inferred.framework/Headers/Inferred.h",
+// CHECK-NEXT:         "[[PREFIX]]/real/module.modulemap"
+// CHECK-NEXT:       ],
+// CHECK-NEXT:       "name": "Inferred"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "translation-units": [
+// CHECK:        ]
+// CHECK:      }


### PR DESCRIPTION
Loading the module map path directly from the PCM is faster. Calling `ModuleMap::getModuleMapFileForUniquing()` causes deserialization of multiple `SLocEntries` and calling `ModuleMap::canonicalizeModuleMapPath()` issues an uncached call to `vfs::FileSystem::getRealPath()`.