### PR TITLE
[libc][NFC] Fix delete operator linkage names after switch to LIBC_NAMESPACE.

### DIFF
--- a/libc/src/__support/CPP/new.h
+++ b/libc/src/__support/CPP/new.h
@@ -84,19 +84,23 @@ LIBC_INLINE void *operator new[](size_t size, std::align_val_t align,
 // they will replace operator delete for the entire application. Including this
 // header file in all libc source files where operator delete is called ensures
 // that only libc call sites use these replacement operator delete functions.
-void operator delete(void *) noexcept __asm__("LIBC_NAMESPACE_delete");
+
+#define DELETE_NAME(name)                                                      \
+  __asm__(LIBC_MACRO_TO_STRING(LIBC_NAMESPACE) "_" LIBC_MACRO_TO_STRING(name))
+
+void operator delete(void *) noexcept DELETE_NAME(delete);
 void operator delete(void *, std::align_val_t) noexcept
-    __asm__("LIBC_NAMESPACE_delete_aligned");
-void operator delete(void *, size_t) noexcept
-    __asm__("LIBC_NAMESPACE_delete_sized");
+    DELETE_NAME(delete_aligned);
+void operator delete(void *, size_t) noexcept DELETE_NAME(delete_sized);
 void operator delete(void *, size_t, std::align_val_t) noexcept
-    __asm__("LIBC_NAMESPACE_delete_sized_aligned");
-void operator delete[](void *) noexcept __asm__("LIBC_NAMESPACE_delete_array");
+    DELETE_NAME(delete_sized_aligned);
+void operator delete[](void *) noexcept DELETE_NAME(delete_array);
 void operator delete[](void *, std::align_val_t) noexcept
-    __asm__("LIBC_NAMESPACE_delete_array_aligned");
-void operator delete[](void *, size_t) noexcept
-    __asm__("LIBC_NAMESPACE_delete_array_sized");
+    DELETE_NAME(delete_array_aligned);
+void operator delete[](void *, size_t) noexcept DELETE_NAME(delete_array_sized);
 void operator delete[](void *, size_t, std::align_val_t) noexcept
-    __asm__("LIBC_NAMESPACE_delete_array_sized_aligned");
+    DELETE_NAME(delete_array_sized_aligned);
+
+#undef DELETE_NAME
 
 #endif // LLVM_LIBC_SRC___SUPPORT_CPP_NEW_H

--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -46,6 +46,9 @@ LIBC_INLINE constexpr bool same_string(char const *lhs, char const *rhs) {
 } // namespace internal
 } // namespace LIBC_NAMESPACE
 
+#define __LIBC_MACRO_TO_STRING(str) #str
+#define LIBC_MACRO_TO_STRING(str) __LIBC_MACRO_TO_STRING(str)
+
 // LLVM_LIBC_IS_DEFINED checks whether a particular macro is defined.
 // Usage: constexpr bool kUseAvx = LLVM_LIBC_IS_DEFINED(__AVX__);
 //


### PR DESCRIPTION
The name __llvm_libc was mass-replaced with LIBC_NAMESPACE which ended
up changing the "__llvm_libc" prefix the delete operator linkage names
to "LIBC_NAMESPACE_<...>". This change corrects it by changing the
namespace prefix to to "__llvm_libc_<version info>".
