### PR TITLE
[RISCV] Fix incorrect codegen for Zfa with negated forms of constants in the lookup table

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -273,7 +273,7 @@ int RISCVLoadFPImm::getLoadFPImm(APFloat FPImm) {
   if (Sign) {
     if (Entry == 16)
       return 0;
-    return false;
+    return -1;
   }
 
   return Entry;

--- a/llvm/test/CodeGen/RISCV/double-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/double-zfa.ll
@@ -143,11 +143,11 @@ define double @loadfpimm16() {
 
 ; Ensure fli isn't incorrectly used for negated versions of numbers in the fli
 ; table.
-; FIXME: Codegen is incorrect.
 define double @loadfpimm17() {
 ; CHECK-LABEL: loadfpimm17:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    fli.d fa0, -1.0
+; CHECK-NEXT:    lui a0, %hi(.LCPI15_0)
+; CHECK-NEXT:    fld fa0, %lo(.LCPI15_0)(a0)
 ; CHECK-NEXT:    ret
   ret double -2.0
 }

--- a/llvm/test/CodeGen/RISCV/float-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/float-zfa.ll
@@ -97,11 +97,11 @@ define float @loadfpimm11() {
 
 ; Ensure fli isn't incorrectly used for negated versions of numbers in the fli
 ; table.
-; FIXME: Codegen is incorrect.
 define float @loadfpimm12() {
 ; CHECK-LABEL: loadfpimm12:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    fli.s fa0, -1.0
+; CHECK-NEXT:    lui a0, 786432
+; CHECK-NEXT:    fmv.w.x fa0, a0
 ; CHECK-NEXT:    ret
   ret float -2.0
 }

--- a/llvm/test/CodeGen/RISCV/half-zfa-fli.ll
+++ b/llvm/test/CodeGen/RISCV/half-zfa-fli.ll
@@ -197,11 +197,11 @@ define half @loadfpimm13() {
 
 ; Ensure fli isn't incorrectly used for negated versions of numbers in the fli
 ; table.
-; FIXME: Codegen is incorrect when Zfa is enabled.
 define half @loadfpimm14() {
 ; CHECK-LABEL: loadfpimm14:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    fli.h fa0, -1.0
+; CHECK-NEXT:    lui a0, 1048572
+; CHECK-NEXT:    fmv.h.x fa0, a0
 ; CHECK-NEXT:    ret
 ;
 ; ZFHMIN-LABEL: loadfpimm14:


### PR DESCRIPTION
The logic in `RISCVLoadFPImm::getLoadFPImm` recognises that the only supported negative value is -1.0, but due to a typo returns `false` otherwise (entry 0, which is -1.0) rather than returning -1 (indicating no match found).