### PR TITLE
[LiveRange] Verify Other LiveRange in Join API

### DIFF
--- a/llvm/lib/CodeGen/LiveInterval.cpp
+++ b/llvm/lib/CodeGen/LiveInterval.cpp
@@ -629,6 +629,7 @@ void LiveRange::join(LiveRange &Other,
                      const int *RHSValNoAssignments,
                      SmallVectorImpl<VNInfo *> &NewVNInfo) {
   verify();
+  Other.verify();
 
   // Determine if any of our values are mapped.  This is uncommon, so we want
   // to avoid the range scan if not.


### PR DESCRIPTION
The LiveRange::join API takes in two live ranges. We should verify the
LiveRange passed in to the Join API as well.
