### PR TITLE
[BasicBlockSections] Introduce the path cloning profile format to BasicBlockSectionsProfileReader.

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -29,10 +29,37 @@
 namespace llvm {
 
 // This structure represents a unique ID for every block specified in the
-// profile.
+// input profile.
 struct ProfileBBID {
+  // Basic block id associated with `MachineBasicBlock::BBID`.
   unsigned BBID;
+  // The clone id associated with the block. This is zero for the original
+  // block. For the cloned ones, it is equal to 1 + index of the associated
+  // path in `FunctionPathAndClusterInfo::ClonePaths`.
   unsigned CloneID;
+};
+
+// This struct represents the cluster information for a machine basic block,
+// which is specifed by a unique ID. This templated struct is used for both the
+// raw input profile (as `BBClusterInfo<ProfileBBID>`) and the processed profile
+// after applying the clonings (as `BBClusterInfo<unsigned>`).
+template <typename BBIDType> struct BBClusterInfo {
+  // Basic block ID.
+  BBIDType BasicBlockID;
+  // Cluster ID this basic block belongs to.
+  unsigned ClusterID;
+  // Position of basic block within the cluster.
+  unsigned PositionInCluster;
+};
+
+// This represents the raw input profile for one function.
+struct FunctionPathAndClusterInfo {
+  // BB Cluster information specified by `ProfileBBID`s (before cloning).
+  SmallVector<BBClusterInfo<ProfileBBID>> ClusterInfo;
+  // Paths to clone. A path a -> b -> c -> d implies cloning b, c, and d along
+  // the edge a -> b (a is not cloned). The index of the path in this vector
+  // determines the `ProfileBBID::CloneID` of the cloned blocks in that path.
+  SmallVector<SmallVector<unsigned>> ClonePaths;
 };
 
 // Provides DenseMapInfo for ProfileBBID.
@@ -54,26 +81,6 @@ template <> struct DenseMapInfo<ProfileBBID> {
     return DenseMapInfo<unsigned>::isEqual(LHS.BBID, RHS.BBID) &&
            DenseMapInfo<unsigned>::isEqual(LHS.CloneID, RHS.CloneID);
   }
-};
-
-// This struct represents the cluster information for a machine basic block,
-// which is specifed by a unique ID.
-template <typename BBIDType> struct BBProfile {
-  // Basic block ID.
-  BBIDType BasicBlockID;
-  // Cluster ID this basic block belongs to.
-  unsigned ClusterID;
-  // Position of basic block within the cluster.
-  unsigned PositionInCluster;
-};
-
-// This represents the profile for one function.
-struct RawFunctionProfile {
-  // BB Cluster information specified by `ProfileBBID`s (before cloning).
-  SmallVector<BBProfile<ProfileBBID>> RawBBProfiles;
-  // Paths to clone. A path a -> b -> c -> d implies cloning b, c, and d along
-  // the edge a -> b.
-  SmallVector<SmallVector<unsigned>> ClonePaths;
 };
 
 class BasicBlockSectionsProfileReader : public ImmutablePass {
@@ -106,11 +113,11 @@ public:
   // function. If the first element is true and the second element is empty, it
   // means unique basic block sections are desired for all basic blocks of the
   // function.
-  std::pair<bool, RawFunctionProfile>
-  getRawProfileForFunction(StringRef FuncName) const;
+  std::pair<bool, FunctionPathAndClusterInfo>
+  getPathAndClusterInfoForFunction(StringRef FuncName) const;
 
   // Initializes the FunctionNameToDIFilename map for the current module and
-  // then reads the profile for matching functions.
+  // then reads the profile for the matching functions.
   bool doInitialization(Module &M) override;
 
 private:
@@ -127,7 +134,7 @@ private:
         inconvertibleErrorCode());
   }
 
-  // Parses a `ProfileBBID` from `S`.
+  // Parses a `ProfileBBID` from `S`. `S` should be in the form "<bbid>" (representing an original block) or "<bbid>.<cloneid>" (representing a cloned block) where bbid is a non-negative integer and cloneid is a positive integer.
   Expected<ProfileBBID> parseProfileBBID(StringRef S) const;
 
   // Reads the basic block sections profile for functions in this module.
