### PR TITLE
[IR] `SingleBlock::push_back` operations to the back of the block

### DIFF
--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -932,10 +932,6 @@ public:
   }
   template <typename OpT = ConcreteType>
   enable_if_single_region<OpT> insert(Block::iterator insertPt, Operation *op) {
-    Block *body = getBody();
-    // Insert op before the block's terminator if it has one
-    if (insertPt == body->end() && body->hasTerminator())
-      insertPt = Block::iterator(body->getTerminator());
     getBody()->getOperations().insert(insertPt, op);
   }
 };


### PR DESCRIPTION
Instead of checking whether the last operation might be a terminator, always insert operations to the end of the block.