### PR TITLE
[mlir][spirv] Implement missing validation rules for ptr variables

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMemoryOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMemoryOps.td
@@ -289,7 +289,9 @@ def SPIRV_PtrAccessChainOp : SPIRV_Op<"PtrAccessChain", [Pure]> {
     MinVersion<SPIRV_V_1_0>,
     MaxVersion<SPIRV_V_1_6>,
     Extension<[]>,
-    Capability<[SPIRV_C_Addresses, SPIRV_C_PhysicalStorageBufferAddresses, SPIRV_C_VariablePointers, SPIRV_C_VariablePointersStorageBuffer]>
+    Capability<[
+      SPIRV_C_Addresses, SPIRV_C_PhysicalStorageBufferAddresses,
+      SPIRV_C_VariablePointers, SPIRV_C_VariablePointersStorageBuffer]>
   ];
 
   let arguments = (ins
@@ -375,10 +377,15 @@ def SPIRV_VariableOp : SPIRV_Op<"Variable", []> {
     must be the `Function` Storage Class.
 
     Initializer is optional. If Initializer is present, it will be the
-    initial value of the variable’s memory content. Initializer must be an
+    initial value of the variable's memory content. Initializer must be an
     <id> from a constant instruction or a global (module scope) OpVariable
     instruction. Initializer must have the same type as the type pointed to
     by Result Type.
+
+    From `SPV_KHR_physical_storage_buffer`:
+    If an OpVariable's pointee type is a pointer (or array of pointers) in
+    PhysicalStorageBuffer storage class, then the variable must be decorated
+    with exactly one of AliasedPointer or RestrictPointer.
 
     <!-- End of AutoGen section -->
 
@@ -396,6 +403,9 @@ def SPIRV_VariableOp : SPIRV_Op<"Variable", []> {
 
     %1 = spirv.Variable : !spirv.ptr<f32, Function>
     %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
+
+    %3 = spirv.Variable {aliased_pointer} :
+      !spirv.ptr<!spirv.ptr<f32, PhysicalStorageBuffer>, Function>
     ```
   }];
 
@@ -407,6 +417,15 @@ def SPIRV_VariableOp : SPIRV_Op<"Variable", []> {
   let results = (outs
     SPIRV_AnyPtr:$pointer
   );
+
+  let extraClassDeclaration = [{
+    ::mlir::spirv::PointerType getPointerType() {
+      return ::llvm::cast<::mlir::spirv::PointerType>(getType());
+    }
+    ::mlir::Type getPointeeType() {
+      return getPointerType().getPointeeType();
+    }
+  }];
 }
 
 #endif // MLIR_DIALECT_SPIRV_IR_MEMORY_OPS

--- a/mlir/test/Dialect/SPIRV/IR/memory-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/memory-ops.mlir
@@ -525,6 +525,61 @@ spirv.module Logical GLSL450 {
 
 // -----
 
+func.func @variable_ptr_physical_buffer() -> () {
+  %0 = spirv.Variable {aliased_pointer} :
+    !spirv.ptr<!spirv.ptr<f32, PhysicalStorageBuffer>, Function>
+  %1 = spirv.Variable {restrict_pointer} :
+    !spirv.ptr<!spirv.ptr<f32, PhysicalStorageBuffer>, Function>
+  return
+}
+
+// -----
+
+func.func @variable_ptr_physical_buffer_no_decoration() -> () {
+  // expected-error @+1 {{must be decorated either 'AliasedPointer' or 'RestrictPointer'}}
+  %0 = spirv.Variable : !spirv.ptr<!spirv.ptr<f32, PhysicalStorageBuffer>, Function>
+  return
+}
+
+// -----
+
+func.func @variable_ptr_physical_buffer_two_alias_decorations() -> () {
+  // expected-error @+1 {{must have exactly one aliasing decoration}}
+  %0 = spirv.Variable {aliased_pointer, restrict_pointer} :
+    !spirv.ptr<!spirv.ptr<f32, PhysicalStorageBuffer>, Function>
+  return
+}
+
+// -----
+
+func.func @variable_ptr_array_physical_buffer() -> () {
+  %0 = spirv.Variable {aliased_pointer} :
+    !spirv.ptr<!spirv.array<4x!spirv.ptr<f32, PhysicalStorageBuffer>>, Function>
+  %1 = spirv.Variable {restrict_pointer} :
+    !spirv.ptr<!spirv.array<4x!spirv.ptr<f32, PhysicalStorageBuffer>>, Function>
+  return
+}
+
+// -----
+
+func.func @variable_ptr_physical_buffer_no_decoration() -> () {
+  // expected-error @+1 {{must be decorated either 'AliasedPointer' or 'RestrictPointer'}}
+  %0 = spirv.Variable :
+    !spirv.ptr<!spirv.array<4x!spirv.ptr<f32, PhysicalStorageBuffer>>, Function>
+  return
+}
+
+// -----
+
+func.func @variable_ptr_physical_buffer_two_alias_decorations() -> () {
+  // expected-error @+1 {{must have exactly one aliasing decoration}}
+  %0 = spirv.Variable {aliased_pointer, restrict_pointer} :
+    !spirv.ptr<!spirv.array<4x!spirv.ptr<f32, PhysicalStorageBuffer>>, Function>
+  return
+}
+
+// -----
+
 func.func @variable_bind() -> () {
   // expected-error @+1 {{cannot have 'descriptor_set' attribute (only allowed in spirv.GlobalVariable)}}
   %0 = spirv.Variable bind(1, 2) : !spirv.ptr<f32, Function>

--- a/mlir/test/Dialect/SPIRV/IR/memory-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/memory-ops.mlir
@@ -562,7 +562,7 @@ func.func @variable_ptr_array_physical_buffer() -> () {
 
 // -----
 
-func.func @variable_ptr_physical_buffer_no_decoration() -> () {
+func.func @variable_ptr_array_physical_buffer_no_decoration() -> () {
   // expected-error @+1 {{must be decorated either 'AliasedPointer' or 'RestrictPointer'}}
   %0 = spirv.Variable :
     !spirv.ptr<!spirv.array<4x!spirv.ptr<f32, PhysicalStorageBuffer>>, Function>
@@ -571,7 +571,7 @@ func.func @variable_ptr_physical_buffer_no_decoration() -> () {
 
 // -----
 
-func.func @variable_ptr_physical_buffer_two_alias_decorations() -> () {
+func.func @variable_ptr_array_physical_buffer_two_alias_decorations() -> () {
   // expected-error @+1 {{must have exactly one aliasing decoration}}
   %0 = spirv.Variable {aliased_pointer, restrict_pointer} :
     !spirv.ptr<!spirv.array<4x!spirv.ptr<f32, PhysicalStorageBuffer>>, Function>


### PR DESCRIPTION
Variables that point to physical storage buffer require aliasing decorations. This is specified by the `SPV_KHR_physical_storage_buffer` extension.

Also add an example of a variable with a decoration attribute.