### PR TITLE
Github Automation: Add support for an optional colon after command name

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -572,12 +572,12 @@ class ReleaseWorkflow:
         """
         This function reads lines from STDIN and executes the first command
         that it finds.  The 2 supported commands are:
-        /cherry-pick commit0 <commit1> <commit2> <...>
-        /branch <owner>/<repo>/<branch>
+        /cherry-pick<:> commit0 <commit1> <commit2> <...>
+        /branch<:> <owner>/<repo>/<branch>
         """
         for line in sys.stdin:
             line.rstrip()
-            m = re.search(r"/([a-z-]+)\s(.+)", line)
+            m = re.search(r"/([a-z-]+)(?::)?\s(.+)", line)
             if not m:
                 continue
             command = m.group(1)


### PR DESCRIPTION
As requested in https://github.com/llvm/llvm-project/issues/64803

example -> /cherry-pick: or /branch: