### PR TITLE
[libc++][NFC] Simplify checks for static assertions in .verify.cpp tests

### DIFF
--- a/libcxx/test/libcxx/algorithms/bad_iterator_traits.verify.cpp
+++ b/libcxx/test/libcxx/algorithms/bad_iterator_traits.verify.cpp
@@ -57,5 +57,5 @@ struct BadIter {
 // behavior when these iterators are passed to standard algorithms.
 void test() {
   std::sort(BadIter(), BadIter());
-  //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}It looks like your iterator's `iterator_traits<It>::reference` does not match the return type of dereferencing the iterator}}
+  //expected-error-re@*:* {{static assertion failed {{.*}}It looks like your iterator's `iterator_traits<It>::reference` does not match the return type of dereferencing the iterator}}
 }

--- a/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.verify.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.verify.cpp
@@ -46,12 +46,12 @@ void pointer_to_incomplete_type() {
 void function_pointer() {
   {
     volatile std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_add(&fun, 0);
   }
   {
     std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_add(&fun, 0);
   }
 }

--- a/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.verify.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.verify.cpp
@@ -49,12 +49,12 @@ void pointer_to_incomplete_type() {
 void function_pointer() {
   {
     volatile std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_add_explicit(&fun, 0, std::memory_order_relaxed);
   }
   {
     std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_add_explicit(&fun, 0, std::memory_order_relaxed);
   }
 }

--- a/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.verify.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.verify.cpp
@@ -46,12 +46,12 @@ void pointer_to_incomplete_type() {
 void function_pointer() {
   {
     volatile std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_sub(&fun, 0);
   }
   {
     std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_sub(&fun, 0);
   }
 }

--- a/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.verify.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.verify.cpp
@@ -49,12 +49,12 @@ void pointer_to_incomplete_type() {
 void function_pointer() {
   {
     volatile std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_sub_explicit(&fun, 0, std::memory_order_relaxed);
   }
   {
     std::atomic<void (*)(int)> fun;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '!is_function<void (int)>::value'{{.*}}Pointer to function isn't allowed}}
     std::atomic_fetch_sub_explicit(&fun, 0, std::memory_order_relaxed);
   }
 }

--- a/libcxx/test/libcxx/containers/sequences/vector/invalid_allocator.verify.cpp
+++ b/libcxx/test/libcxx/containers/sequences/vector/invalid_allocator.verify.cpp
@@ -24,5 +24,5 @@ class FooAllocator {
 };
 
 void func() {
-  std::vector<int, FooAllocator> v; //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}This allocator has to implement rebind}}
+  std::vector<int, FooAllocator> v; //expected-error-re@*:* {{static assertion failed {{.*}}This allocator has to implement rebind}}
 }

--- a/libcxx/test/libcxx/input.output/file.streams/fstreams/filebuf/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/file.streams/fstreams/filebuf/traits_mismatch.verify.cpp
@@ -18,7 +18,7 @@
 #include <fstream>
 
 std::basic_filebuf<char, std::char_traits<wchar_t> > f;
-// expected-error-re@streambuf:* {{{{(static_assert|static assertion)}} failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@streambuf:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 // expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
 // expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
 // expected-error@fstream:* {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/input.output/file.streams/fstreams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/file.streams/fstreams/traits_mismatch.verify.cpp
@@ -18,8 +18,8 @@
 #include <fstream>
 
 std::basic_fstream<char, std::char_traits<wchar_t> > f;
-// expected-error-re@ios:* {{{{(static_assert|static assertion)}} failed{{.*}}traits_type::char_type must be the same type as CharT}}
-// expected-error-re@streambuf:* {{{{(static_assert|static assertion)}} failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@ios:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@streambuf:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 
 // expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
 // expected-error@fstream:* {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/input.output/iostream.format/input.streams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/input.streams/traits_mismatch.verify.cpp
@@ -21,5 +21,5 @@
 struct test_istream
     : public std::basic_istream<char, std::char_traits<wchar_t> > {};
 
-// expected-error-re@ios:* {{{{(static_assert|static assertion)}} failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@ios:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 // expected-error@istream:* {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/input.output/iostream.format/output.streams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/output.streams/traits_mismatch.verify.cpp
@@ -21,5 +21,5 @@
 struct test_ostream
     : public std::basic_ostream<char, std::char_traits<wchar_t> > {};
 
-// expected-error-re@ios:* {{{{(static_assert|static assertion)}} failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@ios:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 // expected-error@ostream:* {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/input.output/string.streams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/string.streams/traits_mismatch.verify.cpp
@@ -19,8 +19,8 @@
 #include <sstream>
 
 std::basic_stringbuf<char, std::char_traits<wchar_t> > sb;
-// expected-error-re@streambuf:* {{{{(static_assert|static assertion)}} failed{{.*}}traits_type::char_type must be the same type as CharT}}
-// expected-error-re@string:* {{{{(static_assert|static assertion)}} failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@streambuf:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@string:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 
 // expected-error@sstream:* {{only virtual member functions can be marked 'override'}}
 // expected-error@sstream:* {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/iterators/predef.iterators/reverse.iterators/bad_template_argument.verify.cpp
+++ b/libcxx/test/libcxx/iterators/predef.iterators/reverse.iterators/bad_template_argument.verify.cpp
@@ -18,5 +18,5 @@
 
 void f() {
   using BadIter = std::reverse_iterator<forward_iterator<int*>>;
-  BadIter i; //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}reverse_iterator<It> requires It to be a bidirectional iterator.}}
+  BadIter i; //expected-error-re@*:* {{static assertion failed{{.*}}reverse_iterator<It> requires It to be a bidirectional iterator.}}
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.bernoulli/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.bernoulli/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::bernoulli_distribution dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.bin/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.bin/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::binomial_distribution<int> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.geo/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.geo/bad_engine.verify.cpp
@@ -26,6 +26,6 @@ void test(std::geometric_distribution<int> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 7 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 7 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.negbin/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.negbin/bad_engine.verify.cpp
@@ -26,6 +26,6 @@ void test(std::negative_binomial_distribution<int> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 7 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 7 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.cauchy/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.cauchy/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::cauchy_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.chisq/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.chisq/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::chi_squared_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 3 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 3 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.f/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.f/bad_engine.verify.cpp
@@ -26,6 +26,6 @@ void test(std::fisher_f_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 4 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 4 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.lognormal/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.lognormal/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::lognormal_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.normal/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.normal/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::normal_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.t/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.t/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::student_t_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 5 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 5 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.exp/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.exp/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::exponential_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.extreme/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.extreme/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::extreme_value_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.gamma/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.gamma/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::gamma_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 3 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 3 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.poisson/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.poisson/bad_engine.verify.cpp
@@ -26,6 +26,6 @@ void test(std::poisson_distribution<int> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 4 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 4 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.weibull/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.weibull/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::weibull_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.samp/rand.dist.samp.discrete/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.samp/rand.dist.samp.discrete/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::discrete_distribution<int> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.samp/rand.dist.samp.pconst/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.samp/rand.dist.samp.pconst/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::piecewise_constant_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.samp/rand.dist.samp.plinear/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.samp/rand.dist.samp.plinear/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::piecewise_linear_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* 2 {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.uni/rand.dist.uni.int/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.uni/rand.dist.uni.int/bad_engine.verify.cpp
@@ -26,6 +26,6 @@ void test(std::uniform_int_distribution<int> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.uni/rand.dist.uni.real/bad_engine.verify.cpp
+++ b/libcxx/test/libcxx/numerics/rand/rand.dis/rand.dist.uni/rand.dist.uni.real/bad_engine.verify.cpp
@@ -25,6 +25,6 @@ void test(std::uniform_real_distribution<double> dist)
   G<int> badg;
   G<unsigned> okg;
 
-  dist(badg); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed}} //expected-note {{in instantiation}}
+  dist(badg); //expected-error@*:* {{static assertion failed}} //expected-note {{in instantiation}}
   dist(okg);
 }

--- a/libcxx/test/libcxx/ranges/range.utility/range.utility.conv/to.internal_constraints.verify.cpp
+++ b/libcxx/test/libcxx/ranges/range.utility/range.utility.conv/to.internal_constraints.verify.cpp
@@ -63,32 +63,32 @@ void test() {
 
   { // No default constructor.
     using C = Container</*HasDefaultCtr=*/false>;
-    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}ranges::to: unable to convert to the given container type}}
+    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{static assertion failed{{.*}}ranges::to: unable to convert to the given container type}}
   }
 
   { // No single-argument constructor.
     using C = Container</*HasDefaultCtr=*/true, /*HasSingleArgCtr=*/false>;
-    (void)std::ranges::to<C>(in, 1); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}ranges::to: unable to convert to the given container type}}
+    (void)std::ranges::to<C>(in, 1); //expected-error-re@*:* {{static assertion failed{{.*}}ranges::to: unable to convert to the given container type}}
   }
 
   { // No `insert` and no `push_back`.
     using C = Container</*HasDefaultCtr=*/true, /*HasSingleArgCtr=*/true,
                         /*HasInsert=*/false, /*HasInsertWithRightSignature=*/false,
                         /*HasPushBack=*/false, /*HasPushBackWithRightSignature=*/false>;
-    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}ranges::to: unable to convert to the given container type}}
+    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{static assertion failed{{.*}}ranges::to: unable to convert to the given container type}}
   }
 
   { // No `push_back`, `insert` has a wrong signature.
     using C = Container</*HasDefaultCtr=*/true, /*HasSingleArgCtr=*/true,
                         /*HasInsert=*/true, /*HasInsertWithRightSignature=*/false,
                         /*HasPushBack=*/false, /*HasPushBackWithRightSignature=*/false>;
-    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}ranges::to: unable to convert to the given container type}}
+    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{static assertion failed{{.*}}ranges::to: unable to convert to the given container type}}
   }
 
   { // No `insert`, `push_back` has a wrong signature.
     using C = Container</*HasDefaultCtr=*/true, /*HasSingleArgCtr=*/true,
                         /*HasInsert=*/false, /*HasInsertWithRightSignature=*/false,
                         /*HasPushBack=*/true, /*HasPushBackWithRightSignature=*/false>;
-    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}ranges::to: unable to convert to the given container type}}
+    (void)std::ranges::to<C>(in); //expected-error-re@*:* {{static assertion failed{{.*}}ranges::to: unable to convert to the given container type}}
   }
 }

