### PR TITLE
[libc][NFC] Fix missing field 'tm_isdst' initializer warning

### DIFF
--- a/libc/test/src/time/TmHelper.h
+++ b/libc/test/src/time/TmHelper.h
@@ -31,7 +31,8 @@ static inline void initialize_tm_data(struct tm *tm_data, int year, int month,
                     // years since 1900
                     .tm_year = year - TimeConstants::TIME_YEAR_BASE,
                     .tm_wday = wday,
-                    .tm_yday = yday};
+                    .tm_yday = yday,
+                    .tm_isdst = 0};
   *tm_data = temp;
 }
 

--- a/libc/test/src/time/mktime_test.cpp
+++ b/libc/test/src/time/mktime_test.cpp
@@ -27,7 +27,7 @@ TEST(LlvmLibcMkTime, FailureSetsErrno) {
   struct tm tm_data {
     .tm_sec = INT_MAX, .tm_min = INT_MAX, .tm_hour = INT_MAX,
     .tm_mday = INT_MAX, .tm_mon = INT_MAX - 1, .tm_year = tm_year(INT_MAX),
-    .tm_wday = 0, .tm_yday = 0
+    .tm_wday = 0, .tm_yday = 0, .tm_isdst = 0
   };
   EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Fails(EOVERFLOW));
 }
@@ -38,7 +38,7 @@ TEST(LlvmLibcMkTime, InvalidSeconds) {
     struct tm tm_data {
       .tm_sec = -1, .tm_min = 0, .tm_hour = 0, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Succeeds(-1));
     EXPECT_TM_EQ((tm{.tm_sec = 59,
@@ -48,7 +48,8 @@ TEST(LlvmLibcMkTime, InvalidSeconds) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 3,
-                     .tm_yday = 364}),
+                     .tm_yday = 364,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -57,7 +58,7 @@ TEST(LlvmLibcMkTime, InvalidSeconds) {
     struct tm tm_data {
       .tm_sec = 60, .tm_min = 0, .tm_hour = 0, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Succeeds(60));
     EXPECT_TM_EQ((tm{.tm_sec = 0,
@@ -67,7 +68,8 @@ TEST(LlvmLibcMkTime, InvalidSeconds) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(1970),
                      .tm_wday = 4,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 }
@@ -78,7 +80,7 @@ TEST(LlvmLibcMkTime, InvalidMinutes) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = -1, .tm_hour = 0, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(-TimeConstants::SECONDS_PER_MIN));
@@ -89,7 +91,8 @@ TEST(LlvmLibcMkTime, InvalidMinutes) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 3,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -98,7 +101,7 @@ TEST(LlvmLibcMkTime, InvalidMinutes) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 60, .tm_hour = 0, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(60 * TimeConstants::SECONDS_PER_MIN));
@@ -109,7 +112,8 @@ TEST(LlvmLibcMkTime, InvalidMinutes) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(1970),
                      .tm_wday = 4,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 }
@@ -120,7 +124,7 @@ TEST(LlvmLibcMkTime, InvalidHours) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = -1, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(-TimeConstants::SECONDS_PER_HOUR));
@@ -131,7 +135,8 @@ TEST(LlvmLibcMkTime, InvalidHours) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 3,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -140,7 +145,7 @@ TEST(LlvmLibcMkTime, InvalidHours) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = 24, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(24 * TimeConstants::SECONDS_PER_HOUR));
@@ -151,7 +156,8 @@ TEST(LlvmLibcMkTime, InvalidHours) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(1970),
                      .tm_wday = 5,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 }
@@ -161,7 +167,7 @@ TEST(LlvmLibcMkTime, InvalidYear) {
   struct tm tm_data {
     .tm_sec = 0, .tm_min = 0, .tm_hour = 0, .tm_mday = 1,
     .tm_mon = Month::JANUARY, .tm_year = tm_year(1969), .tm_wday = 0,
-    .tm_yday = 0
+    .tm_yday = 0, .tm_isdst = 0
   };
   EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
               Succeeds(-TimeConstants::DAYS_PER_NON_LEAP_YEAR *
@@ -173,7 +179,8 @@ TEST(LlvmLibcMkTime, InvalidYear) {
                    .tm_mon = Month::JANUARY,
                    .tm_year = tm_year(1969),
                    .tm_wday = 3,
-                   .tm_yday = 0}),
+                   .tm_yday = 0,
+                   .tm_isdst = 0}),
                tm_data);
 }
 
@@ -185,7 +192,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
     struct tm tm_data {
       .tm_sec = 8, .tm_min = 14, .tm_hour = 3, .tm_mday = 19,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Fails(EOVERFLOW));
   }
@@ -195,7 +202,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
     struct tm tm_data {
       .tm_sec = 7, .tm_min = 15, .tm_hour = 3, .tm_mday = 19,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Fails(EOVERFLOW));
   }
@@ -205,7 +212,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
     struct tm tm_data {
       .tm_sec = 7, .tm_min = 14, .tm_hour = 4, .tm_mday = 19,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Fails(EOVERFLOW));
   }
@@ -215,7 +222,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
     struct tm tm_data {
       .tm_sec = 7, .tm_min = 14, .tm_hour = 3, .tm_mday = 20,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Fails(EOVERFLOW));
   }
@@ -225,7 +232,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
     struct tm tm_data {
       .tm_sec = 7, .tm_min = 14, .tm_hour = 3, .tm_mday = 19,
       .tm_mon = Month::FEBRUARY, .tm_year = tm_year(2038), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Fails(EOVERFLOW));
   }
