### PR TITLE
[sanitizers] Do not define __has_feature in sanitizer/common_interface_defs.h

### DIFF
--- a/compiler-rt/include/sanitizer/asan_interface.h
+++ b/compiler-rt/include/sanitizer/asan_interface.h
@@ -50,7 +50,15 @@ void SANITIZER_CDECL __asan_unpoison_memory_region(void const volatile *addr,
                                                    size_t size);
 
 // Macros provided for convenience.
-#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#ifdef __has_feature
+#if __has_feature(address_sanitizer)
+#define ASAN_DEFINE_REGION_MACROS
+#endif
+#elif defined(__SANITIZE_ADDRESS__)
+#define ASAN_DEFINE_REGION_MACROS
+#endif
+
+#ifdef ASAN_DEFINE_REGION_MACROS
 /// Marks a memory region as unaddressable.
 ///
 /// \note Macro provided for convenience; defined as a no-op if ASan is not
@@ -74,6 +82,7 @@ void SANITIZER_CDECL __asan_unpoison_memory_region(void const volatile *addr,
 #define ASAN_POISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
 #define ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
 #endif
+#undef ASAN_DEFINE_REGION_MACROS
 
 /// Checks if an address is poisoned.
 ///

--- a/compiler-rt/include/sanitizer/common_interface_defs.h
+++ b/compiler-rt/include/sanitizer/common_interface_defs.h
@@ -15,11 +15,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// GCC does not understand __has_feature.
-#if !defined(__has_feature)
-#define __has_feature(x) 0
-#endif
-
 // Windows allows a user to set their default calling convention, but we always
 // use __cdecl
 #ifdef _WIN32

--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -15,6 +15,11 @@
 #include "sanitizer_platform.h"
 #include "sanitizer_redefine_builtins.h"
 
+// GCC does not understand __has_feature.
+#if !defined(__has_feature)
+#define __has_feature(x) 0
+#endif
+
 #ifndef SANITIZER_DEBUG
 # define SANITIZER_DEBUG 0
 #endif


### PR DESCRIPTION
Public headers intended for user code should not define `__has_feature`, because this can break preprocessor checks done later in user code, e.g. if they test `#ifdef __has_feature` to check for real support in the compiler.

Replace the only use in the public header with a check for it being supported before trying to use it. Define the fallback definition in the internal headers, so that other internal sanitizer headers can continue to use it as preferred.

This resolves a bug reported to GCC as https://gcc.gnu.org/PR109882