### PR TITLE
Avoid need for SLocEntryLoaded BitVector

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -490,7 +490,7 @@ public:
 
   bool isExpansion() const { return IsExpansion; }
   bool isFile() const { return !isExpansion(); }
-  [[nodiscard]] bool isLoaded() const { return Loaded; }
+  bool isLoaded() const { return Loaded; }
   void setLoaded(bool Value) { Loaded = Value; }
 
   const FileInfo &getFile() const {

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -477,7 +477,7 @@ class SLocEntry {
   static constexpr int OffsetBits = 8 * sizeof(SourceLocation::UIntTy) - 2;
   SourceLocation::UIntTy Offset : OffsetBits;
   SourceLocation::UIntTy IsExpansion : 1;
-  SourceLocation::UIntTy Loaded : 1;
+  SourceLocation::UIntTy IsLoaded : 1;
   union {
     FileInfo File;
     ExpansionInfo Expansion;

--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -490,8 +490,8 @@ public:
 
   bool isExpansion() const { return IsExpansion; }
   bool isFile() const { return !isExpansion(); }
-  bool isLoaded() const { return Loaded; }
-  void setLoaded(bool Value) { Loaded = Value; }
+  bool isLoaded() const { return IsLoaded; }
+  void setLoaded(bool Value) { IsLoaded = Value; }
 
   const FileInfo &getFile() const {
     assert(isFile() && "Not a file SLocEntry!");

--- a/llvm/include/llvm/ADT/PagedVector.h
+++ b/llvm/include/llvm/ADT/PagedVector.h
@@ -103,6 +103,12 @@ public:
   /// Return the size of the vector.
   [[nodiscard]] size_t size() const { return Size; }
 
+  [[nodiscard]] bool isMaterialized(size_t Index) const {
+    assert(Index < Size);
+    assert(Index / PageSize < PageToDataPtrs.size());
+    return PageToDataPtrs[Index / PageSize] != nullptr;
+  }
+
   /// Resize the vector. Notice that the constructor of the elements will not
   /// be invoked until an element of a given page is accessed, at which point
   /// all the elements of the page will be constructed.

--- a/llvm/include/llvm/ADT/PagedVector.h
+++ b/llvm/include/llvm/ADT/PagedVector.h
@@ -103,8 +103,8 @@ public:
   /// Return the size of the vector.
   [[nodiscard]] size_t size() const { return Size; }
 
-  /// @return true in case the element at index @a Index belongs to a page which
-  /// was already materialised.
+  /// Return true if the element at `Index` belongs to a page which was already
+  /// materialized, i.e., had at least one element accessed.
   [[nodiscard]] bool isMaterialized(size_t Index) const {
     assert(Index < Size);
     assert(Index / PageSize < PageToDataPtrs.size());

--- a/llvm/include/llvm/ADT/PagedVector.h
+++ b/llvm/include/llvm/ADT/PagedVector.h
@@ -106,7 +106,7 @@ public:
   [[nodiscard]] bool isMaterialized(size_t Index) const {
     assert(Index < Size);
     assert(Index / PageSize < PageToDataPtrs.size());
-    return PageToDataPtrs[Index / PageSize] != nullptr;
+    return PageToDataPtrs[Index / PageSize];
   }
 
   /// Resize the vector. Notice that the constructor of the elements will not

--- a/llvm/include/llvm/ADT/PagedVector.h
+++ b/llvm/include/llvm/ADT/PagedVector.h
@@ -103,6 +103,8 @@ public:
   /// Return the size of the vector.
   [[nodiscard]] size_t size() const { return Size; }
 
+  /// @return true in case the element at index @a Index belongs to a page which
+  /// was already materialised.
   [[nodiscard]] bool isMaterialized(size_t Index) const {
     assert(Index < Size);
     assert(Index / PageSize < PageToDataPtrs.size());

--- a/llvm/unittests/ADT/PagedVectorTest.cpp
+++ b/llvm/unittests/ADT/PagedVectorTest.cpp
@@ -185,13 +185,13 @@ TEST(PagedVectorTest, FillNonTrivialConstructor) {
 TEST(PagedVectorTest, IsMaterialized) {
   PagedVector<int, 10> V;
   V.resize(20);
-  EXPECT_EQ(V.isMaterialized(0), false);
-  EXPECT_EQ(V.isMaterialized(1), false);
-  EXPECT_EQ(V.isMaterialized(10), false);
+  EXPECT_FALSE(V.isMaterialized(0));
+  EXPECT_FALSE(V.isMaterialized(1));
+  EXPECT_FALSE(V.isMaterialized(10));
   V[0] = 0;
-  EXPECT_EQ(V.isMaterialized(0), true);
-  EXPECT_EQ(V.isMaterialized(1), true);
-  EXPECT_EQ(V.isMaterialized(10), false);
+  EXPECT_TRUE(V.isMaterialized(0));
+  EXPECT_TRUE(V.isMaterialized(1));
+  EXPECT_FALSE(V.isMaterialized(10));
 }
 
 // Elements are constructed, destructed in pages, so we expect

--- a/llvm/unittests/ADT/PagedVectorTest.cpp
+++ b/llvm/unittests/ADT/PagedVectorTest.cpp
@@ -180,6 +180,20 @@ TEST(PagedVectorTest, FillNonTrivialConstructor) {
   EXPECT_EQ(std::distance(V.materialized_begin(), V.materialized_end()), 10LL);
 }
 
+// Test that isMaterialized returns true for all the elements
+// of the page, not only the one that was accessed.
+TEST(PagedVectorTest, IsMaterialized) {
+  PagedVector<int, 10> V;
+  V.resize(20);
+  EXPECT_EQ(V.isMaterialized(0), false);
+  EXPECT_EQ(V.isMaterialized(1), false);
+  EXPECT_EQ(V.isMaterialized(10), false);
+  V[0] = 0;
+  EXPECT_EQ(V.isMaterialized(0), true);
+  EXPECT_EQ(V.isMaterialized(1), true);
+  EXPECT_EQ(V.isMaterialized(10), false);
+}
+
 // Elements are constructed, destructed in pages, so we expect
 // the number of constructed / destructed elements to be a multiple of the
 // page size and the constructor is invoked when the page is actually accessed


### PR DESCRIPTION
The BitVector is currently used to keep track of which entries of LoadedSLocEntryTable have been loaded. Such information can be stored in the SLocEntry itself. Moreover, thanks to the fact that LoadedSLocEntryTable is now a PagedVector, we can simply consider elements of unmaterialised pages as not loaded.

This trades reducing the number of OffsetBits by one for reducing memory usage of the SourceManager by LoadedSLocEntryTable.size()/8 bytes.