--- a/libcxx/test/libcxx/ranges/range.utility/range.utility.conv/to.static_assert.verify.cpp
+++ b/libcxx/test/libcxx/ranges/range.utility/range.utility.conv/to.static_assert.verify.cpp
@@ -18,8 +18,8 @@ void test() {
   using R = std::vector<int>;
   R in = {1, 2, 3};
 
-  (void)std::ranges::to<const R>(in); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}The target container cannot be const-qualified, please remove the const}}
-  (void)(in | std::ranges::to<const R>()); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}The target container cannot be const-qualified, please remove the const}}
-  (void)std::ranges::to<volatile R>(in); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}The target container cannot be volatile-qualified, please remove the volatile}}
-  (void)(in | std::ranges::to<volatile R>()); //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}The target container cannot be volatile-qualified, please remove the volatile}}
+  (void)std::ranges::to<const R>(in); //expected-error-re@*:* {{static assertion failed{{.*}}The target container cannot be const-qualified, please remove the const}}
+  (void)(in | std::ranges::to<const R>()); //expected-error-re@*:* {{static assertion failed{{.*}}The target container cannot be const-qualified, please remove the const}}
+  (void)std::ranges::to<volatile R>(in); //expected-error-re@*:* {{static assertion failed{{.*}}The target container cannot be volatile-qualified, please remove the volatile}}
+  (void)(in | std::ranges::to<volatile R>()); //expected-error-re@*:* {{static assertion failed{{.*}}The target container cannot be volatile-qualified, please remove the volatile}}
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/and_then.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/and_then.mandates.verify.cpp
@@ -52,7 +52,7 @@ void test() {
     {
       std::expected<int, int> f1(1);
       f1.and_then(lval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<int (&)(int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(**this) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(**this) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -61,7 +61,7 @@ void test() {
     {
       std::expected<int, int> f1(1);
       f1.and_then(lval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<std::expected<int, NotSameAsInt> (&)(int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(**this) must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(**this) must have the same error_type as this expected}}
     }
   }
 
@@ -71,7 +71,7 @@ void test() {
     {
       const std::expected<int, int> f1(1);
       f1.and_then(clval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<int (&)(const int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(**this) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(**this) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -80,7 +80,7 @@ void test() {
     {
       const std::expected<int, int> f1(1);
       f1.and_then(clval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<std::expected<int, NotSameAsInt> (&)(const int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(**this) must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(**this) must have the same error_type as this expected}}
 
     }
   }
@@ -91,7 +91,7 @@ void test() {
     {
       std::expected<int, int> f1(1);
       std::move(f1).and_then(rval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<int (&)(int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(**this)) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(**this)) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -100,7 +100,7 @@ void test() {
     {
       std::expected<int, int> f1(1);
       std::move(f1).and_then(rval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<std::expected<int, NotSameAsInt> (&)(int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(**this)) must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(**this)) must have the same error_type as this expected}}
     }
   }
 
@@ -110,7 +110,7 @@ void test() {
     {
       const std::expected<int, int> f1(1);
       std::move(f1).and_then(crval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<int (&)(const int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(**this)) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(**this)) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -119,7 +119,7 @@ void test() {
     {
       const std::expected<int, int> f1(1);
       std::move(f1).and_then(crval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::and_then<std::expected<int, NotSameAsInt> (&)(const int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(**this)) must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(**this)) must have the same error_type as this expected}}
     }
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/error_or.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/error_or.mandates.verify.cpp
@@ -37,7 +37,7 @@ void test() {
   {
     const std::expected<int, NonCopyable> f1(std::unexpect, 0);
     f1.error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<int, NonCopyable>::error_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be copy constructible}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be copy constructible}}
     // expected-error-re@*:* {{call to deleted constructor of{{.*}}}}
   }
 
@@ -46,7 +46,7 @@ void test() {
   {
     const std::expected<int, NotConvertibleFromInt> f1(std::unexpect, NotConvertibleFromInt{});
     f1.error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<int, NotConvertibleFromInt>::error_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}argument has to be convertible to error_type}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}argument has to be convertible to error_type}}
     // expected-error-re@*:* {{no viable conversion from returned value of type{{.*}}}}
 
   }
@@ -56,7 +56,7 @@ void test() {
   {
     std::expected<int, NonMovable> f1(std::unexpect, 0);
     std::move(f1).error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<int, NonMovable>::error_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be move constructible}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be move constructible}}
     // expected-error-re@*:* {{call to deleted constructor of{{.*}}}}
   }
 
@@ -65,7 +65,7 @@ void test() {
   {
     std::expected<int, NotConvertibleFromInt> f1(std::unexpect, NotConvertibleFromInt{});
     std::move(f1).error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<int, NotConvertibleFromInt>::error_or<int>' requested here}}
-    //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}argument has to be convertible to error_type}}
+    //expected-error-re@*:* {{static assertion failed {{.*}}argument has to be convertible to error_type}}
     // expected-error-re@*:* {{no viable conversion from returned value of type{{.*}}}}
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/or_else.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/or_else.mandates.verify.cpp
@@ -52,7 +52,7 @@ void test() {
     {
       std::expected<int, int> f1(std::unexpected<int>(1));
       f1.or_else(lval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<int (&)(int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -61,7 +61,7 @@ void test() {
     {
       std::expected<int, int> f1(std::unexpected<int>(1));
       f1.or_else(lval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<std::expected<NotSameAsInt, int> (&)(int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
     }
   }
 
@@ -71,7 +71,7 @@ void test() {
     {
       const std::expected<int, int> f1(std::unexpected<int>(1));
       f1.or_else(clval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<int (&)(const int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -80,7 +80,7 @@ void test() {
     {
       const std::expected<int, int> f1(std::unexpected<int>(1));
       f1.or_else(clval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<std::expected<NotSameAsInt, int> (&)(const int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
     }
   }
 
@@ -90,7 +90,7 @@ void test() {
     {
       std::expected<int, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(rval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<int (&)(int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -99,7 +99,7 @@ void test() {
     {
       std::expected<int, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(rval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<std::expected<NotSameAsInt, int> (&)(int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
     }
   }
 
@@ -109,7 +109,7 @@ void test() {
     {
       const std::expected<int, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(crval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<int (&)(const int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -118,7 +118,7 @@ void test() {
     {
       const std::expected<int, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(crval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<int, int>::or_else<std::expected<NotSameAsInt, int> (&)(const int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
     }
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/transform_error.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/transform_error.mandates.verify.cpp
@@ -45,39 +45,39 @@ void test() {
   // Test & overload
   {
     std::expected<int, int> e;
-    e.transform_error(return_unexpected<int&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_unexpected<int&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}[expected.object.general] A program that instantiates the definition of template expected<T, E> for {{.*}} is ill-formed.}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}[expected.object.general] A program that instantiates the definition of template expected<T, E> for {{.*}} is ill-formed.}}
 
-    e.transform_error(return_no_object<int&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_no_object<int&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}[expected.object.general] A program that instantiates the definition of template expected<T, E> for {{.*}} is ill-formed.}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}[expected.object.general] A program that instantiates the definition of template expected<T, E> for {{.*}} is ill-formed.}}
   }
 
   // Test const& overload
   {
     const std::expected<int, int> e;
-    e.transform_error(return_unexpected<const int &>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_unexpected<const int &>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* 2 {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    e.transform_error(return_no_object<const int &>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_no_object<const int &>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* 2 {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
   }
 
   // Test && overload
   {
     std::expected<int, int> e;
-    std::move(e).transform_error(return_unexpected<int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_unexpected<int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* 2 {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    std::move(e).transform_error(return_no_object<int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_no_object<int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* 2 {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
   }
 
   // Test const&& overload
   {
     const std::expected<int, int> e;
-    std::move(e).transform_error(return_unexpected<const int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_unexpected<const int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* 2 {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    std::move(e).transform_error(return_no_object<const int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_no_object<const int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* 2 {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/value.observers.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/value.observers.verify.cpp
@@ -55,7 +55,7 @@ void test() {
     {
       std::expected<int, MoveOnly> e;
       [[maybe_unused]] auto val = e.value();
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be copy constructible}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be copy constructible}}
     }
   }
 
@@ -71,7 +71,7 @@ void test() {
     {
       const std::expected<int, MoveOnly> e;
       [[maybe_unused]] auto val = e.value();
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be copy constructible}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be copy constructible}}
     }
   }
 
@@ -81,7 +81,7 @@ void test() {
     {
       std::expected<int, MoveOnly> e;
       [[maybe_unused]] auto val = std::move(e).value();
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
     }
 
     // is_copy_constructible_v<E> is true and is_constructible_v<E, decltype(std::move(error()))> is true.
@@ -94,7 +94,7 @@ void test() {
     {
       std::expected<int, CopyConstructibleButNotMoveConstructible> e;
       [[maybe_unused]] auto val = std::move(e).value();
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
     }
   }
 
@@ -104,7 +104,7 @@ void test() {
     {
       const std::expected<int, MoveOnly> e;
       [[maybe_unused]] auto val = std::move(e).value();
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
     }
 
     // is_copy_constructible_v<E> is true and is_constructible_v<E, decltype(std::move(error()))> is true.
@@ -117,7 +117,7 @@ void test() {
     {
       const std::expected<int, CopyConstructibleButNotMoveConstructible> e;
       [[maybe_unused]] auto val = std::move(e).value();
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be both copy constructible and constructible from decltype(std::move(error()))}}
     }
   }
 // These diagnostics happen when we try to construct bad_expected_access from the non copy-constructible error type.

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/value_or.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/value_or.mandates.verify.cpp
@@ -37,7 +37,7 @@ void test() {
   {
     const std::expected<NonCopyable, int> f1{5};
     f1.value_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<NonCopyable, int>::value_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}value_type has to be copy constructible}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}value_type has to be copy constructible}}
   }
 
   // const & overload
@@ -45,7 +45,7 @@ void test() {
   {
     const std::expected<NotConvertibleFromInt, int> f1{std::in_place};
     f1.value_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<NotConvertibleFromInt, int>::value_or<int>' requested here}}
-    //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}argument has to be convertible to value_type}}
+    //expected-error-re@*:* {{static assertion failed {{.*}}argument has to be convertible to value_type}}
   }
 
   // && overload
@@ -53,7 +53,7 @@ void test() {
   {
     std::expected<NonMovable, int> f1{5};
     std::move(f1).value_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<NonMovable, int>::value_or<int>' requested here}}
-    //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}value_type has to be move constructible}}
+    //expected-error-re@*:* {{static assertion failed {{.*}}value_type has to be move constructible}}
   }
 
   // && overload
@@ -61,6 +61,6 @@ void test() {
   {
     std::expected<NotConvertibleFromInt, int> f1{std::in_place};
     std::move(f1).value_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<NotConvertibleFromInt, int>::value_or<int>' requested here}}
-    //expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}argument has to be convertible to value_type}}
+    //expected-error-re@*:* {{static assertion failed {{.*}}argument has to be convertible to value_type}}
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.unexpected/class.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.unexpected/class.mandates.verify.cpp
@@ -14,12 +14,12 @@
 
 
 
-template class std::unexpected<int[2]>; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}[expected.un.general]}}
+template class std::unexpected<int[2]>; // expected-error-re@*:* {{static assertion failed {{.*}}[expected.un.general]}}
 
-template class std::unexpected<const int>; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}[expected.un.general]}}
+template class std::unexpected<const int>; // expected-error-re@*:* {{static assertion failed {{.*}}[expected.un.general]}}
 
-template class std::unexpected<int&>; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}[expected.un.general]}}
+template class std::unexpected<int&>; // expected-error-re@*:* {{static assertion failed {{.*}}[expected.un.general]}}
 
-template class std::unexpected<std::unexpected<int>>; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}[expected.un.general]}}
+template class std::unexpected<std::unexpected<int>>; // expected-error-re@*:* {{static assertion failed {{.*}}[expected.un.general]}}
 
-template class std::unexpected<volatile int>; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}[expected.un.general]}}
+template class std::unexpected<volatile int>; // expected-error-re@*:* {{static assertion failed {{.*}}[expected.un.general]}}

--- a/libcxx/test/libcxx/utilities/expected/expected.unexpected/swap.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.unexpected/swap.mandates.verify.cpp
@@ -22,5 +22,5 @@ void swap(Foo&, Foo&) = delete;
 void test() {
   std::unexpected<Foo> f1{Foo{}};
   f1.swap(f1); // expected-note{{in instantiation of member function 'std::unexpected<Foo>::swap' requested here}}
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}unexpected::swap requires is_swappable_v<E> to be true}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}unexpected::swap requires is_swappable_v<E> to be true}}
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.void/and_then.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.void/and_then.mandates.verify.cpp
@@ -52,7 +52,7 @@ void test() {
     {
       std::expected<void, int> f1;
       f1.and_then(lval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<int (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -61,7 +61,7 @@ void test() {
     {
       std::expected<void, int> f1;
       f1.and_then(lval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<std::expected<int, NotSameAsInt> (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must have the same error_type as this expected}}
     }
   }
 
@@ -71,7 +71,7 @@ void test() {
     {
       const std::expected<void, int> f1;
       f1.and_then(clval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<int (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -80,7 +80,7 @@ void test() {
     {
       const std::expected<void, int> f1;
       f1.and_then(clval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<std::expected<int, NotSameAsInt> (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must have the same error_type as this expected}}
     }
   }
 
@@ -90,7 +90,7 @@ void test() {
     {
       std::expected<void, int> f1;
       std::move(f1).and_then(rval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<int (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -99,7 +99,7 @@ void test() {
     {
       std::expected<void, int> f1;
       std::move(f1).and_then(rval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<std::expected<int, NotSameAsInt> (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must have the same error_type as this expected}}
     }
   }
 
@@ -109,7 +109,7 @@ void test() {
     {
       const std::expected<void, int> f1;
       std::move(f1).and_then(crval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<int (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
       // expected-error-re@*:* {{no matching constructor for initialization of{{.*}}}}
     }
@@ -118,7 +118,7 @@ void test() {
     {
       const std::expected<void, int> f1;
       std::move(f1).and_then(crval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::and_then<std::expected<int, NotSameAsInt> (&)()>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f() must have the same error_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f() must have the same error_type as this expected}}
     }
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.void/error_or.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.void/error_or.mandates.verify.cpp
@@ -37,7 +37,7 @@ void test() {
   {
     const std::expected<void, NonCopyable> f1(std::unexpect, 0);
     f1.error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<void, NonCopyable>::error_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be copy constructible}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be copy constructible}}
     // expected-error-re@*:* {{call to deleted constructor of{{.*}}}}
   }
 
@@ -46,7 +46,7 @@ void test() {
   {
     const std::expected<void, NotConvertibleFromInt> f1(std::unexpect, NotConvertibleFromInt{});
     f1.error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<void, NotConvertibleFromInt>::error_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}argument has to be convertible to error_type}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}argument has to be convertible to error_type}}
     // expected-error-re@*:* {{no viable conversion from returned value of type{{.*}}}}
   }
 
@@ -55,7 +55,7 @@ void test() {
   {
     std::expected<void, NonMovable> f1(std::unexpect, 0);
     std::move(f1).error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<void, NonMovable>::error_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}error_type has to be move constructible}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}error_type has to be move constructible}}
     // expected-error-re@*:* {{call to deleted constructor of{{.*}}}}
   }
 
@@ -64,7 +64,7 @@ void test() {
   {
     std::expected<void, NotConvertibleFromInt> f1(std::unexpect, NotConvertibleFromInt{});
     std::move(f1).error_or(5); // expected-note{{in instantiation of function template specialization 'std::expected<void, NotConvertibleFromInt>::error_or<int>' requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}argument has to be convertible to error_type}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}argument has to be convertible to error_type}}
     // expected-error-re@*:* {{no viable conversion from returned value of type{{.*}}}}
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.void/or_else.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.void/or_else.mandates.verify.cpp
@@ -52,7 +52,7 @@ void test() {
     {
       std::expected<void, int> f1(std::unexpected<int>(1));
       f1.or_else(lval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<int (&)(int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
     }
 
@@ -60,7 +60,7 @@ void test() {
     {
       std::expected<void, int> f1(std::unexpected<int>(1));
       f1.or_else(lval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<std::expected<NotSameAsInt, int> (&)(int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
     }
   }
 
@@ -70,7 +70,7 @@ void test() {
     {
       const std::expected<void, int> f1(std::unexpected<int>(1));
       f1.or_else(clval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<int (&)(const int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
     }
 
@@ -78,7 +78,7 @@ void test() {
     {
       const std::expected<void, int> f1(std::unexpected<int>(1));
       f1.or_else(clval_error_type_not_same_as_int);  // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<std::expected<NotSameAsInt, int> (&)(const int &)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(error()) must have the same value_type as this expected}}
     }
   }
 
@@ -88,7 +88,7 @@ void test() {
     {
       std::expected<void, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(rval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<int (&)(int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
     }
 
@@ -96,7 +96,7 @@ void test() {
     {
       std::expected<void, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(rval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<std::expected<NotSameAsInt, int> (&)(int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
     }
   }
 
@@ -106,7 +106,7 @@ void test() {
     {
       const std::expected<void, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(crval_return_not_std_expected); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<int (&)(const int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must be a specialization of std::expected}}
       // expected-error-re@*:* {{{{.*}}cannot be used prior to '::' because it has no members}}
     }
 
@@ -114,7 +114,7 @@ void test() {
     {
       const std::expected<void, int> f1(std::unexpected<int>(1));
       std::move(f1).or_else(crval_error_type_not_same_as_int); // expected-note{{in instantiation of function template specialization 'std::expected<void, int>::or_else<std::expected<NotSameAsInt, int> (&)(const int &&)>' requested here}}
-      // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
+      // expected-error-re@*:* {{static assertion failed {{.*}}The result of f(std::move(error())) must have the same value_type as this expected}}
     }
   }
 }

--- a/libcxx/test/libcxx/utilities/expected/expected.void/transform_error.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.void/transform_error.mandates.verify.cpp
@@ -45,39 +45,39 @@ void test() {
   // Test & overload
   {
     std::expected<void, int> e;
-    e.transform_error(return_unexpected<int&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_unexpected<int&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}A program that instantiates expected<T, E> with a E that is not a valid argument for unexpected<E> is ill-formed}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}A program that instantiates expected<T, E> with a E that is not a valid argument for unexpected<E> is ill-formed}}
 
-    e.transform_error(return_no_object<int&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_no_object<int&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}A program that instantiates expected<T, E> with a E that is not a valid argument for unexpected<E> is ill-formed}}
+    // expected-error-re@*:* {{static assertion failed {{.*}}A program that instantiates expected<T, E> with a E that is not a valid argument for unexpected<E> is ill-formed}}
   }
 
   // Test const& overload
   {
     const std::expected<void, int> e;
-    e.transform_error(return_unexpected<const int &>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_unexpected<const int &>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    e.transform_error(return_no_object<const int &>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    e.transform_error(return_no_object<const int &>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
   }
 
   // Test && overload
   {
     std::expected<void, int> e;
-    std::move(e).transform_error(return_unexpected<int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_unexpected<int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    std::move(e).transform_error(return_no_object<int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_no_object<int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
   }
 
   // Test const&& overload
   {
     const std::expected<void, int> e;
-    std::move(e).transform_error(return_unexpected<const int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_unexpected<const int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
-    std::move(e).transform_error(return_no_object<const int&&>); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
+    std::move(e).transform_error(return_no_object<const int&&>); // expected-error-re@*:* {{static assertion failed {{.*}}The result of {{.*}} must be a valid template argument for unexpected}}
     // expected-error-re@*:* {{{{(excess elements in struct initializer|no matching constructor for initialization of)}}{{.*}}}}
   }
 }

--- a/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/function_type_default_deleter.verify.cpp
+++ b/libcxx/test/libcxx/utilities/memory/util.smartptr/util.smartptr.shared/function_type_default_deleter.verify.cpp
@@ -46,7 +46,7 @@ int main(int, char**) {
     SPtr<3> s3(nullptr, Deleter{}); // OK
   }
 
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}default_delete cannot be instantiated for function types}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}default_delete cannot be instantiated for function types}}
   std::default_delete<FnType<5>> deleter{}; // expected-note {{requested here}}
 
   return 0;

--- a/libcxx/test/libcxx/utilities/utility/pairs/pairs.pair/pair.tuple_element.verify.cpp
+++ b/libcxx/test/libcxx/utilities/utility/pairs/pairs.pair/pair.tuple_element.verify.cpp
@@ -17,5 +17,5 @@
 void f() {
   typedef std::pair<int, double> P;
   std::tuple_element<2, P>::type foo; // expected-note {{requested here}}
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{( due to requirement '2U[L]{0,2} < 2')?}}{{.*}}Index out of bounds in std::tuple_element<std::pair<T1, T2>>}}
+    // expected-error-re@*:* {{static assertion failed{{( due to requirement '2U[L]{0,2} < 2')?}}{{.*}}Index out of bounds in std::tuple_element<std::pair<T1, T2>>}}
 }

--- a/libcxx/test/libcxx/utilities/variant/variant.variant/variant.helper/variant_alternative.verify.cpp
+++ b/libcxx/test/libcxx/utilities/variant/variant.variant/variant.helper/variant_alternative.verify.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
     {
         typedef std::variant<int, double> T;
         std::variant_alternative<2, T>::type foo; // expected-note {{requested here}}
-        // expected-error-re@variant:* {{{{(static_assert|static assertion)}} failed{{( due to requirement '2U[L]{0,2} < sizeof...\(_Types\)')?}}{{.*}}Index out of bounds in std::variant_alternative<>}}
+        // expected-error-re@variant:* {{static assertion failed{{( due to requirement '2U[L]{0,2} < sizeof...\(_Types\)')?}}{{.*}}Index out of bounds in std::variant_alternative<>}}
     }
 
   return 0;

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.sample/sample.verify.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.sample/sample.verify.cpp
@@ -33,7 +33,7 @@ template <class PopulationIterator, class SampleIterator> void test() {
 }
 
 int main(int, char**) {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{( due to requirement '.*')?}}{{.*}}SampleIterator must meet the requirements of RandomAccessIterator}}
+  // expected-error-re@*:* {{static assertion failed{{( due to requirement '.*')?}}{{.*}}SampleIterator must meet the requirements of RandomAccessIterator}}
   // expected-error@*:* 2 {{does not provide a subscript operator}}
   // expected-error@*:* {{invalid operands}}
   test<cpp17_input_iterator<int *>, cpp17_output_iterator<int *> >();

--- a/libcxx/test/std/algorithms/alg.sorting/alg.three.way/lexicographical_compare_three_way_comp.verify.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.three.way/lexicographical_compare_three_way_comp.verify.cpp
@@ -29,19 +29,19 @@ constexpr bool incorrect_comparator(int a, int b) { return a < b; }
 auto test_incorrect_comparator() {
   std::array a{90, 81};
   std::array b{10, 11};
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}The comparator passed to lexicographical_compare_three_way must return a comparison category type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}The comparator passed to lexicographical_compare_three_way must return a comparison category type}}
   // expected-error@*:* {{no viable conversion}}
   return std::lexicographical_compare_three_way(a.begin(), a.end(), b.begin(), b.end(), incorrect_comparator);
 }
 
 auto test_invalid_difference_type_first(
     RandomAccessIteratorBadDifferenceType a, RandomAccessIteratorBadDifferenceType b, int* c, int* d) {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Using a non-integral difference_type is undefined behavior}}}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Using a non-integral difference_type is undefined behavior}}}}
   return std::lexicographical_compare_three_way(a, b, c, d, std::compare_three_way());
 }
 
 auto test_invalid_difference_type_second(
     int* a, int* b, RandomAccessIteratorBadDifferenceType c, RandomAccessIteratorBadDifferenceType d) {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Using a non-integral difference_type is undefined behavior}}}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Using a non-integral difference_type is undefined behavior}}}}
   return std::lexicographical_compare_three_way(a, b, c, d, std::compare_three_way());
 }

