### PR TITLE
[BOLT][RISCV] Implement LO/HI relocations

### DIFF
--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -106,6 +106,9 @@ static bool isSupportedRISCV(uint64_t Type) {
   case ELF::R_RISCV_RVC_BRANCH:
   case ELF::R_RISCV_ADD32:
   case ELF::R_RISCV_SUB32:
+  case ELF::R_RISCV_HI20:
+  case ELF::R_RISCV_LO12_I:
+  case ELF::R_RISCV_LO12_S:
     return true;
   }
 }
@@ -202,6 +205,9 @@ static size_t getSizeForTypeRISCV(uint64_t Type) {
   case ELF::R_RISCV_CALL_PLT:
   case ELF::R_RISCV_ADD32:
   case ELF::R_RISCV_SUB32:
+  case ELF::R_RISCV_HI20:
+  case ELF::R_RISCV_LO12_I:
+  case ELF::R_RISCV_LO12_S:
     return 4;
   case ELF::R_RISCV_GOT_HI20:
     // See extractValueRISCV for why this is necessary.
@@ -519,10 +525,13 @@ static uint64_t extractValueRISCV(uint64_t Type, uint64_t Contents,
     return extractUImmRISCV(Contents & 0xffffffff) +
            extractIImmRISCV(Contents >> 32);
   case ELF::R_RISCV_PCREL_HI20:
+  case ELF::R_RISCV_HI20:
     return extractUImmRISCV(Contents);
   case ELF::R_RISCV_PCREL_LO12_I:
+  case ELF::R_RISCV_LO12_I:
     return extractIImmRISCV(Contents);
   case ELF::R_RISCV_PCREL_LO12_S:
+  case ELF::R_RISCV_LO12_S:
     return extractSImmRISCV(Contents);
   case ELF::R_RISCV_RVC_JUMP:
     return SignExtend64<11>(Contents >> 2);
@@ -692,6 +701,9 @@ static bool isPCRelativeRISCV(uint64_t Type) {
     llvm_unreachable("Unknown relocation type");
   case ELF::R_RISCV_ADD32:
   case ELF::R_RISCV_SUB32:
+  case ELF::R_RISCV_HI20:
+  case ELF::R_RISCV_LO12_I:
+  case ELF::R_RISCV_LO12_S:
     return false;
   case ELF::R_RISCV_JAL:
   case ELF::R_RISCV_CALL:

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -43,6 +43,9 @@ public:
     case ELF::R_RISCV_PCREL_HI20:
     case ELF::R_RISCV_PCREL_LO12_I:
     case ELF::R_RISCV_PCREL_LO12_S:
+    case ELF::R_RISCV_HI20:
+    case ELF::R_RISCV_LO12_I:
+    case ELF::R_RISCV_LO12_S:
       return true;
     default:
       llvm_unreachable("Unexpected RISCV relocation type in code");
@@ -399,6 +402,11 @@ public:
     case ELF::R_RISCV_PCREL_LO12_I:
     case ELF::R_RISCV_PCREL_LO12_S:
       return RISCVMCExpr::create(Expr, RISCVMCExpr::VK_RISCV_PCREL_LO, Ctx);
+    case ELF::R_RISCV_HI20:
+      return RISCVMCExpr::create(Expr, RISCVMCExpr::VK_RISCV_HI, Ctx);
+    case ELF::R_RISCV_LO12_I:
+    case ELF::R_RISCV_LO12_S:
+      return RISCVMCExpr::create(Expr, RISCVMCExpr::VK_RISCV_LO, Ctx);
     case ELF::R_RISCV_CALL:
       return RISCVMCExpr::create(Expr, RISCVMCExpr::VK_RISCV_CALL, Ctx);
     case ELF::R_RISCV_CALL_PLT:

--- a/bolt/test/RISCV/reloc-lohi.s
+++ b/bolt/test/RISCV/reloc-lohi.s
@@ -1,0 +1,26 @@
+// RUN: llvm-mc -triple riscv64 -filetype=obj -o %t.o %s
+// RUN: ld.lld -q -o %t %t.o
+// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN:    | FileCheck %s
+
+  .data
+  .globl d
+  .p2align 3
+d:
+  .dword 0
+
+// CHECK-LABEL: Binary Function "_start" after building cfg {
+// CHECK:      lui t0, %hi(d)
+// CHECK-NEXT: ld t0, %lo(d)(t0)
+// CHECK-NEXT: lui t0, %hi(d)
+// CHECK-NEXT: sd t0, %lo(d)(t0)
+  .text
+  .globl _start
+  .p2align 1
+_start:
+  lui t0, %hi(d)
+  ld t0, %lo(d)(t0)
+  lui t0, %hi(d)
+  sd t0, %lo(d)(t0)
+  ret
+  .size _start, .-_start


### PR DESCRIPTION
Implement the following relocations used by the medlow code model and non-PIE binaries:
- R_RISCV_HI20
- R_RISCV_LO12_I
- R_RISCV_LO12_S