### PR TITLE
[AArch64] Disable loop alignment for Windows targets

### DIFF
--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -1402,6 +1402,9 @@ static void ARM64EmitUnwindInfo(MCStreamer &streamer, WinEH::FrameInfo *info,
     // here, but we'd have to emit the pdata, the xdata header, and the
     // epilogue scopes later, since they depend on whether the we need to
     // split the unwind data.
+    //
+    // If this is fixed, remove code in AArch64ISelLowering.cpp that
+    // disables loop alignment on Windows.
     RawFuncLength = GetAbsDifference(streamer, info->FuncletOrFuncEnd,
                                      info->Begin);
   }

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -1051,7 +1051,12 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
   // Set required alignment.
   setMinFunctionAlignment(Align(4));
   // Set preferred alignments.
-  setPrefLoopAlignment(STI.getPrefLoopAlignment());
+
+  // Don't align loops on Windows. The SEH unwind info generation needs to
+  // know the exact length of functions before the alignments have been
+  // expanded.
+  if (!Subtarget->isTargetWindows())
+    setPrefLoopAlignment(STI.getPrefLoopAlignment());
   setMaxBytesForAlignment(STI.getMaxBytesForLoopAlignment());
   setPrefFunctionAlignment(STI.getPrefFunctionAlignment());
 

--- a/llvm/test/CodeGen/AArch64/sched-loop-align.ll
+++ b/llvm/test/CodeGen/AArch64/sched-loop-align.ll
@@ -1,0 +1,21 @@
+; RUN: llc < %s -mtriple=aarch64-windows | FileCheck %s --check-prefix=WINDOWS
+; RUN: llc < %s -mtriple=aarch64-linux | FileCheck %s --check-prefix=LINUX
+
+define dso_local void @b() #0 {
+entry:
+  br label %for.cond
+
+for.cond:
+  tail call void @a()
+  br label %for.cond
+}
+
+declare dso_local void @a(...)
+
+attributes #0 = { noreturn nounwind uwtable "tune-cpu"="cortex-a53" }
+
+; LINUX-LABEL: b:
+; LINUX: .p2align 4
+
+; WINDOWS-LABEL: b:
+; WINDOWS-NOT: .p2align


### PR DESCRIPTION
This should fix #66912. When emitting SEH unwind info, we need to be able to calculate the exact length of functions before alignments are fixed. Until that limitation is overcome, just disable all loop alignment on Windows targets.