### PR TITLE
[RISCV] Disable constant hoisting for mul by one more/less than a pow…

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -127,6 +127,9 @@ InstructionCost RISCVTTIImpl::getIntImmCostInst(unsigned Opcode, unsigned Idx,
     // Power of 2 is a shift. Negated power of 2 is a shift and a negate.
     if (Imm.isPowerOf2() || Imm.isNegatedPowerOf2())
       return TTI::TCC_Free;
+    // One more or less than a power of 2 can use SLLI+ADD/SUB.
+    if ((Imm + 1).isPowerOf2() || (Imm - 1).isPowerOf2())
+      return TTI::TCC_Free;
     // FIXME: There is no MULI instruction.
     Takes12BitImm = true;
     break;

--- a/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
+++ b/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
@@ -22,9 +22,9 @@ define i64 @test2(i64 %a) nounwind {
 ; Check that we hoist immediates with large values.
 define i64 @test3(i64 %a) nounwind {
 ; CHECK-LABEL: test3
-; CHECK: %const = bitcast i64 32767 to i64
-  %1 = mul i64 %a, 32767
-  %2 = add i64 %1, 32767
+; CHECK: %const = bitcast i64 32766 to i64
+  %1 = mul i64 %a, 32766
+  %2 = add i64 %1, 32766
   ret i64 %2
 }
 
@@ -129,6 +129,24 @@ define i64 @test14(i64 %a) nounwind {
 ; CHECK: mul i64 %a, 2048
   %1 = mul i64 %a, 2048
   %2 = mul i64 %1, 2048
+  ret i64 %2
+}
+
+; Check that we don't hoist mul by one less than a power of 2.
+define i64 @test15(i64 %a) nounwind {
+; CHECK-LABEL: test15
+; CHECK: mul i64 %a, 65535
+  %1 = mul i64 %a, 65535
+  %2 = mul i64 %1, 65535
+  ret i64 %2
+}
+
+; Check that we don't hoist mul by one more than a power of 2.
+define i64 @test16(i64 %a) nounwind {
+; CHECK-LABEL: test16
+; CHECK: mul i64 %a, 65537
+  %1 = mul i64 %a, 65537
+  %2 = mul i64 %1, 65537
   ret i64 %2
 }
 


### PR DESCRIPTION
…er of 2.

We can use a shift+add/sub for these. This often has same or lower latency than a multiply and may have more execution resources available.