### PR TITLE
[libunwind][nfc] avoid prototype warning

### DIFF
--- a/libunwind/src/Unwind-sjlj.c
+++ b/libunwind/src/Unwind-sjlj.c
@@ -82,7 +82,8 @@ struct _Unwind_FunctionContext {
 static _LIBUNWIND_THREAD_LOCAL struct _Unwind_FunctionContext *stack = NULL;
 #endif
 
-static struct _Unwind_FunctionContext *__Unwind_SjLj_GetTopOfFunctionStack() {
+static struct _Unwind_FunctionContext *
+__Unwind_SjLj_GetTopOfFunctionStack(void) {
 #if defined(__APPLE__)
   return _pthread_getspecific_direct(__PTK_LIBC_DYLD_Unwind_SjLj_Key);
 #else


### PR DESCRIPTION
Avoid following prototype related warning.

Unwind-sjlj.c:85:75: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]