@@ -150,16 +157,16 @@ private:
   // empty string if no debug info is available.
   StringMap<SmallString<128>> FunctionNameToDIFilename;
 
-  // This encapsulates the BB cluster information for the whole program.
+  // This contains the BB cluster information for the whole program.
   //
   // For every function name, it contains the cloning and cluster information
   // for (all or some of) its basic blocks. The cluster information for every
   // basic block includes its cluster ID along with the position of the basic
   // block in that cluster.
-  StringMap<RawFunctionProfile> RawProgramProfile;
+  StringMap<FunctionPathAndClusterInfo> ProgramPathAndClusterInfo;
 
   // Some functions have alias names. We use this map to find the main alias
-  // name for which we have mapping in ProgramBBClusterInfo.
+  // name which appears in ProgramPathAndClusterInfo as a key.
   StringMap<StringRef> FuncAliasMap;
 };
 

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -134,7 +134,10 @@ private:
         inconvertibleErrorCode());
   }
 
-  // Parses a `ProfileBBID` from `S`. `S` should be in the form "<bbid>" (representing an original block) or "<bbid>.<cloneid>" (representing a cloned block) where bbid is a non-negative integer and cloneid is a positive integer.
+  // Parses a `ProfileBBID` from `S`. `S` must be in the form "<bbid>"
+  // (representing an original block) or "<bbid>.<cloneid>" (representing a
+  // cloned block) where bbid is a non-negative integer and cloneid is a
+  // positive integer.
   Expected<ProfileBBID> parseProfileBBID(StringRef S) const;
 
   // Reads the basic block sections profile for functions in this module.

--- a/llvm/lib/CodeGen/BasicBlockSections.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSections.cpp
@@ -168,31 +168,6 @@ updateBranches(MachineFunction &MF,
   }
 }
 
-// This function provides the BBCluster information associated with a function.
-// Returns true if a valid association exists and false otherwise.
-bool getBBClusterInfoForFunction(
-    const MachineFunction &MF,
-    BasicBlockSectionsProfileReader *BBSectionsProfileReader,
-    DenseMap<unsigned, BBClusterInfo> &V) {
-
-  // Find the assoicated cluster information.
-  std::pair<bool, SmallVector<BBClusterInfo, 4>> P =
-      BBSectionsProfileReader->getBBClusterInfoForFunction(MF.getName());
-  if (!P.first)
-    return false;
-
-  if (P.second.empty()) {
-    // This indicates that sections are desired for all basic blocks of this
-    // function. We clear the BBClusterInfo vector to denote this.
-    V.clear();
-    return true;
-  }
-
-  for (const BBClusterInfo &BBCI : P.second)
-    V[BBCI.BBID] = BBCI;
-  return true;
-}
-
 // This function sorts basic blocks according to the cluster's information.
 // All explicitly specified clusters of basic blocks will be ordered
 // accordingly. All non-specified BBs go into a separate "Cold" section.
