### PR TITLE
[AMDGPU] Run twoaddr tests with -early-live-intervals

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/gfx10-twoaddr-fma.mir
+++ b/llvm/test/CodeGen/AMDGPU/gfx10-twoaddr-fma.mir
@@ -1,4 +1,5 @@
 # RUN: llc -march=amdgcn -mcpu=gfx1010 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - | FileCheck --check-prefixes=GFX10 %s
+# RUN: llc -march=amdgcn -mcpu=gfx1010 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - -early-live-intervals | FileCheck --check-prefixes=GFX10 %s
 
 # GFX10-LABEL: name: test_fmamk_reg_imm_f16
 # GFX10: %2:vgpr_32 = IMPLICIT_DEF
@@ -43,7 +44,7 @@ body:             |
 ...
 
 # GFX10-LABEL: name: test_fmaak_f16
-# GFX10: %1:vgpr_32 = IMPLICIT_DEF
+# GFX10: %1:vgpr_32 = V_MOV_B32_e32 1078523331, implicit $exec
 # GFX10-NOT: V_MOV_B32
 # GFX10: V_FMAAK_F16 killed %0.sub0, %0.sub1, 1078523331, implicit $mode, implicit $exec
 ---
@@ -58,10 +59,11 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = V_MOV_B32_e32 1078523331, implicit $exec
     %2 = V_FMAC_F16_e32 killed %0.sub0, %0.sub1, %1, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %1
 ...
 
 # GFX10-LABEL: name: test_fmaak_inline_literal_f16
-# GFX10: %1:vgpr_32 = IMPLICIT_DEF
+# GFX10: %1:vgpr_32 = V_MOV_B32_e32 49664, implicit $exec
 # GFX10-NOT: V_MOV_B32
 # GFX10: %2:vgpr_32 = V_FMAAK_F16 16384, killed %0, 49664, implicit $mode, implicit $exec
 
@@ -78,7 +80,5 @@ body:             |
 
     %1:vgpr_32 = V_MOV_B32_e32 49664, implicit $exec
     %2:vgpr_32 = V_FMAC_F16_e32 16384, killed %0, %1, implicit $mode, implicit $exec
-    S_ENDPGM 0
-
+    S_ENDPGM 0, implicit %1
 ...
-

--- a/llvm/test/CodeGen/AMDGPU/twoaddr-fma-f64.mir
+++ b/llvm/test/CodeGen/AMDGPU/twoaddr-fma-f64.mir
@@ -1,4 +1,5 @@
 # RUN: llc -march=amdgcn -mcpu=gfx90a %s -run-pass twoaddressinstruction -verify-machineinstrs -o - | FileCheck -check-prefix=GCN %s
+# RUN: llc -march=amdgcn -mcpu=gfx90a %s -run-pass twoaddressinstruction -verify-machineinstrs -o - -early-live-intervals | FileCheck -check-prefix=GCN %s
 
 # GCN-LABEL: name: test_fmamk_reg_imm_f64
 # GCN: V_FMA_F64_e64 0, killed %0, 0, %2, 0, killed %1, 0, 0, implicit $mode, implicit $exec
@@ -52,7 +53,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = V_MOV_B64_PSEUDO 4607182418800017408, implicit $exec
     %2 = V_FMAC_F64_e32 killed %0.sub0_sub1, %0.sub2_sub3, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 
 # GCN-LABEL: name: test_fmaak_sgpr_src0_f64
@@ -72,7 +73,7 @@ body:             |
     %1 = V_MOV_B64_PSEUDO 4607182418800017408, implicit $exec
     %2 = IMPLICIT_DEF
     %3 = V_FMAC_F64_e32 killed %0, %1, %2, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %2
 ...
 
 # GCN-LABEL: name: test_fmaak_inlineimm_src0_f64
@@ -90,7 +91,7 @@ body:             |
     %0 = V_MOV_B64_PSEUDO 4607182418800017408, implicit $exec
     %1 = IMPLICIT_DEF
     %2 = V_FMAC_F64_e32 4611686018427387904, %0, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 
 # GCN-LABEL: name: test_fmaak_otherimm_src0_f64
@@ -186,5 +187,5 @@ body:             |
     %1 = COPY %0
     %2 = V_MOV_B64_PSEUDO 123456, implicit $exec
     %3 = V_FMAC_F64_e32 killed %0, killed %1, %2, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %2
 ...

--- a/llvm/test/CodeGen/AMDGPU/twoaddr-fma.mir
+++ b/llvm/test/CodeGen/AMDGPU/twoaddr-fma.mir
@@ -1,5 +1,7 @@
 # RUN: llc -march=amdgcn -mcpu=gfx1010 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - | FileCheck --check-prefixes=GCN %s
+# RUN: llc -march=amdgcn -mcpu=gfx1010 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - -early-live-intervals | FileCheck --check-prefixes=GCN %s
 # RUN: llc -march=amdgcn -mcpu=gfx1100 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - | FileCheck --check-prefixes=GCN %s
