### PR TITLE
[MLIR][LLVM] Drop unsupported DISubranges while importing

### DIFF
--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -159,10 +159,15 @@ DISubrangeAttr DebugImporter::translateImpl(llvm::DISubrange *node) {
                               constInt->getSExtValue());
     return IntegerAttr();
   };
-  return DISubrangeAttr::get(context, getIntegerAttrOrNull(node->getCount()),
-                             getIntegerAttrOrNull(node->getLowerBound()),
-                             getIntegerAttrOrNull(node->getUpperBound()),
-                             getIntegerAttrOrNull(node->getStride()));
+  IntegerAttr count = getIntegerAttrOrNull(node->getCount());
+  IntegerAttr upperBound = getIntegerAttrOrNull(node->getUpperBound());
+  // Either count or the upper bound needs to be present. Otherwise, the
+  // metadata is invalid. The conversion might fail due to unsupported DI nodes.
+  if (!count && !upperBound)
+    return {};
+  return DISubrangeAttr::get(
+      context, count, getIntegerAttrOrNull(node->getLowerBound()), upperBound,
+      getIntegerAttrOrNull(node->getStride()));
 }
 
 DISubroutineTypeAttr

--- a/mlir/test/Target/LLVMIR/Import/debug-info.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info.ll
@@ -163,7 +163,8 @@ define void @derived_type() !dbg !3 {
 ; CHECK-DAG: #[[COMP2:.+]] = #llvm.di_composite_type<{{.*}}, file = #[[FILE]], scope = #[[FILE]], baseType = #[[INT]]>
 ; CHECK-DAG: #[[COMP3:.+]] = #llvm.di_composite_type<{{.*}}, flags = Vector, elements = #llvm.di_subrange<count = 4 : i64>>
 ; CHECK-DAG: #[[COMP4:.+]] = #llvm.di_composite_type<{{.*}}, flags = Vector, elements = #llvm.di_subrange<lowerBound = 0 : i64, upperBound = 4 : i64, stride = 1 : i64>>
-; CHECK-DAG: #llvm.di_subroutine_type<types = #[[COMP1]], #[[COMP2]], #[[COMP3]], #[[COMP4]]>
+; CHECK-DAG: #[[COMP5:.+]] = #llvm.di_composite_type<{{.*}}, flags = Vector>
+; CHECK-DAG: #llvm.di_subroutine_type<types = #[[COMP1]], #[[COMP2]], #[[COMP3]], #[[COMP4]], #[[COMP5]]>
 
 define void @composite_type() !dbg !3 {
   ret void
@@ -176,7 +177,7 @@ define void @composite_type() !dbg !3 {
 !2 = !DIFile(filename: "debug-info.ll", directory: "/")
 !3 = distinct !DISubprogram(name: "composite_type", scope: !2, file: !2, spFlags: DISPFlagDefinition, unit: !1, type: !4)
 !4 = !DISubroutineType(types: !5)
-!5 = !{!7, !8, !9, !10}
+!5 = !{!7, !8, !9, !10, !18}
 !6 = !DIBasicType(name: "int")
 !7 = !DICompositeType(tag: DW_TAG_array_type, name: "array1", line: 10, size: 128, align: 32)
 !8 = !DICompositeType(tag: DW_TAG_array_type, name: "array2", file: !2, scope: !2, baseType: !6)
@@ -186,6 +187,12 @@ define void @composite_type() !dbg !3 {
 !12 = !DISubrange(lowerBound: 0, upperBound: 4, stride: 1)
 !13 = !{!11}
 !14 = !{!12}
+
+; Verifies that unsupported subrange nodes are skipped.
+!15 = !DISubrange(count: !16)
+!16 = !DILocalVariable(scope: !3, name: "size")
+!17 = !{!15}
+!18 = !DICompositeType(tag: DW_TAG_array_type, name: "unsupported_elements", flags: DIFlagVector, elements: !17)
 
 ; // -----
 


### PR DESCRIPTION
This revision ensures that unsuppoert DISubranges are properly skipped instead of being transformed into invalid metadata.