### PR TITLE
[Support, ADT] Move llvm::endianness to bit.h

### DIFF
--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_ENDIAN_H
 #define LLVM_SUPPORT_ENDIAN_H
 
+#include "llvm/ADT/bit.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/SwapByteOrder.h"
 #include <cassert>

--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -22,13 +22,6 @@
 #include <type_traits>
 
 namespace llvm {
-
-enum class endianness {
-  big,
-  little,
-  native = llvm::sys::IsBigEndianHost ? big : little
-};
-
 namespace support {
 
 // TODO: Remove the following once we are done migrating to llvm::endianness,

--- a/llvm/include/llvm/Support/SwapByteOrder.h
+++ b/llvm/include/llvm/Support/SwapByteOrder.h
@@ -19,40 +19,12 @@
 #include <cstdint>
 #include <type_traits>
 
-#if defined(__linux__) || defined(__GNU__) || defined(__HAIKU__) ||            \
-    defined(__Fuchsia__) || defined(__EMSCRIPTEN__)
-#include <endian.h>
-#elif defined(_AIX)
-#include <sys/machine.h>
-#elif defined(__sun)
-/* Solaris provides _BIG_ENDIAN/_LITTLE_ENDIAN selector in sys/types.h */
-#include <sys/types.h>
-#define BIG_ENDIAN 4321
-#define LITTLE_ENDIAN 1234
-#if defined(_BIG_ENDIAN)
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
-#elif defined(__MVS__)
-#define BIG_ENDIAN 4321
-#define LITTLE_ENDIAN 1234
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#if !defined(BYTE_ORDER) && !defined(_WIN32)
-#include <machine/endian.h>
-#endif
-#endif
-
 namespace llvm {
 
 namespace sys {
 
-#if defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN
-constexpr bool IsBigEndianHost = true;
-#else
-constexpr bool IsBigEndianHost = false;
-#endif
+constexpr bool IsBigEndianHost =
+    llvm::endianness::native == llvm::endianness::big;
 
 static const bool IsLittleEndianHost = !IsBigEndianHost;
 


### PR DESCRIPTION
In C++20, std::endian comes from `<bit>`.  Following the same spirit,
this patch moves llvm::endianness and the endian detection logic to
bit.h.

Without this patch, llvm::endianness::native is defined in terms of
llvm::sys::IsBigEndianHost.  This patch reverses the dependency.
llvm::sys::IsBigEndianHost is now defined in terms of
llvm::endianness::native.
