### PR TITLE
[BOLT] Fix typos

### DIFF
--- a/bolt/docs/doxygen.cfg.in
+++ b/bolt/docs/doxygen.cfg.in
@@ -1954,7 +1954,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -941,7 +941,7 @@ public:
   bool registerFragment(BinaryFunction &TargetFunction,
                         BinaryFunction &Function) const;
 
-  /// Add unterprocedural reference for \p Function to \p Address
+  /// Add interprocedural reference for \p Function to \p Address
   void addInterproceduralReference(BinaryFunction *Function, uint64_t Address) {
     InterproceduralReferences.push_back({Function, Address});
   }

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -2166,7 +2166,7 @@ public:
   /// is corrupted. If it is unable to fix it, it returns false.
   bool finalizeCFIState();
 
-  /// Return true if this function needs an address-transaltion table after
+  /// Return true if this function needs an address-translation table after
   /// its code emission.
   bool requiresAddressTranslation() const;
 

--- a/bolt/include/bolt/Core/BinarySection.h
+++ b/bolt/include/bolt/Core/BinarySection.h
@@ -127,7 +127,7 @@ class BinarySection {
     return *ContentsOrErr;
   }
 
-  /// Get the set of relocations refering to data in this section that
+  /// Get the set of relocations referring to data in this section that
   /// has been reordered.  The relocation offsets will be modified to
   /// reflect the new data locations.
   RelocationSetType reorderRelocations(bool Inplace) const;

--- a/bolt/include/bolt/Core/DebugData.h
+++ b/bolt/include/bolt/Core/DebugData.h
@@ -63,7 +63,7 @@ std::optional<AttrInfo> findAttributeInfo(const DWARFDie DIE,
                                           dwarf::Attribute Attr);
 
 // DWARF5 Header in order of encoding.
-// Types represent encodnig sizes.
+// Types represent encoding sizes.
 using UnitLengthType = uint32_t;
 using VersionType = uint16_t;
 using AddressSizeType = uint8_t;
@@ -353,13 +353,13 @@ protected:
     }
 
     /// Updates AddressToIndex Map.
-    /// Follows the same symantics as unordered map [].
+    /// Follows the same semantics as unordered map [].
     void updateAddressToIndex(uint64_t Address, uint32_t Index) {
       AddressToIndex[Address] = Index;
     }
 
     /// Updates IndexToAddress Map.
-    /// Follows the same symantics as unordered map [].
+    /// Follows the same semantics as unordered map [].
     void updateIndexToAddrss(uint64_t Address, uint32_t Index) {
       IndexToAddress[Index] = Address;
     }
@@ -455,7 +455,7 @@ public:
   }
 
   /// Adds string to .debug_str.
-  /// On first invokation it initializes internal data stractures.
+  /// On first invocation it initializes internal data structures.
   uint32_t addString(StringRef Str);
 
   /// Returns False if no strings were added to .debug_str.
@@ -466,7 +466,7 @@ private:
   std::mutex WriterMutex;
   /// Initializes Buffer and Stream.
   void initialize();
-  /// Creats internal data stractures.
+  /// Creates internal data structures.
   void create();
   std::unique_ptr<DebugStrBufferVector> StrBuffer;
   std::unique_ptr<raw_svector_ostream> StrStream;
@@ -566,7 +566,7 @@ public:
   void finalize(DIEBuilder &DIEBldr, DIE &Die) override;
 
   /// Returns CU ID.
