### PR TITLE
Simplify diagnostic error management for MLIR properties API (NFC)

### DIFF
--- a/mlir/include/mlir/IR/ExtensibleDialect.h
+++ b/mlir/include/mlir/IR/ExtensibleDialect.h
@@ -476,7 +476,7 @@ public:
   void populateInherentAttrs(Operation *op, NamedAttrList &attrs) final {}
   LogicalResult
   verifyInherentAttrs(OperationName opName, NamedAttrList &attributes,
-                      function_ref<InFlightDiagnostic()> getDiag) final {
+                      function_ref<InFlightDiagnostic()> emitError) final {
     return success();
   }
   int getOpPropertyByteSize() final { return 0; }
@@ -489,8 +489,8 @@ public:
   LogicalResult
   setPropertiesFromAttr(OperationName opName, OpaqueProperties properties,
                         Attribute attr,
-                        function_ref<InFlightDiagnostic &()> getDiag) final {
-    getDiag() << "extensible Dialects don't support properties";
+                        function_ref<InFlightDiagnostic()> emitError) final {
+    emitError() << "extensible Dialects don't support properties";
     return failure();
   }
   Attribute getPropertiesAsAttr(Operation *op) final { return {}; }

--- a/mlir/include/mlir/IR/ODSSupport.h
+++ b/mlir/include/mlir/IR/ODSSupport.h
@@ -28,7 +28,7 @@ namespace mlir {
 /// error message is also emitted.
 LogicalResult
 convertFromAttribute(int64_t &storage, Attribute attr,
-                     function_ref<InFlightDiagnostic &()> getDiag);
+                     function_ref<InFlightDiagnostic()> emitError);
 
 /// Convert the provided int64_t to an IntegerAttr attribute.
 Attribute convertToAttribute(MLIRContext *ctx, int64_t storage);
@@ -39,7 +39,7 @@ Attribute convertToAttribute(MLIRContext *ctx, int64_t storage);
 /// the optional diagnostic is provided an error message is also emitted.
 LogicalResult
 convertFromAttribute(MutableArrayRef<int64_t> storage, Attribute attr,
-                     function_ref<InFlightDiagnostic &()> getDiag);
+                     function_ref<InFlightDiagnostic()> emitError);
 
 /// Convert a DenseI32ArrayAttr to the provided storage. It is expected that the
 /// storage has the same size as the array. An error is returned if the
@@ -47,7 +47,7 @@ convertFromAttribute(MutableArrayRef<int64_t> storage, Attribute attr,
 /// the optional diagnostic is provided an error message is also emitted.
 LogicalResult
 convertFromAttribute(MutableArrayRef<int32_t> storage, Attribute attr,
-                     function_ref<InFlightDiagnostic &()> getDiag);
+                     function_ref<InFlightDiagnostic()> emitError);
 
 /// Convert the provided ArrayRef<int64_t> to a DenseI64ArrayAttr attribute.
 Attribute convertToAttribute(MLIRContext *ctx, ArrayRef<int64_t> storage);

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -1741,8 +1741,8 @@ public:
   template <typename PropertiesTy>
   static LogicalResult
   setPropertiesFromAttr(PropertiesTy &prop, Attribute attr,
-                        function_ref<InFlightDiagnostic &()> getDiag) {
-    return setPropertiesFromAttribute(prop, attr, getDiag);
+                        function_ref<InFlightDiagnostic()> emitError) {
+    return setPropertiesFromAttribute(prop, attr, emitError);
   }
   /// Convert the provided properties to an attribute. This default
   /// implementation forwards to a free function `getPropertiesAsAttribute` that

--- a/mlir/include/mlir/IR/Operation.h
+++ b/mlir/include/mlir/IR/Operation.h
@@ -884,7 +884,7 @@ public:
   /// generic format. An optional diagnostic can be passed in for richer errors.
   LogicalResult
   setPropertiesFromAttribute(Attribute attr,
-                             function_ref<InFlightDiagnostic &()> getDiag);
+                             function_ref<InFlightDiagnostic()> emitError);
 
   /// Copy properties from an existing other properties object. The two objects
   /// must be the same type.

