### PR TITLE
[ARM] Fix printing of 'pop' alias.

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMInstPrinter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMInstPrinter.cpp
@@ -189,7 +189,7 @@ void ARMInstPrinter::printInst(const MCInst *MI, uint64_t Address,
 
   case ARM::LDR_POST_IMM:
     if (MI->getOperand(2).getReg() == ARM::SP &&
-        MI->getOperand(4).getImm() == 4) {
+        ARM_AM::getAM2Offset(MI->getOperand(4).getImm()) == 4) {
       O << '\t' << "pop";
       printPredicateOperand(MI, 5, STI, O);
       O << "\t{";


### PR DESCRIPTION
The condition to print the 'pop' alias could never be fulfilled, because the immediate was encoded for Address Modes 2.