### PR TITLE
[Coverage] Add coverage for constructor member initializers.

### DIFF
--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -1032,11 +1032,20 @@ struct CounterCoverageMappingBuilder
     // lexer may not be able to report back precise token end locations for
     // these children nodes (llvm.org/PR39822), and moreover users will not be
     // able to see coverage for them.
+    Counter BodyCounter = getRegionCounter(Body);
     bool Defaulted = false;
     if (auto *Method = dyn_cast<CXXMethodDecl>(D))
       Defaulted = Method->isDefaulted();
+    if (auto *Ctor = dyn_cast<CXXConstructorDecl>(D)) {
+      for (auto *Initializer : Ctor->inits()) {
+        if (Initializer->isWritten()) {
+          auto *Init = Initializer->getInit();
+          propagateCounts(BodyCounter, Init);
+        }
+      }
+    }
 
-    propagateCounts(getRegionCounter(Body), Body,
+    propagateCounts(BodyCounter, Body,
                     /*VisitChildren=*/!Defaulted);
     assert(RegionStack.empty() && "Regions entered but never exited");
   }

--- a/clang/test/CoverageMapping/ctor.cpp
+++ b/clang/test/CoverageMapping/ctor.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only -main-file-name continue.c %s | FileCheck %s
+
+class A {
+public:
+    int a;
+    A(int a): a(a) {}
+};
+class B: public A {
+public:
+    int b;
+    int c;
+    B(int x, int y)
+    : A(x),                 // CHECK:      File 0, [[@LINE]]:7 -> [[@LINE]]:11 = #0
+                            // CHECK-NEXT: File 0, [[@LINE+1]]:7 -> [[@LINE+1]]:13 = #0
+    b(x == 0? 1: 2),        // CHECK-NEXT: File 0, [[@LINE]]:7 -> [[@LINE]]:19 = #0
+                            // CHECK-NEXT: Branch,File 0, [[@LINE-1]]:7 -> [[@LINE-1]]:13 = #1, (#0 - #1)
+                            // CHECK-NEXT: Gap,File 0, [[@LINE-2]]:14 -> [[@LINE-2]]:15 = #1
+                            // CHECK-NEXT: File 0, [[@LINE-3]]:15 -> [[@LINE-3]]:16 = #1
+                            // CHECK-NEXT: File 0, [[@LINE-4]]:18 -> [[@LINE-4]]:19 = (#0 - #1)
+                            // CHECK-NEXT: File 0, [[@LINE+2]]:7 -> [[@LINE+8]]:8 = #0
+                            // CHECK-NEXT: File 0, [[@LINE+7]]:10 -> [[@LINE+7]]:12 = #0
+    c([&]() {
+                            // CHECK:      File 0, [[@LINE-1]]:13 -> [[@LINE+5]]:6 = #0
+                            // CHECK-NEXT: File 0, [[@LINE+1]]:13 -> [[@LINE+1]]:19 = #0
+        if (y == 0)         // CHECK-NEXT: Branch,File 0, [[@LINE]]:13 -> [[@LINE]]:19 = #1, (#0 - #1)
+            return 1;       // CHECK-NEXT: Gap,File 0, [[@LINE-1]]:20 -> [[@LINE]]:13 = #1
+        return 2;           // CHECK-NEXT: File 0, [[@LINE-1]]:13 -> [[@LINE-1]]:21 = #1
+    }()) {}                 // CHECK-NEXT: Gap,File 0, [[@LINE-2]]:22 -> [[@LINE-1]]:9 = (#0 - #1)
+};                          // CHECK-NEXT: File 0, [[@LINE-2]]:9 -> [[@LINE-2]]:17 = (#0 - #1)
+
+int main() {
+    B b(1,2);
+    return 0;
+}


### PR DESCRIPTION
Before, constructor member initializers are shown as not covered. This adds coverage info for them.