### PR TITLE
[SimplifyCFG] Improve range reducing for switches

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -82,6 +82,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <optional>
 #include <set>
@@ -7158,6 +7159,71 @@ static bool switchToLookupTable(SwitchInst *SI, IRBuilder<> &Builder,
   return true;
 }
 
+/// Try to reduce the range of cases with an unreachable default.
+static bool
+ReduceSwitchRangeWithUnreachableDefault(SwitchInst *SI,
+                                        const SmallVectorImpl<int64_t> &Values,
+                                        uint64_t Base, IRBuilder<> &Builder) {
+  bool HasDefault =
+      !isa<UnreachableInst>(SI->getDefaultDest()->getFirstNonPHIOrDbg());
+  if (HasDefault)
+    return false;
+
+  // Try reducing the range to (idx + offset) & mask
+  // Mask out common high bits
+  uint64_t CommonOnes = std::numeric_limits<uint64_t>::max();
+  uint64_t CommonZeros = std::numeric_limits<uint64_t>::max();
+  for (auto &V : Values) {
+    CommonOnes &= (uint64_t)V;
+    CommonZeros &= ~(uint64_t)V;
+  }
+  uint64_t CommonBits = countl_one(CommonOnes | CommonZeros);
+  unsigned LowBits = 64 - CommonBits;
+  uint64_t Mask = (1ULL << LowBits) - 1;
+  if (Mask == std::numeric_limits<uint64_t>::max())
+    return false;
+  // Now we have some case values in the additive group Z/(2**k)Z.
+  // Find the largest hole in the group and move it to back.
+  uint64_t MaxHole = 0;
+  uint64_t BestOffset = 0;
+  for (unsigned I = 0; I < Values.size(); ++I) {
+    uint64_t Hole = ((uint64_t)Values[I] -
+                     (uint64_t)(I == 0 ? Values.back() : Values[I - 1])) &
+                    Mask;
+    if (Hole > MaxHole) {
+      MaxHole = Hole;
+      BestOffset = Mask - (uint64_t)Values[I] + 1;
+    }
+  }
+
+  SmallVector<int64_t, 4> NewValues;
+  for (auto &V : Values)
+    NewValues.push_back(
+        (((int64_t)(((uint64_t)V + BestOffset) & Mask)) << CommonBits) >>
+        CommonBits);
+
+  llvm::sort(NewValues);
+  if (!isSwitchDense(NewValues))
+    // Transform didn't create a dense switch.
+    return false;
+
+  auto *Ty = cast<IntegerType>(SI->getCondition()->getType());
+  APInt Offset(Ty->getBitWidth(), BestOffset - Base);
+  auto *Index = Builder.CreateAnd(
+      Builder.CreateAdd(SI->getCondition(), ConstantInt::get(Ty, Offset)),
+      Mask);
+  SI->replaceUsesOfWith(SI->getCondition(), Index);
+
+  for (auto Case : SI->cases()) {
+    auto *Orig = Case.getCaseValue();
+    auto CaseVal =
+        (Orig->getValue() + Offset).trunc(LowBits).sext(Ty->getBitWidth());
+    Case.setValue(cast<ConstantInt>(ConstantInt::get(Ty, CaseVal)));
+  }
+
+  return true;
+}
+
 /// Try to transform a switch that has "holes" in it to a contiguous sequence
 /// of cases.
 ///
