### PR TITLE
[clang] Preserve UDL nodes in RemoveNestedImmediateInvocation

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -290,6 +290,8 @@ Bug Fixes in This Version
   (`#67722 <https://github.com/llvm/llvm-project/issues/67722>`_).
 - Fixes a crash when instantiating a lambda with requires clause.
   (`#64462 <https://github.com/llvm/llvm-project/issues/64462>`_)
+- Fixes a regression where the ``UserDefinedLiteral`` was not properly preserved
+  while evaluating consteval functions. (`#63898 <https://github.com/llvm/llvm-project/issues/63898>`_).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18468,7 +18468,10 @@ static void RemoveNestedImmediateInvocation(
       DRSet.erase(cast<DeclRefExpr>(E->getCallee()->IgnoreImplicit()));
       return Base::TransformCXXOperatorCallExpr(E);
     }
-    /// Base::TransformInitializer skip ConstantExpr so we need to visit them
+    /// Base::TransformUserDefinedLiteral doesn't preserve the
+    /// UserDefinedLiteral node.
+    ExprResult TransformUserDefinedLiteral(UserDefinedLiteral *E) { return E; }
+    /// Base::TransformInitializer skips ConstantExpr so we need to visit them
     /// here.
     ExprResult TransformInitializer(Expr *Init, bool NotCopyInit) {
       if (!Init)

--- a/clang/test/AST/ast-dump-udl-consteval.cpp
+++ b/clang/test/AST/ast-dump-udl-consteval.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -xc++ -std=c++23 -ast-dump %s | FileCheck %s
+
+int inline consteval operator""_u32(unsigned long long val) {
+  return val;
+}
+
+void udl() {
+  (void)(0_u32 + 1_u32);
+}
+
+// CHECK: `-BinaryOperator {{.+}} <col:10, col:18> 'int' '+'
+// CHECK-NEXT: |-ConstantExpr {{.+}} <col:10> 'int'
+// CHECK-NEXT: | |-value: Int 0
+// CHECK-NEXT: | `-UserDefinedLiteral {{.+}} <col:10> 'int'
+// CHECK: `-ConstantExpr {{.+}} <col:18> 'int'
+// CHECK-NEXT:   |-value: Int 1
+// CHECK-NEXT:   `-UserDefinedLiteral {{.+}} <col:18> 'int'


### PR DESCRIPTION
D63960 performs a tree transformation on AST to prevent evaluating constant expressions eagerly by removing recorded immediate consteval invocations from subexpressions. (See https://reviews.llvm.org/D63960#inline-600736 for its motivation.)

However, the UDL node has been replaced with a CallExpr in the default TreeTransform since ca844ab0 (inadvertently?). This confuses clangd as it relies on the exact AST node type to decide whether or not to present inlay hints for an expression.

With regard to the fix, I think it's enough to return the UDL expression as-is during the transformation: We've bound it to temporary in its construction, and there's no ConstantExpr to visit under a UDL.

Fixes https://github.com/llvm/llvm-project/issues/63898.