### PR TITLE
[lld] Only report "unable to move location counter backward" error for the last run to assignAddresses

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -170,8 +170,7 @@ void LinkerScript::expandOutputSection(uint64_t size) {
 void LinkerScript::setDot(Expr e, const Twine &loc, bool inSec) {
   uint64_t val = e().getValue();
   if (val < dot && inSec)
-    error(loc + ": unable to move location counter backward for: " +
-          state->outSec->name);
+    lastSectionWithBackwardsCounter = state->outSec;
 
   // Update to location counter means update to section size.
   if (inSec)
@@ -1327,6 +1326,7 @@ LinkerScript::AddressState::AddressState() {
 // Returns a symbol that has changed its section or value, or nullptr if no
 // symbol has changed.
 const Defined *LinkerScript::assignAddresses() {
+  lastSectionWithBackwardsCounter = nullptr;
   if (script->hasSectionsCommand) {
     // With a linker script, assignment of addresses to headers is covered by
     // allocateHeaders().

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -378,6 +378,10 @@ public:
 
   // Sections that will be warned/errored by --orphan-handling.
   SmallVector<const InputSectionBase *, 0> orphanSections;
+
+  // If assignAddress() at any point caused the location counter to move
+  // backwards, this will point to the section where this occured.
+  OutputSection *lastSectionWithBackwardsCounter = nullptr;
 };
 
 LLVM_LIBRARY_VISIBILITY extern std::unique_ptr<LinkerScript> script;

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1697,6 +1697,13 @@ template <class ELFT> void Writer<ELFT>::finalizeAddressDependentContent() {
       }
     }
   }
+
+  if (script->lastSectionWithBackwardsCounter) {
+    error(script->lastSectionWithBackwardsCounter->location +
+          ": unable to move location counter backward for: " +
+          script->lastSectionWithBackwardsCounter->name);
+  }
+
   if (!config->relocatable && config->emachine == EM_RISCV)
     riscvFinalizeRelax(pass);
 


### PR DESCRIPTION
It's possible for sections to fit in a memory segment after other sections have had fixups and relaxations applied, so if this error occurs, we should only pay attention to the last call to assignAddresses which could have updated section addresses and sizes.