### PR TITLE
[AArch64] update "rm" inline asm test

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64_32.ll
+++ b/llvm/test/CodeGen/AArch64/arm64_32.ll
@@ -649,7 +649,7 @@ define <2 x ptr> @test_pointer_vec_load(ptr %addr) {
 define void @test_inline_asm_mem_pointer(ptr %in) {
 ; CHECK-LABEL: test_inline_asm_mem_pointer:
 ; CHECK: str w0,
-  tail call void asm sideeffect "ldr x0, $0", "rm"(ptr %in)
+  tail call void asm sideeffect "ldr x0, $0", "m"(ptr %in)
   ret void
 }
 


### PR DESCRIPTION
Because `x0` is not listed in the clobber list, regalloc could (one day
when #20571 is fixed) allocate `$0` to `x0`:

  ldr x0, x0

This will produce an error when validating the instruction. The intent
of this test FWICT is to check that the parameter in w0 is stored to a
stack slot using w0, since this target triple is the exotic arm64_32
(ILP32). Update the test to simply use "m" constraint. The clobber list
is underconstrained otherwise.