@@ -200,12 +175,12 @@ bool getBBClusterInfoForFunction(
 // clusters, they are moved into a single "Exception" section. Eventually,
 // clusters are ordered in increasing order of their IDs, with the "Exception"
 // and "Cold" succeeding all other clusters.
-// FuncBBClusterInfo represent the cluster information for basic blocks. It
+// BBProfilesByBBID represents the cluster information for basic blocks. It
 // maps from BBID of basic blocks to their cluster information. If this is
 // empty, it means unique sections for all basic blocks in the function.
-static void
-assignSections(MachineFunction &MF,
-               const DenseMap<unsigned, BBClusterInfo> &FuncBBClusterInfo) {
+static void assignSections(
+    MachineFunction &MF,
+    const DenseMap<unsigned, BBProfile<unsigned>> &BBProfilesByBBID) {
   assert(MF.hasBBSections() && "BB Sections is not set for function.");
   // This variable stores the section ID of the cluster containing eh_pads (if
   // all eh_pads are one cluster). If more than one cluster contain eh_pads, we
@@ -216,17 +191,17 @@ assignSections(MachineFunction &MF,
     // With the 'all' option, every basic block is placed in a unique section.
     // With the 'list' option, every basic block is placed in a section
     // associated with its cluster, unless we want individual unique sections
-    // for every basic block in this function (if FuncBBClusterInfo is empty).
+    // for every basic block in this function (if BBProfilesByBBID is empty).
     if (MF.getTarget().getBBSectionsType() == llvm::BasicBlockSection::All ||
-        FuncBBClusterInfo.empty()) {
+        BBProfilesByBBID.empty()) {
       // If unique sections are desired for all basic blocks of the function, we
       // set every basic block's section ID equal to its original position in
       // the layout (which is equal to its number). This ensures that basic
       // blocks are ordered canonically.
       MBB.setSectionID(MBB.getNumber());
     } else {
-      auto I = FuncBBClusterInfo.find(*MBB.getBBID());
-      if (I != FuncBBClusterInfo.end()) {
+      auto I = BBProfilesByBBID.find(*MBB.getBBID());
+      if (I != BBProfilesByBBID.end()) {
         MBB.setSectionID(I->second.ClusterID);
       } else {
         // BB goes into the special cold section if it is not specified in the
@@ -333,16 +308,25 @@ bool BasicBlockSections::runOnMachineFunction(MachineFunction &MF) {
     return true;
   }
 
-  BBSectionsProfileReader = &getAnalysis<BasicBlockSectionsProfileReader>();
+  DenseMap<unsigned, BBProfile<unsigned>> BBProfilesByBBID;
+  if (BBSectionsType == BasicBlockSection::List) {
+    auto [HasProfile, RawProfile] =
+        getAnalysis<BasicBlockSectionsProfileReader>().getRawProfileForFunction(
+            MF.getName());
+    if (!HasProfile)
+      return true;
+    // TODO: Apply the path cloning profile.
+    for (const BBProfile<ProfileBBID> &BBP : RawProfile.RawBBProfiles) {
+      assert(!BBP.BasicBlockID.CloneID && "Path cloning is not supported yet.");
+      BBProfilesByBBID.try_emplace(BBP.BasicBlockID.BBID,
+                                   BBProfile<unsigned>{BBP.BasicBlockID.BBID,
+                                                       BBP.ClusterID,
+                                                       BBP.PositionInCluster});
+    }
+  }
 
-  // Map from BBID of blocks to their cluster information.
-  DenseMap<unsigned, BBClusterInfo> FuncBBClusterInfo;
-  if (BBSectionsType == BasicBlockSection::List &&
-      !getBBClusterInfoForFunction(MF, BBSectionsProfileReader,
-                                   FuncBBClusterInfo))
-    return true;
   MF.setBBSectionsType(BBSectionsType);
-  assignSections(MF, FuncBBClusterInfo);
+  assignSections(MF, BBProfilesByBBID);
 
   // We make sure that the cluster including the entry basic block precedes all
   // other clusters.
@@ -376,8 +360,8 @@ bool BasicBlockSections::runOnMachineFunction(MachineFunction &MF) {
     // If the two basic block are in the same section, the order is decided by
     // their position within the section.
     if (XSectionID.Type == MBBSectionID::SectionType::Default)
-      return FuncBBClusterInfo.lookup(*X.getBBID()).PositionInCluster <
-             FuncBBClusterInfo.lookup(*Y.getBBID()).PositionInCluster;
+      return BBProfilesByBBID.lookup(*X.getBBID()).PositionInCluster <
+             BBProfilesByBBID.lookup(*Y.getBBID()).PositionInCluster;
     return X.getNumber() < Y.getNumber();
   };
 

--- a/llvm/lib/CodeGen/BasicBlockSections.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSections.cpp
@@ -311,17 +311,18 @@ bool BasicBlockSections::runOnMachineFunction(MachineFunction &MF) {
   DenseMap<unsigned, BBClusterInfo<unsigned>> ClusterInfoByBBID;
   if (BBSectionsType == BasicBlockSection::List) {
     auto [HasProfile, PathAndClusterInfo] =
-        getAnalysis<BasicBlockSectionsProfileReader>().getPathAndClusterInfoForFunction(
-            MF.getName());
+        getAnalysis<BasicBlockSectionsProfileReader>()
+            .getPathAndClusterInfoForFunction(MF.getName());
     if (!HasProfile)
       return true;
-    for (const BBClusterInfo<ProfileBBID> &BBP : PathAndClusterInfo.ClusterInfo) {
+    for (const BBClusterInfo<ProfileBBID> &BBP :
+         PathAndClusterInfo.ClusterInfo) {
       // TODO: Apply the path cloning profile.
       assert(!BBP.BasicBlockID.CloneID && "Path cloning is not supported yet");
       const auto [I, Inserted] = ClusterInfoByBBID.try_emplace(
           BBP.BasicBlockID.BBID,
           BBClusterInfo<unsigned>{BBP.BasicBlockID.BBID, BBP.ClusterID,
-                              BBP.PositionInCluster});
+                                  BBP.PositionInCluster});
       (void)I;
       assert(Inserted && "Duplicate BBID found in profile");
     }

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -63,8 +63,9 @@ std::pair<bool, FunctionPathAndClusterInfo>
 BasicBlockSectionsProfileReader::getPathAndClusterInfoForFunction(
     StringRef FuncName) const {
   auto R = ProgramPathAndClusterInfo.find(getAliasName(FuncName));
-  return R != ProgramPathAndClusterInfo.end() ? std::pair(true, R->second)
-                                      : std::pair(false, FunctionPathAndClusterInfo());
+  return R != ProgramPathAndClusterInfo.end()
+             ? std::pair(true, R->second)
+             : std::pair(false, FunctionPathAndClusterInfo());
 }
 
 // Reads the version 1 basic block sections profile. Profile for each function
@@ -85,10 +86,13 @@ BasicBlockSectionsProfileReader::getPathAndClusterInfoForFunction(
 // clone basic blocks along a path. The cloned blocks are then specified in the
 // cluster information.
 // The following profile lists two cloning paths (starting with 'p') for
-// function bar and places the total 9 blocks within two clusters. The blocks in each path are cloned along the path from the first block (the first block is not cloned).
-// For instance, path 1 (1 -> 3 -> 4) specifies that 3 and 4 must be cloned along the edge 1->3. In the clusters, each cloned
-// block is identified by its original block id, along with its clone id. For instance, the cloned blocks from path 1 are represented by 3.1 and 4.1.
-// A block cloned multiple times appears with distinct clone ids. The CFG for bar
+// function bar and places the total 9 blocks within two clusters. The first two
+// blocks of a cloning path specify the edge along which the path is cloned. For
+// instance, path 1 (1 -> 3 -> 4) instructs that 3 and 4 must be cloned along
+// the edge 1->3. Within the given clusters, each cloned block is identified by
+// "<original block id>.<clone id>". For instance, 3.1 represents the first
+// clone of block 3. Original blocks are specified just with their block ids. A
+// block cloned multiple times appears with distinct clone ids. The CFG for bar
 // is shown below before and after cloning with its final clusters labeled.
 //
 // f main
@@ -279,8 +283,8 @@ Error BasicBlockSectionsProfileReader::ReadV0Profile() {
 
         FI->second.ClusterInfo.emplace_back(
             BBClusterInfo<ProfileBBID>({{static_cast<unsigned>(BBID), 0},
-                                    CurrentCluster,
-                                    CurrentPosition++}));
+                                        CurrentCluster,
+                                        CurrentPosition++}));
       }
       CurrentCluster++;
     } else {

--- a/llvm/test/CodeGen/X86/basic-block-sections-clusters-error.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-clusters-error.ll
@@ -32,13 +32,35 @@
 ; RUN: echo '!dummy1' >> %t8
 ; RUN: not --crash llc < %s -O0 -mtriple=x86_64 -function-sections -basic-block-sections=%t8 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR8
 ; CHECK-ERROR8: LLVM ERROR: invalid profile {{.*}} at line 2: invalid specifier: '!'
-; RUN: echo 'v1' > %t0
-; RUN: echo 'm dummy1/module1 dummy1/module2'
+; RUN: echo 'v1' > %t9
+; RUN: echo 'm dummy1/module1 dummy1/module2' >> %t9
 ; RUN: echo 'f dummy1' >> %t9
-; RUN: not --crash llc < %s -O0 -mtriple=x86_64 -function-sections -basic-block-sections=%t8 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR8
-; CHECK-ERROR9: LLVM ERROR: invalid profile {{.*}} at line 2: invalid module name value: 'dummy1/module dummy1/module2'
-
-
+; RUN: not --crash llc < %s -O0 -mtriple=x86_64 -function-sections -basic-block-sections=%t9 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR9
+; CHECK-ERROR9: LLVM ERROR: invalid profile {{.*}} at line 2: invalid module name value: 'dummy1/module1 dummy1/module2'
+;;
+;; Error handling for version 1, cloning paths.
+; RUN: echo 'v1' > %t10
+; RUN: echo 'f dummy1' >> %t10
+; RUN: echo 'c 0 1.1.1' >> %t10
+; RUN: not --crash llc < %s -O0 -mtriple=x86_64 -function-sections -basic-block-sections=%t10 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR10
+; CHECK-ERROR10: LLVM ERROR: invalid profile {{.*}} at line 3: unable to parse basic block id: '1.1.1'
+; RUN: echo 'v1' > %t11
+; RUN: echo 'f dummy1' >> %t11
+; RUN: echo 'c 0 1.a' >> %t11
+; RUN: not --crash llc < %s -O0 -mtriple=x86_64 -function-sections -basic-block-sections=%t11 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR11
+; CHECK-ERROR11: LLVM ERROR: invalid profile {{.*}} at line 3: unable to parse clone id: 'a' 
+; RUN: echo 'v1' > %t12
+; RUN: echo 'f dummy1' >> %t12
+; RUN: echo 'c 0 1' >> %t12
+; RUN: echo 'p 1 2.1' >> %t12
+; RUN: not --crash llc < %s -O0 -mtriple=x86_64 -function-sections -basic-block-sections=%t12 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR12
+; CHECK-ERROR12: LLVM ERROR: invalid profile {{.*}} at line 4: unsigned integer expected: '2.1'
+; RUN: echo 'v1' > %t13
+; RUN: echo 'f dummy1' >> %t13
+; RUN: echo 'c 0 1' >> %t13
+; RUN: echo 'p 1 2 3 2' >> %t13
+; RUN: not --crash llc < %s -O0 -mtriple=x86_64 -function-sections -basic-block-sections=%t13 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR13
+; CHECK-ERROR13: LLVM ERROR: invalid profile {{.*}} at line 4: duplicate cloned block in path: '2'
 
 define i32 @dummy1(i32 %x, i32 %y, i32 %z) {
   entry:
@@ -62,5 +84,4 @@ define i32 @dummy2(i32 %x, i32 %y, i32 %z) !dbg !4 {
 !2 = !{i32 7, !"Dwarf Version", i32 5}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = distinct !DISubprogram(name: "dummy1", scope: !1, unit: !0)
-
 


### PR DESCRIPTION
Following up on prior RFC (https://lists.llvm.org/pipermail/llvm-dev/2020-September/145357.html) we can now improve above our highly-optimized basic-block-sections binary (e.g., 2% for clang) by applying path cloning. Cloning can improve performance by reducing taken branches.

This patch prepares the profile format for applying cloning actions.

The basic block cloning profile format extends the basic block sections profile in two ways.

  1. Specifies the cloning paths with a 'p' specifier. For example, `p 1 4 5` specifies that blocks with BB ids 4 and 5 must be cloned along the edge 1 --> 4.
  2. For each cloned block, it will appear in the cluster info as `<bb_id>.<clone_id>` where `clone_id` is the id associated with this clone.

For example, the following profile specifies one cloned block (2) and determines its cluster position as well.
```
f foo
p 1 2
c 0 1 2.1 3 2 5
```

This patch keeps backward-compatibility (retains the behavior for old profile formats). This feature is only introduced for profile version >= 1.