### PR TITLE
[clang] Add check for duplicates to make_cxx_dr_status script

### DIFF
--- a/clang/test/CXX/drs/dr12xx.cpp
+++ b/clang/test/CXX/drs/dr12xx.cpp
@@ -32,7 +32,7 @@ namespace dr1213 { // dr1213: 7
 }
 
 #if __cplusplus >= 201103L
-namespace dr1223 { // dr1227: yes open
+namespace dr1223 { // dr1223: 17 drafting
 struct M;
 template <typename T>
 struct V;

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -7145,7 +7145,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1223.html">1223</a></td>
     <td>drafting</td>
     <td>Syntactic disambiguation and <I>trailing-return-type</I>s</td>
-    <td align="center">Not resolved</td>
+    <td class="unreleased" align="center">Clang 17</td>
   </tr>
   <tr id="1224">
     <td><a href="https://cplusplus.github.io/CWG/issues/1224.html">1224</a></td>

--- a/clang/www/make_cxx_dr_status
+++ b/clang/www/make_cxx_dr_status
@@ -39,7 +39,11 @@ def collect_tests():
     test_cpp = os.path.join(dr_test_dir, test_cpp)
     found_any = False;
     for match in re.finditer(status_re, open(test_cpp, 'r').read()):
-      status_map[int(match.group(1))] = match.group(2)
+      dr_number = int(match.group(1))
+      if dr_number in status_map:
+        print("error: Comment for dr{} encountered more than once. Duplicate found in {}".format(dr_number, test_cpp))
+        sys.exit(1)
+      status_map[dr_number] = match.group(2)
       found_any = True
     if not found_any:
       print("warning:%s: no '// dr123: foo' comments in this file" % test_cpp, file=sys.stderr)


### PR DESCRIPTION
While working on #67965, I stumbled upon the fact that `make_cxx_dr_status` script doesn't check for duplicated comment (last comment wins), so I added this check.

It even found another instance of duplicated comment: CWG1223 was marked as CWG1227. I fixed status of the former.