### PR TITLE
[MachineInstr] add insert method for variadic instructions

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1818,6 +1818,8 @@ public:
   /// preferred.
   void addOperand(const MachineOperand &Op);
 
+  void insert(mop_iterator It, ArrayRef<MachineOperand> Ops);
+
   /// Replace the instruction descriptor (thus opcode) of
   /// the current instruction with a new one.
   void setDesc(const MCInstrDesc &TID) { MCID = &TID; }

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1819,7 +1819,7 @@ public:
   void addOperand(const MachineOperand &Op);
 
   /// Inserts Ops BEFORE It. Can untie/retie tied operands.
-  void insert(mop_iterator It, ArrayRef<MachineOperand> Ops);
+  void insert(mop_iterator InsertBefore, ArrayRef<MachineOperand> Ops);
 
   /// Replace the instruction descriptor (thus opcode) of
   /// the current instruction with a new one.

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1818,6 +1818,7 @@ public:
   /// preferred.
   void addOperand(const MachineOperand &Op);
 
+  /// Inserts Ops BEFORE It. Can untie/retie tied operands.
   void insert(mop_iterator It, ArrayRef<MachineOperand> Ops);
 
   /// Replace the instruction descriptor (thus opcode) of

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2477,10 +2477,7 @@ MachineInstr::getFirst5RegLLTs() const {
 }
 
 void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
-  assert(isVariadic() && "can only modify variadic instructions");
-  assert(It->getParent() == this && "iterator points to operand of other inst");
-
-  if (Ops.empty())
+  if (!It || Ops.empty())
     return;
 
   // Do one pass to untie operands.
@@ -2494,6 +2491,7 @@ void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
     }
   }
 
+  assert(It->getParent() == this && "iterator points to operand of other inst");
   const unsigned OpIdx = getOperandNo(It);
   const unsigned NumOperands = getNumOperands();
   const unsigned OpsToMove = NumOperands - OpIdx;

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2476,9 +2476,11 @@ MachineInstr::getFirst5RegLLTs() const {
       Reg4, getRegInfo()->getType(Reg4));
 }
 
-void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
-  assert(It != nullptr && "invalid iterator");
-  assert(It->getParent() == this && "iterator points to operand of other inst");
+void MachineInstr::insert(mop_iterator InsertBefore,
+                          ArrayRef<MachineOperand> Ops) {
+  assert(InsertBefore != nullptr && "invalid iterator");
+  assert(InsertBefore->getParent() == this &&
+         "iterator points to operand of other inst");
   if (Ops.empty())
     return;
 
@@ -2493,7 +2495,7 @@ void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
     }
   }
 
-  unsigned OpIdx = getOperandNo(It);
+  unsigned OpIdx = getOperandNo(InsertBefore);
   unsigned NumOperands = getNumOperands();
   unsigned OpsToMove = NumOperands - OpIdx;
 

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2481,7 +2481,7 @@ void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
     return;
 
   // Do one pass to untie operands.
