### PR TITLE
[flang-rt] fix missing llvm_gtest target

### DIFF
--- a/flang-rt/unittests/CMakeLists.txt
+++ b/flang-rt/unittests/CMakeLists.txt
@@ -33,8 +33,9 @@ function(add_flang_rt_unittest_offload_properties target)
   endif()
 endfunction()
 
-if(NOT TARGET llvm_gtest)
-  message(FATAL_ERROR "Target llvm_gtest not found.")
+set(UNITTEST_DIR ${LLVM_THIRD_PARTY_DIR}/unittest)
+if (NOT TARGET llvm_gtest)
+  add_subdirectory(${UNITTEST_DIR} third-party/unittest)
 endif()
 
 function(add_flang_rt_unittest test_dirname)


### PR DESCRIPTION
fixes build fail introduced by https://github.com/llvm/llvm-project/commit/6403287eff71a3d6f6c862346d6ed3f0f000eb70; you can see a failing build [here](https://buildkite.com/llvm-project/github-pull-requests/builds/5171#018aec0c-75ba-431a-a5c8-6a5cba51de28) due to a missing `llvm_gtest` CMake target. To fix, I adapted https://github.com/llvm/llvm-project/blob/6403287eff71a3d6f6c862346d6ed3f0f000eb70/flang/CMakeLists.txt#L176-L180

flang might need more infra/boilerplate there but this fixes the build fail.