### PR TITLE
[lldb][NFCI] Move functionality for getting unsupported DW_FORM values

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.cpp
@@ -61,13 +61,3 @@ DWARFDebugAbbrev::GetAbbreviationDeclarationSet(
     return &(pos->second);
   return nullptr;
 }
-
-// DWARFDebugAbbrev::GetUnsupportedForms()
-void DWARFDebugAbbrev::GetUnsupportedForms(
-    std::set<dw_form_t> &invalid_forms) const {
-  for (const auto &pair : m_abbrevCollMap)
-    for (const auto &decl : pair.second)
-      for (const auto &attr : decl.attributes())
-        if (!DWARFFormValue::FormIsSupported(attr.Form))
-          invalid_forms.insert(attr.Form);
-}

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.h
@@ -36,7 +36,15 @@ public:
   /// llvm::ErrorSuccess() on success, and an appropriate llvm::Error object
   /// otherwise.
   llvm::Error parse();
-  void GetUnsupportedForms(std::set<dw_form_t> &invalid_forms) const;
+
+  DWARFAbbreviationDeclarationCollMapConstIter begin() const {
+    assert(!m_data && "Must call parse before iterating over DWARFDebugAbbrev");
+    return m_abbrevCollMap.begin();
+  }
+
+  DWARFAbbreviationDeclarationCollMapConstIter end() const {
+    return m_abbrevCollMap.end();
+  }
 
 protected:
   DWARFAbbreviationDeclarationCollMap m_abbrevCollMap;


### PR DESCRIPTION
The LLVM implementation of DWARFDebugAbbrev does not have a way of listing all the DW_FORM values that have been parsed but are unsupported or otherwise unknown. AFAICT this functionality does not exist in LLVM at all. Since my primary goal is to unify the implementations and not judge the usefulness or completeness of this functionality, I decided to move it out of LLDB's implementation of DWARFDebugAbbrev for the time being.