### PR TITLE
[MachineLICM] Clear subregister kill flags

### DIFF
--- a/llvm/lib/CodeGen/MachineLICM.cpp
+++ b/llvm/lib/CodeGen/MachineLICM.cpp
@@ -607,7 +607,7 @@ void MachineLICMBase::AddToLiveIns(MCRegister Reg) {
       for (MachineOperand &MO : MI.all_uses()) {
         if (!MO.getReg())
           continue;
-        if (TRI->isSuperRegisterEq(Reg, MO.getReg()))
+        if (TRI->regsOverlap(Reg, MO.getReg()))
           MO.setIsKill(false);
       }
     }

--- a/llvm/test/CodeGen/AArch64/mlicm-stack-write-check.mir
+++ b/llvm/test/CodeGen/AArch64/mlicm-stack-write-check.mir
@@ -17,11 +17,44 @@ body: |
   bb.1:
     ; CHECK-LABEL: bb.1:
     ; CHECK-NOT: $x2 = LDRXui %stack.0, 0
+    ; CHECK: $x0 = ADDXrr $x0, $x2
     liveins: $x0
     DBG_VALUE %stack.0, 0
     $x2 = LDRXui %stack.0, 0 :: (load (s64) from %stack.0)
-    $x0 = ADDXrr $x0, $x2
-    $xzr = SUBSXri $x0, 1, 0, implicit-def $nzcv
+    $x0 = ADDXrr $x0, killed $x2
+    $xzr = SUBSXri killed $x0, 1, 0, implicit-def $nzcv
+    Bcc 11, %bb.1, implicit $nzcv
+    B %bb.2
+
+  bb.2:
+    liveins: $x0
+    %0 = COPY $x0
+    %0 = COPY $x0  ; Force isSSA = false.
+...
+---
+name: test2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: gpr64 }
+stack:
+  - { id: 0, size: 8, type: spill-slot }
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test2
+    ; CHECK-LABEL: bb.0:
+    ; CHECK: $x2 = LDRXui %stack.0, 0
+    liveins: $x0, $x1, $x2
+    B %bb.1
+
+  bb.1:
+    ; CHECK-LABEL: bb.1:
+    ; CHECK-NOT: $x2 = LDRXui %stack.0, 0
+    ; CHECK: $w0 = ADDWrr $w0, $w2
+    liveins: $x0
+    DBG_VALUE %stack.0, 0
+    $x2 = LDRXui %stack.0, 0 :: (load (s64) from %stack.0)
+    $w0 = ADDWrr $w0, killed $w2
+    $wzr = SUBSWri killed $w0, 1, 0, implicit-def $nzcv
     Bcc 11, %bb.1, implicit $nzcv
     B %bb.2
 


### PR DESCRIPTION
When hosting a loop invariant instruction the resulting register must be live in
all the basic blocks of the loop body and the killed flags of the register must
be cleared.

Before this patch killed flags of subregister to a hoisted superregister was not
cleared in the loop body.

This was found in an out of tree target, but the testcase
mlicm-stack-write-check.mir was modified to trigger the case.
