### PR TITLE
Mark an ObjCIvarDecl as invalid if its type contains errors

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18622,6 +18622,9 @@ Decl *Sema::ActOnIvar(Scope *S, SourceLocation DeclStart, Declarator &D,
   ObjCIvarDecl *NewID = ObjCIvarDecl::Create(
       Context, EnclosingContext, DeclStart, Loc, II, T, TInfo, ac, BitWidth);
 
+  if (T->containsErrors())
+    NewID->setInvalidDecl();
+
   if (II) {
     NamedDecl *PrevDecl = LookupSingleName(S, II, Loc, LookupMemberName,
                                            ForVisibleRedeclaration);

--- a/clang/test/SemaObjCXX/ivar-struct.mm
+++ b/clang/test/SemaObjCXX/ivar-struct.mm
@@ -1,8 +1,21 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
-// expected-no-diagnostics
+// RUN: %clang_cc1 -fsyntax-only -Wno-objc-root-class -verify %s
 @interface A {
   struct X {
     int x, y;
   } X;
+}
+@end
+
+static const uint32_t Count = 16; // expected-error {{unknown type name 'uint32_t'}}
+
+struct S0 {
+  S0();
+};
+
+@interface C0
+@end
+
+@implementation C0 {
+  S0 ivar0[Count];
 }
 @end


### PR DESCRIPTION
This fixes an assertion failure in InitializationSequence::Perform.