### PR TITLE
[clang][dataflow] Show triangle in `<details>` element.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
@@ -125,7 +125,7 @@ code.line:has(.bb-select):before {
 .value > summary {
   background-color: #ace;
   display: flex;
-  justify-content: space-between;
+  justify-content: start;
   cursor: pointer;
 }
 .value > summary::before {

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
@@ -122,10 +122,22 @@ code.line:has(.bb-select):before {
   font-size: x-small;
   flex-grow: 1;
 }
-.value summary {
+.value > summary {
   background-color: #ace;
   display: flex;
   justify-content: space-between;
+  cursor: pointer;
+}
+.value > summary::before {
+  content: '►';
+  margin-right: 0.5em;
+  font-size: 0.9em;
+}
+.value[open] > summary::before {
+  content: '▼';
+}
+.value > summary > .location {
+  margin-left: auto;
 }
 .value .address {
   font-size: xx-small;

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
@@ -125,7 +125,6 @@ code.line:has(.bb-select):before {
 .value > summary {
   background-color: #ace;
   display: flex;
-  justify-content: start;
   cursor: pointer;
 }
 .value > summary::before {

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
@@ -18,7 +18,7 @@
         <template data-if="v.value_id"><span class="address">#{{v.value_id}}</span></template>
       </span>
       <template data-if="v.location">
-        <span>{{v.type}} <span class="address">@{{v.location}}</span></span>
+        <span class="location">{{v.type}} <span class="address">@{{v.location}}</span></span>
       </template>
     </summary>
     <template


### PR DESCRIPTION
Also, change the mouse cursor into a pointer instead of a text cursor.

This makes it more discoverable that the element can be opened and closed.
