### PR TITLE
[MLIR][IR] Rename `Block::hasTerminator` to `mightHaveTerminator`

### DIFF
--- a/mlir/include/mlir/IR/Block.h
+++ b/mlir/include/mlir/IR/Block.h
@@ -211,10 +211,10 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// Get the terminator operation of this block. This function asserts that
-  /// the block has a valid terminator operation.
+  /// the block might have a valid terminator operation.
   Operation *getTerminator();
 
-  /// Check whether this block has a terminator.
+  /// Check whether this block might have a terminator.
   bool mightHaveTerminator();
 
   //===--------------------------------------------------------------------===//

--- a/mlir/include/mlir/IR/Block.h
+++ b/mlir/include/mlir/IR/Block.h
@@ -215,7 +215,7 @@ public:
   Operation *getTerminator();
 
   /// Check whether this block has a terminator.
-  bool hasTerminator();
+  bool mightHaveTerminator();
 
   //===--------------------------------------------------------------------===//
   // Predecessors and successors.

--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -2188,7 +2188,7 @@ LogicalResult transform::SequenceOp::verify() {
     }
   }
 
-  if (!getBodyBlock()->hasTerminator())
+  if (!getBodyBlock()->mightHaveTerminator())
     return emitOpError() << "expects to have a terminator in the body";
 
   if (getBodyBlock()->getTerminator()->getOperandTypes() !=

--- a/mlir/lib/IR/Block.cpp
+++ b/mlir/lib/IR/Block.cpp
@@ -234,13 +234,13 @@ void Block::eraseArguments(function_ref<bool(BlockArgument)> shouldEraseFn) {
 //===----------------------------------------------------------------------===//
 
 /// Get the terminator operation of this block. This function asserts that
-/// the block has a valid terminator operation.
+/// the block might have a valid terminator operation.
 Operation *Block::getTerminator() {
   assert(mightHaveTerminator());
   return &back();
 }
 
-/// Check whether this block has a terminator.
+/// Check whether this block might have a terminator.
 bool Block::mightHaveTerminator() {
   return !empty() && back().mightHaveTrait<OpTrait::IsTerminator>();
 }

--- a/mlir/lib/IR/Block.cpp
+++ b/mlir/lib/IR/Block.cpp
@@ -236,12 +236,12 @@ void Block::eraseArguments(function_ref<bool(BlockArgument)> shouldEraseFn) {
 /// Get the terminator operation of this block. This function asserts that
 /// the block has a valid terminator operation.
 Operation *Block::getTerminator() {
-  assert(hasTerminator());
+  assert(mightHaveTerminator());
   return &back();
 }
 
 /// Check whether this block has a terminator.
-bool Block::hasTerminator() {
+bool Block::mightHaveTerminator() {
   return !empty() && back().mightHaveTrait<OpTrait::IsTerminator>();
 }
 


### PR DESCRIPTION
This `Block` member function introduced in 87d77d3cfb5049b3b3714f95b2e48bbc78d8c5f9 may be misleading to users as the last operation in the block might have not been registered, so there would be no way to ensure that is a terminator.