### PR TITLE
[MLIR][Transform] Fix PrintOp::build with StringRef

### DIFF
--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -2311,10 +2311,8 @@ void transform::SequenceOp::build(OpBuilder &builder, OperationState &state,
 
 void transform::PrintOp::build(OpBuilder &builder, OperationState &result,
                                StringRef name) {
-  if (!name.empty()) {
-    result.addAttribute(PrintOp::getNameAttrName(result.name),
-                        builder.getStrArrayAttr(name));
-  }
+  if (!name.empty())
+    result.getOrAddProperties<Properties>().name = builder.getStringAttr(name);
 }
 
 void transform::PrintOp::build(OpBuilder &builder, OperationState &result,


### PR DESCRIPTION
transform::PrintOp::build(OpBuilder &builder, OperationState &result, StringRef name) does not set name correctly. Calling PrintOp::build(builder, result, "whatever name") is going to end up with a PrintOp with no name.

This patch fixes it by replicating the approach from tablegen created code. Refer to build/mlir/include/mlir/Dialect/Transform/IR/TransformOps.cpp.inc