### PR TITLE
[TargetLowering] remove unused virtual from ComputeConstraintToUse

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -4842,9 +4842,8 @@ public:
   /// AsmOperandInfo, setting OpInfo.ConstraintCode and OpInfo.ConstraintType.
   /// If the actual operand being passed in is available, it can be passed in as
   /// Op, otherwise an empty SDValue can be passed.
-  virtual void ComputeConstraintToUse(AsmOperandInfo &OpInfo,
-                                      SDValue Op,
-                                      SelectionDAG *DAG = nullptr) const;
+  void ComputeConstraintToUse(AsmOperandInfo &OpInfo, SDValue Op,
+                              SelectionDAG *DAG = nullptr) const;
 
   /// Given a constraint, return the type of constraint it is for this target.
   virtual ConstraintType getConstraintType(StringRef Constraint) const;

--- a/llvm/tools/llvm-extract/CMakeLists.txt
+++ b/llvm/tools/llvm-extract/CMakeLists.txt
@@ -3,9 +3,10 @@ set(LLVM_LINK_COMPONENTS
   BitWriter
   Core
   IPO
-  IRReader
   IRPrinter
+  IRReader
   Passes
+  SelectionDAG
   Support
   )
 

--- a/llvm/unittests/Analysis/CMakeLists.txt
+++ b/llvm/unittests/Analysis/CMakeLists.txt
@@ -2,11 +2,12 @@ set(LLVM_LINK_COMPONENTS
   Analysis
   AsmParser
   Core
+  IPO
   Passes
+  SelectionDAG
   Support
   TargetParser
   TransformUtils
-  IPO
   )
 
 set(ANALYSIS_TEST_SOURCES

--- a/llvm/unittests/Passes/Plugins/CMakeLists.txt
+++ b/llvm/unittests/Passes/Plugins/CMakeLists.txt
@@ -3,7 +3,7 @@
 # work with DLLs on Windows (where a shared library can't have undefined
 # references), so just skip this testcase on Windows.
 if (NOT WIN32 AND NOT CYGWIN)
-  set(LLVM_LINK_COMPONENTS Support Passes Core AsmParser)
+  set(LLVM_LINK_COMPONENTS Support Passes Core AsmParser SelectionDAG)
   add_llvm_unittest(PluginsTests
     PluginsTest.cpp
     )

--- a/polly/unittests/DeLICM/CMakeLists.txt
+++ b/polly/unittests/DeLICM/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Solaris ld requires this dependency to be made explicit for shared builds.
 set(LLVM_LINK_COMPONENTS
   Core
+  SelectionDAG
   )
 
 add_polly_unittest(DeLICMTests

--- a/polly/unittests/ScheduleOptimizer/CMakeLists.txt
+++ b/polly/unittests/ScheduleOptimizer/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(LLVM_LINK_COMPONENTS
+  SelectionDAG
+  )
 add_polly_unittest(ScheduleOptimizerTests
     ScheduleTreeTransformTest.cpp
   )

--- a/polly/unittests/ScopPassManager/CMakeLists.txt
+++ b/polly/unittests/ScopPassManager/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(LLVM_LINK_COMPONENTS
+  SelectionDAG
+  )
 add_polly_unittest(ScopPassManagerTests
   PassManagerTest.cpp
   )


### PR DESCRIPTION
There are no overrides in tree.

Fix up resulting linkage failures in unittests and sort the dependency
lists.
