### PR TITLE
[clang][dataflow] Show triangle in `<details>` element

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
@@ -123,10 +123,21 @@ code.line:has(.bb-select):before {
   font-size: x-small;
   flex-grow: 1;
 }
-.value summary {
+.value > summary {
   background-color: #ace;
   display: flex;
-  justify-content: space-between;
+  cursor: pointer;
+}
+.value > summary::before {
+  content: '\25ba';  /* Black Right-Pointing Pointer */
+  margin-right: 0.5em;
+  font-size: 0.9em;
+}
+.value[open] > summary::before {
+  content: '\25bc';  /* Black Down-Pointing Triangle */
+}
+.value > summary > .location {
+  margin-left: auto;
 }
 .value .address {
   font-size: xx-small;

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
@@ -18,7 +18,7 @@
         <template data-if="v.value_id"><span class="address">#{{v.value_id}}</span></template>
       </span>
       <template data-if="v.location">
-        <span>{{v.type}} <span class="address">@{{v.location}}</span></span>
+        <span class="location">{{v.type}} <span class="address">@{{v.location}}</span></span>
       </template>
     </summary>
     <template


### PR DESCRIPTION
Also, change the mouse cursor into a pointer instead of a text cursor.

This makes it more discoverable that the element can be opened and
closed.
