### PR TITLE
[clang][Interp] Fix `ArrayInitLoopExpr` handling

### DIFF
--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -827,6 +827,7 @@ bool ByteCodeExprGen<Emitter>::VisitArrayInitLoopExpr(
   // where the LHS is on the stack (the target array)
   // and the RHS is our SubExpr.
   for (size_t I = 0; I != Size; ++I) {
+    BlockScope<Emitter> Scope(this);
     ArrayIndexScope<Emitter> IndexScope(this, I);
 
     if (ElemT) {

--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -887,7 +887,7 @@ bool ByteCodeExprGen<Emitter>::VisitOpaqueValueExpr(const OpaqueValueExpr *E) {
       return false;
   }
 
-  // FIXME: Ideally the cached value should be cleaned up later.
+  // This is cleaned up when the local variable is destroyed.
   OpaqueExprs.insert({E, *LocalIndex});
 
   return true;

--- a/clang/test/AST/Interp/cxx20.cpp
+++ b/clang/test/AST/Interp/cxx20.cpp
@@ -701,13 +701,12 @@ namespace ThreeWayCmp {
   static_assert(pa2 <=> pa1 == 1, "");
 }
 
-// FIXME: Interp should also be able to evaluate this snippet properly.
 namespace ConstexprArrayInitLoopExprDestructors
 {
   struct Highlander {
       int *p = 0;
       constexpr Highlander() {}
-      constexpr void set(int *p) { this->p = p; ++*p; if (*p != 1) throw "there can be only one"; } // expected-note {{not valid in a constant expression}}
+      constexpr void set(int *p) { this->p = p; ++*p; if (*p != 1) throw "there can be only one"; }
       constexpr ~Highlander() { --*p; }
   };
 
@@ -715,19 +714,18 @@ namespace ConstexprArrayInitLoopExprDestructors
       int *p;
       constexpr X(int *p) : p(p) {}
       constexpr X(const X &x, Highlander &&h = Highlander()) : p(x.p) {
-          h.set(p); // expected-note {{in call to '&Highlander()->set(&n)'}}
+          h.set(p);
       }
   };
 
   constexpr int f() {
       int n = 0;
       X x[3] = {&n, &n, &n};
-      auto [a, b, c] = x; // expected-note {{in call to 'X(x[0], Highlander())'}}
+      auto [a, b, c] = x;
       return n;
   }
 
-  static_assert(f() == 0); // expected-error {{not an integral constant expression}} \
-                           // expected-note {{in call to 'f()'}}
+  static_assert(f() == 0);
 
   int main() {
       return f();


### PR DESCRIPTION
This patch implements the changes from #67722 in Interp. 