### PR TITLE
[clang][dataflow] HTML logger: Mark iterations that have converged.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
@@ -45,6 +45,7 @@
     {{entry.block}}
     <template data-if="entry.post_visit">(post-visit)</template>
     <template data-if="!entry.post_visit">({{entry.iter}})</template>
+    <template data-if="entry.converged"> &#x2192;&#x7c;<!--Rightwards arrow, vertical line--></template>
   </div>
 </template>
 </section>
@@ -62,6 +63,7 @@
     <a class="chooser {{selection.bb}}:{{iter.iter}}" data-iter="{{selection.bb}}:{{iter.iter}}">
       <template data-if="iter.post_visit">Post-visit</template>
       <template data-if="!iter.post_visit">Iteration {{iter.iter}}</template>
+      <template data-if="iter.converged"> &#x2192;&#x7c;<!--Rightwards arrow, vertical line--></template>
     </a>
   </template>
 </div>


### PR DESCRIPTION
I've eliminated the `logText("Block converged")` call entirely because

a) These logs are associated with an individual `CFGElement`, while convergence
   should be associated with a block, and

b) The log message was being associated with the wrong block: `recordState()`
   dumps all of the pending log messages, but `blockConverged()` is called after
   the last `recordState()` call for a given block, so that the "Block
   converged" log message was being associated with the first element of the
   _next_ block to be processed.

Example:

![image](https://github.com/llvm/llvm-project/assets/29098113/6a19095c-2dbb-4771-9485-e8e45c9d26fb)