@@ -7173,9 +7239,8 @@ static bool reduceSwitchRange(SwitchInst *SI, IRBuilder<> &Builder,
   if (CondTy->getIntegerBitWidth() > 64 ||
       !DL.fitsInLegalInteger(CondTy->getIntegerBitWidth()))
     return false;
-  // Only bother with this optimization if there are more than 3 switch cases;
-  // SDAG will only bother creating jump tables for 4 or more cases.
-  if (SI->getNumCases() < 4)
+  // Ignore switches with less than three cases.
+  if (SI->getNumCases() < 3)
     return false;
 
   // This transform is agnostic to the signedness of the input or case values. We
@@ -7195,6 +7260,9 @@ static bool reduceSwitchRange(SwitchInst *SI, IRBuilder<> &Builder,
   int64_t Base = Values[0];
   for (auto &V : Values)
     V -= (uint64_t)(Base);
+
+  if (ReduceSwitchRangeWithUnreachableDefault(SI, Values, Base, Builder))
+    return true;
 
   // Now we have signed numbers that have been shifted so that, given enough
   // precision, there are no negative values. Since the rest of the transform

--- a/llvm/test/Transforms/SimplifyCFG/RISCV/switch-of-powers-of-two.ll
+++ b/llvm/test/Transforms/SimplifyCFG/RISCV/switch-of-powers-of-two.ll
@@ -157,22 +157,10 @@ return:
 define i32 @unable_to_create_dense_switch(i32 %x) {
 ; CHECK-LABEL: @unable_to_create_dense_switch(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    switch i32 [[X:%.*]], label [[DEFAULT_CASE:%.*]] [
-; CHECK-NEXT:      i32 1, label [[RETURN:%.*]]
-; CHECK-NEXT:      i32 2, label [[BB3:%.*]]
-; CHECK-NEXT:      i32 4, label [[BB4:%.*]]
-; CHECK-NEXT:      i32 4096, label [[BB5:%.*]]
-; CHECK-NEXT:    ]
-; CHECK:       default_case:
-; CHECK-NEXT:    unreachable
-; CHECK:       bb3:
-; CHECK-NEXT:    br label [[RETURN]]
-; CHECK:       bb4:
-; CHECK-NEXT:    br label [[RETURN]]
-; CHECK:       bb5:
-; CHECK-NEXT:    br label [[RETURN]]
-; CHECK:       return:
-; CHECK-NEXT:    [[P:%.*]] = phi i32 [ 1, [[BB3]] ], [ 0, [[BB4]] ], [ 42, [[BB5]] ], [ 2, [[ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP0:%.*]] = add i32 [[X:%.*]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[TMP0]], 4095
+; CHECK-NEXT:    [[SWITCH_GEP:%.*]] = getelementptr inbounds [5 x i32], ptr @switch.table.unable_to_create_dense_switch, i32 0, i32 [[TMP1]]
+; CHECK-NEXT:    [[P:%.*]] = load i32, ptr [[SWITCH_GEP]], align 4
 ; CHECK-NEXT:    ret i32 [[P]]
 ;
 entry:
@@ -200,11 +188,13 @@ declare i32 @bar(i32)
 define i32 @unable_to_generate_lookup_table(i32 %x, i32 %y) {
 ; RV64I-LABEL: @unable_to_generate_lookup_table(
 ; RV64I-NEXT:  entry:
-; RV64I-NEXT:    switch i32 [[Y:%.*]], label [[DEFAULT_CASE:%.*]] [
+; RV64I-NEXT:    [[TMP0:%.*]] = add i32 [[Y1:%.*]], 0
+; RV64I-NEXT:    [[Y:%.*]] = and i32 [[TMP0]], 63
+; RV64I-NEXT:    switch i32 [[Y]], label [[DEFAULT_CASE:%.*]] [
 ; RV64I-NEXT:      i32 1, label [[BB2:%.*]]
 ; RV64I-NEXT:      i32 2, label [[BB3:%.*]]
 ; RV64I-NEXT:      i32 8, label [[BB4:%.*]]
-; RV64I-NEXT:      i32 64, label [[BB5:%.*]]
+; RV64I-NEXT:      i32 0, label [[BB5:%.*]]
 ; RV64I-NEXT:    ]
 ; RV64I:       default_case:
 ; RV64I-NEXT:    unreachable

--- a/llvm/test/Transforms/SimplifyCFG/rangereduce.ll
+++ b/llvm/test/Transforms/SimplifyCFG/rangereduce.ll
@@ -369,9 +369,9 @@ define i8 @reduce_masked_common_high_bits_fail(i32 %0) {
 ; CHECK-LABEL: @reduce_masked_common_high_bits_fail(
 ; CHECK-NEXT:  start:
 ; CHECK-NEXT:    switch i32 [[TMP0:%.*]], label [[BB2:%.*]] [
-; CHECK-NEXT:    i32 128, label [[BB5:%.*]]
-; CHECK-NEXT:    i32 129, label [[BB4:%.*]]
-; CHECK-NEXT:    i32 511, label [[BB1:%.*]]
+; CHECK-NEXT:      i32 128, label [[BB5:%.*]]
+; CHECK-NEXT:      i32 129, label [[BB4:%.*]]
+; CHECK-NEXT:      i32 511, label [[BB1:%.*]]
 ; CHECK-NEXT:    ]
 ; CHECK:       bb2:
 ; CHECK-NEXT:    unreachable
@@ -409,19 +409,18 @@ define i8 @reduce_masked_default_reachable(i32 %0) {
 ; CHECK-LABEL: @reduce_masked_default_reachable(
 ; CHECK-NEXT:  start:
 ; CHECK-NEXT:    switch i32 [[TMP0:%.*]], label [[COMMON_RET:%.*]] [
-; CHECK-NEXT:    i32 0, label [[BB5:%.*]]
-; CHECK-NEXT:    i32 1, label [[BB4:%.*]]
-; CHECK-NEXT:    i32 255, label [[BB1:%.*]]
+; CHECK-NEXT:      i32 0, label [[BB5:%.*]]
+; CHECK-NEXT:      i32 1, label [[BB4:%.*]]
+; CHECK-NEXT:      i32 255, label [[BB1:%.*]]
 ; CHECK-NEXT:    ]
 ; CHECK:       common.ret:
-; CHECK-NEXT:    [[COMMON_RET_OP:%.*]] = phi i8 [ [[DOT0:%.*]], [[BB5]] ], [ 24, [[START:%.*]] ]
+; CHECK-NEXT:    [[COMMON_RET_OP:%.*]] = phi i8 [ 24, [[START:%.*]] ], [ -1, [[BB1]] ], [ 1, [[BB4]] ], [ 0, [[BB5]] ]
 ; CHECK-NEXT:    ret i8 [[COMMON_RET_OP]]
 ; CHECK:       bb4:
-; CHECK-NEXT:    br label [[BB5]]
+; CHECK-NEXT:    br label [[COMMON_RET]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    br label [[BB5]]
+; CHECK-NEXT:    br label [[COMMON_RET]]
 ; CHECK:       bb5:
-; CHECK-NEXT:    [[DOT0]] = phi i8 [ -1, [[BB1]] ], [ 1, [[BB4]] ], [ 0, [[START]] ]
 ; CHECK-NEXT:    br label [[COMMON_RET]]
 ;
 start:


### PR DESCRIPTION
This patch improves range reducing for switches when the default block is unreachable.
It will mask out the common high bits and move the largest hole to the back.

Example:
```
int f1(int x) {
  switch (x) {
    case 0: return 1;
    case 1: return 2;
    case 255: return 0;
    default: __builtin_unreachable();
  }
}
```
after range reduction:
```
int f1(int x) {
  switch ((x + 1) & 255) {
    case 1: return 1;
    case 2: return 2;
    case 0: return 0;
    default: __builtin_unreachable();
  }
}
```

Fixes #67842.