### PR TITLE
[MLIR][Transform] Add attribute in MatchOp to filter by operand type

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
@@ -535,6 +535,7 @@ def MatchOp : Op<Transform_Dialect, "structured.match",
       - attribute: the matched op must have all specified attributes (with their
         specified values).
       - filter_result_type: the matched op must return exactly this one type.
+      - filter_operand_type: all the operands of the matched op must must be of this type.
 
     Note: Only ops that satisfy all specified constraints are matched.
 
@@ -556,7 +557,8 @@ def MatchOp : Op<Transform_Dialect, "structured.match",
                        OptionalAttr<StrArrayAttr>:$ops,
                        OptionalAttr<MatchInterfaceEnum>:$interface,
                        OptionalAttr<DictionaryAttr>:$op_attrs,
-                       OptionalAttr<TypeAttr>:$filter_result_type);
+                       OptionalAttr<TypeAttr>:$filter_result_type,
+                       OptionalAttr<TypeAttr>:$filter_operand_type);
   // TODO: variadic results when needed.
   let results = (outs TransformHandleTypeInterface:$results);
 
@@ -570,6 +572,7 @@ def MatchOp : Op<Transform_Dialect, "structured.match",
     (`interface` `{` $interface^ `}`)?
     (`attributes` $op_attrs^)?
     (`filter_result_type` `=` $filter_result_type^)?
+    (`filter_operand_type` `=` $filter_operand_type^)?
     `in` $target attr-dict
     `:` functional-type($target, results)
   }];

--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
@@ -535,7 +535,8 @@ def MatchOp : Op<Transform_Dialect, "structured.match",
       - attribute: the matched op must have all specified attributes (with their
         specified values).
       - filter_result_type: the matched op must return exactly this one type.
-      - filter_operand_type: all the operands of the matched op must must be of this type.
+      - filter_operand_type: all the operands of the matched op must must be of
+        this type.
 
     Note: Only ops that satisfy all specified constraints are matched.
 

--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
@@ -535,8 +535,11 @@ def MatchOp : Op<Transform_Dialect, "structured.match",
       - attribute: the matched op must have all specified attributes (with their
         specified values).
       - filter_result_type: the matched op must return exactly this one type.
-      - filter_operand_type: all the operands of the matched op must must be of
-        this type.
+      - filter_operand_types: all the operands of the matched op must must be of
+        this type. If more than a type is specified, then the length of the list
+        must be equal to the number of operands in the matched op, and the match
+        will succeed only if the operand types match all the types in the list
+        in the order in which they are specified.
 
     Note: Only ops that satisfy all specified constraints are matched.
 
@@ -559,7 +562,7 @@ def MatchOp : Op<Transform_Dialect, "structured.match",
                        OptionalAttr<MatchInterfaceEnum>:$interface,
                        OptionalAttr<DictionaryAttr>:$op_attrs,
                        OptionalAttr<TypeAttr>:$filter_result_type,
-                       OptionalAttr<TypeAttr>:$filter_operand_type);
+                       OptionalAttr<TypeArrayAttr>:$filter_operand_types);
   // TODO: variadic results when needed.
   let results = (outs TransformHandleTypeInterface:$results);
 
@@ -573,7 +576,7 @@ def MatchOp : Op<Transform_Dialect, "structured.match",
     (`interface` `{` $interface^ `}`)?
     (`attributes` $op_attrs^)?
     (`filter_result_type` `=` $filter_result_type^)?
-    (`filter_operand_type` `=` $filter_operand_type^)?
+    (`filter_operand_types` `=` $filter_operand_types^)?
     `in` $target attr-dict
     `:` functional-type($target, results)
   }];

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -1180,6 +1180,15 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
         return;
     }
 
+    if (getFilterOperandType().has_value()) {
+      Type t = getFilterOperandType().value();
+      for (auto type : op->getOperandTypes()) {
+        if (type != t) {
+          return;
+        }
+      }
+    }
+
     // All constraints are satisfied.
     res.push_back(op);
     return;

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -1182,11 +1182,10 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
 
     if (getFilterOperandType().has_value()) {
       Type t = getFilterOperandType().value();
-      for (auto type : op->getOperandTypes()) {
-        if (type != t) {
-          return;
-        }
-      }
+      if (!llvm::all_of(op->getOperandTypes(), [&](Type operandType) {
+        return operandType == t;
+      }))
+        return;
     }
 
     // All constraints are satisfied.

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -1182,9 +1182,8 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
 
     if (getFilterOperandType().has_value()) {
       Type t = getFilterOperandType().value();
-      if (!llvm::all_of(op->getOperandTypes(), [&](Type operandType) {
-        return operandType == t;
-      }))
+      if (!llvm::all_of(op->getOperandTypes(),
+                        [&](Type operandType) { return operandType == t; }))
         return;
     }
 

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -1141,7 +1141,7 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
   }
 
   SmallVector<Operation *> res;
