### PR TITLE
[clang][Sema] Fix crash introduced in b2cd9db589335d5885c04df83003a623cf2f05ff

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -185,7 +185,7 @@ calculateConstraintSatisfaction(Sema &S, const Expr *ConstraintExpr,
   ConstraintExpr = ConstraintExpr->IgnoreParenImpCasts();
 
   if (LogicalBinOp BO = ConstraintExpr) {
-    auto EffectiveDetailEnd = Satisfaction.Details.end();
+    size_t EffectiveDetailEndIndex = Satisfaction.Details.size();
     ExprResult LHSRes = calculateConstraintSatisfaction(
         S, BO.getLHS(), Satisfaction, Evaluator);
 
@@ -228,9 +228,12 @@ calculateConstraintSatisfaction(Sema &S, const Expr *ConstraintExpr,
     // The following code removes the irrelevant diagnostic information.
     // FIXME: We should probably delay the addition of diagnostic information
     // until we know the entire expression is false.
-    if (BO.isOr() && IsRHSSatisfied)
+    if (BO.isOr() && IsRHSSatisfied) {
+      auto EffectiveDetailEnd =
+          Satisfaction.Details.begin() + EffectiveDetailEndIndex;
       Satisfaction.Details.erase(EffectiveDetailEnd,
                                  Satisfaction.Details.end());
+    }
 
     return BO.recreateBinOp(S, LHSRes, RHSRes);
   }

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -229,8 +229,8 @@ calculateConstraintSatisfaction(Sema &S, const Expr *ConstraintExpr,
     // FIXME: We should probably delay the addition of diagnostic information
     // until we know the entire expression is false.
     if (BO.isOr() && IsRHSSatisfied) {
-      auto EffectiveDetailEnd =
-          Satisfaction.Details.begin() + EffectiveDetailEndIndex;
+      auto EffectiveDetailEnd = Satisfaction.Details.begin();
+      std::advance(EffectiveDetailEnd, EffectiveDetailEndIndex);
       Satisfaction.Details.erase(EffectiveDetailEnd,
                                  Satisfaction.Details.end());
     }

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1048,3 +1048,19 @@ namespace GH66612 {
   // expected-note@-1{{because 'int' does not satisfy 'Container'}}
   // expected-note@#66612GH_END{{because 'end' would be invalid: reference to overloaded function could not be resolved; did you mean to call it?}}
 }
+
+namespace GH66938 {
+template <class>
+concept True = true;
+
+template <class>
+concept False = false;
+
+template <class T>
+void cand(T t)
+  requires False<T> || False<T> || False<T> || False<T> || False<T> ||
+           False<T> || False<T> || False<T> || False<T> || True<T>
+{}
+
+void test() { cand(42); }
+}


### PR DESCRIPTION
Old iterator is invalidated upon SmallVector elements additions. Stores index instead of iterator to avoid this.

Fixes https://github.com/llvm/llvm-project/issues/66938