### PR TITLE
[PowerPC] Disable float128 on AIX in Clang

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -52,7 +52,7 @@ bool PPCTargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasDirectMove = true;
     } else if (Feature == "+htm") {
       HasHTM = true;
-    } else if (Feature == "+float128") {
+    } else if (Feature == "+float128" && !getTriple().isOSAIX()) {
       HasFloat128 = true;
     } else if (Feature == "+power9-vector") {
       HasP9Vector = true;

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -52,8 +52,8 @@ bool PPCTargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       HasDirectMove = true;
     } else if (Feature == "+htm") {
       HasHTM = true;
-    } else if (Feature == "+float128" && !getTriple().isOSAIX()) {
-      HasFloat128 = true;
+    } else if (Feature == "+float128") {
+      HasFloat128 = !getTriple().isOSAIX();
     } else if (Feature == "+power9-vector") {
       HasP9Vector = true;
     } else if (Feature == "+power10-vector") {

--- a/clang/test/Sema/128bitfloat.cpp
+++ b/clang/test/Sema/128bitfloat.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -verify -std=gnu++11 %s
 // RUN: %clang_cc1 -verify -std=c++11 %s
 // RUN: %clang_cc1 -triple powerpc64-linux -verify -std=c++11 %s
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -target-feature +float128 -verify -std=c++11 %s
 // RUN: %clang_cc1 -triple i686-windows-gnu -verify -std=c++11 %s
 // RUN: %clang_cc1 -triple x86_64-windows-gnu -verify -std=c++11 %s
 // RUN: %clang_cc1 -triple x86_64-windows-msvc -verify -std=c++11 %s


### PR DESCRIPTION
PowerPC AIX backend does not support float128 at all. Diagnose even when specifying -mfloat128 to avoid backend crash.