### PR TITLE
Fix non-determinism in debuginfo

### DIFF
--- a/llvm/include/llvm/IR/DebugInfo.h
+++ b/llvm/include/llvm/IR/DebugInfo.h
@@ -320,11 +320,13 @@ bool isAssignmentTrackingEnabled(const Module &M);
 
 template <> struct DenseMapInfo<at::VarRecord> {
   static inline at::VarRecord getEmptyKey() {
-    return at::VarRecord{nullptr, nullptr};
+    return at::VarRecord{DenseMapInfo<DILocalVariable *>::getEmptyKey(),
+                         DenseMapInfo<DILocation *>::getEmptyKey()};
   }
 
   static inline at::VarRecord getTombstoneKey() {
-    return at::VarRecord{nullptr, nullptr};
+    return at::VarRecord{DenseMapInfo<DILocalVariable *>::getTombstoneKey(),
+                         DenseMapInfo<DILocation *>::getTombstoneKey()};
   }
 
   static unsigned getHashValue(const at::VarRecord &Var) {

--- a/llvm/include/llvm/IR/DebugInfo.h
+++ b/llvm/include/llvm/IR/DebugInfo.h
@@ -246,20 +246,7 @@ bool calculateFragmentIntersect(
 /// explicit using types. In addition, eventually we will want to understand
 /// expressions that modify the base address too, which a DebugVariable doesn't
 /// capture.
-struct VarRecord {
-  DILocalVariable *Var;
-  DILocation *DL;
-
-  VarRecord(DbgVariableIntrinsic *DVI)
-      : Var(DVI->getVariable()), DL(getDebugValueLoc(DVI)) {}
-  VarRecord(DILocalVariable *Var, DILocation *DL) : Var(Var), DL(DL) {}
-  friend bool operator<(const VarRecord &LHS, const VarRecord &RHS) {
-    return std::tie(LHS.Var, LHS.DL) < std::tie(RHS.Var, RHS.DL);
-  }
-  friend bool operator==(const VarRecord &LHS, const VarRecord &RHS) {
-    return std::tie(LHS.Var, LHS.DL) == std::tie(RHS.Var, RHS.DL);
-  }
-};
+using VarRecord = std::pair<DILocalVariable *, DILocation *>;
 
 /// Map of backing storage to a set of variables that are stored to it.
 /// TODO: Backing storage shouldn't be limited to allocas only. Some local
@@ -317,26 +304,6 @@ public:
 
 /// Return true if assignment tracking is enabled for module \p M.
 bool isAssignmentTrackingEnabled(const Module &M);
-
-template <> struct DenseMapInfo<at::VarRecord> {
-  static inline at::VarRecord getEmptyKey() {
-    return at::VarRecord{DenseMapInfo<DILocalVariable *>::getEmptyKey(),
-                         DenseMapInfo<DILocation *>::getEmptyKey()};
-  }
-
-  static inline at::VarRecord getTombstoneKey() {
-    return at::VarRecord{DenseMapInfo<DILocalVariable *>::getTombstoneKey(),
-                         DenseMapInfo<DILocation *>::getTombstoneKey()};
-  }
-
-  static unsigned getHashValue(const at::VarRecord &Var) {
-    return hash_combine(Var.Var, Var.DL);
-  }
-
-  static bool isEqual(const at::VarRecord &A, const at::VarRecord &B) {
-    return A == B;
-  }
-};
 
 } // end namespace llvm
 


### PR DESCRIPTION
Assignment tracking iterates over a SmallSet when adding metadata, which eventually results in debug metadata being added to the module in non-deterministic order.

As reported in #63921, we saw some cases where DWARF DebugLoc entries could have their order reversed, even though there was no functional difference.

This patch replaces the `SmallSet` with a `SmallVector`, and adds the required `DenseMapInfo` specialization to make the ordering deterministic.

Fixes #63921