### PR TITLE
[update_mir_test_checks] Handle multiple defs of vreg

### DIFF
--- a/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/multiple-defs.mir.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/multiple-defs.mir.expected
@@ -8,9 +8,9 @@ body: |
     ; CHECK-LABEL: name: test
     ; CHECK: [[DEF:%[0-9]+]]:gr32 = IMPLICIT_DEF
     ; CHECK-NEXT: [[DEF1:%[0-9]+]]:gr32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:gr32 = IMPLICIT_DEF
     ; CHECK-NEXT: [[DEF2:%[0-9]+]]:gr32 = IMPLICIT_DEF
-    ; CHECK-NEXT: [[DEF2:%[0-9]+]]:gr32 = IMPLICIT_DEF
-    ; CHECK-NEXT: KILL [[DEF2]], [[DEF2]]
+    ; CHECK-NEXT: KILL [[DEF]], [[DEF2]]
     %0:gr32 = IMPLICIT_DEF
     %1:gr32 = IMPLICIT_DEF
     %0:gr32 = IMPLICIT_DEF

--- a/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/multiple-defs.test
+++ b/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/multiple-defs.test
@@ -4,4 +4,3 @@
 # RUN: cp -f %S/Inputs/multiple-defs.mir %t.mir && %update_mir_test_checks %t.mir
 # RUN: diff -u %S/Inputs/multiple-defs.mir.expected %t.mir
 # RUN: FileCheck %t.mir < %t.mir
-# XFAIL: *

--- a/llvm/utils/update_mir_test_checks.py
+++ b/llvm/utils/update_mir_test_checks.py
@@ -204,8 +204,11 @@ def build_function_info_dictionary(
             m = VREG_DEF_RE.match(func_line)
             if m:
                 for vreg in VREG_RE.finditer(m.group("vregs")):
-                    name = mangle_vreg(m.group("opcode"), vreg_map.values())
-                    vreg_map[vreg.group(1)] = name
+                    if vreg.group(1) in vreg_map:
+                        name = vreg_map[vreg.group(1)]
+                    else:
+                        name = mangle_vreg(m.group("opcode"), vreg_map.values())
+                        vreg_map[vreg.group(1)] = name
                     func_line = func_line.replace(
                         vreg.group(1), "[[{}:%[0-9]+]]".format(name), 1
                     )


### PR DESCRIPTION
When (post-SSA) MIR has multiple defs of the same vreg,
update_mir_test_checks would use different variable names for each def
like this, where DEF and DEF1 both refer to %0:
```
    %0:gr32 = IMPLICIT_DEF
    %0:gr32 = IMPLICIT_DEF
-->
    ; CHECK: [[DEF:%[0-9]+]]:gr32 = IMPLICIT_DEF
    ; CHECK-NEXT: [[DEF1:%[0-9]+]]:gr32 = IMPLICIT_DEF
```
This should be harmless, but it messed up the way that mangle_vreg
counts the number of names in vreg_map to come up with a new numeric
suffix, such that you could get the same variable name for different
vregs, like this, where DEF2 refers to both %0 and %2:
```
    %0:gr32 = IMPLICIT_DEF
    %1:gr32 = IMPLICIT_DEF
    %0:gr32 = IMPLICIT_DEF
    %2:gr32 = IMPLICIT_DEF
-->
    ; CHECK: [[DEF:%[0-9]+]]:gr32 = IMPLICIT_DEF
    ; CHECK-NEXT: [[DEF1:%[0-9]+]]:gr32 = IMPLICIT_DEF
    ; CHECK-NEXT: [[DEF2:%[0-9]+]]:gr32 = IMPLICIT_DEF
    ; CHECK-NEXT: [[DEF2:%[0-9]+]]:gr32 = IMPLICIT_DEF
```
Fix this by always using the same variable name for the same vreg.