### PR TITLE
[Corosplit][DebugInfo] Don't add EntryValue ops in variadic DIExpressions

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -2879,10 +2879,9 @@ void coro::salvageDebugInfo(
 
   // Swift async arguments are described by an entry value of the ABI-defined
   // register containing the coroutine context.
-  // For the EntryPoint funclet, don't use EntryValues. This funclet can be
-  // inlined, which would remove the guarantee that this intrinsic targets an
-  // Argument.
-  if (IsSwiftAsyncArg && UseEntryValue && !Expr->isEntryValue())
+  // Entry values in variadic expressions are not supported.
+  if (IsSwiftAsyncArg && UseEntryValue && !Expr->isEntryValue() &&
+      Expr->isSingleLocationExpression())
     Expr = DIExpression::prepend(Expr, DIExpression::EntryValue);
 
   // If the coroutine frame is an Argument, store it in an alloca to improve

--- a/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
+++ b/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
@@ -35,6 +35,7 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
   call void @dont_optimize(ptr %var_with_dbg_value, ptr %var_with_dbg_declare)
   call void @llvm.dbg.value(metadata ptr %var_with_dbg_value, metadata !50, metadata !DIExpression(DW_OP_deref)), !dbg !54
   %i17 = load i32, ptr getelementptr inbounds (<{i32, i32}>, ptr @coroutineBTu, i64 0, i32 1), align 8, !dbg !54
+  call void @llvm.dbg.value(metadata !DIArgList(ptr %var_with_dbg_value, i32 %i17), metadata !501, metadata !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_deref)), !dbg !54
   %i18 = zext i32 %i17 to i64, !dbg !54
   %i19 = call swiftcc ptr @swift_task_alloc(i64 %i18), !dbg !54
 ; CHECK-NOT: define
@@ -44,6 +45,8 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
 ; CHECK-SAME:                   DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8)
 ; CHECK:      @llvm.dbg.value(metadata ptr %[[frame_ptr]], {{.*}} !DIExpression(
 ; CHECK-SAME:                 DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_deref)
+; CHECK:      @llvm.dbg.value(metadata !DIArgList(ptr %[[frame_ptr]], i32 %{{.*}}), {{.*}} !DIExpression(
+; CHECK-SAME:                 DW_OP_LLVM_arg, 0, DW_OP_plus_uconst, 16, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_deref)
 ; CHECK:      call {{.*}} @coroutineB
 
   %i23 = call ptr @llvm.coro.async.resume(), !dbg !54
@@ -139,6 +142,7 @@ declare { ptr } @llvm.coro.suspend.async.sl_p0s(i32, ptr, ptr, ...)
 
 !50 = !DILocalVariable(name: "k1", scope: !48, file: !17, line: 7, type: !53)
 !500 = !DILocalVariable(name: "k2", scope: !48, file: !17, line: 7, type: !53)
+!501 = !DILocalVariable(name: "k3", scope: !48, file: !17, line: 7, type: !53)
 !49 = !{!50, !500}
 
 !16 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !17, producer: "", emissionKind: FullDebug)


### PR DESCRIPTION
These are not supported by the backend.

The comment that got deleted was out of place, and it exists in the call sites of this function.