### PR TITLE
[clang] Fix pretty-printing assume_aligned attributes

### DIFF
--- a/clang/test/AST/attr-print-emit.cpp
+++ b/clang/test/AST/attr-print-emit.cpp
@@ -2,6 +2,12 @@
 // RUN: %clang -emit-ast -o %t.ast %s
 // RUN: %clang_cc1 %t.ast -ast-print | FileCheck %s
 
+// CHECK: void *aa() __attribute__((assume_aligned(64)));
+void *aa() __attribute__((assume_aligned(64)));
+
+// CHECK: void *aa2() __attribute__((assume_aligned(64, 8)));
+void *aa2() __attribute__((assume_aligned(64, 8)));
+
 // CHECK: void xla(int a) __attribute__((xray_log_args(1)));
 void xla(int a) __attribute__((xray_log_args(1)));
 

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -320,11 +320,12 @@ namespace {
     }
 
     std::string getIsOmitted() const override {
-      if (type == "IdentifierInfo *")
+      StringRef T = type;
+      if (T == "IdentifierInfo *" || T == "Expr *")
         return "!get" + getUpperName().str() + "()";
-      if (type == "TypeSourceInfo *")
+      if (T == "TypeSourceInfo *")
         return "!get" + getUpperName().str() + "Loc()";
-      if (type == "ParamIdx")
+      if (T == "ParamIdx")
         return "!get" + getUpperName().str() + "().isValid()";
       return "false";
     }

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -320,13 +320,19 @@ namespace {
     }
 
     std::string getIsOmitted() const override {
-      StringRef T = type;
-      if (T == "IdentifierInfo *" || T == "Expr *")
+      auto IsOneOf = [](StringRef subject, auto... list) {
+        return ((subject == list) || ...);
+      };
+
+      if (IsOneOf(type, "IdentifierInfo *", "Expr *"))
         return "!get" + getUpperName().str() + "()";
-      if (T == "TypeSourceInfo *")
+      if (IsOneOf(type, "TypeSourceInfo *"))
         return "!get" + getUpperName().str() + "Loc()";
-      if (T == "ParamIdx")
+      if (IsOneOf(type, "ParamIdx"))
         return "!get" + getUpperName().str() + "().isValid()";
+
+      assert(IsOneOf(type, "unsigned", "int", "bool", "FunctionDecl *",
+                     "VarDecl *"));
       return "false";
     }
 


### PR DESCRIPTION
Inside `writePrettyPrintFunction()`, we check if we need to emit the given argument:
```C++
if (!arg->isOptional() || arg->getIsOmitted() == "false") {
    FoundNonOptArg = true;
    continue;
}
```
For the `AssumeAligned` attribute, the second argument was optional, but the `getIsOmitted()` returned `false`, thus we treated this argument as **non-optional** in the end because of that disjunction.

It was because `getIsOmitted()` did not account for `Expr *` type, and returned `false` on the fallthrough branch.

Fixes #67156