### PR TITLE
[lldb-vscode] Show value addresses in a short format

### DIFF
--- a/lldb/include/lldb/API/SBType.h
+++ b/lldb/include/lldb/API/SBType.h
@@ -121,6 +121,10 @@ public:
 
   uint64_t GetByteSize();
 
+  /// \return
+  ///    Whether the type is a pointer or a reference.
+  bool IsPointerOrReferenceType();
+
   bool IsPointerType();
 
   bool IsReferenceType();

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -127,6 +127,10 @@ uint64_t SBType::GetByteSize() {
   return 0;
 }
 
+bool SBType::IsPointerOrReferenceType() {
+  return IsPointerType() || IsReferenceType();
+}
+
 bool SBType::IsPointerType() {
   LLDB_INSTRUMENT_VA(this);
 

--- a/lldb/test/API/tools/lldb-vscode/evaluate/main.cpp
+++ b/lldb/test/API/tools/lldb-vscode/evaluate/main.cpp
@@ -43,6 +43,6 @@ int main(int argc, char const *argv[]) {
   my_bool_vec.push_back(true);
   my_bool_vec.push_back(false); // breakpoint 6
   my_bool_vec.push_back(true); // breakpoint 7
-  
+
   return 0;
 }

--- a/lldb/test/API/tools/lldb-vscode/variables/main.cpp
+++ b/lldb/test/API/tools/lldb-vscode/variables/main.cpp
@@ -12,8 +12,14 @@ int test_indexedVariables();
 int main(int argc, char const *argv[]) {
   static float s_local = 2.25;
   PointType pt = { 11,22, {0}};
+  PointType *pt_ptr = new PointType{11, 22, {0}};
+  PointType *another_pt_ptr = nullptr;
   for (int i=0; i<BUFFER_SIZE; ++i)
     pt.buffer[i] = i;
+
+  int some_int = 10;
+  int *some_int_ptr = new int{20};
+  int *another_int_ptr = nullptr;
   int x = s_global - g_global - pt.y; // breakpoint 1
   {
     int x = 42;


### PR DESCRIPTION
The variables pane on VSCode is very narrow by default, and lldb-vscode has been using the default formatter for addresses, which uses 18 characters for each address. That's a bit too much because it prints too many leading zeroes.
As a way to improve readability of variables, I'm adding some logic to format addresses manually using as few chars as possible. I don't want to mess with the default LLDB formatter because, if the user uses the debug console, they should see addresses formatted in the regular way.

I also added some logic to print <null> when a null pointer appears, and <invalid address> when applicable, which is a bit more readable.

For example, this is how a default variables pane looks like:
<img width="228" alt="Screenshot 2023-09-15 at 1 09 18 PM" src="https://github.com/llvm/llvm-project/assets/1613874/2d317760-e4b0-4665-a6b3-15424696852b">


And this is how it looks with the improvement:
<img width="232" alt="Screenshot 2023-09-15 at 1 08 49 PM" src="https://github.com/llvm/llvm-project/assets/1613874/4e6a36e8-5c55-4302-82a3-735b5d6d0b0f">
