### PR TITLE
[lldb][test] Remove expected failure marker for TestPlatformAttach on windows

### DIFF
--- a/lldb/test/API/functionalities/gdb_remote_client/TestPlatformAttach.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPlatformAttach.py
@@ -7,7 +7,6 @@ from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
 
 class TestPlatformAttach(GDBRemoteTestBase):
     @skipIfRemote
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr52451")
     def test_attach(self):
         """Test attaching by name"""
 


### PR DESCRIPTION
Looks like this test passes since #68050.