### PR TITLE
[DiagnosticInfo] Output full file path instead of relative path

### DIFF
--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -159,7 +159,10 @@ std::string DiagnosticInfoWithLocationBase::getLocationStr() const {
   unsigned Column = 0;
   if (isLocationAvailable())
     getLocation(Filename, Line, Column);
-  return (Filename + ":" + Twine(Line) + ":" + Twine(Column)).str();
+  return (getAbsolutePath()
+              ? getAbsolutePath()
+              : Filename + ":" + Twine(Line) + ":" + Twine(Column))
+      .str();
 }
 
 DiagnosticInfoOptimizationBase::Argument::Argument(StringRef Key,

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -157,12 +157,11 @@ std::string DiagnosticInfoWithLocationBase::getLocationStr() const {
   StringRef Filename("<unknown>");
   unsigned Line = 0;
   unsigned Column = 0;
-  if (isLocationAvailable())
+  if (isLocationAvailable()) {
     getLocation(Filename, Line, Column);
-  return (getAbsolutePath()
-              ? getAbsolutePath()
-              : Filename + ":" + Twine(Line) + ":" + Twine(Column))
-      .str();
+    return (getAbsolutePath() + ":" + Twine(Line) + ":" + Twine(Column)).str();
+  }
+  return (Filename + ":" + Twine(Line) + ":" + Twine(Column)).str();
 }
 
 DiagnosticInfoOptimizationBase::Argument::Argument(StringRef Key,

--- a/llvm/test/CodeGen/AMDGPU/resource-optimization-remarks.ll
+++ b/llvm/test/CodeGen/AMDGPU/resource-optimization-remarks.ll
@@ -1,16 +1,16 @@
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -pass-remarks-output=%t -pass-remarks-analysis=kernel-resource-usage -filetype=null %s 2>&1 | FileCheck -check-prefix=STDERR %s
 ; RUN: FileCheck -check-prefix=REMARK %s < %t
 
-; STDERR: remark: foo.cl:27:0: Function Name: test_kernel
-; STDERR-NEXT: remark: foo.cl:27:0:     SGPRs: 28
-; STDERR-NEXT: remark: foo.cl:27:0:     VGPRs: 9
-; STDERR-NEXT: remark: foo.cl:27:0:     AGPRs: 43
-; STDERR-NEXT: remark: foo.cl:27:0:     ScratchSize [bytes/lane]: 0
-; STDERR-NEXT: remark: foo.cl:27:0:     Dynamic Stack: False
-; STDERR-NEXT: remark: foo.cl:27:0:     Occupancy [waves/SIMD]: 5
-; STDERR-NEXT: remark: foo.cl:27:0:     SGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:27:0:     VGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:27:0:     LDS Size [bytes/block]: 512
+; STDERR: remark: {{.*}}foo.cl:27:0: Function Name: test_kernel
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     SGPRs: 28
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     VGPRs: 9
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     AGPRs: 43
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     ScratchSize [bytes/lane]: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     Dynamic Stack: False
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     Occupancy [waves/SIMD]: 5
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     SGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     VGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:27:0:     LDS Size [bytes/block]: 512
 
 ; REMARK-LABEL: --- !Analysis
 ; REMARK: Pass:            kernel-resource-usage
@@ -113,15 +113,15 @@ define amdgpu_kernel void @test_kernel() !dbg !3 {
   ret void
 }
 
-; STDERR: remark: foo.cl:42:0: Function Name: test_func
-; STDERR-NEXT: remark: foo.cl:42:0:     SGPRs: 0
-; STDERR-NEXT: remark: foo.cl:42:0:     VGPRs: 0
-; STDERR-NEXT: remark: foo.cl:42:0:     AGPRs: 0
-; STDERR-NEXT: remark: foo.cl:42:0:     ScratchSize [bytes/lane]: 0
-; STDERR-NEXT: remark: foo.cl:42:0:     Dynamic Stack: False
-; STDERR-NEXT: remark: foo.cl:42:0:     Occupancy [waves/SIMD]: 0
-; STDERR-NEXT: remark: foo.cl:42:0:     SGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:42:0:     VGPRs Spill: 0
+; STDERR: remark: {{.*}}foo.cl:42:0: Function Name: test_func
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     SGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     VGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     AGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     ScratchSize [bytes/lane]: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     Dynamic Stack: False
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     Occupancy [waves/SIMD]: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     SGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:42:0:     VGPRs Spill: 0
 ; STDERR-NOT: LDS Size
 define void @test_func() !dbg !6 {
   call void asm sideeffect "; clobber v17", "~{v17}"()
@@ -130,43 +130,43 @@ define void @test_func() !dbg !6 {
   ret void
 }
 
-; STDERR: remark: foo.cl:8:0: Function Name: empty_kernel
-; STDERR-NEXT: remark: foo.cl:8:0:     SGPRs: 4
-; STDERR-NEXT: remark: foo.cl:8:0:     VGPRs: 0
-; STDERR-NEXT: remark: foo.cl:8:0:     AGPRs: 0
-; STDERR-NEXT: remark: foo.cl:8:0:     ScratchSize [bytes/lane]: 0
-; STDERR-NEXT: remark: foo.cl:8:0:     Dynamic Stack: False
-; STDERR-NEXT: remark: foo.cl:8:0:     Occupancy [waves/SIMD]: 8
-; STDERR-NEXT: remark: foo.cl:8:0:     SGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:8:0:     VGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:8:0:     LDS Size [bytes/block]: 0
+; STDERR: remark: {{.*}}foo.cl:8:0: Function Name: empty_kernel
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     SGPRs: 4
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     VGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     AGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     ScratchSize [bytes/lane]: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     Dynamic Stack: False
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     Occupancy [waves/SIMD]: 8
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     SGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     VGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:8:0:     LDS Size [bytes/block]: 0
 define amdgpu_kernel void @empty_kernel() !dbg !7 {
   ret void
 }
 
-; STDERR: remark: foo.cl:52:0: Function Name: empty_func
-; STDERR-NEXT: remark: foo.cl:52:0:     SGPRs: 0
-; STDERR-NEXT: remark: foo.cl:52:0:     VGPRs: 0
-; STDERR-NEXT: remark: foo.cl:52:0:     AGPRs: 0
-; STDERR-NEXT: remark: foo.cl:52:0:     ScratchSize [bytes/lane]: 0
-; STDERR-NEXT: remark: foo.cl:52:0:     Dynamic Stack: False
-; STDERR-NEXT: remark: foo.cl:52:0:     Occupancy [waves/SIMD]: 0
-; STDERR-NEXT: remark: foo.cl:52:0:     SGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:52:0:     VGPRs Spill: 0
+; STDERR: remark: {{.*}}foo.cl:52:0: Function Name: empty_func
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     SGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     VGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     AGPRs: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     ScratchSize [bytes/lane]: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     Dynamic Stack: False
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     Occupancy [waves/SIMD]: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     SGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:52:0:     VGPRs Spill: 0
 define void @empty_func() !dbg !8 {
   ret void
 }
 
-; STDERR: remark: foo.cl:64:0: Function Name: test_indirect_call
-; STDERR-NEXT: remark: foo.cl:64:0:     SGPRs: 39
-; STDERR-NEXT: remark: foo.cl:64:0:     VGPRs: 32
-; STDERR-NEXT: remark: foo.cl:64:0:     AGPRs: 10
-; STDERR-NEXT: remark: foo.cl:64:0:     ScratchSize [bytes/lane]: 0
-; STDERR-NEXT: remark: foo.cl:64:0:     Dynamic Stack: True
-; STDERR-NEXT: remark: foo.cl:64:0:     Occupancy [waves/SIMD]: 8
-; STDERR-NEXT: remark: foo.cl:64:0:     SGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:64:0:     VGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:64:0:     LDS Size [bytes/block]: 0
+; STDERR: remark: {{.*}}foo.cl:64:0: Function Name: test_indirect_call
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     SGPRs: 39
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     VGPRs: 32
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     AGPRs: 10
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     ScratchSize [bytes/lane]: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     Dynamic Stack: True
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     Occupancy [waves/SIMD]: 8
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     SGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     VGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:64:0:     LDS Size [bytes/block]: 0
 @gv.fptr0 = external hidden unnamed_addr addrspace(4) constant ptr, align 4
 
 define amdgpu_kernel void @test_indirect_call() !dbg !9 {
@@ -175,16 +175,16 @@ define amdgpu_kernel void @test_indirect_call() !dbg !9 {
   ret void
 }
 
-; STDERR: remark: foo.cl:74:0: Function Name: test_indirect_w_static_stack
-; STDERR-NEXT: remark: foo.cl:74:0:     SGPRs: 39
-; STDERR-NEXT: remark: foo.cl:74:0:     VGPRs: 32
-; STDERR-NEXT: remark: foo.cl:74:0:     AGPRs: 10
-; STDERR-NEXT: remark: foo.cl:74:0:     ScratchSize [bytes/lane]: 144
-; STDERR-NEXT: remark: foo.cl:74:0:     Dynamic Stack: True
-; STDERR-NEXT: remark: foo.cl:74:0:     Occupancy [waves/SIMD]: 8
-; STDERR-NEXT: remark: foo.cl:74:0:     SGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:74:0:     VGPRs Spill: 0
-; STDERR-NEXT: remark: foo.cl:74:0:     LDS Size [bytes/block]: 0
+; STDERR: remark: {{.*}}foo.cl:74:0: Function Name: test_indirect_w_static_stack
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     SGPRs: 39
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     VGPRs: 32
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     AGPRs: 10
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     ScratchSize [bytes/lane]: 144
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     Dynamic Stack: True
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     Occupancy [waves/SIMD]: 8
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     SGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     VGPRs Spill: 0
+; STDERR-NEXT: remark: {{.*}}foo.cl:74:0:     LDS Size [bytes/block]: 0
 
 declare void @llvm.memset.p5.i64(ptr addrspace(5) nocapture readonly, i8, i64, i1 immarg)
 

--- a/llvm/test/CodeGen/BPF/warn-call.ll
+++ b/llvm/test/CodeGen/BPF/warn-call.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -march=bpfel < %s 2>&1 >/dev/null | FileCheck %s
 
-; CHECK: error: warn_call.c
+; CHECK: error: {{.*}}warn_call.c
 ; CHECK: built-in function 'memcpy'
 define ptr @warn(ptr returned, ptr, i64) local_unnamed_addr #0 !dbg !6 {
   tail call void @llvm.dbg.value(metadata ptr %0, i64 0, metadata !14, metadata !17), !dbg !18

--- a/llvm/test/CodeGen/BPF/warn-stack.ll
+++ b/llvm/test/CodeGen/BPF/warn-stack.ll
@@ -21,7 +21,7 @@ declare void @doit(ptr) local_unnamed_addr #3
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0(i64, ptr nocapture) #1
 
-; CHECK: error: warn_stack.c
+; CHECK: error: {{.*}}warn_stack.c
 ; CHECK: BPF stack limit
 define void @warn() local_unnamed_addr #0 !dbg !20 {
   %1 = alloca [512 x i8], align 1

--- a/llvm/test/Transforms/LoopFusion/diagnostics_analysis.ll
+++ b/llvm/test/Transforms/LoopFusion/diagnostics_analysis.ll
@@ -3,8 +3,8 @@
 
 @B = common global [1024 x i32] zeroinitializer, align 16
 
-; CHECK: remark: diagnostics_analysis.c:6:3: [test]: Loop is not a candidate for fusion: Loop contains a volatile access
-; CHECK: remark: diagnostics_analysis.c:10:3: [test]: Loop is not a candidate for fusion: Loop has unknown trip count
+; CHECK: remark: {{.*}}diagnostics_analysis.c:6:3: [test]: Loop is not a candidate for fusion: Loop contains a volatile access
+; CHECK: remark: {{.*}}diagnostics_analysis.c:10:3: [test]: Loop is not a candidate for fusion: Loop has unknown trip count
 define void @test(ptr %A, i32 %n) !dbg !15 {
 entry:
   %A.addr = alloca ptr, align 8

--- a/llvm/test/Transforms/LoopFusion/diagnostics_missed.ll
+++ b/llvm/test/Transforms/LoopFusion/diagnostics_missed.ll
@@ -5,7 +5,7 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 @B = common global [1024 x i32] zeroinitializer, align 16, !dbg !0
 
-; CHECK: remark: diagnostics_missed.c:18:3: [non_adjacent]: entry and for.end: Loops are not adjacent
+; CHECK: remark: {{.*}}diagnostics_missed.c:18:3: [non_adjacent]: entry and for.end: Loops are not adjacent
 define void @non_adjacent(ptr noalias %A) !dbg !14 {
 entry:
   br label %for.body
@@ -55,7 +55,7 @@ for.end15:                                        ; preds = %for.cond.cleanup5
   ret void
 }
 
-; CHECK: remark: diagnostics_missed.c:28:3: [different_bounds]: entry and for.end: Loop trip counts are not the same
+; CHECK: remark: {{.*}}diagnostics_missed.c:28:3: [different_bounds]: entry and for.end: Loop trip counts are not the same
 define void @different_bounds(ptr noalias %A) !dbg !36 {
 entry:
   br label %for.body
@@ -105,7 +105,7 @@ for.end15:                                        ; preds = %for.cond.cleanup5
   ret void
 }
 
-; CHECK: remark: diagnostics_missed.c:38:3: [negative_dependence]: entry and for.end: Dependencies prevent fusion
+; CHECK: remark: {{.*}}diagnostics_missed.c:38:3: [negative_dependence]: entry and for.end: Dependencies prevent fusion
 define void @negative_dependence(ptr noalias %A) !dbg !51 {
 entry:
   br label %for.body
@@ -144,7 +144,7 @@ for.end12:                                        ; preds = %for.inc10
   ret void, !dbg !62
 }
 
-; CHECK: remark: diagnostics_missed.c:51:3: [sumTest]: entry and for.cond2.preheader: Dependencies prevent fusion
+; CHECK: remark: {{.*}}diagnostics_missed.c:51:3: [sumTest]: entry and for.cond2.preheader: Dependencies prevent fusion
 define i32 @sumTest(ptr noalias %A) !dbg !63 {
 entry:
   br label %for.body
@@ -186,7 +186,7 @@ for.end12:                                        ; preds = %for.inc10
 ; Function Attrs: nounwind readnone speculatable willreturn
 declare void @llvm.dbg.value(metadata, metadata, metadata) #0
 
-; CHECK: remark: diagnostics_missed.c:62:3: [unsafe_preheader]: for.first.preheader and for.second.preheader: Loop has a non-empty preheader with instructions that cannot be moved
+; CHECK: remark: {{.*}}diagnostics_missed.c:62:3: [unsafe_preheader]: for.first.preheader and for.second.preheader: Loop has a non-empty preheader with instructions that cannot be moved
 define void @unsafe_preheader(ptr noalias %A, ptr noalias %B) {
 for.first.preheader:
   br label %for.first, !dbg !80
@@ -215,7 +215,7 @@ for.end:
   ret void
 }
 
-; CHECK: remark: diagnostics_missed.c:67:3: [unsafe_exitblock]: for.first.preheader and for.second.preheader: Candidate has a non-empty exit block with instructions that cannot be moved
+; CHECK: remark: {{.*}}diagnostics_missed.c:67:3: [unsafe_exitblock]: for.first.preheader and for.second.preheader: Candidate has a non-empty exit block with instructions that cannot be moved
 define void @unsafe_exitblock(ptr noalias %A, ptr noalias %B, i64 %N) {
 for.first.guard:
   %cmp3 = icmp slt i64 0, %N
@@ -258,7 +258,7 @@ for.end:
   ret void
 }
 
-; CHECK: remark: diagnostics_missed.c:72:3: [unsafe_guardblock]: for.first.preheader and for.second.preheader: Candidate has a non-empty guard block with instructions that cannot be moved
+; CHECK: remark: {{.*}}diagnostics_missed.c:72:3: [unsafe_guardblock]: for.first.preheader and for.second.preheader: Candidate has a non-empty guard block with instructions that cannot be moved
 define void @unsafe_guardblock(ptr noalias %A, ptr noalias %B, i64 %N) {
 for.first.guard:
   %cmp3 = icmp slt i64 0, %N

--- a/llvm/test/Transforms/LoopIdiom/memcpy-debugify-remarks.ll
+++ b/llvm/test/Transforms/LoopIdiom/memcpy-debugify-remarks.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 
 ; Check that everything still works when debuginfo is present, and that it is reasonably propagated.
 
-; CHECK: remark: <stdin>:6:1: Formed a call to llvm.memcpy.p0.p0.i64() intrinsic from load and store instruction in test6_dest_align function{{$}}
+; CHECK: remark: {{.*}}<stdin>:6:1: Formed a call to llvm.memcpy.p0.p0.i64() intrinsic from load and store instruction in test6_dest_align function{{$}}
 
 ; YAML:      --- !Passed
 ; YAML-NEXT: Pass:            loop-idiom

--- a/llvm/test/Transforms/LoopIdiom/memset-debugify-remarks.ll
+++ b/llvm/test/Transforms/LoopIdiom/memset-debugify-remarks.ll
@@ -12,7 +12,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ;     *begin = value;
 ; }
 
-; CHECK: remark: <stdin>:4:1: Transformed loop-strided store in _Z15my_basic_memsetPcS_c function into a call to llvm.memset.p0.i64() intrinsic{{$}}
+; CHECK: remark: {{.*}}<stdin>:4:1: Transformed loop-strided store in _Z15my_basic_memsetPcS_c function into a call to llvm.memset.p0.i64() intrinsic{{$}}
 
 ; YAML:      --- !Passed
 ; YAML-NEXT: Pass:            loop-idiom

--- a/llvm/test/Transforms/LoopUnroll/X86/call-remark.ll
+++ b/llvm/test/Transforms/LoopUnroll/X86/call-remark.ll
@@ -5,8 +5,8 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; TTI: remark: <stdin>:7:1: advising against unrolling the loop because it contains a call
-; UNROLL: remark: <stdin>:14:1: unrolled loop by a factor of 8 with run-time trip count
+; TTI: remark: {{.*}}<stdin>:7:1: advising against unrolling the loop because it contains a call
+; UNROLL: remark: {{.*}}<stdin>:14:1: unrolled loop by a factor of 8 with run-time trip count
 
 define void @contains_external_call(i32 %count) {
 ; ALL-LABEL: @contains_external_call(

--- a/llvm/test/Transforms/LoopVectorize/mixed-precision-remarks.ll
+++ b/llvm/test/Transforms/LoopVectorize/mixed-precision-remarks.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -force-vector-interleave=2 -force-vector-width=4 -passes=loop-vectorize -pass-remarks-analysis=loop-vectorize -disable-output < %s 2>&1 | FileCheck %s
 
-; CHECK: remark: mixed-precision.c:3:26: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
+; CHECK: remark: {{.*}}mixed-precision.c:3:26: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
 define void @f(ptr noalias nocapture %X, i64 %N) {
 entry:
   br label %for.body
@@ -21,9 +21,9 @@ for.body:
   br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
 }
 
-; CHECK: remark: mixed-precision.c:8:8: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
-; CHECK: remark: mixed-precision.c:7:16: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
-; CHECK-NOT: remark: mixed-precision.c:7:16: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
+; CHECK: remark: {{.*}}mixed-precision.c:8:8: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
+; CHECK: remark: {{.*}}mixed-precision.c:7:16: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
+; CHECK-NOT: remark: {{.*}}mixed-precision.c:7:16: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance.
 define void @g(ptr noalias nocapture %X, ptr noalias nocapture %Y, i64 %N) {
 entry:
   %pi = alloca double

--- a/llvm/test/Transforms/LowerMatrixIntrinsics/remarks-inlining.ll
+++ b/llvm/test/Transforms/LowerMatrixIntrinsics/remarks-inlining.ll
@@ -47,49 +47,49 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "aarch64-apple-ios"
 
-; CHECK-LABEL: remark: load.h:41:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}load.h:41:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  load(addr %A)
 
-; CHECK-LABEL: remark: load.h:41:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}load.h:41:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  column.major.load.3x5.double(addr %B, 5)
 
-; CHECK-LABEL: remark: load.h:41:11: Lowered with 0 stores, 1 loads, 0 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}load.h:41:11: Lowered with 0 stores, 1 loads, 0 compute ops, 0 exposed transposes
 ; CHECK-NEXT: load(addr %D)
 
-; CHECK-LABEL: remark: assign.h:32:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}assign.h:32:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  load(addr %A)
 
-; CHECK-LABEL: remark: assign.h:32:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}assign.h:32:43: Lowered with 0 stores, 10 loads, 0 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  column.major.load.3x5.double(addr %B, 5)
 
-; CHECK-LABEL: remark: toplevel.c:410:0: Lowered with 10 stores, 20 loads, 10 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}toplevel.c:410:0: Lowered with 10 stores, 20 loads, 10 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:   fadd(
 ; CHECK-NEXT:    load(addr %A),
 ; CHECK-NEXT:    column.major.load.3x5.double(addr %B, 5)),
 ; CHECK-NEXT:   addr %C)
 
-; CHECK-LABEL: remark: toplevel.c:510:0: Lowered with 2 stores, 1 loads, 4 compute ops, 1 exposed transposes
+; CHECK-LABEL: remark: {{.*}}toplevel.c:510:0: Lowered with 2 stores, 1 loads, 4 compute ops, 1 exposed transposes
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:   transpose.2x1.float(load(addr %D)),
 ; CHECK-NEXT:   addr %D)
 
-; CHECK-LABEL: remark: add.h:66:11: Lowered with 0 stores, 0 loads, 10 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}add.h:66:11: Lowered with 0 stores, 0 loads, 10 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  fadd(
 ; CHECK-NEXT:   addr %A,
 ; CHECK-NEXT:   scalar)
 
