### PR TITLE
[clang] [MinGW] Tolerate mingw specific linker options during compilation

### DIFF
--- a/clang/lib/Driver/ToolChains/MinGW.cpp
+++ b/clang/lib/Driver/ToolChains/MinGW.cpp
@@ -709,8 +709,11 @@ void toolchains::MinGW::addClangTargetOptions(
     }
   }
 
-  if (Arg *A = DriverArgs.getLastArgNoClaim(options::OPT_mthreads))
-    A->ignoreTargetSpecific();
+  for (auto Opt : {options::OPT_mthreads, options::OPT_mwindows,
+                   options::OPT_mconsole, options::OPT_mdll}) {
+    if (Arg *A = DriverArgs.getLastArgNoClaim(Opt))
+      A->ignoreTargetSpecific();
+  }
 }
 
 void toolchains::MinGW::AddClangCXXStdlibIncludeArgs(

--- a/clang/test/Driver/mingw-linker-options.c
+++ b/clang/test/Driver/mingw-linker-options.c
@@ -1,0 +1,10 @@
+// RUN: %clang --target=x86_64-windows-gnu -c -mwindows %s -### 2>&1 | FileCheck %s --check-prefix=WARNING
+// RUN: %clang --target=x86_64-windows-gnu -c -mconsole %s -### 2>&1 | FileCheck %s --check-prefix=WARNING
+// RUN: %clang --target=x86_64-windows-gnu -c -mdll %s -### 2>&1 | FileCheck %s --check-prefix=WARNING
+// RUN: %clang --target=x86_64-windows-gnu -c -mthreads %s -### 2>&1 | FileCheck %s --check-prefix=WARNING
+// RUN: not %clang --target=x86_64-windows-msvc -c -mwindows %s -### 2>&1 | FileCheck %s --check-prefix=ERROR
+// RUN: not %clang --target=x86_64-windows-msvc -c -mconsole %s -### 2>&1 | FileCheck %s --check-prefix=ERROR
+// RUN: not %clang --target=x86_64-windows-msvc -c -mdll %s -### 2>&1 | FileCheck %s --check-prefix=ERROR
+// RUN: not %clang --target=x86_64-windows-msvc -c -mthreads %s -### 2>&1 | FileCheck %s --check-prefix=ERROR
+// WARNING: warning: argument unused during compilation: '{{.*}}' [-Wunused-command-line-argument]
+// ERROR: error: unsupported option '{{.*}}' for target '{{.*}}'


### PR DESCRIPTION
Prior to 591c4b64b3650884c2c68eb47d755ebb62981b99, the mingw specific linker options -mthreads, -mconsole, -mwindows and -mdll would be tolerated also at compile time, but generating a warning about being unused.

After that commit, they were marked as target specific, which means that it's an error if they're unused (which would consider them used for the wrong target). These specific options are only relevant when linking, but we want to tolerate them at compile time too, like before.

This was fixed for -mthreads in
a79995ca6004082774a87f7a58ab6be5343364b7, while the other options didn't seem to be commonly used during compilation.

After the 17.x release, we've got more reports about this actually being an issue, in #64464. Therefore, apply the same fix for them; marking them as tolerated for mingw targets during compilation, even if they're unused. Also add a testcase for -mthreads which was already handled.

Thus, this fixes #64464.