### PR TITLE
[libc++] Make sure we forward stdin through executors

### DIFF
--- a/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp
+++ b/libcxx/test/libcxx/selftest/stdin-is-piped.sh.cpp
@@ -6,22 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: Investigate
-// UNSUPPORTED: LIBCXX-AIX-FIXME
-
-// <iostream>
-
-// istream cin;
+// Make sure that the executor pipes standard input to the test-executable being run.
 
 // RUN: %{build}
-// RUN: echo -n 1234 | %{exec} %t.exe
+// RUN: echo "abc" | %{exec} %t.exe
 
-#include <iostream>
-#include <cassert>
+#include <cstdio>
 
 int main(int, char**) {
-    int i;
-    std::cin >> i;
-    assert(i == 1234);
+  int input[] = {std::getchar(), std::getchar(), std::getchar()};
+
+  if (input[0] == 'a' && input[1] == 'b' && input[2] == 'c')
     return 0;
+  return 1;
 }

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-imbue.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin-imbue.sh.cpp
@@ -9,10 +9,6 @@
 // TODO: Investigate
 // UNSUPPORTED: LIBCXX-AIX-FIXME
 
-// TODO: Make it possible to run this test when cross-compiling and running via a SSH executor
-//       This is a workaround to silence issues reported in https://github.com/llvm/llvm-project/pull/66842#issuecomment-1728701639
-// XFAIL: buildhost=windows && target={{.+}}-linux-{{.+}}
-
 // <iostream>
 
 // wistream wcin;

--- a/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.objects/wide.stream.objects/wcin.sh.cpp
@@ -9,10 +9,6 @@
 // TODO: Investigate
 // UNSUPPORTED: LIBCXX-AIX-FIXME
 
-// TODO: Make it possible to run this test when cross-compiling and running via a SSH executor
-//       This is a workaround to silence issues reported in https://github.com/llvm/llvm-project/pull/66842#issuecomment-1728701639
-// XFAIL: buildhost=windows && target={{.+}}-linux-{{.+}}
-
 // <iostream>
 
 // wistream wcin;


### PR DESCRIPTION
This allows running tests like the ones for std::cin even on SSH executors. This was originally reported as https://github.com/llvm/llvm-project/pull/66842#issuecomment-1728701639.