### PR TITLE
[mlir][SME][nfc] Clarify the usage of insertion guard

### DIFF
--- a/mlir/lib/Conversion/VectorToArmSME/VectorToArmSME.cpp
+++ b/mlir/lib/Conversion/VectorToArmSME/VectorToArmSME.cpp
@@ -26,7 +26,8 @@ static bool isSplatZero(Type elemType, DenseElementsAttr val) {
 }
 
 /// Generates a for loop over ZA tile slices where the induction variable is
-/// the tile slice index.
+/// the tile slice index. Sets the IR Builder insertion point as the loop body.
+/// Callers of this method are responsible for restoring it if needed.
 static scf::ForOp getLoopOverTileSlices(PatternRewriter &rewriter, Location loc,
                                         Type eltType) {
   auto step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
@@ -226,8 +227,6 @@ struct ConstantOpToArmSMELowering : public OpRewritePattern<arith::ConstantOp> {
     rewriter.create<arm_sme::MoveVectorToTileSliceOp>(
         loc, tileType, constantOp1D, tile, tileSliceIndex);
 
-    rewriter.setInsertionPointAfter(forOp);
-
     rewriter.replaceOp(constantOp, tile);
 
     return success();
@@ -292,8 +291,6 @@ struct BroadcastOpToArmSMELowering
     // tile slice.
     rewriter.create<arm_sme::MoveVectorToTileSliceOp>(
         loc, tileType, broadcastOp1D, tile, tileSliceIndex);
-
-    rewriter.setInsertionPointAfter(forOp);
 
     rewriter.replaceOp(broadcastOp, tile);
 


### PR DESCRIPTION
Added extra comment that should clarify the need for an insertion guard
when using `getLoopOverTileSlices`. Also removed some redundant calls to
`setInsertionPointAfter` - the insertion guard would overwrite that on
destruction anyway.
