### PR TITLE
[flang][runtime] Support non contiguous array in Finalize/Initialize

### DIFF
--- a/flang/include/flang/Runtime/descriptor.h
+++ b/flang/include/flang/Runtime/descriptor.h
@@ -251,6 +251,13 @@ public:
   }
 
   template <typename A>
+  RT_API_ATTRS A *ElementComponent(
+      const SubscriptValue subscript[], std::size_t componentOffset) const {
+    return OffsetElement<A>(
+        SubscriptsToByteOffset(subscript) + componentOffset);
+  }
+
+  template <typename A>
   RT_API_ATTRS A *ZeroBasedIndexedElement(std::size_t n) const {
     SubscriptValue at[maxRank];
     if (SubscriptsForZeroBasedElementNumber(at, n)) {


### PR DESCRIPTION
Finalize/Initialize may be called on non contiguous arrays when dealing with INTENT(OUT) dummies or non contiguous LHS. Update the related element access to use indices instead of assuming contiguity and manually computing the byte offset.

Also, the descriptor passed to parent type final routines should be set to the parent type, otherwise descriptor.IsContiguous() may wrongfully return true when finalizing parent components. Create a pointer to the parent component when recursing in Finalize.