### PR TITLE
[clang-tidy]: Add TagDecl into LastTagDeclRanges in UseUsingCheck only when it is a definition

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
@@ -61,7 +61,8 @@ void UseUsingCheck::check(const MatchFinder::MatchResult &Result) {
     // before the typedef will be the nested one (PR#50990). Therefore, we also
     // keep track of the parent declaration, so that we can look up the last
     // TagDecl that is a sibling of the typedef in the AST.
-    LastTagDeclRanges[ParentDecl] = MatchedTagDecl->getSourceRange();
+    if (MatchedTagDecl->isThisDeclarationADefinition())
+      LastTagDeclRanges[ParentDecl] = MatchedTagDecl->getSourceRange();
     return;
   }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -279,8 +279,8 @@ Changes in existing checks
   fixes for reordering arguments.
 
 - Improved :doc:`modernize-use-using
-  <clang-tidy/checks/modernize/use-using>` check to fix function pointer
-  ``typedef`` correctly.
+  <clang-tidy/checks/modernize/use-using>` check to fix function pointer and
+  forward declared ``typedef`` correctly.
 
 - Improved :doc:`performance-faster-string-find
   <clang-tidy/checks/performance/faster-string-find>` check to properly escape

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -321,3 +321,7 @@ typedef bool (*ISSUE_65055_2)(int);
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
 // CHECK-FIXES: {{^}}using ISSUE_65055_1 = void (*)(int);{{$}}
 // CHECK-FIXES: {{^}}using ISSUE_65055_2 = bool (*)(int);{{$}}
+
+typedef class ISSUE_67529_1 *ISSUE_67529;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef'
+// CHECK-FIXES: using ISSUE_67529 = class ISSUE_67529_1 *;


### PR DESCRIPTION
Fix issue 67529, [clang-tidy: modernize-use-using fails when type is implicitly forward declared](https://github.com/llvm/llvm-project/issues/67529)
The problem is that using `Lexer` to get record declaration will lose the type information when its original type is pointer or reference. This patch fix this problem by skip adding the tag declaration when it's only a 'declaration' and not a 'definition'.