### PR TITLE
[mlir] add MlirOptMain config callback for context configuration

### DIFF
--- a/mlir/include/mlir/Dialect/Transform/IR/TransformDialect.td
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformDialect.td
@@ -63,6 +63,22 @@ def Transform_Dialect : Dialect {
       using ExtensionTypePrintingHook =
           std::function<void (::mlir::Type, ::mlir::AsmPrinter &)>;
 
+      /// Appends the given module as a transform symbol library available to
+      /// all dialect users.
+      void registerLibraryModule(
+          ::mlir::OwningOpRef<::mlir::ModuleOp> &&library) {
+        libraryModules.push_back(std::move(library));
+      }
+
+      /// Returns a range of registered library modules.
+      auto getLibraryModules() const {
+        return ::llvm::map_range(
+              libraryModules,
+              [](const ::mlir::OwningOpRef<::mlir::ModuleOp> &library) {
+                return library.get();
+              });
+      }
+
     private:
       /// Registers operations specified as template parameters with this
       /// dialect. Checks that they implement the required interfaces.
@@ -120,7 +136,12 @@ def Transform_Dialect : Dialect {
       /// A map from type TypeID to its printing function. No need to do string
       /// lookups when the type is fully constructed.
       ::llvm::DenseMap<::mlir::TypeID, ExtensionTypePrintingHook>
-      typePrintingHooks;
+          typePrintingHooks;
+
+      /// Modules containing symbols, e.g. named sequences, that will be
+      /// resolved by the interpreter when used.
+      ::llvm::SmallVector<::mlir::OwningOpRef<::mlir::ModuleOp>, 2>
+          libraryModules;
   }];
 }
 

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -61,6 +61,19 @@ public:
     return allowUnregisteredDialectsFlag;
   }
 
