### PR TITLE
[clang] Enable --print-supported-extensions for all targets

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5277,7 +5277,7 @@ def print_supported_cpus : Flag<["-", "--"], "print-supported-cpus">,
   MarshallingInfoFlag<FrontendOpts<"PrintSupportedCPUs">>;
 def print_supported_extensions : Flag<["-", "--"], "print-supported-extensions">,
   Visibility<[ClangOption, CC1Option, CLOption]>,
-  HelpText<"Print supported -march extensions (RISC-V, AArch64 and ARM only)">,
+  HelpText<"Print supported -march extensions">,
   MarshallingInfoFlag<FrontendOpts<"PrintSupportedExtensions">>;
 def : Flag<["-"], "mcpu=help">, Alias<print_supported_cpus>;
 def : Flag<["-"], "mtune=help">, Alias<print_supported_cpus>;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4279,19 +4279,9 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     // If --print-supported-cpus, -mcpu=? or -mtune=? is specified, build a
     // custom Compile phase that prints out supported cpu models and quits.
     //
-    // If --print-supported-extensions is specified, call the helper function
-    // RISCVMarchHelp in RISCVISAInfo.cpp that prints out supported extensions
-    // and quits.
+    // If --print-supported-extensions is specified, list all supported flags
+    // within the target and quit.
     if (Arg *A = Args.getLastArg(Opt)) {
-      if (Opt == options::OPT_print_supported_extensions &&
-          !C.getDefaultToolChain().getTriple().isRISCV() &&
-          !C.getDefaultToolChain().getTriple().isAArch64() &&
-          !C.getDefaultToolChain().getTriple().isARM()) {
-        C.getDriver().Diag(diag::err_opt_not_valid_on_target)
-            << "--print-supported-extensions";
-        return;
-      }
-
       // Use the -mcpu=? flag as the dummy input to cc1.
       Actions.clear();
       Action *InputAc = C.MakeAction<InputAction>(*A, types::TY_C);

--- a/clang/test/Driver/print-supported-extensions.c
+++ b/clang/test/Driver/print-supported-extensions.c
@@ -3,16 +3,16 @@
 
 // RUN: %if aarch64-registered-target %{ %clang --target=aarch64-linux-gnu \
 // RUN:   --print-supported-extensions 2>&1 | FileCheck %s --check-prefix AARCH64 %}
-// AARCH64: All available -march extensions for AArch64
+// AARCH64: All available -march extensions for aarch64
 
 // RUN: %if riscv-registered-target %{ %clang --target=riscv64-linux-gnu \
 // RUN:   --print-supported-extensions 2>&1 | FileCheck %s --check-prefix RISCV %}
-// RISCV: All available -march extensions for RISC-V
+// RISCV: All available -march extensions for riscv64
 
 // RUN: %if arm-registered-target %{ %clang --target=arm-linux-gnu \
 // RUN:   --print-supported-extensions 2>&1 | FileCheck %s --check-prefix ARM %}
-// ARM: All available -march extensions for ARM
+// ARM: All available -march extensions for arm
 
-// RUN: %if x86-registered-target %{ not %clang --target=x86_64-linux-gnu \
+// RUN: %if x86-registered-target %{ %clang --target=x86_64-linux-gnu \
 // RUN:   --print-supported-extensions 2>&1 | FileCheck %s --check-prefix X86 %}
-// X86: error: option '--print-supported-extensions' cannot be specified on this target
+// X86: All available -march extensions for x86-64

--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -230,8 +230,14 @@ public:
     return Found != ProcDesc.end() && StringRef(Found->Key) == CPU;
   }
 
+  /// Return processor descriptions.
   ArrayRef<SubtargetSubTypeKV> getAllProcessorDescriptions() const {
     return ProcDesc;
+  }
+
+  /// Return processor features.
+  ArrayRef<SubtargetFeatureKV> getAllProcessorFeatures() const {
+    return ProcFeatures;
   }
 
   virtual unsigned getHwMode() const { return 0; }


### PR DESCRIPTION
This uses MCSubtargetInfo instead, to cover all the architectures. This now also list descriptions along with the names.

The advantage fetching from MCSubtargetInfo is that we rely on tablegen architecture descriptions for all architectures.

---

* Output from `hexagon`:
```
$ ./bin/clang -target hexagon-linux-gnu --print-supported-extensions
clang version 18.0.0 (https://github.com/cbalint13/llvm-project 8049db0990d1695a40de57f136af20ce5340b4a6)
Target: hexagon-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/cbalint/work/GITHUB/llvm-project/build/./bin
All available -march extensions for hexagon

  audio                                    Hexagon Audio extension instructions
  cabac                                    Emit the CABAC instruction
  compound                                 Use compound instructions
  duplex                                   Enable generation of duplex instruction
  hvx                                      Hexagon HVX instructions
  hvx-ieee-fp                              Hexagon HVX IEEE floating point instructions
  hvx-length128b                           Hexagon HVX 128B instructions
  hvx-length64b                            Hexagon HVX 64B instructions
  hvx-qfloat                               Hexagon HVX QFloating point instructions
  hvxv60                                   Hexagon HVX instructions
  hvxv62                                   Hexagon HVX instructions
  hvxv65                                   Hexagon HVX instructions
{...}
```

* Output from `x86_64`:
```
$ ./bin/clang -target x86_64-linux-gnu --print-supported-extensions
clang version 18.0.0 (https://github.com/cbalint13/llvm-project 8049db0990d1695a40de57f136af20ce5340b4a6)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/cbalint/work/GITHUB/llvm-project/build/./bin
All available -march extensions for x86-64

  16bit-mode                               16-bit mode (i8086)
  32bit-mode                               32-bit mode (80386)
  3dnow                                    Enable 3DNow! instructions
  3dnowa                                   Enable 3DNow! Athlon instructions
  64bit                                    Support 64-bit instructions
  64bit-mode                               64-bit mode (x86_64)
  adx                                      Support ADX instructions
  aes                                      Enable AES instructions
  allow-light-256-bit                      (Enable generation of 256-bit load/stores even ....
  amx-bf16                                 Support AMX-BF16 instructions
  amx-complex                              Support AMX-COMPLEX instructions
  amx-fp16                                 Support AMX amx-fp16 instructions
  amx-int8                                 Support AMX-INT8 instructions
  amx-tile                                 Support AMX-TILE instructions
  avx                                      Enable AVX instructions
  avx2                                     Enable AVX2 instructions
  avx512bf16                               Support bfloat16 floating point
  avx512bitalg                             Enable AVX-512 Bit Algorithms
  avx512bw                                 Enable AVX-512 Byte and Word Instructions
  avx512cd                                 Enable AVX-512 Conflict Detection Instructions
{...}
```

---

Cc @DavidSpickett ,  @DanielKristofKiss , @MaskRay 

I also reference here #66582 for past comments on extracting information from MCSubtargetInfo .