--- a/libcxx/test/std/containers/associative/map/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/map/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <map>
 
 std::map<int, int, std::less<int>, std::allocator<long> > m;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/associative/map/map.cons/deduct.verify.cpp
+++ b/libcxx/test/std/containers/associative/map/map.cons/deduct.verify.cpp
@@ -63,7 +63,7 @@ int main(int, char**)
         // refuse to rebind the allocator if Allocator::value_type is not exactly what we expect
         const P arr[] = { {1,1L}, {2,2L}, {3,3L} };
         std::map m(arr, arr + 3, std::allocator<P>());
-            // expected-error-re@map:* {{{{(static_assert|static assertion)}} failed{{( due to requirement '.*')?}}{{.*}}Allocator::value_type must be same type as value_type}}
+            // expected-error-re@map:* {{static assertion failed{{( due to requirement '.*')?}}{{.*}}Allocator::value_type must be same type as value_type}}
     }
     {
         // cannot convert from some arbitrary unrelated type

--- a/libcxx/test/std/containers/associative/map/map.nonmember/compare.three_way.verify.cpp
+++ b/libcxx/test/std/containers/associative/map/map.nonmember/compare.three_way.verify.cpp
@@ -25,9 +25,9 @@ int main(int, char**) {
   {
     std::map<int, int, std::less<int>, std::allocator<int>> s1;
     std::map<int, int, std::less<int>, test_allocator<int>> s2;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
+    // expected-error-re@*:* {{static assertion failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
     s1 <=> s2;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
+    // expected-error-re@*:* {{static assertion failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
     s2 <=> s1;
   }
   // Mismatching comparision functions

--- a/libcxx/test/std/containers/associative/multimap/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/multimap/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <map>
 
 std::multimap<int, int, std::less<int>, std::allocator<long> > m;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/associative/multimap/multimap.cons/deduct.verify.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.cons/deduct.verify.cpp
@@ -63,7 +63,7 @@ int main(int, char**)
         // refuse to rebind the allocator if Allocator::value_type is not exactly what we expect
         const P arr[] = { {1,1L}, {2,2L}, {3,3L} };
         std::multimap m(arr, arr + 3, std::allocator<P>());
-            // expected-error-re@map:* {{{{(static_assert|static assertion)}} failed{{( due to requirement '.*')?}}{{.*}}Allocator::value_type must be same type as value_type}}
+            // expected-error-re@map:* {{static assertion failed{{( due to requirement '.*')?}}{{.*}}Allocator::value_type must be same type as value_type}}
     }
     {
         // cannot convert from some arbitrary unrelated type

--- a/libcxx/test/std/containers/associative/multimap/multimap.nonmember/compare.three_way.verify.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.nonmember/compare.three_way.verify.cpp
@@ -25,9 +25,9 @@ int main(int, char**) {
   {
     std::multimap<int, int, std::less<int>, std::allocator<int>> s1;
     std::multimap<int, int, std::less<int>, test_allocator<int>> s2;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
+    // expected-error-re@*:* {{static assertion failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
     s1 <=> s2;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
+    // expected-error-re@*:* {{static assertion failed due to requirement 'is_same<int, std::pair<const int, int>>::value'{{.*}}Allocator::value_type must be same type as value_type}}
     s2 <=> s1;
   }
   // Mismatching comparision functions

--- a/libcxx/test/std/containers/associative/multiset/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/multiset/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <set>
 
 std::multiset<int, std::less<int>, std::allocator<long> > m;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/associative/set/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/set/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <set>
 
 std::set<int, std::less<int>, std::allocator<long> > m;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/sequences/array/array.fill/fill.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.fill/fill.verify.cpp
@@ -18,7 +18,7 @@ int main(int, char**) {
     typedef double T;
     typedef std::array<const T, 0> C;
     C c = {};
-    // expected-error-re@array:* {{{{(static_assert|static assertion)}} failed{{.*}}cannot fill zero-sized array of type 'const T'}}
+    // expected-error-re@array:* {{static assertion failed{{.*}}cannot fill zero-sized array of type 'const T'}}
     c.fill(5.5); // expected-note {{requested here}}
   }
 

--- a/libcxx/test/std/containers/sequences/array/array.swap/swap.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.swap/swap.verify.cpp
@@ -19,7 +19,7 @@ int main(int, char**) {
     typedef std::array<const T, 0> C;
     C c = {};
     C c2 = {};
-    // expected-error-re@array:* {{{{(static_assert|static assertion)}} failed{{.*}}cannot swap zero-sized array of type 'const T'}}
+    // expected-error-re@array:* {{static assertion failed{{.*}}cannot swap zero-sized array of type 'const T'}}
     c.swap(c2); // expected-note {{requested here}}
   }
 

--- a/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
@@ -21,5 +21,5 @@ void f() {
   typedef std::array<T, 3> C;
   C c = {1, 2, 3.5};
   std::get<3>(c) = 5.5; // expected-note {{requested here}}
-  // expected-error-re@array:* {{{{(static_assert|static assertion)}} failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::get<> (std::array)}}
+  // expected-error-re@array:* {{static assertion failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::get<> (std::array)}}
 }

--- a/libcxx/test/std/containers/sequences/array/array.tuple/tuple_element.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/tuple_element.verify.cpp
@@ -16,4 +16,4 @@
 typedef double T;
 typedef std::array<T, 3> C;
 std::tuple_element<3, C> foo; // expected-note {{requested here}}
-// expected-error-re@array:* {{{{(static_assert|static assertion)}} failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::tuple_element<> (std::array)}}
+// expected-error-re@array:* {{static assertion failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::tuple_element<> (std::array)}}

--- a/libcxx/test/std/containers/sequences/deque/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/deque/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <deque>
 
 std::deque<int, std::allocator<long> > d;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/sequences/forwardlist/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <forward_list>
 
 std::forward_list<int, std::allocator<long> > fl;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/sequences/list/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/list/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <list>
 
 std::list<int, std::allocator<long> > l;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/sequences/vector/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/vector/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <vector>
 
 std::vector<int, std::allocator<long> > v;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.map/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <unordered_map>
 
 std::unordered_map<int, int, std::hash<int>, std::less<int>, std::allocator<long> > m;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.multimap/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <unordered_map>
 
 std::unordered_multimap<int, int, std::hash<int>, std::less<int>, std::allocator<long> > m;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.multiset/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <unordered_set>
 
 std::unordered_multiset<int, std::hash<int>, std::less<int>, std::allocator<long> > v;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.set/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/allocator_mismatch.verify.cpp
@@ -12,4 +12,4 @@
 #include <unordered_set>
 
 std::unordered_set<int, std::hash<int>, std::less<int>, std::allocator<long> > v;
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}Allocator::value_type must be same type as value_type}}
+  // expected-error-re@*:* {{static assertion failed{{.*}}Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/views/mdspan/default_accessor/element_type.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/default_accessor/element_type.verify.cpp
@@ -22,12 +22,12 @@ public:
 };
 
 void not_abstract_class() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}default_accessor: template argument may not be an abstract class}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}default_accessor: template argument may not be an abstract class}}
   [[maybe_unused]] std::default_accessor<AbstractClass> acc;
 }
 
 void not_array_type() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}default_accessor: template argument may not be an array type}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}default_accessor: template argument may not be an array type}}
   [[maybe_unused]] std::default_accessor<int[5]> acc;
 }
 

