### PR TITLE
[RISCV] Extend InstSeq (used in constant mat) to support multiple live regs

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.h
@@ -21,24 +21,35 @@ namespace RISCVMatInt {
 enum OpndKind {
   RegImm, // ADDI/ADDIW/SLLI/SRLI/BSETI/BCLRI
   Imm,    // LUI
-  RegReg, // SH1ADD/SH2ADD/SH3ADD
-  RegX0,  // ADD_UW
+  RegReg // SH1ADD/SH2ADD/SH3ADD
 };
 
 class Inst {
   unsigned Opc;
-  int32_t Imm; // The largest value we need to store is 20 bits.
+  // Reg0 and Reg1 are the offset in the containing sequence which
+  // define the vreg used as the respective operand (if any).  Note
+  // that a sequence implicitly starts with X0, so an offset one
+  // past the start of the sequence is valid, and means X0.
+  uint8_t Reg0 : 4;
+  uint8_t Reg1 : 4;
+  int32_t Imm : 24; // The largest value we need to store is 20 bits.
 
 public:
-  Inst(unsigned Opc, int64_t I) : Opc(Opc), Imm(I) {
+  Inst(unsigned Opc, int64_t I, uint8_t R0, uint8_t R1)
+    : Opc(Opc), Reg0(R0), Reg1(R1), Imm(I) {
     assert(I == Imm && "truncated");
+    assert(Reg0 == R0 && Reg1 == R1 && "truncated");
   }
 
   unsigned getOpcode() const { return Opc; }
   int64_t getImm() const { return Imm; }
+  uint8_t getReg0() const { return Reg0; }
+  uint8_t getReg1() const { return Reg1; }
 
   OpndKind getOpndKind() const;
 };
+static_assert(sizeof(Inst) == 8);
+
 using InstSeq = SmallVector<Inst, 8>;
 
 // Helper to generate an instruction sequence that will materialise the given
@@ -46,7 +57,8 @@ using InstSeq = SmallVector<Inst, 8>;
 // simple struct is produced rather than directly emitting the instructions in
 // order to allow this helper to be used from both the MC layer and during
 // instruction selection.
-InstSeq generateInstSeq(int64_t Val, const FeatureBitset &ActiveFeatures);
+InstSeq generateInstSeq(int64_t Val, const FeatureBitset &ActiveFeatures,
+                        bool AllowMultipleVRegs = false);
 
 // Helper to estimate the number of instructions required to materialise the
 // given immediate value into a register. This estimate does not account for
@@ -60,7 +72,8 @@ InstSeq generateInstSeq(int64_t Val, const FeatureBitset &ActiveFeatures);
 // which is more compressible.
 int getIntMatCost(const APInt &Val, unsigned Size,
                   const FeatureBitset &ActiveFeatures,
-                  bool CompressionCost = false);
+                  bool CompressionCost = false,
+                  bool AllowMultipleVRegs = false);
 } // namespace RISCVMatInt
 } // namespace llvm
 #endif

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4950,26 +4950,10 @@ static SDValue lowerConstant(SDValue Op, SelectionDAG &DAG,
     return Op;
 
   RISCVMatInt::InstSeq Seq =
-      RISCVMatInt::generateInstSeq(Imm, Subtarget.getFeatureBits());
+    RISCVMatInt::generateInstSeq(Imm, Subtarget.getFeatureBits(),
+                                 !DAG.shouldOptForSize());
   if (Seq.size() <= Subtarget.getMaxBuildIntsCost())
     return Op;
-
-  // Special case. See if we can build the constant as (ADD (SLLI X, 32), X) do
-  // that if it will avoid a constant pool.
-  // It will require an extra temporary register though.
-  // If we have Zba we can use (ADD_UW X, (SLLI X, 32)) to handle cases where
-  // low and high 32 bits are the same and bit 31 and 63 are set.
-  if (!DAG.shouldOptForSize()) {
-    int64_t LoVal = SignExtend64<32>(Imm);
-    int64_t HiVal = SignExtend64<32>(((uint64_t)Imm - (uint64_t)LoVal) >> 32);
-    if (LoVal == HiVal ||
-        (Subtarget.hasStdExtZba() && Lo_32(Imm) == Hi_32(Imm))) {
-      RISCVMatInt::InstSeq SeqLo =
-          RISCVMatInt::generateInstSeq(LoVal, Subtarget.getFeatureBits());
-      if ((SeqLo.size() + 2) <= Subtarget.getMaxBuildIntsCost())
-        return Op;
-    }
-  }
 
   // Expand to a constant pool using the default expansion code.
   return SDValue();

--- a/llvm/test/CodeGen/RISCV/rvv/emergency-slot.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/emergency-slot.mir
@@ -83,14 +83,14 @@ body:             |
   ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION def_cfa $x8, 0
   ; CHECK-NEXT:   $x2 = frame-setup ADDI $x2, -272
   ; CHECK-NEXT:   $x10 = frame-setup PseudoReadVLENB
-  ; CHECK-NEXT:   $x11 = frame-setup ADDI killed $x0, 52
+  ; CHECK-NEXT:   $x11 = frame-setup ADDI $x0, 52
   ; CHECK-NEXT:   $x10 = frame-setup MUL killed $x10, killed $x11
   ; CHECK-NEXT:   $x2 = frame-setup SUB $x2, killed $x10
   ; CHECK-NEXT:   $x2 = frame-setup ANDI $x2, -128
   ; CHECK-NEXT:   dead renamable $x15 = PseudoVSETIVLI 1, 72 /* e16, m1, ta, mu */, implicit-def $vl, implicit-def $vtype
   ; CHECK-NEXT:   renamable $v25 = PseudoVMV_V_X_M1 undef $v25, killed renamable $x12, $noreg, 4 /* e16 */, 0 /* tu, mu */, implicit $vl, implicit $vtype
   ; CHECK-NEXT:   $x10 = PseudoReadVLENB
-  ; CHECK-NEXT:   $x11 = ADDI killed $x0, 50
+  ; CHECK-NEXT:   $x11 = ADDI $x0, 50
   ; CHECK-NEXT:   $x10 = MUL killed $x10, killed $x11
   ; CHECK-NEXT:   $x10 = ADD $x2, killed $x10
   ; CHECK-NEXT:   $x10 = ADDI killed $x10, 2047
@@ -130,7 +130,7 @@ body:             |
   ; CHECK-NEXT:   SD killed $x10, $x2, 8 :: (store (s64) into %stack.15)
   ; CHECK-NEXT:   $x10 = PseudoReadVLENB
   ; CHECK-NEXT:   SD killed $x12, $x2, 0 :: (store (s64) into %stack.16)
-  ; CHECK-NEXT:   $x12 = ADDI killed $x0, 50
+  ; CHECK-NEXT:   $x12 = ADDI $x0, 50
   ; CHECK-NEXT:   $x10 = MUL killed $x10, killed $x12
   ; CHECK-NEXT:   $x12 = LD $x2, 0 :: (load (s64) from %stack.16)
   ; CHECK-NEXT:   $x10 = ADD $x2, killed $x10


### PR DESCRIPTION
Posted mostly for discussion.  This turned out to be more invasive and fiddly than I'd expected when I first started.  My guess is that we probably won't land this, but I wanted to show what the option looked like.  

This moves the logic for constant materialization with an additional vreg into common code.  It does so by extending the InstSeq construct to support multiple live values in the sequence.  This converts an InstSeq from being a linear chain of instructions to being a DAG of instructions.

Note that the emergency-slot.mir test change is in principle a bug fix; we're setting kill flags on a register which has later usage.  Its probably an uninteresting bug in practice since it only happens on X0 which is a constant physreg and thus the kill flag is fairly meaningless.