### PR TITLE
[lldb] Fix stdcpp type summary mistakenly marked as regex (NFC)

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1009,7 +1009,7 @@ static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   cpp_category_sp->AddTypeSummary("std::string", eFormatterMatchExact,
                                   std_string_summary_sp);
   cpp_category_sp->AddTypeSummary("std::basic_string<char>",
-                                  eFormatterMatchRegex, std_string_summary_sp);
+                                  eFormatterMatchExact, std_string_summary_sp);
   cpp_category_sp->AddTypeSummary(
       "std::basic_string<char,std::char_traits<char>,std::allocator<char> >",
       eFormatterMatchExact, std_string_summary_sp);


### PR DESCRIPTION
`std::basic_string<char>` is not a regex, and treating it as such could unintentionally
cause a formatter to substring match a template type parameter, for example:
`std::vector<std::basic_string<char>>`.

Differential Revision: https://reviews.llvm.org/D158663
