### PR TITLE
[llvm][NFC] Assert VAArg type

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -1796,12 +1796,16 @@ public:
   VAArgInst(Value *List, Type *Ty, const Twine &NameStr = "",
              Instruction *InsertBefore = nullptr)
     : UnaryInstruction(Ty, VAArg, List, InsertBefore) {
+    assert(!Ty->isStructTy() && !Ty->isArrayTy() &&
+           "by-val structures and arrays unsupported");
     setName(NameStr);
   }
 
   VAArgInst(Value *List, Type *Ty, const Twine &NameStr,
             BasicBlock *InsertAtEnd)
     : UnaryInstruction(Ty, VAArg, List, InsertAtEnd) {
+    assert(!Ty->isStructTy() && !Ty->isArrayTy() &&
+           "by-val structures and arrays unsupported");
     setName(NameStr);
   }
 


### PR DESCRIPTION
Due to the way we have a backend arranged, we fell over a varadic struct bug, and noticed the generic machinery presumes all by-val structs are by hidden pointer.  The documentation even warns:

'Note that the code generator does not yet fully support va\_arg on many targets. Also, it does not currently support va\_arg with aggregate types on any target.'

While this assert would not have triggered in our case, it was surprising to not see a check.  So here's one. Of course it doesn't trigger :)
