### PR TITLE
Fix a bug in handling ^C at the "y/n/a" completion prompt.

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -161,6 +161,10 @@ public:
   /// of Editline.
   static Editline *InstanceFor(::EditLine *editline);
 
+  static void
+  DisplayCompletions(Editline &editline,
+                     llvm::ArrayRef<CompletionResult::Completion> results);
+
   /// Sets a string to be used as a prompt, or combined with a line number to
   /// form a prompt.
   void SetPrompt(const char *prompt);

--- a/lldb/test/API/iohandler/completion/TestIOHandlerCompletion.py
+++ b/lldb/test/API/iohandler/completion/TestIOHandlerCompletion.py
@@ -75,6 +75,12 @@ class IOHandlerCompletionTest(PExpectTest):
         self.child.send("n")
         self.expect_prompt()
 
+        # Start tab completion and abort showing more commands with '^C'.
+        self.child.send("\t")
+        self.child.expect_exact("More (Y/n/a)")
+        self.child.sendcontrol('c')
+        self.expect_prompt()
+
         # Shouldn't crash or anything like that.
         self.child.send("regoinvalid\t")
         self.expect_prompt()


### PR DESCRIPTION
We just forget to check for interrupt while waiting for the answer to the prompt. But if we are in the interrupt state then the lower layers of the EditLine code just eat all characters so we never get out of the query prompt. You're pretty much stuck and have to kill lldb.

The solution is to check for the interrupt. The patch is a little bigger because where I needed to check the Interrupt state I only had the ::EditLine object, but the editor state is held in lldb's EditLine wrapper, so I had to do a little work to get my hands on it.