### PR TITLE
[AArch64] Fix pairing different types of registers when computing CSRs.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3060,7 +3060,7 @@ void AArch64FrameLowering::determineCalleeSaves(MachineFunction &MF,
     // If the function requires all the GP registers to save (SavedRegs),
     // and there are an odd number of GP CSRs at the same time (CSRegs),
     // PairedReg could be in a different register class from Reg, which would
-    // lead to an FPR (usually D8) accidentally being marked saved.
+    // lead to a FPR (usually D8) accidentally being marked saved.
     if (RegIsGPR64 && !AArch64::GPR64RegClass.contains(PairedReg)) {
       PairedReg = AArch64::NoRegister;
       HasUnpairedGPR64 = true;

--- a/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
@@ -240,7 +240,7 @@ static void emitStore(MachineFunction &MF, MachineBasicBlock &MBB,
 }
 
 /// Emit a load-pair instruction for frame-destroy.
-/// If Reg2 is AArch64::NoRegister, emit LTR instead.
+/// If Reg2 is AArch64::NoRegister, emit LDR instead.
 static void emitLoad(MachineFunction &MF, MachineBasicBlock &MBB,
                      MachineBasicBlock::iterator Pos,
                      const TargetInstrInfo &TII, unsigned Reg1, unsigned Reg2,

--- a/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
@@ -219,9 +219,14 @@ static void emitStore(MachineFunction &MF, MachineBasicBlock &MBB,
     else
       Opc = IsPaired ? AArch64::STPXi : AArch64::STRXui;
   }
-  // Fix the implicit scale for non-pair cases.
-  if (!IsPaired)
-    Offset *= 8;
+  // The implicit scale for Offset is 8.
+  TypeSize Scale(0U, false);
+  unsigned Width;
+  int64_t MinOffset, MaxOffset;
+  bool Success =
+      AArch64InstrInfo::getMemOpInfo(Opc, Scale, Width, MinOffset, MaxOffset);
+  assert(Success && "Invalid Opcode");
+  Offset *= (8 / (int)Scale);
 
   MachineInstrBuilder MIB = BuildMI(MBB, Pos, DebugLoc(), TII.get(Opc));
   if (IsPreDec)
@@ -256,9 +261,14 @@ static void emitLoad(MachineFunction &MF, MachineBasicBlock &MBB,
     else
       Opc = IsPaired ? AArch64::LDPXi : AArch64::LDRXui;
   }
-  // Fix the implicit scale for non-pair cases.
-  if (!IsPaired)
-    Offset *= 8;
+  // The implicit scale for Offset is 8.
+  TypeSize Scale(0U, false);
+  unsigned Width;
+  int64_t MinOffset, MaxOffset;
+  bool Success =
+      AArch64InstrInfo::getMemOpInfo(Opc, Scale, Width, MinOffset, MaxOffset);
+  assert(Success && "Invalid Opcode");
+  Offset *= (8 / (int)Scale);
 
   MachineInstrBuilder MIB = BuildMI(MBB, Pos, DebugLoc(), TII.get(Opc));
   if (IsPostDec)

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-odd-csrs.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-odd-csrs.ll
@@ -27,5 +27,5 @@ define void @odd_num_callee_saved_registers_with_fpr(ptr swifterror %error, i32 
 ; CHECK:	ldr	x28, [sp, #16]
 ; CHECK:	ldp	d9, d8, [sp], #112
 
-; CHECK-LINUX-NOT: OUTLINED_FUNCTION_PROLOG:
-; CHECK-LINUX-NOT: OUTLINED_FUNCTION_EPILOG:
+; CHECK-LINUX-NOT: OUTLINED_FUNCTION_PROLOG
+; CHECK-LINUX-NOT: OUTLINED_FUNCTION_EPILOG

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-odd-csrs.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-odd-csrs.ll
@@ -9,10 +9,23 @@ define void @odd_num_callee_saved_registers(ptr swifterror %error, i32 %i) nounw
   ret void
 }
 
+define void @odd_num_callee_saved_registers_with_fpr(ptr swifterror %error, i32 %i) nounwind minsize {
+  call void asm sideeffect "mov x0, #42", "~{x0},~{x19},~{x20},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28},~{d8},~{d9}"() nounwind
+  call void @bar(i32 %i)
+  ret void
+}
+
 ; CHECK-LABEL: _OUTLINED_FUNCTION_PROLOG_x30x29x19x20x22x23x24x25x26x27x28:
 ; CHECK:	str	x28, [sp, #-80]!
 ; CHECK-LABEL: _OUTLINED_FUNCTION_EPILOG_TAIL_x30x29x19x20x22x23x24x25x26x27x28:
 ; CHECK:	ldr	x28, [sp], #96
+
+; CHECK-LABEL: _OUTLINED_FUNCTION_PROLOG_x30x29x19x20x22x23x24x25x26x27x28d8d9:
+; CHECK:	stp	d9, d8, [sp, #-96]!
+; CHECK:	str	x28, [sp, #16]
+; CHECK-LABEL: _OUTLINED_FUNCTION_EPILOG_TAIL_x30x29x19x20x22x23x24x25x26x27x28d8d9
+; CHECK:	ldr	x28, [sp, #16]
+; CHECK:	ldp	d9, d8, [sp], #112
 
 ; CHECK-LINUX-NOT: OUTLINED_FUNCTION_PROLOG:
 ; CHECK-LINUX-NOT: OUTLINED_FUNCTION_EPILOG:

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-odd-csrs.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-odd-csrs.ll
@@ -1,0 +1,18 @@
+; RUN: llc < %s -mtriple=arm64-apple-ios7.0 -homogeneous-prolog-epilog | FileCheck %s
+; RUN: llc < %s -mtriple=aarch64-unknown-linux-gnu  -homogeneous-prolog-epilog | FileCheck %s --check-prefixes=CHECK-LINUX
+
+declare void @bar(i32 %i)
+
+define void @odd_num_callee_saved_registers(ptr swifterror %error, i32 %i) nounwind minsize {
+  call void asm sideeffect "mov x0, #42", "~{x0},~{x19},~{x20},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28}"() nounwind
+  call void @bar(i32 %i)
+  ret void
+}
+
+; CHECK-LABEL: _OUTLINED_FUNCTION_PROLOG_x30x29x19x20x22x23x24x25x26x27x28:
+; CHECK:	str	x28, [sp, #-80]!
+; CHECK-LABEL: _OUTLINED_FUNCTION_EPILOG_TAIL_x30x29x19x20x22x23x24x25x26x27x28:
+; CHECK:	ldr	x28, [sp], #96
+
+; CHECK-LINUX-NOT: OUTLINED_FUNCTION_PROLOG:
+; CHECK-LINUX-NOT: OUTLINED_FUNCTION_EPILOG:

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
@@ -77,21 +77,3 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 define void @swift_async(i8* swiftasync %ctx) minsize "frame-pointer"="all" {
   ret void
 }
-
-declare void @bar(i32 %i)
-
-define void @odd_num_callee_saved_registers(ptr swifterror %error, i32 %i) nounwind minsize {
-  call void asm sideeffect "mov x0, #42", "~{x0},~{x19},~{x20},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28}"() nounwind
-  call void @bar(i32 %i)
-  ret void
-}
-
-; CHECK-LABEL: _OUTLINED_FUNCTION_PROLOG_x30x29x19x20x22x23x24x25x26x27x28:
-; CHECK:	stp	x28, xzr, [sp, #-80]!
-; CHECK-LABEL: _OUTLINED_FUNCTION_EPILOG_TAIL_x30x29x19x20x22x23x24x25x26x27x28:
-; CHECK:	ldp	x28, xzr, [sp], #96
-
-; CHECK-LINUX-LABEL: OUTLINED_FUNCTION_PROLOG_x19x20x22x23x24x25x26x27x28x30x29:
-; CHECK-LINUX:	stp	x29, xzr, [sp, #-8]!
-; CHECK-LINUX-LABEL: OUTLINED_FUNCTION_EPILOG_TAIL_x19x20x22x23x24x25x26x27x28x30x29:
-; CHECK-LINUX:	ldp	x29, xzr, [sp], #96

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
@@ -77,3 +77,21 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 define void @swift_async(i8* swiftasync %ctx) minsize "frame-pointer"="all" {
   ret void
 }
+
+declare void @bar(i32 %i)
+
+define void @odd_num_callee_saved_registers(ptr swifterror %error, i32 %i) nounwind minsize {
+  call void asm sideeffect "mov x0, #42", "~{x0},~{x19},~{x20},~{x22},~{x23},~{x24},~{x25},~{x26},~{x27},~{x28}"() nounwind
+  call void @bar(i32 %i)
+  ret void
+}
+
+; CHECK-LABEL: _OUTLINED_FUNCTION_PROLOG_x30x29x19x20x22x23x24x25x26x27x28:
+; CHECK:	stp	x28, xzr, [sp, #-80]!
+; CHECK-LABEL: _OUTLINED_FUNCTION_EPILOG_TAIL_x30x29x19x20x22x23x24x25x26x27x28:
+; CHECK:	ldp	x28, xzr, [sp], #96
+
+; CHECK-LINUX-LABEL: OUTLINED_FUNCTION_PROLOG_x19x20x22x23x24x25x26x27x28x30x29:
+; CHECK-LINUX:	stp	x29, xzr, [sp, #-8]!
+; CHECK-LINUX-LABEL: OUTLINED_FUNCTION_EPILOG_TAIL_x19x20x22x23x24x25x26x27x28x30x29:
+; CHECK-LINUX:	ldp	x29, xzr, [sp], #96


### PR DESCRIPTION
If a function has odd number of same type of registers to save, and the calling convention also requires odd number of such type of CSRs, an FP register would be accidentally marked as saved when producePairRegisters returns true.

This patch also fixes the AArch64LowerHomogeneousPrologEpilog pass not handling AArch64::NoRegister; actually this pass must be fixed along with the register pairing so i can write a test for it.