### PR TITLE
[lldb][AArch64] Add isAArch64SMEFA64 check to SME testing

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1271,6 +1271,12 @@ class Base(unittest2.TestCase):
     def isAArch64SME(self):
         return self.isAArch64() and "sme" in self.getCPUInfo()
 
+    def isAArch64SMEFA64(self):
+        # smefa64 allows the use of the full A64 instruction set in streaming
+        # mode. This is required by certain test programs to setup register
+        # state.
+        return self.isAArch64SME() and "smefa64" in self.getCPUInfo()
+
     def isAArch64MTE(self):
         return self.isAArch64() and "mte" in self.getCPUInfo()
 

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1275,7 +1275,9 @@ class Base(unittest2.TestCase):
         # smefa64 allows the use of the full A64 instruction set in streaming
         # mode. This is required by certain test programs to setup register
         # state.
-        return self.isAArch64SME() and "smefa64" in self.getCPUInfo()
+        return self.isAArch64SME() and set(["sme", "smefa64"]).issuperset(
+            set(self.getCPUInfo())
+        )
 
     def isAArch64MTE(self):
         return self.isAArch64() and "mte" in self.getCPUInfo()

--- a/lldb/test/API/commands/register/register/aarch64_dynamic_regset/TestArm64DynamicRegsets.py
+++ b/lldb/test/API/commands/register/register/aarch64_dynamic_regset/TestArm64DynamicRegsets.py
@@ -142,8 +142,8 @@ class RegisterCommandsTestCase(TestBase):
     def test_aarch64_dynamic_regset_config_sme(self):
         """Test AArch64 Dynamic Register sets configuration, but only SME
         registers."""
-        if not self.isAArch64SME():
-            self.skipTest("SME must be present.")
+        if not self.isAArch64SMEFA64():
+            self.skipTest("SME and the smefa64 extension must be present")
 
         register_sets = self.setup_register_config_test("sme")
 

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
@@ -109,8 +109,10 @@ class RegisterCommandsTestCase(TestBase):
             self.skipTest("SVE registers must be supported.")
 
         if (mode == Mode.SSVE) and not self.isAArch64SMEFA64():
-            self.skipTest("Streaming SVE registers must be supported and the "
-                          "smefa64 extension must be present.")
+            self.skipTest(
+                "Streaming SVE registers must be supported and the "
+                "smefa64 extension must be present."
+            )
 
         self.build_for_mode(mode)
 
@@ -203,8 +205,10 @@ class RegisterCommandsTestCase(TestBase):
     def setup_svg_test(self, mode):
         # Even when running in SVE mode, we need access to SVG for these tests.
         if not self.isAArch64SMEFA64():
-            self.skipTest("Streaming SVE registers must be present and the "
-                          "smefa64 extension must be present.")
+            self.skipTest(
+                "Streaming SVE registers must be present and the "
+                "smefa64 extension must be present."
+            )
 
         self.build_for_mode(mode)
 

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
@@ -108,8 +108,9 @@ class RegisterCommandsTestCase(TestBase):
         if (mode == Mode.SVE) and not self.isAArch64SVE():
             self.skipTest("SVE registers must be supported.")
 
-        if (mode == Mode.SSVE) and not self.isAArch64SME():
-            self.skipTest("Streaming SVE registers must be supported.")
+        if (mode == Mode.SSVE) and not self.isAArch64SMEFA64():
+            self.skipTest("Streaming SVE registers must be supported and the "
+                          "smefa64 extension must be present.")
 
         self.build_for_mode(mode)
 
@@ -201,8 +202,9 @@ class RegisterCommandsTestCase(TestBase):
 
     def setup_svg_test(self, mode):
         # Even when running in SVE mode, we need access to SVG for these tests.
-        if not self.isAArch64SME():
-            self.skipTest("Streaming SVE registers must be present.")
+        if not self.isAArch64SMEFA64():
+            self.skipTest("Streaming SVE registers must be present and the "
+                          "smefa64 extension must be present.")
 
         self.build_for_mode(mode)
 

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
@@ -85,8 +85,9 @@ class RegisterCommandsTestCase(TestBase):
         if (mode == Mode.SVE) and not self.isAArch64SVE():
             self.skipTest("SVE registers must be supported.")
 
-        if (mode == Mode.SSVE) and not self.isAArch64SME():
-            self.skipTest("SSVE registers must be supported.")
+        if (mode == Mode.SSVE) and not self.isAArch64SMEFA64():
+            self.skipTest("SSVE registers must be supported and the smefa64 "
+                          "extension must be present.")
 
     def sve_registers_configuration_impl(self, mode):
         self.skip_if_needed(mode)

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
@@ -86,8 +86,10 @@ class RegisterCommandsTestCase(TestBase):
             self.skipTest("SVE registers must be supported.")
 
         if (mode == Mode.SSVE) and not self.isAArch64SMEFA64():
-            self.skipTest("SSVE registers must be supported and the smefa64 "
-                          "extension must be present.")
+            self.skipTest(
+                "SSVE registers must be supported and the smefa64 "
+                "extension must be present."
+            )
 
     def sve_registers_configuration_impl(self, mode):
         self.skip_if_needed(mode)

