### PR TITLE
[AArch64] Bail out of HomogeneousPrologEpilog for functions with swif…

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -331,6 +331,10 @@ bool AArch64FrameLowering::homogeneousPrologEpilog(
   if (Exit && getArgumentStackToRestore(MF, *Exit))
     return false;
 
+  auto *AFI = MF.getInfo<AArch64FunctionInfo>();
+  if (AFI->hasSwiftAsyncContext())
+    return false;
+
   return true;
 }
 

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
@@ -72,3 +72,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 ; CHECK-LINUX-NEXT: ldp     x22, x21, [sp, #16]
 ; CHECK-LINUX-NEXT: ldp     x29, x30, [sp], #48
 ; CHECK-LINUX-NEXT: ret     x16
+
+; nothing to check - hit assert if not bailing out for swiftasync
+define void @swift_async(i8* swiftasync %ctx) minsize "frame-pointer"="all" {
+  ret void
+}


### PR DESCRIPTION
…tasync argument

swiftasync introduces a number of frame adjustments which is incompatible with current implementation of HomogeneousPrologEpilog pass.