### PR TITLE
[libc++] Fix __threading_support when used with C11 threading

### DIFF
--- a/libcxx/include/__threading_support
+++ b/libcxx/include/__threading_support
@@ -102,7 +102,7 @@ typedef cnd_t __libcpp_condvar_t;
 #define _LIBCPP_CONDVAR_INITIALIZER {}
 
 // Execute once
-typedef once_flag __libcpp_exec_once_flag;
+typedef ::once_flag __libcpp_exec_once_flag;
 #define _LIBCPP_EXEC_ONCE_INITIALIZER ONCE_FLAG_INIT
 
 // Thread id


### PR DESCRIPTION
Since we are defining these typedefs inside namespace std, we need to refer to ::once_flag (the C Standard Library version). Otherwise 'once_flag' refers to 'std::once_flag', and that's not something we can pass to the C Standard Library '::call_once()' function later on.