### PR TITLE
[Atomic][doc] Fix outdated hook name and description

### DIFF
--- a/llvm/docs/Atomics.rst
+++ b/llvm/docs/Atomics.rst
@@ -409,7 +409,7 @@ Atomics and Codegen
 Atomic operations are represented in the SelectionDAG with ``ATOMIC_*`` opcodes.
 On architectures which use barrier instructions for all atomic ordering (like
 ARM), appropriate fences can be emitted by the AtomicExpand Codegen pass if
-``setInsertFencesForAtomic()`` was used.
+``shouldInsertFencesForAtomic()`` returns true.
 
 The MachineMemOperand for all atomic operations is currently marked as volatile;
 this is not correct in the IR sense of volatile, but CodeGen handles anything

--- a/llvm/lib/Target/XCore/XCoreISelLowering.cpp
+++ b/llvm/lib/Target/XCore/XCoreISelLowering.cpp
@@ -936,7 +936,7 @@ LowerATOMIC_LOAD(SDValue Op, SelectionDAG &DAG) const {
   assert(N->getOpcode() == ISD::ATOMIC_LOAD && "Bad Atomic OP");
   assert((N->getSuccessOrdering() == AtomicOrdering::Unordered ||
           N->getSuccessOrdering() == AtomicOrdering::Monotonic) &&
-         "setInsertFencesForAtomic(true) expects unordered / monotonic");
+         "shouldInsertFencesForAtomic(true) expects unordered / monotonic");
   if (N->getMemoryVT() == MVT::i32) {
     if (N->getAlign() < Align(4))
       report_fatal_error("atomic load must be aligned");
@@ -967,7 +967,7 @@ LowerATOMIC_STORE(SDValue Op, SelectionDAG &DAG) const {
   assert(N->getOpcode() == ISD::ATOMIC_STORE && "Bad Atomic OP");
   assert((N->getSuccessOrdering() == AtomicOrdering::Unordered ||
           N->getSuccessOrdering() == AtomicOrdering::Monotonic) &&
-         "setInsertFencesForAtomic(true) expects unordered / monotonic");
+         "shouldInsertFencesForAtomic(true) expects unordered / monotonic");
   if (N->getMemoryVT() == MVT::i32) {
     if (N->getAlign() < Align(4))
       report_fatal_error("atomic store must be aligned");


### PR DESCRIPTION
`setInsertFencesForAtomic` is `shouldInsertFencesForAtomic` now.
