### PR TITLE
[Clang][InstrProf] Allow mix-up of absolute path with relative path on command line when using -fprofile-list=

### DIFF
--- a/clang/lib/Basic/ProfileList.cpp
+++ b/clang/lib/Basic/ProfileList.cpp
@@ -146,5 +146,14 @@ ProfileList::isFileExcluded(StringRef FileName,
     return Forbid;
   if (SCL->inSection(Section, "src", FileName))
     return Allow;
+  // Convert the input file path to its canonical (absolute) form
+  llvm::SmallString<128> CanonicalFileName(FileName);
+  llvm::sys::fs::make_absolute(CanonicalFileName);
+  if (auto V = inSection(Section, "source", CanonicalFileName))
+    return V;
+  if (SCL->inSection(Section, "!src", CanonicalFileName))
+    return Forbid;
+  if (SCL->inSection(Section, "src", CanonicalFileName))
+    return Allow;
   return std::nullopt;
 }

--- a/clang/test/CodeGen/profile-filter.c
+++ b/clang/test/CodeGen/profile-filter.c
@@ -6,6 +6,9 @@
 // RUN: echo "src:%s" | sed -e 's/\\/\\\\/g' > %t-file.list
 // RUN: %clang_cc1 -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -fprofile-list=%t-file.list -emit-llvm %s -o - | FileCheck %s --check-prefix=FILE
 
+// RUN: cd %S
+// RUN: %clang_cc1 -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -fprofile-list=%t-file.list -emit-llvm profile-filter.c -o - | FileCheck %s --check-prefix=FILE
+
 // RUN: echo -e "[clang]\nfun:test1\n[llvm]\nfun:test2" > %t-section.list
 // RUN: %clang_cc1 -fprofile-instrument=llvm -fprofile-list=%t-section.list -emit-llvm %s -o - | FileCheck %s --check-prefix=SECTION
 


### PR DESCRIPTION
When we have file names in fun.list file in absolute path and relative path are on the command line, -fprofile-list= did not work.

For example -

$ clang++ -O2  -fprofile-instr-generate -fcoverage-mapping -fprofile-list=/home/user/llvm-project/fun.list main.cpp calculator.cpp -o calculator
$ cat fun.list
source:/home/user/llvm-project/main.cpp=skip

Here main.cpp is relative on clang command line but absolute in fun.list

Having a way to give an absolute path can help to reduce ambiguity as other people also tried using the full path https://discourse.llvm.org/t/fprofile-list-flag/70866. 