### PR TITLE
[IR] Fix crash when creating llvm.powi.* by `CreateBinaryIntrinsic`

### DIFF
--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -934,7 +934,8 @@ CallInst *IRBuilderBase::CreateBinaryIntrinsic(Intrinsic::ID ID, Value *LHS,
                                                Instruction *FMFSource,
                                                const Twine &Name) {
   Module *M = BB->getModule();
-  Function *Fn = Intrinsic::getDeclaration(M, ID, { LHS->getType() });
+  Function *Fn =
+      Intrinsic::getDeclaration(M, ID, {LHS->getType(), RHS->getType()});
   return createCallHelper(Fn, {LHS, RHS}, Name, FMFSource);
 }
 

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -55,12 +55,13 @@ protected:
 
 TEST_F(IRBuilderTest, Intrinsics) {
   IRBuilder<> Builder(BB);
-  Value *V;
+  Value *V, *IV;
   Instruction *I;
   CallInst *Call;
   IntrinsicInst *II;
 
   V = Builder.CreateLoad(GV->getValueType(), GV);
+  IV = Builder.getInt32(2);
   I = cast<Instruction>(Builder.CreateFAdd(V, V));
   I->setHasNoInfs(true);
   I->setHasNoNaNs(false);
@@ -106,6 +107,18 @@ TEST_F(IRBuilderTest, Intrinsics) {
   Call = Builder.CreateBinaryIntrinsic(Intrinsic::pow, V, V, I);
   II = cast<IntrinsicInst>(Call);
   EXPECT_EQ(II->getIntrinsicID(), Intrinsic::pow);
+  EXPECT_TRUE(II->hasNoInfs());
+  EXPECT_FALSE(II->hasNoNaNs());
+
+  Call = Builder.CreateBinaryIntrinsic(Intrinsic::powi, V, IV);
+  II = cast<IntrinsicInst>(Call);
+  EXPECT_EQ(II->getIntrinsicID(), Intrinsic::powi);
+  EXPECT_FALSE(II->hasNoInfs());
+  EXPECT_FALSE(II->hasNoNaNs());
+
+  Call = Builder.CreateBinaryIntrinsic(Intrinsic::powi, V, IV, I);
+  II = cast<IntrinsicInst>(Call);
+  EXPECT_EQ(II->getIntrinsicID(), Intrinsic::powi);
   EXPECT_TRUE(II->hasNoInfs());
   EXPECT_FALSE(II->hasNoNaNs());
 


### PR DESCRIPTION
This patch fixes crashes in #67236 when creating `llvm.powi.*` via `IRBuilderBase::CreateBinaryIntrinsic`.
