### PR TITLE
[RISCV] Fix inline asm error for block address

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -236,7 +236,7 @@ bool RISCVAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
   // RISCVDAGToDAGISel::SelectInlineAsmMemoryOperand).
   if (!AddrReg.isReg())
     return true;
-  if (!Offset.isImm() && !Offset.isGlobal())
+  if (!Offset.isImm() && !Offset.isGlobal() && !Offset.isBlockAddress())
     return true;
 
   MCOperand MCO;
@@ -245,7 +245,7 @@ bool RISCVAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI,
 
   if (Offset.isImm())
     OS << MCO.getImm();
-  else if (Offset.isGlobal())
+  else if (Offset.isGlobal() || Offset.isBlockAddress())
     OS << *MCO.getExpr();
   OS << "(" << RISCVInstPrinter::getRegisterName(AddrReg.getReg()) << ")";
   return false;

--- a/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
+++ b/llvm/test/CodeGen/RISCV/inline-asm-mem-constraint.ll
@@ -358,6 +358,166 @@ define void @constraint_m_with_extern_weak_global_3() nounwind {
   ret void
 }
 
+define void @constraint_m_with_local_1() nounwind {
+; RV32I-LABEL: constraint_m_with_local_1:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp0: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp0)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp0)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: constraint_m_with_local_1:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp0: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp0)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp0)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
+;
+; RV32I-MEDIUM-LABEL: constraint_m_with_local_1:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp0: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi6:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi6)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
+;
+; RV64I-MEDIUM-LABEL: constraint_m_with_local_1:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp0: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi6:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp0)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi6)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
+entry:
+  br label %label
+
+label:
+  tail call void asm sideeffect "lw zero, $0", "*m"(ptr elementtype(ptr) blockaddress(@constraint_m_with_local_1, %label))
+  ret void
+}
+
+define void @constraint_m_with_local_2() nounwind {
+; RV32I-LABEL: constraint_m_with_local_2:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp1: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp1)
+; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp1)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, 4(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: constraint_m_with_local_2:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp1: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp1)
+; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp1)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, 4(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
+;
+; RV32I-MEDIUM-LABEL: constraint_m_with_local_2:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp1: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi7:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi7)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
+;
+; RV64I-MEDIUM-LABEL: constraint_m_with_local_2:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp1: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi7:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp1)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi7)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
+entry:
+  br label %label
+
+label:
+  call void asm "lw zero, $0", "*m"(ptr nonnull elementtype(i32) getelementptr inbounds (i8, ptr blockaddress(@constraint_m_with_local_2, %label), i32 4))
+  ret void
+}
+
+define void @constraint_m_with_local_3() nounwind {
+; RV32I-LABEL: constraint_m_with_local_3:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp2: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp2)
+; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp2)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, 2000(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: constraint_m_with_local_3:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp2: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp2)
+; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp2)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, 2000(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
+;
+; RV32I-MEDIUM-LABEL: constraint_m_with_local_3:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp2: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi8:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi8)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
+;
+; RV64I-MEDIUM-LABEL: constraint_m_with_local_3:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp2: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi8:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp2)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi8)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
+entry:
+  br label %label
+
+label:
+  call void asm "lw zero, $0", "*m"(ptr nonnull elementtype(i32) getelementptr inbounds (i8, ptr blockaddress(@constraint_m_with_local_3, %label), i32 2000))
+  ret void
+}
+
 define void @constraint_m_with_multi_operands() nounwind {
 ; RV32I-LABEL: constraint_m_with_multi_operands:
 ; RV32I:       # %bb.0:
@@ -377,9 +537,9 @@ define void @constraint_m_with_multi_operands() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_m_with_multi_operands:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi6:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi9:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi6)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi9)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 0(a0); sw zero, 0(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -387,9 +547,9 @@ define void @constraint_m_with_multi_operands() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_m_with_multi_operands:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi6:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi9:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi6)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi9)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 0(a0); sw zero, 0(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -423,9 +583,9 @@ define void @constraint_m_with_multi_asm() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_m_with_multi_asm:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi7:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi10:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi7)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi10)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -436,9 +596,9 @@ define void @constraint_m_with_multi_asm() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_m_with_multi_asm:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi7:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi10:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi7)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi10)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -456,12 +616,12 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:    lui a1, %hi(eg)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB11_2
+; RV32I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB14_2
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:  # %bb.1: # %normal
 ; RV32I-NEXT:    li a0, 0
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB11_2: # Block address taken
+; RV32I-NEXT:  .LBB14_2: # Block address taken
 ; RV32I-NEXT:    # %fail
 ; RV32I-NEXT:    # Label of block must be emitted
 ; RV32I-NEXT:    li a0, 1
