### PR TITLE
[DWARF] Change to consistently print out abbrev code in .debug_names

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -635,7 +635,7 @@ std::optional<uint64_t> DWARFDebugNames::Entry::getCUOffset() const {
 }
 
 void DWARFDebugNames::Entry::dump(ScopedPrinter &W) const {
-  W.printHex("Abbrev", Abbr->Code);
+  W.startLine() << formatv("Abbrev: {0:x}\n", Abbr->Code);
   W.startLine() << formatv("Tag: {0}\n", Abbr->Tag);
   assert(Abbr->Attributes.size() == Values.size());
   for (auto Tuple : zip_first(Abbr->Attributes, Values)) {

--- a/llvm/test/DebugInfo/X86/debug-names-dwarf64.ll
+++ b/llvm/test/DebugInfo/X86/debug-names-dwarf64.ll
@@ -26,11 +26,11 @@
 ; CHECK-NEXT:     CU[0]: 0x00000000
 ; CHECK-NEXT:   ]
 ; CHECK-NEXT:   Abbreviations [
-; CHECK-NEXT:     Abbreviation 0x34 {
+; CHECK-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; CHECK-NEXT:       Tag: DW_TAG_variable
 ; CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 ; CHECK-NEXT:     }
-; CHECK-NEXT:     Abbreviation 0x24 {
+; CHECK-NEXT:     Abbreviation [[ABBREV:0x[0-9a-f]*]] {
 ; CHECK-NEXT:       Tag: DW_TAG_base_type
 ; CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 ; CHECK-NEXT:     }
@@ -40,7 +40,7 @@
 ; CHECK-NEXT:       Hash: 0xB888030
 ; CHECK-NEXT:       String: {{.+}} "int"
 ; CHECK-NEXT:       Entry @ {{.+}} {
-; CHECK-NEXT:         Abbrev: 0x24
+; CHECK-NEXT:         Abbrev: [[ABBREV]]
 ; CHECK-NEXT:         Tag: DW_TAG_base_type
 ; CHECK-NEXT:         DW_IDX_die_offset: [[TYPEDIE]]
 ; CHECK-NEXT:       }
@@ -51,7 +51,7 @@
 ; CHECK-NEXT:       Hash: 0xB887389
 ; CHECK-NEXT:       String: {{.+}} "foo"
 ; CHECK-NEXT:       Entry @ {{.+}} {
-; CHECK-NEXT:         Abbrev: 0x34
+; CHECK-NEXT:         Abbrev: [[ABBREV1]]
 ; CHECK-NEXT:         Tag: DW_TAG_variable
 ; CHECK-NEXT:         DW_IDX_die_offset: [[VARDIE]]
 ; CHECK-NEXT:       }

--- a/llvm/test/DebugInfo/X86/dwarfdump-debug-names.s
+++ b/llvm/test/DebugInfo/X86/dwarfdump-debug-names.s
@@ -151,7 +151,7 @@
 # CHECK-NEXT:     CU[0]: 0x00000000
 # CHECK-NEXT:   ]
 # CHECK-NEXT:   Abbreviations [
-# CHECK-NEXT:     Abbreviation 0x2e {
+# CHECK-NEXT:     Abbreviation [[ABBREV:0x[0-9a-f]*]] {
 # CHECK-NEXT:       Tag: DW_TAG_subprogram
 # CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 # CHECK-NEXT:     }
@@ -164,7 +164,7 @@
 # CHECK-NEXT:       Hash: 0xB887389
 # CHECK-NEXT:       String: 0x00000000 "foo"
 # CHECK-NEXT:       Entry @ 0x4f {
-# CHECK-NEXT:         Abbrev: 0x2E
+# CHECK-NEXT:         Abbrev: [[ABBREV]]
 # CHECK-NEXT:         Tag: DW_TAG_subprogram
 # CHECK-NEXT:         DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:       }
@@ -173,7 +173,7 @@
 # CHECK-NEXT:       Hash: 0xB5063D0B
 # CHECK-NEXT:       String: 0x00000004 "_Z3foov"
 # CHECK-NEXT:       Entry @ 0x58 {
-# CHECK-NEXT:         Abbrev: 0x2E
+# CHECK-NEXT:         Abbrev: [[ABBREV]]
 # CHECK-NEXT:         Tag: DW_TAG_subprogram
 # CHECK-NEXT:         DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:       }
@@ -197,7 +197,7 @@
 # CHECK-NEXT:     CU[0]: 0x00000002
 # CHECK-NEXT:   ]
 # CHECK-NEXT:   Abbreviations [
-# CHECK-NEXT:     Abbreviation 0x34 {
+# CHECK-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 # CHECK-NEXT:       Tag: DW_TAG_variable
 # CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 # CHECK-NEXT:     }
@@ -207,7 +207,7 @@
 # CHECK-NEXT:       Hash: 0xB8860BA
 # CHECK-NEXT:       String: 0x0000000c "bar"
 # CHECK-NEXT:       Entry @ 0xa3 {
-# CHECK-NEXT:         Abbrev: 0x34
+# CHECK-NEXT:         Abbrev: [[ABBREV1]]
 # CHECK-NEXT:         Tag: DW_TAG_variable
 # CHECK-NEXT:         DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:       }
@@ -237,7 +237,7 @@
 # CHECK-NEXT:     ForeignTU[0]: 0xffffff00ffffffff
 # CHECK-NEXT:   ]
 # CHECK-NEXT:   Abbreviations [
-# CHECK-NEXT:     Abbreviation 0x1 {
+# CHECK-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 # CHECK-NEXT:       Tag: DW_TAG_base_type
 # CHECK-NEXT:       DW_IDX_type_unit: DW_FORM_data4
 # CHECK-NEXT:       DW_IDX_type_hash: DW_FORM_data8
@@ -248,7 +248,7 @@
 # CHECK-NEXT:       Hash: 0xB887389
 # CHECK-NEXT:       String: 0x00000000 "foo"
 # CHECK-NEXT:       Entry @ 0x111 {
-# CHECK-NEXT:         Abbrev: 0x1
+# CHECK-NEXT:         Abbrev: [[ABBREV2]]
 # CHECK-NEXT:         Tag: DW_TAG_base_type
 # CHECK-NEXT:         DW_IDX_type_unit: 0x00000001
 # CHECK-NEXT:         DW_IDX_type_hash: 0x0000ff03ffffffff

--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-misaligned.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-misaligned.s
@@ -84,7 +84,7 @@
 # CHECK:       Name 1 {
 # CHECK-NEXT:    String: 0x00000000 "foo"
 # CHECK-NEXT:    Entry @ 0x37 {
-# CHECK-NEXT:      Abbrev: 0x2E
+# CHECK-NEXT:      Abbrev: 0x2e
 # CHECK-NEXT:      Tag: DW_TAG_subprogram
 # CHECK-NEXT:      DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:    }


### PR DESCRIPTION
Changed so that when Abbrev code is printed out for entry it is done in the same
way as in Abbrev table.
Once letters are present in a hex number in abbrev table they will be lower case, 
and in the Entry upper case. Which makes FIleCheck Pattern recognition fail.
Example in: llvm/test/tools/llvm-dwarfdump/X86/debug-names-misaligned.s
