### PR TITLE
[clang] Ignore GCC 11 `[[malloc(x)]]` attribute

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -289,6 +289,11 @@ Bug Fixes to Compiler Builtins
 Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Clang now emits a warning instead of an error when using the one or two
+  argument form of GCC 11's ``__attribute__((malloc(deallocator)))``
+  or ``__attribute__((malloc(deallocator, ptr-index)))``
+  (`#51607 <https://github.com/llvm/llvm-project/issues/51607>`).
+
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -292,7 +292,7 @@ Bug Fixes to Attribute Support
 - Clang now emits a warning instead of an error when using the one or two
   argument form of GCC 11's ``__attribute__((malloc(deallocator)))``
   or ``__attribute__((malloc(deallocator, ptr-index)))``
-  (`#51607 <https://github.com/llvm/llvm-project/issues/51607>`).
+  (`#51607 <https://github.com/llvm/llvm-project/issues/51607>`_).
 
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1629,6 +1629,8 @@ def IFunc : Attr, TargetSpecificAttr<TargetELF> {
 
 def Restrict : InheritableAttr {
   let Spellings = [Declspec<"restrict">, GCC<"malloc">];
+  let Args = [IdentifierArgument<"Deallocator", /*opt*/ 1>,
+              ParamIdxArgument<"DeallocatorPtrArgIndex", /*opt*/ 1>];
   let Subjects = SubjectList<[Function]>;
   let Documentation = [RestrictDocs];
 }

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1629,7 +1629,7 @@ def IFunc : Attr, TargetSpecificAttr<TargetELF> {
 
 def Restrict : InheritableAttr {
   let Spellings = [Declspec<"restrict">, GCC<"malloc">];
-  let Args = [IdentifierArgument<"Deallocator", /*opt=*/ 1>,
+  let Args = [ExprArgument<"Deallocator", /*opt=*/ 1>,
               ParamIdxArgument<"DeallocatorPtrArgIndex", /*opt=*/ 1>];
   let Subjects = SubjectList<[Function]>;
   let Documentation = [RestrictDocs];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1629,8 +1629,8 @@ def IFunc : Attr, TargetSpecificAttr<TargetELF> {
 
 def Restrict : InheritableAttr {
   let Spellings = [Declspec<"restrict">, GCC<"malloc">];
-  let Args = [IdentifierArgument<"Deallocator", /*opt*/ 1>,
-              ParamIdxArgument<"DeallocatorPtrArgIndex", /*opt*/ 1>];
+  let Args = [IdentifierArgument<"Deallocator", /*opt=*/ 1>,
+              ParamIdxArgument<"DeallocatorPtrArgIndex", /*opt=*/ 1>];
   let Subjects = SubjectList<[Function]>;
   let Documentation = [RestrictDocs];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -4122,6 +4122,9 @@ def RestrictDocs : Documentation {
 The ``malloc`` attribute indicates that the function acts like a system memory
 allocation function, returning a pointer to allocated storage disjoint from the
 storage for any other object accessible to the caller.
+
+The form of ``malloc`` with one or two arguments (supported by GCC 11) is
+currently ignored by Clang.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -177,6 +177,10 @@ def warn_unknown_attribute_ignored : Warning<
   "unknown attribute %0 ignored">, InGroup<UnknownAttributes>;
 def warn_attribute_ignored : Warning<"%0 attribute ignored">,
   InGroup<IgnoredAttributes>;
+def warn_multiarg_malloc_attribute_ignored: Warning<
+  "'malloc' attribute ignored because"
+  " Clang does not support the one/two argument form">,
+  InGroup<IgnoredAttributes>;
 def err_keyword_not_supported_on_target : Error<
   "%0 is not supported on this target">;
 def err_use_of_tag_name_without_tag : Error<

--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -177,10 +177,6 @@ def warn_unknown_attribute_ignored : Warning<
   "unknown attribute %0 ignored">, InGroup<UnknownAttributes>;
 def warn_attribute_ignored : Warning<"%0 attribute ignored">,
   InGroup<IgnoredAttributes>;
-def warn_multiarg_malloc_attribute_ignored: Warning<
-  "'malloc' attribute ignored because"
-  " Clang does not support the one/two argument form">,
-  InGroup<IgnoredAttributes>;
 def err_keyword_not_supported_on_target : Error<
   "%0 is not supported on this target">;
 def err_use_of_tag_name_without_tag : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4252,6 +4252,12 @@ def err_attribute_cleanup_func_must_take_one_arg : Error<
 def err_attribute_cleanup_func_arg_incompatible_type : Error<
   "'cleanup' function %0 parameter has "
   "%diff{type $ which is incompatible with type $|incompatible type}1,2">;
+def err_attribute_malloc_arg_not_function : Error<
+  "'malloc' argument %select{for deallocator |%1 |%1 }0is not a %select{||single }0function">;
+def err_attribute_malloc_arg_not_function_with_pointer_arg : Error<
+  "'malloc' argument %0 must take a pointer type as its first argument">;
+def err_attribute_malloc_arg_refers_to_non_pointer_type : Error<
+  "'malloc' argument '%0' refers to non-pointer type %1 of %2">; // in GCC, this is a warning, not an error
 def err_attribute_regparm_wrong_platform : Error<
   "'regparm' is not valid on this platform">;
 def err_attribute_regparm_invalid_number : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3028,6 +3028,10 @@ def warn_auto_var_is_id : Warning<
   InGroup<DiagGroup<"auto-var-id">>;
 
 // Attributes
+def warn_attribute_form_ignored : Warning<
+  "%0 attribute ignored because Clang does not yet support this attribute signature">,
+  InGroup<IgnoredAttributes>;
+
 def warn_attribute_ignored_no_calls_in_stmt: Warning<
   "%0 attribute is ignored because there exists no call expression inside the "
   "statement">,

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2084,7 +2084,7 @@ static void handleRestrictAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   // FIXME: GCC uses [[malloc(my_func)]] to specify a deallocator for the
   // returned pointer, but this isn't currently supported in LLVM
   // see https://github.com/llvm/llvm-project/issues/51607
-  S.Diag(AL.getLoc(), diag::warn_multiarg_malloc_attribute_ignored);
+  S.Diag(AL.getLoc(), diag::warn_attribute_form_ignored) << AL;
 }
 
 static void handleCPUSpecificAttr(Sema &S, Decl *D, const ParsedAttr &AL) {

--- a/clang/test/Sema/attr-args.c
+++ b/clang/test/Sema/attr-args.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -verify -Wunused -Wused-but-marked-unused -Wunused-parameter -fsyntax-only %s
+// RUN: %clang_cc1 -verify -Wunused -Wused-but-marked-unused -Wunused-parameter -fsyntax-only -fdeclspec %s
 int a;
 
 inline __attribute__((noreturn(a))) void *f1(void);  // expected-error {{'noreturn' attribute takes no arguments}}
@@ -6,7 +6,9 @@ inline __attribute__((always_inline(a))) void *f2(void);  // expected-error {{'a
 inline __attribute__((cdecl(a))) void *f3(void);  // expected-error {{'cdecl' attribute takes no arguments}}
 inline __attribute__((const(a))) void *f4(void);  // expected-error {{'const' attribute takes no arguments}}
 inline __attribute__((fastcall(a))) void *f5(void);  // expected-error {{'fastcall' attribute takes no arguments}}
-inline __attribute__((malloc(a))) void *f5(void);  // expected-error {{'malloc' attribute takes no arguments}}
+inline __declspec(restrict(a)) void *f6_a(void);  // expected-error {{'restrict' attribute takes no arguments}}
+inline __attribute__((malloc(a, 1, a))) void *f6_b(void);  // expected-error {{'malloc' attribute takes no more than 2 arguments}}
+inline __attribute__((malloc(a, 1))) void *f6_c(void);  // expected-warning {{'malloc' attribute ignored because Clang does not support the one/two argument form}}
 inline __attribute__((nothrow(a))) void *f7(void);  // expected-error {{'nothrow' attribute takes no arguments}}
 inline __attribute__((stdcall(a))) void *f8(void);  // expected-error {{'stdcall' attribute takes no arguments}}
 inline __attribute__((used(a))) void *f9(void);  // expected-error {{'used' attribute takes no arguments}}

--- a/clang/test/Sema/attr-args.c
+++ b/clang/test/Sema/attr-args.c
@@ -8,7 +8,7 @@ inline __attribute__((const(a))) void *f4(void);  // expected-error {{'const' at
 inline __attribute__((fastcall(a))) void *f5(void);  // expected-error {{'fastcall' attribute takes no arguments}}
 inline __declspec(restrict(a)) void *f6_a(void);  // expected-error {{'restrict' attribute takes no arguments}}
 inline __attribute__((malloc(a, 1, a))) void *f6_b(void);  // expected-error {{'malloc' attribute takes no more than 2 arguments}}
-inline __attribute__((malloc(a, 1))) void *f6_c(void);  // expected-warning {{'malloc' attribute ignored because Clang does not support the one/two argument form}}
+inline __attribute__((malloc(a, 1))) void *f6_c(void);  // expected-warning {{'malloc' attribute ignored because Clang does not yet support this attribute signature}}
 inline __attribute__((nothrow(a))) void *f7(void);  // expected-error {{'nothrow' attribute takes no arguments}}
 inline __attribute__((stdcall(a))) void *f8(void);  // expected-error {{'stdcall' attribute takes no arguments}}
 inline __attribute__((used(a))) void *f9(void);  // expected-error {{'used' attribute takes no arguments}}

--- a/clang/test/Sema/attr-args.c
+++ b/clang/test/Sema/attr-args.c
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -verify -Wunused -Wused-but-marked-unused -Wunused-parameter -fsyntax-only -fdeclspec %s
 int a;
+void func_a(void * ptr, int a);
+void func_b(int a);
+void __attribute__((overloadable)) ambigious_func(void *); // expected-note {{candidate function}}
+void __attribute__((overloadable)) ambigious_func(void *, int); // expected-note {{candidate function}}
 
 inline __attribute__((noreturn(a))) void *f1(void);  // expected-error {{'noreturn' attribute takes no arguments}}
 inline __attribute__((always_inline(a))) void *f2(void);  // expected-error {{'always_inline' attribute takes no arguments}}
@@ -7,8 +11,14 @@ inline __attribute__((cdecl(a))) void *f3(void);  // expected-error {{'cdecl' at
 inline __attribute__((const(a))) void *f4(void);  // expected-error {{'const' attribute takes no arguments}}
 inline __attribute__((fastcall(a))) void *f5(void);  // expected-error {{'fastcall' attribute takes no arguments}}
 inline __declspec(restrict(a)) void *f6_a(void);  // expected-error {{'restrict' attribute takes no arguments}}
-inline __attribute__((malloc(a, 1, a))) void *f6_b(void);  // expected-error {{'malloc' attribute takes no more than 2 arguments}}
-inline __attribute__((malloc(a, 1))) void *f6_c(void);  // expected-warning {{'malloc' attribute ignored because Clang does not yet support this attribute signature}}
+inline __attribute__((malloc(func_a, 1, a))) void *f6_b(void);  // expected-error {{'malloc' attribute takes no more than 2 arguments}}
+inline __attribute__((malloc(func_a, 1))) void *f6_c(void);  // expected-warning {{'malloc' attribute ignored because Clang does not yet support this attribute signature}}
+inline __attribute__((malloc(1234))) void *f6_d(void);  // expected-error {{'malloc' argument for deallocator is not a function}}
+inline __attribute__((malloc(a))) void *f6_e(void);  // expected-error {{'malloc' argument 'a' is not a function}}
+inline __attribute__((malloc(ambigious_func))) void *f6_f(void);  // expected-error {{'malloc' argument 'ambigious_func' is not a single function}}
+inline __attribute__((malloc(func_b))) void *f6_g(void);  // expected-error {{'malloc' argument 'func_b' must take a pointer type as its first argument}}
+inline __attribute__((malloc(func_a, 3))) void *f6_h(void);  // expected-error {{'malloc' attribute parameter 2 is out of bounds}}
+inline __attribute__((malloc(func_a, 2))) void *f6_i(void);  // expected-error {{'malloc' argument '2' refers to non-pointer type 'int' of 'func_a'}}
 inline __attribute__((nothrow(a))) void *f7(void);  // expected-error {{'nothrow' attribute takes no arguments}}
 inline __attribute__((stdcall(a))) void *f8(void);  // expected-error {{'stdcall' attribute takes no arguments}}
 inline __attribute__((used(a))) void *f9(void);  // expected-error {{'used' attribute takes no arguments}}

--- a/clang/test/SemaCXX/attr-print.cpp
+++ b/clang/test/SemaCXX/attr-print.cpp
@@ -28,6 +28,14 @@ int v __attribute__((visibility("hidden")));
 // CHECK: char *PR24565() __attribute__((malloc))
 char *PR24565() __attribute__((__malloc__));
 
+void my_cleanup_func(char *);
+
+// using __attribute__(malloc()) with args is currently ignored by Clang
+// CHECK: char *PR52265_a()
+__attribute__((malloc(my_cleanup_func))) char *PR52265_a();
+// CHECK: char *PR52265_b()
+__attribute__((malloc(my_cleanup_func, 1))) char *PR52265_b();
+
 // CHECK: class __attribute__((consumable("unknown"))) AttrTester1
 class __attribute__((consumable(unknown))) AttrTester1 {
   // CHECK: void callableWhen() __attribute__((callable_when("unconsumed", "consumed")));


### PR DESCRIPTION
Ignore the `[[malloc(x)]]` or `[[malloc(x, 1)]]` function attribute syntax added in [GCC 11][1].

Unlike `[[malloc]]` with no arguments (which is supported by Clang), GCC uses the one or two argument form to specify a deallocator for GCC's static analyzer.

Code currently compiled with `[[malloc(x)]]` or `__attribute__((malloc(x)))` fails with the following error: `'malloc' attribute takes no arguments`.

[1]: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;f=gcc/doc/extend.texi;h=dce6c58db87ebf7f4477bd3126228e73e4eeee97#patch6

Fixes: https://github.com/llvm/llvm-project/issues/51607
Partial-Bug: https://github.com/llvm/llvm-project/issues/53152 (this PR only ignores `__attribute__((malloc(x)))` and allows it to compile, so only partially fixes the problem).

---

In the future, we can add this attribute to the AST as well. This will let us improve the clang static analyzer's [`unix.MismatchedDeallocator`](https://clang.llvm.org/docs/analyzer/checkers.html#id93) checker.