@@ -471,12 +631,12 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:    lui a1, %hi(eg)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB11_2
+; RV64I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB14_2
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:  # %bb.1: # %normal
 ; RV64I-NEXT:    li a0, 0
 ; RV64I-NEXT:    ret
-; RV64I-NEXT:  .LBB11_2: # Block address taken
+; RV64I-NEXT:  .LBB14_2: # Block address taken
 ; RV64I-NEXT:    # %fail
 ; RV64I-NEXT:    # Label of block must be emitted
 ; RV64I-NEXT:    li a0, 1
@@ -484,16 +644,16 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_m_with_callbr_multi_operands:
 ; RV32I-MEDIUM:       # %bb.0: # %entry
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi8:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi11:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi8)
+; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi11)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB11_2
+; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB14_2
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NEXT:    ret
-; RV32I-MEDIUM-NEXT:  .LBB11_2: # Block address taken
+; RV32I-MEDIUM-NEXT:  .LBB14_2: # Block address taken
 ; RV32I-MEDIUM-NEXT:    # %fail
 ; RV32I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NEXT:    li a0, 1
@@ -501,16 +661,16 @@ define i32 @constraint_m_with_callbr_multi_operands(i32 %a) {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_m_with_callbr_multi_operands:
 ; RV64I-MEDIUM:       # %bb.0: # %entry
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi8:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi11:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi8)
+; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi11)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB11_2
+; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB14_2
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NEXT:    ret
-; RV64I-MEDIUM-NEXT:  .LBB11_2: # Block address taken
+; RV64I-MEDIUM-NEXT:  .LBB14_2: # Block address taken
 ; RV64I-MEDIUM-NEXT:    # %fail
 ; RV64I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NEXT:    li a0, 1
@@ -530,16 +690,16 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:    lui a1, %hi(eg)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB12_3
+; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB15_3
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:  # %bb.1: # %normal0
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB12_3
+; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB15_3
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:  # %bb.2: # %normal1
 ; RV32I-NEXT:    li a0, 0
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB12_3: # Block address taken
+; RV32I-NEXT:  .LBB15_3: # Block address taken
 ; RV32I-NEXT:    # %fail
 ; RV32I-NEXT:    # Label of block must be emitted
 ; RV32I-NEXT:    li a0, 1
@@ -549,16 +709,16 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:    lui a1, %hi(eg)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB12_3
+; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB15_3
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:  # %bb.1: # %normal0
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB12_3
+; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB15_3
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:  # %bb.2: # %normal1
 ; RV64I-NEXT:    li a0, 0
 ; RV64I-NEXT:    ret
-; RV64I-NEXT:  .LBB12_3: # Block address taken
+; RV64I-NEXT:  .LBB15_3: # Block address taken
 ; RV64I-NEXT:    # %fail
 ; RV64I-NEXT:    # Label of block must be emitted
 ; RV64I-NEXT:    li a0, 1
@@ -566,20 +726,20 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_m_with_multi_callbr_asm:
 ; RV32I-MEDIUM:       # %bb.0: # %entry
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi9:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi12:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi9)
+; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi12)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB12_3
+; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB12_3
+; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NEXT:    ret
-; RV32I-MEDIUM-NEXT:  .LBB12_3: # Block address taken
+; RV32I-MEDIUM-NEXT:  .LBB15_3: # Block address taken
 ; RV32I-MEDIUM-NEXT:    # %fail
 ; RV32I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NEXT:    li a0, 1
@@ -587,20 +747,20 @@ define i32 @constraint_m_with_multi_callbr_asm(i32 %a) {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_m_with_multi_callbr_asm:
 ; RV64I-MEDIUM:       # %bb.0: # %entry
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi9:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi12:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi9)
+; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi12)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB12_3
+; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB12_3
+; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB15_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NEXT:    ret
-; RV64I-MEDIUM-NEXT:  .LBB12_3: # Block address taken
+; RV64I-MEDIUM-NEXT:  .LBB15_3: # Block address taken
 ; RV64I-MEDIUM-NEXT:    # %fail
 ; RV64I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NEXT:    li a0, 1
