### PR TITLE
[analyzer] Fix StackAddrEscapeChecker crash on temporary object fields

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StackAddrEscapeChecker.cpp
@@ -369,7 +369,7 @@ void StackAddrEscapeChecker::checkEndFunction(const ReturnStmt *RS,
                                   "Stack address stored into global variable");
 
   for (const auto &P : Cb.V) {
-    const MemRegion *Referrer = P.first;
+    const MemRegion *Referrer = P.first->getBaseRegion();
     const MemRegion *Referred = P.second;
 
     // Generate a report for this bug.
@@ -384,6 +384,8 @@ void StackAddrEscapeChecker::checkEndFunction(const ReturnStmt *RS,
           << CommonSuffix;
       auto Report =
           std::make_unique<PathSensitiveBugReport>(*BT_stackleak, Out.str(), N);
+      if (Range.isValid())
+        Report->addRange(Range);
       Ctx.emitReport(std::move(Report));
       return;
     }
@@ -397,8 +399,14 @@ void StackAddrEscapeChecker::checkEndFunction(const ReturnStmt *RS,
       return "stack";
     }(Referrer->getMemorySpace());
 
-    // This cast supposed to succeed.
-    const VarRegion *ReferrerVar = cast<VarRegion>(Referrer->getBaseRegion());
+    // We should really only have VarRegions here.
+    // Anything else is really surprising, and we should get notified if such
+    // ever happens.
+    const auto *ReferrerVar = dyn_cast<VarRegion>(Referrer);
+    if (!ReferrerVar) {
+      assert(false && "We should have a VarRegion here");
+      continue; // Defensively skip this one.
+    }
     const std::string ReferrerVarName =
         ReferrerVar->getDecl()->getDeclName().getAsString();
 

--- a/clang/test/Analysis/stackaddrleak.cpp
+++ b/clang/test/Analysis/stackaddrleak.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s
+
+using size_t = decltype(sizeof(int));
+void *operator new(size_t, void *p) { return p; }
+
+struct myfunction {
+  union storage_t {
+    char buffer[100];
+    size_t max_align;
+  } storage;
+
+  template <typename Func> myfunction(Func fn) {
+    new (&storage.buffer) Func(fn);
+  }
+  void operator()();
+};
+
+myfunction create_func() {
+  int n;
+  auto c = [&n] {};
+  return c; // expected-warning {{Address of stack memory associated with local variable 'n' is still referred to by a temporary object on the stack upon returning to the caller.  This will be a dangling reference}}
+}
+void gh_66221() {
+  create_func()();
+}


### PR DESCRIPTION
Basically, the issue was that we should have unwrap the base region before we special handle temp object regions.

Fixes https://github.com/llvm/llvm-project/issues/66221

I also decided to add some extra range information to the diagnostics to make it consistent with the other reporting path.