### PR TITLE
[NFC]Rename InstrProf::getFuncName{,orExternalSymbol} to getValueName{,orExternalSymbol}

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -813,7 +813,7 @@ template <class FuncRecordTy, support::endianness Endian>
 Error getFuncNameViaRef(const FuncRecordTy *Record,
                         InstrProfSymtab &ProfileNames, StringRef &FuncName) {
   uint64_t NameRef = getFuncNameRef<FuncRecordTy, Endian>(Record);
-  FuncName = ProfileNames.getValueName(NameRef);
+  FuncName = ProfileNames.getFuncOrVarName(NameRef);
   return Error::success();
 }
 

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -813,7 +813,7 @@ template <class FuncRecordTy, support::endianness Endian>
 Error getFuncNameViaRef(const FuncRecordTy *Record,
                         InstrProfSymtab &ProfileNames, StringRef &FuncName) {
   uint64_t NameRef = getFuncNameRef<FuncRecordTy, Endian>(Record);
-  FuncName = ProfileNames.getFuncName(NameRef);
+  FuncName = ProfileNames.getValueName(NameRef);
   return Error::success();
 }
 

--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -565,19 +565,19 @@ void InstrProfSymtab::finalizeSymtab() {
   Sorted = true;
 }
 
-StringRef InstrProfSymtab::getFuncOrVarNameIfDefined(uint64_t FuncMD5Hash) {
-  StringRef ret = getFuncOrVarName(FuncMD5Hash);
+StringRef InstrProfSymtab::getFuncOrVarNameIfDefined(uint64_t MD5Hash) {
+  StringRef ret = getFuncOrVarName(MD5Hash);
   if (ret.empty())
     return InstrProfSymtab::getExternalSymbol();
   return ret;
 }
 
-StringRef InstrProfSymtab::getFuncOrVarName(uint64_t FuncMD5Hash) {
+StringRef InstrProfSymtab::getFuncOrVarName(uint64_t MD5Hash) {
   finalizeSymtab();
-  auto Result = llvm::lower_bound(MD5NameMap, FuncMD5Hash,
+  auto Result = llvm::lower_bound(MD5NameMap, MD5Hash,
                                   [](const std::pair<uint64_t, StringRef> &LHS,
                                      uint64_t RHS) { return LHS.first < RHS; });
-  if (Result != MD5NameMap.end() && Result->first == FuncMD5Hash)
+  if (Result != MD5NameMap.end() && Result->first == MD5Hash)
     return Result->second;
   return StringRef();
 }

--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -512,12 +512,12 @@ public:
 
   /// Return name of functions or global variables from the name's md5 hash
   /// value. If not found, return an empty string.
-  inline StringRef getValueName(uint64_t ValMD5Hash);
+  inline StringRef getFuncOrVarName(uint64_t ValMD5Hash);
 
-  /// Just like getValueName, except that it will return a non-empty StringRef
-  /// if the value (function or global variable) is external to this symbol
-  /// table. All such cases will be represented using the same StringRef value.
-  inline StringRef getValueNameOrExternalSymbol(uint64_t ValMD5Hash);
+  /// Just like getFuncOrVarName, except that it will return literal string
+  /// 'External Symbol' if the function or global variable is external to
+  /// this symbol table.
+  inline StringRef getFuncOrVarNameIfDefined(uint64_t ValMD5Hash);
 
   /// True if Symbol is the value used to represent external symbols.
   static bool isExternalSymbol(const StringRef &Symbol) {
@@ -565,14 +565,14 @@ void InstrProfSymtab::finalizeSymtab() {
   Sorted = true;
 }
 
-StringRef InstrProfSymtab::getValueNameOrExternalSymbol(uint64_t FuncMD5Hash) {
-  StringRef ret = getValueName(FuncMD5Hash);
+StringRef InstrProfSymtab::getFuncOrVarNameIfDefined(uint64_t FuncMD5Hash) {
+  StringRef ret = getFuncOrVarName(FuncMD5Hash);
   if (ret.empty())
     return InstrProfSymtab::getExternalSymbol();
   return ret;
 }
 
-StringRef InstrProfSymtab::getValueName(uint64_t FuncMD5Hash) {
+StringRef InstrProfSymtab::getFuncOrVarName(uint64_t FuncMD5Hash) {
   finalizeSymtab();
   auto Result = llvm::lower_bound(MD5NameMap, FuncMD5Hash,
                                   [](const std::pair<uint64_t, StringRef> &LHS,

--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -510,14 +510,14 @@ public:
   /// an empty string.
   StringRef getFuncName(uint64_t FuncNameAddress, size_t NameSize);
 
-  /// Return function's PGO name from the name's md5 hash value.
-  /// If not found, return an empty string.
-  inline StringRef getFuncName(uint64_t FuncMD5Hash);
+  /// Return name of functions or global variables from the name's md5 hash
+  /// value. If not found, return an empty string.
+  inline StringRef getValueName(uint64_t ValMD5Hash);
 
-  /// Just like getFuncName, except that it will return a non-empty StringRef
-  /// if the function is external to this symbol table. All such cases
-  /// will be represented using the same StringRef value.
-  inline StringRef getFuncNameOrExternalSymbol(uint64_t FuncMD5Hash);
+  /// Just like getValueName, except that it will return a non-empty StringRef
+  /// if the value (function or global variable) is external to this symbol
+  /// table. All such cases will be represented using the same StringRef value.
+  inline StringRef getValueNameOrExternalSymbol(uint64_t ValMD5Hash);
 
   /// True if Symbol is the value used to represent external symbols.
   static bool isExternalSymbol(const StringRef &Symbol) {
@@ -565,14 +565,14 @@ void InstrProfSymtab::finalizeSymtab() {
   Sorted = true;
 }
 
-StringRef InstrProfSymtab::getFuncNameOrExternalSymbol(uint64_t FuncMD5Hash) {
-  StringRef ret = getFuncName(FuncMD5Hash);
+StringRef InstrProfSymtab::getValueNameOrExternalSymbol(uint64_t FuncMD5Hash) {
+  StringRef ret = getValueName(FuncMD5Hash);
   if (ret.empty())
     return InstrProfSymtab::getExternalSymbol();
   return ret;
 }
 
-StringRef InstrProfSymtab::getFuncName(uint64_t FuncMD5Hash) {
+StringRef InstrProfSymtab::getValueName(uint64_t FuncMD5Hash) {
   finalizeSymtab();
   auto Result = llvm::lower_bound(MD5NameMap, FuncMD5Hash,
                                   [](const std::pair<uint64_t, StringRef> &LHS,

--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -452,7 +452,7 @@ private:
   }
 
   StringRef getName(uint64_t NameRef) const {
-    return Symtab->getValueName(swap(NameRef));
+    return Symtab->getFuncOrVarName(swap(NameRef));
   }
 
   int getCounterTypeSize() const {

--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -452,7 +452,7 @@ private:
   }
 
   StringRef getName(uint64_t NameRef) const {
-    return Symtab->getFuncName(swap(NameRef));
+    return Symtab->getValueName(swap(NameRef));
   }
 
   int getCounterTypeSize() const {

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -722,7 +722,7 @@ void InstrProfWriter::writeRecordInText(StringRef Name, uint64_t Hash,
       std::unique_ptr<InstrProfValueData[]> VD = Func.getValueForSite(VK, S);
       for (uint32_t I = 0; I < ND; I++) {
         if (VK == IPVK_IndirectCallTarget)
-          OS << Symtab.getValueNameOrExternalSymbol(VD[I].Value) << ":"
+          OS << Symtab.getFuncOrVarNameIfDefined(VD[I].Value) << ":"
              << VD[I].Count << "\n";
         else
           OS << VD[I].Value << ":" << VD[I].Count << "\n";
@@ -790,7 +790,7 @@ void InstrProfWriter::writeTextTemporalProfTraceData(raw_fd_ostream &OS,
   for (auto &Trace : TemporalProfTraces) {
     OS << "# Weight:\n" << Trace.Weight << "\n";
     for (auto &NameRef : Trace.FunctionNameRefs)
-      OS << Symtab.getValueName(NameRef) << ",";
+      OS << Symtab.getFuncOrVarName(NameRef) << ",";
     OS << "\n";
   }
   OS << "\n";

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -722,7 +722,7 @@ void InstrProfWriter::writeRecordInText(StringRef Name, uint64_t Hash,
       std::unique_ptr<InstrProfValueData[]> VD = Func.getValueForSite(VK, S);
       for (uint32_t I = 0; I < ND; I++) {
         if (VK == IPVK_IndirectCallTarget)
-          OS << Symtab.getFuncNameOrExternalSymbol(VD[I].Value) << ":"
+          OS << Symtab.getValueNameOrExternalSymbol(VD[I].Value) << ":"
              << VD[I].Count << "\n";
         else
           OS << VD[I].Value << ":" << VD[I].Count << "\n";
@@ -790,7 +790,7 @@ void InstrProfWriter::writeTextTemporalProfTraceData(raw_fd_ostream &OS,
   for (auto &Trace : TemporalProfTraces) {
     OS << "# Weight:\n" << Trace.Weight << "\n";
     for (auto &NameRef : Trace.FunctionNameRefs)
-      OS << Symtab.getFuncName(NameRef) << ",";
+      OS << Symtab.getValueName(NameRef) << ",";
     OS << "\n";
   }
   OS << "\n";

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -2390,7 +2390,7 @@ static void traverseAllValueSites(const InstrProfRecord &Func, uint32_t VK,
       if (Symtab == nullptr)
         OS << format("%4" PRIu64, VD[V].Value);
       else
-        OS << Symtab->getFuncName(VD[V].Value);
+        OS << Symtab->getValueName(VD[V].Value);
       OS << ", " << format("%10" PRId64, VD[V].Count) << " ] ("
          << format("%.2f%%", (VD[V].Count * 100.0 / SiteSum)) << ")\n";
     }
@@ -2644,7 +2644,7 @@ static int showInstrProfile(
       OS << "  Temporal Profile Trace " << i << " (weight=" << Traces[i].Weight
          << " count=" << Traces[i].FunctionNameRefs.size() << "):\n";
       for (auto &NameRef : Traces[i].FunctionNameRefs)
-        OS << "    " << Reader->getSymtab().getFuncName(NameRef) << "\n";
+        OS << "    " << Reader->getSymtab().getValueName(NameRef) << "\n";
     }
   }
 
@@ -3079,7 +3079,7 @@ static int order_main(int argc, const char *argv[]) {
   WithColor::note() << "# Ordered " << Nodes.size() << " functions\n";
   for (auto &N : Nodes) {
     auto [Filename, ParsedFuncName] =
-        getParsedIRPGOFuncName(Reader->getSymtab().getFuncName(N.Id));
+        getParsedIRPGOFuncName(Reader->getSymtab().getValueName(N.Id));
     if (!Filename.empty())
       OS << "# " << Filename << "\n";
     OS << ParsedFuncName << "\n";

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -2390,7 +2390,7 @@ static void traverseAllValueSites(const InstrProfRecord &Func, uint32_t VK,
       if (Symtab == nullptr)
         OS << format("%4" PRIu64, VD[V].Value);
       else
-        OS << Symtab->getValueName(VD[V].Value);
+        OS << Symtab->getFuncOrVarName(VD[V].Value);
       OS << ", " << format("%10" PRId64, VD[V].Count) << " ] ("
          << format("%.2f%%", (VD[V].Count * 100.0 / SiteSum)) << ")\n";
     }
@@ -2644,7 +2644,7 @@ static int showInstrProfile(
       OS << "  Temporal Profile Trace " << i << " (weight=" << Traces[i].Weight
          << " count=" << Traces[i].FunctionNameRefs.size() << "):\n";
       for (auto &NameRef : Traces[i].FunctionNameRefs)
-        OS << "    " << Reader->getSymtab().getValueName(NameRef) << "\n";
+        OS << "    " << Reader->getSymtab().getFuncOrVarName(NameRef) << "\n";
     }
   }
 
@@ -3079,7 +3079,7 @@ static int order_main(int argc, const char *argv[]) {
   WithColor::note() << "# Ordered " << Nodes.size() << " functions\n";
   for (auto &N : Nodes) {
     auto [Filename, ParsedFuncName] =
-        getParsedIRPGOFuncName(Reader->getSymtab().getValueName(N.Id));
+        getParsedIRPGOFuncName(Reader->getSymtab().getFuncOrVarName(N.Id));
     if (!Filename.empty())
       OS << "# " << Filename << "\n";
     OS << ParsedFuncName << "\n";

--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -1250,23 +1250,23 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_test) {
   FuncNames.push_back("bar3");
   InstrProfSymtab Symtab;
   EXPECT_THAT_ERROR(Symtab.create(FuncNames), Succeeded());
-  StringRef R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func1"));
+  StringRef R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("func1"));
   ASSERT_EQ(StringRef("func1"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func2"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("func2"));
   ASSERT_EQ(StringRef("func2"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func3"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("func3"));
   ASSERT_EQ(StringRef("func3"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar1"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("bar1"));
   ASSERT_EQ(StringRef("bar1"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar2"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("bar2"));
   ASSERT_EQ(StringRef("bar2"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar3"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("bar3"));
   ASSERT_EQ(StringRef("bar3"), R);
 
   // negative tests
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar4"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("bar4"));
   ASSERT_EQ(StringRef(), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("foo4"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("foo4"));
   ASSERT_EQ(StringRef(), R);
 
   // Now incrementally update the symtab
@@ -1275,23 +1275,23 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_test) {
   EXPECT_THAT_ERROR(Symtab.addFuncName("blah_3"), Succeeded());
 
   // Check again
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("blah_1"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("blah_1"));
   ASSERT_EQ(StringRef("blah_1"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("blah_2"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("blah_2"));
   ASSERT_EQ(StringRef("blah_2"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("blah_3"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("blah_3"));
   ASSERT_EQ(StringRef("blah_3"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func1"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("func1"));
   ASSERT_EQ(StringRef("func1"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func2"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("func2"));
   ASSERT_EQ(StringRef("func2"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func3"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("func3"));
   ASSERT_EQ(StringRef("func3"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar1"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("bar1"));
   ASSERT_EQ(StringRef("bar1"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar2"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("bar2"));
   ASSERT_EQ(StringRef("bar2"), R);
-  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar3"));
+  R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash("bar3"));
   ASSERT_EQ(StringRef("bar3"), R);
 }
 
@@ -1331,14 +1331,14 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_module_test) {
 
     std::string IRPGOName = getIRPGOFuncName(*F);
     auto IRPGOFuncName =
-        ProfSymtab.getValueName(IndexedInstrProf::ComputeHash(IRPGOName));
+        ProfSymtab.getFuncOrVarName(IndexedInstrProf::ComputeHash(IRPGOName));
     EXPECT_EQ(StringRef(IRPGOName), IRPGOFuncName);
     EXPECT_EQ(StringRef(Funcs[I]),
               getParsedIRPGOFuncName(IRPGOFuncName).second);
     // Ensure we can still read this old record name.
     std::string PGOName = getPGOFuncName(*F);
     auto PGOFuncName =
-        ProfSymtab.getValueName(IndexedInstrProf::ComputeHash(PGOName));
+        ProfSymtab.getFuncOrVarName(IndexedInstrProf::ComputeHash(PGOName));
     EXPECT_EQ(StringRef(PGOName), PGOFuncName);
     EXPECT_THAT(PGOFuncName.str(), EndsWith(Funcs[I].str()));
   }
@@ -1397,9 +1397,9 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_compression_test) {
       // Now do the checks:
       // First sampling some data points:
       StringRef R =
-          Symtab.getValueName(IndexedInstrProf::ComputeHash(FuncNames1[0]));
+          Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash(FuncNames1[0]));
       ASSERT_EQ(StringRef("func_0"), R);
-      R = Symtab.getValueName(IndexedInstrProf::ComputeHash(FuncNames1[1]));
+      R = Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash(FuncNames1[1]));
       ASSERT_EQ(StringRef("f oooooooooooooo_0"), R);
       for (int I = 0; I < 3; I++) {
         std::string N[4];
@@ -1409,7 +1409,7 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_compression_test) {
         N[3] = FuncNames2[2 * I + 1];
         for (int J = 0; J < 4; J++) {
           StringRef R =
-              Symtab.getValueName(IndexedInstrProf::ComputeHash(N[J]));
+              Symtab.getFuncOrVarName(IndexedInstrProf::ComputeHash(N[J]));
           ASSERT_EQ(StringRef(N[J]), R);
         }
       }

--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -1250,23 +1250,23 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_test) {
   FuncNames.push_back("bar3");
   InstrProfSymtab Symtab;
   EXPECT_THAT_ERROR(Symtab.create(FuncNames), Succeeded());
-  StringRef R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("func1"));
+  StringRef R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func1"));
   ASSERT_EQ(StringRef("func1"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("func2"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func2"));
   ASSERT_EQ(StringRef("func2"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("func3"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func3"));
   ASSERT_EQ(StringRef("func3"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("bar1"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar1"));
   ASSERT_EQ(StringRef("bar1"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("bar2"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar2"));
   ASSERT_EQ(StringRef("bar2"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("bar3"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar3"));
   ASSERT_EQ(StringRef("bar3"), R);
 
   // negative tests
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("bar4"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar4"));
   ASSERT_EQ(StringRef(), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("foo4"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("foo4"));
   ASSERT_EQ(StringRef(), R);
 
   // Now incrementally update the symtab
@@ -1275,23 +1275,23 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_test) {
   EXPECT_THAT_ERROR(Symtab.addFuncName("blah_3"), Succeeded());
 
   // Check again
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("blah_1"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("blah_1"));
   ASSERT_EQ(StringRef("blah_1"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("blah_2"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("blah_2"));
   ASSERT_EQ(StringRef("blah_2"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("blah_3"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("blah_3"));
   ASSERT_EQ(StringRef("blah_3"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("func1"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func1"));
   ASSERT_EQ(StringRef("func1"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("func2"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func2"));
   ASSERT_EQ(StringRef("func2"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("func3"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("func3"));
   ASSERT_EQ(StringRef("func3"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("bar1"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar1"));
   ASSERT_EQ(StringRef("bar1"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("bar2"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar2"));
   ASSERT_EQ(StringRef("bar2"), R);
-  R = Symtab.getFuncName(IndexedInstrProf::ComputeHash("bar3"));
+  R = Symtab.getValueName(IndexedInstrProf::ComputeHash("bar3"));
   ASSERT_EQ(StringRef("bar3"), R);
 }
 
@@ -1331,14 +1331,14 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_module_test) {
 
     std::string IRPGOName = getIRPGOFuncName(*F);
     auto IRPGOFuncName =
-        ProfSymtab.getFuncName(IndexedInstrProf::ComputeHash(IRPGOName));
+        ProfSymtab.getValueName(IndexedInstrProf::ComputeHash(IRPGOName));
     EXPECT_EQ(StringRef(IRPGOName), IRPGOFuncName);
     EXPECT_EQ(StringRef(Funcs[I]),
               getParsedIRPGOFuncName(IRPGOFuncName).second);
     // Ensure we can still read this old record name.
     std::string PGOName = getPGOFuncName(*F);
     auto PGOFuncName =
-        ProfSymtab.getFuncName(IndexedInstrProf::ComputeHash(PGOName));
+        ProfSymtab.getValueName(IndexedInstrProf::ComputeHash(PGOName));
     EXPECT_EQ(StringRef(PGOName), PGOFuncName);
     EXPECT_THAT(PGOFuncName.str(), EndsWith(Funcs[I].str()));
   }
@@ -1396,9 +1396,10 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_compression_test) {
 
       // Now do the checks:
       // First sampling some data points:
-      StringRef R = Symtab.getFuncName(IndexedInstrProf::ComputeHash(FuncNames1[0]));
+      StringRef R =
+          Symtab.getValueName(IndexedInstrProf::ComputeHash(FuncNames1[0]));
       ASSERT_EQ(StringRef("func_0"), R);
-      R = Symtab.getFuncName(IndexedInstrProf::ComputeHash(FuncNames1[1]));
+      R = Symtab.getValueName(IndexedInstrProf::ComputeHash(FuncNames1[1]));
       ASSERT_EQ(StringRef("f oooooooooooooo_0"), R);
       for (int I = 0; I < 3; I++) {
         std::string N[4];
@@ -1407,7 +1408,8 @@ TEST_P(MaybeSparseInstrProfTest, instr_prof_symtab_compression_test) {
         N[2] = FuncNames2[2 * I];
         N[3] = FuncNames2[2 * I + 1];
         for (int J = 0; J < 4; J++) {
-          StringRef R = Symtab.getFuncName(IndexedInstrProf::ComputeHash(N[J]));
+          StringRef R =
+              Symtab.getValueName(IndexedInstrProf::ComputeHash(N[J]));
           ASSERT_EQ(StringRef(N[J]), R);
         }
       }


### PR DESCRIPTION
- This function looks up MD5ToNameMap to return a name for a given MD5. https://github.com/llvm/llvm-project/pull/66825 adds MD5 of global variable names into this map. So rename methods and update comments