### PR TITLE
[libcxx] [test] Quote the python executable in the executor

### DIFF
--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -7,15 +7,11 @@
 # ===----------------------------------------------------------------------===##
 import sys
 import re
-import subprocess
+import shlex
 from pathlib import Path
 
 from libcxx.test.dsl import *
 from libcxx.test.features import _isMSVC
-
-
-def quote(x):
-    return subprocess.list2cmdline([x])
 
 
 _warningFlags = [
@@ -325,7 +321,7 @@ DEFAULT_PARAMETERS = [
     Parameter(
         name="executor",
         type=str,
-        default=f"{quote(sys.executable)} {quote(str(Path(__file__).resolve().parent.parent.parent / 'run.py'))}",
+        default=f"{shlex.quote(sys.executable)} {shlex.quote(str(Path(__file__).resolve().parent.parent.parent / 'run.py'))}",
         help="Custom executor to use instead of the configured default.",
         actions=lambda executor: [AddSubstitution("%{executor}", executor)],
     )

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -320,7 +320,7 @@ DEFAULT_PARAMETERS = [
     Parameter(
         name="executor",
         type=str,
-        default=f"{sys.executable} {Path(__file__).resolve().parent.parent.parent / 'run.py'}",
+        default=f"\"{sys.executable}\" {Path(__file__).resolve().parent.parent.parent / 'run.py'}",
         help="Custom executor to use instead of the configured default.",
         actions=lambda executor: [AddSubstitution("%{executor}", executor)],
     )

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -7,10 +7,15 @@
 # ===----------------------------------------------------------------------===##
 import sys
 import re
+import subprocess
 from pathlib import Path
 
 from libcxx.test.dsl import *
 from libcxx.test.features import _isMSVC
+
+
+def quote(x):
+    return subprocess.list2cmdline([x])
 
 
 _warningFlags = [
@@ -320,7 +325,7 @@ DEFAULT_PARAMETERS = [
     Parameter(
         name="executor",
         type=str,
-        default=f"\"{sys.executable}\" {Path(__file__).resolve().parent.parent.parent / 'run.py'}",
+        default=f"{quote(sys.executable)} {quote(str(Path(__file__).resolve().parent.parent.parent / 'run.py'))}",
         help="Custom executor to use instead of the configured default.",
         actions=lambda executor: [AddSubstitution("%{executor}", executor)],
     )


### PR DESCRIPTION
This reapplies the change from
c218c80c730a14a1cbcebd588b18220a879702c6, which was lost in the refactoring in 78d649a417b48cb8a2ba2e755f0e7c8fb8b1bb83.

On Windows, the Python interpreter is by default installed in a path like "C:\Program Files\Python38\python.exe", which requires quoting when included in a concatenated command string (as opposed to a command list, where each argument is a separate element).

This doesn't show up in the CI environments as they use Python installed in a different directory, like C:\Python.