### PR TITLE
[X86] Add detection for more Tremont models

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model.c
+++ b/compiler-rt/lib/builtins/cpu_model.c
@@ -553,6 +553,9 @@ getIntelProcessorTypeAndSubtype(unsigned Family, unsigned Model,
       *Type = INTEL_GOLDMONT_PLUS;
       break;
     case 0x86:
+    case 0x8a: // Lakefield
+    case 0x96: // Elkhart Lake
+    case 0x9c: // Jasper Lake
       CPU = "tremont";
       *Type = INTEL_TREMONT;
       break;

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -913,6 +913,9 @@ getIntelProcessorTypeAndSubtype(unsigned Family, unsigned Model,
       *Type = X86::INTEL_GOLDMONT_PLUS;
       break;
     case 0x86:
+    case 0x8a: // Lakefield
+    case 0x96: // Elkhart Lake
+    case 0x9c: // Jasper Lake
       CPU = "tremont";
       *Type = X86::INTEL_TREMONT;
       break;


### PR DESCRIPTION
Fix the issue that only the server series Tremont processors (Snow Ridge & Elkhart Lake) can be detected as Tremont, while the client series (Jasper Lake & Lakefield) will be guessed as Goldmont.

Noted that Lakefield is missing some features compare to other Tremont processors, but those features are also missing on `FeatureTremont`, which shouldn't be a problem. Those features are `waitpkg`, `movdiri` and `movdir64b`.
