### PR TITLE
[flang][CMake] CYGWIN requires _GNU_SOURCE to be defined.

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -326,6 +326,14 @@ else ()
   add_compile_definitions(FLANG_LITTLE_ENDIAN=1)
 endif ()
 
+if (CYGWIN)
+  # On most UNIX like platforms g++ and clang++ define _GNU_SOURCE as a
+  # predefined macro, which turns on all of the wonderful libc extensions.
+  # However g++ doesn't do this in Cygwin so we have to define it ourselfs
+  # since we depend on GNU/POSIX/BSD extensions.
+  add_definitions(-D_GNU_SOURCE=1)
+endif()
+
 # Configure Flang's Version.inc file.
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/flang/Version.inc.in


### PR DESCRIPTION
Compiling flang on CYGWIN prints this error message on the console:

```
llvm-project/flang/include/flang/Parser/char-block.h: In member function ‘std::string Fortran::parser::CharBlock::NULTerminatedToString() const’: llvm-project/flang/include/flang/Parser/char-block.h:106:26: error: ‘strnlen’ was not declared in this scope; did you mean ‘strlen’?
  106 |         /*not in std::*/ strnlen(interval_.start(), interval_.size())};
      |                          ^~~~~~~
      |                          strlen
```

`strnlen()` exists into NEWLIB, but it requires to define `_GNU_SOURCE` macro somewhere for having its prototype available.
This patch adds this definition, by using the same code written here:

https://github.com/llvm/llvm-project/blob/53602e6193d98b1e814b76a27e99ef7e18c9769c/third-party/benchmark/CMakeLists.txt#L230