-; CHECK-LABEL: remark: store.h:10:11: Lowered with 10 stores, 0 loads, 0 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}store.h:10:11: Lowered with 10 stores, 0 loads, 0 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:   scalar,
 ; CHECK-NEXT:   addr %C)
 
-; CHECK-LABEL: remark: store.h:66:11: Lowered with 2 stores, 0 loads, 0 compute ops, 0 exposed transposes
+; CHECK-LABEL: remark: {{.*}}store.h:66:11: Lowered with 2 stores, 0 loads, 0 compute ops, 0 exposed transposes
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:  scalar,
 ; CHECK-NEXT:  addr %D)
 
-; CHECK-LABEL: remark: transpose.h:13:11: Lowered with 0 stores, 0 loads, 4 compute ops, 1 exposed transposes
+; CHECK-LABEL: remark: {{.*}}transpose.h:13:11: Lowered with 0 stores, 0 loads, 4 compute ops, 1 exposed transposes
 ; CHECK-NEXT:  transpose.2x1.float(addr %D)
 
 define void @toplevel(ptr %A, ptr %B, ptr %C, ptr %D) !dbg !16 {

--- a/llvm/test/Transforms/LowerMatrixIntrinsics/remarks.ll
+++ b/llvm/test/Transforms/LowerMatrixIntrinsics/remarks.ll
@@ -4,7 +4,7 @@
 
 ; RUN: opt -passes=lower-matrix-intrinsics -pass-remarks=lower-matrix-intrinsics -mtriple=arm64-apple-iphoneos < %s 2>&1 | FileCheck %s
 
-; CHECK-LABEL: remark: test.h:40:20: Lowered with 6 stores, 6 loads, 24 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:40:20: Lowered with 6 stores, 6 loads, 24 compute ops
 ; CHECK-NEXT: store(
 ; CHECK-NEXT:  transpose.2x6.double(load(addr %A)),
 ; CHECK-NEXT:  addr %B)
@@ -15,7 +15,7 @@ define void @transpose(ptr %A, ptr %B) !dbg !23 {
   ret void
 }
 
-; CHECK-LABEL: remark: test.h:50:20: Lowered with 2 stores, 12 loads, 22 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:50:20: Lowered with 2 stores, 12 loads, 22 compute ops
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:   multiply.2x6.6x2.double(
 ; CHECK-NEXT:    load(addr %A),
@@ -29,7 +29,7 @@ define void @multiply(ptr %A, ptr %B, ptr %C) !dbg !25 {
   ret void
 }
 
-; CHECK-LABEL: remark: test.h:60:20: Lowered with 6 stores, 6 loads, 0 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:60:20: Lowered with 6 stores, 6 loads, 0 compute ops
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:   column.major.load.3x3.double(addr %A, 5),
 ; CHECK-NEXT:   addr %B)
@@ -39,7 +39,7 @@ define void @column.major.load(ptr %A, ptr %B) !dbg !27 {
   ret void
 }
 
-; CHECK-LABEL: remark: test.h:70:20: Lowered with 6 stores, 6 loads, 0 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:70:20: Lowered with 6 stores, 6 loads, 0 compute ops
 ; CHECK-NEXT:  column.major.store.3x3.double(
 ; CHECK-NEXT:   column.major.load.3x3.double(addr %A, 5),
 ; CHECK-NEXT:   addr %B,
@@ -50,7 +50,7 @@ define void @column.major.store(ptr %A, ptr %B) !dbg !29 {
   ret void
 }
 
-; CHECK-LABEL: remark: test.h:80:20: Lowered with 6 stores, 6 loads, 12 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:80:20: Lowered with 6 stores, 6 loads, 12 compute ops
 ; CHECK-NEXT:  column.major.store.3x3.double(
 ; CHECK-NEXT:   fmul(
 ; CHECK-NEXT:    fadd(
@@ -68,7 +68,7 @@ define void @binaryops(ptr %A, ptr %B) !dbg !31 {
   ret void
 }
 
-; CHECK-LABEL: remark: test.h:90:20: Lowered with 6 stores, 6 loads, 12 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:90:20: Lowered with 6 stores, 6 loads, 12 compute ops
 ; CHECK-NEXT:  column.major.store.3x3.double(
 ; CHECK-NEXT:   fmul(
 ; CHECK-NEXT:    fadd(
@@ -77,7 +77,7 @@ define void @binaryops(ptr %A, ptr %B) !dbg !31 {
 ; CHECK-NEXT:    (reused) column.major.load.3x3.double(addr %A, 5)),
 ; CHECK-NEXT:   addr %B,
 ; CHECK-NEXT:   10)
-; CHECK-NEXT:  remark: test.h:90:20: Lowered with 2 stores, 12 loads, 22 compute ops
+; CHECK-NEXT:  remark: {{.*}}test.h:90:20: Lowered with 2 stores, 12 loads, 22 compute ops
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:   multiply.2x6.6x2.double(
 ; CHECK-NEXT:    load(addr %C),
@@ -98,7 +98,7 @@ define void @multiple_expressions(ptr %A, ptr %B, ptr %C, ptr %D, ptr %E) !dbg !
   ret void
 }
 
-; CHECK-LABEL: remark: test.h:100:20: Lowered with 6 stores, 6 loads, 12 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:100:20: Lowered with 6 stores, 6 loads, 12 compute ops
 ; CHECK-NEXT:  column.major.store.3x3.double(
 ; CHECK-NEXT:   fmul(
 ; CHECK-NEXT:    fadd(
@@ -115,7 +115,7 @@ define void @stackaddresses(ptr %A, ptr %B) !dbg !35 {
   ret void
 }
 
-; CHECK-LABEL: remark: test.h:30:20: Lowered with 10 stores, 9 loads, 30 compute ops
+; CHECK-LABEL: remark: {{.*}}test.h:30:20: Lowered with 10 stores, 9 loads, 30 compute ops
 ; CHECK-NEXT:  store(
 ; CHECK-NEXT:   transpose.5x3.double(load(addr %A)),
 ; CHECK-NEXT:   stack addr %s1)

--- a/llvm/test/Transforms/OpenMP/custom_state_machines_remarks.ll
+++ b/llvm/test/Transforms/OpenMP/custom_state_machines_remarks.ll
@@ -1,10 +1,10 @@
 ; RUN: opt -passes=openmp-opt -pass-remarks=openmp-opt -pass-remarks-missed=openmp-opt -pass-remarks-analysis=openmp-opt -disable-output < %s 2>&1 | FileCheck %s
 target triple = "nvptx64"
 
-; CHECK: remark: llvm/test/Transforms/OpenMP/custom_state_machines_remarks.c:11:1: Generic-mode kernel is executed with a customized state machine that requires a fallback.
-; CHECK: remark: llvm/test/Transforms/OpenMP/custom_state_machines_remarks.c:13:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
-; CHECK: remark: llvm/test/Transforms/OpenMP/custom_state_machines_remarks.c:15:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
-; CHECK: remark: llvm/test/Transforms/OpenMP/custom_state_machines_remarks.c:20:1: Rewriting generic-mode kernel with a customized state machine.
+; CHECK: remark: {{.*}}custom_state_machines_remarks.c:11:1: Generic-mode kernel is executed with a customized state machine that requires a fallback.
+; CHECK: remark: {{.*}}custom_state_machines_remarks.c:13:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
+; CHECK: remark: {{.*}}custom_state_machines_remarks.c:15:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
+; CHECK: remark: {{.*}}custom_state_machines_remarks.c:20:1: Rewriting generic-mode kernel with a customized state machine.
 
 
 ;; void unknown(void);

--- a/llvm/test/Transforms/OpenMP/deduplication_remarks.ll
+++ b/llvm/test/Transforms/OpenMP/deduplication_remarks.ll
@@ -9,8 +9,8 @@ target triple = "x86_64-pc-linux-gnu"
 @0 = private unnamed_addr global %struct.ident_t { i32 0, i32 34, i32 0, i32 0, ptr @.str0 }, align 8
 @.str0 = private unnamed_addr constant [23 x i8] c";unknown;unknown;0;0;;\00", align 1
 
-; CHECK: remark: deduplication_remarks.c:7:10: OpenMP runtime call __kmpc_global_thread_num deduplicated
-; CHECK: remark: deduplication_remarks.c:9:10: OpenMP runtime call __kmpc_global_thread_num deduplicated
+; CHECK: remark: {{.*}}deduplication_remarks.c:7:10: OpenMP runtime call __kmpc_global_thread_num deduplicated
+; CHECK: remark: {{.*}}deduplication_remarks.c:9:10: OpenMP runtime call __kmpc_global_thread_num deduplicated
 define dso_local void @deduplicate() local_unnamed_addr !dbg !14 {
   %1 = tail call i32 @__kmpc_global_thread_num(ptr nonnull @0), !dbg !21
   call void @useI32(i32 %1), !dbg !23

--- a/llvm/test/Transforms/OpenMP/globalization_remarks.ll
+++ b/llvm/test/Transforms/OpenMP/globalization_remarks.ll
@@ -4,8 +4,8 @@ source_filename = "declare_target_codegen_globalization.cpp"
 target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 target triple = "nvptx64"
 
-; CHECK: remark: globalization_remarks.c:5:7: Could not move globalized variable to the stack. Variable is potentially captured in call. Mark parameter as `__attribute__((noescape))` to override.
-; CHECK: remark: globalization_remarks.c:5:7: Found thread data sharing on the GPU. Expect degraded performance due to data globalization.
+; CHECK: remark: {{.*}}globalization_remarks.c:5:7: Could not move globalized variable to the stack. Variable is potentially captured in call. Mark parameter as `__attribute__((noescape))` to override.
+; CHECK: remark: {{.*}}globalization_remarks.c:5:7: Found thread data sharing on the GPU. Expect degraded performance due to data globalization.
 
 %struct.KernelEnvironmentTy = type { %struct.ConfigurationEnvironmentTy, ptr, ptr }
 %struct.ConfigurationEnvironmentTy = type { i8, i8, i8 }

--- a/llvm/test/Transforms/OpenMP/icv_remarks.ll
+++ b/llvm/test/Transforms/OpenMP/icv_remarks.ll
@@ -11,9 +11,9 @@ target triple = "x86_64-unknown-linux-gnu"
 @0 = private unnamed_addr constant %struct.ident_t { i32 0, i32 2, i32 0, i32 0, ptr @.str }, align 8
 @1 = private unnamed_addr constant [26 x i8] c";icv_remarks.c;foo;18;1;;\00", align 1
 
-; CHECK-DAG: remark: icv_remarks.c:12:0: OpenMP ICV nthreads Value: IMPLEMENTATION_DEFINED
-; CHECK-DAG: remark: icv_remarks.c:12:0: OpenMP ICV active_levels Value: 0
-; CHECK-DAG: remark: icv_remarks.c:12:0: OpenMP ICV cancel Value: 0
+; CHECK-DAG: remark: {{.*}}icv_remarks.c:12:0: OpenMP ICV nthreads Value: IMPLEMENTATION_DEFINED
+; CHECK-DAG: remark: {{.*}}icv_remarks.c:12:0: OpenMP ICV active_levels Value: 0
+; CHECK-DAG: remark: {{.*}}icv_remarks.c:12:0: OpenMP ICV cancel Value: 0
 define dso_local void @foo(i32 %a) local_unnamed_addr #0 !dbg !17 {
 entry:
   %.kmpc_loc.addr = alloca %struct.ident_t, align 8
@@ -35,9 +35,9 @@ declare !dbg !9 dso_local i32 @omp_get_max_threads() local_unnamed_addr #1
 
 declare !dbg !12 dso_local void @use(i32) local_unnamed_addr #2
 
-; CHECK-DAG: remark: icv_remarks.c:18:0: OpenMP ICV nthreads Value: IMPLEMENTATION_DEFINED
-; CHECK-DAG: remark: icv_remarks.c:18:0: OpenMP ICV active_levels Value: 0
-; CHECK-DAG: remark: icv_remarks.c:18:0: OpenMP ICV cancel Value: 0
+; CHECK-DAG: remark: {{.*}}icv_remarks.c:18:0: OpenMP ICV nthreads Value: IMPLEMENTATION_DEFINED
+; CHECK-DAG: remark: {{.*}}icv_remarks.c:18:0: OpenMP ICV active_levels Value: 0
+; CHECK-DAG: remark: {{.*}}icv_remarks.c:18:0: OpenMP ICV cancel Value: 0
 define internal void @.omp_outlined.(ptr noalias nocapture readnone %.global_tid., ptr noalias nocapture readnone %.bound_tid.) #3 !dbg !33 {
 entry:
   call void @llvm.dbg.value(metadata ptr %.global_tid., metadata !41, metadata !DIExpression()), !dbg !43

--- a/llvm/test/Transforms/OpenMP/parallel_deletion_remarks.ll
+++ b/llvm/test/Transforms/OpenMP/parallel_deletion_remarks.ll
@@ -22,9 +22,9 @@ target triple = "x86_64-pc-linux-gnu"
 ;
 ; This will delete all but the first parallel region
 
-; CHECK: remark: parallel_deletion_remarks.c:10:1: Removing parallel region with no side-effects.
-; CHECK: remark: parallel_deletion_remarks.c:12:1: Removing parallel region with no side-effects.
-; CHECK: remark: parallel_deletion_remarks.c:14:1: Removing parallel region with no side-effects.
+; CHECK: remark: {{.*}}parallel_deletion_remarks.c:10:1: Removing parallel region with no side-effects.
+; CHECK: remark: {{.*}}parallel_deletion_remarks.c:12:1: Removing parallel region with no side-effects.
+; CHECK: remark: {{.*}}parallel_deletion_remarks.c:14:1: Removing parallel region with no side-effects.
 define dso_local void @delete_parallel() local_unnamed_addr !dbg !15 {
   call void (ptr, i32, ptr, ...) @__kmpc_fork_call(ptr nonnull @0, i32 0, ptr @.omp_outlined.), !dbg !18
   call void (ptr, i32, ptr, ...) @__kmpc_fork_call(ptr nonnull @0, i32 0, ptr @.omp_outlined..2), !dbg !19

--- a/llvm/test/Transforms/OpenMP/remove_globalization.ll
+++ b/llvm/test/Transforms/OpenMP/remove_globalization.ll
@@ -12,11 +12,11 @@ target triple = "nvptx64"
 
 
 ; UTC_ARGS: --disable
-; CHECK-REMARKS: remark: remove_globalization.c:4:2: Could not move globalized variable to the stack. Variable is potentially captured in call. Mark parameter as `__attribute__((noescape))` to override.
-; CHECK-REMARKS: remark: remove_globalization.c:2:2: Moving globalized variable to the stack.
-; CHECK-REMARKS: remark: remove_globalization.c:4:2: Moving globalized variable to the stack.
-; CHECK-REMARKS: remark: remove_globalization.c:10:2: Moving globalized variable to the stack.
-; CHECK-REMARKS: remark: remove_globalization.c:6:2: Moving globalized variable to the stack.
+; CHECK-REMARKS: remark: {{.*}}remove_globalization.c:4:2: Could not move globalized variable to the stack. Variable is potentially captured in call. Mark parameter as `__attribute__((noescape))` to override.
+; CHECK-REMARKS: remark: {{.*}}remove_globalization.c:2:2: Moving globalized variable to the stack.
+; CHECK-REMARKS: remark: {{.*}}remove_globalization.c:4:2: Moving globalized variable to the stack.
+; CHECK-REMARKS: remark: {{.*}}remove_globalization.c:10:2: Moving globalized variable to the stack.
+; CHECK-REMARKS: remark: {{.*}}remove_globalization.c:6:2: Moving globalized variable to the stack.
 ; UTC_ARGS: --enable
 
 ; Make it a weak definition so we will apply custom state machine rewriting but can't use the body in the reasoning.

--- a/llvm/test/Transforms/OpenMP/replace_globalization.ll
+++ b/llvm/test/Transforms/OpenMP/replace_globalization.ll
@@ -6,11 +6,11 @@ target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 target triple = "nvptx64"
 
 ; UTC_ARGS: --disable
-; CHECK-REMARKS: remark: replace_globalization.c:5:7: Replaced globalized variable with 16 bytes of shared memory
-; CHECK-REMARKS: remark: replace_globalization.c:5:14: Replaced globalized variable with 4 bytes of shared memory
+; CHECK-REMARKS: remark: {{.*}}replace_globalization.c:5:7: Replaced globalized variable with 16 bytes of shared memory
+; CHECK-REMARKS: remark: {{.*}}replace_globalization.c:5:14: Replaced globalized variable with 4 bytes of shared memory
 ; CHECK-REMARKS-NOT: 6 bytes
-; CHECK-LIMIT: remark: replace_globalization.c:5:14: Replaced globalized variable with 4 bytes of shared memory
-; CHECK-LIMIT: remark: replace_globalization.c:5:7: Found thread data sharing on the GPU. Expect degraded performance due to data globalization
+; CHECK-LIMIT: remark: {{.*}}replace_globalization.c:5:14: Replaced globalized variable with 4 bytes of shared memory
+; CHECK-LIMIT: remark: {{.*}}replace_globalization.c:5:7: Found thread data sharing on the GPU. Expect degraded performance due to data globalization
 ; UTC_ARGS: --enable
 
 %struct.ident_t = type { i32, i32, i32, i32, ptr }

--- a/llvm/test/Transforms/OpenMP/single_threaded_execution.ll
+++ b/llvm/test/Transforms/OpenMP/single_threaded_execution.ll
@@ -43,8 +43,8 @@ entry:
   ret void
 }
 
-; REMARKS: remark: single_threaded_execution.c:1:0: Could not internalize function. Some optimizations may not be possible.
-; REMARKS-NOT: remark: single_threaded_execution.c:1:0: Could not internalize function. Some optimizations may not be possible.
+; REMARKS: remark: {{.*}}single_threaded_execution.c:1:0: Could not internalize function. Some optimizations may not be possible.
+; REMARKS-NOT: remark: {{.*}}single_threaded_execution.c:1:0: Could not internalize function. Some optimizations may not be possible.
 
 ; CHECK-NOT: [openmp-opt] Basic block @nvptx entry is executed by a single thread.
 ; CHECK-DAG: [openmp-opt] Basic block @nvptx if.then is executed by a single thread.

--- a/llvm/test/Transforms/OpenMP/spmdization_remarks.ll
+++ b/llvm/test/Transforms/OpenMP/spmdization_remarks.ll
@@ -1,12 +1,12 @@
 ; RUN: opt -passes=openmp-opt -pass-remarks=openmp-opt -pass-remarks-missed=openmp-opt -pass-remarks-analysis=openmp-opt -disable-output < %s 2>&1 | FileCheck %s
 target triple = "nvptx64"
 
-; CHECK: remark: llvm/test/Transforms/OpenMP/spmdization_remarks.c:13:5: Value has potential side effects preventing SPMD-mode execution. Add `__attribute__((assume("ompx_spmd_amenable")))` to the called function to override.
-; CHECK: remark: llvm/test/Transforms/OpenMP/spmdization_remarks.c:15:5: Value has potential side effects preventing SPMD-mode execution. Add `__attribute__((assume("ompx_spmd_amenable")))` to the called function to override.
-; CHECK: remark: llvm/test/Transforms/OpenMP/spmdization_remarks.c:11:1: Generic-mode kernel is executed with a customized state machine that requires a fallback.
-; CHECK: remark: llvm/test/Transforms/OpenMP/spmdization_remarks.c:13:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
-; CHECK: remark: llvm/test/Transforms/OpenMP/spmdization_remarks.c:15:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
-; CHECK: remark: llvm/test/Transforms/OpenMP/spmdization_remarks.c:20:1: Transformed generic-mode kernel to SPMD-mode.
+; CHECK: remark: {{.*}}spmdization_remarks.c:13:5: Value has potential side effects preventing SPMD-mode execution. Add `__attribute__((assume("ompx_spmd_amenable")))` to the called function to override.
+; CHECK: remark: {{.*}}spmdization_remarks.c:15:5: Value has potential side effects preventing SPMD-mode execution. Add `__attribute__((assume("ompx_spmd_amenable")))` to the called function to override.
+; CHECK: remark: {{.*}}spmdization_remarks.c:11:1: Generic-mode kernel is executed with a customized state machine that requires a fallback.
+; CHECK: remark: {{.*}}spmdization_remarks.c:13:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
+; CHECK: remark: {{.*}}spmdization_remarks.c:15:5: Call may contain unknown parallel regions. Use `__attribute__((assume("omp_no_parallelism")))` to override.
+; CHECK: remark: {{.*}}spmdization_remarks.c:20:1: Transformed generic-mode kernel to SPMD-mode.
 
 
 ;; void unknown(void);

--- a/llvm/test/Transforms/PhaseOrdering/openmp-opt-module.ll
+++ b/llvm/test/Transforms/PhaseOrdering/openmp-opt-module.ll
@@ -8,7 +8,7 @@ target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 @S = external local_unnamed_addr global ptr
 @foo_kernel_environment = local_unnamed_addr constant %struct.KernelEnvironmentTy { %struct.ConfigurationEnvironmentTy { i8 1, i8 0, i8 1 }, ptr null, ptr null }
 
-; MODULE: remark: openmp_opt_module.c:5:7: Found thread data sharing on the GPU. Expect degraded performance due to data globalization.
+; MODULE: remark: {{.*}}openmp_opt_module.c:5:7: Found thread data sharing on the GPU. Expect degraded performance due to data globalization.
 
 define void @foo() "kernel" {
 entry:

--- a/llvm/test/Transforms/SampleProfile/csspgo-inline-icall.ll
+++ b/llvm/test/Transforms/SampleProfile/csspgo-inline-icall.ll
@@ -55,10 +55,10 @@ attributes #0 = {"use-sample-profile"}
 !11 = distinct !DISubprogram(name: "zoo", linkageName: "_Z3zoov", scope: !1, file: !1, line: 24, unit: !0)
 
 
-; ICP-ALL:      remark: test.cc:4:0: '_Z3foov' inlined into 'test'
-; ICP-ALL-NEXT: remark: test.cc:4:0: '_Z3barv' inlined into 'test'
-; ICP-ALL-NEXT: remark: test.cc:5:0: '_Z3bazv' inlined into 'test'
+; ICP-ALL:      remark: {{.*}}test.cc:4:0: '_Z3foov' inlined into 'test'
+; ICP-ALL-NEXT: remark: {{.*}}test.cc:4:0: '_Z3barv' inlined into 'test'
+; ICP-ALL-NEXT: remark: {{.*}}test.cc:5:0: '_Z3bazv' inlined into 'test'
 ; ICP-ALL-NOT: remark
 
-; ICP-HOT: remark: test.cc:4:0: '_Z3foov' inlined into 'test'
+; ICP-HOT: remark: {{.*}}test.cc:4:0: '_Z3foov' inlined into 'test'
 ; ICP-HOT-NOT: remark

--- a/llvm/test/Transforms/SampleProfile/csspgo-inline.ll
+++ b/llvm/test/Transforms/SampleProfile/csspgo-inline.ll
@@ -28,17 +28,17 @@
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/profile-context-tracker.prof -sample-profile-inline-size -profile-summary-cutoff-hot=999990 -sample-profile-inline-limit-min=10 -sample-profile-inline-growth-limit=1 -profile-sample-accurate -S -pass-remarks=inline -o /dev/null 2>&1 | FileCheck %s --check-prefix=INLINE-NEW-LIMIT2
 
 
-; INLINE-BASE: remark: merged.cpp:14:10: '_Z5funcAi' inlined into 'main' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite main:3:10
-; INLINE-BASE: remark: merged.cpp:27:11: '_Z8funcLeafi' inlined into 'main' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcAi:1:11 @ main:3:10
-; INLINE-BASE: remark: merged.cpp:33:11: '_Z8funcLeafi' inlined into '_Z5funcBi' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcBi:1:11
+; INLINE-BASE: remark: {{.*}}merged.cpp:14:10: '_Z5funcAi' inlined into 'main' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite main:3:10
+; INLINE-BASE: remark: {{.*}}merged.cpp:27:11: '_Z8funcLeafi' inlined into 'main' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcAi:1:11 @ main:3:10
+; INLINE-BASE: remark: {{.*}}merged.cpp:33:11: '_Z8funcLeafi' inlined into '_Z5funcBi' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcBi:1:11
 
-; INLINE-NEW: remark: merged.cpp:14:10: '_Z5funcAi' inlined into 'main' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite main:3:10
+; INLINE-NEW: remark: {{.*}}merged.cpp:14:10: '_Z5funcAi' inlined into 'main' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite main:3:10
 ; INLINE-NEW-NOT: remark
 
 ; INLINE-NEW-LIMIT1-NOT: remark
 
-; INLINE-NEW-LIMIT2: remark: merged.cpp:33:11: '_Z8funcLeafi' inlined into '_Z5funcBi' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcBi:1:11
-; INLINE-NEW-LIMIT2: remark: merged.cpp:27:11: '_Z8funcLeafi' inlined into '_Z5funcAi' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcAi:1:11;
+; INLINE-NEW-LIMIT2: remark: {{.*}}merged.cpp:33:11: '_Z8funcLeafi' inlined into '_Z5funcBi' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcBi:1:11
+; INLINE-NEW-LIMIT2: remark: {{.*}}merged.cpp:27:11: '_Z8funcLeafi' inlined into '_Z5funcAi' to match profiling context with (cost={{[0-9]+}}, threshold={{[0-9]+}}) at callsite _Z5funcAi:1:11;
 ; INLINE-NEW-LIMIT2-NOT: remark
 
 @factor = dso_local global i32 3, align 4, !dbg !0

--- a/llvm/test/Transforms/SampleProfile/misexpect.ll
+++ b/llvm/test/Transforms/SampleProfile/misexpect.ll
@@ -29,11 +29,11 @@
 ;   return 0;
 ; }
 
-; WARNING-DAG: warning: test.cc:9:14: 20.06%
-; WARNING-DAG: warning: test.cc:11:24: 92.74%
+; WARNING-DAG: warning: {{.*}}test.cc:9:14: 20.06%
+; WARNING-DAG: warning: {{.*}}test.cc:11:24: 92.74%
 
-; NONE-NOT: warning: test.cc:9:14: 20.06%
-; NONE-NOT: warning: test.cc:11:24: 92.74%
+; NONE-NOT: warning: {{.*}}test.cc:9:14: 20.06%
+; NONE-NOT: warning: {{.*}}test.cc:11:24: 92.74%
 
 @.str = private unnamed_addr constant [15 x i8] c"result is %lf\0A\00", align 1
 

--- a/llvm/test/Transforms/Util/libcalls-opt-remarks.ll
+++ b/llvm/test/Transforms/Util/libcalls-opt-remarks.ll
@@ -5,7 +5,7 @@
 ; RUN:     -pass-remarks-output=%t -S -pass-remarks=instcombine 2>&1 | FileCheck %s
 ; RUN: cat %t | FileCheck -check-prefix=YAML %s
 
-; CHECK:      remark: libcalls-opt-remarks.c:10:10: folded strlen(select) to select of constants{{$}}
+; CHECK:      remark: {{.*}}libcalls-opt-remarks.c:10:10: folded strlen(select) to select of constants{{$}}
 ; CHECK-NOT:  remark:
 
 ; YAML:      --- !Passed

--- a/llvm/test/Transforms/Util/trivial-auto-var-init-crash-20210521.ll
+++ b/llvm/test/Transforms/Util/trivial-auto-var-init-crash-20210521.ll
@@ -14,7 +14,7 @@ define void @spam() local_unnamed_addr #1 !dbg !3 {
 bb:
   call void @llvm.dbg.value(metadata ptr null, metadata !21, metadata !DIExpression()) #3, !dbg !28
 
-; CHECK: remark: :1:0: Call to memset inserted by -ftrivial-auto-var-init. Memory operation size: 0 bytes.
+; CHECK: remark: {{.*}}:1:0: Call to memset inserted by -ftrivial-auto-var-init. Memory operation size: 0 bytes.
   tail call void @llvm.memset.p0.i64(ptr null, i8 0, i64 0, i1 false), !annotation !33, !dbg !28
   ret void
 }


### PR DESCRIPTION
When clang generates optimization remarks with LTO enabled, the optimization remark dump at the preLTO stage and the LTO stage are not consistent in the sense that remarks at the preLTO stage output absolute file path and remarks at LTO stage output relative file path. So it is inconsistent behavior and what this patch did is to make the behavior consistent: outputting absolute paths for both preLTO and LTO stages. Arguably it would be better to output the full path which could make it easier to locate and diagnose problems. 