### PR TITLE
[Flang][OpenMP][Driver][Test] Fix the omp-driver-offload-test commands

### DIFF
--- a/flang/test/Driver/omp-driver-offload.f90
+++ b/flang/test/Driver/omp-driver-offload.f90
@@ -1,6 +1,10 @@
 ! Test that flang-new OpenMP and OpenMP offload related 
 ! commands forward or expand to the appropriate commands 
-! for flang-new -fc1 as expected.
+! for flang-new -fc1 as expected. Assumes a gfx90a, aarch64,
+! and sm_70 architecture, but doesn't require one to be 
+! installed or compiled for, just testing the appropriate 
+! generation of jobs are created with the correct 
+! corresponding arguments.
 
 ! Test regular -fopenmp with no offload
 ! RUN: %flang -### -fopenmp %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP %s
@@ -44,7 +48,7 @@
 ! OFFLOAD-DEVICE-NOT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
 ! Test regular -fopenmp with offload for basic fopenmp-is-target-device flag addition and correct fopenmp 
-! RUN: not %flang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP-IS-TARGET-DEVICE %s
+! RUN: %flang -### -fopenmp --offload-arch=gfx90a -fopenmp-targets=amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefixes=CHECK-OPENMP-IS-TARGET-DEVICE %s
 ! CHECK-OPENMP-IS-TARGET-DEVICE: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" {{.*}}.f90"
 
 ! Testing appropriate flags are gnerated and appropriately assigned by the driver when offloading
@@ -58,44 +62,51 @@
 ! OPENMP-OFFLOAD-ARGS-NEXT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu" {{.*}} "-fopenmp" {{.*}} "-fembed-offload-object={{.*}}.out" {{.*}}.bc"
 
 ! Test -fopenmp with offload for RTL Flag Options
-! RUN: not %flang -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-assume-threads-oversubscription \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREADS-OVS
 ! CHECK-THREADS-OVS: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
 
-! RUN: not %flang -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-assume-teams-oversubscription  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TEAMS-OVS
 ! CHECK-TEAMS-OVS: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
 
-! RUN: not %flang -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-assume-no-nested-parallelism  \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-NEST-PAR
 ! CHECK-NEST-PAR: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
 
-! RUN: not %flang -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-assume-no-thread-state \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREAD-STATE
 ! CHECK-THREAD-STATE: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
 
-! RUN: not %flang -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
 ! CHECK-TARGET-DEBUG: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
 
-! RUN: not %flang -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-target-debug \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
 ! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
 
-! RUN: not %flang -S -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -S -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-target-debug -fopenmp-assume-threads-oversubscription \
 ! RUN: -fopenmp-assume-teams-oversubscription -fopenmp-assume-no-nested-parallelism \
 ! RUN: -fopenmp-assume-no-thread-state \
@@ -104,8 +115,9 @@
 ! CHECK-RTL-ALL: "-fopenmp-assume-threads-oversubscription" "-fopenmp-assume-no-thread-state" "-fopenmp-assume-no-nested-parallelism"
 ! CHECK-RTL-ALL: {{.*}}.f90"
 
-! RUN: not %flang -### %s -o %t 2>&1 \
-! RUN: -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+! RUN: %flang -### %s -o %t 2>&1 \
+! RUN: -fopenmp --offload-arch=gfx90a \
+! RUN: -fopenmp-targets=amdgcn-amd-amdhsa \
 ! RUN: -fopenmp-version=45 \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-OPENMP-VERSION
 ! CHECK-OPENMP-VERSION: "{{[^"]*}}flang-new" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"


### PR DESCRIPTION
Since the changes to -### to correctly return error codes in D156363, some additions of the not lit keyword and perhaps some changes to how fopenmp-targets is handled; the test omp-driver-offload.f90 has become a little susceptible to what appears to be sporadic failures.

This was because if certain environment variables are set for AMD devices some of the commands succeed happily and the not check causes the test to fail. Whereas, if they were not set the tests would fail and the not test would succeed, allowing the test to pass provided you were not targeting AMD hardware while running the test.

When the environment variables for AMD hardware are set the compiler could find the correct offload architecture to compile for, allowing the command to succeed. However, when not set it'd fail as it can't detect the offload architecture. The solution to this is to specify an AMD architecture via --offload-arch so it always passes, the architecture doesn't really matter, I've chosen to select gfx90a.

Another command was just slightly incorrect, although it emitted the expected output, it'd return an error code as it was trying to emit multiple outputs to one file (had to remove the -o).