### PR TITLE
[clang][ExprConst] Don't create useless temporary variable

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -10950,16 +10950,8 @@ bool ArrayExprEvaluator::VisitCXXParenListOrInitListExpr(
 }
 
 bool ArrayExprEvaluator::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *E) {
-  LValue CommonLV;
-  if (E->getCommonExpr() &&
-      !Evaluate(Info.CurrentCall->createTemporary(
-                    E->getCommonExpr(),
-                    getStorageType(Info.Ctx, E->getCommonExpr()),
-                    ScopeKind::FullExpression, CommonLV),
-                Info, E->getCommonExpr()->getSourceExpr()))
-    return false;
-
-  auto *CAT = cast<ConstantArrayType>(E->getType()->castAsArrayTypeUnsafe());
+  const auto *CAT =
+      cast<ConstantArrayType>(E->getType()->castAsArrayTypeUnsafe());
 
   uint64_t Elements = CAT->getSize().getZExtValue();
   Result = APValue(APValue::UninitArray(), Elements, Elements);


### PR DESCRIPTION
We never use it anyway.

This code has been introduced in
410306bf6ed906af77978caa199e5d96376bae66, but it didn't really do anything back then either, as far as I can tell.

Fixes #57135