### PR TITLE
[flang][runtime] Fix edge cases with ROUND=UP/DOWN

### DIFF
--- a/flang/lib/Decimal/binary-to-decimal.cpp
+++ b/flang/lib/Decimal/binary-to-decimal.cpp
@@ -373,7 +373,8 @@ STREAM &BigRadixFloatingPointNumber<PREC, LOG10RADIX>::Dump(STREAM &o) const {
   if (isNegative_) {
     o << '-';
   }
-  o << "10**(" << exponent_ << ") * ...\n";
+  o << "10**(" << exponent_ << ") * ...  (rounding "
+    << static_cast<int>(rounding_) << ")\n";
   for (int j{digits_}; --j >= 0;) {
     std::string str{std::to_string(digit_[j])};
     o << std::string(20 - str.size(), ' ') << str << " [" << j << ']';


### PR DESCRIPTION
When an unrepresentable nonzero real input value with a very small exponent is currently being read in as zero, don't neglect ROUND=UP/DOWN; return the least nonzero subnormal value instead when appropriate.