### PR TITLE
[Dexter] Associate parser errors with correct file

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
@@ -1,0 +1,14 @@
+// Purpose:
+//      Check that Dexter command syntax errors associate with the line and file
+//      they appeared in rather than the current declared file.
+//
+// RUN: %dexter_regression_test_build %s -o %t
+// RUN: not %dexter_base test --binary %t --debugger 'lldb' -v -- %s \
+// RUN:     | FileCheck %s --implicit-check-not=FAIL-FILENAME-MATCH
+
+// CHECK: err_syntax_dexdeclarefile.cpp(14): Undeclared address: 'not_been_declared'
+
+int main() { return 0; }
+
+// DexDeclareFile('FAIL-FILENAME-MATCH')
+// DexExpectWatchValue('example', address('not_been_declared'))


### PR DESCRIPTION
Currently if Dexter encounters a parser error with a command, the resulting error message will refer to the most recently declared file (i.e. the source file it is testing) rather than the file containing the command itself. This patch fixes this so that parser errors point towards the correct location.