### PR TITLE
[StandardInstrumentations] Ignore VerifierPass/PrintModulePass when printing IR

### DIFF
--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -286,7 +286,8 @@ void unwrapAndPrint(raw_ostream &OS, Any IR) {
 bool isIgnored(StringRef PassID) {
   return isSpecialPass(PassID,
                        {"PassManager", "PassAdaptor", "AnalysisManagerProxy",
-                        "DevirtSCCRepeatedPass", "ModuleInlinerWrapperPass"});
+                        "DevirtSCCRepeatedPass", "ModuleInlinerWrapperPass",
+                        "VerifierPass", "PrintModulePass"});
 }
 
 std::string makeHTMLReady(StringRef SR) {

--- a/llvm/test/Other/ChangePrinters/DotCfg/print-changed-dot-cfg.ll
+++ b/llvm/test/Other/ChangePrinters/DotCfg/print-changed-dot-cfg.ll
@@ -137,7 +137,7 @@ entry:
 ; CHECK-DOT-CFG-SIMPLE-NEXT:     </p></div>
 ; CHECK-DOT-CFG-SIMPLE-NEXT:   <a>4. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-SIMPLE-NEXT:   <a>5. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-SIMPLE-NEXT:   <a>6. Pass PrintModulePass on [module] omitted because no change</a><br/>
+; CHECK-DOT-CFG-SIMPLE-NEXT:   <a>6. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-SIMPLE-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 ; CHECK-DOT-CFG-FUNC-FILTER: <!doctype html><html><head><style>.collapsible { background-color: #777; color: white; cursor: pointer; padding: 18px; width: 100%; border: none; text-align: left; outline: none; font-size: 15px;} .active, .collapsible:hover { background-color: #555;} .content { padding: 0 18px; display: none; overflow: hidden; background-color: #f1f1f1;}</style><title>passes.html</title></head>
@@ -153,7 +153,7 @@ entry:
 ; CHECK-DOT-CFG-FUNC-FILTER-NEXT:     </p></div>
 ; CHECK-DOT-CFG-FUNC-FILTER-NEXT:   <a>4. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-FUNC-FILTER-NEXT:   <a>5. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-FUNC-FILTER-NEXT:   <a>6. Pass PrintModulePass on [module] omitted because no change</a><br/>
+; CHECK-DOT-CFG-FUNC-FILTER-NEXT:   <a>6. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-FUNC-FILTER-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 ; CHECK-DOT-CFG-PRINT-MOD-SCOPE: <!doctype html><html><head><style>.collapsible { background-color: #777; color: white; cursor: pointer; padding: 18px; width: 100%; border: none; text-align: left; outline: none; font-size: 15px;} .active, .collapsible:hover { background-color: #555;} .content { padding: 0 18px; display: none; overflow: hidden; background-color: #f1f1f1;}</style><title>passes.html</title></head>
@@ -171,7 +171,7 @@ entry:
 ; CHECK-DOT-CFG-PRINT-MOD-SCOPE-NEXT:     </p></div>
 ; CHECK-DOT-CFG-PRINT-MOD-SCOPE-NEXT:   <a>4. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-PRINT-MOD-SCOPE-NEXT:   <a>5. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-PRINT-MOD-SCOPE-NEXT:   <a>6. Pass PrintModulePass on [module] omitted because no change</a><br/>
+; CHECK-DOT-CFG-PRINT-MOD-SCOPE-NEXT:   <a>6. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-PRINT-MOD-SCOPE-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 ; CHECK-DOT-CFG-FILTER-MULT-FUNC: <!doctype html><html><head><style>.collapsible { background-color: #777; color: white; cursor: pointer; padding: 18px; width: 100%; border: none; text-align: left; outline: none; font-size: 15px;} .active, .collapsible:hover { background-color: #555;} .content { padding: 0 18px; display: none; overflow: hidden; background-color: #f1f1f1;}</style><title>passes.html</title></head>
@@ -189,7 +189,7 @@ entry:
 ; CHECK-DOT-CFG-FILTER-MULT-FUNC-NEXT:     </p></div>
 ; CHECK-DOT-CFG-FILTER-MULT-FUNC-NEXT:   <a>4. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-MULT-FUNC-NEXT:   <a>5. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-FILTER-MULT-FUNC-NEXT:   <a>6. Pass PrintModulePass on [module] omitted because no change</a><br/>
+; CHECK-DOT-CFG-FILTER-MULT-FUNC-NEXT:   <a>6. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-MULT-FUNC-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 ; CHECK-DOT-CFG-FILTER-PASSES: <!doctype html><html><head><style>.collapsible { background-color: #777; color: white; cursor: pointer; padding: 18px; width: 100%; border: none; text-align: left; outline: none; font-size: 15px;} .active, .collapsible:hover { background-color: #555;} .content { padding: 0 18px; display: none; overflow: hidden; background-color: #f1f1f1;}</style><title>passes.html</title></head>
@@ -207,7 +207,7 @@ entry:
 ; CHECK-DOT-CFG-FILTER-PASSES-NEXT:   <a>5. Pass NoOpFunctionPass on f omitted because no change</a><br/>
 ; CHECK-DOT-CFG-FILTER-PASSES-NEXT:   <a>6. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-PASSES-NEXT:   <a>7. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-FILTER-PASSES-NEXT:   <a>8. Pass PrintModulePass on [module] filtered out</a><br/>
+; CHECK-DOT-CFG-FILTER-PASSES-NEXT:   <a>8. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-PASSES-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 
@@ -229,7 +229,7 @@ entry:
 ; CHECK-DOT-CFG-FILTER-MULT-PASSES-NEXT:   <a>5. Pass NoOpFunctionPass on f omitted because no change</a><br/>
 ; CHECK-DOT-CFG-FILTER-MULT-PASSES-NEXT:   <a>6. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-MULT-PASSES-NEXT:   <a>7. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-FILTER-MULT-PASSES-NEXT:   <a>8. Pass PrintModulePass on [module] filtered out</a><br/>
+; CHECK-DOT-CFG-FILTER-MULT-PASSES-NEXT:   <a>8. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-MULT-PASSES-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 ; CHECK-DOT-CFG-FILTER-FUNC-PASSES: <!doctype html><html><head><style>.collapsible { background-color: #777; color: white; cursor: pointer; padding: 18px; width: 100%; border: none; text-align: left; outline: none; font-size: 15px;} .active, .collapsible:hover { background-color: #555;} .content { padding: 0 18px; display: none; overflow: hidden; background-color: #f1f1f1;}</style><title>passes.html</title></head>
@@ -247,7 +247,7 @@ entry:
 ; CHECK-DOT-CFG-FILTER-FUNC-PASSES-NEXT:   <a>5. Pass NoOpFunctionPass on f omitted because no change</a><br/>
 ; CHECK-DOT-CFG-FILTER-FUNC-PASSES-NEXT:   <a>6. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-FUNC-PASSES-NEXT:   <a>7. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-FILTER-FUNC-PASSES-NEXT:   <a>8. Pass PrintModulePass on [module] filtered out</a><br/>
+; CHECK-DOT-CFG-FILTER-FUNC-PASSES-NEXT:   <a>8. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-FILTER-FUNC-PASSES-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 
@@ -266,7 +266,7 @@ entry:
 ; CHECK-DOT-CFG-MULT-PASSES-FILTER-FUNC-NEXT:   <a>5. Pass InstSimplifyPass on f omitted because no change</a><br/>
 ; CHECK-DOT-CFG-MULT-PASSES-FILTER-FUNC-NEXT:   <a>6. PassManager{{.*}} on f ignored</a><br/>
 ; CHECK-DOT-CFG-MULT-PASSES-FILTER-FUNC-NEXT:   <a>7. ModuleToFunctionPassAdaptor on [module] ignored</a><br/>
-; CHECK-DOT-CFG-MULT-PASSES-FILTER-FUNC-NEXT:   <a>8. Pass PrintModulePass on [module] omitted because no change</a><br/>
+; CHECK-DOT-CFG-MULT-PASSES-FILTER-FUNC-NEXT:   <a>8. PrintModulePass on [module] ignored</a><br/>
 ; CHECK-DOT-CFG-MULT-PASSES-FILTER-FUNC-NEXT: <script>var coll = document.getElementsByClassName("collapsible");var i;for (i = 0; i < coll.length; i++) {coll[i].addEventListener("click", function() { this.classList.toggle("active"); var content = this.nextElementSibling; if (content.style.display === "block"){ content.style.display = "none"; } else { content.style.display= "block"; } }); }</script></body></html>
 
 ; CHECK-DOT-CFG-QUIET-SIMPLE: <!doctype html><html><head><style>.collapsible { background-color: #777; color: white; cursor: pointer; padding: 18px; width: 100%; border: none; text-align: left; outline: none; font-size: 15px;} .active, .collapsible:hover { background-color: #555;} .content { padding: 0 18px; display: none; overflow: hidden; background-color: #f1f1f1;}</style><title>passes.html</title></head>

--- a/llvm/test/Other/ChangePrinters/print-changed-diff.ll
+++ b/llvm/test/Other/ChangePrinters/print-changed-diff.ll
@@ -157,8 +157,8 @@ entry:
 ; CHECK-DIFF-SIMPLE-NEXT:+  ret i32 5
 ; CHECK-DIFF-SIMPLE: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-DIFF-SIMPLE: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-DIFF-SIMPLE: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-DIFF-SIMPLE: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-DIFF-SIMPLE: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-DIFF-SIMPLE: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-DIFF-FUNC-FILTER: *** IR Dump At Start ***
 ; CHECK-DIFF-FUNC-FILTER-NEXT: ; ModuleID = {{.+}}
@@ -171,8 +171,8 @@ entry:
 ; CHECK-DIFF-FUNC-FILTER:+  ret i32 5
 ; CHECK-DIFF-FUNC-FILTER: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-DIFF-FUNC-FILTER: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-DIFF-FUNC-FILTER: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-DIFF-FUNC-FILTER: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-DIFF-FUNC-FILTER: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-DIFF-FUNC-FILTER: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-DIFF-PRINT-MOD-SCOPE: *** IR Dump At Start ***
 ; CHECK-DIFF-PRINT-MOD-SCOPE: ModuleID = {{.+}}
@@ -190,8 +190,8 @@ entry:
 ; CHECK-DIFF-PRINT-MOD-SCOPE:+  ret i32 5
 ; CHECK-DIFF-PRINT-MOD-SCOPE: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-DIFF-PRINT-MOD-SCOPE: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-DIFF-PRINT-MOD-SCOPE: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-DIFF-PRINT-MOD-SCOPE: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-DIFF-PRINT-MOD-SCOPE: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-DIFF-PRINT-MOD-SCOPE: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Dump At Start ***
 ; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Dump After InstSimplifyPass on g ***
@@ -208,8 +208,8 @@ entry:
 ; CHECK-DIFF-FILTER-MULT-FUNC:+  ret i32 5
 ; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-DIFF-FILTER-MULT-FUNC: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-DIFF-FILTER-PASSES: *** IR Dump At Start ***
 ; CHECK-DIFF-FILTER-PASSES: *** IR Dump After InstSimplifyPass on g filtered out ***
@@ -369,8 +369,8 @@ entry:
 ; CHECK-CDIFF-SIMPLE-NEXT:{{.\[32m\+}}  ret i32 5{{.\[0m}}
 ; CHECK-CDIFF-SIMPLE: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-CDIFF-SIMPLE: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-CDIFF-SIMPLE: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-CDIFF-SIMPLE: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-CDIFF-SIMPLE: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-CDIFF-SIMPLE: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-CDIFF-FUNC-FILTER: *** IR Dump At Start ***
 ; CHECK-CDIFF-FUNC-FILTER-NEXT: ; ModuleID = {{.+}}
@@ -383,8 +383,8 @@ entry:
 ; CHECK-CDIFF-FUNC-FILTER:{{.\[32m\+}}  ret i32 5{{.\[0m}}
 ; CHECK-CDIFF-FUNC-FILTER: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-CDIFF-FUNC-FILTER: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-CDIFF-FUNC-FILTER: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-CDIFF-FUNC-FILTER: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-CDIFF-FUNC-FILTER: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-CDIFF-FUNC-FILTER: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-CDIFF-PRINT-MOD-SCOPE: *** IR Dump At Start ***
 ; CHECK-CDIFF-PRINT-MOD-SCOPE: ModuleID = {{.+}}
@@ -402,8 +402,8 @@ entry:
 ; CHECK-CDIFF-PRINT-MOD-SCOPE:{{.\[32m\+}}  ret i32 5{{.\[0m}}
 ; CHECK-CDIFF-PRINT-MOD-SCOPE: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-CDIFF-PRINT-MOD-SCOPE: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-CDIFF-PRINT-MOD-SCOPE: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-CDIFF-PRINT-MOD-SCOPE: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-CDIFF-PRINT-MOD-SCOPE: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-CDIFF-PRINT-MOD-SCOPE: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Dump At Start ***
 ; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Dump After InstSimplifyPass on g ***
@@ -420,8 +420,8 @@ entry:
 ; CHECK-CDIFF-FILTER-MULT-FUNC:{{.\[32m\+}}  ret i32 5{{.\[0m}}
 ; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-CDIFF-FILTER-MULT-FUNC: *** IR Pass PrintModulePass on [module] ignored ***
 
 ; CHECK-CDIFF-FILTER-PASSES: *** IR Dump At Start ***
 ; CHECK-CDIFF-FILTER-PASSES: *** IR Dump After InstSimplifyPass on g filtered out ***

--- a/llvm/test/Other/change-printer.ll
+++ b/llvm/test/Other/change-printer.ll
@@ -116,8 +116,8 @@ entry:
 ; CHECK-SIMPLE-NEXT: define i32 @f()
 ; CHECK-SIMPLE: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-SIMPLE: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-SIMPLE: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-SIMPLE: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-SIMPLE: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-SIMPLE: *** IR Pass PrintModulePass on [module] ignored ***
 ; CHECK-SIMPLE-NOT: *** IR
 
 ; CHECK-FUNC-FILTER: *** IR Dump At Start ***
@@ -199,8 +199,8 @@ entry:
 ; CHECK-SIMPLE-BEFORE-NEXT: define i32 @f()
 ; CHECK-SIMPLE-BEFORE: *** IR Pass PassManager{{.*}} on f ignored ***
 ; CHECK-SIMPLE-BEFORE: *** IR Pass ModuleToFunctionPassAdaptor on [module] ignored ***
-; CHECK-SIMPLE-BEFORE: *** IR Dump After VerifierPass on [module] omitted because no change ***
-; CHECK-SIMPLE-BEFORE: *** IR Dump After PrintModulePass on [module] omitted because no change ***
+; CHECK-SIMPLE-BEFORE: *** IR Pass VerifierPass on [module] ignored ***
+; CHECK-SIMPLE-BEFORE: *** IR Pass PrintModulePass on [module] ignored ***
 ; CHECK-SIMPLE-BEFORE-NOT: *** IR
 
 ; CHECK-FUNC-FILTER-BEFORE: *** IR Dump At Start ***

--- a/llvm/test/Other/print-at-pass-number.ll
+++ b/llvm/test/Other/print-at-pass-number.ll
@@ -28,5 +28,4 @@ bb4:                                              ; preds = %bb1
 ; NUMBER-NEXT: Running pass 2 LCSSAPass
 ; NUMBER-NEXT: Running pass 3 IndVarSimplifyPass
 ; NUMBER-NEXT: Running pass 4 LoopDeletionPass
-; NUMBER-NEXT: Running pass 5 VerifierPass
-; NUMBER-NEXT: Running pass 6 PrintModulePass
+; NUMBER-NOT: Running pass

--- a/llvm/test/Other/printer.ll
+++ b/llvm/test/Other/printer.ll
@@ -15,5 +15,3 @@ define void @foo(){
 ; CHECK:      *** IR Dump After PromotePass
 ; CHECK-NEXT: define void @foo
 ; CHECK:      *** IR Dump After InstCombinePass
-; CHECK-NEXT: define void @foo
-; CHECK:      *** IR Dump After VerifierPass

--- a/llvm/test/Other/scc-pass-printer.ll
+++ b/llvm/test/Other/scc-pass-printer.ll
@@ -34,9 +34,6 @@
 ; INL-MOD-NEXT:   call void @bar()
 ; INL-MOD: define void @bar()
 ; INL-MOD-NEXT:  call void @foo()
-; INL-MOD: IR Dump After
-; INL-MOD-NEXT: ModuleID =
-; INL-MOD-NEXT: source_filename =
 ; INL-MOD-NOT: Printing <null> Function
 
 define void @tester() noinline {


### PR DESCRIPTION
These don't affect the IR, so we should ignore them.
