### PR TITLE
[ARM] Add writeback information to STC and LDC instructions.

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrFormats.td
+++ b/llvm/lib/Target/ARM/ARMInstrFormats.td
@@ -1390,8 +1390,8 @@ class ThumbXI<dag oops, dag iops, AddrMode am, int sz,
 }
 
 class T2I<dag oops, dag iops, InstrItinClass itin,
-          string opc, string asm, list<dag> pattern, AddrMode am = AddrModeNone>
-  : Thumb2I<oops, iops, am, 4, itin, opc, asm, "", pattern>;
+          string opc, string asm, list<dag> pattern, AddrMode am = AddrModeNone, string constraints = "">
+  : Thumb2I<oops, iops, am, 4, itin, opc, asm, constraints, pattern>;
 class T2Ii12<dag oops, dag iops, InstrItinClass itin,
              string opc, string asm, list<dag> pattern>
   : Thumb2I<oops, iops, AddrModeT2_i12, 4, itin, opc, asm, "",pattern>;

--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -5440,17 +5440,17 @@ def CDP2 : ABXI<0b1110, (outs), (ins p_imm:$cop, imm0_15:$opc1,
 }
 
 class ACI<dag oops, dag iops, string opc, string asm,
-            list<dag> pattern, IndexMode im = IndexModeNone,
+            list<dag> pattern, string cstrs = "", IndexMode im = IndexModeNone,
             AddrMode am = AddrModeNone>
   : I<oops, iops, am, 4, im, BrFrm, NoItinerary,
