### PR TITLE
[clang-tidy] add modernize-use-std-numbers

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
@@ -39,6 +39,7 @@ add_clang_library(clangTidyModernizeModule
   UseNullptrCheck.cpp
   UseOverrideCheck.cpp
   UseStartsEndsWithCheck.cpp
+  UseStdNumbersCheck.cpp
   UseStdPrintCheck.cpp
   UseTrailingReturnTypeCheck.cpp
   UseTransparentFunctorsCheck.cpp

--- a/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
@@ -40,6 +40,7 @@
 #include "UseNullptrCheck.h"
 #include "UseOverrideCheck.h"
 #include "UseStartsEndsWithCheck.h"
+#include "UseStdNumbersCheck.h"
 #include "UseStdPrintCheck.h"
 #include "UseTrailingReturnTypeCheck.h"
 #include "UseTransparentFunctorsCheck.h"
@@ -69,6 +70,8 @@ public:
     CheckFactories.registerCheck<PassByValueCheck>("modernize-pass-by-value");
     CheckFactories.registerCheck<UseStartsEndsWithCheck>(
         "modernize-use-starts-ends-with");
+    CheckFactories.registerCheck<UseStdNumbersCheck>(
+        "modernize-use-std-numbers");
     CheckFactories.registerCheck<UseStdPrintCheck>("modernize-use-std-print");
     CheckFactories.registerCheck<RawStringLiteralCheck>(
         "modernize-raw-string-literal");

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -442,4 +442,9 @@ void UseStdNumbersCheck::registerPPCallbacks(
     Preprocessor *const ModuleExpanderPP) {
   IncludeInserter.registerPreprocessor(PP);
 }
+
+void UseStdNumbersCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
+  Options.store(Opts, "DiffThreshold", DiffThresholdString);
+}
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -83,12 +83,11 @@ AST_MATCHER_P(clang::Expr, anyOfExhaustive,
 struct MatchBuilder {
   auto
   ignoreParenAndArithmeticCasting(const Matcher<clang::Expr> Matcher) const {
-    return expr(hasType(qualType(isArithmetic())),
-                ignoringParenCasts((Matcher)));
+    return expr(hasType(qualType(isArithmetic())), ignoringParenCasts(Matcher));
   }
 
   auto ignoreParenAndFloatingCasting(const Matcher<clang::Expr> Matcher) const {
-    return expr(hasType(qualType(isFloating())), ignoringParenCasts((Matcher)));
+    return expr(hasType(qualType(isFloating())), ignoringParenCasts(Matcher));
   }
 
   auto matchMathCall(const StringRef FunctionName,

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -62,7 +62,7 @@ AST_MATCHER_P2(clang::FloatingLiteral, near, double, Value, double, Threshold) {
 // another check.
 AST_MATCHER(clang::Expr, isMacro) { return Node.getBeginLoc().isMacroID(); }
 
-AST_MATCHER_P(clang::QualType, hasUnqualifiedDesugaredType,
+AST_MATCHER_P(clang::QualType, hasCanonicalTypeUnqualified,
               Matcher<clang::QualType>, InnerMatcher) {
   return InnerMatcher.matches(Node->getCanonicalTypeUnqualified(), Finder,
                               Builder);
@@ -228,7 +228,7 @@ RewriteRuleWith<std::string> makeRule(const Matcher<clang::Stmt> Matcher,
 
   return makeRule(
       expr(Matcher, unless(isInTemplateInstantiation()),
-           hasType(qualType(hasCanonicalType(hasUnqualifiedDesugaredType(anyOf(
+           hasType(qualType(hasCanonicalType(hasCanonicalTypeUnqualified(anyOf(
                qualType(asString("float")).bind("float"),
                qualType(asString("double")),
                qualType(asString("long double")).bind("long double"))))))),

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -41,11 +41,6 @@ using clang::transformer::flattenVector;
 using clang::transformer::RewriteRuleWith;
 using llvm::StringRef;
 
-constexpr double Pi = 3.141592653589793238462643383279502884197169399;
-constexpr double Euler = 2.718281828459045235360287471352662497757247093;
-constexpr double Phi = 1.618033988749894848204586834365638117720309179;
-constexpr double Egamma = 0.577215664901532860606512090082402431042159335;
-
 constexpr auto DiffThreshold = 0.001;
 
 AST_MATCHER_P2(clang::FloatingLiteral, near, double, Value, double, Threshold) {
@@ -130,11 +125,11 @@ auto match1Div(const Matcher<clang::Expr> Match) {
 }
 
 auto matchEuler() {
-  return expr(
-      anyOf(matchFloatValueNear(Euler), matchMathCall("exp", matchValue(1))));
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::e),
+                    matchMathCall("exp", matchValue(1))));
 }
 auto matchEulerTopLevel() {
-  return expr(anyOf(matchFloatValueNear(Euler, false),
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::e, false),
                     matchMathCall("exp", matchValue(1))));
 }
 
@@ -148,10 +143,10 @@ auto matchLog10Euler() {
                     matchMathCall("log10", matchEuler())));
 }
 
-auto matchPi() { return matchFloatValueNear(Pi); }
-auto matchPiTopLevel() { return matchFloatValueNear(Pi, false); }
+auto matchPi() { return matchFloatValueNear(llvm::numbers::pi); }
+auto matchPiTopLevel() { return matchFloatValueNear(llvm::numbers::pi, false); }
 
-auto matchEgamma() { return matchFloatValueNear(Egamma, false); }
+auto matchEgamma() { return matchFloatValueNear(llvm::numbers::egamma, false); }
 
 auto matchInvPi() {
   return expr(
@@ -195,7 +190,7 @@ auto matchPhi() {
           hasOperatorName("+"), hasEitherOperand(matchValue(1)),
           hasEitherOperand(matchMathCall("sqrt", matchValue(5))))))),
       hasRHS(matchValue(2)));
-  return expr(anyOf(PhiFormula, matchFloatValueNear(Phi)));
+  return expr(anyOf(PhiFormula, matchFloatValueNear(llvm::numbers::phi)));
 }
 
 EditGenerator

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -391,8 +391,8 @@ void UseStdNumbersCheck::check(const MatchFinder::MatchResult &Result) {
       continue;
     }
 
-    const auto PatternBindString = (ConstantName + "_pattern").str();
-    if (Result.Nodes.getNodeAs<Expr>(PatternBindString) != nullptr) {
+    if (const auto PatternBindString = (ConstantName + "_pattern").str();
+        Result.Nodes.getNodeAs<Expr>(PatternBindString) != nullptr) {
       const auto Code = getCode(ConstantName, IsFloat, IsLongDouble);
       diag(Range.getBegin(), "prefer '%0' to this %select{formula|macro}1")
           << Code << IsMacro << FixItHint::CreateReplacement(Range, Code);

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -303,7 +303,7 @@ UseStdNumbersCheck::UseStdNumbersCheck(const StringRef Name,
   }
 }
 
-void UseStdNumbersCheck::registerMatchers(MatchFinder *Finder) {
+void UseStdNumbersCheck::registerMatchers(MatchFinder *const Finder) {
   const auto Matches = MatchBuilder{DiffThreshold};
   static const auto ConstantMatchers = {
       Matches.matchLog2Euler(),     Matches.matchLog10Euler(),
@@ -436,9 +436,9 @@ void UseStdNumbersCheck::check(const MatchFinder::MatchResult &Result) {
              Result.SourceManager->getFileID(Range.getBegin()), "<numbers>");
 }
 
-void UseStdNumbersCheck::registerPPCallbacks(const SourceManager &SM,
-                                             Preprocessor *PP,
-                                             Preprocessor *ModuleExpanderPP) {
+void UseStdNumbersCheck::registerPPCallbacks(
+    const SourceManager &SM, Preprocessor *const PP,
+    Preprocessor *const ModuleExpanderPP) {
   IncludeInserter.registerPreprocessor(PP);
 }
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -227,7 +227,7 @@ RewriteRuleWith<std::string> makeRule(const Matcher<clang::Stmt> Matcher,
       DefaultEdit, {{"float", FloatEdit}, {"long double", LongDoubleEdit}});
 
   return makeRule(
-      expr(Matcher,
+      expr(Matcher, unless(isInTemplateInstantiation()),
            hasType(qualType(hasCanonicalType(hasUnqualifiedDesugaredType(anyOf(
                qualType(asString("float")).bind("float"),
                qualType(asString("double")),

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -51,12 +51,17 @@ AST_MATCHER_P(clang::FloatingLiteral, near, double, Value) {
 
 AST_MATCHER_P(clang::QualType, hasCanonicalTypeUnqualified,
               Matcher<clang::QualType>, InnerMatcher) {
-  return InnerMatcher.matches(Node->getCanonicalTypeUnqualified(), Finder,
+  return !Node.isNull() &&
+         InnerMatcher.matches(Node->getCanonicalTypeUnqualified(), Finder,
                               Builder);
 }
 
-AST_MATCHER(clang::QualType, isArithmetic) { return Node->isArithmeticType(); }
-AST_MATCHER(clang::QualType, isFloating) { return Node->isFloatingType(); }
+AST_MATCHER(clang::QualType, isArithmetic) {
+  return !Node.isNull() && Node->isArithmeticType();
+}
+AST_MATCHER(clang::QualType, isFloating) {
+  return !Node.isNull() && Node->isFloatingType();
+}
 
 auto ignoreImplicitAndArithmeticCasting(const Matcher<clang::Expr> Matcher) {
   return expr(

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -293,8 +293,8 @@ UseStdNumbersCheck::UseStdNumbersCheck(const StringRef Name,
     : ClangTidyCheck(Name, Context),
       IncludeInserter(Options.getLocalOrGlobal("IncludeStyle",
                                                utils::IncludeSorter::IS_LLVM),
-                      areDiagsSelfContained()) {
-  DiffThresholdString = Options.get("DiffThreshold", "0.001");
+                      areDiagsSelfContained()),
+      DiffThresholdString{Options.get("DiffThreshold", "0.001")} {
   if (DiffThresholdString.getAsDouble(DiffThreshold)) {
     configurationDiag(
         "Invalid DiffThreshold config value: '%0', expected a double")

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -105,7 +105,7 @@ struct MatchBuilder {
   // Used for top-level matchers (i.e. the match that replaces Val with its
   // constant).
   //
-  // E.g. The matcher of `std::numbers::pi` uses this matcher to look to
+  // E.g. The matcher of `std::numbers::pi` uses this matcher to look for
   // floatLiterals that have the value of pi.
   //
   // If the match is for a top-level match, we only care about the literal.

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -9,7 +9,6 @@
 #include "UseStdNumbersCheck.h"
 #include "../ClangTidyDiagnosticConsumer.h"
 #include "clang/AST/ASTContext.h"
-#include "clang/AST/ASTTypeTraits.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/Stmt.h"

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -149,8 +149,8 @@ auto matchPiTopLevel() { return matchFloatValueNear(llvm::numbers::pi, false); }
 auto matchEgamma() { return matchFloatValueNear(llvm::numbers::egamma, false); }
 
 auto matchInvPi() {
-  return expr(
-      anyOf(matchFloatValueNear(llvm::numbers::inv_pi), match1Div(matchPi())));
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::inv_pi, false),
+                    match1Div(matchPi())));
 }
 
 auto matchInvSqrtPi() {
@@ -190,7 +190,8 @@ auto matchPhi() {
           hasOperatorName("+"), hasEitherOperand(matchValue(1)),
           hasEitherOperand(matchMathCall("sqrt", matchValue(5))))))),
       hasRHS(matchValue(2)));
-  return expr(anyOf(PhiFormula, matchFloatValueNear(llvm::numbers::phi)));
+  return expr(
+      anyOf(PhiFormula, matchFloatValueNear(llvm::numbers::phi, false)));
 }
 
 EditGenerator

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -39,7 +39,7 @@ using llvm::StringRef;
 constexpr auto DiffThreshold = 0.001;
 
 AST_MATCHER_P(clang::FloatingLiteral, near, double, Value) {
-  return std::abs(Node.getValue().convertToDouble() - Value) < DiffThreshold;
+  return std::abs(Node.getValueAsApproximateDouble() - Value) < DiffThreshold;
 }
 
 AST_MATCHER_P(clang::QualType, hasCanonicalTypeUnqualified,

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -112,10 +112,9 @@ auto matchFloatLiteralNear(const double Val) {
 auto matchFloatValueNear(const double Val) {
   const auto Float = floatLiteral(near(Val));
 
-  const auto Dref = declRefExpr(to(varDecl(
-      anyOf(isConstexpr(),
-            varDecl(hasType(qualType(isConstQualified(), isArithmetic())))),
-      hasInitializer(Float))));
+  const auto Dref = declRefExpr(
+      to(varDecl(hasType(qualType(isConstQualified(), isFloating())),
+                 hasInitializer(ignoreImplicitAndFloatingCasting(Float)))));
   return expr(ignoreImplicitAndFloatingCasting(anyOf(Float, Dref)));
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -123,10 +123,9 @@ auto matchValue(const int64_t ValInt) {
       expr(ignoreImplicitAndArithmeticCasting(integerLiteral(equals(ValInt))));
   const auto Float = expr(ignoreImplicitAndFloatingCasting(
       matchFloatValueNear(static_cast<double>(ValInt))));
-  const auto Dref = declRefExpr(to(varDecl(
-      anyOf(isConstexpr(),
-            varDecl(hasType(qualType(isConstQualified(), isArithmetic())))),
-      hasInitializer(anyOf(Int, Float)))));
+  const auto Dref = declRefExpr(
+      to(varDecl(hasType(qualType(isConstQualified(), isArithmetic())),
+                 hasInitializer(anyOf(Int, Float)))));
   return expr(anyOf(Int, Float, Dref));
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -60,7 +60,7 @@ AST_MATCHER_P2(clang::FloatingLiteral, near, double, Value, double, Threshold) {
 // Instead, the macro definition is matched and the value is exchanged there.
 // Hinting at replacing macro definitions with language constructs is done in
 // another check.
-AST_MATCHER(clang::Expr, isMathMacro) { return Node.getBeginLoc().isMacroID(); }
+AST_MATCHER(clang::Expr, isMacro) { return Node.getBeginLoc().isMacroID(); }
 
 AST_MATCHER_P(clang::QualType, hasUnqualifiedDesugaredType,
               Matcher<clang::QualType>, InnerMatcher) {
@@ -106,7 +106,7 @@ auto matchFloatValueNear(const double Val,
                          const bool MatchDeclRefExprOrMacro = true) {
   const auto FloatVal = floatLiteral(near(Val, DiffThreshold));
   if (!MatchDeclRefExprOrMacro) {
-    return expr(unless(isMathMacro()), ignoringImplicit(FloatVal));
+    return expr(unless(isMacro()), ignoringImplicit(FloatVal));
   }
 
   const auto Dref = declRefExpr(to(varDecl(

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -179,9 +179,9 @@ auto matchPhi() {
   return expr(anyOf(PhiFormula, matchFloatLiteralNear(llvm::numbers::phi)));
 }
 
-EditGenerator
-chainedIfBound(ASTEdit DefaultEdit,
-               llvm::SmallVector<std::pair<StringRef, ASTEdit>, 2> Edits) {
+EditGenerator applyRuleForBoundOrDefault(
+    ASTEdit DefaultEdit,
+    llvm::SmallVector<std::pair<StringRef, ASTEdit>, 2> Edits) {
   return [Edits = std::move(Edits), DefaultEdit = std::move(DefaultEdit)](
              const MatchFinder::MatchResult &Result) {
     auto &Map = Result.Nodes.getMap();
@@ -204,7 +204,7 @@ RewriteRuleWith<std::string> makeRule(const Matcher<clang::Stmt> Matcher,
   const auto LongDoubleEdit =
       changeTo(cat("std::numbers::", Constant, "_v<long double>"));
 
-  const auto EditRules = chainedIfBound(
+  const auto EditRules = applyRuleForBoundOrDefault(
       DefaultEdit, {{"float", FloatEdit}, {"long double", LongDoubleEdit}});
 
   return makeRule(

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -325,10 +325,10 @@ void UseStdNumbersCheck::registerMatchers(MatchFinder *Finder) {
            unless(hasParent(expr(
                anyOf(implicitCastExpr(hasImplicitDestinationType(isFloating())),
                      explicitCastExpr(hasDestinationType(isFloating())))))),
-           hasType(qualType(hasCanonicalType(hasCanonicalTypeUnqualified(anyOf(
-               qualType(asString("float")).bind("float"),
-               qualType(asString("double")),
-               qualType(asString("long double")).bind("long double"))))))),
+           hasType(qualType(hasCanonicalTypeUnqualified(
+               anyOf(qualType(asString("float")).bind("float"),
+                     qualType(asString("double")),
+                     qualType(asString("long double")).bind("long double")))))),
       this);
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -43,8 +43,8 @@ using llvm::StringRef;
 
 constexpr auto DiffThreshold = 0.001;
 
-AST_MATCHER_P2(clang::FloatingLiteral, near, double, Value, double, Threshold) {
-  return std::abs(Node.getValue().convertToDouble() - Value) < Threshold;
+AST_MATCHER_P(clang::FloatingLiteral, near, double, Value) {
+  return std::abs(Node.getValue().convertToDouble() - Value) < DiffThreshold;
 }
 
 // We don't want to match uses of macros, such as
@@ -99,7 +99,7 @@ auto matchSqrt(const Matcher<clang::Expr> ArgumentMatcher) {
 // Therefore, all top-level matcher set MatchDeclRefExprOrMacro to false
 auto matchFloatValueNear(const double Val,
                          const bool MatchDeclRefExprOrMacro = true) {
-  const auto Float = floatLiteral(near(Val, DiffThreshold));
+  const auto Float = floatLiteral(near(Val));
   if (!MatchDeclRefExprOrMacro) {
     return expr(unless(isMacro()), ignoringImplicit(Float));
   }

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -104,24 +104,24 @@ auto matchSqrt(const Matcher<clang::Expr> ArgumentMatcher) {
 // Therefore, all top-level matcher set MatchDeclRefExprOrMacro to false
 auto matchFloatValueNear(const double Val,
                          const bool MatchDeclRefExprOrMacro = true) {
-  const auto FloatVal = floatLiteral(near(Val, DiffThreshold));
+  const auto Float = floatLiteral(near(Val, DiffThreshold));
   if (!MatchDeclRefExprOrMacro) {
-    return expr(unless(isMacro()), ignoringImplicit(FloatVal));
+    return expr(unless(isMacro()), ignoringImplicit(Float));
   }
 
   const auto Dref = declRefExpr(to(varDecl(
       anyOf(isConstexpr(), varDecl(hasType(qualType(isConstQualified())))),
-      hasInitializer(FloatVal))));
-  return expr(ignoringImplicit(anyOf(FloatVal, Dref)));
+      hasInitializer(Float))));
+  return expr(ignoringImplicit(anyOf(Float, Dref)));
 }
 
 auto matchValue(const int64_t ValInt) {
-  const auto Int2 = integerLiteral(equals(ValInt));
-  const auto Float2 = matchFloatValueNear(static_cast<double>(ValInt));
+  const auto Int = integerLiteral(equals(ValInt));
+  const auto Float = matchFloatValueNear(static_cast<double>(ValInt));
   const auto Dref = declRefExpr(to(varDecl(
       anyOf(isConstexpr(), varDecl(hasType(qualType(isConstQualified())))),
-      hasInitializer(expr(ignoringImplicit(anyOf(Int2, Float2)))))));
-  return expr(ignoringImplicit(anyOf(Int2, Float2, Dref)));
+      hasInitializer(expr(ignoringImplicit(anyOf(Int, Float)))))));
+  return expr(ignoringImplicit(anyOf(Int, Float, Dref)));
 }
 
 auto match1Div(const Matcher<clang::Expr> Match) {

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -1,0 +1,377 @@
+//===--- UseStdNumbersCheck.cpp - clang_tidy -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX_License_Identifier: Apache_2.0 WITH LLVM_exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseStdNumbersCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/Type.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/ASTMatchers/ASTMatchersInternal.h"
+#include "clang/ASTMatchers/ASTMatchersMacros.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/TokenKinds.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/Token.h"
+#include "clang/Tooling/Transformer/RewriteRule.h"
+#include "clang/Tooling/Transformer/Stencil.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MathExtras.h"
+#include <cstdint>
+#include <string>
+
+namespace {
+using namespace clang::ast_matchers;
+using clang::ast_matchers::internal::Matcher;
+using clang::transformer::addInclude;
+using clang::transformer::applyFirst;
+using clang::transformer::ASTEdit;
+using clang::transformer::cat;
+using clang::transformer::changeTo;
+using clang::transformer::edit;
+using clang::transformer::EditGenerator;
+using clang::transformer::flattenVector;
+using clang::transformer::RewriteRuleWith;
+using llvm::StringRef;
+
+constexpr double Pi = 3.141592653589793238462643383279502884197169399;
+constexpr double Euler = 2.718281828459045235360287471352662497757247093;
+constexpr double Phi = 1.618033988749894848204586834365638117720309179;
+constexpr double Egamma = 0.577215664901532860606512090082402431042159335;
+
+constexpr auto DiffThreshold = 0.001;
+
+AST_MATCHER_P2(clang::FloatingLiteral, near, double, Value, double, Threshold) {
+  return std::abs(Node.getValue().convertToDouble() - Value) < Threshold;
+}
+
+// We don't want to match uses of macros, such as
+//
+// auto PiHalved = MY_PI / 2;
+//
+// because a project might use defines for math constants.
+// Instead, the macro definition is matched and the value is exchanged there.
+// Hinting at replacing macro definitions with language constructs is done in
+// another check.
+AST_MATCHER(clang::Expr, isMathMacro) { return Node.getBeginLoc().isMacroID(); }
+
+AST_MATCHER_P(clang::QualType, hasUnqualifiedDesugaredType,
+              Matcher<clang::QualType>, InnerMatcher) {
+  return InnerMatcher.matches(Node->getCanonicalTypeUnqualified(), Finder,
+                              Builder);
+}
+
+auto matchMathCall(const StringRef FunctionName,
+                   const Matcher<clang::Expr> ArgumentMatcher) {
+  return callExpr(callee(functionDecl(hasName(FunctionName))),
+                  hasArgument(0, ignoringImplicit(ArgumentMatcher)));
+}
+
+auto matchSqrt(const Matcher<clang::Expr> ArgumentMatcher) {
+  return matchMathCall("sqrt", ArgumentMatcher);
+}
+
+// 'MatchDeclRefExprOrMacro' is used to differentiate matching expressions where
+// the value of anything used is near 'Val' and matching expressions where we
+// only care about the actual literal.
+// We don't want top-level matches to match a simple DeclRefExpr/macro that was
+// initialized with this value because projects might declare their own
+// constants (e.g. namespaced constants or macros) to be used. We don't want to
+// flag the use of these variables/constants, but modify the definition of the
+// variable or macro.
+//
+// example:
+//   const auto e = 2.71828182; // std::numbers::e
+//                  ^^^^^^^^^^
+//                  match here
+//
+//   auto use = e / 2;
+//              ^
+//   don't match this as a top-level match, this would create noise
+//
+//   auto use2 = log2(e); // std::numbers::log2e
+//               ^^^^^^^
+//               match here, matcher needs to check the initialization
+//               of e to match log2e
+//
+// Therefore, all top-level matcher set MatchDeclRefExprOrMacro to false
+auto matchFloatValueNear(const double Val,
+                         const bool MatchDeclRefExprOrMacro = true) {
+  const auto FloatVal = floatLiteral(near(Val, DiffThreshold));
+  if (!MatchDeclRefExprOrMacro) {
+    return expr(unless(isMathMacro()), ignoringImplicit(FloatVal));
+  }
+
+  const auto Dref = declRefExpr(to(varDecl(
+      anyOf(isConstexpr(), varDecl(hasType(qualType(isConstQualified())))),
+      hasInitializer(FloatVal))));
+  return expr(ignoringImplicit(anyOf(FloatVal, Dref)));
+}
+
+auto matchValue(const int64_t ValInt) {
+  const auto Int2 = integerLiteral(equals(ValInt));
+  const auto Float2 = matchFloatValueNear(static_cast<double>(ValInt));
+  const auto Dref = declRefExpr(to(varDecl(
+      anyOf(isConstexpr(), varDecl(hasType(qualType(isConstQualified())))),
+      hasInitializer(expr(ignoringImplicit(anyOf(Int2, Float2)))))));
+  return expr(ignoringImplicit(anyOf(Int2, Float2, Dref)));
+}
+
+auto match1Div(const Matcher<clang::Expr> Match) {
+  return binaryOperator(hasOperatorName("/"), hasLHS(matchValue(1)),
+                        hasRHS(ignoringImplicit(Match)));
+}
+
+auto matchEuler() {
+  return expr(
+      anyOf(matchFloatValueNear(Euler), matchMathCall("exp", matchValue(1))));
+}
+auto matchEulerTopLevel() {
+  return expr(anyOf(matchFloatValueNear(Euler, false),
+                    matchMathCall("exp", matchValue(1))));
+}
+
+auto matchLog2Euler() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::log2e, false),
+                    matchMathCall("log2", matchEuler())));
+}
+
+auto matchLog10Euler() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::log10e, false),
+                    matchMathCall("log10", matchEuler())));
+}
+
+auto matchPi() { return matchFloatValueNear(Pi); }
+auto matchPiTopLevel() { return matchFloatValueNear(Pi, false); }
+
+auto matchEgamma() { return matchFloatValueNear(Egamma, false); }
+
+auto matchInvPi() {
+  return expr(
+      anyOf(matchFloatValueNear(llvm::numbers::inv_pi), match1Div(matchPi())));
+}
+
+auto matchInvSqrtPi() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::inv_sqrtpi, false),
+                    match1Div(matchSqrt(matchPi()))));
+}
+
+auto matchLn2() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::ln2, false),
+                    matchMathCall("log", ignoringImplicit(matchValue(2)))));
+}
+
+auto machterLn10() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::ln10, false),
+                    matchMathCall("log", ignoringImplicit(matchValue(10)))));
+}
+
+auto matchSqrt2() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::sqrt2, false),
+                    matchSqrt(matchValue(2))));
+}
+
+auto matchSqrt3() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::sqrt3, false),
+                    matchSqrt(matchValue(3))));
+}
+
+auto matchInvSqrt3() {
+  return expr(anyOf(matchFloatValueNear(llvm::numbers::inv_sqrt3, false),
+                    match1Div(matchSqrt(matchValue(3)))));
+}
+
+auto matchPhi() {
+  const auto PhiFormula = binaryOperator(
+      hasOperatorName("/"),
+      hasLHS(parenExpr(has(binaryOperator(
+          hasOperatorName("+"), hasEitherOperand(matchValue(1)),
+          hasEitherOperand(matchMathCall("sqrt", matchValue(5))))))),
+      hasRHS(matchValue(2)));
+  return expr(anyOf(PhiFormula, matchFloatValueNear(Phi)));
+}
+
+EditGenerator
+chainedIfBound(ASTEdit DefaultEdit,
+               llvm::SmallVector<std::pair<StringRef, ASTEdit>, 2> Edits) {
+  return [Edits = std::move(Edits), DefaultEdit = std::move(DefaultEdit)](
+             const MatchFinder::MatchResult &Result) {
+    auto &Map = Result.Nodes.getMap();
+    for (const auto &[Id, EditOfId] : Edits) {
+      if (Map.find(Id) != Map.end()) {
+        return edit(EditOfId)(Result);
+      }
+    }
+    return edit(DefaultEdit)(Result);
+  };
+}
+
+RewriteRuleWith<std::string> makeRule(const Matcher<clang::Stmt> Matcher,
+                                      const StringRef Constant) {
+  static const auto AddNumbersInclude =
+      addInclude("numbers", clang::transformer::IncludeFormat::Angled);
+
+  const auto DefaultEdit = changeTo(cat("std::numbers::", Constant));
+  const auto FloatEdit = changeTo(cat("std::numbers::", Constant, "_v<float>"));
+  const auto LongDoubleEdit =
+      changeTo(cat("std::numbers::", Constant, "_v<long double>"));
+
+  const auto EditRules = chainedIfBound(
+      DefaultEdit, {{"float", FloatEdit}, {"long double", LongDoubleEdit}});
+
+  return makeRule(
+      expr(Matcher,
+           hasType(qualType(hasCanonicalType(hasUnqualifiedDesugaredType(anyOf(
+               qualType(asString("float")).bind("float"),
+               qualType(asString("double")),
+               qualType(asString("long double")).bind("long double"))))))),
+      flattenVector({edit(AddNumbersInclude), EditRules}),
+      cat("prefer std::numbers math constant"));
+}
+
+/*
+  List of all math constants
+  + e
+  + log2e
+  + log10e
+  + pi
+  + inv_pi
+  + inv_sqrtpi
+  + ln2
+  + ln10
+  + sqrt2
+  + sqrt3
+  + inv_sqrt3
+  + egamma
+  + phi
+*/
+
+RewriteRuleWith<std::string> makeRewriteRule() {
+  return applyFirst({
+      makeRule(matchLog2Euler(), "log2e"),
+      makeRule(matchLog10Euler(), "log10e"),
+      makeRule(matchEulerTopLevel(), "e"),
+      makeRule(matchEgamma(), "egamma"),
+      makeRule(matchInvSqrtPi(), "inv_sqrtpi"),
+      makeRule(matchInvPi(), "inv_pi"),
+      makeRule(matchPiTopLevel(), "pi"),
+      makeRule(matchLn2(), "ln2"),
+      makeRule(machterLn10(), "ln10"),
+      makeRule(matchSqrt2(), "sqrt2"),
+      makeRule(matchInvSqrt3(), "inv_sqrt3"),
+      makeRule(matchSqrt3(), "sqrt3"),
+      makeRule(matchPhi(), "phi"),
+  });
+}
+
+class MathConstantMacroCallback : public clang::PPCallbacks {
+public:
+  explicit MathConstantMacroCallback(
+      clang::tidy::modernize::UseStdNumbersCheck *Check)
+      : Check{Check} {};
+
+  void MacroDefined(const clang::Token & /*MacroNameTok*/,
+                    const clang::MacroDirective *MD) override {
+    for (const auto &Tok : MD->getDefinition().getMacroInfo()->tokens()) {
+      if (!Tok.is(clang::tok::numeric_constant)) {
+        continue;
+      }
+
+      const auto Definition =
+          llvm::StringRef{Tok.getLiteralData(), Tok.getLength()};
+      double Value{};
+      Definition.getAsDouble(Value);
+
+      const auto IsNear = [](const auto Lhs, const auto Rhs) {
+        return std::abs(Lhs - Rhs) < DiffThreshold;
+      };
+
+      if (IsNear(Value, llvm::numbers::log2e)) {
+        reportDiag(Tok, "std::numbers::log2e");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::log10e)) {
+        reportDiag(Tok, "std::numbers::log10e");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::e)) {
+        reportDiag(Tok, "std::numbers::e");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::egamma)) {
+        reportDiag(Tok, "std::numbers::egamma");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::inv_sqrtpi)) {
+        reportDiag(Tok, "std::numbers::inv_sqrtpi");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::inv_pi)) {
+        reportDiag(Tok, "std::numbers::inv_pi");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::pi)) {
+        reportDiag(Tok, "std::numbers::pi");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::ln2)) {
+        reportDiag(Tok, "std::numbers::ln2");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::ln10)) {
+        reportDiag(Tok, "std::numbers::ln10");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::sqrt2)) {
+        reportDiag(Tok, "std::numbers::sqrt2");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::inv_sqrt3)) {
+        reportDiag(Tok, "std::numbers::inv_sqrt3");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::sqrt3)) {
+        reportDiag(Tok, "std::numbers::sqrt3");
+        return;
+      }
+      if (IsNear(Value, llvm::numbers::phi)) {
+        reportDiag(Tok, "std::numbers::phi");
+        return;
+      }
+    }
+  }
+
+private:
+  void reportDiag(const clang::Token &Tok, const llvm::StringRef Constant) {
+    Check->diag(Tok.getLocation(), "prefer math constant")
+        << clang::FixItHint::CreateReplacement(
+               clang::SourceRange(Tok.getLocation(), Tok.getLastLoc()),
+               Constant);
+  }
+
+  clang::tidy::modernize::UseStdNumbersCheck *Check{};
+};
+} // namespace
+
+namespace clang::tidy::modernize {
+UseStdNumbersCheck::UseStdNumbersCheck(const StringRef Name,
+                                       ClangTidyContext *const Context)
+    : TransformerClangTidyCheck(Name, Context) {
+  setRule(makeRewriteRule());
+}
+
+void UseStdNumbersCheck::registerPPCallbacks(const SourceManager &SM,
+                                             Preprocessor *PP,
+                                             Preprocessor *ModuleExpanderPP) {
+  utils::TransformerClangTidyCheck::registerPPCallbacks(SM, PP,
+                                                        ModuleExpanderPP);
+  PP->addPPCallbacks(std::make_unique<MathConstantMacroCallback>(this));
+}
+} // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -8,7 +8,6 @@
 
 #include "UseStdNumbersCheck.h"
 #include "../ClangTidyDiagnosticConsumer.h"
