### PR TITLE
[libc] Enable hermetic tests for the stdio test suite

### DIFF
--- a/libc/test/src/stdio/CMakeLists.txt
+++ b/libc/test/src/stdio/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(libc_stdio_unittests)
 
-add_libc_unittest(
+add_libc_test(
   fileop_test
   SUITE
     libc_stdio_unittests
@@ -21,7 +21,7 @@ add_libc_unittest(
     libc.src.stdio.fwrite
 )
 
-add_libc_unittest(
+add_libc_test(
   ungetc_test
   SUITE
     libc_stdio_unittests
@@ -37,7 +37,7 @@ add_libc_unittest(
     libc.src.stdio.ungetc
 )
 
-add_libc_unittest(
+add_libc_test(
   setbuf_test
   SUITE
     libc_stdio_unittests
@@ -53,7 +53,7 @@ add_libc_unittest(
     libc.src.stdio.ungetc
 )
 
-add_libc_unittest(
+add_libc_test(
   setvbuf_test
   SUITE
     libc_stdio_unittests
@@ -69,7 +69,7 @@ add_libc_unittest(
     libc.src.stdio.setvbuf
 )
 
-add_libc_unittest(
+add_libc_test(
   unlocked_fileop_test
   SUITE
     libc_stdio_unittests
@@ -89,7 +89,7 @@ add_libc_unittest(
     libc.src.stdio.fwrite_unlocked
 )
 
-add_libc_unittest(
+add_libc_test(
   fopencookie_test
   SUITE
     libc_stdio_unittests
@@ -137,7 +137,7 @@ add_fp_unittest(
     ${sprintf_test_copts}
 )
 
-add_libc_unittest(
+add_libc_test(
   snprintf_test
   SUITE
     libc_stdio_unittests
@@ -163,7 +163,7 @@ else()
  set(use_system_file "-DLIBC_COPT_STDIO_USE_SYSTEM_FILE")
 endif()
 
-add_libc_unittest(
+add_libc_test(
   fprintf_test
   SUITE
     libc_stdio_unittests
@@ -198,7 +198,7 @@ add_fp_unittest(
     libc.src.stdio.vsprintf
 )
 
-add_libc_unittest(
+add_libc_test(
   vsnprintf_test
   SUITE
     libc_stdio_unittests
@@ -208,7 +208,7 @@ add_libc_unittest(
     libc.src.stdio.vsnprintf
 )
 
-add_libc_unittest(
+add_libc_test(
   vfprintf_test
   SUITE
     libc_stdio_unittests
@@ -243,7 +243,7 @@ if(LLVM_LIBC_FULL_BUILD)
   )
 endif()
 
-add_libc_unittest(
+add_libc_test(
   fscanf_test
   SUITE
     libc_stdio_unittests
@@ -257,7 +257,7 @@ add_libc_unittest(
     ${use_system_file}
 )
 
-add_libc_unittest(
+add_libc_test(
   sscanf_test
   SUITE
     libc_stdio_unittests
@@ -335,7 +335,7 @@ add_libc_test(
 )
 
 if(${LIBC_TARGET_OS} STREQUAL "linux")
-  add_libc_unittest(
+  add_libc_test(
     remove_test
     SUITE
       libc_stdio_unittests
@@ -370,7 +370,7 @@ add_libc_test(
     libc.src.stdio.getc
 )
 
-add_libc_unittest(
+add_libc_test(
   fgetc_unlocked_test
   SUITE
     libc_stdio_unittests
@@ -409,7 +409,7 @@ add_libc_test(
     libc.src.stdio.fwrite
 )
 
-add_libc_unittest(
+add_libc_test(
   ftell_test
   SUITE
     libc_stdio_unittests


### PR DESCRIPTION
Summary:
There are several tests here that are not yet using the `add_libc_test`.
Rather than do this individually we should just update these all at
once. These all pass on my x64 build so I'm assuming it should be fine.
