### PR TITLE
[VFABI] Refactor try demangle for vfabi to use only the vector abi mangled names

### DIFF
--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -174,9 +174,9 @@ static constexpr char const *_LLVM_Scalarize_ = "_LLVM_Scalarize_";
 ///
 /// \param MangledName -> input string in the format
 /// _ZGV<isa><mask><vlen><parameters>_<scalarname>[(<redirection>)].
-/// \param OpTys -> the instruction operand types.
+/// \param CI -> the call instruction.
 std::optional<VFInfo> tryDemangleForVFABI(StringRef MangledName,
-                                          SmallVector<Type *> OpTys);
+                                          const CallInst &CI);
 
 /// Retrieve the `VFParamKind` from a string token.
 VFParamKind getVFParamKindFromString(const StringRef Token);
@@ -222,11 +222,8 @@ class VFDatabase {
     if (ListOfStrings.empty())
       return;
     for (const auto &MangledName : ListOfStrings) {
-      SmallVector<Type *> OpTys;
-      for (Value *Op : CI.operands())
-        OpTys.push_back(Op->getType());
       const std::optional<VFInfo> Shape =
-          VFABI::tryDemangleForVFABI(MangledName, OpTys);
+          VFABI::tryDemangleForVFABI(MangledName, CI);
       // A match is found via scalar and vector names, and also by
       // ensuring that the variant described in the attribute has a
       // corresponding definition or declaration of the vector

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -1464,9 +1464,11 @@ void VFABI::getVectorVariantNames(
 
   for (const auto &S : SetVector<StringRef>(ListAttr.begin(), ListAttr.end())) {
 #ifndef NDEBUG
+    SmallVector<Type *> OpTys;
+    for (Value *Op : CI.operands())
+      OpTys.push_back(Op->getType());
     LLVM_DEBUG(dbgs() << "VFABI: adding mapping '" << S << "'\n");
-    std::optional<VFInfo> Info =
-        VFABI::tryDemangleForVFABI(S, *(CI.getModule()));
+    std::optional<VFInfo> Info = VFABI::tryDemangleForVFABI(S, OpTys);
     assert(Info && "Invalid name for a VFABI variant.");
     assert(CI.getModule()->getFunction(Info->VectorName) &&
            "Vector function is missing.");

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -1464,11 +1464,8 @@ void VFABI::getVectorVariantNames(
 
   for (const auto &S : SetVector<StringRef>(ListAttr.begin(), ListAttr.end())) {
 #ifndef NDEBUG
-    SmallVector<Type *> OpTys;
-    for (Value *Op : CI.operands())
-      OpTys.push_back(Op->getType());
     LLVM_DEBUG(dbgs() << "VFABI: adding mapping '" << S << "'\n");
-    std::optional<VFInfo> Info = VFABI::tryDemangleForVFABI(S, OpTys);
+    std::optional<VFInfo> Info = VFABI::tryDemangleForVFABI(S, CI);
     assert(Info && "Invalid name for a VFABI variant.");
     assert(CI.getModule()->getFunction(Info->VectorName) &&
            "Vector function is missing.");

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -345,12 +345,8 @@ void VFABI::setVectorVariantNames(CallInst *CI,
   Module *M = CI->getModule();
 #ifndef NDEBUG
   for (const std::string &VariantMapping : VariantMappings) {
-    SmallVector<Type *> OpTys;
-    for (Value *Op : CI->operands())
-      OpTys.push_back(Op->getType());
     LLVM_DEBUG(dbgs() << "VFABI: adding mapping '" << VariantMapping << "'\n");
-    std::optional<VFInfo> VI =
-        VFABI::tryDemangleForVFABI(VariantMapping, OpTys);
+    std::optional<VFInfo> VI = VFABI::tryDemangleForVFABI(VariantMapping, *CI);
     assert(VI && "Cannot add an invalid VFABI name.");
     assert(M->getNamedValue(VI->VectorName) &&
            "Cannot add variant to attribute: "

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -345,8 +345,12 @@ void VFABI::setVectorVariantNames(CallInst *CI,
   Module *M = CI->getModule();
 #ifndef NDEBUG
   for (const std::string &VariantMapping : VariantMappings) {
+    SmallVector<Type *> OpTys;
+    for (Value *Op : CI->operands())
+      OpTys.push_back(Op->getType());
     LLVM_DEBUG(dbgs() << "VFABI: adding mapping '" << VariantMapping << "'\n");
-    std::optional<VFInfo> VI = VFABI::tryDemangleForVFABI(VariantMapping, *M);
+    std::optional<VFInfo> VI =
+        VFABI::tryDemangleForVFABI(VariantMapping, OpTys);
     assert(VI && "Cannot add an invalid VFABI name.");
     assert(M->getNamedValue(VI->VectorName) &&
            "Cannot add variant to attribute: "

--- a/llvm/test/Transforms/LoopVectorize/AArch64/masked-call.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/masked-call.ll
@@ -862,8 +862,8 @@ declare <vscale x 2 x i64> @foo_uniform(i64, <vscale x 2 x i1>)
 declare <vscale x 2 x i64> @foo_vector(<vscale x 2 x i64>, <vscale x 2 x i1>)
 declare <vscale x 2 x i64> @foo_vector_nomask(<vscale x 2 x i64>)
 
-attributes #0 = { nounwind "vector-function-abi-variant"="_ZGV_LLVM_Mxv_foo(foo_vector),_ZGV_LLVM_Mxu_foo(foo_uniform)" }
-attributes #1 = { nounwind "vector-function-abi-variant"="_ZGV_LLVM_Mxv_foo(foo_vector)" }
-attributes #2 = { nounwind "vector-function-abi-variant"="_ZGV_LLVM_Nxv_foo(foo_vector_nomask)" }
-attributes #3 = { nounwind "vector-function-abi-variant"="_ZGV_LLVM_Nxv_foo(foo_vector_nomask),_ZGV_LLVM_Mxv_foo(foo_vector)" }
+attributes #0 = { nounwind "vector-function-abi-variant"="_ZGVsMxv_foo(foo_vector),_ZGVsMxu_foo(foo_uniform)" }
+attributes #1 = { nounwind "vector-function-abi-variant"="_ZGVsMxv_foo(foo_vector)" }
+attributes #2 = { nounwind "vector-function-abi-variant"="_ZGVsNxv_foo(foo_vector_nomask)" }
+attributes #3 = { nounwind "vector-function-abi-variant"="_ZGVsNxv_foo(foo_vector_nomask),_ZGVsMxv_foo(foo_vector)" }
 attributes #4 = { "target-features"="+sve" vscale_range(2,16) "no-trapping-math"="false" }

--- a/llvm/test/Transforms/LoopVectorize/AArch64/scalable-call.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/scalable-call.ll
@@ -224,9 +224,9 @@ declare <vscale x 2 x i64> @bar_vec(<vscale x 2 x ptr>)
 declare <vscale x 2 x double> @sin_vec_nxv2f64(<vscale x 2 x double>)
 declare <2 x double> @sin_vec_v2f64(<2 x double>)
 
-attributes #0 = { "vector-function-abi-variant"="_ZGV_LLVM_Nxv_foo(foo_vec)" }
-attributes #1 = { "vector-function-abi-variant"="_ZGV_LLVM_Nxv_bar(bar_vec)" }
-attributes #2 = { "vector-function-abi-variant"="_ZGV_LLVM_Nxv_llvm.sin.f64(sin_vec_nxv2f64)" }
+attributes #0 = { "vector-function-abi-variant"="_ZGVsNxv_foo(foo_vec)" }
+attributes #1 = { "vector-function-abi-variant"="_ZGVsNxv_bar(bar_vec)" }
+attributes #2 = { "vector-function-abi-variant"="_ZGVsNxv_llvm.sin.f64(sin_vec_nxv2f64)" }
 attributes #3 = { "vector-function-abi-variant"="_ZGV_LLVM_N2v_llvm.sin.f64(sin_vec_v2f64)" }
 
 !1 = distinct !{!1, !2, !3}

--- a/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp
+++ b/llvm/tools/vfabi-demangle-fuzzer/vfabi-demangler-fuzzer.cpp
@@ -21,12 +21,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   const std::unique_ptr<Module> M =
       parseAssemblyString("declare i32 @foo(i32 )\n", Err, Ctx);
   const StringRef MangledName((const char *)Data, Size);
-  // Make sure that whatever symbol the demangler is operating on is
-  // present in the module (the signature is not important). This is
-  // because `tryDemangleForVFABI` fails if the function is not
-  // present. We need to make sure we can even invoke
-  // `getOrInsertFunction` because such method asserts on strings with
-  // zeroes.
+  // Make sure we can invoke `getOrInsertFunction` because such method asserts
+  // on strings with zeroes.
   if (!MangledName.empty() && MangledName.find_first_of(0) == StringRef::npos) {
     FunctionType *FTy =
         FunctionType::get(Type::getVoidTy(M->getContext()), false);
@@ -42,7 +38,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     // Do not optimize away the return value. Inspired by
     // https://github.com/google/benchmark/blob/main/include/benchmark/benchmark.h#L307-L345
     asm volatile("" : : "r,m"(Info) : "memory");
-
-    return 0;
   }
+  return 0;
 }

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -50,10 +50,7 @@ protected:
   SmallVector<VFParameter, 8> &Parameters = Info.Shape.Parameters;
   std::string &ScalarName = Info.ScalarName;
   std::string &VectorName = Info.VectorName;
-  // Invoke the parser. We need to make sure that a function exist in
-  // the module because the parser fails if such function don't
-  // exists. Every time this method is invoked the state of the test
-  // is reset.
+  // Invoke the parser.
   //
   // \p MangledName -> the string the parser has to demangle.
   //


### PR DESCRIPTION
    [VFABI] Refactor tryDemangleForVFABI to use only the Vector ABI mangled names
            and the call's argument types to construct the VFInfo.
    
    Currently the tryDemangleForVFABI is incorrectly making assumptions that when
    the mangled name has __LLVM__ set as ISA and _vlen_ is set to scalable/VLA
    the module can be queried to identify the correct VF. This works currently only
    by chance rather than by design and limits the ability to maximise the use for
    the Vector ABI. This behaviour is changed by
    https://github.com/llvm/llvm-project/pull/66656 and
    https://github.com/llvm/llvm-project/pull/67308
    and means demangling can be implemented as expected based solely on the rules
    as documented within the VFABI.