-  DenseMap<unsigned, unsigned> TiedOpIndices;
+  SmallDenseMap<unsigned, unsigned> TiedOpIndices;
   for (const MachineOperand &MO : operands()) {
     if (MO.isReg() && MO.isTied()) {
       unsigned OpNo = getOperandNo(&MO);

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2477,7 +2477,8 @@ MachineInstr::getFirst5RegLLTs() const {
 }
 
 void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
-  if (!It || Ops.empty())
+  assert(It != nullptr && "invalid iterator");
+  if (Ops.empty())
     return;
 
   // Do one pass to untie operands.

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2478,6 +2478,7 @@ MachineInstr::getFirst5RegLLTs() const {
 
 void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
   assert(It != nullptr && "invalid iterator");
+  assert(It->getParent() == this && "iterator points to operand of other inst");
   if (Ops.empty())
     return;
 
@@ -2492,7 +2493,6 @@ void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
     }
   }
 
-  assert(It->getParent() == this && "iterator points to operand of other inst");
   unsigned OpIdx = getOperandNo(It);
   unsigned NumOperands = getNumOperands();
   unsigned OpsToMove = NumOperands - OpIdx;

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2492,9 +2492,9 @@ void MachineInstr::insert(mop_iterator It, ArrayRef<MachineOperand> Ops) {
   }
 
   assert(It->getParent() == this && "iterator points to operand of other inst");
-  const unsigned OpIdx = getOperandNo(It);
-  const unsigned NumOperands = getNumOperands();
-  const unsigned OpsToMove = NumOperands - OpIdx;
+  unsigned OpIdx = getOperandNo(It);
+  unsigned NumOperands = getNumOperands();
+  unsigned OpsToMove = NumOperands - OpIdx;
 
   SmallVector<MachineOperand> MovingOps;
   MovingOps.reserve(OpsToMove);

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -544,6 +544,12 @@ TEST(MachineInstrTest, SpliceOperands) {
   EXPECT_TRUE(MI->getOperand(2).isTied());
   EXPECT_EQ(MI->findTiedOperandIdx(0), 2U);
   EXPECT_EQ(MI->findTiedOperandIdx(2), 0U);
+
+  // bad inputs
+  EXPECT_EQ(MI->getNumOperands(), 10U);
+  MI->insert(nullptr, { MachineOperand::CreateImm(666) });
+  MI->insert(MI->operands_begin(), {});
+  EXPECT_EQ(MI->getNumOperands(), 10U);
 }
 
 } // end namespace

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -547,7 +547,6 @@ TEST(MachineInstrTest, SpliceOperands) {
 
   // bad inputs
   EXPECT_EQ(MI->getNumOperands(), 10U);
-  MI->insert(nullptr, { MachineOperand::CreateImm(666) });
   MI->insert(MI->operands_begin(), {});
   EXPECT_EQ(MI->getNumOperands(), 10U);
 }

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -538,7 +538,7 @@ TEST(MachineInstrTest, SpliceOperands) {
   EXPECT_TRUE(MI->getOperand(1).isTied());
   EXPECT_EQ(MI->findTiedOperandIdx(0), 1U);
   EXPECT_EQ(MI->findTiedOperandIdx(1), 0U);
-  MI->insert(&MI->getOperand(1), { MachineOperand::CreateImm(7) });
+  MI->insert(&MI->getOperand(1), {MachineOperand::CreateImm(7)});
   EXPECT_TRUE(MI->getOperand(0).isTied());
   EXPECT_TRUE(MI->getOperand(1).isImm());
   EXPECT_TRUE(MI->getOperand(2).isTied());

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -529,6 +529,21 @@ TEST(MachineInstrTest, SpliceOperands) {
   EXPECT_EQ(MI->getOperand(6).getImm(), MachineOperand::CreateImm(2).getImm());
   EXPECT_EQ(MI->getOperand(7).getImm(), MachineOperand::CreateImm(3).getImm());
   EXPECT_EQ(MI->getOperand(8).getImm(), MachineOperand::CreateImm(4).getImm());
+
+  // test tied operands
+  MI->getOperand(0).ChangeToRegister(1, /*isDef=*/true);
+  MI->getOperand(1).ChangeToRegister(2, /*isDef=*/false);
+  MI->tieOperands(0, 1);
+  EXPECT_TRUE(MI->getOperand(0).isTied());
+  EXPECT_TRUE(MI->getOperand(1).isTied());
+  EXPECT_EQ(MI->findTiedOperandIdx(0), 1U);
+  EXPECT_EQ(MI->findTiedOperandIdx(1), 0U);
+  MI->insert(&MI->getOperand(1), { MachineOperand::CreateImm(7) });
+  EXPECT_TRUE(MI->getOperand(0).isTied());
+  EXPECT_TRUE(MI->getOperand(1).isImm());
+  EXPECT_TRUE(MI->getOperand(2).isTied());
+  EXPECT_EQ(MI->findTiedOperandIdx(0), 2U);
+  EXPECT_EQ(MI->findTiedOperandIdx(2), 0U);
 }
 
 } // end namespace


### PR DESCRIPTION
As alluded to in #20571, it would be nice if we could mutate operand
lists of MachineInstr's more safely. Add an insert method that together
with removeOperand allows for easier splicing of operands.

Splitting this patch off early to get feedback; I need to either:
- mutate an INLINEASM{_BR} MachinInstr's MachineOperands from being
  registers (physical or virtual) to memory
  (MachineOperandType::MO_FrameIndex).  These are not 1:1 operand
  replacements, but N:M operand replacements. i.e. we need to
  update 2 MachineOperands into the middle of the operand list to 5 (at
  least for x86_64).
- copy, modify, write a new MachineInstr which has its relevant operands
  replaced.

Either approaches are hazarded by existing references to either the
operands being moved, or the instruction being removed+replaced. For my
purposes in regalloc, either seem to work for me, so hopefully reviewers
can help me determine which approach is preferable. The second would
involve no new methods on MachineInstr.

One question I had while looking at this was: "why does MachineInstr
have BOTH a NumOperands member AND a MCInstrDesc member that itself has
a NumOperands member? How many operands can a MachineInstr have? Do I
need to update BOTH (keeping them in sync)?" FWICT, only "variadic"
MachineInstrs have MCInstrDesc with NumOperands (of the MCInstrDesc) set
to zero.  If the MCInstrDesc's NumOperands is non-zero, then the NumOperands
on the MachineInstr itself cannot exceed this value (IIUC) else an assert will
be triggered.

For most non-psuedo instructions (or at least non-varidic instructions),
insert is less likely to be useful.

To run the newly added unittest:
    $ pushd llvm/build; ninja CodeGenTests; popd
    $ ./llvm/build/unittests/CodeGen/CodeGenTests \
        --gtest_filter=MachineInstrTest.SpliceOperands

This is meant to mirror `MCInst::insert`.