### PR TITLE
[GVN] Invalidate ICF cache when clearing the instructions

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2799,6 +2799,7 @@ bool GVNPass::processBlock(BasicBlock *BB) {
       salvageDebugInfo(*I);
       removeInstruction(I);
     }
+    ICF->clear();
     InstrsToErase.clear();
 
     if (AtStart)


### PR DESCRIPTION
This fixes #48805

/home/user/llvm-project/llvm/lib/Analysis/InstructionPrecedenceTracking.cpp:93: void llvm::InstructionPrecedenceTracking::validate(const llvm::BasicBlock *) const: Assertion `It->second == &Insn && "Cached first special instruction is wrong!"' failed.