### PR TITLE
[flang][runtime] Establish derived type desc properly.

### DIFF
--- a/flang/include/flang/Runtime/descriptor.h
+++ b/flang/include/flang/Runtime/descriptor.h
@@ -180,12 +180,16 @@ public:
       const SubscriptValue *extent = nullptr,
       ISO::CFI_attribute_t attribute = CFI_attribute_other);
 
-  // CUDA_TODO: Clang does not support unique_ptr on device.
+  // To create a descriptor for a derived type the caller
+  // must provide non-null dt argument.
+  // The addendum argument is only used for testing purposes,
+  // and it may force a descriptor with an addendum while
+  // dt may be null.
   static RT_API_ATTRS OwningPtr<Descriptor> Create(TypeCode t,
       std::size_t elementBytes, void *p = nullptr, int rank = maxRank,
       const SubscriptValue *extent = nullptr,
       ISO::CFI_attribute_t attribute = CFI_attribute_other,
-      int derivedTypeLenParameters = 0);
+      bool addendum = false, const typeInfo::DerivedType *dt = nullptr);
   static RT_API_ATTRS OwningPtr<Descriptor> Create(TypeCategory, int kind,
       void *p = nullptr, int rank = maxRank,
       const SubscriptValue *extent = nullptr,


### PR DESCRIPTION
Example:
```
module types
  type t
     real,allocatable :: c
  end type t
contains
  function h(x)
    class(t),allocatable :: h
    ...
  end function h
  subroutine test
    type(t),allocatable :: b(:)
    allocate(b(2),source=h(2.5))
  end subroutine test7
end module type
```

`DoFromSourceAssign` creates two descriptors for initializing
`b(1)` and `b(2)` from the result of `h`. This Create call
creates a descriptor without properly initialized addendum,
so the Assign just does shallow copies of the descriptor
representing result of `h` into `b(1)` and `b(2)`.

I modified Create code to properly establish the descriptor
for derived type case.

I had to keep the `addendum` argument to keep the testing
in `flang/unittests/Runtime/TemporaryStack.cpp`.
