### PR TITLE
[libcxx] [test] Add a test parameter for disabling memory intensive tests

### DIFF
--- a/libcxx/test/std/input.output/string.streams/stringstream/stringstream.members/gcount.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/stringstream/stringstream.members/gcount.pass.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: 32-bit-pointer
+// REQUIRES: large_tests
 
 // Test that tellp() does not break the stringstream after INT_MAX, due to use
 // of pbump() that accept int.

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -279,6 +279,14 @@ DEFAULT_PARAMETERS = [
         actions=lambda enabled: [] if not enabled else [AddFeature("long_tests")],
     ),
     Parameter(
+        name="large_tests",
+        choices=[True, False],
+        type=bool,
+        default=True,
+        help="Whether to enable tests that use a lot of memory. This can be useful when running on a device with limited amounts of memory.",
+        actions=lambda enabled: [] if not enabled else [AddFeature("large_tests")],
+    ),
+    Parameter(
         name="hardening_mode",
         choices=["unchecked", "hardened", "safe", "debug"],
         type=str,


### PR DESCRIPTION
Specifically, the test
std/input.output/string.streams/stringstream/stringstream.members/gcount.pass.cpp allocates a std::string with INT_MAX-1 elements, and then writes this to a std::stringstream. On Linux, running this test consumes around 5.0 GB of memory; on Windows, it ends up using up to 6.8 GB of memory.

This limits whether such tests can run on e.g. GitHub Actions runners, where the free runners are limited to 8 GB of memory.

This is somewhat similar to, but still notably different, from the existing test parameter long_tests.