### PR TITLE
[lld][WebAssembly] Improve error message on adding LTO object post-LTO. NFC

### DIFF
--- a/lld/test/wasm/lto/libcall-truncsfhf2.ll
+++ b/lld/test/wasm/lto/libcall-truncsfhf2.ll
@@ -17,4 +17,4 @@ define void @_start() {
   ret void
 }
 
-; CHECK: wasm-ld: error: {{.*}}truncsfhf2.o): attempt to add bitcode file after LTO.
+; CHECK: wasm-ld: error: {{.*}}truncsfhf2.o): attempt to add bitcode file after LTO (__truncsfhf2)

--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -760,7 +760,7 @@ void ArchiveFile::addMember(const Archive::Symbol *sym) {
                 sym->getName());
 
   InputFile *obj = createObjectFile(mb, getName(), c.getChildOffset());
-  symtab->addFile(obj);
+  symtab->addFile(obj, sym->getName());
 }
 
 static uint8_t mapVisibility(GlobalValue::VisibilityTypes gvVisibility) {
@@ -826,9 +826,9 @@ BitcodeFile::BitcodeFile(MemoryBufferRef m, StringRef archiveName,
 
 bool BitcodeFile::doneLTO = false;
 
-void BitcodeFile::parse() {
+void BitcodeFile::parse(StringRef symName) {
   if (doneLTO) {
-    error(toString(this) + ": attempt to add bitcode file after LTO.");
+    error(toString(this) + ": attempt to add bitcode file after LTO (" + symName + ")");
     return;
   }
 

--- a/lld/wasm/InputFiles.h
+++ b/lld/wasm/InputFiles.h
@@ -176,7 +176,7 @@ public:
               uint64_t offsetInArchive);
   static bool classof(const InputFile *f) { return f->kind() == BitcodeKind; }
 
-  void parse();
+  void parse(StringRef symName);
   std::unique_ptr<llvm::lto::InputFile> obj;
 
   // Set to true once LTO is complete in order prevent further bitcode objects

--- a/lld/wasm/SymbolTable.cpp
+++ b/lld/wasm/SymbolTable.cpp
@@ -23,7 +23,7 @@ using namespace llvm::object;
 namespace lld::wasm {
 SymbolTable *symtab;
 
-void SymbolTable::addFile(InputFile *file) {
+void SymbolTable::addFile(InputFile *file, StringRef symName) {
   log("Processing: " + toString(file));
 
   // .a file
@@ -50,7 +50,7 @@ void SymbolTable::addFile(InputFile *file) {
 
   // LLVM bitcode file
   if (auto *f = dyn_cast<BitcodeFile>(file)) {
-    f->parse();
+    f->parse(symName);
     bitcodeFiles.push_back(f);
     return;
   }

--- a/lld/wasm/SymbolTable.h
+++ b/lld/wasm/SymbolTable.h
@@ -40,7 +40,7 @@ public:
 
   void wrap(Symbol *sym, Symbol *real, Symbol *wrap);
 
-  void addFile(InputFile *file);
+  void addFile(InputFile *file, StringRef symName = {});
 
   void compileBitcodeFiles();
 


### PR DESCRIPTION
We have been getting errors from emscripten users where including the name of the symbol that triggered the inclusion would be useful in the diagnosis. e.g:
https://github.com/emscripten-core/emscripten/issues/20275