+# RUN: llc -march=amdgcn -mcpu=gfx1100 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - -early-live-intervals | FileCheck --check-prefixes=GCN %s
 
 # GCN-LABEL: name: test_fmamk_reg_imm_f32
 # GCN: %2:vgpr_32 = IMPLICIT_DEF
@@ -44,7 +46,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_fmaak_f32
-# GCN: %1:vgpr_32 = IMPLICIT_DEF
+# GCN: %1:vgpr_32 = V_MOV_B32_e32 1078523331, implicit $exec
 # GCN-NOT: V_MOV_B32
 # GCN: V_FMAAK_F32 killed %0.sub0, %0.sub1, 1078523331, implicit $mode, implicit $exec
 ---
@@ -59,7 +61,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = V_MOV_B32_e32 1078523331, implicit $exec
     %2 = V_FMAC_F32_e32 killed %0.sub0, %0.sub1, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 
 
@@ -82,7 +84,7 @@ body:             |
     %1 = V_MOV_B32_e32 1078523331, implicit $exec
     %2 = IMPLICIT_DEF
     %3 = V_FMAC_F32_e32 killed %0, %1, %2, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %2
 ...
 
 # GCN-LABEL: name: test_fmaak_inlineimm_src0_f32
@@ -102,7 +104,7 @@ body:             |
     %0 = V_MOV_B32_e32 1078523331, implicit $exec
     %1 = IMPLICIT_DEF
     %2 = V_FMAC_F32_e32 1073741824, %0, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 
 # GCN-LABEL: name: test_fmaak_otherimm_src0_f32
@@ -120,7 +122,7 @@ body:             |
     %0 = V_MOV_B32_e32 1078523331, implicit $exec
     %1 = IMPLICIT_DEF
     %2 = V_FMAC_F32_e32 1120403456, %0, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 
 # GCN-LABEL: name: test_fmaak_other_constantlike_src0_f32
@@ -204,6 +206,7 @@ body: |
     %1:vgpr_32 = IMPLICIT_DEF
     %2:vgpr_32 = IMPLICIT_DEF
     %3:vgpr_32 = V_FMAC_F32_e64 1, %0, 0, %1, 0, %2, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %2
 ...
 
 # GCN-LABEL: name: test_fma_src1mods
@@ -216,6 +219,7 @@ body: |
     %1:vgpr_32 = IMPLICIT_DEF
     %2:vgpr_32 = IMPLICIT_DEF
     %3:vgpr_32 = V_FMAC_F32_e64 0, %0, 1, %1, 0, %2, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %2
 ...
 
 # GCN-LABEL: name: test_fma_src2mods
@@ -228,4 +232,5 @@ body: |
     %1:vgpr_32 = IMPLICIT_DEF
     %2:vgpr_32 = IMPLICIT_DEF
     %3:vgpr_32 = V_FMAC_F32_e64 0, %0, 0, %1, 1, %2, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %2
 ...

--- a/llvm/test/CodeGen/AMDGPU/twoaddr-mad.mir
+++ b/llvm/test/CodeGen/AMDGPU/twoaddr-mad.mir
@@ -1,4 +1,5 @@
 # RUN: llc -march=amdgcn -mcpu=gfx900 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - | FileCheck -check-prefix=GCN %s
+# RUN: llc -march=amdgcn -mcpu=gfx900 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - -early-live-intervals | FileCheck -check-prefix=GCN %s
 
 # GCN-LABEL: name: test_madmk_reg_imm_f32
 # GCN: V_MADMK_F32 killed %0.sub0, 1078523331, killed %1, implicit $mode, implicit $exec
@@ -52,7 +53,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = V_MOV_B32_e32 1078523331, implicit $exec
     %2 = V_MAC_F32_e32 killed %0.sub0, %0.sub1, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 
 # GCN-LABEL: name: test_madmk_reg_imm_f16
@@ -107,6 +108,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = V_MOV_B32_e32 1078523331, implicit $exec
     %2 = V_MAC_F16_e32 killed %0.sub0, %0.sub1, %1, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %1
 ...
 
 # Make sure constant bus restriction isn't violated if src0 is an SGPR.
@@ -129,7 +131,7 @@ body:             |
     %1 = V_MOV_B32_e32 1078523331, implicit $exec
     %2 = IMPLICIT_DEF
     %3 = V_MAC_F32_e32 killed %0, %1, %2, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %2
 ...
 
 # This can still fold if this is an inline immediate.
@@ -149,7 +151,7 @@ body:             |
     %0 = V_MOV_B32_e32 1078523331, implicit $exec
     %1 = IMPLICIT_DEF
     %2 = V_MAC_F32_e32 1073741824, %0, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 # Non-inline immediate uses constant bus already.
 
@@ -168,7 +170,7 @@ body:             |
     %0 = V_MOV_B32_e32 1078523331, implicit $exec
     %1 = IMPLICIT_DEF
     %2 = V_MAC_F32_e32 1120403456, %0, %1, implicit $mode, implicit $exec
-
+    S_ENDPGM 0, implicit %1
 ...
 # Non-inline immediate uses constant bus already.
 
@@ -204,8 +206,7 @@ body:             |
 
     %26:vgpr_32 = V_MOV_B32_e32 49664, implicit $exec
     %28:vgpr_32 = V_MAC_F16_e32 16384, killed %3, %26, implicit $mode, implicit $exec
