### PR TITLE
[clang-transformer] Allow stencils to read from system headers.

### DIFF
--- a/clang/include/clang/Tooling/Transformer/SourceCode.h
+++ b/clang/include/clang/Tooling/Transformer/SourceCode.h
@@ -91,6 +91,12 @@ StringRef getExtendedText(const T &Node, tok::TokenKind Next,
 llvm::Error validateEditRange(const CharSourceRange &Range,
                               const SourceManager &SM);
 
+/// Determines whether \p Range is one that can be read from. If
+/// `AllowSystemHeaders` is false, a range that falls within a system header
+/// fails validation.
+llvm::Error validateRange(const CharSourceRange &Range, const SourceManager &SM,
+                          bool AllowSystemHeaders);
+
 /// Attempts to resolve the given range to one that can be edited by a rewrite;
 /// generally, one that starts and ends within a particular file. If a value is
 /// returned, it satisfies \c validateEditRange.

--- a/clang/lib/Tooling/Transformer/SourceCode.cpp
+++ b/clang/lib/Tooling/Transformer/SourceCode.cpp
@@ -50,9 +50,9 @@ CharSourceRange clang::tooling::maybeExtendRange(CharSourceRange Range,
   return CharSourceRange::getTokenRange(Range.getBegin(), Tok.getLocation());
 }
 
-static llvm::Error validateRange(const CharSourceRange &Range,
-                                 const SourceManager &SM,
-                                 bool AllowSystemHeaders) {
+llvm::Error clang::tooling::validateRange(const CharSourceRange &Range,
+                                          const SourceManager &SM,
+                                          bool AllowSystemHeaders) {
   if (Range.isInvalid())
     return llvm::make_error<StringError>(errc::invalid_argument,
                                          "Invalid range");

--- a/clang/lib/Tooling/Transformer/Stencil.cpp
+++ b/clang/lib/Tooling/Transformer/Stencil.cpp
@@ -229,8 +229,8 @@ public:
       // Validate the original range to attempt to get a meaningful error
       // message. If it's valid, then something else is the cause and we just
       // return the generic failure message.
-      if (auto Err =
-              tooling::validateEditRange(*RawRange, *Match.SourceManager))
+      if (auto Err = tooling::validateRange(*RawRange, *Match.SourceManager,
+                                            /*AllowSystemHeaders=*/true))
         return handleErrors(std::move(Err), [](std::unique_ptr<StringError> E) {
           assert(E->convertToErrorCode() ==
                      llvm::make_error_code(errc::invalid_argument) &&
@@ -245,8 +245,9 @@ public:
           "selected range could not be resolved to a valid source range");
     }
     // Validate `Range`, because `makeFileCharRange` accepts some ranges that
-    // `validateEditRange` rejects.
-    if (auto Err = tooling::validateEditRange(Range, *Match.SourceManager))
+    // `validateRange` rejects.
+    if (auto Err = tooling::validateRange(Range, *Match.SourceManager,
+                                          /*AllowSystemHeaders=*/true))
       return joinErrors(
           llvm::createStringError(errc::invalid_argument,
                                   "selected range is not valid for editing"),


### PR DESCRIPTION
We were previously checking that stencil input ranges were writable. It suffices for them to be readable.