### PR TITLE
[SPIR-V] Fix 64-bit integer literal printing

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -169,7 +169,9 @@ void SPIRVInstPrinter::printInst(const MCInst *MI, uint64_t Address,
         }
         case SPIRV::OpConstantI:
         case SPIRV::OpConstantF:
-          printOpConstantVarOps(MI, NumFixedOps, OS);
+          // The last fixed operand along with any variadic operands that follow
+          // are part of the variable value.
+          printOpConstantVarOps(MI, NumFixedOps - 1, OS);
           break;
         default:
           printRemainingVariableOps(MI, NumFixedOps, OS);

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -217,9 +217,9 @@ def ConstPseudoNull: IntImmLeaf<i64, [{ return Imm.isZero(); }]>;
 
 multiclass IntFPImm<bits<16> opCode, string name> {
   def I: Op<opCode, (outs ID:$dst), (ins TYPE:$type, ID:$src, variable_ops),
-                  "$dst = "#name#" $type $src", [(set ID:$dst, (assigntype PseudoConstI:$src, TYPE:$type))]>;
+                  "$dst = "#name#" $type", [(set ID:$dst, (assigntype PseudoConstI:$src, TYPE:$type))]>;
   def F: Op<opCode, (outs ID:$dst), (ins TYPE:$type, fID:$src, variable_ops),
-                  "$dst = "#name#" $type $src", [(set ID:$dst, (assigntype PseudoConstF:$src, TYPE:$type))]>;
+                  "$dst = "#name#" $type", [(set ID:$dst, (assigntype PseudoConstF:$src, TYPE:$type))]>;
 }
 
 def OpConstantTrue: Op<41, (outs ID:$dst), (ins TYPE:$src_ty), "$dst = OpConstantTrue $src_ty",

--- a/llvm/test/CodeGen/SPIRV/atomicrmw.ll
+++ b/llvm/test/CodeGen/SPIRV/atomicrmw.ll
@@ -1,10 +1,10 @@
 ; RUN: llc -O0 -opaque-pointers=0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK:     %[[#Int:]] = OpTypeInt 32 0
-; CHECK-DAG: %[[#Scope_Device:]] = OpConstant %[[#Int]] 1 {{$}}
+; CHECK-DAG: %[[#Scope_Device:]] = OpConstant %[[#Int]] 1{{$}}
 ; CHECK-DAG: %[[#MemSem_Relaxed:]] = OpConstant %[[#Int]] 0
 ; CHECK-DAG: %[[#MemSem_Acquire:]] = OpConstant %[[#Int]] 2
-; CHECK-DAG: %[[#MemSem_Release:]] = OpConstant %[[#Int]] 4 {{$}}
+; CHECK-DAG: %[[#MemSem_Release:]] = OpConstant %[[#Int]] 4{{$}}
 ; CHECK-DAG: %[[#MemSem_AcquireRelease:]] = OpConstant %[[#Int]] 8
 ; CHECK-DAG: %[[#MemSem_SequentiallyConsistent:]] = OpConstant %[[#Int]] 16
 ; CHECK-DAG: %[[#Value:]] = OpConstant %[[#Int]] 42

--- a/llvm/test/CodeGen/SPIRV/constant/local-integers-constants.ll
+++ b/llvm/test/CodeGen/SPIRV/constant/local-integers-constants.ll
@@ -44,8 +44,8 @@ define i64 @getLargeConstantI64() {
 ; CHECK-DAG: %[[#CST_I8:]] = OpConstant %[[#I8]] 2
 ; CHECK-DAG: %[[#CST_I16:]] = OpConstant %[[#I16]] 65478
 ; CHECK-DAG: %[[#CST_I32:]] = OpConstant %[[#I32]] 42
-; CHECK-DAG: %[[#CST_I64:]] = OpConstant %[[#I64]] 123456789 0
-; CHECK-DAG: %[[#CST_LARGE_I64:]] = OpConstant %[[#I64]] 0 8
+; CHECK-DAG: %[[#CST_I64:]] = OpConstant %[[#I64]] 123456789
+; CHECK-DAG: %[[#CST_LARGE_I64:]] = OpConstant %[[#I64]] 34359738368
 
 ; CHECK: %[[#GET_I8]] = OpFunction %[[#I8]]
 ; CHECK: OpReturnValue %[[#CST_I8]]

--- a/llvm/test/CodeGen/SPIRV/lshr-constexpr.ll
+++ b/llvm/test/CodeGen/SPIRV/lshr-constexpr.ll
@@ -5,7 +5,7 @@
 ; CHECK-SPIRV:     %[[#type_vec:]] = OpTypeVector %[[#type_int32]] 2
 ; CHECK-SPIRV:     %[[#const1:]] = OpConstant %[[#type_int32]] 1
 ; CHECK-SPIRV:     %[[#vec_const:]] = OpConstantComposite %[[#type_vec]] %[[#const1]] %[[#const1]]
-; CHECK-SPIRV:     %[[#const32:]] = OpConstant %[[#type_int64]] 32 0
+; CHECK-SPIRV:     %[[#const32:]] = OpConstant %[[#type_int64]] 32
 
 ; CHECK-SPIRV:     %[[#bitcast_res:]] = OpBitcast %[[#type_int64]] %[[#vec_const]]
 ; CHECK-SPIRV:     %[[#shift_res:]] = OpShiftRightLogical %[[#type_int64]] %[[#bitcast_res]] %[[#const32]]

--- a/llvm/test/CodeGen/SPIRV/uitofp-with-bool.ll
+++ b/llvm/test/CodeGen/SPIRV/uitofp-with-bool.ll
@@ -41,10 +41,10 @@
 ; SPV-DAG: %[[#mone_16:]] = OpConstant %[[#int_16]] 65535
 ; SPV-DAG: %[[#mone_32:]] = OpConstant %[[#int_32]] 4294967295
 ; SPV-DAG: %[[#zero_64:]] = OpConstantNull %[[#int_64]]
-; SPV-DAG: %[[#mone_64:]] = OpConstant %[[#int_64]] 4294967295 4294967295
+; SPV-DAG: %[[#mone_64:]] = OpConstant %[[#int_64]] 18446744073709551615
 ; SPV-DAG: %[[#one_8:]] = OpConstant %[[#int_8]] 1
 ; SPV-DAG: %[[#one_16:]] = OpConstant %[[#int_16]] 1
-; SPV-DAG: %[[#one_64:]] = OpConstant %[[#int_64]] 1 0
+; SPV-DAG: %[[#one_64:]] = OpConstant %[[#int_64]] 1
 ; SPV-DAG: %[[#void:]] = OpTypeVoid
 ; SPV-DAG: %[[#float:]] = OpTypeFloat 32
 ; SPV-DAG: %[[#bool:]] = OpTypeBool


### PR DESCRIPTION
Previously, the SPIR-V instruction printer was always printing the first operand of an `OpConstant`'s literal value as one of the fixed operands. This is incorrect for 64-bit values, where the first operand is actually the value's lower-order word and should be combined with the following higher-order word before printing.

This change fixes that issue by waiting to print the last fixed operand of `OpConstant` instructions until the variadic operands are ready to be printed, then using `NumFixedOps - 1` as the starting operand index for the literal value operands.

Depends on D156049