### PR TITLE
[mlir][vector] don't emit non-rank 1 masked load and store

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
@@ -458,7 +458,8 @@ struct TransferReadToVectorLoadLowering
       if (read.getVectorType().getRank() != 1)
         // vector.maskedload operates on 1-D vectors.
         return rewriter.notifyMatchFailure(
-            read, "vector type is not rank 1, can't create masked load");
+            read, "vector type is not rank 1, can't create masked load, needs "
+                  "VectorToSCF");
 
       Value fill = rewriter.create<vector::SplatOp>(
           read.getLoc(), unbroadcastedVectorType, read.getPadding());
@@ -607,7 +608,8 @@ struct TransferWriteToVectorStoreLowering
         // vector.maskedstore operates on 1-D vectors.
         return rewriter.notifyMatchFailure(
             write.getLoc(), [=](Diagnostic &diag) {
-              diag << "vector type is not rank 1, can't create masked store: "
+              diag << "vector type is not rank 1, can't create masked store, "
+                      "needs VectorToSCF: "
                    << write;
             });
 


### PR DESCRIPTION
The following patterns

  - TransferReadToVectorLoadLowering
  - TransferWriteToVectorStoreLowering

attempt to generate invalid vector.maskedload and vector.maskedstore ops for non rank-1 vector types. These ops operate on 1-D vectors. This patch adds a check to prevent this.