### PR TITLE
[Memory] Call __clear_cache in InvalidateInstructionCache on LoongArch

### DIFF
--- a/llvm/lib/Support/Unix/Memory.inc
+++ b/llvm/lib/Support/Unix/Memory.inc
@@ -237,7 +237,8 @@ void Memory::InvalidateInstructionCache(const void *Addr, size_t Len) {
   for (intptr_t Line = StartLine; Line < EndLine; Line += LineSize)
     asm volatile("icbi 0, %0" : : "r"(Line));
   asm volatile("isync");
-#elif (defined(__arm__) || defined(__aarch64__) || defined(__mips__)) &&       \
+#elif (defined(__arm__) || defined(__aarch64__) || defined(__loongarch__) ||   \
+       defined(__mips__)) &&                                                   \
     defined(__GNUC__)
   // FIXME: Can we safely always call this for __GNUC__ everywhere?
   const char *Start = static_cast<const char *>(Addr);


### PR DESCRIPTION
As the comments of `InvalidateInstructionCache`: Before the JIT can run a block of code that has been emitted it must invalidate the instruction cache on some platforms. I think it applies to LoongArch as LoongArch has a weak memory-model. But I'm not able to write a test to demonstrate this issue. Perhaps self-modifing code should be wrote?