### PR TITLE
add: hidden option to disable slow wasm pass

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
@@ -48,6 +48,12 @@ static cl::opt<bool> WasmDisableExplicitLocals(
              " instruction output for test purposes only."),
     cl::init(false));
 
+static cl::opt<bool> WasmDisableFixIrreducibleControlFlowPass(
+    "wasm-disable-fix-irreducible-control-flow-pass", cl::Hidden,
+    cl::desc("webassembly: disables the fix "
+             " irreducible control flow optimization pass"),
+    cl::init(false));
+
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeWebAssemblyTarget() {
   // Register the target.
   RegisterTargetMachine<WebAssemblyTargetMachine> X(
@@ -537,7 +543,8 @@ void WebAssemblyPassConfig::addPreEmitPass() {
   addPass(createWebAssemblyNullifyDebugValueLists());
 
   // Eliminate multiple-entry loops.
-  addPass(createWebAssemblyFixIrreducibleControlFlow());
+  if (!WasmDisableFixIrreducibleControlFlowPass)
+    addPass(createWebAssemblyFixIrreducibleControlFlow());
 
   // Do various transformations for exception handling.
   // Every CFG-changing optimizations should come before this.


### PR DESCRIPTION
Currently for any wasm target, llvm will make a pass  that removes irreducible control flow. (See [here](https://llvm.org/doxygen/WebAssemblyFixIrreducibleControlFlow_8cpp.html)). This can result in O(NumBlocks * NumNestedLoops * NumIrreducibleLoops + NumLoops * NumLoops) build time, which has resulted in exceedingly long build times when testing. This PR introduces a hidden flag to skip this pass, which brings some of our build times down from 30 minutes to ~6 seconds.