### PR TITLE
[lld-macho][NFC] Remove redundant checks

### DIFF
--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -514,15 +514,13 @@ void macho::resolveLCLinkerOptions() {
     for (unsigned i = 0; i < LCLinkerOptions.size(); ++i) {
       StringRef arg = LCLinkerOptions[i];
       if (arg.consume_front("-l")) {
-        if (config->ignoreAutoLinkOptions.contains(arg))
-          continue;
+        assert(!config->ignoreAutoLinkOptions.contains(arg));
         addLibrary(arg, /*isNeeded=*/false, /*isWeak=*/false,
                    /*isReexport=*/false, /*isHidden=*/false,
                    /*isExplicit=*/false, LoadType::LCLinkerOption);
       } else if (arg == "-framework") {
         StringRef name = LCLinkerOptions[++i];
-        if (config->ignoreAutoLinkOptions.contains(name))
-          continue;
+        assert(!config->ignoreAutoLinkOptions.contains(name));
         addFramework(name, /*isNeeded=*/false, /*isWeak=*/false,
                      /*isReexport=*/false, /*isExplicit=*/false,
                      LoadType::LCLinkerOption);


### PR DESCRIPTION
`ignoreAutoLinkOptions` checks run both in `parseLCLinkerOptions` and `resolveLCLinkerOptions`. Convert the latter check to an assert.