### PR TITLE
[InstrRef][NFC] Improve diagram illustrating locations

### DIFF
--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
@@ -602,8 +602,8 @@ public:
 /// Slot Num (%stack.0)   /
 /// FrameIdx => SpillNum /
 ///              \      /
-///           SpillID (int)              Register number (int)
-///                      \                  /
+///           SpillID (int)   Register number (int)
+///                      \       /
 ///                      LocationID => LocIdx
 ///                                |
 ///                       LocIdx => ValueIDNum


### PR DESCRIPTION
The "register number" arrow should point to `LocationID`, not `LocIdx`.