### PR TITLE
[libc++] Use correct size for deallocation of arrays in shared_ptr

### DIFF
--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -1137,7 +1137,8 @@ private:
         __alloc_.~_Alloc();
         size_t __size = __unbounded_array_control_block::__bytes_for(__count_);
         _AlignedStorage* __storage = reinterpret_cast<_AlignedStorage*>(this);
-        allocator_traits<_StorageAlloc>::deallocate(__tmp, _PointerTraits::pointer_to(*__storage), __size);
+        allocator_traits<_StorageAlloc>::deallocate(
+            __tmp, _PointerTraits::pointer_to(*__storage), __size / sizeof(_AlignedStorage));
     }
 
     _LIBCPP_NO_UNIQUE_ADDRESS _Alloc __alloc_;
@@ -1220,7 +1221,7 @@ private:
 
         _ControlBlockAlloc __tmp(__alloc_);
         __alloc_.~_Alloc();
-        allocator_traits<_ControlBlockAlloc>::deallocate(__tmp, _PointerTraits::pointer_to(*this), sizeof(*this));
+        allocator_traits<_ControlBlockAlloc>::deallocate(__tmp, _PointerTraits::pointer_to(*this), 1);
     }
 
     _LIBCPP_NO_UNIQUE_ADDRESS _Alloc __alloc_;

--- a/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
+++ b/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
@@ -16,10 +16,12 @@
 
 #include <memory>
 
-int main() {
+int main(int, char**) {
   std::allocate_shared<int64_t[]>(std::allocator<int64_t>{}, 10);
   std::make_shared<int64_t[]>(10);
 
   std::allocate_shared<int64_t[10]>(std::allocator<int64_t>{});
   std::make_shared<int64_t[10]>();
+
+  return 0;
 }

--- a/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
+++ b/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// REQUIRES: -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS: -fsized-deallocation
+
+// This test will fail with ASan if the implementation passes different sizes
+// to corresponding allocation and deallocation functions.
+
+#include <memory>
+
+int main() {
+    std::allocate_shared<int64_t[]>(std::allocator<int64_t>{}, 10);
+    std::make_shared<int64_t[]>(10);
+
+    std::allocate_shared<int64_t[10]>(std::allocator<int64_t>{});
+    std::make_shared<int64_t[10]>();
+}

--- a/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
+++ b/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
@@ -17,11 +17,11 @@
 #include <memory>
 
 int main(int, char**) {
-  std::allocate_shared<int64_t[]>(std::allocator<int64_t>{}, 10);
-  std::make_shared<int64_t[]>(10);
+  std::allocate_shared<int[]>(std::allocator<int>{}, 10);
+  std::make_shared<int[]>(10);
 
-  std::allocate_shared<int64_t[10]>(std::allocator<int64_t>{});
-  std::make_shared<int64_t[10]>();
+  std::allocate_shared<int[10]>(std::allocator<int>{});
+  std::make_shared<int[10]>();
 
   return 0;
 }

--- a/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
+++ b/libcxx/test/libcxx/memory/shared_ptr_array.pass.cpp
@@ -17,9 +17,9 @@
 #include <memory>
 
 int main() {
-    std::allocate_shared<int64_t[]>(std::allocator<int64_t>{}, 10);
-    std::make_shared<int64_t[]>(10);
+  std::allocate_shared<int64_t[]>(std::allocator<int64_t>{}, 10);
+  std::make_shared<int64_t[]>(10);
 
-    std::allocate_shared<int64_t[10]>(std::allocator<int64_t>{});
-    std::make_shared<int64_t[10]>();
+  std::allocate_shared<int64_t[10]>(std::allocator<int64_t>{});
+  std::make_shared<int64_t[10]>();
 }


### PR DESCRIPTION
Fixes #68051.

Current implementation passes the number of `_AlignedStorage` objects when it calls to `allocate` and the number of **bytes** on deallocate. This only applies to allocations that allocate control block and the storage together, i.e. `make_shared` and `allocate_shared`.

Found by ASan.