### PR TITLE
[llvm-gsymutil] Print a DWO file missing warning under --quiet flag

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -502,17 +502,27 @@ void DwarfTransformer::handleDie(raw_ostream *OS, CUInfo &CUI, DWARFDie Die) {
 
 Error DwarfTransformer::convert(uint32_t NumThreads, raw_ostream *OS) {
   size_t NumBefore = Gsym.getNumFunctionInfos();
+  std::once_flag flag;
   auto getDie = [&](DWARFUnit &DwarfUnit) -> DWARFDie {
     DWARFDie ReturnDie = DwarfUnit.getUnitDIE(false);
     if (DwarfUnit.getDWOId()) {
       DWARFUnit *DWOCU = DwarfUnit.getNonSkeletonUnitDIE(false).getDwarfUnit();
-      if (OS && !DWOCU->isDWOUnit()) {
-        std::string DWOName = dwarf::toString(
-            DwarfUnit.getUnitDIE().find(
-                {dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}),
-            "");
-        *OS << "warning: Unable to retrieve DWO .debug_info section for "
-            << DWOName << "\n";
+      if (!DWOCU->isDWOUnit()) {
+        if (OS) {
+          std::string DWOName = dwarf::toString(
+              DwarfUnit.getUnitDIE().find(
+                  {dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}),
+              "");
+          *OS << "warning: Unable to retrieve DWO .debug_info section for "
+              << DWOName << "\n";
+        } else {
+          std::call_once(flag, []() {
+            outs()
+                << "warning: Unable to retrieve DWO .debug_info section for "
+                   "some "
+                   "object files. (Remove the --quiet flag for full output)\n";
+          });
+        }
       } else {
         ReturnDie = DWOCU->getUnitDIE(false);
       }


### PR DESCRIPTION
Create binary with split-dwarf:
```
clang++ -g -gdwarf-4 -gsplit-dwarf helloworld.cpp -o hello_split
```

Remane the dwo file to a different name so llvm-gsymutil can't find it
```
mv hello_split-helloworld.dwo hello_split-helloworld--.dwo
```

Now run llvm-gsymutil conversion, it should print out warning with and without the `--quiet` flag
```
$ ./bin/llvm-gsymutil --convert=./hello_split
Input file: ./hello_split
Output file (x86_64): ./hello_split.gsym
warning: Unable to retrieve DWO .debug_info section for hello_split-helloworld.dwo
Loaded 0 functions from DWARF.
Loaded 0 functions from symbol table.
Pruned 0 functions, ended with 0 total
DWARF conversion failed: : no functions to encode
```

```
$ ./bin/llvm-gsymutil --convert=./hello_split --quiet
Input file: ./hello_split
Output file (x86_64): ./hello_split.gsym
warning: Unable to retrieve DWO .debug_info section for some object files. (Remove the --quiet flag for full output)
Pruned 0 functions, ended with 0 total
DWARF conversion failed: : no functions to encode
```