### PR TITLE
[clang-repl] Run by another application shell cause hang.

### DIFF
--- a/llvm/lib/LineEditor/LineEditor.cpp
+++ b/llvm/lib/LineEditor/LineEditor.cpp
@@ -294,6 +294,7 @@ void LineEditor::loadHistory() {}
 
 std::optional<std::string> LineEditor::readLine() const {
   ::fprintf(Data->Out, "%s", Prompt.c_str());
+  ::fflush(Data->Out);
 
   std::string Line;
   do {


### PR DESCRIPTION
clang-repl process launched by another application (For example, python Popen and other API's) is hang and does not print any output. fflush() after prompt fix this porblem.

It does not make any performance problem since it is flush() right before waiting input. 

To run clang-repl in jupyter notebook, it should be fixed. After fix it clang-repl run well with jupyter notebook. see: https://github.com/ormastes/jupyter_kernels/tree/main/clang_repl_kernel