### PR TITLE
[AIX][PowerPC] Teach the Threading Library About the Number of Physical Cores on AIX

### DIFF
--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -118,6 +118,15 @@ if(LLVM_INTEGRATED_CRT_ALLOC)
   endif()
 endif()
 
+# FIXME: We are currently guarding AIX headers with _XOPEN_SOURCE=700.
+# See llvm/CMakeLists.txt. However, we need _SC_NPROCESSORS_ONLN in
+# unistd.h and it is guarded by _ALL_SOURCE, so we remove the _XOPEN_SOURCE
+# guard here. We should remove the guards all together once AIX cleans up
+# the system headers.
+if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  remove_definitions("-D_XOPEN_SOURCE=700")
+endif()
+
 add_subdirectory(BLAKE3)
 
 add_llvm_component_library(LLVMSupport

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -55,10 +55,6 @@
 #include <unistd.h>      // For syscall()
 #endif
 
-#if defined(_AIX)
-#include <sys/systemcfg.h>
-#endif
-
 namespace llvm {
 pthread_t
 llvm_execute_on_thread_impl(void *(*ThreadFunc)(void *), void *Arg,
@@ -375,7 +371,7 @@ static int computeHostNumPhysicalCores() {
   }
   return CPU_COUNT(&Enabled);
 }
-#elif defined(__linux__) && defined(__s390x__)
+#elif (defined(__linux__) && defined(__s390x__)) || defined(_AIX)
 static int computeHostNumPhysicalCores() {
   return sysconf(_SC_NPROCESSORS_ONLN);
 }
@@ -436,8 +432,6 @@ static int computeHostNumPhysicalCores() {
       static_cast<uintptr_t>(reinterpret_cast<unsigned int &>(CVT[CVTCSD])));
   return reinterpret_cast<int &>(CSD[CSD_NUMBER_ONLINE_STANDARD_CPS]);
 }
-#elif defined(_AIX)
-static int computeHostNumPhysicalCores() { return _system_configuration.ncpus; }
 #else
 // On other systems, return -1 to indicate unknown.
 static int computeHostNumPhysicalCores() { return -1; }

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -55,6 +55,10 @@
 #include <unistd.h>      // For syscall()
 #endif
 
+#if defined(_AIX)
+#include <sys/systemcfg.h>
+#endif
+
 namespace llvm {
 pthread_t
 llvm_execute_on_thread_impl(void *(*ThreadFunc)(void *), void *Arg,
@@ -432,6 +436,8 @@ static int computeHostNumPhysicalCores() {
       static_cast<uintptr_t>(reinterpret_cast<unsigned int &>(CVT[CVTCSD])));
   return reinterpret_cast<int &>(CSD[CSD_NUMBER_ONLINE_STANDARD_CPS]);
 }
+#elif defined(_AIX)
+static int computeHostNumPhysicalCores() { return _system_configuration.ncpus; }
 #else
 // On other systems, return -1 to indicate unknown.
 static int computeHostNumPhysicalCores() { return -1; }

--- a/llvm/unittests/Support/Threading.cpp
+++ b/llvm/unittests/Support/Threading.cpp
@@ -29,7 +29,7 @@ static bool isThreadingSupportedArchAndOS() {
   return (Host.isOSWindows() && llvm_is_multithreaded()) || Host.isOSDarwin() ||
          (Host.isX86() && Host.isOSLinux()) ||
          (Host.isOSLinux() && !Host.isAndroid()) ||
-         (Host.isSystemZ() && Host.isOSzOS());
+         (Host.isSystemZ() && Host.isOSzOS()) || Host.isOSAIX();
 #else
   return false;
 #endif


### PR DESCRIPTION
The threading library does not recognize AIX and always returns `-1` for number of physical cores on AIX. This PR teaches the library to recognize AIX and obtain the correct value for the number of physical cores. 