### PR TITLE
[LinkerWrapper] Correctly handle multiple image wrappers

### DIFF
--- a/clang/test/Driver/linker-wrapper.c
+++ b/clang/test/Driver/linker-wrapper.c
@@ -87,6 +87,7 @@
 // CUDA: clang{{.*}} -o [[IMG_SM52:.+]] --target=nvptx64-nvidia-cuda -march=sm_52
 // CUDA: clang{{.*}} -o [[IMG_SM70:.+]] --target=nvptx64-nvidia-cuda -march=sm_70
 // CUDA: fatbinary{{.*}}-64 --create {{.*}}.fatbin --image=profile=sm_70,file=[[IMG_SM70]] --image=profile=sm_52,file=[[IMG_SM52]] 
+// CUDA: usr/bin/ld{{.*}} {{.*}}.openmp.image.{{.*}}.o {{.*}}.cuda.image.{{.*}}.o
 
 // RUN: clang-offload-packager -o %t.out \
 // RUN:   --image=file=%t.elf.o,kind=cuda,triple=nvptx64-nvidia-cuda,arch=sm_80 \


### PR DESCRIPTION
Summary:
We use these image wrappers to do runtime specifica registration of
variables and to load the device image that was compiled. This was
intended to support multiple of these running at the same time, e.g. you
can have a CUDA instance running with OpenMP and they should both
function so long as you do not share state between the two. However,
because we did not use a unique name for this file it would cause
conflicts when included. This patch names the image based off of the
language runtime it's using so that they remain separate.

Fixes: https://github.com/llvm/llvm-project/issues/67583
