### PR TITLE
[clang][Diagnostics] Make 'note' color CYAN

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -212,6 +212,8 @@ Improvements to Clang's diagnostics
   (`#51567: <https://github.com/llvm/llvm-project/issues/51567>`_)
 - Clang now diagnoses narrowing implicit conversions on variable initializers in immediate
   function context and on constexpr variable template initializers.
+- Clang now prints its 'note' diagnostic in cyan instead of black, to be more compatible
+  with terminals with dark background colors. This is also more consistent with GCC.
 
 Bug Fixes in This Version
 -------------------------

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -24,8 +24,7 @@
 
 using namespace clang;
 
-static const enum raw_ostream::Colors noteColor =
-  raw_ostream::BLACK;
+static const enum raw_ostream::Colors noteColor = raw_ostream::CYAN;
 static const enum raw_ostream::Colors remarkColor =
   raw_ostream::BLUE;
 static const enum raw_ostream::Colors fixitColor =


### PR DESCRIPTION
Just using BLACK makes it invisible in terminals with a dark background.

See this screenshot:

![Screenshot from 2023-09-21 12-03-15](https://github.com/llvm/llvm-project/assets/49720664/245a9c4f-da27-4dbd-a14e-15a01adbc734)

With current clang, the "note:" part of the note is almost invisible, because we select BLACK as its color.

Use CYAN instead, which is also what gcc does.