### PR TITLE
[flang] Fix symbol on module subroutine name with same name as generic

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4111,6 +4111,7 @@ bool SubprogramVisitor::BeginSubprogram(const parser::Name &name,
       if (GenericDetails *
           generic{DEREF(FindSymbol(name)).detailsIf<GenericDetails>()}) {
         generic->clear_specific();
+        name.symbol = nullptr;
       } else {
         EraseSymbol(name);
       }

--- a/flang/test/Semantics/symbol28.f90
+++ b/flang/test/Semantics/symbol28.f90
@@ -14,7 +14,7 @@ module m1
   end subroutine
  end interface
 contains
- !DEF: /m1/s MODULE (Subroutine) SubprogramName
+ !DEF: /m1/s MODULE (Subroutine) Subprogram
  module subroutine s
  end subroutine
  !REF: /m1/s2


### PR DESCRIPTION
When a MODULE SUBROUTINE or MODULE FUNCTION is implemented in the same scope as its interface and appears in a generic with the same name, the parse::Name of the implementation was not correctly reset and remained the SubprogramNameDetails symbol after semantics, causing a crash in lowering that picks up the procedure symbols on the parser names.

Reset the parser::Name symbol before the new symbol is created.