### PR TITLE
[mlir][dataflow] Remove early exit in dead code analysis for zero-operand returns

### DIFF
--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -407,10 +407,6 @@ void DeadCodeAnalysis::visitRegionTerminator(
 
 void DeadCodeAnalysis::visitCallableTerminator(Operation *op,
                                                CallableOpInterface callable) {
-  // If there are no exiting values, we have nothing to do.
-  if (op->getNumOperands() == 0)
-    return;
-
   // Add as predecessors to all callsites this return op.
   auto *callsites = getOrCreateFor<PredecessorState>(op, callable);
   bool canResolve = op->hasTrait<OpTrait::ReturnLike>();

--- a/mlir/test/Analysis/DataFlow/test-dead-code-analysis.mlir
+++ b/mlir/test/Analysis/DataFlow/test-dead-code-analysis.mlir
@@ -118,6 +118,18 @@ func.func @test_callgraph(%cond: i1, %arg0: i32) -> i32 {
   return %2 : i32
 }
 
+func.func private @bax(%arg0: i32) {
+  return {void_return}
+}
+
+func.func @test_callgraph_void_return(%arg0: i32) -> i32 {
+  // CHECK: call_void_return:
+  // CHECK: op_preds: (all) predecessors:
+  // CHECK:   func.return {void_return}
+  func.call @bax(%arg0) {tag = "call_void_return"}: (i32) -> ()
+  return %arg0 : i32
+}
+
 // CHECK: test_unknown_branch:
 // CHECK:  region #0
 // CHECK:   ^bb0 = live

--- a/mlir/test/Analysis/DataFlow/test-last-modified-callgraph.mlir
+++ b/mlir/test/Analysis/DataFlow/test-last-modified-callgraph.mlir
@@ -68,6 +68,23 @@ func.func @test_multiple_return_sites(%cond: i1, %a: i32, %ptr: memref<i32>) -> 
 
 // -----
 
+// CHECK-LABEL: test_tag: after_call
+// CHECK: operand #0
+// CHECK-NEXT: - write0
+func.func private @void_return(%ptr: memref<i32>) {
+  return
+}
+
+func.func @test_call_void_return() {
+  %ptr = memref.alloc() : memref<i32>
+  %c0 = arith.constant 0 : i32
+  memref.store %c0, %ptr[] {tag_name = "write0"} : memref<i32>
+  func.call @void_return(%ptr) : (memref<i32>) -> ()
+  memref.load %ptr[] {tag = "after_call"} : memref<i32>
+  return
+}
+
+// -----
 
 func.func private @callee(%arg0: memref<f32>) -> memref<f32> {
   %2 = arith.constant 2.0 : f32


### PR DESCRIPTION
The PredecessorState in dead code analysis does not register zero-operand returns as predecessors of their corresponding call ops. This causes bugs with dense dataflow analyses that use dead code analysis to query for the predecessors of CallOpInterfaces.

This was reasonable for sparse analyses, but isn't for dense ones.