### PR TITLE
[analyzer] Fix crash in BasicValueFactory.cpp with __int128_t integers

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -537,6 +537,14 @@ Static Analyzer
   Read the PR for the details.
   (`#66086 <https://github.com/llvm/llvm-project/pull/66086>`_)
 
+- A few crashes have been found and fixed using randomized testing related
+  to the use of ``_BitInt()`` in tidy checks and in clang analysis. See
+ `#67212 <https://github.com/llvm/llvm-project/pull/67212>`_,
+ `#66782 <https://github.com/llvm/llvm-project/pull/66782>`_,
+ `#65889 <https://github.com/llvm/llvm-project/pull/65889>`_,
+ `#65888 <https://github.com/llvm/llvm-project/pull/65888>`_, and
+ `#65887 <https://github.com/llvm/llvm-project/pull/65887>`_
+
 .. _release-notes-sanitizers:
 
 Sanitizers

--- a/clang/lib/StaticAnalyzer/Core/BasicValueFactory.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BasicValueFactory.cpp
@@ -272,7 +272,7 @@ BasicValueFactory::evalAPSInt(BinaryOperator::Opcode Op,
       // FIXME: This logic should probably go higher up, where we can
       // test these conditions symbolically.
 
-      if (V2.isSigned() && V2.isNegative())
+      if (V2.isNegative() || V2.getBitWidth() > 64)
         return nullptr;
 
       uint64_t Amt = V2.getZExtValue();
@@ -287,7 +287,7 @@ BasicValueFactory::evalAPSInt(BinaryOperator::Opcode Op,
       // FIXME: This logic should probably go higher up, where we can
       // test these conditions symbolically.
 
-      if (V2.isSigned() && V2.isNegative())
+      if (V2.isNegative() || V2.getBitWidth() > 64)
         return nullptr;
 
       uint64_t Amt = V2.getZExtValue();

--- a/clang/test/Analysis/int128-nocrash.c
+++ b/clang/test/Analysis/int128-nocrash.c
@@ -1,0 +1,15 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=optin.portability.UnixAPI \
+// RUN:    -triple x86_64-pc-linux-gnu -x c %s
+
+// Don't crash!
+// expected-no-diagnostics
+const __int128_t a = ( (__int128_t)1 << 64 );
+const _BitInt(72) b = ( 1 << 72 );
+
+void int128() {
+  2 >> a;
+}
+
+void withbitint() {
+  2 >> b;
+}


### PR DESCRIPTION
This change avoids a crash in BasicValueFactory by checking the bit width of an APSInt to avoid calling getZExtValue if greater than 64-bits. This was caught by our internal, randomized test generator.

Clang invocation
clang -cc1 -analyzer-checker=optin.portability.UnixAPI case.c

<src-root>/llvm/include/llvm/ADT/APInt.h:1488:
uint64_t llvm::APInt::getZExtValue() const: Assertion `getActiveBits() <= 64
  && "Too many bits for uint64_t"' failed.
...

 #9 <address> llvm::APInt::getZExtValue() const
     <src-root>/llvm/include/llvm/ADT/APInt.h:1488:5
     clang::BinaryOperatorKind, llvm::APSInt const&, llvm::APSInt const&)
     <src-root>/clang/lib/StaticAnalyzer/Core/BasicValueFactory.cpp:307:37
     llvm::IntrusiveRefCntPtr<clang::ento::ProgramState const>,
     clang::BinaryOperatorKind, clang::ento::NonLoc, clang::ento::NonLoc,
     clang::QualType)
     <src-root>/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp:531:31
     llvm::IntrusiveRefCntPtr<clang::ento::ProgramState const>,
     clang::BinaryOperatorKind, clang::ento::SVal, clang::ento::SVal,
     clang::QualType)
     <src-root>/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp:532:26
...