### PR TITLE
[GISel] Add LookThroughInstrs for getIConstantVRegVal and getIConstan…

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
@@ -171,11 +171,13 @@ void reportGISelWarning(MachineFunction &MF, const TargetPassConfig &TPC,
 
 /// If \p VReg is defined by a G_CONSTANT, return the corresponding value.
 std::optional<APInt> getIConstantVRegVal(Register VReg,
-                                         const MachineRegisterInfo &MRI);
+                                         const MachineRegisterInfo &MRI,
+                                         bool LookThroughInstrs = false);
 
 /// If \p VReg is defined by a G_CONSTANT fits in int64_t returns it.
 std::optional<int64_t> getIConstantVRegSExtVal(Register VReg,
-                                               const MachineRegisterInfo &MRI);
+                                               const MachineRegisterInfo &MRI,
+                                               bool LookThroughInstrs = false);
 
 /// Simple struct used to hold a constant integer value and a virtual
 /// register.

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -304,7 +304,7 @@ std::optional<APInt> llvm::getIConstantVRegVal(Register VReg,
 std::optional<int64_t>
 llvm::getIConstantVRegSExtVal(Register VReg, const MachineRegisterInfo &MRI,
                               bool LookThroughInstrs = false) {
-  std::optional<APInt> Val = getIConstantVRegVal(VReg, MRI);
+  std::optional<APInt> Val = getIConstantVRegVal(VReg, MRI, LookThroughInstrs);
   if (Val && Val->getBitWidth() <= 64)
     return Val->getSExtValue();
   return std::nullopt;

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -291,7 +291,7 @@ void llvm::reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
 
 std::optional<APInt> llvm::getIConstantVRegVal(Register VReg,
                                                const MachineRegisterInfo &MRI,
-                                               bool LookThroughInstrs = false) {
+                                               bool LookThroughInstrs) {
   std::optional<ValueAndVReg> ValAndVReg =
       getIConstantVRegValWithLookThrough(VReg, MRI, LookThroughInstrs);
   assert((!ValAndVReg || ValAndVReg->VReg == VReg) &&
@@ -303,7 +303,7 @@ std::optional<APInt> llvm::getIConstantVRegVal(Register VReg,
 
 std::optional<int64_t>
 llvm::getIConstantVRegSExtVal(Register VReg, const MachineRegisterInfo &MRI,
-                              bool LookThroughInstrs = false) {
+                              bool LookThroughInstrs) {
   std::optional<APInt> Val = getIConstantVRegVal(VReg, MRI, LookThroughInstrs);
   if (Val && Val->getBitWidth() <= 64)
     return Val->getSExtValue();

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -290,9 +290,10 @@ void llvm::reportGISelFailure(MachineFunction &MF, const TargetPassConfig &TPC,
 }
 
 std::optional<APInt> llvm::getIConstantVRegVal(Register VReg,
-                                               const MachineRegisterInfo &MRI) {
-  std::optional<ValueAndVReg> ValAndVReg = getIConstantVRegValWithLookThrough(
-      VReg, MRI, /*LookThroughInstrs*/ false);
+                                               const MachineRegisterInfo &MRI,
+                                               bool LookThroughInstrs = false) {
+  std::optional<ValueAndVReg> ValAndVReg =
+      getIConstantVRegValWithLookThrough(VReg, MRI, LookThroughInstrs);
   assert((!ValAndVReg || ValAndVReg->VReg == VReg) &&
          "Value found while looking through instrs");
   if (!ValAndVReg)
@@ -301,7 +302,8 @@ std::optional<APInt> llvm::getIConstantVRegVal(Register VReg,
 }
 
 std::optional<int64_t>
-llvm::getIConstantVRegSExtVal(Register VReg, const MachineRegisterInfo &MRI) {
+llvm::getIConstantVRegSExtVal(Register VReg, const MachineRegisterInfo &MRI,
+                              bool LookThroughInstrs = false) {
   std::optional<APInt> Val = getIConstantVRegVal(VReg, MRI);
   if (Val && Val->getBitWidth() <= 64)
     return Val->getSExtValue();


### PR DESCRIPTION
…tVRegSExtVal

The implementation of these methods uses getIConstantVRegValWithLookThrough with LookThroughInstrs argument set to false. By adding the optional argument to getIConstantVRegVal and getIConstantVRegSExtVal we can take advantage of the already built look through functionality.