### PR TITLE
[libunwind] Pass -Wl,--export-dynamic on all supported platforms

### DIFF
--- a/libunwind/test/configs/llvm-libunwind-merged.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-merged.cfg.in
@@ -11,8 +11,9 @@ link_flags = []
 if @LIBUNWIND_ENABLE_CET@:
     compile_flags.append('-fcf-protection=full')
 
-if '@CMAKE_SYSTEM_NAME@' == 'Linux':
-    link_flags.append('-Wl,--export-dynamic')
+# On ELF platforms, add -Wl,--export-dynamic if supported by the linker.
+if len('@CMAKE_EXE_EXPORTS_CXX_FLAG@'):
+    link_flags.append('@CMAKE_EXE_EXPORTS_CXX_FLAG@')
 
 if '@CMAKE_DL_LIBS@':
     link_flags.append('-l@CMAKE_DL_LIBS@')

--- a/libunwind/test/configs/llvm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-shared.cfg.in
@@ -10,8 +10,9 @@ link_flags = []
 if @LIBUNWIND_ENABLE_CET@:
     compile_flags.append('-fcf-protection=full')
 
-if '@CMAKE_SYSTEM_NAME@' == 'Linux':
-    link_flags.append('-Wl,--export-dynamic')
+# On ELF platforms, add -Wl,--export-dynamic if supported by the linker.
+if len('@CMAKE_EXE_EXPORTS_CXX_FLAG@'):
+    link_flags.append('@CMAKE_EXE_EXPORTS_CXX_FLAG@')
 
 if '@CMAKE_DL_LIBS@':
     link_flags.append('-l@CMAKE_DL_LIBS@')

--- a/libunwind/test/configs/llvm-libunwind-static.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-static.cfg.in
@@ -13,8 +13,9 @@ if @LIBUNWIND_ENABLE_THREADS@:
 if @LIBUNWIND_ENABLE_CET@:
     compile_flags.append('-fcf-protection=full')
 
-if '@CMAKE_SYSTEM_NAME@' == 'Linux':
-    link_flags.append('-Wl,--export-dynamic')
+# On ELF platforms, add -Wl,--export-dynamic if supported by the linker.
+if len('@CMAKE_EXE_EXPORTS_CXX_FLAG@'):
+    link_flags.append('@CMAKE_EXE_EXPORTS_CXX_FLAG@')
 
 if '@CMAKE_DL_LIBS@':
     link_flags.append('-l@CMAKE_DL_LIBS@')


### PR DESCRIPTION
I was trying to run the tests on FreeBSD and noticed that we weren't printing symbol names. It turns out this is because of the missing -Wl,--export-dynamic flag. Instead of hardcoding the name of the flag and only passing it for Linux hosts, use a pre-existing CMake variable instead. I was not aware of this flag, but it appears to have been supported for the past 16 years (with support for more platforms added later): https://gitlab.kitware.com/cmake/cmake/-/commit/66d1930f5674f08e09f455b3f0777f2de3e0717e