-      opc, asm, "", pattern> {
+      opc, asm, cstrs, pattern> {
   let Inst{27-25} = 0b110;
 }
 class ACInoP<dag oops, dag iops, string opc, string asm,
-          list<dag> pattern, IndexMode im = IndexModeNone,
+          list<dag> pattern, string constraints = "", IndexMode im = IndexModeNone,
           AddrMode am = AddrModeNone>
   : InoP<oops, iops, am, 4, im, BrFrm, NoItinerary,
-         opc, asm, "", pattern> {
+         opc, asm, constraints, pattern> {
   let Inst{31-28} = 0b1111;
   let Inst{27-25} = 0b110;
 }
@@ -5458,7 +5458,7 @@ class ACInoP<dag oops, dag iops, string opc, string asm,
 let DecoderNamespace = "CoProc" in {
 multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
   def _OFFSET : ACI<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5:$addr),
-                    asm, "\t$cop, $CRd, $addr", pattern, IndexModeNone,
+                    asm, "\t$cop, $CRd, $addr", pattern, "", IndexModeNone,
                     AddrMode5> {
     bits<13> addr;
     bits<4> cop;
@@ -5474,8 +5474,8 @@ multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
     let Inst{7-0} = addr{7-0};
     let DecoderMethod = "DecodeCopMemInstruction";
   }
-  def _PRE : ACI<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
-                 asm, "\t$cop, $CRd, $addr!", [], IndexModePre> {
+  def _PRE : ACI<(outs GPR:$Rn_wb), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
+                 asm, "\t$cop, $CRd, $addr!", [], "$addr.base = $Rn_wb", IndexModePre> {
     bits<13> addr;
     bits<4> cop;
     bits<4> CRd;
@@ -5492,7 +5492,7 @@ multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
   }
   def _POST: ACI<(outs), (ins p_imm:$cop, c_imm:$CRd, addr_offset_none:$addr,
                               postidx_imm8s4:$offset),
-                 asm, "\t$cop, $CRd, $addr, $offset", [], IndexModePost> {
+                 asm, "\t$cop, $CRd, $addr, $offset", [], "", IndexModePost> {
     bits<9> offset;
     bits<4> addr;
     bits<4> cop;
@@ -5530,7 +5530,7 @@ multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
 }
 multiclass LdSt2Cop<bit load, bit Dbit, string asm, list<dag> pattern> {
   def _OFFSET : ACInoP<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5:$addr),
-                       asm, "\t$cop, $CRd, $addr", pattern, IndexModeNone,
+                       asm, "\t$cop, $CRd, $addr", pattern, "", IndexModeNone,
                        AddrMode5> {
     bits<13> addr;
     bits<4> cop;
@@ -5546,8 +5546,8 @@ multiclass LdSt2Cop<bit load, bit Dbit, string asm, list<dag> pattern> {
     let Inst{7-0} = addr{7-0};
     let DecoderMethod = "DecodeCopMemInstruction";
   }
-  def _PRE : ACInoP<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
-                    asm, "\t$cop, $CRd, $addr!", [], IndexModePre> {
+  def _PRE : ACInoP<(outs GPR:$Rn_wb), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
+                    asm, "\t$cop, $CRd, $addr!", [], "$addr.base = $Rn_wb", IndexModePre> {
     bits<13> addr;
     bits<4> cop;
     bits<4> CRd;
@@ -5564,7 +5564,7 @@ multiclass LdSt2Cop<bit load, bit Dbit, string asm, list<dag> pattern> {
   }
   def _POST: ACInoP<(outs), (ins p_imm:$cop, c_imm:$CRd, addr_offset_none:$addr,
                                  postidx_imm8s4:$offset),
-                 asm, "\t$cop, $CRd, $addr, $offset", [], IndexModePost> {
+                 asm, "\t$cop, $CRd, $addr, $offset", [], "", IndexModePost> {
     bits<9> offset;
     bits<4> addr;
     bits<4> cop;

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -4383,8 +4383,8 @@ def t2ABS : PseudoInst<(outs rGPR:$dst), (ins rGPR:$src),
 // Coprocessor load/store -- for disassembly only
 //
 class T2CI<bits<4> op31_28, dag oops, dag iops, string opc, string asm,
-           list<dag> pattern, AddrMode am = AddrModeNone>
-  : T2I<oops, iops, NoItinerary, opc, asm, pattern, am> {
+           list<dag> pattern, AddrMode am = AddrModeNone, string constraints = "">
+  : T2I<oops, iops, NoItinerary, opc, asm, pattern, am, constraints> {
   let Inst{31-28} = op31_28;
   let Inst{27-25} = 0b110;
 }
@@ -4408,8 +4408,8 @@ multiclass t2LdStCop<bits<4> op31_28, bit load, bit Dbit, string asm, list<dag> 
     let DecoderMethod = "DecodeCopMemInstruction";
   }
   def _PRE : T2CI<op31_28,
-                  (outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
-                  asm, "\t$cop, $CRd, $addr!", []> {
+                  (outs GPR:$Rn_wb), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
+                  asm, "\t$cop, $CRd, $addr!", [], AddrMode5, "$addr.base = $Rn_wb"> {
     bits<13> addr;
     bits<4> cop;
     bits<4> CRd;

--- a/llvm/lib/Target/ARM/Disassembler/ARMDisassembler.cpp
+++ b/llvm/lib/Target/ARM/Disassembler/ARMDisassembler.cpp
@@ -1862,12 +1862,17 @@ static DecodeStatus DecodeCopMemInstruction(MCInst &Inst, unsigned Insn,
                                             const MCDisassembler *Decoder) {
   DecodeStatus S = MCDisassembler::Success;
 
+  unsigned P = fieldFromInstruction(Insn, 24, 1);
+  unsigned W = fieldFromInstruction(Insn, 21, 1);
   unsigned pred = fieldFromInstruction(Insn, 28, 4);
   unsigned CRd = fieldFromInstruction(Insn, 12, 4);
   unsigned coproc = fieldFromInstruction(Insn, 8, 4);
   unsigned imm = fieldFromInstruction(Insn, 0, 8);
   unsigned Rn = fieldFromInstruction(Insn, 16, 4);
   unsigned U = fieldFromInstruction(Insn, 23, 1);
+  // Pre-Indexed implies writeback to Rn
+  bool IsPreIndexed = (P == 1) && (W == 1);
+
   const FeatureBitset &featureBits =
     ((const MCDisassembler*)Decoder)->getSubtargetInfo().getFeatureBits();
 
@@ -1942,6 +1947,10 @@ static DecodeStatus DecodeCopMemInstruction(MCInst &Inst, unsigned Insn,
 
   if (featureBits[ARM::HasV8Ops] && (coproc != 14))
     return MCDisassembler::Fail;
+
+  if (IsPreIndexed)
+    // Dummy operand for Rn_wb.
+    Inst.addOperand(MCOperand::createImm(0));
 
   Inst.addOperand(MCOperand::createImm(coproc));
   Inst.addOperand(MCOperand::createImm(CRd));


### PR DESCRIPTION
`LDC` and `STC` were missing the write-back register.