### PR TITLE
[libc] Fix `nanosleep` definition in the posix spec

### DIFF
--- a/clang/lib/Headers/llvm_libc_wrappers/time.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/time.h
@@ -25,7 +25,7 @@
 
 _Static_assert(sizeof(clock_t) == sizeof(long), "ABI mismatch!");
 
-#include <llvm-libc-decls/ctype.h>
+#include <llvm-libc-decls/time.h>
 
 #pragma omp end declare target
 

--- a/libc/spec/posix.td
+++ b/libc/spec/posix.td
@@ -44,6 +44,7 @@ def ConstStructDirentPtrPtr : ConstType<StructDirentPtrPtr>;
 
 def StructTimeSpec : NamedType<"struct timespec">;
 def StructTimeSpecPtr : PtrType<StructTimeSpec>;
+def ConstStructTimeSpecPtr : ConstType<StructTimeSpecPtr>;
 
 def StructSchedParam : NamedType<"struct sched_param">;
 def StructSchedParamPtr : PtrType<StructSchedParam>;
@@ -1192,7 +1193,7 @@ def POSIX : StandardSpec<"POSIX"> {
           FunctionSpec<
               "nanosleep",
               RetValSpec<IntType>,
-              [ArgSpec<StructTimeSpecPtr>, ArgSpec<StructTimeSpecPtr>]
+              [ArgSpec<ConstStructTimeSpecPtr>, ArgSpec<StructTimeSpecPtr>]
           >,
       ]
   >;


### PR DESCRIPTION
Summary:
The POSIX standard expects the first argument to this function to be
constant, e.g. https://man7.org/linux/man-pages/man2/nanosleep.2.html.
This fixes that problem and also corrects an obvious problem with
enabling this for offloading.
