### PR TITLE
[libcxx][test] Amend XFAIL directive in no_unique_address tests

### DIFF
--- a/libcxx/test/libcxx/ranges/range.adaptors/range.lazy.split/no_unique_address.compile.pass.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.lazy.split/no_unique_address.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// XFAIL: msvc && !msvc-no-unique-address
+// XFAIL: msvc && (clang-16 || clang-17)
 
 // class lazy_split_view {
 //   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.lazy.split/no_unique_address.compile.pass.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.lazy.split/no_unique_address.compile.pass.cpp
@@ -7,9 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-
-// clang-cl and cl currently don't support [[no_unique_address]]
-// XFAIL: msvc
+// XFAIL: msvc && !msvc-no-unique-address
 
 // class lazy_split_view {
 //   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.split/no_unique_address.compile.pass.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.split/no_unique_address.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// XFAIL: msvc && !msvc-no-unique-address
+// XFAIL: msvc && (clang-16 || clang-17)
 
 // class split_view {
 //   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.split/no_unique_address.compile.pass.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.split/no_unique_address.compile.pass.cpp
@@ -7,9 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-
-// clang-cl and cl currently don't support [[no_unique_address]]
-// XFAIL: msvc
+// XFAIL: msvc && !msvc-no-unique-address
 
 // class split_view {
 //   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();

--- a/libcxx/test/libcxx/ranges/range.factories/range.istream.view/no_unique_address.compile.pass.cpp
+++ b/libcxx/test/libcxx/ranges/range.factories/range.istream.view/no_unique_address.compile.pass.cpp
@@ -8,9 +8,7 @@
 
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-
-// clang-cl and cl currently don't support [[no_unique_address]]
-// XFAIL: msvc
+// XFAIL: msvc && !msvc-no-unique-address
 
 // Test the libc++ extension that the value stored in `std::ranges::istream_view` has been marked
 // as _LIBCPP_NO_UNIQUE_ADDRESS

--- a/libcxx/test/libcxx/ranges/range.factories/range.istream.view/no_unique_address.compile.pass.cpp
+++ b/libcxx/test/libcxx/ranges/range.factories/range.istream.view/no_unique_address.compile.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// XFAIL: msvc && !msvc-no-unique-address
+// XFAIL: msvc && (clang-16 || clang-17)
 
 // Test the libc++ extension that the value stored in `std::ranges::istream_view` has been marked
 // as _LIBCPP_NO_UNIQUE_ADDRESS

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -280,9 +280,10 @@ DEFAULT_FEATURES = [
     Feature(name=lambda cfg: "msvc-{}".format(*_msvcVersion(cfg)), when=_isMSVC),
     Feature(name=lambda cfg: "msvc-{}.{}".format(*_msvcVersion(cfg)), when=_isMSVC),
     Feature(
-        name="msvc-no-unique-address", when=lambda cfg: sourceBuilds(
-          cfg,
-          """
+        name="msvc-no-unique-address",
+        when=lambda cfg: sourceBuilds(
+            cfg,
+            """
           struct A { [[msvc::no_unique_address]] A a; };
           """,
         ),

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -279,15 +279,6 @@ DEFAULT_FEATURES = [
     Feature(name="msvc", when=_isMSVC),
     Feature(name=lambda cfg: "msvc-{}".format(*_msvcVersion(cfg)), when=_isMSVC),
     Feature(name=lambda cfg: "msvc-{}.{}".format(*_msvcVersion(cfg)), when=_isMSVC),
-    Feature(
-        name="msvc-no-unique-address",
-        when=lambda cfg: sourceBuilds(
-            cfg,
-            """
-          struct A { [[msvc::no_unique_address]] A a; };
-          """,
-        ),
-    ),
 ]
 
 # Deduce and add the test features that that are implied by the #defines in

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -279,6 +279,14 @@ DEFAULT_FEATURES = [
     Feature(name="msvc", when=_isMSVC),
     Feature(name=lambda cfg: "msvc-{}".format(*_msvcVersion(cfg)), when=_isMSVC),
     Feature(name=lambda cfg: "msvc-{}.{}".format(*_msvcVersion(cfg)), when=_isMSVC),
+    Feature(
+        name="msvc-no-unique-address", when=lambda cfg: sourceBuilds(
+          cfg,
+          """
+          struct A { [[msvc::no_unique_address]] A a; };
+          """,
+        ),
+    ),
 ]
 
 # Deduce and add the test features that that are implied by the #defines in


### PR DESCRIPTION
This PR amends the `XFAIL` directive to clang < 18 in no_unique_address.compile.pass.cpp tests.

Since PR 67199 implements the [[msvc::no_unique_address]] attribute,
these tests pass in a windows-x64 build against ToT clang-cl:

```
********************
Unexpectedly Passed Tests (3):
llvm-libc++-static-clangcl.cfg.in :: libcxx/ranges/range.adaptors/range.lazy.split/no_unique_address.compile.pass.cpp
llvm-libc++-static-clangcl.cfg.in :: libcxx/ranges/range.adaptors/range.split/no_unique_address.compile.pass.cpp
llvm-libc++-static-clangcl.cfg.in :: libcxx/ranges/range.factories/range.istream.view/no_unique_address.compile.pass.cpp
```