### PR TITLE
[LLVM][DWARF] Create thread safe context for DWP DWARFContext

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -97,7 +97,7 @@ public:
         getDWOContext(StringRef AbsolutePath) = 0;
     virtual const DenseMap<uint64_t, DWARFTypeUnit *> &
     getTypeUnitMap(bool IsDWO) = 0;
-    virtual bool isThreadSafe() = 0;
+    virtual bool isThreadSafe() const = 0;
 
     /// Parse a macro[.dwo] or macinfo[.dwo] section.
     std::unique_ptr<DWARFDebugMacro>

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -97,6 +97,7 @@ public:
         getDWOContext(StringRef AbsolutePath) = 0;
     virtual const DenseMap<uint64_t, DWARFTypeUnit *> &
     getTypeUnitMap(bool IsDWO) = 0;
+    virtual bool isThreadSafe() = 0;
 
     /// Parse a macro[.dwo] or macinfo[.dwo] section.
     std::unique_ptr<DWARFDebugMacro>

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -576,11 +576,13 @@ public:
     auto S = std::make_shared<DWOFile>();
     S->File = std::move(Obj.get());
     StringRef FileName = S->File.getBinary()->getFileName();
+    // Allow multi-threaded access if there is a .dwp file as the CU index and TU index might be accessed from multiple threads.
+    bool ThreadSafe = FileName.find(".dwp") != StringRef::npos;
     S->Context = DWARFContext::create(
         *S->File.getBinary(), DWARFContext::ProcessDebugRelocations::Ignore,
         nullptr, "", WithColor::defaultErrorHandler,
         WithColor::defaultWarningHandler,
-        FileName.find(".dwp") != StringRef::npos);
+        ThreadSafe);
     *Entry = S;
     auto *Ctxt = S->Context.get();
     return std::shared_ptr<DWARFContext>(std::move(S), Ctxt);

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -586,7 +586,7 @@ public:
     return std::shared_ptr<DWARFContext>(std::move(S), Ctxt);
   }
 
-  bool isThreadSafe() override { return false; }
+  bool isThreadSafe() const override { return false; }
 
   const DenseMap<uint64_t, DWARFTypeUnit *> &getNormalTypeUnitMap() {
     if (!NormalTypeUnits) {
@@ -724,7 +724,7 @@ public:
     return ThreadUnsafeDWARFContextState::getDWOContext(AbsolutePath);
   }
 
-  bool isThreadSafe() override { return true; }
+  bool isThreadSafe() const override { return true; }
 
   const DenseMap<uint64_t, DWARFTypeUnit *> &
   getTypeUnitMap(bool IsDWO) override {

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -576,13 +576,13 @@ public:
     auto S = std::make_shared<DWOFile>();
     S->File = std::move(Obj.get());
     StringRef FileName = S->File.getBinary()->getFileName();
-    // Allow multi-threaded access if there is a .dwp file as the CU index and TU index might be accessed from multiple threads.
+    // Allow multi-threaded access if there is a .dwp file as the CU index and
+    // TU index might be accessed from multiple threads.
     bool ThreadSafe = FileName.find(".dwp") != StringRef::npos;
     S->Context = DWARFContext::create(
         *S->File.getBinary(), DWARFContext::ProcessDebugRelocations::Ignore,
         nullptr, "", WithColor::defaultErrorHandler,
-        WithColor::defaultWarningHandler,
-        ThreadSafe);
+        WithColor::defaultWarningHandler, ThreadSafe);
     *Entry = S;
     auto *Ctxt = S->Context.get();
     return std::shared_ptr<DWARFContext>(std::move(S), Ctxt);

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -574,6 +574,7 @@ public:
     }
 
     auto S = std::make_shared<DWOFile>();
+    S->File = std::move(Obj.get());
     // Allow multi-threaded access if there is a .dwp file as the CU index and
     // TU index might be accessed from multiple threads.
     bool ThreadSafe = isThreadSafe();

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -575,8 +575,12 @@ public:
 
     auto S = std::make_shared<DWOFile>();
     S->File = std::move(Obj.get());
-    S->Context = DWARFContext::create(*S->File.getBinary(),
-                                      DWARFContext::ProcessDebugRelocations::Ignore);
+    StringRef FileName = S->File.getBinary()->getFileName();
+    S->Context = DWARFContext::create(
+        *S->File.getBinary(), DWARFContext::ProcessDebugRelocations::Ignore,
+        nullptr, "", WithColor::defaultErrorHandler,
+        WithColor::defaultWarningHandler,
+        FileName.find(".dwp") != StringRef::npos);
     *Entry = S;
     auto *Ctxt = S->Context.get();
     return std::shared_ptr<DWARFContext>(std::move(S), Ctxt);


### PR DESCRIPTION
Right now DWARFContext that is created is the same when input is DWO or DWP file.
Changed so that for DWP it creates a thread safe context. This allows for a multi threaded safe access to {cu,tu}-index

