### PR TITLE
[llvm] Fix 32bit build after change to implement S_INLINEES debug symbol

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -3597,14 +3597,14 @@ void CodeViewDebug::emitInlinees(
     const SmallSet<codeview::TypeIndex, 1> &Inlinees) {
   // Divide the list of inlinees into chunks such that each chunk fits within
   // one record.
-  constexpr auto ChunkSize =
+  constexpr size_t ChunkSize =
       (MaxRecordLength - sizeof(SymbolKind) - sizeof(uint32_t)) /
       sizeof(uint32_t);
 
   SmallVector<TypeIndex> SortedInlinees{Inlinees.begin(), Inlinees.end()};
   llvm::sort(SortedInlinees);
 
-  uint64_t CurrentIndex = 0;
+  size_t CurrentIndex = 0;
   while (CurrentIndex < SortedInlinees.size()) {
     auto Symbol = beginSymbolRecord(SymbolKind::S_INLINEES);
     auto CurrentChunkSize =
@@ -3612,7 +3612,7 @@ void CodeViewDebug::emitInlinees(
     OS.AddComment("Count");
     OS.emitInt32(CurrentChunkSize);
 
-    const uint64_t CurrentChunkEnd = CurrentIndex + CurrentChunkSize;
+    const size_t CurrentChunkEnd = CurrentIndex + CurrentChunkSize;
     for (; CurrentIndex < CurrentChunkEnd; ++CurrentIndex) {
       OS.AddComment("Inlinee");
       OS.emitInt32(SortedInlinees[CurrentIndex].getIndex());


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/67490 broke 32bit builds by having mismatched types in a call to `std::min"

This change standardizes on using `size_t` to avoid the mismatch.