### PR TITLE
[Fuchsia] Build with -fvisibility=default

### DIFF
--- a/clang/cmake/caches/Fuchsia-stage2.cmake
+++ b/clang/cmake/caches/Fuchsia-stage2.cmake
@@ -51,6 +51,12 @@ set(CLANG_PLUGIN_SUPPORT OFF CACHE BOOL "")
 set(ENABLE_LINKER_BUILD_ID ON CACHE BOOL "")
 set(ENABLE_X86_RELAX_RELOCATIONS ON CACHE BOOL "")
 
+# TODO(#67176): relative-vtables doesn't play well with different default
+# visibilities. Making everything hidden visibility causes other complications
+# let's choose default visibility for our entire toolchain.
+set(CMAKE_C_VISIBILITY_PRESET default CACHE STRING "")
+set(CMAKE_CXX_VISIBILITY_PRESET default CACHE STRING "")
+
 set(CMAKE_BUILD_TYPE Release CACHE STRING "")
 if (APPLE)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "")


### PR DESCRIPTION
There was an issue with relative vtables when two TU's which define the same vtable object are built with different default visibilities. Some TU's are built with -fvisibility=hidden in the code base, grep for CMAKE_CXX_VISIBILITY_PRESET to find them. Our whole toolchain, is statically linked, and built with -fPIE anyway, so the cost of overriding local CMAKE_CXX_VISIBILITY_PRESET properties is not high. I've counted that adding this flag increases our llvm binary by 13 relocations. Frankly I'm not sure where those are even coming from.

It would be preferable to use hidden visibility, but that breaks liblld. This can be solved by setting LLDB_EXPORT_ALL_SYMBOLS. After that some ORC tests fail which do symbolic lookup in the tests. It seems that setting CMAKE_CXX_VISIBILITY_PRESET=hidden will not be worth the maintenance burden. Setting it to default works to unblock using relative vtables, so we can just go with that.