+  /// Set the callback to configure the context after processing the regular
+  /// dialect registry, e.g., for preloading a subset of dialects.
+  template <typename FuncTy>
+  MlirOptMainConfig &setContextConfigurationFn(FuncTy &&fn) {
+    contextConfigurationCallback = fn;
+    return *this;
+  }
+  LogicalResult setupContext(MLIRContext &context) const {
+    if (contextConfigurationCallback)
+      return contextConfigurationCallback(context);
+    return success();
+  }
+
   /// Set the debug configuration to use.
   MlirOptMainConfig &setDebugConfig(tracing::DebugConfig config) {
     debugConfig = std::move(config);
@@ -175,6 +188,10 @@ protected:
   /// This option is for convenience during testing only and discouraged in
   /// general.
   bool allowUnregisteredDialectsFlag = false;
+
+  /// The callback for additional configuration of the MLIR context after it has
+  /// been created and populated from the registry.
+  std::function<LogicalResult(MLIRContext &)> contextConfigurationCallback;
 
   /// Configuration for the debugging hooks.
   tracing::DebugConfig debugConfig;

--- a/mlir/lib/Pass/PassManagerOptions.cpp
+++ b/mlir/lib/Pass/PassManagerOptions.cpp
@@ -131,8 +131,12 @@ void mlir::registerPassManagerCLOptions() {
 }
 
 LogicalResult mlir::applyPassManagerCLOptions(PassManager &pm) {
-  if (!options.isConstructed())
+  if (!options.isConstructed()) {
+    emitError(UnknownLoc::get(pm.getContext()))
+        << "could not apply pass manager command line options.\n"
+           "Missing 'registerPassManagerCLOptions' call?\n";
     return failure();
+  }
 
   // Generate a reproducer on crash/failure.
   if (options->reproducerFile.getNumOccurrences())

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -326,6 +326,9 @@ static LogicalResult
 performActions(raw_ostream &os,
                const std::shared_ptr<llvm::SourceMgr> &sourceMgr,
                MLIRContext *context, const MlirOptMainConfig &config) {
+  if (failed(config.setupContext(*context)))
+    return failure();
+
   DefaultTimingManager tm;
   applyDefaultTimingManagerCLOptions(tm);
   TimingScope timing = tm.getRootScope();

--- a/mlir/test/lib/Dialect/Transform/TestTransformDialectInterpreter.cpp
+++ b/mlir/test/lib/Dialect/Transform/TestTransformDialectInterpreter.cpp
@@ -264,5 +264,9 @@ void registerTestTransformDialectEraseSchedulePass() {
 void registerTestTransformDialectInterpreterPass() {
   PassRegistration<TestTransformDialectInterpreterPass> reg;
 }
+/// Creates an instance of the pass for applying transform dialect ops.
+std::unique_ptr<Pass> createTestTransformDialectInterpreterPass() {
+  return std::make_unique<TestTransformDialectInterpreterPass>();
+}
 } // namespace test
 } // namespace mlir

--- a/mlir/unittests/CMakeLists.txt
+++ b/mlir/unittests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(Support)
 add_subdirectory(Rewrite)
 add_subdirectory(TableGen)
 add_subdirectory(Target)
+add_subdirectory(Tools)
 add_subdirectory(Transforms)
 
 if(MLIR_ENABLE_EXECUTION_ENGINE)

--- a/mlir/unittests/Tools/CMakeLists.txt
+++ b/mlir/unittests/Tools/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_unittest(MLIRToolsMlirOptContextPreload
+  MlirOptContextPreload.cpp
+)
+
+target_link_libraries(MLIRToolsMlirOptContextPreload
+  PRIVATE
+  MLIROptLib
+  MLIRParser
+  MLIRTransformDialect
+  MLIRTestTransformDialect
+)

--- a/mlir/unittests/Tools/MlirOptContextPreload.cpp
+++ b/mlir/unittests/Tools/MlirOptContextPreload.cpp
@@ -1,0 +1,192 @@
+//===- MlirOptContextPreload.cpp - Test MlirOptMain parameterization ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/TypeID.h"
+#include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+
+namespace {
+/// A pass that fails if the transform dialect is not loaded in the context.
+/// Sets the flag, the reference to which is passed into the constructor, when
+/// runs to check for lack-of-failure because of the pass not running at all.
+struct CheckIfTransformIsLoadedPass
+    : public PassWrapper<CheckIfTransformIsLoadedPass, OperationPass<>> {
+  explicit CheckIfTransformIsLoadedPass(bool &hasRun) : hasRun(hasRun) {}
+
+  void runOnOperation() override {
+    hasRun = true;
+    if (!getContext().getLoadedDialect<transform::TransformDialect>())
+      return signalPassFailure();
+  }
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CheckIfTransformIsLoadedPass)
+
+private:
+  bool &hasRun;
+};
+} // namespace
+
+TEST(MlirOptMain, ContextPreloadDialect) {
+  registerPassManagerCLOptions();
+
+  MlirOptMainConfig config;
+
+  // Make sure the transform dialect is unconditionally loaded.
+  config.setContextConfigurationFn([](MLIRContext &context) {
+    context.loadDialect<transform::TransformDialect>();
+    return success();
+  });
+
+  // Configure the pass pipeline.
+  bool hasRun = false;
+  config.setPassPipelineSetupFn([&](PassManager &pm) {
+    pm.addPass(std::make_unique<CheckIfTransformIsLoadedPass>(hasRun));
+    return success();
+  });
+
+  // Main.
+  DialectRegistry registry;
+  LogicalResult mainResult = MlirOptMain(
+      llvm::nulls(), llvm::MemoryBuffer::getMemBuffer("", "<empty_buffer>"),
+      registry, config);
+
+  EXPECT_TRUE(succeeded(mainResult));
+  EXPECT_TRUE(hasRun) << "pass has not run";
+}
+
+TEST(MlirOptMain, ContextPreloadDialectNotLoaded) {
+  registerPassManagerCLOptions();
+
+  // Configure the pass pipeline, but do not load the transform dialect
+  // unconditionally. The pass should run and fail.
+  MlirOptMainConfig config;
+  bool hasRun = false;
+  config.setPassPipelineSetupFn([&](PassManager &pm) {
+    pm.addPass(std::make_unique<CheckIfTransformIsLoadedPass>(hasRun));
+    return success();
+  });
+
+  // Main.
+  DialectRegistry registry;
+  LogicalResult mainResult = MlirOptMain(
+      llvm::nulls(), llvm::MemoryBuffer::getMemBuffer("", "<empty_buffer>"),
+      registry, config);
+
+  EXPECT_FALSE(succeeded(mainResult));
+  EXPECT_TRUE(hasRun) << "pass has not run";
+}
+
+TEST(MlirOptMain, ContextPreloadDialectFailure) {
+  registerPassManagerCLOptions();
+
+  // Return failure when configuring the context. The pass should not run.
+  MlirOptMainConfig config;
+  config.setContextConfigurationFn(
+      [](MLIRContext &context) { return failure(); });
+  bool hasRun = false;
+  config.setPassPipelineSetupFn([&](PassManager &pm) {
+    pm.addPass(std::make_unique<CheckIfTransformIsLoadedPass>(hasRun));
+    return success();
+  });
+
+  // Main.
+  DialectRegistry registry;
+  LogicalResult mainResult = MlirOptMain(
+      llvm::nulls(), llvm::MemoryBuffer::getMemBuffer("", "<empty_buffer>"),
+      registry, config);
+
+  EXPECT_FALSE(succeeded(mainResult));
+  EXPECT_FALSE(hasRun) << "pass was not expected to run";
+}
+
+namespace mlir {
+namespace test {
+std::unique_ptr<Pass> createTestTransformDialectInterpreterPass();
+} // namespace test
+} // namespace mlir
+namespace test {
+void registerTestTransformDialectExtension(DialectRegistry &registry);
+} // namespace test
+
+const static llvm::StringLiteral library = R"MLIR(
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence public @print_remark(%arg0: !transform.any_op {transform.readonly}) {
+    transform.test_print_remark_at_operand %arg0, "from external symbol" : !transform.any_op
+    transform.yield
+  }
+})MLIR";
+
+const static llvm::StringLiteral input = R"MLIR(
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence private @print_remark(%arg0: !transform.any_op {transform.readonly})
+  transform.sequence failures(propagate) {
+  ^bb0(%arg0: !transform.any_op):
+    include @print_remark failures(propagate) (%arg0) : (!transform.any_op) -> ()
+  }
+})MLIR";
+
+TEST(MlirOptMain, ContextPreloadConstructedLibrary) {
+  registerPassManagerCLOptions();
+
+  // Make sure the transform dialect is always loaded and make it own a library
+  // module that will be used by the pass.
+  bool emittedDiagnostic = false;
+  MlirOptMainConfig config;
+  config.setContextConfigurationFn([&](MLIRContext &context) {
+    auto *dialect = context.getOrLoadDialect<transform::TransformDialect>();
+
+    ParserConfig parserConfig(&context);
+    OwningOpRef<ModuleOp> transformLibrary = parseSourceString<ModuleOp>(
+        library, parserConfig, "<transform-library>");
+    if (!transformLibrary)
+      return failure();
+
+    dialect->registerLibraryModule(std::move(transformLibrary));
+
+    context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+      if (diag.getSeverity() == DiagnosticSeverity::Remark &&
+          diag.str() == "from external symbol") {
+        emittedDiagnostic = true;
+      }
+    });
+
+    return success();
+  });
+
+  // Pass pipeline configuration.
+  config.setPassPipelineSetupFn([](PassManager &pm) {
+    pm.addPass(mlir::test::createTestTransformDialectInterpreterPass());
+    return success();
+  });
+
+  // We need to register the test extension since the input contains its ops.
+  DialectRegistry registry;
+  ::test::registerTestTransformDialectExtension(registry);
+  std::string fileErrorMessage;
+  std::string output;
+  llvm::raw_string_ostream os(output);
+  LogicalResult mainResult = MlirOptMain(
+      os, llvm::MemoryBuffer::getMemBuffer(input, "<input>"), registry, config);
+
+  ASSERT_TRUE(fileErrorMessage.empty()) << fileErrorMessage;
+  EXPECT_TRUE(succeeded(mainResult));
+  EXPECT_TRUE(emittedDiagnostic)
+      << "did not produce the expected diagnostic from external symbol";
+}


### PR DESCRIPTION
Add a MlirOptMainConfig option letting the caller provide a callback performing additional configuration of the MLIRContext object, similarly to how they can supply a callback for pass manager configuration.

Clients of MlirOptMain, especially downstream, may want to perform additional configuration of the context before running the pass pipeline and are currently unable to do so. This configuration may include preloading dialects (e.g., if a downstream wishes to make some of its dialects "built-in"), diagnostic engine configuration and resource management in context.

Exercise this functionality in the transform dialect from a unit test by letting it preload symbols.