--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -129,7 +129,7 @@ public:
     virtual void populateInherentAttrs(Operation *op, NamedAttrList &attrs) = 0;
     virtual LogicalResult
     verifyInherentAttrs(OperationName opName, NamedAttrList &attributes,
-                        function_ref<InFlightDiagnostic()> getDiag) = 0;
+                        function_ref<InFlightDiagnostic()> emitError) = 0;
     virtual int getOpPropertyByteSize() = 0;
     virtual void initProperties(OperationName opName, OpaqueProperties storage,
                                 OpaqueProperties init) = 0;
@@ -138,7 +138,7 @@ public:
                                            OpaqueProperties properties) = 0;
     virtual LogicalResult
     setPropertiesFromAttr(OperationName, OpaqueProperties, Attribute,
-                          function_ref<InFlightDiagnostic &()> getDiag) = 0;
+                          function_ref<InFlightDiagnostic()> emitError) = 0;
     virtual Attribute getPropertiesAsAttr(Operation *) = 0;
     virtual void copyProperties(OpaqueProperties, OpaqueProperties) = 0;
     virtual bool compareProperties(OpaqueProperties, OpaqueProperties) = 0;
@@ -210,7 +210,7 @@ protected:
     void populateInherentAttrs(Operation *op, NamedAttrList &attrs) final;
     LogicalResult
     verifyInherentAttrs(OperationName opName, NamedAttrList &attributes,
-                        function_ref<InFlightDiagnostic()> getDiag) final;
+                        function_ref<InFlightDiagnostic()> emitError) final;
     int getOpPropertyByteSize() final;
     void initProperties(OperationName opName, OpaqueProperties storage,
                         OpaqueProperties init) final;
@@ -219,7 +219,7 @@ protected:
                                    OpaqueProperties properties) final;
     LogicalResult
     setPropertiesFromAttr(OperationName, OpaqueProperties, Attribute,
-                          function_ref<InFlightDiagnostic &()> getDiag) final;
+                          function_ref<InFlightDiagnostic()> emitError) final;
     Attribute getPropertiesAsAttr(Operation *) final;
     void copyProperties(OpaqueProperties, OpaqueProperties) final;
     bool compareProperties(OpaqueProperties, OpaqueProperties) final;
