### PR TITLE
[mlir] Add support for parsing and printing cyclic aliases

### DIFF
--- a/mlir/docs/LangRef.md
+++ b/mlir/docs/LangRef.md
@@ -183,12 +183,14 @@ starting with a `//` and going until the end of the line.
 
 ```
 // Top level production
-toplevel := (operation | attribute-alias-def | type-alias-def)*
+toplevel := (operation | alias-block-def)*
+alias-block-def := (attribute-alias-def | type-alias-def)*
 ```
 
 The production `toplevel` is the top level production that is parsed by any parsing
-consuming the MLIR syntax. [Operations](#operations),
-[Attribute aliases](#attribute-value-aliases), and [Type aliases](#type-aliases)
+consuming the MLIR syntax. [Operations](#operations) and 
+[Alias Blocks](#alias-block-definitions) consisting of 
+[Attribute aliases](#attribute-value-aliases) and [Type aliases](#type-aliases)
 can be declared on the toplevel.
 
 ### Identifiers and keywords
@@ -880,3 +882,26 @@ version using readAttribute and readType methods.
 There is no restriction on what kind of information a dialect is allowed to
 encode to model its versioning. Currently, versioning is supported only for
 bytecode formats.
+
+## Alias Block Definitions
+
+An alias block is a list of subsequent attribute or type alias definitions that
+are conceptually parsed as one unit.
+This allows any alias definition within the block to reference any other alias 
+definition within the block, regardless if defined lexically later or earlier in
+the block.
+
+```mlir
+// Alias block consisting of #array, !integer_type and #integer_attr.
+#array = [#integer_attr, !integer_type]
+!integer_type = i32
+#integer_attr = 8 : !integer_type
+
+// Illegal. !other_type is not part of this alias block and defined later 
+// in the file.
+!tuple = tuple<i32, !other_type>
+
+func.func @foo() { ... }
+
+!other_type = f32
+```

--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -1365,7 +1365,7 @@ public:
                           AttrOrTypeT> ||
             std::is_base_of_v<TypeTrait::IsMutable<AttrOrTypeT>, AttrOrTypeT>,
         "Only mutable attributes or types can be cyclic");
-    if (failed(pushCyclicParsing(attrOrType.getAsOpaquePointer())))
+    if (failed(pushCyclicParsing(attrOrType)))
       return failure();
 
     return CyclicParseReset(this);
@@ -1377,11 +1377,11 @@ protected:
   virtual FailureOr<AsmDialectResourceHandle>
   parseResourceHandle(Dialect *dialect) = 0;
 
-  /// Pushes a new attribute or type in the form of a type erased pointer
-  /// into an internal set.
+  /// Pushes a new attribute or type into an internal set.
   /// Returns success if the type or attribute was inserted in the set or
   /// failure if it was already contained.
-  virtual LogicalResult pushCyclicParsing(const void *opaquePointer) = 0;
+  virtual LogicalResult
+  pushCyclicParsing(PointerUnion<Attribute, Type> attrOrType) = 0;
 
   /// Removes the element that was last inserted with a successful call to
   /// `pushCyclicParsing`. There must be exactly one `popCyclicParsing` call

--- a/mlir/lib/AsmParser/AsmParserImpl.h
+++ b/mlir/lib/AsmParser/AsmParserImpl.h
@@ -570,8 +570,9 @@ public:
     return parser.parseXInDimensionList();
   }
 
-  LogicalResult pushCyclicParsing(const void *opaquePointer) override {
-    return success(parser.getState().cyclicParsingStack.insert(opaquePointer));
+  LogicalResult
+  pushCyclicParsing(PointerUnion<Attribute, Type> attrOrType) override {
+    return success(parser.getState().cyclicParsingStack.insert(attrOrType));
   }
 
   void popCyclicParsing() override {

--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -49,7 +49,7 @@ using namespace mlir::detail;
 ///                    | distinct-attribute
 ///                    | extended-attribute
 ///
-Attribute Parser::parseAttribute(Type type) {
+Attribute Parser::parseAttribute(Type type, StringRef aliasDefName) {
   switch (getToken().getKind()) {
   // Parse an AffineMap or IntegerSet attribute.
   case Token::kw_affine_map: {
@@ -117,7 +117,7 @@ Attribute Parser::parseAttribute(Type type) {
 
   // Parse an extended attribute, i.e. alias or dialect attribute.
   case Token::hash_identifier:
-    return parseExtendedAttr(type);
+    return parseExtendedAttr(type, aliasDefName);
 
   // Parse floating point and integer attributes.
   case Token::floatliteral:

--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -145,6 +145,10 @@ Attribute Parser::parseAttribute(Type type) {
         parseLocationInstance(locAttr) ||
         parseToken(Token::r_paren, "expected ')' in inline location"))
       return Attribute();
+
+    if (syntaxOnly())
+      return state.syntaxOnlyAttr;
+
     return locAttr;
   }
 
@@ -429,6 +433,9 @@ Attribute Parser::parseDecOrHexAttr(Type type, bool isNegative) {
       return Attribute();
     return FloatAttr::get(floatType, *result);
   }
+
+  if (syntaxOnly())
+    return state.syntaxOnlyAttr;
 
   if (!isa<IntegerType, IndexType>(type))
     return emitError(loc, "integer literal not valid for specified type"),
@@ -1003,7 +1010,9 @@ Attribute Parser::parseDenseElementsAttr(Type attrType) {
   auto type = parseElementsLiteralType(attrType);
   if (!type)
     return nullptr;
-  return literalParser.getAttr(loc, type);
+  if (syntaxOnly())
+    return state.syntaxOnlyAttr;
+  return literalParser.getAttr(loc, cast<ShapedType>(type));
 }
 
 Attribute Parser::parseDenseResourceElementsAttr(Type attrType) {
@@ -1030,6 +1039,9 @@ Attribute Parser::parseDenseResourceElementsAttr(Type attrType) {
       return nullptr;
   }
 
+  if (syntaxOnly())
+    return state.syntaxOnlyAttr;
+
   ShapedType shapedType = dyn_cast<ShapedType>(attrType);
   if (!shapedType) {
     emitError(typeLoc, "`dense_resource` expected a shaped type");
@@ -1044,7 +1056,7 @@ Attribute Parser::parseDenseResourceElementsAttr(Type attrType) {
 ///   elements-literal-type ::= vector-type | ranked-tensor-type
 ///
 /// This method also checks the type has static shape.
-ShapedType Parser::parseElementsLiteralType(Type type) {
+Type Parser::parseElementsLiteralType(Type type) {
   // If the user didn't provide a type, parse the colon type for the literal.
   if (!type) {
     if (parseToken(Token::colon, "expected ':'"))
@@ -1052,6 +1064,9 @@ ShapedType Parser::parseElementsLiteralType(Type type) {
     if (!(type = parseType()))
       return nullptr;
   }
+
+  if (syntaxOnly())
+    return state.syntaxOnlyType;
 
   auto sType = dyn_cast<ShapedType>(type);
   if (!sType) {
@@ -1077,17 +1092,23 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
   // of the type.
   Type indiceEltType = builder.getIntegerType(64);
   if (consumeIf(Token::greater)) {
-    ShapedType type = parseElementsLiteralType(attrType);
+    Type type = parseElementsLiteralType(attrType);
     if (!type)
       return nullptr;
 
+    if (syntaxOnly())
+      return state.syntaxOnlyAttr;
+
     // Construct the sparse elements attr using zero element indice/value
     // attributes.
+    ShapedType shapedType = cast<ShapedType>(type);
     ShapedType indicesType =
-        RankedTensorType::get({0, type.getRank()}, indiceEltType);
-    ShapedType valuesType = RankedTensorType::get({0}, type.getElementType());
+        RankedTensorType::get({0, shapedType.getRank()}, indiceEltType);
+    ShapedType valuesType =
+        RankedTensorType::get({0}, shapedType.getElementType());
     return getChecked<SparseElementsAttr>(
-        loc, type, DenseElementsAttr::get(indicesType, ArrayRef<Attribute>()),
+        loc, shapedType,
+        DenseElementsAttr::get(indicesType, ArrayRef<Attribute>()),
         DenseElementsAttr::get(valuesType, ArrayRef<Attribute>()));
   }
 
@@ -1114,6 +1135,11 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
   if (!type)
     return nullptr;
 
+  if (syntaxOnly())
+    return state.syntaxOnlyAttr;
+
+  ShapedType shapedType = cast<ShapedType>(type);
+
   // If the indices are a splat, i.e. the literal parser parsed an element and
   // not a list, we set the shape explicitly. The indices are represented by a
   // 2-dimensional shape where the second dimension is the rank of the type.
@@ -1121,7 +1147,8 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
   // indice and thus one for the first dimension.
   ShapedType indicesType;
   if (indiceParser.getShape().empty()) {
-    indicesType = RankedTensorType::get({1, type.getRank()}, indiceEltType);
+    indicesType =
+        RankedTensorType::get({1, shapedType.getRank()}, indiceEltType);
   } else {
     // Otherwise, set the shape to the one parsed by the literal parser.
     indicesType = RankedTensorType::get(indiceParser.getShape(), indiceEltType);
@@ -1131,7 +1158,7 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
   // If the values are a splat, set the shape explicitly based on the number of
   // indices. The number of indices is encoded in the first dimension of the
   // indice shape type.
-  auto valuesEltType = type.getElementType();
+  auto valuesEltType = shapedType.getElementType();
   ShapedType valuesType =
       valuesParser.getShape().empty()
           ? RankedTensorType::get({indicesType.getDimSize(0)}, valuesEltType)
@@ -1139,7 +1166,7 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
   auto values = valuesParser.getAttr(valuesLoc, valuesType);
 
   // Build the sparse elements attribute by the indices and values.
-  return getChecked<SparseElementsAttr>(loc, type, indices, values);
+  return getChecked<SparseElementsAttr>(loc, shapedType, indices, values);
 }
 
 Attribute Parser::parseStridedLayoutAttr() {
@@ -1259,6 +1286,9 @@ Attribute Parser::parseDistinctAttr(Type type) {
     if (parseToken(Token::greater, "expected '>' to close distinct attribute"))
       return {};
   }
+
+  if (syntaxOnly())
+    return state.syntaxOnlyAttr;
 
   // Add the distinct attribute to the parser state, if it has not been parsed
   // before. Otherwise, check if the parsed reference attribute matches the one

--- a/mlir/lib/AsmParser/LocationParser.cpp
+++ b/mlir/lib/AsmParser/LocationParser.cpp
@@ -53,6 +53,9 @@ ParseResult Parser::parseCallSiteLocation(LocationAttr &loc) {
   if (parseToken(Token::r_paren, "expected ')' in callsite location"))
     return failure();
 
+  if (syntaxOnly())
+    return success();
+
   // Return the callsite location.
   loc = CallSiteLoc::get(calleeLoc, callerLoc);
   return success();
@@ -79,6 +82,9 @@ ParseResult Parser::parseFusedLocation(LocationAttr &loc) {
     LocationAttr newLoc;
     if (parseLocationInstance(newLoc))
       return failure();
+    if (syntaxOnly())
+      return success();
+
     locations.push_back(newLoc);
     return success();
   };
@@ -135,12 +141,15 @@ ParseResult Parser::parseNameOrFileLineColLocation(LocationAttr &loc) {
     if (parseLocationInstance(childLoc))
       return failure();
 
-    loc = NameLoc::get(StringAttr::get(ctx, str), childLoc);
-
     // Parse the closing ')'.
     if (parseToken(Token::r_paren,
                    "expected ')' after child location of NameLoc"))
       return failure();
+
+    if (syntaxOnly())
+      return success();
+
+    loc = NameLoc::get(StringAttr::get(ctx, str), childLoc);
   } else {
     loc = NameLoc::get(StringAttr::get(ctx, str));
   }
@@ -154,6 +163,10 @@ ParseResult Parser::parseLocationInstance(LocationAttr &loc) {
     Attribute locAttr = parseExtendedAttr(Type());
     if (!locAttr)
       return failure();
+
+    if (syntaxOnly())
+      return success();
+
     if (!(loc = dyn_cast<LocationAttr>(locAttr)))
       return emitError("expected location attribute, but got") << locAttr;
     return success();

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/SourceMgr.h"
 #include <algorithm>
 #include <memory>
@@ -2417,17 +2418,12 @@ public:
   ParseResult parse(Block *topLevelBlock, Location parserLoc);
 
 private:
-  /// Parse an attribute alias declaration.
+  /// Parse an alias block definition.
   ///
   ///   attribute-alias-def ::= '#' alias-name `=` attribute-value
-  ///
-  ParseResult parseAttributeAliasDef();
-
-  /// Parse a type alias declaration.
-  ///
   ///   type-alias-def ::= '!' alias-name `=` type
-  ///
-  ParseResult parseTypeAliasDef();
+  ///   alias-block-def ::= (type-alias-def | attribute-alias-def)+
+  ParseResult parseAliasBlockDef();
 
   /// Parse a top-level file metadata dictionary.
   ///
@@ -2528,69 +2524,184 @@ private:
   Token value;
   Parser &p;
 };
+
+/// Convenient subclass of `ParserState` which configures the parser for
+/// syntax-only parsing. This only copies config and other required state for
+/// parsing but does not copy side-effecting state such as the code completion
+/// context.
+struct SyntaxParserState : ParserState {
+  explicit SyntaxParserState(ParserState &state)
+      : ParserState(state.lex.getSourceMgr(), state.config, state.symbols,
+                    /*asmState=*/nullptr,
+                    /*codeCompleteContext=*/nullptr) {
+    syntaxOnly = true;
+  }
+};
+
 } // namespace
 
-ParseResult TopLevelOperationParser::parseAttributeAliasDef() {
-  assert(getToken().is(Token::hash_identifier));
-  StringRef aliasName = getTokenSpelling().drop_front();
+ParseResult TopLevelOperationParser::parseAliasBlockDef() {
 
-  // Check for redefinitions.
-  if (state.symbols.attributeAliasDefinitions.count(aliasName) > 0)
-    return emitError("redefinition of attribute alias id '" + aliasName + "'");
+  struct UnparsedData {
+    SMRange location;
+    StringRef text;
+  };
 
-  // Make sure this isn't invading the dialect attribute namespace.
-  if (aliasName.contains('.'))
-    return emitError("attribute names with a '.' are reserved for "
-                     "dialect-defined names");
+  // Use a map vector as StringMap has non-deterministic iteration order.
+  using StringMapVector =
+      llvm::MapVector<StringRef, UnparsedData, llvm::StringMap<unsigned>>;
 
-  SMRange location = getToken().getLocRange();
-  consumeToken(Token::hash_identifier);
+  StringMapVector unparsedAttributeAliases;
+  StringMapVector unparsedTypeAliases;
 
-  // Parse the '='.
-  if (parseToken(Token::equal, "expected '=' in attribute alias definition"))
+  // Returns true if this alias has already been defined, either in this block
+  // or a previous one.
+  auto isRedefinition = [&](bool isType, StringRef aliasName) {
+    if (isType)
+      return state.symbols.typeAliasDefinitions.contains(aliasName) ||
+             unparsedTypeAliases.contains(aliasName);
+
+    return state.symbols.attributeAliasDefinitions.contains(aliasName) ||
+           unparsedAttributeAliases.contains(aliasName);
+  };
+
+  // Collect all attribute or type alias definitions in unparsed form first.
+  while (
+      getToken().isAny(Token::exclamation_identifier, Token::hash_identifier)) {
+    StringRef aliasName = getTokenSpelling().drop_front();
+
+    bool isType = getToken().is(mlir::Token::exclamation_identifier);
+    StringRef kind = isType ? "type" : "attribute";
+
+    // Check for redefinitions.
+    if (isRedefinition(isType, aliasName))
+      return emitError("redefinition of ")
+             << kind << " alias id '" << aliasName << "'";
+
+    // Make sure this isn't invading the dialect namespace.
+    if (aliasName.contains('.'))
+      return emitError(kind) << " names with a '.' are reserved for "
+                                "dialect-defined names";
+
+    SMRange location = getToken().getLocRange();
+    consumeToken();
+
+    // Parse the '='.
+    if (parseToken(Token::equal,
+                   "expected '=' in " + kind + " alias definition"))
+      return failure();
+
+    SyntaxParserState skippingParserState(state);
+    Parser syntaxOnlyParser(skippingParserState);
+    const char *start = getToken().getLoc().getPointer();
+    syntaxOnlyParser.resetToken(start);
+
+    // Parse just the syntax of the value, moving the lexer past the definition.
+    if (isType ? !syntaxOnlyParser.parseType()
+               : !syntaxOnlyParser.parseAttribute())
+      return failure();
+
+    // Get the location from the lexers new position.
+    const char *end = syntaxOnlyParser.getToken().getLoc().getPointer();
+    size_t length = end - start;
+
+    StringMapVector &unparsedMap =
+        isType ? unparsedTypeAliases : unparsedAttributeAliases;
+
+    unparsedMap[aliasName] =
+        UnparsedData{location, StringRef(start, length).rtrim()};
+
+    // Move the top-level parser past the alias definition.
+    resetToken(end);
+  }
+
+  auto parseAttributeAlias = [&](StringRef aliasName,
+                                 const UnparsedData &unparsedData) {
+    llvm::SaveAndRestore<SetVector<const void *>> cyclicStack(
+        getState().cyclicParsingStack, {});
+    auto exit = saveAndResetToken(unparsedData.text.data());
+    Attribute attribute = parseAttribute();
+    if (!attribute)
+      return attribute;
+
+    // Register this alias with the parser state.
+    if (state.asmState)
+      state.asmState->addAttrAliasDefinition(aliasName, unparsedData.location,
+                                             attribute);
+
+    return attribute;
+  };
+
+  auto parseTypeAlias = [&](StringRef aliasName,
+                            const UnparsedData &unparsedData) {
+    llvm::SaveAndRestore<SetVector<const void *>> cyclicStack(
+        getState().cyclicParsingStack, {});
+    auto exit = saveAndResetToken(unparsedData.text.data());
+    Type type = parseType();
+    if (!type)
+      return type;
+
+    // Register this alias with the parser state.
+    if (state.asmState)
+      state.asmState->addTypeAliasDefinition(aliasName, unparsedData.location,
+                                             type);
+
+    return type;
+  };
+
+  // Set the callbacks for the lazy parsing of alias definitions in the parser.
+  state.symbols.parseUnknownAttributeAlias =
+      [&](StringRef aliasName) -> FailureOr<Attribute> {
+    auto *iter = unparsedAttributeAliases.find(aliasName);
+    if (iter == unparsedAttributeAliases.end())
+      return failure();
+
+    return parseAttributeAlias(aliasName, iter->second);
+  };
+  state.symbols.parseUnknownTypeAlias =
+      [&](StringRef aliasName) -> FailureOr<Type> {
+    auto *iter = unparsedTypeAliases.find(aliasName);
+    if (iter == unparsedTypeAliases.end())
+      return failure();
+
+    return parseTypeAlias(aliasName, iter->second);
+  };
+
+  // Reset them to nullptr at the end. Keeping them around would lead to the
+  // access of local variables captured in this scope after we've returned from
+  // this function.
+  auto exit = llvm::make_scope_exit([&] {
+    state.symbols.parseUnknownTypeAlias = nullptr;
+    state.symbols.parseUnknownAttributeAlias = nullptr;
+  });
+
+  // Now go through all the unparsed definitions in the block and parse them.
+  // The order here is not significant for correctness, but should be
+  // deterministic. The order can also have an impact on the maximum stack usage
+  // during parsing. This can be improved in the future.
+  auto parse = [](auto &unparsed, auto &definitions, auto &parseFn) {
+    for (auto &&[aliasName, unparsedData] : unparsed) {
+      // Avoid parsing twice.
+      if (definitions.contains(aliasName))
+        continue;
+
+      auto symbol = parseFn(aliasName, unparsedData);
+      if (!symbol)
+        return failure();
+      definitions[aliasName] = symbol;
+    }
+    return success();
+  };
+
+  if (failed(parse(unparsedAttributeAliases,
+                   state.symbols.attributeAliasDefinitions,
+                   parseAttributeAlias)))
     return failure();
 
-  // Parse the attribute value.
-  Attribute attr = parseAttribute();
-  if (!attr)
+  if (failed(parse(unparsedTypeAliases, state.symbols.typeAliasDefinitions,
+                   parseTypeAlias)))
     return failure();
 
-  // Register this alias with the parser state.
-  if (state.asmState)
-    state.asmState->addAttrAliasDefinition(aliasName, location, attr);
-  state.symbols.attributeAliasDefinitions[aliasName] = attr;
-  return success();
-}
-
-ParseResult TopLevelOperationParser::parseTypeAliasDef() {
-  assert(getToken().is(Token::exclamation_identifier));
-  StringRef aliasName = getTokenSpelling().drop_front();
-
-  // Check for redefinitions.
-  if (state.symbols.typeAliasDefinitions.count(aliasName) > 0)
-    return emitError("redefinition of type alias id '" + aliasName + "'");
-
-  // Make sure this isn't invading the dialect type namespace.
-  if (aliasName.contains('.'))
-    return emitError("type names with a '.' are reserved for "
-                     "dialect-defined names");
-
-  SMRange location = getToken().getLocRange();
-  consumeToken(Token::exclamation_identifier);
-
-  // Parse the '='.
-  if (parseToken(Token::equal, "expected '=' in type alias definition"))
-    return failure();
-
-  // Parse the type.
-  Type aliasedType = parseType();
-  if (!aliasedType)
-    return failure();
-
-  // Register this alias with the parser state.
-  if (state.asmState)
-    state.asmState->addTypeAliasDefinition(aliasName, location, aliasedType);
-  state.symbols.typeAliasDefinitions.try_emplace(aliasName, aliasedType);
   return success();
 }
 
@@ -2729,15 +2840,10 @@ ParseResult TopLevelOperationParser::parse(Block *topLevelBlock,
     case Token::error:
       return failure();
 
-    // Parse an attribute alias.
+    // Parse an alias def block.
     case Token::hash_identifier:
-      if (parseAttributeAliasDef())
-        return failure();
-      break;
-
-    // Parse a type alias.
     case Token::exclamation_identifier:
-      if (parseTypeAliasDef())
+      if (parseAliasBlockDef())
         return failure();
       break;
 

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2617,10 +2617,10 @@ ParseResult TopLevelOperationParser::parseAliasBlockDef() {
 
   auto parseAttributeAlias = [&](StringRef aliasName,
                                  const UnparsedData &unparsedData) {
-    llvm::SaveAndRestore<SetVector<const void *>> cyclicStack(
+    llvm::SaveAndRestore<SetVector<PointerUnion<Attribute, Type>>> cyclicStack(
         getState().cyclicParsingStack, {});
     auto exit = saveAndResetToken(unparsedData.text.data());
-    Attribute attribute = parseAttribute();
+    Attribute attribute = parseAttribute(Type(), aliasName);
     if (!attribute)
       return attribute;
 
@@ -2634,10 +2634,10 @@ ParseResult TopLevelOperationParser::parseAliasBlockDef() {
 
   auto parseTypeAlias = [&](StringRef aliasName,
                             const UnparsedData &unparsedData) {
-    llvm::SaveAndRestore<SetVector<const void *>> cyclicStack(
+    llvm::SaveAndRestore<SetVector<PointerUnion<Attribute, Type>>> cyclicStack(
         getState().cyclicParsingStack, {});
     auto exit = saveAndResetToken(unparsedData.text.data());
-    Type type = parseType();
+    Type type = parseType(aliasName);
     if (!type)
       return type;
 

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -202,13 +202,13 @@ public:
   OptionalParseResult parseOptionalType(Type &type);
 
   /// Parse an arbitrary type.
-  Type parseType();
+  Type parseType(StringRef aliasDefName = "");
 
   /// Parse a complex type.
   Type parseComplexType();
 
   /// Parse an extended type.
-  Type parseExtendedType();
+  Type parseExtendedType(StringRef aliasDefName = "");
 
   /// Parse a function type.
   Type parseFunctionType();
@@ -217,7 +217,7 @@ public:
   Type parseMemRefType();
 
   /// Parse a non function type.
-  Type parseNonFunctionType();
+  Type parseNonFunctionType(StringRef aliasDefName = "");
 
   /// Parse a tensor type.
   Type parseTensorType();
@@ -240,7 +240,7 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// Parse an arbitrary attribute with an optional type.
-  Attribute parseAttribute(Type type = {});
+  Attribute parseAttribute(Type type = {}, StringRef aliasDefName = "");
 
   /// Parse an optional attribute with the provided type.
   OptionalParseResult parseOptionalAttribute(Attribute &attribute,
@@ -271,7 +271,7 @@ public:
   Attribute parseDistinctAttr(Type type);
 
   /// Parse an extended attribute.
-  Attribute parseExtendedAttr(Type type);
+  Attribute parseExtendedAttr(Type type, StringRef aliasDefName = "");
 
   /// Parse a float attribute.
   Attribute parseFloatAttr(Type type, bool isNegative);

--- a/mlir/lib/AsmParser/ParserState.h
+++ b/mlir/lib/AsmParser/ParserState.h
@@ -82,7 +82,7 @@ struct ParserState {
 
   /// Stack of potentially cyclic mutable attributes or type currently being
   /// parsed.
-  SetVector<const void *> cyclicParsingStack;
+  SetVector<PointerUnion<Attribute, Type>> cyclicParsingStack;
 
   /// An optional pointer to a struct containing high level parser state to be
   /// populated during parsing.

--- a/mlir/lib/AsmParser/ParserState.h
+++ b/mlir/lib/AsmParser/ParserState.h
@@ -32,6 +32,15 @@ struct SymbolState {
   /// A map from type alias identifier to Type.
   llvm::StringMap<Type> typeAliasDefinitions;
 
+  /// Parser functions set during the parsing of alias-block-defs to parse an
+  /// unknown attribute or type alias. The parameter is the name of the alias.
+  /// The function should return failure if no such alias could be found.
+  /// If any errors occurred during parsing, a null attribute or type should
+  /// be returned.
+  llvm::unique_function<FailureOr<Attribute>(StringRef)>
+      parseUnknownAttributeAlias;
+  llvm::unique_function<FailureOr<Type>(StringRef)> parseUnknownTypeAlias;
+
   /// A map of dialect resource keys to the resolved resource name and handle
   /// to use during parsing.
   DenseMap<const OpAsmDialectInterface *,
@@ -88,6 +97,17 @@ struct ParserState {
   // popped when done. At the top-level we start with "builtin" as the
   // default, so that the top-level `module` operation parses as-is.
   SmallVector<StringRef> defaultDialectStack{"builtin"};
+
+  /// Controls whether the parser is in syntax-only mode.
+  bool syntaxOnly = false;
+
+  /// Attribute and type returned by `parseType`, `parseAttribute` and the more
+  /// specific parsing function to signal syntactic correctness if an attribute
+  /// or type cannot be created without verifying the parsed data as well.
+  /// Callers of such function should only check for null or not null return
+  /// values for error signaling.
+  Type syntaxOnlyType = NoneType::get(config.getContext());
+  Attribute syntaxOnlyAttr = UnitAttr::get(config.getContext());
 };
 
 } // namespace detail

--- a/mlir/lib/AsmParser/TypeParser.cpp
+++ b/mlir/lib/AsmParser/TypeParser.cpp
@@ -58,10 +58,10 @@ OptionalParseResult Parser::parseOptionalType(Type &type) {
 ///   type ::= function-type
 ///          | non-function-type
 ///
-Type Parser::parseType() {
+Type Parser::parseType(StringRef aliasDefName) {
   if (getToken().is(Token::l_paren))
     return parseFunctionType();
-  return parseNonFunctionType();
+  return parseNonFunctionType(aliasDefName);
 }
 
 /// Parse a function result type.
@@ -273,7 +273,7 @@ Type Parser::parseMemRefType() {
 ///   float-type ::= `f16` | `bf16` | `f32` | `f64` | `f80` | `f128`
 ///   none-type ::= `none`
 ///
-Type Parser::parseNonFunctionType() {
+Type Parser::parseNonFunctionType(StringRef aliasDefName) {
   switch (getToken().getKind()) {
   default:
     return (emitWrongTokenError("expected non-function type"), nullptr);
@@ -356,7 +356,7 @@ Type Parser::parseNonFunctionType() {
 
   // extended type
   case Token::exclamation_identifier:
-    return parseExtendedType();
+    return parseExtendedType(aliasDefName);
 
   // Handle completion of a dialect type.
   case Token::code_complete:

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -1192,21 +1192,10 @@ void AliasState::printAliases(AsmPrinter::Impl &p, NewLineCounter &newLine,
     alias.print(p.getStream());
     p.getStream() << " = ";
 
-    if (alias.isTypeAlias()) {
-      // TODO: Support nested aliases in mutable types.
-      Type type = Type::getFromOpaquePointer(opaqueSymbol);
-      if (type.hasTrait<TypeTrait::IsMutable>())
-        p.getStream() << type;
-      else
-        p.printTypeImpl(type);
-    } else {
-      // TODO: Support nested aliases in mutable attributes.
-      Attribute attr = Attribute::getFromOpaquePointer(opaqueSymbol);
-      if (attr.hasTrait<AttributeTrait::IsMutable>())
-        p.getStream() << attr;
-      else
-        p.printAttributeImpl(attr);
-    }
+    if (alias.isTypeAlias())
+      p.printTypeImpl(Type::getFromOpaquePointer(opaqueSymbol));
+    else
+      p.printAttributeImpl(Attribute::getFromOpaquePointer(opaqueSymbol));
 
     p.getStream() << newLine;
   }

--- a/mlir/test/Dialect/LLVMIR/types-typed-pointers.mlir
+++ b/mlir/test/Dialect/LLVMIR/types-typed-pointers.mlir
@@ -106,7 +106,7 @@ func.func @ptr_elem_interface(%arg0: !llvm.ptr<!test.smpla>) {
 !baz = i64
 !qux = !llvm.struct<(!baz)>
 
-!rec = !llvm.struct<"a", (ptr<struct<"a">>)>
+!rec = !llvm.struct<"a", (ptr<!rec>)>
 
 // CHECK: aliases
 llvm.func @aliases() {

--- a/mlir/test/Dialect/SPIRV/IR/types.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/types.mlir
@@ -425,6 +425,11 @@ func.func private @id_struct_redefinition(!spirv.struct<a8, (!spirv.ptr<!spirv.s
 // CHECK: func private @id_struct_recursive(!spirv.struct<a9, (!spirv.ptr<!spirv.struct<b9, (!spirv.ptr<!spirv.struct<a9>, Uniform>)>, Uniform>)>)
 func.func private @id_struct_recursive(!spirv.struct<a9, (!spirv.ptr<!spirv.struct<b9, (!spirv.ptr<!spirv.struct<a9>, Uniform>)>, Uniform>)>) -> ()
 
+!a = !spirv.struct<a9, (!spirv.ptr<!b, Uniform>)>
+!b = !spirv.struct<b9, (!spirv.ptr<!a, Uniform>)>
+// CHECK: func private @id_struct_recursive2(!spirv.struct<a9, (!spirv.ptr<!spirv.struct<b9, (!spirv.ptr<!spirv.struct<a9>, Uniform>)>, Uniform>)>)
+func.func private @id_struct_recursive2(!a) -> ()
+
 // -----
 
 // Equivalent to:
@@ -432,6 +437,11 @@ func.func private @id_struct_recursive(!spirv.struct<a9, (!spirv.ptr<!spirv.stru
 //   struct b { struct a *aPtr, struct b *bPtr; };
 // CHECK: func private @id_struct_recursive(!spirv.struct<a10, (!spirv.ptr<!spirv.struct<b10, (!spirv.ptr<!spirv.struct<a10>, Uniform>, !spirv.ptr<!spirv.struct<b10>, Uniform>)>, Uniform>)>)
 func.func private @id_struct_recursive(!spirv.struct<a10, (!spirv.ptr<!spirv.struct<b10, (!spirv.ptr<!spirv.struct<a10>, Uniform>, !spirv.ptr<!spirv.struct<b10>, Uniform>)>, Uniform>)>) -> ()
+
+!a = !spirv.struct<a10, (!spirv.ptr<!b, Uniform>)>
+!b = !spirv.struct<b10, (!spirv.ptr<!a, Uniform>, !spirv.ptr<!b, Uniform>)>
+// CHECK: func private @id_struct_recursive2(!spirv.struct<a10, (!spirv.ptr<!spirv.struct<b10, (!spirv.ptr<!spirv.struct<a10>, Uniform>, !spirv.ptr<!spirv.struct<b10>, Uniform>)>, Uniform>)>)
+func.func private @id_struct_recursive2(!a) -> ()
 
 // -----
 

--- a/mlir/test/IR/alias-def-groups.mlir
+++ b/mlir/test/IR/alias-def-groups.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-opt -allow-unregistered-dialect -verify-diagnostics -split-input-file %s | FileCheck %s
+
+#array = [#integer_attr, !integer_type]
+!integer_type = i32
+#integer_attr = 8 : !integer_type
+
+// CHECK-LABEL: func @foo()
+func.func @foo() {
+  // CHECK-NEXT: value = [8 : i32, i32]
+  "foo.attr"() { value = #array} : () -> ()
+}
+
+// -----
+
+// Check that only groups may reference later defined aliases.
+
+// expected-error@below {{undefined symbol alias id 'integer_attr'}}
+#array = [!integer_type, #integer_attr]
+!integer_type = i32
+
+func.func @foo() {
+  %0 = "foo.attr"() { value = #array}
+}
+
+#integer_attr = 8 : !integer_type

--- a/mlir/test/IR/recursive-type-and-attr.mlir
+++ b/mlir/test/IR/recursive-type-and-attr.mlir
@@ -1,8 +1,18 @@
 // RUN: mlir-opt %s -test-recursive-types | FileCheck %s
 
-// CHECK: !testrec = !test.test_rec<type_to_alias, test_rec<type_to_alias>>
-// CHECK: ![[$NAME:.*]] = !test.test_rec_alias<name, !test.test_rec_alias<name>>
-// CHECK: ![[$NAME2:.*]] = !test.test_rec_alias<name2, tuple<!test.test_rec_alias<name2>, i32>>
+// CHECK-DAG: !testrec = !test.test_rec<type_to_alias, test_rec<type_to_alias>>
+// CHECK-DAG: ![[$NAME:.*]] = !test.test_rec_alias<name, ![[$NAME]]>
+// CHECK-DAG: ![[$NAME2:.*]] = !test.test_rec_alias<name2, tuple<![[$NAME2]], i32>>
+// CHECK-DAG: #[[$ATTR:.*]] = #test.test_rec_alias<attr, #[[$ATTR]]>
+// CHECK-DAG: #[[$ATTR2:.*]] = #test.test_rec_alias<attr2, [#[[$ATTR2]], 5]>
+
+
+!name = !test.test_rec_alias<name, !name>
+!name2 = !test.test_rec_alias<name2, tuple<!name2, i32>>
+
+#attr = #test.test_rec_alias<attr, #attr>
+#array = [#attr2, 5]
+#attr2 = #test.test_rec_alias<attr2, #array>
 
 // CHECK-LABEL: @roundtrip
 func.func @roundtrip() {
@@ -24,6 +34,14 @@ func.func @roundtrip() {
   // CHECK: () -> ![[$NAME2]]
   "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name2, tuple<!test.test_rec_alias<name2>, i32>>
   "test.dummy_op_for_roundtrip"() : () -> !test.test_rec_alias<name2, tuple<!test.test_rec_alias<name2>, i32>>
+
+  // Check that we can use these aliases, not just print them.
+  // CHECK: value = #[[$ATTR]]
+  // CHECK-SAME: () -> ![[$NAME]]
+  // CHECK-NEXT: value = #[[$ATTR2]]
+  // CHECK-SAME: () -> ![[$NAME2]]
+  "test.dummy_op_for_roundtrip"() { value = #attr } : () -> !name
+  "test.dummy_op_for_roundtrip"() { value = #attr2 } : () -> !name2
   return
 }
 

--- a/mlir/test/lib/Dialect/Test/TestAttrDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestAttrDefs.td
@@ -323,5 +323,22 @@ def Test_IteratorTypeArrayAttr
     : TypedArrayAttrBase<Test_IteratorTypeEnum,
   "Iterator type should be an enum.">;
 
+def TestRecursiveAliasAttr
+    : Test_Attr<"TestRecursiveAlias", [NativeAttrTrait<"IsMutable">]> {
+  let mnemonic = "test_rec_alias";
+  let storageClass = "TestRecursiveAttrStorage";
+  let storageNamespace = "test";
+  let genStorageClass = 0;
+
+  let parameters = (ins "llvm::StringRef":$name);
+
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    Attribute getBody() const;
+
+    void setBody(Attribute attribute);
+  }];
+}
 
 #endif // TEST_ATTRDEFS

--- a/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
+++ b/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
@@ -169,6 +169,11 @@ struct TestOpAsmInterface : public OpAsmDialectInterface {
   //===------------------------------------------------------------------===//
 
   AliasResult getAlias(Attribute attr, raw_ostream &os) const final {
+    if (auto recAliasAttr = dyn_cast<TestRecursiveAliasAttr>(attr)) {
+      os << recAliasAttr.getName();
+      return AliasResult::FinalAlias;
+    }
+
     StringAttr strAttr = dyn_cast<StringAttr>(attr);
     if (!strAttr)
       return AliasResult::NoAlias;

--- a/mlir/test/lib/Dialect/Test/TestTypeDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestTypeDefs.td
@@ -373,7 +373,7 @@ def TestI32 : Test_Type<"TestI32"> {
   let mnemonic = "i32";
 }
 
-def TestRecursiveAlias
+def TestRecursiveAliasType
     : Test_Type<"TestRecursiveAlias", [NativeTypeTrait<"IsMutable">]> {
   let mnemonic = "test_rec_alias";
   let storageClass = "TestRecursiveTypeStorage";


### PR DESCRIPTION
Final part of https://discourse.llvm.org/t/rfc-supporting-aliases-in-cyclic-types-and-attributes/73236

Up until now, the printing of mutable attributes and types as alias were disabled entirely as parsing them would end up in an infinite recursion.
This PR fixes this issue by using the recently added `tryStartCyclicParse` function to registering a mutable attribute or type parsed as part of an alias definition as soon as its immutable key has been parsed.
This makes it possible to break the recursion cycle and make parsing succeed. Combined with a previous patch that made the parser insensitive to the order of aliases in a row, we can also enable the printing of mutable attributes and types.

Depends on https://github.com/llvm/llvm-project/pull/65503. While we lack stacked PRs, please review the first commit on that PR.