-#include "../utils/TransformerClangTidyCheck.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
@@ -18,29 +17,28 @@
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/ASTMatchers/ASTMatchersInternal.h"
 #include "clang/ASTMatchers/ASTMatchersMacros.h"
+#include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LLVM.h"
-#include "clang/Tooling/Transformer/RewriteRule.h"
-#include "clang/Tooling/Transformer/Stencil.h"
+#include "clang/Basic/LangOptions.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Lex/Lexer.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MathExtras.h"
+#include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <initializer_list>
 #include <string>
+#include <tuple>
 #include <utility>
 
 namespace {
 using namespace clang::ast_matchers;
 using clang::ast_matchers::internal::Matcher;
-using clang::transformer::addInclude;
-using clang::transformer::applyFirst;
-using clang::transformer::ASTEdit;
-using clang::transformer::cat;
-using clang::transformer::changeTo;
-using clang::transformer::edit;
-using clang::transformer::EditGenerator;
-using clang::transformer::flattenVector;
-using clang::transformer::RewriteRuleWith;
 using llvm::StringRef;
 
 constexpr auto DiffThreshold = 0.001;
@@ -63,6 +61,19 @@ AST_MATCHER(clang::QualType, isFloating) {
   return !Node.isNull() && Node->isFloatingType();
 }
 
+AST_MATCHER_P(clang::Expr, anyOfExhaustive,
+              llvm::ArrayRef<Matcher<clang::Stmt>>, Exprs) {
+  bool FoundMatch = false;
+  for (const auto &InnerMatcher : Exprs) {
+    clang::ast_matchers::internal::BoundNodesTreeBuilder Result = *Builder;
+    if (InnerMatcher.matches(Node, Finder, &Result)) {
+      *Builder = std::move(Result);
+      FoundMatch = true;
+    }
+  }
+  return FoundMatch;
+}
+
 auto ignoreImplicitAndArithmeticCasting(const Matcher<clang::Expr> Matcher) {
   return expr(
       ignoringImplicit(expr(hasType(qualType(isArithmetic())),
@@ -77,10 +88,10 @@ auto ignoreImplicitAndFloatingCasting(const Matcher<clang::Expr> Matcher) {
 
 auto matchMathCall(const StringRef FunctionName,
                    const Matcher<clang::Expr> ArgumentMatcher) {
-  return callExpr(
-      callee(functionDecl(hasName(FunctionName),
-                          hasParameter(0, hasType(isArithmetic())))),
-      hasArgument(0, ArgumentMatcher));
+  return expr(ignoreImplicitAndFloatingCasting(
+      callExpr(callee(functionDecl(hasName(FunctionName),
+                                   hasParameter(0, hasType(isArithmetic())))),
+               hasArgument(0, ArgumentMatcher))));
 }
 
 auto matchSqrt(const Matcher<clang::Expr> ArgumentMatcher) {
@@ -93,9 +104,10 @@ auto matchSqrt(const Matcher<clang::Expr> ArgumentMatcher) {
 // E.g. The matcher of `std::numbers::pi` uses this matcher to look to
 // floatLiterals that have the value of pi.
 //
-// We only care about the literal if the match is for a top-level match
-auto matchFloatLiteralNear(const double Val) {
-  return expr(ignoreImplicitAndFloatingCasting(floatLiteral(near(Val))));
+// If the match is for a top-level match, we only care about the literal.
+auto matchFloatLiteralNear(const StringRef Constant, const double Val) {
+  return expr(
+      ignoreImplicitAndFloatingCasting(floatLiteral(near(Val)).bind(Constant)));
 }
 
 // Used for non-top-level matchers (i.e. matchers that are used as inner
@@ -140,58 +152,85 @@ auto matchEuler() {
                     matchMathCall("exp", matchValue(1))));
 }
 auto matchEulerTopLevel() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::e),
-                    matchMathCall("exp", matchValue(1))));
+  return expr(anyOf(matchFloatLiteralNear("e_literal", llvm::numbers::e),
+                    matchMathCall("exp", matchValue(1)).bind("e_pattern")))
+      .bind("e");
 }
 
 auto matchLog2Euler() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::log2e),
-                    matchMathCall("log2", matchEuler())));
+  return expr(
+             anyOf(matchFloatLiteralNear("log2e_literal", llvm::numbers::log2e),
+                   matchMathCall("log2", matchEuler()).bind("log2e_pattern")))
+      .bind("log2e");
 }
 
 auto matchLog10Euler() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::log10e),
