### PR TITLE
Set -rpath-link only if the path is nonempty.

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -2366,7 +2366,7 @@ function(llvm_setup_rpath name)
       set_property(TARGET ${name} APPEND_STRING PROPERTY
                    LINK_FLAGS " -Wl,-z,origin ")
     endif()
-    if(LLVM_LINKER_IS_GNULD)
+    if(LLVM_LINKER_IS_GNULD AND NOT ${LLVM_LIBRARY_OUTPUT_INTDIR} STREQUAL "")
       # $ORIGIN is not interpreted at link time by ld.bfd
       set_property(TARGET ${name} APPEND_STRING PROPERTY
                    LINK_FLAGS " -Wl,-rpath-link,${LLVM_LIBRARY_OUTPUT_INTDIR} ")


### PR DESCRIPTION
This cmake rule is used by external clients, who may or may not have
the LLVM_LIBRARY_OUTPUT_INTDIR variable set.

If it is not set, then we pass `-Wl,-rpath-link,` to the compiler.  It
turns out that gcc and clang interpret this differently.

  * gcc passes `-rpath-link ""` to the linker, which is what we want.

  * clang passes `-rpath-link` to the linker.  This is not what we want,
    because then the linker gobbles the next command-line argument,
    whatever it happens to be, and uses it as the -rpath-link target.

Fix this by passing -rpath-link only if we actually have a path we want.
