### PR TITLE
ADT: Replace FPClassTest fabs with inverse_fabs and unknown_sign

### DIFF
--- a/llvm/include/llvm/ADT/FloatingPointMode.h
+++ b/llvm/include/llvm/ADT/FloatingPointMode.h
@@ -269,8 +269,12 @@ LLVM_DECLARE_ENUM_AS_BITMASK(FPClassTest, /* LargestValue */ fcPosInf);
 /// Return the test mask which returns true if the value's sign bit is flipped.
 FPClassTest fneg(FPClassTest Mask);
 
-/// Return the test mask which returns true if the value's sign bit is cleared.
-FPClassTest fabs(FPClassTest Mask);
+/// Return the test mask which returns true after fabs is applied to the value.
+FPClassTest inverse_fabs(FPClassTest Mask);
+
+/// Return the test mask which returns true if the value could have the same set
+/// of classes, but with a different sign.
+FPClassTest unknown_sign(FPClassTest Mask);
 
 /// Write a human readable form of \p Mask to \p OS
 raw_ostream &operator<<(raw_ostream &OS, FPClassTest Mask);

--- a/llvm/lib/Support/FloatingPointMode.cpp
+++ b/llvm/lib/Support/FloatingPointMode.cpp
@@ -32,7 +32,7 @@ FPClassTest llvm::fneg(FPClassTest Mask) {
   return NewMask;
 }
 
-FPClassTest llvm::fabs(FPClassTest Mask) {
+FPClassTest llvm::inverse_fabs(FPClassTest Mask) {
   FPClassTest NewMask = Mask & fcNan;
   if (Mask & fcPosZero)
     NewMask |= fcZero;
@@ -41,6 +41,19 @@ FPClassTest llvm::fabs(FPClassTest Mask) {
   if (Mask & fcPosNormal)
     NewMask |= fcNormal;
   if (Mask & fcPosInf)
+    NewMask |= fcInf;
+  return NewMask;
+}
+
+FPClassTest llvm::unknown_sign(FPClassTest Mask) {
+  FPClassTest NewMask = Mask & fcNan;
+  if (Mask & fcZero)
+    NewMask |= fcZero;
+  if (Mask & fcSubnormal)
+    NewMask |= fcSubnormal;
+  if (Mask & fcNormal)
+    NewMask |= fcNormal;
+  if (Mask & fcInf)
     NewMask |= fcInf;
   return NewMask;
 }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -899,7 +899,7 @@ Instruction *InstCombinerImpl::foldIntrinsicIsFPClass(IntrinsicInst &II) {
 
   Value *FAbsSrc;
   if (match(Src0, m_FAbs(m_Value(FAbsSrc)))) {
-    II.setArgOperand(1, ConstantInt::get(Src1->getType(), fabs(Mask)));
+    II.setArgOperand(1, ConstantInt::get(Src1->getType(), inverse_fabs(Mask)));
     return replaceOperand(II, 0, FAbsSrc);
   }
 


### PR DESCRIPTION
The names are confusing. It's supposed to return the possible classes for the source value of a fabs. Some places were using fneg as a way to express unknown sign, but it's clearer to have something separate for this.

unknown_sign will be used in a subsequent patch and avoids a small bug in copysign handling.