### PR TITLE
[GitHub] Fix `mlir:core` label definition

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -110,16 +110,26 @@ mlir:
   - mlir/**
 
 mlir:core:
-  - mlir/**/Support/**
-  - mlir/**/Parser/**
-  - mlir/**/IR/**
-  - mlir/**/Bytecode/**
-  - mlir/**/AsmParser/**
-  - mlir/**/Pass/**
-  - mlir/**/tools/**
-  - mlir/**/Reducer/**
-  - mlir/**/Transforms/**
-  - mlir/**/Debug/**
+  - mlir/include/mlir/Support/**
+  - mlir/lib/Support/**
+  - mlir/include/mlir/Parser/**
+  - mlir/lib/Parser/**
+  - mlir/include/mlir/IR/**
+  - mlir/lib/IR/**
+  - mlir/include/mlir/Bytecode/**
+  - mlir/lib/Bytecode/**
+  - mlir/include/mlir/AsmParser/**
+  - mlir/lib/AsmParser/**
+  - mlir/include/mlir/Pass/**
+  - mlir/lib/Pass/**
+  - mlir/include/mlir/Tools/**
+  - mlir/lib/Tools/**
+  - mlir/include/mlir/Reducer/**
+  - mlir/lib/Reducer/**
+  - mlir/include/mlir/Transforms/**
+  - mlir/lib/Transforms/**
+  - mlir/include/mlir/Debug/**
+  - mlir/lib/Debug/**
   - mlir/tools/**
 
 mlir:ods:


### PR DESCRIPTION
The current regex for the `mlir:core` PR label is too accepting. It uses `**` as a prefix for all paths, which allows any kind of directory prefix to be inserted when matching. Combined with very common directory suffixes such as `IR` and `Transforms`, it leads to many false positives of being applied to PRs that do not touch MLIR core such as https://github.com/llvm/llvm-project/pull/66520

This PR therefore changes the `mlir:core` labels to only include the specified top-level directories if directly nested under either `lib` for source files, or `include` for header files