### PR TITLE
[TableGen] Fix wrong bits output in GenericTable

### DIFF
--- a/llvm/test/TableGen/generic-tables.td
+++ b/llvm/test/TableGen/generic-tables.td
@@ -25,10 +25,10 @@ include "llvm/TableGen/SearchableTable.td"
 // CHECK-LABEL: GET_ATable_IMPL
 // CHECK: constexpr AEntry ATable[] = {
 // CHECK-NOT:   { "aaa"
-// CHECK:       { "baz", 0x2, 0x6, 0x0 },
-// CHECK:       { "foo", 0x4, 0x4, 0x0 },
-// CHECK:       { "foobar", 0x4, 0x5, 0x0 },
-// CHECK:       { "bar", 0x5, 0x3, 0x0 },
+// CHECK:       { "baz", 0x2, 0x6, 0xFFFFFFFF00000000 },
+// CHECK:       { "foo", 0x4, 0x4, 0x100000000 },
+// CHECK:       { "foobar", 0x4, 0x5, 0x100000000 },
+// CHECK:       { "bar", 0x5, 0x3, 0x100000000 },
 // CHECK: };
 
 // CHECK: const AEntry *lookupATableByValues(uint8_t Val1, uint16_t Val2) {

--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -31,12 +31,12 @@ using namespace llvm;
 
 namespace {
 
-int getAsInt(Init *B) {
+int64_t getAsInt(Init *B) {
   return cast<IntInit>(
              B->convertInitializerTo(IntRecTy::get(B->getRecordKeeper())))
       ->getValue();
 }
-int getInt(Record *R, StringRef Field) {
+int64_t getInt(Record *R, StringRef Field) {
   return getAsInt(R->getValueInit(Field));
 }
 


### PR DESCRIPTION
We used to return `int` in `getAsInt`, while `IntInit::getValue`
returns `int64_t` and `utohexstr` needs `uint64_t`. The casting
causes the wrong hex value when printing bits value.

I split this PR into two commits to show the difference.

