### PR TITLE
[BOLT] Return proper minimal alignment from BF

### DIFF
--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -309,7 +309,7 @@ bool BinaryEmitter::emitFunction(BinaryFunction &Function,
     // tentative layout.
     Section->ensureMinAlignment(Align(opts::AlignFunctions));
 
-    Streamer.emitCodeAlignment(Align(BinaryFunction::MinAlign), &*BC.STI);
+    Streamer.emitCodeAlignment(Function.getMinAlign(), &*BC.STI);
     uint16_t MaxAlignBytes = FF.isSplitFragment()
                                  ? Function.getMaxColdAlignmentBytes()
                                  : Function.getMaxAlignmentBytes();

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -164,8 +164,6 @@ bool shouldPrint(const BinaryFunction &Function) {
 namespace llvm {
 namespace bolt {
 
-constexpr unsigned BinaryFunction::MinAlign;
-
 template <typename R> static bool emptyRange(const R &Range) {
   return Range.begin() == Range.end();
 }

--- a/bolt/lib/Passes/Aligner.cpp
+++ b/bolt/lib/Passes/Aligner.cpp
@@ -158,22 +158,6 @@ void AlignerPass::runOnFunctions(BinaryContext &BC) {
     BinaryContext::IndependentCodeEmitter Emitter =
         BC.createIndependentMCCodeEmitter();
 
-    // Align objects that contains constant islands and no code
-    // to at least 8 bytes.
-    if (!BF.size() && BF.hasIslandsInfo()) {
-      uint16_t Alignment = BF.getConstantIslandAlignment();
-      // Check if we're forcing output alignment and it is greater than minimal
-      // CI required one
-      if (!opts::UseCompactAligner && Alignment < opts::AlignFunctions &&
-          opts::AlignFunctions <= opts::AlignFunctionsMaxBytes)
-        Alignment = opts::AlignFunctions;
-
-      BF.setAlignment(Alignment);
-      BF.setMaxAlignmentBytes(Alignment);
-      BF.setMaxColdAlignmentBytes(Alignment);
-      return;
-    }
-
     if (opts::UseCompactAligner)
       alignCompact(BF, Emitter.MCE.get());
     else

--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -290,7 +290,7 @@ uint64_t LongJmpPass::tentativeLayoutRelocColdPart(
   for (BinaryFunction *Func : SortedFunctions) {
     if (!Func->isSplit())
       continue;
-    DotAddress = alignTo(DotAddress, BinaryFunction::MinAlign);
+    DotAddress = alignTo(DotAddress, Func->getMinAlignment());
     uint64_t Pad =
         offsetToAlignment(DotAddress, llvm::Align(Func->getAlignment()));
     if (Pad <= Func->getMaxColdAlignmentBytes())
@@ -349,7 +349,7 @@ uint64_t LongJmpPass::tentativeLayoutRelocMode(
         DotAddress = alignTo(DotAddress, opts::AlignText);
     }
 
-    DotAddress = alignTo(DotAddress, BinaryFunction::MinAlign);
+    DotAddress = alignTo(DotAddress, Func->getMinAlignment());
     uint64_t Pad =
         offsetToAlignment(DotAddress, llvm::Align(Func->getAlignment()));
     if (Pad <= Func->getMaxAlignmentBytes())

--- a/bolt/test/AArch64/bf_min_alignment.s
+++ b/bolt/test/AArch64/bf_min_alignment.s
@@ -1,0 +1,35 @@
+// This tests checks the minimum alignment of the AARch64 function
+// is equal to 4. Otherwise the jitlinker would fail to link the
+// binary since the size of the first function after reorder is not
+// not a multiple of 4.
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags -fPIC -pie %t.o -o %t.exe -nostdlib -Wl,-q
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: llvm-bolt %t.exe -o %t.bolt --use-old-text=0 --lite=0 \
+# RUN:   --align-functions-max-bytes=1 \
+# RUN:   --data %t.fdata --reorder-functions=exec-count
+# RUN: llvm-nm -n %t.bolt | FileCheck %s
+
+# CHECK: {{0|4|8|c}} T dummy
+# CHECK-NEXT: {{0|4|8|c}} T _start
+
+  .text
+  .align 4
+  .global _start
+  .type _start, %function
+_start:
+# FDATA: 0 [unknown] 0 1 _start 0 0 1
+   bl dymmy
+   ret
+  .size _start, .-_start
+
+  .global dummy
+  .type dummy, %function
+dummy:
+# FDATA: 0 [unknown] 0 1 dummy 0 0 42
+  adr x0, .Lci
+  ret
+.Lci:
+  .byte 0
+  .size dummy, .-dummy


### PR DESCRIPTION
Currently minimal alignment of function is hardcoded to 2 bytes.
Add 2 more cases:
1. In case BF is data in code return the alignment of CI as minimal
alignment
2. For aarch64 and riscv platforms return the minimal value of 4 (added
test for aarch64)
Otherwise fallback to returning the 2 as it previously was.
