### PR TITLE
[Clang] Fix a crash in the diagnostic emission of invalid immediate calls

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -297,6 +297,10 @@ Bug Fixes to C++ Support
   definition the specialization was instantiated from.
   (`#26057 <https://github.com/llvm/llvm-project/issues/26057>`_`)
 
+- Fix a crash when a default member initializer of a base aggregate
+  makes an invalid call to an immediate function.
+  (`#66324 <https://github.com/llvm/llvm-project/issues/66324>`_)
+
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed an import failure of recursive friend class template.

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2514,12 +2514,15 @@ void Sema::DiagnoseImmediateEscalatingReason(FunctionDecl *FD) {
         Range = CurrentInit->isWritten() ? CurrentInit->getSourceRange()
                                          : SourceRange();
       }
+
+      FieldDecl* InitializedField = CurrentInit ? CurrentInit->getAnyMember() : nullptr;
+
       SemaRef.Diag(Loc, diag::note_immediate_function_reason)
           << ImmediateFn << Fn << Fn->isConsteval() << IsCall
           << isa<CXXConstructorDecl>(Fn) << ImmediateFnIsConstructor
-          << (CurrentInit != nullptr)
+          << (InitializedField != nullptr)
           << (CurrentInit && !CurrentInit->isWritten())
-          << (CurrentInit ? CurrentInit->getAnyMember() : nullptr) << Range;
+          << InitializedField << Range;
     }
     bool TraverseCallExpr(CallExpr *E) {
       if (const auto *DR =

--- a/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
+++ b/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
@@ -330,3 +330,26 @@ struct S {
 S s(0); // expected-note {{in the default initializer of 'j'}}
 
 }
+
+namespace GH66324 {
+
+consteval int allocate();  // expected-note  2{{declared here}}
+
+struct _Vector_base {
+  int b =  allocate(); // expected-note 2{{undefined function 'allocate' cannot be used in a constant expression}} \
+  // expected-error {{call to consteval function 'GH66324::allocate' is not a constant expression}} \
+  // expected-note  {{declared here}}
+};
+
+template <typename>
+struct vector : _Vector_base {
+  constexpr vector()
+  // expected-note@-1 {{'vector' is an immediate constructor because its body contains a call to a consteval function 'allocate' and that call is not a constant expression}}
+  : _Vector_base{} {} // expected-note {{in the default initializer of 'b'}}
+};
+
+vector<void> v{};
+// expected-error@-1 {{call to immediate function 'GH66324::vector<void>::vector' is not a constant expression}}
+// expected-note@-2 {{in call to 'vector()'}}
+
+}


### PR DESCRIPTION
`CXXCtorInitializer` may not refer to a FieldDecl because it might also denote another constructor call.

Fixes #66324