### PR TITLE
workflows/release-tasks: Setup FileCheck and not for release-lit

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -81,13 +81,24 @@ jobs:
       - name: Checkout LLVM
         uses: actions/checkout@v4
 
+      - name: Setup Cpp
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: llvm-16.0.6
+          cmake: true
+          ninja: true
+
       - name: Install dependencies
-        run: sudo apt-get install -y python3-setuptools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-setuptools python3-psutil
 
       - name: Test lit
         run: |
-          cd llvm/utils/lit
-          python3 lit.py tests
+          mkdir build && cd build
+          export FILECHECK_OPTS='-dump-input-filter=all -vv -color'
+          cmake ../llvm -DCMAKE_BUILD_TYPE=Release -G Ninja
+          ninja -v -j $(nproc) check-lit
 
       - name: Package lit
         run: |


### PR DESCRIPTION
lit tests require commands FileCheck and not. They must be available in the PATH.

This also guarantees that python3-psutil is installed in order to enable more tests.

Fixes #64892.