### PR TITLE
[BOLT] Err when linking objects of different architectures

### DIFF
--- a/bolt/lib/Rewrite/JITLinkLinker.cpp
+++ b/bolt/lib/Rewrite/JITLinkLinker.cpp
@@ -179,6 +179,13 @@ void JITLinkLinker::loadObject(MemoryBufferRef Obj,
     exit(1);
   }
 
+  if ((*LG)->getTargetTriple().getArch() != BC.TheTriple->getArch()) {
+    errs() << "BOLT-ERROR: linking object withg arch "
+           << (*LG)->getTargetTriple().getArchName()
+           << " into context with arch " << BC.TheTriple->getArchName() << "\n";
+    exit(1);
+  }
+
   auto Ctx = std::make_unique<Context>(*this, MapSections);
   jitlink::link(std::move(*LG), std::move(Ctx));
 }

--- a/bolt/lib/Rewrite/JITLinkLinker.cpp
+++ b/bolt/lib/Rewrite/JITLinkLinker.cpp
@@ -180,7 +180,7 @@ void JITLinkLinker::loadObject(MemoryBufferRef Obj,
   }
 
   if ((*LG)->getTargetTriple().getArch() != BC.TheTriple->getArch()) {
-    errs() << "BOLT-ERROR: linking object withg arch "
+    errs() << "BOLT-ERROR: linking object with arch "
            << (*LG)->getTargetTriple().getArchName()
            << " into context with arch " << BC.TheTriple->getArchName() << "\n";
     exit(1);

--- a/bolt/test/runtime/instrument-wrong-target.s
+++ b/bolt/test/runtime/instrument-wrong-target.s
@@ -1,0 +1,26 @@
+# Test that BOLT errs when trying to instrument a binary with a different
+# architecture than the one BOLT is built for.
+
+# REQUIRES: x86_64-linux,bolt-runtime,target=x86_64{{.*}}
+
+# RUN: llvm-mc -triple aarch64 -filetype=obj %s -o %t.o
+# RUN: ld.lld -q -pie -o %t.exe %t.o
+# RUN: not llvm-bolt --instrument -o %t.out %t.exe 2>&1 | FileCheck %s
+
+# CHECK: BOLT-ERROR: linking object with arch x86_64 into context with arch aarch64
+
+    .text
+    .globl _start
+    .type _start, %function
+_start:
+    # BOLT errs when instrumenting without relocations; create a dummy one.
+    .reloc 0, R_AARCH64_NONE
+    ret
+    .size _start, .-_start
+
+    .globl _fini
+    .type _fini, %function
+    # Force DT_FINI to be created (needed for instrumentation).
+_fini:
+    ret
+    .size _fini, .-_fini


### PR DESCRIPTION
This could happen, for example, when instrumenting an AArch64 binary on an x86 host because the instrumentation library is always built for the host.

Note that this check will probably need to be refined in the future as merely having the same architecture does not guarantee objects can be linked. For example, on RISC-V, the float ABI of all objects should match.