### PR TITLE
[llvm-profdata] Move error handling logic out of normal input's code path

### DIFF
--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -465,17 +465,14 @@ bool SampleProfileReaderText::hasFormat(const MemoryBuffer &Buffer) {
 
 template <typename T> ErrorOr<T> SampleProfileReaderBinary::readNumber() {
   unsigned NumBytesRead = 0;
-  std::error_code EC;
   uint64_t Val = decodeULEB128(Data, &NumBytesRead);
 
-  if (Val > std::numeric_limits<T>::max())
-    EC = sampleprof_error::malformed;
-  else if (Data + NumBytesRead > End)
-    EC = sampleprof_error::truncated;
-  else
-    EC = sampleprof_error::success;
-
-  if (EC) {
+  if (Val > std::numeric_limits<T>::max()) {
+    std::error_code EC = sampleprof_error::malformed;
+    reportError(0, EC.message());
+    return EC;
+  } else if (Data + NumBytesRead > End) {
+    std::error_code EC = sampleprof_error::truncated;
     reportError(0, EC.message());
     return EC;
   }
@@ -485,10 +482,9 @@ template <typename T> ErrorOr<T> SampleProfileReaderBinary::readNumber() {
 }
 
 ErrorOr<StringRef> SampleProfileReaderBinary::readString() {
-  std::error_code EC;
   StringRef Str(reinterpret_cast<const char *>(Data));
   if (Data + Str.size() + 1 > End) {
-    EC = sampleprof_error::truncated;
+    std::error_code EC = sampleprof_error::truncated;
     reportError(0, EC.message());
     return EC;
   }
@@ -499,10 +495,8 @@ ErrorOr<StringRef> SampleProfileReaderBinary::readString() {
 
 template <typename T>
 ErrorOr<T> SampleProfileReaderBinary::readUnencodedNumber() {
-  std::error_code EC;
-
   if (Data + sizeof(T) > End) {
-    EC = sampleprof_error::truncated;
+    std::error_code EC = sampleprof_error::truncated;
     reportError(0, EC.message());
     return EC;
   }
@@ -514,7 +508,6 @@ ErrorOr<T> SampleProfileReaderBinary::readUnencodedNumber() {
 
 template <typename T>
 inline ErrorOr<size_t> SampleProfileReaderBinary::readStringIndex(T &Table) {
-  std::error_code EC;
   auto Idx = readNumber<size_t>();
   if (std::error_code EC = Idx.getError())
     return EC;


### PR DESCRIPTION
Based on disassembly and profiling results, it looks like the cost of std::error_code and llvm::ErrorOr<> are non-trivial, as it involves virtual function calls that are not optimized in -O3.

This patch moves error handling logic into the conditional branch in error checking, only generates std::error_code on actual error instead of the default case to generate sampleprof_error::success.

In the next patch I am looking to change the API to uses a plain old enum for error checking instead, because based on profiling results error handling related code accounts for 7-8% of the profile loading time even if there's no error at all.