### PR TITLE
[Clang] Fix HIP wrapper inclusion of 'algorithm' when using libc++

### DIFF
--- a/clang/lib/Headers/__clang_hip_math.h
+++ b/clang/lib/Headers/__clang_hip_math.h
@@ -14,9 +14,6 @@
 #endif
 
 #if !defined(__HIPCC_RTC__)
-#if defined(__cplusplus)
-#include <algorithm>
-#endif
 #include <limits.h>
 #include <stdint.h>
 #ifdef __OPENMP_AMDGCN__
@@ -1311,11 +1308,11 @@ double min(double __x, double __y) { return __builtin_fmin(__x, __y); }
 
 #if !defined(__HIPCC_RTC__) && !defined(__OPENMP_AMDGCN__)
 __host__ inline static int min(int __arg1, int __arg2) {
-  return std::min(__arg1, __arg2);
+  return __arg1 < __arg2 ? __arg1 : __arg2;
 }
 
 __host__ inline static int max(int __arg1, int __arg2) {
-  return std::max(__arg1, __arg2);
+  return __arg1 > __arg2 ? __arg1 : __arg2;
 }
 #endif // !defined(__HIPCC_RTC__) && !defined(__OPENMP_AMDGCN__)
 #endif


### PR DESCRIPTION
Summary:
The `algorithm` header included here sometimes caused issues when using
`libc++` over `libstdc++`. This was primarily because  of the order they
were included in. This patch just gets rid of this dependency as it was
only used for min and max which are trivial to reimplement.

Fixes: https://github.com/llvm/llvm-project/issues/67938
