### PR TITLE
[MLIR] When generating tests explicitly match only valid SSA var names

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -180,7 +180,7 @@ def process_line(line_chunks, variable_namer):
         else:
             # Otherwise, generate a new variable.
             variable = variable_namer.generate_name(ssa_name)
-            output_line += "%[[" + variable + ":.*]]"
+            output_line += "%[[" + variable + ":" + SSA_RE_STR + "]]"
 
         # Append the non named group.
         output_line += chunk[len(ssa_name) :]


### PR DESCRIPTION
Matching everything for variable names causes problems when there are
multiple values of the same type in a function definition. The match
greedily assigned everything up to the second value definition to the
name of the first value.
