### PR TITLE
[clang] Add missing canonicalization in int literal profile

### DIFF
--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -1335,6 +1335,8 @@ void StmtProfiler::VisitIntegerLiteral(const IntegerLiteral *S) {
   S->getValue().Profile(ID);
 
   QualType T = S->getType();
+  if (Canonical)
+    T = T.getCanonicalType();
   ID.AddInteger(T->getTypeClass());
   if (auto BitIntT = T->getAs<BitIntType>())
     BitIntT->Profile(ID);


### PR DESCRIPTION
The addition of the type kind to the profile ID of IntegerLiterals results in e.g. size_t and unsigned long literals mismatch even on platforms where they are canonically the same type. This patch checks the Canonical field to determine whether to canonicalize the type first.

rdar://116063468