### PR TITLE
[mlir][memref][transform] Add new alloca_to_global op.

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
@@ -153,9 +153,10 @@ def MemRefAllocaToGlobalOp :
       DeclareOpInterfaceMethods<TransformOpInterface>]> {
   let description = [{
     Inserts a new `memref.global` for each provided `memref.alloca` into the
-    provided module and replaces it with a `memref.get_global`. This is useful,
-    for example, for allocations that should reside in the shared memory of
-    a GPU, which have to be declared as globals.
+    provided symbol table (e.g., a `builtin.module`) and replaces it with a
+    `memref.get_global`. This is useful, for example, for allocations that
+    should reside in the shared memory of a GPU, which have to be declared as
+    globals.
 
     #### Example
 
@@ -194,19 +195,20 @@ def MemRefAllocaToGlobalOp :
 
     #### Return modes
 
-    Emits a definite failure if not exactly one `module` payload op was provided
-    or any of the `alloca` payload ops is not inside that module, and succeeds
-    otherwise. The returned handles refer to the `memref.get_global` and
-    `memref.global` ops that were inserted by the transformation.
+    Emits a definite failure if not exactly one symbol table payload op was
+    provided or any of the `alloca` payload ops is not inside that symbol table
+    op, and succeeds otherwise. The returned handles refer to the
+    `memref.get_global` and `memref.global` ops that were inserted by the
+    transformation.
   }];
 
-  let arguments = (ins Transform_ConcreteOpType<"builtin.module">:$module,
+  let arguments = (ins TransformHandleTypeInterface:$symbolTable,
                    Transform_MemRefAllocaOp:$alloca);
-  let results = (outs TransformHandleTypeInterface:$get_global,
+  let results = (outs TransformHandleTypeInterface:$getGlobal,
                   TransformHandleTypeInterface:$global);
 
   let assemblyFormat = [{
-    $alloca `in` $module attr-dict `:` functional-type(operands, results)
+    $alloca `in` $symbolTable attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
@@ -153,7 +153,7 @@ def MemRefAllocaToGlobalOp :
       DeclareOpInterfaceMethods<TransformOpInterface>]> {
   let description = [{
     Inserts a new `memref.global` for each provided `memref.alloca` into the
-    provided symbol table (e.g., a `builtin.module`) and replaces it with a
+    nearest symbol table (e.g., a `builtin.module`) and replaces it with a
     `memref.get_global`. This is useful, for example, for allocations that
     should reside in the shared memory of a GPU, which have to be declared as
     globals.
@@ -164,8 +164,8 @@ def MemRefAllocaToGlobalOp :
 
     ```mlir
     %get_global, %global =
-        transform.memref.alloca_to_global %alloca in %module
-          : (!transform.op<"builtin.module">, !transform.op<"memref.alloca">)
+        transform.memref.alloca_to_global %alloca
+          : (!transform.op<"memref.alloca">)
             -> (!transform.any_op, !transform.any_op)
     ```
 
@@ -195,20 +195,16 @@ def MemRefAllocaToGlobalOp :
 
     #### Return modes
 
-    Emits a definite failure if not exactly one symbol table payload op was
-    provided or any of the `alloca` payload ops is not inside that symbol table
-    op, and succeeds otherwise. The returned handles refer to the
-    `memref.get_global` and `memref.global` ops that were inserted by the
-    transformation.
+    Succeeds always. The returned handles refer to the `memref.get_global` and
+    `memref.global` ops that were inserted by the transformation.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$symbolTable,
-                   Transform_MemRefAllocaOp:$alloca);
+  let arguments = (ins Transform_MemRefAllocaOp:$alloca);
   let results = (outs TransformHandleTypeInterface:$getGlobal,
                   TransformHandleTypeInterface:$global);
 
   let assemblyFormat = [{
-    $alloca `in` $symbolTable attr-dict `:` functional-type(operands, results)
+    $alloca attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
@@ -144,6 +144,71 @@ def ApplyResolveRankedShapedTypeResultDimsPatternsOp : Op<Transform_Dialect,
 }
 
 def Transform_MemRefAllocOp : Transform_ConcreteOpType<"memref.alloc">;
+def Transform_MemRefAllocaOp : Transform_ConcreteOpType<"memref.alloca">;
+
+def MemRefAllocaToGlobalOp :
+  Op<Transform_Dialect, "memref.alloca_to_global",
+     [TransformOpInterface,
+      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+      DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{
+    Inserts a new `memref.global` for each provided `memref.alloca` into the
+    provided module and replaces it with a `memref.get_global`. This is useful,
+    for example, for allocations that should reside in the shared memory of
+    a GPU, which have to be declared as globals.
+
+    #### Example
+
+    Consider the following transform op:
+
+    ```mlir
+    %get_global, %global =
+        transform.memref.alloca_to_global %alloca in %module
+          : (!transform.op<"builtin.module">, !transform.op<"memref.alloca">)
+            -> (!transform.any_op, !transform.any_op)
+    ```
+
+    and the following input payload:
+
+    ```mlir
+    module {
+      func.func @func() {
+        %alloca = memref.alloca() : memref<2x32xf32>
+        // usages of %alloca...
+      }
+    }
+    ```
+
+    then applying the transform op to the payload would result in the following
+    output IR:
+
+    ```mlir
+    module {
+      memref.global "private" @alloc : memref<2x32xf32>
+      func.func @func() {
+        %alloca = memref.get_global @alloc : memref<2x32xf32>
+        // usages of %alloca...
+      }
+    }
+    ```
+
+    #### Return modes
+
+    Emits a definite failure if not exactly one `module` payload op was provided
+    or any of the `alloca` payload ops is not inside that module, and succeeds
+    otherwise. The returned handles refer to the `memref.get_global` and
+    `memref.global` ops that were inserted by the transformation.
+  }];
+
+  let arguments = (ins Transform_ConcreteOpType<"builtin.module">:$module,
+                   Transform_MemRefAllocaOp:$alloca);
+  let results = (outs TransformHandleTypeInterface:$get_global,
+                  TransformHandleTypeInterface:$global);
+
+  let assemblyFormat = [{
+    $alloca `in` $module attr-dict `:` functional-type(operands, results)
+  }];
+}
 
 def MemRefMultiBufferOp : Op<Transform_Dialect, "memref.multibuffer",
     [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,

--- a/mlir/python/mlir/dialects/_memref_transform_ops_ext.py
+++ b/mlir/python/mlir/dialects/_memref_transform_ops_ext.py
@@ -11,6 +11,64 @@ except ImportError as e:
 from typing import Optional, overload, Union
 
 
+class MemRefAllocaToGlobalOp:
+    """Specialization for MemRefAllocaToGlobalOp class."""
+
+    @overload
+    def __init__(
+        self,
+        get_global_type: Type,
+        global_type: Type,
+        module: Union[Operation, OpView, Value],
+        alloca: Union[Operation, OpView, Value],
+        *,
+        loc=None,
+        ip=None
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self,
+        module: Union[Operation, OpView, Value],
+        alloca: Union[Operation, OpView, Value],
+        *,
+        loc=None,
+        ip=None
+    ):
+        ...
+
+    def __init__(
+        self,
+        get_global_type_or_module: Union[Operation, OpView, Type, Value],
+        global_type_or_alloca: Union[Operation, OpView, Type, Value],
+        module_or_none: Optional[Union[Operation, OpView, Value]] = None,
+        alloca_or_none: Optional[Union[Operation, OpView, Value]] = None,
+        *,
+        loc=None,
+        ip=None
+    ):
+        if isinstance(get_global_type_or_module, Type):
+            get_global_type = get_global_type_or_module
+            global_type = global_type_or_alloca
+            module = module_or_none
+            alloca = alloca_or_none
+        else:
+            get_global_type = transform.AnyOpType.get()
+            global_type = transform.AnyOpType.get()
+            module = get_global_type_or_module
+            alloca = global_type_or_alloca
+
+        super().__init__(
+            get_global_type,
+            global_type,
+            module,
+            alloca,
+            loc=loc,
+            ip=ip,
+        )
+
+
 class MemRefMultiBufferOp:
     """Specialization for MemRefMultiBufferOp class."""
 

--- a/mlir/python/mlir/dialects/_memref_transform_ops_ext.py
+++ b/mlir/python/mlir/dialects/_memref_transform_ops_ext.py
@@ -19,7 +19,6 @@ class MemRefAllocaToGlobalOp:
         self,
         get_global_type: Type,
         global_type: Type,
-        module: Union[Operation, OpView, Value],
         alloca: Union[Operation, OpView, Value],
         *,
         loc=None,
@@ -28,41 +27,30 @@ class MemRefAllocaToGlobalOp:
         ...
 
     @overload
-    def __init__(
-        self,
-        module: Union[Operation, OpView, Value],
-        alloca: Union[Operation, OpView, Value],
-        *,
-        loc=None,
-        ip=None
-    ):
+    def __init__(self, alloca: Union[Operation, OpView, Value], *, loc=None, ip=None):
         ...
 
     def __init__(
         self,
-        get_global_type_or_module: Union[Operation, OpView, Type, Value],
-        global_type_or_alloca: Union[Operation, OpView, Type, Value],
-        module_or_none: Optional[Union[Operation, OpView, Value]] = None,
+        get_global_type_or_alloca: Union[Operation, OpView, Type, Value],
+        global_type_or_none: Optional[Type] = None,
         alloca_or_none: Optional[Union[Operation, OpView, Value]] = None,
         *,
         loc=None,
         ip=None
     ):
-        if isinstance(get_global_type_or_module, Type):
-            get_global_type = get_global_type_or_module
-            global_type = global_type_or_alloca
-            module = module_or_none
+        if isinstance(get_global_type_or_alloca, Type):
+            get_global_type = get_global_type_or_alloca
+            global_type = global_type_or_none
             alloca = alloca_or_none
         else:
             get_global_type = transform.AnyOpType.get()
             global_type = transform.AnyOpType.get()
-            module = get_global_type_or_module
-            alloca = global_type_or_alloca
+            alloca = get_global_type_or_alloca
 
         super().__init__(
             get_global_type,
             global_type,
-            module,
             alloca,
             loc=loc,
             ip=ip,

--- a/mlir/test/Dialect/MemRef/transform-ops.mlir
+++ b/mlir/test/Dialect/MemRef/transform-ops.mlir
@@ -3,20 +3,19 @@
 // CHECK-DAG: memref.global "private" @[[ALLOC0:alloc.*]] : memref<2x32xf32>
 // CHECK-DAG: memref.global "private" @[[ALLOC1:alloc.*]] : memref<2x32xf32>
 
-// CHECK: func.func @func(
-func.func @func(%arg0: f32) {
-  %c3 = arith.constant 3 : index
-  %c1 = arith.constant 1 : index
-  // CHECK: scf.forall
-  scf.forall (%arg1, %arg2) in (%c3, %c1) {
+// CHECK-DAG: func.func @func(%[[LB:.*]]: index, %[[UB:.*]]: index)
+func.func @func(%lb: index, %ub: index) {
+  // CHECK-DAG: scf.forall (%[[ARG0:.*]], %[[ARG1:.*]]) in (%[[LB]], %[[UB]])
+  scf.forall (%arg0, %arg1) in (%lb, %ub) {
     // CHECK-DAG: %[[MR0:.*]] = memref.get_global @[[ALLOC0]] : memref<2x32xf32>
     // CHECK-DAG: %[[MR1:.*]] = memref.get_global @[[ALLOC1]] : memref<2x32xf32>
     // CHECK-DAG: memref.store %{{.*}}, %[[MR0]][%{{.*}}, %{{.*}}] : memref<2x32xf32>
     // CHECK-DAG: memref.store %{{.*}}, %[[MR1]][%{{.*}}, %{{.*}}] : memref<2x32xf32>
-    %alloca = memref.alloca() : memref<2x32xf32>
-    %alloca_0 = memref.alloca() : memref<2x32xf32>
-    memref.store %arg0, %alloca[%arg1, %arg2] : memref<2x32xf32>
-    memref.store %arg0, %alloca_0[%arg1, %arg2] : memref<2x32xf32>
+    %cst = arith.constant 0.0 : f32
+    %mr0 = memref.alloca() : memref<2x32xf32>
+    %mr1 = memref.alloca() : memref<2x32xf32>
+    memref.store %cst, %mr0[%arg0, %arg1] : memref<2x32xf32>
+    memref.store %cst, %mr1[%arg0, %arg1] : memref<2x32xf32>
   }
   return
 }

--- a/mlir/test/Dialect/MemRef/transform-ops.mlir
+++ b/mlir/test/Dialect/MemRef/transform-ops.mlir
@@ -23,16 +23,9 @@ func.func @func(%lb: index, %ub: index) {
 transform.sequence failures(propagate) {
 ^bb1(%arg0: !transform.any_op):
   %alloca = transform.structured.match ops{["memref.alloca"]} in %arg0
-      : (!transform.any_op) -> !transform.any_op
-  %module = transform.structured.match ops{["builtin.module"]} in %arg0
-      : (!transform.any_op) -> !transform.any_op
-  %alloca_typed = transform.cast %alloca
-      : !transform.any_op to !transform.op<"memref.alloca">
-  %module_typed = transform.cast %module
-      : !transform.any_op to !transform.op<"builtin.module">
-  %get_global, %global =
-      transform.memref.alloca_to_global %alloca_typed in %module_typed
-        : (!transform.op<"builtin.module">, !transform.op<"memref.alloca">)
+      : (!transform.any_op) -> !transform.op<"memref.alloca">
+  %get_global, %global = transform.memref.alloca_to_global %alloca
+        : (!transform.op<"memref.alloca">)
           -> (!transform.any_op, !transform.any_op)
 }
 

--- a/mlir/test/python/dialects/transform_memref_ext.py
+++ b/mlir/test/python/dialects/transform_memref_ext.py
@@ -21,15 +21,11 @@ def testMemRefAllocaToAllocOpCompact():
     sequence = transform.SequenceOp(
         transform.FailurePropagationMode.Propagate,
         [],
-        transform.OperationType.get("memref.alloc"),
+        transform.OperationType.get("builtin.module"),
+        [transform.OperationType.get("memref.alloca")],
     )
     with InsertionPoint(sequence.body):
-        module = transform.CastOp(
-            transform.OperationType.get("builtin.module"), sequence.bodyTarget
-        )
-        alloca = transform.CastOp(
-            transform.OperationType.get("memref.alloca"), sequence.bodyTarget
-        )
+        module, alloca = sequence.body.arguments
         memref.MemRefAllocaToGlobalOp(module, alloca)
         transform.YieldOp()
     # CHECK-LABEL: TEST: testMemRefAllocaToAllocOpCompact
@@ -43,15 +39,11 @@ def testMemRefAllocaToAllocOpTyped():
     sequence = transform.SequenceOp(
         transform.FailurePropagationMode.Propagate,
         [],
-        transform.OperationType.get("memref.alloc"),
+        transform.OperationType.get("builtin.module"),
+        [transform.OperationType.get("memref.alloca")],
     )
     with InsertionPoint(sequence.body):
-        module = transform.CastOp(
-            transform.OperationType.get("builtin.module"), sequence.bodyTarget
-        )
-        alloca = transform.CastOp(
-            transform.OperationType.get("memref.alloca"), sequence.bodyTarget
-        )
+        module, alloca = sequence.body.arguments
         memref.MemRefAllocaToGlobalOp(
             transform.OperationType.get("memref.get_global"),
             transform.OperationType.get("memref.global"),

--- a/mlir/test/python/dialects/transform_memref_ext.py
+++ b/mlir/test/python/dialects/transform_memref_ext.py
@@ -21,16 +21,14 @@ def testMemRefAllocaToAllocOpCompact():
     sequence = transform.SequenceOp(
         transform.FailurePropagationMode.Propagate,
         [],
-        transform.OperationType.get("builtin.module"),
-        [transform.OperationType.get("memref.alloca")],
+        transform.OperationType.get("memref.alloca"),
     )
     with InsertionPoint(sequence.body):
-        module, alloca = sequence.body.arguments
-        memref.MemRefAllocaToGlobalOp(module, alloca)
+        memref.MemRefAllocaToGlobalOp(sequence.bodyTarget)
         transform.YieldOp()
     # CHECK-LABEL: TEST: testMemRefAllocaToAllocOpCompact
     # CHECK: = transform.memref.alloca_to_global
-    # CHECK-SAME: (!transform.op<"builtin.module">, !transform.op<"memref.alloca">)
+    # CHECK-SAME: (!transform.op<"memref.alloca">)
     # CHECK-SAME: -> (!transform.any_op, !transform.any_op)
 
 
@@ -39,16 +37,13 @@ def testMemRefAllocaToAllocOpTyped():
     sequence = transform.SequenceOp(
         transform.FailurePropagationMode.Propagate,
         [],
-        transform.OperationType.get("builtin.module"),
-        [transform.OperationType.get("memref.alloca")],
+        transform.OperationType.get("memref.alloca"),
     )
     with InsertionPoint(sequence.body):
-        module, alloca = sequence.body.arguments
         memref.MemRefAllocaToGlobalOp(
             transform.OperationType.get("memref.get_global"),
             transform.OperationType.get("memref.global"),
-            module,
-            alloca,
+            sequence.bodyTarget,
         )
         transform.YieldOp()
     # CHECK-LABEL: TEST: testMemRefAllocaToAllocOpTyped


### PR DESCRIPTION
This PR adds a new transform op that replaces `memref.alloca`s with `memref.get_global`s to newly inserted `memref.global`s. This is useful, for example, for allocations that should reside in the shared memory of a GPU, which have to be declared as globals.