### PR TITLE
[InstrProf] Correct buffer size for encodeULEB128

### DIFF
--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -501,7 +501,7 @@ Error collectPGOFuncNameStrings(ArrayRef<std::string> NameStrs,
                                 bool doCompression, std::string &Result) {
   assert(!NameStrs.empty() && "No name data to emit");
 
-  uint8_t Header[16], *P = Header;
+  uint8_t Header[20], *P = Header;
   std::string UncompressedNameStrings =
       join(NameStrs.begin(), NameStrs.end(), getInstrProfNameSeparator());
 


### PR DESCRIPTION
This function uses 16 bytes buffer to encode two 64 bits data. However, the encoding method requires 10 bytes to encode one 64 bits data, so encoded data actually requiress 20 bytes total.

I send a patch about this at https://bugs.llvm.org/show_bug.cgi?id=37447, but it is left as is.  So I'm submitting the patch again.  I personally recommend to remove encodeULEB128 with buffer version and use only encodeULEB128 with stream version.