### PR TITLE
[clang][dataflow] Various formatting tweaks to HTMLLogger.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.css
@@ -19,6 +19,7 @@ section header {
   color: white;
   font-weight: bold;
   font-size: large;
+  padding-right: 0.5em;
 }
 section h2 {
   font-size: medium;
@@ -27,7 +28,7 @@ section h2 {
   border-top: 1px solid #aaa;
 }
 #timeline {
-  min-width: 0;
+  min-width: max-content;
 }
 #timeline .entry.hover {
   background-color: #aaa;
@@ -62,6 +63,10 @@ section h2 {
 #iterations .chooser {
   flex-grow: 1;
   text-align: center;
+  padding-left: 0.2em;
+}
+#iterations .chooser :last-child {
+  padding-right: 0.2em;
 }
 #iterations .chooser:not(.iter-select).hover {
   background-color: #ddd;

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.html
@@ -62,7 +62,7 @@
   <template data-for="iter in cfg[selection.bb].iters">
     <a class="chooser {{selection.bb}}:{{iter.iter}}" data-iter="{{selection.bb}}:{{iter.iter}}">
       <template data-if="iter.post_visit">Post-visit</template>
-      <template data-if="!iter.post_visit">Iteration {{iter.iter}}</template>
+      <template data-if="!iter.post_visit">{{iter.iter}}</template>
       <template data-if="iter.converged"> &#x2192;&#x7c;<!--Rightwards arrow, vertical line--></template>
     </a>
   </template>


### PR DESCRIPTION
*  Ensure timeline entries don't have linebreaks by setting
   `min-width: max-content`.

*  Give the timeline header some padding on the right so it doesn't run into the
   "Function" header.

*  Put some padding around the iteration choosers so they don't run into each
   other.

*  Eliminate the "Iteration" text from the iteration choosers, which took up a
   lot of space. It should be clear what these are without the "Iteration"
   text. (This makes the above problem of iteration choosers running into each
   other less likely, but also add the padding nonetheless.)

Before:

![html_logger_before](https://github.com/llvm/llvm-project/assets/29098113/b938360f-c943-4552-829f-7b4857260959)

After:

![html_logger_after](https://github.com/llvm/llvm-project/assets/29098113/fecf4eab-7992-4e7d-a6e1-451887b699ab)