### PR TITLE
[BOLT] Report JITLink errors appropriately

### DIFF
--- a/bolt/lib/Rewrite/ExecutableFileMemoryManager.cpp
+++ b/bolt/lib/Rewrite/ExecutableFileMemoryManager.cpp
@@ -90,7 +90,7 @@ public:
       : Alloc(std::move(Alloc)) {}
 
   virtual void abandon(OnAbandonedFunction OnAbandoned) override {
-    llvm_unreachable("unexpected abandoned allocation");
+    OnAbandoned(Error::success());
   }
 
   virtual void finalize(OnFinalizedFunction OnFinalized) override {


### PR DESCRIPTION
Previously we would crash with an assertion failure (unreachable code) whenever we had an error in JITLink. Change this to use JITLink API correctly and let it print the error to output, so we can read and more easily diagnose what's happening.

Before this patch:
unexpected abandoned allocation
UNREACHABLE executed at...

After this patch:
BOLT-ERROR: JITLink failed: In graph in-memory object file, section .local.foo: relocation target .text + 0x1 at address 0xa7c00000 is out of range of BranchPCRel32 fixup at 0x132d40f1 (bar, 0x132d40f0 + 0x1)