### PR TITLE
Don't use LLVM_TABLEGEN_FLAGS with mlir-pdll: it's not a TableGen tool

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -108,7 +108,6 @@ function(_pdll_tablegen project ofn)
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ofn}
     COMMAND ${tablegen_exe} ${ARG_UNPARSED_ARGUMENTS} -I ${CMAKE_CURRENT_SOURCE_DIR}
     ${tblgen_includes}
-    ${LLVM_TABLEGEN_FLAGS}
     ${LLVM_TARGET_DEFINITIONS_ABSOLUTE}
     ${tblgen_change_flag}
     ${additional_cmdline}


### PR DESCRIPTION
This can lead to build failure when a project is customizing this flag for TableGen. This seems to have been copy/pasted from TableGen CMake functions.