### PR TITLE
Add support for MLIR to llvm vscale attribute

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -850,4 +850,14 @@ def LLVM_TBAATagArrayAttr
   let constBuilderCall = ?;
 }
 
+//===----------------------------------------------------------------------===//
+// VScaleRangeAttr
+//===----------------------------------------------------------------------===//
+
+def LLVM_VScaleRangeAttr : LLVM_Attr<"VScaleRange", "vscale_range"> {
+  let parameters =  (ins
+    "IntegerAttr":$minRange,
+    "IntegerAttr":$maxRange);
+  let assemblyFormat = "`<` struct(params) `>`";
+}
 #endif // LLVMIR_ATTRDEFS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1393,7 +1393,8 @@ def LLVM_LLVMFuncOp : LLVM_Op<"func", [
     OptionalAttr<UnitAttr>:$arm_locally_streaming,
     OptionalAttr<StrAttr>:$section,
     OptionalAttr<UnnamedAddr>:$unnamed_addr,
-    OptionalAttr<I64Attr>:$alignment
+    OptionalAttr<I64Attr>:$alignment,
+    OptionalAttr<LLVM_VScaleRangeAttr>:$vscale_range
   );
 
   let regions = (region AnyRegion:$body);

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -907,6 +907,11 @@ LogicalResult ModuleTranslation::convertOneFunction(LLVMFuncOp func) {
   else if (func.getArmLocallyStreaming())
     llvmFunc->addFnAttr("aarch64_pstate_sm_body");
 
+  if (auto attr = func.getVscaleRange())
+    llvmFunc->addFnAttr(llvm::Attribute::getWithVScaleRangeArgs(
+        getLLVMContext(), attr->getMinRange().getInt(),
+        attr->getMaxRange().getInt()));
+
   // First, create all blocks so we can jump to them.
   llvm::LLVMContext &llvmContext = llvmFunc->getContext();
   for (auto &bb : func) {

--- a/mlir/test/Dialect/LLVMIR/func.mlir
+++ b/mlir/test/Dialect/LLVMIR/func.mlir
@@ -225,6 +225,12 @@ module {
   llvm.func @any() comdat(@__llvm_comdat::@any) attributes { dso_local } {
     llvm.return
   }
+
+  llvm.func @vscale_roundtrip() vscale_range(1, 2) {
+    // CHECK: @vscale_roundtrip
+    // CHECK-SAME: vscale_range(1, 2)
+    llvm.return
+  }
 }
 
 // -----

--- a/mlir/test/Target/LLVMIR/Import/vscale.ll
+++ b/mlir/test/Target/LLVMIR/Import/vscale.ll
@@ -1,0 +1,7 @@
+; RUN: mlir-translate -import-llvm -split-input-file %s | FileCheck %s
+
+define void @vscale_func() vscale_range(2,8) {
+  ; CHECK: llvm.func @vscale_func()
+  ; CHECK-SAME: vscale_range(2, 8)
+  ret void
+}

--- a/mlir/test/Target/LLVMIR/vscale.mlir
+++ b/mlir/test/Target/LLVMIR/vscale.mlir
@@ -1,0 +1,7 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+llvm.func @vscale_func() vscale_range(2,8) {
+  // CHECK-LABEL: define void @vscale_func
+  // CHECK: attributes #{{.*}} = { vscale_range(2,8) }
+  llvm.return
+}


### PR DESCRIPTION
The vscale_range is used for scalabale vector functionality in Arm Scalable Vector Extension to select the size of vector operation (and I thnk RISCV has something similar).

This patch adds the base support for the vscale_range attribute to the LLVM::FuncOp, and the marshalling for translation to LLVM-IR and import from LLVM-IR to LLVM dialect.

This attribute is intended to be used at higher level MLIR, specified either by command-line options to the compiler or using compiler directives (e.g. pragmas or function attributes in the source code) to indicate the desired range.