### PR TITLE
ISel/RISCV: remove dead code corresponding to VP_FSH[L|R]

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -715,8 +715,6 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
       setOperationAction({ISD::SMIN, ISD::SMAX, ISD::UMIN, ISD::UMAX}, VT,
                          Legal);
 
-      setOperationAction({ISD::VP_FSHL, ISD::VP_FSHR}, VT, Expand);
-
       // Custom-lower extensions and truncations from/to mask types.
       setOperationAction({ISD::ANY_EXTEND, ISD::SIGN_EXTEND, ISD::ZERO_EXTEND},
                          VT, Custom);


### PR DESCRIPTION
70de0e ([VP][RISCV] Add vp.fshl/fshr and RISC-V support.) introduced VP_FSHL and VP_FSHR, by using a generic expansion for all targets: the core of this change is in TargetLowering. However, the commit erroneously introduced dead code in RISCVISelLowering. Remove this dead code.