### PR TITLE
[ADT] Fix llvm::join on containers of char*s

### DIFF
--- a/llvm/include/llvm/ADT/StringExtras.h
+++ b/llvm/include/llvm/ADT/StringExtras.h
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <iterator>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 namespace llvm {
@@ -417,8 +418,13 @@ inline std::string join_impl(IteratorT Begin, IteratorT End,
     return S;
 
   size_t Len = (std::distance(Begin, End) - 1) * Separator.size();
-  for (IteratorT I = Begin; I != End; ++I)
-    Len += (*I).size();
+  for (IteratorT I = Begin; I != End; ++I) {
+    if constexpr (std::is_same_v<std::remove_reference_t<decltype(*I)>,
+                                 const char *>)
+      Len += strlen(*I);
+    else
+      Len += (*I).size();
+  }
   S.reserve(Len);
   size_t PrevCapacity = S.capacity();
   (void)PrevCapacity;

--- a/llvm/include/llvm/ADT/StringExtras.h
+++ b/llvm/include/llvm/ADT/StringExtras.h
@@ -26,7 +26,6 @@
 #include <cstring>
 #include <iterator>
 #include <string>
-#include <type_traits>
 #include <utility>
 
 namespace llvm {
@@ -418,13 +417,8 @@ inline std::string join_impl(IteratorT Begin, IteratorT End,
     return S;
 
   size_t Len = (std::distance(Begin, End) - 1) * Separator.size();
-  for (IteratorT I = Begin; I != End; ++I) {
-    if constexpr (std::is_same_v<std::remove_reference_t<decltype(*I)>,
-                                 const char *>)
-      Len += strlen(*I);
-    else
-      Len += (*I).size();
-  }
+  for (IteratorT I = Begin; I != End; ++I)
+    Len += StringRef(*I).size();
   S.reserve(Len);
   size_t PrevCapacity = S.capacity();
   (void)PrevCapacity;

--- a/llvm/unittests/ADT/StringExtrasTest.cpp
+++ b/llvm/unittests/ADT/StringExtrasTest.cpp
@@ -59,8 +59,8 @@ TEST(StringExtrasTest, isUpper) {
   EXPECT_FALSE(isUpper('\?'));
 }
 
-TEST(StringExtrasTest, Join) {
-  std::vector<std::string> Items;
+template <class ContainerT> void testJoin() {
+  ContainerT Items;
   EXPECT_EQ("", join(Items.begin(), Items.end(), " <sep> "));
 
   Items = {"foo"};
@@ -73,6 +73,19 @@ TEST(StringExtrasTest, Join) {
   EXPECT_EQ("foo <sep> bar <sep> baz",
             join(Items.begin(), Items.end(), " <sep> "));
 }
+
+TEST(StringExtrasTest, Join) {
+  {
+    SCOPED_TRACE("std::vector<std::string>");
+    testJoin<std::vector<std::string>>();
+  }
+  {
+    SCOPED_TRACE("std::vector<const char*>");
+    testJoin<std::vector<const char *>>();
+  }
+}
+
+TEST(StringExtrasTest, JoinCStrings) { std::vector<const char *> Items; }
 
 TEST(StringExtrasTest, JoinItems) {
   const char *Foo = "foo";

--- a/llvm/unittests/ADT/StringExtrasTest.cpp
+++ b/llvm/unittests/ADT/StringExtrasTest.cpp
@@ -85,8 +85,6 @@ TEST(StringExtrasTest, Join) {
   }
 }
 
-TEST(StringExtrasTest, JoinCStrings) { std::vector<const char *> Items; }
-
 TEST(StringExtrasTest, JoinItems) {
   const char *Foo = "foo";
   std::string Bar = "bar";


### PR DESCRIPTION
Currently it tries to call S.size() when preallocating the target string,
which doesn't compile.
vector<const char*> is used a bunch in e.g. clang driver.
