### PR TITLE
[AsmPrint] Dump raw frequencies in `-mbb-profile-dump`

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1940,7 +1940,7 @@ void AsmPrinter::emitFunctionBody() {
     for (const auto &MBB : *MF) {
       *MBBProfileDumpFileOutput.get()
           << MF->getName() << "," << MBB.getBBID() << ","
-          << MBFI.getBlockFreqRelativeToEntryBlock(&MBB) << "\n";
+          << MBFI.getBlockFreq(&MBB).getFrequency() << "\n";
     }
   }
 }

--- a/llvm/test/CodeGen/MLRegAlloc/bb-profile-dump.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/bb-profile-dump.ll
@@ -22,10 +22,10 @@ ifNotEqual:
     ret i64 %sum
 }
 
-; CHECK: f2,0,1.000000e+00
-; CHECK-NEXT: f1,0,1.000000e+00
-; CHECK-NEXT: f1,1,5.000000e-01
-; CHECK-NEXT: f1,2,1.000000e+00
+; CHECK: f2,0,8
+; CHECK-NEXT: f1,0,16
+; CHECK-NEXT: f1,1,8
+; CHECK-NEXT: f1,2,16
 
 ; Check that if we pass -mbb-profile-dump but don't set -basic-block-sections,
 ; we get an appropriate error message

--- a/llvm/test/CodeGen/MLRegAlloc/bb-profile-dump.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/bb-profile-dump.ll
@@ -12,6 +12,8 @@ define i64 @f2(i64 %a, i64 %b) {
     ret i64 %sum
 }
 
+; CHECK: f2,0,8
+
 define i64 @f1() {
     %sum = call i64 @f2(i64 2, i64 2)
     %isEqual = icmp eq i64 %sum, 4
@@ -22,7 +24,6 @@ ifNotEqual:
     ret i64 %sum
 }
 
-; CHECK: f2,0,8
 ; CHECK-NEXT: f1,0,16
 ; CHECK-NEXT: f1,1,8
 ; CHECK-NEXT: f1,2,16


### PR DESCRIPTION
We were losing the function entry count, which is useful to check
profile quality. For the original cases where we want
entrypoint-relative MBB frequencies, the user would just need to divide
these values by the entrypoint (first MBB, with ID=0) value.