### PR TITLE
[mlir][tensor][bufferize] `tensor.empty` bufferizes to allocation

### DIFF
--- a/mlir/lib/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -260,6 +260,8 @@ struct DimOpInterface
 struct EmptyOpInterface
     : public BufferizableOpInterface::ExternalModel<EmptyOpInterface,
                                                     tensor::EmptyOp> {
+  bool bufferizesToAllocation(Operation *op, Value value) const { return true; }
+
   bool resultBufferizesToMemoryWrite(Operation *op, OpResult opResult,
                                      const AnalysisState &state) const {
     // The returned tensor does not have specified contents.


### PR DESCRIPTION
`BufferizableOpInterface::bufferizesToAllocation` is queried when forming equivalence sets during bufferization. It is not really needed for ops like `tensor.empty` which do not have tensor operands, but it should be added for consistency.

This change should have been part of #68080. No test is added because the return value of this function is irrelevant for ops without tensor operands. (However, this function acts as a form documentation, describing the bufferization semantics of the op.)