### PR TITLE
[MLIR][UB] Add inliner interface for UB dialect

### DIFF
--- a/mlir/lib/Dialect/UB/IR/UBOps.cpp
+++ b/mlir/lib/Dialect/UB/IR/UBOps.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -16,6 +17,19 @@
 
 using namespace mlir;
 using namespace mlir::ub;
+
+namespace {
+/// This class defines the interface for handling inlining with UB
+/// operations.
+struct UBInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  /// All UB ops can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // UBDialect
@@ -30,6 +44,7 @@ void UBDialect::initialize() {
 #define GET_ATTRDEF_LIST
 #include "mlir/Dialect/UB/IR/UBOpsAttributes.cpp.inc"
       >();
+  addInterfaces<UBInlinerInterface>();
 }
 
 Operation *UBDialect::materializeConstant(OpBuilder &builder, Attribute value,

--- a/mlir/test/Dialect/UB/inlining.mlir
+++ b/mlir/test/Dialect/UB/inlining.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-opt %s -inline -split-input-file | FileCheck %s
+
+func.func @func() -> i32 {
+  %0 = ub.poison : i32
+  return %0 : i32
+}
+
+// CHECK-LABEL: func @test_inline
+func.func @test_inline(%ptr : !llvm.ptr) -> i32 {
+// CHECK-NOT: call
+  %0 = call @func() : () -> i32
+  return %0 : i32
+}


### PR DESCRIPTION
This revision adds an inliner interface to the UB dialect that allows inlining of `ub.poison` operations.