### PR TITLE
[Clang][CodeGen] Fix use of CXXThisValue with StrictVTablePointers

### DIFF
--- a/clang/test/CodeGenCXX/strict-vtable-pointers-GH67937.cpp
+++ b/clang/test/CodeGenCXX/strict-vtable-pointers-GH67937.cpp
@@ -1,6 +1,5 @@
-// RUN: %clang_cc1 %s -I%S -triple=x86_64-pc-windows-msvc -fstrict-vtable-pointers -disable-llvm-passes -disable-llvm-verifier -O1 -emit-llvm -o %t.ll
+// RUN: %clang_cc1 %s -I%S -triple=x86_64-pc-windows-msvc -fstrict-vtable-pointers -disable-llvm-passes -O1 -emit-llvm -o %t.ll
 // RUN: FileCheck %s < %t.ll
-// RUN: not llvm-as < %t.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-VERIFIER
 
 struct A {
   virtual ~A();
@@ -8,11 +7,6 @@ struct A {
 struct B : virtual A {};
 class C : B {};
 C foo;
-
-// FIXME: This is not supposed to generate invalid IR!
-// CHECK-VERIFIER: Instruction does not dominate all uses!
-// CHECK-VERIFIER-NEXT: %1 = call ptr @llvm.launder.invariant.group.p0(ptr %this1)
-// CHECK-VERIFIER-NEXT: %3 = call ptr @llvm.launder.invariant.group.p0(ptr %1)
 
 // CHECK-LABEL: define {{.*}} @"??0C@@QEAA@XZ"(ptr {{.*}} %this, i32 {{.*}} %is_most_derived)
 // CHECK: ctor.init_vbases:
@@ -24,6 +18,5 @@ C foo;
 // CHECK-NEXT: br label %ctor.skip_vbases
 // CHECK-EMPTY:
 // CHECK-NEXT: ctor.skip_vbases:
-// FIXME: Should be using '%this1' instead of %1 below.
-// CHECK-NEXT: %3 = call ptr @llvm.launder.invariant.group.p0(ptr %1)
+// CHECK-NEXT: %3 = call ptr @llvm.launder.invariant.group.p0(ptr %this1)
 // CHECK-NEXT: %call3 = call noundef ptr @"??0B@@QEAA@XZ"(ptr {{.*}} %3, i32 noundef 0) #2


### PR DESCRIPTION
When emitting non-virtual base initializers for the constructor prologue,
we would potentially use a re-laundered this pointer value from a
previous block, which subsequently would not dominate this use.

With this fix, we always launder the original CXXThisValue.

This fixes https://github.com/llvm/llvm-project/issues/67937