### PR TITLE
[Hexagon][test] Fix more tests on linux-musl

### DIFF
--- a/llvm/test/CodeGen/Hexagon/swp-memrefs-epilog.ll
+++ b/llvm/test/CodeGen/Hexagon/swp-memrefs-epilog.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=hexagon -O2 -fp-contract=fast < %s -pipeliner-experimental-cg=true | FileCheck %s
+; RUN: llc -mtriple=hexagon -O2 -fp-contract=fast < %s -pipeliner-experimental-cg=true | FileCheck %s
 
 ; Test that the memoperands for instructions in the epilog are updated
 ; correctly. Previously, the pipeliner updated the offset for the memoperands

--- a/llvm/test/CodeGen/Hexagon/vararg-formal.ll
+++ b/llvm/test/CodeGen/Hexagon/vararg-formal.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=hexagon < %s | FileCheck %s
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
 
 ; Make sure that the first formal argument is not loaded from memory.
 ; CHECK-NOT: memw


### PR DESCRIPTION
-march=hexagon uses the default target triple and changes the arch part of hexagon. On linux-musl, this essentially becomes hexagon-unknown-linux-musl which has different code generation. Use -mtriple instead.

Link: https://github.com/llvm/llvm-project/commit/944110353b970fc99de3f012292b4c29d4d91999
Link: https://github.com/llvm/llvm-project/issues/48936