### PR TITLE
[Sparc] Remove duplicate ALU and SETHI instructions (NFCI)

### DIFF
--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCCodeEmitter.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCCodeEmitter.cpp
@@ -104,7 +104,6 @@ void SparcMCCodeEmitter::encodeInstruction(const MCInst &MI,
   case SP::GDOP_LDrr:
   case SP::GDOP_LDXrr:
   case SP::TLS_ADDrr:
-  case SP::TLS_ADDXrr:
   case SP::TLS_LDrr:
   case SP::TLS_LDXrr:  SymOpNo = 3; break;
   }

--- a/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
+++ b/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
@@ -301,7 +301,7 @@ void SparcAsmPrinter::printOperand(const MachineInstr *MI, int opNum,
     if (MI->getOpcode() == SP::CALL)
       assert(TF == SparcMCExpr::VK_Sparc_None &&
              "Cannot handle target flags on call address");
-    else if (MI->getOpcode() == SP::SETHIi || MI->getOpcode() == SP::SETHIXi)
+    else if (MI->getOpcode() == SP::SETHIi)
       assert((TF == SparcMCExpr::VK_Sparc_HI
               || TF == SparcMCExpr::VK_Sparc_H44
               || TF == SparcMCExpr::VK_Sparc_HH
@@ -329,7 +329,7 @@ void SparcAsmPrinter::printOperand(const MachineInstr *MI, int opNum,
     else if (MI->getOpcode() == SP::TLS_LDXrr)
       assert(TF == SparcMCExpr::VK_Sparc_TLS_IE_LDX &&
              "Cannot handle target flags on ldx for TLS");
-    else if (MI->getOpcode() == SP::XORri || MI->getOpcode() == SP::XORXri)
+    else if (MI->getOpcode() == SP::XORri)
       assert((TF == SparcMCExpr::VK_Sparc_TLS_LDO_LOX10
               || TF == SparcMCExpr::VK_Sparc_TLS_LE_LOX10) &&
              "Cannot handle target flags on xor for TLS");

--- a/llvm/lib/Target/Sparc/SparcInstr64Bit.td
+++ b/llvm/lib/Target/Sparc/SparcInstr64Bit.td
@@ -144,34 +144,26 @@ def : Pat<(i64 imm:$val),
 
 let Predicates = [Is64Bit] in {
 
-// Register-register instructions.
-let isCodeGenOnly = 1 in {
-defm ANDX    : F3_12<"and", 0b000001, and, I64Regs, i64, i64imm>;
-defm ORX     : F3_12<"or",  0b000010, or,  I64Regs, i64, i64imm>;
-defm XORX    : F3_12<"xor", 0b000011, xor, I64Regs, i64, i64imm>;
+def : Pat<(and i64:$lhs, i64:$rhs), (ANDrr $lhs, $rhs)>;
+def : Pat<(or  i64:$lhs, i64:$rhs), (ORrr  $lhs, $rhs)>;
+def : Pat<(xor i64:$lhs, i64:$rhs), (XORrr $lhs, $rhs)>;
 
-def ANDXNrr  : F3_1<2, 0b000101,
-                 (outs I64Regs:$rd), (ins I64Regs:$rs1, I64Regs:$rs2),
-                 "andn $rs1, $rs2, $rd",
-                 [(set i64:$rd, (and i64:$rs1, (not i64:$rs2)))]>;
-def ORXNrr   : F3_1<2, 0b000110,
-                 (outs I64Regs:$rd), (ins I64Regs:$rs1, I64Regs:$rs2),
-                 "orn $rs1, $rs2, $rd",
-                 [(set i64:$rd, (or i64:$rs1, (not i64:$rs2)))]>;
-def XNORXrr  : F3_1<2, 0b000111,
-                   (outs I64Regs:$rd), (ins I64Regs:$rs1, I64Regs:$rs2),
-                   "xnor $rs1, $rs2, $rd",
-                   [(set i64:$rd, (not (xor i64:$rs1, i64:$rs2)))]>;
+def : Pat<(and i64:$lhs, (i64 simm13:$rhs)), (ANDri $lhs, imm:$rhs)>;
+def : Pat<(or  i64:$lhs, (i64 simm13:$rhs)), (ORri  $lhs, imm:$rhs)>;
+def : Pat<(xor i64:$lhs, (i64 simm13:$rhs)), (XORri $lhs, imm:$rhs)>;
 
-defm ADDX    : F3_12<"add", 0b000000, add, I64Regs, i64, i64imm>;
-defm SUBX    : F3_12<"sub", 0b000100, sub, I64Regs, i64, i64imm>;
+def : Pat<(and i64:$lhs, (not i64:$rhs)), (ANDNrr $lhs, $rhs)>;
+def : Pat<(or  i64:$lhs, (not i64:$rhs)), (ORNrr  $lhs, $rhs)>;
+def : Pat<(not (xor i64:$lhs, i64:$rhs)), (XNORrr $lhs, $rhs)>;
 
-def TLS_ADDXrr : F3_1<2, 0b000000, (outs I64Regs:$rd),
-                   (ins I64Regs:$rs1, I64Regs:$rs2, TailRelocSymTLSAdd:$sym),
-                   "add $rs1, $rs2, $rd, $sym",
-                   [(set i64:$rd,
-                       (tlsadd i64:$rs1, i64:$rs2, tglobaltlsaddr:$sym))]>;
-}
+def : Pat<(add i64:$lhs, i64:$rhs), (ADDrr $lhs, $rhs)>;
+def : Pat<(sub i64:$lhs, i64:$rhs), (SUBrr $lhs, $rhs)>;
+
+def : Pat<(add i64:$lhs, (i64 simm13:$rhs)), (ADDri $lhs, imm:$rhs)>;
+def : Pat<(sub i64:$lhs, (i64 simm13:$rhs)), (SUBri $lhs, imm:$rhs)>;
+
+def : Pat<(tlsadd i64:$rs1, i64:$rs2, tglobaltlsaddr:$sym),
+          (TLS_ADDrr $rs1, $rs2, $sym)>;
 
 def : Pat<(SPcmpicc i64:$a, i64:$b), (CMPrr $a, $b)>;
 def : Pat<(SPcmpicc i64:$a, (i64 simm13:$b)), (CMPri $a, (as_i32imm $b))>;
@@ -459,15 +451,6 @@ def : Pat<(SPselectreg (i64 simm10:$t), i64:$f, imm:$rcond, i64:$rs1),
 
 } // Predicates = [Is64Bit]
 
-
-// 64 bit SETHI
-let Predicates = [Is64Bit], isCodeGenOnly = 1 in {
-def SETHIXi : F2_1<0b100,
-                   (outs IntRegs:$rd), (ins i64imm:$imm22),
-                   "sethi $imm22, $rd",
-                   [(set i64:$rd, SETHIimm:$imm22)]>;
-}
-
 // ATOMICS.
 let Predicates = [Is64Bit, HasV9], Constraints = "$swap = $rd" in {
   def CASXArr: F3_1_asi<3, 0b111110,
@@ -506,25 +489,25 @@ let Predicates = [Is64Bit], hasSideEffects = 1, Uses = [ICC], cc = 0b10 in
 let Predicates = [Is64Bit] in {
 
 def : Pat<(SPhi tglobaladdr:$in), (SETHIi tglobaladdr:$in)>;
-def : Pat<(SPlo tglobaladdr:$in), (ORXri (i64 G0), tglobaladdr:$in)>;
+def : Pat<(SPlo tglobaladdr:$in), (ORri (i64 G0), tglobaladdr:$in)>;
 def : Pat<(SPhi tconstpool:$in), (SETHIi tconstpool:$in)>;
-def : Pat<(SPlo tconstpool:$in), (ORXri (i64 G0), tconstpool:$in)>;
+def : Pat<(SPlo tconstpool:$in), (ORri (i64 G0), tconstpool:$in)>;
 
 // GlobalTLS addresses
 def : Pat<(SPhi tglobaltlsaddr:$in), (SETHIi tglobaltlsaddr:$in)>;
-def : Pat<(SPlo tglobaltlsaddr:$in), (ORXri (i64 G0), tglobaltlsaddr:$in)>;
+def : Pat<(SPlo tglobaltlsaddr:$in), (ORri (i64 G0), tglobaltlsaddr:$in)>;
 def : Pat<(add (SPhi tglobaltlsaddr:$in1), (SPlo tglobaltlsaddr:$in2)),
-          (ADDXri (SETHIXi tglobaltlsaddr:$in1), (tglobaltlsaddr:$in2))>;
+          (ADDri (SETHIi tglobaltlsaddr:$in1), (tglobaltlsaddr:$in2))>;
 def : Pat<(xor (SPhi tglobaltlsaddr:$in1), (SPlo tglobaltlsaddr:$in2)),
-          (XORXri  (SETHIXi tglobaltlsaddr:$in1), (tglobaltlsaddr:$in2))>;
+          (XORri  (SETHIi tglobaltlsaddr:$in1), (tglobaltlsaddr:$in2))>;
 
 // Blockaddress
 def : Pat<(SPhi tblockaddress:$in), (SETHIi tblockaddress:$in)>;
-def : Pat<(SPlo tblockaddress:$in), (ORXri (i64 G0), tblockaddress:$in)>;
+def : Pat<(SPlo tblockaddress:$in), (ORri (i64 G0), tblockaddress:$in)>;
 
 // Add reg, lo.  This is used when taking the addr of a global/constpool entry.
-def : Pat<(add iPTR:$r, (SPlo tglobaladdr:$in)), (ADDXri $r, tglobaladdr:$in)>;
-def : Pat<(add iPTR:$r, (SPlo tconstpool:$in)),  (ADDXri $r, tconstpool:$in)>;
+def : Pat<(add iPTR:$r, (SPlo tglobaladdr:$in)), (ADDri $r, tglobaladdr:$in)>;
+def : Pat<(add iPTR:$r, (SPlo tconstpool:$in)),  (ADDri $r, tconstpool:$in)>;
 def : Pat<(add iPTR:$r, (SPlo tblockaddress:$in)),
-                        (ADDXri $r, tblockaddress:$in)>;
+                        (ADDri $r, tblockaddress:$in)>;
 }

--- a/llvm/test/CodeGen/SPARC/2011-01-11-FrameAddr.ll
+++ b/llvm/test/CodeGen/SPARC/2011-01-11-FrameAddr.ll
@@ -19,10 +19,8 @@ entry:
 
 ;SPARC64-LABEL: frameaddr
 ;SPARC64:       save %sp, -128, %sp
-;SPARC64:       add  %fp, 2047, %i0
 ;SPARC64:       ret
-;SPARC64-NOT:   restore %g0, %g0, %g0
-;SPARC64:       restore
+;SPARC64:       restore %fp, 2047, %o0
 
   %0 = tail call i8* @llvm.frameaddress(i32 0)
   ret i8* %0
@@ -47,7 +45,8 @@ entry:
 ;SPARC64: ldx [%fp+2159],     %[[R0:[goli][0-7]]]
 ;SPARC64: ldx [%[[R0]]+2159], %[[R1:[goli][0-7]]]
 ;SPARC64: ldx [%[[R1]]+2159], %[[R2:[goli][0-7]]]
-;SPARC64: add %[[R2]], 2047, {{.+}}
+;SPARC64: ret
+;SPARC64: restore %[[R2]], 2047, %o0
 
   %0 = tail call i8* @llvm.frameaddress(i32 3)
   ret i8* %0

--- a/llvm/test/CodeGen/SPARC/fp128-split.ll
+++ b/llvm/test/CodeGen/SPARC/fp128-split.ll
@@ -12,11 +12,11 @@ define fp128 @testcase(fp128 %0) {
   ; CHECK:   [[COPY:%[0-9]+]]:qfpregs = COPY $q0
   ; CHECK:   [[COPY1:%[0-9]+]]:dfpregs = COPY [[COPY]].sub_odd64
   ; CHECK:   [[ADDri:%[0-9]+]]:i64regs = ADDri %stack.0, 0
-  ; CHECK:   [[ORXri:%[0-9]+]]:i64regs = ORXri killed [[ADDri]], 8
-  ; CHECK:   STDFrr [[ORXri]], $g0, killed [[COPY1]] :: (store (s64) into %stack.0 + 8)
+  ; CHECK:   [[ORri:%[0-9]+]]:i64regs = ORri killed [[ADDri]], 8
+  ; CHECK:   STDFrr [[ORri]], $g0, killed [[COPY1]] :: (store (s64) into %stack.0 + 8)
   ; CHECK:   [[COPY2:%[0-9]+]]:dfpregs = COPY [[COPY]].sub_even64
   ; CHECK:   STDFri %stack.0, 0, killed [[COPY2]] :: (store (s64) into %stack.0, align 16)
-  ; CHECK:   [[LDXrr:%[0-9]+]]:i64regs = LDXrr [[ORXri]], $g0 :: (load (s64) from %stack.0 + 8)
+  ; CHECK:   [[LDXrr:%[0-9]+]]:i64regs = LDXrr [[ORri]], $g0 :: (load (s64) from %stack.0 + 8)
   ; CHECK:   [[LDXri:%[0-9]+]]:i64regs = LDXri %stack.0, 0 :: (load (s64) from %stack.0, align 16)
   ; CHECK:   [[COPY3:%[0-9]+]]:intregs = COPY [[LDXrr]]
   ; CHECK:   [[COPY4:%[0-9]+]]:intregs = COPY [[LDXri]]
@@ -31,19 +31,19 @@ define fp128 @testcase(fp128 %0) {
   ; CHECK:   [[SRLri:%[0-9]+]]:i64regs = SRLri killed [[ADDCCri]], 0
   ; CHECK:   [[COPY7:%[0-9]+]]:i64regs = COPY [[ADDEri]]
   ; CHECK:   [[SLLXri:%[0-9]+]]:i64regs = SLLXri killed [[COPY7]], 32
-  ; CHECK:   [[ORXrr:%[0-9]+]]:i64regs = ORXrr killed [[SLLXri]], killed [[SRLri]]
+  ; CHECK:   [[ORrr:%[0-9]+]]:i64regs = ORrr killed [[SLLXri]], killed [[SRLri]]
   ; CHECK:   [[ADDri1:%[0-9]+]]:i64regs = ADDri %stack.1, 0
-  ; CHECK:   [[ORXri1:%[0-9]+]]:i64regs = ORXri killed [[ADDri1]], 8
-  ; CHECK:   STXrr [[ORXri1]], $g0, killed [[ORXrr]] :: (store (s64) into %stack.1 + 8, basealign 16)
+  ; CHECK:   [[ORri1:%[0-9]+]]:i64regs = ORri killed [[ADDri1]], 8
+  ; CHECK:   STXrr [[ORri1]], $g0, killed [[ORrr]] :: (store (s64) into %stack.1 + 8, basealign 16)
   ; CHECK:   [[SRLri1:%[0-9]+]]:i64regs = SRLri killed [[ADDEri1]], 0
   ; CHECK:   [[COPY8:%[0-9]+]]:i64regs = COPY [[ADDEri2]]
   ; CHECK:   [[SLLXri1:%[0-9]+]]:i64regs = SLLXri killed [[COPY8]], 32
-  ; CHECK:   [[ORXrr1:%[0-9]+]]:i64regs = ORXrr killed [[SLLXri1]], killed [[SRLri1]]
-  ; CHECK:   STXri %stack.1, 0, killed [[ORXrr1]] :: (store (s64) into %stack.1, align 16)
+  ; CHECK:   [[ORrr1:%[0-9]+]]:i64regs = ORrr killed [[SLLXri1]], killed [[SRLri1]]
+  ; CHECK:   STXri %stack.1, 0, killed [[ORrr1]] :: (store (s64) into %stack.1, align 16)
   ; CHECK:   [[LDDFri:%[0-9]+]]:dfpregs = LDDFri %stack.1, 0 :: (load (s64) from %stack.1, align 16)
   ; CHECK:   [[DEF:%[0-9]+]]:qfpregs = IMPLICIT_DEF
   ; CHECK:   [[INSERT_SUBREG:%[0-9]+]]:qfpregs = INSERT_SUBREG [[DEF]], killed [[LDDFri]], %subreg.sub_even64
-  ; CHECK:   [[LDDFrr:%[0-9]+]]:dfpregs = LDDFrr [[ORXri1]], $g0 :: (load (s64) from %stack.1 + 8)
+  ; CHECK:   [[LDDFrr:%[0-9]+]]:dfpregs = LDDFrr [[ORri1]], $g0 :: (load (s64) from %stack.1 + 8)
   ; CHECK:   [[INSERT_SUBREG1:%[0-9]+]]:qfpregs = INSERT_SUBREG [[INSERT_SUBREG]], killed [[LDDFrr]], %subreg.sub_odd64
   ; CHECK:   $q0 = COPY [[INSERT_SUBREG1]]
   ; CHECK:   RETL 8, implicit $q0


### PR DESCRIPTION
There are no 64-bit variants of these ALU / SETHI instructions in V9. Remove these instruction definitions and add patterns to match DAG nodes to the generic instructions defined in SparcInstrInfo.td.

This is not strictly NFC because of the changes in `2011-01-11-FrameAddr.ll` test. The reason is that Sparc delay slot filler pass handled ADDrr but not ADDXrr, which are now the same instruction.
