### PR TITLE
[LLD][COFF] Mark operator== const to avoid ambiguity in C++20.

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -72,7 +72,7 @@ struct Export {
   StringRef symbolName;
   StringRef exportName; // Name in DLL
 
-  bool operator==(const Export &e) {
+  bool operator==(const Export &e) const {
     return (name == e.name && extName == e.extName &&
             aliasTarget == e.aliasTarget &&
             ordinal == e.ordinal && noname == e.noname &&


### PR DESCRIPTION
C++20 will automatically generate an operator== with reversed operand order, which is ambiguous with the written operator== when one argument is marked const and the other isn't.