### PR TITLE
[BOLT] Fix data race in MCPlusBuilder::getOrCreateAnnotationIndex

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -1790,19 +1790,15 @@ public:
   /// Return annotation index matching the \p Name. Create a new index if the
   /// \p Name wasn't registered previously.
   unsigned getOrCreateAnnotationIndex(StringRef Name) {
-    {
-      if (std::optional<unsigned> Index = getAnnotationIndex(Name))
-        return *Index;
-    }
+    if (std::optional<unsigned> Index = getAnnotationIndex(Name))
+      return *Index;
 
-    {
-      std::unique_lock<llvm::sys::RWMutex> Lock(AnnotationNameMutex);
-      const unsigned Index =
-          AnnotationNameIndexMap.size() + MCPlus::MCAnnotation::kGeneric;
-      AnnotationNameIndexMap.insert(std::make_pair(Name, Index));
-      AnnotationNames.emplace_back(std::string(Name));
-      return Index;
-    }
+    std::unique_lock<llvm::sys::RWMutex> Lock(AnnotationNameMutex);
+    const unsigned Index =
+        AnnotationNameIndexMap.size() + MCPlus::MCAnnotation::kGeneric;
+    AnnotationNameIndexMap.insert(std::make_pair(Name, Index));
+    AnnotationNames.emplace_back(std::string(Name));
+    return Index;
   }
 
   /// Store an annotation value on an MCInst.  This assumes the annotation

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -1791,8 +1791,7 @@ public:
   /// \p Name wasn't registered previously.
   unsigned getOrCreateAnnotationIndex(StringRef Name) {
     {
-      std::optional<unsigned> Index = getAnnotationIndex(Name);
-      if (Index.has_value())
+      if (std::optional<unsigned> Index = getAnnotationIndex(Name))
         return *Index;
     }
 

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -29,6 +29,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/RWMutex.h"
 #include <cassert>
 #include <cstdint>
 #include <map>
@@ -165,6 +166,10 @@ protected:
 
   /// Names of non-standard annotations.
   SmallVector<std::string, 8> AnnotationNames;
+
+  /// A mutex that is used to control parallel accesses to
+  /// AnnotationNameIndexMap and AnnotationsNames.
+  mutable llvm::sys::RWMutex AnnotationNameMutex;
 
   /// Allocate the TailCall annotation value. Clients of the target-specific
   /// MCPlusBuilder classes must use convert/lower/create* interfaces instead.
@@ -1775,6 +1780,7 @@ public:
 
   /// Return annotation index matching the \p Name.
   std::optional<unsigned> getAnnotationIndex(StringRef Name) const {
+    std::shared_lock<llvm::sys::RWMutex> Lock(AnnotationNameMutex);
     auto AI = AnnotationNameIndexMap.find(Name);
     if (AI != AnnotationNameIndexMap.end())
       return AI->second;
@@ -1784,15 +1790,20 @@ public:
   /// Return annotation index matching the \p Name. Create a new index if the
   /// \p Name wasn't registered previously.
   unsigned getOrCreateAnnotationIndex(StringRef Name) {
-    auto AI = AnnotationNameIndexMap.find(Name);
-    if (AI != AnnotationNameIndexMap.end())
-      return AI->second;
+    {
+      std::optional<unsigned> Index = getAnnotationIndex(Name);
+      if (Index.has_value())
+        return *Index;
+    }
 
-    const unsigned Index =
-        AnnotationNameIndexMap.size() + MCPlus::MCAnnotation::kGeneric;
-    AnnotationNameIndexMap.insert(std::make_pair(Name, Index));
-    AnnotationNames.emplace_back(std::string(Name));
-    return Index;
+    {
+      std::unique_lock<llvm::sys::RWMutex> Lock(AnnotationNameMutex);
+      const unsigned Index =
+          AnnotationNameIndexMap.size() + MCPlus::MCAnnotation::kGeneric;
+      AnnotationNameIndexMap.insert(std::make_pair(Name, Index));
+      AnnotationNames.emplace_back(std::string(Name));
+      return Index;
+    }
   }
 
   /// Store an annotation value on an MCInst.  This assumes the annotation


### PR DESCRIPTION
MCPlusBuilder::getOrCreateAnnotationIndex(Name) can be called from different threads, for example when making use of
ParallelUtilities::runOnEachFunctionWithUniqueAllocId.

The race occurs when an Index for a particular annotation Name needs to be created for the first time.

For example, this can easily happen when multiple "copies" of an analysis pass run on different BinaryFunctions, and the analysis pass creates a new Annotation Index to be able to store analysis results as annotations.

This was found by using the ThreadSanitizer.

No regression test was added; I don't think there is good way to write regression tests that verify the absence of data races?