--- a/libcxx/test/std/containers/views/mdspan/layout_left/extents.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/extents.verify.cpp
@@ -23,11 +23,11 @@
 #include <mdspan>
 
 void not_extents() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}layout_left::mapping template argument must be a specialization of extents}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}layout_left::mapping template argument must be a specialization of extents}}
   [[maybe_unused]] std::layout_left::mapping<void> mapping;
 }
 
 void representable() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}layout_left::mapping product of static extents must be representable as index_type.}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}layout_left::mapping product of static extents must be representable as index_type.}}
   [[maybe_unused]] std::layout_left::mapping<std::extents<char, 20, 20>> mapping;
 }

--- a/libcxx/test/std/containers/views/mdspan/layout_right/extents.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/extents.verify.cpp
@@ -23,11 +23,11 @@
 #include <mdspan>
 
 void not_extents() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}layout_right::mapping template argument must be a specialization of extents}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}layout_right::mapping template argument must be a specialization of extents}}
   [[maybe_unused]] std::layout_right::mapping<void> mapping;
 }
 
 void representable() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}layout_right::mapping product of static extents must be representable as index_type.}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}layout_right::mapping product of static extents must be representable as index_type.}}
   [[maybe_unused]] std::layout_right::mapping<std::extents<char, 20, 20>> mapping;
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/conversion.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/conversion.verify.cpp
@@ -43,7 +43,7 @@ void cant_construct_data_handle_type() {
   int data;
   std::mdspan<int, std::extents<int>, std::layout_right, convertible_accessor_but_not_handle<int>> m_nc(&data);
   // expected-error-re@*:* {{{{.*}}no matching constructor for initialization of {{.*}} (aka 'not_const_convertible_handle<const int>')}}
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}mdspan: incompatible data_handle_type for mdspan construction}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: incompatible data_handle_type for mdspan construction}}
   [[maybe_unused]] std::
       mdspan<const int, std::extents<int>, std::layout_right, convertible_accessor_but_not_handle<const int>>
           m_c(m_nc);
