### PR TITLE
[GuardUtils] Revert llvm::isWidenableBranch change

### DIFF
--- a/llvm/lib/Analysis/GuardUtils.cpp
+++ b/llvm/lib/Analysis/GuardUtils.cpp
@@ -24,7 +24,10 @@ bool llvm::isWidenableCondition(const Value *V) {
 }
 
 bool llvm::isWidenableBranch(const User *U) {
-  return extractWidenableCondition(U) != nullptr;
+  Value *Condition, *WidenableCondition;
+  BasicBlock *GuardedBB, *DeoptBB;
+  return parseWidenableBranch(U, Condition, WidenableCondition, GuardedBB,
+                              DeoptBB);
 }
 
 bool llvm::isGuardAsWidenableBranch(const User *U) {


### PR DESCRIPTION
In the d6e7c162e1df3736d8e2b3610a831b7cfa5be99b was introduced util to to extract widenable conditions from branch. That util was applied in the llvm::isWidenableBranch to check if branch is widenable. So we consider branch is widenable if it has widenable condition anywhere in the condition tree. But that will be true when we finish GuardWidening reworking from branch widening to widenable conditions widening. 
For now we still need to check that widenable branch is in the form of: `br(widenable_condition & (...))`,
because that form is assumed by LoopPredication and GuardWidening algorithms.

Fixes: https://github.com/llvm/llvm-project/issues/66418