### PR TITLE
[analyzer][NFC] Simplifications in ArrayBoundV2

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -56,9 +56,9 @@ public:
 std::optional<std::pair<const SubRegion *, NonLoc>>
 computeOffset(ProgramStateRef State, SValBuilder &SVB, SVal Location) {
   QualType T = SVB.getArrayIndexType();
-  auto EvalBinOp = [&SVB, State, T](BinaryOperatorKind Op, NonLoc LHS, NonLoc RHS) {
+  auto EvalBinOp = [&SVB, State, T](BinaryOperatorKind Op, NonLoc L, NonLoc R) {
     // We will use this utility to add and multiply values.
-    return SVB.evalBinOpNN(State, Op, LHS, RHS, T).getAs<NonLoc>();
+    return SVB.evalBinOpNN(State, Op, L, R, T).getAs<NonLoc>();
   };
 
   const auto *Region = dyn_cast_or_null<SubRegion>(Location.getAsRegion());

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -65,7 +65,7 @@ computeOffset(ProgramStateRef State, SValBuilder &SVB, SVal Location) {
   std::optional<NonLoc> Offset = SVB.makeZeroArrayIndex();
 
   const ElementRegion *CurRegion =
-    dyn_cast_or_null<ElementRegion>(Location.getAsRegion());
+      dyn_cast_or_null<ElementRegion>(Location.getAsRegion());
 
   while (CurRegion) {
     const auto Index = CurRegion->getIndex().getAs<NonLoc>();


### PR DESCRIPTION
I'm planning to improve diagnostics generation in `ArrayBoundCheckerV2` but before that I'm refactoring the source code to clean up some over-complicated code and an inaccurate comment.

Changes in this commit:
- Remove the `mutable std::unique_ptr<BugType>` boilerplate, because it's no longer needed.
- Remove the code duplication between the methods `reportOOB()` and `reportTaintedOOB()`.
- Eliminate the class `RegionRawOffsetV2` because it's just a "reinvent the wheel" version of `std::pair` and it was used only once, as a temporary object that was immediately decomposed. (I suspect that `RegionRawOffset` in MemRegion.cpp could also be eliminated.)
- Flatten the code of `computeOffset()` which had contained six nested indentation levels before this commit.
- Ensure that `computeOffset()` returns `std::nullopt` instead of a `{Region, <zero array index>}` pair in the case when it encounters a `Location` that is not an `ElementRegion`. This ensures that the `checkLocation` callback returns early when it handles a memory access where it has "nothing to do" (no subscript operation or equivalent pointer arithmetic). (Note that this is still NFC because zero is a valid index everywhere, so the old logic without this shortcut eventually reached the same conclusion.)
- Correct a wrong explanation comment in `getSimplifiedOffsets()`.