### PR TITLE
[polly] Create component and install target in add_polly_library

### DIFF
--- a/polly/cmake/polly_macros.cmake
+++ b/polly/cmake/polly_macros.cmake
@@ -43,9 +43,12 @@ macro(add_polly_library name)
   endif( LLVM_LINK_COMPONENTS )
   if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY OR ${name} STREQUAL "LLVMPolly")
     install(TARGETS ${name}
+      COMPONENT ${name}
       EXPORT LLVMExports
       LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
       ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX})
+    add_llvm_install_targets(install-${name}
+      COMPONENT ${name})
   endif()
   set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
 endmacro(add_polly_library)


### PR DESCRIPTION
Currently there's no component for LLVMPolly and PollyISL, however they are added to exports whether or not they are installed. This commit calls add_llvm_install_targets in the add_polly_library function to allow installation of LLVMPolly and PollyISL via distribution components, so they can be installed without also installing libPolly.a.