### PR TITLE
[Support] Redefine endianness::native

### DIFF
--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -24,7 +24,11 @@
 namespace llvm {
 namespace support {
 
-enum endianness {big, little, native};
+enum endianness {
+  big,
+  little,
+  native = llvm::sys::IsBigEndianHost ? big : little
+};
 
 // These are named values for common alignments.
 enum {aligned = 0, unaligned = 1};
@@ -47,7 +51,7 @@ constexpr endianness system_endianness() {
 
 template <typename value_type>
 [[nodiscard]] inline value_type byte_swap(value_type value, endianness endian) {
-  if ((endian != native) && (endian != system_endianness()))
+  if (endian != native)
     sys::swapByteOrder(value);
   return value;
 }

--- a/llvm/include/llvm/Support/HashBuilder.h
+++ b/llvm/include/llvm/Support/HashBuilder.h
@@ -86,15 +86,8 @@ private:
 };
 
 /// Implementation of the `HashBuilder` interface.
-///
-/// `support::endianness::native` is not supported. `HashBuilder` is
-/// expected to canonicalize `support::endianness::native` to one of
-/// `support::endianness::big` or `support::endianness::little`.
 template <typename HasherT, support::endianness Endianness>
 class HashBuilderImpl : public HashBuilderBase<HasherT> {
-  static_assert(Endianness != support::endianness::native,
-                "HashBuilder should canonicalize endianness");
-
 public:
   explicit HashBuilderImpl(HasherT &Hasher)
       : HashBuilderBase<HasherT>(Hasher) {}
@@ -395,10 +388,7 @@ private:
 /// Specifiying a non-`native` `Endianness` template parameter allows to compute
 /// stable hash across platforms with different endianness.
 template <class HasherT, support::endianness Endianness>
-using HashBuilder =
-    HashBuilderImpl<HasherT, (Endianness == support::endianness::native
-                                  ? support::endian::system_endianness()
-                                  : Endianness)>;
+using HashBuilder = HashBuilderImpl<HasherT, Endianness>;
 
 namespace hashbuilder_detail {
 class HashCodeHasher {

--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -306,7 +306,6 @@ void writeImmediate(WritableArmRelocation &R, uint32_t Imm) {
 
 Expected<int64_t> readAddendData(LinkGraph &G, Block &B, const Edge &E) {
   support::endianness Endian = G.getEndianness();
-  assert(Endian != support::native && "Declare as little or big explicitly");
 
   Edge::Kind Kind = E.getKind();
   const char *BlockWorkingMem = B.getContent().data();
@@ -404,7 +403,6 @@ Error applyFixupData(LinkGraph &G, Block &B, const Edge &E) {
   char *FixupPtr = BlockWorkingMem + E.getOffset();
 
   auto Write32 = [FixupPtr, Endian = G.getEndianness()](int64_t Value) {
-    assert(Endian != native && "Must be explicit: little or big");
     assert(isInt<32>(Value) && "Must be in signed 32-bit range");
     uint32_t Imm = static_cast<int32_t>(Value);
     if (LLVM_LIKELY(Endian == little))


### PR DESCRIPTION
We should eventually migrate llvm::support::endianness to std::endian
when C++20 is available for the codebase.

This patch prepares our codebase for that future by removing the
assumption that native is a unique value different from both big and
little.  Note that in C++20, native is equal to either big or little
on typical machines, where the endianness is the same for all scalar
types.
