### PR TITLE
[scudo] Convert assert to CHECK macro.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -106,8 +106,8 @@ struct TestAllocatorStorage {
 
   // To alleviate some problem, let's skip the thread safety analysis here.
   static void *get(size_t size) NO_THREAD_SAFETY_ANALYSIS {
-    assert(size <= kMaxSize &&
-           "Allocation size doesn't fit in the allocator storage");
+    CHECK(size <= kMaxSize &&
+          "Allocation size doesn't fit in the allocator storage");
     M.lock();
     return AllocatorStorage;
   }


### PR DESCRIPTION
This code is only for riscv, but use the CHECK macro to avoid unused parameters problems if assert is not defined.