### PR TITLE
[flang][hlfir] Pass vector subscripted elemental call arg by address

### DIFF
--- a/flang/include/flang/Lower/HlfirIntrinsics.h
+++ b/flang/include/flang/Lower/HlfirIntrinsics.h
@@ -19,6 +19,7 @@
 #define FORTRAN_LOWER_HLFIRINTRINSICS_H
 
 #include "flang/Optimizer/Builder/HLFIRTools.h"
+#include "flang/Optimizer/Builder/Todo.h"
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include "llvm/ADT/SmallVector.h"
 #include <cassert>
@@ -47,54 +48,70 @@ struct PreparedActualArgument {
   PreparedActualArgument(hlfir::Entity actual,
                          std::optional<mlir::Value> isPresent)
       : actual{actual}, isPresent{isPresent} {}
+  PreparedActualArgument(hlfir::ElementalAddrOp vectorSubscriptedActual)
+      : actual{vectorSubscriptedActual}, isPresent{std::nullopt} {}
   void setElementalIndices(mlir::ValueRange &indices) {
     oneBasedElementalIndices = &indices;
   }
-  hlfir::Entity getActual(mlir::Location loc,
-                          fir::FirOpBuilder &builder) const {
-    if (oneBasedElementalIndices)
-      return hlfir::getElementAt(loc, builder, actual,
-                                 *oneBasedElementalIndices);
-    return actual;
-  }
+
+  /// Get the prepared actual. If this is an array argument in an elemental
+  /// call, the current element value will be returned.
+  hlfir::Entity getActual(mlir::Location loc, fir::FirOpBuilder &builder) const;
 
   void derefPointersAndAllocatables(mlir::Location loc,
                                     fir::FirOpBuilder &builder) {
-    actual = hlfir::derefPointersAndAllocatables(loc, builder, actual);
+    if (auto *actualEntity = std::get_if<hlfir::Entity>(&actual))
+      actual = hlfir::derefPointersAndAllocatables(loc, builder, *actualEntity);
   }
 
   void loadTrivialScalar(mlir::Location loc, fir::FirOpBuilder &builder) {
-    actual = hlfir::loadTrivialScalar(loc, builder, actual);
+    if (auto *actualEntity = std::get_if<hlfir::Entity>(&actual))
+      actual = hlfir::loadTrivialScalar(loc, builder, *actualEntity);
   }
 
   /// Ensure an array expression argument is fully evaluated in memory before
   /// the call. Useful for impure elemental calls.
   hlfir::AssociateOp associateIfArrayExpr(mlir::Location loc,
                                           fir::FirOpBuilder &builder) {
-    if (!actual.isVariable() && actual.isArray()) {
-      mlir::Type storageType = actual.getType();
-      hlfir::AssociateOp associate = hlfir::genAssociateExpr(
-          loc, builder, actual, storageType, "adapt.impure_arg_eval");
-      actual = hlfir::Entity{associate};
-      return associate;
+    if (auto *actualEntity = std::get_if<hlfir::Entity>(&actual)) {
+      if (!actualEntity->isVariable() && actualEntity->isArray()) {
+        mlir::Type storageType = actualEntity->getType();
+        hlfir::AssociateOp associate = hlfir::genAssociateExpr(
+            loc, builder, *actualEntity, storageType, "adapt.impure_arg_eval");
+        actual = hlfir::Entity{associate};
+        return associate;
+      }
     }
     return {};
   }
 
-  bool isArray() const { return actual.isArray(); }
-
-  mlir::Value genShape(mlir::Location loc, fir::FirOpBuilder &builder) const {
-    return hlfir::genShape(loc, builder, actual);
+  bool isArray() const {
+    return std::holds_alternative<hlfir::ElementalAddrOp>(actual) ||
+           std::get<hlfir::Entity>(actual).isArray();
   }
 
-  mlir::Value genCharLength(mlir::Location loc,
-                            fir::FirOpBuilder &builder) const {
-    return hlfir::genCharLength(loc, builder, actual);
+  mlir::Value genShape(mlir::Location loc, fir::FirOpBuilder &builder) {
+    if (auto *actualEntity = std::get_if<hlfir::Entity>(&actual))
+      return hlfir::genShape(loc, builder, *actualEntity);
+    return std::get<hlfir::ElementalAddrOp>(actual).getShape();
+  }
+
+  mlir::Value genCharLength(mlir::Location loc, fir::FirOpBuilder &builder) {
+    if (auto *actualEntity = std::get_if<hlfir::Entity>(&actual))
+      return hlfir::genCharLength(loc, builder, *actualEntity);
+    auto typeParams = std::get<hlfir::ElementalAddrOp>(actual).getTypeparams();
+    assert(typeParams.size() == 1 &&
+           "failed to retrieve vector subscripted character length");
+    return typeParams[0];
   }
 
   /// When the argument is polymorphic, get mold value with the same dynamic
   /// type.
-  mlir::Value getPolymorphicMold(mlir::Location loc) const { return actual; }
+  mlir::Value getPolymorphicMold(mlir::Location loc) const {
+    if (auto *actualEntity = std::get_if<hlfir::Entity>(&actual))
+      return *actualEntity;
+    TODO(loc, "polymorphic vector subscripts");
+  }
 
   bool handleDynamicOptional() const { return isPresent.has_value(); }
   mlir::Value getIsPresent() const {
@@ -105,7 +122,7 @@ struct PreparedActualArgument {
   void resetOptionalAspect() { isPresent = std::nullopt; }
 
 private:
-  hlfir::Entity actual;
+  std::variant<hlfir::Entity, hlfir::ElementalAddrOp> actual;
   mlir::ValueRange *oneBasedElementalIndices{nullptr};
   // When the actual may be dynamically optional, "isPresent"
   // holds a boolean value indicating the presence of the

--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -1661,11 +1661,13 @@ public:
     // above.
     if (mustBeOrdered) {
       for (auto &preparedActual : loweredActuals) {
-        if (hlfir::AssociateOp associate =
-                preparedActual->associateIfArrayExpr(loc, builder)) {
-          fir::FirOpBuilder *bldr = &builder;
-          callContext.stmtCtx.attachCleanup(
-              [=]() { bldr->create<hlfir::EndAssociateOp>(loc, associate); });
+        if (preparedActual) {
+          if (hlfir::AssociateOp associate =
+                  preparedActual->associateIfArrayExpr(loc, builder)) {
+            fir::FirOpBuilder *bldr = &builder;
+            callContext.stmtCtx.attachCleanup(
+                [=]() { bldr->create<hlfir::EndAssociateOp>(loc, associate); });
+          }
         }
       }
     }

--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -2153,6 +2153,7 @@ genProcedureRef(CallContext &callContext) {
       }
 
       if (isElemental && !arg.hasValueAttribute() &&
+          Fortran::evaluate::IsVariable(*expr) &&
           Fortran::evaluate::HasVectorSubscript(*expr)) {
         // Vector subscripted arguments are copied in calls, except in elemental
         // calls without VALUE attribute where Fortran 2018 15.5.2.4 point 21

--- a/flang/lib/Lower/HlfirIntrinsics.cpp
+++ b/flang/lib/Lower/HlfirIntrinsics.cpp
@@ -152,7 +152,7 @@ mlir::Value HlfirTransformationalIntrinsic::loadBoxAddress(
   if (!arg)
     return mlir::Value{};
 
-  hlfir::Entity actual = arg->getOriginalActual();
+  hlfir::Entity actual = arg->getActual(loc, builder);
 
   if (!arg->handleDynamicOptional()) {
     if (actual.isMutableBox()) {
@@ -193,7 +193,7 @@ llvm::SmallVector<mlir::Value> HlfirTransformationalIntrinsic::getOperandVector(
       operands.emplace_back();
       continue;
     }
-    hlfir::Entity actual = arg->getOriginalActual();
+    hlfir::Entity actual = arg->getActual(loc, builder);
     mlir::Value valArg;
 
     if (!argLowering) {

--- a/flang/test/Lower/HLFIR/elemental-call-vector-subscripts.f90
+++ b/flang/test/Lower/HLFIR/elemental-call-vector-subscripts.f90
@@ -71,3 +71,23 @@ end subroutine
 ! CHECK:           }
 ! CHECK:           hlfir.destroy %[[VAL_10]] : !hlfir.expr<3xf32>
 ! CHECK:           return
+
+subroutine test_not_a_variable(i)
+  interface
+    elemental subroutine foo2(j)
+      integer(8), intent(in) :: j
+    end subroutine
+  end interface
+  integer(8) :: i(:)
+  call foo2((i(i)))
+end subroutine
+! CHECK-LABEL:   func.func @_QPtest_not_a_variable(
+! CHECK:           hlfir.elemental
+! CHECK:           %[[VAL_16:.*]] = hlfir.elemental
+! CHECK:           %[[VAL_20:.*]] = arith.constant 1 : index
+! CHECK:           fir.do_loop %[[VAL_21:.*]] = {{.*}}
+! CHECK:             %[[VAL_22:.*]] = hlfir.apply %[[VAL_16]], %[[VAL_21]] : (!hlfir.expr<?xi64>, index) -> i64
+! CHECK:             %[[VAL_23:.*]]:3 = hlfir.associate %[[VAL_22]] {uniq_name = "adapt.valuebyref"} : (i64) -> (!fir.ref<i64>, !fir.ref<i64>, i1)
+! CHECK:             fir.call @_QPfoo2(%[[VAL_23]]#1){{.*}}: (!fir.ref<i64>) -> ()
+! CHECK:             hlfir.end_associate %[[VAL_23]]#1, %[[VAL_23]]#2 : !fir.ref<i64>, i1
+! CHECK:           }

--- a/flang/test/Lower/HLFIR/elemental-call-vector-subscripts.f90
+++ b/flang/test/Lower/HLFIR/elemental-call-vector-subscripts.f90
@@ -1,0 +1,73 @@
+! Test passing of vector subscripted entities inside elemental
+! procedures.
+! RUN: bbc --emit-hlfir -o - %s | FileCheck %s
+
+subroutine test()
+  interface
+    elemental subroutine foo(x, y)
+      real, intent(in) :: x
+      real, value :: y
+    end subroutine
+  end interface
+  real :: x(10)
+  call foo(x([1,3,7]), 0.)
+end subroutine
+! CHECK-LABEL:   func.func @_QPtest() {
+! CHECK:           %[[VAL_0:.*]] = arith.constant 10 : index
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.array<10xf32> {bindc_name = "x", uniq_name = "_QFtestEx"}
+! CHECK:           %[[VAL_2:.*]] = fir.shape %[[VAL_0]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_1]](%[[VAL_2]]) {uniq_name = "_QFtestEx"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
+! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQro.3xi8.0) : !fir.ref<!fir.array<3xi64>>
+! CHECK:           %[[VAL_5:.*]] = arith.constant 3 : index
+! CHECK:           %[[VAL_6:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_4]](%[[VAL_6]])
+! CHECK:           %[[VAL_8:.*]] = arith.constant 3 : index
+! CHECK:           %[[VAL_9:.*]] = arith.constant 0.000000e+00 : f32
+! CHECK:           %[[VAL_10:.*]] = arith.constant 1 : index
+! CHECK:           fir.do_loop %[[VAL_11:.*]] = %[[VAL_10]] to %[[VAL_8]] step %[[VAL_10]] unordered {
+! CHECK:             %[[VAL_12:.*]] = hlfir.designate %[[VAL_7]]#0 (%[[VAL_11]])  : (!fir.ref<!fir.array<3xi64>>, index) -> !fir.ref<i64>
+! CHECK:             %[[VAL_13:.*]] = fir.load %[[VAL_12]] : !fir.ref<i64>
+! CHECK:             %[[VAL_14:.*]] = hlfir.designate %[[VAL_3]]#0 (%[[VAL_13]])  : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+! CHECK:             fir.call @_QPfoo(%[[VAL_14]], %[[VAL_9]]) {{.*}}: (!fir.ref<f32>, f32) -> ()
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
+
+subroutine test_value()
+  interface
+    elemental subroutine foo_value(x, y)
+      real, value :: x
+      real, value :: y
+    end subroutine
+  end interface
+  real :: x(10)
+  call foo_value(x([1,3,7]), 0.)
+end subroutine
+
+! CHECK-LABEL:   func.func @_QPtest_value() {
+! CHECK:           %[[VAL_0:.*]] = arith.constant 10 : index
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.array<10xf32> {bindc_name = "x", uniq_name = "_QFtest_valueEx"}
+! CHECK:           %[[VAL_2:.*]] = fir.shape %[[VAL_0]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_1]](%[[VAL_2]]) {uniq_name = "_QFtest_valueEx"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
+! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQro.3xi8.0) : !fir.ref<!fir.array<3xi64>>
+! CHECK:           %[[VAL_5:.*]] = arith.constant 3 : index
+! CHECK:           %[[VAL_6:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_4]](%[[VAL_6]])
+! CHECK:           %[[VAL_8:.*]] = arith.constant 3 : index
+! CHECK:           %[[VAL_9:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_10:.*]] = hlfir.elemental %[[VAL_9]] unordered : (!fir.shape<1>) -> !hlfir.expr<3xf32> {
+! CHECK:           ^bb0(%[[VAL_11:.*]]: index):
+! CHECK:             %[[VAL_12:.*]] = hlfir.designate %[[VAL_7]]#0 (%[[VAL_11]])  : (!fir.ref<!fir.array<3xi64>>, index) -> !fir.ref<i64>
+! CHECK:             %[[VAL_13:.*]] = fir.load %[[VAL_12]] : !fir.ref<i64>
+! CHECK:             %[[VAL_14:.*]] = hlfir.designate %[[VAL_3]]#0 (%[[VAL_13]])  : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+! CHECK:             %[[VAL_15:.*]] = fir.load %[[VAL_14]] : !fir.ref<f32>
+! CHECK:             hlfir.yield_element %[[VAL_15]] : f32
+! CHECK:           }
+! CHECK:           %[[VAL_16:.*]] = arith.constant 0.000000e+00 : f32
+! CHECK:           %[[VAL_17:.*]] = arith.constant 1 : index
+! CHECK:           fir.do_loop %[[VAL_18:.*]] = %[[VAL_17]] to %[[VAL_8]] step %[[VAL_17]] unordered {
+! CHECK:             %[[VAL_19:.*]] = hlfir.apply %[[VAL_10]], %[[VAL_18]] : (!hlfir.expr<3xf32>, index) -> f32
+! CHECK:             fir.call @_QPfoo_value(%[[VAL_19]], %[[VAL_16]]) {{.*}}: (f32, f32) -> ()
+! CHECK:           }
+! CHECK:           hlfir.destroy %[[VAL_10]] : !hlfir.expr<3xf32>
+! CHECK:           return


### PR DESCRIPTION
I missed that vector subscripted arguments must still be passed by
address in an elemental call where the dummy argument does not have
the VALUE attribute.

Update PreparedActualArgument to hold an hlfir::Entity or an
hlfir::ElementalOp and to inline the elementalOp body in `getActual`.