### PR TITLE
[libc++] Simplify how the global stream tests are written

### DIFF
--- a/libcxx/test/std/input.output/iostream.format/print.fun/print.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/print.sh.cpp
@@ -7,7 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: no-filesystem
-// UNSUPPORTED: executor-has-no-bash
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
 // XFAIL: availability-fp_to_chars-missing
@@ -29,12 +28,9 @@
 //
 // The testing is based on the testing for std::cout.
 
-// TODO PRINT Use lit builtin echo
-
-// FILE_DEPENDENCIES: echo.sh
 // RUN: %{build}
-// RUN: %{exec} bash echo.sh -n "1234 一二三四 true 0x0" > %t.expected
-// RUN: %{exec} "%t.exe" > %t.actual
+// RUN: echo -n "1234 一二三四 true 0x0" > %t.expected
+// RUN: %{exec} %t.exe > %t.actual
 // RUN: diff -u %t.actual %t.expected
 
 #include <print>

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.sh.cpp
@@ -7,7 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: no-filesystem
-// UNSUPPORTED: executor-has-no-bash
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
 // XFAIL: availability-fp_to_chars-missing
@@ -27,12 +26,9 @@
 //
 // The testing is based on the testing for std::cout.
 
-// TODO PRINT Use lit builtin echo
-
-// FILE_DEPENDENCIES: echo.sh
 // RUN: %{build}
-// RUN: %{exec} bash echo.sh -n "1234 一二三四 true 0x0" > %t.expected
-// RUN: %{exec} "%t.exe" > %t.actual
+// RUN: echo -n "1234 一二三四 true 0x0" > %t.expected
+// RUN: %{exec} %t.exe > %t.actual
 // RUN: diff -u %t.actual %t.expected
 
 #include <print>

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.sh.cpp
@@ -7,7 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: no-filesystem
-// UNSUPPORTED: executor-has-no-bash
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
 // XFAIL: availability-fp_to_chars-missing
@@ -27,12 +26,9 @@
 //
 // The testing is based on the testing for std::cout.
 
-// TODO PRINT Use lit builtin echo
-
-// FILE_DEPENDENCIES: echo.sh
 // RUN: %{build}
-// RUN: %{exec} bash echo.sh -n "1234 一二三四 true 0x0" > %t.expected
-// RUN: %{exec} "%t.exe" > %t.actual
+// RUN: echo -n "1234 一二三四 true 0x0" > %t.expected
+// RUN: %{exec} %t.exe > %t.actual
 // RUN: diff -u %t.actual %t.expected
 
 #include <print>

--- a/libcxx/test/std/input.output/iostream.objects/check-stderr.sh
+++ b/libcxx/test/std/input.output/iostream.objects/check-stderr.sh
@@ -1,4 +1,0 @@
-program=${1}
-expected_stderr=${2}
-${program} 2>stderr.log >stdout.log
-[ "${expected_stderr}" == "$(cat stderr.log)" ]

--- a/libcxx/test/std/input.output/iostream.objects/check-stdout.sh
+++ b/libcxx/test/std/input.output/iostream.objects/check-stdout.sh
@@ -1,4 +1,0 @@
-program=${1}
-expected_stdout=${2}
-${program} 2>stderr.log >stdout.log
-[ "${expected_stdout}" == "$(cat stdout.log)" ]

--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cerr.sh.cpp
@@ -10,10 +10,10 @@
 
 // ostream cerr;
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stderr.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stderr.sh "%t.exe" "1234"
+// RUN: %{exec} %t.exe 2> %t.actual
+// RUN: echo -n 1234 > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cin.sh.cpp
@@ -6,14 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+// TODO: Investigate
+// UNSUPPORTED: LIBCXX-AIX-FIXME
+
 // <iostream>
 
 // istream cin;
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../send-stdin.sh
 // RUN: %{build}
-// RUN: %{exec} bash send-stdin.sh "%t.exe" "1234"
+// RUN: echo -n 1234 | %{exec} %t.exe
 
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/clog.sh.cpp
@@ -10,10 +10,10 @@
 
 // ostream clog;
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stderr.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stderr.sh "%t.exe" "1234"
+// RUN: %{exec} %t.exe 2> %t.actual
+// RUN: echo -n 1234 > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 

--- a/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/narrow.stream.objects/cout.sh.cpp
@@ -10,10 +10,10 @@
 
 // ostream cout;
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stdout.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stdout.sh "%t.exe" "1234"
+// RUN: %{exec} %t.exe > %t.actual
+// RUN: echo -n 1234 > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 

