### PR TITLE
Add -log_file flag

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
@@ -663,6 +663,17 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
     return 0;
   }
 
+  std::unique_ptr<FILE, int(*)(FILE*)> log_file(0, &fclose);
+  if (Flags.log_file) {
+    FILE * f = fopen(Flags.log_file, "w");
+    if (!f) {
+      Printf("ERROR: unable to open log_file [%s]: %s\n", Flags.log_file, strerror(errno));
+      return 1;
+    }
+    log_file.reset(f);
+    SetOutputFile(f);
+  }
+
   if (Flags.close_fd_mask & 2)
     DupAndCloseStderr();
   if (Flags.close_fd_mask & 1)

--- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
+++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
@@ -209,3 +209,4 @@ FUZZER_FLAG_STRING(collect_data_flow,
 FUZZER_FLAG_INT(create_missing_dirs, 0, "Automatically attempt to create "
      "directories for arguments that would normally expect them to already "
      "exist (i.e. artifact_prefix, exact_artifact_path, features_dir, corpus)")
+FUZZER_FLAG_STRING(log_file, "Output file for fuzzer, default is stderr")


### PR DESCRIPTION
It would be nice to have fuzzer's output separated from module's output, so "-log_file" flag is introduced to allow to reroute fuzzer's output to the specified file.