### PR TITLE
[libc++] Don't add reference to system_category when exceptions disabled

### DIFF
--- a/libcxx/src/system_error.cpp
+++ b/libcxx/src/system_error.cpp
@@ -266,8 +266,16 @@ system_error::~system_error() noexcept
 {
 }
 
-void __throw_system_error(int ev, const char* what_arg) {
-  std::__throw_system_error(error_code(ev, system_category()), what_arg);
+void
+__throw_system_error(int ev, const char* what_arg)
+{
+#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+    std::__throw_system_error(error_code(ev, system_category()), what_arg);
+#else
+  // The above could also handle the no-exception case, but for size, avoid referencing system_category() unnecessarily.
+  _LIBCPP_VERBOSE_ABORT(
+      "system_error was thrown in -fno-exceptions mode with error %i and message \"%s\"", ev, what_arg);
+#endif
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/src/system_error.cpp
+++ b/libcxx/src/system_error.cpp
@@ -272,9 +272,8 @@ __throw_system_error(int ev, const char* what_arg)
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     std::__throw_system_error(error_code(ev, system_category()), what_arg);
 #else
-  // The above could also handle the no-exception case, but for size, avoid referencing system_category() unnecessarily.
-  _LIBCPP_VERBOSE_ABORT(
-      "system_error was thrown in -fno-exceptions mode with error %i and message \"%s\"", ev, what_arg);
+    // The above could also handle the no-exception case, but for size, avoid referencing system_category() unnecessarily.
+    _LIBCPP_VERBOSE_ABORT("system_error was thrown in -fno-exceptions mode with error %i and message \"%s\"", ev, what_arg);
 #endif
 }
 


### PR DESCRIPTION
This fixes a size regression in Fuchsia when building a static libc++ multilib with exceptions disabled. Referring to `system_category` in `__throw_system_error` brings in a relatively large amount of additional exception classes into the link without substantially improving the error message.