### PR TITLE
[mlir][llvm] Use zeroinitializer for TargetExtType

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1555,6 +1555,7 @@ def LLVM_ZeroOp
   let results = (outs LLVM_Type:$res);
   let builders = [LLVM_OneResultOpBuilder];
   let assemblyFormat = "attr-dict `:` type($res)";
+  let hasVerifier = 1;
 }
 
 def LLVM_ConstantOp

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1082,16 +1082,9 @@ FailureOr<Value> ModuleImport::convertConstant(llvm::Constant *constant) {
         cast<LLVMTargetExtType>(convertType(constTargetNone->getType()));
     assert(targetExtType.hasProperty(LLVMTargetExtType::HasZeroInit) &&
            "target extension type does not support zero-initialization");
-    // As the number of values needed for initialization is target-specific and
-    // opaque to the compiler, use a single i64 zero-valued attribute to
-    // represent the 'zeroinitializer', which is the only constant value allowed
-    // for target extension types (besides poison and undef).
-    // TODO: Replace with 'zeroinitializer' once there is a dedicated
-    // zeroinitializer operation in the LLVM dialect.
-    return builder
-        .create<LLVM::ConstantOp>(loc, targetExtType,
-                                  builder.getI64IntegerAttr(0))
-        .getRes();
+    // Create llvm.mlir.zero operation to represent zero-initialization of
+    // target extension type.
+    return builder.create<LLVM::ZeroOp>(loc, targetExtType).getRes();
   }
 
   StringRef error = "";

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -344,16 +344,6 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
       return nullptr;
     return llvm::ConstantStruct::get(structType, {real, imag});
   }
-  if (auto *targetExtType = dyn_cast<::llvm::TargetExtType>(llvmType)) {
-    // TODO: Replace with 'zeroinitializer' once there is a dedicated
-    // zeroinitializer operation in the LLVM dialect.
-    auto intAttr = dyn_cast<IntegerAttr>(attr);
-    if (!intAttr || intAttr.getInt() != 0)
-      emitError(loc,
-                "Only zero-initialization allowed for target extension type");
-
-    return llvm::ConstantTargetNone::get(targetExtType);
-  }
   // For integer types, we allow a mismatch in sizes as the index type in
   // MLIR might have a different size than the index type in the LLVM module.
   if (auto intAttr = dyn_cast<IntegerAttr>(attr))

--- a/mlir/test/Dialect/LLVMIR/global.mlir
+++ b/mlir/test/Dialect/LLVMIR/global.mlir
@@ -246,10 +246,16 @@ llvm.mlir.global_dtors { dtors = [@dtor], priorities = [0 : i32]}
 // CHECK: llvm.mlir.global external @target_ext() {addr_space = 0 : i32} : !llvm.target<"spirv.Image", i32, 0>
 llvm.mlir.global @target_ext() : !llvm.target<"spirv.Image", i32, 0>
 
-// CHECK: llvm.mlir.global external @target_ext_init(0 : i64) {addr_space = 0 : i32} : !llvm.target<"spirv.Image", i32, 0>
-llvm.mlir.global @target_ext_init(0 : i64) : !llvm.target<"spirv.Image", i32, 0>
+// CHECK:       llvm.mlir.global external @target_ext_init() {addr_space = 0 : i32} : !llvm.target<"spirv.Image", i32, 0>
+// CHECK-NEXT:    %0 = llvm.mlir.zero : !llvm.target<"spirv.Image", i32, 0>
+// CHECK-NEXT:    llvm.return %0 : !llvm.target<"spirv.Image", i32, 0>
+// CHECK-NEXT:  }
+llvm.mlir.global @target_ext_init() : !llvm.target<"spirv.Image", i32, 0> {
+  %0 = llvm.mlir.zero : !llvm.target<"spirv.Image", i32, 0>
+  llvm.return %0 : !llvm.target<"spirv.Image", i32, 0>
+}
 
 // -----
 
