### PR TITLE
[libc] Fix unused variable in fputc test

### DIFF
--- a/libc/test/src/stdio/fputc_test.cpp
+++ b/libc/test/src/stdio/fputc_test.cpp
@@ -22,7 +22,7 @@ TEST(LlvmLibcPutcTest, PrintOut) {
   }
 
   constexpr char more[] = "A simple string written to stderr\n";
-  for (const char &c : simple) {
+  for (const char &c : more) {
     result = LIBC_NAMESPACE::fputc(
         c, reinterpret_cast<FILE *>(LIBC_NAMESPACE::stderr));
   }


### PR DESCRIPTION
This is probably a copy-and-paste error and the variable 'more' was left unused.