-    S_ENDPGM 0
-
+    S_ENDPGM 0, implicit %26
 ...
 
 # GCN-LABEL: name: test_mad_src0mods
@@ -218,6 +219,7 @@ body: |
     %1:vgpr_32 = IMPLICIT_DEF
     %2:vgpr_32 = IMPLICIT_DEF
     %3:vgpr_32 = V_MAC_F32_e64 1, %0, 0, %1, 0, %2, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %2
 ...
 
 # GCN-LABEL: name: test_mad_src1mods
@@ -230,6 +232,7 @@ body: |
     %1:vgpr_32 = IMPLICIT_DEF
     %2:vgpr_32 = IMPLICIT_DEF
     %3:vgpr_32 = V_MAC_F32_e64 0, %0, 1, %1, 0, %2, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %2
 ...
 
 # GCN-LABEL: name: test_mad_src2mods
@@ -242,4 +245,5 @@ body: |
     %1:vgpr_32 = IMPLICIT_DEF
     %2:vgpr_32 = IMPLICIT_DEF
     %3:vgpr_32 = V_MAC_F32_e64 0, %0, 0, %1, 1, %2, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %2
 ...

--- a/llvm/test/CodeGen/AMDGPU/twoaddr-wmma.mir
+++ b/llvm/test/CodeGen/AMDGPU/twoaddr-wmma.mir
@@ -1,4 +1,5 @@
 # RUN: llc -march=amdgcn -mcpu=gfx1100 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - | FileCheck -check-prefix=GCN %s
+# RUN: llc -march=amdgcn -mcpu=gfx1100 %s -run-pass twoaddressinstruction -verify-machineinstrs -o - -early-live-intervals | FileCheck -check-prefix=GCN %s
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_f16_twoaddr_w32
 # GCN: early-clobber %2:vreg_256 = V_WMMA_F32_16X16X16_F16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec
@@ -15,7 +16,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_256 = V_WMMA_F32_16X16X16_F16_twoaddr_w32 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_256, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_bf16_twoaddr_w32
@@ -33,7 +34,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_256 = V_WMMA_F32_16X16X16_BF16_twoaddr_w32 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_256, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_f16_16x16x16_f16_twoaddr_w32
@@ -51,7 +52,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_256 = V_WMMA_F16_16X16X16_F16_twoaddr_w32 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_256, 0, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_bf16_16x16x16_bf16_twoaddr_w32
@@ -69,7 +70,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_256 = V_WMMA_BF16_16X16X16_BF16_twoaddr_w32 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_256, 0, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu8_twoaddr_w32
@@ -87,7 +88,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_256 = V_WMMA_I32_16X16X16_IU8_twoaddr_w32 8, killed %1:vreg_128, 8, killed %1:vreg_128, 8, %0:vreg_256, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu4_twoaddr_w32
@@ -105,7 +106,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_256 = V_WMMA_I32_16X16X16_IU4_twoaddr_w32 8, killed %1:vreg_64, 8, killed %1:vreg_64, 8, %0:vreg_256, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_f16_twoaddr_w64
@@ -123,7 +124,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_128 = V_WMMA_F32_16X16X16_F16_twoaddr_w64 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_128, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_bf16_twoaddr_w64
@@ -141,7 +142,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_128 = V_WMMA_F32_16X16X16_BF16_twoaddr_w64 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_128, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_f16_16x16x16_f16_twoaddr_w64
@@ -159,7 +160,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_128 = V_WMMA_F16_16X16X16_F16_twoaddr_w64 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_128, 0, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_bf16_16x16x16_bf16_twoaddr_w64
@@ -177,7 +178,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_128 = V_WMMA_BF16_16X16X16_BF16_twoaddr_w64 8, killed %1:vreg_256, 8, killed %1:vreg_256, 8, %0:vreg_128, 0, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu8_twoaddr_w64
@@ -195,7 +196,7 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_128 = V_WMMA_I32_16X16X16_IU8_twoaddr_w64 8, killed %1:vreg_128, 8, killed %1:vreg_128, 8, %0:vreg_128, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu4_twoaddr_w64
@@ -213,5 +214,5 @@ body:             |
     %0 = IMPLICIT_DEF
     %1 = IMPLICIT_DEF
     early-clobber %2:vreg_128 = V_WMMA_I32_16X16X16_IU4_twoaddr_w64 8, killed %1:vreg_64, 8, killed %1:vreg_64, 8, %0:vreg_128, 0, 0, 0, implicit $exec
-
+    S_ENDPGM 0, implicit %0
 ...


### PR DESCRIPTION
Sample test case:

    %3 = V_FMAC_F32_e32 killed %0, %1, %2, implicit $mode, implicit $exec

With LiveVariables this is converted to three-address form just because
there is no "killed" flag on %2. To make it do the same thing with
LiveIntervals I added a later use of %2:

    %3 = V_FMAC_F32_e32 killed %0, %1, %2, implicit $mode, implicit $exec
    S_ENDPGM 0, implicit %2
