### PR TITLE
[LLDB] Export DWARF Parser symbols for external language plugins

### DIFF
--- a/lldb/include/lldb/Expression/DWARFExpression.h
+++ b/lldb/include/lldb/Expression/DWARFExpression.h
@@ -18,9 +18,9 @@
 #include "llvm/DebugInfo/DWARF/DWARFLocationExpression.h"
 #include <functional>
 
-class DWARFUnit;
-
 namespace lldb_private {
+
+class DWARFUnit;
 
 /// \class DWARFExpression DWARFExpression.h
 /// "lldb/Expression/DWARFExpression.h" Encapsulates a DWARF location
@@ -45,7 +45,7 @@ public:
   DWARFExpression(const DataExtractor &data);
 
   /// Destructor
-  virtual ~DWARFExpression();
+  ~DWARFExpression();
 
   /// Return true if the location expression contains data
   bool IsValid() const;

--- a/lldb/include/lldb/Expression/DWARFExpressionList.h
+++ b/lldb/include/lldb/Expression/DWARFExpressionList.h
@@ -13,9 +13,9 @@
 #include "lldb/Utility/RangeMap.h"
 #include "lldb/lldb-private.h"
 
-class DWARFUnit;
-
 namespace lldb_private {
+
+class DWARFUnit;
 
 /// \class DWARFExpressionList DWARFExpressionList.h
 /// "lldb/Expression/DWARFExpressionList.h" Encapsulates a range map from file

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -28,11 +28,13 @@
 #include "lldb/Symbol/CompilerDeclContext.h"
 #include "lldb/lldb-private.h"
 
-class DWARFDIE;
-class DWARFASTParser;
 class PDBASTParser;
 
 namespace lldb_private {
+
+class DWARFDIE;
+class DWARFASTParser;
+
 namespace npdb {
   class PdbAstBuilder;
 } // namespace npdb
@@ -579,7 +581,7 @@ private:
   llvm::Expected<lldb::TypeSystemSP> GetTypeSystemForLanguage(
       lldb::LanguageType language,
       std::optional<CreateCallback> create_callback = std::nullopt);
-  };
+};
 
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DIERef.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DIERef.h
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <optional>
 
+namespace lldb_private {
 /// Identifies a DWARF debug info entry within a given Module. It contains three
 /// "coordinates":
 /// - file_index: identifies the separate stand alone debug info file
@@ -131,10 +132,12 @@ private:
 static_assert(sizeof(DIERef) == 8);
 
 typedef std::vector<DIERef> DIEArray;
+} // namespace lldb_private
 
 namespace llvm {
-template<> struct format_provider<DIERef> {
-  static void format(const DIERef &ref, raw_ostream &OS, StringRef Style);
+template <> struct format_provider<lldb_private::DIERef> {
+  static void format(const lldb_private::DIERef &ref, raw_ostream &OS,
+                     StringRef Style);
 };
 } // namespace llvm
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.h
@@ -17,11 +17,10 @@
 #include "lldb/lldb-enumerations.h"
 #include <optional>
 
-class DWARFDIE;
 namespace lldb_private {
+class DWARFDIE;
 class CompileUnit;
 class ExecutionContext;
-}
 class SymbolFileDWARF;
 
 class DWARFASTParser {
@@ -65,5 +64,6 @@ public:
 
   static lldb::AccessType GetAccessTypeFromDWARF(uint32_t dwarf_accessibility);
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFASTPARSER_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -30,13 +30,13 @@
 
 namespace lldb_private {
 class CompileUnit;
-}
 class DWARFDebugInfoEntry;
 class SymbolFileDWARF;
+} // namespace lldb_private
 
 struct ParsedDWARFTypeAttributes;
 
-class DWARFASTParserClang : public DWARFASTParser {
+class DWARFASTParserClang : public lldb_private::DWARFASTParser {
 public:
   DWARFASTParserClang(lldb_private::TypeSystemClang &ast);
 
@@ -44,32 +44,33 @@ public:
 
   // DWARFASTParser interface.
   lldb::TypeSP ParseTypeFromDWARF(const lldb_private::SymbolContext &sc,
-                                  const DWARFDIE &die,
+                                  const lldb_private::DWARFDIE &die,
                                   bool *type_is_new_ptr) override;
 
   lldb_private::ConstString
-  ConstructDemangledNameFromDWARF(const DWARFDIE &die) override;
+  ConstructDemangledNameFromDWARF(const lldb_private::DWARFDIE &die) override;
 
   lldb_private::Function *
   ParseFunctionFromDWARF(lldb_private::CompileUnit &comp_unit,
-                         const DWARFDIE &die,
+                         const lldb_private::DWARFDIE &die,
                          const lldb_private::AddressRange &func_range) override;
 
   bool
-  CompleteTypeFromDWARF(const DWARFDIE &die, lldb_private::Type *type,
+  CompleteTypeFromDWARF(const lldb_private::DWARFDIE &die,
+                        lldb_private::Type *type,
                         lldb_private::CompilerType &compiler_type) override;
 
   lldb_private::CompilerDecl
-  GetDeclForUIDFromDWARF(const DWARFDIE &die) override;
+  GetDeclForUIDFromDWARF(const lldb_private::DWARFDIE &die) override;
 
   void EnsureAllDIEsInDeclContextHaveBeenParsed(
       lldb_private::CompilerDeclContext decl_context) override;
 
   lldb_private::CompilerDeclContext
-  GetDeclContextForUIDFromDWARF(const DWARFDIE &die) override;
+  GetDeclContextForUIDFromDWARF(const lldb_private::DWARFDIE &die) override;
 
-  lldb_private::CompilerDeclContext
-  GetDeclContextContainingUIDFromDWARF(const DWARFDIE &die) override;
+  lldb_private::CompilerDeclContext GetDeclContextContainingUIDFromDWARF(
+      const lldb_private::DWARFDIE &die) override;
 
   lldb_private::ClangASTImporter &GetClangASTImporter();
 
@@ -87,7 +88,7 @@ public:
   ///         into the given integer type or the integer type isn't supported.
   llvm::Expected<llvm::APInt>
   ExtractIntFromFormValue(const lldb_private::CompilerType &int_type,
-                          const DWARFFormValue &form_value) const;
+                          const lldb_private::DWARFFormValue &form_value) const;
 
   /// Returns the template parameters of a class DWARFDIE as a string.
   ///
@@ -100,7 +101,7 @@ public:
   /// If the DIE's name already has '<>', returns an empty ConstString because
   /// it's assumed that the caller is using the DIE name anyway.
   lldb_private::ConstString
-  GetDIEClassTemplateParams(const DWARFDIE &die) override;
+  GetDIEClassTemplateParams(const lldb_private::DWARFDIE &die) override;
 
 protected:
   /// Protected typedefs and members.
@@ -108,14 +109,17 @@ protected:
   class DelayedAddObjCClassProperty;
   typedef std::vector<DelayedAddObjCClassProperty> DelayedPropertyList;
 
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *, clang::DeclContext *>
+  typedef llvm::DenseMap<const lldb_private::DWARFDebugInfoEntry *,
+                         clang::DeclContext *>
       DIEToDeclContextMap;
-  typedef std::multimap<const clang::DeclContext *, const DWARFDIE>
+  typedef std::multimap<const clang::DeclContext *,
+                        const lldb_private::DWARFDIE>
       DeclContextToDIEMap;
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *,
+  typedef llvm::DenseMap<const lldb_private::DWARFDebugInfoEntry *,
                          lldb_private::OptionalClangModuleID>
       DIEToModuleMap;
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *, clang::Decl *>
+  typedef llvm::DenseMap<const lldb_private::DWARFDebugInfoEntry *,
+                         clang::Decl *>
       DIEToDeclMap;
 
   lldb_private::TypeSystemClang &m_ast;
@@ -126,11 +130,11 @@ protected:
   std::unique_ptr<lldb_private::ClangASTImporter> m_clang_ast_importer_up;
   /// @}
 
-  clang::DeclContext *GetDeclContextForBlock(const DWARFDIE &die);
+  clang::DeclContext *GetDeclContextForBlock(const lldb_private::DWARFDIE &die);
 
-  clang::BlockDecl *ResolveBlockDIE(const DWARFDIE &die);
+  clang::BlockDecl *ResolveBlockDIE(const lldb_private::DWARFDIE &die);
 
-  clang::NamespaceDecl *ResolveNamespaceDIE(const DWARFDIE &die);
+  clang::NamespaceDecl *ResolveNamespaceDIE(const lldb_private::DWARFDIE &die);
 
   /// Returns the namespace decl that a DW_TAG_imported_declaration imports.
   ///
@@ -141,31 +145,33 @@ protected:
   ///          'die' imports. If the imported entity is not a namespace
   ///          or another import declaration, returns nullptr. If an error
   ///          occurs, returns nullptr.
-  clang::NamespaceDecl *ResolveImportedDeclarationDIE(const DWARFDIE &die);
+  clang::NamespaceDecl *
+  ResolveImportedDeclarationDIE(const lldb_private::DWARFDIE &die);
 
-  bool ParseTemplateDIE(const DWARFDIE &die,
+  bool ParseTemplateDIE(const lldb_private::DWARFDIE &die,
                         lldb_private::TypeSystemClang::TemplateParameterInfos
                             &template_param_infos);
 
   bool ParseTemplateParameterInfos(
-      const DWARFDIE &parent_die,
+      const lldb_private::DWARFDIE &parent_die,
       lldb_private::TypeSystemClang::TemplateParameterInfos
           &template_param_infos);
 
-  std::string GetCPlusPlusQualifiedName(const DWARFDIE &die);
+  std::string GetCPlusPlusQualifiedName(const lldb_private::DWARFDIE &die);
 
   bool ParseChildMembers(
-      const DWARFDIE &die, lldb_private::CompilerType &class_compiler_type,
+      const lldb_private::DWARFDIE &die,
+      lldb_private::CompilerType &class_compiler_type,
       std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> &base_classes,
-      std::vector<DWARFDIE> &member_function_dies,
+      std::vector<lldb_private::DWARFDIE> &member_function_dies,
       DelayedPropertyList &delayed_properties,
       const lldb::AccessType default_accessibility,
       lldb_private::ClangASTImporter::LayoutInfo &layout_info);
 
   size_t
   ParseChildParameters(clang::DeclContext *containing_decl_ctx,
-                       const DWARFDIE &parent_die, bool skip_artificial,
-                       bool &is_static, bool &is_variadic,
+                       const lldb_private::DWARFDIE &parent_die,
+                       bool skip_artificial, bool &is_static, bool &is_variadic,
                        bool &has_template_params,
                        std::vector<lldb_private::CompilerType> &function_args,
                        std::vector<clang::ParmVarDecl *> &function_param_decls,
@@ -173,33 +179,39 @@ protected:
 
   size_t ParseChildEnumerators(lldb_private::CompilerType &compiler_type,
                                bool is_signed, uint32_t enumerator_byte_size,
-                               const DWARFDIE &parent_die);
+                               const lldb_private::DWARFDIE &parent_die);
 
   /// Parse a structure, class, or union type DIE.
   lldb::TypeSP ParseStructureLikeDIE(const lldb_private::SymbolContext &sc,
-                                     const DWARFDIE &die,
+                                     const lldb_private::DWARFDIE &die,
                                      ParsedDWARFTypeAttributes &attrs);
 
-  lldb_private::Type *GetTypeForDIE(const DWARFDIE &die);
+  lldb_private::Type *GetTypeForDIE(const lldb_private::DWARFDIE &die);
 
-  clang::Decl *GetClangDeclForDIE(const DWARFDIE &die);
+  clang::Decl *GetClangDeclForDIE(const lldb_private::DWARFDIE &die);
 
-  clang::DeclContext *GetClangDeclContextForDIE(const DWARFDIE &die);
+  clang::DeclContext *
+  GetClangDeclContextForDIE(const lldb_private::DWARFDIE &die);
 
-  clang::DeclContext *GetClangDeclContextContainingDIE(const DWARFDIE &die,
-                                                       DWARFDIE *decl_ctx_die);
-  lldb_private::OptionalClangModuleID GetOwningClangModule(const DWARFDIE &die);
+  clang::DeclContext *
+  GetClangDeclContextContainingDIE(const lldb_private::DWARFDIE &die,
+                                   lldb_private::DWARFDIE *decl_ctx_die);
+  lldb_private::OptionalClangModuleID
+  GetOwningClangModule(const lldb_private::DWARFDIE &die);
 
-  bool CopyUniqueClassMethodTypes(const DWARFDIE &src_class_die,
-                                  const DWARFDIE &dst_class_die,
-                                  lldb_private::Type *class_type,
-                                  std::vector<DWARFDIE> &failures);
+  bool
+  CopyUniqueClassMethodTypes(const lldb_private::DWARFDIE &src_class_die,
+                             const lldb_private::DWARFDIE &dst_class_die,
+                             lldb_private::Type *class_type,
+                             std::vector<lldb_private::DWARFDIE> &failures);
 
-  clang::DeclContext *GetCachedClangDeclContextForDIE(const DWARFDIE &die);
+  clang::DeclContext *
+  GetCachedClangDeclContextForDIE(const lldb_private::DWARFDIE &die);
 
-  void LinkDeclContextToDIE(clang::DeclContext *decl_ctx, const DWARFDIE &die);
+  void LinkDeclContextToDIE(clang::DeclContext *decl_ctx,
+                            const lldb_private::DWARFDIE &die);
 
-  void LinkDeclToDIE(clang::Decl *decl, const DWARFDIE &die);
+  void LinkDeclToDIE(clang::Decl *decl, const lldb_private::DWARFDIE &die);
 
   /// If \p type_sp is valid, calculate and set its symbol context scope, and
   /// update the type list for its backing symbol file.
@@ -207,16 +219,17 @@ protected:
   /// Returns \p type_sp.
   lldb::TypeSP
   UpdateSymbolContextScopeForType(const lldb_private::SymbolContext &sc,
-                                  const DWARFDIE &die, lldb::TypeSP type_sp);
+                                  const lldb_private::DWARFDIE &die,
+                                  lldb::TypeSP type_sp);
 
   /// Follow Clang Module Skeleton CU references to find a type definition.
   lldb::TypeSP ParseTypeFromClangModule(const lldb_private::SymbolContext &sc,
-                                        const DWARFDIE &die,
+                                        const lldb_private::DWARFDIE &die,
                                         lldb_private::Log *log);
 
   // Return true if this type is a declaration to a type in an external
   // module.
-  lldb::ModuleSP GetModuleForType(const DWARFDIE &die);
+  lldb::ModuleSP GetModuleForType(const lldb_private::DWARFDIE &die);
 
 private:
   struct FieldInfo {
@@ -268,32 +281,37 @@ private:
   /// created property.
   /// \param delayed_properties The list of delayed properties that the result
   /// will be appended to.
-  void ParseObjCProperty(const DWARFDIE &die, const DWARFDIE &parent_die,
+  void ParseObjCProperty(const lldb_private::DWARFDIE &die,
+                         const lldb_private::DWARFDIE &parent_die,
                          const lldb_private::CompilerType &class_clang_type,
                          DelayedPropertyList &delayed_properties);
 
   void
-  ParseSingleMember(const DWARFDIE &die, const DWARFDIE &parent_die,
+  ParseSingleMember(const lldb_private::DWARFDIE &die,
+                    const lldb_private::DWARFDIE &parent_die,
                     const lldb_private::CompilerType &class_clang_type,
                     lldb::AccessType default_accessibility,
                     lldb_private::ClangASTImporter::LayoutInfo &layout_info,
                     FieldInfo &last_field_info);
 
-  bool CompleteRecordType(const DWARFDIE &die, lldb_private::Type *type,
+  bool CompleteRecordType(const lldb_private::DWARFDIE &die,
+                          lldb_private::Type *type,
                           lldb_private::CompilerType &clang_type);
-  bool CompleteEnumType(const DWARFDIE &die, lldb_private::Type *type,
+  bool CompleteEnumType(const lldb_private::DWARFDIE &die,
+                        lldb_private::Type *type,
                         lldb_private::CompilerType &clang_type);
 
   lldb::TypeSP ParseTypeModifier(const lldb_private::SymbolContext &sc,
-                                 const DWARFDIE &die,
+                                 const lldb_private::DWARFDIE &die,
                                  ParsedDWARFTypeAttributes &attrs);
   lldb::TypeSP ParseEnum(const lldb_private::SymbolContext &sc,
-                         const DWARFDIE &die, ParsedDWARFTypeAttributes &attrs);
-  lldb::TypeSP ParseSubroutine(const DWARFDIE &die,
+                         const lldb_private::DWARFDIE &die,
+                         ParsedDWARFTypeAttributes &attrs);
+  lldb::TypeSP ParseSubroutine(const lldb_private::DWARFDIE &die,
                                ParsedDWARFTypeAttributes &attrs);
-  lldb::TypeSP ParseArrayType(const DWARFDIE &die,
+  lldb::TypeSP ParseArrayType(const lldb_private::DWARFDIE &die,
                               const ParsedDWARFTypeAttributes &attrs);
-  lldb::TypeSP ParsePointerToMemberType(const DWARFDIE &die,
+  lldb::TypeSP ParsePointerToMemberType(const lldb_private::DWARFDIE &die,
                                         const ParsedDWARFTypeAttributes &attrs);
 
   /// Parses a DW_TAG_inheritance DIE into a base/super class.
@@ -311,7 +329,8 @@ private:
   /// \param layout_info The layout information that will be updated for C++
   /// base classes with the base offset.
   void ParseInheritance(
-      const DWARFDIE &die, const DWARFDIE &parent_die,
+      const lldb_private::DWARFDIE &die,
+      const lldb_private::DWARFDIE &parent_die,
       const lldb_private::CompilerType class_clang_type,
       const lldb::AccessType default_accessibility,
       const lldb::ModuleSP &module_sp,
@@ -328,7 +347,8 @@ private:
   /// \param layout_info The layout information that will be updated for
   //   base classes with the base offset
   void
-  ParseRustVariantPart(DWARFDIE &die, const DWARFDIE &parent_die,
+  ParseRustVariantPart(lldb_private::DWARFDIE &die,
+                       const lldb_private::DWARFDIE &parent_die,
                        lldb_private::CompilerType &class_clang_type,
                        const lldb::AccessType default_accesibility,
                        lldb_private::ClangASTImporter::LayoutInfo &layout_info);
@@ -338,7 +358,7 @@ private:
 /// Some attributes are relevant for all kinds of types (declaration), while
 /// others are only meaningful to a specific type (is_virtual)
 struct ParsedDWARFTypeAttributes {
-  explicit ParsedDWARFTypeAttributes(const DWARFDIE &die);
+  explicit ParsedDWARFTypeAttributes(const lldb_private::DWARFDIE &die);
 
   lldb::AccessType accessibility = lldb::eAccessNone;
   bool is_artificial = false;
@@ -355,12 +375,12 @@ struct ParsedDWARFTypeAttributes {
   const char *mangled_name = nullptr;
   lldb_private::ConstString name;
   lldb_private::Declaration decl;
-  DWARFDIE object_pointer;
-  DWARFFormValue abstract_origin;
-  DWARFFormValue containing_type;
-  DWARFFormValue signature;
-  DWARFFormValue specification;
-  DWARFFormValue type;
+  lldb_private::DWARFDIE object_pointer;
+  lldb_private::DWARFFormValue abstract_origin;
+  lldb_private::DWARFFormValue containing_type;
+  lldb_private::DWARFFormValue signature;
+  lldb_private::DWARFFormValue specification;
+  lldb_private::DWARFFormValue type;
   lldb::LanguageType class_language = lldb::eLanguageTypeUnknown;
   std::optional<uint64_t> byte_size;
   size_t calling_convention = llvm::dwarf::DW_CC_normal;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.cpp
@@ -11,6 +11,7 @@
 #include "DWARFDebugInfo.h"
 
 using namespace lldb_private::dwarf;
+using namespace lldb_private;
 
 DWARFAttributes::DWARFAttributes() : m_infos() {}
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 
+namespace lldb_private {
 class DWARFUnit;
 
 class DWARFAttribute {
@@ -31,6 +32,7 @@ public:
     form = m_form;
     val = m_value;
   }
+
 protected:
   dw_attr_t m_attr;
   dw_form_t m_form;
@@ -72,5 +74,6 @@ protected:
   typedef llvm::SmallVector<AttributeValue, 8> collection;
   collection m_infos;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFATTRIBUTE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.cpp
@@ -120,6 +120,7 @@ DWARFAttributes DWARFBaseDIE::GetAttributes(Recurse recurse) const {
   return DWARFAttributes();
 }
 
+namespace lldb_private {
 bool operator==(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs) {
   return lhs.GetDIE() == rhs.GetDIE() && lhs.GetCU() == rhs.GetCU();
 }
@@ -127,6 +128,7 @@ bool operator==(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs) {
 bool operator!=(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs) {
   return !(lhs == rhs);
 }
+} // namespace lldb_private
 
 const DWARFDataExtractor &DWARFBaseDIE::GetData() const {
   // Clients must check if this DIE is valid before calling this function.

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.h
@@ -15,6 +15,7 @@
 #include "llvm/Support/Error.h"
 #include <optional>
 
+namespace lldb_private {
 class DIERef;
 class DWARFASTParser;
 class DWARFAttributes;
@@ -124,5 +125,6 @@ protected:
 
 bool operator==(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs);
 bool operator!=(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs);
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFBASEDIE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.h
@@ -12,6 +12,7 @@
 #include "DWARFUnit.h"
 #include "llvm/Support/Error.h"
 
+namespace lldb_private {
 class DWARFCompileUnit : public DWARFUnit {
 public:
   void BuildAddressRangeTable(DWARFDebugAranges *debug_aranges) override;
@@ -36,5 +37,6 @@ private:
 
   friend class DWARFUnit;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFCOMPILEUNIT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
@@ -13,6 +13,7 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/iterator_range.h"
 
+namespace lldb_private {
 class DWARFDIE : public DWARFBaseDIE {
 public:
   class child_iterator;
@@ -126,5 +127,6 @@ public:
     return *this;
   }
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDIE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAbbrev.h
@@ -17,6 +17,7 @@
 
 #include <map>
 
+namespace lldb_private {
 using DWARFAbbreviationDeclaration = llvm::DWARFAbbreviationDeclaration;
 using DWARFAbbreviationDeclarationSet = llvm::DWARFAbbreviationDeclarationSet;
 
@@ -51,5 +52,6 @@ protected:
   mutable DWARFAbbreviationDeclarationCollMapConstIter m_prev_abbr_offset_pos;
   mutable std::optional<llvm::DataExtractor> m_data;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGABBREV_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugArangeSet.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugArangeSet.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <vector>
 
+namespace lldb_private {
 class DWARFDebugArangeSet {
 public:
   struct Header {
@@ -62,5 +63,6 @@ protected:
   Header m_header;
   DescriptorColl m_arange_descriptors;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGARANGESET_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.h
@@ -13,6 +13,7 @@
 #include "lldb/Utility/RangeMap.h"
 #include "llvm/Support/Error.h"
 
+namespace lldb_private {
 class DWARFDebugAranges {
 protected:
   typedef lldb_private::RangeDataVector<dw_addr_t, uint32_t, dw_offset_t>
@@ -50,5 +51,6 @@ public:
 protected:
   RangeToDIE m_aranges;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGARANGES_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.h
@@ -21,7 +21,6 @@
 
 namespace lldb_private {
 class DWARFContext;
-}
 
 class DWARFDebugInfo {
 public:
@@ -80,5 +79,6 @@ private:
   DWARFDebugInfo(const DWARFDebugInfo &) = delete;
   const DWARFDebugInfo &operator=(const DWARFDebugInfo &) = delete;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGINFO_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
@@ -23,6 +23,7 @@
 
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
 
+namespace lldb_private {
 class DWARFDeclContext;
 
 #define DIE_SIBLING_IDX_BITSIZE 31
@@ -191,5 +192,6 @@ private:
   void GetAttributes(DWARFUnit *cu, DWARFAttributes &attrs, Recurse recurse,
                      uint32_t curr_depth) const;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGINFOENTRY_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugMacro.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugMacro.h
@@ -19,9 +19,6 @@
 namespace lldb_private {
 
 class DWARFDataExtractor;
-
-} // namespace lldb_private
-
 class SymbolFileDWARF;
 
 class DWARFDebugMacroHeader {
@@ -57,5 +54,6 @@ public:
                    SymbolFileDWARF *sym_file_dwarf,
                    lldb_private::DebugMacrosSP &debug_macros_sp);
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGMACRO_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugRanges.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugRanges.h
@@ -12,10 +12,9 @@
 #include "lldb/Core/dwarf.h"
 #include <map>
 
-class DWARFUnit;
 namespace lldb_private {
+class DWARFUnit;
 class DWARFContext;
-}
 
 class DWARFDebugRanges {
 public:
@@ -28,5 +27,6 @@ public:
 protected:
   std::map<dw_offset_t, DWARFRangeList> m_range_map;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGRANGES_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.cpp
@@ -9,6 +9,7 @@
 #include "DWARFDeclContext.h"
 
 using namespace lldb_private::dwarf;
+using namespace lldb_private;
 
 const char *DWARFDeclContext::GetQualifiedName() const {
   if (m_qualified_name.empty()) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+namespace lldb_private {
 // DWARFDeclContext
 //
 // A class that represents a declaration context all the way down to a
@@ -82,5 +83,6 @@ protected:
   collection m_entries;
   mutable std::string m_qualified_name;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDECLCONTEXT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.h
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <optional>
 
+namespace lldb_private {
 class DWARFUnit;
 class SymbolFileDWARF;
 class DWARFDIE;
@@ -84,7 +85,8 @@ protected:
   // It may be different from compile unit where m_value refers to.
   const DWARFUnit *m_unit = nullptr; // Unit for this form
   dw_form_t m_form = dw_form_t(0);   // Form for this value
-  ValueType m_value;            // Contains all data for the form
+  ValueType m_value;                 // Contains all data for the form
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFFORMVALUE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
@@ -17,10 +17,10 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Target/Statistics.h"
 
+namespace lldb_private {
 class DWARFDeclContext;
 class DWARFDIE;
 
-namespace lldb_private {
 class DWARFIndex {
 public:
   DWARFIndex(Module &module) : m_module(module) {}

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFTypeUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFTypeUnit.h
@@ -12,6 +12,8 @@
 #include "DWARFUnit.h"
 #include "llvm/Support/Error.h"
 
+namespace lldb_private {
+
 class DWARFTypeUnit : public DWARFUnit {
 public:
   void BuildAddressRangeTable(DWARFDebugAranges *debug_aranges) override {}
@@ -33,5 +35,6 @@ private:
 
   friend class DWARFUnit;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFTYPEUNIT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <optional>
 
+namespace lldb_private {
 class DWARFUnit;
 class DWARFCompileUnit;
 class NameToDIE;
@@ -101,6 +102,7 @@ public:
 
   class ScopedExtractDIEs {
     DWARFUnit *m_cu;
+
   public:
     bool m_clear_dies = false;
     ScopedExtractDIEs(DWARFUnit &cu);
@@ -224,7 +226,9 @@ public:
   uint8_t GetUnitType() const { return m_header.GetUnitType(); }
   bool IsTypeUnit() const { return m_header.IsTypeUnit(); }
   /// Note that this check only works for DWARF5+.
-  bool IsSkeletonUnit() const { return GetUnitType() == llvm::dwarf::DW_UT_skeleton; }
+  bool IsSkeletonUnit() const {
+    return GetUnitType() == llvm::dwarf::DW_UT_skeleton;
+  }
 
   std::optional<uint64_t> GetStringOffsetSectionItem(uint32_t index) const;
 
@@ -268,7 +272,6 @@ public:
   /// \returns
   ///   True if any DIEs match any tag in \a tags, false otherwise.
   bool HasAny(llvm::ArrayRef<dw_tag_t> tags);
-
 
   /// Get the fission .dwo file specific error for this compile unit.
   ///
@@ -348,9 +351,9 @@ protected:
   lldb_private::LazyBool m_is_optimized = lldb_private::eLazyBoolCalculate;
   std::optional<lldb_private::FileSpec> m_comp_dir;
   std::optional<lldb_private::FileSpec> m_file_spec;
-  std::optional<dw_addr_t> m_addr_base;  ///< Value of DW_AT_addr_base.
-  dw_addr_t m_loclists_base = 0;         ///< Value of DW_AT_loclists_base.
-  dw_addr_t m_ranges_base = 0;           ///< Value of DW_AT_rnglists_base.
+  std::optional<dw_addr_t> m_addr_base; ///< Value of DW_AT_addr_base.
+  dw_addr_t m_loclists_base = 0;        ///< Value of DW_AT_loclists_base.
+  dw_addr_t m_ranges_base = 0;          ///< Value of DW_AT_rnglists_base.
   std::optional<uint64_t> m_gnu_addr_base;
   std::optional<uint64_t> m_gnu_ranges_base;
 
@@ -387,5 +390,6 @@ private:
   DWARFUnit(const DWARFUnit &) = delete;
   const DWARFUnit &operator=(const DWARFUnit &) = delete;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFUNIT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.h
@@ -13,10 +13,10 @@
 #include "Plugins/SymbolFile/DWARF/NameToDIE.h"
 #include "llvm/ADT/DenseSet.h"
 
+namespace lldb_private {
 class DWARFDebugInfo;
 class SymbolFileDWARFDwo;
 
-namespace lldb_private {
 class ManualDWARFIndex : public DWARFIndex {
 public:
   ManualDWARFIndex(Module &module, SymbolFileDWARF &dwarf,

--- a/lldb/source/Plugins/SymbolFile/DWARF/NameToDIE.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/NameToDIE.h
@@ -16,6 +16,7 @@
 #include "lldb/Core/dwarf.h"
 #include "lldb/lldb-defines.h"
 
+namespace lldb_private {
 class DWARFUnit;
 
 class NameToDIE {
@@ -45,8 +46,7 @@ public:
 
   void
   ForEach(std::function<bool(lldb_private::ConstString name,
-                             const DIERef &die_ref)> const
-              &callback) const;
+                             const DIERef &die_ref)> const &callback) const;
 
   /// Decode a serialized version of this object from data.
   ///
@@ -89,5 +89,6 @@ public:
 protected:
   lldb_private::UniqueCStringMap<DIERef> m_map;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_NAMETODIE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -38,6 +38,7 @@
 #include "DWARFIndex.h"
 #include "UniqueDWARFASTType.h"
 
+namespace lldb_private {
 // Forward Declarations for this DWARF plugin
 class DebugMapModule;
 class DWARFCompileUnit;
@@ -53,7 +54,7 @@ class DWARFTypeUnit;
 class SymbolFileDWARFDebugMap;
 class SymbolFileDWARFDwo;
 class SymbolFileDWARFDwp;
-class UserID;
+struct UserID;
 
 #define DIE_IS_BEING_PARSED ((lldb_private::Type *)1)
 
@@ -339,7 +340,6 @@ public:
     m_file_index = file_index;
   }
 
-protected:
   typedef llvm::DenseMap<const DWARFDebugInfoEntry *, lldb_private::Type *>
       DIEToTypePtr;
   typedef llvm::DenseMap<const DWARFDebugInfoEntry *, lldb::VariableSP>
@@ -575,5 +575,6 @@ protected:
   /// an index that identifies the .DWO or .o file.
   std::optional<uint64_t> m_file_index;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_SYMBOLFILEDWARF_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -166,6 +166,7 @@ SymbolFileDWARFDebugMap::CompileUnitInfo::GetFileRangeMap(
   return file_range_map;
 }
 
+namespace lldb_private {
 class DebugMapModule : public Module {
 public:
   DebugMapModule(const ModuleSP &exe_module_sp, uint32_t cu_idx,
@@ -222,6 +223,7 @@ protected:
   ModuleWP m_exe_module_wp;
   const uint32_t m_cu_idx;
 };
+} // namespace lldb_private
 
 void SymbolFileDWARFDebugMap::Initialize() {
   PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -20,6 +20,7 @@
 
 #include "UniqueDWARFASTType.h"
 
+namespace lldb_private {
 class SymbolFileDWARF;
 class DWARFCompileUnit;
 class DWARFDebugAranges;
@@ -157,11 +158,17 @@ public:
   void GetCompileOptions(
       std::unordered_map<lldb::CompUnitSP, lldb_private::Args> &args) override;
 
+  lldb::TypeSP FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die);
+
+  lldb::TypeSP
+  FindCompleteObjCDefinitionTypeForDIE(const DWARFDIE &die,
+                                       lldb_private::ConstString type_name,
+                                       bool must_be_implementation);
+
 protected:
   enum { kHaveInitializedOSOs = (1 << 0), kNumFlags };
 
   friend class DebugMapModule;
-  friend class DWARFASTParserClang;
   friend class DWARFCompileUnit;
   friend class SymbolFileDWARF;
   struct OSOInfo {
@@ -292,13 +299,7 @@ protected:
 
   CompileUnitInfo *GetCompileUnitInfo(SymbolFileDWARF *oso_dwarf);
 
-  lldb::TypeSP FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die);
-
   bool Supports_DW_AT_APPLE_objc_complete_type(SymbolFileDWARF *skip_dwarf_oso);
-
-  lldb::TypeSP FindCompleteObjCDefinitionTypeForDIE(
-      const DWARFDIE &die, lldb_private::ConstString type_name,
-      bool must_be_implementation);
 
   UniqueDWARFASTTypeMap &GetUniqueDWARFASTTypeMap() {
     return m_unique_ast_type_map;
@@ -403,5 +404,6 @@ protected:
   size_t AddOSOARanges(SymbolFileDWARF *dwarf2Data,
                        DWARFDebugAranges *debug_aranges);
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_SYMBOLFILEDWARFDEBUGMAP_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
@@ -12,6 +12,7 @@
 #include "SymbolFileDWARF.h"
 #include <optional>
 
+namespace lldb_private {
 class SymbolFileDWARFDwo : public SymbolFileDWARF {
   /// LLVM RTTI support.
   static char ID;
@@ -65,9 +66,10 @@ protected:
   lldb::TypeSP
   FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die) override;
 
-  lldb::TypeSP FindCompleteObjCDefinitionTypeForDIE(
-      const DWARFDIE &die, lldb_private::ConstString type_name,
-      bool must_be_implementation) override;
+  lldb::TypeSP
+  FindCompleteObjCDefinitionTypeForDIE(const DWARFDIE &die,
+                                       lldb_private::ConstString type_name,
+                                       bool must_be_implementation) override;
 
   SymbolFileDWARF &GetBaseSymbolFile() const { return m_base_symbol_file; }
 
@@ -77,5 +79,6 @@ protected:
 
   SymbolFileDWARF &m_base_symbol_file;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_SYMBOLFILEDWARFDWO_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Core/Declaration.h"
 
 using namespace lldb_private::dwarf;
+using namespace lldb_private;
 
 bool UniqueDWARFASTTypeList::Find(const DWARFDIE &die,
                                   const lldb_private::Declaration &decl,

--- a/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.h
@@ -16,6 +16,7 @@
 #include "DWARFDIE.h"
 #include "lldb/Core/Declaration.h"
 
+namespace lldb_private {
 class UniqueDWARFASTType {
 public:
   // Constructors and Destructors
@@ -74,8 +75,7 @@ public:
 
   ~UniqueDWARFASTTypeMap() = default;
 
-  void Insert(lldb_private::ConstString name,
-              const UniqueDWARFASTType &entry) {
+  void Insert(lldb_private::ConstString name, const UniqueDWARFASTType &entry) {
     m_collection[name.GetCString()].Append(entry);
   }
 
@@ -95,5 +95,6 @@ protected:
   typedef llvm::DenseMap<const char *, UniqueDWARFASTTypeList> collection;
   collection m_collection;
 };
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_UNIQUEDWARFASTTYPE_H


### PR DESCRIPTION
I'm developing support for the Mojo language as an out-of-tree plugin, and in order to implement the DWARF AST parser, I need to export the DWARF-related symbols that the TypeSystem expects me to use.
I have CMake configured to export all the lldb_private symbols, so, in order get access to these DWARF symbols, I need to move them to the lldb_private namespace.
This change is very NFC, but I also made two other changes: 
- remove the virtual destructor from `DWARFExpression` which doesn't have virtual methods but was giving me linking issues
- remove the clang parser as friend of SymbolFileDWARF and simply make its protected methods public, as both the clang and the mojo parser need to access these functions.

After these changes I was able to do some basic dwarf processing in my plugin and make the type system happy.