### PR TITLE
[libc++] Fix `std::pair`'s  pair-like constructor's incorrect assumption

### DIFF
--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -274,9 +274,9 @@ struct _LIBCPP_TEMPLATE_VIS pair
 
 #  if _LIBCPP_STD_VER >= 23
     // This is a workaround for http://llvm.org/PR60710. We should be able to remove it once Clang is fixed.
-    template <class _PairLike, bool _Enable = tuple_size<remove_cvref_t<_PairLike>>::value == 2>
+    template <class _PairLike>
     _LIBCPP_HIDE_FROM_ABI static constexpr bool __pair_like_explicit_wknd() {
-        if constexpr (tuple_size<remove_cvref_t<_PairLike>>::value == 2) {
+        if constexpr (__pair_like<_PairLike>) {
             return !is_convertible_v<decltype(std::get<0>(std::declval<_PairLike&&>())), first_type> ||
                    !is_convertible_v<decltype(std::get<1>(std::declval<_PairLike&&>())), second_type>;
         }

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/ctor.pair_like.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/ctor.pair_like.pass.cpp
@@ -23,6 +23,37 @@
 #include <type_traits>
 #include <utility>
 
+namespace my_ns{
+
+struct MyPairLike {
+
+template <std::size_t N>
+friend int get(MyPairLike const&)
+{
+  return 0;
+}
+
+};
+
+} // namespace my_ns
+
+namespace std {
+
+template <>
+struct tuple_size<my_ns::MyPairLike> : std::integral_constant<std::size_t, 2> {};
+
+template <std::size_t N>
+struct tuple_element<N, my_ns::MyPairLike> {
+  using type = int;
+};
+
+} // namespace std
+
+// https://github.com/llvm/llvm-project/issues/65620
+// This used to be a hard error
+static_assert(!std::is_constructible_v<std::pair<int,int>, my_ns::MyPairLike const&>);
+
+
 constexpr bool test() {
   // Make sure construction works from array, tuple, and ranges::subrange
   {


### PR DESCRIPTION
GitHub Issue:
https://github.com/llvm/llvm-project/issues/65620

The helper function `__pair_like_explicit_wknd` is only SFINAE-ed with `tuple_size<remove_cvref_t<_PairLike>>::value == 2`, but its function body assumes `std::get` being valid
https://github.com/llvm/llvm-project/blame/main/libcxx/include/__utility/pair.h#L280
