### PR TITLE
MachineBlockPlacement: Avoid overflow problems in scaleThreshold()

### DIFF
--- a/llvm/include/llvm/Support/BlockFrequency.h
+++ b/llvm/include/llvm/Support/BlockFrequency.h
@@ -28,8 +28,11 @@ class BlockFrequency {
 public:
   BlockFrequency(uint64_t Freq = 0) : Frequency(Freq) { }
 
-  /// Returns the maximum possible frequency, the saturation value.
+  /// Returns the maximum possible frequency, the saturation value integer.
   static uint64_t getMaxFrequency() { return UINT64_MAX; }
+
+  /// Returns the maximum possible frequency, the saturation value.
+  static BlockFrequency max() { return BlockFrequency(UINT64_MAX); }
 
   /// Returns the frequency as a fixpoint number scaled by the entry
   /// frequency.


### PR DESCRIPTION
Multiplying block frequency values with integers is dangerous and can produce overflows. Change some block placement code to use the `BlockFrequency::mul` API which returns `std::nullopt` in case of overflow and return the maximum number which will fail the checks in the placement code.