@@ -730,9 +890,9 @@ define void @constraint_o_with_global_1() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_global_1:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi10:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi13:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi10)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi13)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -740,9 +900,9 @@ define void @constraint_o_with_global_1() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_global_1:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi10:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi13:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi10)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi13)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -772,9 +932,9 @@ define void @constraint_o_with_global_2() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_global_2:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi11:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi14:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi11)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi14)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 4(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -782,9 +942,9 @@ define void @constraint_o_with_global_2() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_global_2:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi11:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi14:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi11)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi14)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 4(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -814,9 +974,9 @@ define void @constraint_o_with_global_3() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_global_3:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi12:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi15:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi12)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi15)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -824,9 +984,9 @@ define void @constraint_o_with_global_3() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_global_3:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi12:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi15:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg+8000)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi12)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi15)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -854,9 +1014,9 @@ define void @constraint_o_with_extern_weak_global_1() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_extern_weak_global_1:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi13:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi16:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %got_pcrel_hi(ewg)
-; RV32I-MEDIUM-NEXT:    lw a0, %pcrel_lo(.Lpcrel_hi13)(a0)
+; RV32I-MEDIUM-NEXT:    lw a0, %pcrel_lo(.Lpcrel_hi16)(a0)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -864,9 +1024,9 @@ define void @constraint_o_with_extern_weak_global_1() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_extern_weak_global_1:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi13:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi16:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %got_pcrel_hi(ewg)
-; RV64I-MEDIUM-NEXT:    ld a0, %pcrel_lo(.Lpcrel_hi13)(a0)
+; RV64I-MEDIUM-NEXT:    ld a0, %pcrel_lo(.Lpcrel_hi16)(a0)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -896,9 +1056,9 @@ define void @constraint_o_with_extern_weak_global_2() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_extern_weak_global_2:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi14:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi17:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %got_pcrel_hi(ewg)
-; RV32I-MEDIUM-NEXT:    lw a0, %pcrel_lo(.Lpcrel_hi14)(a0)
+; RV32I-MEDIUM-NEXT:    lw a0, %pcrel_lo(.Lpcrel_hi17)(a0)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 4(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -906,9 +1066,9 @@ define void @constraint_o_with_extern_weak_global_2() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_extern_weak_global_2:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi14:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi17:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %got_pcrel_hi(ewg)
-; RV64I-MEDIUM-NEXT:    ld a0, %pcrel_lo(.Lpcrel_hi14)(a0)
+; RV64I-MEDIUM-NEXT:    ld a0, %pcrel_lo(.Lpcrel_hi17)(a0)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 4(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -938,9 +1098,9 @@ define void @constraint_o_with_extern_weak_global_3() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_extern_weak_global_3:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi15:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi18:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %got_pcrel_hi(ewg)
-; RV32I-MEDIUM-NEXT:    lw a0, %pcrel_lo(.Lpcrel_hi15)(a0)
+; RV32I-MEDIUM-NEXT:    lw a0, %pcrel_lo(.Lpcrel_hi18)(a0)
 ; RV32I-MEDIUM-NEXT:    lui a1, 2
 ; RV32I-MEDIUM-NEXT:    addi a1, a1, -192
 ; RV32I-MEDIUM-NEXT:    add a0, a0, a1
@@ -951,9 +1111,9 @@ define void @constraint_o_with_extern_weak_global_3() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_extern_weak_global_3:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi15:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi18:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %got_pcrel_hi(ewg)
-; RV64I-MEDIUM-NEXT:    ld a0, %pcrel_lo(.Lpcrel_hi15)(a0)
+; RV64I-MEDIUM-NEXT:    ld a0, %pcrel_lo(.Lpcrel_hi18)(a0)
 ; RV64I-MEDIUM-NEXT:    lui a1, 2
 ; RV64I-MEDIUM-NEXT:    addiw a1, a1, -192
 ; RV64I-MEDIUM-NEXT:    add a0, a0, a1
@@ -984,9 +1144,9 @@ define void @constraint_o_with_multi_operands() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_multi_operands:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi16:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi19:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi16)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi19)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 0(a0) \n sw zero, 0(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -994,9 +1154,9 @@ define void @constraint_o_with_multi_operands() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_multi_operands:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi16:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi19:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi16)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi19)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 0(a0) \n sw zero, 0(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -1030,9 +1190,9 @@ define void @constraint_o_with_multi_asm() nounwind {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_multi_asm:
 ; RV32I-MEDIUM:       # %bb.0:
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi17:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi20:
 ; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi17)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi20)
 ; RV32I-MEDIUM-NEXT:    #APP
 ; RV32I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV32I-MEDIUM-NEXT:    #NO_APP
