### PR TITLE
[X86] Use RIP-relative for non-globals in medium code model in classifyLocalReference()

### DIFF
--- a/llvm/lib/Target/X86/X86Subtarget.cpp
+++ b/llvm/lib/Target/X86/X86Subtarget.cpp
@@ -103,10 +103,10 @@ X86Subtarget::classifyLocalReference(const GlobalValue *GV) const {
         if (isa_and_nonnull<Function>(GV))
           return X86II::MO_NO_FLAG; // All code is RIP-relative
         if (auto *GVar = dyn_cast_or_null<GlobalVariable>(GV)) {
-          if (!TM.isLargeData(GVar))
-            return X86II::MO_NO_FLAG;
+          if (TM.isLargeData(GVar))
+            return X86II::MO_GOTOFF;
         }
-        return X86II::MO_GOTOFF;    // Local symbols use GOTOFF.
+        return X86II::MO_NO_FLAG;    // Local symbols use GOTOFF.
       }
       llvm_unreachable("invalid code model");
     }

--- a/llvm/test/CodeGen/X86/code-model-elf.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf.ll
@@ -10,8 +10,6 @@
 ; RUN: llc -verify-machineinstrs < %s -relocation-model=pic    -code-model=medium | FileCheck %s --check-prefix=CHECK --check-prefix=MEDIUM-PIC
 ; RUN: llc -verify-machineinstrs < %s -relocation-model=pic    -code-model=large  | FileCheck %s --check-prefix=CHECK --check-prefix=LARGE-PIC
 
-; FIXME: small pic and medium pic w/ big enough large data threshold should be equivalent
-
 ; Generated from this C source:
 ;
 ; static int static_data[10];

--- a/llvm/test/CodeGen/X86/code-model-elf.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf.ll
@@ -577,16 +577,12 @@ define dso_local float @load_constant_pool(float %x) #0 {
 ;
 ; MEDIUM-SMALL-DATA-PIC-LABEL: load_constant_pool:
 ; MEDIUM-SMALL-DATA-PIC:       # %bb.0:
-; MEDIUM-SMALL-DATA-PIC-NEXT:    leaq _GLOBAL_OFFSET_TABLE_(%rip), %rax
-; MEDIUM-SMALL-DATA-PIC-NEXT:    movabsq ${{\.?LCPI[0-9]+_[0-9]+}}@GOTOFF, %rcx
-; MEDIUM-SMALL-DATA-PIC-NEXT:    addss (%rax,%rcx), %xmm0
+; MEDIUM-SMALL-DATA-PIC-NEXT:    addss {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
 ; MEDIUM-SMALL-DATA-PIC-NEXT:    retq
 ;
 ; MEDIUM-PIC-LABEL: load_constant_pool:
 ; MEDIUM-PIC:       # %bb.0:
-; MEDIUM-PIC-NEXT:    leaq _GLOBAL_OFFSET_TABLE_(%rip), %rax
-; MEDIUM-PIC-NEXT:    movabsq ${{\.?LCPI[0-9]+_[0-9]+}}@GOTOFF, %rcx
-; MEDIUM-PIC-NEXT:    addss (%rax,%rcx), %xmm0
+; MEDIUM-PIC-NEXT:    addss {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
 ; MEDIUM-PIC-NEXT:    retq
 ;
 ; LARGE-PIC-LABEL: load_constant_pool:


### PR DESCRIPTION
We only want to treat globals as potentially far away, not other things like constants in the constant pool.
This matches the object file emission that only puts the large section flag on globals.

Remove FIXME since the remaining differences are accesses to 0 sized globals which are intentional.