### PR TITLE
[Workflow] Update clang-format to 17.0.1

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install clang-format
         uses: aminya/setup-cpp@v1
         with:
-          clangformat: 16.0.6
+          clangformat: 17.0.1
 
       - name: Setup Python env
         uses: actions/setup-python@v4


### PR DESCRIPTION
17.0.1 is our most recent stable version which we decided to follow and it fixes the issue described in llvm/llvm-project#67343