### PR TITLE
[clang][dataflow] Reorder checks to protect against a null pointer dereference.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -531,17 +531,18 @@ public:
       auto *LocDst =
           cast_or_null<RecordStorageLocation>(Env.getStorageLocation(*Arg0));
 
+      if (LocSrc == nullptr || LocDst == nullptr)
+        return;
+
       // The assignment operators are different from the type of the destination
-      // in this model (i.e. in one of their base classes). This must be very rare
-      // and we just bail.
+      // in this model (i.e. in one of their base classes). This must be very
+      // rare and we just bail.
       if (Method->getThisObjectType().getCanonicalType().getUnqualifiedType() !=
           LocDst->getType().getCanonicalType().getUnqualifiedType())
         return;
 
-      if (LocSrc != nullptr && LocDst != nullptr) {
-        copyRecord(*LocSrc, *LocDst, Env);
-        Env.setStorageLocation(*S, *LocDst);
-      }
+      copyRecord(*LocSrc, *LocDst, Env);
+      Env.setStorageLocation(*S, *LocDst);
     }
   }
 


### PR DESCRIPTION
I've received a report of a null pointer dereference happening on the
`LocDst->getType()` dereference. I wasn't unfortunately able to find a repro,
but I'd argue the new version is better for the reduced indentation alone.
