### PR TITLE
[lld/elf] rename relocation section for relocatable file.

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -51,9 +51,6 @@ static bool isSectionPrefix(StringRef prefix, StringRef name) {
 }
 
 static StringRef getOutputSectionName(const InputSectionBase *s) {
-  if (config->relocatable)
-    return s->name;
-
   // This is for --emit-relocs. If .text.foo is emitted as .text.bar, we want
   // to emit .rela.text.foo as .rela.text.bar for consistency (this is not
   // technically required, but not doing it is odd). This code guarantees that.
@@ -65,6 +62,9 @@ static StringRef getOutputSectionName(const InputSectionBase *s) {
       return saver().save(".rel" + out->name);
     }
   }
+
+  if (config->relocatable)
+    return s->name;
 
   // A BssSection created for a common symbol is identified as "COMMON" in
   // linker scripts. It should go to .bss section.


### PR DESCRIPTION
This is for #67910.

It's odd not to rename relocation section when creating relocatable object file even with `--emit-reloc`.