### PR TITLE
[LLVM] [TableGen] Read from uninitialised variable

### DIFF
--- a/llvm/utils/TableGen/VarLenCodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/VarLenCodeEmitterGen.cpp
@@ -114,7 +114,7 @@ static std::pair<StringRef, StringRef> getCustomCoders(ArrayRef<Init *> Args) {
 }
 
 VarLenInst::VarLenInst(const DagInit *DI, const RecordVal *TheDef)
-    : TheDef(TheDef), NumBits(0U) {
+    : TheDef(TheDef), NumBits(0U), HasDynamicSegment(false) {
   buildRec(DI);
   for (const auto &S : Segments)
     NumBits += S.BitWidth;


### PR DESCRIPTION
Fixing an issue found in a UBsan build. When defining a variable-length
encoding with no operands or slices, the HasDynamicSegment member was
read without being initialised.
