### PR TITLE
[Support] Deprecate system_endianness

### DIFF
--- a/clang/include/clang/Serialization/ModuleFileExtension.h
+++ b/clang/include/clang/Serialization/ModuleFileExtension.h
@@ -86,7 +86,7 @@ public:
   /// The default implementation of this function simply does nothing, so the
   /// presence/absence of this extension does not distinguish module files.
   using ExtensionHashBuilder =
-      llvm::HashBuilder<llvm::MD5, llvm::support::endian::system_endianness()>;
+      llvm::HashBuilder<llvm::MD5, llvm::endianness::native>;
   virtual void hashExtension(ExtensionHashBuilder &HBuilder) const;
 
   /// Create a new module file extension writer, which will be

--- a/llvm/include/llvm/ExecutionEngine/Orc/MachOBuilder.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MachOBuilder.h
@@ -86,7 +86,7 @@ private:
   using StringTable = std::vector<StringTableEntry>;
 
   static bool swapStruct() {
-    return MachOTraits::Endianness != support::endian::system_endianness();
+    return MachOTraits::Endianness != llvm::endianness::native;
   }
 
 public:

--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -53,9 +53,9 @@ struct PickAlignment {
 
 namespace endian {
 
-constexpr endianness system_endianness() {
-  return sys::IsBigEndianHost ? big : little;
-}
+LLVM_DEPRECATED("Use llvm::endianness::native instead",
+                "llvm::endianness::native")
+constexpr endianness system_endianness() { return llvm::endianness::native; }
 
 template <typename value_type>
 [[nodiscard]] inline value_type byte_swap(value_type value, endianness endian) {

--- a/llvm/include/llvm/Support/HashBuilder.h
+++ b/llvm/include/llvm/Support/HashBuilder.h
@@ -170,7 +170,7 @@ public:
     // `update` to guarantee the fast path.
     add(Value.size());
     if (hashbuilder_detail::IsHashableData<T>::value &&
-        Endianness == support::endian::system_endianness()) {
+        Endianness == llvm::endianness::native) {
       this->update(ArrayRef(reinterpret_cast<const uint8_t *>(Value.begin()),
                             Value.size() * sizeof(T)));
     } else {
@@ -248,7 +248,7 @@ public:
   ///   template <typename HasherT, support::endianness Endianness>
   ///   friend void addHash(HashBuilder<HasherT, Endianness> &HBuilder,
   ///                       const StructWithFastHash &Value) {
-  ///     if (Endianness == support::endian::system_endianness()) {
+  ///     if (Endianness == llvm::endianness::native) {
   ///       HBuilder.update(ArrayRef(
   ///           reinterpret_cast<const uint8_t *>(&Value), sizeof(Value)));
   ///     } else {
@@ -278,7 +278,7 @@ public:
   ///   template <typename HasherT, support::endianness Endianness>
   ///   friend void addHash(HashBuilder<HasherT, Endianness> &HBuilder,
   ///                       const CustomContainer &Value) {
-  ///     if (Endianness == support::endian::system_endianness()) {
+  ///     if (Endianness == llvm::endianness::native) {
   ///       HBuilder.update(ArrayRef(
   ///           reinterpret_cast<const uint8_t *>(&Value.Size),
   ///           sizeof(Value.Size) + Value.Size * sizeof(Value.Elements[0])));
@@ -373,7 +373,7 @@ private:
 
   template <typename T>
   std::enable_if_t<hashbuilder_detail::IsHashableData<T>::value &&
-                       Endianness == support::endian::system_endianness(),
+                       Endianness == llvm::endianness::native,
                    HashBuilder &>
   addRangeElementsImpl(T *First, T *Last, std::forward_iterator_tag) {
     this->update(ArrayRef(reinterpret_cast<const uint8_t *>(First),

--- a/llvm/lib/DWARFLinkerParallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinkerParallel/DWARFLinkerImpl.cpp
@@ -64,7 +64,7 @@ Error DWARFLinkerImpl::link() {
 
   dwarf::FormParams GlobalFormat = {GlobalData.getOptions().TargetDWARFVersion,
                                     0, dwarf::DwarfFormat::DWARF32};
-  support::endianness GlobalEndianness = support::endian::system_endianness();
+  support::endianness GlobalEndianness = llvm::endianness::native;
 
   if (TheDwarfEmitter) {
     GlobalEndianness = TheDwarfEmitter->getTargetTriple().isLittleEndian()

--- a/llvm/lib/DWARFLinkerParallel/OutputSections.h
+++ b/llvm/lib/DWARFLinkerParallel/OutputSections.h
@@ -432,7 +432,7 @@ protected:
   dwarf::FormParams Format = {4, 4, dwarf::DWARF32};
 
   /// Endiannes for sections.
-  support::endianness Endianness = support::endian::system_endianness();
+  support::endianness Endianness = llvm::endianness::native;
 
   /// All keeping sections.
   using SectionsSetTy = std::map<DebugSectionKind, SectionDescriptor>;

--- a/llvm/lib/DebugInfo/GSYM/FunctionInfo.cpp
+++ b/llvm/lib/DebugInfo/GSYM/FunctionInfo.cpp
@@ -101,7 +101,7 @@ uint64_t FunctionInfo::cacheEncoding() {
   if (!isValid())
     return 0;
   raw_svector_ostream OutStrm(EncodingCache);
-  FileWriter FW(OutStrm, support::endian::system_endianness());
+  FileWriter FW(OutStrm, llvm::endianness::native);
   llvm::Expected<uint64_t> Result = encode(FW);
   if (!Result) {
     EncodingCache.clear();
@@ -123,7 +123,7 @@ llvm::Expected<uint64_t> FunctionInfo::encode(FileWriter &Out) const {
   // precompute exactly how big FunctionInfo objects encode into so we can
   // accurately make segments of a specific size.
   if (!EncodingCache.empty() &&
-      support::endian::system_endianness() == Out.getByteOrder()) {
+      llvm::endianness::native == Out.getByteOrder()) {
     // We already encoded this object, just write out the bytes.
     Out.writeData(llvm::ArrayRef<uint8_t>((const uint8_t *)EncodingCache.data(),
                                           EncodingCache.size()));

--- a/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
@@ -23,11 +23,10 @@
 using namespace llvm;
 using namespace gsym;
 
-GsymReader::GsymReader(std::unique_ptr<MemoryBuffer> Buffer) :
-    MemBuffer(std::move(Buffer)),
-    Endian(support::endian::system_endianness()) {}
+GsymReader::GsymReader(std::unique_ptr<MemoryBuffer> Buffer)
+    : MemBuffer(std::move(Buffer)), Endian(llvm::endianness::native) {}
 
-  GsymReader::GsymReader(GsymReader &&RHS) = default;
+GsymReader::GsymReader(GsymReader &&RHS) = default;
 
 GsymReader::~GsymReader() = default;
 
@@ -60,8 +59,7 @@ GsymReader::create(std::unique_ptr<MemoryBuffer> &MemBuffer) {
 
 llvm::Error
 GsymReader::parse() {
-  BinaryStreamReader FileData(MemBuffer->getBuffer(),
-                              support::endian::system_endianness());
+  BinaryStreamReader FileData(MemBuffer->getBuffer(), llvm::endianness::native);
   // Check for the magic bytes. This file format is designed to be mmap'ed
   // into a process and accessed as read only. This is done for performance
   // and efficiency for symbolicating and parsing GSYM data.
@@ -69,7 +67,7 @@ GsymReader::parse() {
     return createStringError(std::errc::invalid_argument,
                              "not enough data for a GSYM header");
 
-  const auto HostByteOrder = support::endian::system_endianness();
+  const auto HostByteOrder = llvm::endianness::native;
   switch (Hdr->Magic) {
     case GSYM_MAGIC:
       Endian = HostByteOrder;

--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -146,7 +146,7 @@ private:
     Hdr.flags = 0;
     Hdr.reserved = 0;
 
-    if (G.getEndianness() != support::endian::system_endianness())
+    if (G.getEndianness() != llvm::endianness::native)
       MachO::swapStruct(Hdr);
 
     auto HeaderContent = G.allocateContent(
@@ -1460,7 +1460,7 @@ Error MachOPlatform::MachOPlatformPlugin::populateObjCRuntimeObject(
   auto SecContent = SecBlock.getAlreadyMutableContent();
   char *P = SecContent.data();
   auto WriteMachOStruct = [&](auto S) {
-    if (G.getEndianness() != support::endian::system_endianness())
+    if (G.getEndianness() != llvm::endianness::native)
       MachO::swapStruct(S);
     memcpy(P, &S, sizeof(S));
     P += sizeof(S);

--- a/llvm/unittests/DebugInfo/GSYM/GSYMTest.cpp
+++ b/llvm/unittests/DebugInfo/GSYM/GSYMTest.cpp
@@ -628,7 +628,7 @@ TEST(GSYMTest, TestAddressRangeEncodeDecode) {
   // the base address of the parent range for subranges.
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = llvm::support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   const uint64_t BaseAddr = 0x1000;
   const AddressRange Range1(0x1000, 0x1010);
@@ -651,7 +651,7 @@ static void TestAddressRangeEncodeDecodeHelper(const AddressRanges &Ranges,
                                                const uint64_t BaseAddr) {
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = llvm::support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   encodeRanges(Ranges, FW, BaseAddr);
 
@@ -1163,7 +1163,7 @@ TEST(GSYMTest, TestGsymReader) {
   constexpr uint64_t FuncSize = 0x10;
   const uint32_t Func1Name = GC.insertString("foo");
   const uint32_t Func2Name = GC.insertString("bar");
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   GC.addFunctionInfo(FunctionInfo(Func1Addr, FuncSize, Func1Name));
   GC.addFunctionInfo(FunctionInfo(Func2Addr, FuncSize, Func2Name));
   Error FinalizeErr = GC.finalize(llvm::nulls());
@@ -1201,7 +1201,7 @@ TEST(GSYMTest, TestGsymLookups) {
   // symbolication.
   GsymCreator GC;
   FunctionInfo FI(0x1000, 0x100, GC.insertString("main"));
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FI.OptLineTable = LineTable();
   const uint32_t MainFileIndex = GC.insertFile("/tmp/main.c");
   const uint32_t FooFileIndex = GC.insertFile("/tmp/foo.h");
@@ -1354,7 +1354,7 @@ TEST(GSYMTest, TestDWARFFunctionWithAddresses) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -1431,7 +1431,7 @@ TEST(GSYMTest, TestDWARFFunctionWithAddressAndOffset) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -1538,7 +1538,7 @@ TEST(GSYMTest, TestDWARFStructMethodNoMangled) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -1643,7 +1643,7 @@ TEST(GSYMTest, TestDWARFTextRanges) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -1672,7 +1672,7 @@ TEST(GSYMTest, TestEmptySymbolEndAddressOfTextRanges) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -1841,7 +1841,7 @@ TEST(GSYMTest, TestDWARFInlineInfo) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -2101,7 +2101,7 @@ TEST(GSYMTest, TestDWARFNoLines) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -2280,7 +2280,7 @@ TEST(GSYMTest, TestDWARFDeadStripAddr4) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -2420,7 +2420,7 @@ TEST(GSYMTest, TestDWARFDeadStripAddr8) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -2507,7 +2507,7 @@ static Expected<GsymReader> FinalizeEncodeAndDecode(GsymCreator &GC) {
     return std::move(FinalizeErr);
   SmallString<1024> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   llvm::Error Err = GC.encode(FW);
   if (Err)
@@ -3057,7 +3057,7 @@ TEST(GSYMTest, TestDWARFInlineRangeScopes) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -3284,7 +3284,7 @@ TEST(GSYMTest, TestDWARFEmptyInline) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -3520,7 +3520,7 @@ TEST(GSYMTest, TestFinalizeForLineTables) {
   ASSERT_THAT_ERROR(GC.finalize(OS), Succeeded());
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -3800,7 +3800,7 @@ TEST(GSYMTest, TestRangeWarnings) {
   OS.flush();
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());
@@ -4002,7 +4002,7 @@ TEST(GSYMTest, TestEmptyRangeWarnings) {
   OS.flush();
   SmallString<512> Str;
   raw_svector_ostream OutStrm(Str);
-  const auto ByteOrder = support::endian::system_endianness();
+  const auto ByteOrder = llvm::endianness::native;
   FileWriter FW(OutStrm, ByteOrder);
   ASSERT_THAT_ERROR(GC.encode(FW), Succeeded());
   Expected<GsymReader> GR = GsymReader::copyBuffer(OutStrm.str());

--- a/llvm/unittests/Support/HashBuilderTest.cpp
+++ b/llvm/unittests/Support/HashBuilderTest.cpp
@@ -156,7 +156,7 @@ struct /* __attribute__((packed)) */ StructWithFastHash {
   template <typename HasherT, llvm::support::endianness Endianness>
   friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const StructWithFastHash &Value) {
-    if (Endianness == llvm::support::endian::system_endianness()) {
+    if (Endianness == llvm::endianness::native) {
       HBuilder.update(llvm::ArrayRef(reinterpret_cast<const uint8_t *>(&Value),
                                      sizeof(Value)));
     } else {
@@ -180,7 +180,7 @@ public:
   template <typename HasherT, llvm::support::endianness Endianness>
   friend void addHash(llvm::HashBuilder<HasherT, Endianness> &HBuilder,
                       const CustomContainer &Value) {
-    if (Endianness == llvm::support::endian::system_endianness()) {
+    if (Endianness == llvm::endianness::native) {
       HBuilder.update(llvm::ArrayRef(
           reinterpret_cast<const uint8_t *>(&Value.Size),
           sizeof(Value.Size) + Value.Size * sizeof(Value.Elements[0])));

--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -735,8 +735,7 @@ DenseElementsAttr TensorLiteralParser::getHexAttr(SMLoc loc, ShapedType type) {
     return nullptr;
   }
 
-  if (llvm::support::endian::system_endianness() ==
-      llvm::support::endianness::big) {
+  if (llvm::endianness::native == llvm::endianness::big) {
     // Convert endianess in big-endian(BE) machines. `rawData` is
     // little-endian(LE) because HEX in raw data of dense element attribute
     // is always LE format. It is converted into BE here to be used in BE

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2413,8 +2413,7 @@ void AsmPrinter::Impl::printDenseIntOrFPElementsAttr(
   if (!attr.isSplat() && allowHex &&
       shouldPrintElementsAttrWithHex(numElements)) {
     ArrayRef<char> rawData = attr.getRawData();
-    if (llvm::support::endian::system_endianness() ==
-        llvm::support::endianness::big) {
+    if (llvm::endianness::native == llvm::endianness::big) {
       // Convert endianess in big-endian(BE) machines. `rawData` is BE in BE
       // machines. It is converted here to print in LE format.
       SmallVector<char, 64> outDataVec(rawData.size());

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -467,8 +467,7 @@ static bool getBit(const char *rawData, size_t bitPos) {
 /// BE format.
 static void copyAPIntToArrayForBEmachine(APInt value, size_t numBytes,
                                          char *result) {
-  assert(llvm::support::endian::system_endianness() == // NOLINT
-         llvm::support::endianness::big);              // NOLINT
+  assert(llvm::endianness::native == llvm::endianness::big);
   assert(value.getNumWords() * APInt::APINT_WORD_SIZE >= numBytes);
 
   // Copy the words filled with data.
@@ -497,8 +496,7 @@ static void copyAPIntToArrayForBEmachine(APInt value, size_t numBytes,
 /// format.
 static void copyArrayToAPIntForBEmachine(const char *inArray, size_t numBytes,
                                          APInt &result) {
-  assert(llvm::support::endian::system_endianness() == // NOLINT
-         llvm::support::endianness::big);              // NOLINT
+  assert(llvm::endianness::native == llvm::endianness::big);
   assert(result.getNumWords() * APInt::APINT_WORD_SIZE >= numBytes);
 
   // Copy the data that fills the word of `result` from `inArray`.
@@ -539,8 +537,7 @@ static void writeBits(char *rawData, size_t bitPos, APInt value) {
 
   // Otherwise, the bit position is guaranteed to be byte aligned.
   assert((bitPos % CHAR_BIT) == 0 && "expected bitPos to be 8-bit aligned");
-  if (llvm::support::endian::system_endianness() ==
-      llvm::support::endianness::big) {
+  if (llvm::endianness::native == llvm::endianness::big) {
     // Copy from `value` to `rawData + (bitPos / CHAR_BIT)`.
     // Copying the first `llvm::divideCeil(bitWidth, CHAR_BIT)` bytes doesn't
     // work correctly in BE format.
@@ -565,8 +562,7 @@ static APInt readBits(const char *rawData, size_t bitPos, size_t bitWidth) {
   // Otherwise, the bit position must be 8-bit aligned.
   assert((bitPos % CHAR_BIT) == 0 && "expected bitPos to be 8-bit aligned");
   APInt result(bitWidth, 0);
-  if (llvm::support::endian::system_endianness() ==
-      llvm::support::endianness::big) {
+  if (llvm::endianness::native == llvm::endianness::big) {
     // Copy from `rawData + (bitPos / CHAR_BIT)` to `result`.
     // Copying the first `llvm::divideCeil(bitWidth, CHAR_BIT)` bytes doesn't
     // work correctly in BE format.
@@ -1367,8 +1363,7 @@ void DenseIntOrFPElementsAttr::convertEndianOfCharForBEmachine(
   using llvm::support::ulittle32_t;
   using llvm::support::ulittle64_t;
 
-  assert(llvm::support::endian::system_endianness() == // NOLINT
-         llvm::support::endianness::big);              // NOLINT
+  assert(llvm::endianness::native == llvm::endianness::big);
   // NOLINT to avoid warning message about replacing by static_assert()
 
   // Following std::copy_n always converts endianness on BE machine.

--- a/mlir/unittests/Bytecode/BytecodeTest.cpp
+++ b/mlir/unittests/Bytecode/BytecodeTest.cpp
@@ -64,8 +64,7 @@ TEST(Bytecode, MultiModuleWithResource) {
 
   // FIXME: Parsing external resources does not work on big-endian
   // platforms currently.
-  if (llvm::support::endian::system_endianness() ==
-      llvm::support::endianness::big)
+  if (llvm::endianness::native == llvm::endianness::big)
     GTEST_SKIP();
 
   // Try to see if we have a valid resource in the parsed module.


### PR DESCRIPTION
system_endianness() just returns llvm::endianness::native, a
compile-time constant equivalent to std::native in C++20.  This patch
deprecates system_endianness() while replacing all invocations of
system_endianness() with llvm::endianness::native.

While we are at it, this patch replaces
llvm::support::endianness::{bit,little} with
llvm::endianness::{bit,little} in those statements that happen to call
system_endianness().  It does not go out of its way to replace other
occurrences of llvm::support::endianness::{bit,little}.
