### PR TITLE
[scudo] Add missing header in combined_test

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -14,6 +14,7 @@
 #include "combined.h"
 #include "mem_map.h"
 
+#include <algorithm>
 #include <condition_variable>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
It uses `T max( std::initializer_list<T> ilist )` which may not be included in the build path in some build systems.