### PR TITLE
[flang][lowering] Move PDT TODO before length param type lowering

### DIFF
--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -403,21 +403,26 @@ struct TypeBuilderImpl {
       cs.emplace_back(converter.getRecordTypeFieldName(component), ty);
     }
 
+    mlir::Location loc = converter.genLocation(typeSymbol.name());
     // (2) The LEN type parameters.
     for (const auto &param :
          Fortran::semantics::OrderParameterDeclarations(typeSymbol))
       if (param->get<Fortran::semantics::TypeParamDetails>().attr() ==
-          Fortran::common::TypeParamAttr::Len)
+          Fortran::common::TypeParamAttr::Len) {
+        TODO(loc, "parameterized derived types");
+        // TODO: emplace in ps. Beware that param is the symbol in the type
+        // declaration, not instantiation: its kind may not be a constant.
+        // The instantiated symbol in tySpec.scope should be used instead.
         ps.emplace_back(param->name().ToString(), genSymbolType(*param));
+      }
 
     rec.finalize(ps, cs);
     popDerivedTypeInConstruction();
 
-    mlir::Location loc = converter.genLocation(typeSymbol.name());
     if (!ps.empty()) {
-      // This type is a PDT (parametric derived type). Create the functions to
-      // use for allocation, dereferencing, and address arithmetic here.
-      TODO(loc, "parameterized derived types");
+      // TODO: this type is a PDT (parametric derived type) with length
+      // parameter. Create the functions to use for allocation, dereferencing,
+      // and address arithmetic here.
     }
     LLVM_DEBUG(llvm::dbgs() << "derived type: " << rec << '\n');
 


### PR DESCRIPTION
There is a crash before hitting the TODO when the length parameter kind depends on a KIND parameter. I do not want to fix it since I cannot test it because of the TODO, so I just moved to TODO up and added a comment.