### PR TITLE
[Driver] Remove FreeBSD/riscv32 support

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -430,9 +430,6 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
 
   case llvm::Triple::riscv32:
     switch (os) {
-    case llvm::Triple::FreeBSD:
-      return std::make_unique<FreeBSDTargetInfo<RISCV32TargetInfo>>(Triple,
-                                                                    Opts);
     case llvm::Triple::NetBSD:
       return std::make_unique<NetBSDTargetInfo<RISCV32TargetInfo>>(Triple,
                                                                    Opts);

--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -210,11 +210,6 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     else
       CmdArgs.push_back("elf64ltsmip_fbsd");
     break;
-  case llvm::Triple::riscv32:
-    CmdArgs.push_back("-m");
-    CmdArgs.push_back("elf32lriscv");
-    CmdArgs.push_back("-X");
-    break;
   case llvm::Triple::riscv64:
     CmdArgs.push_back("-m");
     CmdArgs.push_back("elf64lriscv");

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -73,9 +73,6 @@
 //
 // Check that RISC-V passes the correct linker emulation.
 //
-// RUN: %clang --target=riscv32-freebsd -### %s %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-RV32I-LD %s
-// CHECK-RV32I-LD: ld{{.*}}" {{.*}} "-m" "elf32lriscv"
 // RUN: %clang --target=riscv64-freebsd -### %s %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-RV64I-LD %s
 // CHECK-RV64I-LD: ld{{.*}}" {{.*}} "-m" "elf64lriscv"

--- a/clang/test/Preprocessor/predefined-macros-no-warnings.c
+++ b/clang/test/Preprocessor/predefined-macros-no-warnings.c
@@ -103,7 +103,6 @@
 // RUN: %clang_cc1 %s -Eonly -Wsystem-headers -Werror -triple amdgcn
 // RUN: %clang_cc1 %s -Eonly -Wsystem-headers -Werror -triple r600
 // RUN: %clang_cc1 %s -Eonly -Wsystem-headers -Werror -triple riscv32
-// RUN: %clang_cc1 %s -Eonly -Wsystem-headers -Werror -triple riscv32-freebsd
 // RUN: %clang_cc1 %s -Eonly -Wsystem-headers -Werror -triple riscv32-linux
 // RUN: %clang_cc1 %s -Eonly -Wsystem-headers -Werror -triple riscv64
 // RUN: %clang_cc1 %s -Eonly -Wsystem-headers -Werror -triple riscv64-freebsd


### PR DESCRIPTION
FreeBSD does not support riscv32 and has no intention of doing so.