### PR TITLE
[LIT] NFC. Add missing punctuation on a LIT driver message

### DIFF
--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -73,7 +73,7 @@ def main(builtin_params={}):
                     "The test suite configuration requested an individual"
                     " test timeout of {0} seconds but a timeout of {1} seconds was"
                     " requested on the command line. Forcing timeout to be {1}"
-                    " seconds"
+                    " seconds."
                 ).format(lit_config.maxIndividualTestTime, opts.maxIndividualTestTime)
             )
             lit_config.maxIndividualTestTime = opts.maxIndividualTestTime


### PR DESCRIPTION
Add missing punctuation on a LIT driver message.
