### PR TITLE
[clang][modules] Remove preloaded SLocEntries from PCM files

### DIFF
--- a/clang/include/clang/Basic/SourceLocation.h
+++ b/clang/include/clang/Basic/SourceLocation.h
@@ -59,6 +59,7 @@ private:
   friend class ASTWriter;
   friend class ASTReader;
   friend class SourceManager;
+  friend class SourceManagerTestHelper;
 
   static FileID get(int V) {
     FileID F;

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -701,6 +701,10 @@ class SourceManager : public RefCountedBase<SourceManager> {
   /// use (-ID - 2).
   SmallVector<SrcMgr::SLocEntry, 0> LoadedSLocEntryTable;
 
+  /// For each allocation in LoadedSLocEntryTable, we keep the new size. This
+  /// can be used to determine whether two FileIDs come from the same AST file.
+  SmallVector<size_t, 0> LoadedSLocEntryTableSegments;
+
   /// The starting offset of the next local SLocEntry.
   ///
   /// This is LocalSLocEntryTable.back().Offset + the size of that entry.
@@ -1648,6 +1652,11 @@ public:
   std::pair<bool, bool>
   isInTheSameTranslationUnit(std::pair<FileID, unsigned> &LOffs,
                              std::pair<FileID, unsigned> &ROffs) const;
+
+  /// Determines whether the two decomposed source location is in the same TU.
+  bool isInTheSameTranslationUnitImpl(
+      const std::pair<FileID, unsigned> &LOffs,
+      const std::pair<FileID, unsigned> &ROffs) const;
 
   /// Determines the order of 2 source locations in the "source location
   /// address space".

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -701,9 +701,10 @@ class SourceManager : public RefCountedBase<SourceManager> {
   /// use (-ID - 2).
   SmallVector<SrcMgr::SLocEntry, 0> LoadedSLocEntryTable;
 
-  /// For each allocation in LoadedSLocEntryTable, we keep the new size. This
-  /// can be used to determine whether two FileIDs come from the same AST file.
-  SmallVector<size_t, 0> LoadedSLocEntryTableSegments;
+  /// For each allocation in LoadedSLocEntryTable, we keep the first FileID.
+  /// We assume exactly one allocation per AST file, and use that to determine
+  /// whether two FileIDs come from the same AST file.
+  SmallVector<FileID, 0> LoadedSLocEntryAllocBegin;
 
   /// The starting offset of the next local SLocEntry.
   ///

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -51,7 +51,7 @@ const unsigned VERSION_MAJOR = 29;
 /// for the previous version could still support reading the new
 /// version by ignoring new kinds of subblocks), this number
 /// should be increased.
-const unsigned VERSION_MINOR = 0;
+const unsigned VERSION_MINOR = 1;
 
 /// An ID number that refers to an identifier in an AST file.
 ///
@@ -524,13 +524,7 @@ enum ASTRecordTypes {
   /// of source-location information.
   SOURCE_LOCATION_OFFSETS = 14,
 
-  /// Record code for the set of source location entries
-  /// that need to be preloaded by the AST reader.
-  ///
-  /// This set contains the source location entry for the
-  /// predefines buffer and for any file entries that need to be
-  /// preloaded.
-  SOURCE_LOCATION_PRELOADS = 15,
+  // ID 15 used to be for source location entry preloads.
 
   /// Record code for the set of ext_vector type names.
   EXT_VECTOR_DECLS = 16,

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -292,9 +292,6 @@ public:
   /// AST file.
   const uint32_t *SLocEntryOffsets = nullptr;
 
-  /// SLocEntries that we're going to preload.
-  SmallVector<uint64_t, 4> PreloadSLocEntries;
-
   /// Remapping table for source locations in this module.
   ContinuousRangeMap<SourceLocation::UIntTy, SourceLocation::IntTy, 2>
       SLocRemap;

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -1986,8 +1986,8 @@ bool SourceManager::isInTheSameTranslationUnitImpl(
 
   if (isLoadedFileID(LOffs.first) && isLoadedFileID(ROffs.first)) {
     auto FindSLocEntryAlloc = [this](FileID FID) {
-      // FileIDs are negative, we store the beginning of each allocation (the
-      // lowest FileID), later allocations have lower FileIDs.
+      // Loaded FileIDs are negative, we store the lowest FileID from each
+      // allocation, later allocations have lower FileIDs.
       return llvm::upper_bound(LoadedSLocEntryAllocBegin, FID, std::greater{});
     };
 

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -461,9 +461,9 @@ SourceManager::AllocateLoadedSLocEntries(unsigned NumSLocEntries,
   LoadedSLocEntryTable.resize(LoadedSLocEntryTable.size() + NumSLocEntries);
   SLocEntryLoaded.resize(LoadedSLocEntryTable.size());
   CurrentLoadedOffset -= TotalSize;
-  int ID = LoadedSLocEntryTable.size();
-  LoadedSLocEntryAllocBegin.push_back(FileID::get(-ID - 2));
-  return std::make_pair(-ID - 1, CurrentLoadedOffset);
+  int BaseID = -int(LoadedSLocEntryTable.size()) - 1;
+  LoadedSLocEntryAllocBegin.push_back(FileID::get(BaseID));
+  return std::make_pair(BaseID, CurrentLoadedOffset);
 }
 
 /// As part of recovering from missing or changed content, produce a
@@ -1988,7 +1988,7 @@ bool SourceManager::isInTheSameTranslationUnitImpl(
     auto FindSLocEntryAlloc = [this](FileID FID) {
       // Loaded FileIDs are negative, we store the lowest FileID from each
       // allocation, later allocations have lower FileIDs.
-      return llvm::upper_bound(LoadedSLocEntryAllocBegin, FID, std::greater{});
+      return llvm::lower_bound(LoadedSLocEntryAllocBegin, FID, std::greater{});
     };
 
     // If both are loaded from different AST files.

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -838,7 +838,6 @@ void ASTWriter::WriteBlockInfoBlock() {
   RECORD(METHOD_POOL);
   RECORD(PP_COUNTER_VALUE);
   RECORD(SOURCE_LOCATION_OFFSETS);
-  RECORD(SOURCE_LOCATION_PRELOADS);
   RECORD(EXT_VECTOR_DECLS);
   RECORD(UNUSED_FILESCOPED_DECLS);
   RECORD(PPD_ENTITIES_OFFSETS);
@@ -2137,7 +2136,6 @@ void ASTWriter::WriteSourceManagerBlock(SourceManager &SourceMgr,
   // entry, which is always the same dummy entry.
   std::vector<uint32_t> SLocEntryOffsets;
   uint64_t SLocEntryOffsetsBase = Stream.GetCurrentBitNo();
-  RecordData PreloadSLocs;
   SLocEntryOffsets.reserve(SourceMgr.local_sloc_entry_size() - 1);
   for (unsigned I = 1, N = SourceMgr.local_sloc_entry_size();
        I != N; ++I) {
@@ -2213,9 +2211,6 @@ void ASTWriter::WriteSourceManagerBlock(SourceManager &SourceMgr,
         Stream.EmitRecordWithBlob(SLocBufferAbbrv, Record,
                                   StringRef(Name.data(), Name.size() + 1));
         EmitBlob = true;
-
-        if (Name == "<built-in>")
-          PreloadSLocs.push_back(SLocEntryOffsets.size());
       }
 
       if (EmitBlob) {
@@ -2277,9 +2272,6 @@ void ASTWriter::WriteSourceManagerBlock(SourceManager &SourceMgr,
     Stream.EmitRecordWithBlob(SLocOffsetsAbbrev, Record,
                               bytes(SLocEntryOffsets));
   }
-  // Write the source location entry preloads array, telling the AST
-  // reader which source locations entries it should load eagerly.
-  Stream.EmitRecord(SOURCE_LOCATION_PRELOADS, PreloadSLocs);
 
   // Write the line table. It depends on remapping working, so it must come
   // after the source location offsets.

--- a/clang/unittests/Basic/SourceManagerTest.cpp
+++ b/clang/unittests/Basic/SourceManagerTest.cpp
@@ -26,6 +26,13 @@
 
 using namespace clang;
 
+namespace clang {
+class SourceManagerTestHelper {
+public:
+  static FileID makeFileID(int ID) { return FileID::get(ID); }
+};
+} // namespace clang
+
 namespace {
 
 // The test fixture.
@@ -407,6 +414,52 @@ TEST_F(SourceManagerTest, getLineNumber) {
   SourceMgr.setMainFileID(mainFileID);
 
   ASSERT_NO_FATAL_FAILURE(SourceMgr.getLineNumber(mainFileID, 1, nullptr));
+}
+
+struct FakeExternalSLocEntrySource : ExternalSLocEntrySource {
+  bool ReadSLocEntry(int ID) override { return {}; }
+  std::pair<SourceLocation, StringRef> getModuleImportLoc(int ID) override {
+    return {};
+  }
+};
+
+TEST_F(SourceManagerTest, loadedSLocEntryIsInTheSameTranslationUnit) {
+  auto InSameTU = [=](int LID, int RID) {
+    return SourceMgr.isInTheSameTranslationUnitImpl(
+        std::make_pair(SourceManagerTestHelper::makeFileID(LID), 0),
+        std::make_pair(SourceManagerTestHelper::makeFileID(RID), 0));
+  };
+
+  FakeExternalSLocEntrySource ExternalSource;
+  SourceMgr.setExternalSLocEntrySource(&ExternalSource);
+
+  unsigned ANumFileIDs = 10;
+  auto [AFirstID, X] = SourceMgr.AllocateLoadedSLocEntries(ANumFileIDs, 10);
+  int ALastID = AFirstID + ANumFileIDs - 1;
+  // FileID(-11)..FileID(-2)
+  ASSERT_EQ(AFirstID, -11);
+  ASSERT_EQ(ALastID, -2);
+
+  unsigned BNumFileIDs = 20;
+  auto [BFirstID, Y] = SourceMgr.AllocateLoadedSLocEntries(BNumFileIDs, 20);
+  int BLastID = BFirstID + BNumFileIDs - 1;
+  // FileID(-31)..FileID(-12)
+  ASSERT_EQ(BFirstID, -31);
+  ASSERT_EQ(BLastID, -12);
+
+  // Loaded vs local.
+  EXPECT_FALSE(InSameTU(-2, 1));
+
+  // Loaded in the same allocation A.
+  EXPECT_TRUE(InSameTU(-11, -2));
+  EXPECT_TRUE(InSameTU(-11, -6));
+
+  // Loaded in the same allocation B.
+  EXPECT_TRUE(InSameTU(-31, -12));
+  EXPECT_TRUE(InSameTU(-31, -16));
+
+  // Loaded from different allocations A and B.
+  EXPECT_FALSE(InSameTU(-12, -11));
 }
 
 #if defined(LLVM_ON_UNIX)


### PR DESCRIPTION
This commit removes the list of SLocEntry offsets to preload eagerly from PCM files. Commit introducing this functionality (258ae54a) doesn't clarify why this would be more performant than the lazy approach used regularly.

Currently, the only SLocEntry the reader is supposed to preload is the predefines buffer, but in my experience, it's not actually referenced in most modules, so the time spent deserializing its SLocEntry is wasted. This is especially noticeable in the dependency scanner, where this change brings 4.56% speedup on my benchmark.
