### PR TITLE
[PowerPC] Rename fp/int conversion nodes

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -1668,14 +1668,18 @@ const char *PPCTargetLowering::getTargetNodeName(unsigned Opcode) const {
   case PPCISD::FSEL:            return "PPCISD::FSEL";
   case PPCISD::XSMAXC:          return "PPCISD::XSMAXC";
   case PPCISD::XSMINC:          return "PPCISD::XSMINC";
-  case PPCISD::FCFID:           return "PPCISD::FCFID";
-  case PPCISD::FCFIDU:          return "PPCISD::FCFIDU";
-  case PPCISD::FCFIDS:          return "PPCISD::FCFIDS";
-  case PPCISD::FCFIDUS:         return "PPCISD::FCFIDUS";
-  case PPCISD::FCTIDZ:          return "PPCISD::FCTIDZ";
-  case PPCISD::FCTIWZ:          return "PPCISD::FCTIWZ";
-  case PPCISD::FCTIDUZ:         return "PPCISD::FCTIDUZ";
-  case PPCISD::FCTIWUZ:         return "PPCISD::FCTIWUZ";
+  case PPCISD::SINT_TO_FP_INREG:
+    return "PPCISD::SINT_TO_FP_INREG";
+  case PPCISD::UINT_TO_FP_INREG:
+    return "PPCISD::UINT_TO_FP_INREG";
+  case PPCISD::FP_TO_I64_INREG:
+    return "PPCISD::FP_TO_I64_INREG";
+  case PPCISD::FP_TO_I32_INREG:
+    return "PPCISD::FP_TO_I32_INREG";
+  case PPCISD::FP_TO_U64_INREG:
+    return "PPCISD::FP_TO_U64_INREG";
+  case PPCISD::FP_TO_U32_INREG:
+    return "PPCISD::FP_TO_U32_INREG";
   case PPCISD::FRE:             return "PPCISD::FRE";
   case PPCISD::FRSQRTE:         return "PPCISD::FRSQRTE";
   case PPCISD::FTSQRT:
@@ -1810,22 +1814,18 @@ const char *PPCTargetLowering::getTargetNodeName(unsigned Opcode) const {
   case PPCISD::FNMSUB:          return "PPCISD::FNMSUB";
   case PPCISD::STRICT_FADDRTZ:
     return "PPCISD::STRICT_FADDRTZ";
-  case PPCISD::STRICT_FCTIDZ:
-    return "PPCISD::STRICT_FCTIDZ";
-  case PPCISD::STRICT_FCTIWZ:
-    return "PPCISD::STRICT_FCTIWZ";
-  case PPCISD::STRICT_FCTIDUZ:
-    return "PPCISD::STRICT_FCTIDUZ";
-  case PPCISD::STRICT_FCTIWUZ:
-    return "PPCISD::STRICT_FCTIWUZ";
-  case PPCISD::STRICT_FCFID:
-    return "PPCISD::STRICT_FCFID";
-  case PPCISD::STRICT_FCFIDU:
-    return "PPCISD::STRICT_FCFIDU";
-  case PPCISD::STRICT_FCFIDS:
-    return "PPCISD::STRICT_FCFIDS";
-  case PPCISD::STRICT_FCFIDUS:
-    return "PPCISD::STRICT_FCFIDUS";
+  case PPCISD::STRICT_FP_TO_I64_INREG:
+    return "PPCISD::STRICT_FP_TO_I64_INREG";
+  case PPCISD::STRICT_FP_TO_I32_INREG:
+    return "PPCISD::STRICT_FP_TO_I32_INREG";
+  case PPCISD::STRICT_FP_TO_U64_INREG:
+    return "PPCISD::STRICT_FP_TO_U64_INREG";
+  case PPCISD::STRICT_FP_TO_U32_INREG:
+    return "PPCISD::STRICT_FP_TO_U32_INREG";
+  case PPCISD::STRICT_SINT_TO_FP_INREG:
+    return "PPCISD::STRICT_SINT_TO_FP_INREG";
+  case PPCISD::STRICT_UINT_TO_FP_INREG:
+    return "PPCISD::STRICT_UINT_TO_FP_INREG";
   case PPCISD::LXVRZX:          return "PPCISD::LXVRZX";
   case PPCISD::STORE_COND:
     return "PPCISD::STORE_COND";
@@ -8168,22 +8168,18 @@ static unsigned getPPCStrictOpcode(unsigned Opc) {
   switch (Opc) {
   default:
     llvm_unreachable("No strict version of this opcode!");
-  case PPCISD::FCTIDZ:
-    return PPCISD::STRICT_FCTIDZ;
-  case PPCISD::FCTIWZ:
-    return PPCISD::STRICT_FCTIWZ;
-  case PPCISD::FCTIDUZ:
-    return PPCISD::STRICT_FCTIDUZ;
-  case PPCISD::FCTIWUZ:
-    return PPCISD::STRICT_FCTIWUZ;
-  case PPCISD::FCFID:
-    return PPCISD::STRICT_FCFID;
-  case PPCISD::FCFIDU:
-    return PPCISD::STRICT_FCFIDU;
-  case PPCISD::FCFIDS:
-    return PPCISD::STRICT_FCFIDS;
-  case PPCISD::FCFIDUS:
-    return PPCISD::STRICT_FCFIDUS;
+  case PPCISD::FP_TO_I64_INREG:
+    return PPCISD::STRICT_FP_TO_I64_INREG;
+  case PPCISD::FP_TO_I32_INREG:
+    return PPCISD::STRICT_FP_TO_I32_INREG;
+  case PPCISD::FP_TO_U64_INREG:
+    return PPCISD::STRICT_FP_TO_U64_INREG;
+  case PPCISD::FP_TO_U32_INREG:
+    return PPCISD::STRICT_FP_TO_U32_INREG;
+  case PPCISD::SINT_TO_FP_INREG:
+    return PPCISD::STRICT_SINT_TO_FP_INREG;
+  case PPCISD::UINT_TO_FP_INREG:
+    return PPCISD::STRICT_UINT_TO_FP_INREG;
   }
 }
 
@@ -8221,13 +8217,14 @@ static SDValue convertFPToInt(SDValue Op, SelectionDAG &DAG,
   switch (DestTy.SimpleTy) {
   default: llvm_unreachable("Unhandled FP_TO_INT type in custom expander!");
   case MVT::i32:
-    Opc = IsSigned ? PPCISD::FCTIWZ
-                   : (Subtarget.hasFPCVT() ? PPCISD::FCTIWUZ : PPCISD::FCTIDZ);
+    Opc = IsSigned ? PPCISD::FP_TO_I32_INREG
+                   : (Subtarget.hasFPCVT() ? PPCISD::FP_TO_U32_INREG
+                                           : PPCISD::FP_TO_I64_INREG);
     break;
   case MVT::i64:
     assert((IsSigned || Subtarget.hasFPCVT()) &&
            "i64 FP_TO_UINT is supported only with FPCVT");
-    Opc = IsSigned ? PPCISD::FCTIDZ : PPCISD::FCTIDUZ;
+    Opc = IsSigned ? PPCISD::FP_TO_I64_INREG : PPCISD::FP_TO_U64_INREG;
   }
   EVT ConvTy = Src.getValueType() == MVT::f128 ? MVT::f128 : MVT::f64;
   SDValue Conv;
@@ -8528,8 +8525,8 @@ static SDValue convertIntToFP(SDValue Op, SDValue Src, SelectionDAG &DAG,
   // If we have FCFIDS, then use it when converting to single-precision.
   // Otherwise, convert to double-precision and then round.
   bool IsSingle = Op.getValueType() == MVT::f32 && Subtarget.hasFPCVT();
-  unsigned ConvOpc = IsSingle ? (IsSigned ? PPCISD::FCFIDS : PPCISD::FCFIDUS)
-                              : (IsSigned ? PPCISD::FCFID : PPCISD::FCFIDU);
+  unsigned ConvOpc =
+      IsSigned ? PPCISD::SINT_TO_FP_INREG : PPCISD::UINT_TO_FP_INREG;
   EVT ConvTy = IsSingle ? MVT::f32 : MVT::f64;
   if (Op->isStrictFPOpcode()) {
     if (!Chain)
@@ -14469,13 +14466,13 @@ combineElementTruncationToVectorTruncation(SDNode *N,
   // This combine happens after legalization so the fp_to_[su]i nodes are
   // already converted to PPCSISD nodes.
   unsigned FirstConversion = FirstInput.getOperand(0).getOpcode();
-  if (FirstConversion == PPCISD::FCTIDZ ||
-      FirstConversion == PPCISD::FCTIDUZ ||
-      FirstConversion == PPCISD::FCTIWZ ||
-      FirstConversion == PPCISD::FCTIWUZ) {
+  if (FirstConversion == PPCISD::FP_TO_I64_INREG ||
+      FirstConversion == PPCISD::FP_TO_U64_INREG ||
+      FirstConversion == PPCISD::FP_TO_I32_INREG ||
+      FirstConversion == PPCISD::FP_TO_U32_INREG) {
     bool IsSplat = true;
-    bool Is32Bit = FirstConversion == PPCISD::FCTIWZ ||
-      FirstConversion == PPCISD::FCTIWUZ;
+    bool Is32Bit = FirstConversion == PPCISD::FP_TO_I32_INREG ||
+                   FirstConversion == PPCISD::FP_TO_U32_INREG;
     EVT SrcVT = FirstInput.getOperand(0).getValueType();
     SmallVector<SDValue, 4> Ops;
     EVT TargetVT = N->getValueType(0);
@@ -14521,8 +14518,8 @@ combineElementTruncationToVectorTruncation(SDNode *N,
     }
 
     unsigned Opcode;
-    if (FirstConversion == PPCISD::FCTIDZ ||
-        FirstConversion == PPCISD::FCTIWZ)
+    if (FirstConversion == PPCISD::FP_TO_I64_INREG ||
+        FirstConversion == PPCISD::FP_TO_I32_INREG)
       Opcode = ISD::FP_TO_SINT;
     else
       Opcode = ISD::FP_TO_UINT;
@@ -14932,9 +14929,8 @@ SDValue PPCTargetLowering::combineFPToIntToFP(SDNode *N,
   if (Subtarget.hasP9Vector() && Subtarget.hasP9Altivec() && SubWordLoad) {
     bool Signed = N->getOpcode() == ISD::SINT_TO_FP;
     bool DstDouble = Op.getValueType() == MVT::f64;
-    unsigned ConvOp = Signed ?
-      (DstDouble ? PPCISD::FCFID  : PPCISD::FCFIDS) :
-      (DstDouble ? PPCISD::FCFIDU : PPCISD::FCFIDUS);
+    unsigned ConvOp =
+        Signed ? PPCISD::SINT_TO_FP_INREG : PPCISD::UINT_TO_FP_INREG;
     SDValue WidthConst =
       DAG.getIntPtrConstant(FirstOperand.getValueType() == MVT::i8 ? 1 : 2,
                             dl, false);
@@ -14966,11 +14962,8 @@ SDValue PPCTargetLowering::combineFPToIntToFP(SDNode *N,
 
   // If we have FCFIDS, then use it when converting to single-precision.
   // Otherwise, convert to double-precision and then round.
-  unsigned FCFOp = (Subtarget.hasFPCVT() && Op.getValueType() == MVT::f32)
-                       ? (Op.getOpcode() == ISD::UINT_TO_FP ? PPCISD::FCFIDUS
-                                                            : PPCISD::FCFIDS)
-                       : (Op.getOpcode() == ISD::UINT_TO_FP ? PPCISD::FCFIDU
-                                                            : PPCISD::FCFID);
+  unsigned FCFOp = Op.getOpcode() == ISD::UINT_TO_FP ? PPCISD::UINT_TO_FP_INREG
+                                                     : PPCISD::SINT_TO_FP_INREG;
   MVT FCFTy = (Subtarget.hasFPCVT() && Op.getValueType() == MVT::f32)
                   ? MVT::f32
                   : MVT::f64;
@@ -14989,9 +14982,9 @@ SDValue PPCTargetLowering::combineFPToIntToFP(SDNode *N,
       return SDValue();
     }
 
-    unsigned FCTOp =
-      Op.getOperand(0).getOpcode() == ISD::FP_TO_SINT ? PPCISD::FCTIDZ :
-                                                        PPCISD::FCTIDUZ;
+    unsigned FCTOp = Op.getOperand(0).getOpcode() == ISD::FP_TO_SINT
+                         ? PPCISD::FP_TO_I64_INREG
+                         : PPCISD::FP_TO_U64_INREG;
 
     SDValue Tmp = DAG.getNode(FCTOp, dl, MVT::f64, Src);
     SDValue FP = DAG.getNode(FCFOp, dl, FCFTy, Tmp);

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.h
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.h
@@ -56,27 +56,15 @@ namespace llvm {
     XSMAXC,
     XSMINC,
 
-    /// FCFID - The FCFID instruction, taking an f64 operand and producing
-    /// and f64 value containing the FP representation of the integer that
-    /// was temporarily in the f64 operand.
-    FCFID,
+    /// Inplace integer-to-float conversion.
+    SINT_TO_FP_INREG,
+    UINT_TO_FP_INREG,
 
-    /// Newer FCFID[US] integer-to-floating-point conversion instructions for
-    /// unsigned integers and single-precision outputs.
-    FCFIDU,
-    FCFIDS,
-    FCFIDUS,
-
-    /// FCTI[D,W]Z - The FCTIDZ and FCTIWZ instructions, taking an f32 or f64
-    /// operand, producing an f64 value containing the integer representation
-    /// of that FP value.
-    FCTIDZ,
-    FCTIWZ,
-
-    /// Newer FCTI[D,W]UZ floating-point-to-integer conversion instructions for
-    /// unsigned integers with round toward zero.
-    FCTIDUZ,
-    FCTIWUZ,
+    /// Inplace float-to-integer conversion.
+    FP_TO_I64_INREG,
+    FP_TO_I32_INREG,
+    FP_TO_U64_INREG,
+    FP_TO_U32_INREG,
 
     /// VEXTS, ByteWidth - takes an input in VSFRC and produces an output in
     /// VSFRC that is sign-extended from ByteWidth to a 64-byte integer.
@@ -476,16 +464,14 @@ namespace llvm {
     XXMFACC,
 
     // Constrained conversion from floating point to int
-    STRICT_FCTIDZ = ISD::FIRST_TARGET_STRICTFP_OPCODE,
-    STRICT_FCTIWZ,
-    STRICT_FCTIDUZ,
-    STRICT_FCTIWUZ,
+    STRICT_FP_TO_I64_INREG = ISD::FIRST_TARGET_STRICTFP_OPCODE,
+    STRICT_FP_TO_I32_INREG,
+    STRICT_FP_TO_U64_INREG,
+    STRICT_FP_TO_U32_INREG,
 
     /// Constrained integer-to-floating-point conversion instructions.
-    STRICT_FCFID,
-    STRICT_FCFIDU,
-    STRICT_FCFIDS,
-    STRICT_FCFIDUS,
+    STRICT_SINT_TO_FP_INREG,
+    STRICT_UINT_TO_FP_INREG,
 
     /// Constrained floating point add in round-to-zero mode.
     STRICT_FADDRTZ,

--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -1800,7 +1800,7 @@ let PPC970_Unit = 3, hasSideEffects = 0, mayRaiseFPException = 1,
     Uses = [RM] in {  // FPU Operations.
 defm FCFID  : XForm_26r<63, 846, (outs f8rc:$RST), (ins f8rc:$RB),
                         "fcfid", "$RST, $RB", IIC_FPGeneral,
-                        [(set f64:$RST, (PPCany_fcfid f64:$RB))]>, isPPC64;
+                        [(set f64:$RST, (PPCany_sint_to_fp f64:$RB))]>, isPPC64;
 defm FCTID  : XForm_26r<63, 814, (outs f8rc:$RST), (ins f8rc:$RB),
                         "fctid", "$RST, $RB", IIC_FPGeneral,
                         []>, isPPC64;
@@ -1809,23 +1809,23 @@ defm FCTIDU : XForm_26r<63, 942, (outs f8rc:$RST), (ins f8rc:$RB),
                         []>, isPPC64;
 defm FCTIDZ : XForm_26r<63, 815, (outs f8rc:$RST), (ins f8rc:$RB),
                         "fctidz", "$RST, $RB", IIC_FPGeneral,
-                        [(set f64:$RST, (PPCany_fctidz f64:$RB))]>, isPPC64;
+                        [(set f64:$RST, (PPCany_fp_to_i64 f64:$RB))]>, isPPC64;
 
 defm FCFIDU  : XForm_26r<63, 974, (outs f8rc:$RST), (ins f8rc:$RB),
                         "fcfidu", "$RST, $RB", IIC_FPGeneral,
-                        [(set f64:$RST, (PPCany_fcfidu f64:$RB))]>, isPPC64;
+                        [(set f64:$RST, (PPCany_uint_to_fp f64:$RB))]>, isPPC64;
 defm FCFIDS  : XForm_26r<59, 846, (outs f4rc:$RST), (ins f8rc:$RB),
                         "fcfids", "$RST, $RB", IIC_FPGeneral,
-                        [(set f32:$RST, (PPCany_fcfids f64:$RB))]>, isPPC64;
+                        [(set f32:$RST, (PPCany_sint_to_fp f64:$RB))]>, isPPC64;
 defm FCFIDUS : XForm_26r<59, 974, (outs f4rc:$RST), (ins f8rc:$RB),
                         "fcfidus", "$RST, $RB", IIC_FPGeneral,
-                        [(set f32:$RST, (PPCany_fcfidus f64:$RB))]>, isPPC64;
+                        [(set f32:$RST, (PPCany_uint_to_fp f64:$RB))]>, isPPC64;
 defm FCTIDUZ : XForm_26r<63, 943, (outs f8rc:$RST), (ins f8rc:$RB),
                         "fctiduz", "$RST, $RB", IIC_FPGeneral,
-                        [(set f64:$RST, (PPCany_fctiduz f64:$RB))]>, isPPC64;
+                        [(set f64:$RST, (PPCany_fp_to_u64 f64:$RB))]>, isPPC64;
 defm FCTIWUZ : XForm_26r<63, 143, (outs f8rc:$RST), (ins f8rc:$RB),
                         "fctiwuz", "$RST, $RB", IIC_FPGeneral,
-                        [(set f64:$RST, (PPCany_fctiwuz f64:$RB))]>, isPPC64;
+                        [(set f64:$RST, (PPCany_fp_to_u32 f64:$RB))]>, isPPC64;
 }
 
 // These instructions store a hash computed from the value of the link register

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -133,36 +133,25 @@ def PPCfrsqrte: SDNode<"PPCISD::FRSQRTE", SDTFPUnaryOp, []>;
 def PPCfsqrt  : SDNode<"PPCISD::FSQRT",   SDTFPUnaryOp, []>;
 def PPCftsqrt : SDNode<"PPCISD::FTSQRT",  SDT_PPCFtsqrt,[]>;
 
-def PPCfcfid  : SDNode<"PPCISD::FCFID",   SDTFPUnaryOp, []>;
-def PPCfcfidu : SDNode<"PPCISD::FCFIDU",  SDTFPUnaryOp, []>;
-def PPCfcfids : SDNode<"PPCISD::FCFIDS",  SDTFPRoundOp, []>;
-def PPCfcfidus: SDNode<"PPCISD::FCFIDUS", SDTFPRoundOp, []>;
-def PPCfctidz : SDNode<"PPCISD::FCTIDZ", SDTFPUnaryOp, []>;
-def PPCfctiwz : SDNode<"PPCISD::FCTIWZ", SDTFPUnaryOp, []>;
-def PPCfctiduz: SDNode<"PPCISD::FCTIDUZ",SDTFPUnaryOp, []>;
-def PPCfctiwuz: SDNode<"PPCISD::FCTIWUZ",SDTFPUnaryOp, []>;
+def SDTToFpInRegOp : SDTypeProfile<1, 1, [ SDTCisFP<0>, SDTCisVT<1, f64> ]>;
+def PPCsint_to_fp: SDNode<"PPCISD::SINT_TO_FP_INREG", SDTToFpInRegOp, []>;
+def PPCuint_to_fp: SDNode<"PPCISD::UINT_TO_FP_INREG", SDTToFpInRegOp, []>;
+def PPCfp_to_i64 : SDNode<"PPCISD::FP_TO_I64_INREG", SDTFPUnaryOp, []>;
+def PPCfp_to_i32 : SDNode<"PPCISD::FP_TO_I32_INREG", SDTFPUnaryOp, []>;
+def PPCfp_to_u64 : SDNode<"PPCISD::FP_TO_U64_INREG", SDTFPUnaryOp, []>;
+def PPCfp_to_u32 : SDNode<"PPCISD::FP_TO_U32_INREG", SDTFPUnaryOp, []>;
 
-def PPCstrict_fcfid : SDNode<"PPCISD::STRICT_FCFID",
-                             SDTFPUnaryOp, [SDNPHasChain]>;
-def PPCstrict_fcfidu : SDNode<"PPCISD::STRICT_FCFIDU",
-                              SDTFPUnaryOp, [SDNPHasChain]>;
-def PPCstrict_fcfids : SDNode<"PPCISD::STRICT_FCFIDS",
-                             SDTFPRoundOp, [SDNPHasChain]>;
-def PPCstrict_fcfidus : SDNode<"PPCISD::STRICT_FCFIDUS",
-                              SDTFPRoundOp, [SDNPHasChain]>;
+def PPCstrict_sint_to_fp: SDNode<"PPCISD::STRICT_SINT_TO_FP_INREG",
+                                  SDTToFpInRegOp, [SDNPHasChain]>;
+def PPCstrict_uint_to_fp: SDNode<"PPCISD::STRICT_UINT_TO_FP_INREG",
+                                  SDTToFpInRegOp, [SDNPHasChain]>;
 
-def PPCany_fcfid : PatFrags<(ops node:$op),
-                             [(PPCfcfid node:$op),
-                              (PPCstrict_fcfid node:$op)]>;
-def PPCany_fcfidu : PatFrags<(ops node:$op),
-                             [(PPCfcfidu node:$op),
-                              (PPCstrict_fcfidu node:$op)]>;
-def PPCany_fcfids : PatFrags<(ops node:$op),
-                              [(PPCfcfids node:$op),
-                               (PPCstrict_fcfids node:$op)]>;
-def PPCany_fcfidus : PatFrags<(ops node:$op),
-                              [(PPCfcfidus node:$op),
-                               (PPCstrict_fcfidus node:$op)]>;
+def PPCany_sint_to_fp: PatFrags<(ops node:$op),
+                                [(PPCsint_to_fp node:$op),
+                                 (PPCstrict_sint_to_fp node:$op)]>;
+def PPCany_uint_to_fp: PatFrags<(ops node:$op),
+                                [(PPCuint_to_fp node:$op),
+                                 (PPCstrict_uint_to_fp node:$op)]>;
 
 def PPCstore_scal_int_from_vsr:
    SDNode<"PPCISD::ST_VSR_SCAL_INT", SDT_PPCstore_scal_int_from_vsr,
@@ -249,27 +238,27 @@ def PPCfnmsub     : SDNode<"PPCISD::FNMSUB"    , SDTFPTernaryOp>;
 
 def PPCextswsli : SDNode<"PPCISD::EXTSWSLI" , SDT_PPCextswsli>;
 
-def PPCstrict_fctidz : SDNode<"PPCISD::STRICT_FCTIDZ",
-                              SDTFPUnaryOp, [SDNPHasChain]>;
-def PPCstrict_fctiwz : SDNode<"PPCISD::STRICT_FCTIWZ",
-                              SDTFPUnaryOp, [SDNPHasChain]>;
-def PPCstrict_fctiduz : SDNode<"PPCISD::STRICT_FCTIDUZ",
-                               SDTFPUnaryOp, [SDNPHasChain]>;
-def PPCstrict_fctiwuz : SDNode<"PPCISD::STRICT_FCTIWUZ",
+def PPCstrict_fp_to_i64: SDNode<"PPCISD::STRICT_FP_TO_I64_INREG",
+                                SDTFPUnaryOp, [SDNPHasChain]>;
+def PPCstrict_fp_to_i32: SDNode<"PPCISD::STRICT_FP_TO_I32_INREG",
+                                SDTFPUnaryOp, [SDNPHasChain]>;
+def PPCstrict_fp_to_u64: SDNode<"PPCISD::STRICT_FP_TO_U64_INREG",
+                                SDTFPUnaryOp, [SDNPHasChain]>;
+def PPCstrict_fp_to_u32: SDNode<"PPCISD::STRICT_FP_TO_U32_INREG",
                                 SDTFPUnaryOp, [SDNPHasChain]>;
 
-def PPCany_fctidz : PatFrags<(ops node:$op),
-                             [(PPCstrict_fctidz node:$op),
-                              (PPCfctidz node:$op)]>;
-def PPCany_fctiwz : PatFrags<(ops node:$op),
-                             [(PPCstrict_fctiwz node:$op),
-                              (PPCfctiwz node:$op)]>;
-def PPCany_fctiduz : PatFrags<(ops node:$op),
-                              [(PPCstrict_fctiduz node:$op),
-                               (PPCfctiduz node:$op)]>;
-def PPCany_fctiwuz : PatFrags<(ops node:$op),
-                              [(PPCstrict_fctiwuz node:$op),
-                               (PPCfctiwuz node:$op)]>;
+def PPCany_fp_to_i64: PatFrags<(ops node:$op),
+                               [(PPCstrict_fp_to_i64 node:$op),
+                                (PPCfp_to_i64 node:$op)]>;
+def PPCany_fp_to_i32: PatFrags<(ops node:$op),
+                               [(PPCstrict_fp_to_i32 node:$op),
+                                (PPCfp_to_i32 node:$op)]>;
+def PPCany_fp_to_u64: PatFrags<(ops node:$op),
+                               [(PPCstrict_fp_to_u64 node:$op),
+                                (PPCfp_to_u64 node:$op)]>;
+def PPCany_fp_to_u32: PatFrags<(ops node:$op),
+                               [(PPCstrict_fp_to_u32 node:$op),
+                                (PPCfp_to_u32 node:$op)]>;
 
 // Move 2 i64 values into a VSX register
 def PPCbuild_fp128: SDNode<"PPCISD::BUILD_FP128",
@@ -2499,7 +2488,7 @@ let Uses = [RM], mayRaiseFPException = 1, hasSideEffects = 0 in {
                           []>;
   defm FCTIWZ : XForm_26r<63, 15, (outs f8rc:$RST), (ins f8rc:$RB),
                           "fctiwz", "$RST, $RB", IIC_FPGeneral,
-                          [(set f64:$RST, (PPCany_fctiwz f64:$RB))]>;
+                          [(set f64:$RST, (PPCany_fp_to_i32 f64:$RB))]>;
 
   defm FRSP   : XForm_26r<63, 12, (outs f4rc:$RST), (ins f8rc:$RB),
                           "frsp", "$RST, $RB", IIC_FPGeneral,

--- a/llvm/lib/Target/PowerPC/PPCInstrVSX.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrVSX.td
@@ -764,50 +764,50 @@ let hasSideEffects = 0 in {
   def XSCVDPSXDS : XX2Form<60, 344,
                       (outs vsfrc:$XT), (ins vsfrc:$XB),
                       "xscvdpsxds $XT, $XB", IIC_VecFP,
-                      [(set f64:$XT, (PPCany_fctidz f64:$XB))]>;
+                      [(set f64:$XT, (PPCany_fp_to_i64 f64:$XB))]>;
   let isCodeGenOnly = 1 in
   def XSCVDPSXDSs : XX2Form<60, 344,
                       (outs vssrc:$XT), (ins vssrc:$XB),
                       "xscvdpsxds $XT, $XB", IIC_VecFP,
-                      [(set f32:$XT, (PPCany_fctidz f32:$XB))]>;
+                      [(set f32:$XT, (PPCany_fp_to_i64 f32:$XB))]>;
   def XSCVDPSXWS : XX2Form<60, 88,
                       (outs vsfrc:$XT), (ins vsfrc:$XB),
                       "xscvdpsxws $XT, $XB", IIC_VecFP,
-                      [(set f64:$XT, (PPCany_fctiwz f64:$XB))]>;
+                      [(set f64:$XT, (PPCany_fp_to_i32 f64:$XB))]>;
   let isCodeGenOnly = 1 in
   def XSCVDPSXWSs : XX2Form<60, 88,
                       (outs vssrc:$XT), (ins vssrc:$XB),
                       "xscvdpsxws $XT, $XB", IIC_VecFP,
-                      [(set f32:$XT, (PPCany_fctiwz f32:$XB))]>;
+                      [(set f32:$XT, (PPCany_fp_to_i32 f32:$XB))]>;
   def XSCVDPUXDS : XX2Form<60, 328,
                       (outs vsfrc:$XT), (ins vsfrc:$XB),
                       "xscvdpuxds $XT, $XB", IIC_VecFP,
-                      [(set f64:$XT, (PPCany_fctiduz f64:$XB))]>;
+                      [(set f64:$XT, (PPCany_fp_to_u64 f64:$XB))]>;
   let isCodeGenOnly = 1 in
   def XSCVDPUXDSs : XX2Form<60, 328,
                       (outs vssrc:$XT), (ins vssrc:$XB),
                       "xscvdpuxds $XT, $XB", IIC_VecFP,
-                      [(set f32:$XT, (PPCany_fctiduz f32:$XB))]>;
+                      [(set f32:$XT, (PPCany_fp_to_u64 f32:$XB))]>;
   def XSCVDPUXWS : XX2Form<60, 72,
                       (outs vsfrc:$XT), (ins vsfrc:$XB),
                       "xscvdpuxws $XT, $XB", IIC_VecFP,
-                      [(set f64:$XT, (PPCany_fctiwuz f64:$XB))]>;
+                      [(set f64:$XT, (PPCany_fp_to_u32 f64:$XB))]>;
   let isCodeGenOnly = 1 in
   def XSCVDPUXWSs : XX2Form<60, 72,
                       (outs vssrc:$XT), (ins vssrc:$XB),
                       "xscvdpuxws $XT, $XB", IIC_VecFP,
-                      [(set f32:$XT, (PPCany_fctiwuz f32:$XB))]>;
+                      [(set f32:$XT, (PPCany_fp_to_u32 f32:$XB))]>;
   def XSCVSPDP : XX2Form<60, 329,
                       (outs vsfrc:$XT), (ins vsfrc:$XB),
                       "xscvspdp $XT, $XB", IIC_VecFP, []>;
   def XSCVSXDDP : XX2Form<60, 376,
                       (outs vsfrc:$XT), (ins vsfrc:$XB),
                       "xscvsxddp $XT, $XB", IIC_VecFP,
-                      [(set f64:$XT, (PPCany_fcfid f64:$XB))]>;
+                      [(set f64:$XT, (PPCany_sint_to_fp f64:$XB))]>;
   def XSCVUXDDP : XX2Form<60, 360,
                       (outs vsfrc:$XT), (ins vsfrc:$XB),
                       "xscvuxddp $XT, $XB", IIC_VecFP,
-                      [(set f64:$XT, (PPCany_fcfidu f64:$XB))]>;
+                      [(set f64:$XT, (PPCany_uint_to_fp f64:$XB))]>;
 
   def XVCVDPSP : XX2Form<60, 393,
                       (outs vsrc:$XT), (ins vsrc:$XB),
@@ -1275,11 +1275,11 @@ let Predicates = [HasVSX, HasP8Vector] in {
   def XSCVSXDSP : XX2Form<60, 312,
                       (outs vssrc:$XT), (ins vsfrc:$XB),
                       "xscvsxdsp $XT, $XB", IIC_VecFP,
-                      [(set f32:$XT, (PPCany_fcfids f64:$XB))]>;
+                      [(set f32:$XT, (PPCany_sint_to_fp f64:$XB))]>;
   def XSCVUXDSP : XX2Form<60, 296,
                       (outs vssrc:$XT), (ins vsfrc:$XB),
                       "xscvuxdsp $XT, $XB", IIC_VecFP,
-                      [(set f32:$XT, (PPCany_fcfidus f64:$XB))]>;
+                      [(set f32:$XT, (PPCany_uint_to_fp f64:$XB))]>;
   } // mayRaiseFPException
 
   // Conversions between vector and scalar single precision
@@ -1488,13 +1488,13 @@ let Predicates = [HasVSX, HasP9Vector] in {
   // Truncate & Convert QP -> (Un)Signed (D)Word (dword[1] is set to zero)
   let mayRaiseFPException = 1 in {
     def XSCVQPSDZ : X_VT5_XO5_VB5<63, 25, 836, "xscvqpsdz",
-        [(set f128:$RST, (PPCany_fctidz f128:$RB))]>;
+        [(set f128:$RST, (PPCany_fp_to_i64 f128:$RB))]>;
     def XSCVQPSWZ : X_VT5_XO5_VB5<63,  9, 836, "xscvqpswz",
-        [(set f128:$RST, (PPCany_fctiwz f128:$RB))]>;
+        [(set f128:$RST, (PPCany_fp_to_i32 f128:$RB))]>;
     def XSCVQPUDZ : X_VT5_XO5_VB5<63, 17, 836, "xscvqpudz",
-        [(set f128:$RST, (PPCany_fctiduz f128:$RB))]>;
+        [(set f128:$RST, (PPCany_fp_to_u64 f128:$RB))]>;
     def XSCVQPUWZ : X_VT5_XO5_VB5<63,  1, 836, "xscvqpuwz",
-        [(set f128:$RST, (PPCany_fctiwuz f128:$RB))]>;
+        [(set f128:$RST, (PPCany_fp_to_u32 f128:$RB))]>;
   }
 
   // Convert (Un)Signed DWord -> QP.
@@ -1843,35 +1843,35 @@ def ScalarLoads {
 }
 
 def DWToSPExtractConv {
-  dag El0US1 = (f32 (PPCfcfidus
+  dag El0US1 = (f32 (PPCuint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S1, 0))))));
-  dag El1US1 = (f32 (PPCfcfidus
+  dag El1US1 = (f32 (PPCuint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S1, 1))))));
-  dag El0US2 = (f32 (PPCfcfidus
+  dag El0US2 = (f32 (PPCuint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S2, 0))))));
-  dag El1US2 = (f32 (PPCfcfidus
+  dag El1US2 = (f32 (PPCuint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S2, 1))))));
-  dag El0SS1 = (f32 (PPCfcfids
+  dag El0SS1 = (f32 (PPCsint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S1, 0))))));
-  dag El1SS1 = (f32 (PPCfcfids
+  dag El1SS1 = (f32 (PPCsint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S1, 1))))));
-  dag El0SS2 = (f32 (PPCfcfids
+  dag El0SS2 = (f32 (PPCsint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S2, 0))))));
-  dag El1SS2 = (f32 (PPCfcfids
+  dag El1SS2 = (f32 (PPCsint_to_fp
                     (f64 (PPCmtvsra (i64 (vector_extract v2i64:$S2, 1))))));
   dag BVU = (v4f32 (build_vector El0US1, El1US1, El0US2, El1US2));
   dag BVS = (v4f32 (build_vector El0SS1, El1SS1, El0SS2, El1SS2));
 }
 
 def WToDPExtractConv {
-  dag El0S = (f64 (PPCfcfid (PPCmtvsra (extractelt v4i32:$A, 0))));
-  dag El1S = (f64 (PPCfcfid (PPCmtvsra (extractelt v4i32:$A, 1))));
-  dag El2S = (f64 (PPCfcfid (PPCmtvsra (extractelt v4i32:$A, 2))));
-  dag El3S = (f64 (PPCfcfid (PPCmtvsra (extractelt v4i32:$A, 3))));
-  dag El0U = (f64 (PPCfcfidu (PPCmtvsrz (extractelt v4i32:$A, 0))));
-  dag El1U = (f64 (PPCfcfidu (PPCmtvsrz (extractelt v4i32:$A, 1))));
-  dag El2U = (f64 (PPCfcfidu (PPCmtvsrz (extractelt v4i32:$A, 2))));
-  dag El3U = (f64 (PPCfcfidu (PPCmtvsrz (extractelt v4i32:$A, 3))));
+  dag El0S = (f64 (PPCsint_to_fp (PPCmtvsra (extractelt v4i32:$A, 0))));
+  dag El1S = (f64 (PPCsint_to_fp (PPCmtvsra (extractelt v4i32:$A, 1))));
+  dag El2S = (f64 (PPCsint_to_fp (PPCmtvsra (extractelt v4i32:$A, 2))));
+  dag El3S = (f64 (PPCsint_to_fp (PPCmtvsra (extractelt v4i32:$A, 3))));
+  dag El0U = (f64 (PPCuint_to_fp (PPCmtvsrz (extractelt v4i32:$A, 0))));
+  dag El1U = (f64 (PPCuint_to_fp (PPCmtvsrz (extractelt v4i32:$A, 1))));
+  dag El2U = (f64 (PPCuint_to_fp (PPCmtvsrz (extractelt v4i32:$A, 2))));
+  dag El3U = (f64 (PPCuint_to_fp (PPCmtvsrz (extractelt v4i32:$A, 3))));
   dag BV02S = (v2f64 (build_vector El0S, El2S));
   dag BV13S = (v2f64 (build_vector El1S, El3S));
   dag BV02U = (v2f64 (build_vector El0U, El2U));
@@ -2228,14 +2228,14 @@ def DblToFlt {
 }
 
 def ExtDbl {
-  dag A0S = (i32 (PPCmfvsr (f64 (PPCfctiwz (f64 (extractelt v2f64:$A, 0))))));
-  dag A1S = (i32 (PPCmfvsr (f64 (PPCfctiwz (f64 (extractelt v2f64:$A, 1))))));
-  dag B0S = (i32 (PPCmfvsr (f64 (PPCfctiwz (f64 (extractelt v2f64:$B, 0))))));
-  dag B1S = (i32 (PPCmfvsr (f64 (PPCfctiwz (f64 (extractelt v2f64:$B, 1))))));
-  dag A0U = (i32 (PPCmfvsr (f64 (PPCfctiwuz (f64 (extractelt v2f64:$A, 0))))));
-  dag A1U = (i32 (PPCmfvsr (f64 (PPCfctiwuz (f64 (extractelt v2f64:$A, 1))))));
-  dag B0U = (i32 (PPCmfvsr (f64 (PPCfctiwuz (f64 (extractelt v2f64:$B, 0))))));
-  dag B1U = (i32 (PPCmfvsr (f64 (PPCfctiwuz (f64 (extractelt v2f64:$B, 1))))));
+  dag A0S = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 (f64 (extractelt v2f64:$A, 0))))));
+  dag A1S = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 (f64 (extractelt v2f64:$A, 1))))));
+  dag B0S = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 (f64 (extractelt v2f64:$B, 0))))));
+  dag B1S = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 (f64 (extractelt v2f64:$B, 1))))));
+  dag A0U = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 (f64 (extractelt v2f64:$A, 0))))));
+  dag A1U = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 (f64 (extractelt v2f64:$A, 1))))));
+  dag B0U = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 (f64 (extractelt v2f64:$B, 0))))));
+  dag B1U = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 (f64 (extractelt v2f64:$B, 1))))));
 }
 
 def ByteToWord {
@@ -2290,64 +2290,64 @@ def WordToDWord {
 }
 
 def FltToIntLoad {
-  dag A = (i32 (PPCmfvsr (PPCfctiwz (f64 (extloadf32 ForceXForm:$A)))));
+  dag A = (i32 (PPCmfvsr (PPCfp_to_i32 (f64 (extloadf32 ForceXForm:$A)))));
 }
 def FltToUIntLoad {
-  dag A = (i32 (PPCmfvsr (PPCfctiwuz (f64 (extloadf32 ForceXForm:$A)))));
+  dag A = (i32 (PPCmfvsr (PPCfp_to_u32 (f64 (extloadf32 ForceXForm:$A)))));
 }
 def FltToLongLoad {
-  dag A = (i64 (PPCmfvsr (PPCfctidz (f64 (extloadf32 ForceXForm:$A)))));
+  dag A = (i64 (PPCmfvsr (PPCfp_to_i64 (f64 (extloadf32 ForceXForm:$A)))));
 }
 def FltToLongLoadP9 {
-  dag A = (i64 (PPCmfvsr (PPCfctidz (f64 (extloadf32 DSForm:$A)))));
+  dag A = (i64 (PPCmfvsr (PPCfp_to_i64 (f64 (extloadf32 DSForm:$A)))));
 }
 def FltToULongLoad {
-  dag A = (i64 (PPCmfvsr (PPCfctiduz (f64 (extloadf32 ForceXForm:$A)))));
+  dag A = (i64 (PPCmfvsr (PPCfp_to_u64 (f64 (extloadf32 ForceXForm:$A)))));
 }
 def FltToULongLoadP9 {
-  dag A = (i64 (PPCmfvsr (PPCfctiduz (f64 (extloadf32 DSForm:$A)))));
+  dag A = (i64 (PPCmfvsr (PPCfp_to_u64 (f64 (extloadf32 DSForm:$A)))));
 }
 def FltToLong {
-  dag A = (i64 (PPCmfvsr (f64 (PPCfctidz (fpextend f32:$A)))));
+  dag A = (i64 (PPCmfvsr (f64 (PPCfp_to_i64 (fpextend f32:$A)))));
 }
 def FltToULong {
-  dag A = (i64 (PPCmfvsr (f64 (PPCfctiduz (fpextend f32:$A)))));
+  dag A = (i64 (PPCmfvsr (f64 (PPCfp_to_u64 (fpextend f32:$A)))));
 }
 def DblToInt {
-  dag A = (i32 (PPCmfvsr (f64 (PPCfctiwz f64:$A))));
-  dag B = (i32 (PPCmfvsr (f64 (PPCfctiwz f64:$B))));
-  dag C = (i32 (PPCmfvsr (f64 (PPCfctiwz f64:$C))));
-  dag D = (i32 (PPCmfvsr (f64 (PPCfctiwz f64:$D))));
+  dag A = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 f64:$A))));
+  dag B = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 f64:$B))));
+  dag C = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 f64:$C))));
+  dag D = (i32 (PPCmfvsr (f64 (PPCfp_to_i32 f64:$D))));
 }
 def DblToUInt {
-  dag A = (i32 (PPCmfvsr (f64 (PPCfctiwuz f64:$A))));
-  dag B = (i32 (PPCmfvsr (f64 (PPCfctiwuz f64:$B))));
-  dag C = (i32 (PPCmfvsr (f64 (PPCfctiwuz f64:$C))));
-  dag D = (i32 (PPCmfvsr (f64 (PPCfctiwuz f64:$D))));
+  dag A = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 f64:$A))));
+  dag B = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 f64:$B))));
+  dag C = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 f64:$C))));
+  dag D = (i32 (PPCmfvsr (f64 (PPCfp_to_u32 f64:$D))));
 }
 def DblToLong {
-  dag A = (i64 (PPCmfvsr (f64 (PPCfctidz f64:$A))));
+  dag A = (i64 (PPCmfvsr (f64 (PPCfp_to_i64 f64:$A))));
 }
 def DblToULong {
-  dag A = (i64 (PPCmfvsr (f64 (PPCfctiduz f64:$A))));
+  dag A = (i64 (PPCmfvsr (f64 (PPCfp_to_u64 f64:$A))));
 }
 def DblToIntLoad {
-  dag A = (i32 (PPCmfvsr (PPCfctiwz (f64 (load ForceXForm:$A)))));
+  dag A = (i32 (PPCmfvsr (PPCfp_to_i32 (f64 (load ForceXForm:$A)))));
 }
 def DblToIntLoadP9 {
-  dag A = (i32 (PPCmfvsr (PPCfctiwz (f64 (load DSForm:$A)))));
+  dag A = (i32 (PPCmfvsr (PPCfp_to_i32 (f64 (load DSForm:$A)))));
 }
 def DblToUIntLoad {
-  dag A = (i32 (PPCmfvsr (PPCfctiwuz (f64 (load ForceXForm:$A)))));
+  dag A = (i32 (PPCmfvsr (PPCfp_to_u32 (f64 (load ForceXForm:$A)))));
 }
 def DblToUIntLoadP9 {
-  dag A = (i32 (PPCmfvsr (PPCfctiwuz (f64 (load DSForm:$A)))));
+  dag A = (i32 (PPCmfvsr (PPCfp_to_u32 (f64 (load DSForm:$A)))));
 }
 def DblToLongLoad {
-  dag A = (i64 (PPCmfvsr (PPCfctidz (f64 (load ForceXForm:$A)))));
+  dag A = (i64 (PPCmfvsr (PPCfp_to_i64 (f64 (load ForceXForm:$A)))));
 }
 def DblToULongLoad {
-  dag A = (i64 (PPCmfvsr (PPCfctiduz (f64 (load ForceXForm:$A)))));
+  dag A = (i64 (PPCmfvsr (PPCfp_to_u64 (f64 (load ForceXForm:$A)))));
 }
 
 // FP load dags (for f32 -> v4f32)
