### PR TITLE
[ci] Diff against main when determining what files have changed for pre-commit CI

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -22,7 +22,7 @@ set -o pipefail
 
 # Environment variables script works with:
 # List of files affected by this commit
-: ${MODIFIED_FILES:=$(git diff --name-only HEAD~1)}
+: ${MODIFIED_FILES:=$(git diff --name-only main...HEAD)}
 # Filter rules for generic windows tests
 : ${WINDOWS_AGENTS:='{"queue": "windows"}'}
 # Filter rules for generic linux tests


### PR DESCRIPTION
Since we moved to Github PRs, the workflow has changed a bit and folks often merge `main` back into their PR branch. This is fine, except the previous way of determining modified files for pre-commit CI would use the content modified just in the latest commit, whatever it is. This means that in case someone merged main back into their PR branch, we'd think that the files in the merge commit were modified by the PR, and we'd spuriously trigger a CI run. This should fix this issue.

The downside is that the merge target is hardcoded to `main`, which might not always be what we want. I still think this is an improvement over the status quo.