### PR TITLE
Change all CHECK lines in test to include DAG to work when the compiler emits debug info in a different order.

### DIFF
--- a/clang/test/CodeGenCXX/debug-info-codeview-unnamed.cpp
+++ b/clang/test/CodeGenCXX/debug-info-codeview-unnamed.cpp
@@ -3,58 +3,58 @@
 
 int main(int argc, char* argv[], char* arge[]) {
   //
-  // LINUX:      [[TYPE_OF_ONE:![0-9]+]] = distinct !DICompositeType(
-  // LINUX-SAME:     tag: DW_TAG_structure_type
-  // LINUX-NOT:      name:
-  // LINUX-NOT:      identifier:
-  // LINUX-SAME:     )
+  // LINUX-DAG:      [[TYPE_OF_ONE:![0-9]+]] = distinct !DICompositeType(
+  // LINUX-DAG-SAME:     tag: DW_TAG_structure_type
+  // LINUX-DAG-SAME-NOT:      name:
+  // LINUX-DAG-SAME-NOT:      identifier:
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       [[TYPE_OF_ONE:![0-9]+]] = distinct !DICompositeType
-  // MSVC-SAME:      tag: DW_TAG_structure_type
-  // MSVC-SAME:      name: "<unnamed-type-one>"
-  // MSVC-SAME:      identifier: ".?AU<unnamed-type-one>@?1??main@@9@"
-  // MSVC-SAME:      )
+  // MSVC-DAG:       [[TYPE_OF_ONE:![0-9]+]] = distinct !DICompositeType
+  // MSVC-DAG-SAME:      tag: DW_TAG_structure_type
+  // MSVC-DAG-SAME:      name: "<unnamed-type-one>"
+  // MSVC-DAG-SAME:      identifier: ".?AU<unnamed-type-one>@?1??main@@9@"
+  // MSVC-DAG-SAME:      )
 
 
   //
-  // LINUX:      [[TYPE_OF_TWO:![0-9]+]] = distinct !DICompositeType(
-  // LINUX-SAME:     tag: DW_TAG_structure_type
-  // LINUX-NOT:      name:
-  // LINUX-NOT:      identifier:
-  // LINUX-SAME:     )
+  // LINUX-DAG:      [[TYPE_OF_TWO:![0-9]+]] = distinct !DICompositeType(
+  // LINUX-DAG-SAME:     tag: DW_TAG_structure_type
+  // LINUX-DAG-SAME-NOT:      name:
+  // LINUX-DAG-SAME-NOT:      identifier:
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       [[TYPE_OF_TWO:![0-9]+]] = distinct !DICompositeType
-  // MSVC-SAME:      tag: DW_TAG_structure_type
-  // MSVC-SAME:      name: "<unnamed-type-two>"
-  // MSVC-SAME:      identifier: ".?AU<unnamed-type-two>@?2??main@@9@"
-  // MSVC-SAME:      )
+  // MSVC-DAG:       [[TYPE_OF_TWO:![0-9]+]] = distinct !DICompositeType
+  // MSVC-DAG-SAME:      tag: DW_TAG_structure_type
+  // MSVC-DAG-SAME:      name: "<unnamed-type-two>"
+  // MSVC-DAG-SAME:      identifier: ".?AU<unnamed-type-two>@?2??main@@9@"
+  // MSVC-DAG-SAME:      )
 
 
   //
-  // LINUX:      [[TYPE_OF_THREE:![0-9]+]] = distinct !DICompositeType(
-  // LINUX-SAME:     tag: DW_TAG_structure_type
-  // LINUX-SAME:     name: "named"
-  // LINUX-NOT:      identifier:
-  // LINUX-SAME:     )
+  // LINUX-DAG:      [[TYPE_OF_THREE:![0-9]+]] = distinct !DICompositeType(
+  // LINUX-DAG-SAME:     tag: DW_TAG_structure_type
+  // LINUX-DAG-SAME:     name: "named"
+  // LINUX-DAG-SAME-NOT:      identifier:
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       [[TYPE_OF_THREE:![0-9]+]] = distinct !DICompositeType
-  // MSVC-SAME:      tag: DW_TAG_structure_type
-  // MSVC-SAME:      name: "named"
-  // MSVC-SAME:      identifier: ".?AUnamed@?1??main@@9@"
-  // MSVC-SAME:      )
+  // MSVC-DAG:       [[TYPE_OF_THREE:![0-9]+]] = distinct !DICompositeType
+  // MSVC-DAG-SAME:      tag: DW_TAG_structure_type
+  // MSVC-DAG-SAME:      name: "named"
+  // MSVC-DAG-SAME:      identifier: ".?AUnamed@?1??main@@9@"
+  // MSVC-DAG-SAME:      )
 
   //
-  // LINUX:      [[TYPE_OF_FOUR:![0-9]+]] = distinct !DICompositeType(
-  // LINUX-SAME:     tag: DW_TAG_class_type
-  // LINUX-NOT:      name:
-  // LINUX-NOT:      identifier:
-  // LINUX-SAME:     )
+  // LINUX-DAG:      [[TYPE_OF_FOUR:![0-9]+]] = distinct !DICompositeType(
+  // LINUX-DAG-SAME:     tag: DW_TAG_class_type
+  // LINUX-DAG-SAME-NOT:      name:
+  // LINUX-DAG-SAME-NOT:      identifier:
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       [[TYPE_OF_FOUR:![0-9]+]] = distinct !DICompositeType
-  // MSVC-SAME:      tag: DW_TAG_class_type
-  // MSVC-SAME:      name: "<lambda_0>"
-  // MSVC-SAME:      identifier: ".?AV<lambda_0>@?0??main@@9@"
-  // MSVC-SAME:      )
+  // MSVC-DAG:       [[TYPE_OF_FOUR:![0-9]+]] = distinct !DICompositeType
+  // MSVC-DAG-SAME:      tag: DW_TAG_class_type
+  // MSVC-DAG-SAME:      name: "<lambda_0>"
+  // MSVC-DAG-SAME:      identifier: ".?AV<lambda_0>@?0??main@@9@"
+  // MSVC-DAG-SAME:      )
 
 
   // In CodeView, the LF_MFUNCTION entry for "bar()" refers to the forward
@@ -63,13 +63,13 @@ int main(int argc, char* argv[], char* arge[]) {
   //
   struct { void bar() {} } one;
   //
-  // LINUX:      !{{[0-9]+}} = !DILocalVariable(name: "one"
-  // LINUX-SAME:     type: [[TYPE_OF_ONE]]
-  // LINUX-SAME:     )
+  // LINUX-DAG:      !{{[0-9]+}} = !DILocalVariable(name: "one"
+  // LINUX-DAG-SAME:     type: [[TYPE_OF_ONE]]
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       !{{[0-9]+}} = !DILocalVariable(name: "one"
-  // MSVC-SAME:      type: [[TYPE_OF_ONE]]
-  // MSVC-SAME:      )
+  // MSVC-DAG:       !{{[0-9]+}} = !DILocalVariable(name: "one"
+  // MSVC-DAG-SAME:      type: [[TYPE_OF_ONE]]
+  // MSVC-DAG-SAME:      )
 
 
   // In CodeView, the LF_POINTER entry for "ptr2unnamed" refers to the forward
@@ -79,13 +79,13 @@ int main(int argc, char* argv[], char* arge[]) {
   struct { int bar; } two = { 42 };
   int decltype(two)::*ptr2unnamed = &decltype(two)::bar;
   //
-  // LINUX:      !{{[0-9]+}} = !DILocalVariable(name: "two"
-  // LINUX-SAME:     type: [[TYPE_OF_TWO]]
-  // LINUX-SAME:     )
+  // LINUX-DAG:      !{{[0-9]+}} = !DILocalVariable(name: "two"
+  // LINUX-DAG-SAME:     type: [[TYPE_OF_TWO]]
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       !{{[0-9]+}} = !DILocalVariable(name: "two"
-  // MSVC-SAME:      type: [[TYPE_OF_TWO]]
-  // MSVC-SAME:      )
+  // MSVC-DAG:       !{{[0-9]+}} = !DILocalVariable(name: "two"
+  // MSVC-DAG-SAME:      type: [[TYPE_OF_TWO]]
+  // MSVC-DAG-SAME:      )
 
 
   // In DWARF, named structures which are not externally visibile do not
@@ -94,13 +94,13 @@ int main(int argc, char* argv[], char* arge[]) {
   //
   struct named { int bar; int named::* p2mem; } three = { 42, &named::bar };
   //
-  // LINUX:      !{{[0-9]+}} = !DILocalVariable(name: "three"
-  // LINUX-SAME:     type: [[TYPE_OF_THREE]]
-  // LINUX-SAME:     )
+  // LINUX-DAG:      !{{[0-9]+}} = !DILocalVariable(name: "three"
+  // LINUX-DAG-SAME:     type: [[TYPE_OF_THREE]]
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       !{{[0-9]+}} = !DILocalVariable(name: "three"
-  // MSVC-SAME:      type: [[TYPE_OF_THREE]]
-  // MSVC-SAME:      )
+  // MSVC-DAG:       !{{[0-9]+}} = !DILocalVariable(name: "three"
+  // MSVC-DAG-SAME:      type: [[TYPE_OF_THREE]]
+  // MSVC-DAG-SAME:      )
 
 
   // In CodeView, the LF_MFUNCTION entry for the lambda "operator()" routine
@@ -110,13 +110,13 @@ int main(int argc, char* argv[], char* arge[]) {
   //
   auto four = [argc](int i) -> int { return argc == i ? 1 : 0; };
   //
-  // LINUX:      !{{[0-9]+}} = !DILocalVariable(name: "four"
-  // LINUX-SAME:     type: [[TYPE_OF_FOUR]]
-  // LINUX-SAME:     )
+  // LINUX-DAG:      !{{[0-9]+}} = !DILocalVariable(name: "four"
+  // LINUX-DAG-SAME:     type: [[TYPE_OF_FOUR]]
+  // LINUX-DAG-SAME:     )
   //
-  // MSVC:       !{{[0-9]+}} = !DILocalVariable(name: "four"
-  // MSVC-SAME:      type: [[TYPE_OF_FOUR]]
-  // MSVC-SAME:      )
+  // MSVC-DAG:       !{{[0-9]+}} = !DILocalVariable(name: "four"
+  // MSVC-DAG-SAME:      type: [[TYPE_OF_FOUR]]
+  // MSVC-DAG-SAME:      )
 
   return 0;
 }


### PR DESCRIPTION
When the changes in f8aab28 were merged into our downstream compiler, it started failing because the compiler with our downstream patches applied was emitting the debug information in a different order than originally expected. The debug info was still correct, just in a different order. This changes the test to be more flexible in the search so that it works more generally.

Sample debug output generated by our downstream compiler for this test:
```
!5 = distinct !DISubprogram(name: "main", scope: !6, file: !6, line: 4, type: !7, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !13)
!6 = !DIFile(filename: "/mnt/sources/git/dev/clang/test/CodeGenCXX/debug-info-codeview-unnamed.cpp", directory: "")
!7 = !DISubroutineType(types: !8)
!8 = !{!9, !9, !10, !10}
!9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
!10 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !11, size: 64)
!11 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !12, size: 64)
!12 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
!13 = !{!14, !15, !16, !17, !23, !24, !27, !28, !30, !35, !36, !44}
!14 = !DILocalVariable(name: "argc", arg: 1, scope: !5, file: !6, line: 4, type: !9)
!15 = !DILocalVariable(name: "argv", arg: 2, scope: !5, file: !6, line: 4, type: !10)
!16 = !DILocalVariable(name: "arge", arg: 3, scope: !5, file: !6, line: 4, type: !10)
!17 = distinct !DICompositeType(tag: DW_TAG_structure_type, scope: !5, file: !6, line: 64, size: 8, flags: DIFlagTypePassByValue, elements: !18)
!18 = !{!19}
!19 = !DISubprogram(name: "bar", scope: !17, file: !6, line: 64, type: !20, scopeLine: 64, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit)
!20 = !DISubroutineType(types: !21)
!21 = !{null, !22}
!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !17, size: 64, flags: DIFlagArtificial | DIFlagObjectPointer)
!23 = !DILocalVariable(name: "one", scope: !5, file: !6, line: 64, type: !17)
!24 = distinct !DICompositeType(tag: DW_TAG_structure_type, scope: !5, file: !6, line: 79, size: 32, flags: DIFlagTypePassByValue, elements: !25)
!25 = !{!26}
!26 = !DIDerivedType(tag: DW_TAG_member, name: "bar", scope: !24, file: !6, line: 79, baseType: !9, size: 32)
!27 = !DILocalVariable(name: "two", scope: !5, file: !6, line: 79, type: !24)
!28 = !DILocalVariable(name: "ptr2unnamed", scope: !5, file: !6, line: 80, type: !29)
!29 = !DIDerivedType(tag: DW_TAG_ptr_to_member_type, baseType: !9, size: 64, extraData: !24)
!30 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "named", scope: !5, file: !6, line: 95, size: 128, flags: DIFlagTypePassByValue, elements: !31)
!31 = !{!32, !33}
!32 = !DIDerivedType(tag: DW_TAG_member, name: "bar", scope: !30, file: !6, line: 95, baseType: !9, size: 32)
!33 = !DIDerivedType(tag: DW_TAG_member, name: "p2mem", scope: !30, file: !6, line: 95, baseType: !34, size: 64, offset: 64)
!34 = !DIDerivedType(tag: DW_TAG_ptr_to_member_type, baseType: !9, size: 64, extraData: !30)
!35 = !DILocalVariable(name: "three", scope: !5, file: !6, line: 95, type: !30)
!36 = distinct !DICompositeType(tag: DW_TAG_class_type, scope: !5, file: !6, line: 111, size: 32, flags: DIFlagTypePassByValue | DIFlagNonTrivial, elements: !37)
!37 = !{!38, !39}
!38 = !DIDerivedType(tag: DW_TAG_member, name: "argc", scope: !36, file: !6, line: 111, baseType: !9, size: 32)
!39 = !DISubprogram(name: "operator()", scope: !36, file: !6, line: 111, type: !40, scopeLine: 111, flags: DIFlagPublic | DIFlagPrototyped, spFlags: DISPFlagLocalToUnit)
!40 = !DISubroutineType(types: !41)
!41 = !{!9, !42, !9}
!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64, flags: DIFlagArtificial | DIFlagObjectPointer)
!43 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !36)
!44 = !DILocalVariable(name: "four", scope: !5, file: !6, line: 111, type: !36)
```
The match of the CHECK line on line 47 capturing a value for `TYPE_OF_FOUR` was matched on line `!36` of the debug output. When it next tried to find the variable definition for "one" the check failed because it had already passed it (it was previously emitted as `!23`).