### PR TITLE
[lldb] Require paused process and frame for "register info" command

### DIFF
--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -406,8 +406,9 @@ public:
   CommandObjectRegisterInfo(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "register info",
                             "View information about a register.", nullptr,
-                            eCommandRequiresRegContext |
-                                eCommandProcessMustBeLaunched) {
+                            eCommandRequiresFrame | eCommandRequiresRegContext |
+                                eCommandProcessMustBeLaunched |
+                                eCommandProcessMustBePaused) {
     SetHelpLong(R"(
 Name             The name lldb uses for the register, optionally with an alias.
 Size             The size of the register in bytes and again in bits.

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -659,3 +659,16 @@ class RegisterCommandsTestCase(TestBase):
             pthread_self_val.GetValueAsUnsigned(0),
             "fs_base does not equal to pthread_self() value.",
         )
+
+    def test_process_must_be_stopped(self):
+        """Check that all register commands error when the process is not stopped."""
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        pid = self.spawnSubprocess(exe, ["wait_for_attach"]).pid
+        self.setAsync(True)
+        self.runCmd("process attach --continue -p %d" % pid)
+
+        err_msg = "Command requires a process which is currently stopped."
+        self.expect("register read pc", substrs=[err_msg], error=True)
+        self.expect("register write pc 0", substrs=[err_msg], error=True)
+        self.expect("register info pc", substrs=[err_msg], error=True)

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -665,6 +665,7 @@ class RegisterCommandsTestCase(TestBase):
         self.build()
         exe = self.getBuildArtifact("a.out")
         pid = self.spawnSubprocess(exe, ["wait_for_attach"]).pid
+        # Async so we can enter commands while the process is running.
         self.setAsync(True)
         self.runCmd("process attach --continue -p %d" % pid)
 


### PR DESCRIPTION
Prior to this the command would simply crash when run on a running process.

Of the three register commands, "info" was the only one missing these requirements. On some level it makes sense because you're not going to read a value or modify anything, but practically I think lldb assumes any time you're going to access register related stuff, the process should be paused.

I noticed this debugging with a remote gdb stub, so I've recreated that scenario using attach in a new test case.