### PR TITLE
[AMDGPU][MachineScheduler] Alternative way to control excess RP.

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -914,8 +914,8 @@ void GCNSchedStage::finalizeGCNRegion() {
   unsigned NewSGPRRP = PressureAfter.getSGPRNum();
 
   if ((NewVGPRRP >= S.VGPRExcessLimit - S.VGPRExcessMargin) ||
-      (NewAGPRRP >= S.VGPRExcessLimit - S.SGPRExcessMargin) ||
-      (NewSGPRRP >= S.SGPRExcessLimit - S.VGPRExcessMargin)) {
+      (NewAGPRRP >= S.VGPRExcessLimit - S.VGPRExcessMargin) ||
+      (NewSGPRRP >= S.SGPRExcessLimit - S.SGPRExcessMargin)) {
     DAG.RegionsWithExcessRP[RegionIdx] = true;
     DAG.RescheduleRegions[RegionIdx] = true;
   }

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -86,6 +86,9 @@ public:
   // Bias for VGPR limits under a high register pressure.
   const unsigned HighRPVGPRBias = 7;
 
+  // Bias for AGPR limits under a high register pressure.
+  const unsigned HighRPAGPRBias = 7;
+
   unsigned SGPRCriticalLimit;
 
   unsigned VGPRCriticalLimit;
@@ -94,11 +97,16 @@ public:
 
   unsigned VGPRExcessLimit;
 
+  unsigned AGPRExcessLimit;
+
   unsigned SGPRLimitBias = 0;
 
   unsigned VGPRLimitBias = 0;
 
+  unsigned AGPRLimitBias = 0;
+
   unsigned VGPRExcessMargin = 1;
+  unsigned AGPRExcessMargin = 1;
   unsigned SGPRExcessMargin = 0;
 
   GCNSchedStrategy(const MachineSchedContext *C);

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -56,10 +56,6 @@ protected:
 
   std::vector<unsigned> MaxPressure;
 
-  unsigned SGPRExcessLimit;
-
-  unsigned VGPRExcessLimit;
-
   unsigned TargetOccupancy;
 
   MachineFunction *MF;
@@ -94,9 +90,16 @@ public:
 
   unsigned VGPRCriticalLimit;
 
+  unsigned SGPRExcessLimit;
+
+  unsigned VGPRExcessLimit;
+
   unsigned SGPRLimitBias = 0;
 
   unsigned VGPRLimitBias = 0;
+
+  unsigned VGPRExcessMargin = 1;
+  unsigned SGPRExcessMargin = 0;
 
   GCNSchedStrategy(const MachineSchedContext *C);
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-add-fma-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-add-fma-mul.ll
@@ -699,24 +699,24 @@ define <4 x double> @test_f64_add_mul(<4 x double> %a, <4 x double> %b, <4 x dou
 ; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-CONTRACT-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX9-CONTRACT-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
-; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:12
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:16
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:20
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:24
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:28
+; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(5)
 ; GFX9-CONTRACT-NEXT:    v_fma_f64 v[16:17], v[16:17], v[24:25], v[31:32]
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:12
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:16
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
-; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[24:25]
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:20
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:24
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
-; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[24:25]
 ; GFX9-CONTRACT-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:28
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:32
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:32
+; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(5)
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[33:34]
+; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(3)
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[35:36]
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
 ; GFX9-CONTRACT-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[20:21]
 ; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[24:25]
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[37:38]
 ; GFX9-CONTRACT-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[22:23]
 ; GFX9-CONTRACT-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -725,24 +725,24 @@ define <4 x double> @test_f64_add_mul(<4 x double> %a, <4 x double> %b, <4 x dou
 ; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-DENORM-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX9-DENORM-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
-; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-DENORM-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:12
+; GFX9-DENORM-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:16
+; GFX9-DENORM-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:20
+; GFX9-DENORM-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:24
+; GFX9-DENORM-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:28
+; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(5)
 ; GFX9-DENORM-NEXT:    v_fma_f64 v[16:17], v[16:17], v[24:25], v[31:32]
-; GFX9-DENORM-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:12
-; GFX9-DENORM-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:16
-; GFX9-DENORM-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
-; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DENORM-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[24:25]
-; GFX9-DENORM-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:20
-; GFX9-DENORM-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:24
-; GFX9-DENORM-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
-; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DENORM-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[24:25]
 ; GFX9-DENORM-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; GFX9-DENORM-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:28
-; GFX9-DENORM-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:32
+; GFX9-DENORM-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:32
+; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(5)
+; GFX9-DENORM-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[33:34]
+; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(3)
+; GFX9-DENORM-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[35:36]
+; GFX9-DENORM-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
+; GFX9-DENORM-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
 ; GFX9-DENORM-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[20:21]
 ; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DENORM-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[24:25]
+; GFX9-DENORM-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[37:38]
 ; GFX9-DENORM-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[22:23]
 ; GFX9-DENORM-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -870,24 +870,24 @@ define <4 x double> @test_f64_add_mul_rhs(<4 x double> %a, <4 x double> %b, <4 x
 ; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-CONTRACT-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX9-CONTRACT-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
-; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:12
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:16
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:20
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:24
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:28
+; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(5)
 ; GFX9-CONTRACT-NEXT:    v_fma_f64 v[16:17], v[16:17], v[24:25], v[31:32]
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:12
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:16
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
-; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[24:25]
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:20
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:24
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
-; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[24:25]
 ; GFX9-CONTRACT-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:28
-; GFX9-CONTRACT-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:32
+; GFX9-CONTRACT-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:32
+; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(5)
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[33:34]
+; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(3)
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[35:36]
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
 ; GFX9-CONTRACT-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[20:21]
 ; GFX9-CONTRACT-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-CONTRACT-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[24:25]
+; GFX9-CONTRACT-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[37:38]
 ; GFX9-CONTRACT-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[22:23]
 ; GFX9-CONTRACT-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -896,24 +896,24 @@ define <4 x double> @test_f64_add_mul_rhs(<4 x double> %a, <4 x double> %b, <4 x
 ; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-DENORM-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:4
 ; GFX9-DENORM-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:8
-; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-DENORM-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:12
+; GFX9-DENORM-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:16
+; GFX9-DENORM-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:20
+; GFX9-DENORM-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:24
+; GFX9-DENORM-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:28
+; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(5)
 ; GFX9-DENORM-NEXT:    v_fma_f64 v[16:17], v[16:17], v[24:25], v[31:32]
-; GFX9-DENORM-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:12
-; GFX9-DENORM-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:16
-; GFX9-DENORM-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
-; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DENORM-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[24:25]
-; GFX9-DENORM-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:20
-; GFX9-DENORM-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:24
-; GFX9-DENORM-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
-; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DENORM-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[24:25]
 ; GFX9-DENORM-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; GFX9-DENORM-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:28
-; GFX9-DENORM-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:32
+; GFX9-DENORM-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:32
+; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(5)
+; GFX9-DENORM-NEXT:    v_fma_f64 v[18:19], v[18:19], v[26:27], v[33:34]
+; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(3)
+; GFX9-DENORM-NEXT:    v_fma_f64 v[20:21], v[20:21], v[28:29], v[35:36]
+; GFX9-DENORM-NEXT:    v_fma_f64 v[0:1], v[0:1], v[8:9], v[16:17]
+; GFX9-DENORM-NEXT:    v_fma_f64 v[2:3], v[2:3], v[10:11], v[18:19]
 ; GFX9-DENORM-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[20:21]
 ; GFX9-DENORM-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DENORM-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[24:25]
+; GFX9-DENORM-NEXT:    v_fma_f64 v[22:23], v[22:23], v[30:31], v[37:38]
 ; GFX9-DENORM-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[22:23]
 ; GFX9-DENORM-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/saddsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/saddsat.ll
@@ -1937,120 +1937,120 @@ define <16 x i32> @v_saddsat_v16i32(<16 x i32> %lhs, <16 x i32> %rhs) {
 ; GFX6-LABEL: v_saddsat_v16i32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_min_i32_e32 v32, 0, v0
-; GFX6-NEXT:    v_bfrev_b32_e32 v31, 1
-; GFX6-NEXT:    v_sub_i32_e32 v32, vcc, v31, v32
-; GFX6-NEXT:    v_max_i32_e32 v32, v32, v16
-; GFX6-NEXT:    v_max_i32_e32 v33, 0, v0
-; GFX6-NEXT:    v_bfrev_b32_e32 v16, -2
-; GFX6-NEXT:    v_sub_i32_e32 v33, vcc, v16, v33
-; GFX6-NEXT:    v_min_i32_e32 v32, v32, v33
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, v0, v32
-; GFX6-NEXT:    v_min_i32_e32 v32, 0, v1
-; GFX6-NEXT:    v_sub_i32_e32 v32, vcc, v31, v32
-; GFX6-NEXT:    v_max_i32_e32 v17, v32, v17
-; GFX6-NEXT:    v_max_i32_e32 v32, 0, v1
-; GFX6-NEXT:    v_sub_i32_e32 v32, vcc, v16, v32
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v32
-; GFX6-NEXT:    v_add_i32_e32 v1, vcc, v1, v17
-; GFX6-NEXT:    v_min_i32_e32 v17, 0, v2
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v31, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_max_i32_e32 v18, 0, v2
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v16, v18
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_add_i32_e32 v2, vcc, v2, v17
-; GFX6-NEXT:    v_min_i32_e32 v17, 0, v3
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v31, v17
-; GFX6-NEXT:    v_max_i32_e32 v18, 0, v3
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v16, v18
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_add_i32_e32 v3, vcc, v3, v17
-; GFX6-NEXT:    v_min_i32_e32 v17, 0, v4
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v31, v17
-; GFX6-NEXT:    v_max_i32_e32 v18, 0, v4
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v20
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v16, v18
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_add_i32_e32 v4, vcc, v4, v17
-; GFX6-NEXT:    v_min_i32_e32 v17, 0, v5
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v31, v17
-; GFX6-NEXT:    v_max_i32_e32 v18, 0, v5
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v21
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v16, v18
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_add_i32_e32 v5, vcc, v5, v17
-; GFX6-NEXT:    v_min_i32_e32 v17, 0, v6
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v31, v17
-; GFX6-NEXT:    v_max_i32_e32 v18, 0, v6
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v22
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v16, v18
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    buffer_load_dword v18, off, s[0:3], s32
-; GFX6-NEXT:    v_add_i32_e32 v6, vcc, v6, v17
-; GFX6-NEXT:    v_min_i32_e32 v17, 0, v7
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v31, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, 0, v7
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v23
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v16, v19
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_min_i32_e32 v19, 0, v8
-; GFX6-NEXT:    v_add_i32_e32 v7, vcc, v7, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v8
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v31, v19
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v16, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, v19, v24
-; GFX6-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX6-NEXT:    v_min_i32_e32 v19, 0, v9
-; GFX6-NEXT:    v_add_i32_e32 v8, vcc, v8, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v9
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v31, v19
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v16, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, v19, v25
-; GFX6-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX6-NEXT:    v_min_i32_e32 v19, 0, v10
-; GFX6-NEXT:    v_add_i32_e32 v9, vcc, v9, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v10
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v31, v19
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v16, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, v19, v26
-; GFX6-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX6-NEXT:    v_min_i32_e32 v19, 0, v11
-; GFX6-NEXT:    v_add_i32_e32 v10, vcc, v10, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v11
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v31, v19
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v16, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, v19, v27
-; GFX6-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX6-NEXT:    v_min_i32_e32 v19, 0, v12
-; GFX6-NEXT:    v_add_i32_e32 v11, vcc, v11, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v12
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v31, v19
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v16, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, v19, v28
-; GFX6-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX6-NEXT:    v_min_i32_e32 v19, 0, v13
-; GFX6-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v13
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v31, v19
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v16, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, v19, v29
-; GFX6-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX6-NEXT:    v_min_i32_e32 v19, 0, v14
-; GFX6-NEXT:    v_add_i32_e32 v13, vcc, v13, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v14
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v31, v19
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v16, v17
-; GFX6-NEXT:    v_max_i32_e32 v19, v19, v30
-; GFX6-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX6-NEXT:    v_add_i32_e32 v14, vcc, v14, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, 0, v15
-; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v17
-; GFX6-NEXT:    v_min_i32_e32 v17, 0, v15
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v31, v17
+; GFX6-NEXT:    v_min_i32_e32 v31, 0, v0
+; GFX6-NEXT:    v_bfrev_b32_e32 v32, 1
+; GFX6-NEXT:    v_sub_i32_e32 v31, vcc, v32, v31
+; GFX6-NEXT:    v_max_i32_e32 v16, v31, v16
+; GFX6-NEXT:    v_max_i32_e32 v31, 0, v0
+; GFX6-NEXT:    v_bfrev_b32_e32 v33, -2
+; GFX6-NEXT:    v_sub_i32_e32 v31, vcc, v33, v31
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v31
+; GFX6-NEXT:    v_add_i32_e32 v0, vcc, v0, v16
+; GFX6-NEXT:    v_min_i32_e32 v16, 0, v1
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v32, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_max_i32_e32 v17, 0, v1
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v33, v17
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_add_i32_e32 v1, vcc, v1, v16
+; GFX6-NEXT:    v_min_i32_e32 v16, 0, v2
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v32, v16
+; GFX6-NEXT:    v_max_i32_e32 v17, 0, v2
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v33, v17
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_add_i32_e32 v2, vcc, v2, v16
+; GFX6-NEXT:    v_min_i32_e32 v16, 0, v3
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v32, v16
+; GFX6-NEXT:    v_max_i32_e32 v17, 0, v3
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v19
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v33, v17
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_add_i32_e32 v3, vcc, v3, v16
+; GFX6-NEXT:    v_min_i32_e32 v16, 0, v4
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v32, v16
+; GFX6-NEXT:    v_max_i32_e32 v17, 0, v4
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v20
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v33, v17
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_add_i32_e32 v4, vcc, v4, v16
+; GFX6-NEXT:    v_min_i32_e32 v16, 0, v5
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v32, v16
+; GFX6-NEXT:    v_max_i32_e32 v17, 0, v5
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v21
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v33, v17
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_add_i32_e32 v5, vcc, v5, v16
+; GFX6-NEXT:    v_min_i32_e32 v16, 0, v6
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v32, v16
+; GFX6-NEXT:    v_max_i32_e32 v17, 0, v6
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v22
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v33, v17
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    buffer_load_dword v17, off, s[0:3], s32
+; GFX6-NEXT:    v_add_i32_e32 v6, vcc, v6, v16
+; GFX6-NEXT:    v_min_i32_e32 v16, 0, v7
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v32, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, 0, v7
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v23
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v33, v18
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v8
+; GFX6-NEXT:    v_add_i32_e32 v7, vcc, v7, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v8
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, v18, v24
+; GFX6-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v9
+; GFX6-NEXT:    v_add_i32_e32 v8, vcc, v8, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v9
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, v18, v25
+; GFX6-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v10
+; GFX6-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v10
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, v18, v26
+; GFX6-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v11
+; GFX6-NEXT:    v_add_i32_e32 v10, vcc, v10, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v11
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, v18, v27
+; GFX6-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v12
+; GFX6-NEXT:    v_add_i32_e32 v11, vcc, v11, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v12
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, v18, v28
+; GFX6-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v13
+; GFX6-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v13
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, v18, v29
+; GFX6-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v14
+; GFX6-NEXT:    v_add_i32_e32 v13, vcc, v13, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v14
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
+; GFX6-NEXT:    v_max_i32_e32 v18, v18, v30
+; GFX6-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX6-NEXT:    v_min_i32_e32 v18, 0, v15
+; GFX6-NEXT:    v_add_i32_e32 v14, vcc, v14, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, 0, v15
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v32, v18
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v33, v16
 ; GFX6-NEXT:    s_waitcnt vmcnt(0)
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v18
+; GFX6-NEXT:    v_max_i32_e32 v17, v18, v17
 ; GFX6-NEXT:    v_min_i32_e32 v16, v17, v16
 ; GFX6-NEXT:    v_add_i32_e32 v15, vcc, v15, v16
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
@@ -2058,120 +2058,120 @@ define <16 x i32> @v_saddsat_v16i32(<16 x i32> %lhs, <16 x i32> %rhs) {
 ; GFX8-LABEL: v_saddsat_v16i32:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_min_i32_e32 v32, 0, v0
-; GFX8-NEXT:    v_bfrev_b32_e32 v31, 1
-; GFX8-NEXT:    v_sub_u32_e32 v32, vcc, v31, v32
-; GFX8-NEXT:    v_max_i32_e32 v32, v32, v16
-; GFX8-NEXT:    v_max_i32_e32 v33, 0, v0
-; GFX8-NEXT:    v_bfrev_b32_e32 v16, -2
-; GFX8-NEXT:    v_sub_u32_e32 v33, vcc, v16, v33
-; GFX8-NEXT:    v_min_i32_e32 v32, v32, v33
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v32
-; GFX8-NEXT:    v_min_i32_e32 v32, 0, v1
-; GFX8-NEXT:    v_sub_u32_e32 v32, vcc, v31, v32
-; GFX8-NEXT:    v_max_i32_e32 v17, v32, v17
-; GFX8-NEXT:    v_max_i32_e32 v32, 0, v1
-; GFX8-NEXT:    v_sub_u32_e32 v32, vcc, v16, v32
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v32
-; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v17
-; GFX8-NEXT:    v_min_i32_e32 v17, 0, v2
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v31, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_max_i32_e32 v18, 0, v2
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v16, v18
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v17
-; GFX8-NEXT:    v_min_i32_e32 v17, 0, v3
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v31, v17
-; GFX8-NEXT:    v_max_i32_e32 v18, 0, v3
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v16, v18
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v3, v17
-; GFX8-NEXT:    v_min_i32_e32 v17, 0, v4
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v31, v17
-; GFX8-NEXT:    v_max_i32_e32 v18, 0, v4
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v20
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v16, v18
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v17
-; GFX8-NEXT:    v_min_i32_e32 v17, 0, v5
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v31, v17
-; GFX8-NEXT:    v_max_i32_e32 v18, 0, v5
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v21
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v16, v18
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v17
-; GFX8-NEXT:    v_min_i32_e32 v17, 0, v6
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v31, v17
-; GFX8-NEXT:    v_max_i32_e32 v18, 0, v6
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v22
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v16, v18
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    buffer_load_dword v18, off, s[0:3], s32
-; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v17
-; GFX8-NEXT:    v_min_i32_e32 v17, 0, v7
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v31, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, 0, v7
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v23
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v16, v19
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_min_i32_e32 v19, 0, v8
-; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v7, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v8
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v31, v19
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v16, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, v19, v24
-; GFX8-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX8-NEXT:    v_min_i32_e32 v19, 0, v9
-; GFX8-NEXT:    v_add_u32_e32 v8, vcc, v8, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v9
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v31, v19
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v16, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, v19, v25
-; GFX8-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX8-NEXT:    v_min_i32_e32 v19, 0, v10
-; GFX8-NEXT:    v_add_u32_e32 v9, vcc, v9, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v10
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v31, v19
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v16, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, v19, v26
-; GFX8-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX8-NEXT:    v_min_i32_e32 v19, 0, v11
-; GFX8-NEXT:    v_add_u32_e32 v10, vcc, v10, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v11
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v31, v19
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v16, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, v19, v27
-; GFX8-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX8-NEXT:    v_min_i32_e32 v19, 0, v12
-; GFX8-NEXT:    v_add_u32_e32 v11, vcc, v11, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v12
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v31, v19
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v16, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, v19, v28
-; GFX8-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX8-NEXT:    v_min_i32_e32 v19, 0, v13
-; GFX8-NEXT:    v_add_u32_e32 v12, vcc, v12, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v13
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v31, v19
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v16, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, v19, v29
-; GFX8-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX8-NEXT:    v_min_i32_e32 v19, 0, v14
-; GFX8-NEXT:    v_add_u32_e32 v13, vcc, v13, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v14
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v31, v19
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v16, v17
-; GFX8-NEXT:    v_max_i32_e32 v19, v19, v30
-; GFX8-NEXT:    v_min_i32_e32 v17, v19, v17
-; GFX8-NEXT:    v_add_u32_e32 v14, vcc, v14, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, 0, v15
-; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v17
-; GFX8-NEXT:    v_min_i32_e32 v17, 0, v15
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v31, v17
+; GFX8-NEXT:    v_min_i32_e32 v31, 0, v0
+; GFX8-NEXT:    v_bfrev_b32_e32 v32, 1
+; GFX8-NEXT:    v_sub_u32_e32 v31, vcc, v32, v31
+; GFX8-NEXT:    v_max_i32_e32 v16, v31, v16
+; GFX8-NEXT:    v_max_i32_e32 v31, 0, v0
+; GFX8-NEXT:    v_bfrev_b32_e32 v33, -2
+; GFX8-NEXT:    v_sub_u32_e32 v31, vcc, v33, v31
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v31
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, v0, v16
+; GFX8-NEXT:    v_min_i32_e32 v16, 0, v1
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v32, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_max_i32_e32 v17, 0, v1
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v33, v17
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_add_u32_e32 v1, vcc, v1, v16
+; GFX8-NEXT:    v_min_i32_e32 v16, 0, v2
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v32, v16
+; GFX8-NEXT:    v_max_i32_e32 v17, 0, v2
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v33, v17
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_add_u32_e32 v2, vcc, v2, v16
+; GFX8-NEXT:    v_min_i32_e32 v16, 0, v3
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v32, v16
+; GFX8-NEXT:    v_max_i32_e32 v17, 0, v3
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v19
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v33, v17
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_add_u32_e32 v3, vcc, v3, v16
+; GFX8-NEXT:    v_min_i32_e32 v16, 0, v4
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v32, v16
+; GFX8-NEXT:    v_max_i32_e32 v17, 0, v4
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v20
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v33, v17
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_add_u32_e32 v4, vcc, v4, v16
+; GFX8-NEXT:    v_min_i32_e32 v16, 0, v5
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v32, v16
+; GFX8-NEXT:    v_max_i32_e32 v17, 0, v5
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v21
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v33, v17
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_add_u32_e32 v5, vcc, v5, v16
+; GFX8-NEXT:    v_min_i32_e32 v16, 0, v6
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v32, v16
+; GFX8-NEXT:    v_max_i32_e32 v17, 0, v6
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v22
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v33, v17
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    buffer_load_dword v17, off, s[0:3], s32
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, v6, v16
+; GFX8-NEXT:    v_min_i32_e32 v16, 0, v7
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v32, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, 0, v7
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v23
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v33, v18
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v8
+; GFX8-NEXT:    v_add_u32_e32 v7, vcc, v7, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v8
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, v18, v24
+; GFX8-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v9
+; GFX8-NEXT:    v_add_u32_e32 v8, vcc, v8, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v9
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, v18, v25
+; GFX8-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v10
+; GFX8-NEXT:    v_add_u32_e32 v9, vcc, v9, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v10
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, v18, v26
+; GFX8-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v11
+; GFX8-NEXT:    v_add_u32_e32 v10, vcc, v10, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v11
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, v18, v27
+; GFX8-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v12
+; GFX8-NEXT:    v_add_u32_e32 v11, vcc, v11, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v12
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, v18, v28
+; GFX8-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v13
+; GFX8-NEXT:    v_add_u32_e32 v12, vcc, v12, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v13
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, v18, v29
+; GFX8-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v14
+; GFX8-NEXT:    v_add_u32_e32 v13, vcc, v13, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v14
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
+; GFX8-NEXT:    v_max_i32_e32 v18, v18, v30
+; GFX8-NEXT:    v_min_i32_e32 v16, v18, v16
+; GFX8-NEXT:    v_min_i32_e32 v18, 0, v15
+; GFX8-NEXT:    v_add_u32_e32 v14, vcc, v14, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, 0, v15
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v32, v18
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v33, v16
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v18
+; GFX8-NEXT:    v_max_i32_e32 v17, v18, v17
 ; GFX8-NEXT:    v_min_i32_e32 v16, v17, v16
 ; GFX8-NEXT:    v_add_u32_e32 v15, vcc, v15, v16
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/ssubsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/ssubsat.ll
@@ -1937,242 +1937,242 @@ define <16 x i32> @v_ssubsat_v16i32(<16 x i32> %lhs, <16 x i32> %rhs) {
 ; GFX6-LABEL: v_ssubsat_v16i32:
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-NEXT:    v_max_i32_e32 v32, -1, v0
-; GFX6-NEXT:    v_bfrev_b32_e32 v31, -2
-; GFX6-NEXT:    v_sub_i32_e32 v32, vcc, v32, v31
-; GFX6-NEXT:    v_max_i32_e32 v32, v32, v16
-; GFX6-NEXT:    v_min_i32_e32 v33, -1, v0
-; GFX6-NEXT:    v_bfrev_b32_e32 v16, 1
-; GFX6-NEXT:    v_sub_i32_e32 v33, vcc, v33, v16
-; GFX6-NEXT:    v_min_i32_e32 v32, v32, v33
-; GFX6-NEXT:    v_sub_i32_e32 v0, vcc, v0, v32
-; GFX6-NEXT:    v_max_i32_e32 v32, -1, v1
-; GFX6-NEXT:    v_sub_i32_e32 v32, vcc, v32, v31
-; GFX6-NEXT:    v_max_i32_e32 v17, v32, v17
-; GFX6-NEXT:    v_min_i32_e32 v32, -1, v1
-; GFX6-NEXT:    v_sub_i32_e32 v32, vcc, v32, v16
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v32
-; GFX6-NEXT:    v_sub_i32_e32 v1, vcc, v1, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v2
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_min_i32_e32 v18, -1, v2
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v16
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_sub_i32_e32 v2, vcc, v2, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v3
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v18, -1, v3
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v16
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_sub_i32_e32 v3, vcc, v3, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v4
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v18, -1, v4
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v20
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v16
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_sub_i32_e32 v4, vcc, v4, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v5
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v18, -1, v5
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v21
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v16
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_sub_i32_e32 v5, vcc, v5, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v6
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v18, -1, v6
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v22
-; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v16
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX6-NEXT:    buffer_load_dword v18, off, s[0:3], s32
-; GFX6-NEXT:    v_sub_i32_e32 v6, vcc, v6, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v7
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v7
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v23
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v7, vcc, v7, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v8
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v8
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v24
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, v8, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v9
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v9
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v25
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v9, vcc, v9, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v10
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v10
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v26
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v10, vcc, v10, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v11
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v11
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v27
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v11, vcc, v11, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v12
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v12
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v28
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v12, vcc, v12, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v13
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v13
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v29
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v13, vcc, v13, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v14
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v14
-; GFX6-NEXT:    v_sub_i32_e32 v19, vcc, v19, v16
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v30
-; GFX6-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX6-NEXT:    v_sub_i32_e32 v14, vcc, v14, v17
-; GFX6-NEXT:    v_max_i32_e32 v17, -1, v15
-; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v31
-; GFX6-NEXT:    v_min_i32_e32 v19, -1, v15
-; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v19, v16
+; GFX6-NEXT:    v_max_i32_e32 v31, -1, v0
+; GFX6-NEXT:    v_bfrev_b32_e32 v32, -2
+; GFX6-NEXT:    v_sub_i32_e32 v31, vcc, v31, v32
+; GFX6-NEXT:    v_max_i32_e32 v16, v31, v16
+; GFX6-NEXT:    v_min_i32_e32 v31, -1, v0
+; GFX6-NEXT:    v_bfrev_b32_e32 v33, 1
+; GFX6-NEXT:    v_sub_i32_e32 v31, vcc, v31, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v31
+; GFX6-NEXT:    v_sub_i32_e32 v0, vcc, v0, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v1
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_min_i32_e32 v17, -1, v1
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_sub_i32_e32 v1, vcc, v1, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v2
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v17, -1, v2
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_sub_i32_e32 v2, vcc, v2, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v3
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v17, -1, v3
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v19
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_sub_i32_e32 v3, vcc, v3, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v4
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v17, -1, v4
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v20
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_sub_i32_e32 v4, vcc, v4, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v5
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v17, -1, v5
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v21
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_sub_i32_e32 v5, vcc, v5, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v6
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v17, -1, v6
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v22
+; GFX6-NEXT:    v_sub_i32_e32 v17, vcc, v17, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX6-NEXT:    buffer_load_dword v17, off, s[0:3], s32
+; GFX6-NEXT:    v_sub_i32_e32 v6, vcc, v6, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v7
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v7
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v23
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v7, vcc, v7, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v8
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v8
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v24
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, v8, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v9
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v9
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v25
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v9, vcc, v9, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v10
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v10
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v26
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v10, vcc, v10, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v11
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v11
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v27
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v11, vcc, v11, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v12
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v12
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v28
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v12, vcc, v12, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v13
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v13
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v29
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v13, vcc, v13, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v14
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v14
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v30
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX6-NEXT:    v_sub_i32_e32 v14, vcc, v14, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, -1, v15
+; GFX6-NEXT:    v_sub_i32_e32 v16, vcc, v16, v32
+; GFX6-NEXT:    v_min_i32_e32 v18, -1, v15
+; GFX6-NEXT:    v_sub_i32_e32 v18, vcc, v18, v33
 ; GFX6-NEXT:    s_waitcnt vmcnt(0)
-; GFX6-NEXT:    v_max_i32_e32 v17, v17, v18
-; GFX6-NEXT:    v_min_i32_e32 v16, v17, v16
+; GFX6-NEXT:    v_max_i32_e32 v16, v16, v17
+; GFX6-NEXT:    v_min_i32_e32 v16, v16, v18
 ; GFX6-NEXT:    v_sub_i32_e32 v15, vcc, v15, v16
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_ssubsat_v16i32:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_max_i32_e32 v32, -1, v0
-; GFX8-NEXT:    v_bfrev_b32_e32 v31, -2
-; GFX8-NEXT:    v_sub_u32_e32 v32, vcc, v32, v31
-; GFX8-NEXT:    v_max_i32_e32 v32, v32, v16
-; GFX8-NEXT:    v_min_i32_e32 v33, -1, v0
-; GFX8-NEXT:    v_bfrev_b32_e32 v16, 1
-; GFX8-NEXT:    v_sub_u32_e32 v33, vcc, v33, v16
-; GFX8-NEXT:    v_min_i32_e32 v32, v32, v33
-; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, v0, v32
-; GFX8-NEXT:    v_max_i32_e32 v32, -1, v1
-; GFX8-NEXT:    v_sub_u32_e32 v32, vcc, v32, v31
-; GFX8-NEXT:    v_max_i32_e32 v17, v32, v17
-; GFX8-NEXT:    v_min_i32_e32 v32, -1, v1
-; GFX8-NEXT:    v_sub_u32_e32 v32, vcc, v32, v16
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v32
-; GFX8-NEXT:    v_sub_u32_e32 v1, vcc, v1, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v2
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_min_i32_e32 v18, -1, v2
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v16
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_sub_u32_e32 v2, vcc, v2, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v3
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v18, -1, v3
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v16
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_sub_u32_e32 v3, vcc, v3, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v4
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v18, -1, v4
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v20
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v16
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_sub_u32_e32 v4, vcc, v4, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v5
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v18, -1, v5
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v21
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v16
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_sub_u32_e32 v5, vcc, v5, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v6
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v18, -1, v6
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v22
-; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v16
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v18
-; GFX8-NEXT:    buffer_load_dword v18, off, s[0:3], s32
-; GFX8-NEXT:    v_sub_u32_e32 v6, vcc, v6, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v7
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v7
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v23
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v7, vcc, v7, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v8
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v8
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v24
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v8, vcc, v8, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v9
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v9
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v25
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v9, vcc, v9, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v10
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v10
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v26
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v10, vcc, v10, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v11
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v11
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v27
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v11, vcc, v11, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v12
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v12
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v28
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v12, vcc, v12, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v13
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v13
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v29
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v13, vcc, v13, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v14
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v14
-; GFX8-NEXT:    v_sub_u32_e32 v19, vcc, v19, v16
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v30
-; GFX8-NEXT:    v_min_i32_e32 v17, v17, v19
-; GFX8-NEXT:    v_sub_u32_e32 v14, vcc, v14, v17
-; GFX8-NEXT:    v_max_i32_e32 v17, -1, v15
-; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v31
-; GFX8-NEXT:    v_min_i32_e32 v19, -1, v15
-; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v19, v16
+; GFX8-NEXT:    v_max_i32_e32 v31, -1, v0
+; GFX8-NEXT:    v_bfrev_b32_e32 v32, -2
+; GFX8-NEXT:    v_sub_u32_e32 v31, vcc, v31, v32
+; GFX8-NEXT:    v_max_i32_e32 v16, v31, v16
+; GFX8-NEXT:    v_min_i32_e32 v31, -1, v0
+; GFX8-NEXT:    v_bfrev_b32_e32 v33, 1
+; GFX8-NEXT:    v_sub_u32_e32 v31, vcc, v31, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v31
+; GFX8-NEXT:    v_sub_u32_e32 v0, vcc, v0, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v1
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_min_i32_e32 v17, -1, v1
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_sub_u32_e32 v1, vcc, v1, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v2
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v17, -1, v2
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_sub_u32_e32 v2, vcc, v2, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v3
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v17, -1, v3
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v19
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_sub_u32_e32 v3, vcc, v3, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v4
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v17, -1, v4
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v20
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_sub_u32_e32 v4, vcc, v4, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v5
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v17, -1, v5
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v21
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_sub_u32_e32 v5, vcc, v5, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v6
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v17, -1, v6
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v22
+; GFX8-NEXT:    v_sub_u32_e32 v17, vcc, v17, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v17
+; GFX8-NEXT:    buffer_load_dword v17, off, s[0:3], s32
+; GFX8-NEXT:    v_sub_u32_e32 v6, vcc, v6, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v7
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v7
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v23
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v7, vcc, v7, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v8
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v8
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v24
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v8, vcc, v8, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v9
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v9
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v25
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v9, vcc, v9, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v10
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v10
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v26
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v10, vcc, v10, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v11
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v11
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v27
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v11, vcc, v11, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v12
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v12
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v28
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v12, vcc, v12, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v13
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v13
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v29
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v13, vcc, v13, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v14
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v14
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v30
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
+; GFX8-NEXT:    v_sub_u32_e32 v14, vcc, v14, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, -1, v15
+; GFX8-NEXT:    v_sub_u32_e32 v16, vcc, v16, v32
+; GFX8-NEXT:    v_min_i32_e32 v18, -1, v15
+; GFX8-NEXT:    v_sub_u32_e32 v18, vcc, v18, v33
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_max_i32_e32 v17, v17, v18
-; GFX8-NEXT:    v_min_i32_e32 v16, v17, v16
+; GFX8-NEXT:    v_max_i32_e32 v16, v16, v17
+; GFX8-NEXT:    v_min_i32_e32 v16, v16, v18
 ; GFX8-NEXT:    v_sub_u32_e32 v15, vcc, v15, v16
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/udiv.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/udiv.i64.ll
@@ -368,253 +368,253 @@ define <2 x i64> @v_udiv_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v10, v4
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v5
 ; GISEL-NEXT:    v_sub_i32_e32 v8, vcc, 0, v4
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v6
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v14, v7
-; GISEL-NEXT:    v_sub_i32_e64 v9, s[4:5], 0, v6
-; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v5, vcc
-; GISEL-NEXT:    v_subb_u32_e64 v12, vcc, 0, v7, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v9, vcc, 0, v5, vcc
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v6
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v7
+; GISEL-NEXT:    v_sub_i32_e32 v14, vcc, 0, v6
+; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v7, vcc
 ; GISEL-NEXT:    v_mac_f32_e32 v10, 0x4f800000, v11
-; GISEL-NEXT:    v_mac_f32_e32 v13, 0x4f800000, v14
+; GISEL-NEXT:    v_mac_f32_e32 v12, 0x4f800000, v13
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v10, v10
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v13
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v12
 ; GISEL-NEXT:    v_mul_f32_e32 v10, 0x5f7ffffc, v10
 ; GISEL-NEXT:    v_mul_f32_e32 v11, 0x5f7ffffc, v11
-; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v10
-; GISEL-NEXT:    v_mul_f32_e32 v14, 0x2f800000, v11
+; GISEL-NEXT:    v_mul_f32_e32 v12, 0x2f800000, v10
+; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v11
+; GISEL-NEXT:    v_trunc_f32_e32 v12, v12
 ; GISEL-NEXT:    v_trunc_f32_e32 v13, v13
-; GISEL-NEXT:    v_trunc_f32_e32 v14, v14
-; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v13
+; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v12
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v12, v12
+; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v13
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v13
-; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v14
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v14
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v10, v10
-; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v13
+; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v12
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v11
-; GISEL-NEXT:    v_mul_lo_u32 v17, v9, v14
-; GISEL-NEXT:    v_mul_lo_u32 v18, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v11
-; GISEL-NEXT:    v_mul_hi_u32 v20, v9, v11
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v19, v17
-; GISEL-NEXT:    v_mul_lo_u32 v19, v14, v18
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v18
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
-; GISEL-NEXT:    v_mul_lo_u32 v19, v8, v10
-; GISEL-NEXT:    v_mul_lo_u32 v20, v15, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v20, v16
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v18, v8, v10
+; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v10
 ; GISEL-NEXT:    v_mul_hi_u32 v20, v8, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v19
-; GISEL-NEXT:    v_mul_lo_u32 v21, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v19
-; GISEL-NEXT:    v_add_i32_e64 v20, s[8:9], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v19, v13, v19
-; GISEL-NEXT:    v_mul_hi_u32 v18, v14, v18
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[12:13], v20, v18
-; GISEL-NEXT:    v_mul_hi_u32 v20, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[14:15], v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[16:17], v18, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[10:11]
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[14:15]
-; GISEL-NEXT:    v_add_i32_e64 v21, s[6:7], v21, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[12:13]
-; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[16:17]
-; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v23, v24
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v22
-; GISEL-NEXT:    v_add_i32_e64 v10, s[6:7], v10, v19
-; GISEL-NEXT:    v_mul_hi_u32 v16, v13, v16
-; GISEL-NEXT:    v_mul_hi_u32 v17, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v11, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v21, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v23, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v8, v10
-; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v10
-; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
-; GISEL-NEXT:    v_mul_hi_u32 v18, v8, v10
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v19
-; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v12, v12, v11
-; GISEL-NEXT:    v_addc_u32_e64 v13, vcc, v13, v16, s[6:7]
-; GISEL-NEXT:    v_mul_hi_u32 v16, v9, v11
-; GISEL-NEXT:    v_addc_u32_e64 v14, vcc, v14, v17, s[8:9]
-; GISEL-NEXT:    v_mul_hi_u32 v17, v10, v20
-; GISEL-NEXT:    v_mul_lo_u32 v8, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v15, v8
-; GISEL-NEXT:    v_mul_hi_u32 v15, v11, v19
-; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v14
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v12, v9
-; GISEL-NEXT:    v_mul_lo_u32 v12, v13, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v13, v20
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v18
-; GISEL-NEXT:    v_mul_lo_u32 v18, v14, v19
-; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v19
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v10, v8
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v13, v8
-; GISEL-NEXT:    v_add_i32_e64 v12, s[4:5], v12, v17
-; GISEL-NEXT:    v_mul_hi_u32 v12, v10, v8
-; GISEL-NEXT:    v_mul_hi_u32 v8, v13, v8
-; GISEL-NEXT:    v_mul_lo_u32 v17, v11, v9
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v17, s[8:9], v18, v17
-; GISEL-NEXT:    v_mul_hi_u32 v18, v11, v9
-; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v17, v15
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v16, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[10:11]
-; GISEL-NEXT:    v_add_i32_e64 v18, s[8:9], v19, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e64 v15, s[4:5], v15, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[8:9]
+; GISEL-NEXT:    v_mul_lo_u32 v21, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v22, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v23, v14, v11
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v16
+; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v18
+; GISEL-NEXT:    v_mul_hi_u32 v24, v10, v18
+; GISEL-NEXT:    v_mul_hi_u32 v18, v12, v18
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v22, v17
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v21
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v21
+; GISEL-NEXT:    v_mul_hi_u32 v21, v13, v21
 ; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v20
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v19
-; GISEL-NEXT:    v_add_i32_e64 v17, s[4:5], v18, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v23
+; GISEL-NEXT:    v_mul_lo_u32 v20, v10, v16
+; GISEL-NEXT:    v_mul_lo_u32 v23, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v26, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v27, v11, v17
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v27
+; GISEL-NEXT:    v_cndmask_b32_e64 v27, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v23, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v21, s[4:5], v22, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v24
 ; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v15, v18
-; GISEL-NEXT:    v_add_i32_e64 v15, s[6:7], v16, v19
-; GISEL-NEXT:    v_mul_lo_u32 v16, v1, v10
-; GISEL-NEXT:    v_mul_hi_u32 v17, v0, v10
-; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
-; GISEL-NEXT:    v_mul_lo_u32 v18, v3, v11
-; GISEL-NEXT:    v_mul_hi_u32 v19, v2, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
-; GISEL-NEXT:    v_add_i32_e64 v8, s[6:7], v8, v12
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v15
-; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, v13, v8, vcc
-; GISEL-NEXT:    v_addc_u32_e64 v9, vcc, v14, v9, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v12, v0, v8
-; GISEL-NEXT:    v_mul_lo_u32 v13, v1, v8
-; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v8
-; GISEL-NEXT:    v_mul_hi_u32 v15, v1, v8
-; GISEL-NEXT:    v_mul_lo_u32 v8, v2, v9
-; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
-; GISEL-NEXT:    v_mul_hi_u32 v16, v2, v9
-; GISEL-NEXT:    v_mul_hi_u32 v21, v3, v9
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v13, v10
-; GISEL-NEXT:    v_add_i32_e64 v8, s[6:7], v18, v8
-; GISEL-NEXT:    v_add_i32_e64 v10, s[8:9], v20, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v9, v14
-; GISEL-NEXT:    v_add_i32_e64 v8, s[6:7], v8, v19
-; GISEL-NEXT:    v_add_i32_e64 v10, s[8:9], v10, v16
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v11, v8
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v13, v14
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v18, v16
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v26
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v26, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v25, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v23, v24
+; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v27, v26
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v18, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v22, v23
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v19
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_addc_u32_e32 v12, vcc, v12, v16, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v10
+; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v10
+; GISEL-NEXT:    v_mul_hi_u32 v18, v8, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v13, v17, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v8, v8, v12
+; GISEL-NEXT:    v_mul_lo_u32 v20, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v14, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v23, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
 ; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v10, v13
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v14, v4, v8
-; GISEL-NEXT:    v_mul_lo_u32 v16, v5, v8
-; GISEL-NEXT:    v_mul_hi_u32 v17, v4, v8
-; GISEL-NEXT:    v_mul_lo_u32 v18, v6, v9
-; GISEL-NEXT:    v_mul_lo_u32 v19, v7, v9
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
-; GISEL-NEXT:    v_mul_hi_u32 v11, v6, v9
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v13
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, 1, v8
-; GISEL-NEXT:    v_sub_i32_e64 v0, s[4:5], v0, v14
-; GISEL-NEXT:    v_add_i32_e64 v14, s[6:7], 1, v9
-; GISEL-NEXT:    v_sub_i32_e64 v2, s[8:9], v2, v18
-; GISEL-NEXT:    v_add_i32_e64 v18, s[10:11], 1, v13
-; GISEL-NEXT:    v_add_i32_e64 v10, s[12:13], v15, v10
-; GISEL-NEXT:    v_add_i32_e64 v15, s[12:13], 1, v14
-; GISEL-NEXT:    v_add_i32_e64 v12, s[14:15], v21, v12
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[14:15], v0, v4
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[16:17], v2, v6
-; GISEL-NEXT:    v_sub_i32_e64 v0, s[18:19], v0, v4
-; GISEL-NEXT:    v_sub_i32_e64 v2, s[20:21], v2, v6
-; GISEL-NEXT:    v_mul_lo_u32 v20, v4, v10
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[22:23], v0, v4
-; GISEL-NEXT:    v_addc_u32_e32 v0, vcc, 0, v10, vcc
-; GISEL-NEXT:    v_mul_lo_u32 v4, v6, v12
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v15, v14
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v18
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v19
+; GISEL-NEXT:    v_mul_lo_u32 v14, v10, v8
+; GISEL-NEXT:    v_mul_lo_u32 v15, v12, v8
+; GISEL-NEXT:    v_mul_hi_u32 v18, v10, v8
+; GISEL-NEXT:    v_mul_hi_u32 v8, v12, v8
+; GISEL-NEXT:    v_mul_lo_u32 v19, v11, v9
+; GISEL-NEXT:    v_mul_lo_u32 v24, v13, v9
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v13, v9
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v22, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v24, v17
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v14, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v22, v19
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v24, v21
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v16, v15
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v18
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v15
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v14
+; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, v12, v8, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v12, v1, v10
+; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v10
+; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v17
+; GISEL-NEXT:    v_addc_u32_e32 v9, vcc, v13, v9, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v13, v3, v11
+; GISEL-NEXT:    v_mul_hi_u32 v15, v2, v11
+; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
+; GISEL-NEXT:    v_mul_lo_u32 v16, v0, v8
+; GISEL-NEXT:    v_mul_lo_u32 v17, v1, v8
+; GISEL-NEXT:    v_mul_hi_u32 v18, v0, v8
+; GISEL-NEXT:    v_mul_hi_u32 v8, v1, v8
+; GISEL-NEXT:    v_mul_lo_u32 v19, v2, v9
+; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
+; GISEL-NEXT:    v_mul_hi_u32 v21, v2, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v3, v9
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v17, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v20, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v15
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v17, v14
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v19, v13
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v20, v15
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v13
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v14, v12
+; GISEL-NEXT:    v_mul_lo_u32 v14, v4, v10
+; GISEL-NEXT:    v_mul_lo_u32 v16, v5, v10
+; GISEL-NEXT:    v_mul_hi_u32 v17, v4, v10
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v15, v13
+; GISEL-NEXT:    v_mul_lo_u32 v15, v6, v11
+; GISEL-NEXT:    v_mul_lo_u32 v18, v7, v11
+; GISEL-NEXT:    v_mul_hi_u32 v19, v6, v11
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v12
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v13
+; GISEL-NEXT:    v_mul_lo_u32 v12, v4, v8
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, 1, v10
+; GISEL-NEXT:    v_addc_u32_e32 v20, vcc, 0, v8, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v21, v6, v9
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, 1, v11
+; GISEL-NEXT:    v_addc_u32_e32 v23, vcc, 0, v9, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, 1, v13
+; GISEL-NEXT:    v_addc_u32_e32 v24, vcc, 0, v20, vcc
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v18, v21
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, 1, v22
+; GISEL-NEXT:    v_addc_u32_e32 v25, vcc, 0, v23, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v18, v19
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v14
+; GISEL-NEXT:    v_subb_u32_e64 v14, s[4:5], v1, v12, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v1, s[4:5], v1, v12
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[4:5]
+; GISEL-NEXT:    v_sub_i32_e64 v2, s[4:5], v2, v15
+; GISEL-NEXT:    v_subb_u32_e64 v15, s[6:7], v3, v17, s[4:5]
+; GISEL-NEXT:    v_sub_i32_e64 v3, s[6:7], v3, v17
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v2, v6
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v14, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, -1, s[6:7]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v5, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v15, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, -1, vcc
+; GISEL-NEXT:    v_subb_u32_e64 v3, vcc, v3, v7, s[4:5]
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v14, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v12, v18, v12, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v4
+; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v15, v7
+; GISEL-NEXT:    v_cndmask_b32_e32 v4, v19, v17, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v6
+; GISEL-NEXT:    v_subbrev_u32_e32 v3, vcc, 0, v3, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v6
-; GISEL-NEXT:    v_addc_u32_e64 v2, s[6:7], 0, v12, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[14:15]
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, -1, s[16:17]
-; GISEL-NEXT:    v_add_i32_e64 v4, s[6:7], v19, v4
-; GISEL-NEXT:    v_addc_u32_e64 v19, s[6:7], 0, v0, s[10:11]
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v17
-; GISEL-NEXT:    v_addc_u32_e64 v17, s[6:7], 0, v2, s[12:13]
-; GISEL-NEXT:    v_add_i32_e64 v4, s[6:7], v4, v11
-; GISEL-NEXT:    v_subb_u32_e64 v11, s[6:7], v1, v16, s[4:5]
-; GISEL-NEXT:    v_sub_i32_e64 v1, s[6:7], v1, v16
-; GISEL-NEXT:    v_subb_u32_e64 v16, s[6:7], v3, v4, s[8:9]
-; GISEL-NEXT:    v_sub_i32_e64 v3, s[6:7], v3, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[22:23]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v11, v5
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[10:11], v11, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, vcc
-; GISEL-NEXT:    v_subb_u32_e64 v1, vcc, v1, v5, s[4:5]
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v16, v7
-; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v3, v7, s[8:9]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v16, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v6, v16, v6, s[10:11]
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, -1, vcc
-; GISEL-NEXT:    v_subbrev_u32_e64 v1, vcc, 0, v1, s[18:19]
-; GISEL-NEXT:    v_subbrev_u32_e64 v3, vcc, 0, v3, s[20:21]
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, v16, v20, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
 ; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v5
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v3, v7
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v1, v5
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[8:9], v3, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v16
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, v1, v4, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v11, s[8:9]
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v1
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[8:9], 0, v3
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, v13, v18, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v14, v15, s[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, v0, v19, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, v2, v17, s[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e32 v0, v8, v1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v2, v9, v3, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e32 v1, v10, v4, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v12, v5, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v3, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v7
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v14, v2, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v13, v16, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, v22, v21, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v20, v24, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, v23, v25, s[4:5]
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v2, v11, v1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v8, v3, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v9, v5, s[4:5]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; CGP-LABEL: v_udiv_v2i64:
@@ -1255,253 +1255,253 @@ define <2 x i64> @v_udiv_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v10, v7
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v8
 ; GISEL-NEXT:    v_sub_i32_e32 v6, vcc, 0, v7
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v4
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v14, v5
-; GISEL-NEXT:    v_sub_i32_e64 v9, s[4:5], 0, v4
-; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v8, vcc
-; GISEL-NEXT:    v_subb_u32_e64 v12, vcc, 0, v5, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v9, vcc, 0, v8, vcc
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v4
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v5
+; GISEL-NEXT:    v_sub_i32_e32 v14, vcc, 0, v4
+; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v5, vcc
 ; GISEL-NEXT:    v_mac_f32_e32 v10, 0x4f800000, v11
-; GISEL-NEXT:    v_mac_f32_e32 v13, 0x4f800000, v14
+; GISEL-NEXT:    v_mac_f32_e32 v12, 0x4f800000, v13
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v10, v10
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v13
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v12
 ; GISEL-NEXT:    v_mul_f32_e32 v10, 0x5f7ffffc, v10
 ; GISEL-NEXT:    v_mul_f32_e32 v11, 0x5f7ffffc, v11
-; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v10
-; GISEL-NEXT:    v_mul_f32_e32 v14, 0x2f800000, v11
+; GISEL-NEXT:    v_mul_f32_e32 v12, 0x2f800000, v10
+; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v11
+; GISEL-NEXT:    v_trunc_f32_e32 v12, v12
 ; GISEL-NEXT:    v_trunc_f32_e32 v13, v13
-; GISEL-NEXT:    v_trunc_f32_e32 v14, v14
-; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v13
+; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v12
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v12, v12
+; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v13
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v13
-; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v14
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v14
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v10, v10
-; GISEL-NEXT:    v_mul_lo_u32 v16, v6, v13
+; GISEL-NEXT:    v_mul_lo_u32 v16, v6, v12
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v11
-; GISEL-NEXT:    v_mul_lo_u32 v17, v9, v14
-; GISEL-NEXT:    v_mul_lo_u32 v18, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v11
-; GISEL-NEXT:    v_mul_hi_u32 v20, v9, v11
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v19, v17
-; GISEL-NEXT:    v_mul_lo_u32 v19, v14, v18
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v18
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
-; GISEL-NEXT:    v_mul_lo_u32 v19, v6, v10
-; GISEL-NEXT:    v_mul_lo_u32 v20, v15, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v20, v16
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v18, v6, v10
+; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v10
 ; GISEL-NEXT:    v_mul_hi_u32 v20, v6, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v19
-; GISEL-NEXT:    v_mul_lo_u32 v21, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v19
-; GISEL-NEXT:    v_add_i32_e64 v20, s[8:9], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v19, v13, v19
-; GISEL-NEXT:    v_mul_hi_u32 v18, v14, v18
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[12:13], v20, v18
-; GISEL-NEXT:    v_mul_hi_u32 v20, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[14:15], v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[16:17], v18, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[10:11]
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[14:15]
-; GISEL-NEXT:    v_add_i32_e64 v21, s[6:7], v21, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[12:13]
-; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[16:17]
-; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v23, v24
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v22
-; GISEL-NEXT:    v_add_i32_e64 v10, s[6:7], v10, v19
-; GISEL-NEXT:    v_mul_hi_u32 v16, v13, v16
-; GISEL-NEXT:    v_mul_hi_u32 v17, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v11, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v21, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v23, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v6, v10
-; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v10
-; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
-; GISEL-NEXT:    v_mul_hi_u32 v18, v6, v10
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v19
-; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v12, v12, v11
-; GISEL-NEXT:    v_addc_u32_e64 v13, vcc, v13, v16, s[6:7]
-; GISEL-NEXT:    v_mul_hi_u32 v16, v9, v11
-; GISEL-NEXT:    v_addc_u32_e64 v14, vcc, v14, v17, s[8:9]
-; GISEL-NEXT:    v_mul_hi_u32 v17, v10, v20
-; GISEL-NEXT:    v_mul_lo_u32 v6, v6, v13
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v15, v6
-; GISEL-NEXT:    v_mul_hi_u32 v15, v11, v19
-; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v14
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v12, v9
-; GISEL-NEXT:    v_mul_lo_u32 v12, v13, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v13, v20
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v18
-; GISEL-NEXT:    v_mul_lo_u32 v18, v14, v19
-; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v19
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v10, v6
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v13, v6
-; GISEL-NEXT:    v_add_i32_e64 v12, s[4:5], v12, v17
-; GISEL-NEXT:    v_mul_hi_u32 v12, v10, v6
-; GISEL-NEXT:    v_mul_hi_u32 v6, v13, v6
-; GISEL-NEXT:    v_mul_lo_u32 v17, v11, v9
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v17, s[8:9], v18, v17
-; GISEL-NEXT:    v_mul_hi_u32 v18, v11, v9
-; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v17, v15
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v16, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[10:11]
-; GISEL-NEXT:    v_add_i32_e64 v18, s[8:9], v19, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e64 v15, s[4:5], v15, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[8:9]
+; GISEL-NEXT:    v_mul_lo_u32 v21, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v22, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v23, v14, v11
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v16
+; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v18
+; GISEL-NEXT:    v_mul_hi_u32 v24, v10, v18
+; GISEL-NEXT:    v_mul_hi_u32 v18, v12, v18
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v22, v17
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v21
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v21
+; GISEL-NEXT:    v_mul_hi_u32 v21, v13, v21
 ; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v20
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v19
-; GISEL-NEXT:    v_add_i32_e64 v17, s[4:5], v18, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v23
+; GISEL-NEXT:    v_mul_lo_u32 v20, v10, v16
+; GISEL-NEXT:    v_mul_lo_u32 v23, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v26, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v27, v11, v17
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v27
+; GISEL-NEXT:    v_cndmask_b32_e64 v27, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v23, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v21, s[4:5], v22, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v24
 ; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v15, v18
-; GISEL-NEXT:    v_add_i32_e64 v15, s[6:7], v16, v19
-; GISEL-NEXT:    v_mul_lo_u32 v16, v1, v10
-; GISEL-NEXT:    v_mul_hi_u32 v17, v0, v10
-; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
-; GISEL-NEXT:    v_mul_lo_u32 v18, v3, v11
-; GISEL-NEXT:    v_mul_hi_u32 v19, v2, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
-; GISEL-NEXT:    v_add_i32_e64 v6, s[6:7], v6, v12
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v15
-; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, v13, v6, vcc
-; GISEL-NEXT:    v_addc_u32_e64 v9, vcc, v14, v9, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v12, v0, v6
-; GISEL-NEXT:    v_mul_lo_u32 v13, v1, v6
-; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v6
-; GISEL-NEXT:    v_mul_hi_u32 v15, v1, v6
-; GISEL-NEXT:    v_mul_lo_u32 v6, v2, v9
-; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
-; GISEL-NEXT:    v_mul_hi_u32 v16, v2, v9
-; GISEL-NEXT:    v_mul_hi_u32 v21, v3, v9
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v13, v10
-; GISEL-NEXT:    v_add_i32_e64 v6, s[6:7], v18, v6
-; GISEL-NEXT:    v_add_i32_e64 v10, s[8:9], v20, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v9, v14
-; GISEL-NEXT:    v_add_i32_e64 v6, s[6:7], v6, v19
-; GISEL-NEXT:    v_add_i32_e64 v10, s[8:9], v10, v16
-; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v11, v6
-; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v13, v14
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v18, v16
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v26
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v26, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v25, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v23, v24
+; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v27, v26
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v18, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v22, v23
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v19
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_addc_u32_e32 v12, vcc, v12, v16, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v16, v6, v10
+; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v10
+; GISEL-NEXT:    v_mul_hi_u32 v18, v6, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v13, v17, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v6, v6, v12
+; GISEL-NEXT:    v_mul_lo_u32 v20, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v14, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v23, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
 ; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v9, v6
-; GISEL-NEXT:    v_add_i32_e64 v9, s[4:5], v10, v13
-; GISEL-NEXT:    v_cndmask_b32_e64 v10, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v14, v7, v6
-; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v6
-; GISEL-NEXT:    v_mul_hi_u32 v17, v7, v6
-; GISEL-NEXT:    v_mul_lo_u32 v18, v4, v9
-; GISEL-NEXT:    v_mul_lo_u32 v19, v5, v9
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v11, v10
-; GISEL-NEXT:    v_mul_hi_u32 v11, v4, v9
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v13
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, 1, v6
-; GISEL-NEXT:    v_sub_i32_e64 v0, s[4:5], v0, v14
-; GISEL-NEXT:    v_add_i32_e64 v14, s[6:7], 1, v9
-; GISEL-NEXT:    v_sub_i32_e64 v2, s[8:9], v2, v18
-; GISEL-NEXT:    v_add_i32_e64 v18, s[10:11], 1, v13
-; GISEL-NEXT:    v_add_i32_e64 v10, s[12:13], v15, v10
-; GISEL-NEXT:    v_add_i32_e64 v15, s[12:13], 1, v14
-; GISEL-NEXT:    v_add_i32_e64 v12, s[14:15], v21, v12
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[14:15], v0, v7
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[16:17], v2, v4
-; GISEL-NEXT:    v_sub_i32_e64 v0, s[18:19], v0, v7
-; GISEL-NEXT:    v_sub_i32_e64 v2, s[20:21], v2, v4
-; GISEL-NEXT:    v_mul_lo_u32 v20, v7, v10
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[22:23], v0, v7
-; GISEL-NEXT:    v_addc_u32_e32 v0, vcc, 0, v10, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v4
-; GISEL-NEXT:    v_mul_lo_u32 v2, v4, v12
-; GISEL-NEXT:    v_add_i32_e64 v4, s[24:25], v16, v20
-; GISEL-NEXT:    v_addc_u32_e64 v7, s[6:7], 0, v12, s[6:7]
-; GISEL-NEXT:    v_add_i32_e64 v2, s[6:7], v19, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, -1, s[14:15]
-; GISEL-NEXT:    v_add_i32_e64 v4, s[6:7], v4, v17
-; GISEL-NEXT:    v_subb_u32_e64 v17, s[6:7], v1, v4, s[4:5]
-; GISEL-NEXT:    v_sub_i32_e64 v1, s[6:7], v1, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, -1, s[16:17]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v17, v8
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[14:15], v17, v8
-; GISEL-NEXT:    v_addc_u32_e64 v17, s[10:11], 0, v0, s[10:11]
-; GISEL-NEXT:    v_subb_u32_e64 v1, s[4:5], v1, v8, s[4:5]
-; GISEL-NEXT:    v_subbrev_u32_e64 v1, s[4:5], 0, v1, s[18:19]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v1, v8
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[10:11], v1, v8
-; GISEL-NEXT:    v_addc_u32_e64 v1, s[12:13], 0, v7, s[12:13]
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[22:23]
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v15, v14
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v18
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v19
+; GISEL-NEXT:    v_mul_lo_u32 v14, v10, v6
+; GISEL-NEXT:    v_mul_lo_u32 v15, v12, v6
+; GISEL-NEXT:    v_mul_hi_u32 v18, v10, v6
+; GISEL-NEXT:    v_mul_hi_u32 v6, v12, v6
+; GISEL-NEXT:    v_mul_lo_u32 v19, v11, v9
+; GISEL-NEXT:    v_mul_lo_u32 v24, v13, v9
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v13, v9
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v22, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v24, v17
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v14, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v22, v19
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v24, v21
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v16, v15
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v18
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v15
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v14
+; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, v12, v6, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v12, v1, v10
+; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v10
+; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v17
+; GISEL-NEXT:    v_addc_u32_e32 v9, vcc, v13, v9, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v13, v3, v11
+; GISEL-NEXT:    v_mul_hi_u32 v15, v2, v11
+; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
+; GISEL-NEXT:    v_mul_lo_u32 v16, v0, v6
+; GISEL-NEXT:    v_mul_lo_u32 v17, v1, v6
+; GISEL-NEXT:    v_mul_hi_u32 v18, v0, v6
+; GISEL-NEXT:    v_mul_hi_u32 v6, v1, v6
+; GISEL-NEXT:    v_mul_lo_u32 v19, v2, v9
+; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
+; GISEL-NEXT:    v_mul_hi_u32 v21, v2, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v3, v9
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v17, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v20, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v15
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v17, v14
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v19, v13
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v20, v15
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v13
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v14, v12
+; GISEL-NEXT:    v_mul_lo_u32 v14, v7, v10
+; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v10
+; GISEL-NEXT:    v_mul_hi_u32 v17, v7, v10
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v15, v13
+; GISEL-NEXT:    v_mul_lo_u32 v15, v4, v11
+; GISEL-NEXT:    v_mul_lo_u32 v18, v5, v11
+; GISEL-NEXT:    v_mul_hi_u32 v19, v4, v11
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v12
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v13
+; GISEL-NEXT:    v_mul_lo_u32 v12, v7, v6
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, 1, v10
+; GISEL-NEXT:    v_addc_u32_e32 v20, vcc, 0, v6, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v21, v4, v9
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, 1, v11
+; GISEL-NEXT:    v_addc_u32_e32 v23, vcc, 0, v9, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, 1, v13
+; GISEL-NEXT:    v_addc_u32_e32 v24, vcc, 0, v20, vcc
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v18, v21
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, 1, v22
+; GISEL-NEXT:    v_addc_u32_e32 v25, vcc, 0, v23, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v18, v19
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v14
+; GISEL-NEXT:    v_subb_u32_e64 v14, s[4:5], v1, v12, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v1, s[4:5], v1, v12
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[4:5]
+; GISEL-NEXT:    v_sub_i32_e64 v2, s[4:5], v2, v15
+; GISEL-NEXT:    v_subb_u32_e64 v15, s[6:7], v3, v17, s[4:5]
+; GISEL-NEXT:    v_sub_i32_e64 v3, s[6:7], v3, v17
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v2, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[6:7]
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v14, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, -1, s[6:7]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v8, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v15, v5
 ; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, -1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v2, vcc, v2, v11
-; GISEL-NEXT:    v_subb_u32_e64 v11, vcc, v3, v2, s[8:9]
-; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v3, v2
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v11, v5
-; GISEL-NEXT:    v_subb_u32_e64 v2, s[8:9], v2, v5, s[8:9]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[8:9], v11, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, vcc
-; GISEL-NEXT:    v_subbrev_u32_e64 v2, vcc, 0, v2, s[20:21]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v16, s[14:15]
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, v11, v4, s[8:9]
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v5
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v2, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v4
-; GISEL-NEXT:    v_cndmask_b32_e64 v2, v2, v8, s[10:11]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v5, v19, s[6:7]
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v2
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[8:9], 0, v3
-; GISEL-NEXT:    v_cndmask_b32_e64 v2, v13, v18, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v14, v15, s[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, v0, v17, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, v7, v1, s[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e32 v0, v6, v2, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v2, v9, v3, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e32 v1, v10, v4, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v12, v5, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e64 v3, vcc, v3, v5, s[4:5]
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v14, v8
+; GISEL-NEXT:    v_cndmask_b32_e32 v12, v18, v12, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v7
+; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v15, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v7, v19, v17, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v2, vcc, v2, v4
+; GISEL-NEXT:    v_subbrev_u32_e32 v3, vcc, 0, v3, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v2, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v3, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, -1, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v8
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v14, v2, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v13, v16, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v1
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, v22, v21, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v20, v24, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, v23, v25, s[4:5]
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v2, v11, v1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v6, v3, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v9, v4, s[4:5]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; CGP-LABEL: v_udiv_v2i64_pow2_shl_denom:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/urem.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/urem.i64.ll
@@ -362,251 +362,251 @@ define <2 x i64> @v_urem_v2i64(<2 x i64> %num, <2 x i64> %den) {
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v10, v4
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v5
 ; GISEL-NEXT:    v_sub_i32_e32 v8, vcc, 0, v4
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v6
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v14, v7
-; GISEL-NEXT:    v_sub_i32_e64 v9, s[4:5], 0, v6
-; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v5, vcc
-; GISEL-NEXT:    v_subb_u32_e64 v12, vcc, 0, v7, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v9, vcc, 0, v5, vcc
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v6
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v7
+; GISEL-NEXT:    v_sub_i32_e32 v14, vcc, 0, v6
+; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v7, vcc
 ; GISEL-NEXT:    v_mac_f32_e32 v10, 0x4f800000, v11
-; GISEL-NEXT:    v_mac_f32_e32 v13, 0x4f800000, v14
+; GISEL-NEXT:    v_mac_f32_e32 v12, 0x4f800000, v13
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v10, v10
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v13
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v12
 ; GISEL-NEXT:    v_mul_f32_e32 v10, 0x5f7ffffc, v10
 ; GISEL-NEXT:    v_mul_f32_e32 v11, 0x5f7ffffc, v11
-; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v10
-; GISEL-NEXT:    v_mul_f32_e32 v14, 0x2f800000, v11
+; GISEL-NEXT:    v_mul_f32_e32 v12, 0x2f800000, v10
+; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v11
+; GISEL-NEXT:    v_trunc_f32_e32 v12, v12
 ; GISEL-NEXT:    v_trunc_f32_e32 v13, v13
-; GISEL-NEXT:    v_trunc_f32_e32 v14, v14
-; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v13
+; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v12
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v12, v12
+; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v13
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v13
-; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v14
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v14
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v10, v10
-; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v13
+; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v12
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v11
-; GISEL-NEXT:    v_mul_lo_u32 v17, v9, v14
-; GISEL-NEXT:    v_mul_lo_u32 v18, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v11
-; GISEL-NEXT:    v_mul_hi_u32 v20, v9, v11
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v19, v17
-; GISEL-NEXT:    v_mul_lo_u32 v19, v14, v18
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v18
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
-; GISEL-NEXT:    v_mul_lo_u32 v19, v8, v10
-; GISEL-NEXT:    v_mul_lo_u32 v20, v15, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v20, v16
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v18, v8, v10
+; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v10
 ; GISEL-NEXT:    v_mul_hi_u32 v20, v8, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v19
-; GISEL-NEXT:    v_mul_lo_u32 v21, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v19
-; GISEL-NEXT:    v_add_i32_e64 v20, s[8:9], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v19, v13, v19
-; GISEL-NEXT:    v_mul_hi_u32 v18, v14, v18
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[12:13], v20, v18
-; GISEL-NEXT:    v_mul_hi_u32 v20, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[14:15], v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[16:17], v18, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[10:11]
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[14:15]
-; GISEL-NEXT:    v_add_i32_e64 v21, s[6:7], v21, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[12:13]
-; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[16:17]
-; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v23, v24
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v22
-; GISEL-NEXT:    v_add_i32_e64 v10, s[6:7], v10, v19
-; GISEL-NEXT:    v_mul_hi_u32 v16, v13, v16
-; GISEL-NEXT:    v_mul_hi_u32 v17, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v11, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v21, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v23, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v8, v10
-; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v10
-; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
-; GISEL-NEXT:    v_mul_hi_u32 v18, v8, v10
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v19
-; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v12, v12, v11
-; GISEL-NEXT:    v_addc_u32_e64 v13, vcc, v13, v16, s[6:7]
-; GISEL-NEXT:    v_mul_hi_u32 v16, v9, v11
-; GISEL-NEXT:    v_addc_u32_e64 v14, vcc, v14, v17, s[8:9]
-; GISEL-NEXT:    v_mul_hi_u32 v17, v10, v20
-; GISEL-NEXT:    v_mul_lo_u32 v8, v8, v13
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v15, v8
-; GISEL-NEXT:    v_mul_hi_u32 v15, v11, v19
-; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v14
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v12, v9
-; GISEL-NEXT:    v_mul_lo_u32 v12, v13, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v13, v20
-; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v18
-; GISEL-NEXT:    v_mul_lo_u32 v18, v14, v19
-; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v19
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v10, v8
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v13, v8
-; GISEL-NEXT:    v_add_i32_e64 v12, s[4:5], v12, v17
-; GISEL-NEXT:    v_mul_hi_u32 v12, v10, v8
-; GISEL-NEXT:    v_mul_hi_u32 v8, v13, v8
-; GISEL-NEXT:    v_mul_lo_u32 v17, v11, v9
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v17, s[8:9], v18, v17
-; GISEL-NEXT:    v_mul_hi_u32 v18, v11, v9
-; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v17, v15
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v16, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[10:11]
-; GISEL-NEXT:    v_add_i32_e64 v18, s[8:9], v19, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e64 v15, s[4:5], v15, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[8:9]
+; GISEL-NEXT:    v_mul_lo_u32 v21, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v22, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v23, v14, v11
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v16
+; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v18
+; GISEL-NEXT:    v_mul_hi_u32 v24, v10, v18
+; GISEL-NEXT:    v_mul_hi_u32 v18, v12, v18
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v22, v17
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v21
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v21
+; GISEL-NEXT:    v_mul_hi_u32 v21, v13, v21
 ; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v20
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v19
-; GISEL-NEXT:    v_add_i32_e64 v17, s[4:5], v18, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v23
+; GISEL-NEXT:    v_mul_lo_u32 v20, v10, v16
+; GISEL-NEXT:    v_mul_lo_u32 v23, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v26, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v27, v11, v17
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v27
+; GISEL-NEXT:    v_cndmask_b32_e64 v27, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v23, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v21, s[4:5], v22, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v24
 ; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v15, v18
-; GISEL-NEXT:    v_add_i32_e64 v15, s[6:7], v16, v19
-; GISEL-NEXT:    v_mul_lo_u32 v16, v1, v10
-; GISEL-NEXT:    v_mul_hi_u32 v17, v0, v10
-; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
-; GISEL-NEXT:    v_mul_lo_u32 v18, v3, v11
-; GISEL-NEXT:    v_mul_hi_u32 v19, v2, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
-; GISEL-NEXT:    v_add_i32_e64 v8, s[6:7], v8, v12
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v15
-; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, v13, v8, vcc
-; GISEL-NEXT:    v_addc_u32_e64 v9, vcc, v14, v9, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v12, v0, v8
-; GISEL-NEXT:    v_mul_lo_u32 v13, v1, v8
-; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v8
-; GISEL-NEXT:    v_mul_hi_u32 v8, v1, v8
-; GISEL-NEXT:    v_mul_lo_u32 v15, v2, v9
-; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
-; GISEL-NEXT:    v_mul_hi_u32 v16, v2, v9
-; GISEL-NEXT:    v_mul_hi_u32 v9, v3, v9
-; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v13, v10
-; GISEL-NEXT:    v_add_i32_e64 v13, s[6:7], v18, v15
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v20, v11
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v26
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v26, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v25, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v23, v24
+; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v27, v26
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v18, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v22, v23
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v19
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_addc_u32_e32 v12, vcc, v12, v16, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v10
+; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v10
+; GISEL-NEXT:    v_mul_hi_u32 v18, v8, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v13, v17, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v8, v8, v12
+; GISEL-NEXT:    v_mul_lo_u32 v20, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v14, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v23, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v9, v8
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v15, v14
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v18
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v19
+; GISEL-NEXT:    v_mul_lo_u32 v14, v10, v8
+; GISEL-NEXT:    v_mul_lo_u32 v15, v12, v8
+; GISEL-NEXT:    v_mul_hi_u32 v18, v10, v8
+; GISEL-NEXT:    v_mul_hi_u32 v8, v12, v8
+; GISEL-NEXT:    v_mul_lo_u32 v19, v11, v9
+; GISEL-NEXT:    v_mul_lo_u32 v24, v13, v9
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v13, v9
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v22, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v24, v17
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v14, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v22, v19
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v24, v21
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v10, v14
-; GISEL-NEXT:    v_add_i32_e64 v13, s[6:7], v13, v19
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v11, v16
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v16, v15
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v18
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v15
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v14
+; GISEL-NEXT:    v_addc_u32_e32 v8, vcc, v12, v8, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v12, v1, v10
+; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v10
+; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v17
+; GISEL-NEXT:    v_addc_u32_e32 v9, vcc, v13, v9, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v13, v3, v11
+; GISEL-NEXT:    v_mul_hi_u32 v15, v2, v11
+; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
+; GISEL-NEXT:    v_mul_lo_u32 v16, v0, v8
+; GISEL-NEXT:    v_mul_lo_u32 v17, v1, v8
+; GISEL-NEXT:    v_mul_hi_u32 v18, v0, v8
+; GISEL-NEXT:    v_mul_hi_u32 v8, v1, v8
+; GISEL-NEXT:    v_mul_lo_u32 v19, v2, v9
+; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
+; GISEL-NEXT:    v_mul_hi_u32 v21, v2, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v3, v9
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v17, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v20, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v15
 ; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v15, v13
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v18, v14
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v20, v16
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v13
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v15
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v17, v14
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v19, v13
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v20, v15
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v13
 ; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v16, v4, v10
-; GISEL-NEXT:    v_mul_lo_u32 v17, v5, v10
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v14, v12
+; GISEL-NEXT:    v_mul_lo_u32 v14, v4, v10
+; GISEL-NEXT:    v_mul_lo_u32 v16, v5, v10
 ; GISEL-NEXT:    v_mul_hi_u32 v10, v4, v10
-; GISEL-NEXT:    v_mul_lo_u32 v18, v6, v11
-; GISEL-NEXT:    v_mul_lo_u32 v19, v7, v11
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v15, v13
+; GISEL-NEXT:    v_mul_lo_u32 v15, v6, v11
+; GISEL-NEXT:    v_mul_lo_u32 v17, v7, v11
 ; GISEL-NEXT:    v_mul_hi_u32 v11, v6, v11
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v14, v13
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v15
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v16
-; GISEL-NEXT:    v_sub_i32_e64 v2, s[4:5], v2, v18
-; GISEL-NEXT:    v_add_i32_e64 v8, s[6:7], v8, v13
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v12
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v0, v4
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v2, v6
-; GISEL-NEXT:    v_sub_i32_e64 v12, s[10:11], v0, v4
-; GISEL-NEXT:    v_sub_i32_e64 v13, s[12:13], v2, v6
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v12
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v13
 ; GISEL-NEXT:    v_mul_lo_u32 v8, v4, v8
 ; GISEL-NEXT:    v_mul_lo_u32 v9, v6, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[8:9]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v12, v4
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v13, v6
-; GISEL-NEXT:    v_sub_i32_e64 v4, s[14:15], v12, v4
-; GISEL-NEXT:    v_sub_i32_e64 v6, s[16:17], v13, v6
-; GISEL-NEXT:    v_add_i32_e64 v8, s[18:19], v17, v8
-; GISEL-NEXT:    v_add_i32_e64 v9, s[18:19], v19, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v8, s[6:7], v8, v10
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v11
-; GISEL-NEXT:    v_subb_u32_e64 v10, s[6:7], v1, v8, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v1, s[6:7], v1, v8
-; GISEL-NEXT:    v_subb_u32_e64 v8, s[6:7], v3, v9, s[4:5]
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v16, v8
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v17, v9
+; GISEL-NEXT:    v_add_i32_e32 v8, vcc, v8, v10
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v14
+; GISEL-NEXT:    v_subb_u32_e64 v10, s[4:5], v1, v8, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v1, s[4:5], v1, v8
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[4:5]
+; GISEL-NEXT:    v_sub_i32_e64 v2, s[4:5], v2, v15
+; GISEL-NEXT:    v_subb_u32_e64 v11, s[6:7], v3, v9, s[4:5]
 ; GISEL-NEXT:    v_sub_i32_e64 v3, s[6:7], v3, v9
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v10, v5
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v5, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v8, v7
-; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v3, v7, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v10, v5
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[8:9], v8, v7
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v2, v6
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, vcc
-; GISEL-NEXT:    v_subbrev_u32_e64 v18, vcc, 0, v1, s[10:11]
-; GISEL-NEXT:    v_subb_u32_e64 v1, vcc, v1, v5, s[10:11]
-; GISEL-NEXT:    v_subbrev_u32_e64 v19, vcc, 0, v3, s[12:13]
-; GISEL-NEXT:    v_subb_u32_e64 v3, vcc, v3, v7, s[12:13]
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, v9, v14, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, v11, v15, s[8:9]
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v5
-; GISEL-NEXT:    v_subbrev_u32_e64 v1, s[4:5], 0, v1, s[14:15]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v19, v7
-; GISEL-NEXT:    v_subbrev_u32_e64 v3, s[6:7], 0, v3, s[16:17]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v18, v5
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[8:9], v19, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, v5, v16, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, v7, v17, s[8:9]
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v5
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[8:9], 0, v7
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, v12, v4, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, v13, v6, s[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v19, v3, s[8:9]
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v10, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[6:7]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v5, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v11, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, -1, vcc
+; GISEL-NEXT:    v_subb_u32_e64 v3, vcc, v3, v7, s[4:5]
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v10, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v8, v12, v8, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v12, vcc, v0, v4
+; GISEL-NEXT:    v_subbrev_u32_e64 v14, s[4:5], 0, v1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v12, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v5, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v11, v7
+; GISEL-NEXT:    v_cndmask_b32_e32 v9, v13, v9, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, v2, v6
+; GISEL-NEXT:    v_subbrev_u32_e64 v16, s[4:5], 0, v3, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v13, v6
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v3, vcc, v3, v7, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v14, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, -1, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v4, vcc, v12, v4
+; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v16, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, -1, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v6, vcc, v13, v6
+; GISEL-NEXT:    v_subbrev_u32_e32 v3, vcc, 0, v3, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v14, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v18, v15, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v16, v7
+; GISEL-NEXT:    v_cndmask_b32_e32 v7, v19, v17, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v4, v12, v4, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v5, v13, v6, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v14, v1, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; GISEL-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v16, v3, s[4:5]
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v9
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, v2, v5, s[4:5]
 ; GISEL-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v8, v3, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v11, v3, s[4:5]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; CGP-LABEL: v_urem_v2i64:
@@ -1681,251 +1681,251 @@ define <2 x i64> @v_urem_v2i64_pow2_shl_denom(<2 x i64> %x, <2 x i64> %y) {
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v10, v7
 ; GISEL-NEXT:    v_cvt_f32_u32_e32 v11, v8
 ; GISEL-NEXT:    v_sub_i32_e32 v6, vcc, 0, v7
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v4
-; GISEL-NEXT:    v_cvt_f32_u32_e32 v14, v5
-; GISEL-NEXT:    v_sub_i32_e64 v9, s[4:5], 0, v4
-; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v8, vcc
-; GISEL-NEXT:    v_subb_u32_e64 v12, vcc, 0, v5, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v9, vcc, 0, v8, vcc
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v12, v4
+; GISEL-NEXT:    v_cvt_f32_u32_e32 v13, v5
+; GISEL-NEXT:    v_sub_i32_e32 v14, vcc, 0, v4
+; GISEL-NEXT:    v_subb_u32_e32 v15, vcc, 0, v5, vcc
 ; GISEL-NEXT:    v_mac_f32_e32 v10, 0x4f800000, v11
-; GISEL-NEXT:    v_mac_f32_e32 v13, 0x4f800000, v14
+; GISEL-NEXT:    v_mac_f32_e32 v12, 0x4f800000, v13
 ; GISEL-NEXT:    v_rcp_iflag_f32_e32 v10, v10
-; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v13
+; GISEL-NEXT:    v_rcp_iflag_f32_e32 v11, v12
 ; GISEL-NEXT:    v_mul_f32_e32 v10, 0x5f7ffffc, v10
 ; GISEL-NEXT:    v_mul_f32_e32 v11, 0x5f7ffffc, v11
-; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v10
-; GISEL-NEXT:    v_mul_f32_e32 v14, 0x2f800000, v11
+; GISEL-NEXT:    v_mul_f32_e32 v12, 0x2f800000, v10
+; GISEL-NEXT:    v_mul_f32_e32 v13, 0x2f800000, v11
+; GISEL-NEXT:    v_trunc_f32_e32 v12, v12
 ; GISEL-NEXT:    v_trunc_f32_e32 v13, v13
-; GISEL-NEXT:    v_trunc_f32_e32 v14, v14
-; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v13
+; GISEL-NEXT:    v_mac_f32_e32 v10, 0xcf800000, v12
+; GISEL-NEXT:    v_cvt_u32_f32_e32 v12, v12
+; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v13
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v13, v13
-; GISEL-NEXT:    v_mac_f32_e32 v11, 0xcf800000, v14
-; GISEL-NEXT:    v_cvt_u32_f32_e32 v14, v14
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v10, v10
-; GISEL-NEXT:    v_mul_lo_u32 v16, v6, v13
+; GISEL-NEXT:    v_mul_lo_u32 v16, v6, v12
 ; GISEL-NEXT:    v_cvt_u32_f32_e32 v11, v11
-; GISEL-NEXT:    v_mul_lo_u32 v17, v9, v14
-; GISEL-NEXT:    v_mul_lo_u32 v18, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v11
-; GISEL-NEXT:    v_mul_hi_u32 v20, v9, v11
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v19, v17
-; GISEL-NEXT:    v_mul_lo_u32 v19, v14, v18
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v18
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
-; GISEL-NEXT:    v_mul_lo_u32 v19, v6, v10
-; GISEL-NEXT:    v_mul_lo_u32 v20, v15, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v20, v16
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v18, v6, v10
+; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v10
 ; GISEL-NEXT:    v_mul_hi_u32 v20, v6, v10
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v19
-; GISEL-NEXT:    v_mul_lo_u32 v21, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v19
-; GISEL-NEXT:    v_add_i32_e64 v20, s[8:9], v20, v21
-; GISEL-NEXT:    v_mul_hi_u32 v19, v13, v19
-; GISEL-NEXT:    v_mul_hi_u32 v18, v14, v18
-; GISEL-NEXT:    v_mul_lo_u32 v20, v13, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[12:13], v20, v18
-; GISEL-NEXT:    v_mul_hi_u32 v20, v10, v16
-; GISEL-NEXT:    v_add_i32_e64 v19, s[14:15], v19, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v18, s[16:17], v18, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v20, s[6:7], v20, v21
-; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, s[10:11]
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[14:15]
-; GISEL-NEXT:    v_add_i32_e64 v21, s[6:7], v21, v22
-; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v23
-; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[12:13]
-; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[16:17]
-; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v23, v24
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v20
-; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v22
-; GISEL-NEXT:    v_add_i32_e64 v10, s[6:7], v10, v19
-; GISEL-NEXT:    v_mul_hi_u32 v16, v13, v16
-; GISEL-NEXT:    v_mul_hi_u32 v17, v14, v17
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v11, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v21, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v23, v19
-; GISEL-NEXT:    v_mul_lo_u32 v20, v6, v10
-; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v10
-; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
-; GISEL-NEXT:    v_mul_hi_u32 v18, v6, v10
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v19
-; GISEL-NEXT:    v_mul_lo_u32 v19, v9, v11
-; GISEL-NEXT:    v_mul_lo_u32 v12, v12, v11
-; GISEL-NEXT:    v_addc_u32_e64 v13, vcc, v13, v16, s[6:7]
-; GISEL-NEXT:    v_mul_hi_u32 v16, v9, v11
-; GISEL-NEXT:    v_addc_u32_e64 v14, vcc, v14, v17, s[8:9]
-; GISEL-NEXT:    v_mul_hi_u32 v17, v10, v20
-; GISEL-NEXT:    v_mul_lo_u32 v6, v6, v13
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v15, v6
-; GISEL-NEXT:    v_mul_hi_u32 v15, v11, v19
-; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v14
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v12, v9
-; GISEL-NEXT:    v_mul_lo_u32 v12, v13, v20
-; GISEL-NEXT:    v_mul_hi_u32 v20, v13, v20
-; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v18
-; GISEL-NEXT:    v_mul_lo_u32 v18, v14, v19
-; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v19
-; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v10, v6
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
-; GISEL-NEXT:    v_mul_lo_u32 v16, v13, v6
-; GISEL-NEXT:    v_add_i32_e64 v12, s[4:5], v12, v17
-; GISEL-NEXT:    v_mul_hi_u32 v12, v10, v6
-; GISEL-NEXT:    v_mul_hi_u32 v6, v13, v6
-; GISEL-NEXT:    v_mul_lo_u32 v17, v11, v9
-; GISEL-NEXT:    v_add_i32_e64 v16, s[6:7], v16, v20
-; GISEL-NEXT:    v_mul_lo_u32 v20, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v17, s[8:9], v18, v17
-; GISEL-NEXT:    v_mul_hi_u32 v18, v11, v9
-; GISEL-NEXT:    v_mul_hi_u32 v9, v14, v9
-; GISEL-NEXT:    v_add_i32_e64 v19, s[10:11], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v17, v15
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v16, v12
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[10:11]
-; GISEL-NEXT:    v_add_i32_e64 v18, s[8:9], v19, v18
-; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v20, v19
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e64 v15, s[4:5], v15, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
-; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[8:9]
+; GISEL-NEXT:    v_mul_lo_u32 v21, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v22, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v23, v14, v11
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v16
+; GISEL-NEXT:    v_mul_lo_u32 v19, v12, v18
+; GISEL-NEXT:    v_mul_hi_u32 v24, v10, v18
+; GISEL-NEXT:    v_mul_hi_u32 v18, v12, v18
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v22, v17
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v21
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v21
+; GISEL-NEXT:    v_mul_hi_u32 v21, v13, v21
 ; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v20
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v19
-; GISEL-NEXT:    v_add_i32_e64 v17, s[4:5], v18, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v23
+; GISEL-NEXT:    v_mul_lo_u32 v20, v10, v16
+; GISEL-NEXT:    v_mul_lo_u32 v23, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v26, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v27, v11, v17
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v27
+; GISEL-NEXT:    v_cndmask_b32_e64 v27, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v20
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v23, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v21, s[4:5], v22, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, s[4:5]
+; GISEL-NEXT:    v_add_i32_e64 v19, s[4:5], v19, v24
 ; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, s[4:5]
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v17
-; GISEL-NEXT:    v_add_i32_e64 v12, s[6:7], v15, v18
-; GISEL-NEXT:    v_add_i32_e64 v15, s[6:7], v16, v19
-; GISEL-NEXT:    v_mul_lo_u32 v16, v1, v10
-; GISEL-NEXT:    v_mul_hi_u32 v17, v0, v10
-; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
-; GISEL-NEXT:    v_mul_lo_u32 v18, v3, v11
-; GISEL-NEXT:    v_mul_hi_u32 v19, v2, v11
-; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
-; GISEL-NEXT:    v_add_i32_e64 v6, s[6:7], v6, v12
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v15
-; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, v13, v6, vcc
-; GISEL-NEXT:    v_addc_u32_e64 v9, vcc, v14, v9, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v12, v0, v6
-; GISEL-NEXT:    v_mul_lo_u32 v13, v1, v6
-; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v6
-; GISEL-NEXT:    v_mul_hi_u32 v6, v1, v6
-; GISEL-NEXT:    v_mul_lo_u32 v15, v2, v9
-; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
-; GISEL-NEXT:    v_mul_hi_u32 v16, v2, v9
-; GISEL-NEXT:    v_mul_hi_u32 v9, v3, v9
-; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v13, v10
-; GISEL-NEXT:    v_add_i32_e64 v13, s[6:7], v18, v15
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v20, v11
+; GISEL-NEXT:    v_add_i32_e64 v18, s[4:5], v18, v26
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v26, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v25, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v23, v24
+; GISEL-NEXT:    v_add_i32_e32 v23, vcc, v27, v26
+; GISEL-NEXT:    v_add_i32_e32 v22, vcc, v22, v25
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v18, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v21, vcc, v21, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v23, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v20, v19
+; GISEL-NEXT:    v_add_i32_e32 v20, vcc, v22, v23
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v19
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v20
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_addc_u32_e32 v12, vcc, v12, v16, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v16, v6, v10
+; GISEL-NEXT:    v_mul_lo_u32 v9, v9, v10
+; GISEL-NEXT:    v_mul_hi_u32 v18, v6, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_addc_u32_e32 v13, vcc, v13, v17, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v17, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v15, v15, v11
+; GISEL-NEXT:    v_mul_hi_u32 v19, v14, v11
+; GISEL-NEXT:    v_mul_lo_u32 v6, v6, v12
+; GISEL-NEXT:    v_mul_lo_u32 v20, v12, v16
+; GISEL-NEXT:    v_mul_hi_u32 v21, v10, v16
+; GISEL-NEXT:    v_mul_hi_u32 v16, v12, v16
+; GISEL-NEXT:    v_mul_lo_u32 v14, v14, v13
+; GISEL-NEXT:    v_mul_lo_u32 v22, v13, v17
+; GISEL-NEXT:    v_mul_hi_u32 v23, v11, v17
+; GISEL-NEXT:    v_mul_hi_u32 v17, v13, v17
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v9, v6
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v15, v14
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v18
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v19
+; GISEL-NEXT:    v_mul_lo_u32 v14, v10, v6
+; GISEL-NEXT:    v_mul_lo_u32 v15, v12, v6
+; GISEL-NEXT:    v_mul_hi_u32 v18, v10, v6
+; GISEL-NEXT:    v_mul_hi_u32 v6, v12, v6
+; GISEL-NEXT:    v_mul_lo_u32 v19, v11, v9
+; GISEL-NEXT:    v_mul_lo_u32 v24, v13, v9
+; GISEL-NEXT:    v_mul_hi_u32 v25, v11, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v13, v9
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v22, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v22, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v24, v17
+; GISEL-NEXT:    v_cndmask_b32_e64 v24, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v14, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v15, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v19, v23
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v25
+; GISEL-NEXT:    v_cndmask_b32_e64 v21, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v20, v14
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v16, v18
+; GISEL-NEXT:    v_add_i32_e32 v18, vcc, v22, v19
+; GISEL-NEXT:    v_add_i32_e32 v19, vcc, v24, v21
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v15, v14
 ; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, s[6:7]
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v10, s[4:5], v10, v14
-; GISEL-NEXT:    v_add_i32_e64 v13, s[6:7], v13, v19
-; GISEL-NEXT:    v_add_i32_e64 v11, s[8:9], v11, v16
+; GISEL-NEXT:    v_add_i32_e32 v17, vcc, v17, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v16, v15
+; GISEL-NEXT:    v_add_i32_e32 v16, vcc, v19, v18
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v15
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v16
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v14
+; GISEL-NEXT:    v_addc_u32_e32 v6, vcc, v12, v6, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v12, v1, v10
+; GISEL-NEXT:    v_mul_hi_u32 v14, v0, v10
+; GISEL-NEXT:    v_mul_hi_u32 v10, v1, v10
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v17
+; GISEL-NEXT:    v_addc_u32_e32 v9, vcc, v13, v9, vcc
+; GISEL-NEXT:    v_mul_lo_u32 v13, v3, v11
+; GISEL-NEXT:    v_mul_hi_u32 v15, v2, v11
+; GISEL-NEXT:    v_mul_hi_u32 v11, v3, v11
+; GISEL-NEXT:    v_mul_lo_u32 v16, v0, v6
+; GISEL-NEXT:    v_mul_lo_u32 v17, v1, v6
+; GISEL-NEXT:    v_mul_hi_u32 v18, v0, v6
+; GISEL-NEXT:    v_mul_hi_u32 v6, v1, v6
+; GISEL-NEXT:    v_mul_lo_u32 v19, v2, v9
+; GISEL-NEXT:    v_mul_lo_u32 v20, v3, v9
+; GISEL-NEXT:    v_mul_hi_u32 v21, v2, v9
+; GISEL-NEXT:    v_mul_hi_u32 v9, v3, v9
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v16
+; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v17, v10
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v19
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v20, v11
+; GISEL-NEXT:    v_cndmask_b32_e64 v20, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v14
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v18
+; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v13, v15
 ; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, 1, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, 1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, 1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v15, v13
-; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v18, v14
-; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v20, v16
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v17
-; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v13
-; GISEL-NEXT:    v_add_i32_e64 v11, s[4:5], v11, v15
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v21
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v16, v12
+; GISEL-NEXT:    v_add_i32_e32 v14, vcc, v17, v14
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v19, v13
+; GISEL-NEXT:    v_add_i32_e32 v15, vcc, v20, v15
+; GISEL-NEXT:    v_add_i32_e32 v10, vcc, v10, v12
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, 1, vcc
+; GISEL-NEXT:    v_add_i32_e32 v11, vcc, v11, v13
 ; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, 1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, 1, s[4:5]
-; GISEL-NEXT:    v_mul_lo_u32 v16, v7, v10
-; GISEL-NEXT:    v_mul_lo_u32 v17, v8, v10
+; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v14, v12
+; GISEL-NEXT:    v_mul_lo_u32 v14, v7, v10
+; GISEL-NEXT:    v_mul_lo_u32 v16, v8, v10
 ; GISEL-NEXT:    v_mul_hi_u32 v10, v7, v10
-; GISEL-NEXT:    v_mul_lo_u32 v18, v4, v11
-; GISEL-NEXT:    v_mul_lo_u32 v19, v5, v11
+; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v15, v13
+; GISEL-NEXT:    v_mul_lo_u32 v15, v4, v11
+; GISEL-NEXT:    v_mul_lo_u32 v17, v5, v11
 ; GISEL-NEXT:    v_mul_hi_u32 v11, v4, v11
-; GISEL-NEXT:    v_add_i32_e32 v13, vcc, v14, v13
-; GISEL-NEXT:    v_add_i32_e32 v12, vcc, v12, v15
-; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v16
-; GISEL-NEXT:    v_sub_i32_e64 v2, s[4:5], v2, v18
-; GISEL-NEXT:    v_add_i32_e64 v6, s[6:7], v6, v13
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v12
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v0, v7
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v2, v4
-; GISEL-NEXT:    v_sub_i32_e64 v12, s[10:11], v0, v7
-; GISEL-NEXT:    v_sub_i32_e64 v13, s[12:13], v2, v4
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v12
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v13
 ; GISEL-NEXT:    v_mul_lo_u32 v6, v7, v6
 ; GISEL-NEXT:    v_mul_lo_u32 v9, v4, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v14, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[8:9]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v12, v7
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[8:9], v13, v4
-; GISEL-NEXT:    v_sub_i32_e64 v7, s[14:15], v12, v7
-; GISEL-NEXT:    v_sub_i32_e64 v4, s[16:17], v13, v4
-; GISEL-NEXT:    v_add_i32_e64 v6, s[18:19], v17, v6
-; GISEL-NEXT:    v_add_i32_e64 v9, s[18:19], v19, v9
-; GISEL-NEXT:    v_cndmask_b32_e64 v16, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[8:9]
-; GISEL-NEXT:    v_add_i32_e64 v6, s[6:7], v6, v10
-; GISEL-NEXT:    v_add_i32_e64 v9, s[6:7], v9, v11
-; GISEL-NEXT:    v_subb_u32_e64 v10, s[6:7], v1, v6, vcc
-; GISEL-NEXT:    v_sub_i32_e64 v1, s[6:7], v1, v6
-; GISEL-NEXT:    v_subb_u32_e64 v6, s[6:7], v3, v9, s[4:5]
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v16, v6
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v17, v9
+; GISEL-NEXT:    v_add_i32_e32 v6, vcc, v6, v10
+; GISEL-NEXT:    v_add_i32_e32 v9, vcc, v9, v11
+; GISEL-NEXT:    v_sub_i32_e32 v0, vcc, v0, v14
+; GISEL-NEXT:    v_subb_u32_e64 v10, s[4:5], v1, v6, vcc
+; GISEL-NEXT:    v_sub_i32_e64 v1, s[4:5], v1, v6
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[4:5]
+; GISEL-NEXT:    v_sub_i32_e64 v2, s[4:5], v2, v15
+; GISEL-NEXT:    v_subb_u32_e64 v11, s[6:7], v3, v9, s[4:5]
 ; GISEL-NEXT:    v_sub_i32_e64 v3, s[6:7], v3, v9
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v10, v8
-; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v8, vcc
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v6, v5
-; GISEL-NEXT:    v_subb_u32_e64 v3, s[4:5], v3, v5, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], v10, v8
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[8:9], v6, v5
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v2, v4
 ; GISEL-NEXT:    v_cndmask_b32_e64 v9, 0, -1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, -1, vcc
-; GISEL-NEXT:    v_subbrev_u32_e64 v18, vcc, 0, v1, s[10:11]
-; GISEL-NEXT:    v_subb_u32_e64 v1, vcc, v1, v8, s[10:11]
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, v9, v14, s[4:5]
-; GISEL-NEXT:    v_subbrev_u32_e64 v14, vcc, 0, v3, s[12:13]
-; GISEL-NEXT:    v_subb_u32_e64 v3, vcc, v3, v5, s[12:13]
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, v11, v15, s[8:9]
-; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v18, v8
-; GISEL-NEXT:    v_subbrev_u32_e64 v1, s[4:5], 0, v1, s[14:15]
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v14, v5
-; GISEL-NEXT:    v_subbrev_u32_e64 v3, s[6:7], 0, v3, s[16:17]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], v18, v8
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[8:9], v14, v5
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, 0, -1, s[4:5]
-; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v11
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, v5, v16, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, v8, v17, s[8:9]
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v5
-; GISEL-NEXT:    v_cmp_ne_u32_e64 s[8:9], 0, v8
-; GISEL-NEXT:    v_cndmask_b32_e64 v5, v12, v7, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v4, v13, v4, s[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, v18, v1, s[6:7]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v14, v3, s[8:9]
-; GISEL-NEXT:    v_cndmask_b32_e32 v0, v0, v5, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[6:7], v10, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, -1, s[6:7]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v8, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v11, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v13, 0, -1, vcc
+; GISEL-NEXT:    v_subb_u32_e64 v3, vcc, v3, v5, s[4:5]
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v10, v8
+; GISEL-NEXT:    v_cndmask_b32_e32 v6, v12, v6, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v12, vcc, v0, v7
+; GISEL-NEXT:    v_subbrev_u32_e64 v14, s[4:5], 0, v1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v12, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v15, 0, -1, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v1, vcc, v1, v8, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v11, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v9, v13, v9, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v13, vcc, v2, v4
+; GISEL-NEXT:    v_subbrev_u32_e64 v16, s[4:5], 0, v3, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v13, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v17, 0, -1, s[4:5]
+; GISEL-NEXT:    v_subb_u32_e32 v3, vcc, v3, v5, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v14, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v18, 0, -1, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v7, vcc, v12, v7
+; GISEL-NEXT:    v_subbrev_u32_e32 v1, vcc, 0, v1, vcc
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v16, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v19, 0, -1, vcc
+; GISEL-NEXT:    v_sub_i32_e32 v4, vcc, v13, v4
+; GISEL-NEXT:    v_subbrev_u32_e32 v3, vcc, 0, v3, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v14, v8
+; GISEL-NEXT:    v_cndmask_b32_e32 v8, v18, v15, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v16, v5
+; GISEL-NEXT:    v_cndmask_b32_e32 v5, v19, v17, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; GISEL-NEXT:    v_cndmask_b32_e32 v7, v12, v7, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v5
+; GISEL-NEXT:    v_cndmask_b32_e64 v4, v13, v4, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, v14, v1, vcc
+; GISEL-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, v0, v7, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v16, v3, s[4:5]
+; GISEL-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v9
 ; GISEL-NEXT:    v_cndmask_b32_e64 v2, v2, v4, s[4:5]
 ; GISEL-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v6, v3, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v11, v3, s[4:5]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; CGP-LABEL: v_urem_v2i64_pow2_shl_denom:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/usubsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/usubsat.ll
@@ -1348,29 +1348,29 @@ define <16 x i32> @v_usubsat_v16i32(<16 x i32> %lhs, <16 x i32> %rhs) {
 ; GFX6-NEXT:    v_sub_i32_e32 v2, vcc, v2, v16
 ; GFX6-NEXT:    v_min_u32_e32 v16, v3, v19
 ; GFX6-NEXT:    v_sub_i32_e32 v3, vcc, v3, v16
-; GFX6-NEXT:    v_min_u32_e32 v16, v4, v20
-; GFX6-NEXT:    v_sub_i32_e32 v4, vcc, v4, v16
-; GFX6-NEXT:    v_min_u32_e32 v16, v5, v21
-; GFX6-NEXT:    v_sub_i32_e32 v5, vcc, v5, v16
-; GFX6-NEXT:    v_min_u32_e32 v16, v6, v22
-; GFX6-NEXT:    v_sub_i32_e32 v6, vcc, v6, v16
-; GFX6-NEXT:    v_min_u32_e32 v16, v7, v23
-; GFX6-NEXT:    v_sub_i32_e32 v7, vcc, v7, v16
-; GFX6-NEXT:    v_min_u32_e32 v16, v8, v24
-; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, v8, v16
-; GFX6-NEXT:    v_min_u32_e32 v16, v9, v25
-; GFX6-NEXT:    v_sub_i32_e32 v9, vcc, v9, v16
-; GFX6-NEXT:    v_min_u32_e32 v16, v10, v26
-; GFX6-NEXT:    v_sub_i32_e32 v10, vcc, v10, v16
 ; GFX6-NEXT:    buffer_load_dword v16, off, s[0:3], s32
-; GFX6-NEXT:    v_min_u32_e32 v17, v11, v27
-; GFX6-NEXT:    v_min_u32_e32 v18, v12, v28
-; GFX6-NEXT:    v_min_u32_e32 v19, v13, v29
-; GFX6-NEXT:    v_min_u32_e32 v20, v14, v30
-; GFX6-NEXT:    v_sub_i32_e32 v11, vcc, v11, v17
-; GFX6-NEXT:    v_sub_i32_e32 v12, vcc, v12, v18
-; GFX6-NEXT:    v_sub_i32_e32 v13, vcc, v13, v19
-; GFX6-NEXT:    v_sub_i32_e32 v14, vcc, v14, v20
+; GFX6-NEXT:    v_min_u32_e32 v17, v4, v20
+; GFX6-NEXT:    v_min_u32_e32 v18, v5, v21
+; GFX6-NEXT:    v_min_u32_e32 v19, v6, v22
+; GFX6-NEXT:    v_min_u32_e32 v20, v7, v23
+; GFX6-NEXT:    v_min_u32_e32 v21, v8, v24
+; GFX6-NEXT:    v_min_u32_e32 v22, v9, v25
+; GFX6-NEXT:    v_min_u32_e32 v23, v10, v26
+; GFX6-NEXT:    v_min_u32_e32 v24, v11, v27
+; GFX6-NEXT:    v_min_u32_e32 v25, v12, v28
+; GFX6-NEXT:    v_min_u32_e32 v26, v13, v29
+; GFX6-NEXT:    v_min_u32_e32 v27, v14, v30
+; GFX6-NEXT:    v_sub_i32_e32 v4, vcc, v4, v17
+; GFX6-NEXT:    v_sub_i32_e32 v5, vcc, v5, v18
+; GFX6-NEXT:    v_sub_i32_e32 v6, vcc, v6, v19
+; GFX6-NEXT:    v_sub_i32_e32 v7, vcc, v7, v20
+; GFX6-NEXT:    v_sub_i32_e32 v8, vcc, v8, v21
+; GFX6-NEXT:    v_sub_i32_e32 v9, vcc, v9, v22
+; GFX6-NEXT:    v_sub_i32_e32 v10, vcc, v10, v23
+; GFX6-NEXT:    v_sub_i32_e32 v11, vcc, v11, v24
+; GFX6-NEXT:    v_sub_i32_e32 v12, vcc, v12, v25
+; GFX6-NEXT:    v_sub_i32_e32 v13, vcc, v13, v26
+; GFX6-NEXT:    v_sub_i32_e32 v14, vcc, v14, v27
 ; GFX6-NEXT:    s_waitcnt vmcnt(0)
 ; GFX6-NEXT:    v_min_u32_e32 v16, v15, v16
 ; GFX6-NEXT:    v_sub_i32_e32 v15, vcc, v15, v16

--- a/llvm/test/CodeGen/AMDGPU/amdhsa-trap-num-sgprs.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdhsa-trap-num-sgprs.ll
@@ -3,7 +3,7 @@
 
 ; GCN-LABEL: {{^}}amdhsa_trap_num_sgprs
 ; TRAP-HANDLER-ENABLE:  NumSgprs: 77
-; TRAP-HANDLER-DISABLE: NumSgprs: 92
+; TRAP-HANDLER-DISABLE: NumSgprs: 85
 define amdgpu_kernel void @amdhsa_trap_num_sgprs(
     ptr addrspace(1) %out0, i32 %in0,
     ptr addrspace(1) %out1, i32 %in1,

--- a/llvm/test/CodeGen/AMDGPU/bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/bf16.ll
@@ -2800,6 +2800,7 @@ define { <32 x i32>, bfloat } @test_overflow_stack(bfloat %a, <32 x i32> %b) {
 ; GCN-NEXT:    v_add_i32_e32 v31, vcc, 0x6c, v0
 ; GCN-NEXT:    buffer_store_dword v30, v2, s[0:3], 0 offen
 ; GCN-NEXT:    v_add_i32_e32 v2, vcc, 0x68, v0
+; GCN-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
 ; GCN-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NEXT:    v_add_i32_e32 v30, vcc, 0x64, v0
 ; GCN-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
@@ -2814,7 +2815,6 @@ define { <32 x i32>, bfloat } @test_overflow_stack(bfloat %a, <32 x i32> %b) {
 ; GCN-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NEXT:    v_add_i32_e32 v27, vcc, 0x50, v0
 ; GCN-NEXT:    v_add_i32_e32 v30, vcc, 0x4c, v0
-; GCN-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
 ; GCN-NEXT:    buffer_store_dword v26, v29, s[0:3], 0 offen
 ; GCN-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NEXT:    v_add_i32_e32 v26, vcc, 0x48, v0
@@ -2897,21 +2897,21 @@ define { <32 x i32>, bfloat } @test_overflow_stack(bfloat %a, <32 x i32> %b) {
 ; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x64, v0
 ; GFX7-NEXT:    buffer_store_dword v27, v2, s[0:3], 0 offen
 ; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x60, v0
+; GFX7-NEXT:    v_add_i32_e32 v27, vcc, 0x5c, v0
 ; GFX7-NEXT:    buffer_store_dword v26, v2, s[0:3], 0 offen
-; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x5c, v0
-; GFX7-NEXT:    buffer_store_dword v25, v2, s[0:3], 0 offen
 ; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x58, v0
+; GFX7-NEXT:    v_add_i32_e32 v26, vcc, 0x54, v0
+; GFX7-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
 ; GFX7-NEXT:    buffer_store_dword v24, v2, s[0:3], 0 offen
-; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x54, v0
-; GFX7-NEXT:    buffer_store_dword v23, v2, s[0:3], 0 offen
-; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x50, v0
-; GFX7-NEXT:    buffer_store_dword v22, v2, s[0:3], 0 offen
-; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x4c, v0
-; GFX7-NEXT:    buffer_store_dword v21, v2, s[0:3], 0 offen
 ; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x48, v0
+; GFX7-NEXT:    v_add_i32_e32 v25, vcc, 0x50, v0
+; GFX7-NEXT:    v_add_i32_e32 v27, vcc, 0x4c, v0
+; GFX7-NEXT:    v_add_i32_e32 v24, vcc, 0x44, v0
+; GFX7-NEXT:    buffer_store_dword v23, v26, s[0:3], 0 offen
+; GFX7-NEXT:    buffer_store_dword v22, v25, s[0:3], 0 offen
+; GFX7-NEXT:    buffer_store_dword v21, v27, s[0:3], 0 offen
 ; GFX7-NEXT:    buffer_store_dword v20, v2, s[0:3], 0 offen
-; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 0x44, v0
-; GFX7-NEXT:    buffer_store_dword v19, v2, s[0:3], 0 offen
+; GFX7-NEXT:    buffer_store_dword v19, v24, s[0:3], 0 offen
 ; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 64, v0
 ; GFX7-NEXT:    buffer_store_dword v18, v2, s[0:3], 0 offen
 ; GFX7-NEXT:    v_add_i32_e32 v2, vcc, 60, v0
@@ -2975,21 +2975,21 @@ define { <32 x i32>, bfloat } @test_overflow_stack(bfloat %a, <32 x i32> %b) {
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x64, v0
 ; GFX8-NEXT:    buffer_store_dword v27, v2, s[0:3], 0 offen
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x60, v0
+; GFX8-NEXT:    v_add_u32_e32 v27, vcc, 0x5c, v0
 ; GFX8-NEXT:    buffer_store_dword v26, v2, s[0:3], 0 offen
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x5c, v0
-; GFX8-NEXT:    buffer_store_dword v25, v2, s[0:3], 0 offen
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x58, v0
+; GFX8-NEXT:    v_add_u32_e32 v26, vcc, 0x54, v0
+; GFX8-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
 ; GFX8-NEXT:    buffer_store_dword v24, v2, s[0:3], 0 offen
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x54, v0
-; GFX8-NEXT:    buffer_store_dword v23, v2, s[0:3], 0 offen
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x50, v0
-; GFX8-NEXT:    buffer_store_dword v22, v2, s[0:3], 0 offen
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x4c, v0
-; GFX8-NEXT:    buffer_store_dword v21, v2, s[0:3], 0 offen
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x48, v0
+; GFX8-NEXT:    v_add_u32_e32 v25, vcc, 0x50, v0
+; GFX8-NEXT:    v_add_u32_e32 v27, vcc, 0x4c, v0
+; GFX8-NEXT:    v_add_u32_e32 v24, vcc, 0x44, v0
+; GFX8-NEXT:    buffer_store_dword v23, v26, s[0:3], 0 offen
+; GFX8-NEXT:    buffer_store_dword v22, v25, s[0:3], 0 offen
+; GFX8-NEXT:    buffer_store_dword v21, v27, s[0:3], 0 offen
 ; GFX8-NEXT:    buffer_store_dword v20, v2, s[0:3], 0 offen
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 0x44, v0
-; GFX8-NEXT:    buffer_store_dword v19, v2, s[0:3], 0 offen
+; GFX8-NEXT:    buffer_store_dword v19, v24, s[0:3], 0 offen
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 64, v0
 ; GFX8-NEXT:    buffer_store_dword v18, v2, s[0:3], 0 offen
 ; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 60, v0
@@ -3035,20 +3035,20 @@ define { <32 x i32>, bfloat } @test_overflow_stack(bfloat %a, <32 x i32> %b) {
 ; GFX9-NEXT:    buffer_store_dword v28, v0, s[0:3], 0 offen offset:104
 ; GFX9-NEXT:    buffer_store_dword v27, v0, s[0:3], 0 offen offset:100
 ; GFX9-NEXT:    buffer_store_dword v26, v0, s[0:3], 0 offen offset:96
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    s_nop 0
+; GFX9-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dword v25, v0, s[0:3], 0 offen offset:92
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dword v24, v0, s[0:3], 0 offen offset:88
 ; GFX9-NEXT:    buffer_store_dword v23, v0, s[0:3], 0 offen offset:84
 ; GFX9-NEXT:    buffer_store_dword v22, v0, s[0:3], 0 offen offset:80
 ; GFX9-NEXT:    buffer_store_dword v21, v0, s[0:3], 0 offen offset:76
 ; GFX9-NEXT:    buffer_store_dword v20, v0, s[0:3], 0 offen offset:72
-; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dword v19, v0, s[0:3], 0 offen offset:68
-; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dword v18, v0, s[0:3], 0 offen offset:64
-; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dword v17, v0, s[0:3], 0 offen offset:60
 ; GFX9-NEXT:    buffer_store_dword v16, v0, s[0:3], 0 offen offset:56
 ; GFX9-NEXT:    buffer_store_dword v15, v0, s[0:3], 0 offen offset:52
@@ -3065,11 +3065,11 @@ define { <32 x i32>, bfloat } @test_overflow_stack(bfloat %a, <32 x i32> %b) {
 ; GFX9-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:8
 ; GFX9-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
 ; GFX9-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen
-; GFX9-NEXT:    s_waitcnt vmcnt(18)
-; GFX9-NEXT:    buffer_store_dword v19, v0, s[0:3], 0 offen offset:124
-; GFX9-NEXT:    buffer_store_dword v20, v0, s[0:3], 0 offen offset:120
-; GFX9-NEXT:    s_waitcnt vmcnt(18)
-; GFX9-NEXT:    buffer_store_dword v18, v0, s[0:3], 0 offen offset:116
+; GFX9-NEXT:    s_waitcnt vmcnt(25)
+; GFX9-NEXT:    buffer_store_dword v27, v0, s[0:3], 0 offen offset:124
+; GFX9-NEXT:    buffer_store_dword v26, v0, s[0:3], 0 offen offset:120
+; GFX9-NEXT:    s_waitcnt vmcnt(25)
+; GFX9-NEXT:    buffer_store_dword v25, v0, s[0:3], 0 offen offset:116
 ; GFX9-NEXT:    buffer_store_short_d16_hi v1, v0, s[0:3], 0 offen offset:128
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/fcanonicalize.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fcanonicalize.f16.ll
@@ -3141,49 +3141,49 @@ define <32 x half> @v_test_canonicalize_var_v32f16(<32 x half> %val) #1 {
 ; VI-LABEL: v_test_canonicalize_var_v32f16:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; VI-NEXT:    v_max_f16_sdwa v20, v0, v0 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_max_f16_sdwa v27, v0, v0 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_e32 v0, v0, v0
-; VI-NEXT:    v_or_b32_e32 v0, v0, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v1, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_or_b32_e32 v0, v0, v27
+; VI-NEXT:    v_max_f16_sdwa v27, v1, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_e32 v1, v1, v1
-; VI-NEXT:    v_or_b32_e32 v1, v1, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v2, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_or_b32_e32 v1, v1, v27
+; VI-NEXT:    v_max_f16_sdwa v27, v2, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_e32 v2, v2, v2
-; VI-NEXT:    v_or_b32_e32 v2, v2, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v3, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_or_b32_e32 v2, v2, v27
+; VI-NEXT:    v_max_f16_sdwa v27, v3, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_e32 v3, v3, v3
-; VI-NEXT:    v_or_b32_e32 v3, v3, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v4, v4 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_max_f16_e32 v4, v4, v4
-; VI-NEXT:    v_or_b32_e32 v4, v4, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v5, v5 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_max_f16_e32 v5, v5, v5
-; VI-NEXT:    v_or_b32_e32 v5, v5, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v6, v6 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_max_f16_e32 v6, v6, v6
-; VI-NEXT:    v_or_b32_e32 v6, v6, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v7, v7 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_max_f16_e32 v7, v7, v7
-; VI-NEXT:    v_or_b32_e32 v7, v7, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v8, v8 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_max_f16_e32 v8, v8, v8
-; VI-NEXT:    v_or_b32_e32 v8, v8, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v9, v9 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_max_f16_e32 v9, v9, v9
-; VI-NEXT:    v_or_b32_e32 v9, v9, v20
-; VI-NEXT:    v_max_f16_sdwa v20, v10, v10 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_max_f16_e32 v10, v10, v10
 ; VI-NEXT:    v_max_f16_sdwa v16, v15, v15 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_sdwa v17, v14, v14 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_sdwa v18, v13, v13 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_sdwa v19, v12, v12 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; VI-NEXT:    v_or_b32_e32 v10, v10, v20
 ; VI-NEXT:    v_max_f16_sdwa v20, v11, v11 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_max_f16_sdwa v21, v10, v10 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_max_f16_sdwa v22, v9, v9 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_max_f16_sdwa v23, v8, v8 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_max_f16_sdwa v24, v7, v7 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_max_f16_sdwa v25, v6, v6 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_max_f16_sdwa v26, v5, v5 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; VI-NEXT:    v_or_b32_e32 v3, v3, v27
+; VI-NEXT:    v_max_f16_sdwa v27, v4, v4 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; VI-NEXT:    v_max_f16_e32 v15, v15, v15
 ; VI-NEXT:    v_max_f16_e32 v14, v14, v14
 ; VI-NEXT:    v_max_f16_e32 v13, v13, v13
 ; VI-NEXT:    v_max_f16_e32 v12, v12, v12
 ; VI-NEXT:    v_max_f16_e32 v11, v11, v11
+; VI-NEXT:    v_max_f16_e32 v10, v10, v10
+; VI-NEXT:    v_max_f16_e32 v9, v9, v9
+; VI-NEXT:    v_max_f16_e32 v8, v8, v8
+; VI-NEXT:    v_max_f16_e32 v7, v7, v7
+; VI-NEXT:    v_max_f16_e32 v6, v6, v6
+; VI-NEXT:    v_max_f16_e32 v5, v5, v5
+; VI-NEXT:    v_max_f16_e32 v4, v4, v4
+; VI-NEXT:    v_or_b32_e32 v4, v4, v27
+; VI-NEXT:    v_or_b32_e32 v5, v5, v26
+; VI-NEXT:    v_or_b32_e32 v6, v6, v25
+; VI-NEXT:    v_or_b32_e32 v7, v7, v24
+; VI-NEXT:    v_or_b32_e32 v8, v8, v23
+; VI-NEXT:    v_or_b32_e32 v9, v9, v22
+; VI-NEXT:    v_or_b32_e32 v10, v10, v21
 ; VI-NEXT:    v_or_b32_e32 v11, v11, v20
 ; VI-NEXT:    v_or_b32_e32 v12, v12, v19
 ; VI-NEXT:    v_or_b32_e32 v13, v13, v18
@@ -3514,17 +3514,17 @@ define <64 x half> @v_test_canonicalize_var_v64f16(<64 x half> %val) #1 {
 ; CI-NEXT:    v_cvt_f16_f32_e32 v24, v30
 ; CI-NEXT:    v_or_b32_e32 v12, v13, v12
 ; CI-NEXT:    v_lshlrev_b32_e32 v13, 16, v14
-; CI-NEXT:    v_or_b32_e32 v13, v15, v13
 ; CI-NEXT:    v_cvt_f16_f32_e32 v14, v28
+; CI-NEXT:    v_or_b32_e32 v13, v15, v13
 ; CI-NEXT:    v_cvt_f16_f32_e32 v15, v27
-; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:36
-; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:32
-; CI-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:44
-; CI-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:40
 ; CI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
 ; CI-NEXT:    v_or_b32_e32 v14, v15, v14
 ; CI-NEXT:    v_lshlrev_b32_e32 v15, 16, v24
 ; CI-NEXT:    v_or_b32_e32 v15, v25, v15
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:36
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:32
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:44
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:40
 ; CI-NEXT:    s_waitcnt vmcnt(11)
 ; CI-NEXT:    v_cvt_f16_f32_e32 v16, v16
 ; CI-NEXT:    s_waitcnt vmcnt(10)
@@ -3549,125 +3549,126 @@ define <64 x half> @v_test_canonicalize_var_v64f16(<64 x half> %val) #1 {
 ; CI-NEXT:    v_or_b32_e32 v18, v19, v18
 ; CI-NEXT:    v_lshlrev_b32_e32 v19, 16, v20
 ; CI-NEXT:    v_or_b32_e32 v19, v21, v19
-; CI-NEXT:    s_waitcnt vmcnt(3)
-; CI-NEXT:    v_cvt_f16_f32_e32 v20, v26
-; CI-NEXT:    s_waitcnt vmcnt(2)
-; CI-NEXT:    v_cvt_f16_f32_e32 v21, v27
-; CI-NEXT:    s_waitcnt vmcnt(1)
-; CI-NEXT:    v_cvt_f16_f32_e32 v26, v28
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    v_cvt_f16_f32_e32 v27, v29
+; CI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:52
+; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:48
+; CI-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:60
+; CI-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:56
+; CI-NEXT:    s_waitcnt vmcnt(7)
+; CI-NEXT:    v_cvt_f16_f32_e32 v20, v24
+; CI-NEXT:    s_waitcnt vmcnt(6)
+; CI-NEXT:    v_cvt_f16_f32_e32 v21, v25
+; CI-NEXT:    s_waitcnt vmcnt(5)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v26
+; CI-NEXT:    s_waitcnt vmcnt(4)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v27
 ; CI-NEXT:    v_lshlrev_b32_e32 v20, 16, v20
 ; CI-NEXT:    v_or_b32_e32 v20, v21, v20
-; CI-NEXT:    v_lshlrev_b32_e32 v21, 16, v26
-; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:52
-; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:48
-; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:60
-; CI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:56
-; CI-NEXT:    v_or_b32_e32 v21, v27, v21
-; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:132
-; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:128
-; CI-NEXT:    s_waitcnt vmcnt(5)
-; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; CI-NEXT:    s_waitcnt vmcnt(4)
-; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; CI-NEXT:    s_waitcnt vmcnt(3)
-; CI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; CI-NEXT:    s_waitcnt vmcnt(2)
+; CI-NEXT:    v_lshlrev_b32_e32 v21, 16, v24
+; CI-NEXT:    v_or_b32_e32 v21, v25, v21
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:132
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:128
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:92
+; CI-NEXT:    s_waitcnt vmcnt(6)
 ; CI-NEXT:    v_cvt_f16_f32_e32 v22, v22
+; CI-NEXT:    s_waitcnt vmcnt(5)
+; CI-NEXT:    v_cvt_f16_f32_e32 v23, v23
+; CI-NEXT:    s_waitcnt vmcnt(3)
+; CI-NEXT:    v_cvt_f16_f32_e32 v26, v29
+; CI-NEXT:    v_lshlrev_b32_e32 v22, 16, v22
+; CI-NEXT:    v_or_b32_e32 v22, v23, v22
+; CI-NEXT:    v_cvt_f16_f32_e32 v23, v28
+; CI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
+; CI-NEXT:    v_or_b32_e32 v23, v26, v23
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:88
+; CI-NEXT:    s_waitcnt vmcnt(3)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    s_waitcnt vmcnt(2)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
 ; CI-NEXT:    s_waitcnt vmcnt(1)
-; CI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    v_cvt_f16_f32_e32 v27, v27
 ; CI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
 ; CI-NEXT:    v_or_b32_e32 v24, v25, v24
-; CI-NEXT:    v_lshlrev_b32_e32 v26, 16, v26
-; CI-NEXT:    v_or_b32_e32 v26, v27, v26
-; CI-NEXT:    v_add_i32_e32 v27, vcc, 0x7c, v0
-; CI-NEXT:    buffer_store_dword v26, v27, s[0:3], 0 offen
-; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:124
-; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:120
-; CI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; CI-NEXT:    v_or_b32_e32 v22, v22, v23
-; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:88
-; CI-NEXT:    s_waitcnt vmcnt(2)
-; CI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; CI-NEXT:    s_waitcnt vmcnt(1)
-; CI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; CI-NEXT:    v_lshlrev_b32_e32 v26, 16, v26
-; CI-NEXT:    v_or_b32_e32 v26, v27, v26
-; CI-NEXT:    v_add_i32_e32 v27, vcc, 0x78, v0
-; CI-NEXT:    buffer_store_dword v26, v27, s[0:3], 0 offen
-; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:116
-; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:112
-; CI-NEXT:    s_waitcnt vmcnt(3)
-; CI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; CI-NEXT:    s_waitcnt vmcnt(1)
-; CI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; CI-NEXT:    v_lshlrev_b32_e32 v26, 16, v26
-; CI-NEXT:    v_or_b32_e32 v26, v27, v26
-; CI-NEXT:    v_add_i32_e32 v27, vcc, 0x74, v0
-; CI-NEXT:    buffer_store_dword v26, v27, s[0:3], 0 offen
-; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:108
-; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:104
-; CI-NEXT:    s_waitcnt vmcnt(1)
-; CI-NEXT:    v_cvt_f16_f32_e32 v25, v26
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    v_cvt_f16_f32_e32 v26, v27
-; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:92
-; CI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; CI-NEXT:    v_or_b32_e32 v25, v26, v25
-; CI-NEXT:    v_add_i32_e32 v26, vcc, 0x70, v0
-; CI-NEXT:    buffer_store_dword v25, v26, s[0:3], 0 offen
-; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:100
-; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:96
-; CI-NEXT:    s_waitcnt vmcnt(3)
-; CI-NEXT:    v_cvt_f16_f32_e32 v27, v27
+; CI-NEXT:    v_add_i32_e32 v25, vcc, 0x7c, v0
+; CI-NEXT:    buffer_store_dword v24, v25, s[0:3], 0 offen
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:124
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:120
 ; CI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; CI-NEXT:    v_or_b32_e32 v23, v23, v27
-; CI-NEXT:    s_waitcnt vmcnt(1)
-; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    s_waitcnt vmcnt(3)
 ; CI-NEXT:    v_cvt_f16_f32_e32 v26, v26
+; CI-NEXT:    v_or_b32_e32 v26, v26, v27
 ; CI-NEXT:    v_add_i32_e32 v27, vcc, 0x68, v0
-; CI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; CI-NEXT:    v_or_b32_e32 v25, v26, v25
-; CI-NEXT:    v_add_i32_e32 v26, vcc, 0x6c, v0
-; CI-NEXT:    buffer_store_dword v25, v26, s[0:3], 0 offen
-; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:68
-; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:64
-; CI-NEXT:    buffer_store_dword v23, v27, s[0:3], 0 offen
-; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:76
+; CI-NEXT:    s_waitcnt vmcnt(1)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
+; CI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
+; CI-NEXT:    v_or_b32_e32 v24, v25, v24
+; CI-NEXT:    v_add_i32_e32 v25, vcc, 0x78, v0
+; CI-NEXT:    buffer_store_dword v24, v25, s[0:3], 0 offen
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:116
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:112
+; CI-NEXT:    s_waitcnt vmcnt(1)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
+; CI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
+; CI-NEXT:    v_or_b32_e32 v24, v25, v24
+; CI-NEXT:    v_add_i32_e32 v25, vcc, 0x74, v0
+; CI-NEXT:    buffer_store_dword v24, v25, s[0:3], 0 offen
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:108
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:104
+; CI-NEXT:    s_waitcnt vmcnt(1)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
+; CI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
+; CI-NEXT:    v_or_b32_e32 v24, v25, v24
+; CI-NEXT:    v_add_i32_e32 v25, vcc, 0x70, v0
+; CI-NEXT:    buffer_store_dword v24, v25, s[0:3], 0 offen
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:100
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:96
+; CI-NEXT:    s_waitcnt vmcnt(1)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
+; CI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
+; CI-NEXT:    v_or_b32_e32 v24, v25, v24
+; CI-NEXT:    v_add_i32_e32 v25, vcc, 0x6c, v0
+; CI-NEXT:    buffer_store_dword v24, v25, s[0:3], 0 offen
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:68
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:64
+; CI-NEXT:    buffer_store_dword v26, v27, s[0:3], 0 offen
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:76
 ; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:72
 ; CI-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:84
 ; CI-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:80
-; CI-NEXT:    s_waitcnt vmcnt(3)
-; CI-NEXT:    v_cvt_f16_f32_e32 v23, v23
+; CI-NEXT:    s_waitcnt vmcnt(6)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    s_waitcnt vmcnt(5)
 ; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; CI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; CI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; CI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; CI-NEXT:    v_or_b32_e32 v25, v26, v25
+; CI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
+; CI-NEXT:    v_or_b32_e32 v24, v25, v24
+; CI-NEXT:    s_waitcnt vmcnt(3)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v26
 ; CI-NEXT:    s_waitcnt vmcnt(2)
 ; CI-NEXT:    v_cvt_f16_f32_e32 v26, v27
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    v_cvt_f16_f32_e32 v27, v29
-; CI-NEXT:    v_or_b32_e32 v23, v26, v23
+; CI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
+; CI-NEXT:    v_or_b32_e32 v25, v26, v25
 ; CI-NEXT:    v_cvt_f16_f32_e32 v26, v28
 ; CI-NEXT:    v_lshlrev_b32_e32 v26, 16, v26
 ; CI-NEXT:    v_or_b32_e32 v26, v27, v26
 ; CI-NEXT:    v_add_i32_e32 v27, vcc, 0x64, v0
 ; CI-NEXT:    buffer_store_dword v26, v27, s[0:3], 0 offen
 ; CI-NEXT:    v_add_i32_e32 v26, vcc, 0x60, v0
-; CI-NEXT:    buffer_store_dword v23, v26, s[0:3], 0 offen
-; CI-NEXT:    v_add_i32_e32 v23, vcc, 0x5c, v0
-; CI-NEXT:    buffer_store_dword v25, v23, s[0:3], 0 offen
-; CI-NEXT:    v_add_i32_e32 v23, vcc, 0x58, v0
+; CI-NEXT:    buffer_store_dword v25, v26, s[0:3], 0 offen
+; CI-NEXT:    v_add_i32_e32 v25, vcc, 0x5c, v0
+; CI-NEXT:    buffer_store_dword v24, v25, s[0:3], 0 offen
+; CI-NEXT:    v_add_i32_e32 v24, vcc, 0x58, v0
+; CI-NEXT:    buffer_store_dword v23, v24, s[0:3], 0 offen
+; CI-NEXT:    v_add_i32_e32 v23, vcc, 0x54, v0
 ; CI-NEXT:    buffer_store_dword v22, v23, s[0:3], 0 offen
-; CI-NEXT:    v_add_i32_e32 v22, vcc, 0x54, v0
-; CI-NEXT:    buffer_store_dword v24, v22, s[0:3], 0 offen
 ; CI-NEXT:    v_add_i32_e32 v22, vcc, 0x50, v0
 ; CI-NEXT:    buffer_store_dword v21, v22, s[0:3], 0 offen
 ; CI-NEXT:    v_add_i32_e32 v21, vcc, 0x4c, v0

--- a/llvm/test/CodeGen/AMDGPU/function-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-args.ll
@@ -670,19 +670,19 @@ define void @void_func_v33i32(<33 x i32> %arg0) #0 {
 ; CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CI-NEXT:    s_mov_b32 s7, 0xf000
 ; CI-NEXT:    s_mov_b32 s6, -1
-; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
-; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
-; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
+; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(5)
+; CI-NEXT:    s_waitcnt vmcnt(8)
 ; CI-NEXT:    buffer_store_dwordx4 v[28:31], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(5)
-; CI-NEXT:    buffer_store_dword v16, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(7)
+; CI-NEXT:    buffer_store_dword v20, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -691,19 +691,19 @@ define void @void_func_v33i32(<33 x i32> %arg0) #0 {
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    s_mov_b32 s7, 0xf000
 ; VI-NEXT:    s_mov_b32 s6, -1
-; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
-; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
-; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
+; VI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(5)
+; VI-NEXT:    s_waitcnt vmcnt(8)
 ; VI-NEXT:    buffer_store_dwordx4 v[28:31], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(5)
-; VI-NEXT:    buffer_store_dword v16, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(7)
+; VI-NEXT:    buffer_store_dword v20, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -712,21 +712,21 @@ define void @void_func_v33i32(<33 x i32> %arg0) #0 {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    s_mov_b32 s7, 0xf000
 ; GFX9-NEXT:    s_mov_b32 s6, -1
-; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
-; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
-; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    buffer_load_dword v31, off, s[0:3], s32
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
+; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
 ; GFX9-NEXT:    s_nop 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(5)
+; GFX9-NEXT:    s_waitcnt vmcnt(8)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[28:31], off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(5)
-; GFX9-NEXT:    buffer_store_dword v16, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(7)
+; GFX9-NEXT:    buffer_store_dword v20, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1389,137 +1389,137 @@ define void @void_func_v32i8(<32 x i8> %arg0) #0 {
 ; CI-LABEL: void_func_v32i8:
 ; CI:       ; %bb.0:
 ; CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CI-NEXT:    v_and_b32_e32 v2, 0xff, v2
-; CI-NEXT:    v_lshlrev_b32_e32 v3, 24, v3
-; CI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; CI-NEXT:    v_or_b32_e32 v2, v3, v2
-; CI-NEXT:    buffer_load_dword v3, off, s[0:3], s32
 ; CI-NEXT:    v_lshlrev_b32_e32 v5, 8, v5
 ; CI-NEXT:    v_and_b32_e32 v4, 0xff, v4
-; CI-NEXT:    v_and_b32_e32 v6, 0xff, v6
 ; CI-NEXT:    v_or_b32_e32 v4, v4, v5
-; CI-NEXT:    v_lshlrev_b32_e32 v5, 24, v7
-; CI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; CI-NEXT:    v_lshlrev_b32_e32 v13, 8, v13
-; CI-NEXT:    v_and_b32_e32 v12, 0xff, v12
-; CI-NEXT:    v_or_b32_e32 v5, v5, v6
-; CI-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; CI-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
-; CI-NEXT:    v_and_b32_e32 v0, 0xff, v0
-; CI-NEXT:    v_or_b32_e32 v12, v12, v13
+; CI-NEXT:    buffer_load_dword v5, off, s[0:3], s32
 ; CI-NEXT:    v_lshlrev_b32_e32 v9, 8, v9
 ; CI-NEXT:    v_and_b32_e32 v8, 0xff, v8
-; CI-NEXT:    v_and_b32_e32 v13, 0xff, v14
-; CI-NEXT:    v_and_b32_e32 v10, 0xff, v10
-; CI-NEXT:    v_or_b32_e32 v7, v4, v5
-; CI-NEXT:    v_or_b32_e32 v0, v0, v1
-; CI-NEXT:    v_lshlrev_b32_e32 v1, 8, v29
-; CI-NEXT:    v_and_b32_e32 v4, 0xff, v28
-; CI-NEXT:    v_and_b32_e32 v6, 0xff, v26
+; CI-NEXT:    v_lshlrev_b32_e32 v13, 8, v13
+; CI-NEXT:    v_and_b32_e32 v12, 0xff, v12
 ; CI-NEXT:    v_or_b32_e32 v8, v8, v9
-; CI-NEXT:    v_lshlrev_b32_e32 v9, 24, v15
-; CI-NEXT:    v_lshlrev_b32_e32 v13, 16, v13
+; CI-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; CI-NEXT:    v_and_b32_e32 v0, 0xff, v0
+; CI-NEXT:    v_and_b32_e32 v9, 0xff, v14
+; CI-NEXT:    v_and_b32_e32 v6, 0xff, v6
+; CI-NEXT:    v_or_b32_e32 v12, v12, v13
+; CI-NEXT:    v_or_b32_e32 v0, v0, v1
+; CI-NEXT:    v_lshlrev_b32_e32 v1, 24, v15
+; CI-NEXT:    v_lshlrev_b32_e32 v7, 24, v7
+; CI-NEXT:    v_and_b32_e32 v2, 0xff, v2
+; CI-NEXT:    v_lshlrev_b32_e32 v9, 16, v9
+; CI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
+; CI-NEXT:    v_and_b32_e32 v10, 0xff, v10
+; CI-NEXT:    v_lshlrev_b32_e32 v3, 24, v3
+; CI-NEXT:    v_and_b32_e32 v13, 0xff, v30
+; CI-NEXT:    v_lshlrev_b32_e32 v14, 8, v29
+; CI-NEXT:    v_and_b32_e32 v15, 0xff, v28
+; CI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; CI-NEXT:    v_or_b32_e32 v1, v1, v9
+; CI-NEXT:    v_and_b32_e32 v9, 0xffff, v12
+; CI-NEXT:    v_or_b32_e32 v6, v7, v6
+; CI-NEXT:    v_and_b32_e32 v4, 0xffff, v4
 ; CI-NEXT:    v_lshlrev_b32_e32 v11, 24, v11
 ; CI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; CI-NEXT:    v_or_b32_e32 v1, v4, v1
-; CI-NEXT:    v_and_b32_e32 v4, 0xff, v30
-; CI-NEXT:    v_lshlrev_b32_e32 v5, 24, v27
-; CI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; CI-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; CI-NEXT:    v_or_b32_e32 v9, v9, v13
+; CI-NEXT:    v_lshlrev_b32_e32 v13, 16, v13
+; CI-NEXT:    v_or_b32_e32 v14, v15, v14
+; CI-NEXT:    v_or_b32_e32 v7, v3, v2
+; CI-NEXT:    v_or_b32_e32 v3, v9, v1
+; CI-NEXT:    v_or_b32_e32 v1, v4, v6
+; CI-NEXT:    v_and_b32_e32 v26, 0xff, v26
+; CI-NEXT:    v_lshlrev_b32_e32 v25, 8, v25
+; CI-NEXT:    v_and_b32_e32 v24, 0xff, v24
 ; CI-NEXT:    v_or_b32_e32 v10, v11, v10
-; CI-NEXT:    v_and_b32_e32 v11, 0xffff, v12
+; CI-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; CI-NEXT:    v_and_b32_e32 v11, 0xffff, v14
+; CI-NEXT:    v_lshlrev_b32_e32 v27, 24, v27
+; CI-NEXT:    v_lshlrev_b32_e32 v15, 16, v26
+; CI-NEXT:    v_or_b32_e32 v0, v0, v7
+; CI-NEXT:    v_or_b32_e32 v12, v27, v15
 ; CI-NEXT:    v_and_b32_e32 v8, 0xffff, v8
-; CI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; CI-NEXT:    v_or_b32_e32 v5, v5, v6
-; CI-NEXT:    v_or_b32_e32 v6, v0, v2
-; CI-NEXT:    v_or_b32_e32 v9, v11, v9
-; CI-NEXT:    v_or_b32_e32 v8, v8, v10
-; CI-NEXT:    v_lshlrev_b32_e32 v10, 8, v25
-; CI-NEXT:    v_and_b32_e32 v11, 0xff, v24
-; CI-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; CI-NEXT:    v_or_b32_e32 v2, v8, v10
+; CI-NEXT:    v_and_b32_e32 v8, 0xff, v20
+; CI-NEXT:    v_and_b32_e32 v9, 0xff, v16
 ; CI-NEXT:    s_mov_b32 s5, 0
 ; CI-NEXT:    s_mov_b32 s4, 16
 ; CI-NEXT:    s_mov_b32 s7, 0xf000
 ; CI-NEXT:    s_mov_b32 s6, -1
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    v_lshlrev_b32_e32 v0, 24, v3
-; CI-NEXT:    v_or_b32_e32 v0, v0, v4
-; CI-NEXT:    v_or_b32_e32 v3, v1, v0
-; CI-NEXT:    v_or_b32_e32 v0, v11, v10
-; CI-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; CI-NEXT:    v_and_b32_e32 v1, 0xff, v22
-; CI-NEXT:    v_or_b32_e32 v2, v0, v5
-; CI-NEXT:    v_lshlrev_b32_e32 v0, 24, v23
-; CI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
-; CI-NEXT:    v_or_b32_e32 v0, v0, v1
-; CI-NEXT:    v_lshlrev_b32_e32 v1, 8, v21
-; CI-NEXT:    v_and_b32_e32 v4, 0xff, v20
-; CI-NEXT:    v_or_b32_e32 v1, v4, v1
-; CI-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; CI-NEXT:    v_and_b32_e32 v4, 0xff, v18
-; CI-NEXT:    v_or_b32_e32 v1, v1, v0
-; CI-NEXT:    v_lshlrev_b32_e32 v0, 24, v19
-; CI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; CI-NEXT:    v_or_b32_e32 v0, v0, v4
-; CI-NEXT:    v_lshlrev_b32_e32 v4, 8, v17
-; CI-NEXT:    v_and_b32_e32 v5, 0xff, v16
-; CI-NEXT:    v_or_b32_e32 v4, v5, v4
+; CI-NEXT:    v_lshlrev_b32_e32 v4, 24, v5
+; CI-NEXT:    v_or_b32_e32 v4, v4, v13
+; CI-NEXT:    v_or_b32_e32 v7, v11, v4
+; CI-NEXT:    v_or_b32_e32 v4, v24, v25
 ; CI-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; CI-NEXT:    v_or_b32_e32 v0, v4, v0
-; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
+; CI-NEXT:    v_and_b32_e32 v5, 0xff, v22
+; CI-NEXT:    v_or_b32_e32 v6, v4, v12
+; CI-NEXT:    v_lshlrev_b32_e32 v4, 24, v23
+; CI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
+; CI-NEXT:    v_or_b32_e32 v4, v4, v5
+; CI-NEXT:    v_lshlrev_b32_e32 v5, 8, v21
+; CI-NEXT:    v_or_b32_e32 v5, v8, v5
+; CI-NEXT:    v_and_b32_e32 v5, 0xffff, v5
+; CI-NEXT:    v_and_b32_e32 v8, 0xff, v18
+; CI-NEXT:    v_or_b32_e32 v5, v5, v4
+; CI-NEXT:    v_lshlrev_b32_e32 v4, 24, v19
+; CI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
+; CI-NEXT:    v_or_b32_e32 v4, v4, v8
+; CI-NEXT:    v_lshlrev_b32_e32 v8, 8, v17
+; CI-NEXT:    v_or_b32_e32 v8, v9, v8
+; CI-NEXT:    v_and_b32_e32 v8, 0xffff, v8
+; CI-NEXT:    v_or_b32_e32 v4, v8, v4
+; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; CI-NEXT:    s_mov_b32 s4, s5
-; CI-NEXT:    buffer_store_dwordx4 v[6:9], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX89-LABEL: void_func_v32i8:
 ; GFX89:       ; %bb.0:
 ; GFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX89-NEXT:    v_lshlrev_b16_e32 v9, 8, v9
+; GFX89-NEXT:    v_or_b32_sdwa v8, v8, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_lshlrev_b16_e32 v9, 8, v11
+; GFX89-NEXT:    v_or_b32_sdwa v9, v10, v9 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    buffer_load_ubyte v10, off, s[0:3], s32
 ; GFX89-NEXT:    v_lshlrev_b16_e32 v13, 8, v13
 ; GFX89-NEXT:    v_or_b32_sdwa v12, v12, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX89-NEXT:    v_lshlrev_b16_e32 v13, 8, v15
-; GFX89-NEXT:    v_or_b32_sdwa v13, v14, v13 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    buffer_load_ubyte v14, off, s[0:3], s32
 ; GFX89-NEXT:    v_lshlrev_b16_e32 v5, 8, v5
+; GFX89-NEXT:    v_lshlrev_b16_e32 v7, 8, v7
+; GFX89-NEXT:    v_lshlrev_b16_e32 v3, 8, v3
+; GFX89-NEXT:    v_or_b32_sdwa v13, v14, v13 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX89-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
+; GFX89-NEXT:    v_lshlrev_b16_e32 v11, 8, v29
+; GFX89-NEXT:    v_lshlrev_b16_e32 v14, 8, v25
+; GFX89-NEXT:    v_lshlrev_b16_e32 v15, 8, v27
+; GFX89-NEXT:    v_lshlrev_b16_e32 v21, 8, v21
+; GFX89-NEXT:    v_lshlrev_b16_e32 v23, 8, v23
+; GFX89-NEXT:    v_lshlrev_b16_e32 v17, 8, v17
+; GFX89-NEXT:    v_lshlrev_b16_e32 v19, 8, v19
 ; GFX89-NEXT:    v_or_b32_sdwa v4, v4, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_lshlrev_b16_e32 v5, 8, v7
-; GFX89-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_lshlrev_b16_e32 v1, 8, v3
-; GFX89-NEXT:    v_lshlrev_b16_e32 v9, 8, v9
-; GFX89-NEXT:    v_or_b32_sdwa v5, v6, v5 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v6, v2, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_lshlrev_b16_e32 v1, 8, v29
-; GFX89-NEXT:    v_or_b32_sdwa v8, v8, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_lshlrev_b16_e32 v9, 8, v11
-; GFX89-NEXT:    v_or_b32_sdwa v7, v28, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_lshlrev_b16_e32 v1, 8, v25
-; GFX89-NEXT:    v_or_b32_sdwa v9, v10, v9 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v10, v24, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_lshlrev_b16_e32 v1, 8, v27
-; GFX89-NEXT:    v_lshlrev_b16_e32 v2, 8, v23
-; GFX89-NEXT:    v_or_b32_sdwa v11, v26, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_lshlrev_b16_e32 v1, 8, v21
-; GFX89-NEXT:    v_lshlrev_b16_e32 v3, 8, v17
-; GFX89-NEXT:    v_lshlrev_b16_e32 v15, 8, v19
-; GFX89-NEXT:    v_or_b32_sdwa v19, v22, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v5, v6, v7 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v6, v2, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX89-NEXT:    v_or_b32_sdwa v2, v8, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v17, v20, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v16, v16, v3 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v15, v18, v15 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v7, v28, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v11, v24, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v14, v26, v15 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v15, v20, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v20, v22, v23 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v16, v16, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v17, v18, v19 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX89-NEXT:    s_mov_b32 s5, 0
 ; GFX89-NEXT:    s_mov_b32 s4, 16
 ; GFX89-NEXT:    s_mov_b32 s7, 0xf000
 ; GFX89-NEXT:    s_mov_b32 s6, -1
 ; GFX89-NEXT:    v_or_b32_sdwa v1, v4, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX89-NEXT:    v_or_b32_sdwa v0, v0, v6 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v6, v10, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v5, v17, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX89-NEXT:    v_or_b32_sdwa v4, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v6, v11, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v5, v15, v20 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX89-NEXT:    v_or_b32_sdwa v4, v16, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX89-NEXT:    v_or_b32_sdwa v3, v12, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX89-NEXT:    s_waitcnt vmcnt(0)
-; GFX89-NEXT:    v_lshlrev_b16_e32 v8, 8, v14
+; GFX89-NEXT:    v_lshlrev_b16_e32 v8, 8, v10
 ; GFX89-NEXT:    v_or_b32_sdwa v8, v30, v8 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX89-NEXT:    v_or_b32_sdwa v7, v7, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX89-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
@@ -2634,13 +2634,13 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:12
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:8
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:12
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2649,9 +2649,9 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dword v20, off, s[4:7], 0
+; CI-NEXT:    buffer_store_dword v26, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx2 v[16:17], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx2 v[24:25], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2666,13 +2666,13 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:12
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:8
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:12
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2681,9 +2681,9 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dword v20, off, s[4:7], 0
+; VI-NEXT:    buffer_store_dword v26, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx2 v[16:17], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx2 v[24:25], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2698,14 +2698,14 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2714,9 +2714,9 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dword v20, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dword v26, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx2 v[16:17], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx2 v[24:25], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2773,14 +2773,14 @@ define void @void_func_v32i32_i1_i8_i16(<32 x i32> %arg0, i1 %arg1, i8 %arg2, i1
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_ubyte v25, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:12
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:16
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_ubyte v16, off, s[0:3], s32 offset:4
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2789,15 +2789,15 @@ define void @void_func_v32i32_i1_i8_i16(<32 x i32> %arg0, i1 %arg1, i8 %arg2, i1
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    v_cvt_f16_f32_e32 v19, v20
-; CI-NEXT:    v_and_b32_e32 v0, 1, v16
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    v_and_b32_e32 v0, 1, v25
 ; CI-NEXT:    buffer_store_byte v0, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v17, off, s[4:7], 0
+; CI-NEXT:    buffer_store_byte v26, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_short v18, off, s[4:7], 0
+; CI-NEXT:    buffer_store_short v27, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_short v19, off, s[4:7], 0
+; CI-NEXT:    buffer_store_short v24, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2812,14 +2812,14 @@ define void @void_func_v32i32_i1_i8_i16(<32 x i32> %arg0, i1 %arg1, i8 %arg2, i1
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_ubyte v24, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_ushort v25, off, s[0:3], s32 offset:8
+; VI-NEXT:    buffer_load_ushort v26, off, s[0:3], s32 offset:12
+; VI-NEXT:    buffer_load_ushort v27, off, s[0:3], s32 offset:16
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_ubyte v20, off, s[0:3], s32 offset:4
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_ushort v16, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_ushort v17, off, s[0:3], s32 offset:12
-; VI-NEXT:    buffer_load_ushort v18, off, s[0:3], s32 offset:16
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2828,14 +2828,14 @@ define void @void_func_v32i32_i1_i8_i16(<32 x i32> %arg0, i1 %arg1, i8 %arg2, i1
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    v_and_b32_e32 v0, 1, v20
+; VI-NEXT:    v_and_b32_e32 v0, 1, v24
 ; VI-NEXT:    buffer_store_byte v0, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v16, off, s[4:7], 0
+; VI-NEXT:    buffer_store_byte v25, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_short v17, off, s[4:7], 0
+; VI-NEXT:    buffer_store_short v26, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_short v18, off, s[4:7], 0
+; VI-NEXT:    buffer_store_short v27, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2850,16 +2850,15 @@ define void @void_func_v32i32_i1_i8_i16(<32 x i32> %arg0, i1 %arg1, i8 %arg2, i1
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_ubyte v24, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_ushort v25, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    buffer_load_ushort v26, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    buffer_load_ushort v27, off, s[0:3], s32 offset:16
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_ubyte v20, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_ushort v16, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_ushort v17, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    buffer_load_ushort v18, off, s[0:3], s32 offset:16
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2868,14 +2867,14 @@ define void @void_func_v32i32_i1_i8_i16(<32 x i32> %arg0, i1 %arg1, i8 %arg2, i1
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    v_and_b32_e32 v0, 1, v20
+; GFX9-NEXT:    v_and_b32_e32 v0, 1, v24
 ; GFX9-NEXT:    buffer_store_byte v0, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v16, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_byte v25, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_short v17, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_short v26, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_short v18, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_short v27, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2941,14 +2940,14 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:12
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
-; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2957,9 +2956,9 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx2 v[16:17], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx2 v[24:25], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx2 v[18:19], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx2 v[26:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2974,14 +2973,14 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:16
+; VI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:12
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
-; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -2990,9 +2989,9 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx2 v[16:17], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx2 v[24:25], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx2 v[18:19], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx2 v[26:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3007,15 +3006,15 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:16
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -3024,9 +3023,9 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx2 v[16:17], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx2 v[24:25], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx2 v[18:19], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx2 v[26:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3083,17 +3082,18 @@ define void @void_func_v32i32_v2i16_v2f16(<32 x i32> %arg0, <2 x i16> %arg1, <2 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:12
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:4
+; CI-NEXT:    s_waitcnt vmcnt(3)
+; CI-NEXT:    v_cvt_f16_f32_e32 v24, v24
+; CI-NEXT:    s_waitcnt vmcnt(2)
+; CI-NEXT:    v_cvt_f16_f32_e32 v25, v25
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:12
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:16
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:4
-; CI-NEXT:    s_waitcnt vmcnt(2)
-; CI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; CI-NEXT:    v_cvt_f16_f32_e32 v19, v20
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -3102,13 +3102,13 @@ define void @void_func_v32i32_v2i16_v2f16(<32 x i32> %arg0, <2 x i16> %arg1, <2 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_short v17, off, s[4:7], 0
+; CI-NEXT:    buffer_store_short v26, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_short v18, off, s[4:7], 0
+; CI-NEXT:    buffer_store_short v27, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_short v16, off, s[4:7], 0
+; CI-NEXT:    buffer_store_short v25, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_short v19, off, s[4:7], 0
+; CI-NEXT:    buffer_store_short v24, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3123,12 +3123,12 @@ define void @void_func_v32i32_v2i16_v2f16(<32 x i32> %arg0, <2 x i16> %arg1, <2 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:8
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -3137,9 +3137,9 @@ define void @void_func_v32i32_v2i16_v2f16(<32 x i32> %arg0, <2 x i16> %arg1, <2 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dword v20, off, s[4:7], 0
+; VI-NEXT:    buffer_store_dword v24, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dword v16, off, s[4:7], 0
+; VI-NEXT:    buffer_store_dword v25, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3154,14 +3154,13 @@ define void @void_func_v32i32_v2i16_v2f16(<32 x i32> %arg0, <2 x i16> %arg1, <2 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
@@ -3170,9 +3169,9 @@ define void @void_func_v32i32_v2i16_v2f16(<32 x i32> %arg0, <2 x i16> %arg1, <2 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dword v20, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dword v24, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dword v16, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dword v25, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3227,29 +3226,29 @@ define void @void_func_v32i32_v2i64_v2f64(<32 x i32> %arg0, <2 x i64> %arg1, <2 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:12
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:32
+; CI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:28
+; CI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:24
+; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:20
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:32
-; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:28
-; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:24
-; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:20
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3264,29 +3263,29 @@ define void @void_func_v32i32_v2i64_v2f64(<32 x i32> %arg0, <2 x i64> %arg1, <2 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:16
+; VI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:12
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:32
+; VI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:28
+; VI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:24
+; VI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:20
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
-; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:32
-; VI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:28
-; VI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:24
-; VI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:20
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3301,31 +3300,31 @@ define void @void_func_v32i32_v2i64_v2f64(<32 x i32> %arg0, <2 x i64> %arg1, <2 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:16
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:32
+; GFX9-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:28
+; GFX9-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:24
+; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:20
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:32
-; GFX9-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:28
-; GFX9-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:24
-; GFX9-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:20
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3388,27 +3387,27 @@ define void @void_func_v32i32_v4i32_v4f32(<32 x i32> %arg0, <4 x i32> %arg1, <4 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:12
+; CI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:32
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:28
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:24
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:20
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:32
-; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:28
-; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:24
-; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:20
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3425,27 +3424,27 @@ define void @void_func_v32i32_v4i32_v4f32(<32 x i32> %arg0, <4 x i32> %arg1, <4 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:16
+; VI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:12
+; VI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:8
+; VI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:32
+; VI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:28
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:24
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:20
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
-; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:32
-; VI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:28
-; VI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:24
-; VI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:20
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3462,29 +3461,28 @@ define void @void_func_v32i32_v4i32_v4f32(<32 x i32> %arg0, <4 x i32> %arg1, <4 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:16
+; GFX9-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:32
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:28
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:24
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:20
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
-; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:32
-; GFX9-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:28
-; GFX9-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:24
-; GFX9-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:20
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3545,41 +3543,41 @@ define void @void_func_v32i32_v8i32_v8f32(<32 x i32> %arg0, <8 x i32> %arg1, <8 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:64
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:60
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:56
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:52
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:64
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:60
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:56
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:52
+; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
+; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:32
+; CI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:28
+; CI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:24
+; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:20
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:16
-; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:12
-; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:48
+; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:44
+; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:40
+; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:36
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:32
-; CI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:28
-; CI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:24
-; CI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:20
 ; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:48
-; CI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:44
-; CI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:40
-; CI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:36
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
+; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3594,41 +3592,41 @@ define void @void_func_v32i32_v8i32_v8f32(<32 x i32> %arg0, <8 x i32> %arg1, <8 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:64
+; VI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:60
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:56
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:52
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:64
-; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:60
-; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:56
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:52
+; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
+; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
+; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
+; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:32
+; VI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:28
+; VI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:24
+; VI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:20
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:16
-; VI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:12
-; VI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:48
+; VI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:44
+; VI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:40
+; VI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:36
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:32
-; VI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:28
-; VI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:24
-; VI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:20
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:48
-; VI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:44
-; VI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:40
-; VI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:36
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
+; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3643,45 +3641,44 @@ define void @void_func_v32i32_v8i32_v8f32(<32 x i32> %arg0, <8 x i32> %arg1, <8 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:64
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:60
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:56
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:52
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:64
-; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:60
-; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:56
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:52
+; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:16
+; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:32
+; GFX9-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:28
+; GFX9-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:24
+; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:20
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:16
-; GFX9-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:48
+; GFX9-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:44
+; GFX9-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:40
+; GFX9-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:36
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:32
-; GFX9-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:28
-; GFX9-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:24
-; GFX9-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:20
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:48
-; GFX9-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:44
-; GFX9-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:40
-; GFX9-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:36
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3756,65 +3753,65 @@ define void @void_func_v32i32_v16i32_v16f32(<32 x i32> %arg0, <16 x i32> %arg1, 
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:64
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:60
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:56
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:52
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:48
+; CI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:44
+; CI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:40
+; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:36
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:64
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:60
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:56
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:52
+; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:96
+; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:92
+; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:88
+; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:84
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:48
-; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:44
-; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:40
-; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:36
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:32
-; CI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:28
-; CI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:24
-; CI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:20
+; CI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:112
+; CI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:108
+; CI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:104
+; CI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:100
+; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:128
+; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:124
+; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:120
+; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:116
 ; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:96
-; CI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:92
-; CI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:88
-; CI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:84
-; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:112
-; CI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108
-; CI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:104
-; CI-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:100
-; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:128
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:124
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:120
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:116
-; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:16
-; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:12
-; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:4
-; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:80
-; CI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:76
-; CI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:72
-; CI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:68
-; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12
+; CI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4
+; CI-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:32
+; CI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:28
+; CI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:24
+; CI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:20
+; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:80
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:76
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:72
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:68
+; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3829,65 +3826,65 @@ define void @void_func_v32i32_v16i32_v16f32(<32 x i32> %arg0, <16 x i32> %arg1, 
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:64
+; VI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:60
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:56
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:52
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:48
+; VI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:44
+; VI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:40
+; VI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:36
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:64
-; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:60
-; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:56
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:52
+; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:96
+; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:92
+; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:88
+; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:84
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:48
-; VI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:44
-; VI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:40
-; VI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:36
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:32
-; VI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:28
-; VI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:24
-; VI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:20
+; VI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:112
+; VI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:108
+; VI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:104
+; VI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:100
+; VI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:128
+; VI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:124
+; VI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:120
+; VI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:116
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:96
-; VI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:92
-; VI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:88
-; VI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:84
-; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:112
-; VI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108
-; VI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:104
-; VI-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:100
-; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:128
-; VI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:124
-; VI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:120
-; VI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:116
-; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:16
-; VI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:12
-; VI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:4
-; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:80
-; VI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:76
-; VI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:72
-; VI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:68
-; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:16
+; VI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12
+; VI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8
+; VI-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4
+; VI-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:32
+; VI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:28
+; VI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:24
+; VI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:20
+; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:80
+; VI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:76
+; VI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:72
+; VI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:68
+; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3902,73 +3899,71 @@ define void @void_func_v32i32_v16i32_v16f32(<32 x i32> %arg0, <16 x i32> %arg1, 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:64
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:60
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:56
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:52
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:48
+; GFX9-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:44
+; GFX9-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:40
+; GFX9-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:36
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:64
-; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:60
-; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:56
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:52
+; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:96
+; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:92
+; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:88
+; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:84
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:48
-; GFX9-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:44
-; GFX9-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:40
-; GFX9-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:36
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:32
-; GFX9-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:28
-; GFX9-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:24
-; GFX9-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:20
+; GFX9-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:112
+; GFX9-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:108
+; GFX9-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:104
+; GFX9-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:100
+; GFX9-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:128
+; GFX9-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:124
+; GFX9-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:120
+; GFX9-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:116
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:96
-; GFX9-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:92
-; GFX9-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:88
-; GFX9-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:84
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:112
-; GFX9-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108
-; GFX9-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:104
-; GFX9-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:100
+; GFX9-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:16
+; GFX9-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4
+; GFX9-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:32
+; GFX9-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:28
+; GFX9-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:24
+; GFX9-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:20
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:128
-; GFX9-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:124
-; GFX9-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:120
-; GFX9-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:116
+; GFX9-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:80
+; GFX9-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:76
+; GFX9-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:72
+; GFX9-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:68
 ; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:16
-; GFX9-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:80
-; GFX9-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:76
-; GFX9-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:72
-; GFX9-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:68
-; GFX9-NEXT:    s_nop 0
-; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4260,65 +4255,65 @@ define void @void_func_v32i32_v16i8(<32 x i32> %arg0, <16 x i8> %arg1) #0 {
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:60
+; CI-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:64
 ; CI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:48
+; CI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:52
+; CI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:56
+; CI-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:36
+; CI-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:40
+; CI-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:44
 ; CI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:64
-; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:48
-; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:52
-; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:56
+; CI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:28
+; CI-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:32
+; CI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:20
+; CI-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:24
 ; CI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:36
-; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:40
-; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:44
-; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:28
+; CI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 offset:16
+; CI-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:12
+; CI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:8
+; CI-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:4
 ; CI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:32
-; CI-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:20
-; CI-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:24
-; CI-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:16
 ; CI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:12
-; CI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:8
-; CI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:4
-; CI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:60
 ; CI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v16, off, s[4:7], 0
+; CI-NEXT:    buffer_store_byte v25, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v24, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v22, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v21, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_byte v20, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v27, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v26, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v23, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v17, off, s[4:7], 0
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    buffer_store_byte v16, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_byte v19, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_byte v18, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v17, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v14, off, s[4:7], 0
+; CI-NEXT:    buffer_store_byte v12, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_byte v13, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v12, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v8, off, s[4:7], 0
+; CI-NEXT:    buffer_store_byte v14, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    buffer_store_byte v15, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v10, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v9, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v11, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v4, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v5, off, s[4:7], 0
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    buffer_store_byte v6, off, s[4:7], 0
 ; CI-NEXT:    s_waitcnt vmcnt(0)
 ; CI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4333,65 +4328,65 @@ define void @void_func_v32i32_v16i8(<32 x i32> %arg0, <16 x i8> %arg1) #0 {
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_ubyte v24, off, s[0:3], s32 offset:60
+; VI-NEXT:    buffer_load_ubyte v25, off, s[0:3], s32 offset:64
 ; VI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_load_ubyte v20, off, s[0:3], s32 offset:48
+; VI-NEXT:    buffer_load_ubyte v21, off, s[0:3], s32 offset:52
+; VI-NEXT:    buffer_load_ubyte v22, off, s[0:3], s32 offset:56
+; VI-NEXT:    buffer_load_ubyte v23, off, s[0:3], s32 offset:36
+; VI-NEXT:    buffer_load_ubyte v26, off, s[0:3], s32 offset:40
+; VI-NEXT:    buffer_load_ubyte v27, off, s[0:3], s32 offset:44
 ; VI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_ubyte v16, off, s[0:3], s32 offset:64
-; VI-NEXT:    buffer_load_ubyte v17, off, s[0:3], s32 offset:48
-; VI-NEXT:    buffer_load_ubyte v18, off, s[0:3], s32 offset:52
-; VI-NEXT:    buffer_load_ubyte v19, off, s[0:3], s32 offset:56
+; VI-NEXT:    buffer_load_ubyte v16, off, s[0:3], s32 offset:28
+; VI-NEXT:    buffer_load_ubyte v17, off, s[0:3], s32 offset:32
+; VI-NEXT:    buffer_load_ubyte v18, off, s[0:3], s32 offset:20
+; VI-NEXT:    buffer_load_ubyte v19, off, s[0:3], s32 offset:24
 ; VI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_ubyte v12, off, s[0:3], s32 offset:36
-; VI-NEXT:    buffer_load_ubyte v13, off, s[0:3], s32 offset:40
-; VI-NEXT:    buffer_load_ubyte v14, off, s[0:3], s32 offset:44
-; VI-NEXT:    buffer_load_ubyte v15, off, s[0:3], s32 offset:28
+; VI-NEXT:    buffer_load_ubyte v12, off, s[0:3], s32 offset:16
+; VI-NEXT:    buffer_load_ubyte v13, off, s[0:3], s32 offset:12
+; VI-NEXT:    buffer_load_ubyte v14, off, s[0:3], s32 offset:8
+; VI-NEXT:    buffer_load_ubyte v15, off, s[0:3], s32 offset:4
 ; VI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_ubyte v8, off, s[0:3], s32 offset:32
-; VI-NEXT:    buffer_load_ubyte v9, off, s[0:3], s32 offset:20
-; VI-NEXT:    buffer_load_ubyte v10, off, s[0:3], s32 offset:24
-; VI-NEXT:    buffer_load_ubyte v11, off, s[0:3], s32 offset:16
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_load_ubyte v4, off, s[0:3], s32 offset:12
-; VI-NEXT:    buffer_load_ubyte v5, off, s[0:3], s32 offset:8
-; VI-NEXT:    buffer_load_ubyte v6, off, s[0:3], s32 offset:4
-; VI-NEXT:    buffer_load_ubyte v20, off, s[0:3], s32 offset:60
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v16, off, s[4:7], 0
+; VI-NEXT:    buffer_store_byte v25, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v24, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v22, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v21, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_byte v20, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v27, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v26, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v23, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v17, off, s[4:7], 0
+; VI-NEXT:    s_waitcnt vmcnt(0)
+; VI-NEXT:    buffer_store_byte v16, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_byte v19, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_byte v18, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v17, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v14, off, s[4:7], 0
+; VI-NEXT:    buffer_store_byte v12, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_byte v13, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v12, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v8, off, s[4:7], 0
+; VI-NEXT:    buffer_store_byte v14, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_store_byte v15, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v10, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v9, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v11, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v4, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v5, off, s[4:7], 0
-; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    buffer_store_byte v6, off, s[4:7], 0
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4406,69 +4401,69 @@ define void @void_func_v32i32_v16i8(<32 x i32> %arg0, <16 x i8> %arg1) #0 {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_dwordx4 v[24:27], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_ubyte v24, off, s[0:3], s32 offset:60
+; GFX9-NEXT:    buffer_load_ubyte v25, off, s[0:3], s32 offset:64
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[20:23], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_load_ubyte v20, off, s[0:3], s32 offset:48
+; GFX9-NEXT:    buffer_load_ubyte v21, off, s[0:3], s32 offset:52
+; GFX9-NEXT:    buffer_load_ubyte v22, off, s[0:3], s32 offset:56
+; GFX9-NEXT:    buffer_load_ubyte v23, off, s[0:3], s32 offset:36
+; GFX9-NEXT:    buffer_load_ubyte v26, off, s[0:3], s32 offset:40
+; GFX9-NEXT:    buffer_load_ubyte v27, off, s[0:3], s32 offset:44
+; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[16:19], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_ubyte v16, off, s[0:3], s32 offset:64
-; GFX9-NEXT:    buffer_load_ubyte v17, off, s[0:3], s32 offset:48
-; GFX9-NEXT:    buffer_load_ubyte v18, off, s[0:3], s32 offset:52
-; GFX9-NEXT:    buffer_load_ubyte v19, off, s[0:3], s32 offset:56
-; GFX9-NEXT:    buffer_load_ubyte v20, off, s[0:3], s32 offset:60
+; GFX9-NEXT:    buffer_load_ubyte v16, off, s[0:3], s32 offset:28
+; GFX9-NEXT:    buffer_load_ubyte v17, off, s[0:3], s32 offset:32
+; GFX9-NEXT:    buffer_load_ubyte v18, off, s[0:3], s32 offset:20
+; GFX9-NEXT:    buffer_load_ubyte v19, off, s[0:3], s32 offset:24
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[12:15], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_ubyte v12, off, s[0:3], s32 offset:36
-; GFX9-NEXT:    buffer_load_ubyte v13, off, s[0:3], s32 offset:40
-; GFX9-NEXT:    buffer_load_ubyte v14, off, s[0:3], s32 offset:44
-; GFX9-NEXT:    buffer_load_ubyte v15, off, s[0:3], s32 offset:28
+; GFX9-NEXT:    buffer_load_ubyte v12, off, s[0:3], s32 offset:16
+; GFX9-NEXT:    buffer_load_ubyte v13, off, s[0:3], s32 offset:12
+; GFX9-NEXT:    buffer_load_ubyte v14, off, s[0:3], s32 offset:8
+; GFX9-NEXT:    buffer_load_ubyte v15, off, s[0:3], s32 offset:4
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[8:11], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_ubyte v8, off, s[0:3], s32 offset:32
-; GFX9-NEXT:    buffer_load_ubyte v9, off, s[0:3], s32 offset:20
-; GFX9-NEXT:    buffer_load_ubyte v10, off, s[0:3], s32 offset:24
-; GFX9-NEXT:    buffer_load_ubyte v11, off, s[0:3], s32 offset:16
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[4:7], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_load_ubyte v4, off, s[0:3], s32 offset:12
-; GFX9-NEXT:    buffer_load_ubyte v5, off, s[0:3], s32 offset:8
-; GFX9-NEXT:    buffer_load_ubyte v6, off, s[0:3], s32 offset:4
-; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    buffer_store_dwordx4 v[0:3], off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v16, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_byte v25, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v24, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v22, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v21, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_byte v20, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v27, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v26, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v23, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v17, off, s[4:7], 0
+; GFX9-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-NEXT:    buffer_store_byte v16, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_byte v19, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_byte v18, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v17, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v14, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_byte v12, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_byte v13, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v12, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v8, off, s[4:7], 0
+; GFX9-NEXT:    buffer_store_byte v14, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    buffer_store_byte v15, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v10, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v9, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v11, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v4, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v5, off, s[4:7], 0
-; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    buffer_store_byte v6, off, s[4:7], 0
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/function-returns.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-returns.ll
@@ -1496,8 +1496,8 @@ define <33 x i32> @v33i32_func_void() #0 {
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    buffer_load_dwordx4 v[1:4], off, s[4:7], 0 offset:112
 ; GFX9-NEXT:    buffer_load_dwordx4 v[5:8], off, s[4:7], 0 offset:96
-; GFX9-NEXT:    buffer_load_dwordx4 v[9:12], off, s[4:7], 0 offset:80
 ; GFX9-NEXT:    buffer_load_dword v33, off, s[4:7], 0 offset:128
+; GFX9-NEXT:    buffer_load_dwordx4 v[9:12], off, s[4:7], 0 offset:80
 ; GFX9-NEXT:    buffer_load_dwordx4 v[13:16], off, s[4:7], 0 offset:64
 ; GFX9-NEXT:    buffer_load_dwordx4 v[17:20], off, s[4:7], 0 offset:48
 ; GFX9-NEXT:    buffer_load_dwordx4 v[21:24], off, s[4:7], 0 offset:32
@@ -1514,12 +1514,12 @@ define <33 x i32> @v33i32_func_void() #0 {
 ; GFX9-NEXT:    buffer_store_dword v6, v0, s[0:3], 0 offen offset:100
 ; GFX9-NEXT:    buffer_store_dword v5, v0, s[0:3], 0 offen offset:96
 ; GFX9-NEXT:    s_waitcnt vmcnt(14)
+; GFX9-NEXT:    buffer_store_dword v33, v0, s[0:3], 0 offen offset:128
+; GFX9-NEXT:    s_waitcnt vmcnt(14)
 ; GFX9-NEXT:    buffer_store_dword v12, v0, s[0:3], 0 offen offset:92
 ; GFX9-NEXT:    buffer_store_dword v11, v0, s[0:3], 0 offen offset:88
 ; GFX9-NEXT:    buffer_store_dword v10, v0, s[0:3], 0 offen offset:84
 ; GFX9-NEXT:    buffer_store_dword v9, v0, s[0:3], 0 offen offset:80
-; GFX9-NEXT:    s_waitcnt vmcnt(17)
-; GFX9-NEXT:    buffer_store_dword v33, v0, s[0:3], 0 offen offset:128
 ; GFX9-NEXT:    s_waitcnt vmcnt(17)
 ; GFX9-NEXT:    buffer_store_dword v16, v0, s[0:3], 0 offen offset:76
 ; GFX9-NEXT:    buffer_store_dword v15, v0, s[0:3], 0 offen offset:72
@@ -1785,8 +1785,8 @@ define { <32 x i32>, i32 } @struct_v32i32_i32_func_void() #0 {
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    buffer_load_dwordx4 v[1:4], off, s[4:7], 0 offset:112
 ; GFX9-NEXT:    buffer_load_dwordx4 v[5:8], off, s[4:7], 0 offset:96
-; GFX9-NEXT:    buffer_load_dwordx4 v[9:12], off, s[4:7], 0 offset:80
 ; GFX9-NEXT:    buffer_load_dword v33, off, s[4:7], 0 offset:128
+; GFX9-NEXT:    buffer_load_dwordx4 v[9:12], off, s[4:7], 0 offset:80
 ; GFX9-NEXT:    buffer_load_dwordx4 v[13:16], off, s[4:7], 0 offset:64
 ; GFX9-NEXT:    buffer_load_dwordx4 v[17:20], off, s[4:7], 0 offset:48
 ; GFX9-NEXT:    buffer_load_dwordx4 v[21:24], off, s[4:7], 0 offset:32
@@ -1803,12 +1803,12 @@ define { <32 x i32>, i32 } @struct_v32i32_i32_func_void() #0 {
 ; GFX9-NEXT:    buffer_store_dword v6, v0, s[0:3], 0 offen offset:100
 ; GFX9-NEXT:    buffer_store_dword v5, v0, s[0:3], 0 offen offset:96
 ; GFX9-NEXT:    s_waitcnt vmcnt(14)
+; GFX9-NEXT:    buffer_store_dword v33, v0, s[0:3], 0 offen offset:128
+; GFX9-NEXT:    s_waitcnt vmcnt(14)
 ; GFX9-NEXT:    buffer_store_dword v12, v0, s[0:3], 0 offen offset:92
 ; GFX9-NEXT:    buffer_store_dword v11, v0, s[0:3], 0 offen offset:88
 ; GFX9-NEXT:    buffer_store_dword v10, v0, s[0:3], 0 offen offset:84
 ; GFX9-NEXT:    buffer_store_dword v9, v0, s[0:3], 0 offen offset:80
-; GFX9-NEXT:    s_waitcnt vmcnt(17)
-; GFX9-NEXT:    buffer_store_dword v33, v0, s[0:3], 0 offen offset:128
 ; GFX9-NEXT:    s_waitcnt vmcnt(17)
 ; GFX9-NEXT:    buffer_store_dword v16, v0, s[0:3], 0 offen offset:76
 ; GFX9-NEXT:    buffer_store_dword v15, v0, s[0:3], 0 offen offset:72
@@ -2074,8 +2074,8 @@ define { i32, <32 x i32> } @struct_i32_v32i32_func_void() #0 {
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    buffer_load_dwordx4 v[1:4], off, s[4:7], 0 offset:240
 ; GFX9-NEXT:    buffer_load_dwordx4 v[5:8], off, s[4:7], 0 offset:224
-; GFX9-NEXT:    buffer_load_dwordx4 v[9:12], off, s[4:7], 0 offset:208
 ; GFX9-NEXT:    buffer_load_dword v33, off, s[4:7], 0
+; GFX9-NEXT:    buffer_load_dwordx4 v[9:12], off, s[4:7], 0 offset:208
 ; GFX9-NEXT:    buffer_load_dwordx4 v[13:16], off, s[4:7], 0 offset:192
 ; GFX9-NEXT:    buffer_load_dwordx4 v[17:20], off, s[4:7], 0 offset:176
 ; GFX9-NEXT:    buffer_load_dwordx4 v[21:24], off, s[4:7], 0 offset:160
@@ -2092,12 +2092,12 @@ define { i32, <32 x i32> } @struct_i32_v32i32_func_void() #0 {
 ; GFX9-NEXT:    buffer_store_dword v6, v0, s[0:3], 0 offen offset:228
 ; GFX9-NEXT:    buffer_store_dword v5, v0, s[0:3], 0 offen offset:224
 ; GFX9-NEXT:    s_waitcnt vmcnt(14)
+; GFX9-NEXT:    buffer_store_dword v33, v0, s[0:3], 0 offen
+; GFX9-NEXT:    s_waitcnt vmcnt(14)
 ; GFX9-NEXT:    buffer_store_dword v12, v0, s[0:3], 0 offen offset:220
 ; GFX9-NEXT:    buffer_store_dword v11, v0, s[0:3], 0 offen offset:216
 ; GFX9-NEXT:    buffer_store_dword v10, v0, s[0:3], 0 offen offset:212
 ; GFX9-NEXT:    buffer_store_dword v9, v0, s[0:3], 0 offen offset:208
-; GFX9-NEXT:    s_waitcnt vmcnt(17)
-; GFX9-NEXT:    buffer_store_dword v33, v0, s[0:3], 0 offen
 ; GFX9-NEXT:    s_waitcnt vmcnt(17)
 ; GFX9-NEXT:    buffer_store_dword v16, v0, s[0:3], 0 offen offset:204
 ; GFX9-NEXT:    buffer_store_dword v15, v0, s[0:3], 0 offen offset:200

--- a/llvm/test/CodeGen/AMDGPU/gfx-callable-return-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/gfx-callable-return-types.ll
@@ -2497,73 +2497,26 @@ define amdgpu_gfx <72 x i32> @return_72xi32(<72 x i32> %val) #1 {
 ; GFX10-LABEL: return_72xi32:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:180 ; 4-byte Folded Spill
-; GFX10-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:176 ; 4-byte Folded Spill
-; GFX10-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:172 ; 4-byte Folded Spill
-; GFX10-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
-; GFX10-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
-; GFX10-NEXT:    s_clause 0x14
-; GFX10-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:128
-; GFX10-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:132
-; GFX10-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:136
-; GFX10-NEXT:    buffer_load_dword v49, off, s[0:3], s32 offset:140
-; GFX10-NEXT:    buffer_load_dword v52, off, s[0:3], s32 offset:144
-; GFX10-NEXT:    buffer_load_dword v54, off, s[0:3], s32 offset:148
-; GFX10-NEXT:    buffer_load_dword v55, off, s[0:3], s32 offset:152
-; GFX10-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:156
-; GFX10-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:160
-; GFX10-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:96
-; GFX10-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:100
-; GFX10-NEXT:    buffer_load_dword v48, off, s[0:3], s32 offset:104
-; GFX10-NEXT:    buffer_load_dword v51, off, s[0:3], s32 offset:108
-; GFX10-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112
-; GFX10-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:116
-; GFX10-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:120
-; GFX10-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:124
-; GFX10-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:64
-; GFX10-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:68
-; GFX10-NEXT:    buffer_load_dword v39, off, s[0:3], s32 offset:72
-; GFX10-NEXT:    buffer_load_dword v50, off, s[0:3], s32 offset:76
 ; GFX10-NEXT:    buffer_store_dword v31, v0, s[0:3], 0 offen offset:120
-; GFX10-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:80
 ; GFX10-NEXT:    buffer_store_dword v30, v0, s[0:3], 0 offen offset:116
-; GFX10-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:84
 ; GFX10-NEXT:    buffer_store_dword v29, v0, s[0:3], 0 offen offset:112
-; GFX10-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:88
 ; GFX10-NEXT:    buffer_store_dword v28, v0, s[0:3], 0 offen offset:108
-; GFX10-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:92
 ; GFX10-NEXT:    buffer_store_dword v27, v0, s[0:3], 0 offen offset:104
-; GFX10-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:32
 ; GFX10-NEXT:    buffer_store_dword v26, v0, s[0:3], 0 offen offset:100
-; GFX10-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:36
 ; GFX10-NEXT:    buffer_store_dword v25, v0, s[0:3], 0 offen offset:96
-; GFX10-NEXT:    buffer_load_dword v25, off, s[0:3], s32 offset:40
 ; GFX10-NEXT:    buffer_store_dword v24, v0, s[0:3], 0 offen offset:92
-; GFX10-NEXT:    buffer_load_dword v24, off, s[0:3], s32 offset:44
 ; GFX10-NEXT:    buffer_store_dword v23, v0, s[0:3], 0 offen offset:88
-; GFX10-NEXT:    buffer_load_dword v23, off, s[0:3], s32 offset:48
 ; GFX10-NEXT:    buffer_store_dword v22, v0, s[0:3], 0 offen offset:84
-; GFX10-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:52
 ; GFX10-NEXT:    buffer_store_dword v21, v0, s[0:3], 0 offen offset:80
-; GFX10-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:56
 ; GFX10-NEXT:    buffer_store_dword v20, v0, s[0:3], 0 offen offset:76
-; GFX10-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:60
 ; GFX10-NEXT:    buffer_store_dword v19, v0, s[0:3], 0 offen offset:72
-; GFX10-NEXT:    buffer_load_dword v19, off, s[0:3], s32 offset:28
 ; GFX10-NEXT:    buffer_store_dword v18, v0, s[0:3], 0 offen offset:68
-; GFX10-NEXT:    buffer_load_dword v18, off, s[0:3], s32 offset:12
 ; GFX10-NEXT:    buffer_store_dword v17, v0, s[0:3], 0 offen offset:64
-; GFX10-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:16
 ; GFX10-NEXT:    buffer_store_dword v16, v0, s[0:3], 0 offen offset:60
-; GFX10-NEXT:    buffer_load_dword v16, off, s[0:3], s32 offset:20
 ; GFX10-NEXT:    buffer_store_dword v15, v0, s[0:3], 0 offen offset:56
-; GFX10-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:24
 ; GFX10-NEXT:    buffer_store_dword v14, v0, s[0:3], 0 offen offset:52
-; GFX10-NEXT:    buffer_load_dword v14, off, s[0:3], s32 offset:4
 ; GFX10-NEXT:    buffer_store_dword v13, v0, s[0:3], 0 offen offset:48
-; GFX10-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:8
 ; GFX10-NEXT:    buffer_store_dword v12, v0, s[0:3], 0 offen offset:44
-; GFX10-NEXT:    buffer_load_dword v12, off, s[0:3], s32
 ; GFX10-NEXT:    buffer_store_dword v11, v0, s[0:3], 0 offen offset:40
 ; GFX10-NEXT:    buffer_store_dword v10, v0, s[0:3], 0 offen offset:36
 ; GFX10-NEXT:    buffer_store_dword v9, v0, s[0:3], 0 offen offset:32
@@ -2572,187 +2525,230 @@ define amdgpu_gfx <72 x i32> @return_72xi32(<72 x i32> %val) #1 {
 ; GFX10-NEXT:    buffer_store_dword v6, v0, s[0:3], 0 offen offset:20
 ; GFX10-NEXT:    buffer_store_dword v5, v0, s[0:3], 0 offen offset:16
 ; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:12
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:160
 ; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:8
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:156
 ; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
-; GFX10-NEXT:    s_waitcnt vmcnt(32)
-; GFX10-NEXT:    buffer_store_dword v41, v0, s[0:3], 0 offen offset:284
-; GFX10-NEXT:    buffer_store_dword v40, v0, s[0:3], 0 offen offset:280
-; GFX10-NEXT:    buffer_store_dword v55, v0, s[0:3], 0 offen offset:276
-; GFX10-NEXT:    buffer_store_dword v54, v0, s[0:3], 0 offen offset:272
-; GFX10-NEXT:    buffer_store_dword v52, v0, s[0:3], 0 offen offset:268
-; GFX10-NEXT:    buffer_store_dword v49, v0, s[0:3], 0 offen offset:264
-; GFX10-NEXT:    buffer_store_dword v38, v0, s[0:3], 0 offen offset:260
-; GFX10-NEXT:    buffer_store_dword v35, v0, s[0:3], 0 offen offset:256
-; GFX10-NEXT:    buffer_store_dword v32, v0, s[0:3], 0 offen offset:252
-; GFX10-NEXT:    s_waitcnt vmcnt(24)
-; GFX10-NEXT:    buffer_store_dword v44, v0, s[0:3], 0 offen offset:248
-; GFX10-NEXT:    buffer_store_dword v43, v0, s[0:3], 0 offen offset:244
-; GFX10-NEXT:    buffer_store_dword v42, v0, s[0:3], 0 offen offset:240
-; GFX10-NEXT:    buffer_store_dword v53, v0, s[0:3], 0 offen offset:236
-; GFX10-NEXT:    buffer_store_dword v51, v0, s[0:3], 0 offen offset:232
-; GFX10-NEXT:    buffer_store_dword v48, v0, s[0:3], 0 offen offset:228
-; GFX10-NEXT:    buffer_store_dword v37, v0, s[0:3], 0 offen offset:224
-; GFX10-NEXT:    buffer_store_dword v34, v0, s[0:3], 0 offen offset:220
-; GFX10-NEXT:    s_waitcnt vmcnt(16)
-; GFX10-NEXT:    buffer_store_dword v28, v0, s[0:3], 0 offen offset:216
-; GFX10-NEXT:    buffer_store_dword v29, v0, s[0:3], 0 offen offset:212
-; GFX10-NEXT:    buffer_store_dword v30, v0, s[0:3], 0 offen offset:208
-; GFX10-NEXT:    buffer_store_dword v31, v0, s[0:3], 0 offen offset:204
-; GFX10-NEXT:    buffer_store_dword v50, v0, s[0:3], 0 offen offset:200
-; GFX10-NEXT:    buffer_store_dword v39, v0, s[0:3], 0 offen offset:196
-; GFX10-NEXT:    buffer_store_dword v36, v0, s[0:3], 0 offen offset:192
-; GFX10-NEXT:    buffer_store_dword v33, v0, s[0:3], 0 offen offset:188
-; GFX10-NEXT:    s_waitcnt vmcnt(8)
-; GFX10-NEXT:    buffer_store_dword v20, v0, s[0:3], 0 offen offset:184
-; GFX10-NEXT:    buffer_store_dword v21, v0, s[0:3], 0 offen offset:180
-; GFX10-NEXT:    buffer_store_dword v22, v0, s[0:3], 0 offen offset:176
-; GFX10-NEXT:    buffer_store_dword v23, v0, s[0:3], 0 offen offset:172
-; GFX10-NEXT:    buffer_store_dword v24, v0, s[0:3], 0 offen offset:168
-; GFX10-NEXT:    buffer_store_dword v25, v0, s[0:3], 0 offen offset:164
-; GFX10-NEXT:    buffer_store_dword v26, v0, s[0:3], 0 offen offset:160
-; GFX10-NEXT:    buffer_store_dword v27, v0, s[0:3], 0 offen offset:156
-; GFX10-NEXT:    s_waitcnt vmcnt(7)
-; GFX10-NEXT:    buffer_store_dword v19, v0, s[0:3], 0 offen offset:152
-; GFX10-NEXT:    s_waitcnt vmcnt(3)
-; GFX10-NEXT:    buffer_store_dword v15, v0, s[0:3], 0 offen offset:148
-; GFX10-NEXT:    buffer_store_dword v16, v0, s[0:3], 0 offen offset:144
-; GFX10-NEXT:    buffer_store_dword v17, v0, s[0:3], 0 offen offset:140
-; GFX10-NEXT:    buffer_store_dword v18, v0, s[0:3], 0 offen offset:136
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:152
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:284
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:148
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:280
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:144
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:276
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:140
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:272
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:136
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:268
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:132
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:264
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:128
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:260
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:124
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:256
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:120
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:252
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:116
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:248
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:112
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:244
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:108
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:240
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:104
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:236
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:100
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:232
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:96
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:228
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:92
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:224
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:88
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:220
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:84
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:216
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:212
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:76
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:208
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:72
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:204
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:200
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:64
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:196
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:60
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:192
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:56
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:188
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:52
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:184
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:48
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:180
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:44
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:176
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:40
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:172
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:36
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:168
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:32
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:164
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:28
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:160
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:24
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:156
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:20
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:152
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:16
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:148
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:12
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:144
+; GFX10-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:4
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:140
+; GFX10-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:8
+; GFX10-NEXT:    s_waitcnt vmcnt(2)
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:136
+; GFX10-NEXT:    buffer_load_dword v3, off, s[0:3], s32
 ; GFX10-NEXT:    s_waitcnt vmcnt(1)
-; GFX10-NEXT:    buffer_store_dword v13, v0, s[0:3], 0 offen offset:132
-; GFX10-NEXT:    buffer_store_dword v14, v0, s[0:3], 0 offen offset:128
+; GFX10-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen offset:132
+; GFX10-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:128
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    buffer_store_dword v12, v0, s[0:3], 0 offen offset:124
+; GFX10-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:124
 ; GFX10-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; GFX10-NEXT:    s_clause 0x4
-; GFX10-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:164
-; GFX10-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:168
-; GFX10-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:172
-; GFX10-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:176
-; GFX10-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:180
-; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: return_72xi32:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    s_clause 0xc
-; GFX11-NEXT:    scratch_store_b32 off, v40, s32 offset:212
-; GFX11-NEXT:    scratch_store_b32 off, v41, s32 offset:208
-; GFX11-NEXT:    scratch_store_b32 off, v42, s32 offset:204
-; GFX11-NEXT:    scratch_store_b32 off, v43, s32 offset:200
-; GFX11-NEXT:    scratch_store_b32 off, v44, s32 offset:196
-; GFX11-NEXT:    scratch_store_b32 off, v56, s32 offset:192
-; GFX11-NEXT:    scratch_store_b32 off, v57, s32 offset:188
-; GFX11-NEXT:    scratch_store_b32 off, v58, s32 offset:184
-; GFX11-NEXT:    scratch_store_b32 off, v59, s32 offset:180
-; GFX11-NEXT:    scratch_store_b32 off, v60, s32 offset:176
-; GFX11-NEXT:    scratch_store_b32 off, v61, s32 offset:172
-; GFX11-NEXT:    scratch_store_b32 off, v62, s32 offset:168
-; GFX11-NEXT:    scratch_store_b32 off, v63, s32 offset:164
-; GFX11-NEXT:    s_clause 0x14
-; GFX11-NEXT:    scratch_load_b32 v36, off, s32 offset:32
-; GFX11-NEXT:    scratch_load_b32 v35, off, s32 offset:28
-; GFX11-NEXT:    scratch_load_b32 v34, off, s32 offset:24
-; GFX11-NEXT:    scratch_load_b32 v51, off, s32 offset:48
-; GFX11-NEXT:    scratch_load_b32 v50, off, s32 offset:44
-; GFX11-NEXT:    scratch_load_b32 v49, off, s32 offset:40
-; GFX11-NEXT:    scratch_load_b32 v55, off, s32 offset:64
-; GFX11-NEXT:    scratch_load_b32 v54, off, s32 offset:60
-; GFX11-NEXT:    scratch_load_b32 v53, off, s32 offset:56
-; GFX11-NEXT:    scratch_load_b32 v40, off, s32 offset:80
-; GFX11-NEXT:    scratch_load_b32 v39, off, s32 offset:76
-; GFX11-NEXT:    scratch_load_b32 v38, off, s32 offset:72
-; GFX11-NEXT:    scratch_load_b32 v44, off, s32 offset:96
-; GFX11-NEXT:    scratch_load_b32 v43, off, s32 offset:92
-; GFX11-NEXT:    scratch_load_b32 v42, off, s32 offset:88
-; GFX11-NEXT:    scratch_load_b32 v59, off, s32 offset:112
-; GFX11-NEXT:    scratch_load_b32 v58, off, s32 offset:108
-; GFX11-NEXT:    scratch_load_b32 v57, off, s32 offset:104
-; GFX11-NEXT:    scratch_load_b32 v63, off, s32 offset:128
-; GFX11-NEXT:    scratch_load_b32 v62, off, s32 offset:124
-; GFX11-NEXT:    scratch_load_b32 v61, off, s32 offset:120
-; GFX11-NEXT:    scratch_store_b128 off, v[17:20], s0 offset:64
-; GFX11-NEXT:    s_clause 0x2
-; GFX11-NEXT:    scratch_load_b32 v20, off, s32 offset:144
-; GFX11-NEXT:    scratch_load_b32 v19, off, s32 offset:140
-; GFX11-NEXT:    scratch_load_b32 v18, off, s32 offset:136
-; GFX11-NEXT:    scratch_store_b128 off, v[9:12], s0 offset:32
-; GFX11-NEXT:    s_clause 0x2
-; GFX11-NEXT:    scratch_load_b32 v12, off, s32 offset:160
-; GFX11-NEXT:    scratch_load_b32 v11, off, s32 offset:156
-; GFX11-NEXT:    scratch_load_b32 v10, off, s32 offset:152
-; GFX11-NEXT:    scratch_store_b128 off, v[5:8], s0 offset:16
-; GFX11-NEXT:    s_clause 0xd
-; GFX11-NEXT:    scratch_load_b32 v8, off, s32 offset:16
-; GFX11-NEXT:    scratch_load_b32 v7, off, s32 offset:12
-; GFX11-NEXT:    scratch_load_b32 v6, off, s32 offset:8
-; GFX11-NEXT:    scratch_load_b32 v5, off, s32 offset:4
-; GFX11-NEXT:    scratch_load_b32 v9, off, s32 offset:148
-; GFX11-NEXT:    scratch_load_b32 v17, off, s32 offset:132
-; GFX11-NEXT:    scratch_load_b32 v60, off, s32 offset:116
-; GFX11-NEXT:    scratch_load_b32 v56, off, s32 offset:100
-; GFX11-NEXT:    scratch_load_b32 v41, off, s32 offset:84
-; GFX11-NEXT:    scratch_load_b32 v37, off, s32 offset:68
-; GFX11-NEXT:    scratch_load_b32 v52, off, s32 offset:52
-; GFX11-NEXT:    scratch_load_b32 v48, off, s32 offset:36
-; GFX11-NEXT:    scratch_load_b32 v33, off, s32 offset:20
 ; GFX11-NEXT:    scratch_load_b32 v32, off, s32
-; GFX11-NEXT:    s_add_i32 s1, s0, 0x110
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_store_b128 off, v[17:20], s0 offset:64
+; GFX11-NEXT:    scratch_store_b128 off, v[9:12], s0 offset:32
+; GFX11-NEXT:    scratch_store_b128 off, v[5:8], s0 offset:16
 ; GFX11-NEXT:    scratch_store_b128 off, v[1:4], s0
-; GFX11-NEXT:    s_add_i32 s2, s0, 0x100
-; GFX11-NEXT:    s_add_i32 s3, s0, 0xf0
-; GFX11-NEXT:    s_add_i32 s34, s0, 0xe0
-; GFX11-NEXT:    s_add_i32 s35, s0, 0xd0
-; GFX11-NEXT:    s_add_i32 s36, s0, 0xc0
-; GFX11-NEXT:    s_add_i32 s37, s0, 0xb0
-; GFX11-NEXT:    s_add_i32 s38, s0, 0xa0
-; GFX11-NEXT:    s_add_i32 s39, s0, 0x90
-; GFX11-NEXT:    s_add_i32 s40, s0, 0x70
-; GFX11-NEXT:    s_add_i32 s41, s0, 0x60
-; GFX11-NEXT:    s_add_i32 s42, s0, 0x50
-; GFX11-NEXT:    s_add_i32 s43, s0, 48
-; GFX11-NEXT:    s_waitcnt vmcnt(10)
-; GFX11-NEXT:    scratch_store_b128 off, v[5:8], s0 offset:128
-; GFX11-NEXT:    s_waitcnt vmcnt(9)
-; GFX11-NEXT:    scratch_store_b128 off, v[9:12], s1
-; GFX11-NEXT:    s_waitcnt vmcnt(8)
-; GFX11-NEXT:    scratch_store_b128 off, v[17:20], s2
-; GFX11-NEXT:    s_waitcnt vmcnt(7)
-; GFX11-NEXT:    scratch_store_b128 off, v[60:63], s3
-; GFX11-NEXT:    s_waitcnt vmcnt(6)
-; GFX11-NEXT:    scratch_store_b128 off, v[56:59], s34
-; GFX11-NEXT:    s_waitcnt vmcnt(5)
-; GFX11-NEXT:    scratch_store_b128 off, v[41:44], s35
-; GFX11-NEXT:    s_waitcnt vmcnt(4)
-; GFX11-NEXT:    scratch_store_b128 off, v[37:40], s36
-; GFX11-NEXT:    s_waitcnt vmcnt(3)
-; GFX11-NEXT:    scratch_store_b128 off, v[52:55], s37
-; GFX11-NEXT:    s_waitcnt vmcnt(2)
-; GFX11-NEXT:    scratch_store_b128 off, v[48:51], s38
-; GFX11-NEXT:    s_waitcnt vmcnt(1)
-; GFX11-NEXT:    scratch_store_b128 off, v[33:36], s39
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:16
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:12
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:8
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:4
+; GFX11-NEXT:    s_add_i32 s1, s0, 0x110
+; GFX11-NEXT:    s_add_i32 s2, s0, 0x50
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    scratch_store_b128 off, v[29:32], s40
-; GFX11-NEXT:    scratch_store_b128 off, v[25:28], s41
-; GFX11-NEXT:    scratch_store_b128 off, v[21:24], s42
-; GFX11-NEXT:    scratch_store_b128 off, v[13:16], s43
-; GFX11-NEXT:    s_clause 0xc
-; GFX11-NEXT:    scratch_load_b32 v63, off, s32 offset:164
-; GFX11-NEXT:    scratch_load_b32 v62, off, s32 offset:168
-; GFX11-NEXT:    scratch_load_b32 v61, off, s32 offset:172
-; GFX11-NEXT:    scratch_load_b32 v60, off, s32 offset:176
-; GFX11-NEXT:    scratch_load_b32 v59, off, s32 offset:180
-; GFX11-NEXT:    scratch_load_b32 v58, off, s32 offset:184
-; GFX11-NEXT:    scratch_load_b32 v57, off, s32 offset:188
-; GFX11-NEXT:    scratch_load_b32 v56, off, s32 offset:192
-; GFX11-NEXT:    scratch_load_b32 v44, off, s32 offset:196
-; GFX11-NEXT:    scratch_load_b32 v43, off, s32 offset:200
-; GFX11-NEXT:    scratch_load_b32 v42, off, s32 offset:204
-; GFX11-NEXT:    scratch_load_b32 v41, off, s32 offset:208
-; GFX11-NEXT:    scratch_load_b32 v40, off, s32 offset:212
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s0 offset:128
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:160
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:156
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:152
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:148
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:144
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:140
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:136
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:132
+; GFX11-NEXT:    s_add_i32 s1, s0, 0x100
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:128
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:124
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:120
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:116
+; GFX11-NEXT:    s_add_i32 s1, s0, 0xf0
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:112
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:108
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:104
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:100
+; GFX11-NEXT:    s_add_i32 s1, s0, 0xe0
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:96
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:92
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:88
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:84
+; GFX11-NEXT:    s_add_i32 s1, s0, 0xd0
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:80
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:76
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:72
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:68
+; GFX11-NEXT:    s_add_i32 s1, s0, 0xc0
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:64
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:60
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:56
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:52
+; GFX11-NEXT:    s_add_i32 s1, s0, 0xb0
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:48
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:44
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:40
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:36
+; GFX11-NEXT:    s_add_i32 s1, s0, 0xa0
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    scratch_load_b32 v3, off, s32 offset:32
+; GFX11-NEXT:    scratch_load_b32 v2, off, s32 offset:28
+; GFX11-NEXT:    scratch_load_b32 v1, off, s32 offset:24
+; GFX11-NEXT:    scratch_load_b32 v0, off, s32 offset:20
+; GFX11-NEXT:    s_add_i32 s1, s0, 0x90
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
+; GFX11-NEXT:    s_add_i32 s1, s0, 0x70
+; GFX11-NEXT:    scratch_store_b128 off, v[29:32], s1
+; GFX11-NEXT:    s_add_i32 s1, s0, 0x60
+; GFX11-NEXT:    s_add_i32 s0, s0, 48
+; GFX11-NEXT:    scratch_store_b128 off, v[25:28], s1
+; GFX11-NEXT:    scratch_store_b128 off, v[21:24], s2
+; GFX11-NEXT:    scratch_store_b128 off, v[13:16], s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   ret <72 x i32> %val
 }
@@ -3035,12 +3031,13 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX10-NEXT:    s_mov_b32 s36, s33
 ; GFX10-NEXT:    s_add_i32 s33, s32, 0x3fe0
 ; GFX10-NEXT:    s_and_b32 s33, s33, 0xffffc000
-; GFX10-NEXT:    s_or_saveexec_b32 s34, -1
-; GFX10-NEXT:    buffer_store_dword v40, off, s[0:3], s33 offset:1536 ; 4-byte Folded Spill
+; GFX10-NEXT:    s_xor_saveexec_b32 s34, -1
+; GFX10-NEXT:    buffer_store_dword v32, off, s[0:3], s33 offset:1536 ; 4-byte Folded Spill
 ; GFX10-NEXT:    s_waitcnt_depctr 0xffe3
 ; GFX10-NEXT:    s_mov_b32 exec_lo, s34
 ; GFX10-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX10-NEXT:    s_add_i32 s32, s32, 0x14000
+; GFX10-NEXT:    buffer_store_dword v40, off, s[0:3], s33 offset:60 ; 4-byte Folded Spill
 ; GFX10-NEXT:    buffer_store_dword v41, off, s[0:3], s33 offset:56 ; 4-byte Folded Spill
 ; GFX10-NEXT:    buffer_store_dword v42, off, s[0:3], s33 offset:52 ; 4-byte Folded Spill
 ; GFX10-NEXT:    buffer_store_dword v43, off, s[0:3], s33 offset:48 ; 4-byte Folded Spill
@@ -3056,7 +3053,7 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX10-NEXT:    buffer_store_dword v61, off, s[0:3], s33 offset:8 ; 4-byte Folded Spill
 ; GFX10-NEXT:    buffer_store_dword v62, off, s[0:3], s33 offset:4 ; 4-byte Folded Spill
 ; GFX10-NEXT:    buffer_store_dword v63, off, s[0:3], s33 ; 4-byte Folded Spill
-; GFX10-NEXT:    v_writelane_b32 v40, s30, 0
+; GFX10-NEXT:    v_writelane_b32 v32, s30, 0
 ; GFX10-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX10-NEXT:    buffer_store_dword v0, off, s[0:3], s32
 ; GFX10-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4
@@ -3133,27 +3130,27 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX10-NEXT:    v_mov_b32_e32 v31, 0
 ; GFX10-NEXT:    s_mov_b32 s35, return_72xi32@abs32@hi
 ; GFX10-NEXT:    s_mov_b32 s34, return_72xi32@abs32@lo
-; GFX10-NEXT:    v_writelane_b32 v40, s31, 1
+; GFX10-NEXT:    v_writelane_b32 v32, s31, 1
 ; GFX10-NEXT:    s_swappc_b64 s[30:31], s[34:35]
 ; GFX10-NEXT:    s_clause 0x28
 ; GFX10-NEXT:    buffer_load_dword v9, off, s[0:3], s33 offset:636
 ; GFX10-NEXT:    buffer_load_dword v1, off, s[0:3], s33 offset:640
-; GFX10-NEXT:    buffer_load_dword v32, off, s[0:3], s33 offset:644
-; GFX10-NEXT:    buffer_load_dword v33, off, s[0:3], s33 offset:648
-; GFX10-NEXT:    buffer_load_dword v34, off, s[0:3], s33 offset:652
-; GFX10-NEXT:    buffer_load_dword v35, off, s[0:3], s33 offset:656
-; GFX10-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:660
-; GFX10-NEXT:    buffer_load_dword v37, off, s[0:3], s33 offset:664
-; GFX10-NEXT:    buffer_load_dword v38, off, s[0:3], s33 offset:668
-; GFX10-NEXT:    buffer_load_dword v39, off, s[0:3], s33 offset:672
-; GFX10-NEXT:    buffer_load_dword v48, off, s[0:3], s33 offset:676
-; GFX10-NEXT:    buffer_load_dword v49, off, s[0:3], s33 offset:680
-; GFX10-NEXT:    buffer_load_dword v50, off, s[0:3], s33 offset:684
-; GFX10-NEXT:    buffer_load_dword v51, off, s[0:3], s33 offset:688
-; GFX10-NEXT:    buffer_load_dword v52, off, s[0:3], s33 offset:692
-; GFX10-NEXT:    buffer_load_dword v53, off, s[0:3], s33 offset:696
-; GFX10-NEXT:    buffer_load_dword v54, off, s[0:3], s33 offset:700
-; GFX10-NEXT:    buffer_load_dword v55, off, s[0:3], s33 offset:704
+; GFX10-NEXT:    buffer_load_dword v33, off, s[0:3], s33 offset:644
+; GFX10-NEXT:    buffer_load_dword v34, off, s[0:3], s33 offset:648
+; GFX10-NEXT:    buffer_load_dword v35, off, s[0:3], s33 offset:652
+; GFX10-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:656
+; GFX10-NEXT:    buffer_load_dword v37, off, s[0:3], s33 offset:660
+; GFX10-NEXT:    buffer_load_dword v38, off, s[0:3], s33 offset:664
+; GFX10-NEXT:    buffer_load_dword v39, off, s[0:3], s33 offset:668
+; GFX10-NEXT:    buffer_load_dword v48, off, s[0:3], s33 offset:672
+; GFX10-NEXT:    buffer_load_dword v49, off, s[0:3], s33 offset:676
+; GFX10-NEXT:    buffer_load_dword v50, off, s[0:3], s33 offset:680
+; GFX10-NEXT:    buffer_load_dword v51, off, s[0:3], s33 offset:684
+; GFX10-NEXT:    buffer_load_dword v52, off, s[0:3], s33 offset:688
+; GFX10-NEXT:    buffer_load_dword v53, off, s[0:3], s33 offset:692
+; GFX10-NEXT:    buffer_load_dword v54, off, s[0:3], s33 offset:696
+; GFX10-NEXT:    buffer_load_dword v55, off, s[0:3], s33 offset:700
+; GFX10-NEXT:    buffer_load_dword v40, off, s[0:3], s33 offset:704
 ; GFX10-NEXT:    buffer_load_dword v41, off, s[0:3], s33 offset:708
 ; GFX10-NEXT:    buffer_load_dword v42, off, s[0:3], s33 offset:712
 ; GFX10-NEXT:    buffer_load_dword v43, off, s[0:3], s33 offset:716
@@ -3227,22 +3224,22 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX10-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:108
 ; GFX10-NEXT:    buffer_store_dword v9, off, s[0:3], s32
 ; GFX10-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:4
-; GFX10-NEXT:    buffer_store_dword v32, off, s[0:3], s32 offset:8
-; GFX10-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:12
-; GFX10-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:16
-; GFX10-NEXT:    buffer_store_dword v35, off, s[0:3], s32 offset:20
-; GFX10-NEXT:    buffer_store_dword v36, off, s[0:3], s32 offset:24
-; GFX10-NEXT:    buffer_store_dword v37, off, s[0:3], s32 offset:28
-; GFX10-NEXT:    buffer_store_dword v38, off, s[0:3], s32 offset:32
-; GFX10-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:36
-; GFX10-NEXT:    buffer_store_dword v48, off, s[0:3], s32 offset:40
-; GFX10-NEXT:    buffer_store_dword v49, off, s[0:3], s32 offset:44
-; GFX10-NEXT:    buffer_store_dword v50, off, s[0:3], s32 offset:48
-; GFX10-NEXT:    buffer_store_dword v51, off, s[0:3], s32 offset:52
-; GFX10-NEXT:    buffer_store_dword v52, off, s[0:3], s32 offset:56
-; GFX10-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:60
-; GFX10-NEXT:    buffer_store_dword v54, off, s[0:3], s32 offset:64
-; GFX10-NEXT:    buffer_store_dword v55, off, s[0:3], s32 offset:68
+; GFX10-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:8
+; GFX10-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:12
+; GFX10-NEXT:    buffer_store_dword v35, off, s[0:3], s32 offset:16
+; GFX10-NEXT:    buffer_store_dword v36, off, s[0:3], s32 offset:20
+; GFX10-NEXT:    buffer_store_dword v37, off, s[0:3], s32 offset:24
+; GFX10-NEXT:    buffer_store_dword v38, off, s[0:3], s32 offset:28
+; GFX10-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:32
+; GFX10-NEXT:    buffer_store_dword v48, off, s[0:3], s32 offset:36
+; GFX10-NEXT:    buffer_store_dword v49, off, s[0:3], s32 offset:40
+; GFX10-NEXT:    buffer_store_dword v50, off, s[0:3], s32 offset:44
+; GFX10-NEXT:    buffer_store_dword v51, off, s[0:3], s32 offset:48
+; GFX10-NEXT:    buffer_store_dword v52, off, s[0:3], s32 offset:52
+; GFX10-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:56
+; GFX10-NEXT:    buffer_store_dword v54, off, s[0:3], s32 offset:60
+; GFX10-NEXT:    buffer_store_dword v55, off, s[0:3], s32 offset:64
+; GFX10-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:68
 ; GFX10-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:72
 ; GFX10-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:76
 ; GFX10-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:80
@@ -3278,7 +3275,7 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX10-NEXT:    v_mov_b32_e32 v1, 42
 ; GFX10-NEXT:    v_add_nc_u32_e32 v0, 0x400, v0
 ; GFX10-NEXT:    s_swappc_b64 s[30:31], s[34:35]
-; GFX10-NEXT:    s_clause 0xe
+; GFX10-NEXT:    s_clause 0xf
 ; GFX10-NEXT:    buffer_load_dword v63, off, s[0:3], s33
 ; GFX10-NEXT:    buffer_load_dword v62, off, s[0:3], s33 offset:4
 ; GFX10-NEXT:    buffer_load_dword v61, off, s[0:3], s33 offset:8
@@ -3294,10 +3291,11 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX10-NEXT:    buffer_load_dword v43, off, s[0:3], s33 offset:48
 ; GFX10-NEXT:    buffer_load_dword v42, off, s[0:3], s33 offset:52
 ; GFX10-NEXT:    buffer_load_dword v41, off, s[0:3], s33 offset:56
-; GFX10-NEXT:    v_readlane_b32 s31, v40, 1
-; GFX10-NEXT:    v_readlane_b32 s30, v40, 0
-; GFX10-NEXT:    s_or_saveexec_b32 s34, -1
-; GFX10-NEXT:    buffer_load_dword v40, off, s[0:3], s33 offset:1536 ; 4-byte Folded Reload
+; GFX10-NEXT:    buffer_load_dword v40, off, s[0:3], s33 offset:60
+; GFX10-NEXT:    v_readlane_b32 s31, v32, 1
+; GFX10-NEXT:    v_readlane_b32 s30, v32, 0
+; GFX10-NEXT:    s_xor_saveexec_b32 s34, -1
+; GFX10-NEXT:    buffer_load_dword v32, off, s[0:3], s33 offset:1536 ; 4-byte Folded Reload
 ; GFX10-NEXT:    s_waitcnt_depctr 0xffe3
 ; GFX10-NEXT:    s_mov_b32 exec_lo, s34
 ; GFX10-NEXT:    s_add_i32 s32, s32, 0xfffec000
@@ -3308,12 +3306,12 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX11-LABEL: call_72xi32:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s46, s33
+; GFX11-NEXT:    s_mov_b32 s40, s33
 ; GFX11-NEXT:    s_add_i32 s33, s32, 0x1ff
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-NEXT:    s_and_b32 s33, s33, 0xfffffe00
-; GFX11-NEXT:    s_or_saveexec_b32 s0, -1
-; GFX11-NEXT:    scratch_store_b32 off, v40, s33 offset:1536 ; 4-byte Folded Spill
+; GFX11-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX11-NEXT:    scratch_store_b32 off, v33, s33 offset:1536 ; 4-byte Folded Spill
 ; GFX11-NEXT:    s_mov_b32 exec_lo, s0
 ; GFX11-NEXT:    s_mov_b32 s0, 0
 ; GFX11-NEXT:    v_mov_b32_e32 v4, 0
@@ -3323,14 +3321,13 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    s_addk_i32 s32, 0xa00
-; GFX11-NEXT:    s_clause 0xe
-; GFX11-NEXT:    scratch_store_b32 off, v41, s33 offset:56
-; GFX11-NEXT:    scratch_store_b32 off, v42, s33 offset:52
-; GFX11-NEXT:    scratch_store_b32 off, v43, s33 offset:48
-; GFX11-NEXT:    scratch_store_b32 off, v44, s33 offset:44
-; GFX11-NEXT:    scratch_store_b32 off, v45, s33 offset:40
-; GFX11-NEXT:    scratch_store_b32 off, v46, s33 offset:36
-; GFX11-NEXT:    scratch_store_b32 off, v47, s33 offset:32
+; GFX11-NEXT:    s_clause 0xd
+; GFX11-NEXT:    scratch_store_b32 off, v40, s33 offset:52
+; GFX11-NEXT:    scratch_store_b32 off, v41, s33 offset:48
+; GFX11-NEXT:    scratch_store_b32 off, v42, s33 offset:44
+; GFX11-NEXT:    scratch_store_b32 off, v43, s33 offset:40
+; GFX11-NEXT:    scratch_store_b32 off, v44, s33 offset:36
+; GFX11-NEXT:    scratch_store_b32 off, v45, s33 offset:32
 ; GFX11-NEXT:    scratch_store_b32 off, v56, s33 offset:28
 ; GFX11-NEXT:    scratch_store_b32 off, v57, s33 offset:24
 ; GFX11-NEXT:    scratch_store_b32 off, v58, s33 offset:20
@@ -3361,7 +3358,7 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s0
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s1
 ; GFX11-NEXT:    s_add_i32 s0, s33, 0x200
-; GFX11-NEXT:    v_writelane_b32 v40, s30, 0
+; GFX11-NEXT:    v_writelane_b32 v33, s30, 0
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, 0
 ; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v2, 0
 ; GFX11-NEXT:    v_dual_mov_b32 v5, 0 :: v_dual_mov_b32 v4, 0
@@ -3378,114 +3375,112 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX11-NEXT:    v_dual_mov_b32 v27, 0 :: v_dual_mov_b32 v26, 0
 ; GFX11-NEXT:    v_dual_mov_b32 v29, 0 :: v_dual_mov_b32 v28, 0
 ; GFX11-NEXT:    v_dual_mov_b32 v31, 0 :: v_dual_mov_b32 v30, 0
-; GFX11-NEXT:    s_mov_b32 s45, return_72xi32@abs32@hi
-; GFX11-NEXT:    s_mov_b32 s44, return_72xi32@abs32@lo
-; GFX11-NEXT:    v_writelane_b32 v40, s31, 1
-; GFX11-NEXT:    s_swappc_b64 s[30:31], s[44:45]
-; GFX11-NEXT:    s_clause 0x1
-; GFX11-NEXT:    scratch_load_b128 v[45:48], off, s33 offset:624
-; GFX11-NEXT:    scratch_load_b128 v[33:36], off, s33 offset:640
+; GFX11-NEXT:    s_mov_b32 s35, return_72xi32@abs32@hi
+; GFX11-NEXT:    s_mov_b32 s34, return_72xi32@abs32@lo
+; GFX11-NEXT:    v_writelane_b32 v33, s31, 1
+; GFX11-NEXT:    s_swappc_b64 s[30:31], s[34:35]
+; GFX11-NEXT:    scratch_load_b128 v[0:3], off, s33 offset:624
 ; GFX11-NEXT:    s_add_i32 s0, s32, 0xa0
-; GFX11-NEXT:    s_waitcnt vmcnt(1)
-; GFX11-NEXT:    v_mov_b32_e32 v32, v48
-; GFX11-NEXT:    s_clause 0x9
-; GFX11-NEXT:    scratch_load_b128 v[48:51], off, s33 offset:656
-; GFX11-NEXT:    scratch_load_b128 v[52:55], off, s33 offset:672
-; GFX11-NEXT:    scratch_load_b128 v[41:44], off, s33 offset:688
+; GFX11-NEXT:    v_mov_b32_e32 v32, 24
+; GFX11-NEXT:    s_add_i32 s1, s32, 0x6c
+; GFX11-NEXT:    s_add_i32 s2, s32, 0x60
+; GFX11-NEXT:    s_add_i32 s3, s32, 0x50
+; GFX11-NEXT:    s_add_i32 s36, s32, 64
+; GFX11-NEXT:    s_add_i32 s37, s32, 48
+; GFX11-NEXT:    s_add_i32 s38, s32, 32
+; GFX11-NEXT:    s_add_i32 s39, s32, 16
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s33 offset:1540 ; 16-byte Folded Spill
+; GFX11-NEXT:    s_clause 0xa
+; GFX11-NEXT:    scratch_load_b128 v[60:63], off, s33 offset:640
+; GFX11-NEXT:    scratch_load_b128 v[4:7], off, s33 offset:656
+; GFX11-NEXT:    scratch_load_b128 v[8:11], off, s33 offset:672
+; GFX11-NEXT:    scratch_load_b128 v[12:15], off, s33 offset:688
 ; GFX11-NEXT:    scratch_load_b128 v[56:59], off, s33 offset:704
-; GFX11-NEXT:    scratch_load_b128 v[60:63], off, s33 offset:720
-; GFX11-NEXT:    scratch_load_b128 v[12:15], off, s33 offset:736
-; GFX11-NEXT:    scratch_load_b128 v[0:3], off, s33 offset:752
-; GFX11-NEXT:    scratch_load_b128 v[4:7], off, s33 offset:768
-; GFX11-NEXT:    scratch_load_b128 v[8:11], off, s33 offset:784
+; GFX11-NEXT:    scratch_load_b128 v[42:45], off, s33 offset:720
+; GFX11-NEXT:    scratch_load_b128 v[38:41], off, s33 offset:736
+; GFX11-NEXT:    scratch_load_b128 v[52:55], off, s33 offset:752
+; GFX11-NEXT:    scratch_load_b128 v[48:51], off, s33 offset:768
+; GFX11-NEXT:    scratch_load_b128 v[34:37], off, s33 offset:784
 ; GFX11-NEXT:    scratch_load_b128 v[16:19], off, s33 offset:512
-; GFX11-NEXT:    s_waitcnt vmcnt(8)
-; GFX11-NEXT:    v_dual_mov_b32 v38, v53 :: v_dual_mov_b32 v37, v52
-; GFX11-NEXT:    s_waitcnt vmcnt(7)
-; GFX11-NEXT:    v_dual_mov_b32 v39, v54 :: v_dual_mov_b32 v52, v44
-; GFX11-NEXT:    s_waitcnt vmcnt(6)
-; GFX11-NEXT:    v_dual_mov_b32 v53, v56 :: v_dual_mov_b32 v54, v57
-; GFX11-NEXT:    s_waitcnt vmcnt(4)
-; GFX11-NEXT:    v_dual_mov_b32 v44, v62 :: v_dual_mov_b32 v57, v12
+; GFX11-NEXT:    s_waitcnt vmcnt(10)
+; GFX11-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_mov_b32 v1, v60
+; GFX11-NEXT:    v_dual_mov_b32 v2, v61 :: v_dual_mov_b32 v3, v62
+; GFX11-NEXT:    s_waitcnt vmcnt(2)
+; GFX11-NEXT:    v_dual_mov_b32 v40, v53 :: v_dual_mov_b32 v53, v48
+; GFX11-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-NEXT:    v_dual_mov_b32 v48, v51 :: v_dual_mov_b32 v51, v36
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[16:19], s33 offset:1572 ; 16-byte Folded Spill
+; GFX11-NEXT:    scratch_load_b128 v[16:19], off, s33 offset:528
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    scratch_store_b128 off, v[16:19], s33 offset:1556 ; 16-byte Folded Spill
+; GFX11-NEXT:    scratch_load_b128 v[16:19], off, s33 offset:544
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    scratch_store_b128 off, v[16:19], s33 offset:1588 ; 16-byte Folded Spill
 ; GFX11-NEXT:    s_clause 0x3
-; GFX11-NEXT:    scratch_load_b128 v[16:19], off, s33 offset:528
-; GFX11-NEXT:    scratch_load_b128 v[20:23], off, s33 offset:544
-; GFX11-NEXT:    scratch_load_b128 v[24:27], off, s33 offset:560
-; GFX11-NEXT:    scratch_load_b128 v[28:31], off, s33 offset:576
-; GFX11-NEXT:    v_mov_b32_e32 v56, v63
-; GFX11-NEXT:    v_mov_b32_e32 v12, v15
-; GFX11-NEXT:    v_dual_mov_b32 v14, v1 :: v_dual_mov_b32 v15, v2
-; GFX11-NEXT:    v_dual_mov_b32 v1, v4 :: v_dual_mov_b32 v2, v5
-; GFX11-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
-; GFX11-NEXT:    s_waitcnt vmcnt(3)
-; GFX11-NEXT:    v_dual_mov_b32 v7, v10 :: v_dual_mov_b32 v8, v19
-; GFX11-NEXT:    s_waitcnt vmcnt(2)
-; GFX11-NEXT:    v_mov_b32_e32 v10, v21
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    scratch_store_b128 off, v[28:31], s33 offset:1572 ; 16-byte Folded Spill
-; GFX11-NEXT:    scratch_load_b128 v[28:31], off, s33 offset:592
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    scratch_store_b128 off, v[28:31], s33 offset:1556 ; 16-byte Folded Spill
+; GFX11-NEXT:    scratch_load_b128 v[16:19], off, s33 offset:560
+; GFX11-NEXT:    scratch_load_b128 v[20:23], off, s33 offset:576
+; GFX11-NEXT:    scratch_load_b128 v[24:27], off, s33 offset:592
 ; GFX11-NEXT:    scratch_load_b128 v[28:31], off, s33 offset:608
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-NEXT:    scratch_store_b128 off, v[28:31], s33 offset:1540 ; 16-byte Folded Spill
-; GFX11-NEXT:    scratch_store_b128 off, v[32:35], s32
-; GFX11-NEXT:    v_mov_b32_e32 v32, v36
-; GFX11-NEXT:    v_dual_mov_b32 v33, v48 :: v_dual_mov_b32 v34, v49
-; GFX11-NEXT:    v_dual_mov_b32 v35, v50 :: v_dual_mov_b32 v36, v51
-; GFX11-NEXT:    v_dual_mov_b32 v48, v55 :: v_dual_mov_b32 v49, v41
-; GFX11-NEXT:    v_mov_b32_e32 v50, v42
-; GFX11-NEXT:    v_dual_mov_b32 v55, v58 :: v_dual_mov_b32 v58, v13
-; GFX11-NEXT:    v_dual_mov_b32 v13, v0 :: v_dual_mov_b32 v0, v3
-; GFX11-NEXT:    v_dual_mov_b32 v3, v6 :: v_dual_mov_b32 v6, v9
-; GFX11-NEXT:    scratch_store_b32 off, v11, s0
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s32
+; GFX11-NEXT:    v_dual_mov_b32 v0, v63 :: v_dual_mov_b32 v1, v4
+; GFX11-NEXT:    v_dual_mov_b32 v2, v5 :: v_dual_mov_b32 v3, v6
+; GFX11-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
+; GFX11-NEXT:    v_dual_mov_b32 v6, v9 :: v_dual_mov_b32 v7, v10
+; GFX11-NEXT:    v_dual_mov_b32 v8, v11 :: v_dual_mov_b32 v9, v12
+; GFX11-NEXT:    v_dual_mov_b32 v10, v13 :: v_dual_mov_b32 v11, v14
+; GFX11-NEXT:    v_dual_mov_b32 v12, v15 :: v_dual_mov_b32 v13, v56
+; GFX11-NEXT:    v_dual_mov_b32 v14, v57 :: v_dual_mov_b32 v15, v58
+; GFX11-NEXT:    v_dual_mov_b32 v56, v59 :: v_dual_mov_b32 v57, v42
+; GFX11-NEXT:    v_dual_mov_b32 v58, v43 :: v_dual_mov_b32 v59, v44
+; GFX11-NEXT:    v_dual_mov_b32 v42, v45 :: v_dual_mov_b32 v43, v38
+; GFX11-NEXT:    v_dual_mov_b32 v44, v39 :: v_dual_mov_b32 v39, v52
+; GFX11-NEXT:    v_dual_mov_b32 v38, v41 :: v_dual_mov_b32 v41, v54
+; GFX11-NEXT:    v_dual_mov_b32 v52, v55 :: v_dual_mov_b32 v55, v50
+; GFX11-NEXT:    v_dual_mov_b32 v54, v49 :: v_dual_mov_b32 v49, v34
+; GFX11-NEXT:    v_mov_b32_e32 v50, v35
+; GFX11-NEXT:    scratch_store_b32 off, v37, s0
 ; GFX11-NEXT:    s_add_i32 s0, s32, 0x90
-; GFX11-NEXT:    v_mov_b32_e32 v51, v43
-; GFX11-NEXT:    v_mov_b32_e32 v41, v59
-; GFX11-NEXT:    scratch_store_b128 off, v[4:7], s0
-; GFX11-NEXT:    v_mov_b32_e32 v7, v18
-; GFX11-NEXT:    s_add_i32 s0, s32, 0x80
-; GFX11-NEXT:    v_dual_mov_b32 v42, v60 :: v_dual_mov_b32 v43, v61
-; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s0
-; GFX11-NEXT:    v_dual_mov_b32 v0, 24 :: v_dual_mov_b32 v9, v20
-; GFX11-NEXT:    s_add_i32 s0, s32, 0x70
-; GFX11-NEXT:    v_mov_b32_e32 v5, v16
-; GFX11-NEXT:    scratch_store_b128 off, v[12:15], s0
-; GFX11-NEXT:    s_add_i32 s0, s32, 0x6c
-; GFX11-NEXT:    v_dual_mov_b32 v6, v17 :: v_dual_mov_b32 v11, v22
-; GFX11-NEXT:    scratch_store_b32 off, v0, s0
-; GFX11-NEXT:    s_add_i32 s0, s32, 0x60
-; GFX11-NEXT:    v_dual_mov_b32 v12, v23 :: v_dual_mov_b32 v29, v45
-; GFX11-NEXT:    scratch_store_b96 off, v[56:58], s0
-; GFX11-NEXT:    s_add_i32 s0, s32, 0x50
-; GFX11-NEXT:    v_mov_b32_e32 v13, v24
-; GFX11-NEXT:    scratch_store_b128 off, v[41:44], s0
-; GFX11-NEXT:    s_add_i32 s0, s32, 64
-; GFX11-NEXT:    v_dual_mov_b32 v14, v25 :: v_dual_mov_b32 v31, v47
-; GFX11-NEXT:    scratch_store_b128 off, v[52:55], s0
-; GFX11-NEXT:    s_add_i32 s0, s32, 48
-; GFX11-NEXT:    v_mov_b32_e32 v15, v26
 ; GFX11-NEXT:    scratch_store_b128 off, v[48:51], s0
-; GFX11-NEXT:    s_add_i32 s0, s32, 32
-; GFX11-NEXT:    v_mov_b32_e32 v16, v27
-; GFX11-NEXT:    scratch_store_b128 off, v[36:39], s0
-; GFX11-NEXT:    s_add_i32 s0, s32, 16
-; GFX11-NEXT:    v_mov_b32_e32 v30, v46
-; GFX11-NEXT:    scratch_store_b128 off, v[32:35], s0
-; GFX11-NEXT:    scratch_load_b128 v[1:4], off, s33 offset:1588 ; 16-byte Folded Reload
-; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    s_add_i32 s0, s32, 0x80
+; GFX11-NEXT:    scratch_store_b128 off, v[52:55], s0
+; GFX11-NEXT:    s_add_i32 s0, s32, 0x70
+; GFX11-NEXT:    scratch_store_b128 off, v[38:41], s0
+; GFX11-NEXT:    scratch_store_b32 off, v32, s1
+; GFX11-NEXT:    scratch_store_b96 off, v[42:44], s2
+; GFX11-NEXT:    scratch_store_b128 off, v[56:59], s3
+; GFX11-NEXT:    scratch_store_b128 off, v[12:15], s36
+; GFX11-NEXT:    scratch_store_b128 off, v[8:11], s37
+; GFX11-NEXT:    scratch_store_b128 off, v[4:7], s38
+; GFX11-NEXT:    scratch_store_b128 off, v[0:3], s39
 ; GFX11-NEXT:    v_mov_b32_e32 v1, 42
-; GFX11-NEXT:    s_clause 0x2
-; GFX11-NEXT:    scratch_load_b128 v[17:20], off, s33 offset:1572
-; GFX11-NEXT:    scratch_load_b128 v[21:24], off, s33 offset:1556
-; GFX11-NEXT:    scratch_load_b128 v[25:28], off, s33 offset:1540
+; GFX11-NEXT:    scratch_load_b128 v[2:5], off, s33 offset:1572 ; 16-byte Folded Reload
 ; GFX11-NEXT:    s_add_i32 s0, s33, 0x400
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_mov_b32_e32 v0, s0
-; GFX11-NEXT:    s_swappc_b64 s[30:31], s[44:45]
-; GFX11-NEXT:    s_clause 0xe
+; GFX11-NEXT:    s_waitcnt vmcnt(4)
+; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v13, v16
+; GFX11-NEXT:    v_mov_b32_e32 v14, v17
+; GFX11-NEXT:    s_waitcnt vmcnt(3)
+; GFX11-NEXT:    v_dual_mov_b32 v16, v19 :: v_dual_mov_b32 v19, v22
+; GFX11-NEXT:    s_waitcnt vmcnt(2)
+; GFX11-NEXT:    v_dual_mov_b32 v22, v25 :: v_dual_mov_b32 v15, v18
+; GFX11-NEXT:    v_dual_mov_b32 v18, v21 :: v_dual_mov_b32 v21, v24
+; GFX11-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-NEXT:    v_dual_mov_b32 v24, v27 :: v_dual_mov_b32 v27, v30
+; GFX11-NEXT:    v_dual_mov_b32 v17, v20 :: v_dual_mov_b32 v20, v23
+; GFX11-NEXT:    v_mov_b32_e32 v25, v28
+; GFX11-NEXT:    v_dual_mov_b32 v23, v26 :: v_dual_mov_b32 v26, v29
+; GFX11-NEXT:    v_mov_b32_e32 v28, v31
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    v_mov_b32_e32 v2, v3
+; GFX11-NEXT:    v_mov_b32_e32 v3, v4
+; GFX11-NEXT:    v_mov_b32_e32 v4, v5
+; GFX11-NEXT:    s_clause 0x2
+; GFX11-NEXT:    scratch_load_b128 v[5:8], off, s33 offset:1556
+; GFX11-NEXT:    scratch_load_b128 v[9:12], off, s33 offset:1588
+; GFX11-NEXT:    scratch_load_b128 v[29:32], off, s33 offset:1540
+; GFX11-NEXT:    s_swappc_b64 s[30:31], s[34:35]
+; GFX11-NEXT:    s_clause 0xd
 ; GFX11-NEXT:    scratch_load_b32 v63, off, s33
 ; GFX11-NEXT:    scratch_load_b32 v62, off, s33 offset:4
 ; GFX11-NEXT:    scratch_load_b32 v61, off, s33 offset:8
@@ -3494,20 +3489,19 @@ define amdgpu_gfx void @call_72xi32() #1 {
 ; GFX11-NEXT:    scratch_load_b32 v58, off, s33 offset:20
 ; GFX11-NEXT:    scratch_load_b32 v57, off, s33 offset:24
 ; GFX11-NEXT:    scratch_load_b32 v56, off, s33 offset:28
-; GFX11-NEXT:    scratch_load_b32 v47, off, s33 offset:32
-; GFX11-NEXT:    scratch_load_b32 v46, off, s33 offset:36
-; GFX11-NEXT:    scratch_load_b32 v45, off, s33 offset:40
-; GFX11-NEXT:    scratch_load_b32 v44, off, s33 offset:44
-; GFX11-NEXT:    scratch_load_b32 v43, off, s33 offset:48
-; GFX11-NEXT:    scratch_load_b32 v42, off, s33 offset:52
-; GFX11-NEXT:    scratch_load_b32 v41, off, s33 offset:56
-; GFX11-NEXT:    v_readlane_b32 s31, v40, 1
-; GFX11-NEXT:    v_readlane_b32 s30, v40, 0
-; GFX11-NEXT:    s_or_saveexec_b32 s0, -1
-; GFX11-NEXT:    scratch_load_b32 v40, off, s33 offset:1536 ; 4-byte Folded Reload
+; GFX11-NEXT:    scratch_load_b32 v45, off, s33 offset:32
+; GFX11-NEXT:    scratch_load_b32 v44, off, s33 offset:36
+; GFX11-NEXT:    scratch_load_b32 v43, off, s33 offset:40
+; GFX11-NEXT:    scratch_load_b32 v42, off, s33 offset:44
+; GFX11-NEXT:    scratch_load_b32 v41, off, s33 offset:48
+; GFX11-NEXT:    scratch_load_b32 v40, off, s33 offset:52
+; GFX11-NEXT:    v_readlane_b32 s31, v33, 1
+; GFX11-NEXT:    v_readlane_b32 s30, v33, 0
+; GFX11-NEXT:    s_xor_saveexec_b32 s0, -1
+; GFX11-NEXT:    scratch_load_b32 v33, off, s33 offset:1536 ; 4-byte Folded Reload
 ; GFX11-NEXT:    s_mov_b32 exec_lo, s0
 ; GFX11-NEXT:    s_addk_i32 s32, 0xf600
-; GFX11-NEXT:    s_mov_b32 s33, s46
+; GFX11-NEXT:    s_mov_b32 s33, s40
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 entry:

--- a/llvm/test/CodeGen/AMDGPU/half.ll
+++ b/llvm/test/CodeGen/AMDGPU/half.ll
@@ -1856,93 +1856,92 @@ define amdgpu_kernel void @global_extload_v16f16_to_v16f64(ptr addrspace(1) %out
 ; CI-NEXT:    s_waitcnt lgkmcnt(0)
 ; CI-NEXT:    v_mov_b32_e32 v0, s2
 ; CI-NEXT:    v_mov_b32_e32 v1, s3
-; CI-NEXT:    flat_load_dwordx4 v[4:7], v[0:1]
+; CI-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
 ; CI-NEXT:    s_add_u32 s2, s2, 16
 ; CI-NEXT:    s_addc_u32 s3, s3, 0
-; CI-NEXT:    v_mov_b32_e32 v0, s2
-; CI-NEXT:    v_mov_b32_e32 v1, s3
-; CI-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
+; CI-NEXT:    v_mov_b32_e32 v5, s3
+; CI-NEXT:    v_mov_b32_e32 v4, s2
+; CI-NEXT:    flat_load_dwordx4 v[4:7], v[4:5]
 ; CI-NEXT:    s_add_u32 s2, s0, 48
 ; CI-NEXT:    s_addc_u32 s3, s1, 0
-; CI-NEXT:    v_mov_b32_e32 v14, s3
-; CI-NEXT:    v_mov_b32_e32 v13, s2
+; CI-NEXT:    v_mov_b32_e32 v9, s3
+; CI-NEXT:    v_mov_b32_e32 v8, s2
 ; CI-NEXT:    s_add_u32 s2, s0, 32
 ; CI-NEXT:    s_addc_u32 s3, s1, 0
-; CI-NEXT:    v_mov_b32_e32 v16, s3
-; CI-NEXT:    v_mov_b32_e32 v15, s2
+; CI-NEXT:    v_mov_b32_e32 v13, s3
+; CI-NEXT:    v_mov_b32_e32 v12, s2
 ; CI-NEXT:    s_add_u32 s2, s0, 16
 ; CI-NEXT:    s_addc_u32 s3, s1, 0
-; CI-NEXT:    v_mov_b32_e32 v18, s3
-; CI-NEXT:    v_mov_b32_e32 v17, s2
+; CI-NEXT:    v_mov_b32_e32 v15, s3
+; CI-NEXT:    v_mov_b32_e32 v14, s2
 ; CI-NEXT:    s_add_u32 s2, s0, 0x70
 ; CI-NEXT:    s_addc_u32 s3, s1, 0
-; CI-NEXT:    v_mov_b32_e32 v12, s1
-; CI-NEXT:    v_mov_b32_e32 v11, s0
-; CI-NEXT:    s_waitcnt vmcnt(1)
-; CI-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; CI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; CI-NEXT:    v_cvt_f32_f16_e32 v9, v8
-; CI-NEXT:    v_lshrrev_b32_e32 v19, 16, v6
-; CI-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; CI-NEXT:    v_cvt_f64_f32_e32 v[7:8], v7
-; CI-NEXT:    v_cvt_f64_f32_e32 v[9:10], v9
-; CI-NEXT:    s_waitcnt vmcnt(0)
-; CI-NEXT:    v_cvt_f32_f16_e32 v21, v0
-; CI-NEXT:    flat_store_dwordx4 v[13:14], v[7:10]
-; CI-NEXT:    s_nop 0
-; CI-NEXT:    v_cvt_f32_f16_e32 v8, v19
-; CI-NEXT:    v_cvt_f64_f32_e32 v[6:7], v6
-; CI-NEXT:    v_lshrrev_b32_e32 v10, 16, v3
-; CI-NEXT:    v_mov_b32_e32 v14, s3
-; CI-NEXT:    v_cvt_f64_f32_e32 v[8:9], v8
-; CI-NEXT:    v_mov_b32_e32 v13, s2
+; CI-NEXT:    v_mov_b32_e32 v17, s3
+; CI-NEXT:    v_mov_b32_e32 v16, s2
 ; CI-NEXT:    s_add_u32 s2, s0, 0x60
 ; CI-NEXT:    s_addc_u32 s3, s1, 0
-; CI-NEXT:    flat_store_dwordx4 v[15:16], v[6:9]
-; CI-NEXT:    v_mov_b32_e32 v16, s3
-; CI-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; CI-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; CI-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; CI-NEXT:    v_lshrrev_b32_e32 v8, 16, v4
-; CI-NEXT:    v_cvt_f32_f16_e32 v9, v4
-; CI-NEXT:    v_cvt_f64_f32_e32 v[4:5], v5
-; CI-NEXT:    v_cvt_f64_f32_e32 v[6:7], v6
-; CI-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; CI-NEXT:    v_mov_b32_e32 v15, s2
+; CI-NEXT:    v_mov_b32_e32 v19, s3
+; CI-NEXT:    v_mov_b32_e32 v11, s1
+; CI-NEXT:    v_mov_b32_e32 v18, s2
 ; CI-NEXT:    s_add_u32 s2, s0, 0x50
-; CI-NEXT:    flat_store_dwordx4 v[17:18], v[4:7]
-; CI-NEXT:    v_cvt_f32_f16_e32 v17, v1
-; CI-NEXT:    v_cvt_f32_f16_e32 v4, v3
-; CI-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; CI-NEXT:    v_cvt_f32_f16_e32 v6, v2
-; CI-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
-; CI-NEXT:    v_lshrrev_b32_e32 v18, 16, v0
-; CI-NEXT:    v_cvt_f64_f32_e32 v[0:1], v9
-; CI-NEXT:    v_cvt_f64_f32_e32 v[2:3], v8
-; CI-NEXT:    v_cvt_f32_f16_e32 v8, v10
-; CI-NEXT:    v_cvt_f32_f16_e32 v10, v5
-; CI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; CI-NEXT:    flat_store_dwordx4 v[11:12], v[0:3]
-; CI-NEXT:    v_cvt_f32_f16_e32 v12, v18
-; CI-NEXT:    v_cvt_f64_f32_e32 v[0:1], v4
-; CI-NEXT:    v_cvt_f64_f32_e32 v[2:3], v8
+; CI-NEXT:    v_mov_b32_e32 v10, s0
 ; CI-NEXT:    s_addc_u32 s3, s1, 0
-; CI-NEXT:    v_cvt_f64_f32_e32 v[8:9], v6
-; CI-NEXT:    v_cvt_f64_f32_e32 v[10:11], v10
 ; CI-NEXT:    s_add_u32 s0, s0, 64
-; CI-NEXT:    flat_store_dwordx4 v[13:14], v[0:3]
 ; CI-NEXT:    s_addc_u32 s1, s1, 0
-; CI-NEXT:    v_cvt_f64_f32_e32 v[0:1], v17
+; CI-NEXT:    s_waitcnt vmcnt(1)
+; CI-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
+; CI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; CI-NEXT:    v_lshrrev_b32_e32 v21, 16, v2
+; CI-NEXT:    v_cvt_f32_f16_e32 v22, v2
+; CI-NEXT:    v_cvt_f32_f16_e32 v2, v20
+; CI-NEXT:    v_lshrrev_b32_e32 v23, 16, v1
+; CI-NEXT:    v_cvt_f32_f16_e32 v24, v1
+; CI-NEXT:    v_lshrrev_b32_e32 v25, 16, v0
+; CI-NEXT:    v_cvt_f32_f16_e32 v26, v0
+; CI-NEXT:    v_cvt_f64_f32_e32 v[0:1], v3
+; CI-NEXT:    v_cvt_f64_f32_e32 v[2:3], v2
+; CI-NEXT:    v_cvt_f32_f16_e32 v20, v21
+; CI-NEXT:    s_waitcnt vmcnt(0)
+; CI-NEXT:    v_lshrrev_b32_e32 v27, 16, v7
+; CI-NEXT:    v_cvt_f32_f16_e32 v28, v7
+; CI-NEXT:    flat_store_dwordx4 v[8:9], v[0:3]
+; CI-NEXT:    v_lshrrev_b32_e32 v8, 16, v6
+; CI-NEXT:    v_cvt_f32_f16_e32 v29, v6
+; CI-NEXT:    v_cvt_f64_f32_e32 v[0:1], v22
+; CI-NEXT:    v_cvt_f64_f32_e32 v[2:3], v20
+; CI-NEXT:    v_cvt_f32_f16_e32 v6, v23
+; CI-NEXT:    v_cvt_f32_f16_e32 v7, v25
+; CI-NEXT:    v_lshrrev_b32_e32 v9, 16, v5
+; CI-NEXT:    v_cvt_f32_f16_e32 v30, v5
+; CI-NEXT:    v_lshrrev_b32_e32 v31, 16, v4
+; CI-NEXT:    v_cvt_f32_f16_e32 v32, v4
+; CI-NEXT:    flat_store_dwordx4 v[12:13], v[0:3]
+; CI-NEXT:    v_cvt_f64_f32_e32 v[4:5], v24
 ; CI-NEXT:    v_cvt_f64_f32_e32 v[2:3], v7
-; CI-NEXT:    v_cvt_f64_f32_e32 v[4:5], v21
-; CI-NEXT:    v_cvt_f64_f32_e32 v[6:7], v12
-; CI-NEXT:    v_mov_b32_e32 v20, s3
-; CI-NEXT:    v_mov_b32_e32 v13, s1
-; CI-NEXT:    v_mov_b32_e32 v19, s2
-; CI-NEXT:    v_mov_b32_e32 v12, s0
-; CI-NEXT:    flat_store_dwordx4 v[15:16], v[8:11]
-; CI-NEXT:    flat_store_dwordx4 v[19:20], v[0:3]
-; CI-NEXT:    flat_store_dwordx4 v[12:13], v[4:7]
+; CI-NEXT:    v_cvt_f64_f32_e32 v[6:7], v6
+; CI-NEXT:    v_cvt_f32_f16_e32 v24, v27
+; CI-NEXT:    v_cvt_f64_f32_e32 v[0:1], v26
+; CI-NEXT:    v_cvt_f32_f16_e32 v25, v8
+; CI-NEXT:    v_cvt_f32_f16_e32 v26, v9
+; CI-NEXT:    v_cvt_f32_f16_e32 v27, v31
+; CI-NEXT:    flat_store_dwordx4 v[14:15], v[4:7]
+; CI-NEXT:    v_cvt_f64_f32_e32 v[12:13], v28
+; CI-NEXT:    v_cvt_f64_f32_e32 v[14:15], v24
+; CI-NEXT:    flat_store_dwordx4 v[10:11], v[0:3]
+; CI-NEXT:    v_cvt_f64_f32_e32 v[8:9], v30
+; CI-NEXT:    v_cvt_f64_f32_e32 v[0:1], v29
+; CI-NEXT:    v_cvt_f64_f32_e32 v[2:3], v25
+; CI-NEXT:    v_cvt_f64_f32_e32 v[10:11], v26
+; CI-NEXT:    v_mov_b32_e32 v21, s3
+; CI-NEXT:    v_mov_b32_e32 v23, s1
+; CI-NEXT:    v_cvt_f64_f32_e32 v[4:5], v32
+; CI-NEXT:    v_cvt_f64_f32_e32 v[6:7], v27
+; CI-NEXT:    v_mov_b32_e32 v20, s2
+; CI-NEXT:    v_mov_b32_e32 v22, s0
+; CI-NEXT:    flat_store_dwordx4 v[16:17], v[12:15]
+; CI-NEXT:    flat_store_dwordx4 v[18:19], v[0:3]
+; CI-NEXT:    flat_store_dwordx4 v[20:21], v[8:11]
+; CI-NEXT:    flat_store_dwordx4 v[22:23], v[4:7]
 ; CI-NEXT:    s_endpgm
 ;
 ; VI-LABEL: global_extload_v16f16_to_v16f64:

--- a/llvm/test/CodeGen/AMDGPU/insert_vector_dynelt.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert_vector_dynelt.ll
@@ -1021,6 +1021,22 @@ define amdgpu_kernel void @bit128_inselt(ptr addrspace(1) %out, <128 x i1> %vec,
 ; GCN-NEXT:    s_load_dwordx2 s[2:3], s[0:1], 0x24
 ; GCN-NEXT:    s_load_dword s0, s[0:1], 0x44
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+; GCN-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v4, 1, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v5, 2, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v6, 3, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v7, 4, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v8, 5, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v9, 6, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v10, 7, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v11, 8, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v12, 9, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v13, 10, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v14, 11, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v15, 12, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v16, 13, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v17, 14, s4
+; GCN-NEXT:    v_lshrrev_b16_e64 v18, 15, s4
 ; GCN-NEXT:    s_lshr_b32 s1, s4, 24
 ; GCN-NEXT:    s_lshr_b32 s8, s4, 16
 ; GCN-NEXT:    s_lshr_b32 s9, s4, 17
@@ -1029,861 +1045,832 @@ define amdgpu_kernel void @bit128_inselt(ptr addrspace(1) %out, <128 x i1> %vec,
 ; GCN-NEXT:    s_lshr_b32 s12, s4, 20
 ; GCN-NEXT:    s_lshr_b32 s13, s4, 21
 ; GCN-NEXT:    s_lshr_b32 s14, s4, 22
-; GCN-NEXT:    s_lshr_b32 s15, s4, 23
-; GCN-NEXT:    s_lshr_b32 s16, s5, 24
-; GCN-NEXT:    s_lshr_b32 s17, s5, 16
-; GCN-NEXT:    s_lshr_b32 s18, s5, 17
-; GCN-NEXT:    s_lshr_b32 s19, s5, 18
-; GCN-NEXT:    s_lshr_b32 s20, s5, 19
-; GCN-NEXT:    s_lshr_b32 s21, s5, 20
-; GCN-NEXT:    s_lshr_b32 s22, s5, 21
-; GCN-NEXT:    s_lshr_b32 s23, s5, 22
-; GCN-NEXT:    s_lshr_b32 s24, s5, 23
-; GCN-NEXT:    s_lshr_b32 s25, s6, 24
-; GCN-NEXT:    s_lshr_b32 s26, s6, 16
-; GCN-NEXT:    s_lshr_b32 s27, s6, 17
-; GCN-NEXT:    s_lshr_b32 s28, s6, 18
-; GCN-NEXT:    s_lshr_b32 s29, s6, 19
-; GCN-NEXT:    s_lshr_b32 s30, s6, 20
-; GCN-NEXT:    s_lshr_b32 s31, s6, 21
-; GCN-NEXT:    s_lshr_b32 s33, s6, 22
-; GCN-NEXT:    s_lshr_b32 s34, s6, 23
-; GCN-NEXT:    s_lshr_b32 s35, s7, 24
-; GCN-NEXT:    s_lshr_b32 s36, s7, 16
-; GCN-NEXT:    s_lshr_b32 s37, s7, 17
-; GCN-NEXT:    s_lshr_b32 s38, s7, 18
-; GCN-NEXT:    s_lshr_b32 s39, s7, 19
-; GCN-NEXT:    s_lshr_b32 s40, s7, 20
-; GCN-NEXT:    s_lshr_b32 s41, s7, 21
-; GCN-NEXT:    s_lshr_b32 s42, s7, 22
-; GCN-NEXT:    s_lshr_b32 s43, s7, 23
+; GCN-NEXT:    s_lshr_b32 s4, s4, 23
+; GCN-NEXT:    s_lshr_b32 s15, s5, 24
+; GCN-NEXT:    s_lshr_b32 s16, s5, 16
+; GCN-NEXT:    s_lshr_b32 s17, s5, 17
+; GCN-NEXT:    s_lshr_b32 s18, s5, 18
+; GCN-NEXT:    s_lshr_b32 s19, s5, 19
+; GCN-NEXT:    s_lshr_b32 s20, s5, 20
+; GCN-NEXT:    s_lshr_b32 s21, s5, 21
+; GCN-NEXT:    s_lshr_b32 s22, s5, 22
+; GCN-NEXT:    s_lshr_b32 s23, s5, 23
+; GCN-NEXT:    s_lshr_b32 s24, s6, 24
+; GCN-NEXT:    s_lshr_b32 s25, s6, 16
+; GCN-NEXT:    s_lshr_b32 s26, s6, 17
+; GCN-NEXT:    s_lshr_b32 s27, s6, 18
+; GCN-NEXT:    s_lshr_b32 s28, s6, 19
+; GCN-NEXT:    s_lshr_b32 s29, s6, 20
+; GCN-NEXT:    s_lshr_b32 s30, s6, 21
+; GCN-NEXT:    s_lshr_b32 s31, s6, 22
+; GCN-NEXT:    s_lshr_b32 s33, s6, 23
+; GCN-NEXT:    s_lshr_b32 s34, s7, 24
+; GCN-NEXT:    s_lshr_b32 s35, s7, 16
+; GCN-NEXT:    s_lshr_b32 s36, s7, 17
+; GCN-NEXT:    s_lshr_b32 s37, s7, 18
+; GCN-NEXT:    s_lshr_b32 s38, s7, 19
+; GCN-NEXT:    s_lshr_b32 s39, s7, 20
+; GCN-NEXT:    s_lshr_b32 s40, s7, 21
+; GCN-NEXT:    s_lshr_b32 s41, s7, 22
+; GCN-NEXT:    s_lshr_b32 s42, s7, 23
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x77
-; GCN-NEXT:    v_mov_b32_e32 v15, s43
+; GCN-NEXT:    v_mov_b32_e32 v22, s42
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x76
-; GCN-NEXT:    v_cndmask_b32_e32 v15, 1, v15, vcc
-; GCN-NEXT:    v_mov_b32_e32 v18, s42
+; GCN-NEXT:    v_cndmask_b32_e32 v22, 1, v22, vcc
+; GCN-NEXT:    v_mov_b32_e32 v25, s41
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v15, 3, v15
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 2, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 3, v22
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 2, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x75
-; GCN-NEXT:    v_or_b32_e32 v15, v15, v18
-; GCN-NEXT:    v_mov_b32_e32 v18, s41
+; GCN-NEXT:    v_or_b32_e32 v22, v22, v25
+; GCN-NEXT:    v_mov_b32_e32 v25, s40
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x74
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_mov_b32_e32 v19, s40
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_mov_b32_e32 v26, s39
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 1, v18
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_and_b32_e32 v18, 3, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 1, v25
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_and_b32_e32 v25, 3, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x73
-; GCN-NEXT:    v_or_b32_e32 v15, v18, v15
-; GCN-NEXT:    v_mov_b32_e32 v18, s39
+; GCN-NEXT:    v_or_b32_e32 v22, v25, v22
+; GCN-NEXT:    v_mov_b32_e32 v25, s38
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x72
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_mov_b32_e32 v19, s38
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_mov_b32_e32 v26, s37
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 3, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x71
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_mov_b32_e32 v19, s37
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
+; GCN-NEXT:    v_mov_b32_e32 v26, s36
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x70
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_mov_b32_e32 v20, s36
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_mov_b32_e32 v27, s35
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v15, 4, v15
-; GCN-NEXT:    v_and_b32_e32 v18, 15, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 4, v22
+; GCN-NEXT:    v_and_b32_e32 v25, 15, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x7f
-; GCN-NEXT:    v_or_b32_e32 v15, v18, v15
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 7, s35
+; GCN-NEXT:    v_or_b32_e32 v22, v25, v22
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 7, s34
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x7e
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 6, s35
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 6, s34
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 3, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x7d
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 5, s35
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 5, s34
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x7c
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 4, s35
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 4, s34
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x7b
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 3, s35
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 3, s34
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x7a
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 2, s35
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 2, s34
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x78
-; GCN-NEXT:    v_mov_b32_e32 v13, s35
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 3, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 2, v20
+; GCN-NEXT:    v_mov_b32_e32 v20, s34
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 3, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 2, v27
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x79
-; GCN-NEXT:    v_or_b32_e32 v19, v19, v20
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 1, s35
-; GCN-NEXT:    v_cndmask_b32_e32 v13, 1, v13, vcc
-; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
+; GCN-NEXT:    v_or_b32_e32 v26, v26, v27
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 1, s34
 ; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_and_b32_e32 v13, 1, v13
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v13, v13, v20
-; GCN-NEXT:    v_and_b32_e32 v13, 3, v13
-; GCN-NEXT:    v_or_b32_e32 v19, v13, v19
-; GCN-NEXT:    v_mov_b32_e32 v13, 15
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 12, v18
-; GCN-NEXT:    v_and_b32_sdwa v19, v19, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
+; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v20, v20, v27
+; GCN-NEXT:    v_and_b32_e32 v20, 3, v20
+; GCN-NEXT:    v_or_b32_e32 v26, v20, v26
+; GCN-NEXT:    v_mov_b32_e32 v20, 15
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 12, v25
+; GCN-NEXT:    v_and_b32_sdwa v26, v26, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x6f
-; GCN-NEXT:    v_or_b32_sdwa v15, v15, v18 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 15, s7
+; GCN-NEXT:    v_or_b32_sdwa v22, v22, v25 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 15, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x6e
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 14, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 14, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 3, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x6d
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 13, s7
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 13, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x6c
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 12, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 12, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x6b
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 11, s7
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 11, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x6a
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 10, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 10, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 3, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 2, v20
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 3, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 2, v27
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x69
-; GCN-NEXT:    v_or_b32_e32 v19, v19, v20
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 9, s7
+; GCN-NEXT:    v_or_b32_e32 v26, v26, v27
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 9, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x68
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 8, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 8, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 1, v20
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_or_b32_e32 v17, v17, v20
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
-; GCN-NEXT:    v_or_b32_e32 v17, v17, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 12, v18
-; GCN-NEXT:    v_and_b32_sdwa v17, v17, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 1, v27
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
+; GCN-NEXT:    v_or_b32_e32 v24, v24, v27
+; GCN-NEXT:    v_and_b32_e32 v24, 3, v24
+; GCN-NEXT:    v_or_b32_e32 v24, v24, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 12, v25
+; GCN-NEXT:    v_and_b32_sdwa v24, v24, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x67
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 7, s7
+; GCN-NEXT:    v_or_b32_e32 v24, v25, v24
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 7, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x66
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 6, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 6, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 3, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x65
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 5, s7
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 5, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x64
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 4, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 4, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x63
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 3, s7
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 3, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x62
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 2, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 2, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 3, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 2, v20
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 3, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 2, v27
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x61
-; GCN-NEXT:    v_or_b32_e32 v19, v19, v20
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 1, s7
+; GCN-NEXT:    v_or_b32_e32 v26, v26, v27
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 1, s7
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x60
-; GCN-NEXT:    v_mov_b32_e32 v16, s7
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
+; GCN-NEXT:    v_mov_b32_e32 v23, s7
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 1, v20
-; GCN-NEXT:    v_and_b32_e32 v16, 1, v16
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v20
-; GCN-NEXT:    v_and_b32_e32 v16, 3, v16
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 4, v18
-; GCN-NEXT:    v_and_b32_e32 v16, 15, v16
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 1, v27
+; GCN-NEXT:    v_and_b32_e32 v23, 1, v23
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v27
+; GCN-NEXT:    v_and_b32_e32 v23, 3, v23
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 4, v25
+; GCN-NEXT:    v_and_b32_e32 v23, 15, v23
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x57
-; GCN-NEXT:    v_or_b32_sdwa v16, v16, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GCN-NEXT:    v_mov_b32_e32 v17, s34
+; GCN-NEXT:    v_or_b32_sdwa v23, v23, v24 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GCN-NEXT:    v_mov_b32_e32 v24, s33
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x56
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_mov_b32_e32 v18, s33
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_mov_b32_e32 v25, s31
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 3, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 2, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 3, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 2, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x55
-; GCN-NEXT:    v_or_b32_e32 v17, v17, v18
-; GCN-NEXT:    v_mov_b32_e32 v18, s31
+; GCN-NEXT:    v_or_b32_e32 v24, v24, v25
+; GCN-NEXT:    v_mov_b32_e32 v25, s30
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x54
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_mov_b32_e32 v19, s30
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_mov_b32_e32 v26, s29
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 1, v18
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_and_b32_e32 v18, 3, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 1, v25
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_and_b32_e32 v25, 3, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x53
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_mov_b32_e32 v18, s29
+; GCN-NEXT:    v_or_b32_e32 v24, v25, v24
+; GCN-NEXT:    v_mov_b32_e32 v25, s28
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x52
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_mov_b32_e32 v19, s28
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_mov_b32_e32 v26, s27
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 3, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x51
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_mov_b32_e32 v19, s27
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
+; GCN-NEXT:    v_mov_b32_e32 v26, s26
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x50
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_mov_b32_e32 v20, s26
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_mov_b32_e32 v27, s25
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 4, v17
-; GCN-NEXT:    v_and_b32_e32 v18, 15, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 4, v24
+; GCN-NEXT:    v_and_b32_e32 v25, 15, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x5f
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 7, s25
+; GCN-NEXT:    v_or_b32_e32 v24, v25, v24
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 7, s24
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x5e
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 6, s25
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 6, s24
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 3, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x5d
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 5, s25
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 5, s24
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x5c
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 4, s25
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 4, s24
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x5b
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 3, s25
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 3, s24
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x5a
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 2, s25
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 2, s24
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x58
-; GCN-NEXT:    v_mov_b32_e32 v3, s25
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 3, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 2, v20
+; GCN-NEXT:    v_mov_b32_e32 v3, s24
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 3, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 2, v27
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x59
-; GCN-NEXT:    v_or_b32_e32 v19, v19, v20
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 1, s25
+; GCN-NEXT:    v_or_b32_e32 v26, v26, v27
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 1, s24
 ; GCN-NEXT:    v_cndmask_b32_e32 v3, 1, v3, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
 ; GCN-NEXT:    v_and_b32_e32 v3, 1, v3
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v3, v3, v20
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v3, v3, v27
 ; GCN-NEXT:    v_and_b32_e32 v3, 3, v3
-; GCN-NEXT:    v_or_b32_e32 v3, v3, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 12, v18
-; GCN-NEXT:    v_and_b32_sdwa v3, v3, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GCN-NEXT:    v_or_b32_e32 v3, v18, v3
+; GCN-NEXT:    v_or_b32_e32 v3, v3, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 12, v25
+; GCN-NEXT:    v_and_b32_sdwa v3, v3, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_or_b32_e32 v3, v25, v3
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x4f
-; GCN-NEXT:    v_or_b32_sdwa v17, v17, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GCN-NEXT:    v_or_b32_sdwa v24, v24, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GCN-NEXT:    v_lshrrev_b16_e64 v3, 15, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x4e
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 14, s6
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 14, s6
 ; GCN-NEXT:    v_cndmask_b32_e32 v3, 1, v3, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
 ; GCN-NEXT:    v_lshlrev_b16_e32 v3, 3, v3
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 2, v18
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 2, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x4d
-; GCN-NEXT:    v_or_b32_e32 v3, v3, v18
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 13, s6
+; GCN-NEXT:    v_or_b32_e32 v3, v3, v25
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 13, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x4c
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 12, s6
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 12, s6
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 1, v18
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
-; GCN-NEXT:    v_and_b32_e32 v18, 3, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 1, v25
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
+; GCN-NEXT:    v_and_b32_e32 v25, 3, v25
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x4b
-; GCN-NEXT:    v_or_b32_e32 v3, v18, v3
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 11, s6
+; GCN-NEXT:    v_or_b32_e32 v3, v25, v3
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 11, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x4a
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 10, s6
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 10, s6
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 3, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x49
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 9, s6
+; GCN-NEXT:    v_or_b32_e32 v25, v25, v26
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 9, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x48
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 8, s6
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 8, s6
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
-; GCN-NEXT:    v_or_b32_e32 v18, v19, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
+; GCN-NEXT:    v_or_b32_e32 v25, v26, v25
 ; GCN-NEXT:    v_lshlrev_b16_e32 v3, 12, v3
-; GCN-NEXT:    v_and_b32_sdwa v18, v18, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_and_b32_sdwa v25, v25, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x47
-; GCN-NEXT:    v_or_b32_e32 v18, v3, v18
+; GCN-NEXT:    v_or_b32_e32 v25, v3, v25
 ; GCN-NEXT:    v_lshrrev_b16_e64 v3, 7, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x46
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 6, s6
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 6, s6
 ; GCN-NEXT:    v_cndmask_b32_e32 v3, 1, v3, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
 ; GCN-NEXT:    v_lshlrev_b16_e32 v3, 3, v3
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 2, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x45
-; GCN-NEXT:    v_or_b32_e32 v3, v3, v19
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 5, s6
+; GCN-NEXT:    v_or_b32_e32 v3, v3, v26
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 5, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x44
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 4, s6
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 4, s6
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
-; GCN-NEXT:    v_or_b32_e32 v19, v20, v19
-; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v26, 1, v26
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
+; GCN-NEXT:    v_or_b32_e32 v26, v27, v26
+; GCN-NEXT:    v_and_b32_e32 v26, 3, v26
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x43
-; GCN-NEXT:    v_or_b32_e32 v19, v19, v3
+; GCN-NEXT:    v_or_b32_e32 v26, v26, v3
 ; GCN-NEXT:    v_lshrrev_b16_e64 v3, 3, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x42
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 2, s6
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 2, s6
 ; GCN-NEXT:    v_cndmask_b32_e32 v3, 1, v3, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
-; GCN-NEXT:    v_and_b32_e32 v20, 1, v20
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
+; GCN-NEXT:    v_and_b32_e32 v27, 1, v27
 ; GCN-NEXT:    v_lshlrev_b16_e32 v3, 3, v3
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 2, v20
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 2, v27
 ; GCN-NEXT:    s_cmpk_lg_i32 s0, 0x41
-; GCN-NEXT:    v_or_b32_e32 v3, v3, v20
-; GCN-NEXT:    v_lshrrev_b16_e64 v20, 1, s6
+; GCN-NEXT:    v_or_b32_e32 v3, v3, v27
+; GCN-NEXT:    v_lshrrev_b16_e64 v27, 1, s6
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 64
 ; GCN-NEXT:    v_mov_b32_e32 v2, s6
-; GCN-NEXT:    v_cndmask_b32_e32 v20, 1, v20, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v27, 1, v27, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    v_cndmask_b32_e32 v2, 1, v2, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v20, 1, v20
+; GCN-NEXT:    v_lshlrev_b16_e32 v27, 1, v27
 ; GCN-NEXT:    v_and_b32_e32 v2, 1, v2
-; GCN-NEXT:    v_or_b32_e32 v2, v2, v20
+; GCN-NEXT:    v_or_b32_e32 v2, v2, v27
 ; GCN-NEXT:    v_and_b32_e32 v2, 3, v2
 ; GCN-NEXT:    v_or_b32_e32 v2, v2, v3
-; GCN-NEXT:    v_or_b32_sdwa v3, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GCN-NEXT:    v_lshlrev_b16_e32 v15, 4, v19
+; GCN-NEXT:    v_or_b32_sdwa v3, v23, v22 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 4, v26
 ; GCN-NEXT:    v_and_b32_e32 v2, 15, v2
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 55
-; GCN-NEXT:    v_or_b32_e32 v2, v2, v15
-; GCN-NEXT:    v_mov_b32_e32 v15, s24
+; GCN-NEXT:    v_or_b32_e32 v2, v2, v22
+; GCN-NEXT:    v_mov_b32_e32 v22, s23
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 54
-; GCN-NEXT:    v_cndmask_b32_e32 v15, 1, v15, vcc
-; GCN-NEXT:    v_mov_b32_e32 v16, s23
+; GCN-NEXT:    v_cndmask_b32_e32 v22, 1, v22, vcc
+; GCN-NEXT:    v_mov_b32_e32 v23, s22
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_and_b32_e32 v16, 1, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v15, 3, v15
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 2, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_and_b32_e32 v23, 1, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 3, v22
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 2, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 53
-; GCN-NEXT:    v_or_b32_sdwa v2, v2, v18 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GCN-NEXT:    v_or_b32_e32 v15, v15, v16
-; GCN-NEXT:    v_mov_b32_e32 v16, s22
+; GCN-NEXT:    v_or_b32_sdwa v2, v2, v25 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GCN-NEXT:    v_or_b32_e32 v22, v22, v23
+; GCN-NEXT:    v_mov_b32_e32 v23, s21
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 52
-; GCN-NEXT:    v_or_b32_sdwa v2, v2, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_mov_b32_e32 v17, s21
+; GCN-NEXT:    v_or_b32_sdwa v2, v2, v24 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_mov_b32_e32 v24, s20
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 1, v16
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_and_b32_e32 v16, 3, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 1, v23
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
+; GCN-NEXT:    v_or_b32_e32 v23, v24, v23
+; GCN-NEXT:    v_and_b32_e32 v23, 3, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 51
-; GCN-NEXT:    v_or_b32_e32 v15, v16, v15
-; GCN-NEXT:    v_mov_b32_e32 v16, s20
+; GCN-NEXT:    v_or_b32_e32 v22, v23, v22
+; GCN-NEXT:    v_mov_b32_e32 v23, s19
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 50
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_mov_b32_e32 v17, s19
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_mov_b32_e32 v24, s18
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 3, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 3, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 2, v24
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 49
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v17
-; GCN-NEXT:    v_mov_b32_e32 v17, s18
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v24
+; GCN-NEXT:    v_mov_b32_e32 v24, s17
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 48
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_mov_b32_e32 v18, s17
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_mov_b32_e32 v25, s16
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 1, v17
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v15, 4, v15
-; GCN-NEXT:    v_and_b32_e32 v16, 15, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 1, v24
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
+; GCN-NEXT:    v_or_b32_e32 v24, v25, v24
+; GCN-NEXT:    v_and_b32_e32 v24, 3, v24
+; GCN-NEXT:    v_or_b32_e32 v23, v24, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 4, v22
+; GCN-NEXT:    v_and_b32_e32 v23, 15, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 63
-; GCN-NEXT:    v_or_b32_e32 v15, v16, v15
-; GCN-NEXT:    v_lshrrev_b16_e64 v16, 7, s16
+; GCN-NEXT:    v_or_b32_e32 v22, v23, v22
+; GCN-NEXT:    v_lshrrev_b16_e64 v23, 7, s15
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 62
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 6, s16
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 6, s15
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 3, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 3, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 2, v24
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 61
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v17
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 5, s16
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v24
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 5, s15
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 60
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 4, s16
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 4, s15
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 1, v17
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 1, v24
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
+; GCN-NEXT:    v_or_b32_e32 v24, v25, v24
+; GCN-NEXT:    v_and_b32_e32 v24, 3, v24
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 59
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 3, s16
+; GCN-NEXT:    v_or_b32_e32 v23, v24, v23
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 3, s15
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 58
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 2, s16
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 2, s15
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 56
-; GCN-NEXT:    v_mov_b32_e32 v14, s16
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 3, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 2, v18
+; GCN-NEXT:    v_mov_b32_e32 v21, s15
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 3, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 2, v25
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 57
-; GCN-NEXT:    v_or_b32_e32 v17, v17, v18
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 1, s16
-; GCN-NEXT:    v_cndmask_b32_e32 v14, 1, v14, vcc
+; GCN-NEXT:    v_or_b32_e32 v24, v24, v25
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 1, s15
+; GCN-NEXT:    v_cndmask_b32_e32 v21, 1, v21, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_and_b32_e32 v14, 1, v14
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 1, v18
-; GCN-NEXT:    v_or_b32_e32 v14, v14, v18
-; GCN-NEXT:    v_and_b32_e32 v14, 3, v14
-; GCN-NEXT:    v_or_b32_e32 v14, v14, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 12, v16
-; GCN-NEXT:    v_and_b32_sdwa v14, v14, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GCN-NEXT:    v_or_b32_e32 v14, v16, v14
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_and_b32_e32 v21, 1, v21
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 1, v25
+; GCN-NEXT:    v_or_b32_e32 v21, v21, v25
+; GCN-NEXT:    v_and_b32_e32 v21, 3, v21
+; GCN-NEXT:    v_or_b32_e32 v21, v21, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 12, v23
+; GCN-NEXT:    v_and_b32_sdwa v21, v21, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_or_b32_e32 v21, v23, v21
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 47
-; GCN-NEXT:    v_or_b32_sdwa v15, v15, v14 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GCN-NEXT:    v_lshrrev_b16_e64 v14, 15, s5
+; GCN-NEXT:    v_or_b32_sdwa v21, v22, v21 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GCN-NEXT:    v_lshrrev_b16_e64 v22, 15, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 46
-; GCN-NEXT:    v_lshrrev_b16_e64 v16, 14, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v14, 1, v14, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v23, 14, s5
+; GCN-NEXT:    v_cndmask_b32_e32 v22, 1, v22, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_and_b32_e32 v16, 1, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v14, 3, v14
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 2, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_and_b32_e32 v23, 1, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 3, v22
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 2, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 45
-; GCN-NEXT:    v_or_b32_e32 v14, v14, v16
-; GCN-NEXT:    v_lshrrev_b16_e64 v16, 13, s5
+; GCN-NEXT:    v_or_b32_e32 v22, v22, v23
+; GCN-NEXT:    v_lshrrev_b16_e64 v23, 13, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 44
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 12, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 12, s5
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 1, v16
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_and_b32_e32 v16, 3, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 1, v23
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
+; GCN-NEXT:    v_or_b32_e32 v23, v24, v23
+; GCN-NEXT:    v_and_b32_e32 v23, 3, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 43
-; GCN-NEXT:    v_or_b32_e32 v14, v16, v14
-; GCN-NEXT:    v_lshrrev_b16_e64 v16, 11, s5
+; GCN-NEXT:    v_or_b32_e32 v22, v23, v22
+; GCN-NEXT:    v_lshrrev_b16_e64 v23, 11, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 42
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 10, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 10, s5
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 3, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 3, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 2, v24
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 41
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v17
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 9, s5
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v24
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 9, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 40
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 8, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 8, s5
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 1, v17
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v14, 12, v14
-; GCN-NEXT:    v_and_b32_sdwa v16, v16, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 1, v24
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
+; GCN-NEXT:    v_or_b32_e32 v24, v25, v24
+; GCN-NEXT:    v_and_b32_e32 v24, 3, v24
+; GCN-NEXT:    v_or_b32_e32 v23, v24, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 12, v22
+; GCN-NEXT:    v_and_b32_sdwa v23, v23, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 39
-; GCN-NEXT:    v_or_b32_e32 v16, v14, v16
-; GCN-NEXT:    v_lshrrev_b16_e64 v14, 7, s5
+; GCN-NEXT:    v_or_b32_e32 v22, v22, v23
+; GCN-NEXT:    v_lshrrev_b16_e64 v23, 7, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 38
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 6, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v14, 1, v14, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 6, s5
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v14, 3, v14
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 3, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 2, v24
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 37
-; GCN-NEXT:    v_or_b32_e32 v14, v14, v17
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 5, s5
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v24
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 5, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 36
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 4, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 4, s5
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 1, v17
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 1, v24
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
+; GCN-NEXT:    v_or_b32_e32 v24, v25, v24
+; GCN-NEXT:    v_and_b32_e32 v24, 3, v24
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 35
-; GCN-NEXT:    v_or_b32_e32 v17, v17, v14
-; GCN-NEXT:    v_lshrrev_b16_e64 v14, 3, s5
+; GCN-NEXT:    v_or_b32_e32 v23, v24, v23
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 3, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 34
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 2, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v14, 1, v14, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 2, s5
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v14, 3, v14
-; GCN-NEXT:    v_lshlrev_b16_e32 v18, 2, v18
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
+; GCN-NEXT:    v_and_b32_e32 v25, 1, v25
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 3, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 2, v25
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 33
-; GCN-NEXT:    v_or_b32_e32 v18, v14, v18
-; GCN-NEXT:    v_lshrrev_b16_e64 v14, 1, s5
+; GCN-NEXT:    v_or_b32_e32 v24, v24, v25
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 1, s5
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 32
 ; GCN-NEXT:    v_mov_b32_e32 v1, s5
-; GCN-NEXT:    v_cndmask_b32_e32 v14, 1, v14, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v25, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    v_cndmask_b32_e32 v1, 1, v1, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v14, 1, v14
+; GCN-NEXT:    v_lshlrev_b16_e32 v25, 1, v25
 ; GCN-NEXT:    v_and_b32_e32 v1, 1, v1
-; GCN-NEXT:    v_or_b32_e32 v1, v1, v14
+; GCN-NEXT:    v_or_b32_e32 v1, v1, v25
 ; GCN-NEXT:    v_and_b32_e32 v1, 3, v1
-; GCN-NEXT:    v_or_b32_e32 v1, v1, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 4, v17
+; GCN-NEXT:    v_or_b32_e32 v1, v1, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 4, v23
 ; GCN-NEXT:    v_and_b32_e32 v1, 15, v1
-; GCN-NEXT:    v_or_b32_e32 v1, v1, v17
-; GCN-NEXT:    v_or_b32_sdwa v1, v1, v16 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GCN-NEXT:    v_or_b32_e32 v1, v1, v23
+; GCN-NEXT:    v_or_b32_sdwa v1, v1, v22 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 23
-; GCN-NEXT:    v_or_b32_sdwa v1, v1, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GCN-NEXT:    v_mov_b32_e32 v15, s15
+; GCN-NEXT:    v_or_b32_sdwa v1, v1, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GCN-NEXT:    v_mov_b32_e32 v21, s4
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 22
-; GCN-NEXT:    v_cndmask_b32_e32 v15, 1, v15, vcc
-; GCN-NEXT:    v_mov_b32_e32 v16, s14
+; GCN-NEXT:    v_cndmask_b32_e32 v21, 1, v21, vcc
+; GCN-NEXT:    v_mov_b32_e32 v22, s14
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_and_b32_e32 v16, 1, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v15, 3, v15
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 2, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v22, 1, v22, vcc
+; GCN-NEXT:    v_and_b32_e32 v22, 1, v22
+; GCN-NEXT:    v_lshlrev_b16_e32 v21, 3, v21
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 2, v22
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 21
-; GCN-NEXT:    v_or_b32_e32 v15, v15, v16
-; GCN-NEXT:    v_mov_b32_e32 v16, s13
+; GCN-NEXT:    v_or_b32_e32 v21, v21, v22
+; GCN-NEXT:    v_mov_b32_e32 v22, s13
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 20
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_mov_b32_e32 v17, s12
+; GCN-NEXT:    v_cndmask_b32_e32 v22, 1, v22, vcc
+; GCN-NEXT:    v_mov_b32_e32 v23, s12
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 1, v16
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_and_b32_e32 v16, 3, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 1, v22
+; GCN-NEXT:    v_and_b32_e32 v23, 1, v23
+; GCN-NEXT:    v_or_b32_e32 v22, v23, v22
+; GCN-NEXT:    v_and_b32_e32 v22, 3, v22
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 19
-; GCN-NEXT:    v_or_b32_e32 v15, v16, v15
-; GCN-NEXT:    v_mov_b32_e32 v16, s11
+; GCN-NEXT:    v_or_b32_e32 v21, v22, v21
+; GCN-NEXT:    v_mov_b32_e32 v22, s11
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 18
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
-; GCN-NEXT:    v_mov_b32_e32 v17, s10
+; GCN-NEXT:    v_cndmask_b32_e32 v22, 1, v22, vcc
+; GCN-NEXT:    v_mov_b32_e32 v23, s10
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 3, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_and_b32_e32 v23, 1, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 3, v22
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 2, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 17
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v17
-; GCN-NEXT:    v_mov_b32_e32 v17, s9
+; GCN-NEXT:    v_or_b32_e32 v22, v22, v23
+; GCN-NEXT:    v_mov_b32_e32 v23, s9
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 16
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_mov_b32_e32 v19, s8
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_mov_b32_e32 v26, s8
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 1, v17
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_or_b32_e32 v17, v19, v17
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v15, 4, v15
-; GCN-NEXT:    v_and_b32_e32 v16, 15, v16
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 1, v23
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_or_b32_e32 v23, v26, v23
+; GCN-NEXT:    v_and_b32_e32 v23, 3, v23
+; GCN-NEXT:    v_or_b32_e32 v22, v23, v22
+; GCN-NEXT:    v_lshlrev_b16_e32 v21, 4, v21
+; GCN-NEXT:    v_and_b32_e32 v22, 15, v22
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 31
-; GCN-NEXT:    v_or_b32_e32 v15, v16, v15
-; GCN-NEXT:    v_lshrrev_b16_e64 v16, 7, s1
+; GCN-NEXT:    v_or_b32_e32 v21, v22, v21
+; GCN-NEXT:    v_lshrrev_b16_e64 v22, 7, s1
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 30
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 6, s1
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v23, 6, s1
+; GCN-NEXT:    v_cndmask_b32_e32 v22, 1, v22, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 3, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
+; GCN-NEXT:    v_and_b32_e32 v23, 1, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 3, v22
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 2, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 29
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v17
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 5, s1
+; GCN-NEXT:    v_or_b32_e32 v22, v22, v23
+; GCN-NEXT:    v_lshrrev_b16_e64 v23, 5, s1
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 28
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 4, s1
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 4, s1
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v23, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 1, v17
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
-; GCN-NEXT:    v_or_b32_e32 v17, v19, v17
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v26, 1, v26, vcc
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 1, v23
+; GCN-NEXT:    v_and_b32_e32 v26, 1, v26
+; GCN-NEXT:    v_or_b32_e32 v23, v26, v23
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 27
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 3, s1
+; GCN-NEXT:    v_lshrrev_b16_e64 v26, 3, s1
+; GCN-NEXT:    v_and_b32_e32 v23, 3, v23
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 26
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 2, s1
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
+; GCN-NEXT:    v_lshrrev_b16_e64 v24, 2, s1
+; GCN-NEXT:    v_or_b32_e32 v22, v23, v22
+; GCN-NEXT:    v_cndmask_b32_e32 v23, 1, v26, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v24, vcc
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 24
-; GCN-NEXT:    v_mov_b32_e32 v18, s1
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 3, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 2, v19
+; GCN-NEXT:    v_mov_b32_e32 v19, s1
+; GCN-NEXT:    v_and_b32_e32 v24, 1, v24
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 25
-; GCN-NEXT:    v_or_b32_e32 v17, v17, v19
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 1, s1
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
+; GCN-NEXT:    v_lshrrev_b16_e64 v25, 1, s1
+; GCN-NEXT:    v_lshlrev_b16_e32 v23, 3, v23
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 2, v24
 ; GCN-NEXT:    v_cndmask_b32_e32 v19, 1, v19, vcc
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_lshlrev_b16_e32 v19, 1, v19
-; GCN-NEXT:    v_or_b32_e32 v18, v18, v19
-; GCN-NEXT:    v_and_b32_e32 v18, 3, v18
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 12, v16
-; GCN-NEXT:    v_and_b32_sdwa v17, v17, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v17
+; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 15
-; GCN-NEXT:    v_or_b32_sdwa v15, v15, v16 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GCN-NEXT:    v_lshrrev_b16_e64 v16, 15, s4
+; GCN-NEXT:    v_or_b32_e32 v23, v23, v24
+; GCN-NEXT:    v_cndmask_b32_e32 v24, 1, v25, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 14
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 14, s4
-; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
-; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 3, v16
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 13
-; GCN-NEXT:    v_or_b32_e32 v16, v16, v17
-; GCN-NEXT:    v_lshrrev_b16_e64 v17, 13, s4
+; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 12
-; GCN-NEXT:    v_lshrrev_b16_e64 v18, 12, s4
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v17, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v16, 1, v16, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    v_cndmask_b32_e32 v18, 1, v18, vcc
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 1, v17
-; GCN-NEXT:    v_and_b32_e32 v18, 1, v18
-; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 11
-; GCN-NEXT:    v_lshrrev_b16_e64 v19, 11, s4
-; GCN-NEXT:    v_and_b32_e32 v17, 3, v17
+; GCN-NEXT:    v_cndmask_b32_e32 v15, 1, v15, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 10
-; GCN-NEXT:    v_lshrrev_b16_e64 v14, 10, s4
-; GCN-NEXT:    v_or_b32_e32 v16, v17, v16
-; GCN-NEXT:    v_cndmask_b32_e32 v17, 1, v19, vcc
-; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
-; GCN-NEXT:    s_cmp_lg_u32 s0, 9
-; GCN-NEXT:    v_lshrrev_b16_e64 v12, 9, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v14, 1, v14, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
+; GCN-NEXT:    s_cmp_lg_u32 s0, 9
+; GCN-NEXT:    v_cndmask_b32_e32 v13, 1, v13, vcc
+; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 8
-; GCN-NEXT:    v_lshrrev_b16_e64 v11, 8, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v12, 1, v12, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 7
-; GCN-NEXT:    v_lshrrev_b16_e64 v10, 7, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v11, 1, v11, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 6
-; GCN-NEXT:    v_lshrrev_b16_e64 v9, 6, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v10, 1, v10, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 5
-; GCN-NEXT:    v_lshrrev_b16_e64 v8, 5, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v9, 1, v9, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 4
-; GCN-NEXT:    v_lshrrev_b16_e64 v7, 4, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v8, 1, v8, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 3
-; GCN-NEXT:    v_lshrrev_b16_e64 v6, 3, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v7, 1, v7, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 2
-; GCN-NEXT:    v_lshrrev_b16_e64 v5, 2, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v6, 1, v6, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 1
-; GCN-NEXT:    v_lshrrev_b16_e64 v4, 1, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v5, 1, v5, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 0
-; GCN-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-NEXT:    v_cndmask_b32_e32 v4, 1, v4, vcc
 ; GCN-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GCN-NEXT:    v_cndmask_b32_e32 v0, 1, v0, vcc
-; GCN-NEXT:    v_and_b32_e32 v14, 1, v14
+; GCN-NEXT:    v_and_b32_e32 v19, 1, v19
+; GCN-NEXT:    v_lshlrev_b16_e32 v24, 1, v24
+; GCN-NEXT:    v_and_b32_e32 v17, 1, v17
+; GCN-NEXT:    v_lshlrev_b16_e32 v16, 1, v16
+; GCN-NEXT:    v_and_b32_e32 v15, 1, v15
+; GCN-NEXT:    v_and_b32_e32 v13, 1, v13
 ; GCN-NEXT:    v_lshlrev_b16_e32 v12, 1, v12
 ; GCN-NEXT:    v_and_b32_e32 v11, 1, v11
 ; GCN-NEXT:    v_and_b32_e32 v9, 1, v9
@@ -1892,8 +1879,12 @@ define amdgpu_kernel void @bit128_inselt(ptr addrspace(1) %out, <128 x i1> %vec,
 ; GCN-NEXT:    v_and_b32_e32 v5, 1, v5
 ; GCN-NEXT:    v_lshlrev_b16_e32 v4, 1, v4
 ; GCN-NEXT:    v_and_b32_e32 v0, 1, v0
-; GCN-NEXT:    v_lshlrev_b16_e32 v17, 3, v17
-; GCN-NEXT:    v_lshlrev_b16_e32 v14, 2, v14
+; GCN-NEXT:    v_or_b32_e32 v19, v19, v24
+; GCN-NEXT:    v_lshlrev_b16_e32 v18, 3, v18
+; GCN-NEXT:    v_lshlrev_b16_e32 v17, 2, v17
+; GCN-NEXT:    v_or_b32_e32 v15, v15, v16
+; GCN-NEXT:    v_lshlrev_b16_e32 v14, 3, v14
+; GCN-NEXT:    v_lshlrev_b16_e32 v13, 2, v13
 ; GCN-NEXT:    v_or_b32_e32 v11, v11, v12
 ; GCN-NEXT:    v_lshlrev_b16_e32 v10, 3, v10
 ; GCN-NEXT:    v_lshlrev_b16_e32 v9, 2, v9
@@ -1901,24 +1892,33 @@ define amdgpu_kernel void @bit128_inselt(ptr addrspace(1) %out, <128 x i1> %vec,
 ; GCN-NEXT:    v_lshlrev_b16_e32 v6, 3, v6
 ; GCN-NEXT:    v_lshlrev_b16_e32 v5, 2, v5
 ; GCN-NEXT:    v_or_b32_e32 v0, v0, v4
-; GCN-NEXT:    v_or_b32_e32 v14, v17, v14
+; GCN-NEXT:    v_and_b32_e32 v19, 3, v19
+; GCN-NEXT:    v_or_b32_e32 v17, v18, v17
+; GCN-NEXT:    v_and_b32_e32 v15, 3, v15
+; GCN-NEXT:    v_or_b32_e32 v13, v14, v13
 ; GCN-NEXT:    v_and_b32_e32 v11, 3, v11
 ; GCN-NEXT:    v_or_b32_e32 v9, v10, v9
 ; GCN-NEXT:    v_and_b32_e32 v7, 3, v7
 ; GCN-NEXT:    v_or_b32_e32 v5, v6, v5
 ; GCN-NEXT:    v_and_b32_e32 v0, 3, v0
-; GCN-NEXT:    v_or_b32_e32 v11, v11, v14
+; GCN-NEXT:    v_or_b32_e32 v19, v19, v23
+; GCN-NEXT:    v_or_b32_e32 v15, v15, v17
+; GCN-NEXT:    v_or_b32_e32 v11, v11, v13
 ; GCN-NEXT:    v_or_b32_e32 v7, v7, v9
 ; GCN-NEXT:    v_or_b32_e32 v0, v0, v5
-; GCN-NEXT:    v_lshlrev_b16_e32 v16, 12, v16
-; GCN-NEXT:    v_and_b32_sdwa v11, v11, v13 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_lshlrev_b16_e32 v22, 12, v22
+; GCN-NEXT:    v_and_b32_sdwa v19, v19, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GCN-NEXT:    v_lshlrev_b16_e32 v15, 12, v15
+; GCN-NEXT:    v_and_b32_sdwa v11, v11, v20 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 ; GCN-NEXT:    v_lshlrev_b16_e32 v7, 4, v7
 ; GCN-NEXT:    v_and_b32_e32 v0, 15, v0
-; GCN-NEXT:    v_or_b32_e32 v11, v16, v11
+; GCN-NEXT:    v_or_b32_e32 v19, v22, v19
+; GCN-NEXT:    v_or_b32_e32 v11, v15, v11
 ; GCN-NEXT:    v_or_b32_e32 v0, v0, v7
+; GCN-NEXT:    v_or_b32_sdwa v19, v21, v19 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GCN-NEXT:    v_or_b32_sdwa v0, v0, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GCN-NEXT:    v_mov_b32_e32 v5, s3
-; GCN-NEXT:    v_or_b32_sdwa v0, v0, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GCN-NEXT:    v_or_b32_sdwa v0, v0, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GCN-NEXT:    v_mov_b32_e32 v4, s2
 ; GCN-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GCN-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i1.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i1.ll
@@ -2317,39 +2317,41 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NEXT:    s_bfe_u32 s57, s3, 0x1000a
 ; GFX6-NEXT:    s_bfe_u32 s58, s3, 0x10008
 ; GFX6-NEXT:    s_bfe_u32 s59, s3, 0x1000e
-; GFX6-NEXT:    s_bfe_u32 s60, s3, 0x10012
-; GFX6-NEXT:    s_bfe_u32 s61, s3, 0x10010
-; GFX6-NEXT:    s_bfe_u32 s62, s3, 0x10016
-; GFX6-NEXT:    s_bfe_u32 s63, s3, 0x1001a
-; GFX6-NEXT:    s_bfe_u32 s64, s3, 0x10018
-; GFX6-NEXT:    s_bfe_u32 s65, s3, 0x1001e
-; GFX6-NEXT:    s_bfe_u32 s66, s3, 0x1001c
-; GFX6-NEXT:    s_bfe_u32 s67, s3, 0x10014
-; GFX6-NEXT:    s_bfe_u32 s68, s3, 0x1000c
+; GFX6-NEXT:    s_bfe_u32 s60, s3, 0x1000c
+; GFX6-NEXT:    s_bfe_u32 s61, s3, 0x10012
+; GFX6-NEXT:    s_bfe_u32 s62, s3, 0x10010
+; GFX6-NEXT:    s_bfe_u32 s63, s3, 0x10016
+; GFX6-NEXT:    s_bfe_u32 s64, s3, 0x1001a
+; GFX6-NEXT:    s_bfe_u32 s65, s3, 0x10018
+; GFX6-NEXT:    s_bfe_u32 s66, s3, 0x1001e
+; GFX6-NEXT:    s_bfe_u32 s67, s3, 0x1001c
+; GFX6-NEXT:    s_bfe_u32 s68, s3, 0x10014
 ; GFX6-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX6-NEXT:    s_mov_b32 s2, -1
-; GFX6-NEXT:    v_mov_b32_e32 v0, s66
+; GFX6-NEXT:    v_mov_b32_e32 v0, s67
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s36
-; GFX6-NEXT:    v_mov_b32_e32 v2, s65
+; GFX6-NEXT:    v_mov_b32_e32 v2, s66
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s35
-; GFX6-NEXT:    v_mov_b32_e32 v4, s64
+; GFX6-NEXT:    v_mov_b32_e32 v4, s65
 ; GFX6-NEXT:    v_mov_b32_e32 v5, s34
-; GFX6-NEXT:    v_mov_b32_e32 v6, s63
+; GFX6-NEXT:    v_mov_b32_e32 v6, s64
 ; GFX6-NEXT:    v_mov_b32_e32 v7, s33
-; GFX6-NEXT:    v_mov_b32_e32 v8, s67
-; GFX6-NEXT:    v_mov_b32_e32 v9, s31
-; GFX6-NEXT:    v_mov_b32_e32 v10, s62
-; GFX6-NEXT:    v_mov_b32_e32 v11, s30
-; GFX6-NEXT:    v_mov_b32_e32 v12, s61
-; GFX6-NEXT:    v_mov_b32_e32 v13, s29
-; GFX6-NEXT:    v_mov_b32_e32 v14, s60
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GFX6-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:224
-; GFX6-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:208
-; GFX6-NEXT:    v_mov_b32_e32 v15, s28
-; GFX6-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:192
-; GFX6-NEXT:    s_waitcnt expcnt(3)
+; GFX6-NEXT:    s_waitcnt expcnt(1)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s68
+; GFX6-NEXT:    v_mov_b32_e32 v1, s31
+; GFX6-NEXT:    v_mov_b32_e32 v2, s63
+; GFX6-NEXT:    v_mov_b32_e32 v3, s30
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s62
+; GFX6-NEXT:    v_mov_b32_e32 v1, s29
+; GFX6-NEXT:    v_mov_b32_e32 v2, s61
+; GFX6-NEXT:    v_mov_b32_e32 v3, s28
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s60
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s27
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s59
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s26
@@ -2901,45 +2903,47 @@ define amdgpu_kernel void @constant_sextload_v64i1_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NEXT:    s_bfe_i32 s50, s3, 0x1000e
 ; GFX6-NEXT:    s_bfe_i32 s51, s3, 0x1000d
 ; GFX6-NEXT:    s_bfe_i32 s52, s3, 0x1000c
-; GFX6-NEXT:    s_bfe_i32 s53, s3, 0x10012
-; GFX6-NEXT:    s_bfe_i32 s54, s3, 0x10011
-; GFX6-NEXT:    s_bfe_i32 s55, s3, 0x10010
-; GFX6-NEXT:    s_bfe_i32 s56, s3, 0x10017
-; GFX6-NEXT:    s_bfe_i32 s57, s3, 0x10016
-; GFX6-NEXT:    s_bfe_i32 s58, s3, 0x10015
-; GFX6-NEXT:    s_bfe_i32 s59, s3, 0x1001b
-; GFX6-NEXT:    s_bfe_i32 s60, s3, 0x1001a
-; GFX6-NEXT:    s_bfe_i32 s61, s3, 0x10019
-; GFX6-NEXT:    s_bfe_i32 s62, s3, 0x10018
-; GFX6-NEXT:    s_ashr_i32 s63, s3, 31
-; GFX6-NEXT:    s_bfe_i32 s64, s3, 0x1001e
-; GFX6-NEXT:    s_bfe_i32 s65, s3, 0x1001d
-; GFX6-NEXT:    s_bfe_i32 s66, s3, 0x1001c
-; GFX6-NEXT:    s_bfe_i32 s67, s3, 0x10014
-; GFX6-NEXT:    s_bfe_i32 s68, s3, 0x10013
+; GFX6-NEXT:    s_bfe_i32 s53, s3, 0x10013
+; GFX6-NEXT:    s_bfe_i32 s54, s3, 0x10012
+; GFX6-NEXT:    s_bfe_i32 s55, s3, 0x10011
+; GFX6-NEXT:    s_bfe_i32 s56, s3, 0x10010
+; GFX6-NEXT:    s_bfe_i32 s57, s3, 0x10017
+; GFX6-NEXT:    s_bfe_i32 s58, s3, 0x10016
+; GFX6-NEXT:    s_bfe_i32 s59, s3, 0x10015
+; GFX6-NEXT:    s_bfe_i32 s60, s3, 0x1001b
+; GFX6-NEXT:    s_bfe_i32 s61, s3, 0x1001a
+; GFX6-NEXT:    s_bfe_i32 s62, s3, 0x10019
+; GFX6-NEXT:    s_bfe_i32 s63, s3, 0x10018
+; GFX6-NEXT:    s_ashr_i32 s64, s3, 31
+; GFX6-NEXT:    s_bfe_i32 s65, s3, 0x1001e
+; GFX6-NEXT:    s_bfe_i32 s66, s3, 0x1001d
+; GFX6-NEXT:    s_bfe_i32 s67, s3, 0x1001c
+; GFX6-NEXT:    s_bfe_i32 s68, s3, 0x10014
 ; GFX6-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX6-NEXT:    s_mov_b32 s2, -1
-; GFX6-NEXT:    v_mov_b32_e32 v0, s66
-; GFX6-NEXT:    v_mov_b32_e32 v1, s65
-; GFX6-NEXT:    v_mov_b32_e32 v2, s64
-; GFX6-NEXT:    v_mov_b32_e32 v3, s63
-; GFX6-NEXT:    v_mov_b32_e32 v4, s62
-; GFX6-NEXT:    v_mov_b32_e32 v5, s61
-; GFX6-NEXT:    v_mov_b32_e32 v6, s60
-; GFX6-NEXT:    v_mov_b32_e32 v7, s59
-; GFX6-NEXT:    v_mov_b32_e32 v8, s67
-; GFX6-NEXT:    v_mov_b32_e32 v9, s58
-; GFX6-NEXT:    v_mov_b32_e32 v10, s57
-; GFX6-NEXT:    v_mov_b32_e32 v11, s56
-; GFX6-NEXT:    v_mov_b32_e32 v12, s55
-; GFX6-NEXT:    v_mov_b32_e32 v13, s54
-; GFX6-NEXT:    v_mov_b32_e32 v14, s53
+; GFX6-NEXT:    v_mov_b32_e32 v0, s67
+; GFX6-NEXT:    v_mov_b32_e32 v1, s66
+; GFX6-NEXT:    v_mov_b32_e32 v2, s65
+; GFX6-NEXT:    v_mov_b32_e32 v3, s64
+; GFX6-NEXT:    v_mov_b32_e32 v4, s63
+; GFX6-NEXT:    v_mov_b32_e32 v5, s62
+; GFX6-NEXT:    v_mov_b32_e32 v6, s61
+; GFX6-NEXT:    v_mov_b32_e32 v7, s60
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GFX6-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:224
-; GFX6-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:208
-; GFX6-NEXT:    v_mov_b32_e32 v15, s68
-; GFX6-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:192
-; GFX6-NEXT:    s_waitcnt expcnt(3)
+; GFX6-NEXT:    s_waitcnt expcnt(1)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s68
+; GFX6-NEXT:    v_mov_b32_e32 v1, s59
+; GFX6-NEXT:    v_mov_b32_e32 v2, s58
+; GFX6-NEXT:    v_mov_b32_e32 v3, s57
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s56
+; GFX6-NEXT:    v_mov_b32_e32 v1, s55
+; GFX6-NEXT:    v_mov_b32_e32 v2, s54
+; GFX6-NEXT:    v_mov_b32_e32 v3, s53
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s52
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s51
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s50
@@ -4506,13 +4510,12 @@ define amdgpu_kernel void @constant_zextload_v16i1_to_v16i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NEXT:    s_mov_b32 s8, s6
 ; GFX6-NEXT:    s_mov_b32 s9, s7
-; GFX6-NEXT:    buffer_load_ushort v29, off, s[8:11], 0
+; GFX6-NEXT:    buffer_load_ushort v31, off, s[8:11], 0
 ; GFX6-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX6-NEXT:    v_mov_b32_e32 v3, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v4, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v6, v1
-; GFX6-NEXT:    v_mov_b32_e32 v7, v1
-; GFX6-NEXT:    v_mov_b32_e32 v9, v1
+; GFX6-NEXT:    v_mov_b32_e32 v8, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v10, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v12, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v14, v1
@@ -4523,36 +4526,35 @@ define amdgpu_kernel void @constant_zextload_v16i1_to_v16i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    v_mov_b32_e32 v24, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v26, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v28, v1
+; GFX6-NEXT:    v_mov_b32_e32 v30, v1
 ; GFX6-NEXT:    s_mov_b32 s0, s4
 ; GFX6-NEXT:    s_mov_b32 s1, s5
 ; GFX6-NEXT:    s_waitcnt vmcnt(0)
-; GFX6-NEXT:    v_bfe_u32 v2, v29, 11, 1
-; GFX6-NEXT:    v_bfe_u32 v0, v29, 10, 1
+; GFX6-NEXT:    v_bfe_u32 v2, v31, 11, 1
+; GFX6-NEXT:    v_bfe_u32 v0, v31, 10, 1
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
-; GFX6-NEXT:    v_bfe_u32 v5, v29, 9, 1
+; GFX6-NEXT:    v_bfe_u32 v29, v31, 5, 1
+; GFX6-NEXT:    v_bfe_u32 v25, v31, 7, 1
+; GFX6-NEXT:    v_bfe_u32 v21, v31, 1, 1
+; GFX6-NEXT:    v_bfe_u32 v17, v31, 3, 1
+; GFX6-NEXT:    v_bfe_u32 v13, v31, 13, 1
+; GFX6-NEXT:    v_lshrrev_b32_e32 v9, 15, v31
+; GFX6-NEXT:    v_bfe_u32 v5, v31, 9, 1
+; GFX6-NEXT:    v_bfe_u32 v27, v31, 4, 1
+; GFX6-NEXT:    v_bfe_u32 v23, v31, 6, 1
+; GFX6-NEXT:    v_and_b32_e32 v19, 1, v31
+; GFX6-NEXT:    v_bfe_u32 v15, v31, 2, 1
+; GFX6-NEXT:    v_bfe_u32 v11, v31, 12, 1
+; GFX6-NEXT:    v_bfe_u32 v7, v31, 14, 1
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_bfe_u32 v3, v29, 8, 1
+; GFX6-NEXT:    v_bfe_u32 v3, v31, 8, 1
 ; GFX6-NEXT:    buffer_store_dwordx4 v[3:6], off, s[0:3], 0 offset:64
-; GFX6-NEXT:    v_lshrrev_b32_e32 v8, 15, v29
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_bfe_u32 v6, v29, 14, 1
-; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:112
-; GFX6-NEXT:    v_bfe_u32 v27, v29, 5, 1
-; GFX6-NEXT:    v_bfe_u32 v23, v29, 7, 1
-; GFX6-NEXT:    v_bfe_u32 v19, v29, 1, 1
-; GFX6-NEXT:    v_bfe_u32 v15, v29, 3, 1
-; GFX6-NEXT:    v_bfe_u32 v11, v29, 13, 1
-; GFX6-NEXT:    v_bfe_u32 v25, v29, 4, 1
-; GFX6-NEXT:    v_bfe_u32 v21, v29, 6, 1
-; GFX6-NEXT:    v_and_b32_e32 v17, 1, v29
-; GFX6-NEXT:    v_bfe_u32 v13, v29, 2, 1
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_bfe_u32 v9, v29, 12, 1
-; GFX6-NEXT:    buffer_store_dwordx4 v[9:12], off, s[0:3], 0 offset:96
-; GFX6-NEXT:    buffer_store_dwordx4 v[13:16], off, s[0:3], 0 offset:16
-; GFX6-NEXT:    buffer_store_dwordx4 v[17:20], off, s[0:3], 0
-; GFX6-NEXT:    buffer_store_dwordx4 v[21:24], off, s[0:3], 0 offset:48
-; GFX6-NEXT:    buffer_store_dwordx4 v[25:28], off, s[0:3], 0 offset:32
+; GFX6-NEXT:    buffer_store_dwordx4 v[7:10], off, s[0:3], 0 offset:112
+; GFX6-NEXT:    buffer_store_dwordx4 v[11:14], off, s[0:3], 0 offset:96
+; GFX6-NEXT:    buffer_store_dwordx4 v[15:18], off, s[0:3], 0 offset:16
+; GFX6-NEXT:    buffer_store_dwordx4 v[19:22], off, s[0:3], 0
+; GFX6-NEXT:    buffer_store_dwordx4 v[23:26], off, s[0:3], 0 offset:48
+; GFX6-NEXT:    buffer_store_dwordx4 v[27:30], off, s[0:3], 0 offset:32
 ; GFX6-NEXT:    s_endpgm
 ;
 ; GFX8-LABEL: constant_zextload_v16i1_to_v16i64:
@@ -5470,136 +5472,138 @@ define amdgpu_kernel void @constant_sextload_v32i1_to_v32i64(ptr addrspace(1) %o
 ; GFX6:       ; %bb.0:
 ; GFX6-NEXT:    s_load_dwordx4 s[0:3], s[0:1], 0x9
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NEXT:    s_load_dword s8, s[2:3], 0x0
+; GFX6-NEXT:    s_load_dword s16, s[2:3], 0x0
 ; GFX6-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX6-NEXT:    s_mov_b32 s2, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NEXT:    s_lshr_b32 s52, s8, 30
-; GFX6-NEXT:    s_lshr_b32 s46, s8, 31
-; GFX6-NEXT:    s_lshr_b32 s48, s8, 28
-; GFX6-NEXT:    s_lshr_b32 s36, s8, 29
-; GFX6-NEXT:    s_lshr_b32 s38, s8, 26
-; GFX6-NEXT:    s_lshr_b32 s26, s8, 27
-; GFX6-NEXT:    s_lshr_b32 s28, s8, 24
-; GFX6-NEXT:    s_lshr_b32 s4, s8, 25
-; GFX6-NEXT:    s_lshr_b32 s6, s8, 22
-; GFX6-NEXT:    s_lshr_b32 s10, s8, 23
-; GFX6-NEXT:    s_lshr_b32 s12, s8, 20
-; GFX6-NEXT:    s_lshr_b32 s14, s8, 21
-; GFX6-NEXT:    s_lshr_b32 s16, s8, 18
-; GFX6-NEXT:    s_lshr_b32 s18, s8, 19
-; GFX6-NEXT:    s_lshr_b32 s20, s8, 16
-; GFX6-NEXT:    s_lshr_b32 s22, s8, 17
-; GFX6-NEXT:    s_lshr_b32 s24, s8, 14
-; GFX6-NEXT:    s_lshr_b32 s30, s8, 15
-; GFX6-NEXT:    s_lshr_b32 s34, s8, 12
-; GFX6-NEXT:    s_lshr_b32 s40, s8, 13
-; GFX6-NEXT:    s_lshr_b32 s42, s8, 10
-; GFX6-NEXT:    s_lshr_b32 s44, s8, 11
-; GFX6-NEXT:    s_bfe_i64 s[50:51], s[8:9], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[52:53], s[52:53], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v0, s50
-; GFX6-NEXT:    v_mov_b32_e32 v1, s51
-; GFX6-NEXT:    s_lshr_b32 s50, s8, 8
-; GFX6-NEXT:    v_mov_b32_e32 v2, s52
-; GFX6-NEXT:    v_mov_b32_e32 v3, s53
-; GFX6-NEXT:    s_lshr_b32 s52, s8, 9
-; GFX6-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v4, s46
-; GFX6-NEXT:    v_mov_b32_e32 v5, s47
-; GFX6-NEXT:    s_lshr_b32 s46, s8, 6
-; GFX6-NEXT:    v_mov_b32_e32 v6, s48
-; GFX6-NEXT:    v_mov_b32_e32 v7, s49
-; GFX6-NEXT:    s_lshr_b32 s48, s8, 7
-; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v8, s36
-; GFX6-NEXT:    v_mov_b32_e32 v9, s37
-; GFX6-NEXT:    s_lshr_b32 s36, s8, 4
-; GFX6-NEXT:    v_mov_b32_e32 v10, s38
-; GFX6-NEXT:    v_mov_b32_e32 v11, s39
-; GFX6-NEXT:    s_lshr_b32 s38, s8, 5
-; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
+; GFX6-NEXT:    s_lshr_b32 s60, s16, 30
+; GFX6-NEXT:    s_lshr_b32 s28, s16, 31
+; GFX6-NEXT:    s_lshr_b32 s30, s16, 28
+; GFX6-NEXT:    s_lshr_b32 s4, s16, 29
+; GFX6-NEXT:    s_lshr_b32 s6, s16, 26
+; GFX6-NEXT:    s_lshr_b32 s8, s16, 27
+; GFX6-NEXT:    s_lshr_b32 s10, s16, 24
+; GFX6-NEXT:    s_lshr_b32 s12, s16, 25
+; GFX6-NEXT:    s_lshr_b32 s14, s16, 22
+; GFX6-NEXT:    s_lshr_b32 s18, s16, 23
+; GFX6-NEXT:    s_lshr_b32 s20, s16, 20
+; GFX6-NEXT:    s_lshr_b32 s22, s16, 21
+; GFX6-NEXT:    s_lshr_b32 s24, s16, 18
+; GFX6-NEXT:    s_lshr_b32 s26, s16, 19
+; GFX6-NEXT:    s_lshr_b32 s34, s16, 16
+; GFX6-NEXT:    s_lshr_b32 s36, s16, 17
+; GFX6-NEXT:    s_lshr_b32 s38, s16, 14
+; GFX6-NEXT:    s_lshr_b32 s40, s16, 15
+; GFX6-NEXT:    s_lshr_b32 s42, s16, 12
+; GFX6-NEXT:    s_lshr_b32 s44, s16, 13
+; GFX6-NEXT:    s_lshr_b32 s46, s16, 10
+; GFX6-NEXT:    s_lshr_b32 s48, s16, 11
+; GFX6-NEXT:    s_lshr_b32 s50, s16, 8
+; GFX6-NEXT:    s_lshr_b32 s52, s16, 9
+; GFX6-NEXT:    s_lshr_b32 s54, s16, 6
+; GFX6-NEXT:    s_lshr_b32 s56, s16, 7
+; GFX6-NEXT:    s_bfe_i64 s[58:59], s[16:17], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[60:61], s[60:61], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v0, s58
+; GFX6-NEXT:    v_mov_b32_e32 v1, s59
+; GFX6-NEXT:    s_lshr_b32 s58, s16, 4
+; GFX6-NEXT:    v_mov_b32_e32 v2, s60
+; GFX6-NEXT:    v_mov_b32_e32 v3, s61
+; GFX6-NEXT:    s_lshr_b32 s60, s16, 5
 ; GFX6-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v12, s26
-; GFX6-NEXT:    v_mov_b32_e32 v13, s27
-; GFX6-NEXT:    s_lshr_b32 s26, s8, 2
-; GFX6-NEXT:    v_mov_b32_e32 v14, s28
-; GFX6-NEXT:    v_mov_b32_e32 v15, s29
-; GFX6-NEXT:    s_lshr_b32 s28, s8, 3
-; GFX6-NEXT:    s_lshr_b32 s8, s8, 1
-; GFX6-NEXT:    s_bfe_i64 s[8:9], s[8:9], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v4, s28
+; GFX6-NEXT:    v_mov_b32_e32 v5, s29
+; GFX6-NEXT:    s_lshr_b32 s28, s16, 2
+; GFX6-NEXT:    v_mov_b32_e32 v6, s30
+; GFX6-NEXT:    v_mov_b32_e32 v7, s31
+; GFX6-NEXT:    s_lshr_b32 s30, s16, 3
+; GFX6-NEXT:    s_lshr_b32 s16, s16, 1
+; GFX6-NEXT:    s_bfe_i64 s[16:17], s[16:17], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[60:61], s[60:61], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[58:59], s[58:59], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[56:57], s[56:57], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[54:55], s[54:55], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[52:53], s[52:53], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[50:51], s[50:51], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[44:45], s[44:45], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[42:43], s[42:43], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[20:21], s[20:21], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[18:19], s[18:19], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[16:17], s[16:17], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[14:15], s[14:15], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[12:13], s[12:13], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[10:11], s[10:11], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[8:9], s[8:9], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[6:7], s[6:7], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[4:5], s[4:5], 0x10000
 ; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:240
+; GFX6-NEXT:    v_mov_b32_e32 v8, s4
+; GFX6-NEXT:    v_mov_b32_e32 v9, s5
 ; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:224
-; GFX6-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:208
-; GFX6-NEXT:    v_mov_b32_e32 v16, s4
-; GFX6-NEXT:    v_mov_b32_e32 v17, s5
-; GFX6-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:192
-; GFX6-NEXT:    s_waitcnt expcnt(3)
+; GFX6-NEXT:    s_waitcnt expcnt(1)
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s7
-; GFX6-NEXT:    v_mov_b32_e32 v4, s10
-; GFX6-NEXT:    v_mov_b32_e32 v5, s11
-; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:176
+; GFX6-NEXT:    v_mov_b32_e32 v4, s8
+; GFX6-NEXT:    v_mov_b32_e32 v5, s9
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:208
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v2, s12
-; GFX6-NEXT:    v_mov_b32_e32 v3, s13
-; GFX6-NEXT:    v_mov_b32_e32 v4, s14
-; GFX6-NEXT:    v_mov_b32_e32 v5, s15
-; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:160
+; GFX6-NEXT:    v_mov_b32_e32 v2, s10
+; GFX6-NEXT:    v_mov_b32_e32 v3, s11
+; GFX6-NEXT:    v_mov_b32_e32 v4, s12
+; GFX6-NEXT:    v_mov_b32_e32 v5, s13
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:192
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v2, s16
-; GFX6-NEXT:    v_mov_b32_e32 v3, s17
+; GFX6-NEXT:    v_mov_b32_e32 v2, s14
+; GFX6-NEXT:    v_mov_b32_e32 v3, s15
 ; GFX6-NEXT:    v_mov_b32_e32 v4, s18
 ; GFX6-NEXT:    v_mov_b32_e32 v5, s19
-; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:144
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:176
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s20
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s21
 ; GFX6-NEXT:    v_mov_b32_e32 v4, s22
 ; GFX6-NEXT:    v_mov_b32_e32 v5, s23
-; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:128
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:160
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s24
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s25
-; GFX6-NEXT:    v_mov_b32_e32 v4, s30
-; GFX6-NEXT:    v_mov_b32_e32 v5, s31
-; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:112
+; GFX6-NEXT:    v_mov_b32_e32 v4, s26
+; GFX6-NEXT:    v_mov_b32_e32 v5, s27
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:144
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s34
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s35
+; GFX6-NEXT:    v_mov_b32_e32 v4, s36
+; GFX6-NEXT:    v_mov_b32_e32 v5, s37
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:128
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v2, s38
+; GFX6-NEXT:    v_mov_b32_e32 v3, s39
 ; GFX6-NEXT:    v_mov_b32_e32 v4, s40
 ; GFX6-NEXT:    v_mov_b32_e32 v5, s41
-; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:96
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:112
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s42
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s43
 ; GFX6-NEXT:    v_mov_b32_e32 v4, s44
 ; GFX6-NEXT:    v_mov_b32_e32 v5, s45
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:96
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v2, s46
+; GFX6-NEXT:    v_mov_b32_e32 v3, s47
+; GFX6-NEXT:    v_mov_b32_e32 v4, s48
+; GFX6-NEXT:    v_mov_b32_e32 v5, s49
 ; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:80
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s50
@@ -5608,26 +5612,26 @@ define amdgpu_kernel void @constant_sextload_v32i1_to_v32i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    v_mov_b32_e32 v5, s53
 ; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:64
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v2, s46
-; GFX6-NEXT:    v_mov_b32_e32 v3, s47
-; GFX6-NEXT:    v_mov_b32_e32 v4, s48
-; GFX6-NEXT:    v_mov_b32_e32 v5, s49
+; GFX6-NEXT:    v_mov_b32_e32 v2, s54
+; GFX6-NEXT:    v_mov_b32_e32 v3, s55
+; GFX6-NEXT:    v_mov_b32_e32 v4, s56
+; GFX6-NEXT:    v_mov_b32_e32 v5, s57
 ; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:48
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v2, s36
-; GFX6-NEXT:    v_mov_b32_e32 v3, s37
-; GFX6-NEXT:    v_mov_b32_e32 v4, s38
-; GFX6-NEXT:    v_mov_b32_e32 v5, s39
+; GFX6-NEXT:    v_mov_b32_e32 v2, s58
+; GFX6-NEXT:    v_mov_b32_e32 v3, s59
+; GFX6-NEXT:    v_mov_b32_e32 v4, s60
+; GFX6-NEXT:    v_mov_b32_e32 v5, s61
 ; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:32
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v2, s26
-; GFX6-NEXT:    v_mov_b32_e32 v3, s27
-; GFX6-NEXT:    v_mov_b32_e32 v4, s28
-; GFX6-NEXT:    v_mov_b32_e32 v5, s29
+; GFX6-NEXT:    v_mov_b32_e32 v2, s28
+; GFX6-NEXT:    v_mov_b32_e32 v3, s29
+; GFX6-NEXT:    v_mov_b32_e32 v4, s30
+; GFX6-NEXT:    v_mov_b32_e32 v5, s31
 ; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:16
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v2, s8
-; GFX6-NEXT:    v_mov_b32_e32 v3, s9
+; GFX6-NEXT:    v_mov_b32_e32 v2, s16
+; GFX6-NEXT:    v_mov_b32_e32 v3, s17
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
 ; GFX6-NEXT:    s_endpgm
 ;
@@ -6039,21 +6043,21 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    s_bfe_u32 s29, s2, 0x1001b
 ; GFX6-NEXT:    s_bfe_u32 s31, s2, 0x1001d
 ; GFX6-NEXT:    s_lshr_b32 s34, s2, 31
-; GFX6-NEXT:    s_bfe_u32 s36, s3, 0x10003
-; GFX6-NEXT:    s_bfe_u32 s37, s3, 0x10005
-; GFX6-NEXT:    s_bfe_u32 s38, s3, 0x10007
-; GFX6-NEXT:    s_bfe_u32 s39, s3, 0x10009
-; GFX6-NEXT:    s_bfe_u32 s40, s3, 0x1000b
-; GFX6-NEXT:    s_bfe_u32 s41, s3, 0x1000d
-; GFX6-NEXT:    s_bfe_u32 s42, s3, 0x1000f
-; GFX6-NEXT:    s_bfe_u32 s43, s3, 0x10011
-; GFX6-NEXT:    s_bfe_u32 s44, s3, 0x10013
-; GFX6-NEXT:    s_bfe_u32 s45, s3, 0x10015
-; GFX6-NEXT:    s_bfe_u32 s46, s3, 0x10017
-; GFX6-NEXT:    s_bfe_u32 s47, s3, 0x10019
-; GFX6-NEXT:    s_bfe_u32 s48, s3, 0x1001b
-; GFX6-NEXT:    s_bfe_u32 s49, s3, 0x1001d
-; GFX6-NEXT:    s_lshr_b32 s50, s3, 31
+; GFX6-NEXT:    s_bfe_u32 s35, s3, 0x10003
+; GFX6-NEXT:    s_bfe_u32 s36, s3, 0x10005
+; GFX6-NEXT:    s_bfe_u32 s37, s3, 0x10007
+; GFX6-NEXT:    s_bfe_u32 s38, s3, 0x10009
+; GFX6-NEXT:    s_bfe_u32 s39, s3, 0x1000b
+; GFX6-NEXT:    s_bfe_u32 s40, s3, 0x1000d
+; GFX6-NEXT:    s_bfe_u32 s41, s3, 0x1000f
+; GFX6-NEXT:    s_bfe_u32 s42, s3, 0x10011
+; GFX6-NEXT:    s_bfe_u32 s43, s3, 0x10013
+; GFX6-NEXT:    s_bfe_u32 s44, s3, 0x10015
+; GFX6-NEXT:    s_bfe_u32 s45, s3, 0x10017
+; GFX6-NEXT:    s_bfe_u32 s46, s3, 0x10019
+; GFX6-NEXT:    s_bfe_u32 s47, s3, 0x1001b
+; GFX6-NEXT:    s_bfe_u32 s48, s3, 0x1001d
+; GFX6-NEXT:    s_lshr_b32 s49, s3, 31
 ; GFX6-NEXT:    s_bfe_u32 s9, s3, 0x10001
 ; GFX6-NEXT:    s_bfe_u32 s6, s2, 0x10001
 ; GFX6-NEXT:    s_and_b32 s7, s2, 1
@@ -6069,7 +6073,7 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    s_bfe_u32 s28, s2, 0x10012
 ; GFX6-NEXT:    s_bfe_u32 s30, s2, 0x10014
 ; GFX6-NEXT:    s_bfe_u32 s33, s2, 0x10016
-; GFX6-NEXT:    s_bfe_u32 s35, s2, 0x10018
+; GFX6-NEXT:    s_bfe_u32 s50, s2, 0x10018
 ; GFX6-NEXT:    s_bfe_u32 s51, s2, 0x1001a
 ; GFX6-NEXT:    s_bfe_u32 s52, s2, 0x1001c
 ; GFX6-NEXT:    s_bfe_u32 s53, s2, 0x1001e
@@ -6093,63 +6097,63 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    s_mov_b32 s2, -1
 ; GFX6-NEXT:    v_mov_b32_e32 v3, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s67
-; GFX6-NEXT:    v_mov_b32_e32 v2, s50
+; GFX6-NEXT:    v_mov_b32_e32 v2, s49
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:496
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s68
-; GFX6-NEXT:    v_mov_b32_e32 v2, s49
+; GFX6-NEXT:    v_mov_b32_e32 v2, s48
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:480
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s66
-; GFX6-NEXT:    v_mov_b32_e32 v2, s48
+; GFX6-NEXT:    v_mov_b32_e32 v2, s47
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:464
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s65
-; GFX6-NEXT:    v_mov_b32_e32 v2, s47
+; GFX6-NEXT:    v_mov_b32_e32 v2, s46
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:448
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s64
-; GFX6-NEXT:    v_mov_b32_e32 v2, s46
+; GFX6-NEXT:    v_mov_b32_e32 v2, s45
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:432
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s63
-; GFX6-NEXT:    v_mov_b32_e32 v2, s45
+; GFX6-NEXT:    v_mov_b32_e32 v2, s44
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:416
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s62
-; GFX6-NEXT:    v_mov_b32_e32 v2, s44
+; GFX6-NEXT:    v_mov_b32_e32 v2, s43
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:400
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s61
-; GFX6-NEXT:    v_mov_b32_e32 v2, s43
+; GFX6-NEXT:    v_mov_b32_e32 v2, s42
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:384
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s60
-; GFX6-NEXT:    v_mov_b32_e32 v2, s42
+; GFX6-NEXT:    v_mov_b32_e32 v2, s41
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:368
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s59
-; GFX6-NEXT:    v_mov_b32_e32 v2, s41
+; GFX6-NEXT:    v_mov_b32_e32 v2, s40
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:352
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s58
-; GFX6-NEXT:    v_mov_b32_e32 v2, s40
+; GFX6-NEXT:    v_mov_b32_e32 v2, s39
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:336
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s57
-; GFX6-NEXT:    v_mov_b32_e32 v2, s39
+; GFX6-NEXT:    v_mov_b32_e32 v2, s38
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:320
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s56
-; GFX6-NEXT:    v_mov_b32_e32 v2, s38
+; GFX6-NEXT:    v_mov_b32_e32 v2, s37
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:304
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s55
-; GFX6-NEXT:    v_mov_b32_e32 v2, s37
+; GFX6-NEXT:    v_mov_b32_e32 v2, s36
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:288
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s54
-; GFX6-NEXT:    v_mov_b32_e32 v2, s36
+; GFX6-NEXT:    v_mov_b32_e32 v2, s35
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:272
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s53
@@ -6164,7 +6168,7 @@ define amdgpu_kernel void @constant_zextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s29
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s35
+; GFX6-NEXT:    v_mov_b32_e32 v0, s50
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s27
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
@@ -6886,319 +6890,316 @@ define amdgpu_kernel void @constant_sextload_v64i1_to_v64i64(ptr addrspace(1) %o
 ; GFX6-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX6-NEXT:    s_mov_b32 s2, -1
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NEXT:    s_lshr_b32 s48, s5, 30
-; GFX6-NEXT:    s_lshr_b32 s46, s5, 28
-; GFX6-NEXT:    s_lshr_b32 s44, s5, 29
-; GFX6-NEXT:    s_lshr_b32 s40, s5, 26
-; GFX6-NEXT:    s_lshr_b32 s42, s5, 27
-; GFX6-NEXT:    s_lshr_b32 s36, s5, 24
-; GFX6-NEXT:    s_lshr_b32 s38, s5, 25
-; GFX6-NEXT:    s_lshr_b32 s30, s5, 22
-; GFX6-NEXT:    s_lshr_b32 s34, s5, 23
-; GFX6-NEXT:    s_lshr_b32 s26, s5, 20
-; GFX6-NEXT:    s_lshr_b32 s28, s5, 21
-; GFX6-NEXT:    s_lshr_b32 s22, s5, 18
-; GFX6-NEXT:    s_lshr_b32 s24, s5, 19
-; GFX6-NEXT:    s_lshr_b32 s18, s5, 16
-; GFX6-NEXT:    s_lshr_b32 s20, s5, 17
-; GFX6-NEXT:    s_lshr_b32 s14, s5, 14
-; GFX6-NEXT:    s_lshr_b32 s16, s5, 15
-; GFX6-NEXT:    s_lshr_b32 s10, s5, 12
-; GFX6-NEXT:    s_lshr_b32 s12, s5, 13
-; GFX6-NEXT:    s_lshr_b32 s6, s5, 10
-; GFX6-NEXT:    s_lshr_b32 s8, s5, 11
-; GFX6-NEXT:    s_mov_b32 s50, s5
-; GFX6-NEXT:    s_bfe_i64 s[50:51], s[50:51], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[52:53], s[4:5], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v0, s50
-; GFX6-NEXT:    v_mov_b32_e32 v1, s51
-; GFX6-NEXT:    s_lshr_b32 s50, s5, 8
-; GFX6-NEXT:    v_mov_b32_e32 v4, s52
-; GFX6-NEXT:    v_mov_b32_e32 v5, s53
-; GFX6-NEXT:    s_lshr_b32 s52, s5, 9
-; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[54:55], s[46:47], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v6, s48
-; GFX6-NEXT:    v_mov_b32_e32 v7, s49
-; GFX6-NEXT:    s_lshr_b32 s46, s5, 6
+; GFX6-NEXT:    s_lshr_b32 s58, s5, 30
+; GFX6-NEXT:    s_lshr_b32 s52, s5, 28
+; GFX6-NEXT:    s_lshr_b32 s54, s5, 29
+; GFX6-NEXT:    s_lshr_b32 s48, s5, 26
+; GFX6-NEXT:    s_lshr_b32 s50, s5, 27
+; GFX6-NEXT:    s_lshr_b32 s44, s5, 24
+; GFX6-NEXT:    s_lshr_b32 s46, s5, 25
+; GFX6-NEXT:    s_lshr_b32 s40, s5, 22
+; GFX6-NEXT:    s_lshr_b32 s42, s5, 23
+; GFX6-NEXT:    s_lshr_b32 s36, s5, 20
+; GFX6-NEXT:    s_lshr_b32 s38, s5, 21
+; GFX6-NEXT:    s_lshr_b32 s30, s5, 18
+; GFX6-NEXT:    s_lshr_b32 s34, s5, 19
+; GFX6-NEXT:    s_lshr_b32 s26, s5, 16
+; GFX6-NEXT:    s_lshr_b32 s28, s5, 17
+; GFX6-NEXT:    s_lshr_b32 s22, s5, 14
+; GFX6-NEXT:    s_lshr_b32 s24, s5, 15
+; GFX6-NEXT:    s_lshr_b32 s18, s5, 12
+; GFX6-NEXT:    s_lshr_b32 s20, s5, 13
+; GFX6-NEXT:    s_lshr_b32 s14, s5, 10
+; GFX6-NEXT:    s_lshr_b32 s16, s5, 11
+; GFX6-NEXT:    s_lshr_b32 s10, s5, 8
+; GFX6-NEXT:    s_lshr_b32 s12, s5, 9
+; GFX6-NEXT:    s_lshr_b32 s6, s5, 6
+; GFX6-NEXT:    s_lshr_b32 s8, s5, 7
+; GFX6-NEXT:    s_mov_b32 s56, s5
+; GFX6-NEXT:    s_ashr_i32 s7, s5, 31
+; GFX6-NEXT:    s_bfe_i64 s[60:61], s[56:57], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v4, s7
+; GFX6-NEXT:    s_lshr_b32 s56, s5, 4
+; GFX6-NEXT:    v_mov_b32_e32 v0, s60
+; GFX6-NEXT:    v_mov_b32_e32 v1, s61
+; GFX6-NEXT:    s_bfe_i64 s[60:61], s[4:5], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[58:59], s[58:59], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v6, s60
+; GFX6-NEXT:    v_mov_b32_e32 v7, s61
+; GFX6-NEXT:    s_lshr_b32 s60, s5, 5
+; GFX6-NEXT:    v_mov_b32_e32 v2, s58
+; GFX6-NEXT:    v_mov_b32_e32 v3, s59
+; GFX6-NEXT:    s_lshr_b32 s58, s5, 2
+; GFX6-NEXT:    s_bfe_i64 s[52:53], s[52:53], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[54:55], s[54:55], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v8, s52
+; GFX6-NEXT:    v_mov_b32_e32 v9, s53
+; GFX6-NEXT:    s_lshr_b32 s52, s5, 3
 ; GFX6-NEXT:    v_mov_b32_e32 v10, s54
 ; GFX6-NEXT:    v_mov_b32_e32 v11, s55
-; GFX6-NEXT:    s_lshr_b32 s48, s5, 7
-; GFX6-NEXT:    s_bfe_i64 s[44:45], s[44:45], 0x10000
-; GFX6-NEXT:    s_ashr_i32 s7, s5, 31
-; GFX6-NEXT:    v_mov_b32_e32 v12, s44
-; GFX6-NEXT:    v_mov_b32_e32 v13, s45
-; GFX6-NEXT:    s_lshr_b32 s44, s5, 4
-; GFX6-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[54:55], s[42:43], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v14, s40
-; GFX6-NEXT:    v_mov_b32_e32 v15, s41
-; GFX6-NEXT:    s_lshr_b32 s42, s5, 5
-; GFX6-NEXT:    v_mov_b32_e32 v16, s54
-; GFX6-NEXT:    v_mov_b32_e32 v17, s55
-; GFX6-NEXT:    s_lshr_b32 s40, s5, 2
-; GFX6-NEXT:    v_mov_b32_e32 v8, s7
-; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v9, s7
-; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:496
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v6, s36
-; GFX6-NEXT:    v_mov_b32_e32 v7, s37
-; GFX6-NEXT:    s_lshr_b32 s36, s5, 3
-; GFX6-NEXT:    v_mov_b32_e32 v8, s38
-; GFX6-NEXT:    v_mov_b32_e32 v9, s39
-; GFX6-NEXT:    s_lshr_b32 s38, s5, 1
-; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:480
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v10, s30
-; GFX6-NEXT:    v_mov_b32_e32 v11, s31
-; GFX6-NEXT:    s_lshr_b32 s30, s4, 30
-; GFX6-NEXT:    v_mov_b32_e32 v12, s34
-; GFX6-NEXT:    v_mov_b32_e32 v13, s35
-; GFX6-NEXT:    s_lshr_b32 s34, s4, 31
-; GFX6-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:464
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v14, s26
-; GFX6-NEXT:    v_mov_b32_e32 v15, s27
-; GFX6-NEXT:    s_lshr_b32 s26, s4, 28
-; GFX6-NEXT:    v_mov_b32_e32 v16, s28
-; GFX6-NEXT:    v_mov_b32_e32 v17, s29
-; GFX6-NEXT:    s_lshr_b32 s28, s4, 29
-; GFX6-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:448
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v6, s22
-; GFX6-NEXT:    v_mov_b32_e32 v7, s23
-; GFX6-NEXT:    s_lshr_b32 s22, s4, 26
-; GFX6-NEXT:    v_mov_b32_e32 v8, s24
-; GFX6-NEXT:    v_mov_b32_e32 v9, s25
-; GFX6-NEXT:    s_lshr_b32 s24, s4, 27
-; GFX6-NEXT:    s_bfe_i64 s[54:55], s[20:21], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[18:19], s[18:19], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:432
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v10, s18
-; GFX6-NEXT:    v_mov_b32_e32 v11, s19
-; GFX6-NEXT:    s_lshr_b32 s20, s4, 24
-; GFX6-NEXT:    v_mov_b32_e32 v12, s54
-; GFX6-NEXT:    v_mov_b32_e32 v13, s55
-; GFX6-NEXT:    s_lshr_b32 s18, s4, 25
-; GFX6-NEXT:    s_bfe_i64 s[16:17], s[16:17], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[14:15], s[14:15], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:416
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v14, s14
-; GFX6-NEXT:    v_mov_b32_e32 v15, s15
-; GFX6-NEXT:    s_lshr_b32 s14, s4, 22
-; GFX6-NEXT:    v_mov_b32_e32 v16, s16
-; GFX6-NEXT:    v_mov_b32_e32 v17, s17
-; GFX6-NEXT:    s_lshr_b32 s16, s4, 23
-; GFX6-NEXT:    s_bfe_i64 s[12:13], s[12:13], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[10:11], s[10:11], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:400
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v6, s10
-; GFX6-NEXT:    v_mov_b32_e32 v7, s11
-; GFX6-NEXT:    s_lshr_b32 s10, s4, 20
-; GFX6-NEXT:    v_mov_b32_e32 v8, s12
-; GFX6-NEXT:    v_mov_b32_e32 v9, s13
-; GFX6-NEXT:    s_lshr_b32 s12, s4, 21
-; GFX6-NEXT:    s_bfe_i64 s[8:9], s[8:9], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[6:7], s[6:7], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:384
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v10, s6
-; GFX6-NEXT:    v_mov_b32_e32 v11, s7
-; GFX6-NEXT:    s_lshr_b32 s6, s4, 18
-; GFX6-NEXT:    v_mov_b32_e32 v12, s8
-; GFX6-NEXT:    v_mov_b32_e32 v13, s9
-; GFX6-NEXT:    s_lshr_b32 s8, s4, 19
-; GFX6-NEXT:    s_bfe_i64 s[52:53], s[52:53], 0x10000
+; GFX6-NEXT:    s_lshr_b32 s54, s5, 1
+; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[50:51], s[50:51], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:368
-; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v12, s48
+; GFX6-NEXT:    v_mov_b32_e32 v13, s49
+; GFX6-NEXT:    s_lshr_b32 s48, s4, 30
 ; GFX6-NEXT:    v_mov_b32_e32 v14, s50
 ; GFX6-NEXT:    v_mov_b32_e32 v15, s51
-; GFX6-NEXT:    s_lshr_b32 s50, s4, 16
-; GFX6-NEXT:    v_mov_b32_e32 v16, s52
-; GFX6-NEXT:    v_mov_b32_e32 v17, s53
-; GFX6-NEXT:    s_lshr_b32 s52, s4, 17
-; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:352
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v6, s46
-; GFX6-NEXT:    v_mov_b32_e32 v7, s47
-; GFX6-NEXT:    s_lshr_b32 s46, s4, 14
-; GFX6-NEXT:    v_mov_b32_e32 v8, s48
-; GFX6-NEXT:    v_mov_b32_e32 v9, s49
-; GFX6-NEXT:    s_lshr_b32 s48, s4, 15
-; GFX6-NEXT:    s_bfe_i64 s[54:55], s[42:43], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[42:43], s[44:45], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:336
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v10, s42
-; GFX6-NEXT:    v_mov_b32_e32 v11, s43
-; GFX6-NEXT:    s_lshr_b32 s42, s4, 12
-; GFX6-NEXT:    v_mov_b32_e32 v12, s54
-; GFX6-NEXT:    v_mov_b32_e32 v13, s55
-; GFX6-NEXT:    s_lshr_b32 s44, s4, 13
-; GFX6-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:320
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v14, s40
-; GFX6-NEXT:    v_mov_b32_e32 v15, s41
-; GFX6-NEXT:    s_lshr_b32 s40, s4, 10
-; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
-; GFX6-NEXT:    v_mov_b32_e32 v16, s36
-; GFX6-NEXT:    v_mov_b32_e32 v17, s37
-; GFX6-NEXT:    s_lshr_b32 s36, s4, 11
-; GFX6-NEXT:    v_mov_b32_e32 v2, s38
-; GFX6-NEXT:    v_mov_b32_e32 v3, s39
-; GFX6-NEXT:    s_lshr_b32 s38, s4, 8
-; GFX6-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:304
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v6, s30
-; GFX6-NEXT:    v_mov_b32_e32 v7, s31
-; GFX6-NEXT:    s_lshr_b32 s30, s4, 9
-; GFX6-NEXT:    v_mov_b32_e32 v8, s34
-; GFX6-NEXT:    v_mov_b32_e32 v9, s35
-; GFX6-NEXT:    s_lshr_b32 s34, s4, 6
-; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:288
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v10, s26
-; GFX6-NEXT:    v_mov_b32_e32 v11, s27
-; GFX6-NEXT:    s_lshr_b32 s26, s4, 7
-; GFX6-NEXT:    v_mov_b32_e32 v12, s28
-; GFX6-NEXT:    v_mov_b32_e32 v13, s29
-; GFX6-NEXT:    s_lshr_b32 s28, s4, 4
-; GFX6-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:272
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v14, s22
-; GFX6-NEXT:    v_mov_b32_e32 v15, s23
-; GFX6-NEXT:    s_lshr_b32 s22, s4, 5
-; GFX6-NEXT:    v_mov_b32_e32 v16, s24
-; GFX6-NEXT:    v_mov_b32_e32 v17, s25
-; GFX6-NEXT:    s_lshr_b32 s24, s4, 2
-; GFX6-NEXT:    s_bfe_i64 s[20:21], s[20:21], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:256
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s20
-; GFX6-NEXT:    v_mov_b32_e32 v1, s21
-; GFX6-NEXT:    s_lshr_b32 s20, s4, 3
-; GFX6-NEXT:    s_lshr_b32 s4, s4, 1
-; GFX6-NEXT:    s_bfe_i64 s[4:5], s[4:5], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[20:21], s[20:21], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x10000
+; GFX6-NEXT:    s_lshr_b32 s50, s4, 31
 ; GFX6-NEXT:    s_bfe_i64 s[44:45], s[44:45], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[62:63], s[46:47], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v16, s44
+; GFX6-NEXT:    v_mov_b32_e32 v17, s45
+; GFX6-NEXT:    s_lshr_b32 s46, s4, 28
+; GFX6-NEXT:    v_mov_b32_e32 v18, s62
+; GFX6-NEXT:    v_mov_b32_e32 v19, s63
+; GFX6-NEXT:    s_lshr_b32 s44, s4, 29
+; GFX6-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[42:43], s[42:43], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[52:53], s[52:53], 0x10000
-; GFX6-NEXT:    s_bfe_i64 s[50:51], s[50:51], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v20, s40
+; GFX6-NEXT:    v_mov_b32_e32 v21, s41
+; GFX6-NEXT:    s_lshr_b32 s40, s4, 26
+; GFX6-NEXT:    v_mov_b32_e32 v22, s42
+; GFX6-NEXT:    v_mov_b32_e32 v23, s43
+; GFX6-NEXT:    s_lshr_b32 s42, s4, 27
+; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v5, s7
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:496
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v2, s36
+; GFX6-NEXT:    v_mov_b32_e32 v3, s37
+; GFX6-NEXT:    s_lshr_b32 s36, s4, 24
+; GFX6-NEXT:    v_mov_b32_e32 v4, s38
+; GFX6-NEXT:    v_mov_b32_e32 v5, s39
+; GFX6-NEXT:    s_lshr_b32 s38, s4, 25
+; GFX6-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:480
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v8, s30
+; GFX6-NEXT:    v_mov_b32_e32 v9, s31
+; GFX6-NEXT:    s_lshr_b32 s30, s4, 22
+; GFX6-NEXT:    v_mov_b32_e32 v10, s34
+; GFX6-NEXT:    v_mov_b32_e32 v11, s35
+; GFX6-NEXT:    s_lshr_b32 s34, s4, 23
+; GFX6-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:464
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v12, s26
+; GFX6-NEXT:    v_mov_b32_e32 v13, s27
+; GFX6-NEXT:    s_lshr_b32 s26, s4, 20
+; GFX6-NEXT:    v_mov_b32_e32 v14, s28
+; GFX6-NEXT:    v_mov_b32_e32 v15, s29
+; GFX6-NEXT:    s_lshr_b32 s28, s4, 21
+; GFX6-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:448
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v16, s22
+; GFX6-NEXT:    v_mov_b32_e32 v17, s23
+; GFX6-NEXT:    s_lshr_b32 s22, s4, 18
+; GFX6-NEXT:    v_mov_b32_e32 v18, s24
+; GFX6-NEXT:    v_mov_b32_e32 v19, s25
+; GFX6-NEXT:    s_lshr_b32 s24, s4, 19
+; GFX6-NEXT:    s_bfe_i64 s[20:21], s[20:21], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[18:19], s[18:19], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:432
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v20, s18
+; GFX6-NEXT:    v_mov_b32_e32 v21, s19
+; GFX6-NEXT:    s_lshr_b32 s18, s4, 16
+; GFX6-NEXT:    v_mov_b32_e32 v22, s20
+; GFX6-NEXT:    v_mov_b32_e32 v23, s21
+; GFX6-NEXT:    s_lshr_b32 s20, s4, 17
+; GFX6-NEXT:    s_bfe_i64 s[16:17], s[16:17], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[14:15], s[14:15], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:416
+; GFX6-NEXT:    v_mov_b32_e32 v24, s14
+; GFX6-NEXT:    v_mov_b32_e32 v25, s15
+; GFX6-NEXT:    s_lshr_b32 s14, s4, 14
+; GFX6-NEXT:    v_mov_b32_e32 v26, s16
+; GFX6-NEXT:    v_mov_b32_e32 v27, s17
+; GFX6-NEXT:    s_lshr_b32 s16, s4, 15
+; GFX6-NEXT:    s_bfe_i64 s[12:13], s[12:13], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[10:11], s[10:11], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:400
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v8, s10
+; GFX6-NEXT:    v_mov_b32_e32 v9, s11
+; GFX6-NEXT:    s_lshr_b32 s10, s4, 12
+; GFX6-NEXT:    v_mov_b32_e32 v10, s12
+; GFX6-NEXT:    v_mov_b32_e32 v11, s13
+; GFX6-NEXT:    s_lshr_b32 s12, s4, 13
 ; GFX6-NEXT:    s_bfe_i64 s[8:9], s[8:9], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[6:7], s[6:7], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:384
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v12, s6
+; GFX6-NEXT:    v_mov_b32_e32 v13, s7
+; GFX6-NEXT:    s_lshr_b32 s62, s4, 10
+; GFX6-NEXT:    v_mov_b32_e32 v14, s8
+; GFX6-NEXT:    v_mov_b32_e32 v15, s9
+; GFX6-NEXT:    s_lshr_b32 s8, s4, 11
+; GFX6-NEXT:    s_bfe_i64 s[6:7], s[60:61], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[56:57], s[56:57], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:368
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v16, s56
+; GFX6-NEXT:    v_mov_b32_e32 v17, s57
+; GFX6-NEXT:    s_lshr_b32 s56, s4, 8
+; GFX6-NEXT:    v_mov_b32_e32 v18, s6
+; GFX6-NEXT:    v_mov_b32_e32 v19, s7
+; GFX6-NEXT:    s_lshr_b32 s60, s4, 9
+; GFX6-NEXT:    s_bfe_i64 s[6:7], s[58:59], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:352
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v20, s6
+; GFX6-NEXT:    v_mov_b32_e32 v21, s7
+; GFX6-NEXT:    s_lshr_b32 s58, s4, 6
+; GFX6-NEXT:    s_bfe_i64 s[6:7], s[52:53], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[52:53], s[54:55], 0x10000
+; GFX6-NEXT:    v_mov_b32_e32 v22, s6
+; GFX6-NEXT:    v_mov_b32_e32 v23, s7
+; GFX6-NEXT:    s_lshr_b32 s54, s4, 7
+; GFX6-NEXT:    v_mov_b32_e32 v2, s52
+; GFX6-NEXT:    v_mov_b32_e32 v3, s53
+; GFX6-NEXT:    s_lshr_b32 s52, s4, 4
+; GFX6-NEXT:    s_bfe_i64 s[6:7], s[50:51], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:336
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v24, s48
+; GFX6-NEXT:    v_mov_b32_e32 v25, s49
+; GFX6-NEXT:    s_lshr_b32 s48, s4, 5
+; GFX6-NEXT:    v_mov_b32_e32 v26, s6
+; GFX6-NEXT:    v_mov_b32_e32 v27, s7
+; GFX6-NEXT:    s_lshr_b32 s50, s4, 2
+; GFX6-NEXT:    s_bfe_i64 s[6:7], s[46:47], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:320
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v8, s6
+; GFX6-NEXT:    v_mov_b32_e32 v9, s7
+; GFX6-NEXT:    s_lshr_b32 s6, s4, 3
+; GFX6-NEXT:    s_lshr_b32 s4, s4, 1
+; GFX6-NEXT:    s_bfe_i64 s[4:5], s[4:5], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[6:7], s[6:7], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[46:47], s[50:51], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[50:51], s[52:53], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[52:53], s[54:55], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[54:55], s[58:59], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[58:59], s[60:61], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[56:57], s[56:57], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[8:9], s[8:9], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[60:61], s[62:63], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[12:13], s[12:13], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[10:11], s[10:11], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[16:17], s[16:17], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[14:15], s[14:15], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[20:21], s[20:21], 0x10000
 ; GFX6-NEXT:    s_bfe_i64 s[18:19], s[18:19], 0x10000
-; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:240
-; GFX6-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:224
-; GFX6-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:208
-; GFX6-NEXT:    v_mov_b32_e32 v2, s18
-; GFX6-NEXT:    v_mov_b32_e32 v3, s19
+; GFX6-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[42:43], s[42:43], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x10000
+; GFX6-NEXT:    s_bfe_i64 s[44:45], s[44:45], 0x10000
+; GFX6-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:304
+; GFX6-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:288
+; GFX6-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:272
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:256
+; GFX6-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:240
+; GFX6-NEXT:    v_mov_b32_e32 v10, s44
+; GFX6-NEXT:    v_mov_b32_e32 v11, s45
+; GFX6-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:224
+; GFX6-NEXT:    s_waitcnt expcnt(2)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s40
+; GFX6-NEXT:    v_mov_b32_e32 v1, s41
+; GFX6-NEXT:    v_mov_b32_e32 v2, s42
+; GFX6-NEXT:    v_mov_b32_e32 v3, s43
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s36
+; GFX6-NEXT:    v_mov_b32_e32 v1, s37
+; GFX6-NEXT:    v_mov_b32_e32 v2, s38
+; GFX6-NEXT:    v_mov_b32_e32 v3, s39
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s30
+; GFX6-NEXT:    v_mov_b32_e32 v1, s31
+; GFX6-NEXT:    v_mov_b32_e32 v2, s34
+; GFX6-NEXT:    v_mov_b32_e32 v3, s35
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:176
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s26
+; GFX6-NEXT:    v_mov_b32_e32 v1, s27
+; GFX6-NEXT:    v_mov_b32_e32 v2, s28
+; GFX6-NEXT:    v_mov_b32_e32 v3, s29
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:160
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s22
+; GFX6-NEXT:    v_mov_b32_e32 v1, s23
+; GFX6-NEXT:    v_mov_b32_e32 v2, s24
+; GFX6-NEXT:    v_mov_b32_e32 v3, s25
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:144
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s18
+; GFX6-NEXT:    v_mov_b32_e32 v1, s19
+; GFX6-NEXT:    v_mov_b32_e32 v2, s20
+; GFX6-NEXT:    v_mov_b32_e32 v3, s21
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:128
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s14
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s15
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s16
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s17
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:176
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:112
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s10
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s11
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s13
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:160
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:96
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s6
-; GFX6-NEXT:    v_mov_b32_e32 v1, s7
+; GFX6-NEXT:    v_mov_b32_e32 v0, s60
+; GFX6-NEXT:    v_mov_b32_e32 v1, s61
 ; GFX6-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX6-NEXT:    v_mov_b32_e32 v3, s9
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:144
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s56
+; GFX6-NEXT:    v_mov_b32_e32 v1, s57
+; GFX6-NEXT:    v_mov_b32_e32 v2, s58
+; GFX6-NEXT:    v_mov_b32_e32 v3, s59
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:64
+; GFX6-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NEXT:    v_mov_b32_e32 v0, s54
+; GFX6-NEXT:    v_mov_b32_e32 v1, s55
+; GFX6-NEXT:    v_mov_b32_e32 v2, s52
+; GFX6-NEXT:    v_mov_b32_e32 v3, s53
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s50
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s51
-; GFX6-NEXT:    v_mov_b32_e32 v2, s52
-; GFX6-NEXT:    v_mov_b32_e32 v3, s53
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:128
+; GFX6-NEXT:    v_mov_b32_e32 v2, s48
+; GFX6-NEXT:    v_mov_b32_e32 v3, s49
+; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:32
 ; GFX6-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s46
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s47
-; GFX6-NEXT:    v_mov_b32_e32 v2, s48
-; GFX6-NEXT:    v_mov_b32_e32 v3, s49
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:112
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s42
-; GFX6-NEXT:    v_mov_b32_e32 v1, s43
-; GFX6-NEXT:    v_mov_b32_e32 v2, s44
-; GFX6-NEXT:    v_mov_b32_e32 v3, s45
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:96
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s40
-; GFX6-NEXT:    v_mov_b32_e32 v1, s41
-; GFX6-NEXT:    v_mov_b32_e32 v2, s36
-; GFX6-NEXT:    v_mov_b32_e32 v3, s37
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s38
-; GFX6-NEXT:    v_mov_b32_e32 v1, s39
-; GFX6-NEXT:    v_mov_b32_e32 v2, s30
-; GFX6-NEXT:    v_mov_b32_e32 v3, s31
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:64
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s34
-; GFX6-NEXT:    v_mov_b32_e32 v1, s35
-; GFX6-NEXT:    v_mov_b32_e32 v2, s26
-; GFX6-NEXT:    v_mov_b32_e32 v3, s27
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s28
-; GFX6-NEXT:    v_mov_b32_e32 v1, s29
-; GFX6-NEXT:    v_mov_b32_e32 v2, s22
-; GFX6-NEXT:    v_mov_b32_e32 v3, s23
-; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:32
-; GFX6-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NEXT:    v_mov_b32_e32 v0, s24
-; GFX6-NEXT:    v_mov_b32_e32 v1, s25
-; GFX6-NEXT:    v_mov_b32_e32 v2, s20
-; GFX6-NEXT:    v_mov_b32_e32 v3, s21
+; GFX6-NEXT:    v_mov_b32_e32 v2, s6
+; GFX6-NEXT:    v_mov_b32_e32 v3, s7
 ; GFX6-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:16
-; GFX6-NEXT:    v_mov_b32_e32 v6, s4
-; GFX6-NEXT:    v_mov_b32_e32 v7, s5
-; GFX6-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0
+; GFX6-NEXT:    v_mov_b32_e32 v8, s4
+; GFX6-NEXT:    v_mov_b32_e32 v9, s5
+; GFX6-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0
 ; GFX6-NEXT:    s_endpgm
 ;
 ; GFX8-LABEL: constant_sextload_v64i1_to_v64i64:

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
@@ -2978,20 +2978,20 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s38, s2, 16
 ; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s41, s5, 16
 ; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s42, s4, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s45, s7, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s46, s6, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s47, s9, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s48, s8, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s49, s11, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s50, s10, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s51, s13, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s52, s12, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s53, s15, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s54, s14, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s43, s7, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s44, s6, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s45, s9, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s46, s8, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s47, s11, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s48, s10, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s49, s13, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s50, s12, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s51, s15, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s52, s14, 16
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s39, s1, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s40, s0, 0xffff
-; GCN-NOHSA-SI-NEXT:    s_and_b32 s43, s3, 0xffff
-; GCN-NOHSA-SI-NEXT:    s_and_b32 s44, s2, 0xffff
+; GCN-NOHSA-SI-NEXT:    s_and_b32 s53, s3, 0xffff
+; GCN-NOHSA-SI-NEXT:    s_and_b32 s54, s2, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s5, s5, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s4, s4, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s7, s7, 0xffff
@@ -3027,6 +3027,7 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s21, s21, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s20, s20, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s23, s23, 0xffff
+; GCN-NOHSA-SI-NEXT:    s_and_b32 s22, s22, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s25, s25, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s24, s24, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s27, s27, 0xffff
@@ -3035,7 +3036,6 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s31, s31, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s30, s30, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_and_b32 s26, s26, 0xffff
-; GCN-NOHSA-SI-NEXT:    s_and_b32 s22, s22, 0xffff
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s0, s36
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s1, s37
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s3, 0xf000
@@ -3048,19 +3048,21 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, s68
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, s29
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, s67
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, s26
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, s66
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v10, s27
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, s65
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v12, s24
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, s64
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v14, s25
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:224
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:208
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v15, s63
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:192
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(3)
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(1)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s26
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s66
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s27
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s65
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s24
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s64
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s25
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s63
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s22
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s62
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s23
@@ -3086,33 +3088,33 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:128
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s14
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s54
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s52
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s15
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s53
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s51
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:112
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s12
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s52
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s50
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s13
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s51
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s49
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:96
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s10
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s50
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s48
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s11
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s49
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s47
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s8
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s48
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s46
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s9
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s47
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s45
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:64
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s6
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s46
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s44
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s7
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s45
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s43
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s4
@@ -3121,9 +3123,9 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s41
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:32
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s44
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s54
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s38
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s43
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s53
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s35
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:16
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
@@ -3222,32 +3224,25 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v29, s1
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v28, s0
-; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0xb0
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v31, s1
-; GCN-HSA-NEXT:    v_mov_b32_e32 v30, s0
-; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0xa0
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v33, s1
-; GCN-HSA-NEXT:    v_mov_b32_e32 v32, s0
-; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x90
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s12
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s64
-; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s13
-; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s63
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v25, s1
-; GCN-HSA-NEXT:    v_mov_b32_e32 v24, s0
-; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x80
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v35, s1
-; GCN-HSA-NEXT:    v_mov_b32_e32 v34, s0
-; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x70
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s14
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s66
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s15
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s65
+; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0xb0
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s12
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s1
+; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0xa0
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s1
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s0
+; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x90
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s64
+; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s13
+; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s63
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s10
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s62
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v10, s11
@@ -3259,31 +3254,38 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v16, s6
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s58
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v18, s7
-; GCN-HSA-NEXT:    v_mov_b32_e32 v19, s57
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s68
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s19
-; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s67
-; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s18
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s4
+; GCN-HSA-NEXT:    v_mov_b32_e32 v19, s57
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s56
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v22, s5
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v23, s55
-; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s54
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s3
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[12:15]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[16:19]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[2:3], v[20:23]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s1
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s0
+; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x80
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s54
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s3
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s53
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[16:19]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[20:23]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[4:7]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s52
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s1
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s0
+; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x70
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s68
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s19
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s67
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s18
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s1
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s0
 ; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x60
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s52
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s47
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s51
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s45
@@ -3813,8 +3815,9 @@ define amdgpu_kernel void @constant_sextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    s_ashr_i32 s62, s6, 16
 ; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s7, s7
 ; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s6, s6
-; GCN-NOHSA-SI-NEXT:    s_ashr_i32 s63, s8, 16
-; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s64, s9
+; GCN-NOHSA-SI-NEXT:    s_ashr_i32 s63, s9, 16
+; GCN-NOHSA-SI-NEXT:    s_ashr_i32 s64, s8, 16
+; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s9, s9
 ; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s8, s8
 ; GCN-NOHSA-SI-NEXT:    s_ashr_i32 s65, s11, 16
 ; GCN-NOHSA-SI-NEXT:    s_ashr_i32 s66, s10, 16
@@ -3828,7 +3831,6 @@ define amdgpu_kernel void @constant_sextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s15, s15
 ; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s14, s14
 ; GCN-NOHSA-SI-NEXT:    s_sext_i32_i16 s10, s10
-; GCN-NOHSA-SI-NEXT:    s_ashr_i32 s9, s9, 16
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s0, s36
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s1, s37
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s3, 0xf000
@@ -3841,19 +3843,21 @@ define amdgpu_kernel void @constant_sextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, s68
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, s13
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, s67
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, s10
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, s66
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v10, s11
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, s65
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v12, s8
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, s63
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v14, s64
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:224
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:208
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v15, s9
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:192
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(3)
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(1)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s10
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s66
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s11
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s65
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s64
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s9
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s63
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s6
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s62
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s7
@@ -3999,48 +4003,39 @@ define amdgpu_kernel void @constant_sextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v26, s0
 ; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0xc0
 ; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
+; GCN-HSA-NEXT:    s_sext_i32_i16 s15, s15
+; GCN-HSA-NEXT:    s_sext_i32_i16 s14, s14
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v29, s1
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v28, s0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s14
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s68
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s15
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s67
 ; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0xb0
 ; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v31, s1
-; GCN-HSA-NEXT:    v_mov_b32_e32 v30, s0
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
+; GCN-HSA-NEXT:    s_sext_i32_i16 s13, s13
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s1
 ; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0xa0
 ; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v33, s1
-; GCN-HSA-NEXT:    s_sext_i32_i16 s13, s13
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s1
 ; GCN-HSA-NEXT:    s_sext_i32_i16 s12, s12
-; GCN-HSA-NEXT:    v_mov_b32_e32 v32, s0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s0
 ; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x90
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s12
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s66
-; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s13
-; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s65
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v25, s1
-; GCN-HSA-NEXT:    v_mov_b32_e32 v24, s0
-; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x80
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v35, s1
+; GCN-HSA-NEXT:    s_sext_i32_i16 s5, s5
+; GCN-HSA-NEXT:    s_sext_i32_i16 s4, s4
 ; GCN-HSA-NEXT:    s_sext_i32_i16 s7, s7
 ; GCN-HSA-NEXT:    s_sext_i32_i16 s6, s6
 ; GCN-HSA-NEXT:    s_sext_i32_i16 s9, s9
 ; GCN-HSA-NEXT:    s_sext_i32_i16 s8, s8
 ; GCN-HSA-NEXT:    s_sext_i32_i16 s11, s11
 ; GCN-HSA-NEXT:    s_sext_i32_i16 s10, s10
-; GCN-HSA-NEXT:    s_sext_i32_i16 s15, s15
-; GCN-HSA-NEXT:    s_sext_i32_i16 s14, s14
-; GCN-HSA-NEXT:    v_mov_b32_e32 v34, s0
-; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x70
-; GCN-HSA-NEXT:    s_sext_i32_i16 s3, s3
-; GCN-HSA-NEXT:    s_sext_i32_i16 s2, s2
-; GCN-HSA-NEXT:    s_sext_i32_i16 s5, s5
-; GCN-HSA-NEXT:    s_sext_i32_i16 s4, s4
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s14
-; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s68
-; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s15
-; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s67
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s12
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s66
+; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s13
+; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s65
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s10
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s64
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v10, s11
@@ -4052,31 +4047,40 @@ define amdgpu_kernel void @constant_sextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v16, s6
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s60
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v18, s7
-; GCN-HSA-NEXT:    v_mov_b32_e32 v19, s59
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s54
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s19
-; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s53
-; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s18
-; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s4
+; GCN-HSA-NEXT:    v_mov_b32_e32 v19, s59
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s58
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v22, s5
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v23, s57
-; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s56
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s3
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[12:15]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[16:19]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[2:3], v[20:23]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s1
+; GCN-HSA-NEXT:    s_sext_i32_i16 s3, s3
+; GCN-HSA-NEXT:    s_sext_i32_i16 s2, s2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s0
+; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x80
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s56
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s3
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s55
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[16:19]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[20:23]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[4:7]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s52
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s1
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s0
+; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x70
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s54
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s19
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s53
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s18
+; GCN-HSA-NEXT:    s_addc_u32 s1, s17, 0
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s1
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s0
 ; GCN-HSA-NEXT:    s_add_u32 s0, s16, 0x60
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s52
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s50
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s51
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s49
@@ -6917,146 +6921,146 @@ define amdgpu_kernel void @constant_sextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NOHSA-SI-NEXT:    s_load_dwordx16 s[0:15], s[18:19], 0x0
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s18, s15
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s20, s13
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s22, s11
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s30, s9
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s28, s7
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s36, s5
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s40, s3
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s44, s1
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s24, s14, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s26, s12, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s34, s10, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s38, s8, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s42, s6, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s46, s4, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s48, s2, 16
-; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s52, s0, 16
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[62:63], s[20:21], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[64:65], s[18:19], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[66:67], s[30:31], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[68:69], s[22:23], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s26, s15
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s28, s13
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s30, s11
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s38, s9
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s40, s7
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s42, s5
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s44, s3
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s46, s1
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s48, s14, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s50, s12, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s52, s10, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s54, s8, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s56, s6, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s58, s4, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s60, s2, 16
+; GCN-NOHSA-SI-NEXT:    s_lshr_b32 s62, s0, 16
 ; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[18:19], s[0:1], 0x100000
 ; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[20:21], s[2:3], 0x100000
 ; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[22:23], s[4:5], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[30:31], s[6:7], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[50:51], s[8:9], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[54:55], s[10:11], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[56:57], s[12:13], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[58:59], s[14:15], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[60:61], s[0:1], 48
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[24:25], s[6:7], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[64:65], s[28:29], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[66:67], s[26:27], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[26:27], s[8:9], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[28:29], s[10:11], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[34:35], s[12:13], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[36:37], s[14:15], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[68:69], s[0:1], 48
 ; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[70:71], s[2:3], 48
 ; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[72:73], s[4:5], 48
-; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[2:3], s[8:9], 48
-; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[4:5], s[12:13], 48
-; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[8:9], s[14:15], 48
-; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[10:11], s[10:11], 48
 ; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[74:75], s[6:7], 48
+; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[76:77], s[8:9], 48
+; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[2:3], s[12:13], 48
+; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[4:5], s[14:15], 48
+; GCN-NOHSA-SI-NEXT:    s_ashr_i64 s[78:79], s[10:11], 48
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s0, s16
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s1, s17
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s64
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s65
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s8
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s9
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v4, s62
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, s63
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, s4
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, s5
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, s68
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, s69
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v10, s10
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, s11
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v12, s66
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, s67
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v14, s2
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v15, s3
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s66
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s67
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s4
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s5
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v4, s64
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, s65
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, s2
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, s3
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s3, 0xf000
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s2, -1
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x100000
 ; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[44:45], s[44:45], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[42:43], s[42:43], 0x100000
 ; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[4:5], s[52:53], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[6:7], s[48:49], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[8:9], s[46:47], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[10:11], s[42:43], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[12:13], s[38:39], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[14:15], s[34:35], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[16:17], s[26:27], 0x100000
-; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[64:65], s[30:31], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[4:5], s[62:63], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[6:7], s[60:61], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[8:9], s[58:59], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[10:11], s[56:57], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[12:13], s[54:55], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[14:15], s[52:53], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[16:17], s[50:51], 0x100000
+; GCN-NOHSA-SI-NEXT:    s_bfe_i64 s[30:31], s[48:49], 0x100000
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:208
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:176
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:144
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(3)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s28
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s29
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(1)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s64
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s65
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s78
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s79
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:176
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s38
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s39
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s76
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s77
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:144
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s40
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s41
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s74
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s75
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:112
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s36
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s37
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s42
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s43
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s72
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s73
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s40
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s41
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s44
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s45
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s70
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s71
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s44
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s45
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s60
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s61
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s46
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s47
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s68
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s69
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:16
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s58
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s59
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v4, s56
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, s57
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, s54
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, s55
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v12, s50
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, s51
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v16, s30
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v17, s31
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s24
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s25
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s36
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s37
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v4, s34
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, s35
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, s28
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, s29
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v12, s26
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, s27
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v16, s24
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v17, s25
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v20, s22
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v21, s23
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v24, s20
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v25, s21
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s30
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s31
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:224
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s22
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s23
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v0, s18
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, s19
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, s16
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, s17
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:192
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v4, s20
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, s21
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v10, s14
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, s15
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:160
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, s18
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, s19
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v14, s12
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v15, s13
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:128
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v18, s10
 ; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v19, s11
 ; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:96
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s8
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s9
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:64
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, s6
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, s7
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:32
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v10, s4
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, s5
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v22, s8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v23, s9
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:64
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v26, s6
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v27, s7
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:32
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v2, s4
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, s5
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
 ; GCN-NOHSA-SI-NEXT:    s_endpgm
 ;
 ; GCN-HSA-LABEL: constant_sextload_v32i16_to_v32i64:
@@ -7130,61 +7134,63 @@ define amdgpu_kernel void @constant_sextload_v32i16_to_v32i64(ptr addrspace(1) %
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v26, s48
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v27, s49
 ; GCN-HSA-NEXT:    s_add_u32 s48, s16, 0x90
+; GCN-HSA-NEXT:    v_mov_b32_e32 v22, s58
 ; GCN-HSA-NEXT:    s_addc_u32 s49, s17, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v23, s59
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v18, s44
 ; GCN-HSA-NEXT:    s_add_u32 s44, s16, 0x70
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v19, s45
 ; GCN-HSA-NEXT:    s_addc_u32 s45, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v30, s44
-; GCN-HSA-NEXT:    v_mov_b32_e32 v22, s58
-; GCN-HSA-NEXT:    v_mov_b32_e32 v31, s45
-; GCN-HSA-NEXT:    s_add_u32 s44, s16, 0x50
-; GCN-HSA-NEXT:    v_mov_b32_e32 v23, s59
-; GCN-HSA-NEXT:    s_addc_u32 s45, s17, 0
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s80
-; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s38
-; GCN-HSA-NEXT:    s_add_u32 s38, s16, 48
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s44
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s45
+; GCN-HSA-NEXT:    s_add_u32 s44, s16, 0x50
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s81
-; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s39
-; GCN-HSA-NEXT:    s_addc_u32 s39, s17, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v28, s48
+; GCN-HSA-NEXT:    s_addc_u32 s45, s17, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s44
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s50
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s51
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v10, s78
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v11, s79
-; GCN-HSA-NEXT:    v_mov_b32_e32 v28, s48
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v12, s52
-; GCN-HSA-NEXT:    v_mov_b32_e32 v6, s36
-; GCN-HSA-NEXT:    s_add_u32 s36, s16, 16
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v13, s53
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v14, s76
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v15, s77
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v29, s49
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v16, s54
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s55
-; GCN-HSA-NEXT:    v_mov_b32_e32 v32, s44
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v7, s37
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s38
-; GCN-HSA-NEXT:    s_addc_u32 s37, s17, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v10, s36
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s56
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s57
-; GCN-HSA-NEXT:    v_mov_b32_e32 v33, s45
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s45
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v22, s40
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v23, s41
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[12:15]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[16:19]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[2:3], v[20:23]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s38
+; GCN-HSA-NEXT:    s_add_u32 s38, s16, 48
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s39
+; GCN-HSA-NEXT:    s_addc_u32 s39, s17, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s38
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s46
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s47
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s42
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s43
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s39
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[12:15]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v11, s37
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[16:19]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[20:23]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[0:3]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[10:11], v[4:7]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s39
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GCN-HSA-NEXT:    s_nop 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s36
+; GCN-HSA-NEXT:    s_add_u32 s36, s16, 16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s37
+; GCN-HSA-NEXT:    s_addc_u32 s37, s17, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s36
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s42
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s43
+; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s37
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GCN-HSA-NEXT:    s_nop 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v2, s14
 ; GCN-HSA-NEXT:    s_add_u32 s14, s16, 0xe0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v3, s15

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i32.ll
@@ -3112,27 +3112,26 @@ define amdgpu_kernel void @constant_sextload_v32i32_to_v32i64(ptr addrspace(1) %
 ; GFX6-NOHSA-NEXT:    s_ashr_i32 s42, s4, 31
 ; GFX6-NOHSA-NEXT:    s_ashr_i32 s43, s7, 31
 ; GFX6-NOHSA-NEXT:    s_ashr_i32 s44, s6, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s45, s17, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s46, s16, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s47, s19, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s48, s18, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s49, s21, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s50, s20, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s51, s23, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s52, s30, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s53, s31, 31
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s52
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s52, s28, 31
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s53
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s53, s29, 31
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s52
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s52, s26, 31
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s53
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s53, s27, 31
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s52
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s52, s22, 31
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s53
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s53, s25, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s45, s9, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s46, s8, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s47, s11, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s48, s17, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s49, s16, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s50, s19, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s51, s18, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s52, s21, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s53, s20, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s54, s23, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s55, s22, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s56, s25, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s57, s24, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s58, s27, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s59, s30, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s60, s31, 31
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s59
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s59, s26, 31
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s60
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s60, s29, 31
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s30
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s31
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s28
@@ -3143,90 +3142,89 @@ define amdgpu_kernel void @constant_sextload_v32i32_to_v32i64(ptr addrspace(1) %
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s25
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s22
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v18, s23
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v20, s20
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v22, s21
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v24, s18
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v26, s19
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[36:39], 0 offset:240
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s20
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s21
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s16
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s17
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s16, s28, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s17, s10, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s18, s13, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s19, s12, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s20, s15, 31
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s21, s14, 31
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s16
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s60
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[36:39], 0 offset:224
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s18
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s19
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s14
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s15
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s59
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s58
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[36:39], 0 offset:208
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s16
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s17
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s16, s24, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s17, s9, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s18, s8, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s19, s11, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s20, s10, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s21, s13, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s22, s12, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s23, s15, 31
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s24, s14, 31
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s16
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s53
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s12
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s13
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s57
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s56
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[36:39], 0 offset:192
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s14
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s15
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s52
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v19, s51
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s10
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s11
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s55
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v19, s54
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[36:39], 0 offset:176
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s12
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v18, s13
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s50
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s49
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[36:39], 0 offset:160
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s8
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v18, s9
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v21, s53
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v23, s52
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[20:23], off, s[36:39], 0 offset:160
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s10
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s11
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s48
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s47
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[36:39], 0 offset:144
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v20, s6
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v22, s7
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v25, s51
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v27, s50
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[24:27], off, s[36:39], 0 offset:144
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s8
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s9
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s46
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s45
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[36:39], 0 offset:128
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v24, s4
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v26, s5
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s49
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s48
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[36:39], 0 offset:128
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s6
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s7
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s24
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s23
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[36:39], 0 offset:112
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s2
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s3
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s21
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s20
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[36:39], 0 offset:112
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s4
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s5
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s22
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v19, s21
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[36:39], 0 offset:96
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s2
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v18, s3
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s20
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s19
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[36:39], 0 offset:80
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s0
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s1
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s18
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s17
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[36:39], 0 offset:64
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s44
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s43
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[36:39], 0 offset:48
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s42
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s41
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[36:39], 0 offset:32
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s40
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v19, s35
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[36:39], 0 offset:16
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s34
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s33
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[36:39], 0
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s0
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s1
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s19
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s18
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[36:39], 0 offset:96
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s17
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s47
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[36:39], 0 offset:80
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s46
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v19, s45
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[36:39], 0 offset:64
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v21, s44
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v23, s43
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[20:23], off, s[36:39], 0 offset:48
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v25, s42
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v27, s41
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[24:27], off, s[36:39], 0 offset:32
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s40
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s35
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[36:39], 0 offset:16
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s34
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s33
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[36:39], 0
 ; GFX6-NOHSA-NEXT:    s_endpgm
 ;
 ; GFX7-HSA-LABEL: constant_sextload_v32i32_to_v32i64:

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i8.ll
@@ -2808,33 +2808,33 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    s_lshr_b32 s22, s2, 24
 ; GFX6-NOHSA-NEXT:    s_bfe_u32 s23, s2, 0x80008
 ; GFX6-NOHSA-NEXT:    s_lshr_b32 s24, s3, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s26, s3, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s27, s4, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s28, s4, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s29, s5, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s30, s5, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s31, s6, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s33, s6, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s34, s7, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s35, s7, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s36, s8, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s37, s8, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s38, s9, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s39, s9, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s40, s10, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s41, s10, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s42, s11, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s43, s11, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s44, s12, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s45, s12, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s46, s13, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s47, s13, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s48, s14, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s49, s14, 0x80008
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s50, s15, 24
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s51, s15, 0x80008
-; GFX6-NOHSA-NEXT:    s_and_b32 s52, s0, 0xff
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s25, s0, 0x80010
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s25, s3, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s26, s4, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s27, s4, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s28, s5, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s29, s5, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s30, s6, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s31, s6, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s33, s7, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s34, s7, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s35, s8, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s36, s8, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s37, s9, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s38, s9, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s39, s10, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s40, s10, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s41, s11, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s42, s11, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s43, s12, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s44, s12, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s45, s13, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s46, s13, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s47, s14, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s48, s14, 0x80008
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s49, s15, 24
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s50, s15, 0x80008
+; GFX6-NOHSA-NEXT:    s_and_b32 s51, s0, 0xff
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s52, s0, 0x80010
 ; GFX6-NOHSA-NEXT:    s_and_b32 s53, s1, 0xff
 ; GFX6-NOHSA-NEXT:    s_bfe_u32 s54, s1, 0x80010
 ; GFX6-NOHSA-NEXT:    s_and_b32 s55, s2, 0xff
@@ -2856,6 +2856,7 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    s_and_b32 s65, s10, 0xff
 ; GFX6-NOHSA-NEXT:    s_bfe_u32 s10, s10, 0x80010
 ; GFX6-NOHSA-NEXT:    s_and_b32 s66, s11, 0xff
+; GFX6-NOHSA-NEXT:    s_bfe_u32 s11, s11, 0x80010
 ; GFX6-NOHSA-NEXT:    s_and_b32 s67, s12, 0xff
 ; GFX6-NOHSA-NEXT:    s_bfe_u32 s12, s12, 0x80010
 ; GFX6-NOHSA-NEXT:    s_and_b32 s68, s13, 0xff
@@ -2864,82 +2865,83 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    s_and_b32 s70, s15, 0xff
 ; GFX6-NOHSA-NEXT:    s_bfe_u32 s15, s15, 0x80010
 ; GFX6-NOHSA-NEXT:    s_bfe_u32 s13, s13, 0x80010
-; GFX6-NOHSA-NEXT:    s_bfe_u32 s11, s11, 0x80010
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s0, s16
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s1, s17
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s3, 0xf000
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s2, -1
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s70
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s51
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s50
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s15
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s50
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s49
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s69
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s49
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s48
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s14
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s48
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s68
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s47
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s13
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s46
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s67
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s45
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s12
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s47
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:224
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:208
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s44
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:192
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(3)
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(1)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s68
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s46
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s13
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s45
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s67
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s44
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s12
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s43
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s66
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s43
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s42
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s11
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s42
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s41
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:176
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s65
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s41
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s40
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s10
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s40
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s39
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:160
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s64
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s39
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s38
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s9
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s38
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s37
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:144
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s63
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s37
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s36
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s8
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s36
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s35
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:128
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s62
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s35
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s34
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s7
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s34
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s33
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:112
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s61
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s33
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s31
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s6
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s31
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s30
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:96
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s60
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s30
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s29
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s5
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s29
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s28
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s59
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s28
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s27
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s4
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s27
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s26
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:64
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s57
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s26
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s25
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s58
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s24
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
@@ -2956,9 +2958,9 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s20
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:16
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s52
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s51
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s19
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s25
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s52
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s18
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
 ; GFX6-NOHSA-NEXT:    s_endpgm
@@ -2985,22 +2987,22 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_bfe_u32 s36, s6, 0x80008
 ; GFX7-HSA-NEXT:    s_lshr_b32 s38, s7, 24
 ; GFX7-HSA-NEXT:    s_bfe_u32 s39, s7, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s41, s8, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s42, s8, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s43, s9, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s44, s9, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s45, s10, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s46, s10, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s47, s11, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s48, s11, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s49, s12, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s50, s12, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s51, s13, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s52, s13, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s53, s14, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s54, s14, 0x80008
-; GFX7-HSA-NEXT:    s_lshr_b32 s55, s15, 24
-; GFX7-HSA-NEXT:    s_bfe_u32 s56, s15, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s40, s8, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s41, s8, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s42, s9, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s43, s9, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s44, s10, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s45, s10, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s46, s11, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s47, s11, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s48, s12, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s49, s12, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s50, s13, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s51, s13, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s52, s14, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s53, s14, 0x80008
+; GFX7-HSA-NEXT:    s_lshr_b32 s54, s15, 24
+; GFX7-HSA-NEXT:    s_bfe_u32 s55, s15, 0x80008
 ; GFX7-HSA-NEXT:    s_and_b32 s24, s0, 0xff
 ; GFX7-HSA-NEXT:    s_bfe_u32 s0, s0, 0x80010
 ; GFX7-HSA-NEXT:    s_and_b32 s27, s1, 0xff
@@ -3011,7 +3013,7 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_bfe_u32 s3, s3, 0x80010
 ; GFX7-HSA-NEXT:    s_and_b32 s37, s4, 0xff
 ; GFX7-HSA-NEXT:    s_bfe_u32 s4, s4, 0x80010
-; GFX7-HSA-NEXT:    s_and_b32 s40, s5, 0xff
+; GFX7-HSA-NEXT:    s_and_b32 s56, s5, 0xff
 ; GFX7-HSA-NEXT:    s_bfe_u32 s5, s5, 0x80010
 ; GFX7-HSA-NEXT:    s_and_b32 s57, s6, 0xff
 ; GFX7-HSA-NEXT:    s_bfe_u32 s58, s6, 0x80010
@@ -3049,63 +3051,63 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v29, s7
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v28, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s68
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s55
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s15
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s54
 ; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xb0
 ; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v31, s7
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v30, s6
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s67
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xa0
 ; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v33, s7
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v32, s6
-; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x90
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s67
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s54
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s53
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v6, s14
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v7, s53
-; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v25, s7
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v24, s6
-; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x80
-; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v35, s7
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s68
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s56
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s15
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s55
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v7, s52
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x90
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v8, s66
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v9, s52
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v9, s51
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v10, s13
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v11, s51
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v11, s50
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v12, s65
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v13, s50
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v13, s49
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v14, s12
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v15, s49
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v15, s48
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v16, s64
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v17, s48
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v17, s47
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v18, s11
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v19, s47
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v34, s6
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s61
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s42
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v6, s8
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v7, s41
-; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x70
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v20, s63
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v21, s46
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v19, s46
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v21, s45
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v22, s10
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s62
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v23, s45
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s44
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v23, s44
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s9
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[12:15]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s43
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[16:19]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[20:23]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[4:7]
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[16:19]
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[2:3], v[20:23]
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s62
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s43
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s9
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s42
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x80
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s61
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s41
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s8
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s40
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x70
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s59
@@ -3126,7 +3128,7 @@ define amdgpu_kernel void @constant_zextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s40
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s56
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s33
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s31
@@ -3626,9 +3628,10 @@ define amdgpu_kernel void @constant_sextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    s_bfe_i32 s57, s11, 0x80010
 ; GFX6-NOHSA-NEXT:    s_bfe_i32 s58, s11, 0x80008
 ; GFX6-NOHSA-NEXT:    s_sext_i32_i8 s11, s11
-; GFX6-NOHSA-NEXT:    s_bfe_i32 s59, s12, 0x80010
-; GFX6-NOHSA-NEXT:    s_bfe_i32 s60, s12, 0x80008
-; GFX6-NOHSA-NEXT:    s_sext_i32_i8 s61, s12
+; GFX6-NOHSA-NEXT:    s_ashr_i32 s59, s12, 24
+; GFX6-NOHSA-NEXT:    s_bfe_i32 s60, s12, 0x80010
+; GFX6-NOHSA-NEXT:    s_bfe_i32 s61, s12, 0x80008
+; GFX6-NOHSA-NEXT:    s_sext_i32_i8 s12, s12
 ; GFX6-NOHSA-NEXT:    s_ashr_i32 s62, s13, 24
 ; GFX6-NOHSA-NEXT:    s_bfe_i32 s63, s13, 0x80010
 ; GFX6-NOHSA-NEXT:    s_bfe_i32 s64, s13, 0x80008
@@ -3641,7 +3644,6 @@ define amdgpu_kernel void @constant_sextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    s_bfe_i32 s70, s15, 0x80008
 ; GFX6-NOHSA-NEXT:    s_sext_i32_i8 s15, s15
 ; GFX6-NOHSA-NEXT:    s_sext_i32_i8 s13, s13
-; GFX6-NOHSA-NEXT:    s_ashr_i32 s12, s12, 24
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s0, s16
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s1, s17
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s3, 0xf000
@@ -3654,19 +3656,21 @@ define amdgpu_kernel void @constant_sextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s67
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s66
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s65
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s13
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s64
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s63
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s62
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s61
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s60
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s59
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:224
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:208
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s12
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:192
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(3)
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(1)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s13
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s64
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s63
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s62
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s12
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s61
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s60
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s59
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s11
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s58
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s57
@@ -3767,15 +3771,15 @@ define amdgpu_kernel void @constant_sextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_ashr_i32 s37, s6, 24
 ; GFX7-HSA-NEXT:    s_bfe_i32 s38, s6, 0x80010
 ; GFX7-HSA-NEXT:    s_bfe_i32 s39, s6, 0x80008
-; GFX7-HSA-NEXT:    s_ashr_i32 s40, s7, 24
-; GFX7-HSA-NEXT:    s_bfe_i32 s41, s7, 0x80010
-; GFX7-HSA-NEXT:    s_bfe_i32 s42, s7, 0x80008
-; GFX7-HSA-NEXT:    s_ashr_i32 s43, s8, 24
-; GFX7-HSA-NEXT:    s_bfe_i32 s44, s8, 0x80010
-; GFX7-HSA-NEXT:    s_bfe_i32 s45, s8, 0x80008
-; GFX7-HSA-NEXT:    s_ashr_i32 s47, s9, 24
-; GFX7-HSA-NEXT:    s_bfe_i32 s48, s9, 0x80010
-; GFX7-HSA-NEXT:    s_bfe_i32 s49, s9, 0x80008
+; GFX7-HSA-NEXT:    s_ashr_i32 s41, s7, 24
+; GFX7-HSA-NEXT:    s_bfe_i32 s42, s7, 0x80010
+; GFX7-HSA-NEXT:    s_bfe_i32 s43, s7, 0x80008
+; GFX7-HSA-NEXT:    s_ashr_i32 s45, s8, 24
+; GFX7-HSA-NEXT:    s_bfe_i32 s46, s8, 0x80010
+; GFX7-HSA-NEXT:    s_bfe_i32 s47, s8, 0x80008
+; GFX7-HSA-NEXT:    s_ashr_i32 s48, s9, 24
+; GFX7-HSA-NEXT:    s_bfe_i32 s49, s9, 0x80010
+; GFX7-HSA-NEXT:    s_bfe_i32 s50, s9, 0x80008
 ; GFX7-HSA-NEXT:    s_ashr_i32 s51, s10, 24
 ; GFX7-HSA-NEXT:    s_bfe_i32 s52, s10, 0x80010
 ; GFX7-HSA-NEXT:    s_bfe_i32 s53, s10, 0x80008
@@ -3794,54 +3798,49 @@ define amdgpu_kernel void @constant_sextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_ashr_i32 s66, s15, 24
 ; GFX7-HSA-NEXT:    s_bfe_i32 s67, s15, 0x80010
 ; GFX7-HSA-NEXT:    s_bfe_i32 s68, s15, 0x80008
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s46, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0xf0
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s50, s9
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v23, s9
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v22, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0xe0
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v25, s9
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v24, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0xd0
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v27, s9
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v26, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0xc0
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v29, s9
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v28, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0xb0
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v31, s9
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v30, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0xa0
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v33, s9
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s14, s14
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v32, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0x90
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s14
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s65
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v6, s64
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v7, s63
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v25, s9
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v24, s8
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0x80
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s11, s11
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s12, s12
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s13, s13
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s40, s6
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xf0
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s44, s7
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v23, s7
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v22, s6
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xe0
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v25, s7
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v24, s6
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xd0
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v27, s7
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v26, s6
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xc0
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
 ; GFX7-HSA-NEXT:    s_sext_i32_i8 s15, s15
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v35, s9
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s10, s10
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v29, s7
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v28, s6
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s15
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s68
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s67
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s66
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xb0
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s14, s14
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0xa0
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s6
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s10, s10
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s11, s11
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s12, s12
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s13, s13
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s14
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s65
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v6, s64
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v7, s63
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x90
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s9, s9
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v8, s13
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v9, s62
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v10, s61
@@ -3853,48 +3852,53 @@ define amdgpu_kernel void @constant_sextload_v64i8_to_v64i32(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v16, s11
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v17, s56
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v18, s55
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v19, s54
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v34, s8
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s46
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s45
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v6, s44
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v7, s43
-; GFX7-HSA-NEXT:    s_add_u32 s8, s16, 0x70
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s7, s7
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v20, s10
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v19, s54
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v21, s53
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v22, s52
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s50
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v23, s51
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s49
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s48
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[12:15]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s47
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[16:19]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[20:23]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[4:7]
-; GFX7-HSA-NEXT:    s_addc_u32 s9, s17, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s8
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s6, s6
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s7
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s42
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s41
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s40
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s9
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
-; GFX7-HSA-NEXT:    s_sext_i32_i8 s5, s5
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s6
-; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x60
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[16:19]
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[2:3], v[20:23]
 ; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s9
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s50
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s49
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s48
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x80
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s8, s8
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s8
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s47
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s46
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s45
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x70
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s44
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s43
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s42
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s41
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s7
+; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x60
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s40
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s39
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s38
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s37
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s7
 ; GFX7-HSA-NEXT:    s_add_u32 s6, s16, 0x50
+; GFX7-HSA-NEXT:    s_sext_i32_i8 s5, s5
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
 ; GFX7-HSA-NEXT:    s_addc_u32 s7, s17, 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s6
@@ -6820,157 +6824,156 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; GFX6-NOHSA-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-NOHSA-NEXT:    s_load_dwordx8 s[0:7], s[10:11], 0x0
 ; GFX6-NOHSA-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s46, s7, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s48, s7, 8
-; GFX6-NOHSA-NEXT:    s_mov_b32 s50, s7
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s10, s6, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s12, s6, 24
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s14, s6, 8
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s16, s5, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s18, s5, 8
-; GFX6-NOHSA-NEXT:    s_mov_b32 s44, s5
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s20, s4, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s22, s4, 24
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s24, s4, 8
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s26, s3, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s28, s3, 8
-; GFX6-NOHSA-NEXT:    s_mov_b32 s40, s3
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s30, s2, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s34, s2, 24
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s36, s2, 8
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s38, s1, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s42, s1, 8
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[58:59], s[50:51], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[60:61], s[44:45], 0x80000
-; GFX6-NOHSA-NEXT:    s_mov_b32 s62, s1
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s56, s0, 16
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s64, s0, 24
-; GFX6-NOHSA-NEXT:    s_lshr_b32 s66, s0, 8
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[44:45], s[0:1], 0x80000
-; GFX6-NOHSA-NEXT:    s_ashr_i64 s[50:51], s[0:1], 56
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[52:53], s[2:3], 0x80000
-; GFX6-NOHSA-NEXT:    s_ashr_i64 s[68:69], s[4:5], 56
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[70:71], s[6:7], 0x80000
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s20, s7, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s22, s7, 8
+; GFX6-NOHSA-NEXT:    s_mov_b32 s10, s7
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s30, s6, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s36, s6, 24
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s38, s6, 8
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s40, s5, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s44, s5, 8
+; GFX6-NOHSA-NEXT:    s_mov_b32 s14, s5
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s48, s4, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s50, s4, 24
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s46, s4, 8
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s42, s3, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s34, s3, 8
+; GFX6-NOHSA-NEXT:    s_mov_b32 s54, s3
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s28, s2, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s24, s2, 24
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s18, s2, 8
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s16, s1, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s58, s1, 8
+; GFX6-NOHSA-NEXT:    s_mov_b32 s52, s1
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s60, s0, 16
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s62, s0, 24
+; GFX6-NOHSA-NEXT:    s_lshr_b32 s64, s0, 8
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[66:67], s[10:11], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[10:11], s[0:1], 0x80000
+; GFX6-NOHSA-NEXT:    s_ashr_i64 s[12:13], s[0:1], 56
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[26:27], s[2:3], 0x80000
+; GFX6-NOHSA-NEXT:    s_ashr_i64 s[56:57], s[2:3], 56
+; GFX6-NOHSA-NEXT:    s_ashr_i64 s[2:3], s[4:5], 56
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[68:69], s[6:7], 0x80000
 ; GFX6-NOHSA-NEXT:    s_ashr_i64 s[6:7], s[6:7], 56
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[4:5], s[4:5], 0x80000
-; GFX6-NOHSA-NEXT:    s_ashr_i64 s[54:55], s[2:3], 56
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[70:71], s[4:5], 0x80000
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s0, s8
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s1, s9
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s6
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s7
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s58
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s59
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s70
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s71
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s68
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s69
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s60
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s61
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s4
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s5
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s6
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s7
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s66
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s67
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s68
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s69
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s2
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s3
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s3, 0xf000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[4:5], s[46:47], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[6:7], s[48:49], 0x80000
 ; GFX6-NOHSA-NEXT:    s_mov_b32 s2, -1
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s4
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s5
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v18, s6
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v19, s7
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:240
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[46:47], s[62:63], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[48:49], s[40:41], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[4:5], s[66:67], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[6:7], s[64:65], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[8:9], s[56:57], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[40:41], s[42:43], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[52:53], s[52:53], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[54:55], s[54:55], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[66:67], s[14:15], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[4:5], s[64:65], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[6:7], s[62:63], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[8:9], s[60:61], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[14:15], s[58:59], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[16:17], s[16:17], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[18:19], s[18:19], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[42:43], s[42:43], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[50:51], s[50:51], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[48:49], s[48:49], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[44:45], s[44:45], 0x80000
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x80000
 ; GFX6-NOHSA-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x80000
 ; GFX6-NOHSA-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[34:35], s[34:35], 0x80000
 ; GFX6-NOHSA-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[28:29], s[28:29], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[26:27], s[26:27], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[24:25], s[24:25], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x80000
 ; GFX6-NOHSA-NEXT:    s_bfe_i64 s[20:21], s[20:21], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[18:19], s[18:19], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[16:17], s[16:17], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[14:15], s[14:15], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[12:13], s[12:13], 0x80000
-; GFX6-NOHSA-NEXT:    s_bfe_i64 s[10:11], s[10:11], 0x80000
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:224
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(1)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s10
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s11
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s12
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s13
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:208
+; GFX6-NOHSA-NEXT:    s_bfe_i64 s[22:23], s[22:23], 0x80000
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s66
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s67
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v18, s70
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v19, s71
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v22, s56
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v23, s57
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s20
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s21
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s54
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s55
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s14
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s15
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:192
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s54
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s55
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s22
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s23
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:224
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s30
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s31
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s48
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s49
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s16
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s17
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:176
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s36
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s37
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[2:5], off, s[0:3], 0 offset:208
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s52
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s53
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s18
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s19
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:160
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s26
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s27
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s38
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s39
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:192
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s20
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s21
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s22
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s23
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:144
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s50
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s51
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s24
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s25
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:128
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s12
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s13
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s40
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s41
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:176
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v4, s46
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v5, s47
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s26
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s27
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:112
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s52
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s53
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s44
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s45
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:160
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s48
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s49
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s44
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s45
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v10, s28
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v11, s29
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:96
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s30
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s31
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s50
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s51
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:144
 ; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v8, s34
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v9, s35
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:80
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s36
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s37
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:64
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s38
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s39
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:48
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(2)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s40
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s41
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:32
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(2)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s10
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s11
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v20, s46
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v21, s47
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[18:21], off, s[0:3], 0 offset:128
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v20, s42
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v21, s43
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:112
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s34
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s35
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:96
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s28
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s29
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s24
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s25
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s18
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s19
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:64
+; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(0)
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v6, s16
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v7, s17
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:48
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v12, s14
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v13, s15
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:32
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v3, s7
 ; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:16
-; GFX6-NOHSA-NEXT:    s_waitcnt expcnt(2)
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v14, s4
-; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v15, s5
-; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v16, s4
+; GFX6-NOHSA-NEXT:    v_mov_b32_e32 v17, s5
+; GFX6-NOHSA-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0
 ; GFX6-NOHSA-NEXT:    s_endpgm
 ;
 ; GFX7-HSA-LABEL: constant_sextload_v32i8_to_v32i64:
@@ -6988,8 +6991,8 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_lshr_b32 s58, s5, 16
 ; GFX7-HSA-NEXT:    s_lshr_b32 s60, s5, 8
 ; GFX7-HSA-NEXT:    s_mov_b32 s62, s5
-; GFX7-HSA-NEXT:    s_lshr_b32 s44, s4, 16
-; GFX7-HSA-NEXT:    s_lshr_b32 s40, s4, 24
+; GFX7-HSA-NEXT:    s_lshr_b32 s46, s4, 16
+; GFX7-HSA-NEXT:    s_lshr_b32 s42, s4, 24
 ; GFX7-HSA-NEXT:    s_lshr_b32 s38, s4, 8
 ; GFX7-HSA-NEXT:    s_lshr_b32 s36, s3, 16
 ; GFX7-HSA-NEXT:    s_lshr_b32 s30, s3, 8
@@ -7006,12 +7009,12 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[12:13], s[2:3], 0x80000
 ; GFX7-HSA-NEXT:    s_ashr_i64 s[20:21], s[2:3], 56
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[24:25], s[4:5], 0x80000
-; GFX7-HSA-NEXT:    s_ashr_i64 s[42:43], s[4:5], 56
+; GFX7-HSA-NEXT:    s_ashr_i64 s[40:41], s[4:5], 56
 ; GFX7-HSA-NEXT:    s_ashr_i64 s[2:3], s[6:7], 56
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[4:5], s[14:15], 0x80000
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[10:11], s[0:1], 0x80000
 ; GFX7-HSA-NEXT:    s_ashr_i64 s[0:1], s[0:1], 56
-; GFX7-HSA-NEXT:    s_bfe_i64 s[46:47], s[6:7], 0x80000
+; GFX7-HSA-NEXT:    s_bfe_i64 s[44:45], s[6:7], 0x80000
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s2
@@ -7029,8 +7032,8 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[30:31], s[30:31], 0x80000
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[36:37], s[36:37], 0x80000
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[38:39], s[38:39], 0x80000
-; GFX7-HSA-NEXT:    s_bfe_i64 s[40:41], s[40:41], 0x80000
-; GFX7-HSA-NEXT:    s_bfe_i64 s[44:45], s[44:45], 0x80000
+; GFX7-HSA-NEXT:    s_bfe_i64 s[42:43], s[42:43], 0x80000
+; GFX7-HSA-NEXT:    s_bfe_i64 s[46:47], s[46:47], 0x80000
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[62:63], s[62:63], 0x80000
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[60:61], s[60:61], 0x80000
 ; GFX7-HSA-NEXT:    s_bfe_i64 s[58:59], s[58:59], 0x80000
@@ -7049,64 +7052,66 @@ define amdgpu_kernel void @constant_sextload_v32i8_to_v32i64(ptr addrspace(1) %o
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v25, s49
 ; GFX7-HSA-NEXT:    s_add_u32 s48, s8, 0xd0
 ; GFX7-HSA-NEXT:    s_addc_u32 s49, s9, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v12, s46
-; GFX7-HSA-NEXT:    s_add_u32 s46, s8, 0xc0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v13, s47
-; GFX7-HSA-NEXT:    s_addc_u32 s47, s9, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v18, s42
-; GFX7-HSA-NEXT:    s_add_u32 s42, s8, 0xb0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v19, s43
-; GFX7-HSA-NEXT:    s_addc_u32 s43, s9, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v30, s42
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v12, s44
+; GFX7-HSA-NEXT:    s_add_u32 s44, s8, 0xc0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v22, s64
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v31, s43
-; GFX7-HSA-NEXT:    s_add_u32 s42, s8, 0xa0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v13, s45
+; GFX7-HSA-NEXT:    s_addc_u32 s45, s9, 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v23, s65
-; GFX7-HSA-NEXT:    s_addc_u32 s43, s9, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v18, s40
+; GFX7-HSA-NEXT:    s_add_u32 s40, s8, 0xb0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v19, s41
+; GFX7-HSA-NEXT:    s_addc_u32 s41, s9, 0
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[22:23], v[0:3]
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s50
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s40
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s41
+; GFX7-HSA-NEXT:    s_add_u32 s40, s8, 0xa0
+; GFX7-HSA-NEXT:    s_addc_u32 s41, s9, 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s40
-; GFX7-HSA-NEXT:    s_add_u32 s40, s8, 0x90
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s51
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v26, s48
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v28, s44
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s41
-; GFX7-HSA-NEXT:    s_addc_u32 s41, s9, 0
+; GFX7-HSA-NEXT:    s_add_u32 s40, s8, 0x90
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v8, s52
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v9, s53
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v10, s54
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v11, s55
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v27, s49
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v28, s46
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v14, s56
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s24
-; GFX7-HSA-NEXT:    s_add_u32 s24, s8, 0x80
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v15, s57
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v29, s47
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v29, s45
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v16, s58
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v17, s59
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v32, s42
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s25
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v8, s40
-; GFX7-HSA-NEXT:    s_addc_u32 s25, s9, 0
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v10, s24
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v20, s62
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v21, s63
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v33, s43
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v22, s60
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v23, s61
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s44
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s45
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v9, s41
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[4:7]
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[8:11]
 ; GFX7-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[12:15]
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v6, s38
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v7, s39
-; GFX7-HSA-NEXT:    v_mov_b32_e32 v11, s25
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[16:19]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[20:23]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[0:3]
-; GFX7-HSA-NEXT:    flat_store_dwordx4 v[10:11], v[4:7]
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[16:19]
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[2:3], v[20:23]
+; GFX7-HSA-NEXT:    s_addc_u32 s41, s9, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s40
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s46
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s47
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s42
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s43
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s41
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GFX7-HSA-NEXT:    s_nop 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v0, s24
+; GFX7-HSA-NEXT:    s_add_u32 s24, s8, 0x80
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v1, s25
+; GFX7-HSA-NEXT:    s_addc_u32 s25, s9, 0
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v4, s24
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s38
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s39
+; GFX7-HSA-NEXT:    v_mov_b32_e32 v5, s25
+; GFX7-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GFX7-HSA-NEXT:    s_nop 0
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v2, s20
 ; GFX7-HSA-NEXT:    s_add_u32 s20, s8, 0x70
 ; GFX7-HSA-NEXT:    v_mov_b32_e32 v3, s21

--- a/llvm/test/CodeGen/AMDGPU/load-global-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-global-i16.ll
@@ -3583,191 +3583,190 @@ define amdgpu_kernel void @global_zextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ; GCN-HSA-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[24:27], v[0:1]
-; GCN-HSA-NEXT:    s_add_u32 s4, s2, 16
-; GCN-HSA-NEXT:    s_addc_u32 s5, s3, 0
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[20:23], v[0:1]
+; GCN-HSA-NEXT:    s_add_u32 s8, s2, 16
+; GCN-HSA-NEXT:    s_addc_u32 s9, s3, 0
 ; GCN-HSA-NEXT:    s_add_u32 s6, s2, 32
 ; GCN-HSA-NEXT:    s_addc_u32 s7, s3, 0
-; GCN-HSA-NEXT:    s_add_u32 s8, s2, 48
-; GCN-HSA-NEXT:    s_addc_u32 s9, s3, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s9
+; GCN-HSA-NEXT:    s_add_u32 s4, s2, 48
+; GCN-HSA-NEXT:    s_addc_u32 s5, s3, 0
 ; GCN-HSA-NEXT:    s_add_u32 s10, s2, 64
-; GCN-HSA-NEXT:    v_mov_b32_e32 v16, s8
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[20:23], v[16:17]
-; GCN-HSA-NEXT:    s_addc_u32 s11, s3, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s10
-; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s11
-; GCN-HSA-NEXT:    s_add_u32 s10, s2, 0x50
 ; GCN-HSA-NEXT:    s_addc_u32 s11, s3, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s10
+; GCN-HSA-NEXT:    s_add_u32 s12, s2, 0x50
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s11
-; GCN-HSA-NEXT:    s_add_u32 s10, s2, 0x60
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[8:11], v[4:5]
-; GCN-HSA-NEXT:    s_addc_u32 s11, s3, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s10
-; GCN-HSA-NEXT:    s_add_u32 s2, s2, 0x70
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s11
-; GCN-HSA-NEXT:    s_addc_u32 s3, s3, 0
 ; GCN-HSA-NEXT:    flat_load_dwordx4 v[4:7], v[4:5]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v13, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v12, s2
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[28:31], v[12:13]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v13, s5
-; GCN-HSA-NEXT:    v_mov_b32_e32 v15, s7
-; GCN-HSA-NEXT:    v_mov_b32_e32 v12, s4
-; GCN-HSA-NEXT:    v_mov_b32_e32 v14, s6
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[16:19], v[12:13]
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[12:15], v[14:15]
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 16
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    s_addc_u32 s13, s3, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s12
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s13
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[16:19], v[0:1]
+; GCN-HSA-NEXT:    s_add_u32 s12, s2, 0x60
+; GCN-HSA-NEXT:    s_addc_u32 s13, s3, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v29, s7
+; GCN-HSA-NEXT:    s_add_u32 s2, s2, 0x70
+; GCN-HSA-NEXT:    v_mov_b32_e32 v28, s6
+; GCN-HSA-NEXT:    s_addc_u32 s3, s3, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v37, s1
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v36, s0
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(7)
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v35, 16, v25
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
-; GCN-HSA-NEXT:    v_and_b32_e32 v34, 0xffff, v25
-; GCN-HSA-NEXT:    v_and_b32_e32 v32, 0xffff, v24
-; GCN-HSA-NEXT:    v_mov_b32_e32 v25, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v24, s2
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[28:31], v[28:29]
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(3)
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v25, 16, v20
+; GCN-HSA-NEXT:    v_and_b32_e32 v26, 0xffff, v21
+; GCN-HSA-NEXT:    v_and_b32_e32 v24, 0xffff, v20
+; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s5
+; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s4
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[32:35], v[20:21]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s12
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s13
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[12:15], v[0:1]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[8:11], v[0:1]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s8
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s9
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 16
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s3
+; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s2
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0xe0
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    s_add_u32 s4, s0, 0xf0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[36:37], v[32:35]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v37, s3
 ; GCN-HSA-NEXT:    s_addc_u32 s5, s1, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v36, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0xc0
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    s_add_u32 s6, s0, 0xd0
+; GCN-HSA-NEXT:    s_add_u32 s6, s0, 0xc0
 ; GCN-HSA-NEXT:    s_addc_u32 s7, s1, 0
-; GCN-HSA-NEXT:    s_add_u32 s8, s0, 0xa0
+; GCN-HSA-NEXT:    s_add_u32 s8, s0, 0xd0
 ; GCN-HSA-NEXT:    s_addc_u32 s9, s1, 0
-; GCN-HSA-NEXT:    s_add_u32 s10, s0, 0xb0
+; GCN-HSA-NEXT:    s_add_u32 s10, s0, 0xa0
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[36:37], v[24:27]
 ; GCN-HSA-NEXT:    s_addc_u32 s11, s1, 0
-; GCN-HSA-NEXT:    s_add_u32 s12, s0, 0x80
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v35, 16, v27
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v33, 16, v26
-; GCN-HSA-NEXT:    v_and_b32_e32 v34, 0xffff, v27
-; GCN-HSA-NEXT:    v_and_b32_e32 v32, 0xffff, v26
-; GCN-HSA-NEXT:    s_addc_u32 s13, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[32:35]
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v26, 16, v23
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; GCN-HSA-NEXT:    v_and_b32_e32 v25, 0xffff, v23
+; GCN-HSA-NEXT:    v_and_b32_e32 v23, 0xffff, v22
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[20:21], v[23:26]
 ; GCN-HSA-NEXT:    s_waitcnt vmcnt(7)
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v27, 16, v1
-; GCN-HSA-NEXT:    v_mov_b32_e32 v33, s13
-; GCN-HSA-NEXT:    v_mov_b32_e32 v32, s12
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v25, 16, v0
-; GCN-HSA-NEXT:    v_and_b32_e32 v26, 0xffff, v1
-; GCN-HSA-NEXT:    v_and_b32_e32 v24, 0xffff, v0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s8
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[24:27]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s9
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v21, 16, v16
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v23, 16, v17
+; GCN-HSA-NEXT:    v_and_b32_e32 v22, 0xffff, v17
+; GCN-HSA-NEXT:    v_and_b32_e32 v20, 0xffff, v16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s11
+; GCN-HSA-NEXT:    v_mov_b32_e32 v16, s10
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[16:17], v[20:23]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v24, s3
+; GCN-HSA-NEXT:    v_mov_b32_e32 v23, s2
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0xb0
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s3
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v22, 16, v19
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v20, 16, v18
+; GCN-HSA-NEXT:    v_and_b32_e32 v21, 0xffff, v19
+; GCN-HSA-NEXT:    v_and_b32_e32 v19, 0xffff, v18
+; GCN-HSA-NEXT:    v_mov_b32_e32 v16, s2
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[16:17], v[19:22]
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x80
+; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s7
+; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s6
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    s_waitcnt vmcnt(7)
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v27, 16, v9
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v25, 16, v8
-; GCN-HSA-NEXT:    v_and_b32_e32 v26, 0xffff, v9
-; GCN-HSA-NEXT:    v_and_b32_e32 v24, 0xffff, v8
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s10
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[24:27]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s11
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v27, 16, v11
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v25, 16, v10
-; GCN-HSA-NEXT:    v_and_b32_e32 v26, 0xffff, v11
-; GCN-HSA-NEXT:    v_and_b32_e32 v24, 0xffff, v10
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[24:27]
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(8)
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v26, 16, v33
+; GCN-HSA-NEXT:    v_and_b32_e32 v25, 0xffff, v33
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(6)
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v19, 16, v13
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v17, 16, v12
+; GCN-HSA-NEXT:    v_and_b32_e32 v18, 0xffff, v13
+; GCN-HSA-NEXT:    v_and_b32_e32 v16, 0xffff, v12
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[20:21], v[16:19]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v13, s9
+; GCN-HSA-NEXT:    v_mov_b32_e32 v22, s3
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v18, 16, v15
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v16, 16, v14
+; GCN-HSA-NEXT:    v_and_b32_e32 v17, 0xffff, v15
+; GCN-HSA-NEXT:    v_and_b32_e32 v15, 0xffff, v14
+; GCN-HSA-NEXT:    v_mov_b32_e32 v12, s8
+; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s2
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x90
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[12:13], v[15:18]
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(7)
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v13, 16, v8
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v15, 16, v9
+; GCN-HSA-NEXT:    v_and_b32_e32 v14, 0xffff, v9
+; GCN-HSA-NEXT:    v_and_b32_e32 v12, 0xffff, v8
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s5
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[23:24], v[12:15]
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v18, 16, v11
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v16, 16, v10
+; GCN-HSA-NEXT:    v_and_b32_e32 v17, 0xffff, v11
+; GCN-HSA-NEXT:    v_and_b32_e32 v15, 0xffff, v10
 ; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v11, 16, v5
 ; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v9, 16, v4
 ; GCN-HSA-NEXT:    v_and_b32_e32 v10, 0xffff, v5
 ; GCN-HSA-NEXT:    v_and_b32_e32 v8, 0xffff, v4
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-HSA-NEXT:    v_mov_b32_e32 v19, s4
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s2
-; GCN-HSA-NEXT:    v_mov_b32_e32 v33, s7
-; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s5
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v27, 16, v7
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v25, 16, v6
-; GCN-HSA-NEXT:    v_and_b32_e32 v26, 0xffff, v7
-; GCN-HSA-NEXT:    v_and_b32_e32 v24, 0xffff, v6
-; GCN-HSA-NEXT:    v_mov_b32_e32 v32, s6
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[8:11]
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(8)
-; GCN-HSA-NEXT:    v_and_b32_e32 v7, 0xffff, v28
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v10, 16, v29
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v8, 16, v28
-; GCN-HSA-NEXT:    v_and_b32_e32 v9, 0xffff, v29
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x90
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[24:27]
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x60
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[19:20], v[15:18]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[21:22], v[8:11]
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v18, 16, v7
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(9)
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v10, 16, v1
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
+; GCN-HSA-NEXT:    v_and_b32_e32 v17, 0xffff, v7
+; GCN-HSA-NEXT:    v_and_b32_e32 v9, 0xffff, v1
+; GCN-HSA-NEXT:    v_and_b32_e32 v7, 0xffff, v0
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v27, 16, v31
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v25, 16, v30
-; GCN-HSA-NEXT:    v_and_b32_e32 v26, 0xffff, v31
-; GCN-HSA-NEXT:    v_and_b32_e32 v24, 0xffff, v30
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[36:37], v[7:10]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[24:27]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v24, 16, v32
+; GCN-HSA-NEXT:    v_and_b32_e32 v23, 0xffff, v32
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x70
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[23:26]
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v22, 16, v35
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v20, 16, v34
+; GCN-HSA-NEXT:    v_and_b32_e32 v21, 0xffff, v35
+; GCN-HSA-NEXT:    v_and_b32_e32 v19, 0xffff, v34
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 64
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v16, 16, v6
+; GCN-HSA-NEXT:    v_and_b32_e32 v15, 0xffff, v6
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[19:22]
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[15:18]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v18, 16, v29
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v16, 16, v28
+; GCN-HSA-NEXT:    v_and_b32_e32 v17, 0xffff, v29
+; GCN-HSA-NEXT:    v_and_b32_e32 v15, 0xffff, v28
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x50
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[15:18]
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v14, 16, v3
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v6, 16, v31
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v4, 16, v30
+; GCN-HSA-NEXT:    v_and_b32_e32 v13, 0xffff, v3
+; GCN-HSA-NEXT:    v_and_b32_e32 v5, 0xffff, v31
+; GCN-HSA-NEXT:    v_and_b32_e32 v3, 0xffff, v30
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 32
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[3:6]
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x60
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v6, 16, v3
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GCN-HSA-NEXT:    v_and_b32_e32 v5, 0xffff, v3
-; GCN-HSA-NEXT:    v_and_b32_e32 v3, 0xffff, v2
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[3:6]
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v1, 16, v20
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x70
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v3, 16, v21
-; GCN-HSA-NEXT:    v_and_b32_e32 v2, 0xffff, v21
-; GCN-HSA-NEXT:    v_and_b32_e32 v0, 0xffff, v20
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 64
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v7, 16, v23
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v5, 16, v22
-; GCN-HSA-NEXT:    v_and_b32_e32 v6, 0xffff, v23
-; GCN-HSA-NEXT:    v_and_b32_e32 v4, 0xffff, v22
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(12)
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v1, 16, v18
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[4:7]
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(12)
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v11, 16, v15
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v7, 16, v17
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v5, 16, v16
-; GCN-HSA-NEXT:    v_and_b32_e32 v0, 0xffff, v18
-; GCN-HSA-NEXT:    v_and_b32_e32 v6, 0xffff, v17
-; GCN-HSA-NEXT:    v_and_b32_e32 v4, 0xffff, v16
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v18, 16, v13
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v16, 16, v12
-; GCN-HSA-NEXT:    v_and_b32_e32 v10, 0xffff, v15
-; GCN-HSA-NEXT:    v_and_b32_e32 v17, 0xffff, v13
-; GCN-HSA-NEXT:    v_and_b32_e32 v15, 0xffff, v12
-; GCN-HSA-NEXT:    v_mov_b32_e32 v13, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v12, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x50
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[12:13], v[15:18]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v13, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v12, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 32
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v9, 16, v14
-; GCN-HSA-NEXT:    v_and_b32_e32 v8, 0xffff, v14
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[12:13], v[8:11]
 ; GCN-HSA-NEXT:    s_add_u32 s0, s0, 48
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s2
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[7:10]
 ; GCN-HSA-NEXT:    s_addc_u32 s1, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[4:7]
-; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v3, 16, v19
-; GCN-HSA-NEXT:    v_mov_b32_e32 v5, s1
-; GCN-HSA-NEXT:    v_and_b32_e32 v2, 0xffff, v19
-; GCN-HSA-NEXT:    v_mov_b32_e32 v4, s0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s0
+; GCN-HSA-NEXT:    v_lshrrev_b32_e32 v12, 16, v2
+; GCN-HSA-NEXT:    v_and_b32_e32 v11, 0xffff, v2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s1
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[11:14]
 ; GCN-HSA-NEXT:    s_endpgm
 ;
 ; GCN-NOHSA-VI-LABEL: global_zextload_v64i16_to_v64i32:
@@ -4389,8 +4388,8 @@ define amdgpu_kernel void @global_sextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ; GCN-HSA-NEXT:    s_addc_u32 s5, s3, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s5
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[20:23], v[0:1]
 ; GCN-HSA-NEXT:    s_add_u32 s4, s2, 0x60
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[16:19], v[0:1]
 ; GCN-HSA-NEXT:    s_addc_u32 s5, s3, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s5
@@ -4400,26 +4399,26 @@ define amdgpu_kernel void @global_sextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-HSA-NEXT:    s_add_u32 s4, s2, 64
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[4:7], v[0:1]
 ; GCN-HSA-NEXT:    s_addc_u32 s5, s3, 0
+; GCN-HSA-NEXT:    s_add_u32 s6, s2, 48
+; GCN-HSA-NEXT:    s_addc_u32 s7, s3, 0
+; GCN-HSA-NEXT:    s_add_u32 s8, s2, 32
+; GCN-HSA-NEXT:    s_addc_u32 s9, s3, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s9
+; GCN-HSA-NEXT:    s_add_u32 s2, s2, 16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s8
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[4:7], v[0:1]
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[24:27], v[20:21]
+; GCN-HSA-NEXT:    s_addc_u32 s3, s3, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v21, s7
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    v_mov_b32_e32 v20, s6
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[8:11], v[0:1]
+; GCN-HSA-NEXT:    flat_load_dwordx4 v[20:23], v[20:21]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s5
-; GCN-HSA-NEXT:    s_add_u32 s4, s2, 48
-; GCN-HSA-NEXT:    s_addc_u32 s5, s3, 0
-; GCN-HSA-NEXT:    s_add_u32 s6, s2, 32
-; GCN-HSA-NEXT:    s_addc_u32 s7, s3, 0
-; GCN-HSA-NEXT:    s_add_u32 s2, s2, 16
 ; GCN-HSA-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
-; GCN-HSA-NEXT:    s_addc_u32 s3, s3, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s2
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[24:27], v[8:9]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s5
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s4
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[8:11], v[8:9]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s7
-; GCN-HSA-NEXT:    v_mov_b32_e32 v16, s6
-; GCN-HSA-NEXT:    flat_load_dwordx4 v[16:19], v[16:17]
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 16
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v37, s1
@@ -4444,14 +4443,14 @@ define amdgpu_kernel void @global_sextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[31:34]
 ; GCN-HSA-NEXT:    s_waitcnt vmcnt(8)
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v29, 16, v20
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v29, 16, v16
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v33, s3
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v32, s2
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0xc0
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v31, 16, v21
-; GCN-HSA-NEXT:    v_bfe_i32 v30, v21, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v28, v20, 0, 16
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v31, 16, v17
+; GCN-HSA-NEXT:    v_bfe_i32 v30, v17, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v28, v16, 0, 16
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[35:36], v[28:31]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v35, s3
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v34, s2
@@ -4460,113 +4459,111 @@ define amdgpu_kernel void @global_sextload_v64i16_to_v64i32(ptr addrspace(1) %ou
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v37, s3
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v36, s2
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0xa0
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v31, 16, v23
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v29, 16, v22
-; GCN-HSA-NEXT:    v_bfe_i32 v30, v23, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v28, v22, 0, 16
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v31, 16, v19
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v29, 16, v18
+; GCN-HSA-NEXT:    v_bfe_i32 v30, v19, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v28, v18, 0, 16
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[28:31]
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v33, s3
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v32, s2
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0xb0
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    v_mov_b32_e32 v39, s3
 ; GCN-HSA-NEXT:    s_waitcnt vmcnt(9)
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v23, 16, v13
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v21, 16, v12
-; GCN-HSA-NEXT:    v_bfe_i32 v22, v13, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v20, v12, 0, 16
-; GCN-HSA-NEXT:    v_mov_b32_e32 v38, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x80
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v19, 16, v13
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v17, 16, v12
+; GCN-HSA-NEXT:    v_bfe_i32 v18, v13, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v16, v12, 0, 16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v39, s3
 ; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v31, 16, v15
 ; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v29, 16, v14
 ; GCN-HSA-NEXT:    v_bfe_i32 v30, v15, 0, 16
 ; GCN-HSA-NEXT:    v_bfe_i32 v28, v14, 0, 16
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[20:23]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v38, s2
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[16:19]
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[36:37], v[28:31]
 ; GCN-HSA-NEXT:    s_waitcnt vmcnt(10)
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v15, 16, v5
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v13, 16, v4
-; GCN-HSA-NEXT:    v_bfe_i32 v14, v5, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v12, v4, 0, 16
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v23, 16, v7
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v21, 16, v6
-; GCN-HSA-NEXT:    v_bfe_i32 v22, v7, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v20, v6, 0, 16
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(9)
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v7, 16, v1
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v5, 16, v0
-; GCN-HSA-NEXT:    v_bfe_i32 v6, v1, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v4, v0, 0, 16
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v15, 16, v7
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v13, 16, v6
+; GCN-HSA-NEXT:    v_bfe_i32 v14, v7, 0, 16
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v19, 16, v5
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v17, 16, v4
+; GCN-HSA-NEXT:    v_bfe_i32 v18, v5, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v16, v4, 0, 16
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x80
+; GCN-HSA-NEXT:    v_bfe_i32 v12, v6, 0, 16
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[16:19]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[38:39], v[12:15]
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(8)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v16, 16, v1
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v14, 16, v0
+; GCN-HSA-NEXT:    v_bfe_i32 v15, v1, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v13, v0, 0, 16
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x90
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[12:15]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[38:39], v[20:23]
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[4:7]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[13:16]
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x60
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v23, 16, v3
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v21, 16, v2
-; GCN-HSA-NEXT:    v_bfe_i32 v22, v3, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v20, v2, 0, 16
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[20:23]
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(11)
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v3, 16, v9
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v1, 16, v8
-; GCN-HSA-NEXT:    v_bfe_i32 v2, v9, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v0, v8, 0, 16
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v18, s3
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v32, 16, v3
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v30, 16, v2
+; GCN-HSA-NEXT:    v_bfe_i32 v31, v3, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v29, v2, 0, 16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s2
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x70
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v16, 16, v27
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v14, 16, v26
+; GCN-HSA-NEXT:    v_bfe_i32 v15, v27, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v13, v26, 0, 16
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v28, 16, v25
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v26, 16, v24
+; GCN-HSA-NEXT:    v_bfe_i32 v27, v25, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v25, v24, 0, 16
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[29:32]
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v3, 16, v23
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v1, 16, v22
+; GCN-HSA-NEXT:    v_bfe_i32 v2, v23, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v0, v22, 0, 16
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v24, 16, v21
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v22, 16, v20
+; GCN-HSA-NEXT:    v_bfe_i32 v23, v21, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v21, v20, 0, 16
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[0:3]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s2
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[17:18], v[21:24]
+; GCN-HSA-NEXT:    v_mov_b32_e32 v18, s3
+; GCN-HSA-NEXT:    v_mov_b32_e32 v17, s2
 ; GCN-HSA-NEXT:    s_add_u32 s2, s0, 64
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v13, 16, v24
-; GCN-HSA-NEXT:    v_bfe_i32 v12, v24, 0, 16
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v24, 16, v11
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v22, 16, v10
-; GCN-HSA-NEXT:    v_bfe_i32 v23, v11, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v21, v10, 0, 16
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[21:24]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x50
-; GCN-HSA-NEXT:    s_waitcnt vmcnt(12)
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v3, 16, v19
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v1, 16, v18
-; GCN-HSA-NEXT:    v_bfe_i32 v2, v19, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v0, v18, 0, 16
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v20, 16, v17
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v18, 16, v16
-; GCN-HSA-NEXT:    v_bfe_i32 v19, v17, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v17, v16, 0, 16
-; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[17:20]
-; GCN-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCN-HSA-NEXT:    v_mov_b32_e32 v8, s2
-; GCN-HSA-NEXT:    s_add_u32 s2, s0, 32
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[0:3]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[17:18], v[0:3]
 ; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v15, 16, v25
-; GCN-HSA-NEXT:    v_bfe_i32 v14, v25, 0, 16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 0x50
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[25:28]
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCN-HSA-NEXT:    s_add_u32 s2, s0, 32
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[13:16]
+; GCN-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v7, 16, v11
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v5, 16, v10
+; GCN-HSA-NEXT:    v_bfe_i32 v6, v11, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v4, v10, 0, 16
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v12, 16, v9
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v10, 16, v8
+; GCN-HSA-NEXT:    v_bfe_i32 v11, v9, 0, 16
+; GCN-HSA-NEXT:    v_bfe_i32 v9, v8, 0, 16
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s3
 ; GCN-HSA-NEXT:    s_add_u32 s0, s0, 48
-; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[12:15]
+; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[9:12]
 ; GCN-HSA-NEXT:    s_addc_u32 s1, s1, 0
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v7, 16, v27
-; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v5, 16, v26
-; GCN-HSA-NEXT:    v_bfe_i32 v6, v27, 0, 16
-; GCN-HSA-NEXT:    v_bfe_i32 v4, v26, 0, 16
 ; GCN-HSA-NEXT:    v_mov_b32_e32 v1, s1
 ; GCN-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[4:7]
 ; GCN-HSA-NEXT:    s_endpgm
@@ -6479,50 +6476,50 @@ define amdgpu_kernel void @global_zextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s9, s7
 ; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[0:3], off, s[8:11], 0
 ; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[4:7], off, s[8:11], 0 offset:16
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, 0
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(1)
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v10, 16, v1
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v14, 16, v2
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v0
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v16, 0xffff, v0
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v12, 0xffff, v2
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v8, 0xffff, v1
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v3
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v0, 0xffff, v3
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v21, 0
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v1
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v3
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v22, 16, v5
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v6
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v24, 0xffff, v6
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v28, 0xffff, v7
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v20, 0xffff, v5
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v23, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v29, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v31, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v25, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v27, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v15, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v17, v21
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v19, v21
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v5
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v2
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v0
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v23, 0xffff, v0
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v19, 0xffff, v2
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v11, 0xffff, v1
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v15, 0xffff, v3
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v6
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v0, 0xffff, v6
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v4
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v27, 0xffff, v4
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v7
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v31, 0xffff, v7
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v7, 0xffff, v5
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v10, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v32, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v34, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v16, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v18, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v12, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v14, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v28, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v30, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v20, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v22, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v24, v8
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v26, v8
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s0, s4
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s1, s5
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:80
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[28:31], off, s[0:3], 0 offset:112
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:16
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:64
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:96
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:32
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[7:10], off, s[0:3], 0 offset:80
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[31:34], off, s[0:3], 0 offset:112
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[15:18], off, s[0:3], 0 offset:48
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[11:14], off, s[0:3], 0 offset:16
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[27:30], off, s[0:3], 0 offset:64
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:96
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[19:22], off, s[0:3], 0 offset:32
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[23:26], off, s[0:3], 0
 ; GCN-NOHSA-SI-NEXT:    s_endpgm
 ;
 ; GCN-HSA-LABEL: global_zextload_v16i16_to_v16i64:
@@ -7243,133 +7240,135 @@ define amdgpu_kernel void @global_sextload_v16i16_to_v16i64(ptr addrspace(1) %ou
 define amdgpu_kernel void @global_zextload_v32i16_to_v32i64(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
 ; GCN-NOHSA-SI-LABEL: global_zextload_v32i16_to_v32i64:
 ; GCN-NOHSA-SI:       ; %bb.0:
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s12, SCRATCH_RSRC_DWORD0
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s13, SCRATCH_RSRC_DWORD1
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s14, -1
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s15, 0xe8f000
-; GCN-NOHSA-SI-NEXT:    s_add_u32 s12, s12, s3
-; GCN-NOHSA-SI-NEXT:    s_addc_u32 s13, s13, 0
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s8, SCRATCH_RSRC_DWORD0
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s9, SCRATCH_RSRC_DWORD1
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s10, -1
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s11, 0xe8f000
+; GCN-NOHSA-SI-NEXT:    s_add_u32 s8, s8, s3
+; GCN-NOHSA-SI-NEXT:    s_addc_u32 s9, s9, 0
 ; GCN-NOHSA-SI-NEXT:    s_load_dwordx4 s[4:7], s[0:1], 0x9
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s3, 0xf000
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s2, -1
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v39, 0
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s10, s2
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s11, s3
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s8, s6
-; GCN-NOHSA-SI-NEXT:    s_mov_b32 s9, s7
-; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[14:17], off, s[8:11], 0
-; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[18:21], off, s[8:11], 0 offset:16
-; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[22:25], off, s[8:11], 0 offset:32
-; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[26:29], off, s[8:11], 0 offset:48
-; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(3)
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v15
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v17
-; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(2)
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v20
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v16
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v14
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v0, 0xffff, v14
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v0, off, s[12:15], 0 offset:4 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v1, off, s[12:15], 0 offset:8 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v2, off, s[12:15], 0 offset:12 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v3, off, s[12:15], 0 offset:16 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v12, 0xffff, v16
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v14, v3
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v30, 0xffff, v15
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v34, 0xffff, v17
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v10, 16, v18
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v8, 0xffff, v18
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v4, 0xffff, v20
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, v5
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v19
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v16, 0xffff, v19
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v21
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v42, 0xffff, v21
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v22
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v46, 0xffff, v22
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v22, 16, v24
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v20, 0xffff, v24
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v23
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v50, 0xffff, v23
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v25
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v54, 0xffff, v25
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v29
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v26
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v58, 0xffff, v26
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v28
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v24, 0xffff, v28
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(1)
-; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v27
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v0, 0xffff, v27
-; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v38, 0xffff, v29
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v41, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, v39
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v55, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v57, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v51, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v53, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v43, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v45, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v17, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v19, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v35, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v37, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v31, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v33, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v25, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v27, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v59, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v61, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v21, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v23, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v47, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v49, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v5, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v7, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v9, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v15, v39
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v12, off, s[12:15], 0 offset:20 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v13, off, s[12:15], 0 offset:24 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v14, off, s[12:15], 0 offset:28 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    buffer_store_dword v15, off, s[12:15], 0 offset:32 ; 4-byte Folded Spill
-; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v12, off, s[12:15], 0 offset:4 ; 4-byte Folded Reload
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v13, off, s[12:15], 0 offset:8 ; 4-byte Folded Reload
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v14, off, s[12:15], 0 offset:12 ; 4-byte Folded Reload
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v15, off, s[12:15], 0 offset:16 ; 4-byte Folded Reload
-; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, v39
-; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v15, v39
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s0, s4
 ; GCN-NOHSA-SI-NEXT:    s_mov_b32 s1, s5
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[38:41], off, s[0:3], 0 offset:240
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[54:57], off, s[0:3], 0 offset:176
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[50:53], off, s[0:3], 0 offset:144
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[42:45], off, s[0:3], 0 offset:112
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:80
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[34:37], off, s[0:3], 0 offset:48
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[30:33], off, s[0:3], 0 offset:16
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:224
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[58:61], off, s[0:3], 0 offset:192
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:160
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[46:49], off, s[0:3], 0 offset:128
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:96
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:64
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v0, off, s[12:15], 0 offset:20 ; 4-byte Folded Reload
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v1, off, s[12:15], 0 offset:24 ; 4-byte Folded Reload
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v2, off, s[12:15], 0 offset:28 ; 4-byte Folded Reload
-; GCN-NOHSA-SI-NEXT:    buffer_load_dword v3, off, s[12:15], 0 offset:32 ; 4-byte Folded Reload
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s4, s6
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s5, s7
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s6, s2
+; GCN-NOHSA-SI-NEXT:    s_mov_b32 s7, s3
+; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[0:3], off, s[4:7], 0
+; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[57:60], off, s[4:7], 0 offset:16
+; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[53:56], off, s[4:7], 0 offset:32
+; GCN-NOHSA-SI-NEXT:    buffer_load_dwordx4 v[49:52], off, s[4:7], 0 offset:48
+; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(3)
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v1
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v3
+; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(2)
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v58
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v60
+; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(1)
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v54
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v56
 ; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:32
-; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v50
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v52
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v51
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v49
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v55
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v53
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v59
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v57
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
+; GCN-NOHSA-SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v4, 0xffff, v0
+; GCN-NOHSA-SI-NEXT:    buffer_store_dword v4, off, s[8:11], 0 offset:4 ; 4-byte Folded Spill
+; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NOHSA-SI-NEXT:    buffer_store_dword v5, off, s[8:11], 0 offset:8 ; 4-byte Folded Spill
+; GCN-NOHSA-SI-NEXT:    buffer_store_dword v6, off, s[8:11], 0 offset:12 ; 4-byte Folded Spill
+; GCN-NOHSA-SI-NEXT:    buffer_store_dword v7, off, s[8:11], 0 offset:16 ; 4-byte Folded Spill
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(3)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v7, 0xffff, v2
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v10, 0xffff, v57
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v13, 0xffff, v59
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v16, 0xffff, v53
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v19, 0xffff, v55
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v22, 0xffff, v49
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v25, 0xffff, v51
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v28, 0xffff, v1
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v31, 0xffff, v3
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v34, 0xffff, v58
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v37, 0xffff, v60
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v40, 0xffff, v54
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v43, 0xffff, v56
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v46, 0xffff, v50
+; GCN-NOHSA-SI-NEXT:    v_and_b32_e32 v3, 0xffff, v52
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v6, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[3:6], off, s[0:3], 0 offset:240
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v47, v4
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v49, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[46:49], off, s[0:3], 0 offset:208
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v44, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v46, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[43:46], off, s[0:3], 0 offset:176
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v41, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v43, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[40:43], off, s[0:3], 0 offset:144
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v38, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v40, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[37:40], off, s[0:3], 0 offset:112
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v35, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v37, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[34:37], off, s[0:3], 0 offset:80
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v32, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v34, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[31:34], off, s[0:3], 0 offset:48
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v29, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v31, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[28:31], off, s[0:3], 0 offset:16
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v26, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v28, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[25:28], off, s[0:3], 0 offset:224
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v23, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v25, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[22:25], off, s[0:3], 0 offset:192
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v20, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v22, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[19:22], off, s[0:3], 0 offset:160
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v17, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v19, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:128
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v14, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v16, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[13:16], off, s[0:3], 0 offset:96
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v11, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v13, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:64
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v8, v4
+; GCN-NOHSA-SI-NEXT:    s_waitcnt expcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v10, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[7:10], off, s[0:3], 0 offset:32
+; GCN-NOHSA-SI-NEXT:    buffer_load_dword v0, off, s[8:11], 0 offset:4 ; 4-byte Folded Reload
+; GCN-NOHSA-SI-NEXT:    buffer_load_dword v1, off, s[8:11], 0 offset:8 ; 4-byte Folded Reload
+; GCN-NOHSA-SI-NEXT:    buffer_load_dword v2, off, s[8:11], 0 offset:12 ; 4-byte Folded Reload
+; GCN-NOHSA-SI-NEXT:    buffer_load_dword v3, off, s[8:11], 0 offset:16 ; 4-byte Folded Reload
+; GCN-NOHSA-SI-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v1, v4
+; GCN-NOHSA-SI-NEXT:    v_mov_b32_e32 v3, v4
+; GCN-NOHSA-SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
 ; GCN-NOHSA-SI-NEXT:    s_endpgm
 ;
 ; GCN-HSA-LABEL: global_zextload_v32i16_to_v32i64:
@@ -7537,96 +7536,95 @@ define amdgpu_kernel void @global_zextload_v32i16_to_v32i64(ptr addrspace(1) %ou
 ; GCN-NOHSA-VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NOHSA-VI-NEXT:    s_mov_b32 s8, s6
 ; GCN-NOHSA-VI-NEXT:    s_mov_b32 s9, s7
-; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[7:10], off, s[8:11], 0
-; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[13:16], off, s[8:11], 0 offset:16
+; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[3:6], off, s[8:11], 0
+; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[7:10], off, s[8:11], 0 offset:16
 ; GCN-NOHSA-VI-NEXT:    s_mov_b32 s0, s4
 ; GCN-NOHSA-VI-NEXT:    s_mov_b32 s1, s5
 ; GCN-NOHSA-VI-NEXT:    s_waitcnt vmcnt(1)
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v6, 0xffff, v10
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v14, 0xffff, v6
 ; GCN-NOHSA-VI-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v17, 0xffff, v14
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v23, 16, v13
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v21, 0xffff, v13
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v25, 0xffff, v16
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v28, 0xffff, v15
-; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[13:16], off, s[8:11], 0 offset:32
-; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[31:34], off, s[8:11], 0 offset:48
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v2, 16, v8
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v0, 0xffff, v8
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v5, 16, v7
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v3, 0xffff, v7
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v8, 16, v10
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v9
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v10, 0xffff, v9
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v20, 16, v8
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v18, 0xffff, v8
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v7
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v22, 0xffff, v7
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v10
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v26, 0xffff, v10
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v9
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v29, 0xffff, v9
+; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[7:10], off, s[8:11], 0 offset:32
+; GCN-NOHSA-VI-NEXT:    buffer_load_dwordx4 v[32:35], off, s[8:11], 0 offset:48
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v0, 0xffff, v4
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v13, 16, v3
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v11, 0xffff, v3
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v16, 16, v6
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v4, 0xffff, v5
 ; GCN-NOHSA-VI-NEXT:    s_waitcnt vmcnt(1)
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v40, 16, v13
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v38, 0xffff, v13
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v46, 16, v15
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v44, 0xffff, v15
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v7
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v39, 0xffff, v7
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v47, 16, v9
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v45, 0xffff, v9
 ; GCN-NOHSA-VI-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v15, 16, v32
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v13, 0xffff, v32
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v34
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v50, 0xffff, v34
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v33
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v32, 0xffff, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v33, 0
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v51, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v53, v33
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v31
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v47, 0xffff, v31
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[50:53], off, s[0:3], 0 offset:240
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v48, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v50, v33
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[47:50], off, s[0:3], 0 offset:192
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v45, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v47, v33
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v43, 16, v16
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v41, 0xffff, v16
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[44:47], off, s[0:3], 0 offset:160
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v42, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v44, v33
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[41:44], off, s[0:3], 0 offset:176
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v39, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v41, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v29, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v31, v33
-; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v14
-; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v35, 0xffff, v14
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v14, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v16, v33
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[38:41], off, s[0:3], 0 offset:128
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v36, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v38, v33
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[28:31], off, s[0:3], 0 offset:96
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v26, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v28, v33
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[13:16], off, s[0:3], 0 offset:208
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[35:38], off, s[0:3], 0 offset:144
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v22, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v35, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v24, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v18, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v20, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v11, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v13, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v7, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v9, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v4, v33
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[25:28], off, s[0:3], 0 offset:112
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[32:35], off, s[0:3], 0 offset:224
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[21:24], off, s[0:3], 0 offset:64
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[17:20], off, s[0:3], 0 offset:80
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[10:13], off, s[0:3], 0 offset:32
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[6:9], off, s[0:3], 0 offset:48
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v1, v33
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v6, v33
-; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[3:6], off, s[0:3], 0
-; GCN-NOHSA-VI-NEXT:    s_nop 0
-; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v3, v33
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v9, 16, v33
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v7, 0xffff, v33
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v35
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v51, 0xffff, v35
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v34
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v33, 0xffff, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v34, 0
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v52, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v54, v34
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v32
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v48, 0xffff, v32
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[51:54], off, s[0:3], 0 offset:240
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v49, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v51, v34
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[48:51], off, s[0:3], 0 offset:192
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v46, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v48, v34
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v44, 16, v10
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v42, 0xffff, v10
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[45:48], off, s[0:3], 0 offset:160
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v43, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v45, v34
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[42:45], off, s[0:3], 0 offset:176
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v40, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v42, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v30, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v32, v34
+; GCN-NOHSA-VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v8
+; GCN-NOHSA-VI-NEXT:    v_and_b32_e32 v36, 0xffff, v8
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v8, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v10, v34
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[39:42], off, s[0:3], 0 offset:128
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v37, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v39, v34
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[29:32], off, s[0:3], 0 offset:96
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v27, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v29, v34
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[7:10], off, s[0:3], 0 offset:208
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[36:39], off, s[0:3], 0 offset:144
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v23, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v36, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v25, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v19, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v21, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v5, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v7, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v15, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v17, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v12, v34
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[26:29], off, s[0:3], 0 offset:112
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[33:36], off, s[0:3], 0 offset:224
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[22:25], off, s[0:3], 0 offset:64
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[18:21], off, s[0:3], 0 offset:80
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:32
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[14:17], off, s[0:3], 0 offset:48
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v1, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v14, v34
+; GCN-NOHSA-VI-NEXT:    v_mov_b32_e32 v3, v34
+; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[11:14], off, s[0:3], 0
 ; GCN-NOHSA-VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:16
 ; GCN-NOHSA-VI-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/load-global-i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-global-i32.ll
@@ -2311,56 +2311,55 @@ define amdgpu_kernel void @global_sextload_v16i32_to_v16i64(ptr addrspace(1) %ou
 ; SI-NOHSA-NEXT:    s_waitcnt lgkmcnt(0)
 ; SI-NOHSA-NEXT:    s_mov_b32 s8, s6
 ; SI-NOHSA-NEXT:    s_mov_b32 s9, s7
-; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[0:3], off, s[8:11], 0 offset:48
-; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[4:7], off, s[8:11], 0 offset:32
-; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[8:11], off, s[8:11], 0 offset:16
-; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[12:15], off, s[8:11], 0
+; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[0:3], off, s[8:11], 0 offset:32
+; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[4:7], off, s[8:11], 0 offset:48
+; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[8:11], off, s[8:11], 0
+; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[12:15], off, s[8:11], 0 offset:16
 ; SI-NOHSA-NEXT:    s_waitcnt vmcnt(3)
 ; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v19, 31, v3
 ; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v17, 31, v2
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v23, 31, v1
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v21, 31, v0
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v20, v0
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v22, v1
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v16, v2
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v18, v3
 ; SI-NOHSA-NEXT:    s_waitcnt vmcnt(2)
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v7
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v6
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v23, 31, v7
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v21, 31, v6
 ; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v5
 ; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v4
 ; SI-NOHSA-NEXT:    v_mov_b32_e32 v24, v4
 ; SI-NOHSA-NEXT:    v_mov_b32_e32 v26, v5
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v6
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v7
-; SI-NOHSA-NEXT:    s_waitcnt vmcnt(1)
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v10
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v9
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v8
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v28, v8
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v30, v9
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v4, v10
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v6, v11
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v20, v6
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v22, v7
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v1
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v0
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v4, v0
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v6, v1
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v16, v2
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v18, v3
 ; SI-NOHSA-NEXT:    s_waitcnt vmcnt(0)
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v11, 31, v15
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v9, 31, v14
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v35, 31, v13
-; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v33, 31, v12
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v32, v12
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v34, v13
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v8, v14
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v10, v15
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v15
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v14
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v13
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v12
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v28, v12
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v30, v13
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v14
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v15
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v15, 31, v11
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v13, 31, v10
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v35, 31, v9
+; SI-NOHSA-NEXT:    v_ashrrev_i32_e32 v33, 31, v8
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v32, v8
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v34, v9
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v12, v10
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v14, v11
 ; SI-NOHSA-NEXT:    s_mov_b32 s0, s4
 ; SI-NOHSA-NEXT:    s_mov_b32 s1, s5
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:96
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:112
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:64
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:80
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:96
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:112
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:64
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:80
 ; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[28:31], off, s[0:3], 0 offset:32
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:48
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
 ; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[32:35], off, s[0:3], 0
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:16
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[12:15], off, s[0:3], 0 offset:16
 ; SI-NOHSA-NEXT:    s_endpgm
 ;
 ; GCNX3-HSA-LABEL: global_sextload_v16i32_to_v16i64:
@@ -2471,22 +2470,30 @@ define amdgpu_kernel void @global_sextload_v16i32_to_v16i64(ptr addrspace(1) %ou
 ; GCNX3-NOHSA-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCNX3-NOHSA-NEXT:    s_mov_b32 s8, s6
 ; GCNX3-NOHSA-NEXT:    s_mov_b32 s9, s7
-; GCNX3-NOHSA-NEXT:    buffer_load_dwordx4 v[0:3], off, s[8:11], 0 offset:32
-; GCNX3-NOHSA-NEXT:    buffer_load_dwordx4 v[4:7], off, s[8:11], 0 offset:48
-; GCNX3-NOHSA-NEXT:    buffer_load_dwordx4 v[8:11], off, s[8:11], 0 offset:16
+; GCNX3-NOHSA-NEXT:    buffer_load_dwordx4 v[0:3], off, s[8:11], 0 offset:16
+; GCNX3-NOHSA-NEXT:    buffer_load_dwordx4 v[4:7], off, s[8:11], 0 offset:32
+; GCNX3-NOHSA-NEXT:    buffer_load_dwordx4 v[8:11], off, s[8:11], 0 offset:48
 ; GCNX3-NOHSA-NEXT:    buffer_load_dwordx4 v[12:15], off, s[8:11], 0
 ; GCNX3-NOHSA-NEXT:    s_mov_b32 s0, s4
 ; GCNX3-NOHSA-NEXT:    s_mov_b32 s1, s5
 ; GCNX3-NOHSA-NEXT:    s_waitcnt vmcnt(3)
 ; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v19, 31, v3
-; GCNX3-NOHSA-NEXT:    s_waitcnt vmcnt(2)
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v5
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v4
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v24, v4
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v26, v5
 ; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v17, 31, v2
+; GCNX3-NOHSA-NEXT:    s_waitcnt vmcnt(1)
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v9
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v8
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v28, v8
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v30, v9
 ; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v23, 31, v7
 ; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v21, 31, v6
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v11
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v10
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v24, v10
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v26, v11
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v11, 31, v5
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v9, 31, v4
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v8, v4
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v10, v5
 ; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v20, v6
 ; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v22, v7
 ; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v1
@@ -2495,32 +2502,23 @@ define amdgpu_kernel void @global_sextload_v16i32_to_v16i64(ptr addrspace(1) %ou
 ; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v6, v1
 ; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v16, v2
 ; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v18, v3
-; GCNX3-NOHSA-NEXT:    s_waitcnt vmcnt(1)
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v11
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v10
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v9
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v8
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v28, v8
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v30, v9
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v0, v10
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v2, v11
 ; GCNX3-NOHSA-NEXT:    s_waitcnt vmcnt(0)
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v11, 31, v15
-; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v9, 31, v14
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v15
+; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v14
 ; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v35, 31, v13
 ; GCNX3-NOHSA-NEXT:    v_ashrrev_i32_e32 v33, 31, v12
 ; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v32, v12
 ; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v34, v13
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v8, v14
-; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v10, v15
-; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:96
-; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:112
-; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:64
-; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:80
-; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[28:31], off, s[0:3], 0 offset:32
-; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:48
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v0, v14
+; GCNX3-NOHSA-NEXT:    v_mov_b32_e32 v2, v15
+; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[28:31], off, s[0:3], 0 offset:96
+; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[24:27], off, s[0:3], 0 offset:112
+; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:64
+; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[20:23], off, s[0:3], 0 offset:80
+; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:32
+; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[16:19], off, s[0:3], 0 offset:48
 ; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[32:35], off, s[0:3], 0
-; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[8:11], off, s[0:3], 0 offset:16
+; GCNX3-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:16
 ; GCNX3-NOHSA-NEXT:    s_endpgm
 ;
 ; EG-LABEL: global_sextload_v16i32_to_v16i64:
@@ -3127,31 +3125,31 @@ define amdgpu_kernel void @global_sextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s5
 ; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 0x50
-; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[20:23], v[0:1]
+; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[16:19], v[0:1]
 ; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s5
 ; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 64
-; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[12:15], v[0:1]
+; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[8:11], v[0:1]
 ; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s4
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s5
 ; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[4:7], v[0:1]
 ; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 48
 ; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v9, s5
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v8, s4
-; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[16:19], v[8:9]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v13, s5
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v12, s4
+; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[20:23], v[12:13]
 ; GCNX3-HSA-NEXT:    s_add_u32 s6, s2, 32
 ; GCNX3-HSA-NEXT:    s_addc_u32 s7, s3, 0
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s2, 16
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s3, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s2
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v9, s7
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v13, s7
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v8, s6
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v12, s6
 ; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
-; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[8:11], v[8:9]
+; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[12:15], v[12:13]
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 16
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v37, s1
@@ -3164,143 +3162,143 @@ define amdgpu_kernel void @global_sextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v29, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xe0
-; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[36:37], v[32:35]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v37, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v36, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xf0
+; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v35, 31, v31
 ; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v33, 31, v30
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v32, v30
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v34, v31
-; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[32:35]
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(8)
 ; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v25
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v33, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v32, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xc0
-; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v35, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v34, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xd0
 ; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v24
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, v24
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, v25
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xf0
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[36:37], v[28:31]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v37, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v36, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xa0
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[28:31]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xc0
+; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v33, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v32, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xd0
 ; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v27
 ; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v26
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, v26
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, v27
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[28:31]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[28:31]
+; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(9)
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v17
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v29, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xa0
+; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v31, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xb0
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v16
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, v16
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, v17
+; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[24:27]
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v33, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v32, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xb0
-; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v39, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v38, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x80
-; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(9)
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v21
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v20
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, v20
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, v21
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v19
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v18
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, v18
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, v19
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v23
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v22
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, v22
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, v23
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[24:27]
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[36:37], v[28:31]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[24:27]
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(10)
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v23, 31, v15
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v21, 31, v14
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v13
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v12
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, v12
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, v13
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v20, v14
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v22, v15
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v19, 31, v11
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v17, 31, v10
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v9
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v8
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, v8
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, v9
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v16, v10
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v18, v11
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(9)
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v15, 31, v5
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v13, 31, v4
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v12, v4
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v14, v5
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v11, 31, v5
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v9, 31, v4
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v8, v4
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v10, v5
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v5, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x90
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[24:27]
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[38:39], v[20:23]
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[12:15]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[24:27]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[16:19]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[8:11]
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v5, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x60
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v26, 31, v7
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v24, 31, v6
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v23, v6
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, v7
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v7
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v6
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, v6
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, v7
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[23:26]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[4:5], v[24:27]
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(12)
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v16
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, v16
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v16, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v15, s2
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v20
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, v20
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v20, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v19, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x70
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v17
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v6, v17
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v21
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v6, v21
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[15:16], v[4:7]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v16, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v15, s2
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[19:20], v[4:7]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v20, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v19, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 64
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v26, 31, v19
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v24, 31, v18
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v23, v18
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, v19
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v23
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v22
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, v22
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, v23
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[15:16], v[23:26]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[19:20], v[24:27]
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(12)
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v18, 31, v9
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v16, 31, v8
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v15, v8
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v17, v9
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v8, s2
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v20, 31, v12
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v19, v12
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v12, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v11, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x50
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v22, 31, v13
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v21, v13
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[15:18]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v9, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v8, s2
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[11:12], v[19:22]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v12, s3
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v15
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v14
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, v14
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v6, v15
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v11, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 32
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v14, 31, v1
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v12, 31, v0
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v11
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v6, v11
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v11, v0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v13, v1
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v10, 31, v1
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v8, 31, v0
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[11:12], v[4:7]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v9, v1
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v7, v0
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s3
 ; GCNX3-HSA-NEXT:    s_add_u32 s0, s0, 48
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[11:14]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[7:10]
 ; GCNX3-HSA-NEXT:    s_addc_u32 s1, s1, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s0
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v22, 31, v3
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v20, 31, v2
-; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v10
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, v10
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v19, v2
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v21, v3
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v18, 31, v3
+; GCNX3-HSA-NEXT:    v_ashrrev_i32_e32 v16, 31, v2
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v15, v2
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v17, v3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s1
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[8:9], v[4:7]
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[19:22]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[0:1], v[15:18]
 ; GCNX3-HSA-NEXT:    s_endpgm
 ;
 ; GCNX3-NOHSA-LABEL: global_sextload_v32i32_to_v32i64:
@@ -3578,230 +3576,109 @@ define amdgpu_kernel void @global_sextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ; EG-NEXT:     MOV * T32.Z, T12.Y,
 ; EG-NEXT:    2(2.802597e-45), 0(0.000000e+00)
 ;
-; GCN-GFX900-HSA-LABEL: global_sextload_v32i32_to_v32i64:
-; GCN-GFX900-HSA:       ; %bb.0:
-; GCN-GFX900-HSA-NEXT:    s_mov_b64 s[10:11], s[2:3]
-; GCN-GFX900-HSA-NEXT:    s_mov_b64 s[8:9], s[0:1]
-; GCN-GFX900-HSA-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x0
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v8, 0
-; GCN-GFX900-HSA-NEXT:    s_add_u32 s8, s8, s7
-; GCN-GFX900-HSA-NEXT:    s_addc_u32 s9, s9, 0
-; GCN-GFX900-HSA-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[0:3], v8, s[2:3] offset:96
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[4:7], v8, s[2:3] offset:112
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[9:12], v8, s[2:3] offset:80
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[13:16], v8, s[2:3] offset:64
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[17:20], v8, s[2:3] offset:48
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[21:24], v8, s[2:3] offset:32
-; GCN-GFX900-HSA-NEXT:    s_waitcnt vmcnt(5)
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v28, 31, v3
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v26, 31, v2
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v25, v2
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v27, v3
-; GCN-GFX900-HSA-NEXT:    s_waitcnt vmcnt(4)
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v32, 31, v7
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v30, 31, v6
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v36, 31, v5
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v34, 31, v4
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v33, v4
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v35, v5
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v29, v6
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v31, v7
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v1
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v0
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v4, v0
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v6, v1
-; GCN-GFX900-HSA-NEXT:    buffer_store_dword v25, off, s[8:11], 0 offset:4 ; 4-byte Folded Spill
-; GCN-GFX900-HSA-NEXT:    s_waitcnt vmcnt(0)
-; GCN-GFX900-HSA-NEXT:    buffer_store_dword v26, off, s[8:11], 0 offset:8 ; 4-byte Folded Spill
-; GCN-GFX900-HSA-NEXT:    buffer_store_dword v27, off, s[8:11], 0 offset:12 ; 4-byte Folded Spill
-; GCN-GFX900-HSA-NEXT:    buffer_store_dword v28, off, s[8:11], 0 offset:16 ; 4-byte Folded Spill
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v28, 31, v12
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v26, 31, v11
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v40, 31, v10
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v38, 31, v9
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v37, v9
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v39, v10
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v25, v11
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v27, v12
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v12, 31, v16
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v10, 31, v15
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v44, 31, v14
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v42, 31, v13
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v41, v13
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v43, v14
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v9, v15
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v11, v16
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v16, 31, v20
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v14, 31, v19
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v48, 31, v18
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v46, 31, v17
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v45, v17
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v47, v18
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v13, v19
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[49:52], v8, s[2:3] offset:16
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v15, v20
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v20, 31, v24
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v18, 31, v23
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v56, 31, v22
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v54, 31, v21
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v53, v21
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v55, v22
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v17, v23
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v19, v24
-; GCN-GFX900-HSA-NEXT:    global_load_dwordx4 v[21:24], v8, s[2:3]
-; GCN-GFX900-HSA-NEXT:    s_nop 0
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[33:36], s[0:1] offset:224
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[29:32], s[0:1] offset:240
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:192
-; GCN-GFX900-HSA-NEXT:    buffer_load_dword v32, off, s[8:11], 0 offset:4 ; 4-byte Folded Reload
-; GCN-GFX900-HSA-NEXT:    s_nop 0
-; GCN-GFX900-HSA-NEXT:    buffer_load_dword v33, off, s[8:11], 0 offset:8 ; 4-byte Folded Reload
-; GCN-GFX900-HSA-NEXT:    buffer_load_dword v34, off, s[8:11], 0 offset:12 ; 4-byte Folded Reload
-; GCN-GFX900-HSA-NEXT:    buffer_load_dword v35, off, s[8:11], 0 offset:16 ; 4-byte Folded Reload
-; GCN-GFX900-HSA-NEXT:    s_waitcnt vmcnt(8)
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v60, 31, v52
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v58, 31, v51
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v50
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v49
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v0, v49
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v2, v50
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v57, v51
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v59, v52
-; GCN-GFX900-HSA-NEXT:    s_waitcnt vmcnt(7)
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v24
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v23
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v22
-; GCN-GFX900-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v21
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v4, v21
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v6, v22
-; GCN-GFX900-HSA-NEXT:    s_waitcnt vmcnt(0)
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[32:35], s[0:1] offset:208
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[37:40], s[0:1] offset:160
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[25:28], s[0:1] offset:176
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[41:44], s[0:1] offset:128
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[9:12], s[0:1] offset:144
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[45:48], s[0:1] offset:96
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[13:16], s[0:1] offset:112
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[53:56], s[0:1] offset:64
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[17:20], s[0:1] offset:80
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1] offset:32
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[57:60], s[0:1] offset:48
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v28, v23
-; GCN-GFX900-HSA-NEXT:    v_mov_b32_e32 v30, v24
-; GCN-GFX900-HSA-NEXT:    global_store_dwordx4 v8, v[28:31], s[0:1] offset:16
-; GCN-GFX900-HSA-NEXT:    s_endpgm
-;
-; GCN-GFX908-HSA-LABEL: global_sextload_v32i32_to_v32i64:
-; GCN-GFX908-HSA:       ; %bb.0:
-; GCN-GFX908-HSA-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x0
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v8, 0
-; GCN-GFX908-HSA-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[0:3], v8, s[2:3] offset:96
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[4:7], v8, s[2:3] offset:112
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[9:12], v8, s[2:3] offset:80
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[13:16], v8, s[2:3] offset:64
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[17:20], v8, s[2:3] offset:48
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[21:24], v8, s[2:3] offset:32
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[49:52], v8, s[2:3] offset:16
-; GCN-GFX908-HSA-NEXT:    s_waitcnt vmcnt(6)
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v25, v2
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v28, 31, v3
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v26, 31, v2
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v27, v3
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_write_b32 a0, v25
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_write_b32 a1, v26
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_write_b32 a2, v27
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_write_b32 a3, v28
-; GCN-GFX908-HSA-NEXT:    s_waitcnt vmcnt(4)
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v28, 31, v12
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v26, 31, v11
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v40, 31, v10
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v38, 31, v9
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v37, v9
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v39, v10
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v25, v11
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v27, v12
-; GCN-GFX908-HSA-NEXT:    s_waitcnt vmcnt(3)
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v12, 31, v16
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v10, 31, v15
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v44, 31, v14
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v42, 31, v13
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v41, v13
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v43, v14
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v9, v15
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v11, v16
-; GCN-GFX908-HSA-NEXT:    s_waitcnt vmcnt(2)
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v16, 31, v20
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v14, 31, v19
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v48, 31, v18
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v46, 31, v17
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v45, v17
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v47, v18
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v13, v19
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v15, v20
-; GCN-GFX908-HSA-NEXT:    s_waitcnt vmcnt(1)
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v20, 31, v24
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v18, 31, v23
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v56, 31, v22
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v54, 31, v21
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v53, v21
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v55, v22
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v17, v23
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v19, v24
-; GCN-GFX908-HSA-NEXT:    global_load_dwordx4 v[21:24], v8, s[2:3]
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v32, 31, v7
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v36, 31, v5
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v34, 31, v4
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v33, v4
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v35, v5
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v30, 31, v6
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v29, v6
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v31, v7
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[33:36], s[0:1] offset:224
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[29:32], s[0:1] offset:240
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_read_b32 v35, a3
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v1
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v0
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v4, v0
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v6, v1
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_read_b32 v34, a2
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_read_b32 v33, a1
-; GCN-GFX908-HSA-NEXT:    v_accvgpr_read_b32 v32, a0
-; GCN-GFX908-HSA-NEXT:    s_waitcnt vmcnt(3)
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v60, 31, v52
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v58, 31, v51
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v50
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v49
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v0, v49
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v2, v50
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v57, v51
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v59, v52
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:192
-; GCN-GFX908-HSA-NEXT:    s_waitcnt vmcnt(3)
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v24
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v23
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v22
-; GCN-GFX908-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v21
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v4, v21
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v6, v22
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[32:35], s[0:1] offset:208
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[37:40], s[0:1] offset:160
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[25:28], s[0:1] offset:176
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[41:44], s[0:1] offset:128
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[9:12], s[0:1] offset:144
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[45:48], s[0:1] offset:96
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[13:16], s[0:1] offset:112
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[53:56], s[0:1] offset:64
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[17:20], s[0:1] offset:80
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1] offset:32
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[57:60], s[0:1] offset:48
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v28, v23
-; GCN-GFX908-HSA-NEXT:    v_mov_b32_e32 v30, v24
-; GCN-GFX908-HSA-NEXT:    global_store_dwordx4 v8, v[28:31], s[0:1] offset:16
-; GCN-GFX908-HSA-NEXT:    s_endpgm
+; GCN-HSA-LABEL: global_sextload_v32i32_to_v32i64:
+; GCN-HSA:       ; %bb.0:
+; GCN-HSA-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x0
+; GCN-HSA-NEXT:    v_mov_b32_e32 v48, 0
+; GCN-HSA-NEXT:    s_waitcnt lgkmcnt(0)
+; GCN-HSA-NEXT:    global_load_dwordx4 v[12:15], v48, s[2:3] offset:96
+; GCN-HSA-NEXT:    global_load_dwordx4 v[16:19], v48, s[2:3] offset:112
+; GCN-HSA-NEXT:    global_load_dwordx4 v[28:31], v48, s[2:3] offset:80
+; GCN-HSA-NEXT:    global_load_dwordx4 v[32:35], v48, s[2:3] offset:64
+; GCN-HSA-NEXT:    global_load_dwordx4 v[40:43], v48, s[2:3] offset:48
+; GCN-HSA-NEXT:    global_load_dwordx4 v[49:52], v48, s[2:3] offset:32
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(5)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v15
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v14
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(4)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v19
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v18
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v11, 31, v17
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v9, 31, v16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v8, v16
+; GCN-HSA-NEXT:    v_mov_b32_e32 v10, v17
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, v18
+; GCN-HSA-NEXT:    v_mov_b32_e32 v6, v19
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v19, 31, v13
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v17, 31, v12
+; GCN-HSA-NEXT:    v_mov_b32_e32 v16, v12
+; GCN-HSA-NEXT:    v_mov_b32_e32 v18, v13
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, v14
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, v15
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(3)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v23, 31, v31
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v21, 31, v30
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v27, 31, v29
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v25, 31, v28
+; GCN-HSA-NEXT:    v_mov_b32_e32 v24, v28
+; GCN-HSA-NEXT:    v_mov_b32_e32 v26, v29
+; GCN-HSA-NEXT:    v_mov_b32_e32 v20, v30
+; GCN-HSA-NEXT:    v_mov_b32_e32 v22, v31
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(2)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v15, 31, v35
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v13, 31, v34
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v31, 31, v33
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v29, 31, v32
+; GCN-HSA-NEXT:    v_mov_b32_e32 v28, v32
+; GCN-HSA-NEXT:    v_mov_b32_e32 v30, v33
+; GCN-HSA-NEXT:    v_mov_b32_e32 v12, v34
+; GCN-HSA-NEXT:    v_mov_b32_e32 v14, v35
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(1)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v35, 31, v43
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v33, 31, v42
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v39, 31, v41
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v37, 31, v40
+; GCN-HSA-NEXT:    v_mov_b32_e32 v36, v40
+; GCN-HSA-NEXT:    v_mov_b32_e32 v38, v41
+; GCN-HSA-NEXT:    v_mov_b32_e32 v32, v42
+; GCN-HSA-NEXT:    v_mov_b32_e32 v34, v43
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(0)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v43, 31, v52
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v41, 31, v51
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v47, 31, v50
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v45, 31, v49
+; GCN-HSA-NEXT:    v_mov_b32_e32 v44, v49
+; GCN-HSA-NEXT:    v_mov_b32_e32 v46, v50
+; GCN-HSA-NEXT:    v_mov_b32_e32 v40, v51
+; GCN-HSA-NEXT:    v_mov_b32_e32 v42, v52
+; GCN-HSA-NEXT:    global_load_dwordx4 v[49:52], v48, s[2:3] offset:16
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(0)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v56, 31, v52
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v54, 31, v51
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v60, 31, v50
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v58, 31, v49
+; GCN-HSA-NEXT:    v_mov_b32_e32 v57, v49
+; GCN-HSA-NEXT:    v_mov_b32_e32 v59, v50
+; GCN-HSA-NEXT:    v_mov_b32_e32 v53, v51
+; GCN-HSA-NEXT:    v_mov_b32_e32 v55, v52
+; GCN-HSA-NEXT:    global_load_dwordx4 v[49:52], v48, s[2:3]
+; GCN-HSA-NEXT:    s_nop 0
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[8:11], s[0:1] offset:224
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[4:7], s[0:1] offset:240
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[16:19], s[0:1] offset:192
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[0:3], s[0:1] offset:208
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[24:27], s[0:1] offset:160
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[20:23], s[0:1] offset:176
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[28:31], s[0:1] offset:128
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[12:15], s[0:1] offset:144
+; GCN-HSA-NEXT:    s_waitcnt vmcnt(8)
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v3, 31, v52
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v1, 31, v51
+; GCN-HSA-NEXT:    v_mov_b32_e32 v0, v51
+; GCN-HSA-NEXT:    v_mov_b32_e32 v2, v52
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v7, 31, v50
+; GCN-HSA-NEXT:    v_ashrrev_i32_e32 v5, 31, v49
+; GCN-HSA-NEXT:    v_mov_b32_e32 v4, v49
+; GCN-HSA-NEXT:    v_mov_b32_e32 v6, v50
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[36:39], s[0:1] offset:96
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[32:35], s[0:1] offset:112
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[44:47], s[0:1] offset:64
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[40:43], s[0:1] offset:80
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[57:60], s[0:1] offset:32
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[53:56], s[0:1] offset:48
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[4:7], s[0:1]
+; GCN-HSA-NEXT:    global_store_dwordx4 v48, v[0:3], s[0:1] offset:16
+; GCN-HSA-NEXT:    s_endpgm
   %ld = load <32 x i32>, ptr addrspace(1) %in
   %ext = sext <32 x i32> %ld to <32 x i64>
   store <32 x i64> %ext, ptr addrspace(1) %out
@@ -3819,33 +3696,33 @@ define amdgpu_kernel void @global_zextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ; SI-NOHSA-NEXT:    s_mov_b32 s11, s3
 ; SI-NOHSA-NEXT:    v_mov_b32_e32 v3, v1
 ; SI-NOHSA-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NOHSA-NEXT:    s_mov_b32 s8, s6
-; SI-NOHSA-NEXT:    s_mov_b32 s9, s7
 ; SI-NOHSA-NEXT:    s_mov_b32 s0, s4
 ; SI-NOHSA-NEXT:    s_mov_b32 s1, s5
-; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[4:7], off, s[8:11], 0 offset:112
-; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[8:11], off, s[8:11], 0 offset:96
+; SI-NOHSA-NEXT:    s_mov_b32 s8, s6
+; SI-NOHSA-NEXT:    s_mov_b32 s9, s7
+; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[4:7], off, s[8:11], 0 offset:96
+; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[8:11], off, s[8:11], 0 offset:112
 ; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[12:15], off, s[8:11], 0
 ; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[16:19], off, s[8:11], 0 offset:16
 ; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[20:23], off, s[8:11], 0 offset:32
 ; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[24:27], off, s[8:11], 0 offset:48
-; SI-NOHSA-NEXT:    s_waitcnt vmcnt(5)
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v4
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v5
+; SI-NOHSA-NEXT:    s_waitcnt vmcnt(4)
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v8
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v9
 ; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[28:31], off, s[8:11], 0 offset:64
 ; SI-NOHSA-NEXT:    buffer_load_dwordx4 v[32:35], off, s[8:11], 0 offset:80
 ; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:224
 ; SI-NOHSA-NEXT:    s_waitcnt expcnt(0)
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v6
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v7
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
-; SI-NOHSA-NEXT:    s_waitcnt vmcnt(8) expcnt(0)
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v8
-; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v9
-; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
-; SI-NOHSA-NEXT:    s_waitcnt expcnt(0)
 ; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v10
 ; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v11
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:240
+; SI-NOHSA-NEXT:    s_waitcnt expcnt(0)
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v4
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v5
+; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:192
+; SI-NOHSA-NEXT:    s_waitcnt expcnt(0)
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v6
+; SI-NOHSA-NEXT:    v_mov_b32_e32 v2, v7
 ; SI-NOHSA-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0 offset:208
 ; SI-NOHSA-NEXT:    s_waitcnt vmcnt(4) expcnt(0)
 ; SI-NOHSA-NEXT:    v_mov_b32_e32 v0, v32
@@ -3904,14 +3781,14 @@ define amdgpu_kernel void @global_zextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 16
 ; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
 ; GCNX3-HSA-NEXT:    s_add_u32 s6, s2, 32
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCNX3-HSA-NEXT:    s_addc_u32 s7, s3, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s3
 ; GCNX3-HSA-NEXT:    s_add_u32 s8, s2, 48
-; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[28:31], v[0:1]
 ; GCNX3-HSA-NEXT:    s_addc_u32 s9, s3, 0
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s10, s2, 64
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s3
 ; GCNX3-HSA-NEXT:    s_addc_u32 s11, s3, 0
+; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[24:27], v[0:1]
 ; GCNX3-HSA-NEXT:    s_add_u32 s12, s2, 0x50
 ; GCNX3-HSA-NEXT:    s_addc_u32 s13, s3, 0
 ; GCNX3-HSA-NEXT:    s_add_u32 s14, s2, 0x60
@@ -3920,10 +3797,10 @@ define amdgpu_kernel void @global_zextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s3, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s3
-; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[32:35], v[0:1]
+; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[28:31], v[0:1]
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s14
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s15
-; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[24:27], v[0:1]
+; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[32:35], v[0:1]
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s12
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s13
 ; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[20:23], v[0:1]
@@ -3944,91 +3821,90 @@ define amdgpu_kernel void @global_zextload_v32i32_to_v32i64(ptr addrspace(1) %ou
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v3, v1
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(7)
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v24
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v25
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s1
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s0
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xe0
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v26
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v27
+; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xf0
+; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(8)
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v28
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v29
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v29, s1
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, s0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[0:3]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v29, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xe0
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v30
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v31
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v31, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xf0
-; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[0:3]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v29, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, s2
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xc0
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(8)
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v32
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v33
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[0:3]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v31, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, s2
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v27, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xd0
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v30
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v31
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v33, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v32, s2
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xa0
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v34
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v35
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v35, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v34, s2
+; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(9)
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v32
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v33
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[0:3]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v27, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0xb0
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[0:3]
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v29, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x80
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(9)
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v24
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v25
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v31, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, s2
+; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x90
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v34
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v35
+; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v25, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v24, s2
-; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x90
-; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[0:3]
-; GCNX3-HSA-NEXT:    s_nop 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v26
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v27
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v27, s3
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v26, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x60
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[32:33], v[0:3]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v31, s3
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(10)
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v20
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v21
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[34:35], v[0:3]
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v30, s2
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[0:3]
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v21, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v22
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v23
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v20, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 0x70
 ; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[28:29], v[0:3]
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(11)
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v16
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v17
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[0:3]
 ; GCNX3-HSA-NEXT:    s_nop 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v18
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v19
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[26:27], v[0:3]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[24:25], v[0:3]
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(12)
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v12
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v13
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v13, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v12, s2
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s0, 64
-; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[30:31], v[0:3]
+; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[20:21], v[0:3]
 ; GCNX3-HSA-NEXT:    s_addc_u32 s3, s1, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, v14
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, v15
@@ -4427,12 +4303,14 @@ define amdgpu_kernel void @global_load_v32i32(ptr addrspace(1) %out, ptr addrspa
 ; GCNX3-HSA-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 16
 ; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
-; GCNX3-HSA-NEXT:    s_add_u32 s6, s2, 48
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s2
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v29, s5
-; GCNX3-HSA-NEXT:    s_addc_u32 s7, s3, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s3
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v28, s4
+; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 48
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v0, s2
+; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, s4
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v1, s3
+; GCNX3-HSA-NEXT:    v_mov_b32_e32 v5, s5
 ; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 32
 ; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[0:3], v[0:1]
 ; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
@@ -4447,9 +4325,7 @@ define amdgpu_kernel void @global_load_v32i32(ptr addrspace(1) %out, ptr addrspa
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v17, s5
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v16, s4
 ; GCNX3-HSA-NEXT:    s_add_u32 s4, s2, 0x70
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v4, s6
 ; GCNX3-HSA-NEXT:    s_addc_u32 s5, s3, 0
-; GCNX3-HSA-NEXT:    v_mov_b32_e32 v5, s7
 ; GCNX3-HSA-NEXT:    s_add_u32 s2, s2, 0x60
 ; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[4:7], v[4:5]
 ; GCNX3-HSA-NEXT:    flat_load_dwordx4 v[8:11], v[8:9]
@@ -4485,10 +4361,9 @@ define amdgpu_kernel void @global_load_v32i32(ptr addrspace(1) %out, ptr addrspa
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v2, s10
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v3, s11
 ; GCNX3-HSA-NEXT:    s_add_u32 s0, s0, 16
-; GCNX3-HSA-NEXT:    s_addc_u32 s1, s1, 0
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(7)
 ; GCNX3-HSA-NEXT:    flat_store_dwordx4 v[2:3], v[4:7]
-; GCNX3-HSA-NEXT:    s_nop 0
+; GCNX3-HSA-NEXT:    s_addc_u32 s1, s1, 0
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v6, s8
 ; GCNX3-HSA-NEXT:    v_mov_b32_e32 v7, s9
 ; GCNX3-HSA-NEXT:    s_waitcnt vmcnt(7)
@@ -4637,3 +4512,6 @@ define amdgpu_kernel void @global_load_v32i32(ptr addrspace(1) %out, ptr addrspa
 }
 
 attributes #0 = { nounwind }
+;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
+; GCN-GFX900-HSA: {{.*}}
+; GCN-GFX908-HSA: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/preserve-wwm-copy-dst-reg.ll
+++ b/llvm/test/CodeGen/AMDGPU/preserve-wwm-copy-dst-reg.ll
@@ -194,9 +194,6 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    ;;#ASMSTART
 ; GFX906-NEXT:    ; def s21
 ; GFX906-NEXT:    ;;#ASMEND
-; GFX906-NEXT:    v_writelane_b32 v40, s21, 24
-; GFX906-NEXT:    s_or_saveexec_b64 s[34:35], -1
-; GFX906-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX906-NEXT:    ;;#ASMSTART
 ; GFX906-NEXT:    ; def s22
 ; GFX906-NEXT:    ;;#ASMEND
@@ -222,6 +219,7 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    ; def s29
 ; GFX906-NEXT:    ;;#ASMEND
 ; GFX906-NEXT:    buffer_load_dword v31, off, s[0:3], s33 offset:4 ; 4-byte Folded Reload
+; GFX906-NEXT:    v_writelane_b32 v40, s21, 24
 ; GFX906-NEXT:    v_writelane_b32 v40, s22, 25
 ; GFX906-NEXT:    v_writelane_b32 v40, s23, 26
 ; GFX906-NEXT:    v_writelane_b32 v40, s24, 27
@@ -244,6 +242,8 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    v_readlane_b32 s9, v40, 7
 ; GFX906-NEXT:    v_readlane_b32 s11, v40, 5
 ; GFX906-NEXT:    v_readlane_b32 s17, v40, 23
+; GFX906-NEXT:    s_or_saveexec_b64 s[34:35], -1
+; GFX906-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX906-NEXT:    s_swappc_b64 s[30:31], s[16:17]
 ; GFX906-NEXT:    s_or_saveexec_b64 s[34:35], -1
 ; GFX906-NEXT:    s_mov_b64 exec, s[34:35]
@@ -569,9 +569,6 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    ;;#ASMSTART
 ; GFX908-NEXT:    ; def s21
 ; GFX908-NEXT:    ;;#ASMEND
-; GFX908-NEXT:    v_writelane_b32 v40, s21, 24
-; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
-; GFX908-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX908-NEXT:    ;;#ASMSTART
 ; GFX908-NEXT:    ; def s22
 ; GFX908-NEXT:    ;;#ASMEND
@@ -597,6 +594,7 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    ; def s29
 ; GFX908-NEXT:    ;;#ASMEND
 ; GFX908-NEXT:    buffer_load_dword v31, off, s[0:3], s33 offset:8 ; 4-byte Folded Reload
+; GFX908-NEXT:    v_writelane_b32 v40, s21, 24
 ; GFX908-NEXT:    v_writelane_b32 v40, s22, 25
 ; GFX908-NEXT:    v_writelane_b32 v40, s23, 26
 ; GFX908-NEXT:    v_writelane_b32 v40, s24, 27
@@ -619,6 +617,8 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    v_readlane_b32 s9, v40, 7
 ; GFX908-NEXT:    v_readlane_b32 s11, v40, 5
 ; GFX908-NEXT:    v_readlane_b32 s17, v40, 23
+; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
+; GFX908-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX908-NEXT:    s_swappc_b64 s[30:31], s[16:17]
 ; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
 ; GFX908-NEXT:    s_mov_b64 exec, s[34:35]

--- a/llvm/test/CodeGen/AMDGPU/preserve-wwm-copy-dst-reg.ll
+++ b/llvm/test/CodeGen/AMDGPU/preserve-wwm-copy-dst-reg.ll
@@ -194,6 +194,9 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    ;;#ASMSTART
 ; GFX906-NEXT:    ; def s21
 ; GFX906-NEXT:    ;;#ASMEND
+; GFX906-NEXT:    v_writelane_b32 v40, s21, 24
+; GFX906-NEXT:    s_or_saveexec_b64 s[34:35], -1
+; GFX906-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX906-NEXT:    ;;#ASMSTART
 ; GFX906-NEXT:    ; def s22
 ; GFX906-NEXT:    ;;#ASMEND
@@ -219,7 +222,6 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    ; def s29
 ; GFX906-NEXT:    ;;#ASMEND
 ; GFX906-NEXT:    buffer_load_dword v31, off, s[0:3], s33 offset:4 ; 4-byte Folded Reload
-; GFX906-NEXT:    v_writelane_b32 v40, s21, 24
 ; GFX906-NEXT:    v_writelane_b32 v40, s22, 25
 ; GFX906-NEXT:    v_writelane_b32 v40, s23, 26
 ; GFX906-NEXT:    v_writelane_b32 v40, s24, 27
@@ -242,8 +244,6 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    v_readlane_b32 s9, v40, 7
 ; GFX906-NEXT:    v_readlane_b32 s11, v40, 5
 ; GFX906-NEXT:    v_readlane_b32 s17, v40, 23
-; GFX906-NEXT:    s_or_saveexec_b64 s[34:35], -1
-; GFX906-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX906-NEXT:    s_swappc_b64 s[30:31], s[16:17]
 ; GFX906-NEXT:    s_or_saveexec_b64 s[34:35], -1
 ; GFX906-NEXT:    s_mov_b64 exec, s[34:35]
@@ -569,6 +569,9 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    ;;#ASMSTART
 ; GFX908-NEXT:    ; def s21
 ; GFX908-NEXT:    ;;#ASMEND
+; GFX908-NEXT:    v_writelane_b32 v40, s21, 24
+; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
+; GFX908-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX908-NEXT:    ;;#ASMSTART
 ; GFX908-NEXT:    ; def s22
 ; GFX908-NEXT:    ;;#ASMEND
@@ -594,7 +597,6 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    ; def s29
 ; GFX908-NEXT:    ;;#ASMEND
 ; GFX908-NEXT:    buffer_load_dword v31, off, s[0:3], s33 offset:8 ; 4-byte Folded Reload
-; GFX908-NEXT:    v_writelane_b32 v40, s21, 24
 ; GFX908-NEXT:    v_writelane_b32 v40, s22, 25
 ; GFX908-NEXT:    v_writelane_b32 v40, s23, 26
 ; GFX908-NEXT:    v_writelane_b32 v40, s24, 27
@@ -617,8 +619,6 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    v_readlane_b32 s9, v40, 7
 ; GFX908-NEXT:    v_readlane_b32 s11, v40, 5
 ; GFX908-NEXT:    v_readlane_b32 s17, v40, 23
-; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
-; GFX908-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX908-NEXT:    s_swappc_b64 s[30:31], s[16:17]
 ; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
 ; GFX908-NEXT:    s_mov_b64 exec, s[34:35]

--- a/llvm/test/CodeGen/AMDGPU/sched-assert-dead-def-subreg-use-other-subreg.mir
+++ b/llvm/test/CodeGen/AMDGPU/sched-assert-dead-def-subreg-use-other-subreg.mir
@@ -21,28 +21,28 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT:   liveins: $sgpr6_sgpr7
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   undef %0.sub3:vreg_512 = V_MOV_B32_e32 0, implicit $exec
-  ; CHECK-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-  ; CHECK-NEXT:   [[V_ADD_U32_e32_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 0, [[V_MOV_B32_e32_]], implicit $exec
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vreg_512 = COPY %0
+  ; CHECK-NEXT:   undef [[V_MOV_B32_e32_:%[0-9]+]].sub3:vreg_512 = V_MOV_B32_e32 0, implicit $exec
+  ; CHECK-NEXT:   [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+  ; CHECK-NEXT:   [[V_ADD_U32_e32_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 0, [[V_MOV_B32_e32_1]], implicit $exec
+  ; CHECK-NEXT:   [[V_MOV_B32_e32_2:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vreg_512 = COPY [[V_MOV_B32_e32_]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   BUFFER_STORE_DWORD_OFFEN %0.sub3, undef %5:vgpr_32, $sgpr24_sgpr25_sgpr26_sgpr27, $sgpr32, 0, 0, 0, implicit $exec :: (store (s32), align 8, addrspace 5)
+  ; CHECK-NEXT:   BUFFER_STORE_DWORD_OFFEN [[V_MOV_B32_e32_]].sub3, undef %5:vgpr_32, $sgpr24_sgpr25_sgpr26_sgpr27, $sgpr32, 0, 0, 0, implicit $exec :: (store (s32), align 8, addrspace 5)
   ; CHECK-NEXT:   dead [[DS_READ_B32_gfx9_:%[0-9]+]]:vgpr_32 = DS_READ_B32_gfx9 undef %7:vgpr_32, 0, 0, implicit $exec
-  ; CHECK-NEXT:   dead [[DS_READ_B64_gfx9_:%[0-9]+]]:vreg_64 = DS_READ_B64_gfx9 [[V_MOV_B32_e32_]], 0, 0, implicit $exec
+  ; CHECK-NEXT:   dead [[DS_READ_B64_gfx9_:%[0-9]+]]:vreg_64 = DS_READ_B64_gfx9 [[V_MOV_B32_e32_1]], 0, 0, implicit $exec
   ; CHECK-NEXT:   dead [[DS_READ_B128_gfx9_:%[0-9]+]]:vreg_128 = DS_READ_B128_gfx9 [[V_ADD_U32_e32_]], 0, 0, implicit $exec
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY [[COPY]].sub0
-  ; CHECK-NEXT:   undef %11.sub1:vreg_512 = COPY [[COPY]].sub1
+  ; CHECK-NEXT:   undef [[COPY2:%[0-9]+]].sub1:vreg_512 = COPY [[COPY]].sub1
   ; CHECK-NEXT:   INLINEASM &"", 1 /* sideeffect attdialect */, 851978 /* regdef:VGPR_16 */, def dead [[COPY1]], 851978 /* regdef:VGPR_16 */, def dead [[COPY]].sub1, 2147483657 /* reguse tiedto:$0 */, [[COPY1]], 2147549193 /* reguse tiedto:$1 */, [[COPY]].sub1
-  ; CHECK-NEXT:   %11.sub0:vreg_512 = COPY [[COPY]].sub0
-  ; CHECK-NEXT:   %11.sub3:vreg_512 = COPY [[COPY]].sub3
-  ; CHECK-NEXT:   [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-  ; CHECK-NEXT:   dead [[V_ADD_CO_U32_e32_:%[0-9]+]]:vgpr_32 = V_ADD_CO_U32_e32 4, [[V_MOV_B32_e32_1]], implicit-def dead $vcc, implicit $exec
-  ; CHECK-NEXT:   %11.sub2:vreg_512 = COPY undef [[V_MOV_B32_e32_]]
-  ; CHECK-NEXT:   %11.sub5:vreg_512 = COPY undef [[V_MOV_B32_e32_]]
-  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:vreg_512 = COPY %11
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]].sub0:vreg_512 = COPY [[COPY]].sub0
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]].sub3:vreg_512 = COPY [[COPY]].sub3
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]].sub2:vreg_512 = COPY undef [[V_MOV_B32_e32_1]]
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]].sub5:vreg_512 = COPY undef [[V_MOV_B32_e32_1]]
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vreg_512 = COPY [[COPY2]]
+  ; CHECK-NEXT:   dead [[V_ADD_CO_U32_e32_:%[0-9]+]]:vgpr_32 = V_ADD_CO_U32_e32 4, [[V_MOV_B32_e32_2]], implicit-def dead $vcc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   bb.0:
     liveins: $sgpr6_sgpr7

--- a/llvm/test/CodeGen/AMDGPU/schedule-relaxed-occupancy.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-relaxed-occupancy.ll
@@ -6,9 +6,9 @@
 
 ; GCN-LABEL: {{^}}load_fma_store:
 ; OCC:    NumVgprs: 32
-; RELAX:    NumVgprs: 64
+; RELAX:    NumVgprs: 62
 ; OCC: NumVGPRsForWavesPerEU: 32
-; RELAX: NumVGPRsForWavesPerEU: 64
+; RELAX: NumVGPRsForWavesPerEU: 62
 ; OCC:    Occupancy: 8
 ; RELAX: Occupancy: 4
 

--- a/llvm/test/CodeGen/AMDGPU/vni8-across-blocks.ll
+++ b/llvm/test/CodeGen/AMDGPU/vni8-across-blocks.ll
@@ -286,13 +286,13 @@ define amdgpu_kernel void @v32i8_liveout(ptr addrspace(1) %src1, ptr addrspace(1
 ; GFX906-LABEL: v32i8_liveout:
 ; GFX906:       ; %bb.0: ; %entry
 ; GFX906-NEXT:    s_load_dwordx4 s[4:7], s[0:1], 0x24
-; GFX906-NEXT:    v_lshlrev_b32_e32 v31, 5, v0
-; GFX906-NEXT:    s_load_dwordx2 s[0:1], s[0:1], 0x34
+; GFX906-NEXT:    s_load_dwordx2 s[2:3], s[0:1], 0x34
+; GFX906-NEXT:    v_lshlrev_b32_e32 v33, 5, v0
 ; GFX906-NEXT:    v_mov_b32_e32 v9, 0
 ; GFX906-NEXT:    v_cmp_gt_u32_e32 vcc, 15, v0
 ; GFX906-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX906-NEXT:    global_load_dwordx4 v[1:4], v31, s[4:5] offset:16
-; GFX906-NEXT:    global_load_dwordx4 v[5:8], v31, s[4:5]
+; GFX906-NEXT:    global_load_dwordx4 v[1:4], v33, s[4:5] offset:16
+; GFX906-NEXT:    global_load_dwordx4 v[5:8], v33, s[4:5]
 ; GFX906-NEXT:    s_waitcnt vmcnt(1)
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v0, 24, v4
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v10, 16, v4
@@ -317,13 +317,13 @@ define amdgpu_kernel void @v32i8_liveout(ptr addrspace(1) %src1, ptr addrspace(1
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v28, 16, v6
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v29, 8, v6
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v30, 24, v5
-; GFX906-NEXT:    v_lshrrev_b32_e32 v32, 16, v5
-; GFX906-NEXT:    v_lshrrev_b32_e32 v33, 8, v5
-; GFX906-NEXT:    s_and_saveexec_b64 s[2:3], vcc
+; GFX906-NEXT:    v_lshrrev_b32_e32 v31, 16, v5
+; GFX906-NEXT:    v_lshrrev_b32_e32 v32, 8, v5
+; GFX906-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX906-NEXT:    s_cbranch_execz .LBB5_2
 ; GFX906-NEXT:  ; %bb.1: ; %bb.1
-; GFX906-NEXT:    global_load_dwordx4 v[1:4], v31, s[6:7] offset:16
-; GFX906-NEXT:    global_load_dwordx4 v[5:8], v31, s[6:7]
+; GFX906-NEXT:    global_load_dwordx4 v[1:4], v33, s[6:7] offset:16
+; GFX906-NEXT:    global_load_dwordx4 v[5:8], v33, s[6:7]
 ; GFX906-NEXT:    s_waitcnt vmcnt(1)
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v0, 24, v4
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v10, 16, v4
@@ -348,19 +348,19 @@ define amdgpu_kernel void @v32i8_liveout(ptr addrspace(1) %src1, ptr addrspace(1
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v28, 16, v6
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v29, 8, v6
 ; GFX906-NEXT:    v_lshrrev_b32_e32 v30, 24, v5
-; GFX906-NEXT:    v_lshrrev_b32_e32 v32, 16, v5
-; GFX906-NEXT:    v_lshrrev_b32_e32 v33, 8, v5
+; GFX906-NEXT:    v_lshrrev_b32_e32 v31, 16, v5
+; GFX906-NEXT:    v_lshrrev_b32_e32 v32, 8, v5
 ; GFX906-NEXT:  .LBB5_2: ; %bb.2
-; GFX906-NEXT:    s_or_b64 exec, exec, s[2:3]
+; GFX906-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v30, 8, v30
-; GFX906-NEXT:    v_lshlrev_b16_e32 v31, 8, v33
+; GFX906-NEXT:    v_or_b32_sdwa v30, v31, v30 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX906-NEXT:    v_lshlrev_b16_e32 v31, 8, v32
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v29, 8, v29
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v27, 8, v27
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v26, 8, v26
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v24, 8, v24
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v23, 8, v23
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v21, 8, v21
-; GFX906-NEXT:    v_or_b32_sdwa v30, v32, v30 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX906-NEXT:    v_or_b32_sdwa v5, v5, v31 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX906-NEXT:    v_or_b32_sdwa v6, v6, v29 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX906-NEXT:    v_or_b32_sdwa v27, v28, v27 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -372,7 +372,7 @@ define amdgpu_kernel void @v32i8_liveout(ptr addrspace(1) %src1, ptr addrspace(1
 ; GFX906-NEXT:    v_or_b32_sdwa v6, v6, v27 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX906-NEXT:    v_or_b32_sdwa v7, v7, v24 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX906-NEXT:    v_or_b32_sdwa v8, v8, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX906-NEXT:    global_store_dwordx4 v9, v[5:8], s[0:1]
+; GFX906-NEXT:    global_store_dwordx4 v9, v[5:8], s[2:3]
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v0, 8, v0
 ; GFX906-NEXT:    v_lshlrev_b16_e32 v5, 8, v20
 ; GFX906-NEXT:    v_or_b32_sdwa v1, v1, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
@@ -393,7 +393,7 @@ define amdgpu_kernel void @v32i8_liveout(ptr addrspace(1) %src1, ptr addrspace(1
 ; GFX906-NEXT:    v_or_b32_sdwa v4, v4, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX906-NEXT:    v_or_b32_sdwa v0, v10, v0 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX906-NEXT:    v_or_b32_sdwa v4, v4, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX906-NEXT:    global_store_dwordx4 v9, v[1:4], s[0:1] offset:16
+; GFX906-NEXT:    global_store_dwordx4 v9, v[1:4], s[2:3] offset:16
 ; GFX906-NEXT:    s_endpgm
 entry:
   %idx = call i32 @llvm.amdgcn.workitem.id.x()


### PR DESCRIPTION
This pull request was created as a discussion place to illustrate the idea: to decide if the region has excess RP in finalizeGCNRegion based on the DAG.getRealRegPressure(RegionIdx). Decide if we should keep or revert the
result of the UnclusteredHighRP stage based on the RP after the stage: if the
RP is not less than before - revert.