@@ -2929,13 +2929,13 @@ def : Pat<(f64 (extractelt v2f64:$S, 0)),
           (f64 (EXTRACT_SUBREG $S, sub_64))>;
 def : Pat<(f64 (extractelt v2f64:$S, 1)),
           (f64 (EXTRACT_SUBREG (XXPERMDI $S, $S, 2), sub_64))>;
-def : Pat<(f64 (PPCfcfid (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
+def : Pat<(f64 (PPCsint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
           (f64 (XSCVSXDDP (COPY_TO_REGCLASS $S, VSFRC)))>;
-def : Pat<(f64 (PPCfcfid (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
+def : Pat<(f64 (PPCsint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
           (f64 (XSCVSXDDP (COPY_TO_REGCLASS (XXPERMDI $S, $S, 2), VSFRC)))>;
-def : Pat<(f64 (PPCfcfidu (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
+def : Pat<(f64 (PPCuint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
           (f64 (XSCVUXDDP (COPY_TO_REGCLASS $S, VSFRC)))>;
-def : Pat<(f64 (PPCfcfidu (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
+def : Pat<(f64 (PPCuint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
           (f64 (XSCVUXDDP (COPY_TO_REGCLASS (XXPERMDI $S, $S, 2), VSFRC)))>;
 
 def : Pat<(f64 (vector_extract v2f64:$S, i64:$Idx)),
@@ -3053,13 +3053,13 @@ def : Pat<(v2i64 (PPCld_vec_be ForceXForm:$src)), (LXVD2X ForceXForm:$src)>;
 def : Pat<(PPCst_vec_be v2i64:$rS, ForceXForm:$dst), (STXVD2X $rS, ForceXForm:$dst)>;
 def : Pat<(v4i32 (PPCld_vec_be ForceXForm:$src)), (LXVW4X ForceXForm:$src)>;
 def : Pat<(PPCst_vec_be v4i32:$rS, ForceXForm:$dst), (STXVW4X $rS, ForceXForm:$dst)>;
-def : Pat<(f64 (PPCfcfid (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
+def : Pat<(f64 (PPCsint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
           (f64 (XSCVSXDDP (COPY_TO_REGCLASS (XXPERMDI $S, $S, 2), VSFRC)))>;
-def : Pat<(f64 (PPCfcfid (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
+def : Pat<(f64 (PPCsint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
           (f64 (XSCVSXDDP (COPY_TO_REGCLASS (f64 (COPY_TO_REGCLASS $S, VSRC)), VSFRC)))>;
-def : Pat<(f64 (PPCfcfidu (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
+def : Pat<(f64 (PPCuint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 0))))),
           (f64 (XSCVUXDDP (COPY_TO_REGCLASS (XXPERMDI $S, $S, 2), VSFRC)))>;
-def : Pat<(f64 (PPCfcfidu (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
+def : Pat<(f64 (PPCuint_to_fp (PPCmtvsra (i64 (vector_extract v2i64:$S, 1))))),
           (f64 (XSCVUXDDP (COPY_TO_REGCLASS (f64 (COPY_TO_REGCLASS $S, VSRC)), VSFRC)))>;
 
 def : Pat<(f64 (vector_extract v2f64:$S, i64:$Idx)),
@@ -3380,21 +3380,21 @@ def : Pat<(f32 (vector_extract v4f32:$S, 2)),
 def : Pat<(f32 (vector_extract v4f32:$S, 3)),
           (f32 (XSCVSPDPN (XXSLDWI $S, $S, 3)))>;
 
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 0))))>;
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 1))))>;
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 2))))>;
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 3))))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 0)), VSFRC))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 1)), VSFRC))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 2)), VSFRC))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 3)), VSFRC))>;
 
 def : Pat<(f32 (vector_extract v4f32:$S, i32:$Idx)),
@@ -3479,21 +3479,21 @@ def : Pat<(f32 (vector_extract v4f32:$S, 3)),
 def : Pat<(f32 (vector_extract v4f32:$S, i64:$Idx)),
           (f32 VectorExtractions.LE_VARIABLE_FLOAT)>;
 
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 3))))>;
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 2))))>;
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 1))))>;
-def : Pat<(f32 (PPCfcfids (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f32 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
           (f32 (XSCVSPDPN (XVCVSXWSP (XXSPLTW $A, 0))))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 0)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 3)), VSFRC))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 1)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 2)), VSFRC))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 2)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 1)), VSFRC))>;
