### PR TITLE
[clang] Fix null dereference on return in lambda attribute statement expr

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -301,6 +301,10 @@ Bug Fixes to C++ Support
   makes an invalid call to an immediate function.
   (`#66324 <https://github.com/llvm/llvm-project/issues/66324>`_)
 
+- Fix crash for a lambda attribute with a statement expression
+  that contains a `return`.
+  (`#48527 <https://github.com/llvm/llvm-project/issues/48527>`_)
+
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed an import failure of recursive friend class template.

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3577,6 +3577,8 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
   CapturingScopeInfo *CurCap = cast<CapturingScopeInfo>(getCurFunction());
   QualType FnRetType = CurCap->ReturnType;
   LambdaScopeInfo *CurLambda = dyn_cast<LambdaScopeInfo>(CurCap);
+  if (CurLambda && CurLambda->CallOperator->getType().isNull())
+    return StmtError();
   bool HasDeducedReturnType =
       CurLambda && hasDeducedReturnType(CurLambda->CallOperator);
 

--- a/clang/test/Parser/gh48527.cpp
+++ b/clang/test/Parser/gh48527.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+int main() { // expected-note {{to match this '{'}}
+    auto a = [](void)__attribute__((b(({ // expected-note {{to match this '('}}
+    return 0;
+} // expected-error 3 {{expected ')'}} \
+  // expected-error {{expected ';' at end of declaration}}
+// expected-error@+2 {{expected ')'}}
+// expected-error@+1 {{expected body of lambda expression}}
+// expected-error {{expected '}'}}

--- a/clang/test/SemaCXX/lambda-expressions.cpp
+++ b/clang/test/SemaCXX/lambda-expressions.cpp
@@ -714,3 +714,7 @@ void foo() {
   // CHECK-NEXT: ConstantExpr
   // CHECK-NEXT: value: Int 2
 }
+
+void GH48527() {
+  auto a = []()__attribute__((b(({ return 0; })))){}; // expected-warning {{unknown attribute 'b' ignored}}
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/48527