### PR TITLE
[libunwind][test] Avoid calling back into libunwind on sanitizer errors

### DIFF
--- a/libunwind/test/configs/apple-libunwind-backdeployment.cfg.in
+++ b/libunwind/test/configs/apple-libunwind-backdeployment.cfg.in
@@ -51,7 +51,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lc++ -lc++abi -lunwind'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --env DYLD_LIBRARY_PATH="%{cxx-runtime-root}:%{abi-runtime-root}:%{unwind-runtime-root}" -- '
+    f'%{{executor}} --execdir %T --env DYLD_LIBRARY_PATH="%{{cxx-runtime-root}}:%{{abi-runtime-root}}:%{{unwind-runtime-root}}"{config.extra_executor_env} -- '
 ))
 
 config.stdlib = 'apple-libc++'

--- a/libunwind/test/configs/cmake-bridge.cfg.in
+++ b/libunwind/test/configs/cmake-bridge.cfg.in
@@ -28,6 +28,14 @@ if @LIBUNWIND_USES_ARM_EHABI@:
 if not @LIBUNWIND_ENABLE_THREADS@:
     config.available_features.add('libunwind-no-threads')
 
+config.extra_executor_env = ""
+if "Memory" in getattr(config, "use_sanitizer", ""):
+    # Avoid calling back into libunwind if we detect a MSan error
+    config.extra_executor_env += " --env MSAN_OPTIONS=fast_unwind_on_fatal=1"
+if "Address" in getattr(config, "use_sanitizer", ""):
+    # Avoid calling back into libunwind if we detect an ASan error
+    config.extra_executor_env += " --env ASAN_OPTIONS=fast_unwind_on_fatal=1"
+
 # Add substitutions for bootstrapping the test suite configuration
 import shlex
 config.substitutions.append(('%{cxx}', shlex.quote('@CMAKE_CXX_COMPILER@')))

--- a/libunwind/test/configs/ibm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/ibm-libunwind-shared.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -lunwind -ldl -Wl,-bbigtoc'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --env LIBPATH=%{lib} -- '
+    f'%{{executor}} --execdir %T --env LIBPATH=%{{lib}}{config.extra_executor_env} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-merged.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-merged.cfg.in
@@ -32,7 +32,7 @@ config.substitutions.append(('%{link_flags}',
     '-L %{{lib}} -Wl,-rpath,%{{lib}} -lc++ {}'.format(' '.join(link_flags))
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    f'%{{executor}} --execdir %T{config.extra_executor_env}-- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-mingw.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-mingw.cfg.in
@@ -11,7 +11,7 @@ config.substitutions.append(('%{link_flags}',
     '-L %{lib} -lunwind'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T --prepend_env PATH=%{lib} -- '
+    f'%{{executor}} --execdir %T --prepend_env PATH=%{{lib}}{config.extra_executor_env} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-shared.cfg.in
@@ -31,7 +31,7 @@ config.substitutions.append(('%{link_flags}',
     '-L %{{lib}} -Wl,-rpath,%{{lib}} -lunwind {}'.format(' '.join(link_flags))
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    f'%{{executor}} --execdir %T{config.extra_executor_env} -- '
 ))
 
 import os, site

--- a/libunwind/test/configs/llvm-libunwind-static.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-static.cfg.in
@@ -34,7 +34,7 @@ config.substitutions.append(('%{link_flags}',
     '%{{lib}}/libunwind.a {}'.format(' '.join(link_flags))
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    f'%{{executor}} --execdir %T{config.extra_executor_env} -- '
 ))
 
 import os, site


### PR DESCRIPTION
The libunwind tests currently trigger MSan diagnostics, but while printing those diagnostics MSan calls back into libunwind to print a stack trace. And then this stack trace triggers another nested MSan fault which ends up recursing infinitely and overflowing the stack.

This change works around this by setting the fast_unwind_on_fatal=1 config option in the evironment for MSan and ASan.