### PR TITLE
Ignore out-of-bounds printf() format string in ASan test

### DIFF
--- a/compiler-rt/test/asan/TestCases/printf-5.c
+++ b/compiler-rt/test/asan/TestCases/printf-5.c
@@ -1,4 +1,4 @@
-// RUN: %clang_asan -O2 %s -o %t
+// RUN: %clang_asan -Wno-excess-initializers -O2 %s -o %t
 // We need replace_intrin=0 to avoid reporting errors in memcpy.
 // RUN: %env_asan_opts=replace_intrin=0:check_printf=1 not %run %t 2>&1 | FileCheck --check-prefix=CHECK-ON %s
 // RUN: %env_asan_opts=replace_intrin=0:check_printf=0 %run %t 2>&1 | FileCheck --check-prefix=CHECK-OFF %s


### PR DESCRIPTION
This warning needs to be disabled. The format string is deliberately too
large.
