### PR TITLE
[analyzer] Simplify SVal for simple NonLoc->Loc casts

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -264,7 +264,8 @@ ProgramStateRef ExprEngine::handleLValueBitCast(
   }
   // Delegate to SValBuilder to process.
   SVal OrigV = state->getSVal(Ex, LCtx);
-  SVal V = svalBuilder.evalCast(OrigV, T, ExTy);
+  SVal SimplifiedOrigV = svalBuilder.simplifySVal(state, OrigV);
+  SVal V = svalBuilder.evalCast(SimplifiedOrigV, T, ExTy);
   // Negate the result if we're treating the boolean as a signed i1
   if (CastE->getCastKind() == CK_BooleanToSignedIntegral && V.isValid())
     V = svalBuilder.evalMinus(V.castAs<NonLoc>());

--- a/clang/test/Analysis/symbol-simplification-nonloc-loc.cpp
+++ b/clang/test/Analysis/symbol-simplification-nonloc-loc.cpp
@@ -1,6 +1,8 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core %s \
 // RUN:    -triple x86_64-pc-linux-gnu -verify
 
+void clang_analyzer_eval(int);
+
 #define BINOP(OP) [](auto x, auto y) { return x OP y; }
 
 template <typename BinOp>
@@ -72,4 +74,28 @@ void zoo1backwards() {
   // expected-warning@+1 {{Dereference of null pointer [core.NullDereference]}}
   *(0 + p) = nullptr;  // warn
   **(0 + p) = 'a';     // no-warning: this should be unreachable
+}
+
+void test_simplified_before_cast_add(long t1) {
+  long long t2 = t1 + 3;
+  if (!t2) {
+    int *p = (int *) t2;
+    clang_analyzer_eval(p == 0); // expected-warning{{TRUE}}
+  }
+}
+
+void test_simplified_before_cast_sub(long t1) {
+  long long t2 = t1 - 3;
+  if (!t2) {
+    int *p = (int *) t2;
+    clang_analyzer_eval(p == 0); // expected-warning{{TRUE}}
+  }
+}
+
+void test_simplified_before_cast_mul(long t1) {
+  long long t2 = t1 * 3;
+  if (!t2) {
+    int *p = (int *) t2;
+    clang_analyzer_eval(p == 0); // expected-warning{{TRUE}}
+  }
 }


### PR DESCRIPTION
NonLoc symbolic SVal to Loc casts are not supported except for nonloc::ConcreteInt.

This change simplifies the source SVals so that the more casts can go through nonloc::ConcreteInt->loc::ConcreteInt path. For example:

```c
  void test_simplified_before_cast_add(long long t1) {
    long long t2 = t1 + 3;
    if (!t2) {
      int *p = (int *) t2;
      clang_analyzer_eval(p == 0); // expected-warning{{TRUE}}
    }
  }
```
If simplified, `t2` is 0, resulting `p` is nullptr, otherwise `p` is unknown.

Fixes #62232