### PR TITLE
[mlir] Move supplemental patterns before op replacement

### DIFF
--- a/mlir/tools/mlir-tblgen/RewriterGen.cpp
+++ b/mlir/tools/mlir-tblgen/RewriterGen.cpp
@@ -1172,9 +1172,22 @@ void PatternEmitter::emitRewriteLogic() {
       os << val << ";\n";
   }
 
+  auto processSupplementalPatterns = [&]() {
+    int numSupplementalPatterns = pattern.getNumSupplementalPatterns();
+    for (int i = 0, offset = -numSupplementalPatterns;
+         i < numSupplementalPatterns; ++i) {
+      DagNode resultTree = pattern.getSupplementalPattern(i);
+      auto val = handleResultPattern(resultTree, offset++, 0);
+      if (resultTree.isNativeCodeCall() &&
+          resultTree.getNumReturnsOfNativeCode() == 0)
+        os << val << ";\n";
+    }
+  };
+
   if (numExpectedResults == 0) {
     assert(replStartIndex >= numResultPatterns &&
            "invalid auxiliary vs. replacement pattern division!");
+    processSupplementalPatterns();
     // No result to replace. Just erase the op.
     os << "rewriter.eraseOp(op0);\n";
   } else {
@@ -1196,18 +1209,8 @@ void PatternEmitter::emitRewriteLogic() {
           "  tblgen_repl_values.push_back(v);\n}\n",
           "\n");
     }
+    processSupplementalPatterns();
     os << "\nrewriter.replaceOp(op0, tblgen_repl_values);\n";
-  }
-
-  // Process supplemtal patterns.
-  int numSupplementalPatterns = pattern.getNumSupplementalPatterns();
-  for (int i = 0, offset = -numSupplementalPatterns;
-       i < numSupplementalPatterns; ++i) {
-    DagNode resultTree = pattern.getSupplementalPattern(i);
-    auto val = handleResultPattern(resultTree, offset++, 0);
-    if (resultTree.isNativeCodeCall() &&
-        resultTree.getNumReturnsOfNativeCode() == 0)
-      os << val << ";\n";
   }
 
   LLVM_DEBUG(llvm::dbgs() << "--- done emitting rewrite logic ---\n");


### PR DESCRIPTION
This moves the C++ code generated from supplemental patterns before op replacement. It is necessary if the supllemental patterns need to access the source op.