@@ -1043,9 +1203,9 @@ define void @constraint_o_with_multi_asm() nounwind {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_multi_asm:
 ; RV64I-MEDIUM:       # %bb.0:
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi17:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi20:
 ; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi17)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi20)
 ; RV64I-MEDIUM-NEXT:    #APP
 ; RV64I-MEDIUM-NEXT:    sw zero, 0(a0)
 ; RV64I-MEDIUM-NEXT:    #NO_APP
@@ -1063,12 +1223,12 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:    lui a1, %hi(eg)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB24_2
+; RV32I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB27_2
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:  # %bb.1: # %normal
 ; RV32I-NEXT:    li a0, 0
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB24_2: # Block address taken
+; RV32I-NEXT:  .LBB27_2: # Block address taken
 ; RV32I-NEXT:    # %fail
 ; RV32I-NEXT:    # Label of block must be emitted
 ; RV32I-NEXT:    li a0, 1
@@ -1078,12 +1238,12 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:    lui a1, %hi(eg)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB24_2
+; RV64I-NEXT:    sw zero, %lo(eg)(a1); sw zero, %lo(eg)(a1); beqz a0, .LBB27_2
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:  # %bb.1: # %normal
 ; RV64I-NEXT:    li a0, 0
 ; RV64I-NEXT:    ret
-; RV64I-NEXT:  .LBB24_2: # Block address taken
+; RV64I-NEXT:  .LBB27_2: # Block address taken
 ; RV64I-NEXT:    # %fail
 ; RV64I-NEXT:    # Label of block must be emitted
 ; RV64I-NEXT:    li a0, 1
@@ -1091,16 +1251,16 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_callbr_multi_operands:
 ; RV32I-MEDIUM:       # %bb.0: # %entry
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi18:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi21:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi18)
+; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi21)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB24_2
+; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB27_2
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV32I-MEDIUM-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NEXT:    ret
-; RV32I-MEDIUM-NEXT:  .LBB24_2: # Block address taken
+; RV32I-MEDIUM-NEXT:  .LBB27_2: # Block address taken
 ; RV32I-MEDIUM-NEXT:    # %fail
 ; RV32I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NEXT:    li a0, 1
@@ -1108,16 +1268,16 @@ define i32 @constraint_o_with_callbr_multi_operands(i32 %a) {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_callbr_multi_operands:
 ; RV64I-MEDIUM:       # %bb.0: # %entry
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi18:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi21:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi18)
+; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi21)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB24_2
+; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); sw zero, 0(a1); beqz a0, .LBB27_2
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal
 ; RV64I-MEDIUM-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NEXT:    ret
-; RV64I-MEDIUM-NEXT:  .LBB24_2: # Block address taken
+; RV64I-MEDIUM-NEXT:  .LBB27_2: # Block address taken
 ; RV64I-MEDIUM-NEXT:    # %fail
 ; RV64I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NEXT:    li a0, 1
@@ -1137,16 +1297,16 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV32I:       # %bb.0: # %entry
 ; RV32I-NEXT:    lui a1, %hi(eg)
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB25_3
+; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB28_3
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:  # %bb.1: # %normal0
 ; RV32I-NEXT:    #APP
-; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB25_3
+; RV32I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB28_3
 ; RV32I-NEXT:    #NO_APP
 ; RV32I-NEXT:  # %bb.2: # %normal1
 ; RV32I-NEXT:    li a0, 0
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB25_3: # Block address taken
+; RV32I-NEXT:  .LBB28_3: # Block address taken
 ; RV32I-NEXT:    # %fail
 ; RV32I-NEXT:    # Label of block must be emitted
 ; RV32I-NEXT:    li a0, 1
