### PR TITLE
[Flang][Driver][OpenMP][Test] Modify one omp-driver-offload.f90 command to not incorrectly expect a single output 

### DIFF
--- a/flang/test/Driver/omp-driver-offload.f90
+++ b/flang/test/Driver/omp-driver-offload.f90
@@ -33,7 +33,7 @@
 ! OFFLOAD-HOST-NOT: "-triple" "nvptx64-nvidia-cuda"
 ! OFFLOAD-HOST-NOT: "{{[^"]*}}flang-new" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
 
-! RUN: not %flang -S -### %s -o %t 2>&1 \
+! RUN: %flang -S -### %s 2>&1 \
 ! RUN: -fopenmp --offload-arch=gfx90a --offload-arch=sm_70 --offload-device-only \
 ! RUN: --target=aarch64-unknown-linux-gnu \
 ! RUN:   | FileCheck %s --check-prefix=OFFLOAD-DEVICE


### PR DESCRIPTION
The test command which tests offloading to multiple device architectures expects multiple outputs, however, the test as written with the -o expects a single output result. This change modifies it to not expect a single output, which allows the command to succeed and allow the removal of the not prefix.