### PR TITLE
[HWASAN] Prevent SEGV in report near inaccessible memory

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_report.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_report.cpp
@@ -357,8 +357,9 @@ static void PrintTagsAroundAddr(tag_t *tag_ptr) {
       "to %zd bytes):\n",
       kShadowAlignment);
   PrintTagInfoAroundAddr(tag_ptr, 3, [](InternalScopedString &s, tag_t *tag) {
-    if (*tag >= 1 && *tag <= kShadowAlignment) {
-      uptr granule_addr = ShadowToMem(reinterpret_cast<uptr>(tag));
+    uptr granule_addr = ShadowToMem(reinterpret_cast<uptr>(tag));
+    if (*tag >= 1 && *tag <= kShadowAlignment &&
+        IsAccessibleMemoryRange(granule_addr, kShadowAlignment)) {
       s.AppendF("%02x",
                 *reinterpret_cast<u8 *>(granule_addr + kShadowAlignment - 1));
     } else {

--- a/compiler-rt/test/hwasan/TestCases/report-unmapped.cpp
+++ b/compiler-rt/test/hwasan/TestCases/report-unmapped.cpp
@@ -1,0 +1,39 @@
+// RUN: %clangxx_hwasan %s -o %t && not %run %t 2>&1 | FileCheck %s
+
+#include <sanitizer/hwasan_interface.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  const size_t kPS = sysconf(_SC_PAGESIZE);
+
+  void *r = nullptr;
+  int res = posix_memalign(&r, kPS, 2 * kPS);
+  if (res) {
+    perror("Failed to mmap: ");
+    abort();
+  }
+  
+  r = __hwasan_tag_pointer(r, 0);
+  __hwasan_tag_memory(r, 1,  2 * kPS);
+  
+  // Disable access to the page just after tag-mismatch report address.
+  res = mprotect((char*)r + kPS, kPS, PROT_NONE);
+  if (res) {
+    perror("Failed to mprotect: ");
+    abort();
+  }
+
+  // Trigger tag-mismatch report.
+  return *((char*)r + kPS - 1);
+}
+
+// CHECK: ERROR: HWAddressSanitizer: tag-mismatch on address
+// CHECK: Memory tags around the buggy address
+// CHECK: Tags for short granules around
+
+// Check that report is complete.
+// CHECK: SUMMARY: HWAddressSanitizer


### PR DESCRIPTION
We can't use IsAccessibleMemoryRange on short granule check because of
performance impact. However we can prevent crashing if report prints out
"Tags for short granules around the buggy address".
