### PR TITLE
add a unit test for the segfault in rust after https://reviews.llvm.org/D159485

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -886,8 +886,15 @@ Instruction::getPrevNonDebugInstruction(bool SkipPseudoOp) const {
 }
 
 const DebugLoc &Instruction::getStableDebugLoc() const {
-  if (isa<DbgInfoIntrinsic>(this))
-    return getNextNonDebugInstruction()->getDebugLoc();
+  if (isa<DbgInfoIntrinsic>(this)) {
+    if (const Instruction* Next = getNextNonDebugInstruction()) {
+      return Next->getDebugLoc();
+    }
+
+    // FIXME: remove, just to demonstrate the test causes Next above to be null.
+    llvm::errs() << "error: getStableDebugLoc:getNextNonDebugInstruction is NULL\n";
+    exit(1);
+  }
   return getDebugLoc();
 }
 

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -566,6 +566,24 @@ TEST(AssignmentTrackingTest, Utils) {
   EXPECT_FALSE(at::getAssignmentMarkers(&Fun2Alloca).empty());
 }
 
+TEST(IRBuilder, GetSetInsertionPointWithEmptyBasicBlock) {
+  LLVMContext C;
+  std::unique_ptr<BasicBlock> BB(BasicBlock::Create(C, "start"));
+  Module *M = new Module("module", C);
+  IRBuilder<> Builder(BB.get());
+  Function *DbgDeclare = Intrinsic::getDeclaration(M, Intrinsic::dbg_declare);
+  Value *DIV = MetadataAsValue::get(C, (Metadata *)nullptr);
+  SmallVector<Value *, 3> Args = {DIV, DIV, DIV};
+  Builder.CreateCall(DbgDeclare, Args);
+
+  // FIXME: remove the dump(), just for debugging.
+  M->dump();
+  BB->dump();
+
+  auto IP = BB->getFirstInsertionPt();
+  Builder.SetInsertPoint(BB.get(), IP);
+}
+
 TEST(AssignmentTrackingTest, InstrMethods) {
   // Test the assignment tracking Instruction methods.
   // This includes:


### PR DESCRIPTION
(this is just for demonstration, let's keep the discussion on https://github.com/llvm/llvm-project/pull/66266)

```sh
ninja unittests/IR/IRTests ; ./unittests/IR/IRTests --gtest_filter='*GetSetInsertionPointWithEmptyBasicBlock*'
```

```
[ RUN      ] IRBuilder.GetSetInsertionPointWithEmptyBasicBlock
; ModuleID = 'module'
source_filename = "module"

; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
declare void @llvm.dbg.declare(metadata %0, metadata %1, metadata %2) #0

attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

start:                                            ; No predecessors!
  call addrspace(0) void @llvm.dbg.declare(metadata <0x56430425ec90>, metadata <0x56430425ec90>, metadata <0x56430425ec90>)

error: getStableDebugLoc:getNextNonDebugInstruction is NULL
```