### PR TITLE
[scudo] Remove AndroidSvelteConfig.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/allocator_config.h
+++ b/compiler-rt/lib/scudo/standalone/allocator_config.h
@@ -195,50 +195,6 @@ struct AndroidConfig {
   template <typename Config> using SecondaryT = MapAllocator<Config>;
 };
 
-struct AndroidSvelteConfig {
-  static const bool MaySupportMemoryTagging = false;
-  template <class A>
-  using TSDRegistryT = TSDRegistrySharedT<A, 2U, 1U>; // Shared, max 2 TSDs.
-
-  struct Primary {
-    using SizeClassMap = SvelteSizeClassMap;
-#if SCUDO_CAN_USE_PRIMARY64
-    static const uptr RegionSizeLog = 27U;
-    typedef u32 CompactPtrT;
-    static const uptr CompactPtrScale = SCUDO_MIN_ALIGNMENT_LOG;
-    static const uptr GroupSizeLog = 18U;
-    static const bool EnableRandomOffset = true;
-    static const uptr MapSizeIncrement = 1UL << 18;
-#else
-    static const uptr RegionSizeLog = 16U;
-    static const uptr GroupSizeLog = 16U;
-    typedef uptr CompactPtrT;
-#endif
-    static const s32 MinReleaseToOsIntervalMs = 1000;
-    static const s32 MaxReleaseToOsIntervalMs = 1000;
-  };
-
-#if SCUDO_CAN_USE_PRIMARY64
-  template <typename Config> using PrimaryT = SizeClassAllocator64<Config>;
-#else
-  template <typename Config> using PrimaryT = SizeClassAllocator32<Config>;
-#endif
-
-  struct Secondary {
-    struct Cache {
-      static const u32 EntriesArraySize = 16U;
-      static const u32 QuarantineSize = 32U;
-      static const u32 DefaultMaxEntriesCount = 4U;
-      static const uptr DefaultMaxEntrySize = 1UL << 18;
-      static const s32 MinReleaseToOsIntervalMs = 0;
-      static const s32 MaxReleaseToOsIntervalMs = 0;
-    };
-    template <typename Config> using CacheT = MapAllocatorCache<Config>;
-  };
-
-  template <typename Config> using SecondaryT = MapAllocator<Config>;
-};
-
 #if SCUDO_CAN_USE_PRIMARY64
 struct FuchsiaConfig {
   static const bool MaySupportMemoryTagging = false;

--- a/compiler-rt/lib/scudo/standalone/benchmarks/malloc_benchmark.cpp
+++ b/compiler-rt/lib/scudo/standalone/benchmarks/malloc_benchmark.cpp
@@ -52,8 +52,6 @@ static const size_t MaxSize = 128 * 1024;
 // cleanly.
 BENCHMARK_TEMPLATE(BM_malloc_free, scudo::AndroidConfig)
     ->Range(MinSize, MaxSize);
-BENCHMARK_TEMPLATE(BM_malloc_free, scudo::AndroidSvelteConfig)
-    ->Range(MinSize, MaxSize);
 #if SCUDO_CAN_USE_PRIMARY64
 BENCHMARK_TEMPLATE(BM_malloc_free, scudo::FuchsiaConfig)
     ->Range(MinSize, MaxSize);
@@ -98,8 +96,6 @@ static const size_t MaxIters = 32 * 1024;
 // FIXME: Add DefaultConfig here once we can tear down the exclusive TSD
 // cleanly.
 BENCHMARK_TEMPLATE(BM_malloc_free_loop, scudo::AndroidConfig)
-    ->Range(MinIters, MaxIters);
-BENCHMARK_TEMPLATE(BM_malloc_free_loop, scudo::AndroidSvelteConfig)
     ->Range(MinIters, MaxIters);
 #if SCUDO_CAN_USE_PRIMARY64
 BENCHMARK_TEMPLATE(BM_malloc_free_loop, scudo::FuchsiaConfig)

--- a/compiler-rt/lib/scudo/standalone/size_class_map.h
+++ b/compiler-rt/lib/scudo/standalone/size_class_map.h
@@ -289,28 +289,6 @@ typedef TableSizeClassMap<AndroidSizeClassConfig> AndroidSizeClassMap;
 static_assert(AndroidSizeClassMap::usesCompressedLSBFormat(), "");
 #endif
 
-struct SvelteSizeClassConfig {
-#if SCUDO_WORDSIZE == 64U
-  static const uptr NumBits = 4;
-  static const uptr MinSizeLog = 4;
-  static const uptr MidSizeLog = 8;
-  static const uptr MaxSizeLog = 14;
-  static const u16 MaxNumCachedHint = 13;
-  static const uptr MaxBytesCachedLog = 10;
-  static const uptr SizeDelta = Chunk::getHeaderSize();
-#else
-  static const uptr NumBits = 4;
-  static const uptr MinSizeLog = 3;
-  static const uptr MidSizeLog = 7;
-  static const uptr MaxSizeLog = 14;
-  static const u16 MaxNumCachedHint = 14;
-  static const uptr MaxBytesCachedLog = 10;
-  static const uptr SizeDelta = Chunk::getHeaderSize();
-#endif
-};
-
-typedef FixedSizeClassMap<SvelteSizeClassConfig> SvelteSizeClassMap;
-
 struct TrustySizeClassConfig {
   static const uptr NumBits = 1;
   static const uptr MinSizeLog = 5;

--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -87,7 +87,6 @@ constexpr size_t kMaxAlign = std::max({
 #if SCUDO_CAN_USE_PRIMARY64
       alignof(scudo::Allocator<scudo::FuchsiaConfig>),
 #endif
-      alignof(scudo::Allocator<scudo::AndroidSvelteConfig>),
       alignof(scudo::Allocator<scudo::AndroidConfig>)
 });
 
@@ -101,7 +100,6 @@ struct TestAllocatorStorage {
 #if SCUDO_CAN_USE_PRIMARY64
         sizeof(scudo::Allocator<scudo::FuchsiaConfig>),
 #endif
-        sizeof(scudo::Allocator<scudo::AndroidSvelteConfig>),
         sizeof(scudo::Allocator<scudo::AndroidConfig>)
   });
 
@@ -167,11 +165,9 @@ template <typename T> using ScudoCombinedDeathTest = ScudoCombinedTest<T>;
 
 #if SCUDO_FUCHSIA
 #define SCUDO_TYPED_TEST_ALL_TYPES(FIXTURE, NAME)                              \
-  SCUDO_TYPED_TEST_TYPE(FIXTURE, NAME, AndroidSvelteConfig)                    \
   SCUDO_TYPED_TEST_TYPE(FIXTURE, NAME, FuchsiaConfig)
 #else
 #define SCUDO_TYPED_TEST_ALL_TYPES(FIXTURE, NAME)                              \
-  SCUDO_TYPED_TEST_TYPE(FIXTURE, NAME, AndroidSvelteConfig)                    \
   SCUDO_TYPED_TEST_TYPE(FIXTURE, NAME, DefaultConfig)                          \
   SCUDO_TYPED_TEST_TYPE(FIXTURE, NAME, AndroidConfig)
 #endif

--- a/compiler-rt/lib/scudo/standalone/tests/primary_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/primary_test.cpp
@@ -8,6 +8,7 @@
 
 #include "tests/scudo_unit_test.h"
 
+#include "allocator_config.h"
 #include "primary32.h"
 #include "primary64.h"
 #include "size_class_map.h"
@@ -283,7 +284,7 @@ SCUDO_TYPED_TEST(ScudoPrimaryTest, PrimaryIterate) {
 }
 
 SCUDO_TYPED_TEST(ScudoPrimaryTest, PrimaryThreaded) {
-  using Primary = TestAllocator<TypeParam, scudo::SvelteSizeClassMap>;
+  using Primary = TestAllocator<TypeParam, scudo::Config::Primary::SizeClassMap>;
   std::unique_ptr<Primary> Allocator(new Primary);
   Allocator->init(/*ReleaseToOsInterval=*/-1);
   std::mutex Mutex;

--- a/compiler-rt/lib/scudo/standalone/tests/release_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/release_test.cpp
@@ -552,22 +552,16 @@ TEST(ScudoReleaseTest, ReleaseFreeMemoryToOSAndroid) {
   testReleaseFreeMemoryToOS<scudo::AndroidSizeClassMap>();
 }
 
-TEST(ScudoReleaseTest, ReleaseFreeMemoryToOSSvelte) {
-  testReleaseFreeMemoryToOS<scudo::SvelteSizeClassMap>();
-}
-
 TEST(ScudoReleaseTest, PageMapMarkRange) {
   testPageMapMarkRange<scudo::DefaultSizeClassMap>();
   testPageMapMarkRange<scudo::AndroidSizeClassMap>();
   testPageMapMarkRange<scudo::FuchsiaSizeClassMap>();
-  testPageMapMarkRange<scudo::SvelteSizeClassMap>();
 }
 
 TEST(ScudoReleaseTest, ReleasePartialRegion) {
   testReleasePartialRegion<scudo::DefaultSizeClassMap>();
   testReleasePartialRegion<scudo::AndroidSizeClassMap>();
   testReleasePartialRegion<scudo::FuchsiaSizeClassMap>();
-  testReleasePartialRegion<scudo::SvelteSizeClassMap>();
 }
 
 template <class SizeClassMap> void testReleaseRangeWithSingleBlock() {
@@ -630,7 +624,6 @@ TEST(ScudoReleaseTest, RangeReleaseRegionWithSingleBlock) {
   testReleaseRangeWithSingleBlock<scudo::DefaultSizeClassMap>();
   testReleaseRangeWithSingleBlock<scudo::AndroidSizeClassMap>();
   testReleaseRangeWithSingleBlock<scudo::FuchsiaSizeClassMap>();
-  testReleaseRangeWithSingleBlock<scudo::SvelteSizeClassMap>();
 }
 
 TEST(ScudoReleaseTest, BufferPool) {

--- a/compiler-rt/lib/scudo/standalone/tests/size_class_map_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/size_class_map_test.cpp
@@ -20,10 +20,6 @@ TEST(ScudoSizeClassMapTest, DefaultSizeClassMap) {
   testSizeClassMap<scudo::DefaultSizeClassMap>();
 }
 
-TEST(ScudoSizeClassMapTest, SvelteSizeClassMap) {
-  testSizeClassMap<scudo::SvelteSizeClassMap>();
-}
-
 TEST(ScudoSizeClassMapTest, AndroidSizeClassMap) {
   testSizeClassMap<scudo::AndroidSizeClassMap>();
 }


### PR DESCRIPTION
This config is not actually used anywhere and it is not used on Android. Since it does not test anything not tested elsewhere, remove it.

Remove the size class data associated with this config too.