@@ -1156,16 +1316,16 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ; RV64I:       # %bb.0: # %entry
 ; RV64I-NEXT:    lui a1, %hi(eg)
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB25_3
+; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB28_3
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:  # %bb.1: # %normal0
 ; RV64I-NEXT:    #APP
-; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB25_3
+; RV64I-NEXT:    sw zero, %lo(eg)(a1); beqz a0, .LBB28_3
 ; RV64I-NEXT:    #NO_APP
 ; RV64I-NEXT:  # %bb.2: # %normal1
 ; RV64I-NEXT:    li a0, 0
 ; RV64I-NEXT:    ret
-; RV64I-NEXT:  .LBB25_3: # Block address taken
+; RV64I-NEXT:  .LBB28_3: # Block address taken
 ; RV64I-NEXT:    # %fail
 ; RV64I-NEXT:    # Label of block must be emitted
 ; RV64I-NEXT:    li a0, 1
@@ -1173,20 +1333,20 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ;
 ; RV32I-MEDIUM-LABEL: constraint_o_with_multi_callbr_asm:
 ; RV32I-MEDIUM:       # %bb.0: # %entry
-; RV32I-MEDIUM-NEXT:  .Lpcrel_hi19:
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi22:
 ; RV32I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi19)
+; RV32I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi22)
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB25_3
+; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV32I-MEDIUM-NEXT:    #APP
-; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB25_3
+; RV32I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
 ; RV32I-MEDIUM-NEXT:    #NO_APP
 ; RV32I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV32I-MEDIUM-NEXT:    li a0, 0
 ; RV32I-MEDIUM-NEXT:    ret
-; RV32I-MEDIUM-NEXT:  .LBB25_3: # Block address taken
+; RV32I-MEDIUM-NEXT:  .LBB28_3: # Block address taken
 ; RV32I-MEDIUM-NEXT:    # %fail
 ; RV32I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV32I-MEDIUM-NEXT:    li a0, 1
@@ -1194,20 +1354,20 @@ define i32 @constraint_o_with_multi_callbr_asm(i32 %a) {
 ;
 ; RV64I-MEDIUM-LABEL: constraint_o_with_multi_callbr_asm:
 ; RV64I-MEDIUM:       # %bb.0: # %entry
-; RV64I-MEDIUM-NEXT:  .Lpcrel_hi19:
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi22:
 ; RV64I-MEDIUM-NEXT:    auipc a1, %pcrel_hi(eg)
-; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi19)
+; RV64I-MEDIUM-NEXT:    addi a1, a1, %pcrel_lo(.Lpcrel_hi22)
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB25_3
+; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.1: # %normal0
 ; RV64I-MEDIUM-NEXT:    #APP
-; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB25_3
+; RV64I-MEDIUM-NEXT:    sw zero, 0(a1); beqz a0, .LBB28_3
 ; RV64I-MEDIUM-NEXT:    #NO_APP
 ; RV64I-MEDIUM-NEXT:  # %bb.2: # %normal1
 ; RV64I-MEDIUM-NEXT:    li a0, 0
 ; RV64I-MEDIUM-NEXT:    ret
-; RV64I-MEDIUM-NEXT:  .LBB25_3: # Block address taken
+; RV64I-MEDIUM-NEXT:  .LBB28_3: # Block address taken
 ; RV64I-MEDIUM-NEXT:    # %fail
 ; RV64I-MEDIUM-NEXT:    # Label of block must be emitted
 ; RV64I-MEDIUM-NEXT:    li a0, 1
@@ -1223,6 +1383,166 @@ normal1:
 
 fail:
   ret i32 1
