### PR TITLE
[FastISel][DebugInfo] Handle dbg.value targeting allocas

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1327,6 +1327,14 @@ bool FastISel::selectIntrinsicCall(const IntrinsicInst *II) {
                         << *DI << "\n");
       return true;
     }
+    if (auto SI = FuncInfo.StaticAllocaMap.find(dyn_cast<AllocaInst>(V));
+        SI != FuncInfo.StaticAllocaMap.end()) {
+      MachineOperand FrameIndexOp = MachineOperand::CreateFI(SI->second);
+      bool IsIndirect = false;
+      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD.getDL(), II, IsIndirect,
+              FrameIndexOp, Var, Expr);
+      return true;
+    }
     if (Register Reg = lookUpRegForValue(V)) {
       // FIXME: This does not handle register-indirect values at offset 0.
       if (!FuncInfo.MF->useDebugInstrRef()) {

--- a/llvm/test/CodeGen/X86/fast-isel-dbg-value-alloca.ll
+++ b/llvm/test/CodeGen/X86/fast-isel-dbg-value-alloca.ll
@@ -1,0 +1,32 @@
+; RUN: llc -fast-isel -fast-isel-abort=1 -mtriple=x86_64-unknown-unknown -stop-after=finalize-isel %s -o - | \
+; RUN:    FileCheck %s
+
+define void @foo(ptr noalias nocapture %arg) !dbg !38 {
+  %k.debug = alloca ptr, align 8
+  store ptr %arg, ptr %k.debug, align 8, !dbg !70
+  call void @llvm.dbg.value(metadata ptr %k.debug, metadata !55, metadata !DIExpression(DW_OP_deref)), !dbg !70
+; CHECK: call void @llvm.dbg.value(metadata ptr %{{.*}}, metadata ![[VAR:.*]], metadata ![[EXPR:.*]])
+; CHECK: DBG_VALUE %stack.0{{.*}}, $noreg, ![[VAR]], ![[EXPR]]
+  ret void, !dbg !70
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.module.flags = !{!6, !7, !8, !9}
+!llvm.dbg.cu = !{!16}
+
+!6 = !{i32 7, !"Dwarf Version", i32 4}
+!7 = !{i32 2, !"Debug Info Version", i32 3}
+!8 = !{i32 1, !"wchar_size", i32 4}
+!9 = !{i32 8, !"PIC Level", i32 2}
+!16 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !17, producer: "blah", isOptimized: false, runtimeVersion: 5, emissionKind: FullDebug, sysroot: "blah", sdk: "blah")
+!17 = !DIFile(filename: "blah", directory: "blah")
+!38 = distinct !DISubprogram(name: "blah", linkageName: "$blah", scope: !17, file: !17, line: 34, type: !39, scopeLine: 34, spFlags: DISPFlagDefinition, unit: !16, retainedNodes: !43)
+!39 = !DISubroutineType(types: !40)
+!40 = !{!41, !41}
+!41 = !DICompositeType(tag: DW_TAG_structure_type, name: "blah")
+!43 = !{!49, !55}
+!49 = !DILocalVariable(name: "x", arg: 1, scope: !38, file: !17, line: 34, type: !41)
+!55 = !DILocalVariable(name: "k", scope: !56, file: !17, line: 36, type: !41)
+!56 = distinct !DILexicalBlock(scope: !38, file: !17, line: 36, column: 9)
+!70 = !DILocation(line: 36, column: 9, scope: !56)

--- a/llvm/test/DebugInfo/COFF/lines-bb-start.ll
+++ b/llvm/test/DebugInfo/COFF/lines-bb-start.ll
@@ -90,6 +90,8 @@ return:                                           ; preds = %if.end, %if.then
 ; CHECK:         .cv_loc {{.*}} # t.c:4:5
 ; CHECK:         jmp     LBB{{.*}}
 ; CHECK: LBB2_{{.*}}:                                 # %if.end
+; CHECK-NEXT: L{{.*}}:
+; CHECK-NEXT: DEBUG_VALUE: lea_dbg_value:
 ; CHECK-NEXT:    .cv_loc {{.*}} # t.c:5:3
 ; CHECK:         leal 4(%esp), %[[reg:[^ ]*]]
 ; CHECK:         movl    %[[reg]], (%esp)


### PR DESCRIPTION
FastISel currently drops dbg.values targeting allocas. It may seem surprising that a simple case would fail to be lowered, but dbg.values targeting allocas are not common; we usually have dbg.declares doing that, and those are handled by the common code between FastISel and SelectionDAGISel.

This patch addresses the issue by querying the static alloca map from FuncInfo. If we have a frame index for it, we create a DBG_VALUE intrinsic from it.