### PR TITLE
[TLI] Added a guard for empty vector function name.

### DIFF
--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -46,6 +46,7 @@ StringLiteral const TargetLibraryInfoImpl::StandardNames[LibFunc::NumLibFuncs] =
 };
 
 std::string VecDesc::getVectorFunctionABIVariantString() const {
+  assert(!VectorFnName.empty() && "Vector function name must not be empty.");
   SmallString<256> Buffer;
   llvm::raw_svector_ostream Out(Buffer);
   Out << VABIPrefix << "_" << ScalarFnName << "(" << VectorFnName << ")";

--- a/llvm/lib/Transforms/Utils/InjectTLIMappings.cpp
+++ b/llvm/lib/Transforms/Utils/InjectTLIMappings.cpp
@@ -92,7 +92,7 @@ static void addMappingsFromTLI(const TargetLibraryInfo &TLI, CallInst &CI) {
 
   auto AddVariantDecl = [&](const ElementCount &VF, bool Predicate) {
     const VecDesc *VD = TLI.getVectorMappingInfo(ScalarName, VF, Predicate);
-    if (VD) {
+    if (VD && !VD->getVectorFnName().empty()) {
       std::string MangledName = VD->getVectorFunctionABIVariantString();
       if (!OriginalSetOfMappings.count(MangledName)) {
         Mappings.push_back(MangledName);


### PR DESCRIPTION
A guard for empty vector function name was removed in #66656. This patch adds the guard back.