### PR TITLE
[docs] Advise contributors to check for truncated PR titles

### DIFF
--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -50,6 +50,9 @@ Create a local branch per commit you want to submit and then push that branch
 to your `fork <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks>`_
 of the llvm-project and
 `create a pull request from the fork <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_.
+As GitHub uses the first line of the commit message truncated to 72 characters
+as the pull request title, you may have to edit to reword or to undo this
+truncation.
 
 Creating Pull Requests with GitHub CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
GitHub will use the first line of the commit as the title for a single-commit PR, but truncates it at 72 characters <https://github.com/orgs/community/discussions/12450>. This truncation makes the PRs less readable if not manually undone, and even worse, the truncated form may survive through to commit if "Squash and rebase" is used in the GitHub web UI. From preparing LLVM Weekly, I've seen this a number of times and it really does make it more annoying to flick through commits.

I'm not sure if this is the best place for the guidance, or whether you get the same behaviour when creating a PR with `gh`, but I'm quite keen we give a warning of some sort about this behaviour.