### PR TITLE
[LLDB][NFC] Create a namespace for the DWARF plugin

### DIFF
--- a/lldb/include/lldb/Expression/DWARFExpression.h
+++ b/lldb/include/lldb/Expression/DWARFExpression.h
@@ -18,9 +18,13 @@
 #include "llvm/DebugInfo/DWARF/DWARFLocationExpression.h"
 #include <functional>
 
-class DWARFUnit;
-
 namespace lldb_private {
+
+namespace plugin {
+namespace dwarf {
+class DWARFUnit;
+} // namespace dwarf
+} // namespace plugin
 
 /// \class DWARFExpression DWARFExpression.h
 /// "lldb/Expression/DWARFExpression.h" Encapsulates a DWARF location
@@ -64,18 +68,20 @@ public:
   /// \return
   ///     The address specified by the operation, if the operation exists, or
   ///     LLDB_INVALID_ADDRESS otherwise.
-  lldb::addr_t GetLocation_DW_OP_addr(const DWARFUnit *dwarf_cu,
+  lldb::addr_t GetLocation_DW_OP_addr(const plugin::dwarf::DWARFUnit *dwarf_cu,
                                       bool &error) const;
 
-  bool Update_DW_OP_addr(const DWARFUnit *dwarf_cu, lldb::addr_t file_addr);
+  bool Update_DW_OP_addr(const plugin::dwarf::DWARFUnit *dwarf_cu,
+                         lldb::addr_t file_addr);
 
   void UpdateValue(uint64_t const_value, lldb::offset_t const_value_byte_size,
                    uint8_t addr_byte_size);
 
-  bool ContainsThreadLocalStorage(const DWARFUnit *dwarf_cu) const;
+  bool
+  ContainsThreadLocalStorage(const plugin::dwarf::DWARFUnit *dwarf_cu) const;
 
   bool LinkThreadLocalStorage(
-      const DWARFUnit *dwarf_cu,
+      const plugin::dwarf::DWARFUnit *dwarf_cu,
       std::function<lldb::addr_t(lldb::addr_t file_addr)> const
           &link_address_callback);
 
@@ -128,13 +134,13 @@ public:
   ///     details of the failure are provided through it.
   static bool Evaluate(ExecutionContext *exe_ctx, RegisterContext *reg_ctx,
                        lldb::ModuleSP module_sp, const DataExtractor &opcodes,
-                       const DWARFUnit *dwarf_cu,
+                       const plugin::dwarf::DWARFUnit *dwarf_cu,
                        const lldb::RegisterKind reg_set,
                        const Value *initial_value_ptr,
                        const Value *object_address_ptr, Value &result,
                        Status *error_ptr);
 
-  static bool ParseDWARFLocationList(const DWARFUnit *dwarf_cu,
+  static bool ParseDWARFLocationList(const plugin::dwarf::DWARFUnit *dwarf_cu,
                                      const DataExtractor &data,
                                      DWARFExpressionList *loc_list);
 

--- a/lldb/include/lldb/Expression/DWARFExpressionList.h
+++ b/lldb/include/lldb/Expression/DWARFExpressionList.h
@@ -13,9 +13,13 @@
 #include "lldb/Utility/RangeMap.h"
 #include "lldb/lldb-private.h"
 
-class DWARFUnit;
-
 namespace lldb_private {
+
+namespace plugin {
+namespace dwarf {
+class DWARFUnit;
+} // namespace dwarf
+} // namespace plugin
 
 /// \class DWARFExpressionList DWARFExpressionList.h
 /// "lldb/Expression/DWARFExpressionList.h" Encapsulates a range map from file
@@ -24,13 +28,14 @@ class DWARFExpressionList {
 public:
   DWARFExpressionList() = default;
 
-  DWARFExpressionList(lldb::ModuleSP module_sp, const DWARFUnit *dwarf_cu,
+  DWARFExpressionList(lldb::ModuleSP module_sp,
+                      const plugin::dwarf::DWARFUnit *dwarf_cu,
                       lldb::addr_t func_file_addr)
       : m_module_wp(module_sp), m_dwarf_cu(dwarf_cu),
         m_func_file_addr(func_file_addr) {}
 
   DWARFExpressionList(lldb::ModuleSP module_sp, DWARFExpression expr,
-                      const DWARFUnit *dwarf_cu)
+                      const plugin::dwarf::DWARFUnit *dwarf_cu)
       : m_module_wp(module_sp), m_dwarf_cu(dwarf_cu) {
     AddExpression(0, LLDB_INVALID_ADDRESS, expr);
   }
@@ -136,7 +141,7 @@ private:
   /// The DWARF compile unit this expression belongs to. It is used to evaluate
   /// values indexing into the .debug_addr section (e.g. DW_OP_GNU_addr_index,
   /// DW_OP_GNU_const_index)
-  const DWARFUnit *m_dwarf_cu = nullptr;
+  const plugin::dwarf::DWARFUnit *m_dwarf_cu = nullptr;
 
   // Function base file address.
   lldb::addr_t m_func_file_addr = LLDB_INVALID_ADDRESS;

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -28,11 +28,17 @@
 #include "lldb/Symbol/CompilerDeclContext.h"
 #include "lldb/lldb-private.h"
 
-class DWARFDIE;
-class DWARFASTParser;
 class PDBASTParser;
 
 namespace lldb_private {
+
+namespace plugin {
+namespace dwarf {
+class DWARFDIE;
+class DWARFASTParser;
+} // namespace dwarf
+} // namespace plugin
+
 namespace npdb {
   class PdbAstBuilder;
 } // namespace npdb
@@ -93,7 +99,8 @@ public:
   /// removing all the TypeSystems from the TypeSystemMap.
   virtual void Finalize() {}
 
-  virtual DWARFASTParser *GetDWARFParser() { return nullptr; }
+  virtual plugin::dwarf::DWARFASTParser *GetDWARFParser() { return nullptr; }
+
   virtual PDBASTParser *GetPDBParser() { return nullptr; }
   virtual npdb::PdbAstBuilder *GetNativePDBParser() { return nullptr; }
 
@@ -563,6 +570,6 @@ private:
       std::optional<CreateCallback> create_callback = std::nullopt);
   };
 
-} // namespace lldb_private
+  } // namespace lldb_private
 
 #endif // LLDB_SYMBOL_TYPESYSTEM_H

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -45,6 +45,7 @@
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 // DWARFExpression constructor
 DWARFExpression::DWARFExpression() : m_data() {}

--- a/lldb/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.cpp
@@ -18,6 +18,7 @@
 using namespace lldb_private;
 using namespace lldb;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 std::unique_ptr<AppleDWARFIndex> AppleDWARFIndex::Create(
     Module &module, DWARFDataExtractor apple_names,

--- a/lldb/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.h
@@ -12,7 +12,8 @@
 #include "Plugins/SymbolFile/DWARF/DWARFIndex.h"
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
 
-namespace lldb_private {
+namespace lldb_private::plugin {
+namespace dwarf {
 class AppleDWARFIndex : public DWARFIndex {
 public:
   static std::unique_ptr<AppleDWARFIndex>
@@ -77,6 +78,7 @@ private:
                  std::optional<dw_tag_t> search_for_tag = std::nullopt,
                  std::optional<uint32_t> search_for_qualhash = std::nullopt);
 };
-} // namespace lldb_private
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_APPLEDWARFINDEX_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DIERef.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DIERef.cpp
@@ -14,6 +14,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 void llvm::format_provider<DIERef>::format(const DIERef &ref, raw_ostream &OS,
                                            StringRef Style) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DIERef.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DIERef.h
@@ -14,6 +14,8 @@
 #include <cassert>
 #include <optional>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 /// Identifies a DWARF debug info entry within a given Module. It contains three
 /// "coordinates":
 /// - file_index: identifies the separate stand alone debug info file
@@ -93,7 +95,7 @@ public:
   /// \return
   ///   Returns a valid DIERef if decoding succeeded, std::nullopt if there was
   ///   unsufficient or invalid values that were decoded.
-  static std::optional<DIERef> Decode(const lldb_private::DataExtractor &data,
+  static std::optional<DIERef> Decode(const DataExtractor &data,
                                       lldb::offset_t *offset_ptr);
 
   /// Encode this object into a data encoder object.
@@ -103,7 +105,7 @@ public:
   /// \param encoder
   ///   A data encoder object that serialized bytes will be encoded into.
   ///
-  void Encode(lldb_private::DataEncoder &encoder) const;
+  void Encode(DataEncoder &encoder) const;
 
   static constexpr uint64_t k_die_offset_bit_size = DW_DIE_OFFSET_MAX_BITSIZE;
   static constexpr uint64_t k_file_index_bit_size =
@@ -131,10 +133,13 @@ private:
 static_assert(sizeof(DIERef) == 8);
 
 typedef std::vector<DIERef> DIEArray;
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 namespace llvm {
-template<> struct format_provider<DIERef> {
-  static void format(const DIERef &ref, raw_ostream &OS, StringRef Style);
+template <> struct format_provider<lldb_private::plugin::dwarf::DIERef> {
+  static void format(const lldb_private::plugin::dwarf::DIERef &ref,
+                     raw_ostream &OS, StringRef Style);
 };
 } // namespace llvm
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.cpp
@@ -18,6 +18,7 @@
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 std::optional<SymbolFile::ArrayInfo>
 DWARFASTParser::ParseChildArrayInfo(const DWARFDIE &parent_die,

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.h
@@ -17,53 +17,53 @@
 #include "lldb/lldb-enumerations.h"
 #include <optional>
 
-class DWARFDIE;
 namespace lldb_private {
 class CompileUnit;
 class ExecutionContext;
 }
+
+namespace lldb_private::plugin {
+namespace dwarf {
+class DWARFDIE;
 class SymbolFileDWARF;
 
 class DWARFASTParser {
 public:
   virtual ~DWARFASTParser() = default;
 
-  virtual lldb::TypeSP ParseTypeFromDWARF(const lldb_private::SymbolContext &sc,
+  virtual lldb::TypeSP ParseTypeFromDWARF(const SymbolContext &sc,
                                           const DWARFDIE &die,
                                           bool *type_is_new_ptr) = 0;
 
-  virtual lldb_private::ConstString
-  ConstructDemangledNameFromDWARF(const DWARFDIE &die) = 0;
+  virtual ConstString ConstructDemangledNameFromDWARF(const DWARFDIE &die) = 0;
 
-  virtual lldb_private::Function *
-  ParseFunctionFromDWARF(lldb_private::CompileUnit &comp_unit,
-                         const DWARFDIE &die,
-                         const lldb_private::AddressRange &range) = 0;
+  virtual Function *ParseFunctionFromDWARF(CompileUnit &comp_unit,
+                                           const DWARFDIE &die,
+                                           const AddressRange &range) = 0;
 
-  virtual bool
-  CompleteTypeFromDWARF(const DWARFDIE &die, lldb_private::Type *type,
-                        lldb_private::CompilerType &compiler_type) = 0;
+  virtual bool CompleteTypeFromDWARF(const DWARFDIE &die, Type *type,
+                                     CompilerType &compiler_type) = 0;
 
-  virtual lldb_private::CompilerDecl
-  GetDeclForUIDFromDWARF(const DWARFDIE &die) = 0;
+  virtual CompilerDecl GetDeclForUIDFromDWARF(const DWARFDIE &die) = 0;
 
-  virtual lldb_private::CompilerDeclContext
+  virtual CompilerDeclContext
   GetDeclContextForUIDFromDWARF(const DWARFDIE &die) = 0;
 
-  virtual lldb_private::CompilerDeclContext
+  virtual CompilerDeclContext
   GetDeclContextContainingUIDFromDWARF(const DWARFDIE &die) = 0;
 
   virtual void EnsureAllDIEsInDeclContextHaveBeenParsed(
-      lldb_private::CompilerDeclContext decl_context) = 0;
+      CompilerDeclContext decl_context) = 0;
 
-  virtual lldb_private::ConstString
-  GetDIEClassTemplateParams(const DWARFDIE &die) = 0;
+  virtual ConstString GetDIEClassTemplateParams(const DWARFDIE &die) = 0;
 
-  static std::optional<lldb_private::SymbolFile::ArrayInfo>
+  static std::optional<SymbolFile::ArrayInfo>
   ParseChildArrayInfo(const DWARFDIE &parent_die,
-                      const lldb_private::ExecutionContext *exe_ctx = nullptr);
+                      const ExecutionContext *exe_ctx = nullptr);
 
   static lldb::AccessType GetAccessTypeFromDWARF(uint32_t dwarf_accessibility);
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFASTPARSER_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -60,6 +60,8 @@
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
+
 DWARFASTParserClang::DWARFASTParserClang(TypeSystemClang &ast)
     : m_ast(ast), m_die_to_decl_ctx(), m_decl_ctx_to_die() {}
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -31,45 +31,51 @@
 namespace lldb_private {
 class CompileUnit;
 }
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFDebugInfoEntry;
 class SymbolFileDWARF;
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 struct ParsedDWARFTypeAttributes;
 
-class DWARFASTParserClang : public DWARFASTParser {
+class DWARFASTParserClang : public lldb_private::plugin::dwarf::DWARFASTParser {
 public:
   DWARFASTParserClang(lldb_private::TypeSystemClang &ast);
 
   ~DWARFASTParserClang() override;
 
   // DWARFASTParser interface.
-  lldb::TypeSP ParseTypeFromDWARF(const lldb_private::SymbolContext &sc,
-                                  const DWARFDIE &die,
-                                  bool *type_is_new_ptr) override;
+  lldb::TypeSP
+  ParseTypeFromDWARF(const lldb_private::SymbolContext &sc,
+                     const lldb_private::plugin::dwarf::DWARFDIE &die,
+                     bool *type_is_new_ptr) override;
 
-  lldb_private::ConstString
-  ConstructDemangledNameFromDWARF(const DWARFDIE &die) override;
+  lldb_private::ConstString ConstructDemangledNameFromDWARF(
+      const lldb_private::plugin::dwarf::DWARFDIE &die) override;
 
   lldb_private::Function *
   ParseFunctionFromDWARF(lldb_private::CompileUnit &comp_unit,
-                         const DWARFDIE &die,
+                         const lldb_private::plugin::dwarf::DWARFDIE &die,
                          const lldb_private::AddressRange &func_range) override;
 
   bool
-  CompleteTypeFromDWARF(const DWARFDIE &die, lldb_private::Type *type,
+  CompleteTypeFromDWARF(const lldb_private::plugin::dwarf::DWARFDIE &die,
+                        lldb_private::Type *type,
                         lldb_private::CompilerType &compiler_type) override;
 
-  lldb_private::CompilerDecl
-  GetDeclForUIDFromDWARF(const DWARFDIE &die) override;
+  lldb_private::CompilerDecl GetDeclForUIDFromDWARF(
+      const lldb_private::plugin::dwarf::DWARFDIE &die) override;
 
   void EnsureAllDIEsInDeclContextHaveBeenParsed(
       lldb_private::CompilerDeclContext decl_context) override;
 
-  lldb_private::CompilerDeclContext
-  GetDeclContextForUIDFromDWARF(const DWARFDIE &die) override;
+  lldb_private::CompilerDeclContext GetDeclContextForUIDFromDWARF(
+      const lldb_private::plugin::dwarf::DWARFDIE &die) override;
 
-  lldb_private::CompilerDeclContext
-  GetDeclContextContainingUIDFromDWARF(const DWARFDIE &die) override;
+  lldb_private::CompilerDeclContext GetDeclContextContainingUIDFromDWARF(
+      const lldb_private::plugin::dwarf::DWARFDIE &die) override;
 
   lldb_private::ClangASTImporter &GetClangASTImporter();
 
@@ -85,9 +91,9 @@ public:
   ///         DWARFFormValue with the bit width of the given integer type.
   ///         Returns an error if the value in the DWARFFormValue does not fit
   ///         into the given integer type or the integer type isn't supported.
-  llvm::Expected<llvm::APInt>
-  ExtractIntFromFormValue(const lldb_private::CompilerType &int_type,
-                          const DWARFFormValue &form_value) const;
+  llvm::Expected<llvm::APInt> ExtractIntFromFormValue(
+      const lldb_private::CompilerType &int_type,
+      const lldb_private::plugin::dwarf::DWARFFormValue &form_value) const;
 
   /// Returns the template parameters of a class DWARFDIE as a string.
   ///
@@ -99,8 +105,8 @@ public:
   /// \return A string, including surrounding '<>', of the template parameters.
   /// If the DIE's name already has '<>', returns an empty ConstString because
   /// it's assumed that the caller is using the DIE name anyway.
-  lldb_private::ConstString
-  GetDIEClassTemplateParams(const DWARFDIE &die) override;
+  lldb_private::ConstString GetDIEClassTemplateParams(
+      const lldb_private::plugin::dwarf::DWARFDIE &die) override;
 
 protected:
   /// Protected typedefs and members.
@@ -108,14 +114,19 @@ protected:
   class DelayedAddObjCClassProperty;
   typedef std::vector<DelayedAddObjCClassProperty> DelayedPropertyList;
 
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *, clang::DeclContext *>
+  typedef llvm::DenseMap<
+      const lldb_private::plugin::dwarf::DWARFDebugInfoEntry *,
+      clang::DeclContext *>
       DIEToDeclContextMap;
-  typedef std::multimap<const clang::DeclContext *, const DWARFDIE>
+  typedef std::multimap<const clang::DeclContext *,
+                        const lldb_private::plugin::dwarf::DWARFDIE>
       DeclContextToDIEMap;
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *,
-                         lldb_private::OptionalClangModuleID>
+  typedef llvm::DenseMap<
+      const lldb_private::plugin::dwarf::DWARFDebugInfoEntry *,
+      lldb_private::OptionalClangModuleID>
       DIEToModuleMap;
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *, clang::Decl *>
+  typedef llvm::DenseMap<
+      const lldb_private::plugin::dwarf::DWARFDebugInfoEntry *, clang::Decl *>
       DIEToDeclMap;
 
   lldb_private::TypeSystemClang &m_ast;
@@ -126,11 +137,14 @@ protected:
   std::unique_ptr<lldb_private::ClangASTImporter> m_clang_ast_importer_up;
   /// @}
 
-  clang::DeclContext *GetDeclContextForBlock(const DWARFDIE &die);
+  clang::DeclContext *
+  GetDeclContextForBlock(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  clang::BlockDecl *ResolveBlockDIE(const DWARFDIE &die);
+  clang::BlockDecl *
+  ResolveBlockDIE(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  clang::NamespaceDecl *ResolveNamespaceDIE(const DWARFDIE &die);
+  clang::NamespaceDecl *
+  ResolveNamespaceDIE(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
   /// Returns the namespace decl that a DW_TAG_imported_declaration imports.
   ///
@@ -141,82 +155,98 @@ protected:
   ///          'die' imports. If the imported entity is not a namespace
   ///          or another import declaration, returns nullptr. If an error
   ///          occurs, returns nullptr.
-  clang::NamespaceDecl *ResolveImportedDeclarationDIE(const DWARFDIE &die);
+  clang::NamespaceDecl *ResolveImportedDeclarationDIE(
+      const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  bool ParseTemplateDIE(const DWARFDIE &die,
+  bool ParseTemplateDIE(const lldb_private::plugin::dwarf::DWARFDIE &die,
                         lldb_private::TypeSystemClang::TemplateParameterInfos
                             &template_param_infos);
 
   bool ParseTemplateParameterInfos(
-      const DWARFDIE &parent_die,
+      const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
       lldb_private::TypeSystemClang::TemplateParameterInfos
           &template_param_infos);
 
-  std::string GetCPlusPlusQualifiedName(const DWARFDIE &die);
+  std::string
+  GetCPlusPlusQualifiedName(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
   bool ParseChildMembers(
-      const DWARFDIE &die, lldb_private::CompilerType &class_compiler_type,
+      const lldb_private::plugin::dwarf::DWARFDIE &die,
+      lldb_private::CompilerType &class_compiler_type,
       std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> &base_classes,
-      std::vector<DWARFDIE> &member_function_dies,
+      std::vector<lldb_private::plugin::dwarf::DWARFDIE> &member_function_dies,
       DelayedPropertyList &delayed_properties,
       const lldb::AccessType default_accessibility,
       lldb_private::ClangASTImporter::LayoutInfo &layout_info);
 
   size_t
   ParseChildParameters(clang::DeclContext *containing_decl_ctx,
-                       const DWARFDIE &parent_die, bool skip_artificial,
-                       bool &is_static, bool &is_variadic,
+                       const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
+                       bool skip_artificial, bool &is_static, bool &is_variadic,
                        bool &has_template_params,
                        std::vector<lldb_private::CompilerType> &function_args,
                        std::vector<clang::ParmVarDecl *> &function_param_decls,
                        unsigned &type_quals);
 
-  size_t ParseChildEnumerators(lldb_private::CompilerType &compiler_type,
-                               bool is_signed, uint32_t enumerator_byte_size,
-                               const DWARFDIE &parent_die);
+  size_t ParseChildEnumerators(
+      lldb_private::CompilerType &compiler_type, bool is_signed,
+      uint32_t enumerator_byte_size,
+      const lldb_private::plugin::dwarf::DWARFDIE &parent_die);
 
   /// Parse a structure, class, or union type DIE.
-  lldb::TypeSP ParseStructureLikeDIE(const lldb_private::SymbolContext &sc,
-                                     const DWARFDIE &die,
-                                     ParsedDWARFTypeAttributes &attrs);
+  lldb::TypeSP
+  ParseStructureLikeDIE(const lldb_private::SymbolContext &sc,
+                        const lldb_private::plugin::dwarf::DWARFDIE &die,
+                        ParsedDWARFTypeAttributes &attrs);
 
-  lldb_private::Type *GetTypeForDIE(const DWARFDIE &die);
+  lldb_private::Type *
+  GetTypeForDIE(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  clang::Decl *GetClangDeclForDIE(const DWARFDIE &die);
+  clang::Decl *
+  GetClangDeclForDIE(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  clang::DeclContext *GetClangDeclContextForDIE(const DWARFDIE &die);
+  clang::DeclContext *
+  GetClangDeclContextForDIE(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  clang::DeclContext *GetClangDeclContextContainingDIE(const DWARFDIE &die,
-                                                       DWARFDIE *decl_ctx_die);
-  lldb_private::OptionalClangModuleID GetOwningClangModule(const DWARFDIE &die);
+  clang::DeclContext *GetClangDeclContextContainingDIE(
+      const lldb_private::plugin::dwarf::DWARFDIE &die,
+      lldb_private::plugin::dwarf::DWARFDIE *decl_ctx_die);
+  lldb_private::OptionalClangModuleID
+  GetOwningClangModule(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  bool CopyUniqueClassMethodTypes(const DWARFDIE &src_class_die,
-                                  const DWARFDIE &dst_class_die,
-                                  lldb_private::Type *class_type,
-                                  std::vector<DWARFDIE> &failures);
+  bool CopyUniqueClassMethodTypes(
+      const lldb_private::plugin::dwarf::DWARFDIE &src_class_die,
+      const lldb_private::plugin::dwarf::DWARFDIE &dst_class_die,
+      lldb_private::Type *class_type,
+      std::vector<lldb_private::plugin::dwarf::DWARFDIE> &failures);
 
-  clang::DeclContext *GetCachedClangDeclContextForDIE(const DWARFDIE &die);
+  clang::DeclContext *GetCachedClangDeclContextForDIE(
+      const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  void LinkDeclContextToDIE(clang::DeclContext *decl_ctx, const DWARFDIE &die);
+  void LinkDeclContextToDIE(clang::DeclContext *decl_ctx,
+                            const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  void LinkDeclToDIE(clang::Decl *decl, const DWARFDIE &die);
+  void LinkDeclToDIE(clang::Decl *decl,
+                     const lldb_private::plugin::dwarf::DWARFDIE &die);
 
   /// If \p type_sp is valid, calculate and set its symbol context scope, and
   /// update the type list for its backing symbol file.
   ///
   /// Returns \p type_sp.
-  lldb::TypeSP
-  UpdateSymbolContextScopeForType(const lldb_private::SymbolContext &sc,
-                                  const DWARFDIE &die, lldb::TypeSP type_sp);
+  lldb::TypeSP UpdateSymbolContextScopeForType(
+      const lldb_private::SymbolContext &sc,
+      const lldb_private::plugin::dwarf::DWARFDIE &die, lldb::TypeSP type_sp);
 
   /// Follow Clang Module Skeleton CU references to find a type definition.
-  lldb::TypeSP ParseTypeFromClangModule(const lldb_private::SymbolContext &sc,
-                                        const DWARFDIE &die,
-                                        lldb_private::Log *log);
+  lldb::TypeSP
+  ParseTypeFromClangModule(const lldb_private::SymbolContext &sc,
+                           const lldb_private::plugin::dwarf::DWARFDIE &die,
+                           lldb_private::Log *log);
 
   // Return true if this type is a declaration to a type in an external
   // module.
-  lldb::ModuleSP GetModuleForType(const DWARFDIE &die);
+  lldb::ModuleSP
+  GetModuleForType(const lldb_private::plugin::dwarf::DWARFDIE &die);
 
 private:
   struct FieldInfo {
@@ -268,33 +298,41 @@ private:
   /// created property.
   /// \param delayed_properties The list of delayed properties that the result
   /// will be appended to.
-  void ParseObjCProperty(const DWARFDIE &die, const DWARFDIE &parent_die,
-                         const lldb_private::CompilerType &class_clang_type,
-                         DelayedPropertyList &delayed_properties);
+  void
+  ParseObjCProperty(const lldb_private::plugin::dwarf::DWARFDIE &die,
+                    const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
+                    const lldb_private::CompilerType &class_clang_type,
+                    DelayedPropertyList &delayed_properties);
 
   void
-  ParseSingleMember(const DWARFDIE &die, const DWARFDIE &parent_die,
+  ParseSingleMember(const lldb_private::plugin::dwarf::DWARFDIE &die,
+                    const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
                     const lldb_private::CompilerType &class_clang_type,
                     lldb::AccessType default_accessibility,
                     lldb_private::ClangASTImporter::LayoutInfo &layout_info,
                     FieldInfo &last_field_info);
 
-  bool CompleteRecordType(const DWARFDIE &die, lldb_private::Type *type,
+  bool CompleteRecordType(const lldb_private::plugin::dwarf::DWARFDIE &die,
+                          lldb_private::Type *type,
                           lldb_private::CompilerType &clang_type);
-  bool CompleteEnumType(const DWARFDIE &die, lldb_private::Type *type,
+  bool CompleteEnumType(const lldb_private::plugin::dwarf::DWARFDIE &die,
+                        lldb_private::Type *type,
                         lldb_private::CompilerType &clang_type);
 
-  lldb::TypeSP ParseTypeModifier(const lldb_private::SymbolContext &sc,
-                                 const DWARFDIE &die,
-                                 ParsedDWARFTypeAttributes &attrs);
+  lldb::TypeSP
+  ParseTypeModifier(const lldb_private::SymbolContext &sc,
+                    const lldb_private::plugin::dwarf::DWARFDIE &die,
+                    ParsedDWARFTypeAttributes &attrs);
   lldb::TypeSP ParseEnum(const lldb_private::SymbolContext &sc,
-                         const DWARFDIE &die, ParsedDWARFTypeAttributes &attrs);
-  lldb::TypeSP ParseSubroutine(const DWARFDIE &die,
+                         const lldb_private::plugin::dwarf::DWARFDIE &die,
+                         ParsedDWARFTypeAttributes &attrs);
+  lldb::TypeSP ParseSubroutine(const lldb_private::plugin::dwarf::DWARFDIE &die,
                                ParsedDWARFTypeAttributes &attrs);
-  lldb::TypeSP ParseArrayType(const DWARFDIE &die,
+  lldb::TypeSP ParseArrayType(const lldb_private::plugin::dwarf::DWARFDIE &die,
                               const ParsedDWARFTypeAttributes &attrs);
-  lldb::TypeSP ParsePointerToMemberType(const DWARFDIE &die,
-                                        const ParsedDWARFTypeAttributes &attrs);
+  lldb::TypeSP
+  ParsePointerToMemberType(const lldb_private::plugin::dwarf::DWARFDIE &die,
+                           const ParsedDWARFTypeAttributes &attrs);
 
   /// Parses a DW_TAG_inheritance DIE into a base/super class.
   ///
@@ -311,7 +349,8 @@ private:
   /// \param layout_info The layout information that will be updated for C++
   /// base classes with the base offset.
   void ParseInheritance(
-      const DWARFDIE &die, const DWARFDIE &parent_die,
+      const lldb_private::plugin::dwarf::DWARFDIE &die,
+      const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
       const lldb_private::CompilerType class_clang_type,
       const lldb::AccessType default_accessibility,
       const lldb::ModuleSP &module_sp,
@@ -328,7 +367,8 @@ private:
   /// \param layout_info The layout information that will be updated for
   //   base classes with the base offset
   void
-  ParseRustVariantPart(DWARFDIE &die, const DWARFDIE &parent_die,
+  ParseRustVariantPart(lldb_private::plugin::dwarf::DWARFDIE &die,
+                       const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
                        lldb_private::CompilerType &class_clang_type,
                        const lldb::AccessType default_accesibility,
                        lldb_private::ClangASTImporter::LayoutInfo &layout_info);
@@ -338,7 +378,8 @@ private:
 /// Some attributes are relevant for all kinds of types (declaration), while
 /// others are only meaningful to a specific type (is_virtual)
 struct ParsedDWARFTypeAttributes {
-  explicit ParsedDWARFTypeAttributes(const DWARFDIE &die);
+  explicit ParsedDWARFTypeAttributes(
+      const lldb_private::plugin::dwarf::DWARFDIE &die);
 
   lldb::AccessType accessibility = lldb::eAccessNone;
   bool is_artificial = false;
@@ -355,12 +396,12 @@ struct ParsedDWARFTypeAttributes {
   const char *mangled_name = nullptr;
   lldb_private::ConstString name;
   lldb_private::Declaration decl;
-  DWARFDIE object_pointer;
-  DWARFFormValue abstract_origin;
-  DWARFFormValue containing_type;
-  DWARFFormValue signature;
-  DWARFFormValue specification;
-  DWARFFormValue type;
+  lldb_private::plugin::dwarf::DWARFDIE object_pointer;
+  lldb_private::plugin::dwarf::DWARFFormValue abstract_origin;
+  lldb_private::plugin::dwarf::DWARFFormValue containing_type;
+  lldb_private::plugin::dwarf::DWARFFormValue signature;
+  lldb_private::plugin::dwarf::DWARFFormValue specification;
+  lldb_private::plugin::dwarf::DWARFFormValue type;
   lldb::LanguageType class_language = lldb::eLanguageTypeUnknown;
   std::optional<uint64_t> byte_size;
   size_t calling_convention = llvm::dwarf::DW_CC_normal;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.cpp
@@ -11,6 +11,7 @@
 #include "DWARFDebugInfo.h"
 
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 DWARFAttributes::DWARFAttributes() : m_infos() {}
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFAttribute.h
@@ -14,6 +14,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFUnit;
 
 class DWARFAttribute {
@@ -31,6 +33,7 @@ public:
     form = m_form;
     val = m_value;
   }
+
 protected:
   dw_attr_t m_attr;
   dw_form_t m_form;
@@ -72,5 +75,7 @@ protected:
   typedef llvm::SmallVector<AttributeValue, 8> collection;
   collection m_infos;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFATTRIBUTE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.cpp
@@ -18,6 +18,7 @@
 #include <optional>
 
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 std::optional<DIERef> DWARFBaseDIE::GetDIERef() const {
   if (!IsValid())
@@ -35,7 +36,7 @@ dw_tag_t DWARFBaseDIE::Tag() const {
 }
 
 const char *DWARFBaseDIE::GetTagAsCString() const {
-  return lldb_private::DW_TAG_value_to_name(Tag());
+  return DW_TAG_value_to_name(Tag());
 }
 
 const char *DWARFBaseDIE::GetAttributeValueAsString(const dw_attr_t attr,
@@ -120,6 +121,8 @@ DWARFAttributes DWARFBaseDIE::GetAttributes(Recurse recurse) const {
   return DWARFAttributes();
 }
 
+namespace lldb_private::plugin {
+namespace dwarf {
 bool operator==(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs) {
   return lhs.GetDIE() == rhs.GetDIE() && lhs.GetCU() == rhs.GetCU();
 }
@@ -127,6 +130,8 @@ bool operator==(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs) {
 bool operator!=(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs) {
   return !(lhs == rhs);
 }
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 const DWARFDataExtractor &DWARFBaseDIE::GetData() const {
   // Clients must check if this DIE is valid before calling this function.

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.h
@@ -15,6 +15,8 @@
 #include "llvm/Support/Error.h"
 #include <optional>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DIERef;
 class DWARFASTParser;
 class DWARFAttributes;
@@ -78,7 +80,7 @@ public:
   // correct section data.
   //
   // Clients must validate that this object is valid before calling this.
-  const lldb_private::DWARFDataExtractor &GetData() const;
+  const DWARFDataExtractor &GetData() const;
 
   // Accessing information about a DIE
   dw_tag_t Tag() const;
@@ -124,5 +126,7 @@ protected:
 
 bool operator==(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs);
 bool operator!=(const DWARFBaseDIE &lhs, const DWARFBaseDIE &rhs);
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFBASEDIE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
@@ -16,6 +16,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 void DWARFCompileUnit::Dump(Stream *s) const {
   s->Format(

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.h
@@ -14,13 +14,15 @@
 
 namespace llvm {
 class DWARFAbbreviationDeclarationSet;
-}
+} // namespace llvm
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFCompileUnit : public DWARFUnit {
 public:
   void BuildAddressRangeTable(DWARFDebugAranges *debug_aranges) override;
 
-  void Dump(lldb_private::Stream *s) const override;
+  void Dump(Stream *s) const override;
 
   static bool classof(const DWARFUnit *unit) { return !unit->IsTypeUnit(); }
 
@@ -40,5 +42,7 @@ private:
 
   friend class DWARFUnit;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFCOMPILEUNIT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFContext.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFContext.cpp
@@ -13,6 +13,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 static DWARFDataExtractor LoadSection(SectionList *section_list,
                                       SectionType section_type) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFContext.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFContext.h
@@ -16,7 +16,8 @@
 #include <memory>
 #include <optional>
 
-namespace lldb_private {
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFContext {
 private:
   SectionList *m_main_section_list;
@@ -78,6 +79,7 @@ public:
 
   llvm::DWARFContext &GetAsLLVM();
 };
-} // namespace lldb_private
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -18,6 +18,7 @@
 
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 namespace {
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
@@ -13,6 +13,8 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/iterator_range.h"
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFDIE : public DWARFBaseDIE {
 public:
   class child_iterator;
@@ -31,14 +33,14 @@ public:
   const char *GetPubname() const;
 
   using DWARFBaseDIE::GetName;
-  void GetName(lldb_private::Stream &s) const;
+  void GetName(Stream &s) const;
 
-  void AppendTypeName(lldb_private::Stream &s) const;
+  void AppendTypeName(Stream &s) const;
 
-  lldb_private::Type *ResolveType() const;
+  Type *ResolveType() const;
 
   // Resolve a type by UID using this DIE's DWARF file
-  lldb_private::Type *ResolveTypeUID(const DWARFDIE &die) const;
+  Type *ResolveTypeUID(const DWARFDIE &die) const;
 
   // Functions for obtaining DIE relations and references
 
@@ -72,8 +74,7 @@ public:
 
   /// Return this DIE's decl context as it is needed to look up types
   /// in Clang's -gmodules debug info format.
-  void GetDeclContext(
-      llvm::SmallVectorImpl<lldb_private::CompilerContext> &context) const;
+  void GetDeclContext(llvm::SmallVectorImpl<CompilerContext> &context) const;
 
   // Getting attribute values from the DIE.
   //
@@ -88,7 +89,7 @@ public:
       std::optional<int> &decl_file, std::optional<int> &decl_line,
       std::optional<int> &decl_column, std::optional<int> &call_file,
       std::optional<int> &call_line, std::optional<int> &call_column,
-      lldb_private::DWARFExpressionList *frame_base) const;
+      DWARFExpressionList *frame_base) const;
 
   /// The range of all the children of this DIE.
   llvm::iterator_range<child_iterator> children() const;
@@ -126,5 +127,7 @@ public:
     return *this;
   }
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDIE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.h
@@ -33,6 +33,6 @@ public:
   llvm::DWARFDataExtractor GetAsLLVMDWARF() const;
   llvm::DataExtractor GetAsLLVM() const;
 };
-}
+} // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDATAEXTRACTOR_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugArangeSet.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugArangeSet.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 DWARFDebugArangeSet::DWARFDebugArangeSet()
     : m_offset(DW_INVALID_OFFSET), m_next_offset(DW_INVALID_OFFSET) {}

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugArangeSet.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugArangeSet.h
@@ -13,6 +13,8 @@
 #include <cstdint>
 #include <vector>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFDebugArangeSet {
 public:
   struct Header {
@@ -42,7 +44,7 @@ public:
   DWARFDebugArangeSet();
   void Clear();
   void SetOffset(uint32_t offset) { m_offset = offset; }
-  llvm::Error extract(const lldb_private::DWARFDataExtractor &data,
+  llvm::Error extract(const DWARFDataExtractor &data,
                       lldb::offset_t *offset_ptr);
   dw_offset_t FindAddress(dw_addr_t address) const;
   size_t NumDescriptors() const { return m_arange_descriptors.size(); }
@@ -62,5 +64,7 @@ protected:
   Header m_header;
   DescriptorColl m_arange_descriptors;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGARANGESET_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.cpp
@@ -15,6 +15,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 // Constructor
 DWARFDebugAranges::DWARFDebugAranges() : m_aranges() {}

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugAranges.h
@@ -13,10 +13,11 @@
 #include "lldb/Utility/RangeMap.h"
 #include "llvm/Support/Error.h"
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFDebugAranges {
 protected:
-  typedef lldb_private::RangeDataVector<dw_addr_t, uint32_t, dw_offset_t>
-      RangeToDIE;
+  typedef RangeDataVector<dw_addr_t, uint32_t, dw_offset_t> RangeToDIE;
 
 public:
   typedef RangeToDIE::Entry Range;
@@ -26,14 +27,14 @@ public:
 
   void Clear() { m_aranges.Clear(); }
 
-  void extract(const lldb_private::DWARFDataExtractor &debug_aranges_data);
+  void extract(const DWARFDataExtractor &debug_aranges_data);
 
   // Use append range multiple times and then call sort
   void AppendRange(dw_offset_t cu_offset, dw_addr_t low_pc, dw_addr_t high_pc);
 
   void Sort(bool minimize);
 
-  void Dump(lldb_private::Log *log) const;
+  void Dump(Log *log) const;
 
   dw_offset_t FindAddress(dw_addr_t address) const;
 
@@ -50,5 +51,7 @@ public:
 protected:
   RangeToDIE m_aranges;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGARANGES_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.cpp
@@ -27,10 +27,10 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 // Constructor
-DWARFDebugInfo::DWARFDebugInfo(SymbolFileDWARF &dwarf,
-                               lldb_private::DWARFContext &context)
+DWARFDebugInfo::DWARFDebugInfo(SymbolFileDWARF &dwarf, DWARFContext &context)
     : m_dwarf(dwarf), m_context(context), m_units(), m_cu_aranges_up() {}
 
 const DWARFDebugAranges &DWARFDebugInfo::GetCompileUnitAranges() {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.h
@@ -19,20 +19,18 @@
 #include "lldb/lldb-private.h"
 #include "llvm/Support/Error.h"
 
-namespace lldb_private {
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFContext;
-}
 
 class DWARFDebugInfo {
 public:
-  typedef dw_offset_t (*Callback)(SymbolFileDWARF *dwarf2Data,
-                                  DWARFUnit *cu,
+  typedef dw_offset_t (*Callback)(SymbolFileDWARF *dwarf2Data, DWARFUnit *cu,
                                   DWARFDebugInfoEntry *die,
                                   const dw_offset_t next_offset,
                                   const uint32_t depth, void *userData);
 
-  explicit DWARFDebugInfo(SymbolFileDWARF &dwarf,
-                          lldb_private::DWARFContext &context);
+  explicit DWARFDebugInfo(SymbolFileDWARF &dwarf, DWARFContext &context);
 
   size_t GetNumUnits();
   DWARFUnit *GetUnitAtIndex(size_t idx);
@@ -58,7 +56,7 @@ protected:
   typedef std::vector<DWARFUnitSP> UnitColl;
 
   SymbolFileDWARF &m_dwarf;
-  lldb_private::DWARFContext &m_context;
+  DWARFContext &m_context;
 
   llvm::once_flag m_units_once_flag;
   UnitColl m_units;
@@ -80,5 +78,7 @@ private:
   DWARFDebugInfo(const DWARFDebugInfo &) = delete;
   const DWARFDebugInfo &operator=(const DWARFDebugInfo &) = delete;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGINFO_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -35,6 +35,7 @@
 
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 extern int g_verbose;
 
 // Extract a debug info entry for a given DWARFUnit from the data

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.h
@@ -22,6 +22,8 @@
 
 #include "llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h"
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFDeclContext;
 
 #define DIE_SIBLING_IDX_BITSIZE 31
@@ -47,8 +49,8 @@ public:
   void BuildFunctionAddressRangeTable(DWARFUnit *cu,
                                       DWARFDebugAranges *debug_aranges) const;
 
-  bool Extract(const lldb_private::DWARFDataExtractor &data,
-               const DWARFUnit *cu, lldb::offset_t *offset_ptr);
+  bool Extract(const DWARFDataExtractor &data, const DWARFUnit *cu,
+               lldb::offset_t *offset_ptr);
 
   using Recurse = DWARFBaseDIE::Recurse;
   DWARFAttributes GetAttributes(DWARFUnit *cu,
@@ -104,13 +106,15 @@ public:
 
   const char *GetPubname(const DWARFUnit *cu) const;
 
-  bool GetDIENamesAndRanges(
-      DWARFUnit *cu, const char *&name, const char *&mangled,
-      DWARFRangeList &rangeList, std::optional<int> &decl_file,
-      std::optional<int> &decl_line, std::optional<int> &decl_column,
-      std::optional<int> &call_file, std::optional<int> &call_line,
-      std::optional<int> &call_column,
-      lldb_private::DWARFExpressionList *frame_base = nullptr) const;
+  bool GetDIENamesAndRanges(DWARFUnit *cu, const char *&name,
+                            const char *&mangled, DWARFRangeList &rangeList,
+                            std::optional<int> &decl_file,
+                            std::optional<int> &decl_line,
+                            std::optional<int> &decl_column,
+                            std::optional<int> &call_file,
+                            std::optional<int> &call_line,
+                            std::optional<int> &call_column,
+                            DWARFExpressionList *frame_base = nullptr) const;
 
   const llvm::DWARFAbbreviationDeclaration *
   GetAbbreviationDeclarationPtr(const DWARFUnit *cu) const;
@@ -190,5 +194,7 @@ private:
   void GetAttributes(DWARFUnit *cu, DWARFAttributes &attrs, Recurse recurse,
                      uint32_t curr_depth) const;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGINFOENTRY_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugMacro.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugMacro.cpp
@@ -15,6 +15,7 @@
 
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 DWARFDebugMacroHeader
 DWARFDebugMacroHeader::ParseHeader(const DWARFDataExtractor &debug_macro_data,

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugMacro.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugMacro.h
@@ -17,11 +17,11 @@
 #include "lldb/lldb-types.h"
 
 namespace lldb_private {
-
 class DWARFDataExtractor;
+}
 
-} // namespace lldb_private
-
+namespace lldb_private::plugin {
+namespace dwarf {
 class SymbolFileDWARF;
 
 class DWARFDebugMacroHeader {
@@ -33,15 +33,14 @@ public:
   };
 
   static DWARFDebugMacroHeader
-  ParseHeader(const lldb_private::DWARFDataExtractor &debug_macro_data,
+  ParseHeader(const DWARFDataExtractor &debug_macro_data,
               lldb::offset_t *offset);
 
   bool OffsetIs64Bit() const { return m_offset_is_64_bit; }
 
 private:
-  static void
-  SkipOperandTable(const lldb_private::DWARFDataExtractor &debug_macro_data,
-                   lldb::offset_t *offset);
+  static void SkipOperandTable(const DWARFDataExtractor &debug_macro_data,
+                               lldb::offset_t *offset);
 
   uint16_t m_version = 0;
   bool m_offset_is_64_bit = false;
@@ -50,12 +49,14 @@ private:
 
 class DWARFDebugMacroEntry {
 public:
-  static void
-  ReadMacroEntries(const lldb_private::DWARFDataExtractor &debug_macro_data,
-                   const lldb_private::DWARFDataExtractor &debug_str_data,
-                   const bool offset_is_64_bit, lldb::offset_t *sect_offset,
-                   SymbolFileDWARF *sym_file_dwarf,
-                   lldb_private::DebugMacrosSP &debug_macros_sp);
+  static void ReadMacroEntries(const DWARFDataExtractor &debug_macro_data,
+                               const DWARFDataExtractor &debug_str_data,
+                               const bool offset_is_64_bit,
+                               lldb::offset_t *sect_offset,
+                               SymbolFileDWARF *sym_file_dwarf,
+                               DebugMacrosSP &debug_macros_sp);
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGMACRO_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugRanges.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugRanges.cpp
@@ -11,6 +11,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFDebugRangeList.h"
 
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 DWARFDebugRanges::DWARFDebugRanges() : m_range_map() {}
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugRanges.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugRanges.h
@@ -12,21 +12,23 @@
 #include "lldb/Core/dwarf.h"
 #include <map>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFUnit;
-namespace lldb_private {
 class DWARFContext;
-}
 
 class DWARFDebugRanges {
 public:
   DWARFDebugRanges();
 
-  void Extract(lldb_private::DWARFContext &context);
+  void Extract(DWARFContext &context);
   DWARFRangeList FindRanges(const DWARFUnit *cu,
                             dw_offset_t debug_ranges_offset) const;
 
 protected:
   std::map<dw_offset_t, DWARFRangeList> m_range_map;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEBUGRANGES_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.cpp
@@ -9,6 +9,7 @@
 #include "DWARFDeclContext.h"
 
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 const char *DWARFDeclContext::GetQualifiedName() const {
   if (m_qualified_name.empty()) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDeclContext.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 // DWARFDeclContext
 //
 // A class that represents a declaration context all the way down to a
@@ -68,8 +70,8 @@ public:
 
   // Same as GetQualifiedName, but the life time of the returned string will
   // be that of the LLDB session.
-  lldb_private::ConstString GetQualifiedNameAsConstString() const {
-    return lldb_private::ConstString(GetQualifiedName());
+  ConstString GetQualifiedNameAsConstString() const {
+    return ConstString(GetQualifiedName());
   }
 
   void Clear() {
@@ -82,5 +84,7 @@ protected:
   collection m_entries;
   mutable std::string m_qualified_name;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDECLCONTEXT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.cpp
@@ -12,7 +12,8 @@
 #include <cstring>
 #include <string>
 
-namespace lldb_private {
+namespace lldb_private::plugin {
+namespace dwarf {
 
 const char *DW_TAG_value_to_name(uint32_t val) {
   static char invalid[100];
@@ -88,4 +89,5 @@ const char *DW_LNS_value_to_name(uint32_t val) {
   return llvmstr.data();
 }
 
-} // namespace lldb_private
+} // namespace dwarf
+} // namespace lldb_private::plugin

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.h
@@ -12,7 +12,8 @@
 #include "lldb/Core/dwarf.h"
 #include <cstdint>
 
-namespace lldb_private {
+namespace lldb_private::plugin {
+namespace dwarf {
 
 typedef uint32_t DRC_class; // Holds DRC_* class bitfields
 
@@ -30,6 +31,7 @@ const char *DW_LANG_value_to_name(uint32_t val);
 
 const char *DW_LNS_value_to_name(uint32_t val);
 
-} // namespace lldb_private
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDEFINES_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
@@ -22,6 +22,7 @@ class DWARFUnit;
 
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 void DWARFFormValue::Clear() {
   m_unit = nullptr;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.h
@@ -13,6 +13,8 @@
 #include <cstddef>
 #include <optional>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFUnit;
 class SymbolFileDWARF;
 class DWARFDIE;
@@ -51,9 +53,8 @@ public:
   ValueType &ValueRef() { return m_value; }
   void SetValue(const ValueType &val) { m_value = val; }
 
-  void Dump(lldb_private::Stream &s) const;
-  bool ExtractValue(const lldb_private::DWARFDataExtractor &data,
-                    lldb::offset_t *offset_ptr);
+  void Dump(Stream &s) const;
+  bool ExtractValue(const DWARFDataExtractor &data, lldb::offset_t *offset_ptr);
   const uint8_t *BlockData() const;
   static std::optional<uint8_t> GetFixedSize(dw_form_t form,
                                              const DWARFUnit *u);
@@ -68,10 +69,10 @@ public:
   const char *AsCString() const;
   dw_addr_t Address() const;
   bool IsValid() const { return m_form != 0; }
-  bool SkipValue(const lldb_private::DWARFDataExtractor &debug_info_data,
+  bool SkipValue(const DWARFDataExtractor &debug_info_data,
                  lldb::offset_t *offset_ptr) const;
   static bool SkipValue(const dw_form_t form,
-                        const lldb_private::DWARFDataExtractor &debug_info_data,
+                        const DWARFDataExtractor &debug_info_data,
                         lldb::offset_t *offset_ptr, const DWARFUnit *unit);
   static bool IsBlockForm(const dw_form_t form);
   static bool IsDataForm(const dw_form_t form);
@@ -84,7 +85,9 @@ protected:
   // It may be different from compile unit where m_value refers to.
   const DWARFUnit *m_unit = nullptr; // Unit for this form
   dw_form_t m_form = dw_form_t(0);   // Form for this value
-  ValueType m_value;            // Contains all data for the form
+  ValueType m_value;                 // Contains all data for the form
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFFORMVALUE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.cpp
@@ -17,6 +17,7 @@
 
 using namespace lldb_private;
 using namespace lldb;
+using namespace lldb_private::plugin::dwarf;
 
 DWARFIndex::~DWARFIndex() = default;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
@@ -17,10 +17,11 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Target/Statistics.h"
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFDeclContext;
 class DWARFDIE;
 
-namespace lldb_private {
 class DWARFIndex {
 public:
   DWARFIndex(Module &module) : m_module(module) {}
@@ -102,6 +103,7 @@ protected:
 
   void ReportInvalidDIERef(DIERef ref, llvm::StringRef name) const;
 };
-} // namespace lldb_private
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFINDEX_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFTypeUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFTypeUnit.cpp
@@ -13,6 +13,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 void DWARFTypeUnit::Dump(Stream *s) const {
   s->Format("{0:x16}: Type Unit: length = {1:x8}, version = {2:x4}, "

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFTypeUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFTypeUnit.h
@@ -14,13 +14,15 @@
 
 namespace llvm {
 class DWARFAbbreviationDeclarationSet;
-}
+} // namespace llvm
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFTypeUnit : public DWARFUnit {
 public:
   void BuildAddressRangeTable(DWARFDebugAranges *debug_aranges) override {}
 
-  void Dump(lldb_private::Stream *s) const override;
+  void Dump(Stream *s) const override;
 
   uint64_t GetTypeHash() { return m_header.GetTypeHash(); }
 
@@ -37,5 +39,7 @@ private:
 
   friend class DWARFUnit;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFTYPEUNIT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -19,6 +19,8 @@
 #include <atomic>
 #include <optional>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFUnit;
 class DWARFCompileUnit;
 class NameToDIE;
@@ -78,21 +80,21 @@ public:
 
   llvm::Error ApplyIndexEntry(const llvm::DWARFUnitIndex::Entry *index_entry);
 
-  static llvm::Expected<DWARFUnitHeader>
-  extract(const lldb_private::DWARFDataExtractor &data, DIERef::Section section,
-          lldb_private::DWARFContext &dwarf_context,
-          lldb::offset_t *offset_ptr);
+  static llvm::Expected<DWARFUnitHeader> extract(const DWARFDataExtractor &data,
+                                                 DIERef::Section section,
+                                                 DWARFContext &dwarf_context,
+                                                 lldb::offset_t *offset_ptr);
 };
 
-class DWARFUnit : public lldb_private::UserID {
+class DWARFUnit : public UserID {
   using die_iterator_range =
       llvm::iterator_range<DWARFDebugInfoEntry::collection::iterator>;
 
 public:
   static llvm::Expected<DWARFUnitSP>
   extract(SymbolFileDWARF &dwarf2Data, lldb::user_id_t uid,
-          const lldb_private::DWARFDataExtractor &debug_info,
-          DIERef::Section section, lldb::offset_t *offset_ptr);
+          const DWARFDataExtractor &debug_info, DIERef::Section section,
+          lldb::offset_t *offset_ptr);
   virtual ~DWARFUnit();
 
   bool IsDWOUnit() { return m_is_dwo; }
@@ -104,6 +106,7 @@ public:
 
   class ScopedExtractDIEs {
     DWARFUnit *m_cu;
+
   public:
     bool m_clear_dies = false;
     ScopedExtractDIEs(DWARFUnit &cu);
@@ -115,8 +118,8 @@ public:
   };
   ScopedExtractDIEs ExtractDIEsScoped();
 
-  bool Verify(lldb_private::Stream *s) const;
-  virtual void Dump(lldb_private::Stream *s) const = 0;
+  bool Verify(Stream *s) const;
+  virtual void Dump(Stream *s) const = 0;
   /// Get the data that contains the DIE information for this unit.
   ///
   /// This will return the correct bytes that contain the data for
@@ -125,7 +128,7 @@ public:
   ///
   /// \return
   ///   The correct data for the DIE information in this unit.
-  const lldb_private::DWARFDataExtractor &GetData() const;
+  const DWARFDataExtractor &GetData() const;
 
   /// Get the size in bytes of the unit header.
   ///
@@ -210,10 +213,10 @@ public:
 
   bool GetIsOptimized();
 
-  const lldb_private::FileSpec &GetCompilationDirectory();
-  const lldb_private::FileSpec &GetAbsolutePath();
-  lldb_private::FileSpec GetFile(size_t file_idx);
-  lldb_private::FileSpec::Style GetPathStyle();
+  const FileSpec &GetCompilationDirectory();
+  const FileSpec &GetAbsolutePath();
+  FileSpec GetFile(size_t file_idx);
+  FileSpec::Style GetPathStyle();
 
   SymbolFileDWARFDwo *GetDwoSymbolFile();
 
@@ -227,7 +230,9 @@ public:
   uint8_t GetUnitType() const { return m_header.GetUnitType(); }
   bool IsTypeUnit() const { return m_header.IsTypeUnit(); }
   /// Note that this check only works for DWARF5+.
-  bool IsSkeletonUnit() const { return GetUnitType() == llvm::dwarf::DW_UT_skeleton; }
+  bool IsSkeletonUnit() const {
+    return GetUnitType() == llvm::dwarf::DW_UT_skeleton;
+  }
 
   std::optional<uint64_t> GetStringOffsetSectionItem(uint32_t index) const;
 
@@ -259,9 +264,9 @@ public:
   /// Return the location table for parsing the given location list data. The
   /// format is chosen according to the unit type. Never returns null.
   std::unique_ptr<llvm::DWARFLocationTable>
-  GetLocationTable(const lldb_private::DataExtractor &data) const;
+  GetLocationTable(const DataExtractor &data) const;
 
-  lldb_private::DWARFDataExtractor GetLocationData() const;
+  DWARFDataExtractor GetLocationData() const;
 
   /// Returns true if any DIEs in the unit match any DW_TAG values in \a tags.
   ///
@@ -272,7 +277,6 @@ public:
   ///   True if any DIEs match any tag in \a tags, false otherwise.
   bool HasAny(llvm::ArrayRef<dw_tag_t> tags);
 
-
   /// Get the fission .dwo file specific error for this compile unit.
   ///
   /// The skeleton compile unit only can have a DWO error. Any other type
@@ -281,7 +285,7 @@ public:
   /// \returns
   ///   A valid DWO error if there is a problem with anything in the
   ///   locating or parsing inforamtion in the .dwo file
-  const lldb_private::Status &GetDwoError() const { return m_dwo_error; }
+  const Status &GetDwoError() const { return m_dwo_error; }
 
   /// Set the fission .dwo file specific error for this compile unit.
   ///
@@ -289,7 +293,7 @@ public:
   /// .dwo file. Things like a missing .dwo file, DWO ID mismatch, and other
   /// .dwo errors can be stored in each compile unit so the issues can be
   /// communicated to the user.
-  void SetDwoError(const lldb_private::Status &error) { m_dwo_error = error; }
+  void SetDwoError(const Status &error) { m_dwo_error = error; }
 
 protected:
   DWARFUnit(SymbolFileDWARF &dwarf, lldb::user_id_t uid,
@@ -298,7 +302,7 @@ protected:
             DIERef::Section section, bool is_dwo);
 
   llvm::Error ExtractHeader(SymbolFileDWARF &dwarf,
-                            const lldb_private::DWARFDataExtractor &data,
+                            const DWARFDataExtractor &data,
                             lldb::offset_t *offset_ptr);
 
   // Get the DWARF unit DWARF debug information entry. Parse the single DIE
@@ -321,7 +325,7 @@ protected:
 
   const std::optional<llvm::DWARFDebugRnglistTable> &GetRnglistTable();
 
-  lldb_private::DWARFDataExtractor GetRnglistData() const;
+  DWARFDataExtractor GetRnglistData() const;
 
   SymbolFileDWARF &m_dwarf;
   std::shared_ptr<DWARFUnit> m_dwo;
@@ -348,12 +352,12 @@ protected:
   DWARFProducer m_producer = eProducerInvalid;
   llvm::VersionTuple m_producer_version;
   std::optional<uint64_t> m_language_type;
-  lldb_private::LazyBool m_is_optimized = lldb_private::eLazyBoolCalculate;
-  std::optional<lldb_private::FileSpec> m_comp_dir;
-  std::optional<lldb_private::FileSpec> m_file_spec;
-  std::optional<dw_addr_t> m_addr_base;  ///< Value of DW_AT_addr_base.
-  dw_addr_t m_loclists_base = 0;         ///< Value of DW_AT_loclists_base.
-  dw_addr_t m_ranges_base = 0;           ///< Value of DW_AT_rnglists_base.
+  LazyBool m_is_optimized = eLazyBoolCalculate;
+  std::optional<FileSpec> m_comp_dir;
+  std::optional<FileSpec> m_file_spec;
+  std::optional<dw_addr_t> m_addr_base; ///< Value of DW_AT_addr_base.
+  dw_addr_t m_loclists_base = 0;        ///< Value of DW_AT_loclists_base.
+  dw_addr_t m_ranges_base = 0;          ///< Value of DW_AT_rnglists_base.
   std::optional<uint64_t> m_gnu_addr_base;
   std::optional<uint64_t> m_gnu_ranges_base;
 
@@ -374,7 +378,7 @@ protected:
   /// If we get an error when trying to load a .dwo file, save that error here.
   /// Errors include .dwo/.dwp file not found, or the .dwp/.dwp file was found
   /// but DWO ID doesn't match, etc.
-  lldb_private::Status m_dwo_error;
+  Status m_dwo_error;
 
 private:
   void ParseProducerInfo();
@@ -390,5 +394,7 @@ private:
   DWARFUnit(const DWARFUnit &) = delete;
   const DWARFUnit &operator=(const DWARFUnit &) = delete;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFUNIT_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -18,6 +18,7 @@
 using namespace lldb_private;
 using namespace lldb;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 llvm::Expected<std::unique_ptr<DebugNamesDWARFIndex>>
 DebugNamesDWARFIndex::Create(Module &module, DWARFDataExtractor debug_names,
@@ -227,7 +228,7 @@ void DebugNamesDWARFIndex::GetNamespaces(
     ConstString name, llvm::function_ref<bool(DWARFDIE die)> callback) {
   for (const DebugNames::Entry &entry :
        m_debug_names_up->equal_range(name.GetStringRef())) {
-    dwarf::Tag entry_tag = entry.tag();
+    lldb_private::dwarf::Tag entry_tag = entry.tag();
     if (entry_tag == DW_TAG_namespace ||
         entry_tag == DW_TAG_imported_declaration) {
       if (!ProcessEntry(entry, callback))

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.h
@@ -17,7 +17,8 @@
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
 #include <optional>
 
-namespace lldb_private {
+namespace lldb_private::plugin {
+namespace dwarf {
 class DebugNamesDWARFIndex : public DWARFIndex {
 public:
   static llvm::Expected<std::unique_ptr<DebugNamesDWARFIndex>>
@@ -89,6 +90,7 @@ private:
   static llvm::DenseSet<dw_offset_t> GetUnits(const DebugNames &debug_names);
 };
 
-} // namespace lldb_private
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DEBUGNAMESDWARFINDEX_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -28,6 +28,7 @@
 using namespace lldb_private;
 using namespace lldb;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 void ManualDWARFIndex::Index() {
   if (m_indexed)

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.h
@@ -13,10 +13,11 @@
 #include "Plugins/SymbolFile/DWARF/NameToDIE.h"
 #include "llvm/ADT/DenseSet.h"
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFDebugInfo;
 class SymbolFileDWARFDwo;
 
-namespace lldb_private {
 class ManualDWARFIndex : public DWARFIndex {
 public:
   ManualDWARFIndex(Module &module, SymbolFileDWARF &dwarf,
@@ -173,6 +174,7 @@ private:
   IndexSet m_set;
   bool m_indexed = false;
 };
-} // namespace lldb_private
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_MANUALDWARFINDEX_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/NameToDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/NameToDIE.cpp
@@ -20,6 +20,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 void NameToDIE::Finalize() {
   m_map.Sort(std::less<DIERef>());

--- a/lldb/source/Plugins/SymbolFile/DWARF/NameToDIE.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/NameToDIE.h
@@ -16,6 +16,8 @@
 #include "lldb/Core/dwarf.h"
 #include "lldb/lldb-defines.h"
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DWARFUnit;
 
 class NameToDIE {
@@ -24,18 +26,18 @@ public:
 
   ~NameToDIE() = default;
 
-  void Dump(lldb_private::Stream *s);
+  void Dump(Stream *s);
 
-  void Insert(lldb_private::ConstString name, const DIERef &die_ref);
+  void Insert(ConstString name, const DIERef &die_ref);
 
   void Append(const NameToDIE &other);
 
   void Finalize();
 
-  bool Find(lldb_private::ConstString name,
+  bool Find(ConstString name,
             llvm::function_ref<bool(DIERef ref)> callback) const;
 
-  bool Find(const lldb_private::RegularExpression &regex,
+  bool Find(const RegularExpression &regex,
             llvm::function_ref<bool(DIERef ref)> callback) const;
 
   /// \a unit must be the skeleton unit if possible, not GetNonSkeletonUnit().
@@ -44,8 +46,7 @@ public:
                         llvm::function_ref<bool(DIERef ref)> callback) const;
 
   void
-  ForEach(std::function<bool(lldb_private::ConstString name,
-                             const DIERef &die_ref)> const
+  ForEach(std::function<bool(ConstString name, const DIERef &die_ref)> const
               &callback) const;
 
   /// Decode a serialized version of this object from data.
@@ -61,9 +62,8 @@ public:
   ///   All strings in cache files are put into string tables for efficiency
   ///   and cache file size reduction. Strings are stored as uint32_t string
   ///   table offsets in the cache data.
-  bool Decode(const lldb_private::DataExtractor &data,
-              lldb::offset_t *offset_ptr,
-              const lldb_private::StringTableReader &strtab);
+  bool Decode(const DataExtractor &data, lldb::offset_t *offset_ptr,
+              const StringTableReader &strtab);
 
   /// Encode this object into a data encoder object.
   ///
@@ -76,8 +76,7 @@ public:
   ///   All strings in cache files are put into string tables for efficiency
   ///   and cache file size reduction. Strings are stored as uint32_t string
   ///   table offsets in the cache data.
-  void Encode(lldb_private::DataEncoder &encoder,
-              lldb_private::ConstStringTable &strtab) const;
+  void Encode(DataEncoder &encoder, ConstStringTable &strtab) const;
 
   /// Used for unit testing the encoding and decoding.
   bool operator==(const NameToDIE &rhs) const;
@@ -87,7 +86,9 @@ public:
   void Clear() { m_map.Clear(); }
 
 protected:
-  lldb_private::UniqueCStringMap<DIERef> m_map;
+  UniqueCStringMap<DIERef> m_map;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_NAMETODIE_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -99,6 +99,7 @@
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 LLDB_PLUGIN_DEFINE(SymbolFileDWARF)
 
@@ -138,9 +139,8 @@ static PluginProperties &GetGlobalPluginProperties() {
 }
 
 static const llvm::DWARFDebugLine::LineTable *
-ParseLLVMLineTable(lldb_private::DWARFContext &context,
-                   llvm::DWARFDebugLine &line, dw_offset_t line_offset,
-                   dw_offset_t unit_offset) {
+ParseLLVMLineTable(DWARFContext &context, llvm::DWARFDebugLine &line,
+                   dw_offset_t line_offset, dw_offset_t unit_offset) {
   Log *log = GetLog(DWARFLog::DebugInfo);
 
   llvm::DWARFDataExtractor data = context.getOrLoadLineData().GetAsLLVMDWARF();
@@ -161,7 +161,7 @@ ParseLLVMLineTable(lldb_private::DWARFContext &context,
   return *line_table;
 }
 
-static bool ParseLLVMLineTablePrologue(lldb_private::DWARFContext &context,
+static bool ParseLLVMLineTablePrologue(DWARFContext &context,
                                        llvm::DWARFDebugLine::Prologue &prologue,
                                        dw_offset_t line_offset,
                                        dw_offset_t unit_offset) {
@@ -2429,7 +2429,7 @@ bool SymbolFileDWARF::DIEInDeclContext(const CompilerDeclContext &decl_ctx,
     // ...But if we are only checking root decl contexts, confirm that the
     // 'die' is a top-level context.
     if (only_root_namespaces)
-      return die.GetParent().Tag() == dwarf::DW_TAG_compile_unit;
+      return die.GetParent().Tag() == llvm::dwarf::DW_TAG_compile_unit;
 
     return true;
   }

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -39,6 +39,14 @@
 #include "DWARFIndex.h"
 #include "UniqueDWARFASTType.h"
 
+class DWARFASTParserClang;
+
+namespace llvm {
+class DWARFDebugAbbrev;
+} // namespace llvm
+
+namespace lldb_private::plugin {
+namespace dwarf {
 // Forward Declarations for this DWARF plugin
 class DebugMapModule;
 class DWARFCompileUnit;
@@ -53,15 +61,10 @@ class DWARFTypeUnit;
 class SymbolFileDWARFDebugMap;
 class SymbolFileDWARFDwo;
 class SymbolFileDWARFDwp;
-class UserID;
 
-namespace llvm {
-class DWARFDebugAbbrev;
-}
+#define DIE_IS_BEING_PARSED ((Type *)1)
 
-#define DIE_IS_BEING_PARSED ((lldb_private::Type *)1)
-
-class SymbolFileDWARF : public lldb_private::SymbolFileCommon {
+class SymbolFileDWARF : public SymbolFileCommon {
   /// LLVM RTTI support.
   static char ID;
 
@@ -79,26 +82,24 @@ public:
   friend class DebugMapModule;
   friend class DWARFCompileUnit;
   friend class DWARFDIE;
-  friend class DWARFASTParserClang;
+  friend class ::DWARFASTParserClang;
 
   // Static Functions
   static void Initialize();
 
   static void Terminate();
 
-  static void DebuggerInitialize(lldb_private::Debugger &debugger);
+  static void DebuggerInitialize(Debugger &debugger);
 
   static llvm::StringRef GetPluginNameStatic() { return "dwarf"; }
 
   static llvm::StringRef GetPluginDescriptionStatic();
 
-  static lldb_private::SymbolFile *
-  CreateInstance(lldb::ObjectFileSP objfile_sp);
+  static SymbolFile *CreateInstance(lldb::ObjectFileSP objfile_sp);
 
   // Constructors and Destructors
 
-  SymbolFileDWARF(lldb::ObjectFileSP objfile_sp,
-                  lldb_private::SectionList *dwo_section_list);
+  SymbolFileDWARF(lldb::ObjectFileSP objfile_sp, SectionList *dwo_section_list);
 
   ~SymbolFileDWARF() override;
 
@@ -108,118 +109,99 @@ public:
 
   // Compile Unit function calls
 
-  lldb::LanguageType
-  ParseLanguage(lldb_private::CompileUnit &comp_unit) override;
+  lldb::LanguageType ParseLanguage(CompileUnit &comp_unit) override;
 
-  lldb_private::XcodeSDK
-  ParseXcodeSDK(lldb_private::CompileUnit &comp_unit) override;
+  XcodeSDK ParseXcodeSDK(CompileUnit &comp_unit) override;
 
-  size_t ParseFunctions(lldb_private::CompileUnit &comp_unit) override;
+  size_t ParseFunctions(CompileUnit &comp_unit) override;
 
-  bool ParseLineTable(lldb_private::CompileUnit &comp_unit) override;
+  bool ParseLineTable(CompileUnit &comp_unit) override;
 
-  bool ParseDebugMacros(lldb_private::CompileUnit &comp_unit) override;
+  bool ParseDebugMacros(CompileUnit &comp_unit) override;
 
-  bool ForEachExternalModule(
-      lldb_private::CompileUnit &, llvm::DenseSet<lldb_private::SymbolFile *> &,
-      llvm::function_ref<bool(lldb_private::Module &)>) override;
+  bool ForEachExternalModule(CompileUnit &, llvm::DenseSet<SymbolFile *> &,
+                             llvm::function_ref<bool(Module &)>) override;
 
-  bool ParseSupportFiles(lldb_private::CompileUnit &comp_unit,
-                         lldb_private::FileSpecList &support_files) override;
+  bool ParseSupportFiles(CompileUnit &comp_unit,
+                         FileSpecList &support_files) override;
 
-  bool ParseIsOptimized(lldb_private::CompileUnit &comp_unit) override;
+  bool ParseIsOptimized(CompileUnit &comp_unit) override;
 
-  size_t ParseTypes(lldb_private::CompileUnit &comp_unit) override;
+  size_t ParseTypes(CompileUnit &comp_unit) override;
 
-  bool ParseImportedModules(
-      const lldb_private::SymbolContext &sc,
-      std::vector<lldb_private::SourceModule> &imported_modules) override;
+  bool
+  ParseImportedModules(const SymbolContext &sc,
+                       std::vector<SourceModule> &imported_modules) override;
 
-  size_t ParseBlocksRecursive(lldb_private::Function &func) override;
+  size_t ParseBlocksRecursive(Function &func) override;
 
-  size_t
-  ParseVariablesForContext(const lldb_private::SymbolContext &sc) override;
+  size_t ParseVariablesForContext(const SymbolContext &sc) override;
 
-  lldb_private::Type *ResolveTypeUID(lldb::user_id_t type_uid) override;
-  std::optional<ArrayInfo> GetDynamicArrayInfoForUID(
-      lldb::user_id_t type_uid,
-      const lldb_private::ExecutionContext *exe_ctx) override;
+  Type *ResolveTypeUID(lldb::user_id_t type_uid) override;
+  std::optional<ArrayInfo>
+  GetDynamicArrayInfoForUID(lldb::user_id_t type_uid,
+                            const ExecutionContext *exe_ctx) override;
 
-  bool CompleteType(lldb_private::CompilerType &compiler_type) override;
+  bool CompleteType(CompilerType &compiler_type) override;
 
-  lldb_private::Type *ResolveType(const DWARFDIE &die,
-                                  bool assert_not_being_parsed = true,
-                                  bool resolve_function_context = false);
+  Type *ResolveType(const DWARFDIE &die, bool assert_not_being_parsed = true,
+                    bool resolve_function_context = false);
 
-  lldb_private::CompilerDecl GetDeclForUID(lldb::user_id_t uid) override;
+  CompilerDecl GetDeclForUID(lldb::user_id_t uid) override;
 
-  lldb_private::CompilerDeclContext
-  GetDeclContextForUID(lldb::user_id_t uid) override;
+  CompilerDeclContext GetDeclContextForUID(lldb::user_id_t uid) override;
 
-  lldb_private::CompilerDeclContext
-  GetDeclContextContainingUID(lldb::user_id_t uid) override;
+  CompilerDeclContext GetDeclContextContainingUID(lldb::user_id_t uid) override;
 
-  void
-  ParseDeclsForContext(lldb_private::CompilerDeclContext decl_ctx) override;
+  void ParseDeclsForContext(CompilerDeclContext decl_ctx) override;
 
-  uint32_t ResolveSymbolContext(const lldb_private::Address &so_addr,
+  uint32_t ResolveSymbolContext(const Address &so_addr,
                                 lldb::SymbolContextItem resolve_scope,
-                                lldb_private::SymbolContext &sc) override;
+                                SymbolContext &sc) override;
 
-  lldb_private::Status
-  CalculateFrameVariableError(lldb_private::StackFrame &frame) override;
+  Status CalculateFrameVariableError(StackFrame &frame) override;
 
-  uint32_t ResolveSymbolContext(
-      const lldb_private::SourceLocationSpec &src_location_spec,
-      lldb::SymbolContextItem resolve_scope,
-      lldb_private::SymbolContextList &sc_list) override;
+  uint32_t ResolveSymbolContext(const SourceLocationSpec &src_location_spec,
+                                lldb::SymbolContextItem resolve_scope,
+                                SymbolContextList &sc_list) override;
 
-  void
-  FindGlobalVariables(lldb_private::ConstString name,
-                      const lldb_private::CompilerDeclContext &parent_decl_ctx,
-                      uint32_t max_matches,
-                      lldb_private::VariableList &variables) override;
-
-  void FindGlobalVariables(const lldb_private::RegularExpression &regex,
+  void FindGlobalVariables(ConstString name,
+                           const CompilerDeclContext &parent_decl_ctx,
                            uint32_t max_matches,
-                           lldb_private::VariableList &variables) override;
+                           VariableList &variables) override;
 
-  void FindFunctions(const lldb_private::Module::LookupInfo &lookup_info,
-                     const lldb_private::CompilerDeclContext &parent_decl_ctx,
-                     bool include_inlines,
-                     lldb_private::SymbolContextList &sc_list) override;
+  void FindGlobalVariables(const RegularExpression &regex, uint32_t max_matches,
+                           VariableList &variables) override;
 
-  void FindFunctions(const lldb_private::RegularExpression &regex,
-                     bool include_inlines,
-                     lldb_private::SymbolContextList &sc_list) override;
+  void FindFunctions(const Module::LookupInfo &lookup_info,
+                     const CompilerDeclContext &parent_decl_ctx,
+                     bool include_inlines, SymbolContextList &sc_list) override;
 
-  void GetMangledNamesForFunction(
-      const std::string &scope_qualified_name,
-      std::vector<lldb_private::ConstString> &mangled_names) override;
+  void FindFunctions(const RegularExpression &regex, bool include_inlines,
+                     SymbolContextList &sc_list) override;
 
   void
-  FindTypes(lldb_private::ConstString name,
-            const lldb_private::CompilerDeclContext &parent_decl_ctx,
-            uint32_t max_matches,
-            llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
-            lldb_private::TypeMap &types) override;
+  GetMangledNamesForFunction(const std::string &scope_qualified_name,
+                             std::vector<ConstString> &mangled_names) override;
 
-  void FindTypes(llvm::ArrayRef<lldb_private::CompilerContext> pattern,
-                 lldb_private::LanguageSet languages,
+  void FindTypes(ConstString name, const CompilerDeclContext &parent_decl_ctx,
+                 uint32_t max_matches,
                  llvm::DenseSet<SymbolFile *> &searched_symbol_files,
-                 lldb_private::TypeMap &types) override;
+                 TypeMap &types) override;
 
-  void GetTypes(lldb_private::SymbolContextScope *sc_scope,
-                lldb::TypeClass type_mask,
-                lldb_private::TypeList &type_list) override;
+  void FindTypes(llvm::ArrayRef<CompilerContext> pattern, LanguageSet languages,
+                 llvm::DenseSet<SymbolFile *> &searched_symbol_files,
+                 TypeMap &types) override;
+
+  void GetTypes(SymbolContextScope *sc_scope, lldb::TypeClass type_mask,
+                TypeList &type_list) override;
 
   llvm::Expected<lldb::TypeSystemSP>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
-  lldb_private::CompilerDeclContext
-  FindNamespace(lldb_private::ConstString name,
-                const lldb_private::CompilerDeclContext &parent_decl_ctx,
-                bool only_root_namespaces) override;
+  CompilerDeclContext FindNamespace(ConstString name,
+                                    const CompilerDeclContext &parent_decl_ctx,
+                                    bool only_root_namespaces) override;
 
   void PreloadSymbols() override;
 
@@ -239,25 +221,22 @@ public:
   DWARFDIE
   GetDeclContextDIEContainingDIE(const DWARFDIE &die);
 
-  bool
-  HasForwardDeclForClangType(const lldb_private::CompilerType &compiler_type);
+  bool HasForwardDeclForClangType(const CompilerType &compiler_type);
 
-  lldb_private::CompileUnit *
-  GetCompUnitForDWARFCompUnit(DWARFCompileUnit &dwarf_cu);
+  CompileUnit *GetCompUnitForDWARFCompUnit(DWARFCompileUnit &dwarf_cu);
 
-  virtual void GetObjCMethods(lldb_private::ConstString class_name,
+  virtual void GetObjCMethods(ConstString class_name,
                               llvm::function_ref<bool(DWARFDIE die)> callback);
 
   bool Supports_DW_AT_APPLE_objc_complete_type(DWARFUnit *cu);
 
-  lldb_private::DebugMacrosSP ParseDebugMacros(lldb::offset_t *offset);
+  DebugMacrosSP ParseDebugMacros(lldb::offset_t *offset);
 
   static DWARFDIE GetParentSymbolContextDIE(const DWARFDIE &die);
 
-  lldb::ModuleSP GetExternalModule(lldb_private::ConstString name);
+  lldb::ModuleSP GetExternalModule(ConstString name);
 
-  typedef std::map<lldb_private::ConstString, lldb::ModuleSP>
-      ExternalTypeModuleMap;
+  typedef std::map<ConstString, lldb::ModuleSP> ExternalTypeModuleMap;
 
   /// Return the list of Clang modules imported by this SymbolFile.
   const ExternalTypeModuleMap &getExternalTypeModules() const {
@@ -275,26 +254,25 @@ public:
   /// If this is a DWARF object with a single CU, return its DW_AT_dwo_id.
   std::optional<uint64_t> GetDWOId();
 
-  static bool
-  DIEInDeclContext(const lldb_private::CompilerDeclContext &parent_decl_ctx,
-                   const DWARFDIE &die, bool only_root_namespaces = false);
+  static bool DIEInDeclContext(const CompilerDeclContext &parent_decl_ctx,
+                               const DWARFDIE &die,
+                               bool only_root_namespaces = false);
 
-  std::vector<std::unique_ptr<lldb_private::CallEdge>>
-  ParseCallEdgesInFunction(lldb_private::UserID func_id) override;
+  std::vector<std::unique_ptr<CallEdge>>
+  ParseCallEdgesInFunction(UserID func_id) override;
 
-  void Dump(lldb_private::Stream &s) override;
+  void Dump(Stream &s) override;
 
-  void DumpClangAST(lldb_private::Stream &s) override;
+  void DumpClangAST(Stream &s) override;
 
   /// List separate dwo files.
-  bool
-  GetSeparateDebugInfo(lldb_private::StructuredData::Dictionary &d) override;
+  bool GetSeparateDebugInfo(StructuredData::Dictionary &d) override;
 
-  lldb_private::DWARFContext &GetDWARFContext() { return m_context; }
+  DWARFContext &GetDWARFContext() { return m_context; }
 
   const std::shared_ptr<SymbolFileDWARFDwo> &GetDwpSymbolFile();
 
-  lldb_private::FileSpec GetFile(DWARFUnit &unit, size_t file_idx);
+  FileSpec GetFile(DWARFUnit &unit, size_t file_idx);
 
   static llvm::Expected<lldb::TypeSystemSP> GetTypeSystem(DWARFUnit &unit);
 
@@ -302,12 +280,11 @@ public:
 
   // CompilerDecl related functions
 
-  static lldb_private::CompilerDecl GetDecl(const DWARFDIE &die);
+  static CompilerDecl GetDecl(const DWARFDIE &die);
 
-  static lldb_private::CompilerDeclContext GetDeclContext(const DWARFDIE &die);
+  static CompilerDeclContext GetDeclContext(const DWARFDIE &die);
 
-  static lldb_private::CompilerDeclContext
-  GetContainingDeclContext(const DWARFDIE &die);
+  static CompilerDeclContext GetContainingDeclContext(const DWARFDIE &die);
 
   static DWARFDeclContext GetDWARFDeclContext(const DWARFDIE &die);
 
@@ -317,39 +294,34 @@ public:
   /// Same as GetLanguage() but reports all C++ versions as C++ (no version).
   static lldb::LanguageType GetLanguageFamily(DWARFUnit &unit);
 
-  lldb_private::StatsDuration::Duration GetDebugInfoParseTime() override {
+  StatsDuration::Duration GetDebugInfoParseTime() override {
     return m_parse_time;
   }
-  lldb_private::StatsDuration::Duration GetDebugInfoIndexTime() override;
+  StatsDuration::Duration GetDebugInfoIndexTime() override;
 
-  lldb_private::StatsDuration &GetDebugInfoParseTimeRef() {
-    return m_parse_time;
-  }
+  StatsDuration &GetDebugInfoParseTimeRef() { return m_parse_time; }
 
   virtual lldb::offset_t
-  GetVendorDWARFOpcodeSize(const lldb_private::DataExtractor &data,
+  GetVendorDWARFOpcodeSize(const DataExtractor &data,
                            const lldb::offset_t data_offset,
                            const uint8_t op) const {
     return LLDB_INVALID_OFFSET;
   }
 
-  virtual bool
-  ParseVendorDWARFOpcode(uint8_t op, const lldb_private::DataExtractor &opcodes,
-                         lldb::offset_t &offset,
-                         std::vector<lldb_private::Value> &stack) const {
+  virtual bool ParseVendorDWARFOpcode(uint8_t op, const DataExtractor &opcodes,
+                                      lldb::offset_t &offset,
+                                      std::vector<Value> &stack) const {
     return false;
   }
 
-  lldb_private::ConstString ConstructFunctionDemangledName(const DWARFDIE &die);
+  ConstString ConstructFunctionDemangledName(const DWARFDIE &die);
 
   std::optional<uint64_t> GetFileIndex() const { return m_file_index; }
   void SetFileIndex(std::optional<uint64_t> file_index) {
     m_file_index = file_index;
   }
 
-protected:
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *, lldb_private::Type *>
-      DIEToTypePtr;
+  typedef llvm::DenseMap<const DWARFDebugInfoEntry *, Type *> DIEToTypePtr;
   typedef llvm::DenseMap<const DWARFDebugInfoEntry *, lldb::VariableSP>
       DIEToVariableSP;
   typedef llvm::DenseMap<const DWARFDebugInfoEntry *,
@@ -361,69 +333,64 @@ protected:
   const SymbolFileDWARF &operator=(const SymbolFileDWARF &) = delete;
 
   virtual void LoadSectionData(lldb::SectionType sect_type,
-                               lldb_private::DWARFDataExtractor &data);
+                               DWARFDataExtractor &data);
 
-  bool DeclContextMatchesThisSymbolFile(
-      const lldb_private::CompilerDeclContext &decl_ctx);
+  bool DeclContextMatchesThisSymbolFile(const CompilerDeclContext &decl_ctx);
 
   uint32_t CalculateNumCompileUnits() override;
 
   lldb::CompUnitSP ParseCompileUnitAtIndex(uint32_t index) override;
 
-  lldb_private::TypeList &GetTypeList() override;
+  TypeList &GetTypeList() override;
 
   lldb::CompUnitSP ParseCompileUnit(DWARFCompileUnit &dwarf_cu);
 
-  virtual DWARFCompileUnit *
-  GetDWARFCompileUnit(lldb_private::CompileUnit *comp_unit);
+  virtual DWARFCompileUnit *GetDWARFCompileUnit(CompileUnit *comp_unit);
 
   DWARFUnit *GetNextUnparsedDWARFCompileUnit(DWARFUnit *prev_cu);
 
-  bool GetFunction(const DWARFDIE &die, lldb_private::SymbolContext &sc);
+  bool GetFunction(const DWARFDIE &die, SymbolContext &sc);
 
-  lldb_private::Function *ParseFunction(lldb_private::CompileUnit &comp_unit,
-                                        const DWARFDIE &die);
+  Function *ParseFunction(CompileUnit &comp_unit, const DWARFDIE &die);
 
-  size_t ParseBlocksRecursive(lldb_private::CompileUnit &comp_unit,
-                              lldb_private::Block *parent_block,
+  size_t ParseBlocksRecursive(CompileUnit &comp_unit, Block *parent_block,
                               const DWARFDIE &die,
                               lldb::addr_t subprogram_low_pc, uint32_t depth);
 
-  size_t ParseTypes(const lldb_private::SymbolContext &sc, const DWARFDIE &die,
+  size_t ParseTypes(const SymbolContext &sc, const DWARFDIE &die,
                     bool parse_siblings, bool parse_children);
 
-  lldb::TypeSP ParseType(const lldb_private::SymbolContext &sc,
-                         const DWARFDIE &die, bool *type_is_new);
+  lldb::TypeSP ParseType(const SymbolContext &sc, const DWARFDIE &die,
+                         bool *type_is_new);
 
   bool ParseSupportFiles(DWARFUnit &dwarf_cu, const lldb::ModuleSP &module,
-                         lldb_private::FileSpecList &support_files);
+                         FileSpecList &support_files);
 
-  lldb_private::Type *ResolveTypeUID(const DWARFDIE &die,
-                                     bool assert_not_being_parsed);
+  Type *ResolveTypeUID(const DWARFDIE &die, bool assert_not_being_parsed);
 
-  lldb_private::Type *ResolveTypeUID(const DIERef &die_ref);
+  Type *ResolveTypeUID(const DIERef &die_ref);
 
-  lldb::VariableSP ParseVariableDIE(const lldb_private::SymbolContext &sc,
+  lldb::VariableSP ParseVariableDIE(const SymbolContext &sc,
                                     const DWARFDIE &die,
                                     const lldb::addr_t func_low_pc);
-  lldb::VariableSP ParseVariableDIECached(const lldb_private::SymbolContext &sc,
+  lldb::VariableSP ParseVariableDIECached(const SymbolContext &sc,
                                           const DWARFDIE &die);
 
-  void
-  ParseAndAppendGlobalVariable(const lldb_private::SymbolContext &sc,
-                               const DWARFDIE &die,
-                               lldb_private::VariableList &cc_variable_list);
+  void ParseAndAppendGlobalVariable(const SymbolContext &sc,
+                                    const DWARFDIE &die,
+                                    VariableList &cc_variable_list);
 
-  size_t ParseVariablesInFunctionContext(const lldb_private::SymbolContext &sc,
+  size_t ParseVariablesInFunctionContext(const SymbolContext &sc,
                                          const DWARFDIE &die,
                                          const lldb::addr_t func_low_pc);
 
-  size_t ParseVariablesInFunctionContextRecursive(
-      const lldb_private::SymbolContext &sc, const DWARFDIE &die,
-      lldb::addr_t func_low_pc, DIEArray &accumulator);
+  size_t ParseVariablesInFunctionContextRecursive(const SymbolContext &sc,
+                                                  const DWARFDIE &die,
+                                                  lldb::addr_t func_low_pc,
+                                                  DIEArray &accumulator);
 
-  size_t PopulateBlockVariableList(lldb_private::VariableList &variable_list,
-                                   const lldb_private::SymbolContext &sc,
+  size_t PopulateBlockVariableList(VariableList &variable_list,
+                                   const SymbolContext &sc,
                                    llvm::ArrayRef<DIERef> variable_dies,
                                    lldb::addr_t func_low_pc);
 
@@ -434,25 +401,22 @@ protected:
 
   // Given a die_offset, figure out the symbol context representing that die.
   bool ResolveFunction(const DWARFDIE &die, bool include_inlines,
-                       lldb_private::SymbolContextList &sc_list);
+                       SymbolContextList &sc_list);
 
   /// Resolve functions and (possibly) blocks for the given file address and a
   /// compile unit. The compile unit comes from the sc argument and it must be
   /// set. The results of the lookup (if any) are written back to the symbol
   /// context.
   void ResolveFunctionAndBlock(lldb::addr_t file_vm_addr, bool lookup_block,
-                               lldb_private::SymbolContext &sc);
+                               SymbolContext &sc);
 
   virtual lldb::TypeSP
   FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die);
 
-  virtual lldb::TypeSP
-  FindCompleteObjCDefinitionTypeForDIE(const DWARFDIE &die,
-                                       lldb_private::ConstString type_name,
-                                       bool must_be_implementation);
+  virtual lldb::TypeSP FindCompleteObjCDefinitionTypeForDIE(
+      const DWARFDIE &die, ConstString type_name, bool must_be_implementation);
 
-  lldb_private::Symbol *
-  GetObjCClassSymbol(lldb_private::ConstString objc_class_name);
+  Symbol *GetObjCClassSymbol(ConstString objc_class_name);
 
   lldb::TypeSP GetTypeForDIE(const DWARFDIE &die,
                              bool resolve_function_context = false);
@@ -475,12 +439,11 @@ protected:
 
   bool DIEDeclContextsMatch(const DWARFDIE &die1, const DWARFDIE &die2);
 
-  bool ClassContainsSelector(const DWARFDIE &class_die,
-                             lldb_private::ConstString selector);
+  bool ClassContainsSelector(const DWARFDIE &class_die, ConstString selector);
 
   /// Parse call site entries (DW_TAG_call_site), including any nested call site
   /// parameters (DW_TAG_call_site_parameter).
-  std::vector<std::unique_ptr<lldb_private::CallEdge>>
+  std::vector<std::unique_ptr<CallEdge>>
   CollectCallEdges(lldb::ModuleSP module, DWARFDIE function_die);
 
   /// If this symbol file is linked to by a debug map (see
@@ -490,16 +453,15 @@ protected:
   /// needed, on success and LLDB_INVALID_ADDRESS otherwise.
   lldb::addr_t FixupAddress(lldb::addr_t file_addr);
 
-  bool FixupAddress(lldb_private::Address &addr);
+  bool FixupAddress(Address &addr);
 
-  typedef llvm::SetVector<lldb_private::Type *> TypeSet;
+  typedef llvm::SetVector<Type *> TypeSet;
 
   void GetTypes(const DWARFDIE &die, dw_offset_t min_die_offset,
                 dw_offset_t max_die_offset, uint32_t type_mask,
                 TypeSet &type_set);
 
-  typedef lldb_private::RangeDataVector<lldb::addr_t, lldb::addr_t,
-                                        lldb_private::Variable *>
+  typedef RangeDataVector<lldb::addr_t, lldb::addr_t, Variable *>
       GlobalVariableMap;
 
   GlobalVariableMap &GetGlobalAranges();
@@ -523,15 +485,14 @@ protected:
 
   void FindDwpSymbolFile();
 
-  const lldb_private::FileSpecList &GetTypeUnitSupportFiles(DWARFTypeUnit &tu);
+  const FileSpecList &GetTypeUnitSupportFiles(DWARFTypeUnit &tu);
 
-  void InitializeFirstCodeAddressRecursive(
-      const lldb_private::SectionList &section_list);
+  void InitializeFirstCodeAddressRecursive(const SectionList &section_list);
 
   void InitializeFirstCodeAddress();
 
-  void GetCompileOptions(
-      std::unordered_map<lldb::CompUnitSP, lldb_private::Args> &args) override;
+  void
+  GetCompileOptions(std::unordered_map<lldb::CompUnitSP, Args> &args) override;
 
   lldb::ModuleWP m_debug_map_module_wp;
   SymbolFileDWARFDebugMap *m_debug_map_symfile;
@@ -539,7 +500,7 @@ protected:
   llvm::once_flag m_dwp_symfile_once_flag;
   std::shared_ptr<SymbolFileDWARFDwo> m_dwp_symfile;
 
-  lldb_private::DWARFContext m_context;
+  DWARFContext m_context;
 
   llvm::once_flag m_info_once_flag;
   std::unique_ptr<DWARFDebugInfo> m_info;
@@ -547,14 +508,13 @@ protected:
   std::unique_ptr<llvm::DWARFDebugAbbrev> m_abbr;
   std::unique_ptr<GlobalVariableMap> m_global_aranges_up;
 
-  typedef std::unordered_map<lldb::offset_t, lldb_private::DebugMacrosSP>
-      DebugMacrosMap;
+  typedef std::unordered_map<lldb::offset_t, DebugMacrosSP> DebugMacrosMap;
   DebugMacrosMap m_debug_macros_map;
 
   ExternalTypeModuleMap m_external_type_modules;
-  std::unique_ptr<lldb_private::DWARFIndex> m_index;
+  std::unique_ptr<DWARFIndex> m_index;
   bool m_fetched_external_modules : 1;
-  lldb_private::LazyBool m_supports_DW_AT_APPLE_objc_complete_type;
+  LazyBool m_supports_DW_AT_APPLE_objc_complete_type;
 
   typedef std::set<DIERef> DIERefSet;
   typedef llvm::StringMap<DIERefSet> NameToOffsetMap;
@@ -565,8 +525,7 @@ protected:
   DIEToVariableSP m_die_to_variable_sp;
   DIEToClangType m_forward_decl_die_to_clang_type;
   ClangTypeToDIE m_forward_decl_clang_type_to_die;
-  llvm::DenseMap<dw_offset_t, lldb_private::FileSpecList>
-      m_type_unit_support_files;
+  llvm::DenseMap<dw_offset_t, FileSpecList> m_type_unit_support_files;
   std::vector<uint32_t> m_lldb_cu_to_dwarf_unit;
   /// DWARF does not provide a good way for traditional (concatenating) linkers
   /// to invalidate debug info describing dead-stripped code. These linkers will
@@ -575,7 +534,7 @@ protected:
   /// Try to filter out this debug info by comparing it to the lowest code
   /// address in the module.
   lldb::addr_t m_first_code_address = LLDB_INVALID_ADDRESS;
-  lldb_private::StatsDuration m_parse_time;
+  StatsDuration m_parse_time;
   std::atomic_flag m_dwo_warning_issued = ATOMIC_FLAG_INIT;
   /// If this DWARF file a .DWO file or a DWARF .o file on mac when
   /// no dSYM file is being used, this file index will be set to a
@@ -583,5 +542,7 @@ protected:
   /// an index that identifies the .DWO or .o file.
   std::optional<uint64_t> m_file_index;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_SYMBOLFILEDWARF_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -43,6 +43,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 char SymbolFileDWARFDebugMap::ID;
 
@@ -167,6 +168,8 @@ SymbolFileDWARFDebugMap::CompileUnitInfo::GetFileRangeMap(
   return file_range_map;
 }
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class DebugMapModule : public Module {
 public:
   DebugMapModule(const ModuleSP &exe_module_sp, uint32_t cu_idx,
@@ -223,6 +226,8 @@ protected:
   ModuleWP m_exe_module_wp;
   const uint32_t m_cu_idx;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 void SymbolFileDWARFDebugMap::Initialize() {
   PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -21,12 +21,16 @@
 #include "UniqueDWARFASTType.h"
 #include "lldb/Utility/StructuredData.h"
 
+class DWARFASTParserClang;
+
+namespace lldb_private::plugin {
+namespace dwarf {
 class SymbolFileDWARF;
 class DWARFCompileUnit;
 class DWARFDebugAranges;
 class DWARFDeclContext;
 
-class SymbolFileDWARFDebugMap : public lldb_private::SymbolFileCommon {
+class SymbolFileDWARFDebugMap : public SymbolFileCommon {
   /// LLVM RTTI support.
   static char ID;
 
@@ -48,8 +52,7 @@ public:
 
   static llvm::StringRef GetPluginDescriptionStatic();
 
-  static lldb_private::SymbolFile *
-  CreateInstance(lldb::ObjectFileSP objfile_sp);
+  static SymbolFile *CreateInstance(lldb::ObjectFileSP objfile_sp);
 
   // Constructors and Destructors
   SymbolFileDWARFDebugMap(lldb::ObjectFileSP objfile_sp);
@@ -59,114 +62,94 @@ public:
   void InitializeObject() override;
 
   // Compile Unit function calls
-  lldb::LanguageType
-  ParseLanguage(lldb_private::CompileUnit &comp_unit) override;
-  lldb_private::XcodeSDK
-  ParseXcodeSDK(lldb_private::CompileUnit &comp_unit) override;
+  lldb::LanguageType ParseLanguage(CompileUnit &comp_unit) override;
+  XcodeSDK ParseXcodeSDK(CompileUnit &comp_unit) override;
   llvm::SmallSet<lldb::LanguageType, 4>
-  ParseAllLanguages(lldb_private::CompileUnit &comp_unit) override;
-  size_t ParseFunctions(lldb_private::CompileUnit &comp_unit) override;
-  bool ParseLineTable(lldb_private::CompileUnit &comp_unit) override;
-  bool ParseDebugMacros(lldb_private::CompileUnit &comp_unit) override;
+  ParseAllLanguages(CompileUnit &comp_unit) override;
+  size_t ParseFunctions(CompileUnit &comp_unit) override;
+  bool ParseLineTable(CompileUnit &comp_unit) override;
+  bool ParseDebugMacros(CompileUnit &comp_unit) override;
 
-  bool ForEachExternalModule(
-      lldb_private::CompileUnit &, llvm::DenseSet<lldb_private::SymbolFile *> &,
-      llvm::function_ref<bool(lldb_private::Module &)>) override;
+  bool ForEachExternalModule(CompileUnit &, llvm::DenseSet<SymbolFile *> &,
+                             llvm::function_ref<bool(Module &)>) override;
 
-  bool ParseSupportFiles(lldb_private::CompileUnit &comp_unit,
-                         lldb_private::FileSpecList &support_files) override;
+  bool ParseSupportFiles(CompileUnit &comp_unit,
+                         FileSpecList &support_files) override;
 
-  bool ParseIsOptimized(lldb_private::CompileUnit &comp_unit) override;
+  bool ParseIsOptimized(CompileUnit &comp_unit) override;
 
-  size_t ParseTypes(lldb_private::CompileUnit &comp_unit) override;
+  size_t ParseTypes(CompileUnit &comp_unit) override;
 
-  bool ParseImportedModules(
-      const lldb_private::SymbolContext &sc,
-      std::vector<lldb_private::SourceModule> &imported_modules) override;
-  size_t ParseBlocksRecursive(lldb_private::Function &func) override;
-  size_t
-  ParseVariablesForContext(const lldb_private::SymbolContext &sc) override;
+  bool
+  ParseImportedModules(const SymbolContext &sc,
+                       std::vector<SourceModule> &imported_modules) override;
+  size_t ParseBlocksRecursive(Function &func) override;
+  size_t ParseVariablesForContext(const SymbolContext &sc) override;
 
-  lldb_private::Type *ResolveTypeUID(lldb::user_id_t type_uid) override;
-  std::optional<ArrayInfo> GetDynamicArrayInfoForUID(
-      lldb::user_id_t type_uid,
-      const lldb_private::ExecutionContext *exe_ctx) override;
+  Type *ResolveTypeUID(lldb::user_id_t type_uid) override;
+  std::optional<ArrayInfo>
+  GetDynamicArrayInfoForUID(lldb::user_id_t type_uid,
+                            const ExecutionContext *exe_ctx) override;
 
-  lldb_private::CompilerDeclContext
-  GetDeclContextForUID(lldb::user_id_t uid) override;
-  lldb_private::CompilerDeclContext
-  GetDeclContextContainingUID(lldb::user_id_t uid) override;
-  void
-  ParseDeclsForContext(lldb_private::CompilerDeclContext decl_ctx) override;
+  CompilerDeclContext GetDeclContextForUID(lldb::user_id_t uid) override;
+  CompilerDeclContext GetDeclContextContainingUID(lldb::user_id_t uid) override;
+  void ParseDeclsForContext(CompilerDeclContext decl_ctx) override;
 
-  bool CompleteType(lldb_private::CompilerType &compiler_type) override;
-  uint32_t ResolveSymbolContext(const lldb_private::Address &so_addr,
+  bool CompleteType(CompilerType &compiler_type) override;
+  uint32_t ResolveSymbolContext(const Address &so_addr,
                                 lldb::SymbolContextItem resolve_scope,
-                                lldb_private::SymbolContext &sc) override;
-  uint32_t ResolveSymbolContext(
-      const lldb_private::SourceLocationSpec &src_location_spec,
-      lldb::SymbolContextItem resolve_scope,
-      lldb_private::SymbolContextList &sc_list) override;
+                                SymbolContext &sc) override;
+  uint32_t ResolveSymbolContext(const SourceLocationSpec &src_location_spec,
+                                lldb::SymbolContextItem resolve_scope,
+                                SymbolContextList &sc_list) override;
 
-  lldb_private::Status
-  CalculateFrameVariableError(lldb_private::StackFrame &frame) override;
+  Status CalculateFrameVariableError(StackFrame &frame) override;
 
-  void
-  FindGlobalVariables(lldb_private::ConstString name,
-                      const lldb_private::CompilerDeclContext &parent_decl_ctx,
-                      uint32_t max_matches,
-                      lldb_private::VariableList &variables) override;
-  void FindGlobalVariables(const lldb_private::RegularExpression &regex,
+  void FindGlobalVariables(ConstString name,
+                           const CompilerDeclContext &parent_decl_ctx,
                            uint32_t max_matches,
-                           lldb_private::VariableList &variables) override;
-  void FindFunctions(const lldb_private::Module::LookupInfo &lookup_info,
-                     const lldb_private::CompilerDeclContext &parent_decl_ctx,
-                     bool include_inlines,
-                     lldb_private::SymbolContextList &sc_list) override;
-  void FindFunctions(const lldb_private::RegularExpression &regex,
-                     bool include_inlines,
-                     lldb_private::SymbolContextList &sc_list) override;
-  void
-  FindTypes(lldb_private::ConstString name,
-            const lldb_private::CompilerDeclContext &parent_decl_ctx,
-            uint32_t max_matches,
-            llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
-            lldb_private::TypeMap &types) override;
-  void
-  FindTypes(llvm::ArrayRef<lldb_private::CompilerContext> context,
-            lldb_private::LanguageSet languages,
-            llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
-            lldb_private::TypeMap &types) override;
-  lldb_private::CompilerDeclContext
-  FindNamespace(lldb_private::ConstString name,
-                const lldb_private::CompilerDeclContext &parent_decl_ctx,
-                bool only_root_namespaces) override;
-  void GetTypes(lldb_private::SymbolContextScope *sc_scope,
-                lldb::TypeClass type_mask,
-                lldb_private::TypeList &type_list) override;
-  std::vector<std::unique_ptr<lldb_private::CallEdge>>
-  ParseCallEdgesInFunction(lldb_private::UserID func_id) override;
+                           VariableList &variables) override;
+  void FindGlobalVariables(const RegularExpression &regex, uint32_t max_matches,
+                           VariableList &variables) override;
+  void FindFunctions(const Module::LookupInfo &lookup_info,
+                     const CompilerDeclContext &parent_decl_ctx,
+                     bool include_inlines, SymbolContextList &sc_list) override;
+  void FindFunctions(const RegularExpression &regex, bool include_inlines,
+                     SymbolContextList &sc_list) override;
+  void FindTypes(ConstString name, const CompilerDeclContext &parent_decl_ctx,
+                 uint32_t max_matches,
+                 llvm::DenseSet<SymbolFile *> &searched_symbol_files,
+                 TypeMap &types) override;
+  void FindTypes(llvm::ArrayRef<CompilerContext> context, LanguageSet languages,
+                 llvm::DenseSet<SymbolFile *> &searched_symbol_files,
+                 TypeMap &types) override;
+  CompilerDeclContext FindNamespace(ConstString name,
+                                    const CompilerDeclContext &parent_decl_ctx,
+                                    bool only_root_namespaces) override;
+  void GetTypes(SymbolContextScope *sc_scope, lldb::TypeClass type_mask,
+                TypeList &type_list) override;
+  std::vector<std::unique_ptr<CallEdge>>
+  ParseCallEdgesInFunction(UserID func_id) override;
 
-  void DumpClangAST(lldb_private::Stream &s) override;
+  void DumpClangAST(Stream &s) override;
 
   /// List separate oso files.
-  bool
-  GetSeparateDebugInfo(lldb_private::StructuredData::Dictionary &d) override;
+  bool GetSeparateDebugInfo(StructuredData::Dictionary &d) override;
 
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
   // Statistics overrides.
-  lldb_private::ModuleList GetDebugInfoModules() override;
+  ModuleList GetDebugInfoModules() override;
 
-  void GetCompileOptions(
-      std::unordered_map<lldb::CompUnitSP, lldb_private::Args> &args) override;
+  void
+  GetCompileOptions(std::unordered_map<lldb::CompUnitSP, Args> &args) override;
 
 protected:
   enum { kHaveInitializedOSOs = (1 << 0), kNumFlags };
 
   friend class DebugMapModule;
-  friend class DWARFASTParserClang;
+  friend class ::DWARFASTParserClang;
   friend class DWARFCompileUnit;
   friend class SymbolFileDWARF;
   struct OSOInfo {
@@ -177,16 +160,15 @@ protected:
 
   typedef std::shared_ptr<OSOInfo> OSOInfoSP;
 
-  typedef lldb_private::RangeDataVector<lldb::addr_t, lldb::addr_t,
-                                        lldb::addr_t>
+  typedef RangeDataVector<lldb::addr_t, lldb::addr_t, lldb::addr_t>
       FileRangeMap;
 
   // Class specific types
   struct CompileUnitInfo {
-    lldb_private::FileSpec so_file;
-    lldb_private::ConstString oso_path;
+    FileSpec so_file;
+    ConstString oso_path;
     llvm::sys::TimePoint<> oso_mod_time;
-    lldb_private::Status oso_load_error;
+    Status oso_load_error;
     OSOInfoSP oso_sp;
     /// The compile units that an object file contains.
     llvm::SmallVector<lldb::CompUnitSP, 2> compile_units_sps;
@@ -228,28 +210,26 @@ protected:
 
   static SymbolFileDWARF *GetSymbolFileAsSymbolFileDWARF(SymbolFile *sym_file);
 
-  bool GetFileSpecForSO(uint32_t oso_idx, lldb_private::FileSpec &file_spec);
+  bool GetFileSpecForSO(uint32_t oso_idx, FileSpec &file_spec);
 
-  CompileUnitInfo *GetCompUnitInfo(const lldb_private::SymbolContext &sc);
-  CompileUnitInfo *GetCompUnitInfo(const lldb_private::CompileUnit &comp_unit);
+  CompileUnitInfo *GetCompUnitInfo(const SymbolContext &sc);
+  CompileUnitInfo *GetCompUnitInfo(const CompileUnit &comp_unit);
 
-  size_t GetCompUnitInfosForModule(const lldb_private::Module *oso_module,
+  size_t GetCompUnitInfosForModule(const Module *oso_module,
                                    std::vector<CompileUnitInfo *> &cu_infos);
 
-  lldb_private::Module *
-  GetModuleByCompUnitInfo(CompileUnitInfo *comp_unit_info);
+  Module *GetModuleByCompUnitInfo(CompileUnitInfo *comp_unit_info);
 
-  lldb_private::Module *GetModuleByOSOIndex(uint32_t oso_idx);
+  Module *GetModuleByOSOIndex(uint32_t oso_idx);
 
-  lldb_private::ObjectFile *
-  GetObjectFileByCompUnitInfo(CompileUnitInfo *comp_unit_info);
+  ObjectFile *GetObjectFileByCompUnitInfo(CompileUnitInfo *comp_unit_info);
 
-  lldb_private::ObjectFile *GetObjectFileByOSOIndex(uint32_t oso_idx);
+  ObjectFile *GetObjectFileByOSOIndex(uint32_t oso_idx);
 
   uint32_t GetCompUnitInfoIndex(const CompileUnitInfo *comp_unit_info);
 
-  SymbolFileDWARF *GetSymbolFile(const lldb_private::SymbolContext &sc);
-  SymbolFileDWARF *GetSymbolFile(const lldb_private::CompileUnit &comp_unit);
+  SymbolFileDWARF *GetSymbolFile(const SymbolContext &sc);
+  SymbolFileDWARF *GetSymbolFile(const CompileUnit &comp_unit);
 
   SymbolFileDWARF *GetSymbolFileByCompUnitInfo(CompileUnitInfo *comp_unit_info);
 
@@ -280,11 +260,11 @@ protected:
   static int SymbolContainsSymbolWithID(lldb::user_id_t *symbol_idx_ptr,
                                         const CompileUnitInfo *comp_unit_info);
 
-  void PrivateFindGlobalVariables(
-      lldb_private::ConstString name,
-      const lldb_private::CompilerDeclContext &parent_decl_ctx,
-      const std::vector<uint32_t> &name_symbol_indexes, uint32_t max_matches,
-      lldb_private::VariableList &variables);
+  void
+  PrivateFindGlobalVariables(ConstString name,
+                             const CompilerDeclContext &parent_decl_ctx,
+                             const std::vector<uint32_t> &name_symbol_indexes,
+                             uint32_t max_matches, VariableList &variables);
 
   void SetCompileUnit(SymbolFileDWARF *oso_dwarf,
                       const lldb::CompUnitSP &cu_sp);
@@ -302,8 +282,7 @@ protected:
   bool Supports_DW_AT_APPLE_objc_complete_type(SymbolFileDWARF *skip_dwarf_oso);
 
   lldb::TypeSP FindCompleteObjCDefinitionTypeForDIE(
-      const DWARFDIE &die, lldb_private::ConstString type_name,
-      bool must_be_implementation);
+      const DWARFDIE &die, ConstString type_name, bool must_be_implementation);
 
   UniqueDWARFASTTypeMap &GetUniqueDWARFASTTypeMap() {
     return m_unique_ast_type_map;
@@ -334,19 +313,16 @@ protected:
     lldb::addr_t m_oso_file_addr = LLDB_INVALID_ADDRESS;
   };
 
-  typedef lldb_private::RangeDataVector<lldb::addr_t, lldb::addr_t, OSOEntry>
-      DebugMap;
+  typedef RangeDataVector<lldb::addr_t, lldb::addr_t, OSOEntry> DebugMap;
 
   // Member Variables
   std::bitset<kNumFlags> m_flags;
   std::vector<CompileUnitInfo> m_compile_unit_infos;
   std::vector<uint32_t> m_func_indexes; // Sorted by address
   std::vector<uint32_t> m_glob_indexes;
-  std::map<std::pair<lldb_private::ConstString, llvm::sys::TimePoint<>>,
-           OSOInfoSP>
-      m_oso_map;
+  std::map<std::pair<ConstString, llvm::sys::TimePoint<>>, OSOInfoSP> m_oso_map;
   UniqueDWARFASTTypeMap m_unique_ast_type_map;
-  lldb_private::LazyBool m_supports_DW_AT_APPLE_objc_complete_type;
+  LazyBool m_supports_DW_AT_APPLE_objc_complete_type;
   DebugMap m_debug_map;
 
   // When an object file from the debug map gets parsed in
@@ -370,7 +346,7 @@ protected:
   /// \return
   ///     Returns true if \a addr was converted to be an executable
   ///     section/offset address, false otherwise.
-  bool LinkOSOAddress(lldb_private::Address &addr);
+  bool LinkOSOAddress(Address &addr);
 
   /// Convert a .o file "file address" to an executable "file address".
   ///
@@ -401,12 +377,13 @@ protected:
   ///     Returns a valid line table full of linked addresses, or NULL
   ///     if none of the line table addresses exist in the main
   ///     executable.
-  lldb_private::LineTable *
-  LinkOSOLineTable(SymbolFileDWARF *oso_symfile,
-                   lldb_private::LineTable *line_table);
+  LineTable *LinkOSOLineTable(SymbolFileDWARF *oso_symfile,
+                              LineTable *line_table);
 
   size_t AddOSOARanges(SymbolFileDWARF *dwarf2Data,
                        DWARFDebugAranges *debug_aranges);
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_SYMBOLFILEDWARFDEBUGMAP_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
@@ -21,6 +21,7 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::plugin::dwarf;
 
 char SymbolFileDWARFDwo::ID;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
@@ -12,6 +12,8 @@
 #include "SymbolFileDWARF.h"
 #include <optional>
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class SymbolFileDWARFDwo : public SymbolFileDWARF {
   /// LLVM RTTI support.
   static char ID;
@@ -32,7 +34,7 @@ public:
 
   DWARFCompileUnit *GetDWOCompileUnitForHash(uint64_t hash);
 
-  void GetObjCMethods(lldb_private::ConstString class_name,
+  void GetObjCMethods(ConstString class_name,
                       llvm::function_ref<bool(DWARFDIE die)> callback) override;
 
   llvm::Expected<lldb::TypeSystemSP>
@@ -41,15 +43,13 @@ public:
   DWARFDIE
   GetDIE(const DIERef &die_ref) override;
 
-  lldb::offset_t
-  GetVendorDWARFOpcodeSize(const lldb_private::DataExtractor &data,
-                           const lldb::offset_t data_offset,
-                           const uint8_t op) const override;
+  lldb::offset_t GetVendorDWARFOpcodeSize(const DataExtractor &data,
+                                          const lldb::offset_t data_offset,
+                                          const uint8_t op) const override;
 
-  bool ParseVendorDWARFOpcode(
-      uint8_t op, const lldb_private::DataExtractor &opcodes,
-      lldb::offset_t &offset,
-      std::vector<lldb_private::Value> &stack) const override;
+  bool ParseVendorDWARFOpcode(uint8_t op, const DataExtractor &opcodes,
+                              lldb::offset_t &offset,
+                              std::vector<Value> &stack) const override;
 
 protected:
   DIEToTypePtr &GetDIEToType() override;
@@ -65,9 +65,10 @@ protected:
   lldb::TypeSP
   FindDefinitionTypeForDWARFDeclContext(const DWARFDIE &die) override;
 
-  lldb::TypeSP FindCompleteObjCDefinitionTypeForDIE(
-      const DWARFDIE &die, lldb_private::ConstString type_name,
-      bool must_be_implementation) override;
+  lldb::TypeSP
+  FindCompleteObjCDefinitionTypeForDIE(const DWARFDIE &die,
+                                       ConstString type_name,
+                                       bool must_be_implementation) override;
 
   SymbolFileDWARF &GetBaseSymbolFile() const { return m_base_symbol_file; }
 
@@ -77,5 +78,7 @@ protected:
 
   SymbolFileDWARF &m_base_symbol_file;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_SYMBOLFILEDWARFDWO_H

--- a/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Core/Declaration.h"
 
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 
 bool UniqueDWARFASTTypeList::Find(const DWARFDIE &die,
                                   const lldb_private::Declaration &decl,

--- a/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/UniqueDWARFASTType.h
@@ -16,13 +16,15 @@
 #include "DWARFDIE.h"
 #include "lldb/Core/Declaration.h"
 
+namespace lldb_private::plugin {
+namespace dwarf {
 class UniqueDWARFASTType {
 public:
   // Constructors and Destructors
   UniqueDWARFASTType() : m_type_sp(), m_die(), m_declaration() {}
 
   UniqueDWARFASTType(lldb::TypeSP &type_sp, const DWARFDIE &die,
-                     const lldb_private::Declaration &decl, int32_t byte_size)
+                     const Declaration &decl, int32_t byte_size)
       : m_type_sp(type_sp), m_die(die), m_declaration(decl),
         m_byte_size(byte_size) {}
 
@@ -44,7 +46,7 @@ public:
 
   lldb::TypeSP m_type_sp;
   DWARFDIE m_die;
-  lldb_private::Declaration m_declaration;
+  Declaration m_declaration;
   int32_t m_byte_size = -1;
 };
 
@@ -60,7 +62,7 @@ public:
     m_collection.push_back(entry);
   }
 
-  bool Find(const DWARFDIE &die, const lldb_private::Declaration &decl,
+  bool Find(const DWARFDIE &die, const Declaration &decl,
             const int32_t byte_size, UniqueDWARFASTType &entry) const;
 
 protected:
@@ -74,14 +76,12 @@ public:
 
   ~UniqueDWARFASTTypeMap() = default;
 
-  void Insert(lldb_private::ConstString name,
-              const UniqueDWARFASTType &entry) {
+  void Insert(ConstString name, const UniqueDWARFASTType &entry) {
     m_collection[name.GetCString()].Append(entry);
   }
 
-  bool Find(lldb_private::ConstString name, const DWARFDIE &die,
-            const lldb_private::Declaration &decl, const int32_t byte_size,
-            UniqueDWARFASTType &entry) const {
+  bool Find(ConstString name, const DWARFDIE &die, const Declaration &decl,
+            const int32_t byte_size, UniqueDWARFASTType &entry) const {
     const char *unique_name_cstr = name.GetCString();
     collection::const_iterator pos = m_collection.find(unique_name_cstr);
     if (pos != m_collection.end()) {
@@ -95,5 +95,7 @@ protected:
   typedef llvm::DenseMap<const char *, UniqueDWARFASTTypeList> collection;
   collection m_collection;
 };
+} // namespace dwarf
+} // namespace lldb_private::plugin
 
 #endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_UNIQUEDWARFASTTYPE_H

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -86,6 +86,7 @@
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
 using namespace clang;
 using llvm::StringSwitch;
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -514,7 +514,7 @@ public:
                                               size_t bit_size);
 
   // TypeSystem methods
-  DWARFASTParser *GetDWARFParser() override;
+  plugin::dwarf::DWARFASTParser *GetDWARFParser() override;
   PDBASTParser *GetPDBParser() override;
   npdb::PdbAstBuilder *GetNativePDBParser() override;
 


### PR DESCRIPTION
As a followup of https://github.com/llvm/llvm-project/pull/67851, I'm defining a new namespace `lldb_plugin::dwarf` for the classes in this Plugins/SymbolFile/DWARF folder. This change is very NFC and helped me with exporting the necessary symbols for my out-of-tree language plugin. The only class that I didn't change is ClangDWARFASTParser, because that shouldn't be in the same namespace as the generic language-agnostic dwarf parser.
It would be a good idea if other plugins follow the same namespace scheme.
