### PR TITLE
[clang][Interp] Fix returning nullptr from functions

### DIFF
--- a/clang/lib/AST/Interp/Interp.h
+++ b/clang/lib/AST/Interp/Interp.h
@@ -214,7 +214,8 @@ bool Ret(InterpState &S, CodePtr &PC, APValue &Result) {
     // FIXME: We could be calling isLive() here, but the emitted diagnostics
     // seem a little weird, at least if the returned expression is of
     // pointer type.
-    if (!Ret.isLive())
+    // Null pointers are considered live here.
+    if (!Ret.isZero() && !Ret.isLive())
       return false;
   }
 

--- a/clang/test/AST/Interp/functions.cpp
+++ b/clang/test/AST/Interp/functions.cpp
@@ -343,3 +343,10 @@ namespace TemplateUndefined {
   constexpr int l = consume(0);
   static_assert(l == 0, "");
 }
+
+namespace PtrReturn {
+  constexpr void *a() {
+    return nullptr;
+  }
+  static_assert(a() == nullptr, "");
+}


### PR DESCRIPTION
isLive() is false for null pointers, so we need to special-case this here.