### PR TITLE
[clang] Default x86-64's medium code model -mlarge-data-threshold to 65535

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4250,7 +4250,7 @@ def mcmodel_EQ : Joined<["-"], "mcmodel=">, Group<m_Group>,
   MarshallingInfoString<TargetOpts<"CodeModel">, [{"default"}]>;
 def mlarge_data_threshold_EQ : Joined<["-"], "mlarge-data-threshold=">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option]>,
-  MarshallingInfoInt<TargetOpts<"LargeDataThreshold">>;
+  MarshallingInfoInt<TargetOpts<"LargeDataThreshold">, "65535">;
 def mtls_size_EQ : Joined<["-"], "mtls-size=">, Group<m_Group>,
   Flags<[NoXarchOption]>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Specify bit size of immediate TLS offsets (AArch64 ELF only): "

--- a/clang/test/CodeGen/large-data-threshold.c
+++ b/clang/test/CodeGen/large-data-threshold.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown -S %s -o - -mcmodel=medium -mlarge-data-threshold=200 | FileCheck %s --check-prefix=ASM-SMALL
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown -S %s -o - -mcmodel=medium -mlarge-data-threshold=2 | FileCheck %s --check-prefix=ASM-LARGE
 
-// IR-DEFAULT: !{i32 1, !"Large Data Threshold", i64 0}
+// IR-DEFAULT: !{i32 1, !"Large Data Threshold", i64 65535}
 // IR-CUSTOM: !{i32 1, !"Large Data Threshold", i64 200}
 
 // ASM-SMALL-NOT: movabsq


### PR DESCRIPTION
This matches gcc.

This means that by default, under x86-64's medium code model we treat globals < 2^16 bytes as "small data" and globals >= 2^16 bytes as "large data".

The previous clang behavior of treating all data as "large data" can be set with `-mlarge-data-threshold=0`.

See https://discourse.llvm.org/t/rfc-matching-gccs-mlarge-data-threshold-for-x86-64s-medium-code-model/73727.
