### PR TITLE
[mlir] Add `opt-level` to `test-lower-to-nvvm` Pipeline

### DIFF
--- a/mlir/test/lib/Dialect/GPU/TestLowerToNVVM.cpp
+++ b/mlir/test/lib/Dialect/GPU/TestLowerToNVVM.cpp
@@ -74,6 +74,10 @@ struct TestLowerToNVVMOptions
       *this, "cubin-format",
       llvm::cl::desc("Compilation format to use to serialize to cubin."),
       llvm::cl::init("isa")};
+  PassOptions::Option<int> optLevel{
+      *this, "opt-level",
+      llvm::cl::desc("Optimization level for NVVM compilation"),
+      llvm::cl::init(2)};
 };
 
 //===----------------------------------------------------------------------===//
@@ -242,6 +246,7 @@ void buildLowerToNVVMPassPipeline(OpPassManager &pm,
   nvvmTargetOptions.triple = options.cubinTriple;
   nvvmTargetOptions.chip = options.cubinChip;
   nvvmTargetOptions.features = options.cubinFeatures;
+  nvvmTargetOptions.optLevel = options.optLevel;
   pm.addPass(createGpuNVVMAttachTarget(nvvmTargetOptions));
 
   // Convert GPU to LLVM.


### PR DESCRIPTION
This PR adds the `opt-level` parameter to control code optimization for NVIDIA GPU targets in the `test-lower-to-nvvm` pipeline.