### PR TITLE
[clang][USR] Encode full decl-context also for anon namespaces

### DIFF
--- a/clang/lib/Index/USRGeneration.cpp
+++ b/clang/lib/Index/USRGeneration.cpp
@@ -9,6 +9,7 @@
 #include "clang/Index/USRGeneration.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DeclVisitor.h"
 #include "clang/Basic/FileManager.h"
@@ -368,14 +369,14 @@ void USRGenerator::VisitTemplateTemplateParmDecl(
 }
 
 void USRGenerator::VisitNamespaceDecl(const NamespaceDecl *D) {
+  if (IgnoreResults)
+    return;
+  VisitDeclContext(D->getDeclContext());
   if (D->isAnonymousNamespace()) {
     Out << "@aN";
     return;
   }
-
-  VisitDeclContext(D->getDeclContext());
-  if (!IgnoreResults)
-    Out << "@N@" << D->getName();
+  Out << "@N@" << D->getName();
 }
 
 void USRGenerator::VisitFunctionTemplateDecl(const FunctionTemplateDecl *D) {

--- a/clang/test/Index/USR/decl-context.cpp
+++ b/clang/test/Index/USR/decl-context.cpp
@@ -1,0 +1,14 @@
+// RUN: c-index-test core -print-source-symbols -- -std=c++20 %s | FileCheck %s
+
+namespace ns {
+namespace {
+struct Foo {};
+// CHECK: [[@LINE-1]]:8 | struct/C | Foo | c:decl-context.cpp@N@ns@aN@S@Foo
+}
+}
+namespace ns2 {
+namespace {
+struct Foo {};
+// CHECK: [[@LINE-1]]:8 | struct/C | Foo | c:decl-context.cpp@N@ns2@aN@S@Foo
+}
+}


### PR DESCRIPTION
Otherwise we create collisions, e.g. a struct named Foo inside an anonymous
namespace will get the same USR no matter what the surrounding decl-context is.