-def : Pat<(f64 (PPCfcfid (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f64 (PPCsint_to_fp (f64 (PPCmtvsra (i32 (extractelt v4i32:$A, 3)))))),
           (f64 (COPY_TO_REGCLASS (XVCVSXWDP (XXSPLTW $A, 0)), VSFRC))>;
 
 // LIWAX - This instruction is used for sign extending i32 -> i64.
@@ -4172,21 +4172,21 @@ defm : ScalToVecWPermute<
   (VSPLTHs 3, (LXSIHZX ForceXForm:$src)),
   (SUBREG_TO_REG (i64 1), (LXSIHZX ForceXForm:$src), sub_64)>;
 
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 0)))>;
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 4)))>;
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 8)))>;
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 12)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 0)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 4)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 8)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 12)))>;
 def : Pat<(v4i32 (insertelt v4i32:$A, i32:$B, 0)),
           (v4i32 (XXINSERTW v4i32:$A, AlignValues.I32_TO_BE_WORD1, 0))>;
@@ -4381,25 +4381,25 @@ foreach Idx = 0-7 in {
                     (and (i32 (vector_extract v8i16:$src, Idx)), 65535))),
             (f128 (XSCVUDQP (EXTRACT_SUBREG
                               (VEXTRACTUH !add(Idx, Idx), $src), sub_64)))>;
