### PR TITLE
[clang-format] Fix a bug in aligning trailing comments

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -1062,7 +1062,7 @@ void WhitespaceManager::alignTrailingComments() {
       const int OriginalSpaces =
           C.OriginalWhitespaceRange.getEnd().getRawEncoding() -
           C.OriginalWhitespaceRange.getBegin().getRawEncoding() -
-          C.Tok->NewlinesBefore;
+          C.Tok->LastNewlineOffset;
       assert(OriginalSpaces >= 0);
       const auto RestoredLineLength =
           C.StartOfTokenColumn + C.TokenLength + OriginalSpaces;

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -3053,6 +3053,12 @@ TEST_F(FormatTestComments, AlignTrailingCommentsLeave) {
                "}",
                Style);
 
+  Style.AlignEscapedNewlines = FormatStyle::ENAS_Left;
+  verifyNoChange("#define FOO    \\\n"
+                 "  /* foo(); */ \\\n"
+                 "  bar();",
+                 Style);
+
   // Allow to keep 2 empty lines
   Style.MaxEmptyLinesToKeep = 2;
   EXPECT_EQ("// do not touch\n"


### PR DESCRIPTION
Fixes #67116.