### PR TITLE
[libc++abi][test][VE] Add '-ldl' to support VE

### DIFF
--- a/libcxx/test/configs/ve-libc++-shared.cfg.in
+++ b/libcxx/test/configs/ve-libc++-shared.cfg.in
@@ -1,0 +1,28 @@
+# This testing configuration handles running the test suite against LLVM's
+# libc++ for VE using a shared library.
+
+lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
+
+config.substitutions.append(('%{flags}',
+    '-pthread' + (' -isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else '')
+))
+config.substitutions.append(('%{compile_flags}',
+    '-nostdinc++ -I %{include} -I %{target-include} -I %{libcxx}/test/support'
+))
+# VE requires libdl library.
+config.substitutions.append(('%{link_flags}',
+    '-nostdlib++ -L %{lib} -Wl,-rpath,%{lib} -lc++ -ldl'
+))
+config.substitutions.append(('%{exec}',
+    '%{executor} --execdir %T -- '
+))
+
+import os, site
+site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
+    libcxx.test.params.DEFAULT_PARAMETERS,
+    libcxx.test.features.DEFAULT_FEATURES,
+    config,
+    lit_config
+)

--- a/libcxxabi/test/configs/ve-libc++abi-shared.cfg.in
+++ b/libcxxabi/test/configs/ve-libc++abi-shared.cfg.in
@@ -1,0 +1,28 @@
+# This testing configuration handles running the test suite against LLVM's
+# libc++abi for VE using a shared library.
+
+lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
+
+config.substitutions.append(('%{flags}',
+    '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
+))
+config.substitutions.append(('%{compile_flags}',
+    '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS'
+))
+# VE requires libdl library.
+config.substitutions.append(('%{link_flags}',
+    '-nostdlib++ -L %{lib} -Wl,-rpath,%{lib} -lc++ -lc++abi -pthread -ldl'
+))
+config.substitutions.append(('%{exec}',
+    '%{executor} --execdir %T -- '
+))
+
+import os, site
+site.addsitedir(os.path.join('@LIBCXXABI_LIBCXX_PATH@', 'utils'))
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
+    libcxx.test.params.DEFAULT_PARAMETERS,
+    libcxx.test.features.DEFAULT_FEATURES,
+    config,
+    lit_config
+)


### PR DESCRIPTION
Tests are linked under -nostdlib++ option, so it is required to add system's libraries correctly.  So, I add libdl.so which is required for VE.