-  def : Pat<(f32 (PPCfcfidus
+  def : Pat<(f32 (PPCuint_to_fp
                    (f64 (PPCmtvsrz (and (i32 (vector_extract v8i16:$src, Idx)),
                                         65535))))),
             (f32 (XSCVUXDSP (EXTRACT_SUBREG
                               (VEXTRACTUH !add(Idx, Idx), $src), sub_64)))>;
-  def : Pat<(f32 (PPCfcfids
+  def : Pat<(f32 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                           (i32 (sext_inreg (vector_extract v8i16:$src, Idx),
                                i16)))))),
           (f32 (XSCVSXDSP (EXTRACT_SUBREG
                             (VEXTSH2D (VEXTRACTUH !add(Idx, Idx), $src)),
                             sub_64)))>;
-  def : Pat<(f64 (PPCfcfidu
+  def : Pat<(f64 (PPCuint_to_fp
                    (f64 (PPCmtvsrz
                           (and (i32 (vector_extract v8i16:$src, Idx)),
                                65535))))),
             (f64 (XSCVUXDDP (EXTRACT_SUBREG
                               (VEXTRACTUH !add(Idx, Idx), $src), sub_64)))>;
-  def : Pat<(f64 (PPCfcfid
+  def : Pat<(f64 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                           (i32 (sext_inreg (vector_extract v8i16:$src, Idx),
                                i16)))))),
@@ -4420,26 +4420,26 @@ foreach Idx = 0-15 in {
             (f128 (XSCVUDQP
                     (EXTRACT_SUBREG (VEXTRACTUB Idx, $src), sub_64)))>;
 
-  def : Pat<(f32 (PPCfcfidus
+  def : Pat<(f32 (PPCuint_to_fp
                    (f64 (PPCmtvsrz
                           (and (i32 (vector_extract v16i8:$src, Idx)),
                                255))))),
             (f32 (XSCVUXDSP (EXTRACT_SUBREG
                               (VEXTRACTUB !add(Idx, Idx), $src), sub_64)))>;
-  def : Pat<(f32 (PPCfcfids
+  def : Pat<(f32 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                           (i32 (sext_inreg (vector_extract v16i8:$src, Idx),
                                i8)))))),
           (f32 (XSCVSXDSP (EXTRACT_SUBREG
                             (VEXTSH2D (VEXTRACTUB !add(Idx, Idx), $src)),
                             sub_64)))>;
-  def : Pat<(f64 (PPCfcfidu
+  def : Pat<(f64 (PPCuint_to_fp
                    (f64 (PPCmtvsrz
                           (and (i32 (vector_extract v16i8:$src, Idx)),
                           255))))),
             (f64 (XSCVUXDDP (EXTRACT_SUBREG
                               (VEXTRACTUB !add(Idx, Idx), $src), sub_64)))>;
-  def : Pat<(f64 (PPCfcfid
+  def : Pat<(f64 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                           (i32 (sext_inreg (vector_extract v16i8:$src, Idx),
                                i8)))))),
@@ -4456,21 +4456,21 @@ def : Pat<(f128 (uint_to_fp (i32 (PPCmfvsr f64:$src)))),
 
 // Little endian Power9 subtarget.
 let Predicates = [HasVSX, HasP9Vector, IsLittleEndian] in {
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 12)))>;
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 8)))>;
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 4)))>;
-def : Pat<(f32 (PPCfcfidus (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f32 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
           (f32 (XSCVUXDSP (XXEXTRACTUW $A, 0)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 0)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 12)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 1)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 8)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 2)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 4)))>;
