### PR TITLE
Add command line option --no-trap-after-noreturn

### DIFF
--- a/llvm/lib/CodeGen/LLVMTargetMachine.cpp
+++ b/llvm/lib/CodeGen/LLVMTargetMachine.cpp
@@ -37,6 +37,11 @@ static cl::opt<bool>
     EnableTrapUnreachable("trap-unreachable", cl::Hidden,
                           cl::desc("Enable generating trap for unreachable"));
 
+static cl::opt<bool> EnableNoTrapAfterNoreturn(
+    "no-trap-after-noreturn", cl::Hidden,
+    cl::desc("Do not emit a trap instruction for 'unreachable' IR instructions "
+             "after noreturn calls, even if --trap-unreachable is set."));
+
 void LLVMTargetMachine::initAsmInfo() {
   MRI.reset(TheTarget.createMCRegInfo(getTargetTriple().str()));
   assert(MRI && "Unable to create reg info");
@@ -95,6 +100,8 @@ LLVMTargetMachine::LLVMTargetMachine(const Target &T,
 
   if (EnableTrapUnreachable)
     this->Options.TrapUnreachable = true;
+  if (EnableNoTrapAfterNoreturn)
+    this->Options.NoTrapAfterNoreturn = true;
 }
 
 TargetTransformInfo

--- a/llvm/test/CodeGen/ARM/trap-unreachable.ll
+++ b/llvm/test/CodeGen/ARM/trap-unreachable.ll
@@ -11,9 +11,10 @@ define void @test_trap_unreachable() #0 {
 attributes #0 = { nounwind }
 
 declare void @no_return() noreturn
+declare void @could_return()
 
-define void @test_ntanr() {
-; CHECK-LABEL:           test_ntanr:
+define void @test_ntanr_noreturn() {
+; CHECK-LABEL:           test_ntanr_noreturn:
 ; CHECK:                 @ %bb.0:
 ; CHECK-NEXT:              push {r7, lr}
 ; CHECK-NEXT:              bl no_return
@@ -21,5 +22,15 @@ define void @test_ntanr() {
 ; NTANR-NOT:               .inst.n 0xdefe
 ;
   call void @no_return()
+  unreachable
+}
+
+define void @test_ntanr_could_return() {
+; CHECK-LABEL: test_ntanr_could_return:
+; CHECK:       @ %bb.0:
+; CHECK-NEXT:    push {r7, lr}
+; CHECK-NEXT:    bl could_return
+; CHECK-NEXT:    .inst.n 0xdefe
+  call void @could_return()
   unreachable
 }

--- a/llvm/test/CodeGen/ARM/trap-unreachable.ll
+++ b/llvm/test/CodeGen/ARM/trap-unreachable.ll
@@ -1,8 +1,25 @@
-; RUN: llc -mtriple=thumbv7 -trap-unreachable < %s | FileCheck %s
-; CHECK: .inst.n 0xdefe
+; RUN: llc -mtriple=thumbv7 -trap-unreachable < %s | FileCheck %s --check-prefixes CHECK,TRAP_UNREACHABLE
+; RUN: llc -mtriple=thumbv7 -trap-unreachable -no-trap-after-noreturn < %s | FileCheck %s --check-prefixes CHECK,NTANR
 
-define void @test() #0 {
+define void @test_trap_unreachable() #0 {
+; CHECK-LABEL: test_trap_unreachable:
+; CHECK:       @ %bb.0:
+; CHECK-NEXT:    .inst.n 0xdefe
   unreachable
 }
 
 attributes #0 = { nounwind }
+
+declare void @no_return() noreturn
+
+define void @test_ntanr() {
+; CHECK-LABEL:           test_ntanr:
+; CHECK:                 @ %bb.0:
+; CHECK-NEXT:              push {r7, lr}
+; CHECK-NEXT:              bl no_return
+; TRAP_UNREACHABLE-NEXT:   .inst.n 0xdefe
+; NTANR-NOT:               .inst.n 0xdefe
+;
+  call void @no_return()
+  unreachable
+}


### PR DESCRIPTION
Add the command line option --no-trap-after-noreturn, which exposes the pre-existing TargetOption `NoTrapAfterNoreturn`.

This pull request was split off from this one: https://github.com/llvm/llvm-project/pull/65876