### PR TITLE
Reapply "[libc++][ranges] Add benchmarks for the `from_range` constructors of `vector` and `deque`."

### DIFF
--- a/libcxx/benchmarks/CMakeLists.txt
+++ b/libcxx/benchmarks/CMakeLists.txt
@@ -76,7 +76,27 @@ set(BENCHMARK_LIBCXX_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/benchmark-libcxx)
 set(BENCHMARK_NATIVE_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/benchmark-native)
 
 add_library(               cxx-benchmarks-flags INTERFACE)
-target_compile_features(   cxx-benchmarks-flags INTERFACE cxx_std_20)
+
+# TODO(cmake): remove. This is a workaround to prevent older versions of GCC
+# from failing the configure step because they don't support C++23.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13.0")
+  return()
+endif()
+#TODO(cmake): remove the `add_compile_options`. Currently we have to explicitly
+# pass the `std:c++latest` flag on Windows to work around an issue where
+# requesting `cxx_std_23` results in an error -- somehow CMake fails to
+# translate the `c++23` flag into `c++latest`, and the highest numbered C++
+# version that MSVC flags support is C++20.
+if (MSVC)
+  add_compile_options(/std:c++latest)
+# ibm-clang does not recognize the cxx_std_23 flag, so use this as a temporary
+# workaround on AIX as well.
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  add_compile_options(-std=c++23)
+else()
+  target_compile_features( cxx-benchmarks-flags INTERFACE cxx_std_23)
+endif()
+
 target_compile_options(    cxx-benchmarks-flags INTERFACE -fsized-deallocation -nostdinc++)
 target_include_directories(cxx-benchmarks-flags INTERFACE "${LIBCXX_GENERATED_INCLUDE_DIR}"
                                                 INTERFACE "${BENCHMARK_LIBCXX_INSTALL}/include"

--- a/libcxx/benchmarks/ContainerBenchmarks.h
+++ b/libcxx/benchmarks/ContainerBenchmarks.h
@@ -70,6 +70,16 @@ void BM_ConstructIterIter(benchmark::State& st, Container, GenInputs gen) {
 }
 
 template <class Container, class GenInputs>
+void BM_ConstructFromRange(benchmark::State& st, Container, GenInputs gen) {
+  auto in = gen(st.range(0));
+  benchmark::DoNotOptimize(&in);
+  while (st.KeepRunning()) {
+    Container c(std::from_range, in);
+    DoNotOptimizeData(c);
+  }
+}
+
+template <class Container, class GenInputs>
 void BM_InsertValue(benchmark::State& st, Container c, GenInputs gen) {
   auto in        = gen(st.range(0));
   const auto end = in.end();

--- a/libcxx/benchmarks/deque.bench.cpp
+++ b/libcxx/benchmarks/deque.bench.cpp
@@ -30,4 +30,13 @@ BENCHMARK_CAPTURE(BM_ConstructIterIter, deque_size_t, std::deque<size_t>{}, getR
 BENCHMARK_CAPTURE(BM_ConstructIterIter, deque_string, std::deque<std::string>{}, getRandomStringInputs)
     ->Arg(TestNumInputs);
 
+BENCHMARK_CAPTURE(BM_ConstructFromRange, deque_char, std::deque<char>{}, getRandomIntegerInputs<char>)
+    ->Arg(TestNumInputs);
+
+BENCHMARK_CAPTURE(BM_ConstructFromRange, deque_size_t, std::deque<size_t>{}, getRandomIntegerInputs<size_t>)
+    ->Arg(TestNumInputs);
+
+BENCHMARK_CAPTURE(BM_ConstructFromRange, deque_string, std::deque<std::string>{}, getRandomStringInputs)
+    ->Arg(TestNumInputs);
+
 BENCHMARK_MAIN();

--- a/libcxx/benchmarks/vector_operations.bench.cpp
+++ b/libcxx/benchmarks/vector_operations.bench.cpp
@@ -30,4 +30,13 @@ BENCHMARK_CAPTURE(BM_ConstructIterIter, vector_size_t, std::vector<size_t>{}, ge
 BENCHMARK_CAPTURE(BM_ConstructIterIter, vector_string, std::vector<std::string>{}, getRandomStringInputs)
     ->Arg(TestNumInputs);
 
+BENCHMARK_CAPTURE(BM_ConstructFromRange, vector_char, std::vector<char>{}, getRandomIntegerInputs<char>)
+    ->Arg(TestNumInputs);
+
+BENCHMARK_CAPTURE(BM_ConstructFromRange, vector_size_t, std::vector<size_t>{}, getRandomIntegerInputs<size_t>)
+    ->Arg(TestNumInputs);
+
+BENCHMARK_CAPTURE(BM_ConstructFromRange, vector_string, std::vector<std::string>{}, getRandomStringInputs)
+    ->Arg(TestNumInputs);
+
 BENCHMARK_MAIN();


### PR DESCRIPTION
This reverts commit 10edd5d9436153ace82009a04900ac67d3adc202 and guards
against older versions of GCC to work around the problem.
