### PR TITLE
[Support] Rename HashBuilderImpl to HashBuilder (NFC)

### DIFF
--- a/clang/include/clang/Basic/ObjCRuntime.h
+++ b/clang/include/clang/Basic/ObjCRuntime.h
@@ -483,7 +483,7 @@ public:
   }
 
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const ObjCRuntime &OCR) {
     HBuilder.add(OCR.getKind(), OCR.getVersion());
   }

--- a/clang/include/clang/Basic/Sanitizers.h
+++ b/clang/include/clang/Basic/Sanitizers.h
@@ -78,7 +78,7 @@ public:
   llvm::hash_code hash_value() const;
 
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const SanitizerMask &SM) {
     HBuilder.addRange(&SM.maskLoToHigh[0], &SM.maskLoToHigh[kNumElem]);
   }

--- a/clang/include/clang/Lex/HeaderSearchOptions.h
+++ b/clang/include/clang/Lex/HeaderSearchOptions.h
@@ -268,7 +268,7 @@ inline llvm::hash_code hash_value(const HeaderSearchOptions::Entry &E) {
 }
 
 template <typename HasherT, llvm::support::endianness Endianness>
-inline void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+inline void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                     const HeaderSearchOptions::Entry &E) {
   HBuilder.add(E.Path, E.Group, E.IsFramework, E.IgnoreSysRoot);
 }
@@ -279,7 +279,7 @@ hash_value(const HeaderSearchOptions::SystemHeaderPrefix &SHP) {
 }
 
 template <typename HasherT, llvm::support::endianness Endianness>
-inline void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+inline void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                     const HeaderSearchOptions::SystemHeaderPrefix &SHP) {
   HBuilder.add(SHP.Prefix, SHP.IsSystemHeader);
 }

--- a/clang/include/clang/Serialization/ModuleFileExtension.h
+++ b/clang/include/clang/Serialization/ModuleFileExtension.h
@@ -86,8 +86,7 @@ public:
   /// The default implementation of this function simply does nothing, so the
   /// presence/absence of this extension does not distinguish module files.
   using ExtensionHashBuilder =
-      llvm::HashBuilderImpl<llvm::MD5,
-                            llvm::support::endian::system_endianness()>;
+      llvm::HashBuilder<llvm::MD5, llvm::support::endian::system_endianness()>;
   virtual void hashExtension(ExtensionHashBuilder &HBuilder) const;
 
   /// Create a new module file extension writer, which will be

--- a/llvm/include/llvm/Support/VersionTuple.h
+++ b/llvm/include/llvm/Support/VersionTuple.h
@@ -22,8 +22,7 @@
 #include <tuple>
 
 namespace llvm {
-template <typename HasherT, support::endianness Endianness>
-class HashBuilderImpl;
+template <typename HasherT, support::endianness Endianness> class HashBuilder;
 class raw_ostream;
 class StringRef;
 
@@ -175,7 +174,7 @@ public:
   }
 
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(HashBuilder<HasherT, Endianness> &HBuilder,
                       const VersionTuple &VT) {
     HBuilder.add(VT.Major, VT.Minor, VT.Subminor, VT.Build);
   }

--- a/llvm/unittests/ADT/HashingTest.cpp
+++ b/llvm/unittests/ADT/HashingTest.cpp
@@ -425,7 +425,7 @@ struct StructWithHashBuilderSupport {
   char C;
   int I;
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const StructWithHashBuilderSupport &Value) {
     HBuilder.add(Value.C, Value.I);
   }
@@ -440,7 +440,7 @@ struct StructWithHashBuilderAndHashValueSupport {
   char C;
   int I;
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const StructWithHashBuilderAndHashValueSupport &Value) {}
   friend hash_code
   hash_value(const StructWithHashBuilderAndHashValueSupport &Value) {

--- a/llvm/unittests/Support/HashBuilderTest.cpp
+++ b/llvm/unittests/Support/HashBuilderTest.cpp
@@ -125,7 +125,7 @@ struct SimpleStruct {
 };
 
 template <typename HasherT, llvm::support::endianness Endianness>
-void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
              const SimpleStruct &Value) {
   HBuilder.add(Value.C);
   HBuilder.add(Value.I);
@@ -139,7 +139,7 @@ struct StructWithoutCopyOrMove {
   StructWithoutCopyOrMove &operator=(const StructWithoutCopyOrMove &) = delete;
 
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const StructWithoutCopyOrMove &Value) {
     HBuilder.add(Value.I);
   }
@@ -154,7 +154,7 @@ struct /* __attribute__((packed)) */ StructWithFastHash {
   // If possible, we want to hash both `I` and `C` in a single `update`
   // call for performance concerns.
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const StructWithFastHash &Value) {
     if (Endianness == llvm::support::endian::system_endianness()) {
       HBuilder.update(llvm::ArrayRef(reinterpret_cast<const uint8_t *>(&Value),
@@ -178,7 +178,7 @@ public:
       Elements[I] = I;
   }
   template <typename HasherT, llvm::support::endianness Endianness>
-  friend void addHash(llvm::HashBuilderImpl<HasherT, Endianness> &HBuilder,
+  friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const CustomContainer &Value) {
     if (Endianness == llvm::support::endian::system_endianness()) {
       HBuilder.update(llvm::ArrayRef(


### PR DESCRIPTION
Commit 9370271ec5debcb59e34629d5bd357c44213b2d3 made HashBuilder an
alias for HashBuilderImpl:

  template <class HasherT, support::endianness Endianness>
  using HashBuilder = HashBuilderImpl<HasherT, Endianness>;

This patch renames HashBuilderImpl to HashBuilder while removing the
alias above.
