### PR TITLE
[lldb[test] TestCppUnionStaticMembers.py: XFAIL assertions on windows 

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -511,6 +511,10 @@ def expectedFailureNetBSD(bugnumber=None):
     return expectedFailureOS(["netbsd"], bugnumber)
 
 
+def expectedFailureWindows(bugnumber=None):
+    return expectedFailureOS(["windows"], bugnumber)
+
+
 # TODO: This decorator does not do anything. Remove it.
 def expectedFlakey(expected_fn, bugnumber=None):
     def expectedFailure_impl(func):

--- a/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
+++ b/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
@@ -27,6 +27,7 @@ class CppUnionStaticMembersTestCase(TestBase):
                 name="val", value="137"
             )])
 
+    @expectedFailureWindows
     def test_expr_union_static_members(self):
         """Tests that frame variable and expr work
         for union static data members"""

--- a/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
+++ b/lldb/test/API/lang/cpp/union-static-data-members/TestCppUnionStaticMembers.py
@@ -8,14 +8,14 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class CppUnionStaticMembersTestCase(TestBase):
-    def test(self):
+    def test_print_union(self):
         """Tests that frame variable and expr work
-           for union static data members"""
+        for union with static data members"""
         self.build()
 
         (target, process, main_thread, _) = lldbutil.run_to_source_breakpoint(
             self, "return 0", lldb.SBFileSpec("main.cpp")
-        )                                                                     
+        )
 
         self.expect("frame variable foo", substrs=["val = 42"])
         self.expect("frame variable bar", substrs=["val = 137"])
@@ -27,6 +27,15 @@ class CppUnionStaticMembersTestCase(TestBase):
                 name="val", value="137"
             )])
 
+    def test_expr_union_static_members(self):
+        """Tests that frame variable and expr work
+        for union static data members"""
+        self.build()
+
+        (target, process, main_thread, _) = lldbutil.run_to_source_breakpoint(
+            self, "return 0", lldb.SBFileSpec("main.cpp")
+        )
+
         self.expect_expr("Foo::sVal1", result_type="const int", result_value="-42")
         self.expect_expr("Foo::sVal2", result_type="Foo", result_children=[ValueCheck(
                 name="val", value="42"
@@ -37,6 +46,12 @@ class CppUnionStaticMembersTestCase(TestBase):
         """Tests that frame variable and expr work
            for union static data members in anonymous
            namespaces"""
+        self.build()
+
+        (target, process, main_thread, _) = lldbutil.run_to_source_breakpoint(
+            self, "return 0", lldb.SBFileSpec("main.cpp")
+        )
+
         self.expect_expr("Bar::sVal1", result_type="const int", result_value="-137")
         self.expect_expr("Bar::sVal2", result_type="Bar", result_children=[ValueCheck(
                 name="val", value="137"


### PR DESCRIPTION
### Commit 1:

Split out the assertions that fail on Windows in preparation to
XFAILing them.

Drive-by change:
* Add a missing `self.build()` call in `test_union_in_anon_namespace`
* Fix formatting

### Commit 2:

[[lldb][lldbsuite] Add expectedFailureWindows decorator](https://github.com/llvm/llvm-project/pull/68408/commits/b5fc63d9372b41ac4bdd3a95a40907b6ec32225d)

### Commit 3:

Apply `expectedFailureWindows` to failing test