### PR TITLE
[LVI] Handle icmp of ashr.

### DIFF
--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -1273,7 +1273,7 @@ define void @ashr_sge(i8 %x) {
 ; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
 ; CHECK:       if:
 ; CHECK-NEXT:    call void @check1(i1 true)
-; CHECK-NEXT:    [[C3:%.*]] = icmp uge i8 [[X]], 4
+; CHECK-NEXT:    [[C3:%.*]] = icmp uge i8 [[X]], 1
 ; CHECK-NEXT:    call void @check1(i1 [[C3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       else:
@@ -1283,9 +1283,9 @@ define void @ashr_sge(i8 %x) {
   %c = icmp sge i8 %s, 0
   br i1 %c, label %if, label %else
 if:
-  %c2 = icmp sge i8 %x, 3
+  %c2 = icmp sge i8 %x, 0
   call void @check1(i1 %c2)
-  %c3 = icmp sge i8 %x, 4
+  %c3 = icmp sge i8 %x, 1
   call void @check1(i1 %c3)
   ret void
 else:
@@ -1299,7 +1299,7 @@ define void @ashr_slt(i8 %x) {
 ; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
 ; CHECK:       if:
 ; CHECK-NEXT:    call void @check1(i1 true)
-; CHECK-NEXT:    [[C3:%.*]] = icmp slt i8 [[X]], 2
+; CHECK-NEXT:    [[C3:%.*]] = icmp ult i8 [[X]], -1
 ; CHECK-NEXT:    call void @check1(i1 [[C3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       else:
@@ -1309,9 +1309,9 @@ define void @ashr_slt(i8 %x) {
   %c = icmp slt i8 %s, 0
   br i1 %c, label %if, label %else
 if:
-  %c2 = icmp slt i8 %x, 3
+  %c2 = icmp slt i8 %x, 0
   call void @check1(i1 %c2)
-  %c3 = icmp slt i8 %x, 2
+  %c3 = icmp slt i8 %x, -1
   call void @check1(i1 %c3)
   ret void
 else:

--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -1243,23 +1243,23 @@ define <2 x i1> @non_const_range_minmax_vec(<2 x i8> %a, <2 x i8> %b) {
 define void @ashr_sgt(i8 %x) {
 ; CHECK-LABEL: @ashr_sgt(
 ; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
-; CHECK-NEXT:    [[C:%.*]] = icmp sgt i8 [[S]], 0
+; CHECK-NEXT:    [[C:%.*]] = icmp sgt i8 [[S]], 1
 ; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
 ; CHECK:       if:
 ; CHECK-NEXT:    call void @check1(i1 true)
-; CHECK-NEXT:    [[C3:%.*]] = icmp ugt i8 [[X]], 4
+; CHECK-NEXT:    [[C3:%.*]] = icmp ugt i8 [[X]], 8
 ; CHECK-NEXT:    call void @check1(i1 [[C3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       else:
 ; CHECK-NEXT:    ret void
 ;
   %s = ashr i8 %x, 2
-  %c = icmp sgt i8 %s, 0
+  %c = icmp sgt i8 %s, 1
   br i1 %c, label %if, label %else
 if:
-  %c2 = icmp sgt i8 %x, 3
+  %c2 = icmp sgt i8 %x, 7
   call void @check1(i1 %c2)
-  %c3 = icmp sgt i8 %x, 4
+  %c3 = icmp sgt i8 %x, 8
   call void @check1(i1 %c3)
   ret void
 else:
@@ -1269,23 +1269,23 @@ else:
 define void @ashr_sge(i8 %x) {
 ; CHECK-LABEL: @ashr_sge(
 ; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
-; CHECK-NEXT:    [[C:%.*]] = icmp sge i8 [[S]], 0
+; CHECK-NEXT:    [[C:%.*]] = icmp sge i8 [[S]], 1
 ; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
 ; CHECK:       if:
 ; CHECK-NEXT:    call void @check1(i1 true)
-; CHECK-NEXT:    [[C3:%.*]] = icmp uge i8 [[X]], 1
+; CHECK-NEXT:    [[C3:%.*]] = icmp uge i8 [[X]], 5
 ; CHECK-NEXT:    call void @check1(i1 [[C3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       else:
 ; CHECK-NEXT:    ret void
 ;
   %s = ashr i8 %x, 2
-  %c = icmp sge i8 %s, 0
+  %c = icmp sge i8 %s, 1
   br i1 %c, label %if, label %else
 if:
-  %c2 = icmp sge i8 %x, 0
+  %c2 = icmp sge i8 %x, 4
   call void @check1(i1 %c2)
-  %c3 = icmp sge i8 %x, 1
+  %c3 = icmp sge i8 %x, 5
   call void @check1(i1 %c3)
   ret void
 else:
@@ -1295,23 +1295,23 @@ else:
 define void @ashr_slt(i8 %x) {
 ; CHECK-LABEL: @ashr_slt(
 ; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
-; CHECK-NEXT:    [[C:%.*]] = icmp slt i8 [[S]], 0
+; CHECK-NEXT:    [[C:%.*]] = icmp slt i8 [[S]], 1
 ; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
 ; CHECK:       if:
 ; CHECK-NEXT:    call void @check1(i1 true)
-; CHECK-NEXT:    [[C3:%.*]] = icmp ult i8 [[X]], -1
+; CHECK-NEXT:    [[C3:%.*]] = icmp slt i8 [[X]], 3
 ; CHECK-NEXT:    call void @check1(i1 [[C3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       else:
 ; CHECK-NEXT:    ret void
 ;
   %s = ashr i8 %x, 2
-  %c = icmp slt i8 %s, 0
+  %c = icmp slt i8 %s, 1
   br i1 %c, label %if, label %else
 if:
-  %c2 = icmp slt i8 %x, 0
+  %c2 = icmp slt i8 %x, 4
   call void @check1(i1 %c2)
-  %c3 = icmp slt i8 %x, -1
+  %c3 = icmp slt i8 %x, 3
   call void @check1(i1 %c3)
   ret void
 else:
@@ -1321,23 +1321,23 @@ else:
 define void @ashr_sle(i8 %x) {
 ; CHECK-LABEL: @ashr_sle(
 ; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
-; CHECK-NEXT:    [[C:%.*]] = icmp sle i8 [[S]], 0
+; CHECK-NEXT:    [[C:%.*]] = icmp sle i8 [[S]], 1
 ; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
 ; CHECK:       if:
 ; CHECK-NEXT:    call void @check1(i1 true)
-; CHECK-NEXT:    [[C3:%.*]] = icmp sle i8 [[X]], 2
+; CHECK-NEXT:    [[C3:%.*]] = icmp sle i8 [[X]], 6
 ; CHECK-NEXT:    call void @check1(i1 [[C3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       else:
 ; CHECK-NEXT:    ret void
 ;
   %s = ashr i8 %x, 2
-  %c = icmp sle i8 %s, 0
+  %c = icmp sle i8 %s, 1
   br i1 %c, label %if, label %else
 if:
-  %c2 = icmp sle i8 %x, 3
+  %c2 = icmp sle i8 %x, 7
   call void @check1(i1 %c2)
-  %c3 = icmp sle i8 %x, 2
+  %c3 = icmp sle i8 %x, 6
   call void @check1(i1 %c3)
   ret void
 else:

--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -1240,6 +1240,110 @@ define <2 x i1> @non_const_range_minmax_vec(<2 x i8> %a, <2 x i8> %b) {
   ret <2 x i1> %cmp1
 }
 
+define void @ashr_sgt(i8 %x) {
+; CHECK-LABEL: @ashr_sgt(
+; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[C:%.*]] = icmp sgt i8 [[S]], 0
+; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
+; CHECK:       if:
+; CHECK-NEXT:    call void @check1(i1 true)
+; CHECK-NEXT:    [[C3:%.*]] = icmp ugt i8 [[X]], 4
+; CHECK-NEXT:    call void @check1(i1 [[C3]])
+; CHECK-NEXT:    ret void
+; CHECK:       else:
+; CHECK-NEXT:    ret void
+;
+  %s = ashr i8 %x, 2
+  %c = icmp sgt i8 %s, 0
+  br i1 %c, label %if, label %else
+if:
+  %c2 = icmp sgt i8 %x, 3
+  call void @check1(i1 %c2)
+  %c3 = icmp sgt i8 %x, 4
+  call void @check1(i1 %c3)
+  ret void
+else:
+  ret void
+}
+
+define void @ashr_sge(i8 %x) {
+; CHECK-LABEL: @ashr_sge(
+; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[C:%.*]] = icmp sge i8 [[S]], 0
+; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
+; CHECK:       if:
+; CHECK-NEXT:    call void @check1(i1 true)
+; CHECK-NEXT:    [[C3:%.*]] = icmp uge i8 [[X]], 4
+; CHECK-NEXT:    call void @check1(i1 [[C3]])
+; CHECK-NEXT:    ret void
+; CHECK:       else:
+; CHECK-NEXT:    ret void
+;
+  %s = ashr i8 %x, 2
+  %c = icmp sge i8 %s, 0
+  br i1 %c, label %if, label %else
+if:
+  %c2 = icmp sge i8 %x, 3
+  call void @check1(i1 %c2)
+  %c3 = icmp sge i8 %x, 4
+  call void @check1(i1 %c3)
+  ret void
+else:
+  ret void
+}
+
+define void @ashr_slt(i8 %x) {
+; CHECK-LABEL: @ashr_slt(
+; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[C:%.*]] = icmp slt i8 [[S]], 0
+; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
+; CHECK:       if:
+; CHECK-NEXT:    call void @check1(i1 true)
+; CHECK-NEXT:    [[C3:%.*]] = icmp slt i8 [[X]], 2
+; CHECK-NEXT:    call void @check1(i1 [[C3]])
+; CHECK-NEXT:    ret void
+; CHECK:       else:
+; CHECK-NEXT:    ret void
+;
+  %s = ashr i8 %x, 2
+  %c = icmp slt i8 %s, 0
+  br i1 %c, label %if, label %else
+if:
+  %c2 = icmp slt i8 %x, 3
+  call void @check1(i1 %c2)
+  %c3 = icmp slt i8 %x, 2
+  call void @check1(i1 %c3)
+  ret void
+else:
+  ret void
+}
+
+define void @ashr_sle(i8 %x) {
+; CHECK-LABEL: @ashr_sle(
+; CHECK-NEXT:    [[S:%.*]] = ashr i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[C:%.*]] = icmp sle i8 [[S]], 0
+; CHECK-NEXT:    br i1 [[C]], label [[IF:%.*]], label [[ELSE:%.*]]
+; CHECK:       if:
+; CHECK-NEXT:    call void @check1(i1 true)
+; CHECK-NEXT:    [[C3:%.*]] = icmp sle i8 [[X]], 2
+; CHECK-NEXT:    call void @check1(i1 [[C3]])
+; CHECK-NEXT:    ret void
+; CHECK:       else:
+; CHECK-NEXT:    ret void
+;
+  %s = ashr i8 %x, 2
+  %c = icmp sle i8 %s, 0
+  br i1 %c, label %if, label %else
+if:
+  %c2 = icmp sle i8 %x, 3
+  call void @check1(i1 %c2)
+  %c3 = icmp sle i8 %x, 2
+  call void @check1(i1 %c3)
+  ret void
+else:
+  ret void
+}
+
 declare i8 @llvm.umin.i8(i8, i8)
 declare i8 @llvm.umax.i8(i8, i8)
 declare <2 x i8> @llvm.umin.v2i8(<2 x i8>, <2 x i8>)


### PR DESCRIPTION
This handles the case where this combine:
icmp sgt (ashr X, ShAmtC), C --> icmp sgt X, ((C + 1) << ShAmtC) - 1

wasn't performed by instcombine.

Proof of the original combine: https://alive2.llvm.org/ce/z/SfpsvX

This is a port of the review in https://reviews.llvm.org/D151911 to GitHub.
