### PR TITLE
[libunwind][nfc] Avoid type warning of debug printf

### DIFF
--- a/libunwind/src/Unwind-sjlj.c
+++ b/libunwind/src/Unwind-sjlj.c
@@ -42,18 +42,12 @@ struct _Unwind_FunctionContext {
 
   // set by personality handler to be parameters passed to landing pad function
   uint64_t                        resumeParameters[4];
-
-  // specify format for debug dump of resumeLocation and resumeParameters[]
-#define SJLJ_PRI_PTR PRIxPTR
 #else
   // set by calling function before registering to be the landing pad
   uint32_t                        resumeLocation;
 
   // set by personality handler to be parameters passed to landing pad function
   uint32_t                        resumeParameters[4];
-
-  // specify format for debug dump of resumeLocation and resumeParameters[]
-#define SJLJ_PRI_PTR PRIuPTR
 #endif
 
   // set by calling function before registering
@@ -433,9 +427,9 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetGR(struct _Unwind_Context *context,
 /// Called by personality handler during phase 2 to alter register values.
 _LIBUNWIND_EXPORT void _Unwind_SetGR(struct _Unwind_Context *context, int index,
                                      uintptr_t new_value) {
-  _LIBUNWIND_TRACE_API(
-      "_Unwind_SetGR(context=%p, reg=%d, value=0x%" SJLJ_PRI_PTR ")",
-      (void *)context, index, new_value);
+  _LIBUNWIND_TRACE_API("_Unwind_SetGR(context=%p, reg=%d, value=0x%" PRIxPTR
+                       ")",
+                       (void *)context, index, new_value);
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
   ufc->resumeParameters[index] = new_value;
 }
@@ -444,7 +438,7 @@ _LIBUNWIND_EXPORT void _Unwind_SetGR(struct _Unwind_Context *context, int index,
 /// Called by personality handler during phase 2 to get instruction pointer.
 _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIP(struct _Unwind_Context *context) {
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
-  _LIBUNWIND_TRACE_API("_Unwind_GetIP(context=%p) => 0x%" SJLJ_PRI_PTR,
+  _LIBUNWIND_TRACE_API("_Unwind_GetIP(context=%p) => 0x%" PRIxPTR,
                        (void *)context, ufc->resumeLocation + 1);
   return ufc->resumeLocation + 1;
 }
@@ -457,7 +451,7 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIPInfo(struct _Unwind_Context *context,
                                               int *ipBefore) {
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
   *ipBefore = 0;
-  _LIBUNWIND_TRACE_API("_Unwind_GetIPInfo(context=%p, %p) => 0x%" SJLJ_PRI_PTR,
+  _LIBUNWIND_TRACE_API("_Unwind_GetIPInfo(context=%p, %p) => 0x%" PRIxPTR,
                        (void *)context, (void *)ipBefore,
                        ufc->resumeLocation + 1);
   return ufc->resumeLocation + 1;
@@ -467,7 +461,7 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIPInfo(struct _Unwind_Context *context,
 /// Called by personality handler during phase 2 to alter instruction pointer.
 _LIBUNWIND_EXPORT void _Unwind_SetIP(struct _Unwind_Context *context,
                                      uintptr_t new_value) {
-  _LIBUNWIND_TRACE_API("_Unwind_SetIP(context=%p, value=0x%" SJLJ_PRI_PTR ")",
+  _LIBUNWIND_TRACE_API("_Unwind_SetIP(context=%p, value=0x%" PRIxPTR ")",
                        (void *)context, new_value);
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
   ufc->resumeLocation = new_value - 1;

--- a/libunwind/src/Unwind-sjlj.c
+++ b/libunwind/src/Unwind-sjlj.c
@@ -42,12 +42,18 @@ struct _Unwind_FunctionContext {
 
   // set by personality handler to be parameters passed to landing pad function
   uint64_t                        resumeParameters[4];
+
+  // specify format for debug dump of resumeLocation and resumeParameters[]
+#define SJLJ_PRI_PTR PRIxPTR
 #else
   // set by calling function before registering to be the landing pad
   uint32_t                        resumeLocation;
 
   // set by personality handler to be parameters passed to landing pad function
   uint32_t                        resumeParameters[4];
+
+  // specify format for debug dump of resumeLocation and resumeParameters[]
+#define SJLJ_PRI_PTR PRIuPTR
 #endif
 
   // set by calling function before registering
@@ -427,9 +433,9 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetGR(struct _Unwind_Context *context,
 /// Called by personality handler during phase 2 to alter register values.
 _LIBUNWIND_EXPORT void _Unwind_SetGR(struct _Unwind_Context *context, int index,
                                      uintptr_t new_value) {
-  _LIBUNWIND_TRACE_API("_Unwind_SetGR(context=%p, reg=%d, value=0x%" PRIuPTR
-                       ")",
-                       (void *)context, index, new_value);
+  _LIBUNWIND_TRACE_API(
+      "_Unwind_SetGR(context=%p, reg=%d, value=0x%" SJLJ_PRI_PTR ")",
+      (void *)context, index, new_value);
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
   ufc->resumeParameters[index] = new_value;
 }
@@ -438,7 +444,7 @@ _LIBUNWIND_EXPORT void _Unwind_SetGR(struct _Unwind_Context *context, int index,
 /// Called by personality handler during phase 2 to get instruction pointer.
 _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIP(struct _Unwind_Context *context) {
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
-  _LIBUNWIND_TRACE_API("_Unwind_GetIP(context=%p) => 0x%" PRIu32,
+  _LIBUNWIND_TRACE_API("_Unwind_GetIP(context=%p) => 0x%" SJLJ_PRI_PTR,
                        (void *)context, ufc->resumeLocation + 1);
   return ufc->resumeLocation + 1;
 }
@@ -451,7 +457,7 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIPInfo(struct _Unwind_Context *context,
                                               int *ipBefore) {
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
   *ipBefore = 0;
-  _LIBUNWIND_TRACE_API("_Unwind_GetIPInfo(context=%p, %p) => 0x%" PRIu32,
+  _LIBUNWIND_TRACE_API("_Unwind_GetIPInfo(context=%p, %p) => 0x%" SJLJ_PRI_PTR,
                        (void *)context, (void *)ipBefore,
                        ufc->resumeLocation + 1);
   return ufc->resumeLocation + 1;
@@ -461,7 +467,7 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIPInfo(struct _Unwind_Context *context,
 /// Called by personality handler during phase 2 to alter instruction pointer.
 _LIBUNWIND_EXPORT void _Unwind_SetIP(struct _Unwind_Context *context,
                                      uintptr_t new_value) {
-  _LIBUNWIND_TRACE_API("_Unwind_SetIP(context=%p, value=0x%" PRIuPTR ")",
+  _LIBUNWIND_TRACE_API("_Unwind_SetIP(context=%p, value=0x%" SJLJ_PRI_PTR ")",
                        (void *)context, new_value);
   _Unwind_FunctionContext_t ufc = (_Unwind_FunctionContext_t) context;
   ufc->resumeLocation = new_value - 1;


### PR DESCRIPTION
Change PRIu32 to PRIxPTR to avoid type warning of debug printf since VE uses 64 bits SjLj.  I don't use PRIuPTR since the print message has 0x-prefix from the beginning.  I also change related PRIuPTR to PRIxPTR since those uses 0x-prefix too.