### PR TITLE
[ThinLTO][NFC] Add Module Name Debug Print when Generating Module Maps

### DIFF
--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -151,6 +151,7 @@ static StringMap<lto::InputFile *>
 generateModuleMap(std::vector<std::unique_ptr<lto::InputFile>> &Modules) {
   StringMap<lto::InputFile *> ModuleMap;
   for (auto &M : Modules) {
+    LLVM_DEBUG(dbgs() << "Adding module " << M->getName() << " to ModuleMap\n");
     assert(!ModuleMap.contains(M->getName()) &&
            "Expect unique Buffer Identifier");
     ModuleMap[M->getName()] = M.get();


### PR DESCRIPTION
When computing the module maps, `ThinLTOCodeGenerator` asserts if it sees duplicating module names. This PR adds a debug print, so that the list of modules already added can be printed. With this information, one can identify which modules are causing the duplication. 