### PR TITLE
[clang][dataflow] Fix two null pointer dereferences in `getMemberForAccessor()`.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -289,11 +289,14 @@ static void insertIfFunction(const Decl &D,
 }
 
 static MemberExpr *getMemberForAccessor(const CXXMemberCallExpr &C) {
+  if (!C.getMethodDecl())
+    return nullptr;
   auto *Body = dyn_cast_or_null<CompoundStmt>(C.getMethodDecl()->getBody());
   if (!Body || Body->size() != 1)
     return nullptr;
   if (auto *RS = dyn_cast<ReturnStmt>(*Body->body_begin()))
-    return dyn_cast<MemberExpr>(RS->getRetValue()->IgnoreParenImpCasts());
+    if (auto *Return = RS->getRetValue())
+      return dyn_cast<MemberExpr>(Return->IgnoreParenImpCasts());
   return nullptr;
 }
 

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -1463,6 +1463,7 @@ TEST(TransferTest, StructModeledFieldsWithAccessor) {
       int getIntNotAccessed() const { return IntNotAccessed; }
       int getIntNoDefinition() const;
       int &getIntRef() { return IntRef; }
+      void returnVoid() const { return; }
     };
 
     void target() {
@@ -1473,6 +1474,14 @@ TEST(TransferTest, StructModeledFieldsWithAccessor) {
       int i2 = s.getWithInc(1);
       int i3 = s.getIntNoDefinition();
       int &iref = s.getIntRef();
+
+      // Regression test: Don't crash on an indirect call (which doesn't have
+      // an associated `CXXMethodDecl`).
+      auto ptr_to_member_fn = &S::getPtr;
+      p1 = (s.*ptr_to_member_fn)();
+
+      // Regression test: Don't crash on a return statement without a value.
+      s.returnVoid();
       // [[p]]
     }
   )";


### PR DESCRIPTION
The additions to the test trigger crashes without the fixes.
