### PR TITLE
[flang][NFCI]Use config structure for MLIR to LLVM pass creation

### DIFF
--- a/flang/include/flang/Tools/CLOptions.inc
+++ b/flang/include/flang/Tools/CLOptions.inc
@@ -16,7 +16,6 @@
 #include "flang/Optimizer/CodeGen/CodeGen.h"
 #include "flang/Optimizer/HLFIR/Passes.h"
 #include "flang/Optimizer/Transforms/Passes.h"
-#include "llvm/Frontend/Debug/Options.h"
 #include "llvm/Passes/OptimizationLevel.h"
 #include "llvm/Support/CommandLine.h"
 
@@ -184,29 +183,28 @@ inline void addExternalNameConversionPass(
 /// incremental conversion of FIR.
 ///
 /// \param pm - MLIR pass manager that will hold the pipeline definition
-inline void createDefaultFIROptimizerPassPipeline(mlir::PassManager &pm,
-    llvm::OptimizationLevel optLevel = defaultOptLevel,
-    bool stackArrays = false, bool loopVersioning = false) {
+inline void createDefaultFIROptimizerPassPipeline(
+    mlir::PassManager &pm, const MLIRToLLVMPassPipelineConfig &pc) {
   // simplify the IR
   mlir::GreedyRewriteConfig config;
   config.enableRegionSimplification = false;
   pm.addPass(mlir::createCSEPass());
-  fir::addAVC(pm, optLevel);
+  fir::addAVC(pm, pc.OptLevel);
   pm.addNestedPass<mlir::func::FuncOp>(fir::createCharacterConversionPass());
   pm.addPass(mlir::createCanonicalizerPass(config));
   pm.addPass(fir::createSimplifyRegionLitePass());
-  if (optLevel.isOptimizingForSpeed()) {
+  if (pc.OptLevel.isOptimizingForSpeed()) {
     // These passes may increase code size.
     pm.addPass(fir::createSimplifyIntrinsicsPass());
     pm.addPass(fir::createAlgebraicSimplificationPass(config));
   }
 
-  if (loopVersioning)
+  if (pc.LoopVersioning)
     pm.addPass(fir::createLoopVersioningPass());
 
   pm.addPass(mlir::createCSEPass());
 
-  if (stackArrays)
+  if (pc.StackArrays)
     pm.addPass(fir::createStackArraysPass());
   else
     fir::addMemoryAllocationOpt(pm);
@@ -291,19 +289,17 @@ inline void createDebugPasses(
   }
 }
 
-inline void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
-    llvm::OptimizationLevel optLevel = defaultOptLevel,
-    bool underscoring = true,
-    llvm::codegenoptions::DebugInfoKind debugInfo = NoDebugInfo) {
+inline void createDefaultFIRCodeGenPassPipeline(
+    mlir::PassManager &pm, MLIRToLLVMPassPipelineConfig config) {
   fir::addBoxedProcedurePass(pm);
   pm.addNestedPass<mlir::func::FuncOp>(
       fir::createAbstractResultOnFuncOptPass());
   pm.addNestedPass<fir::GlobalOp>(fir::createAbstractResultOnGlobalOptPass());
   fir::addCodeGenRewritePass(pm);
   fir::addTargetRewritePass(pm);
-  fir::addExternalNameConversionPass(pm, underscoring);
-  fir::createDebugPasses(pm, debugInfo);
-  fir::addFIRToLLVMPass(pm, optLevel);
+  fir::addExternalNameConversionPass(pm, config.Underscoring);
+  fir::createDebugPasses(pm, config.DebugInfo);
+  fir::addFIRToLLVMPass(pm, config.OptLevel);
 }
 
 /// Create a pass pipeline for lowering from MLIR to LLVM IR
@@ -311,20 +307,15 @@ inline void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
 /// \param pm - MLIR pass manager that will hold the pipeline definition
 /// \param optLevel - optimization level used for creating FIR optimization
 ///   passes pipeline
-inline void createMLIRToLLVMPassPipeline(mlir::PassManager &pm,
-    llvm::OptimizationLevel optLevel = defaultOptLevel,
-    bool stackArrays = false, bool underscoring = true,
-    bool loopVersioning = false,
-    llvm::codegenoptions::DebugInfoKind debugInfo = NoDebugInfo) {
-  fir::createHLFIRToFIRPassPipeline(pm, optLevel);
+inline void createMLIRToLLVMPassPipeline(
+    mlir::PassManager &pm, const MLIRToLLVMPassPipelineConfig &config) {
+  fir::createHLFIRToFIRPassPipeline(pm, config.OptLevel);
 
   // Add default optimizer pass pipeline.
-  fir::createDefaultFIROptimizerPassPipeline(
-      pm, optLevel, stackArrays, loopVersioning);
+  fir::createDefaultFIROptimizerPassPipeline(pm, config);
 
   // Add codegen pass pipeline.
-  fir::createDefaultFIRCodeGenPassPipeline(
-      pm, optLevel, underscoring, debugInfo);
+  fir::createDefaultFIRCodeGenPassPipeline(pm, config);
 }
 #undef FLANG_EXCLUDE_CODEGEN
 #endif

--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -18,6 +18,24 @@
 
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "llvm/Frontend/Debug/Options.h"
+#include "llvm/Passes/OptimizationLevel.h"
+
+/// Configuriation for the MLIR to LLVM pass pipeline.
+struct MLIRToLLVMPassPipelineConfig {
+  MLIRToLLVMPassPipelineConfig(llvm::OptimizationLevel level) {
+    OptLevel = level;
+    StackArrays = false;
+    Underscoring = true;
+    LoopVersioning = false;
+    DebugInfo = llvm::codegenoptions::NoDebugInfo;
+  }
+  llvm::OptimizationLevel OptLevel; ///< optimisation level
+  bool StackArrays; ///< convert memory allocations to alloca.
+  bool Underscoring; ///< add underscores to function names.
+  bool LoopVersioning; ///< Run the version loop pass.
+  llvm::codegenoptions::DebugInfoKind DebugInfo; ///< Debug info generation.
+};
 
 struct OffloadModuleOpts {
   OffloadModuleOpts() {}

--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -23,18 +23,15 @@
 
 /// Configuriation for the MLIR to LLVM pass pipeline.
 struct MLIRToLLVMPassPipelineConfig {
-  MLIRToLLVMPassPipelineConfig(llvm::OptimizationLevel level) {
+  explicit MLIRToLLVMPassPipelineConfig(llvm::OptimizationLevel level) {
     OptLevel = level;
-    StackArrays = false;
-    Underscoring = true;
-    LoopVersioning = false;
-    DebugInfo = llvm::codegenoptions::NoDebugInfo;
   }
   llvm::OptimizationLevel OptLevel; ///< optimisation level
-  bool StackArrays; ///< convert memory allocations to alloca.
-  bool Underscoring; ///< add underscores to function names.
-  bool LoopVersioning; ///< Run the version loop pass.
-  llvm::codegenoptions::DebugInfoKind DebugInfo; ///< Debug info generation.
+  bool StackArrays = false; ///< convert memory allocations to alloca.
+  bool Underscoring = true; ///< add underscores to function names.
+  bool LoopVersioning = false; ///< Run the version loop pass.
+  llvm::codegenoptions::DebugInfoKind DebugInfo =
+      llvm::codegenoptions::NoDebugInfo; ///< Debug info generation.
 };
 
 struct OffloadModuleOpts {

--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -13,6 +13,7 @@
 #ifndef FORTRAN_TOOLS_CROSS_TOOL_HELPERS_H
 #define FORTRAN_TOOLS_CROSS_TOOL_HELPERS_H
 
+#include "flang/Frontend/CodeGenOptions.h"
 #include "flang/Frontend/LangOptions.h"
 #include <cstdint>
 
@@ -26,6 +27,15 @@ struct MLIRToLLVMPassPipelineConfig {
   explicit MLIRToLLVMPassPipelineConfig(llvm::OptimizationLevel level) {
     OptLevel = level;
   }
+  explicit MLIRToLLVMPassPipelineConfig(llvm::OptimizationLevel level,
+      const Fortran::frontend::CodeGenOptions &opts) {
+    OptLevel = level;
+    StackArrays = opts.StackArrays;
+    Underscoring = opts.Underscoring;
+    LoopVersioning = opts.LoopVersioning;
+    DebugInfo = opts.getDebugInfo();
+  }
+
   llvm::OptimizationLevel OptLevel; ///< optimisation level
   bool StackArrays = false; ///< convert memory allocations to alloca.
   bool Underscoring = true; ///< add underscores to function names.

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -713,15 +713,7 @@ void CodeGenAction::generateLLVMIR() {
   pm.addPass(std::make_unique<Fortran::lower::VerifierPass>());
   pm.enableVerifier(/*verifyPasses=*/true);
 
-  const auto targetOpts = ci.getInvocation().getTargetOpts();
-  const llvm::Triple triple(targetOpts.triple);
-
-  MLIRToLLVMPassPipelineConfig config(level);
-
-  config.StackArrays = opts.StackArrays;
-  config.Underscoring = opts.Underscoring;
-  config.LoopVersioning = opts.LoopVersioning;
-  config.DebugInfo = opts.getDebugInfo();
+  MLIRToLLVMPassPipelineConfig config(level, opts);
 
   // Create the pass pipeline
   fir::createMLIRToLLVMPassPipeline(pm, config);

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -713,10 +713,18 @@ void CodeGenAction::generateLLVMIR() {
   pm.addPass(std::make_unique<Fortran::lower::VerifierPass>());
   pm.enableVerifier(/*verifyPasses=*/true);
 
+  const auto targetOpts = ci.getInvocation().getTargetOpts();
+  const llvm::Triple triple(targetOpts.triple);
+
+  MLIRToLLVMPassPipelineConfig config(level);
+
+  config.StackArrays = opts.StackArrays;
+  config.Underscoring = opts.Underscoring;
+  config.LoopVersioning = opts.LoopVersioning;
+  config.DebugInfo = opts.getDebugInfo();
+
   // Create the pass pipeline
-  fir::createMLIRToLLVMPassPipeline(pm, level, opts.StackArrays,
-                                    opts.Underscoring, opts.LoopVersioning,
-                                    opts.getDebugInfo());
+  fir::createMLIRToLLVMPassPipeline(pm, config);
   (void)mlir::applyPassManagerCLOptions(pm);
 
   // run the pass manager

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -368,7 +368,8 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
     pm.addPass(std::make_unique<Fortran::lower::VerifierPass>());
 
     // Add O2 optimizer pass pipeline.
-    fir::createDefaultFIROptimizerPassPipeline(pm, llvm::OptimizationLevel::O2);
+    fir::createDefaultFIROptimizerPassPipeline(
+        pm, MLIRToLLVMPassPipelineConfig(llvm::OptimizationLevel::O2));
   }
 
   if (mlir::succeeded(pm.run(mlirModule))) {

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -17,6 +17,7 @@
 #include "flang/Optimizer/Support/InitFIR.h"
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Transforms/Passes.h"
+#include "flang/Tools/CrossToolHelpers.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -118,12 +119,13 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
     if (mlir::failed(passPipeline.addToPipeline(pm, errorHandler)))
       return mlir::failure();
   } else {
+    MLIRToLLVMPassPipelineConfig config(llvm::OptimizationLevel::O2);
     if (codeGenLLVM) {
       // Run only CodeGen passes.
-      fir::createDefaultFIRCodeGenPassPipeline(pm);
+      fir::createDefaultFIRCodeGenPassPipeline(pm, config);
     } else {
       // Run tco with O2 by default.
-      fir::createMLIRToLLVMPassPipeline(pm, llvm::OptimizationLevel::O2);
+      fir::createMLIRToLLVMPassPipeline(pm, config);
     }
     fir::addLLVMDialectToLLVMPass(pm, out.os());
   }


### PR DESCRIPTION
The CreateMLIRToLLVMPassPipeline function has quite a few arguments, all of which has default values. Create a struct, with a constructor for the default values, and pass that struct instead.

Re-arrange a few include files to make everything available.

No functional change intended.