### PR TITLE
[clang] NFC: Remove unused `FileEntry::getLastRef()`

### DIFF
--- a/clang/include/clang/Basic/FileEntry.h
+++ b/clang/include/clang/Basic/FileEntry.h
@@ -426,7 +426,6 @@ class FileEntry {
 public:
   ~FileEntry();
   StringRef getName() const { return LastRef->getName(); }
-  FileEntryRef getLastRef() const { return *LastRef; }
 
   StringRef tryGetRealPathName() const { return RealPathName; }
   off_t getSize() const { return Size; }


### PR DESCRIPTION
The last usage of the deprecated `FileEntry::getLastRef()` was removed in #67838, let's remove it entirely.