### PR TITLE
[RISCV][NFC] Remove rdty arg of PseudoLoad and the default rdty value of PseudoFloatLoad

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -241,8 +241,8 @@ class PseudoQuietFCMP<DAGOperand Ty>
 }
 
 // Pseudo load instructions.
-class PseudoLoad<string opcodestr, RegisterClass rdty = GPR>
-    : Pseudo<(outs rdty:$rd), (ins bare_symbol:$addr), [], opcodestr, "$rd, $addr"> {
+class PseudoIntLoad<string opcodestr>
+    : Pseudo<(outs GPR:$rd), (ins bare_symbol:$addr), [], opcodestr, "$rd, $addr"> {
   let hasSideEffects = 0;
   let mayLoad = 1;
   let mayStore = 0;
@@ -250,7 +250,7 @@ class PseudoLoad<string opcodestr, RegisterClass rdty = GPR>
   let isAsmParserOnly = 1;
 }
 
-class PseudoFloatLoad<string opcodestr, RegisterClass rdty = GPR>
+class PseudoFloatLoad<string opcodestr, RegisterClass rdty>
     : Pseudo<(outs GPR:$tmp, rdty:$rd), (ins bare_symbol:$addr), [], opcodestr, "$rd, $addr, $tmp"> {
   let hasSideEffects = 0;
   let mayLoad = 1;

--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -241,7 +241,7 @@ class PseudoQuietFCMP<DAGOperand Ty>
 }
 
 // Pseudo load instructions.
-class PseudoIntLoad<string opcodestr>
+class PseudoLoad<string opcodestr>
     : Pseudo<(outs GPR:$rd), (ins bare_symbol:$addr), [], opcodestr, "$rd, $addr"> {
   let hasSideEffects = 0;
   let mayLoad = 1;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -920,19 +920,19 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 32,
 def PseudoLI : Pseudo<(outs GPR:$rd), (ins ixlenimm_li:$imm), [],
                       "li", "$rd, $imm">;
 
-def PseudoLB  : PseudoLoad<"lb">;
-def PseudoLBU : PseudoLoad<"lbu">;
-def PseudoLH  : PseudoLoad<"lh">;
-def PseudoLHU : PseudoLoad<"lhu">;
-def PseudoLW  : PseudoLoad<"lw">;
+def PseudoLB  : PseudoIntLoad<"lb">;
+def PseudoLBU : PseudoIntLoad<"lbu">;
+def PseudoLH  : PseudoIntLoad<"lh">;
+def PseudoLHU : PseudoIntLoad<"lhu">;
+def PseudoLW  : PseudoIntLoad<"lw">;
 
 def PseudoSB  : PseudoStore<"sb">;
 def PseudoSH  : PseudoStore<"sh">;
 def PseudoSW  : PseudoStore<"sw">;
 
 let Predicates = [IsRV64] in {
-def PseudoLWU : PseudoLoad<"lwu">;
-def PseudoLD  : PseudoLoad<"ld">;
+def PseudoLWU : PseudoIntLoad<"lwu">;
+def PseudoLD  : PseudoIntLoad<"ld">;
 def PseudoSD  : PseudoStore<"sd">;
 } // Predicates = [IsRV64]
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -920,19 +920,19 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 32,
 def PseudoLI : Pseudo<(outs GPR:$rd), (ins ixlenimm_li:$imm), [],
                       "li", "$rd, $imm">;
 
-def PseudoLB  : PseudoIntLoad<"lb">;
-def PseudoLBU : PseudoIntLoad<"lbu">;
-def PseudoLH  : PseudoIntLoad<"lh">;
-def PseudoLHU : PseudoIntLoad<"lhu">;
-def PseudoLW  : PseudoIntLoad<"lw">;
+def PseudoLB  : PseudoLoad<"lb">;
+def PseudoLBU : PseudoLoad<"lbu">;
+def PseudoLH  : PseudoLoad<"lh">;
+def PseudoLHU : PseudoLoad<"lhu">;
+def PseudoLW  : PseudoLoad<"lw">;
 
 def PseudoSB  : PseudoStore<"sb">;
 def PseudoSH  : PseudoStore<"sh">;
 def PseudoSW  : PseudoStore<"sw">;
 
 let Predicates = [IsRV64] in {
-def PseudoLWU : PseudoIntLoad<"lwu">;
-def PseudoLD  : PseudoIntLoad<"ld">;
+def PseudoLWU : PseudoLoad<"lwu">;
+def PseudoLD  : PseudoLoad<"ld">;
 def PseudoSD  : PseudoStore<"sd">;
 } // Predicates = [IsRV64]
 


### PR DESCRIPTION
`rdty` of `PseudoLoad` is always `GPR` and it will never be `GPR` for
`PseudoFloatLoad`.
