### PR TITLE
[flang] Prevent IR name clashes between BIND(C) and external procedures

### DIFF
--- a/flang/include/flang/Common/Fortran.h
+++ b/flang/include/flang/Common/Fortran.h
@@ -114,5 +114,12 @@ bool AreCompatibleCUDADataAttrs(
 
 static constexpr char blankCommonObjectName[] = "__BLNK__";
 
+// Get the assembly name for a non BIND(C) external symbol other than the blank
+// common block.
+inline std::string GetExternalAssemblyName(
+    std::string symbolName, bool underscoring) {
+  return underscoring ? std::move(symbolName) + "_" : std::move(symbolName);
+}
+
 } // namespace Fortran::common
 #endif // FORTRAN_COMMON_FORTRAN_H_

--- a/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/ExternalNameConversion.cpp
@@ -38,11 +38,8 @@ mangleExternalName(const std::pair<fir::NameUniquer::NameKind,
   if (result.first == fir::NameUniquer::NameKind::COMMON &&
       result.second.name.empty())
     return Fortran::common::blankCommonObjectName;
-
-  if (appendUnderscore)
-    return result.second.name + "_";
-
-  return result.second.name;
+  return Fortran::common::GetExternalAssemblyName(result.second.name,
+                                                  appendUnderscore);
 }
 
 /// Update the early outlining parent name

--- a/flang/test/Semantics/bind-c14.f90
+++ b/flang/test/Semantics/bind-c14.f90
@@ -1,0 +1,9 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -funderscoring
+
+subroutine conflict()
+end subroutine
+
+!ERROR: BIND(C) procedure assembly name conflicts with non BIND(C) procedure assembly name
+subroutine foo(x)  bind(c, name="conflict_")
+  real :: x
+end subroutine

--- a/flang/test/Semantics/bind-c14.f90
+++ b/flang/test/Semantics/bind-c14.f90
@@ -1,9 +1,35 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1 -funderscoring
 
-subroutine conflict()
+subroutine conflict1()
 end subroutine
 
 !ERROR: BIND(C) procedure assembly name conflicts with non BIND(C) procedure assembly name
-subroutine foo(x)  bind(c, name="conflict_")
+subroutine foo(x)  bind(c, name="conflict1_")
   real :: x
+end subroutine
+
+subroutine no_conflict1() bind(c, name="")
+end subroutine
+subroutine foo2() bind(c, name="conflict2_")
+end subroutine
+
+subroutine bar()
+  interface
+    subroutine no_conflict1() bind(c, name="")
+    end subroutine
+    ! ERROR: Non BIND(C) procedure assembly name conflicts with BIND(C) procedure assembly name
+    subroutine conflict2()
+    end subroutine
+  end interface
+  call no_conflict1()
+  call conflict2
+end subroutine
+
+subroutine no_conflict2() bind(c, name="no_conflict2_")
+end subroutine
+
+subroutine _()
+end subroutine
+
+subroutine dash_no_conflict() bind(c, name="")
 end subroutine


### PR DESCRIPTION
Defining a procedure with a BIND(C, NAME="...") where the binding label matches the assembly name of a non BIND(C) external procedure in the same file causes a failure when generating the LLVM IR because of the assembly symbol name clash.

Prevent this crash with a clearer semantic error.