@@ -408,8 +408,8 @@ public:
   /// attributes when parsed from the older generic syntax pre-Properties.
   LogicalResult
   verifyInherentAttrs(NamedAttrList &attributes,
-                      function_ref<InFlightDiagnostic()> getDiag) const {
-    return getImpl()->verifyInherentAttrs(*this, attributes, getDiag);
+                      function_ref<InFlightDiagnostic()> emitError) const {
+    return getImpl()->verifyInherentAttrs(*this, attributes, emitError);
   }
   /// This hooks return the number of bytes to allocate for the op properties.
   int getOpPropertyByteSize() const {
@@ -439,8 +439,9 @@ public:
   /// Define the op properties from the provided Attribute.
   LogicalResult setOpPropertiesFromAttribute(
       OperationName opName, OpaqueProperties properties, Attribute attr,
-      function_ref<InFlightDiagnostic &()> getDiag) const {
-    return getImpl()->setPropertiesFromAttr(opName, properties, attr, getDiag);
+      function_ref<InFlightDiagnostic()> emitError) const {
+    return getImpl()->setPropertiesFromAttr(opName, properties, attr,
+                                            emitError);
   }
 
   void copyOpProperties(OpaqueProperties lhs, OpaqueProperties rhs) const {
@@ -596,9 +597,9 @@ public:
     }
     LogicalResult
     verifyInherentAttrs(OperationName opName, NamedAttrList &attributes,
-                        function_ref<InFlightDiagnostic()> getDiag) final {
+                        function_ref<InFlightDiagnostic()> emitError) final {
       if constexpr (hasProperties)
-        return ConcreteOp::verifyInherentAttrs(opName, attributes, getDiag);
+        return ConcreteOp::verifyInherentAttrs(opName, attributes, emitError);
       return success();
     }
     // Detect if the concrete operation defined properties.
@@ -636,12 +637,12 @@ public:
     LogicalResult
     setPropertiesFromAttr(OperationName opName, OpaqueProperties properties,
                           Attribute attr,
-                          function_ref<InFlightDiagnostic &()> getDiag) final {
+                          function_ref<InFlightDiagnostic()> emitError) final {
       if constexpr (hasProperties) {
         auto p = properties.as<Properties *>();
-        return ConcreteOp::setPropertiesFromAttr(*p, attr, getDiag);
+        return ConcreteOp::setPropertiesFromAttr(*p, attr, emitError);
       }
-      getDiag() << "this operation does not support properties";
+      emitError() << "this operation does not support properties";
       return failure();
     }
     Attribute getPropertiesAsAttr(Operation *op) final {
@@ -1010,7 +1011,7 @@ public:
   // optionally emit diagnostics on error through the provided diagnostic.
   LogicalResult
   setProperties(Operation *op,
-                function_ref<InFlightDiagnostic &()> getDiag) const;
+                function_ref<InFlightDiagnostic()> emitError) const;
 
   void addOperands(ValueRange newOperands);
 

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -1446,16 +1446,11 @@ Operation *OperationParser::parseGenericOperation() {
   // Try setting the properties for the operation, using a diagnostic to print
   // errors.
   if (properties) {
-    std::unique_ptr<InFlightDiagnostic> diagnostic;
-    auto getDiag = [&]() -> InFlightDiagnostic & {
-      if (!diagnostic) {
-        diagnostic = std::make_unique<InFlightDiagnostic>(
-            mlir::emitError(srcLocation, "invalid properties ")
-            << properties << " for op " << name << ": ");
-      }
-      return *diagnostic;
+    auto emitError = [&]() {
+      return mlir::emitError(srcLocation, "invalid properties ")
+             << properties << " for op " << name << ": ";
     };
-    if (failed(op->setPropertiesFromAttribute(properties, getDiag)))
+    if (failed(op->setPropertiesFromAttribute(properties, emitError)))
       return nullptr;
   }
 
@@ -2009,17 +2004,12 @@ OperationParser::parseCustomOperation(ArrayRef<ResultRecord> resultIDs) {
 
   // Try setting the properties for the operation.
   if (properties) {
-    std::unique_ptr<InFlightDiagnostic> diagnostic;
-    auto getDiag = [&]() -> InFlightDiagnostic & {
-      if (!diagnostic) {
-        diagnostic = std::make_unique<InFlightDiagnostic>(
-            mlir::emitError(srcLocation, "invalid properties ")
-            << properties << " for op " << op->getName().getStringRef()
-            << ": ");
-      }
-      return *diagnostic;
+    auto emitError = [&]() {
+      return mlir::emitError(srcLocation, "invalid properties ")
+             << properties << " for op " << op->getName().getStringRef()
+             << ": ";
     };
-    if (failed(op->setPropertiesFromAttribute(properties, getDiag)))
+    if (failed(op->setPropertiesFromAttribute(properties, emitError)))
       return nullptr;
   }
   return op;

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -416,18 +416,13 @@ static LogicalResult inferOperationTypes(OperationState &state) {
     auto prop = std::make_unique<char[]>(info->getOpPropertyByteSize());
     properties = OpaqueProperties(prop.get());
     if (properties) {
-      std::unique_ptr<InFlightDiagnostic> diagnostic;
-      auto getDiag = [&]() -> InFlightDiagnostic & {
-        if (!diagnostic) {
-          diagnostic = std::make_unique<InFlightDiagnostic>(
-              emitError(state.location)
-              << " failed properties conversion while building "
-              << state.name.getStringRef() << " with `" << attributes << "`: ");
-        }
-        return *diagnostic;
+      auto emitError = [&]() {
+        return mlir::emitError(state.location)
+               << " failed properties conversion while building "
+               << state.name.getStringRef() << " with `" << attributes << "`: ";
       };
       if (failed(info->setOpPropertiesFromAttribute(state.name, properties,
-                                                    attributes, getDiag)))
+                                                    attributes, emitError)))
         return failure();
     }
     if (succeeded(inferInterface->inferReturnTypes(

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -834,7 +834,7 @@ void OperationName::UnregisteredOpModel::populateInherentAttrs(
     Operation *op, NamedAttrList &attrs) {}
 LogicalResult OperationName::UnregisteredOpModel::verifyInherentAttrs(
     OperationName opName, NamedAttrList &attributes,
-    function_ref<InFlightDiagnostic()> getDiag) {
+    function_ref<InFlightDiagnostic()> emitError) {
   return success();
 }
 int OperationName::UnregisteredOpModel::getOpPropertyByteSize() {
@@ -852,7 +852,7 @@ void OperationName::UnregisteredOpModel::populateDefaultProperties(
     OperationName opName, OpaqueProperties properties) {}
 LogicalResult OperationName::UnregisteredOpModel::setPropertiesFromAttr(
     OperationName opName, OpaqueProperties properties, Attribute attr,
-    function_ref<InFlightDiagnostic &()> getDiag) {
+    function_ref<InFlightDiagnostic()> emitError) {
   *properties.as<Attribute *>() = attr;
   return success();
 }

--- a/mlir/lib/IR/ODSSupport.cpp
+++ b/mlir/lib/IR/ODSSupport.cpp
@@ -20,10 +20,10 @@ using namespace mlir;
 
 LogicalResult
 mlir::convertFromAttribute(int64_t &storage, Attribute attr,
-                           function_ref<InFlightDiagnostic &()> getDiag) {
+                           function_ref<InFlightDiagnostic()> emitError) {
   auto valueAttr = dyn_cast<IntegerAttr>(attr);
   if (!valueAttr) {
-    getDiag() << "expected IntegerAttr for key `value`";
+    emitError() << "expected IntegerAttr for key `value`";
     return failure();
   }
   storage = valueAttr.getValue().getSExtValue();
@@ -36,16 +36,16 @@ Attribute mlir::convertToAttribute(MLIRContext *ctx, int64_t storage) {
 template <typename DenseArrayTy, typename T>
 LogicalResult
 convertDenseArrayFromAttr(MutableArrayRef<T> storage, Attribute attr,
-                          function_ref<InFlightDiagnostic &()> getDiag,
+                          function_ref<InFlightDiagnostic()> emitError,
                           StringRef denseArrayTyStr) {
   auto valueAttr = dyn_cast<DenseArrayTy>(attr);
   if (!valueAttr) {
-    getDiag() << "expected " << denseArrayTyStr << " for key `value`";
+    emitError() << "expected " << denseArrayTyStr << " for key `value`";
     return failure();
   }
   if (valueAttr.size() != static_cast<int64_t>(storage.size())) {
-    getDiag() << "size mismatch in attribute conversion: " << valueAttr.size()
-              << " vs " << storage.size();
+    emitError() << "size mismatch in attribute conversion: " << valueAttr.size()
+                << " vs " << storage.size();
     return failure();
   }
   llvm::copy(valueAttr.asArrayRef(), storage.begin());
@@ -53,14 +53,14 @@ convertDenseArrayFromAttr(MutableArrayRef<T> storage, Attribute attr,
 }
 LogicalResult
 mlir::convertFromAttribute(MutableArrayRef<int64_t> storage, Attribute attr,
-                           function_ref<InFlightDiagnostic &()> getDiag) {
-  return convertDenseArrayFromAttr<DenseI64ArrayAttr>(storage, attr, getDiag,
+                           function_ref<InFlightDiagnostic()> emitError) {
+  return convertDenseArrayFromAttr<DenseI64ArrayAttr>(storage, attr, emitError,
                                                       "DenseI64ArrayAttr");
 }
 LogicalResult
 mlir::convertFromAttribute(MutableArrayRef<int32_t> storage, Attribute attr,
-                           function_ref<InFlightDiagnostic &()> getDiag) {
-  return convertDenseArrayFromAttr<DenseI32ArrayAttr>(storage, attr, getDiag,
+                           function_ref<InFlightDiagnostic()> emitError) {
+  return convertDenseArrayFromAttr<DenseI32ArrayAttr>(storage, attr, emitError,
                                                       "DenseI32ArrayAttr");
 }
 

--- a/mlir/lib/IR/Operation.cpp
+++ b/mlir/lib/IR/Operation.cpp
@@ -352,14 +352,14 @@ Attribute Operation::getPropertiesAsAttribute() {
   return info->getOpPropertiesAsAttribute(this);
 }
 LogicalResult Operation::setPropertiesFromAttribute(
-    Attribute attr, function_ref<InFlightDiagnostic &()> getDiag) {
+    Attribute attr, function_ref<InFlightDiagnostic()> emitError) {
   std::optional<RegisteredOperationName> info = getRegisteredInfo();
   if (LLVM_UNLIKELY(!info)) {
     *getPropertiesStorage().as<Attribute *>() = attr;
     return success();
   }
   return info->setOpPropertiesFromAttribute(
-      this->getName(), this->getPropertiesStorage(), attr, getDiag);
+      this->getName(), this->getPropertiesStorage(), attr, emitError);
 }
 
 void Operation::copyProperties(OpaqueProperties rhs) {

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -199,10 +199,10 @@ OperationState::~OperationState() {
 }
 
 LogicalResult OperationState::setProperties(
-    Operation *op, function_ref<InFlightDiagnostic &()> getDiag) const {
+    Operation *op, function_ref<InFlightDiagnostic()> emitError) const {
   if (LLVM_UNLIKELY(propertiesAttr)) {
     assert(!properties);
-    return op->setPropertiesFromAttribute(propertiesAttr, getDiag);
+    return op->setPropertiesFromAttribute(propertiesAttr, emitError);
   }
   if (properties)
     propertiesSetter(op->getPropertiesStorage(), properties);

--- a/mlir/lib/TableGen/CodeGenHelpers.cpp
+++ b/mlir/lib/TableGen/CodeGenHelpers.cpp
@@ -133,9 +133,9 @@ static ::mlir::LogicalResult {0}(
 /// functions are stripped anyways.
 static const char *const attrConstraintCode = R"(
 static ::mlir::LogicalResult {0}(
-    ::mlir::Attribute attr, ::llvm::StringRef attrName, llvm::function_ref<::mlir::InFlightDiagnostic()> getDiag) {{
+    ::mlir::Attribute attr, ::llvm::StringRef attrName, llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) {{
   if (attr && !({1}))
-    return getDiag() << "attribute '" << attrName
+    return emitError() << "attribute '" << attrName
         << "' failed to satisfy constraint: {2}";
   return ::mlir::success();
 }

--- a/mlir/test/lib/Dialect/Test/TestDialect.cpp
+++ b/mlir/test/lib/Dialect/Test/TestDialect.cpp
@@ -55,10 +55,10 @@ Attribute MyPropStruct::asAttribute(MLIRContext *ctx) const {
 }
 LogicalResult
 MyPropStruct::setFromAttr(MyPropStruct &prop, Attribute attr,
-                          function_ref<InFlightDiagnostic &()> getDiag) {
+                          function_ref<InFlightDiagnostic()> emitError) {
   StringAttr strAttr = dyn_cast<StringAttr>(attr);
   if (!strAttr) {
-    getDiag() << "Expect StringAttr but got " << attr;
+    emitError() << "Expect StringAttr but got " << attr;
     return failure();
   }
   prop.content = strAttr.getValue();
@@ -108,7 +108,7 @@ static void writeToMlirBytecode(::mlir::DialectBytecodeWriter &writer,
 
 static LogicalResult
 setPropertiesFromAttribute(PropertiesWithCustomPrint &prop, Attribute attr,
-                           function_ref<InFlightDiagnostic &()> getDiag);
+                           function_ref<InFlightDiagnostic()> emitError);
 static DictionaryAttr
 getPropertiesAsAttribute(MLIRContext *ctx,
                          const PropertiesWithCustomPrint &prop);
@@ -119,7 +119,7 @@ static ParseResult customParseProperties(OpAsmParser &parser,
                                          PropertiesWithCustomPrint &prop);
 static LogicalResult
 setPropertiesFromAttribute(VersionedProperties &prop, Attribute attr,
-                           function_ref<InFlightDiagnostic &()> getDiag);
+                           function_ref<InFlightDiagnostic()> emitError);
 static DictionaryAttr getPropertiesAsAttribute(MLIRContext *ctx,
                                                const VersionedProperties &prop);
 static llvm::hash_code computeHash(const VersionedProperties &prop);
@@ -1138,20 +1138,20 @@ OpFoldResult ManualCppOpWithFold::fold(ArrayRef<Attribute> attributes) {
 
 static LogicalResult
 setPropertiesFromAttribute(PropertiesWithCustomPrint &prop, Attribute attr,
-                           function_ref<InFlightDiagnostic &()> getDiag) {
+                           function_ref<InFlightDiagnostic()> emitError) {
   DictionaryAttr dict = dyn_cast<DictionaryAttr>(attr);
   if (!dict) {
-    getDiag() << "expected DictionaryAttr to set TestProperties";
+    emitError() << "expected DictionaryAttr to set TestProperties";
     return failure();
   }
   auto label = dict.getAs<mlir::StringAttr>("label");
   if (!label) {
-    getDiag() << "expected StringAttr for key `label`";
+    emitError() << "expected StringAttr for key `label`";
     return failure();
   }
   auto valueAttr = dict.getAs<IntegerAttr>("value");
   if (!valueAttr) {
-    getDiag() << "expected IntegerAttr for key `value`";
+    emitError() << "expected IntegerAttr for key `value`";
     return failure();
   }
 
@@ -1187,20 +1187,20 @@ static ParseResult customParseProperties(OpAsmParser &parser,
 }
 static LogicalResult
 setPropertiesFromAttribute(VersionedProperties &prop, Attribute attr,
-                           function_ref<InFlightDiagnostic &()> getDiag) {
+                           function_ref<InFlightDiagnostic()> emitError) {
   DictionaryAttr dict = dyn_cast<DictionaryAttr>(attr);
   if (!dict) {
-    getDiag() << "expected DictionaryAttr to set VersionedProperties";
+    emitError() << "expected DictionaryAttr to set VersionedProperties";
     return failure();
   }
   auto value1Attr = dict.getAs<IntegerAttr>("value1");
   if (!value1Attr) {
-    getDiag() << "expected IntegerAttr for key `value1`";
+    emitError() << "expected IntegerAttr for key `value1`";
     return failure();
   }
   auto value2Attr = dict.getAs<IntegerAttr>("value2");
   if (!value2Attr) {
-    getDiag() << "expected IntegerAttr for key `value2`";
+    emitError() << "expected IntegerAttr for key `value2`";
     return failure();
   }
 

--- a/mlir/test/lib/Dialect/Test/TestDialect.h
+++ b/mlir/test/lib/Dialect/Test/TestDialect.h
@@ -95,7 +95,7 @@ public:
   mlir::Attribute asAttribute(mlir::MLIRContext *ctx) const;
   static mlir::LogicalResult
   setFromAttr(MyPropStruct &prop, mlir::Attribute attr,
-              llvm::function_ref<mlir::InFlightDiagnostic &()> getDiag);
+              llvm::function_ref<mlir::InFlightDiagnostic()> emitError);
   llvm::hash_code hash() const;
   bool operator==(const MyPropStruct &rhs) const {
     return content == rhs.content;

--- a/mlir/test/mlir-tblgen/constraint-unique.td
+++ b/mlir/test/mlir-tblgen/constraint-unique.td
@@ -71,7 +71,7 @@ def OpC : NS_Op<"op_c"> {
 /// Test that an attribute contraint was generated.
 // CHECK:    static ::mlir::LogicalResult [[$A_ATTR_CONSTRAINT:__mlir_ods_local_attr_constraint.*]](
 // CHECK:      if (attr && !((attrPred(attr, *op))))
-// CHECK-NEXT:   return getDiag() << "attribute '" << attrName
+// CHECK-NEXT:   return emitError() << "attribute '" << attrName
 // CHECK-NEXT:       << "' failed to satisfy constraint: an attribute";
 
 /// Test that duplicate attribute constraint was not generated.
@@ -81,7 +81,7 @@ def OpC : NS_Op<"op_c"> {
 // CHECK:    static ::mlir::LogicalResult [[$O_ATTR_CONSTRAINT:__mlir_ods_local_attr_constraint.*]](
 // CHECK:    static ::mlir::LogicalResult [[$O_ATTR_CONSTRAINT:__mlir_ods_local_attr_constraint.*]](
 // CHECK:      if (attr && !((attrPred(attr, *op))))
-// CHECK-NEXT:   return getDiag() << "attribute '" << attrName
+// CHECK-NEXT:   return emitError() << "attribute '" << attrName
 // CHECK-NEXT:       << "' failed to satisfy constraint: another attribute";
 
 /// Test that a successor contraint was generated.

--- a/mlir/test/mlir-tblgen/interfaces-as-constraints.td
+++ b/mlir/test/mlir-tblgen/interfaces-as-constraints.td
@@ -35,12 +35,12 @@ def OpUsingAllOfThose : Op<Test_Dialect, "OpUsingAllOfThose"> {
 
 // CHECK: static ::mlir::LogicalResult {{__mlir_ods_local_attr_constraint.*}}(
 // CHECK:   if (attr && !((::llvm::isa<TopLevelAttrInterface>(attr))))
-// CHECK-NEXT:     return getDiag() << "attribute '" << attrName
+// CHECK-NEXT:     return emitError() << "attribute '" << attrName
 // CHECK-NEXT:        << "' failed to satisfy constraint: TopLevelAttrInterface instance";
 
 // CHECK: static ::mlir::LogicalResult {{__mlir_ods_local_attr_constraint.*}}(
 // CHECK:   if (attr && !((::llvm::isa<test::AttrInterfaceInNamespace>(attr))))
-// CHECK-NEXT:    return getDiag() << "attribute '" << attrName
+// CHECK-NEXT:    return emitError() << "attribute '" << attrName
 // CHECK-NEXT:        << "' failed to satisfy constraint: AttrInterfaceInNamespace instance";
 
 // CHECK: TopLevelAttrInterface OpUsingAllOfThose::getAttr1()


### PR DESCRIPTION
This is a follow-up to 8c2bff1ab929 which lazy-initialized the diagnostic and removed the need to dynamically abandon() an InFlightDiagnostic. This further simplifies the code to not needed to return a reference to an InFlightDiagnostic and instead eagerly emit errors.

Also use `emitError` as name instead of `getDiag` which seems more explicit and in-line with the common usage.