### PR TITLE
[mlir] avoid crash in transform.sequence verifier

### DIFF
--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -2188,6 +2188,9 @@ LogicalResult transform::SequenceOp::verify() {
     }
   }
 
+  if (!getBodyBlock()->hasTerminator())
+    return emitOpError() << "expects to have a terminator in the body";
+
   if (getBodyBlock()->getTerminator()->getOperandTypes() !=
       getOperation()->getResultTypes()) {
     InFlightDiagnostic diag = emitOpError()

--- a/mlir/test/Dialect/Transform/ops-invalid.mlir
+++ b/mlir/test/Dialect/Transform/ops-invalid.mlir
@@ -24,6 +24,16 @@ transform.sequence failures(propagate) {
 
 // -----
 
+// expected-error @below {{expects to have a terminator in the body}}
+"transform.sequence"() <{failure_propagation_mode = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
+^bb0(%arg0: !transform.any_op):
+  transform.apply_patterns to %arg0 {
+  } : !transform.any_op
+}) : () -> ()
+
+
+// -----
+
 // expected-error @below {{'transform.sequence' op expects trailing entry block arguments to be of type implementing TransformHandleTypeInterface, TransformValueHandleTypeInterface or TransformParamTypeInterface}}
 // expected-note @below {{argument #1 does not}}
 transform.sequence failures(propagate) {


### PR DESCRIPTION
The verifier was unconditionally accessing the body block terminator, but it's not guaranteed that the block has one in general.