### PR TITLE
[Driver] Silence stdlib warning when linking C on FreeBSD

### DIFF
--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -356,6 +356,9 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   ToolChain.addProfileRTLibs(Args, CmdArgs);
 
+  // Silence warnings when linking C code with a C++ '-stdlib' argument.
+  Args.ClaimAllArgs(options::OPT_stdlib_EQ);
+
   const char *Exec = Args.MakeArgString(getToolChain().GetLinkerPath());
   C.addCommand(std::make_unique<Command>(JA, *this,
                                          ResponseFileSupport::AtFileCurCP(),


### PR DESCRIPTION
Similar to the Gnu toolchain, ignore uses of '-stdlib=libc++' when linking C code. CMake insists on adding it to the command line when linking C, and a bunch of other build systems do similarly.