### PR TITLE
[libc++][hardening] Enable comparator checks for safe mode too

### DIFF
--- a/libcxx/include/__algorithm/comp_ref_type.h
+++ b/libcxx/include/__algorithm/comp_ref_type.h
@@ -63,9 +63,9 @@ struct __debug_less
     void __do_compare_assert(long, _LHS &, _RHS &) {}
 };
 
-// Pass the comparator by lvalue reference. Or in debug mode, using a
+// Pass the comparator by lvalue reference. Or in debug/safe mode, using a
 // debugging wrapper that stores a reference.
-#if _LIBCPP_ENABLE_DEBUG_MODE
+#if _LIBCPP_ENABLE_DEBUG_MODE || _LIBCPP_ENABLE_SAFE_MODE
 template <class _Comp>
 using __comp_ref_type = __debug_less<_Comp>;
 #else

--- a/libcxx/include/__algorithm/three_way_comp_ref_type.h
+++ b/libcxx/include/__algorithm/three_way_comp_ref_type.h
@@ -56,9 +56,9 @@ struct __debug_three_way_comp {
   }
 };
 
-// Pass the comparator by lvalue reference. Or in debug mode, using a
+// Pass the comparator by lvalue reference. Or in debug/safe mode, using a
 // debugging wrapper that stores a reference.
-#  if _LIBCPP_ENABLE_DEBUG_MODE
+#  if _LIBCPP_ENABLE_DEBUG_MODE || _LIBCPP_ENABLE_SAFE_MODE
 template <class _Comp>
 using __three_way_comp_ref_type = __debug_three_way_comp<_Comp>;
 #  else

--- a/libcxx/test/libcxx/algorithms/alg.sorting/alg.heap.operations/make.heap/complexity.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/alg.sorting/alg.heap.operations/make.heap/complexity.pass.cpp
@@ -64,7 +64,7 @@ int main(int, char**)
   std::make_heap(v.begin(), v.end());
   assert(stats.copied == 0);
   assert(stats.moved == 153'486);
-#if !_LIBCPP_ENABLE_DEBUG_MODE
+#if !_LIBCPP_ENABLE_DEBUG_MODE && !_LIBCPP_ENABLE_SAFE_MODE
   assert(stats.compared == 188'285);
 #endif
 

--- a/libcxx/test/libcxx/algorithms/alg.sorting/assert.sort.invalid_comparator.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/alg.sorting/assert.sort.invalid_comparator.pass.cpp
@@ -10,13 +10,14 @@
 
 // REQUIRES: has-unix-headers
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: !libcpp-hardening-mode=debug
+// UNSUPPORTED: !libcpp-hardening-mode=debug && !libcpp-hardening-mode=safe
 // XFAIL: availability-verbose_abort-missing
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DEBUG_STRICT_WEAK_ORDERING_CHECK
 // When the debug mode is enabled, this test fails because we actually catch on the fly that the comparator is not
 // a strict-weak ordering before we catch that we'd dereference out-of-bounds inside std::sort, which leads to different
 // errors than the ones tested below.
 // XFAIL: libcpp-hardening-mode=debug
+// XFAIL: libcpp-hardening-mode=safe
 
 // This test uses a specific combination of an invalid comparator and sequence of values to
 // ensure that our sorting functions do not go out-of-bounds and satisfy strict weak ordering in that case.

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/complexity.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/complexity.pass.cpp
@@ -68,7 +68,7 @@ int main(int, char**) {
     std::sort_heap(first, last);
     LIBCPP_ASSERT(stats.copied == 0);
     LIBCPP_ASSERT(stats.moved <= 2 * n + n * logn);
-#if !_LIBCPP_ENABLE_DEBUG_MODE
+#if !_LIBCPP_ENABLE_DEBUG_MODE && !_LIBCPP_ENABLE_SAFE_MODE
     LIBCPP_ASSERT(stats.compared <= n * logn);
     (void)debug_comparisons;
 #else

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp
@@ -262,7 +262,7 @@ void test_complexity() {
     std::ranges::sort_heap(first, last, &MyInt::Comp);
     LIBCPP_ASSERT(stats.copied == 0);
     LIBCPP_ASSERT(stats.moved <= 2 * n + n * logn);
-#if !_LIBCPP_ENABLE_DEBUG_MODE
+#if !_LIBCPP_ENABLE_DEBUG_MODE && !_LIBCPP_ENABLE_SAFE_MODE
     LIBCPP_ASSERT(stats.compared <= n * logn);
     (void)debug_comparisons;
 #else

--- a/libcxx/test/std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp
@@ -79,7 +79,7 @@ test_one(unsigned N, unsigned M)
         assert(ia[0] == static_cast<int>(N)-1);
         assert(ia[N-1] == 0);
         assert(std::is_sorted(ia, ia+N, std::greater<value_type>()));
-#if !_LIBCPP_ENABLE_DEBUG_MODE
+#if !_LIBCPP_ENABLE_DEBUG_MODE && !_LIBCPP_ENABLE_SAFE_MODE
         assert(pred.count() <= (N-1));
 #endif
     }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.three.way/lexicographical_compare_three_way_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.three.way/lexicographical_compare_three_way_comp.pass.cpp
@@ -156,7 +156,7 @@ constexpr void test_comparator_invocation_count() {
   // The comparator is invoked only `min(left.size(), right.size())` times
   test_lexicographical_compare<const int*, const int*>(
       std::array{0, 1, 2}, std::array{0, 1, 2, 3}, compare_last_digit_counting, std::strong_ordering::less);
-#if !_LIBCPP_ENABLE_DEBUG_MODE
+#if !_LIBCPP_ENABLE_DEBUG_MODE && !_LIBCPP_ENABLE_SAFE_MODE
   assert(compare_invocation_count <= 3);
 #else
   assert(compare_invocation_count <= 6);


### PR DESCRIPTION
The comparator checks are currently only enabled in debug mode, but were previously part of the assertions mode, which has recently been added back as safe mode.

We would like to have these assertions enabled without enabling full debug mode, and I assume this now being in debug mode only was just an oversight in the hardening mode shuffling.
