### PR TITLE
[lldb][DWARFASTParserClang][NFC] Fix comment regarding static data member detection

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2878,8 +2878,8 @@ void DWARFASTParserClang::ParseSingleMember(
     attrs.accessibility = eAccessNone;
 
   // Handle static members, which are typically members without
-  // locations. However, GCC *never* emits DW_AT_data_member_location
-  // for static data members of unions.
+  // locations. However, GCC doesn't emit DW_AT_data_member_location
+  // for any union members (regardless of linkage).
   // Non-normative text pre-DWARFv5 recommends marking static
   // data members with an DW_AT_external flag. Clang emits this consistently
   // whereas GCC emits it only for static data members if not part of an


### PR DESCRIPTION
Fixes misleading comment introduced in
`f74aaca63202cabb512c78fe19196ff348d436a8` (https://github.com/llvm/llvm-project/pull/68300)