### PR TITLE
[flang] Centralize automatic deallocation code in lowering

### DIFF
--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -57,7 +57,7 @@ void genDeallocateBox(AbstractConverter &converter,
                       const fir::MutableBoxValue &box, mlir::Location loc,
                       mlir::Value declaredTypeDesc = {});
 
-/// Deallocate an allocatable if it allocated at the end of its lifetime.
+/// Deallocate an allocatable if it is allocated at the end of its lifetime.
 void genDeallocateIfAllocated(AbstractConverter &converter,
                               const fir::MutableBoxValue &box,
                               mlir::Location loc);

--- a/flang/include/flang/Lower/Allocatable.h
+++ b/flang/include/flang/Lower/Allocatable.h
@@ -57,6 +57,11 @@ void genDeallocateBox(AbstractConverter &converter,
                       const fir::MutableBoxValue &box, mlir::Location loc,
                       mlir::Value declaredTypeDesc = {});
 
+/// Deallocate an allocatable if it allocated at the end of its lifetime.
+void genDeallocateIfAllocated(AbstractConverter &converter,
+                              const fir::MutableBoxValue &box,
+                              mlir::Location loc);
+
 /// Create a MutableBoxValue for an allocatable or pointer entity.
 /// If the variables is a local variable that is not a dummy, it will be
 /// initialized to unallocated/diassociated status.

--- a/flang/include/flang/Optimizer/Builder/MutableBox.h
+++ b/flang/include/flang/Optimizer/Builder/MutableBox.h
@@ -120,10 +120,11 @@ void finalizeRealloc(fir::FirOpBuilder &builder, mlir::Location loc,
                      bool takeLboundsIfRealloc,
                      const MutableBoxReallocation &realloc);
 
-/// Finalize a mutable box if it is allocated or associated. This includes both
-/// calling the finalizer, if any, and deallocating the storage.
-void genFinalization(fir::FirOpBuilder &builder, mlir::Location loc,
-                     const fir::MutableBoxValue &box);
+/// Deallocate a mutable box with fir.freemem if it is allocated or associated.
+/// This only deallocates the storage and does not call finalization, the
+/// mutable box is not nullified.
+void genFreememIfAllocated(fir::FirOpBuilder &builder, mlir::Location loc,
+                           const fir::MutableBoxValue &box);
 
 void genInlinedAllocation(fir::FirOpBuilder &builder, mlir::Location loc,
                           const fir::MutableBoxValue &box,
@@ -131,8 +132,10 @@ void genInlinedAllocation(fir::FirOpBuilder &builder, mlir::Location loc,
                           mlir::ValueRange lenParams, llvm::StringRef allocName,
                           bool mustBeHeap = false);
 
-mlir::Value genInlinedDeallocate(fir::FirOpBuilder &builder, mlir::Location loc,
-                                 const fir::MutableBoxValue &box);
+/// Deallocate an mutable box storage with fir.freemem without calling any
+/// final procedures. The mutable box is not nullified.
+mlir::Value genFreemem(fir::FirOpBuilder &builder, mlir::Location loc,
+                       const fir::MutableBoxValue &box);
 
 /// When the MutableBoxValue was passed as a fir.ref<fir.box> to a call that may
 /// have modified it, update the MutableBoxValue according to the

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -706,14 +706,7 @@ public:
             return;
           }
           // deallocate allocated in createHostAssociateVarClone value
