### PR TITLE
[clangd] Adapt Inlay Hint support for Deducing This

### DIFF
--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -872,7 +872,8 @@ private:
     else
       ForwardedParams = {Params.begin(), Params.end()};
 
-    auto ForwardedParamsRef = maybeDropCxxExplicitObjectParameters(ForwardedParams);
+    auto ForwardedParamsRef =
+        maybeDropCxxExplicitObjectParameters(ForwardedParams);
     NameVec ParameterNames = chooseParameterNames(ForwardedParamsRef);
 
     // Exclude setters (i.e. functions with one argument whose name begins with

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -872,7 +872,7 @@ private:
           maybeDropCxxExplicitObjectParameters(ForwardedParamsStorage);
     } else {
       Params = maybeDropCxxExplicitObjectParameters(Callee.Loc.getParams());
-      ForwardedParamsStorage = {Params.begin(), Params.end()};
+      ForwardedParams = {Params.begin(), Params.end()};
     }
 
     NameVec ParameterNames = chooseParameterNames(ForwardedParams);


### PR DESCRIPTION
This is a follow-up for D140828, making Clangd omit the explicit object parameter in a call to member function with Deducing This.

Given that the parent patch is still in its infancy and might undergo several reverting-relanding processes, one can feel free to revert this if encountering any CI failure. And please let me know if I should alter anything.