### PR TITLE
[flang][lowering] propagate location info of macro expansions

### DIFF
--- a/flang/test/Lower/macro-debug-file-loc.f90
+++ b/flang/test/Lower/macro-debug-file-loc.f90
@@ -1,0 +1,13 @@
+! Test that the expanded macros have the location information
+! RUN: %flang_fc1 -mmlir --mlir-print-debuginfo -emit-fir -o - %s | FileCheck %s
+
+#define CMD(fname) fname()
+
+subroutine foo()
+end subroutine
+
+subroutine test()
+  ! CHECK: fir.call @_QPfoo() fastmath<contract> : () -> () loc(#[[CALL_LOC:.*]])
+  call CMD(foo)
+end subroutine
+! CHECK: #[[CALL_LOC]] = loc("{{.*}}macro-debug-file-loc.f90":11:3)


### PR DESCRIPTION
Currently flang-new -g is failing when compiling code containing a call in a macro to a function defined in the same file.

The verification added in https://reviews.llvm.org/D157447 is valid, flang lowering was failing to propagate location information in code from macro expansion because GetSourcePositionRange does not work with them (it fails to come with an end location), but we do not need a range for the MLIR location, only the start.

Use GetSourcePosition instead that works with code from macro expansion.

Note that the source location is the one of the statement where the macro appeared, if needed some FusedLocation could be later built to keep a link to the macro location in the debug info.