### PR TITLE
[libc++abi] Handle catch null pointer-to-object

### DIFF
--- a/libcxxabi/src/private_typeinfo.cpp
+++ b/libcxxabi/src/private_typeinfo.cpp
@@ -161,16 +161,9 @@ const void* dyn_cast_to_derived(const void* static_ptr,
     // Fallback to the slow path to check that static_type is a public
     //   base type of dynamic_type.
     // Using giant short cut.  Add that information to info.
-    __dynamic_cast_info info = {
-        dst_type,
-        static_ptr,
-        static_type,
-        src2dst_offset,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        1,  // number_of_dst_type
-        false, false, false,
-        true, nullptr
-    };
+    __dynamic_cast_info info = {dst_type, static_ptr, static_type, src2dst_offset, 0,      0, 0, 0, 0, 0, 0, 0,
+                                1, // number_of_dst_type
+                                false,    false,      false,       true,           nullptr};
     // Do the  search
     dst_type->search_above_dst(&info, dynamic_ptr, dynamic_ptr, public_path, false);
 #ifdef _LIBCXXABI_FORGIVING_DYNAMIC_CAST
@@ -189,14 +182,8 @@ const void* dyn_cast_to_derived(const void* static_ptr,
                     "should have public visibility. At least one of them is hidden. %s"
                     ", %s.\n", static_type->name(), dst_type->name());
         // Redo the search comparing type_info's using strcmp
-        info = {
-            dst_type,
-            static_ptr,
-            static_type,
-            src2dst_offset,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, false, false, false,
-            true, nullptr
-        };
+        info = {dst_type, static_ptr, static_type, src2dst_offset, 0,     0,     0,    0,      0, 0,
+                0,        0,          0,           false,          false, false, true, nullptr};
         info.number_of_dst_type = 1;
         dst_type->search_above_dst(&info, dynamic_ptr, dynamic_ptr, public_path, true);
     }
@@ -235,16 +222,24 @@ const void* dyn_cast_try_downcast(const void* static_ptr,
     }
 
     // Try to search a path from dynamic_type to dst_type.
