### PR TITLE
[clang][modules] Move `SLocEntry` search into `ASTReader`

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -499,6 +499,14 @@ public:
     return Expansion;
   }
 
+  /// Creates an incomplete SLocEntry that is only able to report its offset.
+  static SLocEntry getOffsetOnly(SourceLocation::UIntTy Offset) {
+    assert(!(Offset & (1ULL << OffsetBits)) && "Offset is too large");
+    SLocEntry E;
+    E.Offset = Offset;
+    return E;
+  }
+
   static SLocEntry get(SourceLocation::UIntTy Offset, const FileInfo &FI) {
     assert(!(Offset & (1ULL << OffsetBits)) && "Offset is too large");
     SLocEntry E;
@@ -728,6 +736,12 @@ class SourceManager : public RefCountedBase<SourceManager> {
   ///
   /// Same indexing as LoadedSLocEntryTable.
   llvm::BitVector SLocEntryLoaded;
+
+  /// A bitmap that indicates whether the entries of LoadedSLocEntryTable
+  /// have already had their offset loaded from the external source.
+  ///
+  /// Superset of SLocEntryLoaded. Same indexing as SLocEntryLoaded.
+  llvm::BitVector SLocEntryOffsetLoaded;
 
   /// An external source for source location entries.
   ExternalSLocEntrySource *ExternalSLocEntries = nullptr;

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -534,6 +534,9 @@ public:
   virtual bool ReadSLocEntry(int ID) = 0;
 
   /// Get the index ID for the loaded SourceLocation offset.
+  ///
+  /// \returns Invalid index ID (0) if an error occurred that prevented the
+  /// SLocEntry  from being loaded.
   virtual int getSLocEntryID(SourceLocation::UIntTy SLocOffset) = 0;
 
   /// Retrieve the module import location and name for the given ID, if

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -533,6 +533,9 @@ public:
   /// entry from being loaded.
   virtual bool ReadSLocEntry(int ID) = 0;
 
+  /// Get the index ID for the loaded SourceLocation offset.
+  virtual int getSLocEntryID(SourceLocation::UIntTy SLocOffset) = 0;
+
   /// Retrieve the module import location and name for the given ID, if
   /// in fact it was loaded from a module (rather than, say, a precompiled
   /// header).

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -2157,8 +2157,8 @@ public:
   int getSLocEntryID(SourceLocation::UIntTy SLocOffset) override;
   /// Try to read the offset of the SLocEntry at the given index in the given
   /// module file.
-  std::optional<SourceLocation::UIntTy> readSLocOffset(ModuleFile *F,
-                                                       unsigned Index);
+  llvm::Expected<SourceLocation::UIntTy> readSLocOffset(ModuleFile *F,
+                                                        unsigned Index);
 
   /// Retrieve the module import location and module name for the
   /// given source manager entry ID.

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -2153,6 +2153,12 @@ public:
 
   /// Read the source location entry with index ID.
   bool ReadSLocEntry(int ID) override;
+  /// Get the index ID for the loaded SourceLocation offset.
+  int getSLocEntryID(SourceLocation::UIntTy SLocOffset) override;
+  /// Read the offset of the SLocEntry at the given index in the given module
+  /// file.
+  std::optional<SourceLocation::UIntTy> readSLocOffset(ModuleFile *F,
+                                                       unsigned Index);
 
   /// Retrieve the module import location and module name for the
   /// given source manager entry ID.

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -2155,8 +2155,8 @@ public:
   bool ReadSLocEntry(int ID) override;
   /// Get the index ID for the loaded SourceLocation offset.
   int getSLocEntryID(SourceLocation::UIntTy SLocOffset) override;
-  /// Read the offset of the SLocEntry at the given index in the given module
-  /// file.
+  /// Try to read the offset of the SLocEntry at the given index in the given
+  /// module file.
   std::optional<SourceLocation::UIntTy> readSLocOffset(ModuleFile *F,
                                                        unsigned Index);
 

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -291,9 +291,6 @@ public:
   /// Stream bit offsets for all of the source location entries in the AST file.
   const uint32_t *SLocEntryOffsets = nullptr;
 
-  /// SLocEntry offsets that have been loaded from the AST file.
-  std::vector<SourceLocation::UIntTy> SLocEntryOffsetLoaded;
-
   /// SLocEntries that we're going to preload.
   SmallVector<uint64_t, 4> PreloadSLocEntries;
 

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -288,7 +288,8 @@ public:
   /// for the entry is SLocEntryOffsetsBase + SLocEntryOffsets[i].
   uint64_t SLocEntryOffsetsBase = 0;
 
-  /// Stream bit offsets for all of the source location entries in the AST file.
+  /// Offsets for all of the source location entries in the
+  /// AST file.
   const uint32_t *SLocEntryOffsets = nullptr;
 
   /// SLocEntries that we're going to preload.

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -288,9 +288,11 @@ public:
   /// for the entry is SLocEntryOffsetsBase + SLocEntryOffsets[i].
   uint64_t SLocEntryOffsetsBase = 0;
 
-  /// Offsets for all of the source location entries in the
-  /// AST file.
+  /// Stream bit offsets for all of the source location entries in the AST file.
   const uint32_t *SLocEntryOffsets = nullptr;
+
+  /// SLocEntry offsets that have been loaded from the AST file.
+  std::vector<SourceLocation::UIntTy> SLocEntryOffsetLoaded;
 
   /// SLocEntries that we're going to preload.
   SmallVector<uint64_t, 4> PreloadSLocEntries;

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -864,6 +864,11 @@ FileID SourceManager::getFileIDLocal(SourceLocation::UIntTy SLocOffset) const {
 /// This function knows that the SourceLocation is in a loaded buffer, not a
 /// local one.
 FileID SourceManager::getFileIDLoaded(SourceLocation::UIntTy SLocOffset) const {
+  if (SLocOffset < CurrentLoadedOffset) {
+    assert(0 && "Invalid SLocOffset or bad function choice");
+    return FileID();
+  }
+
   return FileID::get(ExternalSLocEntries->getSLocEntryID(SLocOffset));
 }
 

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -338,6 +338,7 @@ void SourceManager::clearIDTables() {
   LocalSLocEntryTable.clear();
   LoadedSLocEntryTable.clear();
   SLocEntryLoaded.clear();
+  SLocEntryOffsetLoaded.clear();
   LastLineNoFileIDQuery = FileID();
   LastLineNoContentCache = nullptr;
   LastFileIDLookup = FileID();
@@ -460,6 +461,7 @@ SourceManager::AllocateLoadedSLocEntries(unsigned NumSLocEntries,
   }
   LoadedSLocEntryTable.resize(LoadedSLocEntryTable.size() + NumSLocEntries);
   SLocEntryLoaded.resize(LoadedSLocEntryTable.size());
+  SLocEntryOffsetLoaded.resize(LoadedSLocEntryTable.size());
   CurrentLoadedOffset -= TotalSize;
   int ID = LoadedSLocEntryTable.size();
   return std::make_pair(-ID - 1, CurrentLoadedOffset);
@@ -608,7 +610,7 @@ FileID SourceManager::createFileIDImpl(ContentCache &File, StringRef Filename,
     assert(!SLocEntryLoaded[Index] && "FileID already loaded");
     LoadedSLocEntryTable[Index] = SLocEntry::get(
         LoadedOffset, FileInfo::get(IncludePos, File, FileCharacter, Filename));
-    SLocEntryLoaded[Index] = true;
+    SLocEntryLoaded[Index] = SLocEntryOffsetLoaded[Index] = true;
     return FileID::get(LoadedID);
   }
   unsigned FileSize = File.getSize();
@@ -668,7 +670,7 @@ SourceManager::createExpansionLocImpl(const ExpansionInfo &Info,
     assert(Index < LoadedSLocEntryTable.size() && "FileID out of range");
     assert(!SLocEntryLoaded[Index] && "FileID already loaded");
     LoadedSLocEntryTable[Index] = SLocEntry::get(LoadedOffset, Info);
-    SLocEntryLoaded[Index] = true;
+    SLocEntryLoaded[Index] = SLocEntryOffsetLoaded[Index] = true;
     return SourceLocation::getMacroLoc(LoadedOffset);
   }
   LocalSLocEntryTable.push_back(SLocEntry::get(NextLocalOffset, Info));

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -864,10 +864,7 @@ FileID SourceManager::getFileIDLocal(SourceLocation::UIntTy SLocOffset) const {
 /// This function knows that the SourceLocation is in a loaded buffer, not a
 /// local one.
 FileID SourceManager::getFileIDLoaded(SourceLocation::UIntTy SLocOffset) const {
-  int ID = ExternalSLocEntries->getSLocEntryID(SLocOffset);
-  bool Invalid = false;
-  (void)getLoadedSLocEntryByID(ID, &Invalid);
-  return Invalid ? FileID() : FileID::get(ID);
+  return FileID::get(ExternalSLocEntries->getSLocEntryID(SLocOffset));
 }
 
 SourceLocation SourceManager::

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -1491,19 +1491,16 @@ int ASTReader::getSLocEntryID(SourceLocation::UIntTy SLocOffset) {
          "Corrupted global sloc offset map");
   ModuleFile *F = SLocMapI->second;
 
-  std::vector<unsigned> Indices(F->LocalNumSLocEntries);
-  for (unsigned I = 0; I != F->LocalNumSLocEntries; ++I)
-    Indices[I] = I;
-
-  auto It = llvm::upper_bound(Indices, SLocOffset,
-                    [&](SourceLocation::UIntTy Offset, unsigned Index) {
-                      if (F->SLocEntryOffsetLoaded[Index] == -1U) {
-                        auto MaybeEntryOffset = readSLocOffset(F, Index);
-                        assert(MaybeEntryOffset && "Corrupted AST file");
-                        F->SLocEntryOffsetLoaded[Index] = *MaybeEntryOffset;
-                      }
-                      return Offset < F->SLocEntryOffsetLoaded[Index];
-                    });
+  auto It = llvm::upper_bound(
+      llvm::index_range(0, F->LocalNumSLocEntries), SLocOffset,
+      [&](SourceLocation::UIntTy Offset, std::size_t Index) {
+        if (F->SLocEntryOffsetLoaded[Index] == -1U) {
+          auto MaybeEntryOffset = readSLocOffset(F, Index);
+          assert(MaybeEntryOffset && "Corrupted AST file");
+          F->SLocEntryOffsetLoaded[Index] = *MaybeEntryOffset;
+        }
+        return Offset < F->SLocEntryOffsetLoaded[Index];
+      });
   // The iterator points to the first entry with start offset greater than the
   // offset of interest. The previous entry must contain the offset of interest.
   It = std::prev(It);

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -1575,9 +1575,9 @@ bool ASTReader::ReadSLocEntry(int ID) {
   };
 
   ModuleFile *F = GlobalSLocEntryMap.find(-ID)->second;
+  unsigned Index = ID - F->SLocEntryBaseID;
   if (llvm::Error Err = F->SLocEntryCursor.JumpToBit(
-          F->SLocEntryOffsetsBase +
-          F->SLocEntryOffsets[ID - F->SLocEntryBaseID])) {
+          F->SLocEntryOffsetsBase + F->SLocEntryOffsets[Index])) {
     Error(std::move(Err));
     return true;
   }
@@ -1612,6 +1612,9 @@ bool ASTReader::ReadSLocEntry(int ID) {
     return true;
 
   case SM_SLOC_FILE_ENTRY: {
+    SourceLocation::UIntTy Offset = BaseOffset + Record[0];
+    F->SLocEntryOffsetLoaded[Index] = Offset;
+
     // We will detect whether a file changed and return 'Failure' for it, but
     // we will also try to fail gracefully by setting up the SLocEntry.
     unsigned InputID = Record[4];
@@ -1632,8 +1635,8 @@ bool ASTReader::ReadSLocEntry(int ID) {
     }
     SrcMgr::CharacteristicKind
       FileCharacter = (SrcMgr::CharacteristicKind)Record[2];
-    FileID FID = SourceMgr.createFileID(*File, IncludeLoc, FileCharacter, ID,
-                                        BaseOffset + Record[0]);
+    FileID FID =
+        SourceMgr.createFileID(*File, IncludeLoc, FileCharacter, ID, Offset);
     SrcMgr::FileInfo &FileInfo =
           const_cast<SrcMgr::FileInfo&>(SourceMgr.getSLocEntry(FID).getFile());
     FileInfo.NumCreatedFIDs = Record[5];
@@ -1663,8 +1666,10 @@ bool ASTReader::ReadSLocEntry(int ID) {
   }
 
   case SM_SLOC_BUFFER_ENTRY: {
+    SourceLocation::UIntTy Offset = BaseOffset + Record[0];
+    F->SLocEntryOffsetLoaded[Index] = Offset;
+
     const char *Name = Blob.data();
-    unsigned Offset = Record[0];
     SrcMgr::CharacteristicKind
       FileCharacter = (SrcMgr::CharacteristicKind)Record[2];
     SourceLocation IncludeLoc = ReadSourceLocation(*F, Record[1]);
@@ -1676,7 +1681,7 @@ bool ASTReader::ReadSLocEntry(int ID) {
     if (!Buffer)
       return true;
     FileID FID = SourceMgr.createFileID(std::move(Buffer), FileCharacter, ID,
-                                        BaseOffset + Offset, IncludeLoc);
+                                        Offset, IncludeLoc);
     if (Record[3]) {
       auto &FileInfo =
           const_cast<SrcMgr::FileInfo &>(SourceMgr.getSLocEntry(FID).getFile());
@@ -1686,13 +1691,15 @@ bool ASTReader::ReadSLocEntry(int ID) {
   }
 
   case SM_SLOC_EXPANSION_ENTRY: {
+    SourceLocation::UIntTy Offset = BaseOffset + Record[0];
+    F->SLocEntryOffsetLoaded[Index] = Offset;
+
     LocSeq::State Seq;
     SourceLocation SpellingLoc = ReadSourceLocation(*F, Record[1], Seq);
     SourceLocation ExpansionBegin = ReadSourceLocation(*F, Record[2], Seq);
     SourceLocation ExpansionEnd = ReadSourceLocation(*F, Record[3], Seq);
     SourceMgr.createExpansionLoc(SpellingLoc, ExpansionBegin, ExpansionEnd,
-                                 Record[5], Record[4], ID,
-                                 BaseOffset + Record[0]);
+                                 Record[5], Record[4], ID, Offset);
     break;
   }
   }

--- a/clang/test/Modules/explicit-build-missing-files.cpp
+++ b/clang/test/Modules/explicit-build-missing-files.cpp
@@ -50,6 +50,7 @@ int y = a2<int>;
 // CHECK: In module 'a':
 // CHECK-NEXT: a.h:1:45: error:
 
+int z = b<int>;
 // MISSING-B: could not find file '{{.*}}b.h'
 // MISSING-B-NOT: please delete the module cache
 #endif

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2263,8 +2263,7 @@ private:
 
 struct index_iterator
     : llvm::iterator_facade_base<index_iterator,
-                                 std::random_access_iterator_tag, std::size_t,
-                                 std::ptrdiff_t> {
+                                 std::random_access_iterator_tag, std::size_t> {
   index_iterator(std::size_t Index) : Index(Index) {}
 
   index_iterator &operator+=(std::ptrdiff_t N) {

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2261,42 +2261,67 @@ private:
   mutable range_reference_tuple Storage;
 };
 
+struct index_iterator
+    : llvm::iterator_facade_base<index_iterator,
+                                 std::random_access_iterator_tag, std::size_t,
+                                 std::ptrdiff_t> {
+  index_iterator(std::size_t Index) : Index(Index) {}
+
+  index_iterator &operator+=(std::ptrdiff_t N) {
+    Index += N;
+    return *this;
+  }
+
+  index_iterator &operator-=(std::ptrdiff_t N) {
+    Index -= N;
+    return *this;
+  }
+
+  std::ptrdiff_t operator-(const index_iterator &R) const {
+    return Index - R.Index;
+  }
+
+  // Note: This dereference operator returns a value instead of a reference
+  // and does not strictly conform to the C++17's definition of forward
+  // iterator. However, it satisfies all the forward_iterator requirements
+  // that the `zip_common` depends on and fully conforms to the C++20
+  // definition of forward iterator.
+  std::size_t operator*() const { return Index; }
+
+  friend bool operator==(const index_iterator &Lhs, const index_iterator &Rhs) {
+    return Lhs.Index == Rhs.Index;
+  }
+
+  friend bool operator<(const index_iterator &Lhs, const index_iterator &Rhs) {
+    return Lhs.Index < Rhs.Index;
+  }
+
+private:
+  std::size_t Index;
+};
+
 /// Infinite stream of increasing 0-based `size_t` indices.
 struct index_stream {
-  struct iterator : iterator_facade_base<iterator, std::forward_iterator_tag,
-                                         const iterator> {
-    iterator &operator++() {
-      assert(Index != std::numeric_limits<std::size_t>::max() &&
-             "Attempting to increment end iterator");
-      ++Index;
-      return *this;
-    }
-
-    // Note: This dereference operator returns a value instead of a reference
-    // and does not strictly conform to the C++17's definition of forward
-    // iterator. However, it satisfies all the forward_iterator requirements
-    // that the `zip_common` depends on and fully conforms to the C++20
-    // definition of forward iterator.
-    std::size_t operator*() const { return Index; }
-
-    friend bool operator==(const iterator &Lhs, const iterator &Rhs) {
-      return Lhs.Index == Rhs.Index;
-    }
-
-    std::size_t Index = 0;
-  };
-
-  iterator begin() const { return {}; }
-  iterator end() const {
+  index_iterator begin() const { return {0}; }
+  index_iterator end() const {
     // We approximate 'infinity' with the max size_t value, which should be good
     // enough to index over any container.
-    iterator It;
-    It.Index = std::numeric_limits<std::size_t>::max();
-    return It;
+    return index_iterator{std::numeric_limits<std::size_t>::max()};
   }
 };
 
 } // end namespace detail
+
+/// Increasing range of `size_t` indices.
+class index_range {
+  std::size_t Begin;
+  std::size_t End;
+
+public:
+  index_range(std::size_t Begin, std::size_t End) : Begin(Begin), End(End) {}
+  detail::index_iterator begin() const { return {Begin}; }
+  detail::index_iterator end() const { return {End}; }
+};
 
 /// Given two or more input ranges, returns a new range whose values are are
 /// tuples (A, B, C, ...), such that A is the 0-based index of the item in the


### PR DESCRIPTION
In `SourceManager::getFileID()`, Clang performs binary search over its buffer of `SLocEntries`. For modules, this binary search fully deserializes the entire `SLocEntry` block for each visited entry. For some entries, that includes decompressing the associated buffer (e.g. the predefines buffer, macro expansion buffers, contents of volatile files), which shows up in profiles of the dependency scanner.

This patch moves the binary search over loaded entries into `ASTReader`, which can perform cheaper partial deserialization during the binary search, reducing the wall time of dependency scans by ~3%. This also reduces the number of retired instructions by ~1.4% on regular (implicit) modules compilation.

Note that this patch drops the optimizations based on the last lookup ID (pruning the search space and performing linear search before resorting to the full binary search). Instead, it reduces the search space by asking `ASTReader::GlobalSLocOffsetMap` for the containing `ModuleFile` and only does binary search over entries of single module file.