### PR TITLE
Fix typo "x84_64"

### DIFF
--- a/clang/test/Driver/cuda-detect.cu
+++ b/clang/test/Driver/cuda-detect.cu
@@ -29,7 +29,7 @@
 // RUN:   --sysroot=%S/Inputs/CUDA-nolibdevice --cuda-path-ignore-env 2>&1 | FileCheck %s -check-prefix NOCUDA
 // RUN: %clang -v --target=x86_64-unknown-linux \
 // RUN:   --sysroot=%S/Inputs/CUDA-nolibdevice --cuda-path-ignore-env 2>&1 | FileCheck %s -check-prefix NOCUDA
-// RUN: %clang -v --target=x84_64-apple-macosx \
+// RUN: %clang -v --target=x86_64-apple-macosx \
 // RUN:   --sysroot=%S/Inputs/CUDA-nolibdevice --cuda-path-ignore-env 2>&1 | FileCheck %s -check-prefix NOCUDA
 
 // ... unless the user doesn't need libdevice

--- a/llvm/lib/Target/X86/X86RegisterInfo.td
+++ b/llvm/lib/Target/X86/X86RegisterInfo.td
@@ -508,7 +508,7 @@ def GR64_NOREX_NOSP : RegisterClass<"X86", [i64], 64,
                                     (and GR64_NOREX, GR64_NOSP)>;
 
 // Register classes used for ABIs that use 32-bit address accesses,
-// while using the whole x84_64 ISA.
+// while using the whole x86_64 ISA.
 
 // In such cases, it is fine to use RIP as we are sure the 32 high
 // bits are not set. We do not need variants for NOSP as RIP is not


### PR DESCRIPTION
Apparently great minds think alike: I noticed these while correcting the same typo in MSVC's sources.