### PR TITLE
[mlir] WIP: preload transform libraries before the pass

### DIFF
--- a/mlir/include/mlir/Dialect/Transform/IR/TransformDialect.h
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformDialect.h
@@ -10,6 +10,7 @@
 #define MLIR_DIALECT_TRANSFORM_IR_TRANSFORMDIALECT_H
 
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/TypeID.h"
@@ -315,7 +316,30 @@ public:
   BuildOnly() : DerivedTy(/*buildOnly=*/true) {}
 };
 
+class TransformLibraries : public TransformDialectData<TransformLibraries> {
+public:
+  explicit TransformLibraries(MLIRContext *ctx) : TransformDialectData(ctx) {}
+
+  void parseAndAddLibrary(StringRef filename);
+  void addLibrary(OwningOpRef<ModuleOp> &&library);
+
+  auto getLibraries() const {
+    return llvm::make_range(libraries.begin(), libraries.end());
+  }
+
+  bool isOk() const { return !hadFailures; }
+
+private:
+  SmallVector<OwningOpRef<ModuleOp>> libraries;
+  bool hadFailures = false;
+};
+
+void registerTransformLibraryPreloader(DialectRegistry &registry,
+                                       StringRef filename);
+
 } // namespace transform
 } // namespace mlir
+
+MLIR_DECLARE_EXPLICIT_TYPE_ID(mlir::transform::TransformLibraries)
 
 #endif // MLIR_DIALECT_TRANSFORM_IR_TRANSFORMDIALECT_H

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -90,6 +90,13 @@ public:
   }
   StringRef getIrdlFile() const { return irdlFileFlag; }
 
+  /// Set the transform dialect library to preload.
+  MlirOptMainConfig &setTransformLibrary(StringRef file) {
+    transformLibraryFlag = file;
+    return *this;
+  }
+  StringRef getTransformLibrary() const { return transformLibraryFlag; }
+
   /// Set the bytecode version to emit.
   MlirOptMainConfig &setEmitBytecodeVersion(int64_t version) {
     emitBytecodeVersion = version;
@@ -222,6 +229,9 @@ protected:
 
   /// Verify that the input IR round-trips perfectly.
   bool verifyRoundtripFlag = false;
+
+  /// Transform dialect library to preload.
+  std::string transformLibraryFlag = "";
 };
 
 /// This defines the function type used to setup the pass manager. This can be

--- a/mlir/lib/Tools/mlir-opt/CMakeLists.txt
+++ b/mlir/lib/Tools/mlir-opt/CMakeLists.txt
@@ -13,4 +13,5 @@ add_mlir_library(MLIROptLib
   MLIRPluginsLib
   MLIRSupport
   MLIRIRDL
+  MLIRTransformDialect
   )

--- a/mlir/test/Dialect/LLVM/lower-to-llvm-e2e.mlir
+++ b/mlir/test/Dialect/LLVM/lower-to-llvm-e2e.mlir
@@ -2,7 +2,8 @@
 
 // RUN: mlir-opt %s -test-lower-to-llvm -cse | FileCheck %s
 
-// RUN: mlir-opt %s -test-transform-dialect-interpreter="transform-library-file-name=%p/lower-to-llvm-transform-symbol-def.mlir debug-payload-root-tag=payload" \
+// RUN: mlir-opt %s -test-transform-dialect-interpreter="debug-payload-root-tag=payload" \
+// RUN:   -transform-library=%p/lower-to-llvm-transform-symbol-def.mlir \
 // RUN:   -test-transform-dialect-erase-schedule -cse \
 // RUN: | FileCheck %s
 

--- a/mlir/test/Integration/Dialect/Transform/match_batch_matmul.mlir
+++ b/mlir/test/Integration/Dialect/Transform/match_batch_matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --test-transform-dialect-interpreter='transform-library-file-name=%p/match_matmul_common.mlir' --verify-diagnostics
+// RUN: mlir-opt %s --test-transform-dialect-interpreter --transform-library=%p/match_matmul_common.mlir --verify-diagnostics
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @_match_matmul_like(

--- a/mlir/test/Integration/Dialect/Transform/match_matmul.mlir
+++ b/mlir/test/Integration/Dialect/Transform/match_matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --test-transform-dialect-interpreter='transform-library-file-name=%p/match_matmul_common.mlir' --verify-diagnostics
+// RUN: mlir-opt %s --test-transform-dialect-interpreter --transform-library=%p/match_matmul_common.mlir --verify-diagnostics
 
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @_match_matmul_like(


### PR DESCRIPTION
Loading in a pass happens at pass initialization time, and may be repeated if the pass is called more than once. Consider a different mechanism based on extra data owned by the transform dialect. This requires changes to mlir-opt (and equivalent downstream setups), but there is precedent with IRDL.