@@ -52,6 +52,6 @@ void cant_construct_data_handle_type() {
 void mapping_constructible_despite_extents_compatibility() {
   int data;
   std::mdspan<int, std::extents<int>, always_convertible_layout> m(&data);
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}mdspan: incompatible extents for mdspan construction}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: incompatible extents for mdspan construction}}
   [[maybe_unused]] std::mdspan<int, std::extents<int, 5>, always_convertible_layout> m2(m);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/element_type.verify.cpp
@@ -24,16 +24,16 @@ public:
 };
 
 void not_abstract_class() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}mdspan: ElementType template parameter may not be an abstract class}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter may not be an abstract class}}
   [[maybe_unused]] std::mdspan<AbstractClass, std::extents<int>> m;
 }
 
 void not_array_type() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}mdspan: ElementType template parameter may not be an array type}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter may not be an array type}}
   [[maybe_unused]] std::mdspan<int[5], std::extents<int>> m;
 }
 
 void element_type_mismatch() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}mdspan: ElementType template parameter must match AccessorPolicy::element_type}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: ElementType template parameter must match AccessorPolicy::element_type}}
   [[maybe_unused]] std::mdspan<int, std::extents<int>, std::layout_right, std::default_accessor<const int>> m;
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/extents.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/extents.verify.cpp
@@ -18,6 +18,6 @@
 #include <mdspan>
 
 void not_extents() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}mdspan: Extents template parameter must be a specialization of extents.}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: Extents template parameter must be a specialization of extents.}}
   [[maybe_unused]] std::mdspan<int, int> m;
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/mapping.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/mapping.verify.cpp
@@ -18,6 +18,6 @@
 #include <mdspan>
 
 void not_layout_policy() {
-  // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}mdspan: LayoutPolicy template parameter is invalid. A common mistake is to pass a layout mapping instead of a layout policy}}
+  // expected-error-re@*:* {{static assertion failed {{.*}}mdspan: LayoutPolicy template parameter is invalid. A common mistake is to pass a layout mapping instead of a layout policy}}
   [[maybe_unused]] std::mdspan<int, std::extents<int>, std::layout_left::template mapping<std::extents<int>>> m;
 }

