### PR TITLE
[Demangler] support demangling for AIX function entry names

### DIFF
--- a/llvm/lib/Demangle/Demangle.cpp
+++ b/llvm/lib/Demangle/Demangle.cpp
@@ -50,6 +50,10 @@ bool llvm::nonMicrosoftDemangle(std::string_view MangledName,
   char *Demangled = nullptr;
   if (isItaniumEncoding(MangledName))
     Demangled = itaniumDemangle(MangledName);
+  // AIX function entries start with '.'.
+  else if (starts_with(MangledName, '.') &&
+           isItaniumEncoding(MangledName.substr(1)))
+    Demangled = itaniumDemangle(MangledName.substr(1));
   else if (isRustEncoding(MangledName))
     Demangled = rustDemangle(MangledName);
   else if (isDLangEncoding(MangledName))

--- a/llvm/test/tools/llvm-cxxfilt/delimiters.test
+++ b/llvm/test/tools/llvm-cxxfilt/delimiters.test
@@ -69,5 +69,5 @@ CHECK: Foo~,,
 CHECK: Foo⦙Bar
 CHECK: Foo,,Bar::Baz  Foo,Bar:Baz
 CHECK: A::foo(int)
-CHECK: ._ZN1A3fooEi
-CHECK: _Z3Foo$ ._Z3Foo
+CHECK: A::foo(int)
+CHECK: _Z3Foo$ Foo

--- a/llvm/test/tools/llvm-cxxfilt/delimiters.test
+++ b/llvm/test/tools/llvm-cxxfilt/delimiters.test
@@ -29,6 +29,8 @@ RUN:      '_Z3Foo}'   \
 RUN:      '_Z3Foo~,,' \
 RUN:      '_Z3Foo⦙_Z3Bar' \
 RUN:      '_Z3Foo,,_Z3Bar::_Z3Baz  _Z3Foo,_Z3Bar:_Z3Baz' \
+RUN:      '_ZN1A3fooEi' \
+RUN:      '._ZN1A3fooEi' \
 COM: Piping the echo output causes '⦙' to be converted to '?' in some
 COM: builds/environments. Redirect echo output to and from %t to work
 COM: around this. See D111072.
@@ -66,4 +68,6 @@ CHECK: Foo}
 CHECK: Foo~,,
 CHECK: Foo⦙Bar
 CHECK: Foo,,Bar::Baz  Foo,Bar:Baz
+CHECK: A::foo(int)
+CHECK: ._ZN1A3fooEi
 CHECK: _Z3Foo$ ._Z3Foo


### PR DESCRIPTION
AIX has two symbols for a function, one is function descriptor and another one is function entry(there is a leading dot). See details in https://www.ibm.com/docs/en/aix/7.1?topic=formats-xcoff-object-file-format

```
a function descriptor, which contains the following three values:

    The address of the executable code for a function.
    The address of the TOC anchor (TOC base address) of the module that contains the function.
    The environment pointer (used by languages such as Pascal and PL/I).
```

A symbol table example:
```
[9]	m   0x00000060     .text     1    weak                    ._ZN1A3fooEi
[10]	a4  0x00000005       0    0     LD       PR    0    0
[13]	m   0x000000cc     .data     1    weak                    _ZN1A3fooEi
[14]	a4  0x0000000c       0    0     SD       DS    0    0
```

For now, llvm-cxxfilt is able to demangle `_ZN1A3fooEi`, but it can not demangle function entry name `._ZN1A3fooEi`.  Support demangling the function entry names as well. Sanitizers will check the function entries' demangle names in the LIT tests.