### PR TITLE
[libc] Added missing operator delete generated by gcc/clang

### DIFF
--- a/libc/test/UnitTest/HermeticTestUtils.cpp
+++ b/libc/test/UnitTest/HermeticTestUtils.cpp
@@ -123,7 +123,7 @@ unsigned long __getauxval(unsigned long id) {
 
 } // extern "C"
 
-void *operator new(unsigned long size, void *ptr) { return ptr; }
+void *operator new(size_t size, void *ptr) { return ptr; }
 
 void *operator new(size_t size) { return malloc(size); }
 
@@ -136,3 +136,16 @@ void operator delete(void *) {
 }
 
 void operator delete(void *ptr, size_t size) { __builtin_trap(); }
+
+// Defining members in the std namespace is not preferred. But, we do it here
+// so that we can use it to define the operator new which takes std::align_val_t
+// argument.
+namespace std {
+enum class align_val_t : size_t {};
+} // namespace std
+
+void operator delete(void *mem, std::align_val_t) noexcept { __builtin_trap(); }
+
+void operator delete(void *mem, unsigned int, std::align_val_t) noexcept {
+  __builtin_trap();
+}


### PR DESCRIPTION
This patch adds two operator delete functions that are being generated by clang 15 on rv32 (operator delete(void *mem, std::align_val_t)) and by gcc 13 on intel 64 (operator delete(void *mem, unsigned long)).