### PR TITLE
[flang][lowering] Fix clash between string literals of different kinds

### DIFF
--- a/flang/lib/Lower/ConvertConstant.cpp
+++ b/flang/lib/Lower/ConvertConstant.cpp
@@ -323,7 +323,8 @@ genScalarLit(fir::FirOpBuilder &builder, mlir::Location loc,
 
   auto size = builder.getKindMap().getCharacterBitsize(KIND) / 8 * value.size();
   llvm::StringRef strVal(reinterpret_cast<const char *>(value.c_str()), size);
-  std::string globalName = fir::factory::uniqueCGIdent("cl", strVal);
+  std::string globalName = fir::factory::uniqueCGIdent(
+      KIND == 1 ? "cl"s : "cl"s + std::to_string(KIND), strVal);
   fir::GlobalOp global = builder.getNamedGlobal(globalName);
   fir::CharacterType type =
       fir::CharacterType::get(builder.getContext(), KIND, len);

--- a/flang/test/Lower/HLFIR/constant-character.f90
+++ b/flang/test/Lower/HLFIR/constant-character.f90
@@ -1,0 +1,17 @@
+! Test that character literals of different types do not clash.
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s
+
+subroutine repro(c1, c4)
+  character(kind=1,len=*) :: c1
+  character(kind=4,len=*) :: c4
+  print *, ""
+  print *, 4_""
+end subroutine
+!CHECK-LABEL: func.func @_QPrepro
+!CHECK:    fir.address_of(@_QQcl.) : !fir.ref<!fir.char<1,0>>
+!CHECK:    fir.call @_FortranAioOutputAscii
+!CHECK:    fir.address_of(@_QQcl4.) : !fir.ref<!fir.char<4,0>>
+!CHECK:    fir.call @_FortranAioOutputDescriptor(
+
+!CHECK-DAG:  fir.global linkonce @_QQcl. constant : !fir.char<1,0>
+!CHECK-DAG:  fir.global linkonce @_QQcl4. constant : !fir.char<4,0>


### PR DESCRIPTION
At least fir.global for empty string literals of different kinds. Add the kind to the prefix if it is not 1.