--- a/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
@@ -41,8 +41,9 @@ class SVESIMDRegistersTestCase(TestBase):
         if (mode == Mode.SVE) and not self.isAArch64SVE():
             self.skipTest("SVE registers must be supported.")
 
-        if (mode == Mode.SSVE) and not self.isAArch64SME():
-            self.skipTest("SSVE registers must be supported.")
+        if (mode == Mode.SSVE) and not self.isAArch64SMEFA64():
+            self.skipTest("SSVE registers must be supported and the smefa64 "
+                          "extension must be present.")
 
     def make_simd_value(self, n):
         pad = " ".join(["0x00"] * 7)

--- a/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
@@ -42,8 +42,10 @@ class SVESIMDRegistersTestCase(TestBase):
             self.skipTest("SVE registers must be supported.")
 
         if (mode == Mode.SSVE) and not self.isAArch64SMEFA64():
-            self.skipTest("SSVE registers must be supported and the smefa64 "
-                          "extension must be present.")
+            self.skipTest(
+                "SSVE registers must be supported and the smefa64 "
+                "extension must be present."
+            )
 
     def make_simd_value(self, n):
         pad = " ".join(["0x00"] * 7)

--- a/lldb/test/API/commands/register/register/aarch64_za_register/za_dynamic_resize/TestZAThreadedDynamic.py
+++ b/lldb/test/API/commands/register/register/aarch64_za_register/za_dynamic_resize/TestZAThreadedDynamic.py
@@ -65,8 +65,10 @@ class AArch64ZAThreadedTestCase(TestBase):
         self.expect("register read za", substrs=[self.gen_za_value(svg, lambda r: 0)])
 
     def za_test_impl(self, enable_za):
-        if not self.isAArch64SME():
-            self.skipTest("SME must be present.")
+        # Although the test program doesn't obviously do any operations that
+        # would need smefa64, calls to libc functions like memset may do.
+        if not self.isAArch64SMEFA64():
+            self.skipTest("SME and the sm3fa64 extension must be present")
 
         self.build()
         supported_vg = self.get_supported_vg()

--- a/lldb/test/API/commands/register/register/aarch64_za_register/za_dynamic_resize/main.c
+++ b/lldb/test/API/commands/register/register/aarch64_za_register/za_dynamic_resize/main.c
@@ -29,6 +29,7 @@ void set_za_register(int svl, int value_offset) {
   // you have. So setting one that didn't exist would actually set one that did.
   // That's why we need the streaming vector length here.
   for (int i = 0; i < svl; ++i) {
+    // This may involve instructions that require the smefa64 extension.
     memset(data, i + value_offset, MAX_VL_BYTES);
     // Each one of these loads a VL sized row of ZA.
     asm volatile("mov w12, %w0\n\t"

--- a/lldb/test/API/commands/register/register/aarch64_za_register/za_save_restore/TestZARegisterSaveRestore.py
+++ b/lldb/test/API/commands/register/register/aarch64_za_register/za_save_restore/TestZARegisterSaveRestore.py
@@ -106,8 +106,8 @@ class AArch64ZATestCase(TestBase):
         self.expect("register read za", substrs=[self.make_za_value(vl, lambda row: 0)])
 
     def za_expr_test_impl(self, sve_mode, za_state, swap_start_vl):
-        if not self.isAArch64SME():
-            self.skipTest("SME must be present.")
+        if not self.isAArch64SMEFA64():
+            self.skipTest("SME and the smefa64 extension must be present.")
 
         supported_svg = self.get_supported_svg()
         if len(supported_svg) < 2:


### PR DESCRIPTION
FEAT_SME_FA64 (smefa64 in Linux cpuinfo) allows the use of the full A64 instruction set while in streaming SVE mode.

See https://developer.arm.com/documentation/ddi0616/latest/ for details.

This means for example if we want to write to the ffr register during or use floating point registers while in streaming mode, we need this extension.

I initially was using QEMU which has it by default, and switched to Arm's FVP which does not. So this change adds a more strict check and converts most of the tests to use that. It would be possible in some cases to avoid the offending instructions but it would be a lot of effort and liable to fail randomly as the C library changes.

It is also my assumption that the majority of systems will have smefa64 as QEMU has chosen to have. If I turn out to be wrong, we can make the effort to get the tests working without smefa64.

`isAArch64SME` remains for some tests, which are as follows:
* `test_aarch64_dynamic_regset_config` merely checks for the presence of a register set, which appears for any SME system not just one with smefa64.
* `test_aarch64_dynamic_regset_config_sme_za_disabled` only needs the ZA register and does not enter streaming mode.
* `test_sme_not_present` tests for the absence of the SME register set, so must be skipped if any form of SME is present.
* Various tests in `TestSVERegisters.py` need to know if SME is present at all to generate an expected SVCR value. Earlier in the callstack something else checked `isAArch64SMEFA64` already.
* `TestAArch64LinuxTLSRegisters.py` needs to test the `tpidr2` register if any form of SME is present. msr/mrs instructions are used to do this and are allowed even if smefa64 is not present. 