### PR TITLE
Changing TimeProfiler.cpp clock from microseconds to nanoseconds

### DIFF
--- a/lld/test/MachO/map-file.s
+++ b/lld/test/MachO/map-file.s
@@ -89,7 +89,7 @@
 # CHECK-NEXT: 0x[[#%X,BSS]]            0x00000001  [  2] _number
 # CHECK-EMPTY:
 
-# MAPFILE: "name":"Total Write map file"
+# MAPFILE: "name":"Total: Write map file"
 
 # RUN: %lld -demangle -dead_strip -map %t/stripped-map %t/test.o -force_load \
 # RUN:   %t/libfoo.a %t/c-string-literal.o %t/libbaz.dylib -o %t/stripped


### PR DESCRIPTION
This PR was part of PR #68016. This change allow the profiling to trace better some short events, which can help application developers.