### PR TITLE
[clang][Diagnostics] Add bitfield source range to zero width diags

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18161,7 +18161,8 @@ ExprResult Sema::VerifyBitField(SourceLocation FieldLoc,
 
   // Zero-width bitfield is ok for anonymous field.
   if (Value == 0 && FieldName)
-    return Diag(FieldLoc, diag::err_bitfield_has_zero_width) << FieldName;
+    return Diag(FieldLoc, diag::err_bitfield_has_zero_width)
+           << FieldName << BitWidth->getSourceRange();
 
   if (Value.isSigned() && Value.isNegative()) {
     if (FieldName)

--- a/clang/test/Misc/misc-source-ranges.cpp
+++ b/clang/test/Misc/misc-source-ranges.cpp
@@ -1,0 +1,7 @@
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info %s 2>&1 | FileCheck %s
+
+struct S {
+  char a : 12 - 12;
+};
+// CHECK: misc-source-ranges.cpp:[[@LINE-2]]:8:{[[@LINE-2]]:12-[[@LINE-2]]:19}
+


### PR DESCRIPTION
Before:
```
array.cpp:157:8: error: named bit-field 'a' has zero width
  157 |   char a : 12 - 12;
      |        ^
1 error generated.
```

After:

```
array.cpp:157:8: error: named bit-field 'a' has zero width
  157 |   char a : 12 - 12;
      |        ^   ~~~~~~~
1 error generated.
```