--- a/libcxx/test/std/language.support/support.dynamic/ptr.launder/launder.types.verify.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/ptr.launder/launder.types.verify.cpp
@@ -26,10 +26,10 @@ int main(int, char**)
     (void) std::launder((               void *) nullptr);
     (void) std::launder((const          void *) nullptr);
     (void) std::launder((      volatile void *) nullptr);
-    (void) std::launder((const volatile void *) nullptr);  // expected-error-re@new:* 4 {{{{(static_assert|static assertion)}} failed{{.*}}can't launder cv-void}}
+    (void) std::launder((const volatile void *) nullptr);  // expected-error-re@new:* 4 {{static assertion failed{{.*}}can't launder cv-void}}
     // expected-error@new:* 0-4 {{void pointer argument to '__builtin_launder' is not allowed}}
 
-    (void) std::launder(foo);                              // expected-error-re@new:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}can't launder functions}}
+    (void) std::launder(foo);                              // expected-error-re@new:* 1 {{static assertion failed{{.*}}can't launder functions}}
     // expected-error@new:* 0-1 {{function pointer argument to '__builtin_launder' is not allowed}}
 
   return 0;

--- a/libcxx/test/std/numerics/bit/bit.pow.two/bit_ceil.verify.cpp
+++ b/libcxx/test/std/numerics/bit/bit.pow.two/bit_ceil.verify.cpp
@@ -33,19 +33,19 @@ constexpr bool toobig()
 int main(int, char**)
 {
     // Make sure we generate a compile-time error for UB
-    static_assert(toobig<unsigned char>(),      ""); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<unsigned short>(),     ""); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<unsigned>(),           ""); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<unsigned long>(),      ""); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<unsigned long long>(), ""); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
+    static_assert(toobig<unsigned char>(),      ""); // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<unsigned short>(),     ""); // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<unsigned>(),           ""); // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<unsigned long>(),      ""); // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<unsigned long long>(), ""); // expected-error {{static assertion expression is not an integral constant expression}}
 
-    static_assert(toobig<std::uint8_t>(), "");   // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<std::uint16_t>(), "");  // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<std::uint32_t>(), "");  // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<std::uint64_t>(), "");  // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<std::size_t>(), "");    // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<std::uintmax_t>(), ""); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    static_assert(toobig<std::uintptr_t>(), ""); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
+    static_assert(toobig<std::uint8_t>(), "");   // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<std::uint16_t>(), "");  // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<std::uint32_t>(), "");  // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<std::uint64_t>(), "");  // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<std::size_t>(), "");    // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<std::uintmax_t>(), ""); // expected-error {{static assertion expression is not an integral constant expression}}
+    static_assert(toobig<std::uintptr_t>(), ""); // expected-error {{static assertion expression is not an integral constant expression}}
 
     return 0;
 }

--- a/libcxx/test/std/numerics/numbers/illformed.verify.cpp
+++ b/libcxx/test/std/numerics/numbers/illformed.verify.cpp
@@ -11,7 +11,7 @@
 #include <numbers>
 
 // Initializing the primary template is ill-formed.
-int log2e{std::numbers::log2e_v<int>}; // expected-error-re@numbers:* {{{{(static_assert|static assertion)}} failed{{.*}}A program that instantiates a primary template of a mathematical constant variable template is ill-formed.}}
+int log2e{std::numbers::log2e_v<int>}; // expected-error-re@numbers:* {{static assertion failed{{.*}}A program that instantiates a primary template of a mathematical constant variable template is ill-formed.}}
 int log10e{std::numbers::log10e_v<int>};
 int pi{std::numbers::pi_v<int>};
 int inv_pi{std::numbers::inv_pi_v<int>};

--- a/libcxx/test/std/numerics/rand/rand.eng/rand.eng.lcong/params.verify.cpp
+++ b/libcxx/test/std/numerics/rand/rand.eng/rand.eng.lcong/params.verify.cpp
@@ -19,12 +19,12 @@ int main(int, char**)
 {
     typedef unsigned long long T;
 
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '1ULL == 0 || 1ULL < 1ULL'{{.*}}linear_congruential_engine invalid parameters}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '1ULL == 0 || 1ULL < 1ULL'{{.*}}linear_congruential_engine invalid parameters}}
     std::linear_congruential_engine<T, 0, 0, 0> e2;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement '1ULL == 0 || 1ULL < 1ULL'{{.*}}linear_congruential_engine invalid parameters}}
+    // expected-error-re@*:* {{static assertion failed due to requirement '1ULL == 0 || 1ULL < 1ULL'{{.*}}linear_congruential_engine invalid parameters}}
     std::linear_congruential_engine<T, 0, 1, 1> e3;
     std::linear_congruential_engine<T, 1, 0, 1> e4;
-    // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed due to requirement 'is_unsigned<int>::value'{{.*}}_UIntType must be unsigned type}}
+    // expected-error-re@*:* {{static assertion failed due to requirement 'is_unsigned<int>::value'{{.*}}_UIntType must be unsigned type}}
     std::linear_congruential_engine<int, 0, 0, 0> e5;
 
     return 0;

--- a/libcxx/test/std/strings/basic.string/char.bad.verify.cpp
+++ b/libcxx/test/std/strings/basic.string/char.bad.verify.cpp
@@ -33,20 +33,20 @@ void f() {
     typedef char C[3];
     static_assert(std::is_array<C>::value, "");
     std::basic_string<C, test_traits<C> > s;
-    // expected-error-re@string:* {{{{(static_assert|static assertion)}} failed{{.*}}Character type of basic_string must not be an array}}
+    // expected-error-re@string:* {{static assertion failed{{.*}}Character type of basic_string must not be an array}}
   }
 
   {
     // not trivial
     static_assert(!std::is_trivial<NotTrivial>::value, "");
     std::basic_string<NotTrivial, test_traits<NotTrivial> > s;
-    // expected-error-re@string:* {{{{(static_assert|static assertion)}} failed{{.*}}Character type of basic_string must be trivial}}
+    // expected-error-re@string:* {{static assertion failed{{.*}}Character type of basic_string must be trivial}}
   }
 
   {
     // not standard layout
     static_assert(!std::is_standard_layout<NotStandardLayout>::value, "");
     std::basic_string<NotStandardLayout, test_traits<NotStandardLayout> > s;
-    // expected-error-re@string:* {{{{(static_assert|static assertion)}} failed{{.*}}Character type of basic_string must be standard-layout}}
+    // expected-error-re@string:* {{static assertion failed{{.*}}Character type of basic_string must be standard-layout}}
   }
 }

--- a/libcxx/test/std/strings/string.view/char.bad.verify.cpp
+++ b/libcxx/test/std/strings/string.view/char.bad.verify.cpp
@@ -35,21 +35,21 @@ int main(int, char**) {
     typedef char C[3];
     static_assert(std::is_array<C>::value, "");
     std::basic_string_view<C, test_traits<C> > sv;
-    //  expected-error-re@string_view:* {{{{(static_assert|static assertion)}} failed{{.*}}Character type of basic_string_view must not be an array}}
+    //  expected-error-re@string_view:* {{static assertion failed{{.*}}Character type of basic_string_view must not be an array}}
   }
 
   {
     //  not trivial
     static_assert(!std::is_trivial<NotTrivial>::value, "");
     std::basic_string_view<NotTrivial, test_traits<NotTrivial> > sv;
-    //  expected-error-re@string_view:* {{{{(static_assert|static assertion)}} failed{{.*}}Character type of basic_string_view must be trivial}}
+    //  expected-error-re@string_view:* {{static assertion failed{{.*}}Character type of basic_string_view must be trivial}}
   }
 
   {
     //  not standard layout
     static_assert(!std::is_standard_layout<NotStandardLayout>::value, "");
     std::basic_string_view<NotStandardLayout, test_traits<NotStandardLayout> > sv;
-    //  expected-error-re@string_view:* {{{{(static_assert|static assertion)}} failed{{.*}}Character type of basic_string_view must be standard-layout}}
+    //  expected-error-re@string_view:* {{static assertion failed{{.*}}Character type of basic_string_view must be standard-layout}}
   }
 
   return 0;

