### PR TITLE
[clangd] Collect comments from function definitions into the index

### DIFF
--- a/clang-tools-extra/clangd/index/Symbol.h
+++ b/clang-tools-extra/clangd/index/Symbol.h
@@ -145,9 +145,11 @@ struct Symbol {
     ImplementationDetail = 1 << 2,
     /// Symbol is visible to other files (not e.g. a static helper function).
     VisibleOutsideFile = 1 << 3,
+    /// Symbol has an attached documentation comment.
+    HasDocComment = 1 << 4
   };
-
   SymbolFlag Flags = SymbolFlag::None;
+
   /// FIXME: also add deprecation message and fixit?
 };
 

--- a/clang-tools-extra/clangd/index/SymbolCollector.h
+++ b/clang-tools-extra/clangd/index/SymbolCollector.h
@@ -161,7 +161,8 @@ public:
 private:
   const Symbol *addDeclaration(const NamedDecl &, SymbolID,
                                bool IsMainFileSymbol);
-  void addDefinition(const NamedDecl &, const Symbol &DeclSymbol);
+  void addDefinition(const NamedDecl &, const Symbol &DeclSymbol,
+                     bool SkipDocCheck);
   void processRelations(const NamedDecl &ND, const SymbolID &ID,
                         ArrayRef<index::SymbolRelation> Relations);
 

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -1477,6 +1477,58 @@ TEST_F(SymbolCollectorTest, Documentation) {
                         forCodeCompletion(false))));
 }
 
+TEST_F(SymbolCollectorTest, DocumentationInMain) {
+  const std::string Header = R"(
+    // doc Foo
+    class Foo {
+      void f();
+    };
+  )";
+  const std::string Main = R"(
+    // doc f
+    void Foo::f() {}
+  )";
+  CollectorOpts.StoreAllDocumentation = true;
+  runSymbolCollector(Header, Main);
+  EXPECT_THAT(Symbols,
+              UnorderedElementsAre(
+                  AllOf(qName("Foo"), doc("doc Foo"), forCodeCompletion(true)),
+                  AllOf(qName("Foo::f"), doc("doc f"), returnType(""),
+                        forCodeCompletion(false))));
+}
+
+TEST_F(SymbolCollectorTest, DocumentationAtDeclThenDef) {
+  const std::string Header = R"(
+    class Foo {
+      // doc f decl
+      void f();
+    };
+  )";
+  const std::string Main = R"(
+    // doc f def
+    void Foo::f() {}
+  )";
+  CollectorOpts.StoreAllDocumentation = true;
+  runSymbolCollector(Header, Main);
+  EXPECT_THAT(Symbols,
+              UnorderedElementsAre(AllOf(qName("Foo")),
+                                   AllOf(qName("Foo::f"), doc("doc f decl"))));
+}
+
+TEST_F(SymbolCollectorTest, DocumentationAtDefThenDecl) {
+  const std::string Header = R"(
+    // doc f def
+    void f() {}
+
+    // doc f decl
+    void f();
+  )";
+  CollectorOpts.StoreAllDocumentation = true;
+  runSymbolCollector(Header, "" /*Main*/);
+  EXPECT_THAT(Symbols,
+              UnorderedElementsAre(AllOf(qName("f"), doc("doc f def"))));
+}
+
 TEST_F(SymbolCollectorTest, ClassMembers) {
   const std::string Header = R"(
     class Foo {


### PR DESCRIPTION
This is useful with projects that put their (doxygen) comments at the implementation site, rather than the header.