-                    matchMathCall("log10", matchEuler())));
+  return expr(
+             anyOf(
+                 matchFloatLiteralNear("log10e_literal", llvm::numbers::log10e),
+                 matchMathCall("log10", matchEuler()).bind("log10e_pattern")))
+      .bind("log10e");
 }
 
 auto matchPi() { return matchFloatValueNear(llvm::numbers::pi); }
-auto matchPiTopLevel() { return matchFloatLiteralNear(llvm::numbers::pi); }
+auto matchPiTopLevel() {
+  return matchFloatLiteralNear("pi_literal", llvm::numbers::pi).bind("pi");
+}
 
-auto matchEgamma() { return matchFloatLiteralNear(llvm::numbers::egamma); }
+auto matchEgamma() {
+  return matchFloatLiteralNear("egamma_literal", llvm::numbers::egamma)
+      .bind("egamma");
+}
 
 auto matchInvPi() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::inv_pi),
-                    match1Div(matchPi())));
+  return expr(anyOf(matchFloatLiteralNear("inv_pi_literal",
+                                          llvm::numbers::inv_pi),
+                    match1Div(matchPi()).bind("inv_pi_pattern")))
+      .bind("inv_pi");
 }
 
 auto matchInvSqrtPi() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::inv_sqrtpi),
-                    match1Div(matchSqrt(matchPi()))));
+  return expr(anyOf(matchFloatLiteralNear("inv_sqrtpi_literal",
+                                          llvm::numbers::inv_sqrtpi),
+                    match1Div(matchSqrt(matchPi())).bind("inv_sqrtpi_pattern")))
+      .bind("inv_sqrtpi");
 }
 
 auto matchLn2() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::ln2),
-                    matchMathCall("log", ignoringImplicit(matchValue(2)))));
+  return expr(anyOf(matchFloatLiteralNear("ln2_literal", llvm::numbers::ln2),
+                    matchMathCall("log", ignoringImplicit(matchValue(2)))
+                        .bind("ln2_pattern")))
+      .bind("ln2");
 }
 
 auto machterLn10() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::ln10),
-                    matchMathCall("log", ignoringImplicit(matchValue(10)))));
+  return expr(anyOf(matchFloatLiteralNear("ln10_literal", llvm::numbers::ln10),
+                    matchMathCall("log", ignoringImplicit(matchValue(10)))
+                        .bind("ln10_pattern")))
+      .bind("ln10");
 }
 
 auto matchSqrt2() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::sqrt2),
-                    matchSqrt(matchValue(2))));
+  return expr(
+             anyOf(matchFloatLiteralNear("sqrt2_literal", llvm::numbers::sqrt2),
+                   matchSqrt(matchValue(2)).bind("sqrt2_pattern")))
+      .bind("sqrt2");
 }
 
 auto matchSqrt3() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::sqrt3),
-                    matchSqrt(matchValue(3))));
+  return expr(
+             anyOf(matchFloatLiteralNear("sqrt3_literal", llvm::numbers::sqrt3),
+                   matchSqrt(matchValue(3)).bind("sqrt3_pattern")))
+      .bind("sqrt3");
 }
 
 auto matchInvSqrt3() {
-  return expr(anyOf(matchFloatLiteralNear(llvm::numbers::inv_sqrt3),
-                    match1Div(matchSqrt(matchValue(3)))));
+  return expr(
+             anyOf(
+                 matchFloatLiteralNear("inv_sqrt3_literal",
+                                       llvm::numbers::inv_sqrt3),
+                 match1Div(matchSqrt(matchValue(3))).bind("inv_sqrt3_pattern")))
+      .bind("inv_sqrt3");
 }
 
 auto matchPhi() {
@@ -201,88 +240,179 @@ auto matchPhi() {
           hasOperatorName("+"), hasEitherOperand(matchValue(1)),
           hasEitherOperand(matchMathCall("sqrt", matchValue(5))))))),
       hasRHS(matchValue(2)));
-  return expr(anyOf(PhiFormula, matchFloatLiteralNear(llvm::numbers::phi)));
+  return expr(anyOf(PhiFormula.bind("phi_pattern"),
+                    matchFloatLiteralNear("phi_literal", llvm::numbers::phi)))
+      .bind("phi");
 }
 
