### PR TITLE
[libc] Update integration test's linking options

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -525,7 +525,7 @@ function(add_integration_test test_name)
                            --target=${LIBC_GPU_TARGET_TRIPLE})
   endif()
 
-  target_link_options(${fq_build_target_name} PRIVATE -nostdlib -static)
+  target_link_options(${fq_build_target_name} PRIVATE -nolibc -nostartfiles -nostdlib++ -static)
   target_link_libraries(
     ${fq_build_target_name}
     # The NVIDIA 'nvlink' linker does not currently support static libraries.


### PR DESCRIPTION
This patch set the integration test's linking options to be the same one used in the hermetic tests.

In particular, by removing -nostdlib the tests are linked with libgcc/compiler-rt and this fixes an issue undefined reference to __udivdi3 and __umoddi3 in rv32.