### PR TITLE
[llvm][CMake] Expand error message shown when -fuse-ld= test fails

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -327,7 +327,10 @@ if( LLVM_USE_LINKER )
     CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
   check_cxx_source_compiles("int main() { return 0; }" CXX_SUPPORTS_CUSTOM_LINKER)
   if ( NOT CXX_SUPPORTS_CUSTOM_LINKER )
-    message(FATAL_ERROR "Host compiler does not support '-fuse-ld=${LLVM_USE_LINKER}'")
+    message(FATAL_ERROR "Host compiler does not support '-fuse-ld=${LLVM_USE_LINKER}'. "
+                        "Please make sure that '${LLVM_USE_LINKER}' is installed and "
+                        "that your host compiler can compile a simple program when "
+                        "given the option '-fuse-ld=${LLVM_USE_LINKER}'.")
   endif()
 endif()
 


### PR DESCRIPTION
This is one of the most common issues new users face, especially as so many reccomended CMake configurations include `-DLLVM_ENABLE_LLD=ON`.

I don't want the error message to get too long but let's at least say that there are 2 main reasons for the failure. If it's not those then maybe folks will find the actual problem while trying to discount them.

The new message looks like:
```
CMake Error at cmake/modules/HandleLLVMOptions.cmake:330 (message):
  Host compiler does not support '-fuse-ld=not_a_linker'.  Please make sure
  that 'not_a_linker' is installed and that your host compiler can compile a
  simple program when given the option '-fuse-ld=not_a_linker'.
Call Stack (most recent call first):
  CMakeLists.txt:910 (include)
```