### PR TITLE
Do not remove empty basic blocks which have address taken.

### DIFF
--- a/llvm/lib/CodeGen/GCEmptyBasicBlocks.cpp
+++ b/llvm/lib/CodeGen/GCEmptyBasicBlocks.cpp
@@ -58,7 +58,7 @@ bool GCEmptyBasicBlocks::runOnMachineFunction(MachineFunction &MF) {
     // TODO If a block is an eh pad, or it has address taken, we don't remove
     // it. Removing such blocks is possible, but it probably requires a more
     // complex logic.
-    if (MBB->isEHPad() || MBB->isMachineBlockAddressTaken())
+    if (MBB->isEHPad() || MBB->hasAddressTaken())
       continue;
     // Skip blocks with real code.
     bool HasAnyRealCode = llvm::any_of(*MBB, [](const MachineInstr &MI) {

--- a/llvm/test/CodeGen/X86/gc-empty-basic-blocks.ll
+++ b/llvm/test/CodeGen/X86/gc-empty-basic-blocks.ll
@@ -1,6 +1,8 @@
-;; This test verifies that -gc-empty-basic-blocks removes empty blocks.
+;; This test verifies that -gc-empty-basic-blocks removes regular empty blocks
+;; but does not remove empty blocks which have their address taken.
 ; RUN: llc < %s -mtriple=x86_64 -O0 -gc-empty-basic-blocks | FileCheck %s
 
+;; This function has a regular empty block.
 define void @foo(i1 zeroext %0) nounwind {
   br i1 %0, label %2, label %empty_block
 
@@ -10,7 +12,7 @@ define void @foo(i1 zeroext %0) nounwind {
 ; CHECK-NEXT:    jmp .LBB0_3
 
 2:                                               ; preds = %1
-  %3 = call i32 @bar()
+  %3 = call i32 @baz()
   br label %4
 
 ; CHECK-LABEL: .LBB0_1:
@@ -19,8 +21,8 @@ define void @foo(i1 zeroext %0) nounwind {
 empty_block:                                     ; preds = %1
   unreachable
 
-; CHECK-NOT: %empty_block
-; CHECK-NOT: .LBB0_2
+; CHECK-NOT:     %empty_block
+; CHECK-NOT:   .LBB0_2
 
 4:                                               ; preds = %2, %empty_block
   ret void
@@ -30,4 +32,23 @@ empty_block:                                     ; preds = %1
 
 }
 
-declare i32 @bar()
+;; This function has an empty block which has its address taken. Check that it
+;; is not removed by -gc-empty-basic-blocks.
+define void @bar(i1 zeroext %0) nounwind {
+entry:
+  %1 = select i1 %0, ptr blockaddress(@bar, %empty_block), ptr blockaddress(@bar, %bb2) ; <ptr> [#uses=1]
+  indirectbr ptr %1, [label %empty_block, label %bb2]
+
+; CHECK-LABEL: bar:
+
+empty_block:                                                ; preds = %entry
+  unreachable
+
+; CHECK-LABEL: .LBB1_1: # %empty_block
+
+bb2:                                                ; preds = %entry
+  %2 = call i32 @baz()
+  ret void
+}
+
+declare i32 @baz()


### PR DESCRIPTION
This PR replaces `isMachineBlockAddressTaken` by `hasAddressTaken` to include blocks which have their IR address taken as well. These blocks are also not removable since their predecessors' terminators do not directly point to the block.