### PR TITLE
[mlir][memref] Fix offset update in emulating narrow type for strided memref

### DIFF
--- a/mlir/lib/Dialect/MemRef/Transforms/EmulateNarrowType.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/EmulateNarrowType.cpp
@@ -272,6 +272,12 @@ void memref::populateMemRefNarrowTypeEmulationConversions(
 
         StridedLayoutAttr layoutAttr;
         if (offset != 0) {
+          // Check if the number of bytes are a multiple of the loadStoreWidth
+          // and if so, divide it by the loadStoreWidth to get the offset.
+          if ((offset * width) % loadStoreWidth != 0)
+            return std::nullopt;
+          offset = (offset * width) / loadStoreWidth;
+
           layoutAttr = StridedLayoutAttr::get(ty.getContext(), offset,
                                               ArrayRef<int64_t>{1});
         }


### PR DESCRIPTION
The offset when converting type in emulating narrow types did not account for the offset in strided memrefs. This patch fixes this.