### PR TITLE
libclc: clspv: update gen_convert.cl for clspv

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -174,6 +174,12 @@ add_custom_command(
 	DEPENDS ${script_loc} )
 add_custom_target( "generate_convert.cl" DEPENDS convert.cl )
 
+add_custom_command(
+	OUTPUT clspv-convert.cl
+	COMMAND ${Python3_EXECUTABLE} ${script_loc} --clspv > clspv-convert.cl
+	DEPENDS ${script_loc} )
+add_custom_target( "clspv-generate_convert.cl" DEPENDS clspv-convert.cl )
+
 enable_testing()
 
 foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
@@ -218,11 +224,14 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 	# Add the generated convert.cl here to prevent adding
 	# the one listed in SOURCES
 	if( NOT ${ARCH} STREQUAL "spirv" AND NOT ${ARCH} STREQUAL "spirv64" )
-		set( rel_files convert.cl )
-		set( objects convert.cl )
 		if( NOT ENABLE_RUNTIME_SUBNORMAL AND NOT ${ARCH} STREQUAL "clspv" AND
 		    NOT ${ARCH} STREQUAL "clspv64" )
+			set( rel_files convert.cl )
+			set( objects convert.cl )
 			list( APPEND rel_files generic/lib/subnormal_use_default.ll )
+		elseif(${ARCH} STREQUAL "clspv" OR ${ARCH} STREQUAL "clspv64")
+			set( rel_files clspv-convert.cl )
+			set( objects clspv-convert.cl )
 		endif()
 	else()
 		set( rel_files )
@@ -286,6 +295,8 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 		# multiple invocations
 		add_dependencies( builtins.link.${arch_suffix}
 			generate_convert.cl )
+		add_dependencies( builtins.link.${arch_suffix}
+			clspv-generate_convert.cl )
 		# CMake will turn this include into absolute path
 		target_include_directories( builtins.link.${arch_suffix} PRIVATE
 			"generic/include" )


### PR DESCRIPTION
Add a clspv switch in gen_convert.cl
This is needed as Vulkan SPIR-V does not respect the assumptions
needed to have the generic convert.cl compliant on many platforms.

It is needed because of the conversion of TYPE_MAX and
TYPE_MIN. Depending on the platform the behaviour can vary, but most
of them just do not convert correctly those 2 values.

Because of that, we also need to avoid having explicit function for
simple conversions because it allows llvm to optimise the code, thus
removing some of the added checks that are in fact needed.