### PR TITLE
[WebAssembly] Add path to PIC mode for wasm tables

### DIFF
--- a/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.cpp
+++ b/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.cpp
@@ -71,8 +71,7 @@ void WebAssembly::wasmSymbolSetType(MCSymbolWasm *Sym, const Type *GlobalVT,
   // that is a reference type.
   wasm::ValType ValTy;
   bool IsTable = false;
-  if (GlobalVT->isArrayTy() && WebAssembly::isWebAssemblyReferenceType(
-                                   GlobalVT->getArrayElementType())) {
+  if (WebAssembly::isWebAssemblyTableType(GlobalVT)) {
     IsTable = true;
     const Type *ElTy = GlobalVT->getArrayElementType();
     if (WebAssembly::isWebAssemblyExternrefType(ElTy))

--- a/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
+++ b/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
@@ -28,14 +28,16 @@ namespace WebAssembly {
 
 /// Return true if this is a WebAssembly Externref Type.
 inline bool isWebAssemblyExternrefType(const Type *Ty) {
-  return Ty->isPointerTy() && Ty->getPointerAddressSpace() ==
-         WebAssembly::WasmAddressSpace::WASM_ADDRESS_SPACE_EXTERNREF;
+  return Ty->isPointerTy() &&
+         Ty->getPointerAddressSpace() ==
+             WebAssembly::WasmAddressSpace::WASM_ADDRESS_SPACE_EXTERNREF;
 }
 
 /// Return true if this is a WebAssembly Funcref Type.
 inline bool isWebAssemblyFuncrefType(const Type *Ty) {
-  return Ty->isPointerTy() && Ty->getPointerAddressSpace() ==
-         WebAssembly::WasmAddressSpace::WASM_ADDRESS_SPACE_FUNCREF;
+  return Ty->isPointerTy() &&
+         Ty->getPointerAddressSpace() ==
+             WebAssembly::WasmAddressSpace::WASM_ADDRESS_SPACE_FUNCREF;
 }
 
 /// Return true if this is a WebAssembly Reference Type.

--- a/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
+++ b/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
@@ -45,8 +45,8 @@ inline bool isWebAssemblyReferenceType(const Type *Ty) {
 
 /// Return true if the table represents a WebAssembly table type.
 inline bool isWebAssemblyTableType(const Type *Ty) {
-  return Ty->isArrayTy() && 
-     isWebAssemblyReferenceType(Ty->getArrayElementType());
+  return Ty->isArrayTy() &&
+         isWebAssemblyReferenceType(Ty->getArrayElementType());
 }
 
 // Convert StringRef to ValType / HealType / BlockType

--- a/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
+++ b/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
@@ -28,13 +28,13 @@ namespace WebAssembly {
 
 /// Return true if this is a WebAssembly Externref Type.
 inline bool isWebAssemblyExternrefType(const Type *Ty) {
-  return Ty->getPointerAddressSpace() ==
+  return Ty->isPointerTy() && Ty->getPointerAddressSpace() ==
          WebAssembly::WasmAddressSpace::WASM_ADDRESS_SPACE_EXTERNREF;
 }
 
 /// Return true if this is a WebAssembly Funcref Type.
 inline bool isWebAssemblyFuncrefType(const Type *Ty) {
-  return Ty->getPointerAddressSpace() ==
+  return Ty->isPointerTy() && Ty->getPointerAddressSpace() ==
          WebAssembly::WasmAddressSpace::WASM_ADDRESS_SPACE_FUNCREF;
 }
 

--- a/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
+++ b/llvm/lib/Target/WebAssembly/Utils/WebAssemblyTypeUtilities.h
@@ -43,6 +43,12 @@ inline bool isWebAssemblyReferenceType(const Type *Ty) {
   return isWebAssemblyExternrefType(Ty) || isWebAssemblyFuncrefType(Ty);
 }
 
+/// Return true if the table represents a WebAssembly table type.
+inline bool isWebAssemblyTableType(const Type *Ty) {
+  return Ty->isArrayTy() && 
+     isWebAssemblyReferenceType(Ty->getArrayElementType());
+}
+
 // Convert StringRef to ValType / HealType / BlockType
 
 MVT parseMVT(StringRef Type);

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1725,7 +1725,6 @@ SDValue WebAssemblyTargetLowering::LowerGlobalAddress(SDValue Op,
 
   unsigned OperandFlags = 0;
   const GlobalValue *GV = GA->getGlobal();
-  // is PIC but not a WebAssembly table.
   // Since WebAssembly tables cannot yet be shared accross modules, we don't
   // need special treatment for tables in PIC mode.
   if (isPositionIndependent() &&

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1728,10 +1728,7 @@ SDValue WebAssemblyTargetLowering::LowerGlobalAddress(SDValue Op,
   // is PIC but not a WebAssembly table.
   // Since WebAssembly tables cannot yet be shared accross modules, we don't need special
   // treatment for tables in PIC mode.
-  if (isPositionIndependent() && 
-      !(GV->getValueType()->isArrayTy() && 
-        WebAssembly::isWebAssemblyReferenceType(GV->getValueType()->getArrayElementType()))) {
-    
+  if (isPositionIndependent() && !WebAssembly::isWebAssemblyTableType(GV->getValueType())) {
     if (getTargetMachine().shouldAssumeDSOLocal(*GV->getParent(), GV)) {
       MachineFunction &MF = DAG.getMachineFunction();
       MVT PtrVT = getPointerTy(MF.getDataLayout());

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1724,8 +1724,14 @@ SDValue WebAssemblyTargetLowering::LowerGlobalAddress(SDValue Op,
     fail(DL, DAG, "Invalid address space for WebAssembly target");
 
   unsigned OperandFlags = 0;
-  if (isPositionIndependent()) {
-    const GlobalValue *GV = GA->getGlobal();
+  const GlobalValue *GV = GA->getGlobal();
+  // is PIC but not a WebAssembly table.
+  // Since WebAssembly tables cannot yet be shared accross modules, we don't need special
+  // treatment for tables in PIC mode.
+  if (isPositionIndependent() && 
+      !(GV->getValueType()->isArrayTy() && 
+        WebAssembly::isWebAssemblyReferenceType(GV->getValueType()->getArrayElementType()))) {
+    
     if (getTargetMachine().shouldAssumeDSOLocal(*GV->getParent(), GV)) {
       MachineFunction &MF = DAG.getMachineFunction();
       MVT PtrVT = getPointerTy(MF.getDataLayout());

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1726,9 +1726,10 @@ SDValue WebAssemblyTargetLowering::LowerGlobalAddress(SDValue Op,
   unsigned OperandFlags = 0;
   const GlobalValue *GV = GA->getGlobal();
   // is PIC but not a WebAssembly table.
-  // Since WebAssembly tables cannot yet be shared accross modules, we don't need special
-  // treatment for tables in PIC mode.
-  if (isPositionIndependent() && !WebAssembly::isWebAssemblyTableType(GV->getValueType())) {
+  // Since WebAssembly tables cannot yet be shared accross modules, we don't
+  // need special treatment for tables in PIC mode.
+  if (isPositionIndependent() &&
+      !WebAssembly::isWebAssemblyTableType(GV->getValueType())) {
     if (getTargetMachine().shouldAssumeDSOLocal(*GV->getParent(), GV)) {
       MachineFunction &MF = DAG.getMachineFunction();
       MVT PtrVT = getPointerTy(MF.getDataLayout());

--- a/llvm/test/MC/WebAssembly/reloc-pic.s
+++ b/llvm/test/MC/WebAssembly/reloc-pic.s
@@ -213,7 +213,7 @@ REF-.tabletype mytable, externref
 # REF:              - Index:           10
 # REF-NEXT:           Kind:            TABLE
 # REF-NEXT:           Name:            mytable
-# REF-NEXT:           Flags:           [ UNDEFINED ]
+# REF-NEXT:           Flags:           [ BINDING_LOCAL ]
 # REF-NEXT:           Table:           1
 # REF-NEXT:         - Index:           11
 # REF-NEXT:           Kind:            TABLE

--- a/llvm/test/MC/WebAssembly/reloc-pic.s
+++ b/llvm/test/MC/WebAssembly/reloc-pic.s
@@ -1,5 +1,5 @@
-# RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj < %s | obj2yaml | FileCheck %s
-# RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+reference-types -filetype=obj < %s | obj2yaml | FileCheck --check-prefix=REF %s
+# RUN: sed -e '/^REF-/d' %s | llvm-mc -triple=wasm32-unknown-unknown -filetype=obj | obj2yaml | FileCheck %s
+# RUN: sed -e 's/^REF-//g' %s | llvm-mc -triple=wasm32-unknown-unknown -mattr=+reference-types -filetype=obj | obj2yaml | FileCheck --check-prefix=REF %s
 
 # Verify that @GOT relocation entryes result in R_WASM_GLOBAL_INDEX_LEB against
 # against the corrsponding function or data symbol and that the corresponding
@@ -49,6 +49,9 @@ hidden_func:
 #.hidden hidden_func
 #.hidden hidden_data
 .size default_data, 4
+
+REF-mytable:
+REF-.tabletype mytable, externref
 
 # CHECK:      --- !WASM
 # CHECK-NEXT: FileHeader:
@@ -208,6 +211,11 @@ hidden_func:
 # CHECK-NEXT:         Flags:           [ BINDING_LOCAL ]
 # CHECK-NEXT:         Function:        5
 # REF:              - Index:           10
+# REF-NEXT:           Kind:            TABLE
+# REF-NEXT:           Name:            mytable
+# REF-NEXT:           Flags:           [ UNDEFINED ]
+# REF-NEXT:           Table:           1
+# REF-NEXT:         - Index:           11
 # REF-NEXT:           Kind:            TABLE
 # REF-NEXT:           Name:            __indirect_function_table
 # REF-NEXT:           Flags:           [ UNDEFINED, NO_STRIP ]


### PR DESCRIPTION
Currently tables cannot be shared between compilation units, therefore
no special treatment is needed for tables.

Fixes #65191