### PR TITLE
[libc][NFC] Add compile options only to the header libraries which use them.

### DIFF
--- a/libc/src/stdio/CMakeLists.txt
+++ b/libc/src/stdio/CMakeLists.txt
@@ -137,7 +137,6 @@ add_entrypoint_object(
     fscanf.h
   DEPENDS
     ${scanf_deps}
-  ${use_system_file}
 )
 
 add_entrypoint_object(
@@ -148,7 +147,6 @@ add_entrypoint_object(
     scanf.h
   DEPENDS
     ${scanf_deps}
-  ${use_system_file}
 )
 
 add_entrypoint_object(
@@ -194,7 +192,6 @@ add_entrypoint_object(
     printf.h
   DEPENDS
     ${printf_deps}
-  ${use_system_file}
 )
 
 add_entrypoint_object(
@@ -206,7 +203,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.arg_list
     libc.src.stdio.printf_core.vfprintf_internal
-  ${use_system_file}
 )
 
 add_entrypoint_object(
@@ -239,7 +235,6 @@ add_entrypoint_object(
     vprintf.h
   DEPENDS
     ${printf_deps}
-  ${use_system_file}
 )
 
 add_entrypoint_object(
@@ -251,7 +246,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.arg_list
     libc.src.stdio.printf_core.vfprintf_internal
-  ${use_system_file}
 )
 
 add_subdirectory(printf_core)

--- a/libc/src/stdio/printf_core/CMakeLists.txt
+++ b/libc/src/stdio/printf_core/CMakeLists.txt
@@ -125,4 +125,5 @@ add_header_library(
     libc.src.__support.arg_list
     libc.src.stdio.printf_core.printf_main
     libc.src.stdio.printf_core.writer
+  ${use_system_file}
 )

--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -90,4 +90,5 @@ add_header_library(
     libc.include.stdio
     libc.src.__support.File.file
     libc.src.__support.arg_list
+  ${use_system_file}
 )


### PR DESCRIPTION
Other libraries dependent on these libraries will automatically inherit
those compile options. This change in particular affects the compile
option "-DLIBC_COPT_STDIO_USE_SYSTEM_FILE".