+}
+
+define void @constraint_o_with_local_1() nounwind {
+; RV32I-LABEL: constraint_o_with_local_1:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp3: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp3)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, %lo(.Ltmp3)(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: constraint_o_with_local_1:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp3: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp3)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, %lo(.Ltmp3)(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
+;
+; RV32I-MEDIUM-LABEL: constraint_o_with_local_1:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp3: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi23:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi23)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
+;
+; RV64I-MEDIUM-LABEL: constraint_o_with_local_1:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp3: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi23:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp3)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi23)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, 0(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
+entry:
+  br label %label
+
+label:
+  tail call void asm sideeffect "lw zero, $0", "*o"(ptr elementtype(ptr) blockaddress(@constraint_o_with_local_1, %label))
+  ret void
+}
+
+define void @constraint_o_with_local_2() nounwind {
+; RV32I-LABEL: constraint_o_with_local_2:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp4: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp4)
+; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp4)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, 4(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: constraint_o_with_local_2:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp4: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp4)
+; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp4)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, 4(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
+;
+; RV32I-MEDIUM-LABEL: constraint_o_with_local_2:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp4: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi24:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi24)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
+;
+; RV64I-MEDIUM-LABEL: constraint_o_with_local_2:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp4: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi24:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp4)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi24)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, 4(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
+entry:
+  br label %label
+
+label:
+  call void asm "lw zero, $0", "*o"(ptr nonnull elementtype(i32) getelementptr inbounds (i8, ptr blockaddress(@constraint_o_with_local_2, %label), i32 4))
+  ret void
+}
+
+define void @constraint_o_with_local_3() nounwind {
+; RV32I-LABEL: constraint_o_with_local_3:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:  .Ltmp5: # Block address taken
+; RV32I-NEXT:  # %bb.1: # %label
+; RV32I-NEXT:    lui a0, %hi(.Ltmp5)
+; RV32I-NEXT:    addi a0, a0, %lo(.Ltmp5)
+; RV32I-NEXT:    #APP
+; RV32I-NEXT:    lw zero, 2000(a0)
+; RV32I-NEXT:    #NO_APP
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: constraint_o_with_local_3:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:  .Ltmp5: # Block address taken
+; RV64I-NEXT:  # %bb.1: # %label
+; RV64I-NEXT:    lui a0, %hi(.Ltmp5)
+; RV64I-NEXT:    addi a0, a0, %lo(.Ltmp5)
+; RV64I-NEXT:    #APP
+; RV64I-NEXT:    lw zero, 2000(a0)
+; RV64I-NEXT:    #NO_APP
+; RV64I-NEXT:    ret
+;
+; RV32I-MEDIUM-LABEL: constraint_o_with_local_3:
+; RV32I-MEDIUM:       # %bb.0: # %entry
+; RV32I-MEDIUM-NEXT:  .Ltmp5: # Block address taken
+; RV32I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV32I-MEDIUM-NEXT:  .Lpcrel_hi25:
+; RV32I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5)
+; RV32I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi25)
+; RV32I-MEDIUM-NEXT:    #APP
+; RV32I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV32I-MEDIUM-NEXT:    #NO_APP
+; RV32I-MEDIUM-NEXT:    ret
+;
+; RV64I-MEDIUM-LABEL: constraint_o_with_local_3:
+; RV64I-MEDIUM:       # %bb.0: # %entry
+; RV64I-MEDIUM-NEXT:  .Ltmp5: # Block address taken
+; RV64I-MEDIUM-NEXT:  # %bb.1: # %label
+; RV64I-MEDIUM-NEXT:  .Lpcrel_hi25:
+; RV64I-MEDIUM-NEXT:    auipc a0, %pcrel_hi(.Ltmp5)
+; RV64I-MEDIUM-NEXT:    addi a0, a0, %pcrel_lo(.Lpcrel_hi25)
+; RV64I-MEDIUM-NEXT:    #APP
+; RV64I-MEDIUM-NEXT:    lw zero, 2000(a0)
+; RV64I-MEDIUM-NEXT:    #NO_APP
+; RV64I-MEDIUM-NEXT:    ret
+entry:
+  br label %label
+
+label:
+  call void asm "lw zero, $0", "*o"(ptr nonnull elementtype(i32) getelementptr inbounds (i8, ptr blockaddress(@constraint_o_with_local_3, %label), i32 2000))
+  ret void
 }
 
 define void @constraint_A(ptr %a) nounwind {


### PR DESCRIPTION
After commit cedf2ea, `RISCVMergeBaseOffset` can handle `BlockAddress`
currently. But we didn't handle it in `PrintAsmMemoryOperand` so we
get `invalid operand in inline asm` error.

This patch fixes the error.
