### PR TITLE
[lld][COFF][LTO] Implement /lldemit:asm option

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -48,7 +48,7 @@ enum class ExportSource {
   ModuleDefinition,
 };
 
-enum class EmitKind { Obj, LLVM };
+enum class EmitKind { Obj, LLVM, ASM };
 
 // Represents an /export option.
 struct Export {

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1859,6 +1859,8 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       config->emit = EmitKind::Obj;
     else if (s == "llvm")
       config->emit = EmitKind::LLVM;
+    else if (s == "asm")
+      config->emit = EmitKind::ASM;
     else
       error("/lldemit: unknown option: " + s);
   }

--- a/lld/test/COFF/lto-emit-asm.ll
+++ b/lld/test/COFF/lto-emit-asm.ll
@@ -1,0 +1,28 @@
+; REQUIRES: x86
+; RUN: llvm-as %s -o %t.obj
+
+; RUN: lld-link /lldemit:asm /dll /noentry /include:f1 /include:f2 %t.obj /opt:lldltopartitions=1 /out:%t.1p /lldsavetemps
+; RUN: cat %t.1p.lto.s | FileCheck %s
+; RUN: llvm-dis %t.1p.0.4.opt.bc -o - | FileCheck --check-prefix=OPT %s
+
+; RUN: lld-link /lldemit:asm /dll /noentry /include:f1 /include:f2 %t.obj /opt:lldltopartitions=2 /out:%t.2p
+; RUN: cat %t.2p.lto.s %t.2p.lto.1.s | FileCheck %s
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+;; Note: we also check for the presence of comments; /lldemit:asm output should be verbose.
+
+; CHECK-DAG: # -- Begin function f1
+; CHECK-DAG: f1:
+; OPT: define void @f1()
+define void @f1() {
+  ret void
+}
+
+; CHECK-DAG: # -- Begin function f2
+; CHECK-DAG: f2:
+; OPT: define void @f2()
+define void @f2() {
+  ret void
+}

--- a/lld/test/COFF/pdb-thinlto.ll
+++ b/lld/test/COFF/pdb-thinlto.ll
@@ -29,8 +29,8 @@ declare void @foo()
 
 ; CHECK:                           Modules
 ; CHECK: ============================================================
-; CHECK: Mod 0000 | `{{.*}}main.exe.lto.main.bc`:
-; CHECK: Obj: `{{.*}}main.exe.lto.main.bc`:
-; CHECK: Mod 0001 | `{{.*}}main.exe.lto.foo.bc`:
-; CHECK: Obj: `{{.*}}main.exe.lto.foo.bc`:
+; CHECK: Mod 0000 | `{{.*}}main.exe.lto.main.obj`:
+; CHECK: Obj: `{{.*}}main.exe.lto.main.obj`:
+; CHECK: Mod 0001 | `{{.*}}main.exe.lto.foo.obj`:
+; CHECK: Obj: `{{.*}}main.exe.lto.foo.obj`:
 ; CHECK: Mod 0002 | `* Linker *`:


### PR DESCRIPTION
With this new option, assembly code will be emited instead of object code.
This is analogous to the `--lto-emit-asm` option in the ELF linker.