### PR TITLE
[lldb] Add config and decorator for wide character support in Editline

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1027,6 +1027,10 @@ def skipIfEditlineSupportMissing(func):
     return _get_bool_config_skip_if_decorator("editline")(func)
 
 
+def skipIfEditlineWideCharSupportMissing(func):
+    return _get_bool_config_skip_if_decorator("editline_wchar")(func)
+
+
 def skipIfFBSDVMCoreSupportMissing(func):
     return _get_bool_config_skip_if_decorator("fbsdvmcore")(func)
 

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -781,6 +781,9 @@ SBStructuredData SBDebugger::GetBuildConfiguration() {
   AddBoolConfigEntry(
       *config_up, "editline", LLDB_ENABLE_LIBEDIT,
       "A boolean value that indicates if editline support is enabled in LLDB");
+  AddBoolConfigEntry(*config_up, "editline_wchar", LLDB_EDITLINE_USE_WCHAR,
+                     "A boolean value that indicates if editline wide "
+                     "characters support is enabled in LLDB");
   AddBoolConfigEntry(
       *config_up, "lzma", LLDB_ENABLE_LZMA,
       "A boolean value that indicates if lzma support is enabled in LLDB");

--- a/lldb/test/API/terminal/TestEditline.py
+++ b/lldb/test/API/terminal/TestEditline.py
@@ -47,6 +47,7 @@ class EditlineTest(PExpectTest):
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
+    @skipIfEditlineWideCharSupportMissing
     def test_prompt_unicode(self):
         """Test that we can use Unicode in the LLDB prompt."""
         self.launch(use_colors=True, encoding="utf-8")


### PR DESCRIPTION
Add a configuration entry for whether LLDB was configured with wide character support in Editline and use it in a decorator to guard the UTF-8 prompt test.