--- a/libcxx/test/std/input.output/iostream.objects/send-stdin.sh
+++ b/libcxx/test/std/input.output/iostream.objects/send-stdin.sh
@@ -1,3 +1,0 @@
-program=${1}
-input=${2}
-echo -n ${input} | ${program}

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/check-stderr.sh
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/check-stderr.sh
@@ -1,5 +1,0 @@
-# Check that the stderr of the executed program matches a reference file.
-program=${1}
-expected_file=${2}
-${program} 2>stderr.log >stdout.log
-cmp stderr.log "${expected_file}"

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/check-stdout.sh
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/check-stdout.sh
@@ -1,5 +1,0 @@
-# Check that the stdout of the executed program matches a reference file.
-program=${1}
-expected_file=${2}
-${program} 2>stderr.log >stdout.log
-cmp stdout.log "${expected_file}"

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/send-stdin.sh
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/send-stdin.sh
@@ -1,4 +1,0 @@
-# Pass a reference file as stdin to a test executable.
-program=${1}
-input=${2}
-cat ${input} | ${program}

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcerr-imbue.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcerr-imbue.sh.cpp
@@ -12,10 +12,10 @@
 
 // UNSUPPORTED: no-wide-characters
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stderr.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stderr.sh "%t.exe" "zzzz"
+// RUN: %{exec} %t.exe 2> %t.actual
+// RUN: echo -n zzzz > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcerr-wide-mode.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcerr-wide-mode.sh.cpp
@@ -13,10 +13,10 @@
 // UNSUPPORTED: no-wide-characters
 // REQUIRES: target={{.+}}-windows-{{.+}}
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: check-stderr.sh, test.dat
+// FILE_DEPENDENCIES: test.dat
 // RUN: %{build}
-// RUN: %{exec} bash check-stderr.sh "%t.exe" "test.dat"
+// RUN: %{exec} %t.exe 2> %t.actual
+// RUN: diff test.dat %t.actual
 
 // Check that wcerr works, preserving the unicode characters, after switching
 // stderr to wide mode.

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcerr.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcerr.sh.cpp
@@ -12,10 +12,10 @@
 
 // XFAIL: no-wide-characters
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stderr.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stderr.sh "%t.exe" "1234"
+// RUN: %{exec} %t.exe 2> %t.actual
+// RUN: echo -n 1234 > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-imbue.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-imbue.sh.cpp
@@ -6,16 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+// TODO: Investigate
+// UNSUPPORTED: LIBCXX-AIX-FIXME
+
 // <iostream>
 
 // wistream wcin;
 
 // UNSUPPORTED: no-wide-characters
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../send-stdin.sh
 // RUN: %{build}
-// RUN: %{exec} bash send-stdin.sh "%t.exe" "1234"
+// RUN: echo -n 1234 | %{exec} %t.exe
 
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-wide-mode.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-wide-mode.sh.cpp
@@ -13,10 +13,9 @@
 // UNSUPPORTED: no-wide-characters
 // REQUIRES: target={{.+}}-windows-{{.+}}
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: send-stdin.sh, test.dat
+// FILE_DEPENDENCIES: test.dat
 // RUN: %{build}
-// RUN: %{exec} bash send-stdin.sh "%t.exe" "test.dat"
+// RUN: cat test.dat | %{exec} %t.exe
 
 // Check that wcin works, preserving the unicode characters, after switching
 // stdin to wide mode.

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin.sh.cpp
@@ -6,16 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+// TODO: Investigate
+// UNSUPPORTED: LIBCXX-AIX-FIXME
+
 // <iostream>
 
 // wistream wcin;
 
 // XFAIL: no-wide-characters
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../send-stdin.sh
 // RUN: %{build}
-// RUN: %{exec} bash send-stdin.sh "%t.exe" "1234"
+// RUN: echo -n 1234 | %{exec} %t.exe
 
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wclog.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wclog.sh.cpp
@@ -12,10 +12,10 @@
 
 // XFAIL: no-wide-characters
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stderr.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stderr.sh "%t.exe" "1234"
+// RUN: %{exec} %t.exe 2> %t.actual
+// RUN: echo -n 1234 > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcout-imbue.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcout-imbue.sh.cpp
@@ -12,10 +12,10 @@
 
 // UNSUPPORTED: no-wide-characters
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stdout.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stdout.sh "%t.exe" "zzzz"
+// RUN: %{exec} %t.exe > %t.actual
+// RUN: echo -n zzzz > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcout-wide-mode.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcout-wide-mode.sh.cpp
@@ -13,10 +13,10 @@
 // UNSUPPORTED: no-wide-characters
 // REQUIRES: target={{.+}}-windows-{{.+}}
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: check-stdout.sh, test.dat
+// FILE_DEPENDENCIES: test.dat
 // RUN: %{build}
-// RUN: %{exec} bash check-stdout.sh "%t.exe" "test.dat"
+// RUN: %{exec} %t.exe > %t.actual
+// RUN: diff test.dat %t.actual
 
 // Check that wcout works, preserving the unicode characters, after switching
 // stdout to wide mode.

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcout.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcout.sh.cpp
@@ -12,10 +12,10 @@
 
 // XFAIL: no-wide-characters
 
-// UNSUPPORTED: executor-has-no-bash
-// FILE_DEPENDENCIES: ../check-stdout.sh
 // RUN: %{build}
-// RUN: %{exec} bash check-stdout.sh "%t.exe" "1234"
+// RUN: %{exec} %t.exe > %t.actual
+// RUN: echo -n 1234 > %t.expected
+// RUN: diff %t.expected %t.actual
 
 #include <iostream>
 


### PR DESCRIPTION
Instead of relying on Bash, use the builtin Lit commands whenever possible. The motivation is to stop running %t.exe behind Bash, which breaks on macOS 13.5 with SIP enabled because DYLD_LIBRARY_PATH isn't forwarded to the underlying process when running through a protected process.

For more details, see [1].

[1]: https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/RuntimeProtections/RuntimeProtections.html