### PR TITLE
[DX] Support pipeline state masks

### DIFF
--- a/llvm/include/llvm/MC/DXContainerPSVInfo.h
+++ b/llvm/include/llvm/MC/DXContainerPSVInfo.h
@@ -51,6 +51,18 @@ struct PSVRuntimeInfo {
   SmallVector<PSVSignatureElement> OutputElements;
   SmallVector<PSVSignatureElement> PatchOrPrimElements;
 
+  // The interface here is bad, and we'll want to change this in the future. We
+  // probably will want to build out these mask vectors as vectors of bools and
+  // have this utility object convert them to the bit masks. I don't want to
+  // over-engineer this API now since we don't know what the data coming in to
+  // feed it will look like, so I kept it extremely simple for the immediate use
+  // case.
+  SmallVector<uint32_t> OutputVectorMasks[4];
+  SmallVector<uint32_t> PatchOrPrimMasks;
+  SmallVector<uint32_t> InputOutputMap[4];
+  SmallVector<uint32_t> InputPatchMap;
+  SmallVector<uint32_t> PatchOutputMap;
+
   // Serialize PSVInfo into the provided raw_ostream. The version field
   // specifies the data version to encode, the default value specifies encoding
   // the highest supported version.

--- a/llvm/include/llvm/MC/DXContainerPSVInfo.h
+++ b/llvm/include/llvm/MC/DXContainerPSVInfo.h
@@ -14,6 +14,7 @@
 #include "llvm/BinaryFormat/DXContainer.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include <array>
 #include <numeric>
 #include <stdint.h>
 
@@ -51,15 +52,16 @@ struct PSVRuntimeInfo {
   SmallVector<PSVSignatureElement> OutputElements;
   SmallVector<PSVSignatureElement> PatchOrPrimElements;
 
+  // TODO: Make this interface user-friendly.
   // The interface here is bad, and we'll want to change this in the future. We
   // probably will want to build out these mask vectors as vectors of bools and
   // have this utility object convert them to the bit masks. I don't want to
   // over-engineer this API now since we don't know what the data coming in to
   // feed it will look like, so I kept it extremely simple for the immediate use
   // case.
-  SmallVector<uint32_t> OutputVectorMasks[4];
+  std::array<SmallVector<uint32_t>, 4> OutputVectorMasks;
   SmallVector<uint32_t> PatchOrPrimMasks;
-  SmallVector<uint32_t> InputOutputMap[4];
+  std::array<SmallVector<uint32_t>, 4> InputOutputMap;
   SmallVector<uint32_t> InputPatchMap;
   SmallVector<uint32_t> PatchOutputMap;
 

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/TargetParser/Triple.h"
+#include <array>
 #include <variant>
 
 namespace llvm {
@@ -132,9 +133,9 @@ class PSVRuntimeInfo {
   SigElementArray SigOutputElements;
   SigElementArray SigPatchOrPrimElements;
 
-  ViewArray<uint32_t> OutputVectorMasks[4];
+  std::array<ViewArray<uint32_t>, 4> OutputVectorMasks;
   ViewArray<uint32_t> PatchOrPrimMasks;
-  ViewArray<uint32_t> InputOutputMap[4];
+  std::array<ViewArray<uint32_t>, 4> InputOutputMap;
   ViewArray<uint32_t> InputPatchMap;
   ViewArray<uint32_t> PatchOutputMap;
 

--- a/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
+++ b/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
@@ -113,6 +113,13 @@ struct PSVInfo {
   SmallVector<SignatureElement> SigOutputElements;
   SmallVector<SignatureElement> SigPatchOrPrimElements;
 
+  using MaskVector = SmallVector<llvm::yaml::Hex32>;
+  MaskVector OutputVectorMasks[4];
+  MaskVector PatchOrPrimMasks;
+  MaskVector InputOutputMap[4];
+  MaskVector InputPatchMap;
+  MaskVector PatchOutputMap;
+
   void mapInfoForVersion(yaml::IO &IO);
 
   PSVInfo();
@@ -143,6 +150,7 @@ struct Object {
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DXContainerYAML::Part)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DXContainerYAML::ResourceBindInfo)
 LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DXContainerYAML::SignatureElement)
+LLVM_YAML_IS_SEQUENCE_VECTOR(llvm::DXContainerYAML::PSVInfo::MaskVector)
 LLVM_YAML_DECLARE_ENUM_TRAITS(llvm::dxbc::PSV::SemanticKind)
 LLVM_YAML_DECLARE_ENUM_TRAITS(llvm::dxbc::PSV::ComponentType)
 LLVM_YAML_DECLARE_ENUM_TRAITS(llvm::dxbc::PSV::InterpolationMode)

--- a/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
+++ b/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
@@ -19,6 +19,7 @@
 #include "llvm/BinaryFormat/DXContainer.h"
 #include "llvm/ObjectYAML/YAML.h"
 #include "llvm/Support/YAMLTraits.h"
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -114,9 +115,9 @@ struct PSVInfo {
   SmallVector<SignatureElement> SigPatchOrPrimElements;
 
   using MaskVector = SmallVector<llvm::yaml::Hex32>;
-  MaskVector OutputVectorMasks[4];
+  std::array<MaskVector, 4> OutputVectorMasks;
   MaskVector PatchOrPrimMasks;
-  MaskVector InputOutputMap[4];
+  std::array<MaskVector, 4> InputOutputMap;
   MaskVector InputPatchMap;
   MaskVector PatchOutputMap;
 

--- a/llvm/include/llvm/Support/EndianStream.h
+++ b/llvm/include/llvm/Support/EndianStream.h
@@ -26,6 +26,15 @@ namespace support {
 namespace endian {
 
 template <typename value_type>
+inline void write_array(raw_ostream &os, ArrayRef<value_type> values,
+                        endianness endian) {
+  for (const auto orig : values) {
+    value_type value = byte_swap<value_type>(orig, endian);
+    os.write((const char *)&value, sizeof(value_type));
+  }
+}
+
+template <typename value_type>
 inline void write(raw_ostream &os, value_type value, endianness endian) {
   value = byte_swap<value_type>(value, endian);
   os.write((const char *)&value, sizeof(value_type));

--- a/llvm/lib/MC/DXContainerPSVInfo.cpp
+++ b/llvm/lib/MC/DXContainerPSVInfo.cpp
@@ -147,4 +147,17 @@ void PSVRuntimeInfo::write(raw_ostream &OS, uint32_t Version) const {
     OS.write(reinterpret_cast<const char *>(&SignatureElements[0]),
              SignatureElements.size() * sizeof(v0::SignatureElement));
   }
+
+  for (const auto &MaskVector : OutputVectorMasks)
+    support::endian::write_array(OS, ArrayRef<uint32_t>(MaskVector),
+                                 support::little);
+  support::endian::write_array(OS, ArrayRef<uint32_t>(PatchOrPrimMasks),
+                               support::little);
+  for (const auto &MaskVector : InputOutputMap)
+    support::endian::write_array(OS, ArrayRef<uint32_t>(MaskVector),
+                                 support::little);
+  support::endian::write_array(OS, ArrayRef<uint32_t>(InputPatchMap),
+                               support::little);
+  support::endian::write_array(OS, ArrayRef<uint32_t>(PatchOutputMap),
+                               support::little);
 }

--- a/llvm/lib/Object/DXContainer.cpp
+++ b/llvm/lib/Object/DXContainer.cpp
@@ -321,6 +321,68 @@ Error DirectX::PSVRuntimeInfo::parse(uint16_t ShaderKind) {
     Current += PSize;
   }
 
+  ArrayRef<uint8_t> OutputVectorCounts = getOutputVectorCounts();
+  uint8_t PatchConstOrPrimVectorCount = getPatchConstOrPrimVectorCount();
+  uint8_t InputVectorCount = getInputVectorCount();
+
+  auto maskDwordSize = [](uint8_t Vector) {
+    return (static_cast<uint32_t>(Vector) + 7) >> 3;
+  };
+
+  auto mapTableSize = [maskDwordSize](uint8_t X, uint8_t Y) {
+    return maskDwordSize(Y) * X * 4;
+  };
+
+  if (usesViewID()) {
+    for (uint32_t I = 0; I < 4; ++I) {
+      // The vector mask is one bit per component and 4 components per vector.
+      // We can compute the number of dwords required by rounding up to the next
+      // multiple of 8.
+      uint32_t NumDwords =
+          maskDwordSize(static_cast<uint32_t>(OutputVectorCounts[I]));
+      size_t NumBytes = NumDwords * sizeof(uint32_t);
+      OutputVectorMasks[I].Data = Data.substr(Current - Data.begin(), NumBytes);
+      Current += NumBytes;
+    }
+
+    if (ShaderStage == Triple::Hull && PatchConstOrPrimVectorCount > 0) {
+      uint32_t NumDwords = maskDwordSize(PatchConstOrPrimVectorCount);
+      size_t NumBytes = NumDwords * sizeof(uint32_t);
+      PatchOrPrimMasks.Data = Data.substr(Current - Data.begin(), NumBytes);
+      Current += NumBytes;
+    }
+  }
+
+  // Input/Output mapping table
+  for (uint32_t I = 0; I < 4; ++I) {
+    if (InputVectorCount == 0 || OutputVectorCounts[I] == 0)
+      continue;
+    uint32_t NumDwords = mapTableSize(InputVectorCount, OutputVectorCounts[I]);
+    size_t NumBytes = NumDwords * sizeof(uint32_t);
+    InputOutputMap[I].Data = Data.substr(Current - Data.begin(), NumBytes);
+    Current += NumBytes;
+  }
+
+  // Hull shader: Input/Patch mapping table
+  if (ShaderStage == Triple::Hull && PatchConstOrPrimVectorCount > 0 &&
+      InputVectorCount > 0) {
+    uint32_t NumDwords =
+        mapTableSize(InputVectorCount, PatchConstOrPrimVectorCount);
+    size_t NumBytes = NumDwords * sizeof(uint32_t);
+    InputPatchMap.Data = Data.substr(Current - Data.begin(), NumBytes);
+    Current += NumBytes;
+  }
+
+  // Domain Shader: Patch/Output mapping table
+  if (ShaderStage == Triple::Domain && PatchConstOrPrimVectorCount > 0 &&
+      OutputVectorCounts[0] > 0) {
+    uint32_t NumDwords =
+        mapTableSize(PatchConstOrPrimVectorCount, OutputVectorCounts[0]);
+    size_t NumBytes = NumDwords * sizeof(uint32_t);
+    PatchOutputMap.Data = Data.substr(Current - Data.begin(), NumBytes);
+    Current += NumBytes;
+  }
+
   return Error::success();
 }
 

--- a/llvm/lib/Object/DXContainer.cpp
+++ b/llvm/lib/Object/DXContainer.cpp
@@ -334,7 +334,7 @@ Error DirectX::PSVRuntimeInfo::parse(uint16_t ShaderKind) {
   };
 
   if (usesViewID()) {
-    for (uint32_t I = 0; I < 4; ++I) {
+    for (uint32_t I = 0; I < OutputVectorCounts.size(); ++I) {
       // The vector mask is one bit per component and 4 components per vector.
       // We can compute the number of dwords required by rounding up to the next
       // multiple of 8.
@@ -354,7 +354,7 @@ Error DirectX::PSVRuntimeInfo::parse(uint16_t ShaderKind) {
   }
 
   // Input/Output mapping table
-  for (uint32_t I = 0; I < 4; ++I) {
+  for (uint32_t I = 0; I < OutputVectorCounts.size(); ++I) {
     if (InputVectorCount == 0 || OutputVectorCounts[I] == 0)
       continue;
     uint32_t NumDwords = mapTableSize(InputVectorCount, OutputVectorCounts[I]);

--- a/llvm/lib/ObjectYAML/DXContainerEmitter.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerEmitter.cpp
@@ -219,7 +219,8 @@ void DXContainerWriter::writeParts(raw_ostream &OS) {
             El.Allocated, El.Kind, El.Type, El.Mode, El.DynamicMask,
             El.Stream});
 
-      for (int I = 0; I < 4; ++I) {
+      static_assert(PSV.OutputVectorMasks.size() == PSV.InputOutputMap.size());
+      for (unsigned I = 0; I < PSV.OutputVectorMasks.size(); ++I) {
         PSV.OutputVectorMasks[I].insert(PSV.OutputVectorMasks[I].begin(),
                                         P.Info->OutputVectorMasks[I].begin(),
                                         P.Info->OutputVectorMasks[I].end());

--- a/llvm/lib/ObjectYAML/DXContainerEmitter.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerEmitter.cpp
@@ -219,6 +219,25 @@ void DXContainerWriter::writeParts(raw_ostream &OS) {
             El.Allocated, El.Kind, El.Type, El.Mode, El.DynamicMask,
             El.Stream});
 
+      for (int I = 0; I < 4; ++I) {
+        PSV.OutputVectorMasks[I].insert(PSV.OutputVectorMasks[I].begin(),
+                                        P.Info->OutputVectorMasks[I].begin(),
+                                        P.Info->OutputVectorMasks[I].end());
+        PSV.InputOutputMap[I].insert(PSV.InputOutputMap[I].begin(),
+                                     P.Info->InputOutputMap[I].begin(),
+                                     P.Info->InputOutputMap[I].end());
+      }
+
+      PSV.PatchOrPrimMasks.insert(PSV.PatchOrPrimMasks.begin(),
+                                  P.Info->PatchOrPrimMasks.begin(),
+                                  P.Info->PatchOrPrimMasks.end());
+      PSV.InputPatchMap.insert(PSV.InputPatchMap.begin(),
+                               P.Info->InputPatchMap.begin(),
+                               P.Info->InputPatchMap.end());
+      PSV.PatchOutputMap.insert(PSV.PatchOutputMap.begin(),
+                                P.Info->PatchOutputMap.begin(),
+                                P.Info->PatchOutputMap.end());
+
       PSV.finalize(static_cast<Triple::EnvironmentType>(
           Triple::Pixel + P.Info->Info.ShaderStage));
       PSV.write(OS, P.Info->Version);

--- a/llvm/lib/ObjectYAML/DXContainerYAML.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerYAML.cpp
@@ -139,6 +139,24 @@ void MappingTraits<DXContainerYAML::PSVInfo>::mapping(
   IO.mapRequired("SigInputElements", PSV.SigInputElements);
   IO.mapRequired("SigOutputElements", PSV.SigOutputElements);
   IO.mapRequired("SigPatchOrPrimElements", PSV.SigPatchOrPrimElements);
+
+  Triple::EnvironmentType Stage = dxbc::getShaderStage(PSV.Info.ShaderStage);
+  if (PSV.Info.UsesViewID) {
+    MutableArrayRef<SmallVector<llvm::yaml::Hex32>> MutableOutMasks(
+        PSV.OutputVectorMasks);
+    IO.mapRequired("OutputVectorMasks", MutableOutMasks);
+    if (Stage == Triple::EnvironmentType::Hull)
+      IO.mapRequired("PatchOrPrimMasks", PSV.PatchOrPrimMasks);
+  }
+  MutableArrayRef<SmallVector<llvm::yaml::Hex32>> MutableIOMap(
+      PSV.InputOutputMap);
+  IO.mapRequired("InputOutputMap", MutableIOMap);
+
+  if (Stage == Triple::EnvironmentType::Hull)
+    IO.mapRequired("InputPatchMap", PSV.InputPatchMap);
+
+  if (Stage == Triple::EnvironmentType::Domain)
+    IO.mapRequired("PatchOutputMap", PSV.PatchOutputMap);
 }
 
 void MappingTraits<DXContainerYAML::Part>::mapping(IO &IO,

--- a/llvm/test/ObjectYAML/DXContainer/DomainMaskVectors.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/DomainMaskVectors.yaml
@@ -1,0 +1,200 @@
+# RUN: yaml2obj %s | obj2yaml | FileCheck %s
+--- !dxcontainer
+Header:
+  Hash:            [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                     0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+  Version:
+    Major:           1
+    Minor:           0
+  FileSize:        4616
+  PartCount:       8
+  PartOffsets:     [ 64, 80, 140, 200, 580, 952, 2756, 2784 ]
+Parts:
+  - Name:            SFI0
+    Size:            8
+    Flags:
+      Doubles:         false
+      ComputeShadersPlusRawAndStructuredBuffers: false
+      UAVsAtEveryStage: false
+      Max64UAVs:       false
+      MinimumPrecision: false
+      DX11_1_DoubleExtensions: false
+      DX11_1_ShaderExtensions: false
+      LEVEL9ComparisonFiltering: false
+      TiledResources:  false
+      StencilRef:      false
+      InnerCoverage:   false
+      TypedUAVLoadAdditionalFormats: false
+      ROVs:            false
+      ViewportAndRTArrayIndexFromAnyShaderFeedingRasterizer: false
+      WaveOps:         false
+      Int64Ops:        false
+      ViewID:          true
+      Barycentrics:    false
+      NativeLowPrecision: false
+      ShadingRate:     false
+      Raytracing_Tier_1_1: false
+      SamplerFeedback: false
+      AtomicInt64OnTypedResource: false
+      AtomicInt64OnGroupShared: false
+      DerivativesInMeshAndAmpShaders: false
+      ResourceDescriptorHeapIndexing: false
+      SamplerDescriptorHeapIndexing: false
+      RESERVED:        false
+      AtomicInt64OnHeapResource: false
+      AdvancedTextureOps: false
+      WriteableMSAATextures: false
+      NextUnusedBit:   false
+  - Name:            ISG1
+    Size:            52
+  - Name:            OSG1
+    Size:            52
+  - Name:            PSG1
+    Size:            372
+  - Name:            PSV0
+    Size:            364
+    PSVInfo:
+      Version:         2
+      ShaderStage:     4
+      InputControlPointCount: 16
+      OutputPositionPresent: 1
+      TessellatorDomain: 3
+      MinimumWaveLaneCount: 0
+      MaximumWaveLaneCount: 4294967295
+      UsesViewID:      1
+      SigPatchConstOrPrimVectors: 7
+      SigInputVectors: 1
+      SigOutputVectors: [ 1, 0, 0, 0 ]
+      NumThreadsX:     0
+      NumThreadsY:     0
+      NumThreadsZ:     0
+      ResourceStride:  24
+      Resources:
+        - Type:            2
+          Space:           0
+          LowerBound:      0
+          UpperBound:      0
+          Kind:            13
+          Flags:           0
+      SigInputElements:
+        - Name:            AAA_HSFoo
+          Indices:         [ 0 ]
+          StartRow:        0
+          Cols:            3
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Linear
+          DynamicMask:     0x0
+          Stream:          0
+      SigOutputElements:
+        - Name:            ''
+          Indices:         [ 0 ]
+          StartRow:        0
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Position
+          ComponentType:   Float32
+          Interpolation:   LinearNoperspective
+          DynamicMask:     0x0
+          Stream:          0
+      SigPatchOrPrimElements:
+        - Name:            ''
+          Indices:         [ 0, 1, 2, 3 ]
+          StartRow:        0
+          Cols:            1
+          StartCol:        3
+          Allocated:       true
+          Kind:            TessFactor
+          ComponentType:   Float32
+          Interpolation:   Undefined
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            ''
+          Indices:         [ 0, 1 ]
+          StartRow:        4
+          Cols:            1
+          StartCol:        3
+          Allocated:       true
+          Kind:            InsideTessFactor
+          ComponentType:   Float32
+          Interpolation:   Undefined
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            AAA
+          Indices:         [ 0 ]
+          StartRow:        6
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Undefined
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            BBB
+          Indices:         [ 0, 1, 2 ]
+          StartRow:        0
+          Cols:            3
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Undefined
+          DynamicMask:     0x0
+          Stream:          0
+      OutputVectorMasks:
+        - [ 0x1 ]
+        - [  ]
+        - [  ]
+        - [  ]
+      InputOutputMap:
+        - [ 0x0, 0xD, 0x0, 0x0 ]
+        - [  ]
+        - [  ]
+        - [  ]
+      PatchOutputMap:  [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 
+                         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x0 ]
+  - Name:            STAT
+    Size:            1796
+  - Name:            HASH
+    Size:            20
+    Hash:
+      IncludesSource:  false
+      Digest:          [ 0xD4, 0x48, 0xCB, 0xFE, 0xF9, 0xCD, 0x92, 0x7B, 
+                         0xBD, 0x2B, 0x9A, 0x9D, 0xB4, 0x6F, 0x3E, 0x83 ]
+  - Name:            DXIL
+    Size:            24
+    Program:
+      MajorVersion:    6
+      MinorVersion:    1
+      ShaderKind:      4
+      Size:            6
+      DXILMajorVersion: 1
+      DXILMinorVersion: 1
+      DXILSize:        0
+...
+
+# Verify the vector sizes and ViewID use.
+# CHECK: UsesViewID:      1
+# CHECK-NEXT: SigPatchConstOrPrimVectors: 7
+# CHECK-NEXT: SigInputVectors: 1
+# CHECK-NEXT: SigOutputVectors: [ 1, 0, 0, 0 ]
+
+# Verify the vector mask encodings.
+# CHECK: OutputVectorMasks:
+# CHECK-NEXT:   - [ 0x1 ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [ 0x0, 0xD, 0x0, 0x0 ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: PatchOutputMap:  [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 
+# CHECK-NEXT:                    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
+# CHECK-NEXT:                    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x0 ]

--- a/llvm/test/ObjectYAML/DXContainer/GeometryMaskVectors.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/GeometryMaskVectors.yaml
@@ -1,0 +1,174 @@
+# RUN: yaml2obj %s | obj2yaml | FileCheck %s
+--- !dxcontainer
+Header:
+  Hash:            [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                     0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+  Version:
+    Major:           1
+    Minor:           0
+  FileSize:        3836
+  PartCount:       7
+  PartOffsets:     [ 60, 76, 204, 292, 584, 2092, 2120 ]
+Parts:
+  - Name:            SFI0
+    Size:            8
+    Flags:
+      Doubles:         false
+      ComputeShadersPlusRawAndStructuredBuffers: false
+      UAVsAtEveryStage: false
+      Max64UAVs:       false
+      MinimumPrecision: false
+      DX11_1_DoubleExtensions: false
+      DX11_1_ShaderExtensions: false
+      LEVEL9ComparisonFiltering: false
+      TiledResources:  false
+      StencilRef:      false
+      InnerCoverage:   false
+      TypedUAVLoadAdditionalFormats: false
+      ROVs:            false
+      ViewportAndRTArrayIndexFromAnyShaderFeedingRasterizer: false
+      WaveOps:         false
+      Int64Ops:        false
+      ViewID:          true
+      Barycentrics:    false
+      NativeLowPrecision: false
+      ShadingRate:     false
+      Raytracing_Tier_1_1: false
+      SamplerFeedback: false
+      AtomicInt64OnTypedResource: false
+      AtomicInt64OnGroupShared: false
+      DerivativesInMeshAndAmpShaders: false
+      ResourceDescriptorHeapIndexing: false
+      SamplerDescriptorHeapIndexing: false
+      RESERVED:        false
+      AtomicInt64OnHeapResource: false
+      AdvancedTextureOps: false
+      WriteableMSAATextures: false
+      NextUnusedBit:   false
+  - Name:            ISG1
+    Size:            120
+  - Name:            OSG1
+    Size:            80
+  - Name:            PSV0
+    Size:            284
+    PSVInfo:
+      Version:         2
+      ShaderStage:     2
+      InputPrimitive:  3
+      OutputTopology:  1
+      OutputStreamMask: 3
+      OutputPositionPresent: 0
+      MinimumWaveLaneCount: 0
+      MaximumWaveLaneCount: 4294967295
+      UsesViewID:      1
+      MaxVertexCount:  3
+      SigInputVectors: 3
+      SigOutputVectors: [ 1, 1, 0, 0 ]
+      NumThreadsX:     0
+      NumThreadsY:     0
+      NumThreadsZ:     0
+      ResourceStride:  24
+      Resources:       []
+      SigInputElements:
+        - Name:            ''
+          Indices:         [ 0 ]
+          StartRow:        0
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Position
+          ComponentType:   Float32
+          Interpolation:   LinearNoperspective
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            AAA
+          Indices:         [ 2 ]
+          StartRow:        1
+          Cols:            2
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Linear
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            AAA
+          Indices:         [ 3 ]
+          StartRow:        2
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Linear
+          DynamicMask:     0x0
+          Stream:          0
+      SigOutputElements:
+        - Name:            BBB
+          Indices:         [ 0 ]
+          StartRow:        0
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Linear
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            CCC
+          Indices:         [ 0 ]
+          StartRow:        0
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Linear
+          DynamicMask:     0x0
+          Stream:          1
+      SigPatchOrPrimElements: []
+      OutputVectorMasks:
+        - [ 0xE ]
+        - [ 0x5 ]
+        - [  ]
+        - [  ]
+      InputOutputMap:
+        - [ 0x2, 0x4, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+        - [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x2, 0x4, 0x8 ]
+        - [  ]
+        - [  ]
+  - Name:            STAT
+    Size:            1500
+  - Name:            HASH
+    Size:            20
+    Hash:
+      IncludesSource:  false
+      Digest:          [ 0x10, 0xA2, 0x84, 0xA5, 0x76, 0xA6, 0x28, 0x82, 
+                         0x21, 0x39, 0x1, 0xE0, 0x53, 0x19, 0xBE, 0x79 ]
+  - Name:            DXIL
+    Size:            24
+    Program:
+      MajorVersion:    6
+      MinorVersion:    1
+      ShaderKind:      2
+      Size:            6
+      DXILMajorVersion: 1
+      DXILMinorVersion: 1
+      DXILSize:        0
+...
+
+# Verify the vector sizes.
+# CHECK: SigInputVectors: 3
+# CHECK-NEXT: SigOutputVectors: [ 1, 1, 0, 0 ]
+
+# Verify the vector mask encodings.
+# CHECK: OutputVectorMasks:
+# CHECK-NEXT:   - [ 0xE ]
+# CHECK-NEXT:   - [ 0x5 ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [ 0x2, 0x4, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+# CHECK-NEXT:   - [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x2, 0x4, 0x8 ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]

--- a/llvm/test/ObjectYAML/DXContainer/HullMaskVectors.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/HullMaskVectors.yaml
@@ -1,0 +1,181 @@
+# RUN: yaml2obj %s | obj2yaml | FileCheck %s
+--- !dxcontainer
+Header:
+  Hash:            [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
+                     0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+  Version:
+    Major:           1
+    Minor:           0
+  FileSize:        4612
+  PartCount:       8
+  PartOffsets:     [ 64, 80, 148, 208, 488, 740, 2468, 2496 ]
+Parts:
+  - Name:            SFI0
+    Size:            8
+    Flags:
+      Doubles:         false
+      ComputeShadersPlusRawAndStructuredBuffers: false
+      UAVsAtEveryStage: false
+      Max64UAVs:       false
+      MinimumPrecision: false
+      DX11_1_DoubleExtensions: false
+      DX11_1_ShaderExtensions: false
+      LEVEL9ComparisonFiltering: false
+      TiledResources:  false
+      StencilRef:      false
+      InnerCoverage:   false
+      TypedUAVLoadAdditionalFormats: false
+      ROVs:            false
+      ViewportAndRTArrayIndexFromAnyShaderFeedingRasterizer: false
+      WaveOps:         false
+      Int64Ops:        false
+      ViewID:          true
+      Barycentrics:    false
+      NativeLowPrecision: false
+      ShadingRate:     false
+      Raytracing_Tier_1_1: false
+      SamplerFeedback: false
+      AtomicInt64OnTypedResource: false
+      AtomicInt64OnGroupShared: false
+      DerivativesInMeshAndAmpShaders: false
+      ResourceDescriptorHeapIndexing: false
+      SamplerDescriptorHeapIndexing: false
+      RESERVED:        false
+      AtomicInt64OnHeapResource: false
+      AdvancedTextureOps: false
+      WriteableMSAATextures: false
+      NextUnusedBit:   false
+  - Name:            ISG1
+    Size:            60
+  - Name:            OSG1
+    Size:            52
+  - Name:            PSG1
+    Size:            272
+  - Name:            PSV0
+    Size:            244
+    PSVInfo:
+      Version:         2
+      ShaderStage:     3
+      InputControlPointCount: 32
+      OutputControlPointCount: 16
+      TessellatorDomain: 3
+      TessellatorOutputPrimitive: 3
+      MinimumWaveLaneCount: 0
+      MaximumWaveLaneCount: 4294967295
+      UsesViewID:      1
+      SigPatchConstOrPrimVectors: 7
+      SigInputVectors: 1
+      SigOutputVectors: [ 1, 0, 0, 0 ]
+      NumThreadsX:     0
+      NumThreadsY:     0
+      NumThreadsZ:     0
+      ResourceStride:  24
+      Resources:       []
+      SigInputElements:
+        - Name:            Sem_HSFoo_Input_qq
+          Indices:         [ 0 ]
+          StartRow:        0
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Linear
+          DynamicMask:     0x0
+          Stream:          0
+      SigOutputElements:
+        - Name:            Sem_HSFoo
+          Indices:         [ 0 ]
+          StartRow:        0
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Linear
+          DynamicMask:     0x0
+          Stream:          0
+      SigPatchOrPrimElements:
+        - Name:            ''
+          Indices:         [ 0, 1, 2, 3 ]
+          StartRow:        0
+          Cols:            1
+          StartCol:        3
+          Allocated:       true
+          Kind:            TessFactor
+          ComponentType:   Float32
+          Interpolation:   Undefined
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            ''
+          Indices:         [ 0, 1 ]
+          StartRow:        4
+          Cols:            1
+          StartCol:        3
+          Allocated:       true
+          Kind:            InsideTessFactor
+          ComponentType:   Float32
+          Interpolation:   Undefined
+          DynamicMask:     0x0
+          Stream:          0
+        - Name:            AAA
+          Indices:         [ 0 ]
+          StartRow:        6
+          Cols:            4
+          StartCol:        0
+          Allocated:       true
+          Kind:            Arbitrary
+          ComponentType:   Float32
+          Interpolation:   Undefined
+          DynamicMask:     0x0
+          Stream:          0
+      OutputVectorMasks:
+        - [ 0x4 ]
+        - [  ]
+        - [  ]
+        - [  ]
+      PatchOrPrimMasks: [ 0x800080 ]
+      InputOutputMap:
+        - [ 0x5, 0x2, 0x4, 0xC ]
+        - [  ]
+        - [  ]
+        - [  ]
+      InputPatchMap:   [ 0x880000, 0x8888, 0x800000, 0x880000 ]
+  - Name:            STAT
+    Size:            1720
+  - Name:            HASH
+    Size:            20
+    Hash:
+      IncludesSource:  false
+      Digest:          [ 0xF4, 0x87, 0x4C, 0x40, 0xFD, 0x7A, 0x89, 0xFE, 
+                         0x1F, 0xC3, 0xAB, 0x8C, 0xC7, 0x18, 0xA9, 0xA ]
+  - Name:            DXIL
+    Size:            24
+    Program:
+      MajorVersion:    6
+      MinorVersion:    1
+      ShaderKind:      3
+      Size:            5627
+      DXILMajorVersion: 1
+      DXILMinorVersion: 1
+      DXILSize:        0
+...
+
+# Verify the vector sizes and ViewID use.
+# CHECK: UsesViewID:      1
+# CHECK-NEXT: SigPatchConstOrPrimVectors: 7
+# CHECK-NEXT: SigInputVectors: 1
+# CHECK-NEXT: SigOutputVectors: [ 1, 0, 0, 0 ]
+
+# Verify the vector encodings.
+# CHECK: OutputVectorMasks:
+# CHECK-NEXT:   - [ 0x4 ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: PatchOrPrimMasks: [ 0x800080 ]
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [ 0x5, 0x2, 0x4, 0xC ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-amplification.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-amplification.yaml
@@ -17,8 +17,8 @@ Parts:
       PayloadSizeInBytes: 4092
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
@@ -33,6 +33,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -52,8 +57,8 @@ Parts:
 # CHECK-NEXT: PayloadSizeInBytes: 4092
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
@@ -68,4 +73,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-compute.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-compute.yaml
@@ -16,8 +16,8 @@ Parts:
       ShaderStage:     5
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
@@ -32,6 +32,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -50,8 +55,8 @@ Parts:
 # CHECK-NEXT: ShaderStage:     5
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
@@ -66,4 +71,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-domain.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-domain.yaml
@@ -19,10 +19,10 @@ Parts:
       TessellatorDomain: 2056
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigPatchConstOrPrimVectors:  128
-      SigInputVectors: 64
-      SigOutputVectors: [ 8, 16, 32, 64 ]
+      UsesViewID:      0
+      SigPatchConstOrPrimVectors:  0
+      SigInputVectors: 0
+      SigOutputVectors: [ 0, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
         - Type:            1
@@ -36,6 +36,12 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
+      PatchOutputMap: []
   - Name:            DXIL
     Size:            24
     Program:
@@ -57,10 +63,10 @@ Parts:
 # CHECK-NEXT: TessellatorDomain: 2056
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigPatchConstOrPrimVectors:  128
-# CHECK-NEXT: SigInputVectors: 64
-# CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigPatchConstOrPrimVectors:  0
+# CHECK-NEXT: SigInputVectors: 0
+# CHECK-NEXT: SigOutputVectors: [ 0, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
 # CHECK-NEXT: - Type:            1
@@ -74,4 +80,10 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: PatchOutputMap: [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-geometry.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-geometry.yaml
@@ -20,9 +20,9 @@ Parts:
       OutputPositionPresent: 1
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
+      UsesViewID:      0
       MaxVertexCount:  4096
-      SigInputVectors: 64
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
@@ -37,6 +37,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -59,9 +64,9 @@ Parts:
 # CHECK-NEXT: OutputPositionPresent: 1
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
+# CHECK-NEXT: UsesViewID:      0
 # CHECK-NEXT: MaxVertexCount:  4096
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
@@ -76,4 +81,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-hull.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-hull.yaml
@@ -20,10 +20,10 @@ Parts:
       TessellatorOutputPrimitive: 8192
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigPatchConstOrPrimVectors:  128
-      SigInputVectors: 64
-      SigOutputVectors: [ 8, 16, 32, 64 ]
+      UsesViewID:      0
+      SigPatchConstOrPrimVectors:  0
+      SigInputVectors: 0
+      SigOutputVectors: [ 0, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
         - Type:            1
@@ -37,6 +37,12 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
+      InputPatchMap: []
   - Name:            DXIL
     Size:            24
     Program:
@@ -59,10 +65,10 @@ Parts:
 # CHECK-NEXT: TessellatorOutputPrimitive: 8192
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigPatchConstOrPrimVectors:  128
-# CHECK-NEXT: SigInputVectors: 64
-# CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigPatchConstOrPrimVectors:  0
+# CHECK-NEXT: SigInputVectors: 0
+# CHECK-NEXT: SigOutputVectors: [ 0, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
 # CHECK-NEXT: - Type:            1
@@ -76,4 +82,10 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: InputPatchMap: [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-mesh.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-mesh.yaml
@@ -21,10 +21,10 @@ Parts:
       MaxOutputPrimitives: 4092
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
+      UsesViewID:      0
       SigPrimVectors:  128
       MeshOutputTopology: 16
-      SigInputVectors: 64
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
@@ -39,6 +39,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -62,10 +67,10 @@ Parts:
 # CHECK-NEXT: MaxOutputPrimitives: 4092
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
+# CHECK-NEXT: UsesViewID:      0
 # CHECK-NEXT: SigPrimVectors:  128
 # CHECK-NEXT: MeshOutputTopology: 16
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
@@ -80,4 +85,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-pixel.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-pixel.yaml
@@ -18,8 +18,8 @@ Parts:
       SampleFrequency: 96
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
@@ -34,6 +34,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -54,8 +59,8 @@ Parts:
 # CHECK-NEXT: SampleFrequency: 96
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
@@ -70,4 +75,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv1-vertex.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv1-vertex.yaml
@@ -17,8 +17,8 @@ Parts:
       OutputPositionPresent: 1
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
@@ -33,6 +33,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -52,8 +57,8 @@ Parts:
 # CHECK-NEXT: OutputPositionPresent: 1
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: ResourceStride: 16
 # CHECK-NEXT: Resources:
@@ -68,4 +73,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-amplification.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-amplification.yaml
@@ -17,8 +17,8 @@ Parts:
       PayloadSizeInBytes: 4092
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
@@ -40,6 +40,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -59,8 +64,8 @@ Parts:
 # CHECK-NEXT: PayloadSizeInBytes: 4092
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
@@ -82,4 +87,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-compute.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-compute.yaml
@@ -16,8 +16,8 @@ Parts:
       ShaderStage:     5
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
@@ -39,6 +39,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -57,8 +62,8 @@ Parts:
 # CHECK-NEXT: ShaderStage:     5
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
@@ -80,4 +85,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-domain.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-domain.yaml
@@ -19,10 +19,10 @@ Parts:
       TessellatorDomain: 2056
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigPatchConstOrPrimVectors:  128
-      SigInputVectors: 64
-      SigOutputVectors: [ 8, 16, 32, 64 ]
+      UsesViewID:      0
+      SigPatchConstOrPrimVectors:  0
+      SigInputVectors: 0
+      SigOutputVectors: [ 0, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
       NumThreadsZ:     2048
@@ -43,6 +43,12 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
+      PatchOutputMap: []
   - Name:            DXIL
     Size:            24
     Program:
@@ -64,10 +70,10 @@ Parts:
 # CHECK-NEXT: TessellatorDomain: 2056
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigPatchConstOrPrimVectors:  128
-# CHECK-NEXT: SigInputVectors: 64
-# CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigPatchConstOrPrimVectors:  0
+# CHECK-NEXT: SigInputVectors: 0
+# CHECK-NEXT: SigOutputVectors: [ 0, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
 # CHECK-NEXT: NumThreadsZ:     2048
@@ -88,4 +94,10 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: PatchOutputMap: [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-geometry.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-geometry.yaml
@@ -20,9 +20,9 @@ Parts:
       OutputPositionPresent: 1
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
+      UsesViewID:      0
       MaxVertexCount:  4096
-      SigInputVectors: 64
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
@@ -44,6 +44,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -66,9 +71,9 @@ Parts:
 # CHECK-NEXT: OutputPositionPresent: 1
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
+# CHECK-NEXT: UsesViewID:      0
 # CHECK-NEXT: MaxVertexCount:  4096
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
@@ -90,4 +95,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-hull.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-hull.yaml
@@ -20,10 +20,10 @@ Parts:
       TessellatorOutputPrimitive: 8192
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigPatchConstOrPrimVectors:  128
-      SigInputVectors: 64
-      SigOutputVectors: [ 8, 16, 32, 64 ]
+      UsesViewID:      0
+      SigPatchConstOrPrimVectors:  0
+      SigInputVectors: 0
+      SigOutputVectors: [ 0, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
       NumThreadsZ:     2048
@@ -44,6 +44,12 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
+      InputPatchMap: []
   - Name:            DXIL
     Size:            24
     Program:
@@ -66,10 +72,10 @@ Parts:
 # CHECK-NEXT: TessellatorOutputPrimitive: 8192
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigPatchConstOrPrimVectors:  128
-# CHECK-NEXT: SigInputVectors: 64
-# CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigPatchConstOrPrimVectors:  0
+# CHECK-NEXT: SigInputVectors: 0
+# CHECK-NEXT: SigOutputVectors: [ 0, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
 # CHECK-NEXT: NumThreadsZ:     2048
@@ -90,4 +96,10 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT: InputPatchMap: [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-mesh.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-mesh.yaml
@@ -21,10 +21,10 @@ Parts:
       MaxOutputPrimitives: 4092
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
+      UsesViewID:      0
       SigPrimVectors:  128
       MeshOutputTopology: 16
-      SigInputVectors: 64
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
@@ -46,6 +46,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -69,10 +74,10 @@ Parts:
 # CHECK-NEXT: MaxOutputPrimitives: 4092
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
+# CHECK-NEXT: UsesViewID:      0
 # CHECK-NEXT: SigPrimVectors:  128
 # CHECK-NEXT: MeshOutputTopology: 16
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
@@ -94,4 +99,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-pixel.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-pixel.yaml
@@ -18,8 +18,8 @@ Parts:
       SampleFrequency: 96
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
@@ -41,6 +41,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -61,8 +66,8 @@ Parts:
 # CHECK-NEXT: SampleFrequency: 96
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
@@ -84,4 +89,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/PSVv2-vertex.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/PSVv2-vertex.yaml
@@ -17,8 +17,8 @@ Parts:
       OutputPositionPresent: 1
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       NumThreadsX:     512
       NumThreadsY:     1024
@@ -40,6 +40,11 @@ Parts:
       SigInputElements: []
       SigOutputElements: []
       SigPatchOrPrimElements: []
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:
@@ -59,8 +64,8 @@ Parts:
 # CHECK-NEXT: OutputPositionPresent: 1
 # CHECK-NEXT: MinimumWaveLaneCount: 0
 # CHECK-NEXT: MaximumWaveLaneCount: 4294967295
-# CHECK-NEXT: UsesViewID:      128
-# CHECK-NEXT: SigInputVectors: 64
+# CHECK-NEXT: UsesViewID:      0
+# CHECK-NEXT: SigInputVectors: 0
 # CHECK-NEXT: SigOutputVectors: [ 8, 16, 32, 64 ]
 # CHECK-NEXT: NumThreadsX:     512
 # CHECK-NEXT: NumThreadsY:     1024
@@ -82,4 +87,9 @@ Parts:
 # CHECK-NEXT: SigInputElements: []
 # CHECK-NEXT: SigOutputElements: []
 # CHECK-NEXT: SigPatchOrPrimElements: []
+# CHECK-NEXT: InputOutputMap:
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
+# CHECK-NEXT:   - [  ]
 # CHECK-NEXT: Name

--- a/llvm/test/ObjectYAML/DXContainer/SigElements.yaml
+++ b/llvm/test/ObjectYAML/DXContainer/SigElements.yaml
@@ -18,8 +18,8 @@ Parts:
       SampleFrequency: 96
       MinimumWaveLaneCount: 0
       MaximumWaveLaneCount: 4294967295
-      UsesViewID:      128
-      SigInputVectors: 64
+      UsesViewID:      0
+      SigInputVectors: 0
       SigOutputVectors: [ 8, 16, 32, 64 ]
       ResourceStride:       16
       Resources:
@@ -78,6 +78,11 @@ Parts:
           Interpolation:   LinearSample
           DynamicMask:     0x2
           Stream:          3
+      InputOutputMap:
+        - [  ]
+        - [  ]
+        - [  ]
+        - [  ]
   - Name:            DXIL
     Size:            24
     Program:

--- a/llvm/tools/obj2yaml/dxcontainer2yaml.cpp
+++ b/llvm/tools/obj2yaml/dxcontainer2yaml.cpp
@@ -108,6 +108,25 @@ dumpDXContainer(MemoryBufferRef Source) {
             DXContainerYAML::SignatureElement(
                 El, PSVInfo->getStringTable(),
                 PSVInfo->getSemanticIndexTable()));
+
+      if (PSVInfo->usesViewID()) {
+        for (int I = 0; I < 4; ++I)
+          for (auto Mask : PSVInfo->getOutputVectorMasks(I))
+            NewPart.Info->OutputVectorMasks[I].push_back(Mask);
+        for (auto Mask : PSVInfo->getPatchOrPrimMasks())
+          NewPart.Info->PatchOrPrimMasks.push_back(Mask);
+      }
+
+      for (int I = 0; I < 4; ++I)
+        for (auto Mask : PSVInfo->getInputOutputMap(I))
+          NewPart.Info->InputOutputMap[I].push_back(Mask);
+
+      for (auto Mask : PSVInfo->getInputPatchMap())
+        NewPart.Info->InputPatchMap.push_back(Mask);
+
+      for (auto Mask : PSVInfo->getPatchOutputMap())
+        NewPart.Info->PatchOutputMap.push_back(Mask);
+
       break;
     }
     case dxbc::PartType::Unknown:


### PR DESCRIPTION
The DXContainer pipeline state information encodes a bunch of mask vectors that are used to track things about the inputs and outputs from each shader.

This adds support for reading and writing them throught he YAML test interfaces. The writing logic in MC is extremely primitive and we'll want to revisit the API for that, but since I'm not sure how we'll want to generate the mask bits from DXIL during code generation I didn't want to spend too much time on the API.

Fixes #59479