### PR TITLE
[clang-tidy] Add recursion protection in ExceptionSpecAnalyzer

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor.cpp
@@ -1,4 +1,6 @@
 // RUN: %check_clang_tidy %s performance-noexcept-move-constructor %t -- -- -fexceptions
+// RUN: %check_clang_tidy -std=c++17 -check-suffixes=,ERR %s performance-noexcept-move-constructor %t \
+// RUN:                   -- --fix-errors -- -fexceptions -DENABLE_ERROR
 
 namespace std
 {
@@ -397,3 +399,18 @@ namespace gh68101
       Container(Container&&) noexcept(std::is_nothrow_move_constructible<T>::value);
   };
 } // namespace gh68101
+
+namespace gh111436
+{
+
+template <typename value_type> class set {
+  set(set &&) = default;
+
+#ifdef ENABLE_ERROR
+  set(initializer_list<value_type> __l) {};
+  // CHECK-MESSAGES-ERR: :[[@LINE-1]]:7: error: member 'initializer_list' cannot have template arguments [clang-diagnostic-error]
+  // CHECK-MESSAGES-ERR: :[[@LINE-2]]:36: error: expected ')' [clang-diagnostic-error]
+#endif
+};
+
+} // namespace gh111436


### PR DESCRIPTION
Normally endless recursion should not happen in ExceptionSpecAnalyzer, but if AST would be malformed (missing include), this could cause crash.

I run into this issue when due to missing include constructor argument were parsed as FieldDecl.
As checking for recursion cost nothing, why not to do this in check just in case.

Fixes #111436