### PR TITLE
[PowerPC] Inline callee if its target-features are a subset of the caller

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
@@ -885,6 +885,19 @@ PPCTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
   return BaseT::getIntrinsicInstrCost(ICA, CostKind);
 }
 
+bool PPCTTIImpl::areInlineCompatible(const Function *Caller,
+                                     const Function *Callee) const {
+  // Allow inlining only when the Callee has a subset of the Caller's features.
+  const TargetMachine &TM = getTLI()->getTargetMachine();
+
+  const FeatureBitset &CallerBits =
+      TM.getSubtargetImpl(*Caller)->getFeatureBits();
+  const FeatureBitset &CalleeBits =
+      TM.getSubtargetImpl(*Callee)->getFeatureBits();
+
+  return (CallerBits & CalleeBits) == CalleeBits;
+}
+
 bool PPCTTIImpl::areTypesABICompatible(const Function *Caller,
                                        const Function *Callee,
                                        const ArrayRef<Type *> &Types) const {

--- a/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.h
@@ -138,6 +138,8 @@ public:
       bool UseMaskForCond = false, bool UseMaskForGaps = false);
   InstructionCost getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
                                         TTI::TargetCostKind CostKind);
+  bool areInlineCompatible(const Function *Caller,
+                           const Function *Callee) const;
   bool areTypesABICompatible(const Function *Caller, const Function *Callee,
                              const ArrayRef<Type *> &Types) const;
   bool hasActiveVectorLength(unsigned Opcode, Type *DataType,

--- a/llvm/test/Transforms/Inline/PowerPC/inline-target-features.ll
+++ b/llvm/test/Transforms/Inline/PowerPC/inline-target-features.ll
@@ -1,0 +1,37 @@
+; RUN: opt < %s -mtriple=powerpc64le-unknown-linux-gnu -S -passes=inline | FileCheck %s
+; Check that we only inline when we have compatible target features.
+
+target datalayout = "e-m:e-Fn32-i64:64-n32:64-S128-v256:256:256-v512:512:512"
+target triple = "powerpc64le-unknown-linux-gnu"
+
+define i32 @f1() #0 {
+; CHECK-LABEL: define i32 @f1(
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 (...) @f0()
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+  %call = call i32 (...) @f0()
+  ret i32 %call
+}
+
+define i32 @f2() #1 {
+; CHECK-LABEL: define i32 @f2(
+; CHECK-NEXT:    [[CALL_I:%.*]] = call i32 (...) @f0()
+; CHECK-NEXT:    ret i32 [[CALL_I]]
+;
+  %call = call i32 @f1()
+  ret i32 %call
+}
+
+define i32 @f3() #0 {
+; CHECK-LABEL: define i32 @f3(
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @f2()
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+  %call = call i32 @f2()
+  ret i32 %call
+}
+
+declare i32 @f0(...) #0
+
+attributes #0 = { "target-cpu"="pwr7" "target-features"="-crbits,-crypto,-direct-move,-isa-v207-instructions,-power8-vector" }
+attributes #1 = { "target-cpu"="pwr8" "target-features"="+crbits,+crypto,+direct-move,+isa-v207-instructions,+power8-vector" }


### PR DESCRIPTION
Simliar to other plateforms (X86, ARM), it should be safe to inline callees if their target-features
are a subset of the caller.  
