### PR TITLE
[llvm][MC] Add public getAllProcessorFeatures()

### DIFF
--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -230,8 +230,14 @@ public:
     return Found != ProcDesc.end() && StringRef(Found->Key) == CPU;
   }
 
+  /// Return processor descriptions.
   ArrayRef<SubtargetSubTypeKV> getAllProcessorDescriptions() const {
     return ProcDesc;
+  }
+
+  /// Return processor features.
+  ArrayRef<SubtargetFeatureKV> getAllProcessorFeatures() const {
+    return ProcFeatures;
   }
 
   virtual unsigned getHwMode() const { return 0; }


### PR DESCRIPTION
This patch add a public ```getAllProcessorFeatures()``` accessor to the private [ProcFeatures](https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm/MC/MCSubtargetInfo.h#L80) array  of [MCSubtargetInfo](https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm/MC/MCSubtargetInfo.h#L76) class.

 * Currently there is no way to list all features of the subtarget, except toggling or checking it's pinned flags. 
 * It is very useful to know all the possible flags of subtarget cpu and this simple public accessor can provide it.

The proposed accessor here is inline with  [getAllProcessorDescriptions()](https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm/MC/MCSubtargetInfo.h#L233-L235) for the [ProcDesc](https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm/MC/MCSubtargetInfo.h#L81) subarchitecture details.

The targeted private array type [ProcFeatures](https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm/MC/MCSubtargetInfo.h#L35-L39) also contains human readable information about the features. This data originates from tablegen architecture description.