--- a/libcxx/test/std/strings/string.view/string.view.comparison/comparison.verify.cpp
+++ b/libcxx/test/std/strings/string.view/string.view.comparison/comparison.verify.cpp
@@ -62,13 +62,13 @@ void test() {
   // These diagnostics are issued for
   // - Every invalid ordering
   // - Every type
-  // expected-error-re@string_view:* 15 {{{{(static_assert|static assertion)}} failed{{.*}}return type is not a comparison category type}}
+  // expected-error-re@string_view:* 15 {{static assertion failed{{.*}}return type is not a comparison category type}}
 
   // This diagnostic is not issued for Ordering == void.
   // expected-error@string_view:* 10 {{no matching conversion for static_cast from}}
 #else
   // One less test run when wchar_t is unavailable.
-  // expected-error-re@string_view:* 12 {{{{(static_assert|static assertion)}} failed{{.*}}return type is not a comparison category type}}
+  // expected-error-re@string_view:* 12 {{static assertion failed{{.*}}return type is not a comparison category type}}
   // expected-error@string_view:* 8 {{no matching conversion for static_cast from}}
 #endif
     type{} <=> type{};

--- a/libcxx/test/std/thread/thread.semaphore/ctor.verify.cpp
+++ b/libcxx/test/std/thread/thread.semaphore/ctor.verify.cpp
@@ -14,6 +14,6 @@
 #include <semaphore>
 
 void not_positive() {
-  std::counting_semaphore<-1> s(2); // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}The least maximum value must be a positive number}}
+  std::counting_semaphore<-1> s(2); // expected-error-re@*:* {{static assertion failed{{.*}}The least maximum value must be a positive number}}
   (void)s;
 }

--- a/libcxx/test/std/time/time.hms/hhmmss.verify.cpp
+++ b/libcxx/test/std/time/time.hms/hhmmss.verify.cpp
@@ -21,10 +21,10 @@ struct A {};
 
 int main(int, char**)
 {
-    std::chrono::hh_mm_ss<void> h0;        // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
-    std::chrono::hh_mm_ss<int> h1;         // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
-    std::chrono::hh_mm_ss<std::string> h2; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
-    std::chrono::hh_mm_ss<A> h3;           // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
+    std::chrono::hh_mm_ss<void> h0;        // expected-error-re@*:* {{static assertion failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
+    std::chrono::hh_mm_ss<int> h1;         // expected-error-re@*:* {{static assertion failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
+    std::chrono::hh_mm_ss<std::string> h2; // expected-error-re@*:* {{static assertion failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
+    std::chrono::hh_mm_ss<A> h3;           // expected-error-re@*:* {{static assertion failed{{.*}}template parameter of hh_mm_ss must be a std::chrono::duration}}
 
     return 0;
 }

--- a/libcxx/test/std/utilities/any/any.nonmembers/any.cast/any_cast_request_invalid_value_category.verify.cpp
+++ b/libcxx/test/std/utilities/any/any.nonmembers/any.cast/any_cast_request_invalid_value_category.verify.cpp
@@ -24,12 +24,12 @@ struct TestType {};
 void test_const_lvalue_cast_request_non_const_lvalue()
 {
     const std::any a;
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
     // expected-error@any:* {{drops 'const' qualifier}}
     std::any_cast<TestType &>(a); // expected-note {{requested here}}
 
     const std::any a2(42);
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
     // expected-error@any:* {{drops 'const' qualifier}}
     std::any_cast<int&>(a2); // expected-note {{requested here}}
 }
@@ -37,22 +37,22 @@ void test_const_lvalue_cast_request_non_const_lvalue()
 void test_lvalue_any_cast_request_rvalue()
 {
     std::any a;
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be an lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be an lvalue reference or a CopyConstructible type}}
     std::any_cast<TestType &&>(a); // expected-note {{requested here}}
 
     std::any a2(42);
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be an lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be an lvalue reference or a CopyConstructible type}}
     std::any_cast<int&&>(a2); // expected-note {{requested here}}
 }
 
 void test_rvalue_any_cast_request_lvalue()
 {
     std::any a;
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be an rvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be an rvalue reference or a CopyConstructible type}}
     // expected-error@any:* {{non-const lvalue reference to type 'TestType' cannot bind to a temporary}}
     std::any_cast<TestType &>(std::move(a)); // expected-note {{requested here}}
 
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be an rvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be an rvalue reference or a CopyConstructible type}}
     // expected-error@any:* {{non-const lvalue reference to type 'int' cannot bind to a temporary}}
     std::any_cast<int&>(42);
 }

--- a/libcxx/test/std/utilities/any/any.nonmembers/any.cast/const_correctness.verify.cpp
+++ b/libcxx/test/std/utilities/any/any.nonmembers/any.cast/const_correctness.verify.cpp
@@ -32,15 +32,15 @@ struct TestType2 {};
 void f() {
     std::any a;
 
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
     std::any_cast<TestType &>(static_cast<std::any const&>(a)); // expected-note {{requested here}}
 
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
     std::any_cast<TestType &&>(static_cast<std::any const&>(a)); // expected-note {{requested here}}
 
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
     std::any_cast<TestType2 &>(static_cast<std::any const&&>(a)); // expected-note {{requested here}}
 
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
     std::any_cast<TestType2 &&>(static_cast<std::any const&&>(a)); // expected-note {{requested here}}
 }

--- a/libcxx/test/std/utilities/any/any.nonmembers/any.cast/not_copy_constructible.verify.cpp
+++ b/libcxx/test/std/utilities/any/any.nonmembers/any.cast/not_copy_constructible.verify.cpp
@@ -46,14 +46,14 @@ struct no_move {
 
 void f() {
     std::any a;
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be an lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be an lvalue reference or a CopyConstructible type}}
     std::any_cast<no_copy>(static_cast<std::any&>(a)); // expected-note {{requested here}}
 
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be a const lvalue reference or a CopyConstructible type}}
     std::any_cast<no_copy>(static_cast<std::any const&>(a)); // expected-note {{requested here}}
 
     std::any_cast<no_copy>(static_cast<std::any &&>(a)); // OK
 
-    // expected-error-re@any:* {{{{(static_assert|static assertion)}} failed{{.*}}ValueType is required to be an rvalue reference or a CopyConstructible type}}
+    // expected-error-re@any:* {{static assertion failed{{.*}}ValueType is required to be an rvalue reference or a CopyConstructible type}}
     std::any_cast<no_move>(static_cast<std::any &&>(a));
 }

--- a/libcxx/test/std/utilities/any/any.nonmembers/any.cast/reference_types.verify.cpp
+++ b/libcxx/test/std/utilities/any/any.nonmembers/any.cast/reference_types.verify.cpp
@@ -22,30 +22,30 @@ int main(int, char**)
 {
     std::any a = 1;
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int &>(&a); // expected-note {{requested here}}
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int &&>(&a); // expected-note {{requested here}}
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int const &>(&a); // expected-note {{requested here}}
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int const&&>(&a); // expected-note {{requested here}}
 
     const std::any& a2 = a;
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int &>(&a2); // expected-note {{requested here}}
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int &&>(&a2); // expected-note {{requested here}}
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int const &>(&a2); // expected-note {{requested here}}
 
-    // expected-error-re@any:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}_ValueType may not be a reference.}}
+    // expected-error-re@any:* 1 {{static assertion failed{{.*}}_ValueType may not be a reference.}}
     std::any_cast<int const &&>(&a2); // expected-note {{requested here}}
 
   return 0;

--- a/libcxx/test/std/utilities/format/format.formatter/format.parse.ctx/check_arg_id.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.parse.ctx/check_arg_id.verify.cpp
@@ -22,6 +22,6 @@ constexpr bool test() {
 }
 
 void f() {
-  // expected-error-re@+1 {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
+  // expected-error@+1 {{static assertion expression is not an integral constant expression}}
   static_assert(test());
 }

--- a/libcxx/test/std/utilities/format/format.formatter/format.parse.ctx/next_arg_id.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.parse.ctx/next_arg_id.verify.cpp
@@ -23,6 +23,6 @@ constexpr bool test() {
 }
 
 void f() {
-  // expected-error-re@+1 {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
+  // expected-error@+1 {{static assertion expression is not an integral constant expression}}
   static_assert(test());
 }

--- a/libcxx/test/std/utilities/function.objects/func.bind_front/bind_front.verify.cpp
+++ b/libcxx/test/std/utilities/function.objects/func.bind_front/bind_front.verify.cpp
@@ -37,7 +37,7 @@ void f() {
     const int c = 1;
 
     auto p = std::bind_front(pass, c);
-    static_assert(p() == 1); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
+    static_assert(p() == 1); // expected-error {{static assertion expression is not an integral constant expression}}
 
     auto d = std::bind_front(do_nothing, n); // expected-error {{no matching function for call to 'bind_front'}}
 

--- a/libcxx/test/std/utilities/intseq/intseq.make/make_integer_seq.verify.cpp
+++ b/libcxx/test/std/utilities/intseq/intseq.make/make_integer_seq.verify.cpp
@@ -27,5 +27,5 @@ typedef std::make_integer_sequence<int, -3> MakeSeqT;
 #if TEST_HAS_BUILTIN(__make_integer_seq)
 MakeSeqT i; // expected-error@*:* {{integer sequences must have non-negative sequence length}}
 #else
-MakeSeqT i; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}std::make_integer_sequence must have a non-negative sequence length}}
+MakeSeqT i; // expected-error-re@*:* {{static assertion failed{{.*}}std::make_integer_sequence must have a non-negative sequence length}}
 #endif

