### PR TITLE
[LLD] [COFF] Don't look up relative paths to parent directories in the search paths

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -483,7 +483,10 @@ StringRef LinkerDriver::findFile(StringRef filename) {
     return filename;
   };
 
-  if (sys::path::is_absolute(filename))
+  bool hasParentDir = filename.starts_with("../") ||
+                      filename.starts_with("..\\") ||
+                      filename.contains("/../") || filename.contains("\\..\\");
+  if (sys::path::is_absolute(filename) || hasParentDir)
     return getFilename(filename);
   bool hasExt = filename.contains('.');
   for (StringRef dir : searchPaths) {

--- a/lld/test/COFF/relative_search_paths.test
+++ b/lld/test/COFF/relative_search_paths.test
@@ -2,3 +2,7 @@ We should be able to find libraries with relative search paths.
 # RUN: mkdir -p %t.dir/relative/path
 # RUN: cp %p/Inputs/std64.lib %t.dir/relative/path
 # RUN: lld-link %p/Inputs/hello64.obj /libpath:%t.dir relative/path/std64.lib /entry:main
+
+Check that we don't resolve file names like ../std64.lib relative to a libpath.
+# RUN: cp %p/Inputs/std64.lib %t.dir
+# RUN: not lld-link %p/Inputs/hello64.obj /libpath:%t.dir/relative ../std64.lib /entry:main


### PR DESCRIPTION
In b6c2f100c23bb715edbec57a4894f1ae551cd1d4, we allowed looking up relative paths within the search directories. This was done with the intention to allow resolving paths like <triple>/clang_rt.builtins.lib within a base search directory. However we shouldn't try to look up e.g. a path like ../../../../lib/libLLVMSupport.a in the search paths. In some cases, this could actually lead to accidental matches, for a file other than the one that was intended.

This should fix one aspect of #67779.