### PR TITLE
[libc++] Re-enable the clang_modules_include test for Objective-C++

### DIFF
--- a/libcxx/test/libcxx/clang_modules_include.gen.py
+++ b/libcxx/test/libcxx/clang_modules_include.gen.py
@@ -47,11 +47,8 @@ for header in public_headers:
 #include <{header}>
 """)
 
-# TODO: Remove the UNSUPPORTED{BLOCKLIT}: clang-modules-build once issues with this test have been figured out.
 print(f"""\
 //--- __std_clang_module.compile.pass.mm
-// UNSUPPORTED{BLOCKLIT}: clang-modules-build
-
 // RUN{BLOCKLIT}: %{{cxx}} %s %{{flags}} %{{compile_flags}} -fmodules -fcxx-modules -fmodules-cache-path=%t -fsyntax-only
 
 // REQUIRES{BLOCKLIT}: clang-modules-build


### PR DESCRIPTION
This reverts commit aa60b2687, which was a temporary workaround.
The underlying issue was fixed in Clang via c2c840bd92cf.

This was originally https://reviews.llvm.org/D158694.