### PR TITLE
[XCOFF][OBJECT] get symbol size by calling XCOFF interfaces

### DIFF
--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -780,27 +780,35 @@ public:
            "Symbol table entry pointer cannot be nullptr!");
   }
 
-#define Entry32                                                                \
-  reinterpret_cast<const XCOFFSymbolEntry32 *>(getRawDataRefImpl().p)
-#define Entry64                                                                \
-  reinterpret_cast<const XCOFFSymbolEntry64 *>(getRawDataRefImpl().p)
-
-  const XCOFFSymbolEntry32 *getSymbol32() const { return Entry32; }
-  const XCOFFSymbolEntry64 *getSymbol64() const { return Entry64; }
+  const XCOFFSymbolEntry32 *getSymbol32() const {
+    return reinterpret_cast<const XCOFFSymbolEntry32 *>(getRawDataRefImpl().p);
+  }
+  const XCOFFSymbolEntry64 *getSymbol64() const {
+    return reinterpret_cast<const XCOFFSymbolEntry64 *>(getRawDataRefImpl().p);
+  }
 
   uint64_t getValue() const {
     return getObject()->is64Bit() ? getValue64() : getValue32();
   }
 
-  uint32_t getValue32() const { return Entry32->Value; }
+  uint32_t getValue32() const {
+    return reinterpret_cast<const XCOFFSymbolEntry32 *>(getRawDataRefImpl().p)
+        ->Value;
+  }
 
-  uint64_t getValue64() const { return Entry64->Value; }
+  uint64_t getValue64() const {
+    return reinterpret_cast<const XCOFFSymbolEntry64 *>(getRawDataRefImpl().p)
+        ->Value;
+  }
 
   uint64_t getSize() const {
     return getObject()->getSymbolSize(getRawDataRefImpl());
   }
 
-#define GETVALUE(X)  getObject()->is64Bit() ? Entry64->X : Entry32->X
+#define GETVALUE(X)                                                            \
+  getObject()->is64Bit()                                                       \
+      ? reinterpret_cast<const XCOFFSymbolEntry64 *>(getRawDataRefImpl().p)->X \
+      : reinterpret_cast<const XCOFFSymbolEntry32 *>(getRawDataRefImpl().p)->X
 
   int16_t getSectionNumber() const { return GETVALUE(SectionNumber); }
 
@@ -825,11 +833,8 @@ public:
 #undef GETVALUE
 
   uintptr_t getEntryAddress() const {
-    return getObject()->is64Bit() ? reinterpret_cast<uintptr_t>(Entry64)
-                                  : reinterpret_cast<uintptr_t>(Entry32);
+    return getRawDataRefImpl().p;
   }
-#undef Entry32
-#undef Entry64
 
   Expected<StringRef> getName() const;
   bool isFunction() const;

--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -774,7 +774,7 @@ public:
 
   XCOFFSymbolRef(DataRefImpl SymEntDataRef,
                  const XCOFFObjectFile *OwningObjectPtr)
