### PR TITLE
libclc: generic: add half implementation for erf/erfc

### DIFF
--- a/libclc/generic/lib/math/erf.cl
+++ b/libclc/generic/lib/math/erf.cl
@@ -399,4 +399,16 @@ _CLC_OVERLOAD _CLC_DEF double erf(double y) {
 
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, erf, double);
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+_CLC_OVERLOAD _CLC_DEF half erf(half h) {
+    return (half)erf((float)h);
+}
+
+_CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, half, erf, half);
+
+#endif
+
 #endif

--- a/libclc/generic/lib/math/erfc.cl
+++ b/libclc/generic/lib/math/erfc.cl
@@ -410,4 +410,16 @@ _CLC_OVERLOAD _CLC_DEF double erfc(double x) {
 
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, erfc, double);
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+_CLC_OVERLOAD _CLC_DEF half erfc(half h) {
+    return (half)erfc((float)h);
+}
+
+_CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, half, erfc, half);
+
+#endif
+
 #endif


### PR DESCRIPTION
libclc does not have a half implementation for erf/erfc
Add one based on the float implementation by extending the input and truncating the output.