### PR TITLE
[ADT] Fix MappedIteratorTest.

### DIFF
--- a/llvm/unittests/ADT/MappedIteratorTest.cpp
+++ b/llvm/unittests/ADT/MappedIteratorTest.cpp
@@ -174,7 +174,7 @@ TYPED_TEST(MappedIteratorTestBasic, MoveAssign) {
 
     I3 = std::move(I2);
 
-    EXPECT_EQ(I2, I1) << "move assigned iterator is a different position";
+    EXPECT_EQ(I3, I1) << "move assigned iterator is a different position";
   }
 }
 


### PR DESCRIPTION
Caught on builds with expensive and _GLIBCXX_DEBUG checks enabled.

See related discussion in
<https://reviews.llvm.org/D134675#inline-1472177>.