### PR TITLE
[github] Make branch workflow more robust

### DIFF
--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -70,7 +70,7 @@ jobs:
     if: >-
       (github.repository == 'llvm/llvm-project') &&
       !startswith(github.event.comment.body, '<!--IGNORE-->') &&
-      contains(github.event.comment.body, '/branch')
+      contains(github.event.comment.body, '/branch ')
 
     steps:
       - name: Fetch LLVM sources


### PR DESCRIPTION
Avoid false positives by requiring space after `/branch` command so the action won't trigger on diffs that include filenames like `.../BranchProbabilityInfo.cpp`.