### PR TITLE
[StructuralEquivalence] fix crash & improve comparing on GenericSelectionExpr

### DIFF
--- a/clang/lib/AST/ASTStructuralEquivalence.cpp
+++ b/clang/lib/AST/ASTStructuralEquivalence.cpp
@@ -247,6 +247,20 @@ class StmtComparer {
 
   bool IsStmtEquivalent(const GenericSelectionExpr *E1,
                         const GenericSelectionExpr *E2) {
+    if (!IsStructurallyEquivalent(Context,
+                                  const_cast<Expr *>(E1->getControllingExpr()),
+                                  const_cast<Expr *>(E2->getControllingExpr())))
+      return false;
+
+    for (auto Pair : zip_longest(E1->getAssocExprs(), E2->getAssocExprs())) {
+      std::optional<Expr *> Child1 = std::get<0>(Pair);
+      std::optional<Expr *> Child2 = std::get<1>(Pair);
+      if (!Child1 || !Child2)
+        return false;
+      if (!IsStructurallyEquivalent(Context, *Child1, *Child2))
+        return false;
+    }
+
     for (auto Pair : zip_longest(E1->getAssocTypeSourceInfos(),
                                  E2->getAssocTypeSourceInfos())) {
       std::optional<TypeSourceInfo *> Child1 = std::get<0>(Pair);
@@ -254,6 +268,12 @@ class StmtComparer {
       // Skip this case if there are a different number of associated types.
       if (!Child1 || !Child2)
         return false;
+
+      if (!(*Child1) != !(*Child2))
+        return false;
+
+      if (!(*Child1))
+        continue;
 
       if (!IsStructurallyEquivalent(Context, (*Child1)->getType(),
                                     (*Child2)->getType()))

--- a/clang/unittests/AST/StructuralEquivalenceTest.cpp
+++ b/clang/unittests/AST/StructuralEquivalenceTest.cpp
@@ -2091,6 +2091,28 @@ TEST_F(StructuralEquivalenceStmtTest, GenericSelectionExprOrderDiffers) {
   EXPECT_FALSE(testStructuralMatch(t));
 }
 
+TEST_F(StructuralEquivalenceStmtTest, GenericSelectionExprControlDiffers) {
+  auto t = makeWrappedStmts("_Generic(0u, unsigned int: 0, float: 1)",
+                            "_Generic(1u, unsigned int: 0, float: 1)", Lang_C99,
+                            genericSelectionExpr());
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceStmtTest, GenericSelectionExprAssocExprDiffers) {
+  auto t = makeWrappedStmts("_Generic(0u, unsigned int: 0, float: 1)",
+                            "_Generic(0u, unsigned int: 1u, float: 1)",
+                            Lang_C99, genericSelectionExpr());
+  EXPECT_FALSE(testStructuralMatch(t));
+}
+
+TEST_F(StructuralEquivalenceStmtTest,
+       GenericSelectionExprDefaultNoTypeSourceInfo) {
+  auto t = makeWrappedStmts("_Generic(0u, unsigned int: 0, default: 1)",
+                            "_Generic(0u, unsigned int: 0, default: 1)",
+                            Lang_C99, genericSelectionExpr());
+  EXPECT_TRUE(testStructuralMatch(t));
+}
+
 TEST_F(StructuralEquivalenceStmtTest, GenericSelectionExprDependentResultSame) {
   auto t = makeStmts(
       R"(


### PR DESCRIPTION
1. fix crash on 'default' assoc which has no TypeSourceInfo (nullptr);
2. improve equivalency comparison on control expr & associated exprs.