--- a/libcxx/test/std/utilities/intseq/intseq.make/make_integer_seq_fallback.verify.cpp
+++ b/libcxx/test/std/utilities/intseq/intseq.make/make_integer_seq_fallback.verify.cpp
@@ -21,4 +21,4 @@
 #include <utility>
 
 typedef std::make_integer_sequence<int, -3> MakeSeqT;
-MakeSeqT i; // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed{{.*}}std::make_integer_sequence must have a non-negative sequence length}}
+MakeSeqT i; // expected-error-re@*:* {{static assertion failed{{.*}}std::make_integer_sequence must have a non-negative sequence length}}

--- a/libcxx/test/std/utilities/memory/default.allocator/allocator.members/allocate.constexpr.size.verify.cpp
+++ b/libcxx/test/std/utilities/memory/default.allocator/allocator.members/allocate.constexpr.size.verify.cpp
@@ -33,6 +33,6 @@ constexpr bool test()
 }
 
 void f() {
-    static_assert(test<double>()); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
-    LIBCPP_STATIC_ASSERT(test<const double>()); // expected-error-re {{{{(static_assert|static assertion)}} expression is not an integral constant expression}}
+    static_assert(test<double>()); // expected-error {{static assertion expression is not an integral constant expression}}
+    LIBCPP_STATIC_ASSERT(test<const double>()); // expected-error {{static assertion expression is not an integral constant expression}}
 }

--- a/libcxx/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.verify.cpp
+++ b/libcxx/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.verify.cpp
@@ -22,7 +22,7 @@ int main(int, char**)
   // expected-error@+1 {{no member named 'is_constant_evaluated' in namespace 'std'}}
   bool b = std::is_constant_evaluated();
 #else
-  // expected-error-re@+1 {{{{(static_assert|static assertion)}} failed}}
+  // expected-error@+1 {{static assertion failed}}
   static_assert(!std::is_constant_evaluated(), "");
   // expected-warning-re@-1 0-1 {{'std::is_constant_evaluated' will always evaluate to {{('true' in a manifestly constant-evaluated expression|true in this context)}}}}
 #endif

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
@@ -24,23 +24,23 @@ struct NonDestructible { ~NonDestructible() = delete; };
 int main(int, char**)
 {
     {
-    std::optional<char &> o1;          // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a reference type is ill-formed}}
-    std::optional<NonDestructible> o2; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
-    std::optional<char[20]> o3;        // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with an array type is ill-formed}}
+    std::optional<char &> o1;          // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a reference type is ill-formed}}
+    std::optional<NonDestructible> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
+    std::optional<char[20]> o3;        // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with an array type is ill-formed}}
     }
 
     {
-    std::optional<               std::in_place_t> o1; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<const          std::in_place_t> o2; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<      volatile std::in_place_t> o3; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<const volatile std::in_place_t> o4; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<               std::in_place_t> o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<const          std::in_place_t> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<      volatile std::in_place_t> o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<const volatile std::in_place_t> o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
     }
 
     {
-    std::optional<               std::nullopt_t> o1; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<const          std::nullopt_t> o2; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<      volatile std::nullopt_t> o3; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<const volatile std::nullopt_t> o4; // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<               std::nullopt_t> o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<const          std::nullopt_t> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<      volatile std::nullopt_t> o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<const volatile std::nullopt_t> o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
     }
 
     return 0;

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.verify.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
 
     {
 //  optional(nullopt_t)
-    std::optional opt(std::nullopt);   // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional opt(std::nullopt);   // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
     }
 
   return 0;

--- a/libcxx/test/std/utilities/optional/optional.object/optional_requires_destructible_object.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional_requires_destructible_object.verify.cpp
@@ -25,22 +25,22 @@ int main(int, char**)
 {
     using std::optional;
     {
-        // expected-error-re@optional:* 2 {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a reference type is ill-formed}}
+        // expected-error-re@optional:* 2 {{static assertion failed{{.*}}instantiation of optional with a reference type is ill-formed}}
         optional<int&> opt1;
         optional<int&&> opt2;
     }
     {
-        // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
+        // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
         optional<X> opt3;
     }
     {
-        // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a non-object type is undefined behavior}}
-        // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
+        // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-object type is undefined behavior}}
+        // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
         optional<void()> opt4;
     }
     {
-        // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a non-object type is undefined behavior}}
-        // expected-error-re@optional:* {{{{(static_assert|static assertion)}} failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
+        // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-object type is undefined behavior}}
+        // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
         // expected-error@optional:* 1+ {{cannot form a reference to 'void'}}
         optional<const void> opt4;
     }

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.verify.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.verify.cpp
@@ -23,4 +23,4 @@
 using T =  std::tuple<int, long, void*>;
 using E1 = typename std::tuple_element<1, T &>::type; // expected-error{{undefined template}}
 using E2 = typename std::tuple_element<3, T>::type;
-using E3 = typename std::tuple_element<4, T const>::type; // expected-error-re@*:* 2 {{{{(static_assert|static assertion)}} failed}}
+using E3 = typename std::tuple_element<4, T const>::type; // expected-error@*:* 2 {{static assertion failed}}

--- a/libcxx/test/std/utilities/utility/forward/forward.verify.cpp
+++ b/libcxx/test/std/utilities/utility/forward/forward.verify.cpp
@@ -23,7 +23,7 @@ int main(int, char**)
 {
     {
         (void)std::forward<A&>(source());  // expected-note {{requested here}}
-        // expected-error-re@*:* 1 {{{{(static_assert|static assertion)}} failed{{.*}}cannot forward an rvalue as an lvalue}}
+        // expected-error-re@*:* 1 {{static assertion failed{{.*}}cannot forward an rvalue as an lvalue}}
     }
     {
         const A ca = A();

--- a/libcxx/test/std/utilities/variant/variant.relops/relops_bool_conv.verify.cpp
+++ b/libcxx/test/std/utilities/variant/variant.relops/relops_bool_conv.verify.cpp
@@ -75,7 +75,7 @@ int main(int, char**) {
   using V = std::variant<int, ComparesToMyBoolExplicit>;
   V v1(42);
   V v2(101);
-  // expected-error-re@variant:* 6 {{{{(static_assert|static assertion)}} failed{{.*}}the relational operator does not return a type which is implicitly convertible to bool}}
+  // expected-error-re@variant:* 6 {{static assertion failed{{.*}}the relational operator does not return a type which is implicitly convertible to bool}}
   // expected-error@variant:* 6 {{no viable conversion}}
   (void)(v1 == v2); // expected-note {{here}}
   (void)(v1 != v2); // expected-note {{here}}

--- a/libcxx/test/std/utilities/variant/variant.variant/variant_array.verify.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/variant_array.verify.cpp
@@ -24,7 +24,7 @@
 
 int main(int, char**)
 {
-    // expected-error-re@variant:* 3 {{{{(static_assert|static assertion)}} failed}}
+    // expected-error@variant:* 3 {{static assertion failed}}
     std::variant<int, int[]> v; // expected-note {{requested here}}
     std::variant<int, int[42]> v2; // expected-note {{requested here}}
     std::variant<int, int[][42]> v3; // expected-note {{requested here}}

--- a/libcxx/test/std/utilities/variant/variant.variant/variant_empty.verify.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/variant_empty.verify.cpp
@@ -19,7 +19,7 @@
 
 int main(int, char**)
 {
-    // expected-error-re@variant:* 1 {{{{(static_assert|static assertion)}} failed}}
+    // expected-error@variant:* 1 {{static assertion failed}}
     std::variant<> v; // expected-note {{requested here}}
 
   return 0;

--- a/libcxx/test/std/utilities/variant/variant.variant/variant_reference.verify.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/variant_reference.verify.cpp
@@ -19,7 +19,7 @@
 
 int main(int, char**)
 {
-    // expected-error-re@variant:* 3 {{{{(static_assert|static assertion)}} failed}}
+    // expected-error@variant:* 3 {{static assertion failed}}
     std::variant<int, int&> v; // expected-note {{requested here}}
     std::variant<int, const int &> v2; // expected-note {{requested here}}
     std::variant<int, int&&> v3; // expected-note {{requested here}}

--- a/libcxx/test/std/utilities/variant/variant.variant/variant_void.verify.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/variant_void.verify.cpp
@@ -24,7 +24,7 @@
 
 int main(int, char**)
 {
-    // expected-error-re@variant:* 3 {{{{(static_assert|static assertion)}} failed}}
+    // expected-error@variant:* 3 {{static assertion failed}}
     std::variant<int, void> v; // expected-note {{requested here}}
     std::variant<int, const void> v2; // expected-note {{requested here}}
     std::variant<const volatile void, int> v3; // expected-note {{requested here}}


### PR DESCRIPTION
We don't neeed to handle both spellings anymore since we don't support Clang 15 anymore.