### PR TITLE
[runtimes] Bump the supported AppleClang version to AppleClang 15

### DIFF
--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -117,7 +117,7 @@ velocity, libc++ drops support for older compilers as newer ones are released.
 Compiler     Versions        Restrictions               Support policy
 ============ =============== ========================== =====================
 Clang        15, 16, 17-git                             latest two stable releases per `LLVM's release page <https://releases.llvm.org>`_ and the development version
-AppleClang   14                                         latest stable release per `Xcode's release page <https://developer.apple.com/documentation/xcode-release-notes>`_
+AppleClang   15                                         latest stable release per `Xcode's release page <https://developer.apple.com/documentation/xcode-release-notes>`_
 Open XL      17.1 (AIX)                                 latest stable release per `Open XL's documentation page <https://www.ibm.com/docs/en/openxl-c-and-cpp-aix>`_
 GCC          12              In C++11 or later only     latest stable release per `GCC's release page <https://gcc.gnu.org/releases.html>`_
 ============ =============== ========================== =====================

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -37,8 +37,8 @@
 #      warning "Libc++ only supports Clang 15 and later"
 #    endif
 #  elif defined(_LIBCPP_APPLE_CLANG_VER)
-#    if _LIBCPP_APPLE_CLANG_VER < 1400
-#      warning "Libc++ only supports AppleClang 14 and later"
+#    if _LIBCPP_APPLE_CLANG_VER < 1500
+#      warning "Libc++ only supports AppleClang 15 and later"
 #    endif
 #  elif defined(_LIBCPP_GCC_VER)
 #    if _LIBCPP_GCC_VER < 1300

--- a/libcxx/test/libcxx/atomics/bit-int.verify.cpp
+++ b/libcxx/test/libcxx/atomics/bit-int.verify.cpp
@@ -12,8 +12,6 @@
 // disable them for now until their behavior can be designed better later.
 // See https://reviews.llvm.org/D84049 for details.
 
-// UNSUPPORTED: apple-clang-14
-
 // UNSUPPORTED: c++03
 
 #include <atomic>

--- a/libcxx/test/libcxx/experimental/fexperimental-library.compile.pass.cpp
+++ b/libcxx/test/libcxx/experimental/fexperimental-library.compile.pass.cpp
@@ -12,9 +12,6 @@
 // GCC does not support the -fexperimental-library flag
 // UNSUPPORTED: gcc
 
-// AppleClang does not support the -fexperimental-library flag yet
-// UNSUPPORTED: apple-clang-14.0
-
 // Clang on AIX currently pretends that it is Clang 15, even though it is not (as of writing
 // this, LLVM 15 hasn't even been branched yet).
 // UNSUPPORTED: clang-15 && buildhost=aix

--- a/libcxx/test/libcxx/memory/aligned_allocation_macro.compile.pass.cpp
+++ b/libcxx/test/libcxx/memory/aligned_allocation_macro.compile.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: c++03, c++11, c++14
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 #include <new>
 
 #include "test_macros.h"

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.pass.cpp
@@ -16,9 +16,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.replace.indirect.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.replace.indirect.pass.cpp
@@ -18,9 +18,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.pass.cpp
@@ -16,9 +16,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.replace.indirect.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.replace.indirect.pass.cpp
@@ -19,9 +19,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.replace.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.replace.pass.cpp
@@ -16,9 +16,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/nodiscard.verify.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/nodiscard.verify.cpp
@@ -20,9 +20,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align.pass.cpp
@@ -13,9 +13,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // asan and msan will not call the new handler.
 // UNSUPPORTED: sanitizer-new-delete
 

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.pass.cpp
@@ -13,9 +13,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // asan and msan will not call the new handler.
 // UNSUPPORTED: sanitizer-new-delete
 

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.replace.indirect.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.replace.indirect.pass.cpp
@@ -18,9 +18,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.replace.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.replace.pass.cpp
@@ -16,9 +16,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/nodiscard.verify.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/nodiscard.verify.cpp
@@ -20,9 +20,6 @@
 // We get availability markup errors when aligned allocation is missing
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
 // nor does the dynamic library shipped with z/OS.
 // UNSUPPORTED: target={{.+}}-zos{{.*}}

--- a/libcxx/test/std/language.support/support.srcloc/general.pass.cpp
+++ b/libcxx/test/std/language.support/support.srcloc/general.pass.cpp
@@ -8,7 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: clang-15
-// UNSUPPORTED: apple-clang-14
 
 #include <source_location>
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // This test is hitting Clang bugs with LSV in older versions of Clang.
-// UNSUPPORTED: clang-modules-build && (clang-15 || apple-clang-14)
+// UNSUPPORTED: clang-modules-build && clang-15
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 

