### PR TITLE
[clang][dataflow] Fix handling of cyclical data structures in HTMLLogger.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
@@ -88,10 +88,12 @@ public:
 
   void dump(Value &V) {
     JOS.attribute("value_id", llvm::to_string(&V));
-    if (!Visited.insert(&V).second)
-      return;
-
     JOS.attribute("kind", debugString(V.getKind()));
+    if (!Visited.insert(&V).second) {
+      JOS.attribute("[in_cycle]", " ");
+      return;
+    }
+    auto EraseVisited = llvm::make_scope_exit([&] { Visited.erase(&V); });
 
     switch (V.getKind()) {
     case Value::Kind::Integer:
@@ -123,12 +125,15 @@ public:
   }
   void dump(const StorageLocation &L) {
     JOS.attribute("location", llvm::to_string(&L));
-    if (!Visited.insert(&L).second)
-      return;
-
     JOS.attribute("type", L.getType().getAsString());
     if (auto *V = Env.getValue(L))
       dump(*V);
+
+    if (!Visited.insert(&L).second) {
+      JOS.attribute("[in_cycle]", " ");
+      return;
+    }
+    auto EraseVisited = llvm::make_scope_exit([&] { Visited.erase(&L); });
 
     if (auto *RLoc = dyn_cast<RecordStorageLocation>(&L)) {
       for (const auto &Child : RLoc->children())


### PR DESCRIPTION
*  Include more information. We can include the "kind" field for values and
   "type" for storage locations without risking infinite recursion. Previously,
   we would display these as "undefined" (simply because this is the JavaScript
   value for a variable that isn't set), which is potentially confusing.
   Similarly, `dump(StorageLocation&)` can unconditionally call `dump(Value&)`
   without risking infinite recursion, and this ensures that the "value_id" and
   "kind" fields are populated.

*  Remove entries from `Visited` when we exit `dump()`. This ensures that we
   correctly display values and storage locations that occur multiple times in a
   dump (without being nested).

*  If we detect a cycle, add an "[in_cycle]" atttribute to make it clear why
   the display is truncated.

**Cyclical data structure before**

![cyclical_data_structure_before](https://github.com/llvm/llvm-project/assets/29098113/c8e14368-c017-410e-9258-79243a80101f)

**Cyclical data structure after**

![cyclical_data_structure_after](https://github.com/llvm/llvm-project/assets/29098113/f3fe057c-c828-41e1-bdf7-16a0a338fa54)

**Repeated value before**

Note how the value for p:is_null is being displayed as "undefined" because it is the same `Value` as the previous p:from_nullable:

![repeated_value_before](https://github.com/llvm/llvm-project/assets/29098113/b8af43ac-1a14-4b6f-aa2a-c9e88834d5c6)

**Repeated value after**

p:is_null is now displayed correctly:

![repeated_value_after](https://github.com/llvm/llvm-project/assets/29098113/1fd5f753-2a2e-4442-b6e0-f3f40d4a5b5e)

