### PR TITLE
[mlir][python] smaller scope for vector enumgen

### DIFF
--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -381,7 +381,8 @@ declare_mlir_dialect_python_bindings(
   TD_FILE dialects/VectorOps.td
   SOURCES dialects/vector.py
   DIALECT_NAME vector
-  GEN_ENUM_BINDINGS)
+  GEN_ENUM_BINDINGS_TD_FILE
+    "dialects/VectorAttributes.td")
 
 ################################################################################
 # Python extensions.

--- a/mlir/python/mlir/dialects/VectorAttributes.td
+++ b/mlir/python/mlir/dialects/VectorAttributes.td
@@ -1,0 +1,14 @@
+//===-- VectorAttributes.td - Entry point for bindings -----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef PYTHON_BINDINGS_VECTOR_ATTRDEFS_TD
+#define PYTHON_BINDINGS_VECTOR_ATTRDEFS_TD
+
+include "mlir/Dialect/Vector/IR/VectorAttributes.td"
+
+#endif // PYTHON_BINDINGS_VECTOR_ATTRDEFS_TD

--- a/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
@@ -1353,13 +1353,6 @@ gentbl_filegroup(
     tbl_outs = [
         (
             [
-                "-gen-python-enum-bindings",
-                "-bind-dialect=vector",
-            ],
-            "mlir/dialects/_vector_enum_gen.py",
-        ),
-        (
-            [
                 "-gen-python-op-bindings",
                 "-bind-dialect=vector",
             ],
@@ -1368,6 +1361,26 @@ gentbl_filegroup(
     ],
     tblgen = "//mlir:mlir-tblgen",
     td_file = "mlir/dialects/VectorOps.td",
+    deps = [
+        "//mlir:ArithOpsTdFiles",
+        "//mlir:OpBaseTdFiles",
+        "//mlir:VectorOpsTdFiles",
+    ],
+)
+
+gentbl_filegroup(
+    name = "VectorAttributesPyGen",
+    tbl_outs = [
+        (
+            [
+                "-gen-python-enum-bindings",
+                "-bind-dialect=vector",
+            ],
+            "mlir/dialects/_vector_enum_gen.py",
+        ),
+    ],
+    tblgen = "//mlir:mlir-tblgen",
+    td_file = "mlir/dialects/VectorAttributes.td",
     deps = [
         "//mlir:ArithOpsTdFiles",
         "//mlir:OpBaseTdFiles",


### PR DESCRIPTION
Don't generate enums from the main VectorOps.td file as that transitively includes enums from Arith.