### PR TITLE
[scudo] Add missing thread-safety analysis annotations.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tsd.h
+++ b/compiler-rt/lib/scudo/standalone/tsd.h
@@ -53,7 +53,8 @@ template <class Allocator> struct alignas(SCUDO_CACHE_LINE_SIZE) TSD {
   inline void unlock() NO_THREAD_SAFETY_ANALYSIS { Mutex.unlock(); }
   inline uptr getPrecedence() { return atomic_load_relaxed(&Precedence); }
 
-  void commitBack(Allocator *Instance) ASSERT_CAPABILITY(Mutex) {
+  void commitBack(Allocator *Instance) ASSERT_CAPABILITY(Mutex)
+      REQUIRES(Mutex) {
     Instance->commitBack(this);
   }
 
@@ -66,11 +67,12 @@ template <class Allocator> struct alignas(SCUDO_CACHE_LINE_SIZE) TSD {
   // TODO(chiahungduan): Ideally, we want to do `Mutex.assertHeld` but acquiring
   // TSD doesn't always require holding the lock. Add this assertion while the
   // lock is always acquired.
-  typename Allocator::CacheT &getCache() ASSERT_CAPABILITY(Mutex) {
+  typename Allocator::CacheT &getCache() ASSERT_CAPABILITY(Mutex)
+      REQUIRES(Mutex) {
     return Cache;
   }
   typename Allocator::QuarantineCacheT &getQuarantineCache()
-      ASSERT_CAPABILITY(Mutex) {
+      ASSERT_CAPABILITY(Mutex) REQUIRES(Mutex) {
     return QuarantineCache;
   }
 


### PR DESCRIPTION
This avoids new warnings from `-Wthread-safety` after https://github.com/llvm/llvm-project/pull/67776, see https://github.com/llvm/llvm-project/pull/67795.

Note that this are not really useful since thread safety analysis is disabled anyway here: llvm-project/compiler-rt/lib/scudo/standalone/tsd_exclusive.h:172