### PR TITLE
[libc++] Add std::fpclassify overloads for floating-point.

### DIFF
--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -387,8 +387,16 @@ namespace __math {
 
 // fpclassify
 
-template <class _A1, std::__enable_if_t<std::is_floating_point<_A1>::value, int> = 0>
-_LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(_A1 __x) _NOEXCEPT {
+_LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(float __x) _NOEXCEPT {
+  return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+}
+
+template <class = int>
+_LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(double __x) _NOEXCEPT {
+  return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+}
+
+_LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(long double __x) _NOEXCEPT {
   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
 }
 

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -387,7 +387,7 @@ namespace __math {
 
 // fpclassify
 
-// template on float/long double overloads to make them weaker than same overloads from MSVC runtime 
+// template on non-double overloads to make them weaker than same overloads from MSVC runtime
 template <class = int>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(float __x) _NOEXCEPT {
   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -387,6 +387,7 @@ namespace __math {
 
 // fpclassify
 
+template <class = int>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(float __x) _NOEXCEPT {
   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
 }
@@ -396,6 +397,7 @@ _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(double __x) _N
   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
 }
 
+template <class = int>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(long double __x) _NOEXCEPT {
   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
 }
@@ -409,11 +411,11 @@ _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(_A1 __x) _NOEX
 
 _LIBCPP_END_NAMESPACE_STD
 
+using std::__math::fpclassify;
 using std::__math::signbit;
 
 // The MSVC runtime already provides these functions as templates
 #ifndef _LIBCPP_MSVCRT
-using std::__math::fpclassify;
 using std::__math::isfinite;
 using std::__math::isgreater;
 using std::__math::isgreaterequal;

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -387,6 +387,7 @@ namespace __math {
 
 // fpclassify
 
+// template on float/long double overloads to make them weaker than same overloads from MSVC runtime 
 template <class = int>
 _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(float __x) _NOEXCEPT {
   return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -409,11 +409,11 @@ _LIBCPP_NODISCARD_EXT inline _LIBCPP_HIDE_FROM_ABI int fpclassify(_A1 __x) _NOEX
 
 _LIBCPP_END_NAMESPACE_STD
 
-using std::__math::fpclassify;
 using std::__math::signbit;
 
 // The MSVC runtime already provides these functions as templates
 #ifndef _LIBCPP_MSVCRT
+using std::__math::fpclassify;
 using std::__math::isfinite;
 using std::__math::isgreater;
 using std::__math::isgreaterequal;

--- a/libcxx/test/std/numerics/c.math/cmath.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/cmath.pass.cpp
@@ -603,12 +603,20 @@ void test_fpclassify()
     static_assert((std::is_same<decltype(std::fpclassify(0)), int>::value), "");
     static_assert((std::is_same<decltype(std::fpclassify((long double)0)), int>::value), "");
     static_assert((std::is_same<decltype(fpclassify(Ambiguous())), Ambiguous>::value), "");
+    static_assert((std::is_same<decltype(fpclassify(Value<float>())), int>::value), "");
+    static_assert((std::is_same<decltype(fpclassify(Value<double>())), int>::value), "");
+    static_assert((std::is_same<decltype(fpclassify(Value<long double>())), int>::value), "");
+    static_assert(noexcept(std::fpclassify((float)0)), "");
+    static_assert(noexcept(std::fpclassify((double)0)), "");
+    static_assert(noexcept(std::fpclassify((long double)0)), "");
+    static_assert(noexcept(std::fpclassify(0)), "");
     assert(std::fpclassify(-1.0) == FP_NORMAL);
     assert(std::fpclassify(0) == FP_ZERO);
     assert(std::fpclassify(1) == FP_NORMAL);
     assert(std::fpclassify(-1) == FP_NORMAL);
     assert(std::fpclassify(std::numeric_limits<int>::max()) == FP_NORMAL);
     assert(std::fpclassify(std::numeric_limits<int>::min()) == FP_NORMAL);
+    assert(std::fpclassify(Value<double, 1>()) == FP_NORMAL);
 }
 
 void test_isfinite()

--- a/libcxx/test/std/numerics/c.math/cmath.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/cmath.pass.cpp
@@ -606,10 +606,10 @@ void test_fpclassify()
     static_assert((std::is_same<decltype(fpclassify(Value<float>())), int>::value), "");
     static_assert((std::is_same<decltype(fpclassify(Value<double>())), int>::value), "");
     static_assert((std::is_same<decltype(fpclassify(Value<long double>())), int>::value), "");
-    static_assert(noexcept(std::fpclassify((float)0)), "");
-    static_assert(noexcept(std::fpclassify((double)0)), "");
-    static_assert(noexcept(std::fpclassify((long double)0)), "");
-    static_assert(noexcept(std::fpclassify(0)), "");
+    ASSERT_NOEXCEPT(std::fpclassify((float)0));
+    ASSERT_NOEXCEPT(std::fpclassify((double)0));
+    ASSERT_NOEXCEPT(std::fpclassify((long double)0));
+    ASSERT_NOEXCEPT(std::fpclassify(0));
     assert(std::fpclassify(-1.0) == FP_NORMAL);
     assert(std::fpclassify(0) == FP_ZERO);
     assert(std::fpclassify(1) == FP_NORMAL);


### PR DESCRIPTION
Standard says that implementation of math functions that have floating-point-type parameter should provide an "overload for each cv-unqualified floating-point type".
