### PR TITLE
[mlir][arith] Add LLVM lowering for `maxnumf`, `minnumf` ops

### DIFF
--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -57,12 +57,18 @@ using FPToUIOpLowering =
 using MaximumFOpLowering =
     VectorConvertToLLVMPattern<arith::MaximumFOp, LLVM::MaximumOp,
                                arith::AttrConvertFastMathToLLVM>;
+using MaxNumFOpLowering =
+    VectorConvertToLLVMPattern<arith::MaxNumFOp, LLVM::MaxNumOp,
+                               arith::AttrConvertFastMathToLLVM>;
 using MaxSIOpLowering =
     VectorConvertToLLVMPattern<arith::MaxSIOp, LLVM::SMaxOp>;
 using MaxUIOpLowering =
     VectorConvertToLLVMPattern<arith::MaxUIOp, LLVM::UMaxOp>;
 using MinimumFOpLowering =
     VectorConvertToLLVMPattern<arith::MinimumFOp, LLVM::MinimumOp,
+                               arith::AttrConvertFastMathToLLVM>;
+using MinNumFOpLowering =
+    VectorConvertToLLVMPattern<arith::MinNumFOp, LLVM::MinNumOp,
                                arith::AttrConvertFastMathToLLVM>;
 using MinSIOpLowering =
     VectorConvertToLLVMPattern<arith::MinSIOp, LLVM::SMinOp>;
@@ -496,9 +502,11 @@ void mlir::arith::populateArithToLLVMConversionPatterns(
     IndexCastOpSILowering,
     IndexCastOpUILowering,
     MaximumFOpLowering,
+    MaxNumFOpLowering,
     MaxSIOpLowering,
     MaxUIOpLowering,
     MinimumFOpLowering,
+    MinNumFOpLowering,
     MinSIOpLowering,
     MinUIOpLowering,
     MulFOpLowering,

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -526,6 +526,10 @@ func.func @minmaxf(%arg0 : f32, %arg1 : f32) -> f32 {
   %0 = arith.minimumf %arg0, %arg1 : f32
   // CHECK: = llvm.intr.maximum(%arg0, %arg1) : (f32, f32) -> f32
   %1 = arith.maximumf %arg0, %arg1 : f32
+  // CHECK: = llvm.intr.minnum(%arg0, %arg1) : (f32, f32) -> f32
+  %2 = arith.minnumf %arg0, %arg1 : f32
+  // CHECK: = llvm.intr.maxnum(%arg0, %arg1) : (f32, f32) -> f32
+  %3 = arith.maxnumf %arg0, %arg1 : f32
   return %0 : f32
 }
 


### PR DESCRIPTION
This patch is part of a larger initiative aimed at fixing floating-point `max` and `min` operations in MLIR: https://discourse.llvm.org/t/rfc-fix-floating-point-max-and-min-operations-in-mlir/72671.
    
The commit addresses the task 1.4 of the RFC by adding LLVM lowering to the corresponding LLVM intrinsics.
    
Please **note**: this PR is part of a stack of patches and depends on #66429.