### PR TITLE
[clang] Setup whitespace detection and clang-format as Github actions

### DIFF
--- a/.github/workflows/clang/pr-check-trailing-whitespace.yml
+++ b/.github/workflows/clang/pr-check-trailing-whitespace.yml
@@ -1,0 +1,14 @@
+name: Ensure there are no trailing whitespace
+
+on:
+  pull_request:
+    paths:
+    - 'clang/**'
+
+jobs:
+  example:
+    name: Find Trailing Whitespace
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: harupy/find-trailing-whitespace@master

--- a/.github/workflows/clang/pr-clang-format.yml
+++ b/.github/workflows/clang/pr-clang-format.yml
@@ -1,0 +1,18 @@
+name: clang-format Check
+
+on:
+  pull_request:
+    paths:
+    - 'clang/**'
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '16'
+        check-path: 'clang/'

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -63,7 +63,7 @@ const Expr *Expr::getBestDynamicClassTypeExpr() const {
   }
 
   return E;
-}
+}   
 
 const CXXRecordDecl *Expr::getBestDynamicClassType() const {
   const Expr *E = getBestDynamicClassTypeExpr();

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -79,6 +79,12 @@ Cl Expr::ClassifyImpl(ASTContext &Ctx, SourceLocation *Loc) const {
   return Classification(kind, modifiable);
 }
 
+static int not_well_formatted_code(int i)
+{
+   int hi = i ;
+    return hi;
+}
+
 /// Classify an expression which creates a temporary, based on its type.
 static Cl::Kinds ClassifyTemporary(QualType T) {
   if (T->isRecordType())

--- a/clang/utils/ci/buildkite-pipeline.yml
+++ b/clang/utils/ci/buildkite-pipeline.yml
@@ -17,17 +17,6 @@ env:
     # LLVM RELEASE bump version
     LLVM_HEAD_VERSION: "17"
 steps:
-  - label: "Format"
-    commands:
-      - "clang/utils/ci/run-buildbot check-format"
-    agents:
-      queue: "linux"
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-    timeout_in_minutes: 120
-
   - label: "Building and testing clang (Linux)"
     commands:
       - "clang/utils/ci/run-buildbot build-clang"

--- a/clang/utils/ci/run-buildbot
+++ b/clang/utils/ci/run-buildbot
@@ -69,9 +69,6 @@ cmake --version
 ninja --version
 
 case "${BUILDER}" in
-check-format)
-    ! grep -rnI '[[:blank:]]$' clang/lib clang/include clang/docs
-;;
 build-clang)
     mkdir install
     # We use Release here to avoid including debug information. Otherwise, the


### PR DESCRIPTION
Instead of using the BuildKite jobs, use GitHub actions to detect clang-format violations and trailing whitespace in PRs.

Fixes #66468