### PR TITLE
[libc++] Bump the C++ Standard used to compile the dylib to C++23

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -504,10 +504,10 @@ remove_flags(-Wno-pedantic -pedantic-errors -pedantic)
 # Required flags ==============================================================
 function(cxx_add_basic_build_flags target)
 
-  # Require C++23 for all targets.
+  # Use C++23 for all targets.
   set_target_properties(${target} PROPERTIES
     CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED YES
+    CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS NO)
 
   # When building the dylib, don't warn for unavailable aligned allocation

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -504,10 +504,9 @@ remove_flags(-Wno-pedantic -pedantic-errors -pedantic)
 # Required flags ==============================================================
 function(cxx_add_basic_build_flags target)
 
-  # Require C++20 for all targets. C++17 is needed to use aligned allocation
-  # in the dylib. C++20 is needed to use char8_t.
+  # Require C++23 for all targets.
   set_target_properties(${target} PROPERTIES
-    CXX_STANDARD 20
+    CXX_STANDARD 23
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO)
 

--- a/libcxx/src/include/sso_allocator.h
+++ b/libcxx/src/include/sso_allocator.h
@@ -11,6 +11,7 @@
 #define _LIBCPP_SSO_ALLOCATOR_H
 
 #include <__config>
+#include <cstddef>
 #include <memory>
 #include <new>
 #include <type_traits>
@@ -34,7 +35,7 @@ public:
 template <class _Tp, size_t _Np>
 class _LIBCPP_HIDDEN __sso_allocator
 {
-    typename aligned_storage<sizeof(_Tp) * _Np>::type buf_;
+    alignas(_Tp) std::byte buf_[sizeof(_Tp) * _Np];
     bool __allocated_;
 public:
     typedef size_t            size_type;

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <clocale>
 #include <codecvt>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -87,7 +88,7 @@ struct release
 template <class T, class ...Args>
 T& make(Args ...args)
 {
-    static typename aligned_storage<sizeof(T)>::type buf;
+    alignas(T) static std::byte buf[sizeof(T)];
     auto *obj = ::new (&buf) T(args...);
     return *obj;
 }
@@ -541,7 +542,7 @@ const locale&
 locale::__imp::make_classic()
 {
     // only one thread can get in here and it only gets in once
-    static aligned_storage<sizeof(locale)>::type buf;
+    alignas(locale) static std::byte buf[sizeof(locale)];
     locale* c = reinterpret_cast<locale*>(&buf);
     c->__locale_ = &make<__imp>(1u);
     return *c;
@@ -558,7 +559,7 @@ locale&
 locale::__imp::make_global()
 {
     // only one thread can get in here and it only gets in once
-    static aligned_storage<sizeof(locale)>::type buf;
+    alignas(locale) static std::byte buf[sizeof(locale)];
     auto *obj = ::new (&buf) locale(locale::classic());
     return *obj;
 }

--- a/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
+++ b/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
@@ -33,7 +33,7 @@ set(Clang_DIR "${Clang_DIR_SAVE}" CACHE PATH "The directory containing a CMake c
 
 message(STATUS "Found system-installed LLVM ${LLVM_PACKAGE_VERSION} with headers in ${LLVM_INCLUDE_DIRS}")
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 # Link only against clangTidy itself, not anything that clangTidy uses; otherwise we run setup code multiple times
 # which results in clang-tidy crashing
@@ -58,7 +58,7 @@ add_library(cxx-tidy MODULE ${SOURCES})
 target_link_libraries(cxx-tidy clangTidy)
 
 set_target_properties(cxx-tidy PROPERTIES
-                      CXX_STANDARD 23
+                      CXX_STANDARD 20
                       CXX_STANDARD_REQUIRED YES
                       CXX_EXTENSIONS NO)
 

--- a/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
+++ b/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
@@ -33,7 +33,7 @@ set(Clang_DIR "${Clang_DIR_SAVE}" CACHE PATH "The directory containing a CMake c
 
 message(STATUS "Found system-installed LLVM ${LLVM_PACKAGE_VERSION} with headers in ${LLVM_INCLUDE_DIRS}")
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 # Link only against clangTidy itself, not anything that clangTidy uses; otherwise we run setup code multiple times
 # which results in clang-tidy crashing
@@ -58,7 +58,7 @@ add_library(cxx-tidy MODULE ${SOURCES})
 target_link_libraries(cxx-tidy clangTidy)
 
 set_target_properties(cxx-tidy PROPERTIES
-                      CXX_STANDARD 20
+                      CXX_STANDARD 23
                       CXX_STANDARD_REQUIRED YES
                       CXX_EXTENSIONS NO)
 

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -171,7 +171,7 @@ target_link_libraries(cxxabi_shared_objects PUBLIC cxxabi-headers)
 set_target_properties(cxxabi_shared_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
-    CXX_STANDARD 20
+    CXX_STANDARD 23
     CXX_STANDARD_REQUIRED OFF
     COMPILE_FLAGS "${LIBCXXABI_COMPILE_FLAGS}"
     DEFINE_SYMBOL ""
@@ -251,7 +251,7 @@ target_link_libraries(cxxabi_static_objects PUBLIC cxxabi-headers)
 set_target_properties(cxxabi_static_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
-    CXX_STANDARD 20
+    CXX_STANDARD 23
     CXX_STANDARD_REQUIRED OFF
     COMPILE_FLAGS "${LIBCXXABI_COMPILE_FLAGS}"
 )


### PR DESCRIPTION
This is necessary in order to implement some papers like P2467R1, which require using C++23 declarations in the dylib. It is a good habit to keep building the dylib with a recent standard version regardless.

With this patch, we also stop strictly enforcing that the targets are built with C++23. Concretely, C++23 will soon be required in order to build the dylib, but not enforcing it strictly works around some issues like the documentation bots using an old and unsupported compiler. Since these bots do not actually build the library, not strictly enforcing the C++ Standard makes our CMake build more resilient to these kinds of situation. This is just a workaround though, the better way of going about would be to update the compiler on the documentation bot but we don't seem to have control over that.