### PR TITLE
[clang] Fix a crash from nested ArrayInitLoopExpr

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -372,7 +372,7 @@ Bug Fixes to C++ Support
   argument. Fixes:
   (`#67395 <https://github.com/llvm/llvm-project/issues/67395>`_)
 
-- Fixed a bug causing destructors of constant-evaluated structured bindings 
+- Fixed a bug causing destructors of constant-evaluated structured bindings
   initialized by array elements to be called in the wrong evaluation context.
 
 Bug Fixes to AST Handling

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -269,6 +269,8 @@ Bug Fixes in This Version
 - Fixes crash when trying to obtain the common sugared type of
   `decltype(instantiation-dependent-expr)`.
   Fixes (`#67603 <https://github.com/llvm/llvm-project/issues/67603>`_)
+- Fixes a crash caused by a multidimensional array being captured by a lambda
+  (`#67722 <https://github.com/llvm/llvm-project/issues/67722>`_).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -369,6 +371,9 @@ Bug Fixes to C++ Support
 - Fix crash when fold expression was used in the initialization of default
   argument. Fixes:
   (`#67395 <https://github.com/llvm/llvm-project/issues/67395>`_)
+
+- Fix a bug when destructors in a ``constexpr`` structured binding were
+  called at the wrong place.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -372,8 +372,8 @@ Bug Fixes to C++ Support
   argument. Fixes:
   (`#67395 <https://github.com/llvm/llvm-project/issues/67395>`_)
 
-- Fix a bug when destructors in a ``constexpr`` structured binding were
-  called at the wrong place.
+- Fixed a bug causing destructors of constant-evaluated structured bindings 
+  initialized by array elements to be called in the wrong evaluation context.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -10950,9 +10950,6 @@ bool ArrayExprEvaluator::VisitCXXParenListOrInitListExpr(
 }
 
 bool ArrayExprEvaluator::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *E) {
-
-  FullExpressionRAII Scope(Info);
-
   LValue CommonLV;
   if (E->getCommonExpr() &&
       !Evaluate(Info.CurrentCall->createTemporary(
@@ -10972,6 +10969,16 @@ bool ArrayExprEvaluator::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *E) {
 
   bool Success = true;
   for (EvalInfo::ArrayInitLoopIndex Index(Info); Index != Elements; ++Index) {
+    // C++ [class.temporary]/5
+    // There are four contexts in which temporaries are destroyed at a different
+    // point than the end of the full-expression. [...] The second context is
+    // when a copy constructor is called to copy an element of an array while
+    // the entire array is copied [...]. In either case, if the constructor has
+    // one or more default arguments, the destruction of every temporary created
+    // in a default argument is sequenced before the construction of the next
+    // array element, if any.
+    FullExpressionRAII Scope(Info);
+
     if (!EvaluateInPlace(Result.getArrayInitializedElt(Index),
                          Info, Subobject, E->getSubExpr()) ||
         !HandleLValueArrayAdjustment(Info, E, Subobject,
@@ -10980,6 +10987,9 @@ bool ArrayExprEvaluator::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *E) {
         return false;
       Success = false;
     }
+
+    // Make sure we run the destructors too.
+    Scope.destroy();
   }
 
   return Success;

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -10967,19 +10967,20 @@ bool ArrayExprEvaluator::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *E) {
   LValue Subobject = This;
   Subobject.addArray(Info, E, CAT);
 
-  bool Success = true;
   for (EvalInfo::ArrayInitLoopIndex Index(Info); Index != Elements; ++Index) {
     if (!EvaluateInPlace(Result.getArrayInitializedElt(Index),
                          Info, Subobject, E->getSubExpr()) ||
         !HandleLValueArrayAdjustment(Info, E, Subobject,
                                      CAT->getElementType(), 1)) {
-      if (!Info.noteFailure())
-        return false;
-      Success = false;
+
+      // There's no need to try and evaluate the rest, as those are the exact
+      // same expressions.
+      std::ignore = Info.noteFailure();
+      return false;
     }
   }
 
-  return Success;
+  return true;
 }
 
 bool ArrayExprEvaluator::VisitCXXConstructExpr(const CXXConstructExpr *E) {

--- a/clang/test/AST/Interp/arrays.cpp
+++ b/clang/test/AST/Interp/arrays.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify %s
-// RUN: %clang_cc1 -verify=ref -DCUR_INTERP %s
+// RUN: %clang_cc1 -verify=ref %s
 
 constexpr int m = 3;
 constexpr const int *foo[][5] = {
@@ -352,10 +352,6 @@ namespace ZeroInit {
 }
 
 namespace ArrayInitLoop {
-  /// FIXME: The ArrayInitLoop for the decomposition initializer in g() has
-  /// f(n) as its CommonExpr. We need to evaluate that exactly once and not
-  /// N times as we do right now.
-#ifndef CUR_INTERP
   struct X {
       int arr[3];
   };
@@ -369,5 +365,4 @@ namespace ArrayInitLoop {
   }
   static_assert(g() == 6); // expected-error {{failed}} \
                            // expected-note {{15 == 6}}
-#endif
 }

--- a/clang/test/AST/Interp/arrays.cpp
+++ b/clang/test/AST/Interp/arrays.cpp
@@ -352,6 +352,9 @@ namespace ZeroInit {
 }
 
 namespace ArrayInitLoop {
+  /// FIXME: The ArrayInitLoop for the decomposition initializer in g() has
+  /// f(n) as its CommonExpr. We need to evaluate that exactly once and not
+  /// N times as we do right now.
   struct X {
       int arr[3];
   };

--- a/clang/test/AST/nested-array-init-loop-in-lambda-capture.cpp
+++ b/clang/test/AST/nested-array-init-loop-in-lambda-capture.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -std=c++17 -verify %s
+// RUN: %clang_cc1 -std=c++17 -verify=ref %s
+
+// ref-no-diagnostics
+// expected-no-diagnostics
+
+void used_to_crash() {
+  int s[2][2];
+
+  int arr[4];
+
+  arr[0] = [s] { return s[0][0]; }();
+}


### PR DESCRIPTION
For the following snippets clang performs the same steps:
```
  S s[2][2];

  auto [a1,a2] = s;
```

```
void crash() {
  S s[2][2];

  int arr[4];

  arr[0] = [s] { return s[0][0].i; }();
}
```

From the two however the latter crashes. The source of the crash is that we create a temporary variable for the source array expression, the `ArrayInitLoop` is performed on.

```
-ArrayInitLoopExpr ... 'S[2][2]'
 |-OpaqueValueExpr ...
 | `-DeclRefExpr ... 'S[2][2]' lvalue Var ... 's' 'S[2][2]'
 `-ArrayInitLoopExpr ... 'S[2]' 
   |-OpaqueValueExpr ... <-- a temporary is created for this during every iteration
   | `<SourceArray> 
   `-...
```
The problem is that we are unable to differentiate between the temporaries that are created in the different iterations, as we only use the pointer to the node as the key, which stays the same.

As for why only the second snippet crashes, the reason is that after evaluating the first iteration, we note a failure and would return, however during analyzing the second snippet, the `CheckingForUndefinedBehavior` flag is set, probably because we assign to an array member and clang wants us to keep going.

~~This patch changes the described behaviour, as if we keep going the exact same expression would be evaluated again and it would fail again, so there's no point of doing that.~~ A different solution would be to wrap the temporary in a `FullExpressionRAII` so that the temporary is cleaned up before it is created once again.

Fixes #57135

