### PR TITLE
[lldb][NFCI] Remove unneeded ConstString from intel-pt plugin

### DIFF
--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPT.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPT.cpp
@@ -48,8 +48,8 @@ enum {
 #include "TraceIntelPTPropertiesEnum.inc"
 };
 
-ConstString TraceIntelPT::PluginProperties::GetSettingName() {
-  return ConstString(TraceIntelPT::GetPluginNameStatic());
+llvm::StringRef TraceIntelPT::PluginProperties::GetSettingName() {
+  return TraceIntelPT::GetPluginNameStatic();
 }
 
 TraceIntelPT::PluginProperties::PluginProperties() : Properties() {

--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPT.h
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPT.h
@@ -26,7 +26,7 @@ public:
   /// Properties to be used with the `settings` command.
   class PluginProperties : public Properties {
   public:
-    static ConstString GetSettingName();
+    static llvm::StringRef GetSettingName();
 
     PluginProperties();
 


### PR DESCRIPTION
This is a follow-up to 14d95b26aee0ac0ac8a70252e8a3c7a986e0e812. I would have changed it in that commit, but I don't build the intel-pt plugin so I didn't see this until later.