### PR TITLE
[libc++] Fix implementation of iota_view::size

### DIFF
--- a/libcxx/include/__ranges/iota_view.h
+++ b/libcxx/include/__ranges/iota_view.h
@@ -363,15 +363,14 @@ namespace ranges {
               (integral<_Start> && integral<_BoundSentinel>) || sized_sentinel_for<_BoundSentinel, _Start>
     {
       if constexpr (__integer_like<_Start> && __integer_like<_BoundSentinel>) {
-        if (__value_ < 0) {
-          if (__bound_sentinel_ < 0) {
-            return std::__to_unsigned_like(-__value_) - std::__to_unsigned_like(-__bound_sentinel_);
-          }
-          return std::__to_unsigned_like(__bound_sentinel_) + std::__to_unsigned_like(-__value_);
-        }
-        return std::__to_unsigned_like(__bound_sentinel_) - std::__to_unsigned_like(__value_);
+        return (__value_ < 0)
+                 ? ((__bound_sentinel_ < 0)
+                        ? std::__to_unsigned_like(-__value_) - std::__to_unsigned_like(-__bound_sentinel_)
+                        : std::__to_unsigned_like(__bound_sentinel_) + std::__to_unsigned_like(-__value_))
+                 : std::__to_unsigned_like(__bound_sentinel_) - std::__to_unsigned_like(__value_);
+      } else {
+        return std::__to_unsigned_like(__bound_sentinel_ - __value_);
       }
-      return std::__to_unsigned_like(__bound_sentinel_ - __value_);
     }
   };
 

--- a/libcxx/test/std/ranges/range.factories/range.iota.view/size.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.iota.view/size.pass.cpp
@@ -10,9 +10,10 @@
 
 // constexpr auto size() const requires see below;
 
-#include <ranges>
 #include <cassert>
+#include <concepts>
 #include <limits>
+#include <ranges>
 
 #include "test_macros.h"
 #include "types.h"
@@ -87,6 +88,15 @@ constexpr bool test() {
   {
     const std::ranges::iota_view<SomeInt, SomeInt> io(SomeInt(10), SomeInt(10));
     assert(io.size() == 0);
+  }
+
+  // Make sure iota_view<short, short> works properly. For details,
+  // see https://github.com/llvm/llvm-project/issues/67551.
+  {
+    static_assert(std::ranges::sized_range<std::ranges::iota_view<short, short>>);
+    std::ranges::iota_view<short, short> io(10, 20);
+    std::same_as<unsigned int> auto sz = io.size();
+    assert(sz == 10);
   }
 
   return true;


### PR DESCRIPTION
We were incorrectly deducing the return type of size() because we were not using ternary operators in the implementation (as the spec says). Instead of deducing the common type of the expressions in the spec, we would deduce potentially different return types and fail to compile.

Fixes #67551