### PR TITLE
[flang] Remove IEEE_DENORM from IEEE_ALL

### DIFF
--- a/flang/module/__fortran_ieee_exceptions.f90
+++ b/flang/module/__fortran_ieee_exceptions.f90
@@ -27,10 +27,8 @@ module __Fortran_ieee_exceptions
     ieee_denorm = ieee_flag_type(32) ! PGI extension
 
   type(ieee_flag_type), parameter :: &
-    ieee_usual(*) = [ &
-      ieee_overflow, ieee_divide_by_zero, ieee_invalid ], &
-    ieee_all(*) = [ &
-      ieee_usual, ieee_underflow, ieee_inexact, ieee_denorm ]
+    ieee_usual(*) = [ ieee_overflow, ieee_divide_by_zero, ieee_invalid ], &
+    ieee_all(*) = [ ieee_usual, ieee_underflow, ieee_inexact ]
 
   type :: ieee_modes_type ! Fortran 2018, 17.7
     private


### PR DESCRIPTION
The array of all exceptions IEEE_ALL defined in the intrinsic module IEEE_EXCEPTIONS should contain only what the standard mandates.  Existing code depends on it having only five elements. The legacy extension exception flag IEEE_DENORM shouldn't be an element.