### PR TITLE
[OpenMP] Fix -Wc++98-compat-extra-semi warning (NFC)

### DIFF
--- a/openmp/libomptarget/src/interface.cpp
+++ b/openmp/libomptarget/src/interface.cpp
@@ -358,7 +358,7 @@ EXTERN int __tgt_activate_record_replay(int64_t DeviceId, uint64_t MemorySize,
   assert(Rc == OFFLOAD_SUCCESS &&
          "__tgt_activate_record_replay unexpected failure!");
   return OMP_TGT_SUCCESS;
-};
+}
 
 /// Implements a target kernel entry that replays a pre-recorded kernel.
 /// \param Loc Source location associated with this target region (unused).


### PR DESCRIPTION
Compiling OpenMP with LLVM 16 triggers the following warning:
warning: extra ';' outside of a function is incompatible with C++98
