### PR TITLE
[flang] Round derived type byte sizes up to alignment multiple

### DIFF
--- a/flang/lib/Semantics/compute-offsets.cpp
+++ b/flang/lib/Semantics/compute-offsets.cpp
@@ -116,6 +116,8 @@ void ComputeOffsetsHelper::Compute(Scope &scope) {
       DoSymbol(*symbol);
     }
   }
+  // Ensure that the size is a multiple of the alignment
+  offset_ = Align(offset_, alignment_);
   scope.set_size(offset_);
   scope.SetAlignment(alignment_);
   // Assign offsets in COMMON blocks, unless this scope is a BLOCK construct,

--- a/flang/test/Semantics/offsets02.f90
+++ b/flang/test/Semantics/offsets02.f90
@@ -8,11 +8,17 @@ subroutine s1
     real(8) :: a
     real(4) :: b
   end type
-  !CHECK: x1 size=12 offset=0:
-  !CHECK: y1 size=12 offset=16:
+  type t2
+    type(t1) c
+    real(4) d
+  end type
+  !CHECK: x1 size=16 offset=0:
+  !CHECK: y1 size=16 offset=16:
   type(t1) :: x1, y1
   !CHECK: z1 size=160 offset=32:
   type(t1) :: z1(10)
+  !CHECK: z2 size=24 offset=192
+  type(t2) z2
 end
 
 ! Like t1 but t2 does not need to be aligned on 64-bit boundary


### PR DESCRIPTION
When calculating sizes and offsets of types and components, be sure to round the size of a derived type up to a multiple of its alignment.