### PR TITLE
[InstCombine] Fix test with experimental.guard + nounwind (NFC)

### DIFF
--- a/llvm/test/Transforms/InstCombine/sdiv-guard.ll
+++ b/llvm/test/Transforms/InstCombine/sdiv-guard.ll
@@ -4,10 +4,11 @@
 declare void @llvm.experimental.guard(i1, ...)
 
 ; Regression test. If %flag is false then %s == 0 and guard should be triggered.
-define i32 @a(i1 %flag, i32 %X) nounwind readnone {
+define i32 @a(i1 %flag, i32 %X) {
 ; CHECK-LABEL: @a(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], 0
-; CHECK-NEXT:    call void (i1, ...) @llvm.experimental.guard(i1 [[CMP]]) #[[ATTR2:[0-9]+]] [ "deopt"() ]
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i32 [[X:%.*]], 0
+; CHECK-NEXT:    [[CMP:%.*]] = select i1 [[FLAG:%.*]], i1 [[CMP1]], i1 false
+; CHECK-NEXT:    call void (i1, ...) @llvm.experimental.guard(i1 [[CMP]]) [ "deopt"() ]
 ; CHECK-NEXT:    [[R:%.*]] = sdiv i32 100, [[X]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;


### PR DESCRIPTION
The function is marked nounwind, so experimental.guard becomes nounwind as well, and in conjunction with willreturn becomes guaranteed-to-transfer. Thus the optimization that this test was supposed to be guarding against is performed. This regressed in fbfb1c790982277eaa5134c2b6aa001e97fe828d when experimental.guard was marked willreturn.

I believe this is an error in the test case, and it should not be using nounwind. However, I wanted to double check whether experimental.guard should be willreturn or not. (And possibly nounwind instead -- it depends on how one wants to model them.)