@@ -235,7 +242,7 @@ TEST(LlvmLibcMkTime, InvalidEndOf32BitEpochYear) {
     struct tm tm_data {
       .tm_sec = 7, .tm_min = 14, .tm_hour = 3, .tm_mday = 19,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2039), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Fails(EOVERFLOW));
   }
@@ -246,7 +253,7 @@ TEST(LlvmLibcMkTime, InvalidMonths) {
     // -1 month from 1970-01-01 00:00:00 returns 1969-12-01 00:00:00.
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = 0, .tm_mday = 0, .tm_mon = -1,
-      .tm_year = tm_year(1970), .tm_wday = 0, .tm_yday = 0
+      .tm_year = tm_year(1970), .tm_wday = 0, .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(-32 * TimeConstants::SECONDS_PER_DAY));
@@ -257,7 +264,8 @@ TEST(LlvmLibcMkTime, InvalidMonths) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 1,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -265,7 +273,7 @@ TEST(LlvmLibcMkTime, InvalidMonths) {
     // 1970-13-01 00:00:00 returns 1971-01-01 00:00:00.
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = 0, .tm_mday = 1, .tm_mon = 12,
-      .tm_year = tm_year(1970), .tm_wday = 0, .tm_yday = 0
+      .tm_year = tm_year(1970), .tm_wday = 0, .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(TimeConstants::DAYS_PER_NON_LEAP_YEAR *
@@ -277,7 +285,8 @@ TEST(LlvmLibcMkTime, InvalidMonths) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(1971),
                      .tm_wday = 5,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 }
@@ -288,7 +297,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = 0, .tm_mday = (1 - 1),
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(-1 * TimeConstants::SECONDS_PER_DAY));
@@ -299,7 +308,8 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 3,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -308,7 +318,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = 0, .tm_mday = 32,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(31 * TimeConstants::SECONDS_PER_DAY));
@@ -319,7 +329,8 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::FEBRUARY,
                      .tm_year = tm_year(1970),
                      .tm_wday = 0,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -328,7 +339,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = 0, .tm_mday = 29,
       .tm_mon = Month::FEBRUARY, .tm_year = tm_year(1970), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(59 * TimeConstants::SECONDS_PER_DAY));
@@ -339,7 +350,8 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::MARCH,
                      .tm_year = tm_year(1970),
                      .tm_wday = 0,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -348,7 +360,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
     struct tm tm_data {
       .tm_sec = 0, .tm_min = 0, .tm_hour = 0, .tm_mday = 30,
       .tm_mon = Month::FEBRUARY, .tm_year = tm_year(1972), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data),
                 Succeeds(((2 * TimeConstants::DAYS_PER_NON_LEAP_YEAR) + 60) *
@@ -360,7 +372,8 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::MARCH,
                      .tm_year = tm_year(1972),
                      .tm_wday = 3,
-                     .tm_yday = 0}),
+                     .tm_yday = 0,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 }
@@ -371,7 +384,7 @@ TEST(LlvmLibcMkTime, EndOf32BitEpochYear) {
   struct tm tm_data {
     .tm_sec = 7, .tm_min = 14, .tm_hour = 3, .tm_mday = 19,
     .tm_mon = Month::JANUARY, .tm_year = tm_year(2038), .tm_wday = 0,
-    .tm_yday = 0
+    .tm_yday = 0, .tm_isdst = 0
   };
   EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Succeeds(0x7FFFFFFF));
   EXPECT_TM_EQ((tm{.tm_sec = 7,
@@ -381,7 +394,8 @@ TEST(LlvmLibcMkTime, EndOf32BitEpochYear) {
                    .tm_mon = Month::JANUARY,
                    .tm_year = tm_year(2038),
                    .tm_wday = 2,
-                   .tm_yday = 7}),
+                   .tm_yday = 7,
+                   .tm_isdst = 0}),
                tm_data);
 }
 
@@ -393,7 +407,7 @@ TEST(LlvmLibcMkTime, Max64BitYear) {
     struct tm tm_data {
       .tm_sec = 50, .tm_min = 50, .tm_hour = 12, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2170), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Succeeds(6311479850));
     EXPECT_TM_EQ((tm{.tm_sec = 50,
@@ -403,7 +417,8 @@ TEST(LlvmLibcMkTime, Max64BitYear) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2170),
                      .tm_wday = 1,
-                     .tm_yday = 50}),
+                     .tm_yday = 50,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 
@@ -412,7 +427,7 @@ TEST(LlvmLibcMkTime, Max64BitYear) {
     struct tm tm_data {
       .tm_sec = 50, .tm_min = 50, .tm_hour = 12, .tm_mday = 1,
       .tm_mon = Month::JANUARY, .tm_year = tm_year(2147483647), .tm_wday = 0,
-      .tm_yday = 0
+      .tm_yday = 0, .tm_isdst = 0
     };
     EXPECT_THAT(LIBC_NAMESPACE::mktime(&tm_data), Succeeds(67767976202043050));
     EXPECT_TM_EQ((tm{.tm_sec = 50,
@@ -422,7 +437,8 @@ TEST(LlvmLibcMkTime, Max64BitYear) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2147483647),
                      .tm_wday = 2,
-                     .tm_yday = 50}),
+                     .tm_yday = 50,
+                     .tm_isdst = 0}),
                  tm_data);
   }
 }


### PR DESCRIPTION
This patch fixes several warnings thrown by clang about an uninitialized member of struct tm, tm_isdst.

Weirdly, gcc doesn't complain about it, probably this member is never read in the tests.