-  bool wrong_operand_filter = false;
+  bool incorrectNumOperandTypes = false;
   auto matchFun = [&](Operation *op) {
     if (getOps().has_value() && !strs.contains(op->getName().getStringRef()))
       return;
@@ -1184,19 +1184,31 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
     if (getFilterOperandTypes().has_value()) {
       mlir::ArrayAttr types = getFilterOperandTypes().value();
       auto operandTypes = op->getOperandTypes();
-      if (types.size() != operandTypes.size()) {
-        wrong_operand_filter = true;
-        return;
-      }
 
-      for (auto const &it :
-           llvm::zip(getFilterOperandTypes().value(), operandTypes)) {
-        auto attr = dyn_cast<mlir::TypeAttr>(std::get<0>(it));
-        Type type = attr.getValue().cast<::mlir::Type>();
-        Type t = getElementTypeOrSelf(std::get<1>(it));
-
-        if (type != t)
+      if (types.size() == 1) {
+        // All the operands must must be equal to the specified type
+        auto typeattr =
+            dyn_cast<mlir::TypeAttr>(getFilterOperandTypes().value()[0]);
+        Type t = typeattr.getValue().cast<::mlir::Type>();
+        if (!llvm::all_of(op->getOperandTypes(),
+                          [&](Type operandType) { return operandType == t; }))
           return;
+      } else {
+        // The operand types must match all the types in the list (in the same
+        // order in with they are specified)
+        if (types.size() != operandTypes.size()) {
+          incorrectNumOperandTypes = true;
+          return;
+        }
+
+        for (auto [attr, operandType] :
+             llvm::zip_equal(getFilterOperandTypes().value(), operandTypes)) {
+          auto typeattr = dyn_cast<mlir::TypeAttr>(attr);
+          Type type = typeattr.getValue().cast<::mlir::Type>();
+
+          if (type != operandType)
+            return;
+        }
       }
     }
 
@@ -1206,8 +1218,9 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
   };
 
   (*payloadOps.begin())->walk(matchFun);
-  if (wrong_operand_filter)
-    return emitDefiniteFailure("filter_operand_types length must be equal to "
+  if (incorrectNumOperandTypes)
+    return emitDefiniteFailure("If filter_operand_types contains more than a "
+                               "type, then it must contain as much types as "
                                "the number of operands in the target ops");
   results.set(cast<OpResult>(getResult()), res);
   return DiagnosedSilenceableFailure::success();

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -1203,7 +1203,7 @@ transform::MatchOp::apply(transform::TransformRewriter &rewriter,
 
         for (auto [attr, operandType] :
              llvm::zip_equal(getFilterOperandTypes().value(), operandTypes)) {
-          auto typeattr = dyn_cast<mlir::TypeAttr>(attr);
+          auto typeattr = cast<mlir::TypeAttr>(attr);
           Type type = typeattr.getValue().cast<::mlir::Type>();
 
           if (type != operandType)

--- a/mlir/test/Dialect/Linalg/transform-op-match.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-match.mlir
@@ -39,6 +39,23 @@ transform.sequence failures(propagate) {
 
 // -----
 
+func.func @by_operand_type() {
+  %c0 = arith.constant 1.0: f32
+  // expected-remark @below {{matched op name}}
+  %res = arith.fptoui %c0 : f32 to i32
+  return
+}
+
+transform.sequence failures(propagate) {
+^bb1(%arg1: !transform.any_op):
+  %match_name = transform.structured.match
+    ops{["arith.fptoui"]} filter_operand_type = f32 in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
+  transform.test_consume_operand %match_name : !transform.any_op
+}
+
+// -----
+
 func.func @foo(%a: tensor<4x4xf32>, %b: tensor<4x4xf32>, %c: tensor<4x4xf32>) {
   %c0 = arith.constant 0.0 : f32
   // expected-remark @below {{tileable}}

--- a/mlir/test/Dialect/Linalg/transform-op-match.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-match.mlir
@@ -52,38 +52,11 @@ transform.sequence failures(propagate) {
     ops{["arith.fptoui"]} filter_operand_type = f32 in %arg1 : (!transform.any_op) -> !transform.any_op
   transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
   transform.test_consume_operand %match_name : !transform.any_op
-}
 
-// -----
-
-func.func @by_operand_type_negative_match() {
-  %c0 = arith.constant 1.0: f32
-  %res = arith.fptoui %c0 : f32 to i32
-  return
-}
-
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %match_name = transform.structured.match
+  %no_match_name = transform.structured.match
     ops{["arith.fptoui"]} filter_operand_type = i32 in %arg1 : (!transform.any_op) -> !transform.any_op
-  transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
-  transform.test_consume_operand %match_name : !transform.any_op
-}
-
-// -----
-
-func.func @by_operand_type_negative_match() {
-  %c0 = arith.constant 1.0: f32
-  %res = arith.fptoui %c0 : f32 to i32
-  return
-}
-
-transform.sequence failures(propagate) {
-^bb1(%arg1: !transform.any_op):
-  %match_name = transform.structured.match
-    ops{["arith.fptoui"]} filter_operand_type = i32 in %arg1 : (!transform.any_op) -> !transform.any_op
-  transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
-  transform.test_consume_operand %match_name : !transform.any_op
+  transform.test_print_remark_at_operand %no_match_name, "should not match" : !transform.any_op
+  transform.test_consume_operand %no_match_name : !transform.any_op
 }
 
 // -----

--- a/mlir/test/Dialect/Linalg/transform-op-match.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-match.mlir
@@ -56,6 +56,38 @@ transform.sequence failures(propagate) {
 
 // -----
 
+func.func @by_operand_type_negative_match() {
+  %c0 = arith.constant 1.0: f32
+  %res = arith.fptoui %c0 : f32 to i32
+  return
+}
+
+transform.sequence failures(propagate) {
+^bb1(%arg1: !transform.any_op):
+  %match_name = transform.structured.match
+    ops{["arith.fptoui"]} filter_operand_type = i32 in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
+  transform.test_consume_operand %match_name : !transform.any_op
+}
+
+// -----
+
+func.func @by_operand_type_negative_match() {
+  %c0 = arith.constant 1.0: f32
+  %res = arith.fptoui %c0 : f32 to i32
+  return
+}
+
+transform.sequence failures(propagate) {
+^bb1(%arg1: !transform.any_op):
+  %match_name = transform.structured.match
+    ops{["arith.fptoui"]} filter_operand_type = i32 in %arg1 : (!transform.any_op) -> !transform.any_op
+  transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
+  transform.test_consume_operand %match_name : !transform.any_op
+}
+
+// -----
+
 func.func @foo(%a: tensor<4x4xf32>, %b: tensor<4x4xf32>, %c: tensor<4x4xf32>) {
   %c0 = arith.constant 0.0 : f32
   // expected-remark @below {{tileable}}

--- a/mlir/test/Dialect/Linalg/transform-op-match.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-match.mlir
@@ -49,14 +49,18 @@ func.func @by_operand_type() {
 transform.sequence failures(propagate) {
 ^bb1(%arg1: !transform.any_op):
   %match_name = transform.structured.match
-    ops{["arith.fptoui"]} filter_operand_type = f32 in %arg1 : (!transform.any_op) -> !transform.any_op
+    ops{["arith.fptoui"]} filter_operand_types = [f32] in %arg1 : (!transform.any_op) -> !transform.any_op
   transform.test_print_remark_at_operand %match_name, "matched op name" : !transform.any_op
   transform.test_consume_operand %match_name : !transform.any_op
 
   %no_match_name = transform.structured.match
-    ops{["arith.fptoui"]} filter_operand_type = i32 in %arg1 : (!transform.any_op) -> !transform.any_op
+    ops{["arith.fptoui"]} filter_operand_types = [i32] in %arg1 : (!transform.any_op) -> !transform.any_op
   transform.test_print_remark_at_operand %no_match_name, "should not match" : !transform.any_op
   transform.test_consume_operand %no_match_name : !transform.any_op
+
+  // expected-error @+1 {{filter_operand_types length must be equal to the number of operands in the target ops}}
+  %failure_match = transform.structured.match
+    ops{["arith.fptoui"]} filter_operand_types = [i32, i32] in %arg1 : (!transform.any_op) -> !transform.any_op
 }
 
 // -----


### PR DESCRIPTION
This patchs adds the `filter_operand_type` attribute to transform::MatchOp. With this attribute, the MatchOp will only match an op when the type of all the operands are equal to the specified type.
