### PR TITLE
[flang][runtime] Handle incomplete NAMELIST input derived type compon…

### DIFF
--- a/flang/runtime/descriptor-io.h
+++ b/flang/runtime/descriptor-io.h
@@ -288,7 +288,11 @@ static bool DefaultComponentwiseIO(IoStatementState &io,
           *compArray.Element<typeInfo::Component>(at)};
       if (!DefaultComponentIO<DIR>(
               io, component, descriptor, subscripts, handler, table)) {
-        return false;
+        // Truncated nonempty namelist input sequence?
+        auto *listInput{
+            io.get_if<ListDirectedStatementState<Direction::Input>>()};
+        return DIR == Direction::Input && (j > 0 || k > 0) && listInput &&
+            listInput->inNamelistSequence();
       }
     }
   }

--- a/flang/runtime/io-stmt.h
+++ b/flang/runtime/io-stmt.h
@@ -295,8 +295,7 @@ template <>
 class ListDirectedStatementState<Direction::Input>
     : public FormattedIoStatementState<Direction::Input> {
 public:
-  bool inNamelistArray() const { return inNamelistArray_; }
-  void set_inNamelistArray(bool yes = true) { inNamelistArray_ = yes; }
+  bool inNamelistSequence() const { return inNamelistSequence_; }
 
   // Skips value separators, handles repetition and null values.
   // Vacant when '/' appears; present with descriptor == ListDirectedNullValue
@@ -308,11 +307,11 @@ public:
   // input statement.  This member function resets some state so that
   // repetition and null values work correctly for each successive
   // NAMELIST input item.
-  void ResetForNextNamelistItem(bool inNamelistArray) {
+  void ResetForNextNamelistItem(bool inNamelistSequence) {
     remaining_ = 0;
     eatComma_ = false;
     realPart_ = imaginaryPart_ = false;
-    inNamelistArray_ = inNamelistArray;
+    inNamelistSequence_ = inNamelistSequence;
   }
 
 private:
@@ -322,7 +321,7 @@ private:
   bool hitSlash_{false}; // once '/' is seen, nullify further items
   bool realPart_{false};
   bool imaginaryPart_{false};
-  bool inNamelistArray_{false};
+  bool inNamelistSequence_{false};
 };
 
 template <Direction DIR>


### PR DESCRIPTION
…ent list

When a derived type value appears in NAMELIST input, its components' values appear in sequence.  This sequence can be truncated by a NAME= that begins the next NAMELIST input item, or by the terminal '/' that ends the NAMELIST group.  Extend the mechanism already in place for truncated array item lists in NAMELIST input so that it also applies to derived type component sequences, and rename things appropriately.