### PR TITLE
[lldb] Fix --persistent-result description

### DIFF
--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -390,7 +390,7 @@ let Command = "expression" in {
     Arg<"Boolean">,
     Desc<"Persist expression result in a variable for subsequent use. "
     "Expression results will be labeled with $-prefixed variables, e.g. $0, "
-    "$1, etc. Defaults to true.">;
+    "$1, etc.">;
 }
 
 let Command = "frame diag" in {


### PR DESCRIPTION
The default is not static, it depends on context. For `expression`, the default is true, but for `dwim-print`, the default is false.

rdar://116320377