### PR TITLE
[libc] Correct 'memrchr' definition and re-enable on GPU

### DIFF
--- a/libc/spec/gnu_ext.td
+++ b/libc/spec/gnu_ext.td
@@ -69,7 +69,7 @@ def GnuExtensions : StandardSpec<"GNUExtensions"> {
         FunctionSpec<
             "memrchr",
             RetValSpec<VoidPtr>,
-            [ArgSpec<VoidPtr>, ArgSpec<IntType>, ArgSpec<SizeTType>]
+            [ArgSpec<ConstVoidPtr>, ArgSpec<IntType>, ArgSpec<SizeTType>]
         >,
         FunctionSpec<
             "strerror_r",


### PR DESCRIPTION
Summary:
This was disabled on the GPU because it conflicted with the definition
in `glibc`. According to information online and in the `glibc`
implementation, the first argument should be a `const void *`. Fixing
this resolves the problem when exporting this to offloading languages.
