### PR TITLE
[clang][dataflow] Tweak styling of iteration tabs.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
@@ -64,15 +64,16 @@ section h2 {
   text-align: center;
 }
 #iterations .chooser:not(.iter-select).hover {
-  background-color: #aaa;
+  background-color: #ddd;
 }
 #iterations .iter-select {
   font-weight: bold;
-  background-color: #ccc;
 }
 #iterations .chooser:not(.iter-select) {
   text-decoration: underline;
   color: blue;
+  cursor: pointer;
+  background-color: #ccc;
 }
 
 code.filename {


### PR DESCRIPTION
- On non-selected tabs, set cursor to 'pointer' to indicate they're clickable

- Selected tab shares the same background as the contents to emphasize that it's
  associated with that content. (Compare with Google Chrome or VS Code, which do
  this similarly.)

- Hovered-over tab becomes slightly brighter to indicate that clicking it will
  make it even brighter (again, Chrome does this in a similar way).

Example:

![image](https://github.com/llvm/llvm-project/assets/29098113/e588068d-edff-49a8-b468-09dbb3255c3e)

(Mouse cursor is over "Iteration 2", but unfortunately I couldn't get the screenshot to include the cursor.)