### PR TITLE
[flang] Do not write implicit SAVE attribute into the mod file.

### DIFF
--- a/flang/test/Semantics/modfile58.f90
+++ b/flang/test/Semantics/modfile58.f90
@@ -1,0 +1,18 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+
+! Test that the implicit SAVE attribute (set
+! for the equivalenced symbols) is not written
+! into the mod file.
+module implicit_save
+  real dx,dy
+  common /blk/ dx
+  equivalence(dx,dy)
+end module implicit_save
+
+!Expect: implicit_save.mod
+!moduleimplicit_save
+!real(4)::dx
+!real(4)::dy
+!common/blk/dx
+!equivalence(dx,dy)
+!end


### PR DESCRIPTION
If it happens that a symbol has an implicit SAVE attribute,
we have to omit it in the mod file writer. Otherwise it may
violate F202X C862:
The SAVE attribute shall not be specified for... an object that is
in a common block.
