### PR TITLE
[lldb] Add SetValueFromCString API to SyntheticFronend

### DIFF
--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -589,6 +589,14 @@ public:
 
   virtual bool IsSynthetic() { return false; }
 
+  void SetSyntheticFrontend(SyntheticChildrenFrontEnd *synth_front) {
+    m_synthetic_frontend = synth_front;
+  }
+
+  SyntheticChildrenFrontEnd *GetSyntheticFrontend() const {
+    return m_synthetic_frontend;
+  }
+
   lldb::ValueObjectSP
   GetQualifiedRepresentationIfAvailable(lldb::DynamicValueType dynValue,
                                         bool synthValue);
@@ -897,6 +905,9 @@ protected:
 
   /// Unique identifier for every value object.
   UserID m_id;
+
+  // If frontend exist - we may try to update our value through it
+  SyntheticChildrenFrontEnd *m_synthetic_frontend = nullptr;
 
   // Utility class for initializing all bitfields in ValueObject's constructors.
   // FIXME: This could be done via default initializers once we have C++20.

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -34,9 +34,13 @@ protected:
 
 public:
   SyntheticChildrenFrontEnd(ValueObject &backend)
-      : m_backend(backend), m_valid(true) {}
+      : m_backend(backend), m_valid(true) {
+    m_backend.SetSyntheticFrontend(this);
+  }
 
-  virtual ~SyntheticChildrenFrontEnd() = default;
+  virtual ~SyntheticChildrenFrontEnd() {
+    m_backend.SetSyntheticFrontend(nullptr);
+  }
 
   virtual size_t CalculateNumChildren() = 0;
 
@@ -74,6 +78,10 @@ public:
   // expected to use the return as the name of the type of this ValueObject for
   // display purposes
   virtual ConstString GetSyntheticTypeName() { return ConstString(); }
+
+  virtual bool SetValueFromCString(const char *value_str, Status &error) {
+    return false;
+  }
 
   typedef std::shared_ptr<SyntheticChildrenFrontEnd> SharedPointer;
   typedef std::unique_ptr<SyntheticChildrenFrontEnd> AutoPointer;

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1479,7 +1479,7 @@ bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
   if (value_type == Value::ValueType::Scalar) {
     // If the value is already a scalar, then let the scalar change itself:
     m_value.GetScalar().SetValueFromCString(value_str, encoding, byte_size);
-  } else if (byte_size <= 16) {
+  } else if (byte_size <= 16 && encoding != eEncodingInvalid) {
     // If the value fits in a scalar, then make a new scalar and again let the
     // scalar code do the conversion, then figure out where to put the new
     // value.
@@ -1535,6 +1535,9 @@ bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
     }
   } else {
     // We don't support setting things bigger than a scalar at present.
+    // But maybe our frontend knows how to update the value.
+    if (auto *frontend = GetSyntheticFrontend())
+      return frontend->SetValueFromCString(value_str, error);
     error.SetErrorString("unable to write aggregate data type");
     return false;
   }


### PR DESCRIPTION
It is a first of three patches neded for adding an ability to update std::string/wstring/etc during debug process. This patch adds to the synthetic child interface a “change value” method which goes back to the synthetic child provider and ask it if it knows how to change the underlying value that the synthetic child represents

Overall context is avaliable in the following question: https://discourse.llvm.org/t/clarify-hostaddress-loadaddress-logic/72175/3:

~~

Huawei RRI, OS Lab