### PR TITLE
Add missed Darwin/i386 for `withHostArch`

### DIFF
--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1930,6 +1930,9 @@ static Triple withHostArch(Triple T) {
 #elif defined(__x86_64__)
   T.setArch(Triple::x86_64);
   T.setArchName("x86_64");
+#elif defined(__i386__)
+  T.setArch(Triple::x86);
+  T.setArchName("i386");
 #elif defined(__powerpc__)
   T.setArch(Triple::ppc);
   T.setArchName("powerpc");


### PR DESCRIPTION
This regression was introduced at LLVM-17 via dc078e6eaacff66596fac76b6104aa504f77d45d