### PR TITLE
[mlir][spirv] Suffix NV cooperative matrix props with `_nv`

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVAttributes.td
@@ -58,7 +58,7 @@ def SPIRV_LinkageAttributesAttr : SPIRV_Attr<"LinkageAttributes", "linkage_attri
 // target. Represents `VkCooperativeMatrixPropertiesNV`. See
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCooperativeMatrixPropertiesNV.html
 def SPIRV_CooperativeMatrixPropertiesNVAttr :
-    SPIRV_Attr<"CooperativeMatrixPropertiesNV", "coop_matrix_props"> {
+    SPIRV_Attr<"CooperativeMatrixPropertiesNV", "coop_matrix_props_nv"> {
   let parameters = (ins
     "int":$m_size,
     "int":$n_size,

--- a/mlir/test/Dialect/SPIRV/IR/target-and-abi.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/target-and-abi.mlir
@@ -208,14 +208,14 @@ func.func @target_env_extra_fields() attributes {
 
 // -----
 
-func.func @target_env_cooperative_matrix() attributes{
+func.func @target_env_cooperative_matrix_nv() attributes{
   // CHECK:      spirv.target_env = #spirv.target_env<
   // CHECK-SAME:   SPV_NV_cooperative_matrix
-  // CHECK-SAME: #spirv.coop_matrix_props<
+  // CHECK-SAME: #spirv.coop_matrix_props_nv<
   // CHECK-SAME:   m_size = 8, n_size = 8, k_size = 32,
   // CHECK-SAME:   a_type = i8, b_type = i8, c_type = i32,
   // CHECK-SAME:   result_type = i32, scope = <Subgroup>>
-  // CHECK-SAME: #spirv.coop_matrix_props<
+  // CHECK-SAME: #spirv.coop_matrix_props_nv<
   // CHECK-SAME:   m_size = 8, n_size = 8, k_size = 16,
   // CHECK-SAME:   a_type = f16, b_type = f16, c_type = f16,
   // CHECK-SAME:   result_type = f16, scope = <Subgroup>>
@@ -223,7 +223,7 @@ func.func @target_env_cooperative_matrix() attributes{
   #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class,
                             SPV_NV_cooperative_matrix]>,
   #spirv.resource_limits<
-    cooperative_matrix_properties_nv = [#spirv.coop_matrix_props<
+    cooperative_matrix_properties_nv = [#spirv.coop_matrix_props_nv<
       m_size = 8,
       n_size = 8,
       k_size = 32,
@@ -232,7 +232,7 @@ func.func @target_env_cooperative_matrix() attributes{
       c_type = i32,
       result_type = i32,
       scope = #spirv.scope<Subgroup>
-    >, #spirv.coop_matrix_props<
+    >, #spirv.coop_matrix_props_nv<
       m_size = 8,
       n_size = 8,
       k_size = 16,


### PR DESCRIPTION
This is in preparation for adding a KHR variant which does not share the same parameters and needs a separate attribute.