### PR TITLE
[llvm][Support] fix convertToSnakeFromCamelCase

### DIFF
--- a/llvm/lib/Support/StringExtras.cpp
+++ b/llvm/lib/Support/StringExtras.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cctype>
 
@@ -96,18 +97,13 @@ std::string llvm::convertToSnakeFromCamelCase(StringRef input) {
   if (input.empty())
     return "";
 
-  std::string snakeCase;
-  snakeCase.reserve(input.size());
-  for (char c : input) {
-    if (!std::isupper(c)) {
-      snakeCase.push_back(c);
-      continue;
-    }
-
-    if (!snakeCase.empty() && snakeCase.back() != '_')
-      snakeCase.push_back('_');
-    snakeCase.push_back(llvm::toLower(c));
+  std::string snakeCase = input.str();
+  for (int i = 0; i < 10; ++i) {
+    snakeCase = llvm::Regex("([A-Z]+)([A-Z][a-z])").sub("\\1_\\2", snakeCase);
+    snakeCase = llvm::Regex("([a-z0-9])([A-Z])").sub("\\1_\\2", snakeCase);
   }
+  std::transform(snakeCase.begin(), snakeCase.end(), snakeCase.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
   return snakeCase;
 }
 

--- a/llvm/lib/Support/StringExtras.cpp
+++ b/llvm/lib/Support/StringExtras.cpp
@@ -97,10 +97,13 @@ std::string llvm::convertToSnakeFromCamelCase(StringRef input) {
   if (input.empty())
     return "";
 
+  llvm::Regex trailingCap = llvm::Regex("([A-Z]+)([A-Z][a-z])");
+  llvm::Regex leadingCap = llvm::Regex("([a-z0-9])([A-Z])");
+
   std::string snakeCase = input.str();
   for (int i = 0; i < 10; ++i) {
-    snakeCase = llvm::Regex("([A-Z]+)([A-Z][a-z])").sub("\\1_\\2", snakeCase);
-    snakeCase = llvm::Regex("([a-z0-9])([A-Z])").sub("\\1_\\2", snakeCase);
+    snakeCase = trailingCap.sub("\\1_\\2", snakeCase);
+    snakeCase = leadingCap.sub("\\1_\\2", snakeCase);
   }
   std::transform(snakeCase.begin(), snakeCase.end(), snakeCase.begin(),
                  [](unsigned char c) { return std::tolower(c); });

--- a/llvm/lib/Support/StringExtras.cpp
+++ b/llvm/lib/Support/StringExtras.cpp
@@ -98,18 +98,17 @@ std::string llvm::convertToSnakeFromCamelCase(StringRef input) {
 
   std::string snakeCase;
   snakeCase.reserve(input.size());
-  auto check = [&input](size_t j, std::function<bool(int)> check) {
-    return j < input.size() ? check(input[j]) : false;
+  auto check = [&input](size_t j, function_ref<bool(int)> predicate) {
+    return j < input.size() && predicate(input[j]);
   };
   for (size_t i = 0; i < input.size(); ++i) {
-    snakeCase.push_back(input[i]);
+    snakeCase.push_back(tolower(input[i]));
+    // Handles "runs" of capitals, such as in OPName -> op_name.
     if (check(i, isupper) && check(i + 1, isupper) && check(i + 2, islower))
       snakeCase.push_back('_');
     if ((check(i, islower) || check(i, isdigit)) && check(i + 1, isupper))
       snakeCase.push_back('_');
   }
-  std::transform(snakeCase.begin(), snakeCase.end(), snakeCase.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
   return snakeCase;
 }
 

--- a/llvm/unittests/ADT/StringExtrasTest.cpp
+++ b/llvm/unittests/ADT/StringExtrasTest.cpp
@@ -184,6 +184,11 @@ TEST(StringExtrasTest, ConvertToSnakeFromCamelCase) {
 
   testConvertToSnakeCase("OpName", "op_name");
   testConvertToSnakeCase("opName", "op_name");
+  testConvertToSnakeCase("OPName", "op_name");
+  testConvertToSnakeCase("opNAME", "op_name");
+  testConvertToSnakeCase("opNAMe", "op_na_me");
+  testConvertToSnakeCase("opnameE", "opname_e");
+  testConvertToSnakeCase("OPNameOPName", "op_name_op_name");
   testConvertToSnakeCase("_OpName", "_op_name");
   testConvertToSnakeCase("Op_Name", "op_name");
   testConvertToSnakeCase("", "");

--- a/llvm/unittests/ADT/StringExtrasTest.cpp
+++ b/llvm/unittests/ADT/StringExtrasTest.cpp
@@ -186,6 +186,7 @@ TEST(StringExtrasTest, ConvertToSnakeFromCamelCase) {
   testConvertToSnakeCase("opName", "op_name");
   testConvertToSnakeCase("OPName", "op_name");
   testConvertToSnakeCase("Intel_OCL_BI", "intel_ocl_bi");
+  testConvertToSnakeCase("I32Attr", "i32_attr");
   testConvertToSnakeCase("opNAME", "op_name");
   testConvertToSnakeCase("opNAMe", "op_na_me");
   testConvertToSnakeCase("opnameE", "opname_e");

--- a/llvm/unittests/ADT/StringExtrasTest.cpp
+++ b/llvm/unittests/ADT/StringExtrasTest.cpp
@@ -185,6 +185,7 @@ TEST(StringExtrasTest, ConvertToSnakeFromCamelCase) {
   testConvertToSnakeCase("OpName", "op_name");
   testConvertToSnakeCase("opName", "op_name");
   testConvertToSnakeCase("OPName", "op_name");
+  testConvertToSnakeCase("Intel_OCL_BI", "intel_ocl_bi");
   testConvertToSnakeCase("opNAME", "op_name");
   testConvertToSnakeCase("opNAMe", "op_na_me");
   testConvertToSnakeCase("opnameE", "opname_e");


### PR DESCRIPTION
Currently runs of caps aren't handled correctly so e.g. something like `Intel_OCL_BI` is snake cased to `intel_o_c_l_b_i` (previously discussed on this [phabricator patch](https://reviews.llvm.org/rG92233062c17590d3157bdc6db430fcdfc54312fe)). 