### PR TITLE
[libc] Fix pthread_create_test for 32 bit systems

### DIFF
--- a/libc/test/integration/src/pthread/pthread_create_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_create_test.cpp
@@ -287,7 +287,6 @@ static void run_failure_tests() {
   run_failure_config(PTHREAD_STACK_MIN, SIZE_MAX);
   run_failure_config(PTHREAD_STACK_MIN, SIZE_MAX - PTHREAD_STACK_MIN);
   run_failure_config(SIZE_MAX / 2, SIZE_MAX / 2);
-  run_failure_config(SIZE_MAX / 4, SIZE_MAX / 4);
   run_failure_config(SIZE_MAX / 2 + 1234, SIZE_MAX / 2);
 
   // Test invalid parameters that are impossible to obtain via the

--- a/libc/test/integration/src/pthread/pthread_create_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_create_test.cpp
@@ -287,6 +287,7 @@ static void run_failure_tests() {
   run_failure_config(PTHREAD_STACK_MIN, SIZE_MAX);
   run_failure_config(PTHREAD_STACK_MIN, SIZE_MAX - PTHREAD_STACK_MIN);
   run_failure_config(SIZE_MAX / 2, SIZE_MAX / 2);
+  run_failure_config(3 * (SIZE_MAX / 4), SIZE_MAX / 4);
   run_failure_config(SIZE_MAX / 2 + 1234, SIZE_MAX / 2);
 
   // Test invalid parameters that are impossible to obtain via the


### PR DESCRIPTION
The test tries to set the guard_size and stack_size of a thread to SIZE_MAX / 4, which is a huge value in 64-bit systems but 1GB in 32-bit ones.

We remove this test since the previous line already sets a value that fails in both 64-bit and 32-bit systems.