### PR TITLE
[FuncSpec] Adjust the names of specializations and promoted stack val…

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
@@ -252,6 +252,7 @@ class FunctionSpecializer {
   SmallPtrSet<Function *, 32> FullySpecialized;
   DenseMap<Function *, CodeMetrics> FunctionMetrics;
   DenseMap<Function *, unsigned> FunctionGrowth;
+  unsigned NGlobals = 0;
 
 public:
   FunctionSpecializer(

--- a/llvm/test/Transforms/FunctionSpecialization/bug55000-read-uninitialized-value.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/bug55000-read-uninitialized-value.ll
@@ -4,8 +4,8 @@ declare hidden i1 @compare(ptr) align 2
 declare hidden { i8, ptr } @getType(ptr) align 2
 
 ; CHECK-LABEL: @foo
-; CHECK-LABEL: @foo.1
-; CHECK-LABEL: @foo.2
+; CHECK-LABEL: @foo.specialized.1
+; CHECK-LABEL: @foo.specialized.2
 
 define internal void @foo(ptr %TLI, ptr %DL, ptr %Ty, ptr %ValueVTs, ptr %Offsets, i64 %StartingOffset) {
 entry:

--- a/llvm/test/Transforms/FunctionSpecialization/compiler-crash-58759.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/compiler-crash-58759.ll
@@ -23,5 +23,5 @@ declare i32 @p0(i32 noundef)
 declare i32 @p1(i32 noundef)
 
 ;; Tests that `f` has been fully specialize and it didn't cause compiler crash.
-;; CHECK-DAG: f.1
-;; CHECK-DAG: f.2
+;; CHECK-DAG: f.specialized.1
+;; CHECK-DAG: f.specialized.2

--- a/llvm/test/Transforms/FunctionSpecialization/compiler-crash-60191.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/compiler-crash-60191.ll
@@ -60,7 +60,7 @@ define i32 @f2(i32 %offset) {
 }
 
 ; Tests that `func` has been specialized and it didn't cause compiler crash.
-; CHECK-DAG: func.1
-; CHECK-DAG: func.2
-; CHECK-DAG: func.3
+; CHECK-DAG: func.specialized.1
+; CHECK-DAG: func.specialized.2
+; CHECK-DAG: func.specialized.3
 

--- a/llvm/test/Transforms/FunctionSpecialization/compiler-crash-promote-alloca.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/compiler-crash-promote-alloca.ll
@@ -2,7 +2,7 @@
 
 ; Tests that `bar` has been specialized and that the compiler did not crash
 ; while attempting to promote the alloca in `entry`.
-; CHECK: bar.1
+; CHECK: bar.specialized.1
 
 @block = internal constant [8 x i8] zeroinitializer, align 1
 

--- a/llvm/test/Transforms/FunctionSpecialization/constant-struct.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/constant-struct.ll
@@ -8,7 +8,7 @@ define i32 @foo(i32 %y0, i32 %y1) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[Y:%.*]] = insertvalue { i32, i32 } undef, i32 [[Y0:%.*]], 0
 ; CHECK-NEXT:    [[YY:%.*]] = insertvalue { i32, i32 } [[Y]], i32 [[Y1:%.*]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @add.1({ i32, i32 } { i32 2, i32 3 }, { i32, i32 } [[YY]])
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @add.specialized.1({ i32, i32 } { i32 2, i32 3 }, { i32, i32 } [[YY]])
 ; CHECK-NEXT:    ret i32 [[CALL]]
 ;
 entry:
@@ -23,7 +23,7 @@ define i32 @bar(i32 %x0, i32 %x1) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[X:%.*]] = insertvalue { i32, i32 } undef, i32 [[X0:%.*]], 0
 ; CHECK-NEXT:    [[XX:%.*]] = insertvalue { i32, i32 } [[X]], i32 [[X1:%.*]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @add.2({ i32, i32 } [[XX]], { i32, i32 } { i32 3, i32 2 })
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @add.specialized.2({ i32, i32 } [[XX]], { i32, i32 } { i32 3, i32 2 })
 ; CHECK-NEXT:    ret i32 [[CALL]]
 ;
 entry:

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-always-inline.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-always-inline.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -passes="ipsccp<func-spec>" -force-specialization -S < %s | FileCheck %s
 
-; CHECK-NOT: foo.{{[0-9]+}}
+; CHECK-NOT: foo.specialized.{{[0-9]+}}
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression.ll
@@ -30,10 +30,10 @@ define internal i64 @zoo(i1 %flag) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br i1 [[FLAG:%.*]], label [[PLUS:%.*]], label [[MINUS:%.*]]
 ; CHECK:       plus:
-; CHECK-NEXT:    [[TMP0:%.*]] = call i64 @func2.2(ptr getelementptr inbounds ([[STRUCT:%.*]], ptr @Global, i64 0, i32 3))
+; CHECK-NEXT:    [[TMP0:%.*]] = call i64 @func2.specialized.2(ptr getelementptr inbounds ([[STRUCT:%.*]], ptr @Global, i64 0, i32 3))
 ; CHECK-NEXT:    br label [[MERGE:%.*]]
 ; CHECK:       minus:
-; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @func2.1(ptr getelementptr inbounds ([[STRUCT]], ptr @Global, i64 0, i32 4))
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @func2.specialized.1(ptr getelementptr inbounds ([[STRUCT]], ptr @Global, i64 0, i32 4))
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
 ; CHECK-NEXT:    [[TMP2:%.*]] = phi i64 [ ptrtoint (ptr getelementptr inbounds ([[STRUCT]], ptr @Global, i64 0, i32 3) to i64), [[PLUS]] ], [ ptrtoint (ptr getelementptr inbounds ([[STRUCT]], ptr @Global, i64 0, i32 4) to i64), [[MINUS]] ]

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression3.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression3.ll
@@ -4,8 +4,8 @@
 define i32 @main() {
 ; CHECK-LABEL: @main(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    tail call void @wombat.1(ptr undef, i64 undef, i64 undef, ptr @quux)
-; CHECK-NEXT:    tail call void @wombat.2(ptr undef, i64 undef, i64 undef, ptr @eggs)
+; CHECK-NEXT:    tail call void @wombat.specialized.1(ptr undef, i64 undef, i64 undef, ptr @quux)
+; CHECK-NEXT:    tail call void @wombat.specialized.2(ptr undef, i64 undef, i64 undef, ptr @eggs)
 ; CHECK-NEXT:    ret i32 undef
 ;
 bb:

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression4.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression4.ll
@@ -2,7 +2,7 @@
 
 ; Check that we don't crash and specialise on a function call with byval attribute.
 
-; CHECK-NOT: wombat.{{[0-9]+}}
+; CHECK-NOT: wombat.specialized.{{[0-9]+}}
 
 declare ptr @quux()
 declare ptr @eggs()

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression5.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-expression5.ll
@@ -3,7 +3,7 @@
 
 ; Check that we don't crash and specialise on a scalar global variable with byval attribute.
 
-; CHECK-NOT: wombat.{{[0-9]+}}
+; CHECK-NOT: wombat.specialized.{{[0-9]+}}
 
 %struct.pluto = type { %struct.spam }
 %struct.quux = type { i16 }

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-integers.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-constant-integers.ll
@@ -1,8 +1,8 @@
 ; RUN: opt -passes="ipsccp<func-spec>" -funcspec-for-literal-constant=true -force-specialization -S < %s | FileCheck %s
 
 ; Check that the literal constant parameter could be specialized.
-; CHECK: @foo.1(
-; CHECK: @foo.2(
+; CHECK: @foo.specialized.1(
+; CHECK: @foo.specialized.2(
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-minsize.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-minsize.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -passes="ipsccp<func-spec>" -S < %s | FileCheck %s
 
-; CHECK-NOT: @compute.1
-; CHECK-NOT: @compute.2
+; CHECK-NOT: @compute.specialized.1
+; CHECK-NOT: @compute.specialized.2
 
 define i64 @main(i64 %x, i1 %flag) {
 entry:

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-minsize2.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-minsize2.ll
@@ -3,8 +3,8 @@
 ; Checks for callsites that have been annotated with MinSize. No specialisation
 ; expected here:
 ;
-; CHECK-NOT: @compute.1
-; CHECK-NOT: @compute.2
+; CHECK-NOT: @compute.specialized.1
+; CHECK-NOT: @compute.specialized.2
 
 define i64 @main(i64 %x, i1 %flag) {
 entry:

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-minsize3.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-minsize3.ll
@@ -4,7 +4,7 @@
 ; specialisation for the call that does not have the attribute:
 ;
 ; CHECK: plus:
-; CHECK:   %tmp0 = call i64 @compute.1(i64 %x, ptr @plus)
+; CHECK:   %tmp0 = call i64 @compute.specialized.1(i64 %x, ptr @plus)
 ; CHECK:   br label %merge
 ; CHECK: minus:
 ; CHECK:   %tmp1 = call i64 @compute(i64 %x, ptr @minus) #0

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-nodup.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-nodup.ll
@@ -3,8 +3,8 @@
 ; Function @foo has function attribute 'noduplicate', so check that we don't
 ; specialize it:
 
-; CHECK-NOT: @foo.1(
-; CHECK-NOT: @foo.2(
+; CHECK-NOT: @foo.specialized.1(
+; CHECK-NOT: @foo.specialized.2(
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-nodup2.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-nodup2.ll
@@ -5,8 +5,8 @@
 ; Please note that the use of the hardwareloop intrinsic is arbitrary; it's
 ; just an easy to use intrinsic that has NoDuplicate.
 
-; CHECK-NOT: @foo.1(
-; CHECK-NOT: @foo.2(
+; CHECK-NOT: @foo.specialized.1(
+; CHECK-NOT: @foo.specialized.2(
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-noexec.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-noexec.ll
@@ -2,8 +2,8 @@
 
 ; The if.then block is not executed, so check that we don't specialise here.
 
-; CHECK-NOT: @foo.1(
-; CHECK-NOT: @foo.2(
+; CHECK-NOT: @foo.specialized.1(
+; CHECK-NOT: @foo.specialized.2(
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-nonconst-glob.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-nonconst-glob.ll
@@ -7,8 +7,8 @@
 ; Global B is not constant. We do not specialise on addresses unless we
 ; enable that:
 
-; ON-ADDRESS: call i32 @foo.1(i32 %x, ptr @A)
-; ON-ADDRESS: call i32 @foo.2(i32 %y, ptr @B)
+; ON-ADDRESS: call i32 @foo.specialized.1(i32 %x, ptr @A)
+; ON-ADDRESS: call i32 @foo.specialized.2(i32 %y, ptr @B)
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 
@@ -21,7 +21,7 @@ define dso_local i32 @bar(i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[TOBOOL:%.*]] = icmp ne i32 [[X:%.*]], 0
 ; CHECK-NEXT:    br i1 [[TOBOOL]], label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[CALL:%.*]] = call i32 @foo.1(i32 [[X]], ptr @A)
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @foo.specialized.1(i32 [[X]], ptr @A)
 ; CHECK-NEXT:    br label [[RETURN:%.*]]
 ; CHECK:       if.else:
 ; CHECK-NEXT:    [[CALL1:%.*]] = call i32 @foo(i32 [[Y:%.*]], ptr @B)
@@ -60,11 +60,11 @@ entry:
   ret i32 %add
 }
 
-; CHECK-LABEL: define internal i32 @foo.1(i32 %x, ptr %b) {
+; CHECK-LABEL: define internal i32 @foo.specialized.1(i32 %x, ptr %b) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    %0 = load i32, ptr @A, align 4
 ; CHECK-NEXT:    %add = add nsw i32 %x, %0
 ; CHECK-NEXT:    ret i32 %add
 ; CHECK-NEXT:  }
 
-; CHECK-NOT: define internal i32 @foo.2(
+; CHECK-NOT: define internal i32 @foo.specialized.2(

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-recursive2.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-recursive2.ll
@@ -2,8 +2,8 @@
 
 ; Volatile store preventing recursive specialisation:
 ;
-; CHECK:     @recursiveFunc.1
-; CHECK-NOT: @recursiveFunc.2
+; CHECK:     @recursiveFunc.specialized.1
+; CHECK-NOT: @recursiveFunc.specialized.2
 
 @Global = internal constant i32 1, align 4
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-recursive3.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-recursive3.ll
@@ -2,8 +2,8 @@
 
 ; Duplicate store preventing recursive specialisation:
 ;
-; CHECK:     @recursiveFunc.1
-; CHECK-NOT: @recursiveFunc.2
+; CHECK:     @recursiveFunc.specialized.1
+; CHECK-NOT: @recursiveFunc.specialized.2
 
 @Global = internal constant i32 1, align 4
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization-recursive4.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization-recursive4.ll
@@ -2,8 +2,8 @@
 
 ; Alloca is not an integer type:
 ;
-; CHECK:     @recursiveFunc.1
-; CHECK-NOT: @recursiveFunc.2
+; CHECK:     @recursiveFunc.specialized.1
+; CHECK-NOT: @recursiveFunc.specialized.2
 
 @Global = internal constant i32 1, align 4
 

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization.ll
@@ -7,10 +7,10 @@ define i64 @main(i64 %x, i1 %flag) {
 ; CHECK:      entry:
 ; CHECK-NEXT:   br i1 %flag, label %plus, label %minus
 ; CHECK:      plus:
-; CHECK-NEXT:   [[TMP0:%.+]] = call i64 @compute.1(i64 %x, ptr @plus)
+; CHECK-NEXT:   [[TMP0:%.+]] = call i64 @compute.specialized.1(i64 %x, ptr @plus)
 ; CHECK-NEXT:   br label %merge
 ; CHECK:      minus:
-; CHECK-NEXT:   [[TMP1:%.+]] = call i64 @compute.2(i64 %x, ptr @minus)
+; CHECK-NEXT:   [[TMP1:%.+]] = call i64 @compute.specialized.2(i64 %x, ptr @minus)
 ; CHECK-NEXT:   br label %merge
 ; CHECK:      merge:
 ; CHECK-NEXT:   [[TMP2:%.+]] = phi i64 [ [[TMP0]], %plus ], [ [[TMP1]], %minus ]
@@ -18,7 +18,7 @@ define i64 @main(i64 %x, i1 %flag) {
 ; CHECK-NEXT: }
 ;
 ; NOFSPEC-LABEL: @main(i64 %x, i1 %flag) {
-; NOFSPEC-NOT: call i64 @compute.{{[0-9]+}}(
+; NOFSPEC-NOT: call i64 @compute.specialized.{{[0-9]+}}(
 ; NOFSPEC: call i64 @compute(
 ;
 entry:
@@ -39,20 +39,20 @@ merge:
 
 ; CHECK-NOT: define internal i64 @compute(
 ;
-; CHECK-LABEL: define internal i64 @compute.1(i64 %x, ptr %binop) {
+; CHECK-LABEL: define internal i64 @compute.specialized.1(i64 %x, ptr %binop) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.+]] = call i64 @plus(i64 %x)
 ; CHECK-NEXT:    ret i64 [[TMP0]]
 ; CHECK-NEXT:  }
 ;
-; CHECK-LABEL: define internal i64 @compute.2(i64 %x, ptr %binop) {
+; CHECK-LABEL: define internal i64 @compute.specialized.2(i64 %x, ptr %binop) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.+]] = call i64 @minus(i64 %x)
 ; CHECK-NEXT:    ret i64 [[TMP0]]
 ; CHECK-NEXT:  }
 ;
 ; NOFSPEC: define internal i64 @compute(
-; NOFSPEC-NOT: define internal i64 @compute.{{[0-9]+}}(
+; NOFSPEC-NOT: define internal i64 @compute.specialized.{{[0-9]+}}(
 ;
 define internal i64 @compute(i64 %x, ptr %binop) {
 entry:

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization2.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization2.ll
@@ -3,8 +3,8 @@
 ; RUN: opt -passes="ipsccp<func-spec>,deadargelim" -funcspec-max-iters=1 -force-specialization -S < %s | FileCheck %s
 ; RUN: opt -passes="ipsccp<func-spec>,deadargelim" -funcspec-max-iters=0 -force-specialization -S < %s | FileCheck %s --check-prefix=DISABLED
 
-; DISABLED-NOT: @func.1(
-; DISABLED-NOT: @func.2(
+; DISABLED-NOT: @func.specialized.1(
+; DISABLED-NOT: @func.specialized.2(
 
 define internal i32 @func(ptr %0, i32 %1, ptr nocapture %2) {
   %4 = alloca i32, align 4
@@ -42,15 +42,15 @@ define internal void @decrement(ptr nocapture %0) {
 }
 
 define i32 @main(ptr %0, i32 %1) {
-; CHECK:    call void @func.2(ptr [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK:    call void @func.specialized.2(ptr [[TMP0:%.*]], i32 [[TMP1:%.*]])
   %3 = call i32 @func(ptr %0, i32 %1, ptr nonnull @increment)
-; CHECK:    call void @func.1(ptr [[TMP0]], i32 0)
+; CHECK:    call void @func.specialized.1(ptr [[TMP0]], i32 0)
   %4 = call i32 @func(ptr %0, i32 %3, ptr nonnull @decrement)
 ; CHECK:    ret i32 0
   ret i32 %4
 }
 
-; CHECK: @func.1(
+; CHECK: @func.specialized.1(
 ; CHECK:    [[TMP3:%.*]] = alloca i32, align 4
 ; CHECK:    store i32 [[TMP1:%.*]], ptr [[TMP3]], align 4
 ; CHECK:    [[TMP4:%.*]] = load i32, ptr [[TMP3]], align 4
@@ -63,13 +63,13 @@ define i32 @main(ptr %0, i32 %1) {
 ; CHECK:    call void @decrement(ptr [[TMP9]])
 ; CHECK:    [[TMP10:%.*]] = load i32, ptr [[TMP3]], align 4
 ; CHECK:    [[TMP11:%.*]] = add nsw i32 [[TMP10]], -1
-; CHECK:    call void @func.1(ptr [[TMP0]], i32 [[TMP11]])
+; CHECK:    call void @func.specialized.1(ptr [[TMP0]], i32 [[TMP11]])
 ; CHECK:    br label [[TMP12:%.*]]
 ; CHECK:       12:
 ; CHECK:    ret void
 ;
 ;
-; CHECK: @func.2(
+; CHECK: @func.specialized.2(
 ; CHECK:    [[TMP3:%.*]] = alloca i32, align 4
 ; CHECK:    store i32 [[TMP1:%.*]], ptr [[TMP3]], align 4
 ; CHECK:    [[TMP4:%.*]] = load i32, ptr [[TMP3]], align 4
@@ -82,7 +82,7 @@ define i32 @main(ptr %0, i32 %1) {
 ; CHECK:    call void @increment(ptr [[TMP9]])
 ; CHECK:    [[TMP10:%.*]] = load i32, ptr [[TMP3]], align 4
 ; CHECK:    [[TMP11:%.*]] = add nsw i32 [[TMP10]], -1
-; CHECK:    call void @func.2(ptr [[TMP0]], i32 [[TMP11]])
+; CHECK:    call void @func.specialized.2(ptr [[TMP0]], i32 [[TMP11]])
 ; CHECK:    br label [[TMP12:%.*]]
 ; CHECK:       12:
 ; CHECK:    ret void

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization3.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization3.ll
@@ -12,9 +12,9 @@ target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 
 define dso_local i32 @bar(i32 %x, i32 %y) {
 ; COMMON-LABEL: @bar
-; FORCE:        %call = call i32 @foo.1(i32 %x, ptr @A)
-; FORCE:        %call1 = call i32 @foo.2(i32 %y, ptr @B)
-; DISABLED-NOT: %call1 = call i32 @foo.1(
+; FORCE:        %call = call i32 @foo.specialized.1(i32 %x, ptr @A)
+; FORCE:        %call1 = call i32 @foo.specialized.2(i32 %y, ptr @B)
+; DISABLED-NOT: %call1 = call i32 @foo.specialized.1(
 entry:
   %tobool = icmp ne i32 %x, 0
   br i1 %tobool, label %if.then, label %if.else
@@ -34,14 +34,14 @@ return:
 
 ; FORCE-NOT: define internal i32 @foo(
 ;
-; FORCE:      define internal i32 @foo.1(i32 %x, ptr %b) {
+; FORCE:      define internal i32 @foo.specialized.1(i32 %x, ptr %b) {
 ; FORCE-NEXT: entry:
 ; FORCE-NEXT:   %0 = load i32, ptr @A, align 4
 ; FORCE-NEXT:   %add = add nsw i32 %x, %0
 ; FORCE-NEXT:   ret i32 %add
 ; FORCE-NEXT: }
 ;
-; FORCE:      define internal i32 @foo.2(i32 %x, ptr %b) {
+; FORCE:      define internal i32 @foo.specialized.2(i32 %x, ptr %b) {
 ; FORCE-NEXT: entry:
 ; FORCE-NEXT:   %0 = load i32, ptr @B, align 4
 ; FORCE-NEXT:   %add = add nsw i32 %x, %0

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization4.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization4.ll
@@ -39,10 +39,10 @@ entry:
   ret i32 %add1
 }
 
-; CONST1:     define internal i32 @foo.1(i32 %x, ptr %b, ptr %c)
-; CONST1-NOT: define internal i32 @foo.2(i32 %x, ptr %b, ptr %c)
+; CONST1:     define internal i32 @foo.specialized.1(i32 %x, ptr %b, ptr %c)
+; CONST1-NOT: define internal i32 @foo.specialized.2(i32 %x, ptr %b, ptr %c)
 
-; CHECK:        define internal i32 @foo.1(i32 %x, ptr %b, ptr %c) {
+; CHECK:        define internal i32 @foo.specialized.1(i32 %x, ptr %b, ptr %c) {
 ; CHECK-NEXT:   entry:
 ; CHECK-NEXT:     %0 = load i32, ptr @A, align 4
 ; CHECK-NEXT:     %add = add nsw i32 %x, %0
@@ -51,7 +51,7 @@ entry:
 ; CHECK-NEXT:     ret i32 %add1
 ; CHECK-NEXT:   }
 
-; CHECK: define internal i32 @foo.2(i32 %x, ptr %b, ptr %c) {
+; CHECK: define internal i32 @foo.specialized.2(i32 %x, ptr %b, ptr %c) {
 ; CHECK-NEXT:   entry:
 ; CHECK-NEXT:     %0 = load i32, ptr @B, align 4
 ; CHECK-NEXT:     %add = add nsw i32 %x, %0

--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization5.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization5.ll
@@ -2,8 +2,8 @@
 
 ; There's nothing to specialize here as both calls are the same, so check that:
 ;
-; CHECK-NOT: define internal i32 @foo.1(
-; CHECK-NOT: define internal i32 @foo.2(
+; CHECK-NOT: define internal i32 @foo.specialized.1(
+; CHECK-NOT: define internal i32 @foo.specialized.2(
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 

--- a/llvm/test/Transforms/FunctionSpecialization/get-possible-constants.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/get-possible-constants.ll
@@ -12,7 +12,7 @@ entry:
 }
 
 ; CHECK-LABEL: define dso_local i32 @f0
-; CHECK:       tail call fastcc i32 @g.[[#A:]]({{.*}}@p0)
+; CHECK:       tail call fastcc i32 @g.specialized.[[#A:]]({{.*}}@p0)
 ;
 define dso_local i32 @f0(i32 noundef %x) {
 entry:
@@ -21,7 +21,7 @@ entry:
 }
 
 ; CHECK-LABEL: define dso_local i32 @f1
-; CHECK:       tail call fastcc i32 @g.[[#B:]]({{.*}}@p1)
+; CHECK:       tail call fastcc i32 @g.specialized.[[#B:]]({{.*}}@p1)
 ;
 define dso_local i32 @f1(i32 noundef %x) {
 entry:
@@ -40,7 +40,7 @@ entry:
 }
 
 ; CHECK-LABEL: define dso_local i32 @g0
-; CHECK:       tail call fastcc i32 @f.[[#C:]]({{.*}}@p0)
+; CHECK:       tail call fastcc i32 @f.specialized.[[#C:]]({{.*}}@p0)
 ;
 define dso_local i32 @g0(i32 noundef %x) {
 entry:
@@ -56,7 +56,7 @@ entry:
 }
 
 ; CHECK-LABEL: define dso_local i32 @g1
-; CHECK:       tail call fastcc i32 @f.[[#D:]]({{.*}}@p1)
+; CHECK:       tail call fastcc i32 @f.specialized.[[#D:]]({{.*}}@p1)
 ;
 define dso_local i32 @g1(i32 noundef %x) {
 entry:
@@ -76,7 +76,7 @@ entry:
 ; Also check that for callsites which reside in the body of newly created
 ; (specialized) functions, the lattice value of the arguments is known.
 ;
-; CHECK-DAG: define internal fastcc i32 @g.[[#A]]
-; CHECK-DAG: define internal fastcc i32 @g.[[#B]]
-; CHECK-DAG: define internal fastcc i32 @f.[[#C]]
-; CHECK-DAG: define internal fastcc i32 @f.[[#D]]
+; CHECK-DAG: define internal fastcc i32 @g.specialized.[[#A]]
+; CHECK-DAG: define internal fastcc i32 @g.specialized.[[#B]]
+; CHECK-DAG: define internal fastcc i32 @f.specialized.[[#C]]
+; CHECK-DAG: define internal fastcc i32 @f.specialized.[[#D]]

--- a/llvm/test/Transforms/FunctionSpecialization/global-rank.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/global-rank.ll
@@ -47,5 +47,5 @@ declare i32 @qq(i32 noundef)
 ; `f` to be chosen, whereas the old algorithm would choose
 ; one specialsation of `f` and one of `g`.
 
-; CHECK-DAG: define internal i32 @f.1
-; CHECK-DAG: define internal i32 @f.2
+; CHECK-DAG: define internal i32 @f.specialized.1
+; CHECK-DAG: define internal i32 @f.specialized.2

--- a/llvm/test/Transforms/FunctionSpecialization/global-var-constants.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/global-var-constants.ll
@@ -65,14 +65,14 @@ entry:
 ; is allowed, then it is performed where possible.
 
 ; GLOBALS-LABEL: define internal i32 @g()
-; GLOBALS: call i32 @f.2()
+; GLOBALS: call i32 @f.specialized.2()
 
 ; GLOBALS-LABEL: define i32 @h0(ptr %p)
 ; GLOBALS: call i32 @g()
 
 ; GLOBALS-LABEL: define i32 @h1()
-; GLOBALS: call i32 @f.2()
+; GLOBALS: call i32 @f.specialized.2()
 
 ; GLOBALS-LABEL: define i32 @h2()
-; GLOBALS: call i32 @f.1()
+; GLOBALS: call i32 @f.specialized.1()
 

--- a/llvm/test/Transforms/FunctionSpecialization/identical-specializations.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/identical-specializations.ll
@@ -6,14 +6,14 @@ define i64 @main(i64 %x, i64 %y, i1 %flag) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br i1 [[FLAG:%.*]], label [[PLUS:%.*]], label [[MINUS:%.*]]
 ; CHECK:       plus:
-; CHECK-NEXT:    [[CMP0:%.*]] = call i64 @compute.2(i64 [[X:%.*]], i64 [[Y:%.*]], ptr @plus, ptr @minus)
+; CHECK-NEXT:    [[CMP0:%.*]] = call i64 @compute.specialized.2(i64 [[X:%.*]], i64 [[Y:%.*]], ptr @plus, ptr @minus)
 ; CHECK-NEXT:    br label [[MERGE:%.*]]
 ; CHECK:       minus:
-; CHECK-NEXT:    [[CMP1:%.*]] = call i64 @compute.3(i64 [[X]], i64 [[Y]], ptr @minus, ptr @plus)
+; CHECK-NEXT:    [[CMP1:%.*]] = call i64 @compute.specialized.3(i64 [[X]], i64 [[Y]], ptr @minus, ptr @plus)
 ; CHECK-NEXT:    br label [[MERGE]]
 ; CHECK:       merge:
 ; CHECK-NEXT:    [[PH:%.*]] = phi i64 [ [[CMP0]], [[PLUS]] ], [ [[CMP1]], [[MINUS]] ]
-; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.2(i64 [[PH]], i64 42, ptr @plus, ptr @minus)
+; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.specialized.2(i64 [[PH]], i64 42, ptr @plus, ptr @minus)
 ; CHECK-NEXT:    ret i64 [[CMP2]]
 ;
 entry:
@@ -60,20 +60,20 @@ entry:
   ret i64 %sub
 }
 
-; CHECK-LABEL: @compute.1
+; CHECK-LABEL: @compute.specialized.1
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP0:%.*]] = call i64 %binop1(i64 [[X:%.*]], i64 [[Y:%.*]])
 ; CHECK-NEXT:    [[CMP1:%.*]] = call i64 @plus(i64 [[X]], i64 [[Y]])
-; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.1(i64 [[X]], i64 [[Y]], ptr %binop1, ptr @plus)
+; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.specialized.1(i64 [[X]], i64 [[Y]], ptr %binop1, ptr @plus)
 
-; CHECK-LABEL: @compute.2
+; CHECK-LABEL: @compute.specialized.2
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP0:%.*]] = call i64 @plus(i64 [[X:%.*]], i64 [[Y:%.*]])
 ; CHECK-NEXT:    [[CMP1:%.*]] = call i64 @minus(i64 [[X]], i64 [[Y]])
-; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.1(i64 [[X]], i64 [[Y]], ptr @plus, ptr @plus)
+; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.specialized.1(i64 [[X]], i64 [[Y]], ptr @plus, ptr @plus)
 
-; CHECK-LABEL: @compute.3
+; CHECK-LABEL: @compute.specialized.3
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP0:%.*]] = call i64 @minus(i64 [[X:%.*]], i64 [[Y:%.*]])
 ; CHECK-NEXT:    [[CMP1:%.*]] = call i64 @plus(i64 [[X]], i64 [[Y]])
-; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.3(i64 [[X]], i64 [[Y]], ptr @minus, ptr @plus)
+; CHECK-NEXT:    [[CMP2:%.*]] = call i64 @compute.specialized.3(i64 [[X]], i64 [[Y]], ptr @minus, ptr @plus)

--- a/llvm/test/Transforms/FunctionSpecialization/literal-const.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/literal-const.ll
@@ -66,27 +66,27 @@ entry:
 ; CHECK-NOLIT-NOT: @addf.
 
 ; CHECK-LIT-LABEL: define i32 @f0
-; CHECK-LIT: call i32 @neg.[[#A:]]
+; CHECK-LIT: call i32 @neg.specialized.[[#A:]]
 
 ; CHECK-LIT-LABEL: define i32 @f1
-; CHECK-LIT: call i32 @neg.[[#B:]]
+; CHECK-LIT: call i32 @neg.specialized.[[#B:]]
 
 ; CHECK-LIT-LABEL: define i32 @g0
-; CHECK-LIT: call i32 @add.[[#C:]]
+; CHECK-LIT: call i32 @add.specialized.[[#C:]]
 
 ; CHECK-LIT-LABEL: define i32 @g1
-; CHECK-LIT: call i32 @add.[[#D:]]
+; CHECK-LIT: call i32 @add.specialized.[[#D:]]
 
 ; CHECK-LIT-LABEL: define float @h0
-; CHECK-LIT: call float @addf.[[#E:]]
+; CHECK-LIT: call float @addf.specialized.[[#E:]]
 
 ; CHECK-LIT-LABEL: define float @h1
-; CHECK-LIT: call float @addf.[[#F:]]
+; CHECK-LIT: call float @addf.specialized.[[#F:]]
 
 ; Check all of `neg`, `add`, and `addf` were specialised.
-; CHECK-LIT-DAG: @neg.[[#A]]
-; CHECK-LIT-DAG: @neg.[[#B]]
-; CHECK-LIT-DAG: @add.[[#C]]
-; CHECK-LIT-DAG: @add.[[#D]]
-; CHECK-LIT-DAG: @addf.[[#E]]
-; CHECK-LIT-DAG: @addf.[[#F]]
+; CHECK-LIT-DAG: @neg.specialized.[[#A]]
+; CHECK-LIT-DAG: @neg.specialized.[[#B]]
+; CHECK-LIT-DAG: @add.specialized.[[#C]]
+; CHECK-LIT-DAG: @add.specialized.[[#D]]
+; CHECK-LIT-DAG: @addf.specialized.[[#E]]
+; CHECK-LIT-DAG: @addf.specialized.[[#F]]

--- a/llvm/test/Transforms/FunctionSpecialization/no-spec-unused-arg.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/no-spec-unused-arg.ll
@@ -17,4 +17,4 @@ define i32 @g1() {
 ; to be a constant without the need for function specialisation and
 ; the second parameter is unused.
 
-;  CHECK-NOT: @f.
+;  CHECK-NOT: @f.specialized.

--- a/llvm/test/Transforms/FunctionSpecialization/noinline.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/noinline.ll
@@ -31,5 +31,5 @@ entry:
 }
 
 ; Check that a noinline function is specialized, even if it's small.
-; CHECK: @f.1
-; CHECK: @f.2
+; CHECK: @f.specialized.1
+; CHECK: @f.specialized.2

--- a/llvm/test/Transforms/FunctionSpecialization/non-argument-tracked.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/non-argument-tracked.ll
@@ -29,9 +29,9 @@ define internal i32 @f2(i32 %i) {
 ;; All calls are to specilisation instances.
 
 ; CHECK-LABEL: define i32 @g0
-; CHECK:         call void @f0.[[#A:]]()
-; CHECK-NEXT:    call void @f1.[[#B:]]()
-; CHECK-NEXT:    call void @f2.[[#C:]]()
+; CHECK:         call void @f0.specialized.[[#A:]]()
+; CHECK-NEXT:    call void @f1.specialized.[[#B:]]()
+; CHECK-NEXT:    call void @f2.specialized.[[#C:]]()
 ; CHECK-NEXT:    ret i32 9
 define i32 @g0(i32 %i) {
   %u0 = call i32 @f0(i32 1)
@@ -43,9 +43,9 @@ define i32 @g0(i32 %i) {
 }
 
 ; CHECK-LABEL: define i32 @g1
-; CHECK:         call void @f0.[[#D:]]()
-; CHECK-NEXT:    call void @f1.[[#E:]]()
-; CHECK-NEXT:    call void @f2.[[#F:]]()
+; CHECK:         call void @f0.specialized.[[#D:]]()
+; CHECK-NEXT:    call void @f1.specialized.[[#E:]]()
+; CHECK-NEXT:    call void @f2.specialized.[[#F:]]()
 ; CHECK-NEXT:    ret i32 12
 define i32 @g1(i32 %i) {
   %u0 = call i32 @f0(i32 2)
@@ -58,9 +58,9 @@ define i32 @g1(i32 %i) {
 
 ; All of the function are specialized and all clones are with internal linkage.
 
-; CHECK-DAG: define internal void @f0.[[#A]]() {
-; CHECK-DAG: define internal void @f1.[[#B]]() {
-; CHECK-DAG: define internal void @f2.[[#C]]() {
-; CHECK-DAG: define internal void @f0.[[#D]]() {
-; CHECK-DAG: define internal void @f1.[[#E]]() {
-; CHECK-DAG: define internal void @f2.[[#F]]() {
+; CHECK-DAG: define internal void @f0.specialized.[[#A]]() {
+; CHECK-DAG: define internal void @f1.specialized.[[#B]]() {
+; CHECK-DAG: define internal void @f2.specialized.[[#C]]() {
+; CHECK-DAG: define internal void @f0.specialized.[[#D]]() {
+; CHECK-DAG: define internal void @f1.specialized.[[#E]]() {
+; CHECK-DAG: define internal void @f2.specialized.[[#F]]() {

--- a/llvm/test/Transforms/FunctionSpecialization/promoteContantStackValues.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/promoteContantStackValues.ll
@@ -27,53 +27,53 @@ ret.block:
   ret void
 }
 
-; ITERS1:  @funcspec.arg = internal constant i32 0
-; ITERS1:  @funcspec.arg.1 = internal constant i32 6
-; ITERS1:  @funcspec.arg.3 = internal constant i32 1
-; ITERS1:  @funcspec.arg.4 = internal constant i32 5
+; ITERS1:  @specialized.arg.1 = internal constant i32 0
+; ITERS1:  @specialized.arg.2 = internal constant i32 6
+; ITERS1:  @specialized.arg.3 = internal constant i32 1
+; ITERS1:  @specialized.arg.4 = internal constant i32 5
 
-; ITERS2:  @funcspec.arg = internal constant i32 0
-; ITERS2:  @funcspec.arg.1 = internal constant i32 6
-; ITERS2:  @funcspec.arg.3 = internal constant i32 1
-; ITERS2:  @funcspec.arg.4 = internal constant i32 5
-; ITERS2:  @funcspec.arg.6 = internal constant i32 2
-; ITERS2:  @funcspec.arg.7 = internal constant i32 4
+; ITERS2:  @specialized.arg.1 = internal constant i32 0
+; ITERS2:  @specialized.arg.2 = internal constant i32 6
+; ITERS2:  @specialized.arg.3 = internal constant i32 1
+; ITERS2:  @specialized.arg.4 = internal constant i32 5
+; ITERS2:  @specialized.arg.5 = internal constant i32 2
+; ITERS2:  @specialized.arg.6 = internal constant i32 4
 
-; ITERS3:  @funcspec.arg = internal constant i32 0
-; ITERS3:  @funcspec.arg.1 = internal constant i32 6
-; ITERS3:  @funcspec.arg.3 = internal constant i32 1
-; ITERS3:  @funcspec.arg.4 = internal constant i32 5
-; ITERS3:  @funcspec.arg.6 = internal constant i32 2
-; ITERS3:  @funcspec.arg.7 = internal constant i32 4
-; ITERS3:  @funcspec.arg.9 = internal constant i32 3
-; ITERS3:  @funcspec.arg.10 = internal constant i32 3
+; ITERS3:  @specialized.arg.1 = internal constant i32 0
+; ITERS3:  @specialized.arg.2 = internal constant i32 6
+; ITERS3:  @specialized.arg.3 = internal constant i32 1
+; ITERS3:  @specialized.arg.4 = internal constant i32 5
+; ITERS3:  @specialized.arg.5 = internal constant i32 2
+; ITERS3:  @specialized.arg.6 = internal constant i32 4
+; ITERS3:  @specialized.arg.7 = internal constant i32 3
+; ITERS3:  @specialized.arg.8 = internal constant i32 3
 
-; ITERS4:  @funcspec.arg = internal constant i32 0
-; ITERS4:  @funcspec.arg.1 = internal constant i32 6
-; ITERS4:  @funcspec.arg.3 = internal constant i32 1
-; ITERS4:  @funcspec.arg.4 = internal constant i32 5
-; ITERS4:  @funcspec.arg.6 = internal constant i32 2
-; ITERS4:  @funcspec.arg.7 = internal constant i32 4
-; ITERS4:  @funcspec.arg.9 = internal constant i32 3
-; ITERS4:  @funcspec.arg.10 = internal constant i32 3
+; ITERS4:  @specialized.arg.1 = internal constant i32 0
+; ITERS4:  @specialized.arg.2 = internal constant i32 6
+; ITERS4:  @specialized.arg.3 = internal constant i32 1
+; ITERS4:  @specialized.arg.4 = internal constant i32 5
+; ITERS4:  @specialized.arg.5 = internal constant i32 2
+; ITERS4:  @specialized.arg.6 = internal constant i32 4
+; ITERS4:  @specialized.arg.7 = internal constant i32 3
+; ITERS4:  @specialized.arg.8 = internal constant i32 3
 
 define i32 @main() {
 ; ITERS1-LABEL: @main(
 ; ITERS1-NEXT:    call void @print_val(i32 0, i32 6)
-; ITERS1-NEXT:    call void @recursiveFunc(ptr nonnull @funcspec.arg.3, i32 1, ptr nonnull @funcspec.arg.4)
+; ITERS1-NEXT:    call void @recursiveFunc(ptr nonnull @specialized.arg.3, i32 1, ptr nonnull @specialized.arg.4)
 ; ITERS1-NEXT:    ret i32 0
 ;
 ; ITERS2-LABEL: @main(
 ; ITERS2-NEXT:    call void @print_val(i32 0, i32 6)
 ; ITERS2-NEXT:    call void @print_val(i32 1, i32 5)
-; ITERS2-NEXT:    call void @recursiveFunc(ptr nonnull @funcspec.arg.6, i32 1, ptr nonnull @funcspec.arg.7)
+; ITERS2-NEXT:    call void @recursiveFunc(ptr nonnull @specialized.arg.5, i32 1, ptr nonnull @specialized.arg.6)
 ; ITERS2-NEXT:    ret i32 0
 ;
 ; ITERS3-LABEL: @main(
 ; ITERS3-NEXT:    call void @print_val(i32 0, i32 6)
 ; ITERS3-NEXT:    call void @print_val(i32 1, i32 5)
 ; ITERS3-NEXT:    call void @print_val(i32 2, i32 4)
-; ITERS3-NEXT:    call void @recursiveFunc(ptr nonnull @funcspec.arg.9, i32 1, ptr nonnull @funcspec.arg.10)
+; ITERS3-NEXT:    call void @recursiveFunc(ptr nonnull @specialized.arg.7, i32 1, ptr nonnull @specialized.arg.8)
 ; ITERS3-NEXT:    ret i32 0
 ;
 ; ITERS4-LABEL: @main(

--- a/llvm/test/Transforms/FunctionSpecialization/remove-dead-recursive-function.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/remove-dead-recursive-function.ll
@@ -19,14 +19,14 @@ merge:
 
 ; CHECK-NOT: define internal i64 @compute(
 ;
-; CHECK-LABEL: define internal i64 @compute.1(i64 %n, ptr %binop) {
+; CHECK-LABEL: define internal i64 @compute.specialized.1(i64 %n, ptr %binop) {
 ; CHECK:  [[TMP0:%.+]] = call i64 @plus(i64 %n)
-; CHECK:  [[TMP1:%.+]] = call i64 @compute.1(i64 [[TMP2:%.+]], ptr @plus)
+; CHECK:  [[TMP1:%.+]] = call i64 @compute.specialized.1(i64 [[TMP2:%.+]], ptr @plus)
 ; CHECK:  add nsw i64 [[TMP1]], [[TMP0]]
 ;
-; CHECK-LABEL: define internal i64 @compute.2(i64 %n, ptr %binop) {
+; CHECK-LABEL: define internal i64 @compute.specialized.2(i64 %n, ptr %binop) {
 ; CHECK:  [[TMP0:%.+]] = call i64 @minus(i64 %n)
-; CHECK:  [[TMP1:%.+]] = call i64 @compute.2(i64 [[TMP2:%.+]], ptr @minus)
+; CHECK:  [[TMP1:%.+]] = call i64 @compute.specialized.2(i64 [[TMP2:%.+]], ptr @minus)
 ; CHECK:  add nsw i64 [[TMP1]], [[TMP0]]
 ;
 define internal i64 @compute(i64 %n, ptr %binop) {

--- a/llvm/test/Transforms/FunctionSpecialization/specialization-order.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/specialization-order.ll
@@ -21,7 +21,7 @@ entry:
 
 define dso_local i32 @g0(i32 %x, i32 %y) {
 ; CHECK-LABEL: @g0
-; CHECK:       call i32 @f.3(i32 [[X:%.*]], i32 [[Y:%.*]])
+; CHECK:       call i32 @f.specialized.3(i32 [[X:%.*]], i32 [[Y:%.*]])
 entry:
   %call = tail call i32 @f(i32 %x, i32 %y, ptr @add, ptr @add)
   ret i32 %call
@@ -30,7 +30,7 @@ entry:
 
 define dso_local i32 @g1(i32 %x, i32 %y) {
 ; CHECK-LABEL: @g1(
-; CHECK:       call i32 @f.2(i32 [[X:%.*]], i32 [[Y:%.*]])
+; CHECK:       call i32 @f.specialized.2(i32 [[X:%.*]], i32 [[Y:%.*]])
 entry:
   %call = tail call i32 @f(i32 %x, i32 %y, ptr @sub, ptr @add)
   ret i32 %call
@@ -38,21 +38,21 @@ entry:
 
 define dso_local i32 @g2(i32 %x, i32 %y, ptr %v) {
 ; CHECK-LABEL: @g2
-; CHECK:       call i32 @f.1(i32 [[X:%.*]], i32 [[Y:%.*]], ptr [[V:%.*]])
+; CHECK:       call i32 @f.specialized.1(i32 [[X:%.*]], i32 [[Y:%.*]], ptr [[V:%.*]])
 entry:
   %call = tail call i32 @f(i32 %x, i32 %y, ptr @sub, ptr %v)
   ret i32 %call
 }
 
-; CHECK-LABEL: define {{.*}} i32 @f.1
+; CHECK-LABEL: define {{.*}} i32 @f.specialized.1
 ; CHECK:       call i32 @sub(i32 %x, i32 %y)
 ; CHECK-NEXT:  call i32 %v(i32 %x, i32 %y)
 
-; CHECK-LABEL: define {{.*}} i32 @f.2
+; CHECK-LABEL: define {{.*}} i32 @f.specialized.2
 ; CHECK:       call i32 @sub(i32 %x, i32 %y)
 ; CHECK-NEXT:  call i32 @add(i32 %x, i32 %y)
 
-; CHECK-LABEL: define {{.*}} i32 @f.3
+; CHECK-LABEL: define {{.*}} i32 @f.specialized.3
 ; CHECK:       call i32 @add(i32 %x, i32 %y)
 ; CHECK-NEXT:   call i32 @add(i32 %x, i32 %y)
 

--- a/llvm/test/Transforms/FunctionSpecialization/specialize-multiple-arguments.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/specialize-multiple-arguments.ll
@@ -38,7 +38,7 @@ define i64 @main(i64 %x, i64 %y, i1 %flag) {
 ; ONE-NEXT:    [[TMP0:%.*]] = call i64 @compute(i64 [[X:%.*]], i64 [[Y:%.*]], ptr @power, ptr @mul)
 ; ONE-NEXT:    br label [[MERGE:%.*]]
 ; ONE:       minus:
-; ONE-NEXT:    [[TMP1:%.*]] = call i64 @compute.1(i64 [[X]], i64 [[Y]], ptr @plus, ptr @minus)
+; ONE-NEXT:    [[TMP1:%.*]] = call i64 @compute.specialized.1(i64 [[X]], i64 [[Y]], ptr @plus, ptr @minus)
 ; ONE-NEXT:    br label [[MERGE]]
 ; ONE:       merge:
 ; ONE-NEXT:    [[TMP2:%.*]] = phi i64 [ [[TMP0]], [[PLUS]] ], [ [[TMP1]], [[MINUS]] ]
@@ -52,25 +52,25 @@ define i64 @main(i64 %x, i64 %y, i1 %flag) {
 ; TWO-NEXT:    [[TMP0:%.*]] = call i64 @compute(i64 [[X:%.*]], i64 [[Y:%.*]], ptr @power, ptr @mul)
 ; TWO-NEXT:    br label [[MERGE:%.*]]
 ; TWO:       minus:
-; TWO-NEXT:    [[TMP1:%.*]] = call i64 @compute.2(i64 [[X]], i64 [[Y]], ptr @plus, ptr @minus)
+; TWO-NEXT:    [[TMP1:%.*]] = call i64 @compute.specialized.2(i64 [[X]], i64 [[Y]], ptr @plus, ptr @minus)
 ; TWO-NEXT:    br label [[MERGE]]
 ; TWO:       merge:
 ; TWO-NEXT:    [[TMP2:%.*]] = phi i64 [ [[TMP0]], [[PLUS]] ], [ [[TMP1]], [[MINUS]] ]
-; TWO-NEXT:    [[TMP3:%.*]] = call i64 @compute.1(i64 [[TMP2]], i64 42, ptr @minus, ptr @power)
+; TWO-NEXT:    [[TMP3:%.*]] = call i64 @compute.specialized.1(i64 [[TMP2]], i64 42, ptr @minus, ptr @power)
 ; TWO-NEXT:    ret i64 [[TMP3]]
 ;
 ; THREE-LABEL: @main(
 ; THREE-NEXT:  entry:
 ; THREE-NEXT:    br i1 [[FLAG:%.*]], label [[PLUS:%.*]], label [[MINUS:%.*]]
 ; THREE:       plus:
-; THREE-NEXT:    [[TMP0:%.*]] = call i64 @compute.1(i64 [[X:%.*]], i64 [[Y:%.*]], ptr @power, ptr @mul)
+; THREE-NEXT:    [[TMP0:%.*]] = call i64 @compute.specialized.1(i64 [[X:%.*]], i64 [[Y:%.*]], ptr @power, ptr @mul)
 ; THREE-NEXT:    br label [[MERGE:%.*]]
 ; THREE:       minus:
-; THREE-NEXT:    [[TMP1:%.*]] = call i64 @compute.2(i64 [[X]], i64 [[Y]], ptr @plus, ptr @minus)
+; THREE-NEXT:    [[TMP1:%.*]] = call i64 @compute.specialized.2(i64 [[X]], i64 [[Y]], ptr @plus, ptr @minus)
 ; THREE-NEXT:    br label [[MERGE]]
 ; THREE:       merge:
 ; THREE-NEXT:    [[TMP2:%.*]] = phi i64 [ [[TMP0]], [[PLUS]] ], [ [[TMP1]], [[MINUS]] ]
-; THREE-NEXT:    [[TMP3:%.*]] = call i64 @compute.3(i64 [[TMP2]], i64 42, ptr @minus, ptr @power)
+; THREE-NEXT:    [[TMP3:%.*]] = call i64 @compute.specialized.3(i64 [[TMP2]], i64 42, ptr @minus, ptr @power)
 ; THREE-NEXT:    ret i64 [[TMP3]]
 ;
 entry:
@@ -92,7 +92,7 @@ merge:
 
 ; THREE-NOT: define internal i64 @compute
 ;
-; THREE-LABEL: define internal i64 @compute.1(i64 %x, i64 %y, ptr %binop1, ptr %binop2) {
+; THREE-LABEL: define internal i64 @compute.specialized.1(i64 %x, i64 %y, ptr %binop1, ptr %binop2) {
 ; THREE-NEXT:  entry:
 ; THREE-NEXT:    [[TMP0:%.+]] = call i64 @power(i64 %x, i64 %y)
 ; THREE-NEXT:    [[TMP1:%.+]] = call i64 @mul(i64 %x, i64 %y)
@@ -103,7 +103,7 @@ merge:
 ; THREE-NEXT:    ret i64 [[TMP5]]
 ; THREE-NEXT:  }
 ;
-; THREE-LABEL: define internal i64 @compute.2(i64 %x, i64 %y, ptr %binop1, ptr %binop2) {
+; THREE-LABEL: define internal i64 @compute.specialized.2(i64 %x, i64 %y, ptr %binop1, ptr %binop2) {
 ; THREE-NEXT:  entry:
 ; THREE-NEXT:    [[TMP0:%.+]] = call i64 @plus(i64 %x, i64 %y)
 ; THREE-NEXT:    [[TMP1:%.+]] = call i64 @minus(i64 %x, i64 %y)
@@ -114,7 +114,7 @@ merge:
 ; THREE-NEXT:    ret i64 [[TMP5]]
 ; THREE-NEXT:  }
 ;
-; THREE-LABEL: define internal i64 @compute.3(i64 %x, i64 %y, ptr %binop1, ptr %binop2) {
+; THREE-LABEL: define internal i64 @compute.specialized.3(i64 %x, i64 %y, ptr %binop1, ptr %binop2) {
 ; THREE-NEXT:  entry:
 ; THREE-NEXT:    [[TMP0:%.+]] = call i64 @minus(i64 %x, i64 %y)
 ; THREE-NEXT:    [[TMP1:%.+]] = call i64 @power(i64 %x, i64 %y)

--- a/llvm/test/Transforms/FunctionSpecialization/track-return.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/track-return.ll
@@ -3,8 +3,8 @@
 define i64 @main() {
 ; CHECK:       define i64 @main
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[C1:%.*]] = call i64 @foo.1(i1 true, i64 3, i64 1)
-; CHECK-NEXT:    [[C2:%.*]] = call i64 @foo.2(i1 false, i64 4, i64 -1)
+; CHECK-NEXT:    [[C1:%.*]] = call i64 @foo.specialized.1(i1 true, i64 3, i64 1)
+; CHECK-NEXT:    [[C2:%.*]] = call i64 @foo.specialized.2(i1 false, i64 4, i64 -1)
 ; CHECK-NEXT:    ret i64 8
 ;
 entry:
@@ -16,22 +16,22 @@ entry:
 
 define internal i64 @foo(i1 %flag, i64 %m, i64 %n) {
 ;
-; CHECK:       define internal i64 @foo.1
+; CHECK:       define internal i64 @foo.specialized.1
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label %plus
 ; CHECK:       plus:
-; CHECK-NEXT:    [[N0:%.*]] = call i64 @binop.4(i64 3, i64 1)
-; CHECK-NEXT:    [[RES0:%.*]] = call i64 @bar.6(i64 4)
+; CHECK-NEXT:    [[N0:%.*]] = call i64 @binop.specialized.4(i64 3, i64 1)
+; CHECK-NEXT:    [[RES0:%.*]] = call i64 @bar.specialized.6(i64 4)
 ; CHECK-NEXT:    br label %merge
 ; CHECK:       merge:
 ; CHECK-NEXT:    ret i64 undef
 ;
-; CHECK:       define internal i64 @foo.2
+; CHECK:       define internal i64 @foo.specialized.2
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label %minus
 ; CHECK:       minus:
-; CHECK-NEXT:    [[N1:%.*]] = call i64 @binop.3(i64 4, i64 -1)
-; CHECK-NEXT:    [[RES1:%.*]] = call i64 @bar.5(i64 3)
+; CHECK-NEXT:    [[N1:%.*]] = call i64 @binop.specialized.3(i64 4, i64 -1)
+; CHECK-NEXT:    [[RES1:%.*]] = call i64 @bar.specialized.5(i64 3)
 ; CHECK-NEXT:    br label %merge
 ; CHECK:       merge:
 ; CHECK-NEXT:    ret i64 undef
@@ -56,11 +56,11 @@ merge:
 
 define internal i64 @binop(i64 %x, i64 %y) {
 ;
-; CHECK:       define internal i64 @binop.3
+; CHECK:       define internal i64 @binop.specialized.3
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    ret i64 undef
 ;
-; CHECK:       define internal i64 @binop.4
+; CHECK:       define internal i64 @binop.specialized.4
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    ret i64 undef
 ;
@@ -71,7 +71,7 @@ entry:
 
 define internal i64 @bar(i64 %n) {
 ;
-; CHECK:       define internal i64 @bar.5
+; CHECK:       define internal i64 @bar.specialized.5
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label %if.else
 ; CHECK:       if.else:
@@ -79,7 +79,7 @@ define internal i64 @bar(i64 %n) {
 ; CHECK:       if.end:
 ; CHECK-NEXT:    ret i64 undef
 ;
-; CHECK:       define internal i64 @bar.6
+; CHECK:       define internal i64 @bar.specialized.6
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label %if.then
 ; CHECK:       if.then:


### PR DESCRIPTION
…ues.

Currently the naming scheme is a bit funky; the specializations are named after the original function followed by an arbitrary decimal number. This makes it hard to debug inlined specializations of recursive functions. With this patch I am adding ".funcspec." in between of the original name and the suffix, which is now a single increment counter.