### PR TITLE
[clang] Correct behavior of `LLVM_UNREACHABLE_OPTIMIZE=OFF` for `Release` builds

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -343,8 +343,8 @@ Bug Fixes in This Version
 - Fix a crash when evaluating value-dependent structured binding
   variables at compile time.
   Fixes (`#67690 <https://github.com/llvm/llvm-project/issues/67690>`_)
-- Fixes a regression where ``LLVM_UNREACHABLE_OPTIMIZE=OFF`` cannot be used
-  with ``Release`` mode builds. (`#68237 <https://github.com/llvm/llvm-project/issues/68237>`_)
+- Fixes a ``clang-17`` regression where ``LLVM_UNREACHABLE_OPTIMIZE=OFF``
+  cannot be used with ``Release`` mode builds. (`#68237 <https://github.com/llvm/llvm-project/issues/68237>`_).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -343,6 +343,8 @@ Bug Fixes in This Version
 - Fix a crash when evaluating value-dependent structured binding
   variables at compile time.
   Fixes (`#67690 <https://github.com/llvm/llvm-project/issues/67690>`_)
+- Fixes a regression where ``LLVM_UNREACHABLE_OPTIMIZE=OFF`` cannot be used
+  with ``Release`` mode builds. (`#68237 <https://github.com/llvm/llvm-project/issues/68237>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -2690,7 +2690,8 @@ static void emitAttributes(RecordKeeper &Records, raw_ostream &OS,
         OS << ", ";
         emitFormInitializer(OS, Spellings[0], "0");
       } else {
-        OS << ", (\n";
+        OS << ", [&]() {\n";
+        OS << "    switch (S) {\n";
         std::set<std::string> Uniques;
         unsigned Idx = 0;
         for (auto I = Spellings.begin(), E = Spellings.end(); I != E;
@@ -2698,15 +2699,19 @@ static void emitAttributes(RecordKeeper &Records, raw_ostream &OS,
           const FlattenedSpelling &S = *I;
           const auto &Name = SemanticToSyntacticMap[Idx];
           if (Uniques.insert(Name).second) {
-            OS << "    S == " << Name << " ? AttributeCommonInfo::Form";
+            OS << "    case " << Name << ":\n";
+            OS << "      return  AttributeCommonInfo::Form";
             emitFormInitializer(OS, S, Name);
-            OS << " :\n";
+            OS << ";\n";
           }
         }
-        OS << "    (llvm_unreachable(\"Unknown attribute spelling!\"), "
-           << " AttributeCommonInfo::Form";
+        OS << "    default:\n";
+        OS << "      llvm_unreachable(\"Unknown attribute spelling!\");\n"
+           << "      return AttributeCommonInfo::Form";
         emitFormInitializer(OS, Spellings[0], "0");
-        OS << "))";
+        OS << ";\n"
+           << "    }\n"
+           << "  }()";
       }
 
       OS << ");\n";

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -2700,7 +2700,7 @@ static void emitAttributes(RecordKeeper &Records, raw_ostream &OS,
           const auto &Name = SemanticToSyntacticMap[Idx];
           if (Uniques.insert(Name).second) {
             OS << "    case " << Name << ":\n";
-            OS << "      return  AttributeCommonInfo::Form";
+            OS << "      return AttributeCommonInfo::Form";
             emitFormInitializer(OS, S, Name);
             OS << ";\n";
           }


### PR DESCRIPTION
# Codegen
### Before
```c++
AArch64SVEPcsAttr *AArch64SVEPcsAttr::CreateImplicit(ASTContext &Ctx, SourceRange Range, Spelling S) {
  AttributeCommonInfo I(Range, NoSemaHandlerAttribute, (
    S == GNU_aarch64_sve_pcs ? AttributeCommonInfo::Form{AttributeCommonInfo::AS_GNU, GNU_aarch64_sve_pcs, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/} :
    S == CXX11_clang_aarch64_sve_pcs ? AttributeCommonInfo::Form{AttributeCommonInfo::AS_CXX11, CXX11_clang_aarch64_sve_pcs, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/} :
    S == C23_clang_aarch64_sve_pcs ? AttributeCommonInfo::Form{AttributeCommonInfo::AS_C23, C23_clang_aarch64_sve_pcs, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/} :
    (llvm_unreachable("Unknown attribute spelling!"),  AttributeCommonInfo::Form{AttributeCommonInfo::AS_GNU, 0, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/})));
  return CreateImplicit(Ctx, I);
}
```

### After
```c++
AArch64SVEPcsAttr *AArch64SVEPcsAttr::CreateImplicit(ASTContext &Ctx, SourceRange Range, Spelling S) {
  AttributeCommonInfo I(Range, NoSemaHandlerAttribute, [&]() {
    switch (S) {
    case GNU_aarch64_sve_pcs:
      return AttributeCommonInfo::Form{AttributeCommonInfo::AS_GNU, GNU_aarch64_sve_pcs, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/};
    case CXX11_clang_aarch64_sve_pcs:
      return AttributeCommonInfo::Form{AttributeCommonInfo::AS_CXX11, CXX11_clang_aarch64_sve_pcs, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/};
    case C23_clang_aarch64_sve_pcs:
      return AttributeCommonInfo::Form{AttributeCommonInfo::AS_C23, C23_clang_aarch64_sve_pcs, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/};
    default:
      llvm_unreachable("Unknown attribute spelling!");
      return AttributeCommonInfo::Form{AttributeCommonInfo::AS_GNU, 0, false /*IsAlignas*/, false /*IsRegularKeywordAttribute*/};
    }
  }());
  return CreateImplicit(Ctx, I);
}
```

Fixes #68237 