### PR TITLE
[scudo] Avoid deprecated-volatile warning in HybridMutex::delayLoop

### DIFF
--- a/compiler-rt/lib/scudo/standalone/mutex.h
+++ b/compiler-rt/lib/scudo/standalone/mutex.h
@@ -58,13 +58,11 @@ private:
     // are the fastest operations) so that we are unlikely to wait too long for
     // fast operations.
     constexpr u32 SpinTimes = 16;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-    volatile u32 V;
-    for (u32 I = 0; I < SpinTimes; ++I)
-      V = 0;
-#pragma GCC diagnostic pop
+    volatile u32 V = 0;
+    for (u32 I = 0; I < SpinTimes; ++I) {
+      u32 Tmp = V + 1;
+      V = Tmp;
+    }
   }
 
   void assertHeldImpl();

--- a/compiler-rt/lib/scudo/standalone/mutex.h
+++ b/compiler-rt/lib/scudo/standalone/mutex.h
@@ -58,9 +58,13 @@ private:
     // are the fastest operations) so that we are unlikely to wait too long for
     // fast operations.
     constexpr u32 SpinTimes = 16;
-    volatile u32 V = 0;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+    volatile u32 V;
     for (u32 I = 0; I < SpinTimes; ++I)
-      ++V;
+      V = 0;
+#pragma GCC diagnostic pop
   }
 
   void assertHeldImpl();


### PR DESCRIPTION
That can prevent compilation with -Werror and -std=c++20:
mutex.h:63:7: error: increment of object of volatile-qualified type 'volatile u32' (aka 'volatile unsigned int') is deprecated [-Werror,-Wdeprecated-volatile]
