### PR TITLE
[clang-format] Correctly annotate keyword operator function name

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3294,6 +3294,11 @@ static bool isFunctionDeclarationName(bool IsCpp, const FormatToken &Current,
         !Previous->isOneOf(tok::kw_return, tok::kw_co_return)) {
       return true;
     }
+    if (Previous->is(tok::r_paren) && Previous->is(TT_TypeDeclarationParen)) {
+      assert(Previous->MatchingParen);
+      assert(Previous->MatchingParen->is(TT_TypeDeclarationParen));
+      return true;
+    }
     if (!Previous->isOneOf(tok::star, tok::amp, tok::ampamp, TT_TemplateCloser))
       return false;
     Next = skipOperatorName(Next);

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3296,6 +3296,7 @@ static bool isFunctionDeclarationName(bool IsCpp, const FormatToken &Current,
     }
     if (Previous->is(tok::r_paren) && Previous->is(TT_TypeDeclarationParen)) {
       assert(Previous->MatchingParen);
+      assert(Previous->MatchingParen->is(tok::l_paren));
       assert(Previous->MatchingParen->is(TT_TypeDeclarationParen));
       return true;
     }

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -753,6 +753,16 @@ TEST_F(TokenAnnotatorTest, UnderstandsOverloadedOperators) {
   EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_OverloadedOperator);
   EXPECT_TOKEN(Tokens[9], tok::l_paren, TT_OverloadedOperatorLParen);
   EXPECT_TOKEN(Tokens[11], tok::amp, TT_PointerOrReference);
+
+  Tokens = annotate("decltype(auto) operator()(T &x);");
+  ASSERT_EQ(Tokens.size(), 14u) << Tokens;
+  EXPECT_TOKEN(Tokens[1], tok::l_paren, TT_TypeDeclarationParen);
+  EXPECT_TOKEN(Tokens[3], tok::r_paren, TT_TypeDeclarationParen);
+  EXPECT_TOKEN(Tokens[4], tok::kw_operator, TT_FunctionDeclarationName);
+  EXPECT_TOKEN(Tokens[5], tok::l_paren, TT_OverloadedOperator);
+  EXPECT_TOKEN(Tokens[6], tok::r_paren, TT_OverloadedOperator);
+  EXPECT_TOKEN(Tokens[7], tok::l_paren, TT_OverloadedOperatorLParen);
+  EXPECT_TOKEN(Tokens[9], tok::amp, TT_PointerOrReference);
 }
 
 TEST_F(TokenAnnotatorTest, OverloadedOperatorInTemplate) {


### PR DESCRIPTION
Fixes #66890.