### PR TITLE
[InstCombine] Remove unnecessary one-use-check

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -3646,10 +3646,9 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
     // ((A & B) ^ B) | ((A & B) ^ A) -> A ^ B
     // (B ^ (A & B)) | (A ^ (A & B)) -> A ^ B
     const auto TryXorOpt = [&](Value *Lhs, Value *Rhs) -> Instruction * {
-      if (match(Lhs, m_OneUse(m_c_Xor(m_And(m_Value(A), m_Value(B)),
-                                      m_Deferred(A)))) &&
-          match(Rhs, m_OneUse(m_c_Xor(m_And(m_Specific(A), m_Specific(B)),
-                                      m_Deferred(B))))) {
+      if (match(Lhs, m_c_Xor(m_And(m_Value(A), m_Value(B)), m_Deferred(A))) &&
+          match(Rhs,
+                m_c_Xor(m_And(m_Specific(A), m_Specific(B)), m_Deferred(B)))) {
         return BinaryOperator::CreateXor(A, B);
       }
       return nullptr;

--- a/llvm/test/Transforms/InstCombine/or-xor-xor.ll
+++ b/llvm/test/Transforms/InstCombine/or-xor-xor.ll
@@ -97,11 +97,10 @@ define i3 @or_xor_xor_normal_multiple_uses_and(i3 %a, i3 %b) {
 
 define i32 @or_xor_xor_negative_multiple_uses_xor1(i32 %a, i32 %b) {
 ; CHECK-LABEL: @or_xor_xor_negative_multiple_uses_xor1(
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    [[XOR1:%.*]] = xor i32 [[AND]], [[B]]
+; CHECK-NEXT:    [[AND1:%.*]] = xor i32 [[A:%.*]], -1
+; CHECK-NEXT:    [[XOR1:%.*]] = and i32 [[AND1]], [[B:%.*]]
 ; CHECK-NEXT:    call void @use.i32(i32 [[XOR1]])
-; CHECK-NEXT:    [[XOR2:%.*]] = xor i32 [[AND]], [[A]]
-; CHECK-NEXT:    [[OR:%.*]] = or i32 [[XOR1]], [[XOR2]]
+; CHECK-NEXT:    [[OR:%.*]] = xor i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i32 [[OR]]
 ;
   %and = and i32 %a, %b
@@ -114,11 +113,10 @@ define i32 @or_xor_xor_negative_multiple_uses_xor1(i32 %a, i32 %b) {
 
 define i5 @or_xor_xor_negative_multiple_uses_xor2(i5 %a, i5 %b) {
 ; CHECK-LABEL: @or_xor_xor_negative_multiple_uses_xor2(
-; CHECK-NEXT:    [[AND:%.*]] = and i5 [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    [[XOR1:%.*]] = xor i5 [[AND]], [[B]]
-; CHECK-NEXT:    [[XOR2:%.*]] = xor i5 [[AND]], [[A]]
+; CHECK-NEXT:    [[A1:%.*]] = xor i5 [[B:%.*]], -1
+; CHECK-NEXT:    [[XOR2:%.*]] = and i5 [[A1]], [[A:%.*]]
 ; CHECK-NEXT:    call void @use.i5(i5 [[XOR2]])
-; CHECK-NEXT:    [[OR:%.*]] = or i5 [[XOR1]], [[XOR2]]
+; CHECK-NEXT:    [[OR:%.*]] = xor i5 [[A]], [[B]]
 ; CHECK-NEXT:    ret i5 [[OR]]
 ;
   %and = and i5 %a, %b


### PR DESCRIPTION
This removes a oneUse check, that is actually unecessary (see Alive2 link).

Alive2: https://alive2.llvm.org/ce/z/qEkUEf
Original patch: https://reviews.llvm.org/D159380