-def : Pat<(f64 (PPCfcfidu (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
+def : Pat<(f64 (PPCuint_to_fp (f64 (PPCmtvsrz (i32 (extractelt v4i32:$A, 3)))))),
           (f64 (XSCVUXDDP (XXEXTRACTUW $A, 0)))>;
 def : Pat<(v4i32 (insertelt v4i32:$A, i32:$B, 0)),
           (v4i32 (XXINSERTW v4i32:$A, AlignValues.I32_TO_BE_WORD1, 12))>;
@@ -4685,13 +4685,13 @@ foreach Idx = [[0,14],[1,12],[2,10],[3,8],[4,6],[5,4],[6,2],[7,0]] in {
                          65535))),
             (f128 (XSCVUDQP (EXTRACT_SUBREG
                               (VEXTRACTUH !head(!tail(Idx)), $src), sub_64)))>;
-  def : Pat<(f32 (PPCfcfidus
+  def : Pat<(f32 (PPCuint_to_fp
                    (f64 (PPCmtvsrz
                           (and (i32 (vector_extract v8i16:$src, !head(Idx))),
                           65535))))),
             (f32 (XSCVUXDSP (EXTRACT_SUBREG
                               (VEXTRACTUH !head(!tail(Idx)), $src), sub_64)))>;
-  def : Pat<(f32 (PPCfcfids
+  def : Pat<(f32 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                           (i32 (sext_inreg (vector_extract v8i16:$src,
                                            !head(Idx)), i16)))))),
@@ -4699,13 +4699,13 @@ foreach Idx = [[0,14],[1,12],[2,10],[3,8],[4,6],[5,4],[6,2],[7,0]] in {
                     (EXTRACT_SUBREG
                      (VEXTSH2D (VEXTRACTUH !head(!tail(Idx)), $src)),
                      sub_64)))>;
-  def : Pat<(f64 (PPCfcfidu
+  def : Pat<(f64 (PPCuint_to_fp
                    (f64 (PPCmtvsrz
                           (and (i32 (vector_extract v8i16:$src, !head(Idx))),
                           65535))))),
             (f64 (XSCVUXDDP (EXTRACT_SUBREG
                               (VEXTRACTUH !head(!tail(Idx)), $src), sub_64)))>;
-  def : Pat<(f64 (PPCfcfid
+  def : Pat<(f64 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                         (i32 (sext_inreg
                             (vector_extract v8i16:$src, !head(Idx)), i16)))))),
@@ -4732,13 +4732,13 @@ foreach Idx = [[0,15],[1,14],[2,13],[3,12],[4,11],[5,10],[6,9],[7,8],[8,7],
                     (EXTRACT_SUBREG
                       (VEXTRACTUB !head(!tail(Idx)), $src), sub_64)))>;
 
-  def : Pat<(f32 (PPCfcfidus
+  def : Pat<(f32 (PPCuint_to_fp
                    (f64 (PPCmtvsrz
                           (and (i32 (vector_extract v16i8:$src, !head(Idx))),
                           255))))),
             (f32 (XSCVUXDSP (EXTRACT_SUBREG
                               (VEXTRACTUB !head(!tail(Idx)), $src), sub_64)))>;
-  def : Pat<(f32 (PPCfcfids
+  def : Pat<(f32 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                           (i32 (sext_inreg
                             (vector_extract v16i8:$src, !head(Idx)), i8)))))),
@@ -4746,13 +4746,13 @@ foreach Idx = [[0,15],[1,14],[2,13],[3,12],[4,11],[5,10],[6,9],[7,8],[8,7],
                     (EXTRACT_SUBREG (VEXTSH2D
                                       (VEXTRACTUB !head(!tail(Idx)), $src)),
                                     sub_64)))>;
-  def : Pat<(f64 (PPCfcfidu
+  def : Pat<(f64 (PPCuint_to_fp
                    (f64 (PPCmtvsrz
                           (and (i32
                             (vector_extract v16i8:$src, !head(Idx))), 255))))),
             (f64 (XSCVUXDDP (EXTRACT_SUBREG
                               (VEXTRACTUB !head(!tail(Idx)), $src), sub_64)))>;
-  def : Pat<(f64 (PPCfcfidu
+  def : Pat<(f64 (PPCuint_to_fp
                    (f64 (PPCmtvsra
                         (i32 (sext_inreg
                             (vector_extract v16i8:$src, !head(Idx)), i8)))))),
@@ -4761,7 +4761,7 @@ foreach Idx = [[0,15],[1,14],[2,13],[3,12],[4,11],[5,10],[6,9],[7,8],[8,7],
                                       (VEXTRACTUB !head(!tail(Idx)), $src)),
                                     sub_64)))>;
 
-  def : Pat<(f64 (PPCfcfid
+  def : Pat<(f64 (PPCsint_to_fp
                    (f64 (PPCmtvsra
                         (i32 (sext_inreg
                           (vector_extract v16i8:$src, !head(Idx)), i8)))))),


### PR DESCRIPTION
PowerPC backend uses `FCFID*` and `FCTI(D|W)*` as custom ISD node name for in-place conversion between float and integers. But we do not always use these instructions.

Also, separate nodes from int to f32/f64/f128 are not needed, since we can differentiate them by node types.

Migrated from https://reviews.llvm.org/D148494