### PR TITLE
[libunwind] Add Unwind-wasm.c to CMakeLists.txt

### DIFF
--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBUNWIND_C_SOURCES
     UnwindLevel1.c
     UnwindLevel1-gcc-ext.c
     Unwind-sjlj.c
+    Unwind-wasm.c
     )
 set_source_files_properties(${LIBUNWIND_C_SOURCES}
                             PROPERTIES

--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -12,6 +12,7 @@
 
 #include <stdbool.h>
 #include <threads.h>
+
 #include "config.h"
 #include "unwind.h"
 

--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -11,12 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include <stdbool.h>
-#include <threads.h>
 
 #include "config.h"
 #include "unwind.h"
 
 #ifdef __USING_WASM_EXCEPTIONS__
+
+#include <threads.h>
 
 _Unwind_Reason_Code __gxx_personality_wasm0(int version, _Unwind_Action actions,
                                             uint64_t exceptionClass,

--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -13,10 +13,10 @@
 #include <stdbool.h>
 
 #include "config.h"
-#include "unwind.h"
 
 #ifdef __USING_WASM_EXCEPTIONS__
 
+#include "unwind.h"
 #include <threads.h>
 
 _Unwind_Reason_Code __gxx_personality_wasm0(int version, _Unwind_Action actions,

--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifdef __USING_WASM_EXCEPTIONS__
-
-#include "config.h"
-#include "unwind.h"
 #include <stdbool.h>
 #include <threads.h>
+#include "config.h"
+#include "unwind.h"
+
+#ifdef __USING_WASM_EXCEPTIONS__
 
 _Unwind_Reason_Code __gxx_personality_wasm0(int version, _Unwind_Action actions,
                                             uint64_t exceptionClass,
@@ -118,4 +118,4 @@ _Unwind_GetRegionStart(struct _Unwind_Context *context) {
   return 0;
 }
 
-#endif
+#endif // defined(__USING_WASM_EXCEPTIONS__)

--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -17,7 +17,6 @@
 #include <stdbool.h>
 #include <threads.h>
 
-
 _Unwind_Reason_Code __gxx_personality_wasm0(int version, _Unwind_Action actions,
                                             uint64_t exceptionClass,
                                             _Unwind_Exception *unwind_exception,

--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifdef __USING_WASM_EXCEPTIONS__
+
 #include "config.h"
 #include "unwind.h"
 #include <stdbool.h>
 #include <threads.h>
 
-#ifdef __USING_WASM_EXCEPTIONS__
 
 _Unwind_Reason_Code __gxx_personality_wasm0(int version, _Unwind_Action actions,
                                             uint64_t exceptionClass,


### PR DESCRIPTION
This was missing when the file was added in https://github.com/llvm/llvm-project/commit/058222b2316615194c089f2bc68d11341f39d26e.

Also reordered some headers to make LLVM CI and clang-format happy.