### PR TITLE
[clang] Bump latest release to 17 for C++ DR Status page

### DIFF
--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -12653,7 +12653,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2141.html">2141</a></td>
     <td>CD4</td>
     <td>Ambiguity in <I>new-expression</I> with <I>elaborated-type-specifier</I></td>
-    <td class="unreleased" align="center">Clang 17</td>
+    <td class="full" align="center">Clang 17</td>
   </tr>
   <tr id="2142">
     <td><a href="https://cplusplus.github.io/CWG/issues/2142.html">2142</a></td>
@@ -14189,7 +14189,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2397.html">2397</a></td>
     <td>CD6</td>
     <td><TT>auto</TT> specifier for pointers and references to arrays</td>
-    <td class="unreleased" align="center">Clang 17</td>
+    <td class="full" align="center">Clang 17</td>
   </tr>
   <tr class="open" id="2398">
     <td><a href="https://cplusplus.github.io/CWG/issues/2398.html">2398</a></td>
@@ -14915,7 +14915,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2518.html">2518</a></td>
     <td>C++23</td>
     <td>Conformance requirements and <TT>#error</TT>/<TT>#warning</TT></td>
-    <td class="unreleased" align="center">Clang 17</td>
+    <td class="full" align="center">Clang 17</td>
   </tr>
   <tr id="2519">
     <td><a href="https://cplusplus.github.io/CWG/issues/2519.html">2519</a></td>
@@ -14933,7 +14933,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2521.html">2521</a></td>
     <td>C++23</td>
     <td>User-defined literals and reserved identifiers</td>
-    <td class="unreleased" align="center">Clang 17</td>
+    <td class="full" align="center">Clang 17</td>
   </tr>
   <tr class="open" id="2522">
     <td><a href="https://cplusplus.github.io/CWG/issues/2522.html">2522</a></td>
@@ -15893,7 +15893,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2681.html">2681</a></td>
     <td>C++23</td>
     <td>Deducing member array type from string literal</td>
-    <td class="unreleased" align="center">Clang 17</td>
+    <td class="full" align="center">Clang 17</td>
   </tr>
   <tr id="2682">
     <td><a href="https://cplusplus.github.io/CWG/issues/2682.html">2682</a></td>

--- a/clang/www/make_cxx_dr_status
+++ b/clang/www/make_cxx_dr_status
@@ -122,7 +122,7 @@ out_file.write('''\
     <th>Available in Clang?</th>
   </tr>''')
 
-latest_release = 16
+latest_release = 17
 
 def availability(issue):
   status = status_map.get(issue, 'unknown')


### PR DESCRIPTION
`make_cxx_dr_status` has a hardcoded number of the latest release, for the purpose of determining whether a particular DR is available to users or not yet. I'm bumping it to 17.