### PR TITLE
[clang] NFC: Deprecate `FileEntry::getName()`

### DIFF
--- a/clang/include/clang/Basic/FileEntry.h
+++ b/clang/include/clang/Basic/FileEntry.h
@@ -394,6 +394,7 @@ class FileEntry {
 
 public:
   ~FileEntry();
+  LLVM_DEPRECATED("Use FileEntryRef::getName() instead.", "")
   StringRef getName() const { return LastRef->getName(); }
 
   StringRef tryGetRealPathName() const { return RealPathName; }

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -284,7 +284,6 @@ TEST_F(FileManagerTest, getFileRefReturnsCorrectNameForDifferentStatPath) {
   ASSERT_FALSE(!F1Alias);
   ASSERT_FALSE(!F1Alias2);
   EXPECT_EQ("dir/f1.cpp", F1->getName());
-  EXPECT_EQ("dir/f1.cpp", F1->getFileEntry().getName());
   EXPECT_EQ("dir/f1.cpp", F1Alias->getName());
   EXPECT_EQ("dir/f1.cpp", F1Alias2->getName());
   EXPECT_EQ(&F1->getFileEntry(), &F1Alias->getFileEntry());
@@ -303,7 +302,6 @@ TEST_F(FileManagerTest, getFileRefReturnsCorrectNameForDifferentStatPath) {
   ASSERT_FALSE(!F2Alias);
   ASSERT_FALSE(!F2Alias2);
   EXPECT_EQ("dir/f2.cpp", F2->getName());
-  EXPECT_EQ("dir/f2.cpp", F2->getFileEntry().getName());
   EXPECT_EQ("dir/f2.cpp", F2Alias->getName());
   EXPECT_EQ("dir/f2.cpp", F2Alias2->getName());
   EXPECT_EQ(&F2->getFileEntry(), &F2Alias->getFileEntry());

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -284,6 +284,9 @@ TEST_F(FileManagerTest, getFileRefReturnsCorrectNameForDifferentStatPath) {
   ASSERT_FALSE(!F1Alias);
   ASSERT_FALSE(!F1Alias2);
   EXPECT_EQ("dir/f1.cpp", F1->getName());
+  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN
+  EXPECT_EQ("dir/f1.cpp", F1->getFileEntry().getName());
+  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END
   EXPECT_EQ("dir/f1.cpp", F1Alias->getName());
   EXPECT_EQ("dir/f1.cpp", F1Alias2->getName());
   EXPECT_EQ(&F1->getFileEntry(), &F1Alias->getFileEntry());
@@ -302,6 +305,9 @@ TEST_F(FileManagerTest, getFileRefReturnsCorrectNameForDifferentStatPath) {
   ASSERT_FALSE(!F2Alias);
   ASSERT_FALSE(!F2Alias2);
   EXPECT_EQ("dir/f2.cpp", F2->getName());
+  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN
+  EXPECT_EQ("dir/f2.cpp", F2->getFileEntry().getName());
+  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END
   EXPECT_EQ("dir/f2.cpp", F2Alias->getName());
   EXPECT_EQ("dir/f2.cpp", F2Alias2->getName());
   EXPECT_EQ(&F2->getFileEntry(), &F2Alias->getFileEntry());

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -284,9 +284,9 @@ TEST_F(FileManagerTest, getFileRefReturnsCorrectNameForDifferentStatPath) {
   ASSERT_FALSE(!F1Alias);
   ASSERT_FALSE(!F1Alias2);
   EXPECT_EQ("dir/f1.cpp", F1->getName());
-  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   EXPECT_EQ("dir/f1.cpp", F1->getFileEntry().getName());
-  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
   EXPECT_EQ("dir/f1.cpp", F1Alias->getName());
   EXPECT_EQ("dir/f1.cpp", F1Alias2->getName());
   EXPECT_EQ(&F1->getFileEntry(), &F1Alias->getFileEntry());
@@ -305,9 +305,9 @@ TEST_F(FileManagerTest, getFileRefReturnsCorrectNameForDifferentStatPath) {
   ASSERT_FALSE(!F2Alias);
   ASSERT_FALSE(!F2Alias2);
   EXPECT_EQ("dir/f2.cpp", F2->getName());
-  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
   EXPECT_EQ("dir/f2.cpp", F2->getFileEntry().getName());
-  LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END
+  LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
   EXPECT_EQ("dir/f2.cpp", F2Alias->getName());
   EXPECT_EQ("dir/f2.cpp", F2Alias2->getName());
   EXPECT_EQ(&F2->getFileEntry(), &F2Alias->getFileEntry());

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -159,20 +159,20 @@
 
 // clang-format off
 #if defined(__clang__) || defined(__GNUC__)
-#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN                         \
+#define LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH                             \
   _Pragma("GCC diagnostic push")                                               \
   _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END                           \
+#define LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP                              \
   _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)
-#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN                         \
+#define LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH                             \
   _Pragma("warning(push)")                                                     \
   _Pragma("warning(disable : 4996)")
-#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END                           \
+#define LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP                              \
   _Pragma("warning(pop)")
 #else
-#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN
-#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END
+#define LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_PUSH
+#define LLVM_SUPPRESS_DEPRECATED_DECLARATIONS_POP
 #endif
 // clang-format on
 

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -157,6 +157,25 @@
 #define LLVM_DEPRECATED(MSG, FIX) [[deprecated(MSG)]]
 #endif
 
+// clang-format off
+#if defined(__clang__) || defined(__GNUC__)
+#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN                         \
+  _Pragma("GCC diagnostic push")                                               \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END                           \
+  _Pragma("GCC diagnostic pop")
+#elif defined(_MSC_VER)
+#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN                         \
+  _Pragma("warning(push)")                                                     \
+  _Pragma("warning(disable : 4996)")
+#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END                           \
+  _Pragma("warning(pop)")
+#else
+#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_BEGIN
+#define LLVM_IGNORE_DEPRECATIONS_OF_DECLARATIONS_END
+#endif
+// clang-format on
+
 // Indicate that a non-static, non-const C++ member function reinitializes
 // the entire object to a known state, independent of the previous state of
 // the object.


### PR DESCRIPTION
All uses of `FileEntry::getName()` were removed in favor of `FileEntryRef::getName()`. This patch finally formally deprecates that function. The plan is to remove it entirely in the main branch after we cut the release branch for LLVM 18.