-// expected-error @+1 {{expected zero value for global with target extension type}}
-llvm.mlir.global @target_fail(1 : i64) : !llvm.target<"spirv.Image", i32, 0>
+// expected-error @+1 {{global with target extension type can only be initialized with zero-initializer}}
+llvm.mlir.global @target_fail(0 : i64) : !llvm.target<"spirv.Image", i32, 0>

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -1336,16 +1336,18 @@ func.func @invalid_target_ext_atomic(%arg0 : !llvm.ptr) {
 
 // -----
 
-func.func @invalid_target_ext_constant() {
+func.func @invalid_target_ext_constant_unsupported() {
   // expected-error@+1 {{target extension type does not support zero-initializer}}
-  %0 = llvm.mlir.constant(0 : index) : !llvm.target<"invalid_constant">
+  %0 = llvm.mlir.zero : !llvm.target<"invalid_constant">
+  llvm.return
 }
 
 // -----
 
 func.func @invalid_target_ext_constant() {
-  // expected-error@+1 {{only zero-initializer allowed for target extension types}}
-  %0 = llvm.mlir.constant(42 : index) : !llvm.target<"spirv.Event">
+  // expected-error@+1 {{does not support target extension type.}}
+  %0 = llvm.mlir.constant(0 : index) : !llvm.target<"spirv.Event">
+  llvm.return
 }
 
 // -----

--- a/mlir/test/Target/LLVMIR/Import/target-ext-type.ll
+++ b/mlir/test/Target/LLVMIR/Import/target-ext-type.ll
@@ -2,7 +2,7 @@
 
 ; CHECK-LABEL: llvm.mlir.global external @global() {addr_space = 0 : i32}
 ; CHECK-SAME:    !llvm.target<"spirv.DeviceEvent">
-; CHECK-NEXT:      %0 = llvm.mlir.constant(0 : i64) : !llvm.target<"spirv.DeviceEvent">
+; CHECK-NEXT:      %0 = llvm.mlir.zero : !llvm.target<"spirv.DeviceEvent">
 ; CHECK-NEXT:      llvm.return %0 : !llvm.target<"spirv.DeviceEvent">
 @global = global target("spirv.DeviceEvent") zeroinitializer
 
@@ -45,7 +45,7 @@ define target("spirv.Event") @func2() {
 
 ; CHECK-LABEL: llvm.func @func3()
 define void @func3() {
-  ; CHECK-NEXT:    %0 = llvm.mlir.constant(0 : i64) : !llvm.target<"spirv.DeviceEvent">
+  ; CHECK-NEXT:    %0 = llvm.mlir.zero : !llvm.target<"spirv.DeviceEvent">
   ; CHECK-NEXT:    %1 = llvm.freeze %0 : !llvm.target<"spirv.DeviceEvent">
   %val = freeze target("spirv.DeviceEvent") zeroinitializer
   ; CHECK-NEXT:    llvm.return

--- a/mlir/test/Target/LLVMIR/target-ext-type.mlir
+++ b/mlir/test/Target/LLVMIR/target-ext-type.mlir
@@ -2,7 +2,7 @@
 
 // CHECK: @global = global target("spirv.DeviceEvent") zeroinitializer
 llvm.mlir.global external @global() {addr_space = 0 : i32} : !llvm.target<"spirv.DeviceEvent"> {
-  %0 = llvm.mlir.constant(0 : i64) : !llvm.target<"spirv.DeviceEvent">
+  %0 = llvm.mlir.zero : !llvm.target<"spirv.DeviceEvent">
   llvm.return %0 : !llvm.target<"spirv.DeviceEvent">
 }
 
@@ -22,7 +22,7 @@ llvm.func @func2() -> !llvm.target<"spirv.Event"> {
 // CHECK-NEXT:    %1 = freeze target("spirv.DeviceEvent") zeroinitializer
 // CHECK-NEXT:    ret void
 llvm.func @func3() {
-  %0 = llvm.mlir.constant(0 : i64) : !llvm.target<"spirv.DeviceEvent">
+  %0 = llvm.mlir.zero : !llvm.target<"spirv.DeviceEvent">
   %1 = llvm.freeze %0 : !llvm.target<"spirv.DeviceEvent">
   llvm.return
 }


### PR DESCRIPTION
Use the recently introduced llvm.mlir.zero operation for values with LLVM target extension type. Replaces the previous workaround that uses a single zero-valued integer attribute constant operation.