### PR TITLE
[libc][Obvious] Remove the previous ErrnoSetterMatcher target.

### DIFF
--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -8,17 +8,6 @@ add_custom_target(libc-long-running-tests)
 
 add_subdirectory(UnitTest)
 
-add_header_library(
-  errno_setter_matcher
-  HDRS
-    ErrnoSetterMatcher.h
-  DEPENDS
-    libc.src.__support.common
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.StringUtil.error_to_string
-    libc.src.errno.errno
-)
-
 if(LIBC_TARGET_ARCHITECTURE_IS_GPU AND
    (NOT TARGET libc.utils.gpu.loader OR NOT TARGET libc.startup.gpu.crt1))
   message(WARNING "Cannot build libc GPU tests, missing loader implementation")

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -165,5 +165,10 @@ add_unittest_framework_library(
 add_header_library(
   ErrnoSetterMatcher
   HDRS
-    ErrnoSetterMatcher
+    ErrnoSetterMatcher.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.StringUtil.error_to_string
+    libc.src.errno.errno
 )

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -9,7 +9,6 @@ add_libc_test(
   DEPENDS
     libc.src.errno.errno
     libc.src.stdlib.atof
-    libc.test.errno_setter_matcher
 )
 
 add_header_library(


### PR DESCRIPTION
A target still depending on the old target has been updated.
