### PR TITLE
[lld][LoongArch] Print error when encountering R_LARCH_ALIGN

### DIFF
--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -521,6 +521,14 @@ RelExpr LoongArch::getRelExpr(const RelType type, const Symbol &s,
   case R_LARCH_RELAX:
     // LoongArch linker relaxation is not implemented yet.
     return R_NONE;
+  case R_LARCH_ALIGN:
+    // Not just a hint; always padded to the worst-case number of NOPs, so may
+    // not currently be aligned, and without linker relaxation support we can't
+    // delete NOPs to realign.
+    errorOrWarn(getErrorLocation(loc) +
+                "relocation R_LARCH_ALIGN requires "
+                "unimplemented linker relaxation; recompile with -mno-relax");
+    return R_NONE;
 
   // Other known relocs that are explicitly unimplemented:
   //

--- a/lld/test/ELF/loongarch-reloc-align.s
+++ b/lld/test/ELF/loongarch-reloc-align.s
@@ -1,0 +1,15 @@
+# REQUIRES: loongarch
+
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 %s -o %t.o
+# RUN: not ld.lld %t.o -o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: relocation R_LARCH_ALIGN requires unimplemented linker relaxation
+
+.global _start
+_start:
+    addi.d $t0, $t0, 1
+1:
+    nop
+    .reloc 1b, R_LARCH_ALIGN, 12
+    nop
+    nop


### PR DESCRIPTION
GAS (from binutils 2.41) defaults to emit `R_LARCH_ALIGN` for the `.align` directive for later linker relaxation in `ld`. But `lld` hasn't implemented relaxation on LoongArch currently. So we print a more valuable error than the default when encountering `R_LARCH_ALIGN`.

Similar to https://reviews.llvm.org/D71820.