### PR TITLE
[builtins][NFC] Avoid using CRT_LDBL_128BIT in tests

### DIFF
--- a/compiler-rt/test/builtins/Unit/compiler_rt_fmaxl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_fmaxl_test.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include "fp_lib.h"
 
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
 
 int test__compiler_rt_fmaxl(fp_t x, fp_t y) {
   fp_t crt_value = __compiler_rt_fmaxl(x, y);
@@ -43,7 +43,7 @@ fp_t cases[] = {
 #endif
 
 int main() {
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
   const unsigned N = sizeof(cases) / sizeof(cases[0]);
   unsigned i, j;
   for (i = 0; i < N; ++i) {

--- a/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_logbl_test.c
@@ -6,7 +6,7 @@
 #include "fp_lib.h"
 #include "int_lib.h"
 
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
 
 int test__compiler_rt_logbl(fp_t x) {
 #if defined(__ve__)
@@ -42,7 +42,7 @@ double cases[] = {
 #endif
 
 int main() {
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
   const unsigned N = sizeof(cases) / sizeof(cases[0]);
   unsigned i;
   for (i = 0; i < N; ++i) {

--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbnl_test.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "fp_lib.h"
 
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
 
 int test__compiler_rt_scalbnl(const char *mode, fp_t x, int y) {
 #if defined(__ve__)
@@ -67,7 +67,7 @@ int iterate_cases(const char *mode) {
 #endif
 
 int main() {
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
   if (iterate_cases("default")) return 1;
 
   // Skip rounding mode tests (fesetround) because compiler-rt's quad-precision

--- a/compiler-rt/test/builtins/Unit/floattitf_test.c
+++ b/compiler-rt/test/builtins/Unit/floattitf_test.c
@@ -7,7 +7,7 @@
 #include <float.h>
 #include <stdio.h>
 
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
 
 /* Returns: convert a ti_int to a fp_t, rounding toward even. */
 
@@ -39,7 +39,7 @@ char assumption_3[sizeof(fp_t) * CHAR_BIT == 128] = {0};
 #endif
 
 int main() {
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
   if (test__floattitf(0, 0.0))
     return 1;
 

--- a/compiler-rt/test/builtins/Unit/floatuntitf_test.c
+++ b/compiler-rt/test/builtins/Unit/floatuntitf_test.c
@@ -7,7 +7,7 @@
 #include <float.h>
 #include <stdio.h>
 
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
 
 /* Returns: convert a tu_int to a fp_t, rounding toward even. */
 
@@ -39,7 +39,7 @@ char assumption_3[sizeof(fp_t) * CHAR_BIT == 128] = {0};
 #endif
 
 int main() {
-#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+#if defined(CRT_HAS_TF_MODE)
   if (test__floatuntitf(0, 0.0))
     return 1;
 


### PR DESCRIPTION
https://reviews.llvm.org/D153812 removed this macro from implementations. Clean this up from tests as well.