--- a/libcxx/test/std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp
+++ b/libcxx/test/std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: no-threads
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// XFAIL: clang-15, apple-clang-14
+// XFAIL: clang-15
 
 // checks that CTAD for std::packaged_task works properly with static operator() overloads
 

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/assign.U.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/assign.U.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 //  template<class U = T>
 //   constexpr expected& operator=(U&& v);
 //

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/assign.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/assign.copy.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // constexpr expected& operator=(const expected& rhs);
 //
 // Effects:

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/assign.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/assign.move.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // constexpr expected& operator=(expected&& rhs) noexcept(see below);
 //
 // Constraints:

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/assign.unexpected.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/assign.unexpected.copy.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // template<class G>
 //   constexpr expected& operator=(const unexpected<G>& e);
 //

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/assign.unexpected.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/assign.unexpected.move.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // template<class G>
 //   constexpr expected& operator=(unexpected<G>&& e);
 //

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // template<class... Args>
 //   constexpr T& emplace(Args&&... args) noexcept;
 // Constraints: is_nothrow_constructible_v<T, Args...> is true.

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // template<class U, class... Args>
 //   constexpr explicit expected(in_place_t, initializer_list<U> il, Args&&... args);
 //

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // template<class U, class... Args>
 //   constexpr explicit expected(unexpect_t, initializer_list<U> il, Args&&... args);
 //

--- a/libcxx/test/std/utilities/expected/expected.expected/dtor.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/dtor.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // constexpr ~expected();
 //
 // Effects: If has_value() is true, destroys val, otherwise destroys unex.

--- a/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
@@ -7,7 +7,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: clang-15, apple-clang-14
+// XFAIL: clang-15
 
 // friend constexpr void swap(expected& x, expected& y) noexcept(noexcept(x.swap(y)));
 

--- a/libcxx/test/std/utilities/expected/expected.void/assign/assign.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/assign/assign.copy.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // constexpr expected& operator=(const expected& rhs);
 //
 // Effects:

--- a/libcxx/test/std/utilities/expected/expected.void/assign/assign.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/assign/assign.move.pass.cpp
@@ -6,8 +6,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
 
 // constexpr expected& operator=(expected&& rhs) noexcept(see below);
 //

--- a/libcxx/test/std/utilities/expected/expected.void/assign/assign.unexpected.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/assign/assign.unexpected.copy.pass.cpp
@@ -6,8 +6,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
 
 // template<class G>
 //   constexpr expected& operator=(const unexpected<G>& e);

--- a/libcxx/test/std/utilities/expected/expected.void/assign/assign.unexpected.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/assign/assign.unexpected.move.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // template<class G>
 //   constexpr expected& operator=(unexpected<G>&& e);
 //

--- a/libcxx/test/std/utilities/expected/expected.void/assign/emplace.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/assign/emplace.pass.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
-
 // constexpr void emplace() noexcept;
 //
 // Effects: If has_value() is false, destroys unex and sets has_val to true.

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
@@ -6,8 +6,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
 
 // template<class U, class... Args>
 //   constexpr explicit expected(unexpect_t, initializer_list<U> il, Args&&... args);

--- a/libcxx/test/std/utilities/expected/expected.void/dtor.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/dtor.pass.cpp
@@ -6,8 +6,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
 
 // constexpr ~expected();
 //

--- a/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
@@ -7,7 +7,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: clang-15, apple-clang-14
+// XFAIL: clang-15
 
 // friend constexpr void swap(expected& x, expected& y) noexcept(noexcept(swap(x,y)));
 

--- a/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
@@ -6,8 +6,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// Older Clangs do not support the C++20 feature to constrain destructors
-// XFAIL: apple-clang-14
 
 // constexpr void swap(expected& rhs) noexcept(see below);
 //

--- a/libcxx/test/std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp
+++ b/libcxx/test/std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// XFAIL: clang-15, apple-clang-14
+// XFAIL: clang-15
 
 // checks that CTAD for std::function works properly with static operator() overloads
 

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.bounded.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.bounded.pass.cpp
@@ -11,9 +11,6 @@
 // This test requires support for aligned allocation to test overaligned types.
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // <memory>
 
 // shared_ptr

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.unbounded.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.unbounded.pass.cpp
@@ -11,9 +11,6 @@
 // This test requires support for aligned allocation to test overaligned types.
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // <memory>
 
 // shared_ptr

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.array.bounded.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.array.bounded.pass.cpp
@@ -11,9 +11,6 @@
 // This test requires support for aligned allocation to test overaligned types.
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // <memory>
 
 // shared_ptr

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.array.unbounded.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.array.unbounded.pass.cpp
@@ -11,9 +11,6 @@
 // This test requires support for aligned allocation to test overaligned types.
 // XFAIL: availability-aligned_allocation-missing
 
-// https://reviews.llvm.org/D129198 is not in AppleClang 14
-// XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.13{{(.0)?}} && apple-clang-14
-
 // <memory>
 
 // shared_ptr


### PR DESCRIPTION
AppleClang 15 was released on September 18th and is now stable. Per our policy, we're bumping the supported AppleClang compiler to the latest release. This allows cleaning up the test suite, but most importantly unblocking various other patches that are blocked on bumping the compiler requirements.