### PR TITLE
[mlir][linalg][transform][python] Allow no args in MaskedVectorize.

### DIFF
--- a/mlir/python/mlir/dialects/_structured_transform_ops_ext.py
+++ b/mlir/python/mlir/dialects/_structured_transform_ops_ext.py
@@ -366,7 +366,7 @@ class MaskedVectorizeOp:
     def __init__(
         self,
         target: Union[Operation, OpView, Value],
-        vector_sizes: Union[DynamicIndexList, ArrayAttr],
+        vector_sizes: Optional[Union[DynamicIndexList, ArrayAttr]] = None,
         *,
         vectorize_nd_extract: Optional[bool] = None,
         scalable_sizes: OptionalBoolList = None,
@@ -374,7 +374,13 @@ class MaskedVectorizeOp:
         loc=None,
         ip=None,
     ):
-        if scalable_sizes is None and static_vector_sizes is None:
+        if (
+            scalable_sizes is None
+            and static_vector_sizes is None
+            and vector_sizes is None
+        ):
+            dynamic_vector_sizes = []
+        elif scalable_sizes is None and static_vector_sizes is None:
             (
                 dynamic_vector_sizes,
                 static_vector_sizes,

--- a/mlir/test/python/dialects/transform_structured_ext.py
+++ b/mlir/test/python/dialects/transform_structured_ext.py
@@ -171,6 +171,16 @@ def testMatchOpNamesList(target):
 
 @run
 @create_sequence
+def testMaskedVectorizeNoArgs(target):
+    structured.MaskedVectorizeOp(target)
+    # CHECK-LABEL: TEST: testMaskedVectorizeNoArgs
+    # CHECK: transform.sequence
+    # CHECK: transform.structured.masked_vectorize
+    # CHECK-NOT:     vector_sizes
+
+
+@run
+@create_sequence
 def testMaskedVectorizeStatic(target):
     structured.MaskedVectorizeOp(target, [16, 4])
     # CHECK-LABEL: TEST: testMaskedVectorizeStatic


### PR DESCRIPTION
The mix-in of this op did not allow to pass in no argument. This special case is now handled correctly and covered by the tests.