### PR TITLE
[SPIRV] Do not remove capability from all caps

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -528,8 +528,8 @@ void SPIRV::RequirementHandler::addAvailableCaps(const CapabilityList &ToAdd) {
 void SPIRV::RequirementHandler::removeCapabilityIf(
     const Capability::Capability ToRemove,
     const Capability::Capability IfPresent) {
-  if (AvailableCaps.contains(IfPresent))
-    AvailableCaps.erase(ToRemove);
+  if (AllCaps.contains(IfPresent))
+    AllCaps.erase(ToRemove);
 }
 
 namespace llvm {

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -60,11 +60,17 @@ struct Requirements {
 struct RequirementHandler {
 private:
   CapabilityList MinimalCaps;
+  
+  // AllCaps and AvailableCaps are related but different. AllCaps is a subset of 
+  // AvailableCaps. AvailableCaps is the complete set of capabilities that are available
+  // to the current target. AllCaps is the set of capabilities that are required
+  // by the current module.
   SmallSet<Capability::Capability, 8> AllCaps;
+  DenseSet<unsigned> AvailableCaps;
+
   SmallSet<Extension::Extension, 4> AllExtensions;
   unsigned MinVersion; // 0 if no min version is defined.
   unsigned MaxVersion; // 0 if no max version is defined.
-  DenseSet<unsigned> AvailableCaps;
   // Remove a list of capabilities from dedupedCaps and add them to AllCaps,
   // recursing through their implicitly declared capabilities too.
   void pruneCapabilities(const CapabilityList &ToPrune);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -60,11 +60,11 @@ struct Requirements {
 struct RequirementHandler {
 private:
   CapabilityList MinimalCaps;
-  
-  // AllCaps and AvailableCaps are related but different. AllCaps is a subset of 
-  // AvailableCaps. AvailableCaps is the complete set of capabilities that are available
-  // to the current target. AllCaps is the set of capabilities that are required
-  // by the current module.
+
+  // AllCaps and AvailableCaps are related but different. AllCaps is a subset of
+  // AvailableCaps. AvailableCaps is the complete set of capabilities that are
+  // available to the current target. AllCaps is the set of capabilities that
+  // are required by the current module.
   SmallSet<Capability::Capability, 8> AllCaps;
   DenseSet<unsigned> AvailableCaps;
 


### PR DESCRIPTION
We were removing bit_instructions cap from All caps but this was a mistake.

Test SPV_KHR_bit_instructions was failing. Remove function removeCapabilityIf. It was not being done correctly and is now unnecessary.