### PR TITLE
[SelectionDAG][RISCV] Mask constants to narrow size in TargetLowering::expandUnalignedStore.

### DIFF
--- a/llvm/test/CodeGen/RISCV/unaligned-load-store.ll
+++ b/llvm/test/CodeGen/RISCV/unaligned-load-store.ll
@@ -416,57 +416,26 @@ define void @merge_stores_i32_i64(ptr %p) {
   ret void
 }
 
-; FIXME: We shouldn't generate multiple constant pools entries with shifted
-; values.
-;.LCPI0_0:
-;        .quad   280223976814164                 # 0xfedcba987654
-;.LCPI0_1:
-;        .quad   71737338064426034               # 0xfedcba98765432
-;.LCPI0_2:
-;        .quad   -81985529216486896              # 0xfedcba9876543210
 define void @store_large_constant(ptr %x) {
-; RV32I-LABEL: store_large_constant:
-; RV32I:       # %bb.0:
-; RV32I-NEXT:    li a1, 254
-; RV32I-NEXT:    sb a1, 7(a0)
-; RV32I-NEXT:    li a1, 220
-; RV32I-NEXT:    sb a1, 6(a0)
-; RV32I-NEXT:    li a1, 186
-; RV32I-NEXT:    sb a1, 5(a0)
-; RV32I-NEXT:    li a1, 152
-; RV32I-NEXT:    sb a1, 4(a0)
-; RV32I-NEXT:    li a1, 118
-; RV32I-NEXT:    sb a1, 3(a0)
-; RV32I-NEXT:    li a1, 84
-; RV32I-NEXT:    sb a1, 2(a0)
-; RV32I-NEXT:    li a1, 50
-; RV32I-NEXT:    sb a1, 1(a0)
-; RV32I-NEXT:    li a1, 16
-; RV32I-NEXT:    sb a1, 0(a0)
-; RV32I-NEXT:    ret
-;
-; RV64I-LABEL: store_large_constant:
-; RV64I:       # %bb.0:
-; RV64I-NEXT:    li a1, 254
-; RV64I-NEXT:    sb a1, 7(a0)
-; RV64I-NEXT:    li a1, 220
-; RV64I-NEXT:    sb a1, 6(a0)
-; RV64I-NEXT:    li a1, 186
-; RV64I-NEXT:    sb a1, 5(a0)
-; RV64I-NEXT:    li a1, 152
-; RV64I-NEXT:    sb a1, 4(a0)
-; RV64I-NEXT:    li a1, 118
-; RV64I-NEXT:    lui a2, %hi(.LCPI16_0)
-; RV64I-NEXT:    ld a2, %lo(.LCPI16_0)(a2)
-; RV64I-NEXT:    lui a3, %hi(.LCPI16_1)
-; RV64I-NEXT:    ld a3, %lo(.LCPI16_1)(a3)
-; RV64I-NEXT:    lui a4, %hi(.LCPI16_2)
-; RV64I-NEXT:    ld a4, %lo(.LCPI16_2)(a4)
-; RV64I-NEXT:    sb a1, 3(a0)
-; RV64I-NEXT:    sb a2, 2(a0)
-; RV64I-NEXT:    sb a3, 1(a0)
-; RV64I-NEXT:    sb a4, 0(a0)
-; RV64I-NEXT:    ret
+; SLOW-LABEL: store_large_constant:
+; SLOW:       # %bb.0:
+; SLOW-NEXT:    li a1, 254
+; SLOW-NEXT:    sb a1, 7(a0)
+; SLOW-NEXT:    li a1, 220
+; SLOW-NEXT:    sb a1, 6(a0)
+; SLOW-NEXT:    li a1, 186
+; SLOW-NEXT:    sb a1, 5(a0)
+; SLOW-NEXT:    li a1, 152
+; SLOW-NEXT:    sb a1, 4(a0)
+; SLOW-NEXT:    li a1, 118
+; SLOW-NEXT:    sb a1, 3(a0)
+; SLOW-NEXT:    li a1, 84
+; SLOW-NEXT:    sb a1, 2(a0)
+; SLOW-NEXT:    li a1, 50
+; SLOW-NEXT:    sb a1, 1(a0)
+; SLOW-NEXT:    li a1, 16
+; SLOW-NEXT:    sb a1, 0(a0)
+; SLOW-NEXT:    ret
 ;
 ; RV32I-FAST-LABEL: store_large_constant:
 ; RV32I-FAST:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/unaligned-load-store.ll
+++ b/llvm/test/CodeGen/RISCV/unaligned-load-store.ll
@@ -415,3 +415,75 @@ define void @merge_stores_i32_i64(ptr %p) {
   store i32 0, ptr %p2
   ret void
 }
+
+; FIXME: We shouldn't generate multiple constant pools entries with shifted
+; values.
+;.LCPI0_0:
+;        .quad   280223976814164                 # 0xfedcba987654
+;.LCPI0_1:
+;        .quad   71737338064426034               # 0xfedcba98765432
+;.LCPI0_2:
+;        .quad   -81985529216486896              # 0xfedcba9876543210
+define void @store_large_constant(ptr %x) {
+; RV32I-LABEL: store_large_constant:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    li a1, 254
+; RV32I-NEXT:    sb a1, 7(a0)
+; RV32I-NEXT:    li a1, 220
+; RV32I-NEXT:    sb a1, 6(a0)
+; RV32I-NEXT:    li a1, 186
+; RV32I-NEXT:    sb a1, 5(a0)
+; RV32I-NEXT:    li a1, 152
+; RV32I-NEXT:    sb a1, 4(a0)
+; RV32I-NEXT:    li a1, 118
+; RV32I-NEXT:    sb a1, 3(a0)
+; RV32I-NEXT:    li a1, 84
+; RV32I-NEXT:    sb a1, 2(a0)
+; RV32I-NEXT:    li a1, 50
+; RV32I-NEXT:    sb a1, 1(a0)
+; RV32I-NEXT:    li a1, 16
+; RV32I-NEXT:    sb a1, 0(a0)
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: store_large_constant:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    li a1, 254
+; RV64I-NEXT:    sb a1, 7(a0)
+; RV64I-NEXT:    li a1, 220
+; RV64I-NEXT:    sb a1, 6(a0)
+; RV64I-NEXT:    li a1, 186
+; RV64I-NEXT:    sb a1, 5(a0)
+; RV64I-NEXT:    li a1, 152
+; RV64I-NEXT:    sb a1, 4(a0)
+; RV64I-NEXT:    li a1, 118
+; RV64I-NEXT:    lui a2, %hi(.LCPI16_0)
+; RV64I-NEXT:    ld a2, %lo(.LCPI16_0)(a2)
+; RV64I-NEXT:    lui a3, %hi(.LCPI16_1)
+; RV64I-NEXT:    ld a3, %lo(.LCPI16_1)(a3)
+; RV64I-NEXT:    lui a4, %hi(.LCPI16_2)
+; RV64I-NEXT:    ld a4, %lo(.LCPI16_2)(a4)
+; RV64I-NEXT:    sb a1, 3(a0)
+; RV64I-NEXT:    sb a2, 2(a0)
+; RV64I-NEXT:    sb a3, 1(a0)
+; RV64I-NEXT:    sb a4, 0(a0)
+; RV64I-NEXT:    ret
+;
+; RV32I-FAST-LABEL: store_large_constant:
+; RV32I-FAST:       # %bb.0:
+; RV32I-FAST-NEXT:    lui a1, 1043916
+; RV32I-FAST-NEXT:    addi a1, a1, -1384
+; RV32I-FAST-NEXT:    sw a1, 4(a0)
+; RV32I-FAST-NEXT:    lui a1, 484675
+; RV32I-FAST-NEXT:    addi a1, a1, 528
+; RV32I-FAST-NEXT:    sw a1, 0(a0)
+; RV32I-FAST-NEXT:    ret
+;
+; RV64I-FAST-LABEL: store_large_constant:
+; RV64I-FAST:       # %bb.0:
+; RV64I-FAST-NEXT:    lui a1, %hi(.LCPI16_0)
+; RV64I-FAST-NEXT:    ld a1, %lo(.LCPI16_0)(a1)
+; RV64I-FAST-NEXT:    sd a1, 0(a0)
+; RV64I-FAST-NEXT:    ret
+  store i64 18364758544493064720, ptr %x, align 1
+  ret void
+}


### PR DESCRIPTION
If the SRL for Hi constant folds, but we don't remove those bits from the Lo, we can end up with strange constant folding. I've only seen this with constants being lowered to constant pools during lowering on RISC-V.

On the first split we create two i32 trunc stores and a srl to shift the high part down. The srl gets constant folded, but to produce a new i32 constant. But the truncstore for the low store still uses the original constant.
    
This original constant then gets converted to a constant pool before we revisit the stores to further split them. The constant pool prevents further constant folding of the additional srls.
    
After legalization is done, we run DAGCombiner and get some constant folding of srl via computeKnownBits which can peek through the constant pool load. This can create new constants that also need a constant pool.