-          mlir::Value needs_dealloc =
-              fir::factory::genIsAllocatedOrAssociatedTest(*builder, loc,
-                                                           new_box);
-          builder->genIfThen(loc, needs_dealloc)
-              .genThen([&]() {
-                Fortran::lower::genDeallocateBox(*this, new_box, loc);
-              })
-              .end();
+          Fortran::lower::genDeallocateIfAllocated(*this, new_box, loc);
         },
         [&](const auto &) -> void {
           // Do nothing

--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -461,10 +461,13 @@ fir::ExtendedValue Fortran::lower::genCallOpAndResult(
     allocatedResult->match(
         [&](const fir::MutableBoxValue &box) {
           if (box.isAllocatable() && !cleanupWithDestroy) {
-            // 9.7.3.2 point 4. Finalize allocatables.
+            // 9.7.3.2 point 4. Deallocate allocatable results. Note that
+            // finalization was done independently by calling
+            // genDerivedTypeDestroy above and is not triggered by this inline
+            // dealloction.
             fir::FirOpBuilder *bldr = &converter.getFirOpBuilder();
             stmtCtx.attachCleanup([bldr, loc, box]() {
-              fir::factory::genFinalization(*bldr, loc, box);
+              fir::factory::genFreememIfAllocated(*bldr, loc, box);
             });
           }
         },

--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -464,7 +464,7 @@ fir::ExtendedValue Fortran::lower::genCallOpAndResult(
             // 9.7.3.2 point 4. Deallocate allocatable results. Note that
             // finalization was done independently by calling
             // genDerivedTypeDestroy above and is not triggered by this inline
-            // dealloction.
+            // deallocation.
             fir::FirOpBuilder *bldr = &converter.getFirOpBuilder();
             stmtCtx.attachCleanup([bldr, loc, box]() {
               fir::factory::genFreememIfAllocated(*bldr, loc, box);

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2646,26 +2646,14 @@ public:
         }
         // Passing a POINTER to a POINTER, or an ALLOCATABLE to an ALLOCATABLE.
         fir::MutableBoxValue mutableBox = genMutableBoxValue(*expr);
+        if (fir::isAllocatableType(argTy) && arg.isIntentOut() &&
+            Fortran::semantics::IsBindCProcedure(*procRef.proc().GetSymbol()))
+          Fortran::lower::genDeallocateIfAllocated(converter, mutableBox, loc);
         mlir::Value irBox =
             fir::factory::getMutableIRBox(builder, loc, mutableBox);
         caller.placeInput(arg, irBox);
         if (arg.mayBeModifiedByCall())
           mutableModifiedByCall.emplace_back(std::move(mutableBox));
-        if (fir::isAllocatableType(argTy) && arg.isIntentOut() &&
-            Fortran::semantics::IsBindCProcedure(*procRef.proc().GetSymbol())) {
-          if (mutableBox.isDerived() || mutableBox.isPolymorphic() ||
-              mutableBox.isUnlimitedPolymorphic()) {
-            mlir::Value isAlloc = fir::factory::genIsAllocatedOrAssociatedTest(
-                builder, loc, mutableBox);
-            builder.genIfThen(loc, isAlloc)
-                .genThen([&]() {
-                  Fortran::lower::genDeallocateBox(converter, mutableBox, loc);
-                })
-                .end();
-          } else {
-            Fortran::lower::genDeallocateBox(converter, mutableBox, loc);
-          }
-        }
         continue;
       }
       if (arg.passBy == PassBy::BaseAddress || arg.passBy == PassBy::BoxChar ||

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -749,40 +749,17 @@ static void deallocateIntentOut(Fortran::lower::AbstractConverter &converter,
       }
       mlir::Location loc = converter.getCurrentLocation();
       fir::FirOpBuilder &builder = converter.getFirOpBuilder();
-      auto genDeallocateWithTypeDesc = [&]() {
-        if (mutBox->isDerived() || mutBox->isPolymorphic() ||
-            mutBox->isUnlimitedPolymorphic()) {
-          mlir::Value isAlloc = fir::factory::genIsAllocatedOrAssociatedTest(
-              builder, loc, *mutBox);
-          builder.genIfThen(loc, isAlloc)
-              .genThen([&]() {
-                if (mutBox->isPolymorphic()) {
-                  mlir::Value declaredTypeDesc;
-                  assert(sym.GetType());
-                  if (const Fortran::semantics::DerivedTypeSpec
-                          *derivedTypeSpec = sym.GetType()->AsDerived()) {
-                    declaredTypeDesc = Fortran::lower::getTypeDescAddr(
-                        converter, loc, *derivedTypeSpec);
-                  }
-                  genDeallocateBox(converter, *mutBox, loc, declaredTypeDesc);
-                } else {
-                  genDeallocateBox(converter, *mutBox, loc);
-                }
-              })
-              .end();
-        } else {
-          genDeallocateBox(converter, *mutBox, loc);
-        }
-      };
 
       if (Fortran::semantics::IsOptional(sym)) {
         auto isPresent = builder.create<fir::IsPresentOp>(
             loc, builder.getI1Type(), fir::getBase(extVal));
         builder.genIfThen(loc, isPresent)
-            .genThen([&]() { genDeallocateWithTypeDesc(); })
+            .genThen([&]() {
+              Fortran::lower::genDeallocateIfAllocated(converter, *mutBox, loc);
+            })
             .end();
       } else {
-        genDeallocateWithTypeDesc();
+        Fortran::lower::genDeallocateIfAllocated(converter, *mutBox, loc);
       }
     }
   }

--- a/flang/test/Lower/Intrinsics/system_clock.f90
+++ b/flang/test/Lower/Intrinsics/system_clock.f90
@@ -53,13 +53,13 @@ subroutine ss(count)
   ! CHECK:     fir.store %[[V_29]] to %arg0 : !fir.ref<i64>
   ! CHECK:   }
   ! CHECK:   %[[V_12:[0-9]+]] = fir.convert %[[V_9]] : (!fir.ptr<i64>) -> i64
-  ! CHECK:   %[[V_13:[0-9]+]] = arith.cmpi ne, %[[V_12]], %c0{{.*}}_i64 : i64
+  ! CHECK:   %[[V_13:[0-9]+]] = arith.cmpi ne, %[[V_12]], %c0{{.*}} : i64
   ! CHECK:   fir.if %[[V_13]] {
-  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
+  ! CHECK:     %[[V_29:[0-9]+]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
   ! CHECK:     fir.store %[[V_29]] to %[[V_9]] : !fir.ptr<i64>
   ! CHECK:   }
   ! CHECK:   %[[V_14:[0-9]+]] = fir.convert %[[V_10]] : (!fir.heap<i64>) -> i64
-  ! CHECK:   %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_14]], %c0{{.*}}_i64_0 : i64
+  ! CHECK:   %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_14]], %c0{{.*}} : i64
   ! CHECK:   fir.if %[[V_15]] {
   ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
   ! CHECK:     fir.store %[[V_29]] to %[[V_10]] : !fir.heap<i64>
@@ -77,24 +77,24 @@ subroutine ss(count)
   ! CHECK:     %[[V_39:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_38]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
   ! CHECK:     %[[V_40:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_31]]) {{.*}}: (!fir.ref<i8>) -> i32
   ! CHECK:   } else {
-  ! CHECK:     %[[V_29]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:     %[[V_29:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
   ! CHECK:     %[[V_30:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:     %[[V_31]] = fir.convert %[[V_29]] : (!fir.ptr<i64>) -> i64
-  ! CHECK:     %[[V_32]] = arith.cmpi ne, %[[V_31]], %c0{{.*}}_i64_3 : i64
+  ! CHECK:     %[[V_31:[0-9]+]] = fir.convert %[[V_29]] : (!fir.ptr<i64>) -> i64
+  ! CHECK:     %[[V_32:[0-9]+]] = arith.cmpi ne, %[[V_31]], %c0{{.*}} : i64
   ! CHECK:     fir.if %[[V_32]] {
   ! CHECK:       %[[V_45:[0-9]+]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
   ! CHECK:       fir.store %[[V_45]] to %[[V_29]] : !fir.ptr<i64>
   ! CHECK:     }
-  ! CHECK:     %[[V_33]] = fir.convert %[[V_30]] : (!fir.heap<i64>) -> i64
-  ! CHECK:     %[[V_34]] = arith.cmpi ne, %[[V_33]], %c0{{.*}}_i64_4 : i64
+  ! CHECK:     %[[V_33:[0-9]+]] = fir.convert %[[V_30]] : (!fir.heap<i64>) -> i64
+  ! CHECK:     %[[V_34:[0-9]+]] = arith.cmpi ne, %[[V_33]], %c0{{.*}} : i64
   ! CHECK:     fir.if %[[V_34]] {
   ! CHECK:       %[[V_45]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
   ! CHECK:       fir.store %[[V_45]] to %[[V_30]] : !fir.heap<i64>
   ! CHECK:     }
-  ! CHECK:     %[[V_37]] = fir.call @_FortranAioBeginExternalListOutput
-  ! CHECK:     %[[V_38]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:     %[[V_39]] = fir.load %[[V_38]] : !fir.ptr<i64>
-  ! CHECK:     %[[V_40]] = fir.call @_FortranAioOutputInteger64(%[[V_37]], %[[V_39]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
+  ! CHECK:     %[[V_37:[0-9]+]] = fir.call @_FortranAioBeginExternalListOutput
+  ! CHECK:     %[[V_38:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
+  ! CHECK:     %[[V_39:[0-9]+]] = fir.load %[[V_38]] : !fir.ptr<i64>
+  ! CHECK:     %[[V_40:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_37]], %[[V_39]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
   ! CHECK:     %[[V_41:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
   ! CHECK:     %[[V_42:[0-9]+]] = fir.load %[[V_41]] : !fir.heap<i64>
   ! CHECK:     %[[V_43:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_37]], %[[V_42]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
@@ -120,13 +120,13 @@ subroutine ss(count)
   ! CHECK:     fir.store %[[V_29]] to %arg0 : !fir.ref<i64>
   ! CHECK:   }
   ! CHECK:   %[[V_24:[0-9]+]] = fir.convert %[[V_21]] : (!fir.ptr<i64>) -> i64
-  ! CHECK:   %[[V_25:[0-9]+]] = arith.cmpi ne, %[[V_24]], %c0{{.*}}_i64_1 : i64
+  ! CHECK:   %[[V_25:[0-9]+]] = arith.cmpi ne, %[[V_24]], %c0{{.*}} : i64
   ! CHECK:   fir.if %[[V_25]] {
   ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
   ! CHECK:     fir.store %[[V_29]] to %[[V_21]] : !fir.ptr<i64>
   ! CHECK:   }
   ! CHECK:   %[[V_26:[0-9]+]] = fir.convert %[[V_22]] : (!fir.heap<i64>) -> i64
-  ! CHECK:   %[[V_27:[0-9]+]] = arith.cmpi ne, %[[V_26]], %c0{{.*}}_i64_2 : i64
+  ! CHECK:   %[[V_27:[0-9]+]] = arith.cmpi ne, %[[V_26]], %c0{{.*}} : i64
   ! CHECK:   fir.if %[[V_27]] {
   ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
   ! CHECK:     fir.store %[[V_29]] to %[[V_22]] : !fir.heap<i64>

--- a/flang/test/Lower/OpenMP/FIR/parallel-private-clause.f90
+++ b/flang/test/Lower/OpenMP/FIR/parallel-private-clause.f90
@@ -146,20 +146,20 @@ end subroutine
 !FIRDialect-DAG: omp.parallel   {
 !FIRDialect-DAG:  [[TMP203:%.*]] = fir.alloca !fir.box<!fir.heap<f32>> {bindc_name = "x5", pinned, uniq_name = "{{.*}}Ex5"}
 
-!FIRDialect-DAG: fir.if %7 {
+!FIRDialect-DAG: fir.if %{{.*}} {
 
-!FIRDialect-DAG:   fir.store %13 to [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+!FIRDialect-DAG:   fir.store %{{.*}} to [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 !FIRDialect-DAG: } else {
 
-!FIRDialect-DAG:   fir.store %13 to [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+!FIRDialect-DAG:   fir.store %{{.*}} to [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 !FIRDialect-DAG: }
 !FIRDialect-DAG: fir.call @_QFprivate_clause_real_call_allocatablePhelper_private_clause_real_call_allocatable([[TMP203]]) fastmath<contract> : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> ()
-!FIRDialect-DAG: %8 = fir.load [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+!FIRDialect-DAG: %{{.*}} = fir.load [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 
-!FIRDialect-DAG: fir.if %11 {
-!FIRDialect-DAG:   %12 = fir.load [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+!FIRDialect-DAG: fir.if %{{.*}} {
+!FIRDialect-DAG:   %{{.*}} = fir.load [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 
-!FIRDialect-DAG:     fir.store %15 to [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+!FIRDialect-DAG:     fir.store %{{.*}} to [[TMP203]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 !FIRDialect-DAG:   }
 !FIRDialect-DAG:   omp.terminator
 !FIRDialect-DAG:   }
@@ -353,9 +353,9 @@ end subroutine
 subroutine simd_loop_1
   integer :: i
   real, allocatable :: r;
-  ! IRDialect:     [[R:%.*]] = fir.alloca !fir.box<!fir.heap<f32>> {bindc_name = "r", pinned, uniq_name = "{{.*}}Er"}
-  ! IRDialect:     fir.store {{%.*}} to [[R]] : !fir.ref<!fir.box<!fir.heap<f32>>>
-  ! IRDialect:     fir.store {{%.*}} to [[R]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! FIRDialect:     [[R:%.*]] = fir.alloca !fir.box<!fir.heap<f32>> {bindc_name = "r", pinned, uniq_name = "{{.*}}Er"}
+  ! FIRDialect:     fir.store {{%.*}} to [[R]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+  ! FIRDialect:     fir.store {{%.*}} to [[R]] : !fir.ref<!fir.box<!fir.heap<f32>>>
 
   ! FIRDialect:     %[[LB:.*]] = arith.constant 1 : i32
   ! FIRDialect:     %[[UB:.*]] = arith.constant 9 : i32


### PR DESCRIPTION
There are currently several places that automatically deallocate allocatble if they are allocated:
 - INTENT(OUT) allocatable are deallocated on entry in the callee
 - INTENT(OUT) allocatable are also deallocated on the caller side of BIND(C) function in case the implementation is in C.
 - Results of function returning allocatable are deallocated after usage.
 - OPENMP privatized allocatable are deallocated at the end of OPENMP region.

Introduce genDeallocateIfAllocated that centralize all this code, except for the function return that use genFreememIfAllocated since finalization is done separately currently.

`fir::factory::genFinalization` and `fir::factory::genInlinedDeallocation` are removed and replaced by genFreemem since their name were misleading: finalization was not called.

There is a fallout in the tests because previous generated code did not check the allocated status when doing inline deallocation. This was OK since free(null) is guaranteed to be a no-op, but this makes compiler code more complex, is a bit surprising in the generated IR IMHO, and it relied on knowing when genDeallocateBox inserts runtime calls or uses inlined code.

@kiranchandramohan, the OpenMP test in Lower/OpenMP/FIR/parallel-private-clause.f90 is updated because it contained hardcoded SSA value numbers that got broken by slight changes in the non OMP parts. There is no functional change in the OMP part.