### PR TITLE
[RISCV] Create new build vector instead of relying on getNode constan…

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -3530,8 +3530,8 @@ static SDValue lowerBuildVectorOfConstants(SDValue Op, SelectionDAG &DAG,
       (NumElts <= 4 || VT.getSizeInBits() > Subtarget.getRealMinVLen())) {
     unsigned SignBits = DAG.ComputeNumSignBits(Op);
     if (EltBitSize - SignBits < 8) {
-      SDValue Source =
-        DAG.getNode(ISD::TRUNCATE, DL, VT.changeVectorElementType(MVT::i8), Op);
+      SDValue Source = DAG.getBuildVector(VT.changeVectorElementType(MVT::i8),
+                                          DL, Op->ops());
       Source = convertToScalableVector(ContainerVT.changeVectorElementType(MVT::i8),
                                        Source, DAG, Subtarget);
       SDValue Res = DAG.getNode(RISCVISD::VSEXT_VL, DL, ContainerVT, Source, Mask, VL);


### PR DESCRIPTION
…t folding.

We want to create a build_vector with narrower elements here. Normally getNode on the ISD::TRUNCATE will constant fold this to a new BUILD_VECTOR. If it doesn't constant fold, we end up with a cycle in the DAG because we truncate the node we are replacing. Constant folding can fail if one of the elements is an opaque constant.

The failing case I saw involved an opaque constant created by a memset that was expanded. Not sure exactly what happened after that.

This patch creates a new build_vector with the new type directly.