### PR TITLE
[clang][Interp] Only evaluate the source array initialization of an `ArrayInitLoopExpr` once

### DIFF
--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -812,7 +812,8 @@ bool ByteCodeExprGen<Emitter>::VisitArrayInitLoopExpr(
   assert(!DiscardResult);
 
   StoredOpaqueValueScope<Emitter> StoredOpaqueScope(this);
-  StoredOpaqueScope.VisitAndStoreOpaqueValue(E->getCommonExpr());
+  if (!StoredOpaqueScope.VisitAndStoreOpaqueValue(E->getCommonExpr()))
+    return false;
 
   const Expr *SubExpr = E->getSubExpr();
   size_t Size = E->getArraySize().getZExtValue();

--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -846,12 +846,11 @@ bool ByteCodeExprGen<Emitter>::VisitArrayInitLoopExpr(
 
 template <class Emitter>
 bool ByteCodeExprGen<Emitter>::VisitOpaqueValueExpr(const OpaqueValueExpr *E) {
-  if(OpaqueExprs.contains(E))
+  if (OpaqueExprs.contains(E))
     return this->emitGetLocal(*classify(E), OpaqueExprs[E], E);
 
   if (Initializing)
     return this->visitInitializer(E->getSourceExpr());
-  
   return this->visit(E->getSourceExpr());
 }
 

--- a/clang/lib/AST/Interp/ByteCodeExprGen.h
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.h
@@ -485,19 +485,21 @@ template <class Emitter> class StoredOpaqueValueScope final {
 public:
   StoredOpaqueValueScope(ByteCodeExprGen<Emitter> *Ctx) : Ctx(Ctx) {}
 
-  bool VisitAndStoreOpaqueValue(const OpaqueValueExpr* Ove) {
+  bool VisitAndStoreOpaqueValue(const OpaqueValueExpr *Ove) {
     assert(Ove && "OpaqueValueExpr is a nullptr!");
-    assert(!Ctx->OpaqueExprs.contains(Ove) && "OpaqueValueExpr already stored!");
+    assert(!Ctx->OpaqueExprs.contains(Ove) &&
+           "OpaqueValueExpr already stored!");
 
     std::optional<PrimType> CommonTy = Ctx->classify(Ove);
-    std::optional<unsigned> LocalIndex = Ctx->allocateLocalPrimitive(Ove, *CommonTy, Ove->getType().isConstQualified());
+    std::optional<unsigned> LocalIndex = Ctx->allocateLocalPrimitive(
+        Ove, *CommonTy, Ove->getType().isConstQualified());
     if (!LocalIndex)
       return false;
 
     if (!Ctx->visit(Ove))
       return false;
 
-    if(!Ctx->emitSetLocal(*CommonTy, *LocalIndex, Ove))
+    if (!Ctx->emitSetLocal(*CommonTy, *LocalIndex, Ove))
       return false;
 
     Ctx->OpaqueExprs.insert({Ove, *LocalIndex});
@@ -507,13 +509,13 @@ public:
   }
 
   ~StoredOpaqueValueScope() {
-    for(const auto *SV : StoredValues)
+    for (const auto *SV : StoredValues)
       Ctx->OpaqueExprs.erase(SV);
   }
 
 private:
   ByteCodeExprGen<Emitter> *Ctx;
-  std::vector<const OpaqueValueExpr*> StoredValues;
+  std::vector<const OpaqueValueExpr *> StoredValues;
 };
 
 } // namespace interp

--- a/clang/test/AST/Interp/arrays.cpp
+++ b/clang/test/AST/Interp/arrays.cpp
@@ -352,9 +352,6 @@ namespace ZeroInit {
 }
 
 namespace ArrayInitLoop {
-  /// FIXME: The ArrayInitLoop for the decomposition initializer in g() has
-  /// f(n) as its CommonExpr. We need to evaluate that exactly once and not
-  /// N times as we do right now.
   struct X {
       int arr[3];
   };
@@ -366,8 +363,7 @@ namespace ArrayInitLoop {
       auto [a, b, c] = f(n).arr;
       return a + b + c;
   }
-  static_assert(g() == 6); // expected-error {{failed}} \
-                           // expected-note {{15 == 6}}
+  static_assert(g() == 6);
 }
 
 namespace StringZeroFill {

--- a/clang/test/AST/Interp/arrays.cpp
+++ b/clang/test/AST/Interp/arrays.cpp
@@ -363,7 +363,7 @@ namespace ArrayInitLoop {
       auto [a, b, c] = f(n).arr;
       return a + b + c;
   }
-  static_assert(g() == 6);
+  static_assert(g() == 6, "");
 }
 
 namespace StringZeroFill {

--- a/clang/test/AST/Interp/cxx20.cpp
+++ b/clang/test/AST/Interp/cxx20.cpp
@@ -733,3 +733,15 @@ namespace ConstexprArrayInitLoopExprDestructors
       return f();
   }
 }
+
+namespace NonPrimitiveOpaqueValue
+{
+  struct X {
+    int x;
+    constexpr operator bool() const { return x != 0; }
+  };
+
+  constexpr int ternary() { return X(0) ?: X(0); }
+
+  static_assert(!ternary(), "");
+}


### PR DESCRIPTION
At the moment in `Interp` the source array initialization (`getCommonExpr()`) of an `ArrayInitLoopExpr` is evaluated during every iteration, when it should only be evaluated once.

The initializer is always wrapped inside an `OpaqueValueExpr`, which in `ExprConstant` is evaluated once per scope and their result is stored so that the next time `ExprConstant` sees the same expression, it can return the result only.

This patch intents to achieve a similar functionality inside `Interp` by storing the result of the `OpaqueValueExpr` in a local variable.