### PR TITLE
[flang][Driver] Support -rpath, -shared, and -static in the frontend

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5253,7 +5253,8 @@ def resource_dir : Separate<["-"], "resource-dir">,
 def resource_dir_EQ : Joined<["-"], "resource-dir=">, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption]>,
   Alias<resource_dir>;
-def rpath : Separate<["-"], "rpath">, Flags<[LinkerInput]>, Group<Link_Group>;
+def rpath : Separate<["-"], "rpath">, Flags<[LinkerInput]>, Group<Link_Group>,
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
 def rtlib_EQ : Joined<["-", "--"], "rtlib=">, Visibility<[ClangOption, CLOption]>,
   HelpText<"Compiler runtime library to use">;
 def frtlib_add_rpath: Flag<["-"], "frtlib-add-rpath">, Flags<[NoArgumentUnused]>,
@@ -5304,7 +5305,8 @@ def segs__read__only__addr : Separate<["-"], "segs_read_only_addr">;
 def segs__read__write__addr : Separate<["-"], "segs_read_write_addr">;
 def segs__read__ : Joined<["-"], "segs_read_">;
 def shared_libgcc : Flag<["-"], "shared-libgcc">;
-def shared : Flag<["-", "--"], "shared">, Group<Link_Group>;
+def shared : Flag<["-", "--"], "shared">, Group<Link_Group>,
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
 def single__module : Flag<["-"], "single_module">;
 def specs_EQ : Joined<["-", "--"], "specs=">, Group<Link_Group>;
 def specs : Separate<["-", "--"], "specs">, Flags<[Unsupported]>;
@@ -5314,6 +5316,7 @@ def start_no_unused_arguments : Flag<["--"], "start-no-unused-arguments">,
 def static_libgcc : Flag<["-"], "static-libgcc">;
 def static_libstdcxx : Flag<["-"], "static-libstdc++">;
 def static : Flag<["-", "--"], "static">, Group<Link_Group>,
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   Flags<[NoArgumentUnused]>;
 def std_default_EQ : Joined<["-"], "std-default=">;
 def std_EQ : Joined<["-", "--"], "std=">,

--- a/flang/test/Driver/dynamic-linker.f90
+++ b/flang/test/Driver/dynamic-linker.f90
@@ -1,0 +1,20 @@
+! Verify that certain linker flags are known to the frontend and are passed on
+! to the linker.
+
+! RUN: %flang -### --target=x86_64-linux-gnu -rpath /path/to/dir -shared \
+! RUN:     -static %s 2>&1 | FileCheck \
+! RUN:     --check-prefixes=GNU-LINKER-OPTIONS %s
+! RUN: %flang -### --target=x86_64-windows-msvc -rpath /path/to/dir -shared \
+! RUN:     -static %s 2>&1 | FileCheck \
+! RUN:     --check-prefixes=MSVC-LINKER-OPTIONS %s
+
+! TODO: Could the linker have an extension or a suffix?
+! GNU-LINKER-OPTIONS: "{{.*}}ld{{(.exe)?}}"
+! GNU-LINKER-OPTIONS-SAME: "-shared"
+! GNU-LINKER-OPTIONS-SAME: "-static"
+! GNU-LINKER-OPTIONS-SAME: "-rpath" "/path/to/dir"
+
+! For MSVC, adding -static does not add any additional linker options.
+! MSVC-LINKER-OPTIONS: "{{.*}}link.exe"
+! MSVC-LINKER-OPTIONS-SAME: "-dll"
+! MSVC-LINKER-OPTIONS-SAME: "-rpath" "/path/to/dir"


### PR DESCRIPTION
Enable -rpath, -shared, and -static for the flang frontend. This brings it in line with clang. Fixes issue #65546.