### PR TITLE
[clang-format] Don't split "DPI"/"DPI-C" in Verilog imports

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -2273,14 +2273,11 @@ ContinuationIndenter::createBreakableToken(const FormatToken &Current,
     // The "DPI"/"DPI-C" in SystemVerilog direct programming interface imports
     // cannot be split, e.g.
     // `import "DPI" function foo();`
-    StringRef Text = Current.TokenText;
-    if (Style.isVerilog()) {
-      const FormatToken *Prev = Current.getPreviousNonComment();
-      if (Prev && Prev == State.Line->getFirstNonComment() &&
-          Prev->TokenText == "import") {
-        return nullptr;
-      }
+    if (Style.isVerilog() && Current.Previous &&
+        Current.Previous->isOneOf(tok::kw_export, Keywords.kw_import)) {
+      return nullptr;
     }
+    StringRef Text = Current.TokenText;
 
     // We need this to address the case where there is an unbreakable tail only
     // if certain other formatting decisions have been taken. The

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -2270,9 +2270,10 @@ ContinuationIndenter::createBreakableToken(const FormatToken &Current,
     if (State.Stack.back().IsInsideObjCArrayLiteral)
       return nullptr;
 
-    // The "DPI"/"DPI-C" in SystemVerilog direct programming interface imports
-    // cannot be split, e.g.
+    // The "DPI"/"DPI-C" in SystemVerilog direct programming interface
+    // imports/exports cannot be split, e.g.
     // `import "DPI" function foo();`
+    // FIXME: make this use same infra as C++ import checks
     if (Style.isVerilog() && Current.Previous &&
         Current.Previous->isOneOf(tok::kw_export, Keywords.kw_import)) {
       return nullptr;

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -2270,7 +2270,15 @@ ContinuationIndenter::createBreakableToken(const FormatToken &Current,
     if (State.Stack.back().IsInsideObjCArrayLiteral)
       return nullptr;
 
+    // The "DPI" (or "DPI-C") in SystemVerilog direct programming interface
+    // imports cannot be split, e.g.
+    // `import "DPI" function foo();`
+    // FIXME: We should see if this is an import statement instead of hardcoding
+    // "DPI"/"DPI-C".
     StringRef Text = Current.TokenText;
+    if (Style.isVerilog() && (Text == "\"DPI\"" || Text == "\"DPI-C\""))
+      return nullptr;
+
     // We need this to address the case where there is an unbreakable tail only
     // if certain other formatting decisions have been taken. The
     // UnbreakableTailLength of Current is an overapproximation in that case and

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -2270,14 +2270,17 @@ ContinuationIndenter::createBreakableToken(const FormatToken &Current,
     if (State.Stack.back().IsInsideObjCArrayLiteral)
       return nullptr;
 
-    // The "DPI" (or "DPI-C") in SystemVerilog direct programming interface
-    // imports cannot be split, e.g.
+    // The "DPI"/"DPI-C" in SystemVerilog direct programming interface imports
+    // cannot be split, e.g.
     // `import "DPI" function foo();`
-    // FIXME: We should see if this is an import statement instead of hardcoding
-    // "DPI"/"DPI-C".
     StringRef Text = Current.TokenText;
-    if (Style.isVerilog() && (Text == "\"DPI\"" || Text == "\"DPI-C\""))
-      return nullptr;
+    if (Style.isVerilog()) {
+      const FormatToken *Prev = Current.getPreviousNonComment();
+      if (Prev && Prev == State.Line->getFirstNonComment() &&
+          Prev->TokenText == "import") {
+        return nullptr;
+      }
+    }
 
     // We need this to address the case where there is an unbreakable tail only
     // if certain other formatting decisions have been taken. The

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -1253,7 +1253,7 @@ TEST_F(FormatTestVerilog, StringLiteral) {
    "xxxx"});)",
                R"(x({"xxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx ", "xxxx"});)",
                getStyleWithColumns(getDefaultStyle(), 23));
-  // "DPI"/"DPI-C" in imports cannot be split.
+  // import "DPI"/"DPI-C" cannot be split.
   verifyFormat(R"(import
     "DPI-C" function t foo
     ();)",

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -1253,6 +1253,12 @@ TEST_F(FormatTestVerilog, StringLiteral) {
    "xxxx"});)",
                R"(x({"xxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx ", "xxxx"});)",
                getStyleWithColumns(getDefaultStyle(), 23));
+  // "DPI"/"DPI-C" in imports cannot be split.
+  verifyFormat(R"(import
+    "DPI-C" function t foo
+    ();)",
+               R"(import "DPI-C" function t foo();)",
+               getStyleWithColumns(getDefaultStyle(), 23));
   // These kinds of strings don't exist in Verilog.
   verifyNoCrash(R"(x(@"xxxxxxxxxxxxxxxx xxxx");)",
                 getStyleWithColumns(getDefaultStyle(), 23));

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -1253,11 +1253,14 @@ TEST_F(FormatTestVerilog, StringLiteral) {
    "xxxx"});)",
                R"(x({"xxxxxxxxxxxxxxxx xxxxxxxxxxxxxxxx ", "xxxx"});)",
                getStyleWithColumns(getDefaultStyle(), 23));
-  // import "DPI"/"DPI-C" cannot be split.
+  // import/export "DPI"/"DPI-C" cannot be split.
   verifyFormat(R"(import
-    "DPI-C" function t foo
+    "DPI-C" function void foo
     ();)",
-               R"(import "DPI-C" function t foo();)",
+               R"(import "DPI-C" function void foo();)",
+               getStyleWithColumns(getDefaultStyle(), 23));
+  verifyFormat(R"(export "DPI-C" function foo;)",
+               R"(export "DPI-C" function foo;)",
                getStyleWithColumns(getDefaultStyle(), 23));
   // These kinds of strings don't exist in Verilog.
   verifyNoCrash(R"(x(@"xxxxxxxxxxxxxxxx xxxx");)",


### PR DESCRIPTION
The spec doesn't allow splitting these strings and we're seeing compile issues with splitting it.

String splitting was enabled for Verilog in https://reviews.llvm.org/D154093.
