### PR TITLE
[clang-repl] Disable InterpreterExceptionTest on RISC-V

### DIFF
--- a/clang/unittests/Interpreter/ExceptionTests/InterpreterExceptionTest.cpp
+++ b/clang/unittests/Interpreter/ExceptionTests/InterpreterExceptionTest.cpp
@@ -122,6 +122,11 @@ extern "C" int throw_exception() {
                               Triple.getArch() == llvm::Triple::aarch64_32))
     GTEST_SKIP();
 
+  // FIXME: RISC-V fails as .eh_frame handling is not yet implemented in
+  // JITLink for RISC-V. See PR #66067.
+  if (Triple.isRISCV())
+    GTEST_SKIP();
+
   llvm::cantFail(Interp->ParseAndExecute(ExceptionCode));
   testing::internal::CaptureStdout();
   auto ThrowException =


### PR DESCRIPTION
This test fails as .eh_frame handling is not yet implemented for RISC-V in JITLink. #66067 is proposed to address this.

Skip the test until the issue is resolved. It seems that D159167 enabled this test for more than just ppc64. As the test always failed, it just wasn't run until now, I think skipping is the correct interim approach (as is already done for Arm, Darwin, and others).