### PR TITLE
[AArch64] Fix for misched-branch-targets.mir test

### DIFF
--- a/llvm/test/CodeGen/AArch64/misched-branch-targets.mir
+++ b/llvm/test/CodeGen/AArch64/misched-branch-targets.mir
@@ -1,6 +1,9 @@
 # RUN: llc -o - -run-pass=machine-scheduler -misched=shuffle %s | FileCheck %s
 # RUN: llc -o - -run-pass=postmisched %s | FileCheck %s
 
+# REQUIRES: asserts
+# -misched=shuffle is only available with assertions enabled
+
 # Check that instructions that are recognized as branch targets by BTI
 # are not reordered by machine instruction schedulers.
 


### PR DESCRIPTION
Fix test failure in non-assertion builds introduced by f1b2dd2a111f038420b3f69d4ce0b3b3f245c873.