### PR TITLE
Object: account for short output names

### DIFF
--- a/lld/test/COFF/implib-name.test
+++ b/lld/test/COFF/implib-name.test
@@ -70,3 +70,4 @@ CHECK-NODEF-DLL: default.dll
 CHECK-NODEF-DLL: default.dll
 CHECK-NODEF-DLL: default.dll
 
+# RUN: lld-link /nologo /machine:x64 /out:%T/exe %T/object.obj /entry:f /subsystem:CONSOLE

--- a/llvm/lib/Object/COFFImportFile.cpp
+++ b/llvm/lib/Object/COFFImportFile.cpp
@@ -140,7 +140,7 @@ class ObjectFactory {
 
 public:
   ObjectFactory(StringRef S, MachineTypes M)
-      : Machine(M), ImportName(S), Library(S.drop_back(4)),
+      : Machine(M), ImportName(S), Library(llvm::sys::path::stem(S)),
         ImportDescriptorSymbolName(("__IMPORT_DESCRIPTOR_" + Library).str()),
         NullThunkSymbolName(("\x7f" + Library + "_NULL_THUNK_DATA").str()) {}
 


### PR DESCRIPTION
The import library thunk name suffix uses the stem of the file. We currently would attempt to trim the suffix by dropping the trailing 4 characters (under the assumption that the output name was `.lib`). This now uses the `llvm::sys::path` API for computing the stem. This avoids an assertion failure when the name is less the 4 characters and assertions are enabled.