### PR TITLE
[RISCV] Fold `addi` into load / store even if they are in different BBs.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.h
@@ -951,6 +951,8 @@ private:
     return false;
   };
 
+  void finalizeLowering(MachineFunction &MF) const override;
+
   /// For available scheduling models FDIV + two independent FMULs are much
   /// faster than two FDIVs.
   unsigned combineRepeatedFPDivisors() const override;


### PR DESCRIPTION
Currently, since ISel only looks at one basic block at a time we miss some opportunities to combine load / store with `addi`. Such opportunities may occur when GEP and the use of GEP are in different basic blocks.

In this PR we combine `addi` with memory access in `RISCVISelLowering:finalizeLowering`.

According to my measurements, this patch is about 1% in dynamic instruciton count on mcf.