### PR TITLE
Fix warning on align directives with non-zero fill value

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -3452,7 +3452,7 @@ bool AsmParser::parseDirectiveAlign(bool IsPow2, unsigned ValueSize) {
     }
   }
 
-  if (HasFillExpr) {
+  if (HasFillExpr && FillExpr != 0) {
     MCSection *Sec = getStreamer().getCurrentSectionOnly();
     if (Sec && Sec->isVirtualSection()) {
       ReturnVal |=

--- a/llvm/test/MC/ELF/nobits-non-zero-value.s
+++ b/llvm/test/MC/ELF/nobits-non-zero-value.s
@@ -15,5 +15,8 @@
 # CHECK: {{.*}}.s:[[#@LINE+1]]:11: warning: ignoring non-zero fill value in SHT_NOBITS section '.bss'
 .align 4, 42
 
+# CHECK-NOT: {{.*}}.s:[[#@LINE+1]]:11: warning: ignoring non-zero fill value in SHT_NOBITS section '.bss'
+.align 4, 0
+
 # CHECK: <unknown>:0: error: SHT_NOBITS section '.bss' cannot have non-zero initializers
   .long 1


### PR DESCRIPTION
The original patch (PR #66792) did not properly check the non-zero fill value condition. This patch adds a new test case to ensure the overly aggressive check does not return.