-EditGenerator applyRuleForBoundOrDefault(
-    ASTEdit DefaultEdit,
-    llvm::SmallVector<std::pair<StringRef, ASTEdit>, 2> Edits) {
-  return [Edits = std::move(Edits), DefaultEdit = std::move(DefaultEdit)](
-             const MatchFinder::MatchResult &Result) {
-    auto &Map = Result.Nodes.getMap();
-    for (const auto &[Id, EditOfId] : Edits) {
-      if (Map.find(Id) != Map.end()) {
-        return edit(EditOfId)(Result);
-      }
-    }
-    return edit(DefaultEdit)(Result);
-  };
+std::string getCode(const StringRef Constant, const bool IsFloat,
+                    const bool IsLongDouble) {
+  if (IsFloat) {
+    return ("std::numbers::" + Constant + "_v<float>").str();
+  }
+  if (IsLongDouble) {
+    return ("std::numbers::" + Constant + "_v<long double>").str();
+  }
+  return ("std::numbers::" + Constant).str();
 }
 
-RewriteRuleWith<std::string> makeRule(const Matcher<clang::Stmt> Matcher,
-                                      const StringRef Constant) {
-  static const auto AddNumbersInclude =
-      addInclude("numbers", clang::transformer::IncludeFormat::Angled);
+bool isRangeOfCompleteMacro(const clang::SourceRange &Range,
+                            const clang::SourceManager &SM,
+                            const clang::LangOptions &LO) {
+  if (!Range.getBegin().isMacroID()) {
+    return false;
+  }
+  if (!clang::Lexer::isAtStartOfMacroExpansion(Range.getBegin(), SM, LO)) {
+    return false;
+  }
 
-  const auto DefaultEdit = changeTo(cat("std::numbers::", Constant));
-  const auto FloatEdit = changeTo(cat("std::numbers::", Constant, "_v<float>"));
-  const auto LongDoubleEdit =
-      changeTo(cat("std::numbers::", Constant, "_v<long double>"));
+  if (!Range.getEnd().isMacroID()) {
+    return false;
+  }
 
-  const auto EditRules = applyRuleForBoundOrDefault(
-      DefaultEdit, {{"float", FloatEdit}, {"long double", LongDoubleEdit}});
+  if (!clang::Lexer::isAtEndOfMacroExpansion(Range.getEnd(), SM, LO)) {
+    return false;
+  }
 
-  return makeRule(
-      expr(ignoreImplicitAndFloatingCasting(Matcher),
-           unless(isInTemplateInstantiation()),
-           hasType(qualType(hasCanonicalType(hasCanonicalTypeUnqualified(anyOf(
-               qualType(asString("float")).bind("float"),
-               qualType(asString("double")),
-               qualType(asString("long double")).bind("long double"))))))),
-      flattenVector({edit(AddNumbersInclude), EditRules}),
-      cat("prefer std::numbers math constant"));
+  return true;
 }
 
-/*
-  List of all math constants
-  + e
-  + log2e
-  + log10e
-  + pi
-  + inv_pi
-  + inv_sqrtpi
-  + ln2
-  + ln10
-  + sqrt2
-  + sqrt3
-  + inv_sqrt3
-  + egamma
-  + phi
-*/
-
-RewriteRuleWith<std::string> makeRewriteRule() {
-  return applyFirst({
-      makeRule(matchLog2Euler(), "log2e"),
-      makeRule(matchLog10Euler(), "log10e"),
-      makeRule(matchEulerTopLevel(), "e"),
-      makeRule(matchEgamma(), "egamma"),
-      makeRule(matchInvSqrtPi(), "inv_sqrtpi"),
-      makeRule(matchInvPi(), "inv_pi"),
-      makeRule(matchPiTopLevel(), "pi"),
-      makeRule(matchLn2(), "ln2"),
-      makeRule(machterLn10(), "ln10"),
-      makeRule(matchSqrt2(), "sqrt2"),
-      makeRule(matchInvSqrt3(), "inv_sqrt3"),
-      makeRule(matchSqrt3(), "sqrt3"),
-      makeRule(matchPhi(), "phi"),
-  });
-}
 } // namespace
 
 namespace clang::tidy::modernize {
 UseStdNumbersCheck::UseStdNumbersCheck(const StringRef Name,
                                        ClangTidyContext *const Context)
-    : TransformerClangTidyCheck(Name, Context) {
-  setRule(makeRewriteRule());
+    : ClangTidyCheck(Name, Context),
+      IncludeInserter(Options.getLocalOrGlobal("IncludeStyle",
+                                               utils::IncludeSorter::IS_LLVM),
+                      areDiagsSelfContained()) {}
+
+void UseStdNumbersCheck::registerMatchers(MatchFinder *Finder) {
+  static const auto ConstantMatchers = {
+      matchLog2Euler(), matchLog10Euler(), matchEulerTopLevel(), matchEgamma(),
+      matchInvSqrtPi(), matchInvPi(),      matchPiTopLevel(),    matchLn2(),
+      machterLn10(),    matchSqrt2(),      matchInvSqrt3(),      matchSqrt3(),
+      matchPhi(),
+  };
+
+  Finder->addMatcher(
+      expr(anyOfExhaustive(ConstantMatchers),
+           unless(isInTemplateInstantiation()),
+           unless(hasParent(expr(
+               anyOf(implicitCastExpr(hasImplicitDestinationType(isFloating())),
+                     explicitCastExpr(hasDestinationType(isFloating())))))),
+           hasType(qualType(hasCanonicalType(hasCanonicalTypeUnqualified(anyOf(
+               qualType(asString("float")).bind("float"),
+               qualType(asString("double")),
+               qualType(asString("long double")).bind("long double"))))))),
+      this);
+}
+
+void UseStdNumbersCheck::check(const MatchFinder::MatchResult &Result) {
+  /*
+    List of all math constants in the `<numbers>` header
+    + e
+    + log2e
+    + log10e
+    + pi
+    + inv_pi
+    + inv_sqrtpi
+    + ln2
+    + ln10
+    + sqrt2
+    + sqrt3
+    + inv_sqrt3
+    + egamma
+    + phi
+  */
+
+  // The ordering determines what constants are looked at first.
+  // E.g. look at 'inv_sqrt3' before 'sqrt3' to be able to replace the larger
+  // expression
+  constexpr auto Constants = std::array<std::pair<StringRef, double>, 13>{
+      std::pair{StringRef{"log2e"}, llvm::numbers::log2e},
+      std::pair{StringRef{"log10e"}, llvm::numbers::log10e},
+      std::pair{StringRef{"e"}, llvm::numbers::e},
+      std::pair{StringRef{"egamma"}, llvm::numbers::egamma},
+      std::pair{StringRef{"inv_sqrtpi"}, llvm::numbers::inv_sqrtpi},
+      std::pair{StringRef{"inv_pi"}, llvm::numbers::inv_pi},
+      std::pair{StringRef{"pi"}, llvm::numbers::pi},
+      std::pair{StringRef{"ln2"}, llvm::numbers::ln2},
+      std::pair{StringRef{"ln10"}, llvm::numbers::ln10},
+      std::pair{StringRef{"sqrt2"}, llvm::numbers::sqrt2},
+      std::pair{StringRef{"inv_sqrt3"}, llvm::numbers::inv_sqrt3},
+      std::pair{StringRef{"sqrt3"}, llvm::numbers::sqrt3},
+      std::pair{StringRef{"phi"}, llvm::numbers::phi},
+  };
+
+  auto MatchedLiterals =
+      llvm::SmallVector<std::tuple<std::string, double, const Expr *>>{};
+
+  const auto &SM = *Result.SourceManager;
+  const auto &LO = Result.Context->getLangOpts();
+
+  const auto IsFloat = Result.Nodes.getNodeAs<QualType>("float") != nullptr;
+  const auto IsLongDouble =
+      Result.Nodes.getNodeAs<QualType>("long double") != nullptr;
+
+  for (const auto &[ConstantName, ConstantValue] : Constants) {
+    const auto *const Match = Result.Nodes.getNodeAs<Expr>(ConstantName);
+    if (Match == nullptr) {
+      continue;
+    }
+
+    const auto Range = Match->getSourceRange();
+
+    if (Range.getBegin().isMacroID() &&
+        !isRangeOfCompleteMacro(Range, SM, LO)) {
+      continue;
+    }
+
+    const auto PatternBindString = (ConstantName + "_pattern").str();
+    if (Result.Nodes.getNodeAs<Expr>(PatternBindString) != nullptr) {
+      const auto Code = getCode(ConstantName, IsFloat, IsLongDouble);
+      diag(Range.getBegin(), "prefer '%0' math constant")
+          << Code << FixItHint::CreateReplacement(Range, Code);
+      return;
+    }
+
+    const auto LiteralBindString = (ConstantName + "_literal").str();
+    if (const auto *const Literal =
+            Result.Nodes.getNodeAs<FloatingLiteral>(LiteralBindString)) {
+      MatchedLiterals.emplace_back(
+          ConstantName,
+          std::abs(Literal->getValueAsApproximateDouble() - ConstantValue),
+          Match);
+    }
+  }
+
+  // We may have had no matches with literals, but a match with a pattern that
+  // was a subexpression of a macro which was therefore skipped.
+  if (MatchedLiterals.empty()) {
+    return;
+  }
+
+  llvm::sort(MatchedLiterals, [](const auto &LHS, const auto &RHS) {
+    return std::get<1>(LHS) < std::get<1>(RHS);
+  });
+
+  const auto &[Constant, _, Node] = MatchedLiterals.front();
+
+  const auto Range = Node->getSourceRange();
+  if (Range.getBegin().isMacroID() && !isRangeOfCompleteMacro(Range, SM, LO)) {
+    return;
+  }
+
+  const auto Code = getCode(Constant, IsFloat, IsLongDouble);
+  diag(Range.getBegin(), "prefer '%0' math constant")
+      << Code << FixItHint::CreateReplacement(Range, Code)
+      << IncludeInserter.createIncludeInsertion(
+             Result.SourceManager->getFileID(Range.getBegin()), "<numbers>");
+}
+
+void UseStdNumbersCheck::registerPPCallbacks(const SourceManager &SM,
+                                             Preprocessor *PP,
+                                             Preprocessor *ModuleExpanderPP) {
+  IncludeInserter.registerPreprocessor(PP);
 }
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -320,7 +320,6 @@ void UseStdNumbersCheck::registerMatchers(MatchFinder *const Finder) {
   Finder->addMatcher(
       expr(traverse(TK_IgnoreUnlessSpelledInSource,
                     expr(anyOfExhaustive(ConstantMatchers))),
-           unless(isInTemplateInstantiation()),
            unless(hasParent(expr(
                anyOf(implicitCastExpr(hasImplicitDestinationType(isFloating())),
                      explicitCastExpr(hasDestinationType(isFloating())))))),

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -350,7 +350,7 @@ public:
 
 private:
   void reportDiag(const clang::Token &Tok, const llvm::StringRef Constant) {
-    Check->diag(Tok.getLocation(), "prefer math constant")
+    Check->diag(Tok.getLocation(), "prefer std::numbers math constant")
         << clang::FixItHint::CreateReplacement(
                clang::SourceRange(Tok.getLocation(), Tok.getLastLoc()),
                Constant);

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -7,20 +7,27 @@
 //===----------------------------------------------------------------------===//
 
 #include "UseStdNumbersCheck.h"
+#include "../ClangTidyDiagnosticConsumer.h"
+#include "../utils/TransformerClangTidyCheck.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/ASTMatchers/ASTMatchersInternal.h"
 #include "clang/ASTMatchers/ASTMatchersMacros.h"
+#include "clang/Basic/LLVM.h"
 #include "clang/Tooling/Transformer/RewriteRule.h"
 #include "clang/Tooling/Transformer/Stencil.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MathExtras.h"
 #include <cstdint>
+#include <cstdlib>
 #include <string>
+#include <utility>
 
 namespace {
 using namespace clang::ast_matchers;

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -315,18 +315,14 @@ void UseStdNumbersCheck::registerMatchers(MatchFinder *const Finder) {
       Matches.matchPhi(),
   };
 
-  // Using 'TK_IgnoreUnlessSpelledInSource' here instead of at the check level
-  // to figure out what the type is that the matched constants are used as.
   Finder->addMatcher(
-      expr(traverse(TK_IgnoreUnlessSpelledInSource,
-                    expr(anyOfExhaustive(ConstantMatchers))),
-           unless(hasParent(expr(
-               anyOf(implicitCastExpr(hasImplicitDestinationType(isFloating())),
-                     explicitCastExpr(hasDestinationType(isFloating())))))),
-           hasType(qualType(hasCanonicalTypeUnqualified(
-               anyOf(qualType(asString("float")).bind("float"),
-                     qualType(asString("double")),
-                     qualType(asString("long double")).bind("long double")))))),
+      expr(
+          anyOfExhaustive(ConstantMatchers),
+          unless(hasParent(explicitCastExpr(hasDestinationType(isFloating())))),
+          hasType(qualType(hasCanonicalTypeUnqualified(
+              anyOf(qualType(asString("float")).bind("float"),
+                    qualType(asString("double")),
+                    qualType(asString("long double")).bind("long double")))))),
       this);
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -387,6 +387,9 @@ void UseStdNumbersCheck::check(const MatchFinder::MatchResult &Result) {
     const auto Range = Match->getSourceRange();
 
     const auto IsMacro = Range.getBegin().isMacroID();
+
+    // We do not want to emit a diagnostic when we are matching a macro, but the
+    // match inside of the macro does not cover the whole macro.
     if (IsMacro && !isRangeOfCompleteMacro(Range, SM, LO)) {
       continue;
     }
@@ -410,7 +413,7 @@ void UseStdNumbersCheck::check(const MatchFinder::MatchResult &Result) {
   }
 
   // We may have had no matches with literals, but a match with a pattern that
-  // was a subexpression of a macro which was therefore skipped.
+  // was a part of a macro which was therefore skipped.
   if (MatchedLiterals.empty()) {
     return;
   }
@@ -423,6 +426,9 @@ void UseStdNumbersCheck::check(const MatchFinder::MatchResult &Result) {
 
   const auto Range = Node->getSourceRange();
   const auto IsMacro = Range.getBegin().isMacroID();
+
+  // We do not want to emit a diagnostic when we are matching a macro, but the
+  // match inside of the macro does not cover the whole macro.
   if (IsMacro && !isRangeOfCompleteMacro(Range, SM, LO)) {
     return;
   }

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -1,4 +1,4 @@
-//===--- UseStdNumbersCheck.cpp - clang_tidy -------------------------===//
+//===--- UseStdNumbersCheck.cpp - clang_tidy ------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -123,9 +123,10 @@ auto matchValue(const int64_t ValInt) {
       expr(ignoreImplicitAndArithmeticCasting(integerLiteral(equals(ValInt))));
   const auto Float = expr(ignoreImplicitAndFloatingCasting(
       matchFloatValueNear(static_cast<double>(ValInt))));
-  const auto Dref = declRefExpr(
-      to(varDecl(hasType(qualType(isConstQualified(), isArithmetic())),
-                 hasInitializer(anyOf(Int, Float)))));
+  const auto Dref = declRefExpr(to(varDecl(
+      hasType(qualType(isConstQualified(), isArithmetic())),
+      hasInitializer(expr(anyOf(ignoringImplicit(Int),
+                                ignoreImplicitAndFloatingCasting(Float)))))));
   return expr(anyOf(Int, Float, Dref));
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
@@ -16,8 +16,8 @@ namespace clang::tidy::modernize {
 /// Finds constants and function calls to math functions that can be replaced
 /// with c++20's mathematical constants from the ``numbers`` header and
 /// offers fix-it hints.
-/// Does not match the use of variables or macros with that value, and instead,
-/// offers a replacement at the definition of said variables and macros.
+/// Does not match the use of variables with that value, and instead,
+/// offers a replacement at the definition of those variables.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-numbers.html
@@ -28,9 +28,6 @@ public:
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus20;
   }
-
-  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
-                           Preprocessor *ModuleExpanderPP) override;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
@@ -1,0 +1,37 @@
+//===--- UseStdNumbersCheck.h - clang-tidy ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESTDNUMBERSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESTDNUMBERSCHECK_H
+
+#include "../utils/TransformerClangTidyCheck.h"
+
+namespace clang::tidy::modernize {
+
+/// Finds constants and function calls to math functions that can be replaced
+/// with c++20's mathematical constants ('numbers' header). Does not match the
+/// use of variables or macros with that value and instead offers a replacement
+/// at the definition of said variables and macros.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-numbers.html
+class UseStdNumbersCheck : public utils::TransformerClangTidyCheck {
+public:
+  UseStdNumbersCheck(StringRef Name, ClangTidyContext *Context);
+
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus20;
+  }
+
+  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                           Preprocessor *ModuleExpanderPP) override;
+};
+
+} // namespace clang::tidy::modernize
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESTDNUMBERSCHECK_H

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
@@ -35,10 +35,13 @@ public:
                            Preprocessor *ModuleExpanderPP) override;
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override {
     Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
+    Options.store(Opts, "DiffThreshold", DiffThresholdString);
   }
 
 private:
   utils::IncludeInserter IncludeInserter;
+  StringRef DiffThresholdString;
+  double DiffThreshold;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
@@ -37,6 +37,9 @@ public:
     Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
     Options.store(Opts, "DiffThreshold", DiffThresholdString);
   }
+  std::optional<TraversalKind> getCheckTraversalKind() const override {
+    return TK_IgnoreUnlessSpelledInSource;
+  }
 
 private:
   utils::IncludeInserter IncludeInserter;

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
@@ -33,10 +33,7 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;
-  void storeOptions(ClangTidyOptions::OptionMap &Opts) override {
-    Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
-    Options.store(Opts, "DiffThreshold", DiffThresholdString);
-  }
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
   }

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
@@ -14,9 +14,10 @@
 namespace clang::tidy::modernize {
 
 /// Finds constants and function calls to math functions that can be replaced
-/// with c++20's mathematical constants ('numbers' header). Does not match the
-/// use of variables or macros with that value and instead offers a replacement
-/// at the definition of said variables and macros.
+/// with c++20's mathematical constants from the ``numbers`` header and
+/// offers fix-it hints.
+/// Does not match the use of variables or macros with that value, and instead,
+/// offers a replacement at the definition of said variables and macros.
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-numbers.html

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESTDNUMBERSCHECK_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USESTDNUMBERSCHECK_H
 
-#include "../utils/TransformerClangTidyCheck.h"
+#include "../ClangTidyCheck.h"
+#include "../utils/IncludeInserter.h"
 
 namespace clang::tidy::modernize {
 
@@ -21,13 +22,23 @@ namespace clang::tidy::modernize {
 ///
 /// For the user-facing documentation see:
 /// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-numbers.html
-class UseStdNumbersCheck : public utils::TransformerClangTidyCheck {
+class UseStdNumbersCheck : public ClangTidyCheck {
 public:
   UseStdNumbersCheck(StringRef Name, ClangTidyContext *Context);
 
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus20;
   }
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                           Preprocessor *ModuleExpanderPP) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override {
+    Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
+  }
+
+private:
+  utils::IncludeInserter IncludeInserter;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -197,7 +197,8 @@ New checks
   <clang-tidy/checks/modernize/use-std-numbers>` check.
 
   Finds constants and function calls to math functions that can be replaced
-  with c++20's mathematical constants ('numbers' header).
+  with c++20's mathematical constants from the ``numbers`` header and
+  offers fix-it hints.
 
 - New :doc:`performance-enum-size
   <clang-tidy/checks/performance/enum-size>` check.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -197,7 +197,7 @@ New checks
   <clang-tidy/checks/modernize/use-std-numbers>` check.
 
   Finds constants and function calls to math functions that can be replaced
-  with c++20's mathematical constants from the ``numbers`` header and
+  with C++20's mathematical constants from the ``numbers`` header and
   offers fix-it hints.
 
 - New :doc:`performance-enum-size

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -193,6 +193,12 @@ New checks
   replacing with ``starts_with`` when the method exists in the class. Notably,
   this will work with ``std::string`` and ``std::string_view``.
 
+- New :doc:`modernize-use-std-numbers
+  <clang-tidy/checks/modernize/use-std-numbers>` check.
+
+  Finds constants and function calls to math functions that can be replaced
+  with c++20's mathematical constants ('numbers' header).
+
 - New :doc:`performance-enum-size
   <clang-tidy/checks/performance/enum-size>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -293,6 +293,7 @@ Clang-Tidy Checks
    :doc:`modernize-use-nullptr <modernize/use-nullptr>`, "Yes"
    :doc:`modernize-use-override <modernize/use-override>`, "Yes"
    :doc:`modernize-use-starts-ends-with <modernize/use-starts-ends-with>`, "Yes"
+   :doc:`modernize-use-std-numbers <modernize/use-std-numbers>`, "Yes"
    :doc:`modernize-use-std-print <modernize/use-std-print>`, "Yes"
    :doc:`modernize-use-trailing-return-type <modernize/use-trailing-return-type>`, "Yes"
    :doc:`modernize-use-transparent-functors <modernize/use-transparent-functors>`, "Yes"

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -7,7 +7,7 @@ Finds constants and function calls to math functions that can be replaced
 with C++20's mathematical constants from the ``numbers`` header and offers
 fix-it hints.
 Does not match the use of variables with that value, and instead,
-offers a replacement at the definition of those variables.
+offers a replacement for the definition of those variables.
 Function calls that match the pattern of how the constant is calculated are
 matched and replaced with the ``std::numbers`` constant.
 The use of macros gets replaced with the corresponding ``std::numbers``

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -5,7 +5,7 @@ modernize-use-std-numbers
 
 Finds constants and function calls to math functions that can be replaced
 with c++20's mathematical constants from the ``numbers`` header and offers fix-it hints.
-Does not match the use of variables or macros with that value and instead, offers a replacement
+Does not match the use of variables or macros with that value, and instead, offers a replacement
 at the definition of said variables and macros.
 
 .. code-block:: c++

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -56,3 +56,19 @@ where appropriate.
         floatSink(MY_PI);                           // floatSink(std::numbers::pi);
         floatSink(static_cast<float>(MY_PI));       // floatSink(std::numbers::pi_v<float>);
     }
+
+Options
+-------
+
+.. option:: DiffThreshold
+
+    A floating point value that sets the detection threshold for when literals
+    match a constant.
+    A literal matches a constant if
+    ``abs(literal - constant) < DiffThreshold`` evaluates to true.
+    Default is `0.001`.
+
+.. option:: IncludeStyle
+
+   A string specifying which include-style is used, `llvm` or `google`. Default
+   is `llvm`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -31,28 +31,28 @@ The following list of constants from the ``numbers`` header are supported:
 
 The list currently includes all constants as of C++20.
 
-The replacements try to match the type of the inserted constant by how the
-removed expression was used, e.g., switching between ``std::numbers::e`` to
-``std::numbers::e_v<float>`` or ``std::numbers::e_v<long double>``
+The replacements use the type of the matched constant and can remove explicit casts,
+i.e., switching between ``std::numbers::e``, ``std::numbers::e_v<float>`` and ``std::numbers::e_v<long double>``
 where appropriate.
 
 .. code-block:: c++
 
     double sqrt(double);
-    double log(double);
+    double log2(double);
     void sink(auto&&) {}
     void floatSink(float);
 
     #define MY_PI 3.1415926
 
     void foo() {
-        const double Pi = 3.141592653589;  // const double Pi = std::numbers::pi
-        const auto Use = Pi / 2;           // no match for Pi
-        static constexpr double Euler = 2.7182818; // static constexpr double Euler = std::numbers::e;
+        const double Pi = 3.141592653589;           // const double Pi = std::numbers::pi
+        const auto Use = Pi / 2;                    // no match for Pi
+        static constexpr double Euler = 2.7182818;  // static constexpr double Euler = std::numbers::e;
 
-        log2(exp(1));     // std::numbers::log2e;
-        log2(Euler);      // std::numbers::log2e;
-        1 / sqrt(MY_PI);  // std::numbers::inv_sqrtpi;
-        sink(MY_PI);      // sink(std::numbers::pi);
-        floatSink(MY_PI); // floatSink(std::numbers::pi_v<float>);
+        log2(exp(1));                               // std::numbers::log2e;
+        log2(Euler);                                // std::numbers::log2e;
+        1 / sqrt(MY_PI);                            // std::numbers::inv_sqrtpi;
+        sink(MY_PI);                                // sink(std::numbers::pi);
+        floatSink(MY_PI);                           // floatSink(std::numbers::pi);
+        floatSink(static_cast<float>(MY_PI));       // floatSink(std::numbers::pi_v<float>);
     }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -5,14 +5,15 @@ modernize-use-std-numbers
 
 Finds constants and function calls to math functions that can be replaced
 with c++20's mathematical constants from the ``numbers`` header and offers fix-it hints.
-Does not match the use of variables or macros with that value, and instead, offers a replacement
-at the definition of said variables and macros.
+Does not match the use of variables with that value, and instead,
+offers a replacement at the definition of those variables.
 
 .. code-block:: c++
     double sqrt(double);
     double log(double);
+    void sink(auto&&) {}
 
-    #define MY_PI 3.1415926  // #define MY_PI std::numbers::pi
+    #define MY_PI 3.1415926
 
     void foo() {
         const double Pi = 3.141592653589;  // const double Pi = std::numbers::pi
@@ -22,4 +23,5 @@ at the definition of said variables and macros.
         log2(exp(1));     // std::numbers::log2e;
         log2(Euler);      // std::numbers::log2e;
         1 / sqrt(MY_PI);  // std::numbers::inv_sqrtpi;
+        sink(MY_PI);      // sink(std::numbers::pi);
     }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -9,6 +9,7 @@ Does not match the use of variables with that value, and instead,
 offers a replacement at the definition of those variables.
 
 .. code-block:: c++
+
     double sqrt(double);
     double log(double);
     void sink(auto&&) {}

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -4,7 +4,7 @@ modernize-use-std-numbers
 =========================
 
 Finds constants and function calls to math functions that can be replaced
-with c++20's mathematical constants from the ``numbers`` header and offers
+with C++20's mathematical constants from the ``numbers`` header and offers
 fix-it hints.
 Does not match the use of variables with that value, and instead,
 offers a replacement at the definition of those variables.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -3,8 +3,8 @@
 modernize-use-std-numbers
 =========================
 
-This check finds constants and function calls to math functions that can be replaced
-with c++20's mathematical constants ('numbers' header) and offers fixit-hints.
+Finds constants and function calls to math functions that can be replaced
+with c++20's mathematical constants from the ``numbers`` header and offers fix-it hints.
 Does not match the use of variables or macros with that value and instead, offers a replacement
 at the definition of said variables and macros.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -4,15 +4,44 @@ modernize-use-std-numbers
 =========================
 
 Finds constants and function calls to math functions that can be replaced
-with c++20's mathematical constants from the ``numbers`` header and offers fix-it hints.
+with c++20's mathematical constants from the ``numbers`` header and offers
+fix-it hints.
 Does not match the use of variables with that value, and instead,
 offers a replacement at the definition of those variables.
+Function calls that match the pattern of how the constant is calculated are
+matched and replaced with the ``std::numbers`` constant.
+The use of macros gets replaced with the corresponding ``std::numbers``
+constant, instead of changing the macro definition.
+
+The following list of constants from the ``numbers`` header are supported:
+
+* e
+* log2e
+* log10e
+* pi
+* inv_pi
+* inv_sqrtpi
+* ln2
+* ln10
+* sqrt2
+* sqrt3
+* inv_sqrt3
+* egamma
+* phi
+
+The list currently includes all constants as of C++20.
+
+The replacements try to match the type of the inserted constant by how the
+removed expression was used, e.g., switching between ``std::numbers::e`` to
+``std::numbers::e_v<float>`` or ``std::numbers::e_v<long double>``
+where appropriate.
 
 .. code-block:: c++
 
     double sqrt(double);
     double log(double);
     void sink(auto&&) {}
+    void floatSink(float);
 
     #define MY_PI 3.1415926
 
@@ -25,4 +54,5 @@ offers a replacement at the definition of those variables.
         log2(Euler);      // std::numbers::log2e;
         1 / sqrt(MY_PI);  // std::numbers::inv_sqrtpi;
         sink(MY_PI);      // sink(std::numbers::pi);
+        floatSink(MY_PI); // floatSink(std::numbers::pi_v<float>);
     }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -31,9 +31,10 @@ The following list of constants from the ``numbers`` header are supported:
 
 The list currently includes all constants as of C++20.
 
-The replacements use the type of the matched constant and can remove explicit casts,
-i.e., switching between ``std::numbers::e``, ``std::numbers::e_v<float>`` and ``std::numbers::e_v<long double>``
-where appropriate.
+The replacements use the type of the matched constant and can remove explicit
+casts, i.e., switching between ``std::numbers::e``,
+``std::numbers::e_v<float>`` and ``std::numbers::e_v<long double>`` where
+appropriate.
 
 .. code-block:: c++
 
@@ -64,8 +65,8 @@ Options
 
     A floating point value that sets the detection threshold for when literals
     match a constant. A literal matches a constant if
-    ``abs(literal - constant) < DiffThreshold`` evaluates to ``true``. Default is
-    `0.001`.
+    ``abs(literal - constant) < DiffThreshold`` evaluates to ``true``. Default
+    is `0.001`.
 
 .. option:: IncludeStyle
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -63,10 +63,9 @@ Options
 .. option:: DiffThreshold
 
     A floating point value that sets the detection threshold for when literals
-    match a constant.
-    A literal matches a constant if
-    ``abs(literal - constant) < DiffThreshold`` evaluates to true.
-    Default is `0.001`.
+    match a constant. A literal matches a constant if
+    ``abs(literal - constant) < DiffThreshold`` evaluates to ``true``. Default is
+    `0.001`.
 
 .. option:: IncludeStyle
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -1,0 +1,25 @@
+.. title:: clang-tidy - modernize-use-std-numbers
+
+modernize-use-std-numbers
+=========================
+
+This check finds constants and function calls to math functions that can be replaced
+with c++20's mathematical constants ('numbers' header) and offers fixit-hints.
+Does not match the use of variables or macros with that value and instead, offers a replacement
+at the definition of said variables and macros.
+
+.. code-block:: c++
+    double sqrt(double);
+    double log(double);
+
+    #define MY_PI 3.1415926  // #define MY_PI std::numbers::pi
+
+    void foo() {
+        const double Pi = 3.141592653589;  // const double Pi = std::numbers::pi
+        const auto Use = Pi / 2;           // no match for Pi
+        static constexpr double Euler = 2.7182818; // static constexpr double Euler = std::numbers::e;
+
+        log2(exp(1));     // std::numbers::log2e;
+        log2(Euler);      // std::numbers::log2e;
+        1 / sqrt(MY_PI);  // std::numbers::inv_sqrtpi;
+    }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-numbers.rst
@@ -15,19 +15,19 @@ constant, instead of changing the macro definition.
 
 The following list of constants from the ``numbers`` header are supported:
 
-* e
-* log2e
-* log10e
-* pi
-* inv_pi
-* inv_sqrtpi
-* ln2
-* ln10
-* sqrt2
-* sqrt3
-* inv_sqrt3
-* egamma
-* phi
+* ``e``
+* ``log2e``
+* ``log10e``
+* ``pi``
+* ``inv_pi``
+* ``inv_sqrtpi``
+* ``ln2``
+* ``ln10``
+* ``sqrt2``
+* ``sqrt3``
+* ``inv_sqrt3``
+* ``egamma``
+* ``phi``
 
 The list currently includes all constants as of C++20.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -1,6 +1,7 @@
-// RUN: %check_clang_tidy -std=c++20 %s modernize-use-std-numbers %t
+// RUN: %check_clang_tidy -check-suffix=ALL -std=c++20 %s modernize-use-std-numbers %t
+// RUN: %check_clang_tidy -check-suffix=ALL,IMPRECISE -std=c++20 %s modernize-use-std-numbers %t -- -config="{CheckOptions: { modernize-use-std-numbers.DiffThreshold: 0.01 }}"
 
-// CHECK-FIXES: #include <numbers>
+// CHECK-FIXES-ALL: #include <numbers>
 
 namespace bar {
     double sqrt(double Arg);
@@ -9,8 +10,8 @@ namespace bar {
     auto sqrt(T val) { return sqrt(static_cast<double>(val)); }
 
     static constexpr double e = 2.718281828459045235360287471352662497757247093;
-    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e' to this literal, differs by '0.00e+00' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double e = std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e' to this literal, differs by '0.00e+00' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double e = std::numbers::e;
 }
 
 double exp(double Arg);
@@ -37,90 +38,100 @@ using my_float = float;
 
 void foo(){
     static constexpr double Pi = 3.1415926;
-    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double Pi = std::numbers::pi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:34: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Pi = std::numbers::pi;
 
     static constexpr double Euler = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double Euler = std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:37: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Euler = std::numbers::e;
 
     static constexpr double Phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double Phi = std::numbers::phi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:35: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Phi = std::numbers::phi;
 
     static constexpr double PiCopy = Pi;
     static constexpr double PiDefineFromMacro = MY_PI;
-    // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double PiDefineFromMacro = std::numbers::pi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:49: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double PiDefineFromMacro = std::numbers::pi;
 
-    // not close enough to match value (DiffThreshold)
     static constexpr double Pi2 = 3.14;
+    // CHECK-MESSAGES-IMPRECISE: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi' to this literal, differs by '1.59e-03' [modernize-use-std-numbers]
+    // CHECK-FIXES-IMPRECISE: static constexpr double Pi2 = std::numbers::pi;
     static constexpr double Euler2 = 2.71;
+    // CHECK-MESSAGES-IMPRECISE: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '8.28e-03' [modernize-use-std-numbers]
+    // CHECK-FIXES-IMPRECISE: static constexpr double Euler2 = std::numbers::e;
     static constexpr double Phi2 = 1.61;
+    // CHECK-MESSAGES-IMPRECISE: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi' to this literal, differs by '8.03e-03' [modernize-use-std-numbers]
+    // CHECK-FIXES-IMPRECISE: static constexpr double Phi2 = std::numbers::phi;
 
     static constexpr double Pi3 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double Pi3 = std::numbers::pi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Pi3 = std::numbers::pi;
 
     static constexpr double Euler3 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double Euler3 = std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Euler3 = std::numbers::e;
 
     static constexpr double Phi3 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double Phi3 = std::numbers::phi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Phi3 = std::numbers::phi;
 
     static constexpr long double Pi4 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr long double Pi4 = std::numbers::pi_v<long double>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:40: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr long double Pi4 = std::numbers::pi_v<long double>;
 
     static constexpr long double Euler4 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer 'std::numbers::e_v<long double>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr long double Euler4 = std::numbers::e_v<long double>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:43: warning: prefer 'std::numbers::e_v<long double>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr long double Euler4 = std::numbers::e_v<long double>;
 
     static constexpr long double Phi4 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::phi_v<long double>' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:41: warning: prefer 'std::numbers::phi_v<long double>' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
 
     static constexpr my_double Euler5 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr my_double Euler5 = std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:41: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr my_double Euler5 = std::numbers::e;
 
     static constexpr my_float Euler6 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::e_v<float>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr my_float Euler6 = std::numbers::e_v<float>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:40: warning: prefer 'std::numbers::e_v<float>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr my_float Euler6 = std::numbers::e_v<float>;
 
     static constexpr int NotEuler7 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr int NotEuler7 = std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr int NotEuler7 = std::numbers::e;
 
     static constexpr double InvPi = 1.0 / Pi;
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::inv_pi'  to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr double InvPi = std::numbers::inv_pi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:37: warning: prefer 'std::numbers::inv_pi'  to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double InvPi = std::numbers::inv_pi;
 
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>'  to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2_v<float>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>'  to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2_v<float>;
 
     sink(MY_PI);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::pi);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::pi);
+
+    auto X = 42.0;
+    auto Y = X * 3.14;
+    // CHECK-MESSAGES-IMPRECISE: :[[@LINE-1]]:18: warning: prefer 'std::numbers::pi' to this literal, differs by '1.59e-03' [modernize-use-std-numbers]
+    // CHECK-FIXES-IMPRECISE: auto Y = X * std::numbers::pi;
 
     constexpr static auto One = 1;
     constexpr static auto Two = 2;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     bar::sqrt(Two);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     bar::sqrt(2.0);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     auto Not2 = 2;
     Not2 = 42;
@@ -128,170 +139,170 @@ void foo(){
 
     const auto Actually2 = 2;
     bar::sqrt(Actually2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     exp(1);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::e;
 
     exp(One);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::e;
 
     exp(1.00000000000001);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::e;
 
     log2(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log2e;
 
     log2(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log2e;
 
     log2(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log2e;
 
     log2(Euler5);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log2e;
 
     log2(Euler6);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log2e_v<float>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log2e_v<float>;
 
     log2(NotEuler7);
 
     auto log2e = 1.4426950;
-    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer 'std::numbers::log2e' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: auto log2e = std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:18: warning: prefer 'std::numbers::log2e' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: auto log2e = std::numbers::log2e;
 
     floatSink(log2(Euler));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(Euler)));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(1.4426950);
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(1.4426950));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(log2(static_cast<float>(Euler)));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(static_cast<float>(Euler))));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(static_cast<int>(Euler))));
 
     floatSink(static_cast<int>(log2(static_cast<float>(Euler))));
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     floatSink(1.4426950F);
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<double>(1.4426950F));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<int>(1.4426950F));
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     log10(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log10e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log10e;
 
     log10(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log10e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log10e;
 
     log10(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log10e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log10e;
 
     auto log10e = .434294;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::log10e' to this literal, differs by '4.82e-07' [modernize-use-std-numbers]
-    // CHECK-FIXES: auto log10e = std::numbers::log10e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:19: warning: prefer 'std::numbers::log10e' to this literal, differs by '4.82e-07' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: auto log10e = std::numbers::log10e;
 
     auto egamma = 0.5772156 * 42;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::egamma' to this literal, differs by '6.49e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: auto egamma = std::numbers::egamma * 42;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:19: warning: prefer 'std::numbers::egamma' to this literal, differs by '6.49e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: auto egamma = std::numbers::egamma * 42;
 
     sink(InvPi);
 
     sink(1 / Pi);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_pi' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::inv_pi);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_pi' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::inv_pi);
 
     sink(1 / bar::sqrt(Pi));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::inv_sqrtpi);
 
     sink(1 / bar::sqrt(MY_PI));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::inv_sqrtpi);
 
     log(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::ln2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::ln2;
 
     log(10);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::ln10;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::ln10;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     sink(1 / bar::sqrt(3));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::inv_sqrt3);
 
     sink(INV_SQRT3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this macro [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this macro [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::inv_sqrt3);
 
     const auto inv_sqrt3f = .577350269F;
-    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::inv_sqrt3_v<float>' to this literal, differs by '1.04e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: const auto inv_sqrt3f = std::numbers::inv_sqrt3_v<float>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:29: warning: prefer 'std::numbers::inv_sqrt3_v<float>' to this literal, differs by '1.04e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: const auto inv_sqrt3f = std::numbers::inv_sqrt3_v<float>;
 
     bar::sqrt(3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt3;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt3;
 
     auto somePhi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: auto somePhi = std::numbers::phi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:20: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: auto somePhi = std::numbers::phi;
 
     sink(Phi);
 
     sink((42 + bar::sqrt(5)) / 2);
 
     sink((1 + bar::sqrt(5)) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::phi);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::phi);
 
     sink((bar::sqrt(5.0F) + 1) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::phi_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::phi_v<float>);
 }
 
 
@@ -299,56 +310,61 @@ void foo(){
 template <typename T>
 void baz(){
     static constexpr T Pi = 3.1415926;
-    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr T Pi = std::numbers::pi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:29: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr T Pi = std::numbers::pi;
 
     static constexpr T Euler = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr T Euler = std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:32: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr T Euler = std::numbers::e;
 
     static constexpr T Phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr T Phi = std::numbers::phi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:30: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr T Phi = std::numbers::phi;
 
     static constexpr T PiCopy = Pi;
     static constexpr T PiDefineFromMacro = MY_PI;
-    // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr T PiDefineFromMacro = std::numbers::pi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:44: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr T PiDefineFromMacro = std::numbers::pi;
 
-    // not close enough to match value (DiffThreshold)
     static constexpr T Pi2 = 3.14;
+    // CHECK-MESSAGES-IMPRECISE: :[[@LINE-1]]:30: warning: prefer 'std::numbers::pi' to this literal, differs by '1.59e-03' [modernize-use-std-numbers]
+    // CHECK-FIXES-IMPRECISE: static constexpr T Pi2 = std::numbers::pi;
     static constexpr T Euler2 = 2.71;
+    // CHECK-MESSAGES-IMPRECISE: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e' to this literal, differs by '8.28e-03' [modernize-use-std-numbers]
+    // CHECK-FIXES-IMPRECISE: static constexpr T Euler2 = std::numbers::e;
     static constexpr T Phi2 = 1.61;
+    // CHECK-MESSAGES-IMPRECISE: :[[@LINE-1]]:31: warning: prefer 'std::numbers::phi' to this literal, differs by '8.03e-03' [modernize-use-std-numbers]
+    // CHECK-FIXES-IMPRECISE: static constexpr T Phi2 = std::numbers::phi;
 
     static constexpr T Pi3 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr T Pi3 = std::numbers::pi_v<long double>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:30: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr T Pi3 = std::numbers::pi_v<long double>;
 
     static constexpr T Euler3 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e_v<long double>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr T Euler3 = std::numbers::e_v<long double>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e_v<long double>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr T Euler3 = std::numbers::e_v<long double>;
 
     static constexpr T Phi3 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer 'std::numbers::phi_v<long double>' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: static constexpr T Phi3 = std::numbers::phi_v<long double>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:31: warning: prefer 'std::numbers::phi_v<long double>' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr T Phi3 = std::numbers::phi_v<long double>;
 
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2_v<float>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2_v<float>;
 
     constexpr static T One = 1;
     constexpr static T Two = 2;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     bar::sqrt(Two);
 
     bar::sqrt(2.0);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     T Not2 = 2;
     Not2 = 42;
@@ -358,93 +374,93 @@ void baz(){
     bar::sqrt(Actually2);
 
     exp(1);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::e;
 
     exp(One);
 
     exp(1.00000000000001);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::e;
 
     log2(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log2e;
 
     log2(Euler);
 
     log2(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log2e;
 
     T log2e = 1.4426950;
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: T log2e = std::numbers::log2e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: T log2e = std::numbers::log2e;
 
     log10(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log10e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log10e;
 
     log10(Euler);
 
     log10(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::log10e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::log10e;
 
     T log10e = .434294;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::log10e' to this literal, differs by '4.82e-07' [modernize-use-std-numbers]
-    // CHECK-FIXES: T log10e = std::numbers::log10e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:16: warning: prefer 'std::numbers::log10e' to this literal, differs by '4.82e-07' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: T log10e = std::numbers::log10e;
 
     T egamma = 0.5772156 * 42;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::egamma' to this literal, differs by '6.49e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: T egamma = std::numbers::egamma * 42;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:16: warning: prefer 'std::numbers::egamma' to this literal, differs by '6.49e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: T egamma = std::numbers::egamma * 42;
 
     sink(1 / Pi);
 
     sink(1 / bar::sqrt(Pi));
 
     sink(1 / bar::sqrt(MY_PI));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::inv_sqrtpi);
 
 
     log(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::ln2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::ln2;
 
     log(10);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::ln10;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::ln10;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt2;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt2;
 
     sink(1 / bar::sqrt(3));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this formula [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES-ALL: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::inv_sqrt3);
 
     bar::sqrt(3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: std::numbers::sqrt3;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: std::numbers::sqrt3;
 
     T phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES: T phi = std::numbers::phi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:13: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: T phi = std::numbers::phi;
 
     sink((42 + bar::sqrt(5)) / 2);
 
     sink((1 + bar::sqrt(5)) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::phi);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::phi);
 
     sink((bar::sqrt(5.0F) + 1) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES: sink(std::numbers::phi_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: sink(std::numbers::phi_v<float>);
 }
 
 template <typename T>

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -32,6 +32,7 @@ void floatSink(float) {}
 #define MY_PI 3.1415926
 
 #define INV_SQRT3 1 / bar::sqrt(3)
+#define NOT_INV_SQRT3 1 / bar::sqrt(3) + 1
 
 using my_double = double;
 using my_float = float;
@@ -280,6 +281,8 @@ void foo(){
     // CHECK-MESSAGES-ALL: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this macro [modernize-use-std-numbers]
     // CHECK-FIXES-ALL: sink(std::numbers::inv_sqrt3);
 
+    sink(NOT_INV_SQRT3);
+
     const auto inv_sqrt3f = .577350269F;
     // CHECK-MESSAGES-ALL: :[[@LINE-1]]:29: warning: prefer 'std::numbers::inv_sqrt3_v<float>' to this literal, differs by '1.04e-08' [modernize-use-std-numbers]
     // CHECK-FIXES-ALL: const auto inv_sqrt3f = std::numbers::inv_sqrt3_v<float>;
@@ -470,4 +473,17 @@ void foobar(){
 }
 void use_foobar() {
     foobar<float>();
+}
+
+#define BIG_MARCO                                                              \
+  struct InvSqrt3 {                                                            \
+    template <typename T> static T get() { return 1 / bar::sqrt(3); }          \
+  }
+
+BIG_MARCO;
+
+void use_BIG_MACRO() {
+InvSqrt3 f{};
+f.get<float>();
+f.get<double>();
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -9,7 +9,7 @@ namespace bar {
     auto sqrt(T val) { return sqrt(static_cast<double>(val)); }
 
     static constexpr double e = 2.718281828459045235360287471352662497757247093;
-    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e' to this literal, differs by '0.00e+00' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double e = std::numbers::e;
 }
 
@@ -37,20 +37,20 @@ using my_float = float;
 
 void foo(){
     static constexpr double Pi = 3.1415926;
-    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Pi = std::numbers::pi;
 
     static constexpr double Euler = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Euler = std::numbers::e;
 
     static constexpr double Phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Phi = std::numbers::phi;
 
     static constexpr double PiCopy = Pi;
     static constexpr double PiDefineFromMacro = MY_PI;
-    // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double PiDefineFromMacro = std::numbers::pi;
 
     // not close enough to match value (DiffThreshold)
@@ -59,67 +59,67 @@ void foo(){
     static constexpr double Phi2 = 1.61;
 
     static constexpr double Pi3 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Pi3 = std::numbers::pi;
 
     static constexpr double Euler3 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Euler3 = std::numbers::e;
 
     static constexpr double Phi3 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Phi3 = std::numbers::phi;
 
     static constexpr long double Pi4 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::pi_v<long double>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Pi4 = std::numbers::pi_v<long double>;
 
     static constexpr long double Euler4 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer 'std::numbers::e_v<long double>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer 'std::numbers::e_v<long double>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Euler4 = std::numbers::e_v<long double>;
 
     static constexpr long double Phi4 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::phi_v<long double>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::phi_v<long double>' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
 
     static constexpr my_double Euler5 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr my_double Euler5 = std::numbers::e;
 
     static constexpr my_float Euler6 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::e_v<float>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr my_float Euler6 = std::numbers::e_v<float>;
 
     static constexpr int NotEuler7 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr int NotEuler7 = std::numbers::e;
 
     static constexpr double InvPi = 1.0 / Pi;
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::inv_pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::inv_pi'  to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double InvPi = std::numbers::inv_pi;
 
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>'  to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2_v<float>;
 
     sink(MY_PI);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::pi);
 
     constexpr static auto One = 1;
     constexpr static auto Two = 2;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(Two);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(2.0);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     auto Not2 = 2;
@@ -128,157 +128,157 @@ void foo(){
 
     const auto Actually2 = 2;
     bar::sqrt(Actually2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     exp(1);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(One);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(1.00000000000001);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     log2(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler5);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler6);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e_v<float>;
 
     log2(NotEuler7);
 
     auto log2e = 1.4426950;
-    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer 'std::numbers::log2e' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: auto log2e = std::numbers::log2e;
 
     floatSink(log2(Euler));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(Euler)));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(1.4426950);
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(1.4426950));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(log2(static_cast<float>(Euler)));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(static_cast<float>(Euler))));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(static_cast<int>(Euler))));
 
     floatSink(static_cast<int>(log2(static_cast<float>(Euler))));
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     floatSink(1.4426950F);
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<double>(1.4426950F));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<int>(1.4426950F));
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     log10(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     auto log10e = .434294;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::log10e' to this literal, differs by '4.82e-07' [modernize-use-std-numbers]
     // CHECK-FIXES: auto log10e = std::numbers::log10e;
 
     auto egamma = 0.5772156 * 42;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::egamma' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::egamma' to this literal, differs by '6.49e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: auto egamma = std::numbers::egamma * 42;
 
     sink(InvPi);
 
     sink(1 / Pi);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_pi' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_pi);
 
     sink(1 / bar::sqrt(Pi));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
     sink(1 / bar::sqrt(MY_PI));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
     log(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln2;
 
     log(10);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln10;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     sink(1 / bar::sqrt(3));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
     sink(INV_SQRT3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this macro [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
     const auto inv_sqrt3f = .577350269F;
-    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::inv_sqrt3_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::inv_sqrt3_v<float>' to this literal, differs by '1.04e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: const auto inv_sqrt3f = std::numbers::inv_sqrt3_v<float>;
 
     bar::sqrt(3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt3;
 
     auto somePhi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: auto somePhi = std::numbers::phi;
 
     sink(Phi);
@@ -286,11 +286,11 @@ void foo(){
     sink((42 + bar::sqrt(5)) / 2);
 
     sink((1 + bar::sqrt(5)) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi);
 
     sink((bar::sqrt(5.0F) + 1) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi_v<float>);
 }
 
@@ -299,20 +299,20 @@ void foo(){
 template <typename T>
 void baz(){
     static constexpr T Pi = 3.1415926;
-    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Pi = std::numbers::pi;
 
     static constexpr T Euler = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Euler = std::numbers::e;
 
     static constexpr T Phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Phi = std::numbers::phi;
 
     static constexpr T PiCopy = Pi;
     static constexpr T PiDefineFromMacro = MY_PI;
-    // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T PiDefineFromMacro = std::numbers::pi;
 
     // not close enough to match value (DiffThreshold)
@@ -321,33 +321,33 @@ void baz(){
     static constexpr T Phi2 = 1.61;
 
     static constexpr T Pi3 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::pi_v<long double>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Pi3 = std::numbers::pi_v<long double>;
 
     static constexpr T Euler3 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e_v<long double>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e_v<long double>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Euler3 = std::numbers::e_v<long double>;
 
     static constexpr T Phi3 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer 'std::numbers::phi_v<long double>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer 'std::numbers::phi_v<long double>' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Phi3 = std::numbers::phi_v<long double>;
 
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2_v<float>;
 
     constexpr static T One = 1;
     constexpr static T Two = 2;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(Two);
 
     bar::sqrt(2.0);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     T Not2 = 2;
@@ -358,47 +358,47 @@ void baz(){
     bar::sqrt(Actually2);
 
     exp(1);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(One);
 
     exp(1.00000000000001);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     log2(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler);
 
     log2(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     T log2e = 1.4426950;
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: T log2e = std::numbers::log2e;
 
     log10(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(Euler);
 
     log10(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     T log10e = .434294;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::log10e' to this literal, differs by '4.82e-07' [modernize-use-std-numbers]
     // CHECK-FIXES: T log10e = std::numbers::log10e;
 
     T egamma = 0.5772156 * 42;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::egamma' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::egamma' to this literal, differs by '6.49e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: T egamma = std::numbers::egamma * 42;
 
     sink(1 / Pi);
@@ -406,44 +406,44 @@ void baz(){
     sink(1 / bar::sqrt(Pi));
 
     sink(1 / bar::sqrt(MY_PI));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' to this macro, differs by '5.36e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
 
     log(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln2;
 
     log(10);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln10;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     sink(1 / bar::sqrt(3));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' to this formula [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
     bar::sqrt(3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt3;
 
     T phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
     // CHECK-FIXES: T phi = std::numbers::phi;
 
     sink((42 + bar::sqrt(5)) / 2);
 
     sink((1 + bar::sqrt(5)) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi);
 
     sink((bar::sqrt(5.0F) + 1) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi_v<float>);
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -1,0 +1,205 @@
+// RUN: %check_clang_tidy -std=c++20 %s modernize-use-std-numbers %t
+
+// CHECK-FIXES: #include <numbers>
+
+namespace bar {
+    double sqrt(double Arg);
+    float sqrt(float Arg);
+    template <typename T>
+    auto sqrt(T val) { return sqrt(static_cast<double>(val)); }
+
+    static constexpr double e = 2.718281828459045235360287471352662497757247093;
+    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double e = std::numbers::e;
+}
+
+double exp(double Arg);
+double log(double Arg);
+double log2(double Arg);
+double log10(double Arg);
+
+template<typename T>
+void sink(T&&) { }
+
+#define MY_PI 3.1415926
+// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer math constant [modernize-use-std-numbers]
+// CHECK-FIXES: #define MY_PI std::numbers::pi
+#define MY_PI2 static_cast<float>(3.1415926)
+// CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer math constant [modernize-use-std-numbers]
+// CHECK-FIXES: #define MY_PI2 static_cast<float>(std::numbers::pi)
+
+#define INV_SQRT3 1 / bar::sqrt(3)
+
+void foo(){
+    static constexpr double Pi = 3.1415926;
+    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double Pi = std::numbers::pi;
+
+    static constexpr double Euler = 2.7182818;
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double Euler = std::numbers::e;
+
+    static constexpr double Phi = 1.6180339;
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double Phi = std::numbers::phi;
+
+    static constexpr double PiCopy = Pi;
+    static constexpr double PiDefine = MY_PI;
+
+    // not close enough to match value (DiffThreshold)
+    static constexpr double Pi2 = 3.14;
+    static constexpr double Euler2 = 2.71;
+    static constexpr double Phi2 = 1.61;
+
+    static constexpr double Pi3 = 3.1415926L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double Pi3 = std::numbers::pi;
+
+    static constexpr double Euler3 = 2.7182818L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double Euler3 = std::numbers::e;
+
+    static constexpr double Phi3 = 1.6180339L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double Phi3 = std::numbers::phi;
+
+    static constexpr long double Pi4 = 3.1415926L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr long double Pi4 = std::numbers::pi_v<long double>;
+
+    static constexpr long double Euler4 = 2.7182818L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr long double Euler4 = std::numbers::e_v<long double>;
+
+    static constexpr long double Phi4 = 1.6180339L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
+
+    using my_float = const float;
+    static constexpr my_float Actually2MyFloat = 2;
+    bar::sqrt(Actually2MyFloat);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2_v<float>;
+
+    constexpr static auto One = 1;
+    constexpr static auto Two = 2;
+
+    bar::sqrt(2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    bar::sqrt(Two);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    bar::sqrt(2.0);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    auto Not2 = 2;
+    Not2 = 42;
+    bar::sqrt(Not2);
+
+    const auto Actually2 = 2;
+    bar::sqrt(Actually2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    exp(1);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::e;
+
+    exp(One);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::e;
+
+    exp(1.00000000000001);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::e;
+
+    log2(exp(1));
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log2e;
+
+    log2(Euler);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log2e;
+
+    log2(bar::e);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log2e;
+
+    auto log2e = 1.4426950;
+    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: auto log2e = std::numbers::log2e;
+
+    log10(exp(1));
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log10e;
+
+    log10(Euler);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log10e;
+
+    log10(bar::e);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log10e;
+
+    auto log10e = .434294;
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: auto log10e = std::numbers::log10e;
+
+    auto egamma = 0.5772156 * 42;
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: auto egamma = std::numbers::egamma * 42;
+
+    sink(1 / Pi);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::inv_pi);
+
+    sink(1 / bar::sqrt(Pi));
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
+
+    sink(1 / bar::sqrt(MY_PI));
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
+
+
+    log(2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::ln2;
+
+    log(10);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::ln10;
+
+    bar::sqrt(2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    sink(1 / bar::sqrt(3));
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
+
+    bar::sqrt(3);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt3;
+
+    auto phi = 1.6180339;
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: auto phi = std::numbers::phi;
+
+    sink((42 + bar::sqrt(5)) / 2);
+
+    sink((1 + bar::sqrt(5)) / 2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::phi);
+
+    sink((bar::sqrt(5.0F) + 1) / 2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::phi_v<float>);
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -9,7 +9,7 @@ namespace bar {
     auto sqrt(T val) { return sqrt(static_cast<double>(val)); }
 
     static constexpr double e = 2.718281828459045235360287471352662497757247093;
-    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double e = std::numbers::e;
 }
 
@@ -22,25 +22,25 @@ template<typename T>
 void sink(T&&) { }
 
 #define MY_PI 3.1415926
-// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer math constant [modernize-use-std-numbers]
+// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
 // CHECK-FIXES: #define MY_PI std::numbers::pi
 #define MY_PI2 static_cast<float>(3.1415926)
-// CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer math constant [modernize-use-std-numbers]
+// CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
 // CHECK-FIXES: #define MY_PI2 static_cast<float>(std::numbers::pi)
 
 #define INV_SQRT3 1 / bar::sqrt(3)
 
 void foo(){
     static constexpr double Pi = 3.1415926;
-    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Pi = std::numbers::pi;
 
     static constexpr double Euler = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Euler = std::numbers::e;
 
     static constexpr double Phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Phi = std::numbers::phi;
 
     static constexpr double PiCopy = Pi;
@@ -52,48 +52,48 @@ void foo(){
     static constexpr double Phi2 = 1.61;
 
     static constexpr double Pi3 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Pi3 = std::numbers::pi;
 
     static constexpr double Euler3 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Euler3 = std::numbers::e;
 
     static constexpr double Phi3 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Phi3 = std::numbers::phi;
 
     static constexpr long double Pi4 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Pi4 = std::numbers::pi_v<long double>;
 
     static constexpr long double Euler4 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Euler4 = std::numbers::e_v<long double>;
 
     static constexpr long double Phi4 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
 
     using my_float = const float;
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2_v<float>;
 
     constexpr static auto One = 1;
     constexpr static auto Two = 2;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(Two);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(2.0);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     auto Not2 = 2;
@@ -102,104 +102,104 @@ void foo(){
 
     const auto Actually2 = 2;
     bar::sqrt(Actually2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     exp(1);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(One);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(1.00000000000001);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     log2(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     auto log2e = 1.4426950;
-    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto log2e = std::numbers::log2e;
 
     log10(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     auto log10e = .434294;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto log10e = std::numbers::log10e;
 
     auto egamma = 0.5772156 * 42;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto egamma = std::numbers::egamma * 42;
 
     sink(1 / Pi);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_pi);
 
     sink(1 / bar::sqrt(Pi));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
     sink(1 / bar::sqrt(MY_PI));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
 
     log(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln2;
 
     log(10);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln10;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     sink(1 / bar::sqrt(3));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
     bar::sqrt(3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt3;
 
     auto phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto phi = std::numbers::phi;
 
     sink((42 + bar::sqrt(5)) / 2);
 
     sink((1 + bar::sqrt(5)) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi);
 
     sink((bar::sqrt(5.0F) + 1) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi_v<float>);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -66,16 +66,16 @@ void foo(){
     // CHECK-FIXES-IMPRECISE: static constexpr double Phi2 = std::numbers::phi;
 
     static constexpr double Pi3 = 3.1415926L;
-    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES-ALL: static constexpr double Pi3 = std::numbers::pi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Pi3 = std::numbers::pi_v<long double>;
 
     static constexpr double Euler3 = 2.7182818L;
-    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES-ALL: static constexpr double Euler3 = std::numbers::e;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e_v<long double>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Euler3 = std::numbers::e_v<long double>;
 
     static constexpr double Phi3 = 1.6180339L;
-    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES-ALL: static constexpr double Phi3 = std::numbers::phi;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi_v<long double>' to this literal, differs by '8.87e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr double Phi3 = std::numbers::phi_v<long double>;
 
     static constexpr long double Pi4 = 3.1415926L;
     // CHECK-MESSAGES-ALL: :[[@LINE-1]]:40: warning: prefer 'std::numbers::pi_v<long double>' to this literal, differs by '5.36e-08' [modernize-use-std-numbers]
@@ -94,8 +94,8 @@ void foo(){
     // CHECK-FIXES-ALL: static constexpr my_double Euler5 = std::numbers::e;
 
     static constexpr my_float Euler6 = 2.7182818;
-    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:40: warning: prefer 'std::numbers::e_v<float>' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES-ALL: static constexpr my_float Euler6 = std::numbers::e_v<float>;
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:40: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: static constexpr my_float Euler6 = std::numbers::e;
 
     static constexpr int NotEuler7 = 2.7182818;
     // CHECK-MESSAGES-ALL: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' to this literal, differs by '2.85e-08' [modernize-use-std-numbers]
@@ -183,16 +183,16 @@ void foo(){
     // CHECK-FIXES-ALL: auto log2e = std::numbers::log2e;
 
     floatSink(log2(Euler));
-    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
-    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' to this formula [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e);
 
     floatSink(static_cast<float>(log2(Euler)));
     // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this formula [modernize-use-std-numbers]
     // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(1.4426950);
-    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e);
 
     floatSink(static_cast<float>(1.4426950));
     // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '4.09e-08' [modernize-use-std-numbers]
@@ -217,8 +217,8 @@ void foo(){
     // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<double>(1.4426950F));
-    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
-    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e_v<float>);
+    // CHECK-MESSAGES-ALL: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]
+    // CHECK-FIXES-ALL: floatSink(std::numbers::log2e);
 
     floatSink(static_cast<int>(1.4426950F));
     // CHECK-MESSAGES-ALL: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' to this literal, differs by '1.93e-08' [modernize-use-std-numbers]

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -15,7 +15,12 @@ namespace bar {
 
 double exp(double Arg);
 double log(double Arg);
+
 double log2(double Arg);
+float log2(float Arg);
+template <typename T>
+auto log2(T val) { return log2(static_cast<double>(val)); }
+
 double log10(double Arg);
 
 template<typename T>
@@ -26,6 +31,9 @@ void floatSink(float) {}
 #define MY_PI 3.1415926
 
 #define INV_SQRT3 1 / bar::sqrt(3)
+
+using my_double = double;
+using my_float = float;
 
 void foo(){
     static constexpr double Pi = 3.1415926;
@@ -74,11 +82,18 @@ void foo(){
     // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
 
+    static constexpr my_double Euler5 = 2.7182818;
+    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr my_double Euler5 = std::numbers::e;
+
+    static constexpr my_float Euler6 = 2.7182818;
+    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr my_float Euler6 = std::numbers::e_v<float>;
+
     static constexpr double InvPi = 1.0 / Pi;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double InvPi = std::numbers::inv_pi;
 
-    using my_float = const float;
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
@@ -137,6 +152,14 @@ void foo(){
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
+    log2(Euler5);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log2e;
+
+    log2(Euler6);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log2e_v<float>;
+
     auto log2e = 1.4426950;
     // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto log2e = std::numbers::log2e;
@@ -172,7 +195,7 @@ void foo(){
 
     floatSink(static_cast<int>(log2(static_cast<float>(Euler))));
     // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e));
+    // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     floatSink(1.4426950F);
     // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
@@ -303,7 +326,6 @@ void baz(){
     // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Phi3 = std::numbers::phi_v<long double>;
 
-    using my_float = const float;
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -82,6 +82,10 @@ void foo(){
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2_v<float>;
 
+    sink(MY_PI);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::pi);
+
     constexpr static auto One = 1;
     constexpr static auto Two = 2;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -90,6 +90,10 @@ void foo(){
     // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr my_float Euler6 = std::numbers::e_v<float>;
 
+    static constexpr int NotEuler7 = 2.7182818;
+    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr int NotEuler7 = std::numbers::e;
+
     static constexpr double InvPi = 1.0 / Pi;
     // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double InvPi = std::numbers::inv_pi;
@@ -159,6 +163,8 @@ void foo(){
     log2(Euler6);
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e_v<float>;
+
+    log2(NotEuler7);
 
     auto log2e = 1.4426950;
     // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer std::numbers math constant [modernize-use-std-numbers]

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -22,11 +22,6 @@ template<typename T>
 void sink(T&&) { }
 
 #define MY_PI 3.1415926
-// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-// CHECK-FIXES: #define MY_PI std::numbers::pi
-#define MY_PI2 static_cast<float>(3.1415926)
-// CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-// CHECK-FIXES: #define MY_PI2 static_cast<float>(std::numbers::pi)
 
 #define INV_SQRT3 1 / bar::sqrt(3)
 
@@ -44,7 +39,9 @@ void foo(){
     // CHECK-FIXES: static constexpr double Phi = std::numbers::phi;
 
     static constexpr double PiCopy = Pi;
-    static constexpr double PiDefine = MY_PI;
+    static constexpr double PiDefineFromMacro = MY_PI;
+    // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double PiDefineFromMacro = std::numbers::pi;
 
     // not close enough to match value (DiffThreshold)
     static constexpr double Pi2 = 3.14;
@@ -171,8 +168,8 @@ void foo(){
 
     sink(1 / bar::sqrt(MY_PI));
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
-
 
     log(2);
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
@@ -189,6 +186,10 @@ void foo(){
     sink(1 / bar::sqrt(3));
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
+
+    sink(INV_SQRT3);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
     bar::sqrt(3);
@@ -229,7 +230,9 @@ void baz(){
     // CHECK-FIXES: static constexpr T Phi = std::numbers::phi;
 
     static constexpr T PiCopy = Pi;
-    static constexpr T PiDefine = MY_PI;
+    static constexpr T PiDefineFromMacro = MY_PI;
+    // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr T PiDefineFromMacro = std::numbers::pi;
 
     // not close enough to match value (DiffThreshold)
     static constexpr T Pi2 = 3.14;
@@ -324,6 +327,7 @@ void baz(){
 
     sink(1 / bar::sqrt(MY_PI));
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -471,8 +471,12 @@ void foobar(){
     const T Two = 2;
     bar::sqrt(Two);
 }
-void use_foobar() {
+void use_templates() {
     foobar<float>();
+    foobar<double>();
+
+    baz<float>();
+    baz<double>();
 }
 
 #define BIG_MARCO                                                              \

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -9,7 +9,7 @@ namespace bar {
     auto sqrt(T val) { return sqrt(static_cast<double>(val)); }
 
     static constexpr double e = 2.718281828459045235360287471352662497757247093;
-    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double e = std::numbers::e;
 }
 
@@ -37,20 +37,20 @@ using my_float = float;
 
 void foo(){
     static constexpr double Pi = 3.1415926;
-    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Pi = std::numbers::pi;
 
     static constexpr double Euler = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Euler = std::numbers::e;
 
     static constexpr double Phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Phi = std::numbers::phi;
 
     static constexpr double PiCopy = Pi;
     static constexpr double PiDefineFromMacro = MY_PI;
-    // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double PiDefineFromMacro = std::numbers::pi;
 
     // not close enough to match value (DiffThreshold)
@@ -59,67 +59,67 @@ void foo(){
     static constexpr double Phi2 = 1.61;
 
     static constexpr double Pi3 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Pi3 = std::numbers::pi;
 
     static constexpr double Euler3 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Euler3 = std::numbers::e;
 
     static constexpr double Phi3 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double Phi3 = std::numbers::phi;
 
     static constexpr long double Pi4 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::pi_v<long double>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Pi4 = std::numbers::pi_v<long double>;
 
     static constexpr long double Euler4 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: prefer 'std::numbers::e_v<long double>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Euler4 = std::numbers::e_v<long double>;
 
     static constexpr long double Phi4 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::phi_v<long double>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
 
     static constexpr my_double Euler5 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr my_double Euler5 = std::numbers::e;
 
     static constexpr my_float Euler6 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: prefer 'std::numbers::e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr my_float Euler6 = std::numbers::e_v<float>;
 
     static constexpr int NotEuler7 = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr int NotEuler7 = std::numbers::e;
 
     static constexpr double InvPi = 1.0 / Pi;
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer 'std::numbers::inv_pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr double InvPi = std::numbers::inv_pi;
 
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2_v<float>;
 
     sink(MY_PI);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::pi);
 
     constexpr static auto One = 1;
     constexpr static auto Two = 2;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(Two);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(2.0);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     auto Not2 = 2;
@@ -128,169 +128,169 @@ void foo(){
 
     const auto Actually2 = 2;
     bar::sqrt(Actually2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     exp(1);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(One);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(1.00000000000001);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     log2(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler5);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler6);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e_v<float>;
 
     log2(NotEuler7);
 
     auto log2e = 1.4426950;
-    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto log2e = std::numbers::log2e;
 
     floatSink(log2(Euler));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(Euler)));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(1.4426950);
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(1.4426950));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(log2(static_cast<float>(Euler)));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(static_cast<float>(Euler))));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<float>(log2(static_cast<int>(Euler))));
 
     floatSink(static_cast<int>(log2(static_cast<float>(Euler))));
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     floatSink(1.4426950F);
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<double>(1.4426950F));
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
 
     floatSink(static_cast<int>(1.4426950F));
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::log2e_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     log10(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(Euler);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     auto log10e = .434294;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto log10e = std::numbers::log10e;
 
     auto egamma = 0.5772156 * 42;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer 'std::numbers::egamma' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto egamma = std::numbers::egamma * 42;
 
     sink(InvPi);
 
     sink(1 / Pi);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_pi);
 
     sink(1 / bar::sqrt(Pi));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
     sink(1 / bar::sqrt(MY_PI));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
     log(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln2;
 
     log(10);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln10;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     sink(1 / bar::sqrt(3));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
     sink(INV_SQRT3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
+    const auto inv_sqrt3f = .577350269F;
+    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::inv_sqrt3_v<float>' math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: const auto inv_sqrt3f = std::numbers::inv_sqrt3_v<float>;
+
     bar::sqrt(3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt3;
 
-    auto phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-FIXES: auto phi = std::numbers::phi;
+    auto somePhi = 1.6180339;
+    // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: auto somePhi = std::numbers::phi;
 
     sink(Phi);
 
     sink((42 + bar::sqrt(5)) / 2);
 
     sink((1 + bar::sqrt(5)) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi);
 
     sink((bar::sqrt(5.0F) + 1) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi_v<float>);
 }
 
@@ -299,20 +299,20 @@ void foo(){
 template <typename T>
 void baz(){
     static constexpr T Pi = 3.1415926;
-    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Pi = std::numbers::pi;
 
     static constexpr T Euler = 2.7182818;
-    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Euler = std::numbers::e;
 
     static constexpr T Phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Phi = std::numbers::phi;
 
     static constexpr T PiCopy = Pi;
     static constexpr T PiDefineFromMacro = MY_PI;
-    // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:44: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T PiDefineFromMacro = std::numbers::pi;
 
     // not close enough to match value (DiffThreshold)
@@ -321,33 +321,33 @@ void baz(){
     static constexpr T Phi2 = 1.61;
 
     static constexpr T Pi3 = 3.1415926L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer 'std::numbers::pi_v<long double>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Pi3 = std::numbers::pi_v<long double>;
 
     static constexpr T Euler3 = 2.7182818L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer 'std::numbers::e_v<long double>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Euler3 = std::numbers::e_v<long double>;
 
     static constexpr T Phi3 = 1.6180339L;
-    // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer 'std::numbers::phi_v<long double>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr T Phi3 = std::numbers::phi_v<long double>;
 
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2_v<float>;
 
     constexpr static T One = 1;
     constexpr static T Two = 2;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     bar::sqrt(Two);
 
     bar::sqrt(2.0);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     T Not2 = 2;
@@ -358,47 +358,47 @@ void baz(){
     bar::sqrt(Actually2);
 
     exp(1);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     exp(One);
 
     exp(1.00000000000001);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::e;
 
     log2(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     log2(Euler);
 
     log2(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log2e;
 
     T log2e = 1.4426950;
-    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer 'std::numbers::log2e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: T log2e = std::numbers::log2e;
 
     log10(exp(1));
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer 'std::numbers::e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     log10(Euler);
 
     log10(bar::e);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::log10e;
 
     T log10e = .434294;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::log10e' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: T log10e = std::numbers::log10e;
 
     T egamma = 0.5772156 * 42;
-    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer 'std::numbers::egamma' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: T egamma = std::numbers::egamma * 42;
 
     sink(1 / Pi);
@@ -406,44 +406,44 @@ void baz(){
     sink(1 / bar::sqrt(Pi));
 
     sink(1 / bar::sqrt(MY_PI));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrtpi' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:24: warning: prefer 'std::numbers::pi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
 
 
     log(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln2;
 
     log(10);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::ln10' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::ln10;
 
     bar::sqrt(2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt2' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt2;
 
     sink(1 / bar::sqrt(3));
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
-    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::inv_sqrt3' math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
 
     bar::sqrt(3);
-    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer 'std::numbers::sqrt3' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: std::numbers::sqrt3;
 
     T phi = 1.6180339;
-    // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: T phi = std::numbers::phi;
 
     sink((42 + bar::sqrt(5)) / 2);
 
     sink((1 + bar::sqrt(5)) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi);
 
     sink((bar::sqrt(5.0F) + 1) / 2);
-    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer 'std::numbers::phi_v<float>' math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi_v<float>);
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -203,3 +203,163 @@ void foo(){
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::phi_v<float>);
 }
+
+
+
+template <typename T>
+void baz(){
+    static constexpr T Pi = 3.1415926;
+    // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr T Pi = std::numbers::pi;
+
+    static constexpr T Euler = 2.7182818;
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr T Euler = std::numbers::e;
+
+    static constexpr T Phi = 1.6180339;
+    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr T Phi = std::numbers::phi;
+
+    static constexpr T PiCopy = Pi;
+    static constexpr T PiDefine = MY_PI;
+
+    // not close enough to match value (DiffThreshold)
+    static constexpr T Pi2 = 3.14;
+    static constexpr T Euler2 = 2.71;
+    static constexpr T Phi2 = 1.61;
+
+    static constexpr T Pi3 = 3.1415926L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr T Pi3 = std::numbers::pi_v<long double>;
+
+    static constexpr T Euler3 = 2.7182818L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr T Euler3 = std::numbers::e_v<long double>;
+
+    static constexpr T Phi3 = 1.6180339L;
+    // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr T Phi3 = std::numbers::phi_v<long double>;
+
+    using my_float = const float;
+    static constexpr my_float Actually2MyFloat = 2;
+    bar::sqrt(Actually2MyFloat);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2_v<float>;
+
+    constexpr static T One = 1;
+    constexpr static T Two = 2;
+
+    bar::sqrt(2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    bar::sqrt(Two);
+
+    bar::sqrt(2.0);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    T Not2 = 2;
+    Not2 = 42;
+    bar::sqrt(Not2);
+
+    const T Actually2 = 2;
+    bar::sqrt(Actually2);
+
+    exp(1);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::e;
+
+    exp(One);
+
+    exp(1.00000000000001);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::e;
+
+    log2(exp(1));
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log2e;
+
+    log2(Euler);
+
+    log2(bar::e);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log2e;
+
+    T log2e = 1.4426950;
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: T log2e = std::numbers::log2e;
+
+    log10(exp(1));
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:11: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log10e;
+
+    log10(Euler);
+
+    log10(bar::e);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::log10e;
+
+    T log10e = .434294;
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: T log10e = std::numbers::log10e;
+
+    T egamma = 0.5772156 * 42;
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: T egamma = std::numbers::egamma * 42;
+
+    sink(1 / Pi);
+
+    sink(1 / bar::sqrt(Pi));
+
+    sink(1 / bar::sqrt(MY_PI));
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::inv_sqrtpi);
+
+
+    log(2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::ln2;
+
+    log(10);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::ln10;
+
+    bar::sqrt(2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt2;
+
+    sink(1 / bar::sqrt(3));
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:14: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::inv_sqrt3);
+
+    bar::sqrt(3);
+    // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: std::numbers::sqrt3;
+
+    T phi = 1.6180339;
+    // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: T phi = std::numbers::phi;
+
+    sink((42 + bar::sqrt(5)) / 2);
+
+    sink((1 + bar::sqrt(5)) / 2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::phi);
+
+    sink((bar::sqrt(5.0F) + 1) / 2);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: sink(std::numbers::phi_v<float>);
+}
+
+template <typename T>
+void foobar(){
+    const T Two = 2;
+    bar::sqrt(Two);
+}
+void use_foobar() {
+    foobar<float>();
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -21,6 +21,8 @@ double log10(double Arg);
 template<typename T>
 void sink(T&&) { }
 
+void floatSink(float) {}
+
 #define MY_PI 3.1415926
 
 #define INV_SQRT3 1 / bar::sqrt(3)
@@ -138,6 +140,52 @@ void foo(){
     auto log2e = 1.4426950;
     // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto log2e = std::numbers::log2e;
+
+    floatSink(log2(Euler));
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(static_cast<float>(log2(Euler)));
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(1.4426950);
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(static_cast<float>(1.4426950));
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(log2(static_cast<float>(Euler)));
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(static_cast<float>(log2(static_cast<float>(Euler))));
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(static_cast<float>(log2(static_cast<int>(Euler))));
+
+    floatSink(static_cast<int>(log2(static_cast<float>(Euler))));
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e));
+
+    floatSink(1.4426950F);
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(static_cast<double>(1.4426950F));
+    // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-MESSAGES: :[[@LINE-2]]:35: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(std::numbers::log2e_v<float>);
+
+    floatSink(static_cast<int>(1.4426950F));
+    // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: floatSink(static_cast<int>(std::numbers::log2e_v<float>));
 
     log10(exp(1));
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: prefer std::numbers math constant [modernize-use-std-numbers]

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-numbers.cpp
@@ -75,6 +75,10 @@ void foo(){
     // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: static constexpr long double Phi4 = std::numbers::phi_v<long double>;
 
+    static constexpr double InvPi = 1.0 / Pi;
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: prefer std::numbers math constant [modernize-use-std-numbers]
+    // CHECK-FIXES: static constexpr double InvPi = std::numbers::inv_pi;
+
     using my_float = const float;
     static constexpr my_float Actually2MyFloat = 2;
     bar::sqrt(Actually2MyFloat);
@@ -155,6 +159,8 @@ void foo(){
     // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto egamma = std::numbers::egamma * 42;
 
+    sink(InvPi);
+
     sink(1 / Pi);
     // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: sink(std::numbers::inv_pi);
@@ -192,6 +198,8 @@ void foo(){
     auto phi = 1.6180339;
     // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: prefer std::numbers math constant [modernize-use-std-numbers]
     // CHECK-FIXES: auto phi = std::numbers::phi;
+
+    sink(Phi);
 
     sink((42 + bar::sqrt(5)) / 2);
 


### PR DESCRIPTION
Finds constants and function calls to math functions that can be replaced
with c++20's mathematical constants from the 'numbers' header and
offers fix-it hints.
Does not match the use of variables with that value, and instead,
offers a replacement at the definition of those variables.