### PR TITLE
[LangRef] Refine header for "Preserving DI Intrinsics" section

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -29969,7 +29969,7 @@ Preserving Debug Information Intrinsics
 These intrinsics are used to carry certain debuginfo together with
 IR-level operations. For example, it may be desirable to
 know the structure/union name and the original user-level field
-indices. Such information got lost in IR GetElementPtr instruction
+indices. Such information gets lost in IR GetElementPtr instruction
 since the IR types are different from debugInfo types and unions
 are converted to structs in IR.
 


### PR DESCRIPTION
Prior to this change, the "Preserving DI Intrinsics" section was incorrectly headered, causing the documentation about BPF DI preserving intrinsics to be misplaced under the "Objective-C ARC Runtime Intrinsics" section in the document hierarchy.

This change corrects the header for the "Preserving DI Intrinsics" section, ensuring it is properly placed within the documentation hierarchy as its own distinct section.