### PR TITLE
[RISCV] Add missing V extensions for zvk-invalid-features.c

### DIFF
--- a/clang/test/Sema/zvk-invalid-features.c
+++ b/clang/test/Sema/zvk-invalid-features.c
@@ -1,5 +1,7 @@
 // REQUIRES: riscv-registered-target
-// RUN: %clang_cc1 -triple riscv64 %s -fsyntax-only -verify
+// RUN: %clang_cc1 -triple riscv64 %s -target-feature +v -fsyntax-only -verify
+
+#include <riscv_vector.h>
 
 void test_zvk_features() {
   // zvbb


### PR DESCRIPTION
If we don't include riscv_vector.h, even we add the target-feature,
it still can't find the intrinsic interface.