-  /// For Skelton CU it is a CU Offset.
+  /// For Skeleton CU it is a CU Offset.
   /// For DWO CU it is a DWO ID.
   uint64_t getCUID() const {
     return CU.isDWOUnit() ? *CU.getDWOId() : CU.getOffset();

--- a/bolt/include/bolt/Core/DynoStats.h
+++ b/bolt/include/bolt/Core/DynoStats.h
@@ -121,7 +121,7 @@ public:
   /// Maps instruction opcodes to:
   /// 1. Accumulated executed instruction counts.
   /// 2. a multimap that records highest execution counts, function names,
-  /// and BB offsets where intructions of these opcodes occur.
+  /// and BB offsets where instructions of these opcodes occur.
   using MaxOpcodeHistogramTy =
       std::multimap<uint64_t, std::pair<StringRef, uint32_t>>;
   using OpcodeHistogramTy =

--- a/bolt/include/bolt/Core/Exceptions.h
+++ b/bolt/include/bolt/Core/Exceptions.h
@@ -77,7 +77,7 @@ public:
   ///   void PatcherCallback(uint64_t Value, uint64_t Offset, uint64_t Type);
   ///
   /// where Value is a value of the reference, Offset - is an offset into the
-  /// frame data at which the reference occured, and Type is a DWARF encoding
+  /// frame data at which the reference occurred, and Type is a DWARF encoding
   /// type of the reference.
   static Error parse(DWARFDataExtractor Data, uint64_t EHFrameAddress,
                      PatcherCallbackTy PatcherCallback);

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -1088,7 +1088,7 @@ public:
 
   /// Replace the compound memory operand of Inst with an immediate operand.
   /// The value of the immediate operand is computed by reading the \p
-  /// ConstantData array starting from \p offset and assuming little-endianess.
+  /// ConstantData array starting from \p offset and assuming little-endianness.
   /// Return true on success. The given instruction is modified in place.
   virtual bool replaceMemOperandWithImm(MCInst &Inst, StringRef ConstantData,
                                         uint64_t Offset) const {

--- a/bolt/include/bolt/Core/Relocation.h
+++ b/bolt/include/bolt/Core/Relocation.h
@@ -61,7 +61,7 @@ struct Relocation {
 
   /// Handle special cases when relocation should not be processed by BOLT or
   /// change relocation \p Type to proper one before continuing if \p Contents
-  /// and \P Type mismatch occured.
+  /// and \P Type mismatch occurred.
   static bool skipRelocationProcess(uint64_t &Type, uint64_t Contents);
 
   // Adjust value depending on relocation type (make it PC relative or not)

--- a/bolt/include/bolt/Passes/FixRelaxationPass.h
+++ b/bolt/include/bolt/Passes/FixRelaxationPass.h
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file declares the FixRelaxations class, which locates instructions with
-// wrong targets and fixes them. Such problems usually occures when linker
+// wrong targets and fixes them. Such problems usually occurs when linker
 // relaxes (changes) instructions, but doesn't fix relocations types properly
 // for them.
 //

--- a/bolt/include/bolt/Passes/InstrumentationSummary.h
+++ b/bolt/include/bolt/Passes/InstrumentationSummary.h
@@ -35,7 +35,7 @@ class BinaryFunction;
 // counters. It also provides function names and offsets used when writing the
 // fdata file.
 
-// Location information -- analoguous to the concept of the same name in fdata
+// Location information -- analogous to the concept of the same name in fdata
 // writing/reading. The difference is that the name is stored as an index to a
 // string table written separately.
 struct LocDescription {

--- a/bolt/include/bolt/Passes/ReorderAlgorithm.h
+++ b/bolt/include/bolt/Passes/ReorderAlgorithm.h
@@ -42,7 +42,7 @@ public:
   virtual void clusterBasicBlocks(BinaryFunction &BF,
                                   bool ComputeEdges = false) = 0;
 
-  /// Compute for each cluster its averagae execution frequency, that is
+  /// Compute for each cluster its average execution frequency, that is
   /// the sum of average frequencies of its blocks (execution count / # instrs).
   /// The average frequencies are stored in the AvgFreq vector, index by the
   /// cluster indices in the Clusters vector.
@@ -128,7 +128,7 @@ private:
   //  A -> B with execution count 500,
   //  A -> C with execution count 100, and
   //  D -> B with execution count 150
-  // wher B, C are the only successors of A and A, D are thr only predessecors
+  // where B, C are the only successors of A and A, D are the only predecessors
   // of B. Then if we choose to layout edge A -> B as a fallthrough, the win in
   // branches would be 500 - 100 - 150 = 250. That is the weight of edge A->B.
   int64_t calculateWeight(const EdgeTy &E, const BinaryFunction &BF) const;
@@ -144,8 +144,8 @@ public:
   void reset() override;
 };
 
-/// Objects of this class implement various basic block reordering alogrithms.
-/// Most of these algorithms depend on a clustering alogrithm.
+/// Objects of this class implement various basic block reordering algorithms.
+/// Most of these algorithms depend on a clustering algorithm.
 /// Here we have 3 conflicting goals as to how to layout clusters. If we want
 /// to minimize jump offsets, we should put clusters with heavy inter-cluster
 /// dependence as close as possible. If we want to maximize the probability

--- a/bolt/include/bolt/Passes/StackReachingUses.h
+++ b/bolt/include/bolt/Passes/StackReachingUses.h
@@ -41,7 +41,7 @@ public:
   /// Answer whether the stack position written by the store represented in
   /// \p StoreFIE is loaded from or consumed in any way. The set of all
   /// relevant expressions reaching this store should be in \p Candidates.
-  /// If \p IncludelocalAccesses is false, we only consider wheter there is
+  /// If \p IncludelocalAccesses is false, we only consider whether there is
   /// a callee that consumes this stack position.
   bool isStoreUsed(const FrameIndexEntry &StoreFIE, ExprIterator Candidates,
                    bool IncludeLocalAccesses = true) const;

--- a/bolt/include/bolt/Passes/StokeInfo.h
+++ b/bolt/include/bolt/Passes/StokeInfo.h
@@ -9,7 +9,7 @@
 //  Pass to get information for functions for the Stoke Optimization
 //  To use the Stoke optimization technique to optimize the HHVM.
 //  This Pass solves the two major problems to use the Stoke program without
-//  proting its code:
+//  probing its code:
 //
 //  1. Stoke works on function level, but it is only limited to relative
 //  small functions which are loop-free, call-free, exception-free, etc.

--- a/bolt/include/bolt/Passes/TailDuplication.h
+++ b/bolt/include/bolt/Passes/TailDuplication.h
@@ -81,7 +81,7 @@ class TailDuplication : public BinaryFunctionPass {
   /// Returns true if Reg is used by Inst
   bool regIsUsed(const MCInst &Inst, unsigned Reg, BinaryContext &BC) const;
 
-  /// Returns true if Reg is overwritten before its used by StartBB's sucessors
+  /// Returns true if Reg is overwritten before its used by StartBB's successors
   bool isOverwrittenBeforeUsed(BinaryBasicBlock &StartBB, unsigned Reg) const;
 
   /// Constant and Copy Propagate for the block formed by OriginalBB and

--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -301,7 +301,7 @@ private:
   ErrorOr<AggregatedLBREntry> parseAggregatedLBREntry();
 
   /// Parse either buildid:offset or just offset, representing a location in the
-  /// binary. Used exclusevely for pre-aggregated LBR samples.
+  /// binary. Used exclusively for pre-aggregated LBR samples.
   ErrorOr<Location> parseLocationOrOffset();
 
   /// Check if a field separator is the next char to parse and, if yes, consume

--- a/bolt/include/bolt/Profile/DataReader.h
+++ b/bolt/include/bolt/Profile/DataReader.h
@@ -350,9 +350,9 @@ protected:
   ///
   /// The examples records branches from local symbol func (from t2.c), offset
   /// 11, to global symbol globalfunc, offset 1d, with 1775 branches, no
-  /// mispreds. Of these branches, 1002 were preceeded by a sequence of
+  /// mispreds. Of these branches, 1002 were preceded by a sequence of
   /// branches from func, offset 18 to offset 20 and then from offset 31 to
-  /// offset d. The rest 773 branches were preceeded by a different sequence
+  /// offset d. The rest 773 branches were preceded by a different sequence
   /// of branches, from func, offset 18 to offset 60 and then from offset 71 to
   /// offset d.
   std::error_code parse();

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1393,7 +1393,7 @@ void BinaryContext::foldFunction(BinaryFunction &ChildBF,
 }
 
 void BinaryContext::fixBinaryDataHoles() {
-  assert(validateObjectNesting() && "object nesting inconsitency detected");
+  assert(validateObjectNesting() && "object nesting inconsistency detected");
 
   for (BinarySection &Section : allocatableSections()) {
     std::vector<std::pair<uint64_t, uint64_t>> Holes;
@@ -1442,7 +1442,7 @@ void BinaryContext::fixBinaryDataHoles() {
     }
   }
 
-  assert(validateObjectNesting() && "object nesting inconsitency detected");
+  assert(validateObjectNesting() && "object nesting inconsistency detected");
   assert(validateHoles() && "top level hole detected in object map");
 }
 
@@ -1787,7 +1787,7 @@ void BinaryContext::printCFI(raw_ostream &OS, const MCCFIInstruction &Inst) {
 MarkerSymType BinaryContext::getMarkerType(const SymbolRef &Symbol) const {
   // For aarch64 and riscv, the ABI defines mapping symbols so we identify data
   // in the code section (see IHI0056B). $x identifies a symbol starting code or
-  // the end of a data chunk inside code, $d indentifies start of data.
+  // the end of a data chunk inside code, $d identifies start of data.
   if ((!isAArch64() && !isRISCV()) || ELFSymbolRef(Symbol).getSize())
     return MarkerSymType::NONE;
 

--- a/bolt/lib/Core/BinarySection.cpp
+++ b/bolt/lib/Core/BinarySection.cpp
@@ -227,7 +227,7 @@ void BinarySection::print(raw_ostream &OS) const {
 BinarySection::RelocationSetType
 BinarySection::reorderRelocations(bool Inplace) const {
   assert(PendingRelocations.empty() &&
-         "reodering pending relocations not supported");
+         "reordering pending relocations not supported");
   RelocationSetType NewRelocations;
   for (const Relocation &Rel : relocations()) {
     uint64_t RelAddr = Rel.Offset + getAddress();

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -188,7 +188,7 @@ uint64_t DebugRangeListsSectionWriter::addRanges(
 }
 
 struct LocListsRangelistsHeader {
-  UnitLengthType UnitLength; // Size of loclist entris section, not including
+  UnitLengthType UnitLength; // Size of loclist entries section, not including
                              // size of header.
   VersionType Version;
   AddressSizeType AddressSize;
@@ -446,8 +446,8 @@ static void updateAddressBase(DIEBuilder &DIEBlder, DebugAddrWriter &AddrWriter,
 }
 
 void DebugAddrWriter::update(DIEBuilder &DIEBlder, DWARFUnit &CU) {
-  // Handling the case wehre debug information is a mix of Debug fission and
-  // monolitic.
+  // Handling the case where debug information is a mix of Debug fission and
+  // monolithic.
   if (!CU.getDWOId())
     return;
   const uint64_t CUID = getCUID(CU);

--- a/bolt/lib/Core/DynoStats.cpp
+++ b/bolt/lib/Core/DynoStats.cpp
@@ -136,7 +136,7 @@ void DynoStats::operator+=(const DynoStats &Other) {
     if (I == OpcodeHistogram.end()) {
       OpcodeHistogram.emplace(Stat);
     } else {
-      // Merge Other Historgrams, log only the opts::PrintDynoOpcodeStat'th
+      // Merge other histograms, log only the opts::PrintDynoOpcodeStat'th
       // maximum counts.
       I->second.first += Stat.second.first;
       auto &MMap = I->second.second;

--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -280,7 +280,7 @@ static bool skipRelocationProcessAArch64(uint64_t &Type, uint64_t Contents) {
   // changed TLS access model (e.g. changed global dynamic model
   // to initial exec), thus changing the instructions. The static
   // relocations might be invalid at this point and we might no
-  // need to proccess these relocations anymore.
+  // need to process these relocations anymore.
   // More information could be found by searching
   // elfNN_aarch64_tls_relax in bfd
   switch (Type) {
@@ -486,7 +486,7 @@ static uint64_t extractValueAArch64(uint64_t Type, uint64_t Contents,
   case ELF::R_AARCH64_MOVW_UABS_G1:
   case ELF::R_AARCH64_MOVW_UABS_G0_NC:
   case ELF::R_AARCH64_MOVW_UABS_G0:
-    // The shift goest in bits 22:21 of MOV* instructions
+    // The shift goes in bits 22:21 of MOV* instructions
     uint8_t Shift = (Contents >> 21) & 0x3;
     // Immediate goes in bits 20:5
     Contents = (Contents >> 5) & 0xffff;

--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -34,7 +34,7 @@ cl::opt<std::string> InstrumentationFilename(
 
 cl::opt<std::string> InstrumentationBinpath(
     "instrumentation-binpath",
-    cl::desc("path to instumented binary in case if /proc/self/map_files "
+    cl::desc("path to instrumented binary in case if /proc/self/map_files "
              "is not accessible due to access restriction issues"),
     cl::Optional, cl::cat(BoltInstrCategory));
 

--- a/bolt/lib/Passes/JTFootprintReduction.cpp
+++ b/bolt/lib/Passes/JTFootprintReduction.cpp
@@ -232,7 +232,7 @@ void JTFootprintReduction::optimizeFunction(BinaryFunction &Function,
       continue;
     }
 
-    llvm_unreachable("Should either optimize PIC or NonPIC successfuly");
+    llvm_unreachable("Should either optimize PIC or NonPIC successfully");
   }
 
   if (!Modified.count(&Function))

--- a/bolt/lib/Passes/ReorderData.cpp
+++ b/bolt/lib/Passes/ReorderData.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // TODO:
-// - make sure writeable data isn't put on same cache line unless temporally
+// - make sure writable data isn't put on same cache line unless temporally
 // local
 // - estimate temporal locality by looking at CFG?
 
@@ -328,7 +328,7 @@ ReorderData::sortedByCount(BinaryContext &BC,
 
 // TODO
 // add option for cache-line alignment (or just use cache-line when section
-// is writeable)?
+// is writable)?
 void ReorderData::setSectionOrder(BinaryContext &BC,
                                   BinarySection &OutputSection,
                                   DataOrder::iterator Begin,

--- a/bolt/lib/Passes/RetpolineInsertion.cpp
+++ b/bolt/lib/Passes/RetpolineInsertion.cpp
@@ -52,9 +52,9 @@ cl::opt<RetpolineInsertion::AvailabilityOptions> R11Availability(
     cl::values(clEnumValN(RetpolineInsertion::AvailabilityOptions::NEVER,
                           "never", "r11 not available"),
                clEnumValN(RetpolineInsertion::AvailabilityOptions::ALWAYS,
-                          "always", "r11 avaialable before calls and jumps"),
+                          "always", "r11 available before calls and jumps"),
                clEnumValN(RetpolineInsertion::AvailabilityOptions::ABI, "abi",
-                          "r11 avaialable before calls but not before jumps")),
+                          "r11 available before calls but not before jumps")),
     cl::ZeroOrMore, cl::cat(BoltCategory));
 
 } // namespace opts

--- a/bolt/lib/Passes/ShrinkWrapping.cpp
+++ b/bolt/lib/Passes/ShrinkWrapping.cpp
@@ -903,7 +903,7 @@ bool ShrinkWrapping::isBestSavePosCold(unsigned CSR, MCInst *&BestPosSave,
   return true;
 }
 
-/// Auxiliar function used to create basic blocks for critical edges and update
+/// Auxiliary function used to create basic blocks for critical edges and update
 /// the dominance frontier with these new locations
 void ShrinkWrapping::splitFrontierCritEdges(
     BinaryFunction *Func, SmallVector<ProgramPoint, 4> &Frontier,

--- a/bolt/lib/Passes/TailDuplication.cpp
+++ b/bolt/lib/Passes/TailDuplication.cpp
@@ -236,7 +236,7 @@ void TailDuplication::constantAndCopyPropagate(
         break;
     }
 
-    // If the register was replaced everwhere and it was overwritten in either
+    // If the register was replaced everywhere and it was overwritten in either
     // one of the iterated through blocks or one of the successor blocks, delete
     // the original move instruction
     if (ReplacedEverywhere &&
@@ -276,7 +276,7 @@ TailDuplication::moderateDuplicate(BinaryBasicBlock &BB,
   // The block must be hot
   if (BB.getKnownExecutionCount() == 0)
     return BlocksToDuplicate;
-  // and its sucessor is not already in the same cache line
+  // and its successor is not already in the same cache line
   if (isInCacheLine(BB, Tail))
     return BlocksToDuplicate;
   // and its size do not exceed the maximum allowed size
@@ -299,7 +299,7 @@ TailDuplication::aggressiveDuplicate(BinaryBasicBlock &BB,
   // The block must be hot
   if (BB.getKnownExecutionCount() == 0)
     return BlocksToDuplicate;
-  // and its sucessor is not already in the same cache line
+  // and its successor is not already in the same cache line
   if (isInCacheLine(BB, Tail))
     return BlocksToDuplicate;
 

--- a/bolt/lib/Rewrite/BoltDiff.cpp
+++ b/bolt/lib/Rewrite/BoltDiff.cpp
@@ -672,7 +672,7 @@ public:
 
 };
 
-} // end nampespace bolt
+} // end namespace bolt
 } // end namespace llvm
 
 void RewriteInstance::compare(RewriteInstance &RI2) {

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -1306,7 +1306,7 @@ void DWARFRewriter::updateLineTableOffsets(const MCAsmLayout &Layout) {
     std::optional<DWARFFormValue> StmtList =
         Unit->getUnitDIE().find(dwarf::DW_AT_stmt_list);
     std::optional<uint64_t> Offset = dwarf::toSectionOffset(StmtList);
-    assert(Offset && "Was not able to retreive value of DW_AT_stmt_list.");
+    assert(Offset && "Was not able to retrieve value of DW_AT_stmt_list.");
     return *Offset;
   };
 
@@ -1635,7 +1635,7 @@ std::optional<StringRef> updateDebugData(
   case DWARFSectionKind::DW_SECT_LOCLISTS: {
     OutputBuffer = LocWriter.getBuffer();
     // Creating explicit StringRef here, otherwise
-    // with impicit conversion it will take null byte as end of
+    // with implicit conversion it will take null byte as end of
     // string.
     return StringRef(reinterpret_cast<const char *>(OutputBuffer->data()),
                      OutputBuffer->size());
@@ -1904,7 +1904,7 @@ void DWARFRewriter::writeDWOFiles(
            "No RangeListsWriter for DWO ID.");
     RangeListssWriter = RangeListsWritersByCU[DWOId].get();
 
-    // Handling .debug_rnglists.dwo seperatly. The original .o/.dwo might not
+    // Handling .debug_rnglists.dwo separately. The original .o/.dwo might not
     // have .debug_rnglists so won't be part of the loop below.
     if (!RangeListssWriter->empty()) {
       std::unique_ptr<DebugBufferVector> OutputData;

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4452,7 +4452,7 @@ void RewriteInstance::updateELFSymbolTable(
               OutputAddress >= Function->getCodeSection()->getOutputAddress() &&
               OutputAddress < (Function->getCodeSection()->getOutputAddress() +
                                Function->getCodeSection()->getOutputSize()) &&
-              "Cannot locate fragment containg secondary entrypoint");
+              "Cannot locate fragment containing secondary entrypoint");
           FF = Function->getLayout().fragment_begin();
         }
 

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -160,7 +160,7 @@ cl::opt<ProfileFormatKind> ProfileFormat(
         "format to dump profile output in aggregation mode, default is fdata"),
     cl::init(PF_Fdata),
     cl::values(clEnumValN(PF_Fdata, "fdata", "offset-based plaintext format"),
-               clEnumValN(PF_YAML, "yaml", "dense YAML reprensentation")),
+               clEnumValN(PF_YAML, "yaml", "dense YAML representation")),
     cl::ZeroOrMore, cl::Hidden, cl::cat(BoltCategory));
 
 cl::opt<bool> SplitEH("split-eh", cl::desc("split C++ exception handling code"),

--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -323,7 +323,7 @@ public:
 
   /// Basic member accessing interface. Here we pass the allocator explicitly to
   /// avoid storing a pointer to it as part of this table (remember there is one
-  /// hash for each indirect call site, so we wan't to minimize our footprint).
+  /// hash for each indirect call site, so we want to minimize our footprint).
   MapEntry &get(uint64_t Key, BumpPtrAllocator &Alloc) {
     if (!__bolt_instr_conservative) {
       TryLock L(M);
@@ -1281,7 +1281,7 @@ void Graph::computeEdgeFrequencies(const uint64_t *Counters,
 
 /// Write to \p FD all of the edge profiles for function \p FuncDesc. Uses
 /// \p Alloc to allocate helper dynamic structures used to compute profile for
-/// edges that we do not explictly instrument.
+/// edges that we do not explicitly instrument.
 const uint8_t *writeFunctionProfile(int FD, ProfileWriterContext &Ctx,
                                     const uint8_t *FuncDesc,
                                     BumpPtrAllocator &Alloc) {
@@ -1514,7 +1514,7 @@ extern "C" void __bolt_instr_clear_counters() {
 ///  * Program execution ended, finalization methods are running and BOLT
 ///    hooked into FINI from your binary dynamic section;
 ///  * You used the sleep timer option and during initialization we forked
-///    a separete process that will call this function periodically;
+///    a separate process that will call this function periodically;
 ///  * BOLT prints this function address so you can attach a debugger and
 ///    call this function directly to get your profile written to disk
 ///    on demand.

--- a/bolt/test/AArch64/got-ld64-relaxation.test
+++ b/bolt/test/AArch64/got-ld64-relaxation.test
@@ -1,5 +1,5 @@
 // This test checks that ADR+LDR instruction sequence relaxed by the linker
-// to the ADR+ADD sequence is properly reconized and handled by bolt
+// to the ADR+ADD sequence is properly recognized and handled by bolt
 
 // RUN: yaml2obj %p/Inputs/got-ld64-relaxation.yaml &> %t.exe
 // RUN: llvm-bolt %t.exe -o /dev/null --print-fix-relaxations \

--- a/bolt/test/AArch64/unmarked-data.test
+++ b/bolt/test/AArch64/unmarked-data.test
@@ -9,7 +9,7 @@
 
 // YAML is based in the following assembly:
 
-  .equ val, 0x070b0f03  // we use constant that is not a valid instruction so that it can't be silently dissassembled
+  .equ val, 0x070b0f03  // we use constant that is not a valid instruction so that it can't be silently disassembled
   .text
 
 first:

--- a/bolt/test/X86/Inputs/dwarf5-cu-no-debug-addr-helper.s
+++ b/bolt/test/X86/Inputs/dwarf5-cu-no-debug-addr-helper.s
@@ -4,7 +4,7 @@
 #       int i;
 # } Foo;
 
-# Manually modifed to remove DW_AT_addr_base and DW_AT_location.
+# Manually modified to remove DW_AT_addr_base and DW_AT_location.
 
 	.text
 	.file	"helper.cpp"
@@ -104,7 +104,7 @@
 	.long	.Lstr_offsets_base0             # DW_AT_str_offsets_base
 	.long	.Lline_table_start0             # DW_AT_stmt_list
 	.byte	2                               # DW_AT_comp_dir
-	#.long	.Laddr_table_base0              # DW_AT_addr_base mannually removed
+	#.long	.Laddr_table_base0              # DW_AT_addr_base manually removed
 	.byte	2                               # Abbrev [2] 0x1e:0xc DW_TAG_variable
 	.byte	3                               # DW_AT_name
 	.long	35                              # DW_AT_type

--- a/bolt/test/X86/Inputs/linenumber.cpp
+++ b/bolt/test/X86/Inputs/linenumber.cpp
@@ -1,6 +1,6 @@
 int f() {
   // This will be removed by BOLT but they make sure we have some extra space
-  // to insert branches and don't run out of space when rewritting the function.
+  // to insert branches and don't run out of space when rewriting the function.
   asm("nop");
   asm("nop");
   asm("nop");

--- a/bolt/test/X86/double-jump.test
+++ b/bolt/test/X86/double-jump.test
@@ -1,4 +1,4 @@
-# Test the double jump removqal peephole.
+# Test the double jump removal peephole.
 
 # This test has commands that rely on shell capabilities that won't execute
 # correctly on Windows e.g. subshell execution

--- a/bolt/test/X86/dwarf5-call-pc-function-null-check.test
+++ b/bolt/test/X86/dwarf5-call-pc-function-null-check.test
@@ -8,7 +8,7 @@
 # RUN: llvm-dwarfdump --show-form --verbose --debug-info %t.exe.bolt >> %t.txt
 # RUN: cat %t.txt | FileCheck --check-prefix=CHECK %s
 
-# Test checks we correclty handle nullptr returned by getBinaryFunctionContainingAddress for DW_AT_call_pc.
+# Test checks we correctly handle nullptr returned by getBinaryFunctionContainingAddress for DW_AT_call_pc.
 # This happens when address is not contained in any function.
 
 # CHECK: DW_AT_call_pc [DW_FORM_addrx]

--- a/bolt/test/X86/dwarf5-split-dwarf4-monolithic.test
+++ b/bolt/test/X86/dwarf5-split-dwarf4-monolithic.test
@@ -244,7 +244,7 @@
 # POSTCHECK-DWO-MAIN: DW_TAG_inlined_subroutine [12]
 # POSTCHECK-DWO-MAIN-NEXT: DW_AT_abstract_origin [DW_FORM_ref4]
 # POSTCHECK-DWO-MAIN-NEXT: DW_AT_ranges [DW_FORM_rnglistx] (indexed (0x2) rangelist = 0x00000020
-# Encded as a pair. So it's offset from base address.
+# Encoded as a pair. So it's offset from base address.
 # POSTCHECK-DWO-MAIN-NEXT: [0x0000000000000003, 0x0000000000000007)
 # POSTCHECK-DWO-MAIN-NEXT: [0x0000000000000013, 0x0000000000000019))
 

--- a/bolt/test/X86/dynrelocs.s
+++ b/bolt/test/X86/dynrelocs.s
@@ -12,7 +12,7 @@
 # but it can happen. In these cases we cannot corrupt the
 # output binary by writing out dynamic relocs incorrectly. The linker
 # avoids emitting relocs against read-only sections but we override
-# this behvior with the -z notext flag. During runtime, these pages
+# this behavior with the -z notext flag. During runtime, these pages
 # are mapped with write permission and then changed to read-only after
 # the dynamic linker finishes processing the dynamic relocs.
 

--- a/bolt/test/X86/fallthrough-to-noop.test
+++ b/bolt/test/X86/fallthrough-to-noop.test
@@ -1,4 +1,4 @@
-# Check that profile data for the fall-through jump is not ingored when there is
+# Check that profile data for the fall-through jump is not ignored when there is
 # a conditional jump followed by a no-op.
 
 RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown \

--- a/bolt/test/X86/tail-duplication-cache.s
+++ b/bolt/test/X86/tail-duplication-cache.s
@@ -11,7 +11,7 @@
 # RUN:    --print-finalized --tail-duplication=cache -o %t.out2 \
 # RUN:    | FileCheck --check-prefix="CHECK2" %s
 
-# A test where the tail is duplicated to eliminate an uncoditional jump
+# A test where the tail is duplicated to eliminate an unconditional jump
 # FDATA: 1 main #.BB0_br# 1 main #.BB4# 0 100
 # FDATA: 1 main #.BB0_br# 1 main #.BB1# 0 100
 # FDATA: 1 main #.BB1_br# 1 main #.BB3# 0 50

--- a/bolt/test/runtime/X86/instrumentation-ind-calls.s
+++ b/bolt/test/runtime/X86/instrumentation-ind-calls.s
@@ -1,5 +1,5 @@
 # This reproduces a bug with instrumentation when trying to count calls
-# when the target address is computed with a referece to the stack pointer.
+# when the target address is computed with a reference to the stack pointer.
 # Our instrumentation code uses the stack to save registers to be
 # transparent with the instrumented code, but we end up updating the stack
 # pointer while doing so, which affects this target address calculation.


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/63097

Before merging please make sure the change to bolt/include/bolt/Passes/StokeInfo.h is correct.

bolt/include/bolt/Passes/StokeInfo.h

```diff
  //  This Pass solves the two major problems to use the Stoke program without
- //  proting its code:
+ //  probing its code:
```

I'm still not happy about the awkward wording in this comment.

bolt/include/bolt/Passes/FixRelaxationPass.h

```
$ ed -s bolt/include/bolt/Passes/FixRelaxationPass.h <<<'9,12p'
// This file declares the FixRelaxations class, which locates instructions with
// wrong targets and fixes them. Such problems usually occures when linker
// relaxes (changes) instructions, but doesn't fix relocations types properly
// for them.
$
```


bolt/docs/doxygen.cfg.in
bolt/include/bolt/Core/BinaryContext.h
bolt/include/bolt/Core/BinaryFunction.h
bolt/include/bolt/Core/BinarySection.h
bolt/include/bolt/Core/DebugData.h
bolt/include/bolt/Core/DynoStats.h
bolt/include/bolt/Core/Exceptions.h
bolt/include/bolt/Core/MCPlusBuilder.h
bolt/include/bolt/Core/Relocation.h
bolt/include/bolt/Passes/FixRelaxationPass.h
bolt/include/bolt/Passes/InstrumentationSummary.h
bolt/include/bolt/Passes/ReorderAlgorithm.h
bolt/include/bolt/Passes/StackReachingUses.h
bolt/include/bolt/Passes/StokeInfo.h
bolt/include/bolt/Passes/TailDuplication.h
bolt/include/bolt/Profile/DataAggregator.h
bolt/include/bolt/Profile/DataReader.h
bolt/lib/Core/BinaryContext.cpp
bolt/lib/Core/BinarySection.cpp
bolt/lib/Core/DebugData.cpp
bolt/lib/Core/DynoStats.cpp
bolt/lib/Core/Relocation.cpp
bolt/lib/Passes/Instrumentation.cpp
bolt/lib/Passes/JTFootprintReduction.cpp
bolt/lib/Passes/ReorderData.cpp
bolt/lib/Passes/RetpolineInsertion.cpp
bolt/lib/Passes/ShrinkWrapping.cpp
bolt/lib/Passes/TailDuplication.cpp
bolt/lib/Rewrite/BoltDiff.cpp
bolt/lib/Rewrite/DWARFRewriter.cpp
bolt/lib/Rewrite/RewriteInstance.cpp
bolt/lib/Utils/CommandLineOpts.cpp
bolt/runtime/instr.cpp
bolt/test/AArch64/got-ld64-relaxation.test
bolt/test/AArch64/unmarked-data.test
bolt/test/X86/Inputs/dwarf5-cu-no-debug-addr-helper.s
bolt/test/X86/Inputs/linenumber.cpp
bolt/test/X86/double-jump.test
bolt/test/X86/dwarf5-call-pc-function-null-check.test
bolt/test/X86/dwarf5-split-dwarf4-monolithic.test
bolt/test/X86/dynrelocs.s
bolt/test/X86/fallthrough-to-noop.test
bolt/test/X86/tail-duplication-cache.s
bolt/test/runtime/X86/instrumentation-ind-calls.s