### PR TITLE
[mlir][transform] Fix handling of transitive includes in interpreter.

### DIFF
--- a/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterPassBase.cpp
+++ b/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterPassBase.cpp
@@ -388,19 +388,19 @@ static LogicalResult defineDeclaredSymbols(Block &block, ModuleOp definitions) {
                       << externalSymbolFunc.getNameAttr().getValue()
                       << " for symbol usages\n");
     externalSymbolFunc.walk([&](CallOpInterface callOp) {
-      LLVM_DEBUG(DBGS() << "  found symbol usage in:\n" << callOp << "\n");
+      LLVM_DEBUG(DBGS() << "  call op in:\n" << callOp << "\n");
       CallInterfaceCallable callable = callOp.getCallableForCallee();
       if (!isa<SymbolRefAttr>(callable)) {
-        LLVM_DEBUG(DBGS() << "    not a 'SymbolRefAttr'\n");
+        LLVM_DEBUG(DBGS() << "    not a symbol usage\n");
         return WalkResult::advance();
       }
 
-      StringRef callableSymbol =
+      StringRef callableSymbolName =
           cast<SymbolRefAttr>(callable).getLeafReference();
-      LLVM_DEBUG(DBGS() << "    looking for @" << callableSymbol
+      LLVM_DEBUG(DBGS() << "    looking for @" << callableSymbolName
                         << " in definitions: ");
 
-      Operation *callableOp = definitionsSymbolTable.lookup(callableSymbol);
+      Operation *callableOp = definitionsSymbolTable.lookup(callableSymbolName);
       if (!isa<SymbolRefAttr>(callable)) {
         LLVM_DEBUG(llvm::dbgs() << "not found\n");
         return WalkResult::advance();
@@ -409,13 +409,13 @@ static LogicalResult defineDeclaredSymbols(Block &block, ModuleOp definitions) {
                               << callableOp->getLoc() << "\n");
 
       if (!block.getParent() || !block.getParent()->getParentOp()) {
-        LLVM_DEBUG(DBGS() << "could not get parent of provided block");
+        LLVM_DEBUG(DBGS() << "could not get parent op of provided block");
         return WalkResult::advance();
       }
 
       SymbolTable targetSymbolTable(block.getParent()->getParentOp());
-      if (targetSymbolTable.lookup(callableSymbol)) {
-        LLVM_DEBUG(DBGS() << "    symbol @" << callableSymbol
+      if (targetSymbolTable.lookup(callableSymbolName)) {
+        LLVM_DEBUG(DBGS() << "    symbol @" << callableSymbolName
                           << " already present in target\n");
         return WalkResult::advance();
       }

--- a/mlir/test/Dialect/Transform/test-interpreter-external-symbol-decl-transitive.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-external-symbol-decl-transitive.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(test-transform-dialect-interpreter{transform-library-file-name=%p/test-interpreter-external-symbol-def.mlir})" \
+// RUN:             --verify-diagnostics --split-input-file | FileCheck %s
+
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(test-transform-dialect-interpreter{transform-library-file-name=%p/test-interpreter-external-symbol-def.mlir}, test-transform-dialect-interpreter)" \
+// RUN:             --verify-diagnostics --split-input-file | FileCheck %s
+
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(test-transform-dialect-interpreter{transform-library-file-name=%p/test-interpreter-external-symbol-def.mlir}, test-transform-dialect-interpreter{transform-library-file-name=%p/test-interpreter-external-symbol-def.mlir})" \
+// RUN:             --verify-diagnostics --split-input-file | FileCheck %s
+
+// The definition of the @bar named sequence is provided in another file. It
+// will be included because of the pass option. That sequence uses another named
+// sequence @foo, which should be made available here. Repeated application of
+// the same pass, with or without the library option, should not be a problem.
+// Note that the same diagnostic produced twice at the same location only
+// needs to be matched once.
+
+// expected-remark @below {{message}}
+module attributes {transform.with_named_sequence} {
+  // CHECK-DAG: transform.named_sequence @foo
+  // CHECK-DAG: transform.named_sequence @bar
+  transform.named_sequence private @bar(!transform.any_op {transform.readonly})
+
+  transform.sequence failures(propagate) {
+  ^bb0(%arg0: !transform.any_op):
+    include @bar failures(propagate) (%arg0) : (!transform.any_op) -> ()
+  }
+}

--- a/mlir/test/Dialect/Transform/test-interpreter-external-symbol-def.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter-external-symbol-def.mlir
@@ -1,6 +1,11 @@
 // RUN: mlir-opt %s
 
 module attributes {transform.with_named_sequence} {
+  transform.named_sequence @bar(%arg0: !transform.any_op) {
+    transform.include @foo failures(propagate) (%arg0) : (!transform.any_op) -> ()
+    transform.yield
+  }
+
   transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) {
     transform.test_print_remark_at_operand %arg0, "message" : !transform.any_op
     transform.yield


### PR DESCRIPTION
Until now, the interpreter would only load those symbols from the provided library files that were declared in the main transform module. However, sequences in the library may include other sequences on their own. Until now, if such sequences were not *also* declared in the main transform module, the interpreter would fail to resolve them. Forward declaring all of them is undesirable as it defeats the purpose of encapsulation into library modules.

This PR extends the loading missing as follows: in `defineDeclaredSymbols`, not only are the definitions inserted that are forward-declared in the main module, but any such inserted definition is scanned for further dependencies, and those are processed in the same way as the forward-declarations from the main module.