### PR TITLE
[Support] Rename llvm::support::endianness to llvm::endianness

### DIFF
--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -22,13 +22,21 @@
 #include <type_traits>
 
 namespace llvm {
-namespace support {
 
-enum endianness {
+enum class endianness {
   big,
   little,
   native = llvm::sys::IsBigEndianHost ? big : little
 };
+
+namespace support {
+
+// TODO: Remove the following once we are done migrating to llvm::endianness,
+// llvm::endianness::big, etc.
+using endianness = llvm::endianness;
+constexpr llvm::endianness big = llvm::endianness::big;
+constexpr llvm::endianness little = llvm::endianness::little;
+constexpr llvm::endianness native = llvm::endianness::native;
 
 // These are named values for common alignments.
 enum {aligned = 0, unaligned = 1};


### PR DESCRIPTION
As part of an effort to make our codebase ready for the migration from
llvm::support::endianness to std::endian in C++20, this patch renames
llvm::support::endianness to llvm::endianness.

The intent of this patch is to make fully qualified names less
painful.  That is, with this patch, we can just say
llvm::endianness::big rather than llvm::support::endianness::big.

I'm not renaming llvm::support::endianness to llvm::endian because we
have a lot of places with "using namespace support;" where it would be
ambiguous whether "endian" refers to llvm::endian or
llvm::support::endian.

This patch defines several helpers for gradual migration:

  namespace llvm {
  namespace support {
  using endianness = llvm::endianness;
  constexpr llvm::endianness big = llvm::endianness::big;
  constexpr llvm::endianness little = llvm::endianness::little;
  constexpr llvm::endianness native = llvm::endianness::native;

While we are at it, this patch changes the enum to "enum class".  The
"enum class" prevents implicit conversions from endianness to bool.
I've fixed three such instances of implicit conversions:

  95f4b2a70850b5e6ab83ec21af3fe5246cac0675
  8de2ecc2e75d496fc7fc8a24c3acf71732a3bd0c
  a7517e12caab0750d3dfd7c0c6faec9acc7e5a2b
