### PR TITLE
[Flang] [OpenMP] [Semantics] Add semantic support for IS_DEVICE_PTR nd HAS_DEVICE_ADDR clauses on  OMP TARGET directive and add more semantic checks for OMP TARGET.

### DIFF
--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -695,7 +695,8 @@ public:
       OmpShared, OmpPrivate, OmpLinear, OmpFirstPrivate, OmpLastPrivate,
       // OpenMP data-mapping attribute
       OmpMapTo, OmpMapFrom, OmpMapToFrom, OmpMapAlloc, OmpMapRelease,
-      OmpMapDelete, OmpUseDevicePtr, OmpUseDeviceAddr,
+      OmpMapDelete, OmpUseDevicePtr, OmpUseDeviceAddr, OmpIsDevicePtr,
+      OmpHasDeviceAddr,
       // OpenMP data-copying attribute
       OmpCopyIn, OmpCopyPrivate,
       // OpenMP miscellaneous flags

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -268,13 +268,16 @@ TYPE_PARSER(
                   parenthesized(Parser<OmpObjectList>{}))) ||
     "GRAINSIZE" >> construct<OmpClause>(construct<OmpClause::Grainsize>(
                        parenthesized(scalarIntExpr))) ||
+    "HAS_DEVICE_ADDR" >>
+        construct<OmpClause>(construct<OmpClause::HasDeviceAddr>(
+            parenthesized(Parser<OmpObjectList>{}))) ||
     "HINT" >> construct<OmpClause>(
                   construct<OmpClause::Hint>(parenthesized(constantExpr))) ||
     "IF" >> construct<OmpClause>(construct<OmpClause::If>(
                 parenthesized(Parser<OmpIfClause>{}))) ||
     "INBRANCH" >> construct<OmpClause>(construct<OmpClause::Inbranch>()) ||
     "IS_DEVICE_PTR" >> construct<OmpClause>(construct<OmpClause::IsDevicePtr>(
-                           parenthesized(nonemptyList(name)))) ||
+                           parenthesized(Parser<OmpObjectList>{}))) ||
     "LASTPRIVATE" >> construct<OmpClause>(construct<OmpClause::Lastprivate>(
                          parenthesized(Parser<OmpObjectList>{}))) ||
     "LINEAR" >> construct<OmpClause>(construct<OmpClause::Linear>(

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -801,6 +801,12 @@ std::string Symbol::OmpFlagToClauseName(Symbol::Flag ompFlag) {
   case Symbol::Flag::OmpCopyPrivate:
     clauseName = "COPYPRIVATE";
     break;
+  case Symbol::Flag::OmpIsDevicePtr:
+    clauseName = "IS_DEVICE_PTR";
+    break;
+  case Symbol::Flag::OmpHasDeviceAddr:
+    clauseName = "HAS_DEVICE_ADDR";
+    break;
   default:
     clauseName = "";
     break;

--- a/flang/test/Semantics/OpenMP/target01.f90
+++ b/flang/test/Semantics/OpenMP/target01.f90
@@ -1,10 +1,31 @@
 ! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
-! OpenMP Version 4.5
-
-integer :: x
+ 
+use iso_c_binding
+integer :: x,y
+type(C_PTR) :: b
 !ERROR: Variable 'x' may not appear on both MAP and PRIVATE clauses on a TARGET construct
 !$omp target map(x) private(x)
-x = x + 1
+  x = x + 1
+!$omp end target
+
+!ERROR: Variable 'y' in IS_DEVICE_PTR clause must be of type C_PTR
+!$omp target map(x) is_device_ptr(y)
+  x = x + 1
+!$omp end target
+
+!ERROR: Variable 'b' may not appear on both IS_DEVICE_PTR and HAS_DEVICE_ADDR clauses on a TARGET construct
+!$omp target map(x) is_device_ptr(b) has_device_addr(b)
+  x = x + 1
+!$omp end target
+
+!ERROR: Variable 'b' may not appear on both IS_DEVICE_PTR and PRIVATE clauses on a TARGET construct
+!$omp target map(x) is_device_ptr(b) private(b)
+  x = x + 1
+!$omp end target
+
+!ERROR: Variable 'y' may not appear on both HAS_DEVICE_ADDR and FIRSTPRIVATE clauses on a TARGET construct
+!$omp target map(x) has_device_addr(y) firstprivate(y)
+  y = y - 1
 !$omp end target
 
 end

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -299,13 +299,11 @@ def OMPC_UseDevicePtr : Clause<"use_device_ptr"> {
 }
 def OMPC_IsDevicePtr : Clause<"is_device_ptr"> {
   let clangClass = "OMPIsDevicePtrClause";
-  let flangClass = "Name";
-  let isValueList = true;
+  let flangClass = "OmpObjectList";
 }
 def OMPC_HasDeviceAddr : Clause<"has_device_addr"> {
   let clangClass = "OMPHasDeviceAddrClause";
-  let flangClass = "Name";
-  let isValueList = true;
+  let flangClass = "OmpObjectList";
 }
 def OMPC_TaskReduction : Clause<"task_reduction"> {
   let clangClass = "OMPTaskReductionClause";


### PR DESCRIPTION
Summary of this patch

- Add semantic support for HAS_DEVICE_ADDR and IS_DEVICE_PTR clauses.
- A list item that appears in an IS_DEVICE_PTR clause must be a valid device pointer for the device data environment.
- A list item may not be specified in both an IS_DEVICE_PTR clause and a HAS_DEVICE_ADDR clauses on the directive.
- A list item that appears in an IS_DEVICE_PTR or a HAS_DEVICE_ADDR clauses must not be specified in any data-sharing attribute clause on the same target construct.