### PR TITLE
[NewGVN] Patch replacement instruction even for removed instructions

### DIFF
--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -4030,9 +4030,18 @@ bool NewGVN::eliminateInstructions(Function &F) {
             // because stores are put in terms of the stored value, we skip
             // stored values here. If the stored value is really dead, it will
             // still be marked for deletion when we process it in its own class.
-            if (!EliminationStack.empty() && Def != EliminationStack.back() &&
-                isa<Instruction>(Def) && !FromStore)
-              markInstructionForDeletion(cast<Instruction>(Def));
+            auto *DefI = dyn_cast<Instruction>(Def);
+            if (!EliminationStack.empty() && DefI && !FromStore) {
+              Value *DominatingLeader = EliminationStack.back();
+              if (DominatingLeader != Def) {
+                // Even if the instruction is removed, we still need to update
+                // flags/metadata due to downstreams users of the leader.
+                if (!match(DefI, m_Intrinsic<Intrinsic::ssa_copy>()))
+                  patchReplacementInstruction(DefI, DominatingLeader);
+
+                markInstructionForDeletion(DefI);
+              }
+            }
             continue;
           }
           // At this point, we know it is a Use we are trying to possibly

--- a/llvm/test/Transforms/NewGVN/flags.ll
+++ b/llvm/test/Transforms/NewGVN/flags.ll
@@ -23,7 +23,7 @@ entry:
 define void @test2(i8 %start, i8 %high) {
 ; CHECK-LABEL: define void @test2
 ; CHECK-SAME: (i8 [[START:%.*]], i8 [[HIGH:%.*]]) {
-; CHECK-NEXT:    [[START1:%.*]] = add nsw i8 [[START]], 4
+; CHECK-NEXT:    [[START1:%.*]] = add i8 [[START]], 4
 ; CHECK-NEXT:    [[T1:%.*]] = icmp ult i8 [[START1]], [[HIGH]]
 ; CHECK-NEXT:    call void @use(i1 [[T1]])
 ; CHECK-NEXT:    call void @use(i1 [[T1]])


### PR DESCRIPTION
When removing an instruction, we still need to merge its IR flags into the leader, because there may have been a transitive use.

Fixes https://github.com/llvm/llvm-project/issues/53218.