### PR TITLE
Remove 'vectorizers' label from PR labeler

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -309,10 +309,6 @@ tools:llvm-mca:
   - llvm/include/llvm/MCA/**
   - llvm/lib/MCA/**
 
-vectorizers:
-  - llvm/lib/Transforms/Vectorize/**
-  - llvm/include/llvm/Transforms/Vectorize/**
-
 clang:
   - any:
     - clang/**


### PR DESCRIPTION
It's subsumed by an order of magnitude more popular `vectorization` label that is applied for the same path patterns.

Statistics (issues and PRs together):
`vectorization`: 91 open, 91 closed
`vectorizers`: 8 open, 5 closed 

All `vectorizers` usages has occurred in just the past 2 weeks, and likely by our bot.