### PR TITLE
[Target] Change `no-trap-after-noreturn` to `trap-after-noreturn`

### DIFF
--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -274,8 +274,8 @@ namespace llvm {
     /// Emit target-specific trap instruction for 'unreachable' IR instructions.
     unsigned TrapUnreachable : 1;
 
-    /// Do not emit a trap instruction for 'unreachable' IR instructions behind
-    /// noreturn calls, even if TrapUnreachable is true.
+    /// Emit a trap instruction for 'unreachable' IR instructions behind
+    /// noreturn calls, if TrapUnreachable is true.
     unsigned TrapAfterNoreturn : 1;
 
     /// Bit size of immediate TLS offsets (0 == use the default).

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -134,7 +134,7 @@ namespace llvm {
           FunctionSections(false), DataSections(false),
           IgnoreXCOFFVisibility(false), XCOFFTracebackTable(true),
           UniqueSectionNames(true), UniqueBasicBlockSectionNames(false),
-          TrapUnreachable(false), NoTrapAfterNoreturn(false), TLSSize(0),
+          TrapUnreachable(false), TrapAfterNoreturn(true), TLSSize(0),
           EmulatedTLS(false), EnableIPRA(false), EmitStackSizeSection(false),
           EnableMachineOutliner(false), EnableMachineFunctionSplitter(false),
           SupportsDefaultOutlining(false), EmitAddrsig(false),
@@ -276,7 +276,7 @@ namespace llvm {
 
     /// Do not emit a trap instruction for 'unreachable' IR instructions behind
     /// noreturn calls, even if TrapUnreachable is true.
-    unsigned NoTrapAfterNoreturn : 1;
+    unsigned TrapAfterNoreturn : 1;
 
     /// Bit size of immediate TLS offsets (0 == use the default).
     unsigned TLSSize : 8;

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2881,7 +2881,7 @@ bool IRTranslator::translateUnreachable(const User &U, MachineIRBuilder &MIRBuil
 
   auto &UI = cast<UnreachableInst>(U);
   // We may be able to ignore unreachable behind a noreturn call.
-  if (!MF->getTarget().Options.NoTrapAfterNoreturn) {
+  if (!MF->getTarget().Options.TrapAfterNoreturn) {
     const BasicBlock &BB = *UI.getParent();
     if (&UI != &BB.front()) {
       BasicBlock::const_iterator PredI =

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2881,7 +2881,7 @@ bool IRTranslator::translateUnreachable(const User &U, MachineIRBuilder &MIRBuil
 
   auto &UI = cast<UnreachableInst>(U);
   // We may be able to ignore unreachable behind a noreturn call.
-  if (MF->getTarget().Options.NoTrapAfterNoreturn) {
+  if (!MF->getTarget().Options.NoTrapAfterNoreturn) {
     const BasicBlock &BB = *UI.getParent();
     if (&UI != &BB.front()) {
       BasicBlock::const_iterator PredI =

--- a/llvm/lib/CodeGen/LLVMTargetMachine.cpp
+++ b/llvm/lib/CodeGen/LLVMTargetMachine.cpp
@@ -37,8 +37,8 @@ static cl::opt<bool>
     EnableTrapUnreachable("trap-unreachable", cl::Hidden,
                           cl::desc("Enable generating trap for unreachable"));
 
-static cl::opt<bool> EnableNoTrapAfterNoreturn(
-    "no-trap-after-noreturn", cl::Hidden,
+static cl::opt<bool> EnableTrapAfterNoreturn(
+    "trap-after-noreturn", cl::Hidden, cl::init(true),
     cl::desc("Do not emit a trap instruction for 'unreachable' IR instructions "
              "after noreturn calls, even if --trap-unreachable is set."));
 
@@ -100,8 +100,8 @@ LLVMTargetMachine::LLVMTargetMachine(const Target &T,
 
   if (EnableTrapUnreachable)
     this->Options.TrapUnreachable = true;
-  if (EnableNoTrapAfterNoreturn)
-    this->Options.NoTrapAfterNoreturn = true;
+  if (!EnableTrapAfterNoreturn)
+    this->Options.TrapAfterNoreturn = false;
 }
 
 TargetTransformInfo

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3225,7 +3225,7 @@ void SelectionDAGBuilder::visitUnreachable(const UnreachableInst &I) {
     return;
 
   // We may be able to ignore unreachable behind a noreturn call.
-  if (DAG.getTarget().Options.NoTrapAfterNoreturn) {
+  if (!DAG.getTarget().Options.TrapAfterNoreturn) {
     if (const CallInst *Call = dyn_cast_or_null<CallInst>(I.getPrevNode())) {
       if (Call->doesNotReturn())
         return;

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -338,7 +338,7 @@ AArch64TargetMachine::AArch64TargetMachine(const Target &T, const Triple &TT,
 
   if (TT.isOSBinFormatMachO()) {
     this->Options.TrapUnreachable = true;
-    this->Options.NoTrapAfterNoreturn = true;
+    this->Options.TrapAfterNoreturn = false;
   }
 
   if (getMCAsmInfo()->usesWindowsCFI()) {

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -252,7 +252,7 @@ ARMBaseTargetMachine::ARMBaseTargetMachine(const Target &T, const Triple &TT,
 
   if (TT.isOSBinFormatMachO()) {
     this->Options.TrapUnreachable = true;
-    this->Options.NoTrapAfterNoreturn = true;
+    this->Options.TrapAfterNoreturn = false;
   }
 
   // ARM supports the debug entry values.

--- a/llvm/lib/Target/NVPTX/NVPTX.h
+++ b/llvm/lib/Target/NVPTX/NVPTX.h
@@ -48,7 +48,7 @@ FunctionPass *createNVPTXImageOptimizerPass();
 FunctionPass *createNVPTXLowerArgsPass();
 FunctionPass *createNVPTXLowerAllocaPass();
 FunctionPass *createNVPTXLowerUnreachablePass(bool TrapUnreachable,
-                                              bool NoTrapAfterNoreturn);
+                                              bool TrapAfterNoreturn);
 MachineFunctionPass *createNVPTXPeephole();
 MachineFunctionPass *createNVPTXProxyRegErasurePass();
 

--- a/llvm/lib/Target/NVPTX/NVPTXLowerUnreachable.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXLowerUnreachable.cpp
@@ -117,7 +117,7 @@ StringRef NVPTXLowerUnreachable::getPassName() const {
 bool NVPTXLowerUnreachable::isLoweredToTrap(const UnreachableInst &I) const {
   if (!TrapUnreachable)
     return false;
-  if (NoTrapAfterNoreturn)
+  if (TrapAfterNoreturn)
     return true;
   const CallInst *Call = dyn_cast_or_null<CallInst>(I.getPrevNode());
   return Call && Call->doesNotReturn();

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -405,7 +405,7 @@ void NVPTXPassConfig::addIRPasses() {
 
   const auto &Options = getNVPTXTargetMachine().Options;
   addPass(createNVPTXLowerUnreachablePass(Options.TrapUnreachable,
-                                          Options.NoTrapAfterNoreturn));
+                                          Options.TrapAfterNoreturn));
 }
 
 bool NVPTXPassConfig::addInstSelector() {

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -235,7 +235,7 @@ X86TargetMachine::X86TargetMachine(const Target &T, const Triple &TT,
   // the calling function, and TrapUnreachable is an easy way to get that.
   if (TT.isPS() || TT.isOSBinFormatMachO()) {
     this->Options.TrapUnreachable = true;
-    this->Options.NoTrapAfterNoreturn = TT.isOSBinFormatMachO();
+    this->Options.NoTrapAfterNoreturn = !TT.isOSBinFormatMachO();
   }
 
   setMachineOutliner(true);

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -235,7 +235,7 @@ X86TargetMachine::X86TargetMachine(const Target &T, const Triple &TT,
   // the calling function, and TrapUnreachable is an easy way to get that.
   if (TT.isPS() || TT.isOSBinFormatMachO()) {
     this->Options.TrapUnreachable = true;
-    this->Options.NoTrapAfterNoreturn = !TT.isOSBinFormatMachO();
+    this->Options.TrapAfterNoreturn = !TT.isOSBinFormatMachO();
   }
 
   setMachineOutliner(true);

--- a/llvm/test/CodeGen/ARM/trap-unreachable.ll
+++ b/llvm/test/CodeGen/ARM/trap-unreachable.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -mtriple=thumbv7 -trap-unreachable < %s | FileCheck %s --check-prefixes CHECK,TRAP_UNREACHABLE
-; RUN: llc -mtriple=thumbv7 -trap-unreachable -no-trap-after-noreturn < %s | FileCheck %s --check-prefixes CHECK,NTANR
+; RUN: llc -mtriple=thumbv7 -trap-unreachable -trap-after-noreturn=false < %s | FileCheck %s --check-prefixes CHECK,NTANR
 
 define void @test_trap_unreachable() #0 {
 ; CHECK-LABEL: test_trap_unreachable:

--- a/llvm/test/CodeGen/NVPTX/unreachable.ll
+++ b/llvm/test/CodeGen/NVPTX/unreachable.ll
@@ -6,6 +6,10 @@
 ; RUN:     | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-TRAP
 ; RUN: llc < %s -march=nvptx64 -mcpu=sm_20 -verify-machineinstrs -trap-unreachable \
 ; RUN:     | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-TRAP
+; RUN: llc < %s -march=nvptx -mcpu=sm_20 -verify-machineinstrs -trap-unreachable -trap-after-noreturn=false \
+; RUN:     | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NOTRAP
+; RUN: llc < %s -march=nvptx64 -mcpu=sm_20 -verify-machineinstrs -trap-unreachable -trap-after-noreturn=false \
+; RUN:     | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NOTRAP
 ; RUN: %if ptxas && !ptxas-12.0 %{ llc < %s -march=nvptx -mcpu=sm_20 -verify-machineinstrs | %ptxas-verify %}
 ; RUN: %if ptxas %{ llc < %s -march=nvptx64 -mcpu=sm_20 -verify-machineinstrs | %ptxas-verify %}
 


### PR DESCRIPTION
This was suggested in https://github.com/llvm/llvm-project/commit/5b7a7ec5a2106772de90a59c52e9fac7481f7e8a to avoid too many negates (e.g. `!NoTrapAfterNoreturn`).