### PR TITLE
[libc] Pull more definitions from linux/stat.h

### DIFF
--- a/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
@@ -9,20 +9,45 @@
 #ifndef __LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H
 #define __LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H
 
-// File mode flags
-#define S_IRWXU 0700
-#define S_IRUSR 0400
-#define S_IWUSR 0200
-#define S_IXUSR 0100
-#define S_IRWXG 070
-#define S_IRGRP 040
-#define S_IWGRP 020
-#define S_IXGRP 010
-#define S_IRWXO 07
-#define S_IROTH 04
-#define S_IWOTH 02
-#define S_IXOTH 01
-#define S_ISUID 04000
-#define S_ISGID 02000
+// Definitions from linux/stat.h
+#define S_IFMT  00170000
+#define S_IFSOCK 0140000
+#define S_IFLNK  0120000
+#define S_IFREG  0100000
+#define S_IFBLK  0060000
+#define S_IFDIR  0040000
+#define S_IFCHR  0020000
+#define S_IFIFO  0010000
+#define S_ISUID  0004000
+#define S_ISGID  0002000
+#define S_ISVTX  0001000
+
+#define S_ISLNK(m)      (((m) & S_IFMT) == S_IFLNK)
+#define S_ISREG(m)      (((m) & S_IFMT) == S_IFREG)
+#define S_ISDIR(m)      (((m) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(m)      (((m) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(m)      (((m) & S_IFMT) == S_IFBLK)
+#define S_ISFIFO(m)     (((m) & S_IFMT) == S_IFIFO)
+#define S_ISSOCK(m)     (((m) & S_IFMT) == S_IFSOCK)
+
+#define S_IRWXU 00700
+#define S_IRUSR 00400
+#define S_IWUSR 00200
+#define S_IXUSR 00100
+
+#define S_IRWXG 00070
+#define S_IRGRP 00040
+#define S_IWGRP 00020
+#define S_IXGRP 00010
+
+#define S_IRWXU 00700
+#define S_IRUSR 00400
+#define S_IWUSR 00200
+#define S_IXUSR 00100
+
+#define S_IRWXG 00070
+#define S_IRGRP 00040
+#define S_IWGRP 00020
+#define S_IXGRP 00010
 
 #endif // __LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H

--- a/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
@@ -40,14 +40,4 @@
 #define S_IWGRP 00020
 #define S_IXGRP 00010
 
-#define S_IRWXU 00700
-#define S_IRUSR 00400
-#define S_IWUSR 00200
-#define S_IXUSR 00100
-
-#define S_IRWXG 00070
-#define S_IRGRP 00040
-#define S_IWGRP 00020
-#define S_IXGRP 00010
-
 #endif // __LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H

--- a/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-stat-macros.h
@@ -40,4 +40,9 @@
 #define S_IWGRP 00020
 #define S_IXGRP 00010
 
+#define S_IRWXO 00007
+#define S_IROTH 00004
+#define S_IWOTH 00002
+#define S_IXOTH 00001
+
 #endif // __LLVM_LIBC_MACROS_LINUX_SYS_STAT_MACROS_H


### PR DESCRIPTION
For file handling, we need more definitions from
linux/stat.h, so this pulls them in.  It also adjusts other definitions to match the kernel's exactly [NFC] so that it's easy to verify that there's been no divergence one day when it's time to use linux/stat.h directly.

Tested:
check-libc