### PR TITLE
[mlir][Vector] Fix doc generation

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Vector/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(Vector vector)
-add_mlir_doc(VectorOps Vector Dialects/ -gen-op-doc)
+add_mlir_doc(VectorOps VectorOps Dialects/ -gen-op-doc)
 
 # Add Vector operations
 set(LLVM_TARGET_DEFINITIONS VectorOps.td)


### PR DESCRIPTION
The format is
`add_mlir_doc(<table gen file> <output md name> <output dir> <command>)`

Using the Vector.td file does not work as it does not include VectorOps.td (so the docs are empty). If the output name is not VectorOps.md, the mlir-www site does not find the ops (and instead overwrites it with an empty template).