### PR TITLE
[LLParser] Merge xor constantexpr parsing with add/mul/shl/lshr/ashr.

### DIFF
--- a/llvm/test/Assembler/2003-05-21-MalformedShiftCrash.ll
+++ b/llvm/test/Assembler/2003-05-21-MalformedShiftCrash.ll
@@ -1,5 +1,5 @@
 ; Found by inspection of the code
 ; RUN: not llvm-as < %s > /dev/null 2> %t
-; RUN: grep "constexpr requires integer operands" %t
+; RUN: grep "constexpr requires integer or integer vector operands" %t
 
 @0 = global i32 ashr (float 1.0, float 2.0)


### PR DESCRIPTION
Not sure if xor is sticking around or not. I see and/or was already removed.

This changes the error messages and makes one error message more accurate.