### PR TITLE
[Libomptarget] Explicitly pass the OpenMP device libraries to tests

### DIFF
--- a/openmp/libomptarget/CMakeLists.txt
+++ b/openmp/libomptarget/CMakeLists.txt
@@ -95,6 +95,16 @@ if("libc" IN_LIST LLVM_ENABLE_RUNTIMES AND (LIBC_GPU_BUILD OR
                                             LIBC_GPU_ARCHITECTURES))
   set(LIBC_GPU_SUPPORT TRUE)
 endif()
+
+# Find the path of the GPU libc static library.
+find_library(GPU_LIBC_PATH NAMES cgpu
+             PATHS ${LIBOMPTARGET_LLVM_LIBRARY_DIR} NO_DEFAULT_PATH)
+if((NOT GPU_LIBC_PATH) OR (NOT LIBC_GPU_SUPPORT))
+  set(GPU_LIBC_PATH "")
+endif()
+
+set(LIBOMPTARGET_GPU_LIBC_PATH  ${GPU_LIBC_PATH} CACHE STRING
+    "Location of the 'libcgpu.a' library ")
 set(LIBOMPTARGET_GPU_LIBC_SUPPORT ${LIBC_GPU_SUPPORT} CACHE BOOL
     "Libomptarget support for the GPU libc")
 pythonize_bool(LIBOMPTARGET_GPU_LIBC_SUPPORT)

--- a/openmp/libomptarget/test/lit.cfg
+++ b/openmp/libomptarget/test/lit.cfg
@@ -128,6 +128,7 @@ elif config.operating_system == 'Darwin':
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
 else: # Unices
+    config.test_flags += " -nogpulib"
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
     config.test_flags += " -Wl,-rpath," + config.llvm_lib_directory
@@ -150,6 +151,10 @@ def remove_suffix_if_present(name):
         return name[:-8]
     else:
         return name
+
+def add_libraries(source):
+    return source + " " + config.libomptarget_libc_path + " " + \
+           config.library_dir + "/libomptarget.devicertl.a"
 
 # substitutions
 # - for targets that exist in the system create the actual command.
@@ -229,12 +234,10 @@ for libomptarget_target in config.libomptarget_all_targets:
             "%libomptarget-run-" + libomptarget_target))
         config.substitutions.append(("%libomptarget-compilexx-" + \
             libomptarget_target, \
-            "%clangxx-" + libomptarget_target + " %s -o %t" + \
-            (" -lcgpu" if config.libomptarget_has_libc else "")))
+            "%clangxx-" + libomptarget_target + add_libraries(" %s -o %t")))
         config.substitutions.append(("%libomptarget-compile-" + \
             libomptarget_target, \
-            "%clang-" + libomptarget_target + " %s -o %t" +
-            (" -lcgpu" if config.libomptarget_has_libc else "")))
+            "%clang-" + libomptarget_target + add_libraries(" %s -o %t")))
         config.substitutions.append(("%libomptarget-compile-fortran-" + \
             libomptarget_target, \
             "%flang-" + libomptarget_target + " %s -o %t"))
@@ -256,12 +259,10 @@ for libomptarget_target in config.libomptarget_all_targets:
             "%libomptarget-run-" + libomptarget_target))
         config.substitutions.append(("%libomptarget-compileoptxx-" + \
             libomptarget_target, \
-            "%clangxx-" + libomptarget_target + " -O3 %s -o %t" +
-            (" -lcgpu" if config.libomptarget_has_libc else "")))
+            "%clangxx-" + libomptarget_target + add_libraries(" -O3 %s -o %t")))
         config.substitutions.append(("%libomptarget-compileopt-" + \
             libomptarget_target, \
-            "%clang-" + libomptarget_target + " -O3 %s -o %t" +
-            (" -lcgpu" if config.libomptarget_has_libc else "")))
+            "%clang-" + libomptarget_target + add_libraries(" -O3 %s -o %t")))
         config.substitutions.append(("%libomptarget-run-" + \
             libomptarget_target, \
             "%t"))

--- a/openmp/libomptarget/test/lit.site.cfg.in
+++ b/openmp/libomptarget/test/lit.site.cfg.in
@@ -23,6 +23,7 @@ config.libomptarget_not = "@OPENMP_NOT_EXECUTABLE@"
 config.libomptarget_debug = @LIBOMPTARGET_DEBUG@
 config.has_libomptarget_ompt = @LIBOMPTARGET_OMPT_SUPPORT@
 config.libomptarget_has_libc = @LIBOMPTARGET_GPU_LIBC_SUPPORT@
+config.libomptarget_libc_path = "@LIBOMPTARGET_GPU_LIBC_PATH@"
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg")


### PR DESCRIPTION
Summary:
We have tests that depend on two static libraries
`libomptarget.devicertl.a` and `libcgpu.a`. These are currently
implicitly picked up and searched through the standard path. This patch
changes that to pass `-nogpulib` to disable implicit runtime path
searches. We then explicitly passed the built libraries to the
compilations so that we know exactly which libraries are being used.

Depends on: https://github.com/llvm/llvm-project/pull/68220

Fixes https://github.com/llvm/llvm-project/issues/68141
