### PR TITLE
[RISCV] Explicitly create IMPLICIT_DEF instead of UNDEF for vectors i…

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -2104,8 +2104,9 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
     if (IsStrided && !Subtarget->hasOptimizedZeroStrideLoad())
       break;
 
-    SmallVector<SDValue> Operands =
-      {CurDAG->getUNDEF(VT), Ld->getBasePtr()};
+    SmallVector<SDValue> Operands = {
+        SDValue(CurDAG->getMachineNode(TargetOpcode::IMPLICIT_DEF, DL, VT), 0),
+        Ld->getBasePtr()};
     if (IsStrided)
       Operands.push_back(CurDAG->getRegister(RISCV::X0, XLenVT));
     uint64_t Policy = RISCVII::MASK_AGNOSTIC | RISCVII::TAIL_AGNOSTIC;


### PR DESCRIPTION
…n RISCVDAGToDAGISel::Select.

UNDEF needs to go through isel itself. All of the nodes have been topologically sorted so that instruction selection precedes from root to entry node. If we create a new node that needs to go through isel, we have to insert it into the correct place in the topological sort. If we don't, it might not get selected at all in some cases.

Some targets have a function like X86's insertDAGNode to sort newly created nodes.

To avoid introducing such a function on RISC-V, we can directly emit the IMPLICIT_DEF node that UNDEF would get selected to.