### PR TITLE
[Clang] Fix constant evaluating a captured variable in a lambda

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8366,9 +8366,9 @@ bool LValueExprEvaluator::VisitVarDecl(const Expr *E, const VarDecl *VD) {
       return false;
 
     if (auto *FD = Info.CurrentCall->LambdaCaptureFields.lookup(VD)) {
-      auto *MD = cast<CXXMethodDecl>(Info.CurrentCall->Callee);
       // Start with 'Result' referring to the complete closure object...
-      if (MD->isExplicitObjectMemberFunction()) {
+      if (auto *MD = cast<CXXMethodDecl>(Info.CurrentCall->Callee);
+          MD->isExplicitObjectMemberFunction()) {
         APValue *RefValue =
             Info.getParamSlot(Info.CurrentCall->Arguments, MD->getParamDecl(0));
         Result.setFrom(Info.Ctx, *RefValue);

--- a/clang/test/SemaCXX/cxx2b-deducing-this-constexpr.cpp
+++ b/clang/test/SemaCXX/cxx2b-deducing-this-constexpr.cpp
@@ -54,3 +54,21 @@ consteval void test() {
     static_assert(*s == 42);
     static_assert((s << 11) == 31);
 }
+
+namespace GH68070 {
+
+constexpr auto f = [x = 3]<typename Self>(this Self&& self) {
+    return x;
+};
+
+auto g = [x = 3]<typename Self>(this Self&& self) {
+    return x;
+};
+
+int test() {
+  constexpr int a = f();
+  static_assert(a == 3);
+  return f() + g();
+}
+
+}


### PR DESCRIPTION
with an explicit parameter.

We tried to read a pointer to a non-existent `This` APValue when constant-evaluating an explicit object lambda call operator (the `this` pointer is never set in explicit object member functions)

Fixes #68070