### PR TITLE
[clang-tidy] Fix support for typedefs in readability-identifier-naming

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
@@ -256,26 +256,6 @@ public:
       return true;
     }
 
-    // Fix type aliases in value declarations.
-    if (const auto *Value = dyn_cast<ValueDecl>(Decl)) {
-      if (const Type *TypePtr = Value->getType().getTypePtrOrNull()) {
-        if (const auto *Typedef = TypePtr->getAs<TypedefType>())
-          Check->addUsage(Typedef->getDecl(), Value->getSourceRange(), SM);
-      }
-    }
-
-    // Fix type aliases in function declarations.
-    if (const auto *Value = dyn_cast<FunctionDecl>(Decl)) {
-      if (const auto *Typedef =
-              Value->getReturnType().getTypePtr()->getAs<TypedefType>())
-        Check->addUsage(Typedef->getDecl(), Value->getSourceRange(), SM);
-      for (const ParmVarDecl *Param : Value->parameters()) {
-        if (const TypedefType *Typedef =
-                Param->getType().getTypePtr()->getAs<TypedefType>())
-          Check->addUsage(Typedef->getDecl(), Value->getSourceRange(), SM);
-      }
-    }
-
     // Fix overridden methods
     if (const auto *Method = dyn_cast<CXXMethodDecl>(Decl)) {
       if (const CXXMethodDecl *Overridden = getOverrideMethod(Method)) {
@@ -337,6 +317,11 @@ public:
                         DepMemberRef->getMemberNameInfo().getSourceRange(), SM);
     }
 
+    return true;
+  }
+
+  bool VisitTypedefTypeLoc(const TypedefTypeLoc &Loc) {
+    Check->addUsage(Loc.getTypedefNameDecl(), Loc.getSourceRange(), SM);
     return true;
   }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -291,7 +291,9 @@ Changes in existing checks
   warnings when a type's forward declaration precedes its definition.
   Additionally, it now provides appropriate warnings for ``struct`` and
   ``union`` in C, while also incorporating support for the
-  ``Leading_upper_snake_case`` naming convention.
+  ``Leading_upper_snake_case`` naming convention. The handling of ``typedef``
+  has been enhanced, particularly within complex types like function pointers
+  and cases where style checks were omitted when functions started with macros.
 
 - Improved :doc:`readability-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check to take

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -729,3 +729,21 @@ struct forward_declared_as_struct;
 class forward_declared_as_struct {
 };
 
+namespace pr55156 {
+
+typedef enum {
+  VALUE0,
+  VALUE1,
+} ValueType;
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: invalid case style for typedef 'ValueType' [readability-identifier-naming]
+// CHECK-FIXES: {{^}}} value_type_t;
+
+#define STATIC_MACRO static
+STATIC_MACRO void someFunc(ValueType a_v1, const ValueType& a_v2) {}
+// CHECK-FIXES: {{^}}STATIC_MACRO void someFunc(value_type_t a_v1, const value_type_t& a_v2) {}
+STATIC_MACRO void someFunc(const ValueType** p_a_v1, ValueType (*p_a_v2)()) {}
+// CHECK-FIXES: {{^}}STATIC_MACRO void someFunc(const value_type_t** p_a_v1, value_type_t (*p_a_v2)()) {}
+STATIC_MACRO ValueType someFunc() {}
+// CHECK-FIXES: {{^}}STATIC_MACRO value_type_t someFunc() {}
+#undef STATIC_MACRO
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -731,12 +731,18 @@ class forward_declared_as_struct {
 
 namespace pr55156 {
 
+template<typename> struct Wrap;
+
 typedef enum {
   VALUE0,
   VALUE1,
 } ValueType;
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: invalid case style for typedef 'ValueType' [readability-identifier-naming]
 // CHECK-FIXES: {{^}}} value_type_t;
+
+typedef ValueType (*MyFunPtr)(const ValueType&, Wrap<ValueType>*);
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: invalid case style for typedef 'MyFunPtr' [readability-identifier-naming]
+// CHECK-FIXES: {{^}}typedef value_type_t (*my_fun_ptr_t)(const value_type_t&, Wrap<value_type_t>*);
 
 #define STATIC_MACRO static
 STATIC_MACRO void someFunc(ValueType a_v1, const ValueType& a_v2) {}
@@ -745,5 +751,7 @@ STATIC_MACRO void someFunc(const ValueType** p_a_v1, ValueType (*p_a_v2)()) {}
 // CHECK-FIXES: {{^}}STATIC_MACRO void someFunc(const value_type_t** p_a_v1, value_type_t (*p_a_v2)()) {}
 STATIC_MACRO ValueType someFunc() {}
 // CHECK-FIXES: {{^}}STATIC_MACRO value_type_t someFunc() {}
+STATIC_MACRO void someFunc(MyFunPtr, const MyFunPtr****) {}
+// CHECK-FIXES: {{^}}STATIC_MACRO void someFunc(my_fun_ptr_t, const my_fun_ptr_t****) {}
 #undef STATIC_MACRO
 }


### PR DESCRIPTION
Typedef rename were not properly handled when typedef were used behind pointer, or as a part of function type. Additionally because entire function were passed as an source-range, when function started with macro, such change were not marked for a fix.

Removed workaround and used proper TypedefTypeLoc instead.

Fixes #55156, #54699