### PR TITLE
Detect apple m2 processors

### DIFF
--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1418,6 +1418,7 @@ StringRef sys::getHostCPUName() {
 #define CPUFAMILY_ARM_VORTEX_TEMPEST 0x07d34b9f
 #define CPUFAMILY_ARM_LIGHTNING_THUNDER 0x462504d2
 #define CPUFAMILY_ARM_FIRESTORM_ICESTORM 0x1b588bb3
+#define CPUFAMILY_ARM_BLIZZARD_AVALANCHE 0xda33d83d
 
 StringRef sys::getHostCPUName() {
   uint32_t Family;
@@ -1443,9 +1444,11 @@ StringRef sys::getHostCPUName() {
     return "apple-a13";
   case CPUFAMILY_ARM_FIRESTORM_ICESTORM:
     return "apple-m1";
+  case CPUFAMILY_ARM_BLIZZARD_AVALANCHE:
+    return "apple-m2";
   default:
     // Default to the newest CPU we know about.
-    return "apple-m1";
+    return "apple-m2";
   }
 }
 #elif defined(_AIX)


### PR DESCRIPTION
Currently on MacOS getHostCPUName only detects M1 processors and not M2 processors. The M2 CPU family is the following:

```
❯ sysctl hw.cpufamily
hw.cpufamily: -634136515
```

This PR sets the target CPU to apple-m2.