### PR TITLE
[libc][NFC] Couple of small warning fixes

### DIFF
--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -115,7 +115,7 @@ namespace internal {
 
 // Returns floor(log_10(2^e)); requires 0 <= e <= 42039.
 LIBC_INLINE constexpr uint32_t log10_pow2(const uint64_t e) {
-  LIBC_ASSERT(e >= 0 && e <= 42039 &&
+  LIBC_ASSERT(e <= 42039 &&
               "Incorrect exponent to perform log10_pow2 approximation.");
   // This approximation is based on the float value for log_10(2). It first
   // gives an incorrect result for our purposes at 42039 (well beyond the 16383

--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -28,7 +28,9 @@ namespace internal {
 LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // This needs to be translated to EOF at the callsite. This is to avoid
   // including stdio.h in this file.
-  if (c > 127)
+  // The standard states that wint_t may either be an alias of wchar_t or
+  // an alias of an integer type, so we need to keep the c < 0 check.
+  if (c > 127 || c < 0)
     return cpp::nullopt;
   return static_cast<int>(c);
 }

--- a/libc/src/__support/wctype_utils.h
+++ b/libc/src/__support/wctype_utils.h
@@ -28,7 +28,7 @@ namespace internal {
 LIBC_INLINE cpp::optional<int> wctob(wint_t c) {
   // This needs to be translated to EOF at the callsite. This is to avoid
   // including stdio.h in this file.
-  if (c > 127 || c < 0)
+  if (c > 127)
     return cpp::nullopt;
   return static_cast<int>(c);
 }

--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -95,6 +95,7 @@ bool test(RunContext *Ctx, TestCond Cond, ValType LHS, ValType RHS,
   case TestCond::GE:
     return ExplainDifference(LHS >= RHS, "greater than or equal to");
   }
+  __builtin_unreachable();
 }
 
 } // namespace internal

--- a/libc/test/src/__support/CPP/bitset_test.cpp
+++ b/libc/test/src/__support/CPP/bitset_test.cpp
@@ -194,7 +194,7 @@ TEST(LlvmLibcBitsetTest, SetRangeTest) {
   // Check setting exactly one unit
   bitset.set_range(0, 63);
   for (size_t j = 0; j < 256; ++j)
-    EXPECT_EQ(bitset.test(j), (j >= 0 && j <= 63));
+    EXPECT_EQ(bitset.test(j), j <= 63);
   bitset.reset();
 
   // Check ranges across unit boundaries work.

--- a/libc/test/src/__support/CPP/type_traits_test.cpp
+++ b/libc/test/src/__support/CPP/type_traits_test.cpp
@@ -157,7 +157,7 @@ struct A {
 
 struct B : public A {
   virtual ~B() {}
-  virtual void apply() { state = B_APPLY_CALLED; }
+  virtual void apply() override { state = B_APPLY_CALLED; }
 };
 
 void free_function() {}

--- a/libc/test/src/math/smoke/FrexpTest.h
+++ b/libc/test/src/math/smoke/FrexpTest.h
@@ -93,4 +93,4 @@ public:
   using LlvmLibcFrexpTest = FrexpTest<T>;                                      \
   TEST_F(LlvmLibcFrexpTest, SpecialNumbers) { testSpecialNumbers(&func); }     \
   TEST_F(LlvmLibcFrexpTest, PowersOfTwo) { testPowersOfTwo(&func); }           \
-  TEST_F(LlvmLibcFrexpTest, SomeIntegers) { testSomeIntegers(&func); }\
+  TEST_F(LlvmLibcFrexpTest, SomeIntegers) { testSomeIntegers(&func); }

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -72,6 +72,7 @@ static inline mpfr_rnd_t get_mpfr_rounding_mode(RoundingMode mode) {
     return MPFR_RNDN;
     break;
   }
+  __builtin_unreachable();
 }
 
 class MPFRNumber {


### PR DESCRIPTION
This patch fixes a couple of warning when compiling with gcc 13:

* CPP/type_traits_test.cpp: 'apply' overrides a member function but is not marked 'override'

* UnitTest/LibcTest.cpp:98: control reaches end of non-void function
* MPFRWrapper/MPFRUtils.cpp:75: control reaches end of non-void function

* smoke/FrexpTest.h:92: backslash-newline at end of file