### PR TITLE
fix: added <limits> to fix compile error

### DIFF
--- a/llvm/utils/benchmark/src/benchmark_register.h
+++ b/llvm/utils/benchmark/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
I presume you don't take any PR to release/9.x but thought I might as well open this. 

This header is missing and causes a compile error on my machine. 