### PR TITLE
[lldb] Modify the DWARFDebugAbbrev interface to be closer to LLVM's

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.h
@@ -29,18 +29,19 @@ typedef DWARFAbbreviationDeclarationCollMap::const_iterator
 
 class DWARFDebugAbbrev {
 public:
-  DWARFDebugAbbrev();
+  DWARFDebugAbbrev(const lldb_private::DWARFDataExtractor &data);
   const DWARFAbbreviationDeclarationSet *
   GetAbbreviationDeclarationSet(dw_offset_t cu_abbr_offset) const;
   /// Extract all abbreviations for a particular compile unit.  Returns
   /// llvm::ErrorSuccess() on success, and an appropriate llvm::Error object
   /// otherwise.
-  llvm::Error parse(const lldb_private::DWARFDataExtractor &data);
+  llvm::Error parse();
   void GetUnsupportedForms(std::set<dw_form_t> &invalid_forms) const;
 
 protected:
   DWARFAbbreviationDeclarationCollMap m_abbrevCollMap;
   mutable DWARFAbbreviationDeclarationCollMapConstIter m_prev_abbr_offset_pos;
+  mutable std::optional<llvm::DataExtractor> m_data;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGABBREV_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -622,8 +622,8 @@ DWARFDebugAbbrev *SymbolFileDWARF::DebugAbbrev() {
   if (debug_abbrev_data.GetByteSize() == 0)
     return nullptr;
 
-  auto abbr = std::make_unique<DWARFDebugAbbrev>();
-  llvm::Error error = abbr->parse(debug_abbrev_data);
+  auto abbr = std::make_unique<DWARFDebugAbbrev>(debug_abbrev_data);
+  llvm::Error error = abbr->parse();
   if (error) {
     Log *log = GetLog(DWARFLog::DebugInfo);
     LLDB_LOG_ERROR(log, std::move(error),


### PR DESCRIPTION
I want to work towards unifying the implementations. It would be a lot easier to do if LLDB's DWARFDebugAbbrev looked more similar to LLVM's implementation, so this change moves in that direction.