### PR TITLE
[hwasan] Update (Post-)DominatorTreeAnalysis and LoopAnalysis incrementally

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1535,10 +1535,10 @@ void HWAddressSanitizer::sanitizeFunction(Function &F,
                    Mapping.WithFrameRecord &&
                    !SInfo.AllocasToInstrument.empty());
 
+  DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(F);
+  PostDominatorTree &PDT = FAM.getResult<PostDominatorTreeAnalysis>(F);
+  LoopInfo &LI = FAM.getResult<LoopAnalysis>(F);
   if (!SInfo.AllocasToInstrument.empty()) {
-    const DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(F);
-    const PostDominatorTree &PDT = FAM.getResult<PostDominatorTreeAnalysis>(F);
-    const LoopInfo &LI = FAM.getResult<LoopAnalysis>(F);
     Value *StackTag = getStackBaseTag(EntryIRB);
     Value *UARTag = getUARTag(EntryIRB);
     instrumentStack(SInfo, StackTag, UARTag, DT, PDT, LI);
@@ -1557,10 +1557,7 @@ void HWAddressSanitizer::sanitizeFunction(Function &F,
     }
   }
 
-  DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(F);
-  PostDominatorTree &PDT = FAM.getResult<PostDominatorTreeAnalysis>(F);
   DomTreeUpdater DTU(DT, PDT, DomTreeUpdater::UpdateStrategy::Lazy);
-  LoopInfo &LI = FAM.getResult<LoopAnalysis>(F);
   for (auto &Operand : OperandsToInstrument)
     instrumentMemAccess(Operand, &DTU, &LI);
   DTU.flush();

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -438,9 +438,11 @@ PreservedAnalyses HWAddressSanitizerPass::run(Module &M,
     HWASan.sanitizeFunction(F, FAM);
 
   PreservedAnalyses PA = PreservedAnalyses::none();
-  // DominatorTreeAnalysis and LoopAnalysis are incrementally updated
-  // throughout this pass whenever SplitBlockAndInsertIfThen is called.
+  // DominatorTreeAnalysis, PostDominatorTreeAnalysis, and LoopAnalysis
+  // are incrementally updated throughout this pass whenever
+  // SplitBlockAndInsertIfThen is called.
   PA.preserve<DominatorTreeAnalysis>();
+  PA.preserve<PostDominatorTreeAnalysis>();
   PA.preserve<LoopAnalysis>();
   // GlobalsAA is considered stateless and does not get invalidated unless
   // explicitly invalidated; PreservedAnalyses::none() is not enough. Sanitizers


### PR DESCRIPTION
HWAddressSanitizerPass::run sanitizes functions one by one. The sanitization of each function - which may split blocks via insertShadowTagCheck - may result in some cached analyses are invalid. This matters because sanitizeFunction(F', FAM) may indirectly call the global stack safety analysis, hence we need to make sure the analyses of F are up to date.

Bug report: https://github.com/llvm/llvm-project/issues/66934
