### PR TITLE
[sanitizer_common] Add internal_wcs[n]cpy functions

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp
@@ -228,9 +228,8 @@ char *internal_strncpy(char *dst, const char *src, uptr n) {
 
 wchar_t *internal_wcsncpy(wchar_t *dst, const wchar_t *src, uptr n) {
   uptr i;
-  for (i = 0; i < n && src[i]; ++i) {
+  for (i = 0; i < n && src[i]; ++i)
     dst[i] = src[i];
-  }
   internal_memset(dst + i, 0, (n - i) * sizeof(wchar_t));
   return dst;
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp
@@ -225,6 +225,7 @@ char *internal_strncpy(char *dst, const char *src, uptr n) {
   internal_memset(dst + i, '\0', n - i);
   return dst;
 }
+
 wchar_t *internal_wcsncpy(wchar_t *dst, const wchar_t *src, uptr n) {
   uptr i;
   for (i = 0; i < n && src[i]; ++i) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp
@@ -199,6 +199,14 @@ char *internal_strncat(char *dst, const char *src, uptr n) {
   return dst;
 }
 
+wchar_t *internal_wcscpy(wchar_t *dst, const wchar_t *src) {
+  wchar_t *dst_it = dst;
+  do {
+    *dst_it++ = *src++;
+  } while (*src);
+  return dst;
+}
+
 uptr internal_strlcpy(char *dst, const char *src, uptr maxlen) {
   const uptr srclen = internal_strlen(src);
   if (srclen < maxlen) {
@@ -215,6 +223,14 @@ char *internal_strncpy(char *dst, const char *src, uptr n) {
   for (i = 0; i < n && src[i]; i++)
     dst[i] = src[i];
   internal_memset(dst + i, '\0', n - i);
+  return dst;
+}
+wchar_t *internal_wcsncpy(wchar_t *dst, const wchar_t *src, uptr n) {
+  uptr i;
+  for (i = 0; i < n && src[i]; ++i) {
+    dst[i] = src[i];
+  }
+  internal_memset(dst + i, 0, (n - i) * sizeof(wchar_t));
   return dst;
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_libc.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_libc.h
@@ -71,7 +71,8 @@ int internal_snprintf(char *buffer, uptr length, const char *format, ...)
     FORMAT(3, 4);
 uptr internal_wcslen(const wchar_t *s);
 uptr internal_wcsnlen(const wchar_t *s, uptr maxlen);
-
+wchar_t *internal_wcscpy(wchar_t *dst, const wchar_t *src);
+wchar_t *internal_wcsncpy(wchar_t *dst, const wchar_t *src, uptr maxlen);
 // Return true if all bytes in [mem, mem+size) are zero.
 // Optimized for the case when the result is true.
 bool mem_is_zero(const char *mem, uptr size);


### PR DESCRIPTION
These functions are required for the related wcs[n]cpy functions to be wrapped on Windows, since given our current method of wrapping functions, calling REAL(wcs[n]cpy) is broken.

@vitalybuka requested that these changes be split out from llvm/llvm-project#66128.