### PR TITLE
[bazel] Add filegroup for builtin_headers

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -1694,6 +1694,11 @@ builtin_headers = glob(
     "lib/Headers/riscv_vector.h",
 ]
 
+filegroup(
+    name = "builtin_headers_files",
+    srcs = builtin_headers,
+)
+
 genrule(
     name = "builtin_headers_gen",
     srcs = builtin_headers,


### PR DESCRIPTION
I'd like to package these files into a distribution tar as part of https://github.com/dzbarsky/static-clang. I'm currently applying patches to the llvm repo but figured this bit could be upstreamed.

(Also open to ideas what to do about the `config.bzl` change in https://github.com/dzbarsky/static-clang/blob/master/llvm.patch - it's needed to link with musl libc)