-      : OwningObjectPtr(OwningObjectPtr) {
+      : SymbolRef(SymEntDataRef, OwningObjectPtr) {
     assert(OwningObjectPtr && "OwningObjectPtr cannot be nullptr!");
     assert(SymEntDataRef.p != 0 &&
            "Symbol table entry pointer cannot be nullptr!");
@@ -795,8 +795,7 @@ public:
   uint64_t getValue64() const { return Entry64->Value; }
 
   uint64_t getSize() const {
-    return cast<XCOFFObjectFile>(BasicSymbolRef::getObject())
-        ->getSymbolSize(getRawDataRefImpl());
+    return getObject()->getSymbolSize(getRawDataRefImpl());
   }
 
 #define GETVALUE(X) Entry32 ? Entry32->X : Entry64->X
@@ -834,7 +833,10 @@ public:
   Expected<XCOFFCsectAuxRef> getXCOFFCsectAuxRef() const;
 
 private:
-  const XCOFFObjectFile *OwningObjectPtr;
+  const XCOFFObjectFile *getObject() const {
+    return cast<XCOFFObjectFile>(BasicSymbolRef::getObject());
+  }
+
   const XCOFFSymbolEntry32 *Entry32 = nullptr;
   const XCOFFSymbolEntry64 *Entry64 = nullptr;
 };

--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -844,8 +844,7 @@ private:
 class xcoff_symbol_iterator : public symbol_iterator {
 public:
   xcoff_symbol_iterator(const basic_symbol_iterator &B)
-      : symbol_iterator(SymbolRef(B->getRawDataRefImpl(),
-                                  cast<XCOFFObjectFile>(B->getObject()))) {}
+      : symbol_iterator(B) {}
 
   const XCOFFSymbolRef *operator->() const {
     return static_cast<const XCOFFSymbolRef *>(symbol_iterator::operator->());

--- a/llvm/lib/Object/SymbolSize.cpp
+++ b/llvm/lib/Object/SymbolSize.cpp
@@ -59,6 +59,13 @@ llvm::object::computeSymbolSizes(const ObjectFile &O) {
     return Ret;
   }
 
+  if (const auto *E = dyn_cast<XCOFFObjectFile>(&O)) {
+    auto Syms = E->symbols();
+    for (XCOFFSymbolRef Sym : Syms)
+      Ret.push_back({Sym, Sym.getSize()});
+    return Ret;
+  }
+
   // Collect sorted symbol addresses. Include dummy addresses for the end
   // of each section.
   std::vector<SymEntry> Addresses;

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1252,7 +1252,7 @@ bool XCOFFSymbolRef::isFunction() const {
     return false;
 
   const int16_t SectNum = getSectionNumber();
-  Expected<DataRefImpl> SI = OwningObjectPtr->getSectionByNum(SectNum);
+  Expected<DataRefImpl> SI = getObject()->getSectionByNum(SectNum);
   if (!SI) {
     // If we could not get the section, then this symbol should not be
     // a function. So consume the error and return `false` to move on.
@@ -1260,7 +1260,7 @@ bool XCOFFSymbolRef::isFunction() const {
     return false;
   }
 
-  return (OwningObjectPtr->getSectionFlags(SI.get()) & XCOFF::STYP_TEXT);
+  return (getObject()->getSectionFlags(SI.get()) & XCOFF::STYP_TEXT);
 }
 
 bool XCOFFSymbolRef::isCsectSymbol() const {
@@ -1279,13 +1279,13 @@ Expected<XCOFFCsectAuxRef> XCOFFSymbolRef::getXCOFFCsectAuxRef() const {
   if (auto Err = NameOrErr.takeError())
     return std::move(Err);
 
-  uint32_t SymbolIdx = OwningObjectPtr->getSymbolIndex(getEntryAddress());
+  uint32_t SymbolIdx = getObject()->getSymbolIndex(getEntryAddress());
   if (!NumberOfAuxEntries) {
     return createError("csect symbol \"" + *NameOrErr + "\" with index " +
                        Twine(SymbolIdx) + " contains no auxiliary entry");
   }
 
-  if (!OwningObjectPtr->is64Bit()) {
+  if (!getObject()->is64Bit()) {
     // In XCOFF32, the csect auxilliary entry is always the last auxiliary
     // entry for the symbol.
     uintptr_t AuxAddr = XCOFFObjectFile::getAdvancedSymbolEntryAddress(
@@ -1298,10 +1298,10 @@ Expected<XCOFFCsectAuxRef> XCOFFSymbolRef::getXCOFFCsectAuxRef() const {
   for (uint8_t Index = NumberOfAuxEntries; Index > 0; --Index) {
     uintptr_t AuxAddr = XCOFFObjectFile::getAdvancedSymbolEntryAddress(
         getEntryAddress(), Index);
-    if (*OwningObjectPtr->getSymbolAuxType(AuxAddr) ==
+    if (*getObject()->getSymbolAuxType(AuxAddr) ==
         XCOFF::SymbolAuxType::AUX_CSECT) {
 #ifndef NDEBUG
-      OwningObjectPtr->checkSymbolEntryPointer(AuxAddr);
+      getObject()->checkSymbolEntryPointer(AuxAddr);
 #endif
       return XCOFFCsectAuxRef(viewAs<XCOFFCsectAuxEnt64>(AuxAddr));
     }
@@ -1322,10 +1322,10 @@ Expected<StringRef> XCOFFSymbolRef::getName() const {
     if (Entry32->NameInStrTbl.Magic != XCOFFSymbolRef::NAME_IN_STR_TBL_MAGIC)
       return generateXCOFFFixedNameStringRef(Entry32->SymbolName);
 
-    return OwningObjectPtr->getStringTableEntry(Entry32->NameInStrTbl.Offset);
+    return getObject()->getStringTableEntry(Entry32->NameInStrTbl.Offset);
   }
 
-  return OwningObjectPtr->getStringTableEntry(Entry64->Offset);
+  return getObject()->getStringTableEntry(Entry64->Offset);
 }
 
 // Explictly instantiate template classes.

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1318,14 +1318,15 @@ Expected<StringRef> XCOFFSymbolRef::getName() const {
   if (getStorageClass() & 0x80)
     return StringRef("Unimplemented Debug Name");
 
-  if (Entry32) {
-    if (Entry32->NameInStrTbl.Magic != XCOFFSymbolRef::NAME_IN_STR_TBL_MAGIC)
-      return generateXCOFFFixedNameStringRef(Entry32->SymbolName);
+  if (!getObject()->is64Bit()) {
+    if (getSymbol32()->NameInStrTbl.Magic !=
+        XCOFFSymbolRef::NAME_IN_STR_TBL_MAGIC)
+      return generateXCOFFFixedNameStringRef(getSymbol32()->SymbolName);
 
-    return getObject()->getStringTableEntry(Entry32->NameInStrTbl.Offset);
+    return getObject()->getStringTableEntry(getSymbol32()->NameInStrTbl.Offset);
   }
 
-  return getObject()->getStringTableEntry(Entry64->Offset);
+  return getObject()->getStringTableEntry(getSymbol64()->Offset);
 }
 
 // Explictly instantiate template classes.

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -689,6 +689,10 @@ basic_symbol_iterator XCOFFObjectFile::symbol_end() const {
   return basic_symbol_iterator(SymbolRef(SymDRI, this));
 }
 
+XCOFFObjectFile::xcoff_symbol_iterator_range XCOFFObjectFile::symbols() const {
+  return xcoff_symbol_iterator_range(symbol_begin(), symbol_end());
+}
+
 section_iterator XCOFFObjectFile::section_begin() const {
   DataRefImpl DRI;
   DRI.p = getSectionHeaderTableAddress();

--- a/llvm/test/DebugInfo/Symbolize/XCOFF/xcoff-symbolize-data.ll
+++ b/llvm/test/DebugInfo/Symbolize/XCOFF/xcoff-symbolize-data.ll
@@ -35,23 +35,20 @@
 ; CHECK-EMPTY:
 
 ;; Test a function scope static variable.
-;; FIXME: fix the wrong size 152
 ; CHECK: f()::function_global
-; CHECK-NEXT: 144 152
+; CHECK-NEXT: 144 4
 ; CHECK-NEXT: /t.cpp:8
 ; CHECK-EMPTY:
 
 ;; Test a global scope static variable that is used in current compilation unit.
-;; FIXME: fix the wrong size 152
 ; CHECK: beta
-; CHECK-NEXT: 148 152
+; CHECK-NEXT: 148 4
 ; CHECK-NEXT: /t.cpp:13
 ; CHECK-EMPTY:
 
 ;; Test another global scope static variable that is used in current compilation unit.
-;; FIXME: fix the wrong size 152
 ; CHECK: alpha
-; CHECK-NEXT: 152 152
+; CHECK-NEXT: 152 4
 ; CHECK-NEXT: /t.cpp:12
 ; CHECK-EMPTY:
 


### PR DESCRIPTION
Computing the symbol size as the gap between sorted symbols are not right for XCOFF. 

For XCOFF, the size info is stored in aux symbol and can be got from existing XCOFF interface `getSymbolSize()`.
This patch changes XCOFFObjectFile to call this API to get sizes for symbols.