### PR TITLE
[AIX] cxx_std_23 is currently not a known feature to ibm-clang

### DIFF
--- a/libcxx/benchmarks/CMakeLists.txt
+++ b/libcxx/benchmarks/CMakeLists.txt
@@ -81,7 +81,9 @@ add_library(               cxx-benchmarks-flags INTERFACE)
 # requesting `cxx_std_23` results in an error -- somehow CMake fails to
 # translate the `c++23` flag into `c++latest`, and the highest numbered C++
 # version that MSVC flags support is C++20.
-if (MSVC)
+# ibm-clang does not recognize the cxx_std_32 flag, so use this as a temporary
+# workaround on AIX as well.
+if (MSVC OR ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
   add_compile_options(/std:c++latest)
 else()
   target_compile_features( cxx-benchmarks-flags INTERFACE cxx_std_23)

--- a/libcxx/benchmarks/CMakeLists.txt
+++ b/libcxx/benchmarks/CMakeLists.txt
@@ -81,10 +81,12 @@ add_library(               cxx-benchmarks-flags INTERFACE)
 # requesting `cxx_std_23` results in an error -- somehow CMake fails to
 # translate the `c++23` flag into `c++latest`, and the highest numbered C++
 # version that MSVC flags support is C++20.
-# ibm-clang does not recognize the cxx_std_32 flag, so use this as a temporary
-# workaround on AIX as well.
 if (MSVC OR ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
   add_compile_options(/std:c++latest)
+# ibm-clang does not recognize the cxx_std_32 flag, so use this as a temporary
+# workaround on AIX as well.
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  add_compile_options(-std=c++23)
 else()
   target_compile_features( cxx-benchmarks-flags INTERFACE cxx_std_23)
 endif()

--- a/libcxx/benchmarks/CMakeLists.txt
+++ b/libcxx/benchmarks/CMakeLists.txt
@@ -81,7 +81,7 @@ add_library(               cxx-benchmarks-flags INTERFACE)
 # requesting `cxx_std_23` results in an error -- somehow CMake fails to
 # translate the `c++23` flag into `c++latest`, and the highest numbered C++
 # version that MSVC flags support is C++20.
-if (MSVC OR ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+if (MSVC)
   add_compile_options(/std:c++latest)
 # ibm-clang does not recognize the cxx_std_32 flag, so use this as a temporary
 # workaround on AIX as well.


### PR DESCRIPTION
Temporary workaround for the following CMake error:
```
CMake Error in /llvm/libcxx/benchmarks/CMakeLists.txt:
The compiler feature "cxx_std_23" is not known to CXX compiler
"IBMClang"
```