### PR TITLE
[RISCV] Fix a crash from trying to truncate an FP type in lowerBuildV…

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -3517,7 +3517,7 @@ static SDValue lowerBuildVectorOfConstants(SDValue Op, SelectionDAG &DAG,
   // narrow vector is known to materialize cheaply.
   // TODO: We really should be costing the smaller vector.  There are
   // profitable cases this misses.
-  if (EltBitSize > 8 &&
+  if (EltBitSize > 8 && VT.isInteger() &&
       (NumElts <= 4 || VT.getSizeInBits() > Subtarget.getRealMinVLen())) {
     unsigned SignBits = DAG.ComputeNumSignBits(Op);
     if (EltBitSize - SignBits < 8) {

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fp-buildvec.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fp-buildvec.ll
@@ -1076,3 +1076,10 @@ define <32 x double> @buildvec_v32f64(double %e0, double %e1, double %e2, double
   %v31 = insertelement <32 x double> %v30, double %e31, i64 31
   ret <32 x double> %v31
 }
+
+; FIXME: These constants have enough sign bits that we could use vmv.v.x/i and
+; vsext, but we don't support this for FP yet.
+define <2 x float> @signbits() {
+entry:
+  ret <2 x float> <float 0x36A0000000000000, float 0.000000e+00>
+}


### PR DESCRIPTION
…ectorOfConstants.

ComputeNumSignBits can return an answer for FP constants based on bitcasting them to int.

Check for an integer type so we don't create an illegal truncate.

We could support this case with bitcasts, but I leave that to a separate patch.