### PR TITLE
[mlir][bufferization] Add `dump_alias_sets` option to transform op

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/TransformOps/BufferizationTransformOps.td
+++ b/mlir/include/mlir/Dialect/Bufferization/TransformOps/BufferizationTransformOps.td
@@ -85,6 +85,7 @@ def OneShotBufferizeOp
       DefaultValuedAttr<BoolAttr, "false">:$allow_return_allocs_from_loops,
       DefaultValuedAttr<BoolAttr, "false">:$allow_unknown_ops,
       DefaultValuedAttr<BoolAttr, "false">:$bufferize_function_boundaries,
+      DefaultValuedAttr<BoolAttr, "false">:$dump_alias_sets,
       DefaultValuedAttr<BoolAttr, "false">:$test_analysis_only,
       DefaultValuedAttr<BoolAttr, "false">:$print_conflicts,
       DefaultValuedAttr<StrAttr, "\"memref.copy\"">:$memcpy_op);

--- a/mlir/lib/Dialect/Bufferization/TransformOps/BufferizationTransformOps.cpp
+++ b/mlir/lib/Dialect/Bufferization/TransformOps/BufferizationTransformOps.cpp
@@ -47,6 +47,10 @@ void transform::BufferLoopHoistingOp::getEffects(
 LogicalResult transform::OneShotBufferizeOp::verify() {
   if (getMemcpyOp() != "memref.copy" && getMemcpyOp() != "linalg.copy")
     return emitOpError() << "unsupported memcpy op";
+  if (getPrintConflicts() && !getTestAnalysisOnly())
+    return emitOpError() << "'print_conflicts' requires 'test_analysis_only'";
+  if (getDumpAliasSets() && !getTestAnalysisOnly())
+    return emitOpError() << "'dump_alias_sets' requires 'test_analysis_only'";
   return success();
 }
 
@@ -58,6 +62,7 @@ transform::OneShotBufferizeOp::apply(transform::TransformRewriter &rewriter,
   options.allowReturnAllocsFromLoops = getAllowReturnAllocsFromLoops();
   options.allowUnknownOps = getAllowUnknownOps();
   options.bufferizeFunctionBoundaries = getBufferizeFunctionBoundaries();
+  options.dumpAliasSets = getDumpAliasSets();
   options.testAnalysisOnly = getTestAnalysisOnly();
   options.printConflicts = getPrintConflicts();
   if (getFunctionBoundaryTypeConversion().has_value())


### PR DESCRIPTION
Add `dump_alias_sets` to `transform.bufferization.one_shot_bufferize`. This option is useful for debugging. Also improve the verifier to ensure that `test_analysis_only` is set when other debugging flags are enabled.