### PR TITLE
[flang][runtime] Better non-repeatable RANDOM_INIT()

### DIFF
--- a/flang/runtime/random.cpp
+++ b/flang/runtime/random.cpp
@@ -20,10 +20,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <ctime>
 #include <limits>
 #include <memory>
 #include <random>
+#include <time.h>
 
 namespace Fortran::runtime {
 
@@ -100,7 +100,13 @@ void RTNAME(RandomInit)(bool repeatable, bool /*image_distinct*/) {
     if (repeatable) {
       generator.seed(0);
     } else {
-      generator.seed(std::time(nullptr));
+#ifdef CLOCK_REALTIME
+      timespec ts;
+      clock_gettime(CLOCK_REALTIME, &ts);
+      generator.seed(ts.tv_sec & ts.tv_nsec);
+#else
+      generator.seed(time(nullptr));
+#endif
     }
   }
 }


### PR DESCRIPTION
Use a higher-frequency clock base when initializing the pseudo-random number generator to implement
  CALL  RANDOM_INIT(REPEATABLE=.FALSE.)