### PR TITLE
[lit] Fix shell commands with newlines

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -55,7 +55,7 @@ kDevNull = "/dev/null"
 #
 # COMMAND that follows %dbg(ARG) is also captured. COMMAND can be
 # empty as a result of conditinal substitution.
-kPdbgRegex = "%dbg\\(([^)'\"]*)\\)(.*)"
+kPdbgRegex = "%dbg\\(([^)'\"]*)\\)((?:.|\\n)*)"
 
 
 def buildPdbgCommand(msg, cmd):

--- a/llvm/utils/lit/tests/Inputs/shtest-inject/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-inject/lit.cfg
@@ -1,6 +1,7 @@
 import lit
 
-preamble_commands = ['echo "THIS WAS"', 'echo "INJECTED"']
+# Check multiple commands, and check newlines.
+preamble_commands = ['echo "THIS WAS"', 'echo\n"INJECTED"']
 
 config.name = "shtest-inject"
 config.suffixes = [".txt"]

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/lit.local.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/lit.local.cfg
@@ -1,3 +1,8 @@
 import lit.formats
 
 config.test_format = lit.formats.ShTest(execute_external=True)
+config.substitutions.append(("%{cmds-with-newlines}", """
+true &&
+echo abc |
+FileCheck %s
+"""))

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/lit.local.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/lit.local.cfg
@@ -2,7 +2,7 @@ import lit.formats
 
 config.test_format = lit.formats.ShTest(execute_external=True)
 config.substitutions.append(("%{cmds-with-newlines}", """
-true &&
 echo abc |
-FileCheck %s
+FileCheck %s &&
+false
 """))

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/run-line-with-newline.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/run-line-with-newline.txt
@@ -1,2 +1,2 @@
 # RUN: %{cmds-with-newlines}
-# CHECK: bac
+# CHECK: abc

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/run-line-with-newline.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/run-line-with-newline.txt
@@ -1,0 +1,2 @@
+# RUN: %{cmds-with-newlines}
+# CHECK: bac

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/lit.local.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/lit.local.cfg
@@ -1,3 +1,8 @@
 import lit.formats
 
 config.test_format = lit.formats.ShTest(execute_external=False)
+config.substitutions.append(("%{cmds-with-newlines}", """
+true &&
+echo abc |
+FileCheck %s
+"""))

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/lit.local.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/lit.local.cfg
@@ -2,7 +2,7 @@ import lit.formats
 
 config.test_format = lit.formats.ShTest(execute_external=False)
 config.substitutions.append(("%{cmds-with-newlines}", """
-true &&
 echo abc |
-FileCheck %s
+FileCheck %s &&
+false
 """))

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/run-line-with-newline.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/run-line-with-newline.txt
@@ -1,2 +1,2 @@
 # RUN: %{cmds-with-newlines}
-# CHECK: bac
+# CHECK: abc

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/run-line-with-newline.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/internal-shell/run-line-with-newline.txt
@@ -1,0 +1,2 @@
+# RUN: %{cmds-with-newlines}
+# CHECK: bac

--- a/llvm/utils/lit/tests/shtest-inject.py
+++ b/llvm/utils/lit/tests/shtest-inject.py
@@ -14,7 +14,8 @@
 #  CHECK-TEST1-NEXT: # | THIS WAS
 #  CHECK-TEST1-NEXT: # `---{{-*}}
 #  CHECK-TEST1-NEXT: # preamble command line
-#  CHECK-TEST1-NEXT: echo "INJECTED"
+#  CHECK-TEST1-NEXT: echo
+#  CHECK-TEST1-NEXT: "INJECTED"
 #  CHECK-TEST1-NEXT: # executed command: echo INJECTED
 #  CHECK-TEST1-NEXT: # .---command stdout{{-*}}
 #  CHECK-TEST1-NEXT: # | INJECTED

--- a/llvm/utils/lit/tests/shtest-run-at-line.py
+++ b/llvm/utils/lit/tests/shtest-run-at-line.py
@@ -7,7 +7,7 @@
 # END.
 
 
-# CHECK: Testing: 6 tests
+# CHECK: Testing: 8 tests
 
 
 # In the case of the external shell, we check for only RUN lines in stderr in
@@ -48,6 +48,15 @@
 #   CHECK-NOT: RUN
 #       CHECK: --
 
+# CHECK-LABEL: FAIL: shtest-run-at-line :: external-shell/run-line-with-newline.txt
+
+#      CHECK: Command Output (stderr)
+# CHECK-NEXT: --
+# CHECK-NEXT: {{^}}RUN: at line 1: true &&
+# CHECK-NEXT: echo abc |
+# CHECK-NEXT: FileCheck {{.*}}
+#  CHECK-NOT: RUN
+
 
 # CHECK-LABEL: FAIL: shtest-run-at-line :: internal-shell/basic.txt
 
@@ -87,3 +96,16 @@
 # CHECK-NEXT: # executed command: echo 'foo baz'
 # CHECK-NEXT: # executed command: FileCheck {{.*}}
 # CHECK-NOT:  RUN
+
+# CHECK-LABEL: FAIL: shtest-run-at-line :: internal-shell/run-line-with-newline.txt
+
+#      CHECK: Command Output (stdout)
+# CHECK-NEXT: --
+# CHECK-NEXT: # RUN: at line 1
+# CHECK-NEXT: true &&
+# CHECK-NEXT: echo abc |
+# CHECK-NEXT: FileCheck {{.*}}
+# CHECK-NEXT: # executed command: true
+# CHECK-NEXT: # executed command: echo abc
+# CHECK-NEXT: # executed command: FileCheck {{.*}}
+#  CHECK-NOT: RUN

--- a/llvm/utils/lit/tests/shtest-run-at-line.py
+++ b/llvm/utils/lit/tests/shtest-run-at-line.py
@@ -52,9 +52,9 @@
 
 #      CHECK: Command Output (stderr)
 # CHECK-NEXT: --
-# CHECK-NEXT: {{^}}RUN: at line 1: true &&
-# CHECK-NEXT: echo abc |
-# CHECK-NEXT: FileCheck {{.*}}
+# CHECK-NEXT: {{^}}RUN: at line 1: echo abc |
+# CHECK-NEXT: FileCheck {{.*}} &&
+# CHECK-NEXT: false
 #  CHECK-NOT: RUN
 
 
@@ -102,10 +102,10 @@
 #      CHECK: Command Output (stdout)
 # CHECK-NEXT: --
 # CHECK-NEXT: # RUN: at line 1
-# CHECK-NEXT: true &&
 # CHECK-NEXT: echo abc |
-# CHECK-NEXT: FileCheck {{.*}}
-# CHECK-NEXT: # executed command: true
+# CHECK-NEXT: FileCheck {{.*}} &&
+# CHECK-NEXT: false
 # CHECK-NEXT: # executed command: echo abc
 # CHECK-NEXT: # executed command: FileCheck {{.*}}
+# CHECK-NEXT: # executed command: false
 #  CHECK-NOT: RUN


### PR DESCRIPTION
In PR #65242 (landed as 9e739fdb85ac672f3e25e971d96e71823e07ebda), I claimed that RUN lines cannot contain newlines.  Actually, they can after substitution expansion.  More generally, a lit config file can define substitutions or preamble commands containing newlines.  While both of those cases seem unlikely in practice,
[D154987](https://reviews.llvm.org/D154987) proposes PYTHON directives where it seems very likely.

Regardless of the use case, without this patch, such newlines break expansion of `%dbg(RUN: at line N)`, and the fix is simple.