### PR TITLE
[libc++] Add regression test for #67449

### DIFF
--- a/libcxx/test/std/utilities/memory/pointer.conversion/to_address.pass.cpp
+++ b/libcxx/test/std/utilities/memory/pointer.conversion/to_address.pass.cpp
@@ -153,6 +153,14 @@ constexpr bool test() {
     assert(std::to_address(&p11) == &p11);
     ASSERT_SAME_TYPE(decltype(std::to_address(&p11)), int(**)());
 
+    // See https://github.com/llvm/llvm-project/issues/67449
+    {
+        struct S { };
+        S* p = nullptr;
+        assert(std::to_address<S>(p) == p);
+        ASSERT_SAME_TYPE(decltype(std::to_address<S>(p)), S*);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Even though the underlying issue was fixed in #65177 when we made std::pointer_traits SFINAE-friendly, it is worth adding a regression test since it's so easy to do.