-    __dynamic_cast_info dynamic_to_dst_info = {
-        dynamic_type,
-        dst_ptr_to_static,
-        dst_type,
-        src2dst_offset,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        1,  // number_of_dst_type
-        false, false, false,
-        true, nullptr
-    };
+    __dynamic_cast_info dynamic_to_dst_info = {dynamic_type,
+                                               dst_ptr_to_static,
+                                               dst_type,
+                                               src2dst_offset,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               0,
+                                               1, // number_of_dst_type
+                                               false,
+                                               false,
+                                               false,
+                                               true,
+                                               nullptr};
     dynamic_type->search_above_dst(&dynamic_to_dst_info, dynamic_ptr, dynamic_ptr, public_path, false);
     if (dynamic_to_dst_info.path_dst_ptr_to_static_ptr != unknown) {
         // We have found at least one path from dynamic_ptr to dst_ptr. The
@@ -265,14 +260,8 @@ const void* dyn_cast_slow(const void* static_ptr,
     // Not using giant short cut.  Do the search
 
     // Initialize info struct for this search.
-    __dynamic_cast_info info = {
-        dst_type,
-        static_ptr,
-        static_type,
-        src2dst_offset,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, false, false, false,
-        true, nullptr
-    };
+    __dynamic_cast_info info = {dst_type, static_ptr, static_type, src2dst_offset, 0,     0,     0,    0,      0, 0,
+                                0,        0,          0,           false,          false, false, true, nullptr};
 
     dynamic_type->search_below_dst(&info, dynamic_ptr, public_path, false);
 #ifdef _LIBCXXABI_FORGIVING_DYNAMIC_CAST
@@ -292,13 +281,8 @@ const void* dyn_cast_slow(const void* static_ptr,
                             "%s, %s, %s.\n", static_type->name(), dynamic_type->name(),
                     dst_type->name());
         // Redo the search comparing type_info's using strcmp
-        info = {
-            dst_type,
-            static_ptr,
-            static_type,
-            src2dst_offset,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, false, false, false, true, nullptr
-        };
+        info = {dst_type, static_ptr, static_type, src2dst_offset, 0,     0,     0,    0,      0, 0,
+                0,        0,          0,           false,          false, false, true, nullptr};
         dynamic_type->search_below_dst(&info, dynamic_ptr, public_path, true);
     }
 #endif // _LIBCXXABI_FORGIVING_DYNAMIC_CAST
@@ -487,9 +471,7 @@ __class_type_info::can_catch(const __shim_type_info* thrown_type,
         return false;
     // bullet 2
     assert(adjustedPtr && "catching a class without an object?");
-    __dynamic_cast_info info = {thrown_class_type, 0, this, -1,
-                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                true, nullptr };
+    __dynamic_cast_info info = {thrown_class_type, 0, this, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, true, nullptr};
     info.number_of_dst_type = 1;
     thrown_class_type->has_unambiguous_public_base(&info, adjustedPtr, public_path);
     if (info.path_dst_ptr_to_static_ptr == public_path)
@@ -716,9 +698,8 @@ __pointer_type_info::can_catch(const __shim_type_info* thrown_type,
     if (thrown_class_type == 0)
         return false;
     bool have_object = adjustedPtr != nullptr;
-    __dynamic_cast_info info = {thrown_class_type, 0, catch_class_type, -1,
-                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                have_object, nullptr};
+    __dynamic_cast_info info = {thrown_class_type, 0,      catch_class_type, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                have_object,       nullptr};
     info.number_of_dst_type = 1;
     thrown_class_type->has_unambiguous_public_base(&info, adjustedPtr, public_path);
     if (info.path_dst_ptr_to_static_ptr == public_path)

--- a/libcxxabi/src/private_typeinfo.h
+++ b/libcxxabi/src/private_typeinfo.h
@@ -110,6 +110,13 @@ struct _LIBCXXABI_HIDDEN __dynamic_cast_info
     bool found_any_static_type;
     // Set whenever a search can be stopped
     bool search_done;
+
+    // Data that modifies the search mechanism.
+
+    // There is no object (seen when we throw a null pointer to object).
+    bool have_object;
+    // Virtual base
+    const void* vbase_cookie;
 };
 
 // Has no base class

--- a/libcxxabi/test/catch_null_pointer_to_object_pr64953.pass.cpp
+++ b/libcxxabi/test/catch_null_pointer_to_object_pr64953.pass.cpp
@@ -1,0 +1,194 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This test case checks specifically the cases under bullet 3.3:
+//
+//  C++ ABI 15.3:
+//  A handler is a match for an exception object of type E if
+//     *  The handler is of type cv T or cv T& and E and T are the same type
+//        (ignoring the top-level cv-qualifiers), or
+//     *  the handler is of type cv T or cv T& and T is an unambiguous base
+//        class of E, or
+//  >  *  the handler is of type cv1 T* cv2 and E is a pointer type that can   <
+//  >     be converted to the type of the handler by either or both of         <
+//  >       o  a standard pointer conversion (4.10 [conv.ptr]) not involving   <
+//  >          conversions to private or protected or ambiguous classes        <
+//  >       o  a qualification conversion                                      <
+//     *  the handler is a pointer or pointer to member type and E is
+//        std::nullptr_t
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+// This test requires the fix to
+// https://github.com/llvm/llvm-project/issues/64953, which is in libc++abi.dylib.
+// The fix is not contained in older macOS system dylibs, so the test will fail
+// there.
+// FIXME: In the case that we are testing `natively` with the CI scripts we
+// currently pass the newly-built libraries to the execution, this leads to an
+// XPASS here so that we have to make these UNSUPPORTED for now (they should be
+// XFAILs when tested against current [macOS14] and previous installed libc++abi
+// as described above).
+// UNSUPPORTED: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14|15}}{{.*}}
+// UNSUPPORTED: stdlib=apple-libc++ && target={{.+}}-apple-macosx{{11|12|13|14}}{{.*}}
+
+#include <exception>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdio.h>
+
+struct Base {
+  int b;
+};
+struct Base2 {
+  int b;
+};
+struct Derived1 : Base {
+  int b;
+};
+struct Derived2 : Base {
+  int b;
+};
+struct Derived3 : Base2 {
+  int b;
+};
+struct Private : private Base {
+  int b;
+};
+struct Protected : protected Base {
+  int b;
+};
+struct Virtual1 : virtual Base {
+  int b;
+};
+struct Virtual2 : virtual Base {
+  int b;
+};
+
+struct Ambiguous1 : Derived1, Derived2 {
+  int b;
+};
+struct Ambiguous2 : Derived1, Private {
+  int b;
+};
+struct Ambiguous3 : Derived1, Protected {
+  int b;
+};
+
+struct NoPublic1 : Private, Base2 {
+  int b;
+};
+struct NoPublic2 : Protected, Base2 {
+  int b;
+};
+
+struct Catchable1 : Derived3, Derived1 {
+  int b;
+};
+struct Catchable2 : Virtual1, Virtual2 {
+  int b;
+};
+struct Catchable3 : virtual Base, Virtual2 {
+  int b;
+};
+
+// Check that, when we have a null pointer-to-object that we catch a nullptr.
+template <typename T // Handler type
+          ,
+          typename E // Thrown exception type
+          >
+void assert_catches() {
+  try {
+    throw static_cast<E>(0);
+    printf("%s\n", __PRETTY_FUNCTION__);
+    assert(false && "Statements after throw must be unreachable");
+  } catch (T t) {
+    assert(t == nullptr);
+    return;
+  } catch (...) {
+    printf("%s\n", __PRETTY_FUNCTION__);
+    assert(false && "Should not have entered catch-all");
+  }
+
+  printf("%s\n", __PRETTY_FUNCTION__);
+  assert(false && "The catch should have returned");
+}
+
+template <typename T // Handler type
+          ,
+          typename E // Thrown exception type
+          >
+void assert_cannot_catch() {
+  try {
+    throw static_cast<E>(0);
+    printf("%s\n", __PRETTY_FUNCTION__);
+    assert(false && "Statements after throw must be unreachable");
+  } catch (T t) {
+    printf("%s\n", __PRETTY_FUNCTION__);
+    assert(false && "Should not have entered the catch");
+  } catch (...) {
+    assert(true);
+    return;
+  }
+
+  printf("%s\n", __PRETTY_FUNCTION__);
+  assert(false && "The catch-all should have returned");
+}
+
+// Check that when we have a pointer-to-actual-object we, in fact, get the
+// adjusted pointer to the base class.
+template <typename T // Handler type
+          ,
+          typename O // Object type
+          >
+void assert_catches_bp() {
+  O* o = new (O);
+  try {
+    throw o;
+    printf("%s\n", __PRETTY_FUNCTION__);
+    assert(false && "Statements after throw must be unreachable");
+  } catch (T t) {
+    assert(t == static_cast<T>(o));
+    //__builtin_printf("o = %p t = %p\n", o, t);
+    delete o;
+    return;
+  } catch (...) {
+    printf("%s\n", __PRETTY_FUNCTION__);
+    assert(false && "Should not have entered catch-all");
+  }
+
+  printf("%s\n", __PRETTY_FUNCTION__);
+  assert(false && "The catch should have returned");
+}
+
+void f1() {
+  assert_catches<Base*, Catchable1*>();
+  assert_catches<Base*, Catchable2*>();
+  assert_catches<Base*, Catchable3*>();
+}
+
+void f2() {
+  assert_cannot_catch<Base*, Ambiguous1*>();
+  assert_cannot_catch<Base*, Ambiguous2*>();
+  assert_cannot_catch<Base*, Ambiguous3*>();
+  assert_cannot_catch<Base*, NoPublic1*>();
+  assert_cannot_catch<Base*, NoPublic2*>();
+}
+
+void f3() {
+  assert_catches_bp<Base*, Catchable1>();
+  assert_catches_bp<Base*, Catchable2>();
+  assert_catches_bp<Base*, Catchable3>();
+}
+
+int main(int, char**) {
+  f1();
+  f2();
+  f3();
+  return 0;
+}


### PR DESCRIPTION
This addresses cases (currently failing) where we throw a null pointer-to- object and is a proposed fix for
https://github.com/llvm/llvm-project/issues/64953

We are trying to satisfy the following bullet from the C++ ABI 15.3:

 *  the handler is of type cv1 T* cv2 and E is a pointer type that can be converted to the type of the handler by either or both of:

    o  a standard pointer conversion (4.10 [conv.ptr]) not involving conversions to private or protected or ambiguous classes.

    o  a qualification conversion.

The existing implementation assesses the ambiguity of bases by computing the offsets to them; ambiguous cases are then when the same base appears at different offsets.  The computation of offset  includes indirecting through the vtables to find the offsets to virtual bases.

When the thrown pointer points to a real object, this is quite efficient since, if the base is found, and it is not ambiguous and on a public path, the offset is needed to return the adjusted pointer (and the indirections are not particularly expensive to compute).

However, when we throw a null pointer-to-object, this scheme is no longer applicable (and the code currently bypasses the relevant computations, leading to the incorrect catches reported in the issue).

-----

The solution proposed here takes a composite approach:

1. When the pointer-to-object points to a real instance (well, at least, it is determined to be non-null), we use the existing scheme.

2. When the pointer-to-object is null:

 * We note that there is no real object.
 * When we are processing non-virtual bases, we continue to compute the offsets, but for a notional dummy object based at 0.  This is OK, since we never need to access the object content for non-virtual bases.
 * When we are processing a path with one or more virtual bases, we remember a cookie corresponding to the inner-most virtual base found so far (and set the notional offset to 0).  Offsets to inner non-virtual bases are then computed as normal.

A base is then ambiguous iff:
  * There is a recorded virtual base cookie and that is different from the current one or,
  * The non-virtual base offsets differ.

When a handler for a pointer succeeds in catching a base pointer for a thrown null pointer-to-object, we still return a nullptr (so the adjustment to the pointer is not required and need not be computed).

Since we noted that there was no object when starting the search for ambiguous bases, we know that we can skip the pointer adjustment.

This was : Differential Revision: https://reviews.llvm.org/D158769