### PR TITLE
[Clang][RISCV] Remove duplicate functions isRVVSizelessBuiltinType. NFC

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -2117,9 +2117,6 @@ public:
   /// Returns true for SVE scalable vector types.
   bool isSVESizelessBuiltinType() const;
 
-  /// Returns true for RVV scalable vector types.
-  bool isRVVSizelessBuiltinType() const;
-
   /// Check if this is a WebAssembly Externref Type.
   bool isWebAssemblyExternrefType() const;
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -9521,10 +9521,9 @@ static uint64_t getRVVTypeSize(ASTContext &Context, const BuiltinType *Ty) {
 
 bool ASTContext::areCompatibleRVVTypes(QualType FirstType,
                                        QualType SecondType) {
-  assert(
-      ((FirstType->isRVVSizelessBuiltinType() && SecondType->isVectorType()) ||
-       (FirstType->isVectorType() && SecondType->isRVVSizelessBuiltinType())) &&
-      "Expected RVV builtin type and vector type!");
+  assert(((FirstType->isRVVType() && SecondType->isVectorType()) ||
+          (FirstType->isVectorType() && SecondType->isRVVType())) &&
+         "Expected RVV builtin type and vector type!");
 
   auto IsValidCast = [this](QualType FirstType, QualType SecondType) {
     if (const auto *BT = FirstType->getAs<BuiltinType>()) {
@@ -9546,10 +9545,9 @@ bool ASTContext::areCompatibleRVVTypes(QualType FirstType,
 
 bool ASTContext::areLaxCompatibleRVVTypes(QualType FirstType,
                                           QualType SecondType) {
-  assert(
-      ((FirstType->isRVVSizelessBuiltinType() && SecondType->isVectorType()) ||
-       (FirstType->isVectorType() && SecondType->isRVVSizelessBuiltinType())) &&
-      "Expected RVV builtin type and vector type!");
+  assert(((FirstType->isRVVType() && SecondType->isVectorType()) ||
+          (FirstType->isVectorType() && SecondType->isRVVType())) &&
+         "Expected RVV builtin type and vector type!");
 
   auto IsLaxCompatible = [this](QualType FirstType, QualType SecondType) {
     const auto *BT = FirstType->getAs<BuiltinType>();

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2403,7 +2403,7 @@ bool Type::isWebAssemblyTableType() const {
 bool Type::isSizelessType() const { return isSizelessBuiltinType(); }
 
 bool Type::isSizelessVectorType() const {
-  return isSVESizelessBuiltinType() || isRVVSizelessBuiltinType();
+  return isSVESizelessBuiltinType() || isRVVType();
 }
 
 bool Type::isSVESizelessBuiltinType() const {
@@ -2412,19 +2412,6 @@ bool Type::isSVESizelessBuiltinType() const {
       // SVE Types
 #define SVE_TYPE(Name, Id, SingletonId) case BuiltinType::Id:
 #include "clang/Basic/AArch64SVEACLETypes.def"
-      return true;
-    default:
-      return false;
-    }
-  }
-  return false;
-}
-
-bool Type::isRVVSizelessBuiltinType() const {
-  if (const BuiltinType *BT = getAs<BuiltinType>()) {
-    switch (BT->getKind()) {
-#define RVV_TYPE(Name, Id, SingletonId) case BuiltinType::Id:
-#include "clang/Basic/RISCVVTypes.def"
       return true;
     default:
       return false;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8272,7 +8272,7 @@ bool Sema::isValidRVVBitcast(QualType srcTy, QualType destTy) {
   assert(srcTy->isVectorType() || destTy->isVectorType());
 
   auto ValidScalableConversion = [](QualType FirstType, QualType SecondType) {
-    if (!FirstType->isRVVSizelessBuiltinType())
+    if (!FirstType->isRVVType())
       return false;
 
     const auto *VecTy = SecondType->getAs<VectorType>();
@@ -10254,8 +10254,8 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
       }
 
     // Allow assignments between fixed-length and sizeless RVV vectors.
-    if ((LHSType->isRVVSizelessBuiltinType() && RHSType->isVectorType()) ||
-        (LHSType->isVectorType() && RHSType->isRVVSizelessBuiltinType())) {
+    if ((LHSType->isRVVType() && RHSType->isVectorType()) ||
+        (LHSType->isVectorType() && RHSType->isRVVType())) {
       if (Context.areCompatibleRVVTypes(LHSType, RHSType) ||
           Context.areLaxCompatibleRVVTypes(LHSType, RHSType)) {
         Kind = CK_BitCast;
@@ -11201,7 +11201,7 @@ QualType Sema::CheckVectorOperands(ExprResult &LHS, ExprResult &RHS,
         SecondVecType->getVectorKind() == VectorKind::Generic) {
       if (FirstType->isSVESizelessBuiltinType())
         return true;
-      if (FirstType->isRVVSizelessBuiltinType()) {
+      if (FirstType->isRVVType()) {
         SVEorRVV = 1;
         return true;
       }

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1880,8 +1880,7 @@ static bool IsVectorConversion(Sema &S, QualType FromType, QualType ToType,
       return true;
     }
 
-  if (ToType->isRVVSizelessBuiltinType() ||
-      FromType->isRVVSizelessBuiltinType())
+  if (ToType->isRVVType() || FromType->isRVVType())
     if (S.Context.areCompatibleRVVTypes(FromType, ToType) ||
         S.Context.areLaxCompatibleRVVTypes(FromType, ToType)) {
       ICK = ICK_RVV_Vector_Conversion;


### PR DESCRIPTION
`isRVVSizelessBuiltinType` and `isRVVType` has the same functionality. This commit removes the former since we have more variants available in `isRVVType`.