### PR TITLE
[Debuginfod] Accept compressed encodings in client

### DIFF
--- a/llvm/lib/Debuginfod/HTTPClient.cpp
+++ b/llvm/lib/Debuginfod/HTTPClient.cpp
@@ -97,6 +97,8 @@ HTTPClient::HTTPClient() {
   assert(Curl && "Curl could not be initialized");
   // Set the callback hooks.
   curl_easy_setopt(Curl, CURLOPT_WRITEFUNCTION, curlWriteFunction);
+  // Detect supported compressed encodings and accept all.
+  curl_easy_setopt(Curl, CURLOPT_ACCEPT_ENCODING, "");
 }
 
 HTTPClient::~HTTPClient() { curl_easy_cleanup(Curl); }

--- a/llvm/test/tools/llvm-debuginfod-find/headers.test
+++ b/llvm/test/tools/llvm-debuginfod-find/headers.test
@@ -16,9 +16,11 @@ RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache DEBUGINFOD_HEADERS_FILE=%S/Inputs/
 RUN:   | FileCheck --check-prefix ERR -DHEADER_FILE=%S/Inputs/headers %s
 
 NO-HEADERS: Accept: */*
+NO-HEADERS-NEXT: Accept-Encoding: {{.*}}
 NO-HEADERS-NOT: {{.}}
 
 HEADERS:      Accept: */*
+HEADERS-NEXT: Accept-Encoding: {{.*}}
 HEADERS-NEXT: A: B
 HEADERS-NEXT: C: D
 HEADERS-NEXT: E: F


### PR DESCRIPTION
All encodings that the underlying libcurl supports are automatically detected and accepted. libcurl will then decompress on the fly. This improves effective network transfer rate and prevents server-side decompression for files stored compressed.

Fixes #63534