### PR TITLE
[libc][cmake] Report invalid clang-tidy path

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -190,7 +190,17 @@ if(LLVM_LIBC_ENABLE_LINTING)
     if(LLVM_LIBC_CLANG_TIDY)
       # Check clang-tidy major version.
       execute_process(COMMAND ${LLVM_LIBC_CLANG_TIDY} "--version"
-                      OUTPUT_VARIABLE CLANG_TIDY_OUTPUT)
+        OUTPUT_VARIABLE CLANG_TIDY_OUTPUT
+        ERROR_VARIABLE CLANG_TIDY_ERROR
+        RESULT_VARIABLE CLANG_TIDY_RESULT)
+
+      if(CLANG_TIDY_RESULT AND NOT CLANG_TIDY_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to execute '${LLVM_LIBC_CLANG_TIDY} --version'
+          output : '${CLANG_TIDY_OUTPUT}'
+          error  : '${CLANG_TIDY_ERROR}'
+          result : '${CLANG_TIDY_RESULT}'
+          ")
+      endif()
       string(REGEX MATCH "[0-9]+" CLANG_TIDY_VERSION "${CLANG_TIDY_OUTPUT}")
       string(REGEX MATCH "[0-9]+" CLANG_MAJOR_VERSION
         "${CMAKE_CXX_COMPILER_VERSION}")


### PR DESCRIPTION
Adds better error reporting for clang-tidy.
