### PR TITLE
Fix the Modules/compiler_builtins.m test

### DIFF
--- a/clang/test/Modules/Inputs/System/usr/include/stdint.h
+++ b/clang/test/Modules/Inputs/System/usr/include/stdint.h
@@ -30,6 +30,7 @@ typedef unsigned int uintmax_t;
 
 // additional types for unwind.h
 
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
 
 #endif /* STDINT_H */


### PR DESCRIPTION
Sometimes unwind.h needs uint32_t also.