### PR TITLE
[llvm-profdata] Use simple enum for error checking in Sample Profile Reader

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -43,7 +43,7 @@ class raw_ostream;
 
 const std::error_category &sampleprof_category();
 
-enum class sampleprof_error {
+enum sampleprof_error {
   success = 0,
   bad_magic,
   unsupported_version,


### PR DESCRIPTION

Benchmarking data show that around 7% of the time is spent on handling llvm::ErrorOr<T> and std::error_code, which are not efficiently processed. This has a significant impact on profile load time, so it should be changed into a simple enum and check if it is 0 instead.