### PR TITLE
[clang][dataflow] Remove buggy assertion.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -43,20 +43,8 @@ const Environment *StmtToEnvMap::getEnvironment(const Stmt &S) const {
   if (!CFCtx.isBlockReachable(*BlockIt->getSecond()))
     return nullptr;
   const auto &State = BlockToState[BlockIt->getSecond()->getBlockID()];
-  if (!(State)) {
-    LLVM_DEBUG({
-      // State can be null when this block is unreachable from the block that
-      // called this method.
-      bool hasUnreachableEdgeFromPred = false;
-      for (auto B : BlockIt->getSecond()->preds())
-        if (!B) {
-          hasUnreachableEdgeFromPred = true;
-          break;
-        }
-      assert(hasUnreachableEdgeFromPred);
-    });
+  if (!(State))
     return nullptr;
-  }
   return &State->Env;
 }
 


### PR DESCRIPTION
The assertion fails on the test TransferTest.EvaluateBlockWithUnreachablePreds
(which I think, ironically, was introuced in the same patch as the assertion).

This just wasn't obvious because the assertion is inside an `LLVM_DEBUG` block
and is thus only executed if the command-line flag `-debug` is passed. We don't
have any CI builds that do this, so it's almost guaranteed that assertions like
this will start failing over time (if they ever passed in the first place --
which I'm not sure about here).

It's not clear to me whether there's _some_ assertion we might be able to make
here -- I've looked at this for a while but haven't been able to come up with
anything obvious. For the time being, I think it's best to simply delete the
assertion.
