### PR TITLE
[mlir][c] Change mlirOperationPrint API

### DIFF
--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -657,7 +657,7 @@ MLIR_CAPI_EXPORTED bool mlirOperationRemoveAttributeByName(MlirOperation op,
 /// Prints an operation by sending chunks of the string representation and
 /// forwarding `userData to `callback`. Note that the callback may be called
 /// several times with consecutive chunks of the string.
-MLIR_CAPI_EXPORTED void mlirOperationPrint(MlirOperation op,
+MLIR_CAPI_EXPORTED void mlirOperationPrint(MlirOperation op, MlirAsmState state,
                                            MlirStringCallback callback,
                                            void *userData);
 

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -665,9 +665,11 @@ bool mlirOperationRemoveAttributeByName(MlirOperation op, MlirStringRef name) {
   return !!unwrap(op)->removeAttr(unwrap(name));
 }
 
-void mlirOperationPrint(MlirOperation op, MlirStringCallback callback,
-                        void *userData) {
+void mlirOperationPrint(MlirOperation op, MlirAsmState state,
+                        MlirStringCallback callback, void *userData) {
   detail::CallbackOstream stream(callback, userData);
+  if (state.ptr)
+    unwrap(op)->print(stream, *unwrap(state));
   unwrap(op)->print(stream);
 }
 

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -369,7 +369,7 @@ static void printFirstOfEach(MlirContext ctx, MlirOperation operation) {
   mlirBlockPrint(block, printToStderr, NULL);
   fprintf(stderr, "\n");
   fprintf(stderr, "First operation: ");
-  mlirOperationPrint(operation, printToStderr, NULL);
+  mlirOperationPrint(operation, (MlirAsmState){NULL}, printToStderr, NULL);
   fprintf(stderr, "\n");
   // clang-format off
   // CHECK:   %[[C0:.*]] = arith.constant 0 : index
@@ -403,7 +403,7 @@ static void printFirstOfEach(MlirContext ctx, MlirOperation operation) {
   // Get the block terminator and print it.
   MlirOperation terminator = mlirBlockGetTerminator(block);
   fprintf(stderr, "Terminator: ");
-  mlirOperationPrint(terminator, printToStderr, NULL);
+  mlirOperationPrint(terminator, (MlirAsmState){NULL}, printToStderr, NULL);
   fprintf(stderr, "\n");
   // CHECK: Terminator: func.return
 
@@ -447,7 +447,7 @@ static void printFirstOfEach(MlirContext ctx, MlirOperation operation) {
       operation, mlirStringRefCreateFromCString("custom_attr"),
       mlirBoolAttrGet(ctx, 1));
   fprintf(stderr, "Op with set attr: ");
-  mlirOperationPrint(operation, printToStderr, NULL);
+  mlirOperationPrint(operation, (MlirAsmState){NULL}, printToStderr, NULL);
   fprintf(stderr, "\n");
   // CHECK: Op with set attr: {{.*}} {custom_attr = true}
 
@@ -1889,7 +1889,8 @@ int testOperands(void) {
   }
 
   fprintf(stderr, "Use owner: ");
-  mlirOperationPrint(mlirOpOperandGetOwner(use2), printToStderr, NULL);
+  mlirOperationPrint(mlirOpOperandGetOwner(use2), (MlirAsmState){NULL},
+                     printToStderr, NULL);
   fprintf(stderr, "\n");
   // CHECK: Use owner: "dummy.op"
 
@@ -1911,13 +1912,15 @@ int testOperands(void) {
 
   MlirOpOperand use3 = mlirValueGetFirstUse(constOneValue);
   fprintf(stderr, "First use owner: ");
-  mlirOperationPrint(mlirOpOperandGetOwner(use3), printToStderr, NULL);
+  mlirOperationPrint(mlirOpOperandGetOwner(use3), (MlirAsmState){NULL},
+                     printToStderr, NULL);
   fprintf(stderr, "\n");
   // CHECK: First use owner: "dummy.op2"
 
   use3 = mlirOpOperandGetNextUse(mlirValueGetFirstUse(constOneValue));
   fprintf(stderr, "Second use owner: ");
-  mlirOperationPrint(mlirOpOperandGetOwner(use3), printToStderr, NULL);
+  mlirOperationPrint(mlirOpOperandGetOwner(use3), (MlirAsmState){NULL},
+                     printToStderr, NULL);
   fprintf(stderr, "\n");
   // CHECK: Second use owner: "dummy.op"
 
@@ -1943,13 +1946,15 @@ int testOperands(void) {
 
   MlirOpOperand use4 = mlirValueGetFirstUse(constTwoValue);
   fprintf(stderr, "First replacement use owner: ");
-  mlirOperationPrint(mlirOpOperandGetOwner(use4), printToStderr, NULL);
+  mlirOperationPrint(mlirOpOperandGetOwner(use4), (MlirAsmState){NULL},
+                     printToStderr, NULL);
   fprintf(stderr, "\n");
   // CHECK: First replacement use owner: "dummy.op"
 
   use4 = mlirOpOperandGetNextUse(mlirValueGetFirstUse(constTwoValue));
   fprintf(stderr, "Second replacement use owner: ");
-  mlirOperationPrint(mlirOpOperandGetOwner(use4), printToStderr, NULL);
+  mlirOperationPrint(mlirOpOperandGetOwner(use4), (MlirAsmState){NULL},
+                     printToStderr, NULL);
   fprintf(stderr, "\n");
   // CHECK: Second replacement use owner: "dummy.op2"
 
@@ -1992,8 +1997,8 @@ int testClone(void) {
   MlirOperation constOne = mlirOperationClone(constZero);
   mlirOperationSetAttributeByName(constOne, valueStringRef, indexOneLiteral);
 
-  mlirOperationPrint(constZero, printToStderr, NULL);
-  mlirOperationPrint(constOne, printToStderr, NULL);
+  mlirOperationPrint(constZero, (MlirAsmState){NULL}, printToStderr, NULL);
+  mlirOperationPrint(constOne, (MlirAsmState){NULL}, printToStderr, NULL);
   // CHECK: arith.constant 0 : index
   // CHECK: arith.constant 1 : index
 


### PR DESCRIPTION
Enable passing in MlirAsmState optionally (allow for passing in null) to
allow using the more efficient print calling API. If no state is passed in then, as is existing behavior, a new AsmState is implicitly created by walking the parent op and renumbering values. This makes the cost more explicit and avoidable.