### PR TITLE
[ValueTracking] Analyze `Select` in `isKnownNonEqual`.

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -3129,27 +3129,13 @@ static bool isNonEqualSelect(const Value *V1, const Value *V2, unsigned Depth,
     return false;
 
   if (const SelectInst *SI2 = dyn_cast<SelectInst>(V2)) {
-    const Value *TVal1 = nullptr;
-    const Value *TVal2 = nullptr;
-    const Value *FVal1 = nullptr;
-    const Value *FVal2 = nullptr;
     const Value *Cond1 = SI1->getCondition();
     const Value *Cond2 = SI2->getCondition();
-    if (Cond1 == Cond2) {
-      TVal1 = SI1->getTrueValue();
-      TVal2 = SI2->getTrueValue();
-      FVal1 = SI1->getFalseValue();
-      FVal2 = SI2->getFalseValue();
-    }
-    if (match(Cond1, m_Not(m_Specific(Cond2)))) {
-      TVal1 = SI1->getFalseValue();
-      TVal2 = SI2->getTrueValue();
-      FVal1 = SI1->getTrueValue();
-      FVal2 = SI2->getFalseValue();
-    }
-    if (TVal1)
-      return isKnownNonEqual(TVal1, TVal2, Depth + 1, Q) &&
-             isKnownNonEqual(FVal1, FVal2, Depth + 1, Q);
+    if (Cond1 == Cond2)
+      return isKnownNonEqual(SI1->getTrueValue(), SI2->getTrueValue(),
+                             Depth + 1, Q) &&
+             isKnownNonEqual(SI1->getFalseValue(), SI2->getFalseValue(),
+                             Depth + 1, Q);
   }
   return isKnownNonEqual(SI1->getTrueValue(), V2, Depth + 1, Q) &&
          isKnownNonEqual(SI1->getFalseValue(), V2, Depth + 1, Q);

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -3171,9 +3171,6 @@ static bool isKnownNonEqual(const Value *V1, const Value *V2, unsigned Depth,
     };
   }
 
-  if (isNonEqualSelect(V1, V2, Depth, Q) || isNonEqualSelect(V2, V1, Depth, Q))
-    return true;
-
   if (isAddOfNonZero(V1, V2, Depth, Q) || isAddOfNonZero(V2, V1, Depth, Q))
     return true;
 
@@ -3193,6 +3190,10 @@ static bool isKnownNonEqual(const Value *V1, const Value *V2, unsigned Depth,
         Known2.Zero.intersects(Known1.One))
       return true;
   }
+
+  if (isNonEqualSelect(V1, V2, Depth, Q) || isNonEqualSelect(V2, V1, Depth, Q))
+    return true;
+
   return false;
 }
 

--- a/llvm/test/Analysis/BasicAA/non-equal-select.ll
+++ b/llvm/test/Analysis/BasicAA/non-equal-select.ll
@@ -1,0 +1,33 @@
+; RUN: opt < %s -aa-pipeline=basic-aa -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
+@G = global [10 x i32] zeroinitializer, align 4
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, argmem: none, inaccessiblemem: none) uwtable
+define void @select_in_gep1(i1 %c, i64 noundef %x) {
+entry:
+; CHECK: Function: select_in_gep1
+; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
+  %add1_ = add nsw i64 %x, 1
+  %add2_ = add nsw i64 %x, 2
+  %select_ = select i1 %c, i64 %add1_, i64 %add2_
+  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select_
+  store i32 42, ptr %arrayidx1, align 4
+  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %x
+  store i32 43, ptr %arrayidx2, align 4
+  ret void
+}
+
+define void @select_in_gep2(i1 %c, i64 noundef %x) {
+entry:
+  ; TODO: should be "NoAlias" here as well.
+; CHECK: Function: select_in_gep2
+; CHECK: MayAlias:     i32* %arrayidx1, i32* %arrayidx2
+  %add1_ = add nsw i64 %x, 1
+  %add2_ = add nsw i64 %x, 2
+  %add3_ = add nsw i64 %x, 3
+  %select_ = select i1 %c, i64 %add1_, i64 %add2_
+  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select_
+  store i32 42, ptr %arrayidx1, align 4
+  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %add3_
+  store i32 43, ptr %arrayidx2, align 4
+  ret void
+}

--- a/llvm/test/Analysis/BasicAA/non-equal-select.ll
+++ b/llvm/test/Analysis/BasicAA/non-equal-select.ll
@@ -1,10 +1,9 @@
 ; RUN: opt < %s -aa-pipeline=basic-aa -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
 @G = global [10 x i32] zeroinitializer, align 4
 
-; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(readwrite, argmem: none, inaccessiblemem: none) uwtable
-define void @select_in_gep1(i1 %c, i64 noundef %x) {
+define void @select_in_gep1(i1 %c, i64 %x) {
 entry:
-; CHECK: Function: select_in_gep1
+; CHECK-LABEL: Function: select_in_gep1
 ; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
   %add1_ = add nsw i64 %x, 1
   %add2_ = add nsw i64 %x, 2
@@ -16,10 +15,10 @@ entry:
   ret void
 }
 
-define void @select_in_gep2(i1 %c, i64 noundef %x) {
+define void @select_in_gep2(i1 %c, i64 %x) {
 entry:
   ; TODO: should be "NoAlias" here as well.
-; CHECK: Function: select_in_gep2
+; CHECK-LABEL: Function: select_in_gep2
 ; CHECK: MayAlias:     i32* %arrayidx1, i32* %arrayidx2
   %add1_ = add nsw i64 %x, 1
   %add2_ = add nsw i64 %x, 2
@@ -28,6 +27,85 @@ entry:
   %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select_
   store i32 42, ptr %arrayidx1, align 4
   %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %add3_
+  store i32 43, ptr %arrayidx2, align 4
+  ret void
+}
+
+define void @two_selects_in_gep_same_cond(i1 %c, i64 %x) {
+entry:
+; CHECK-LABEL: Function: two_selects_in_gep_same_cond
+; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
+  %add1_ = add nsw i64 %x, 1
+  %add2_ = add nsw i64 %x, 2
+  %select1_ = select i1 %c, i64 %x, i64 %add1_
+  %select2_ = select i1 %c, i64 %add2_, i64 %x
+  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select1_
+  store i32 42, ptr %arrayidx1, align 4
+  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select2_
+  store i32 43, ptr %arrayidx2, align 4
+  ret void
+}
+
+define void @two_selects_in_gep_opposite_cond1(i1 %c, i64 %x) {
+entry:
+; CHECK-LABEL: Function: two_selects_in_gep_opposite_cond1
+; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
+  %add1_ = add nsw i64 %x, 1
+  %add2_ = add nsw i64 %x, 2
+  %not_c = xor i1 %c, -1
+  %select1_ = select i1 %c, i64 %x, i64 %add1_
+  %select2_ = select i1 %not_c, i64 %x, i64 %add2_
+  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select1_
+  store i32 42, ptr %arrayidx1, align 4
+  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select2_
+  store i32 43, ptr %arrayidx2, align 4
+  ret void
+}
+
+define void @two_selects_in_gep_opposite_cond2(i1 %c, i64 %x) {
+entry:
+; CHECK-LABEL: Function: two_selects_in_gep_opposite_cond2
+; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
+  %add1_ = add nsw i64 %x, 1
+  %add2_ = add nsw i64 %x, 2
+  %not_c = xor i1 %c, -1
+  %select1_ = select i1 %not_c, i64 %x, i64 %add1_
+  %select2_ = select i1 %c, i64 %x, i64 %add2_
+  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select1_
+  store i32 42, ptr %arrayidx1, align 4
+  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select2_
+  store i32 43, ptr %arrayidx2, align 4
+  ret void
+}
+
+define void @two_selects_in_gep_different_cond1(i1 %c1, i1 %c2, i64 %x) {
+entry:
+; CHECK-LABEL: Function: two_selects_in_gep_different_cond1
+; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
+  %add1_ = add nsw i64 %x, 1
+  %add2_ = add nsw i64 %x, 2
+  %add3_ = add nsw i64 %x, 3
+  %add4_ = add nsw i64 %x, 4
+  %select1_ = select i1 %c1, i64 %add1_, i64 %add2_
+  %select2_ = select i1 %c2, i64 %add3_, i64 %add4_
+  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select1_
+  store i32 42, ptr %arrayidx1, align 4
+  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select2_
+  store i32 43, ptr %arrayidx2, align 4
+  ret void
+}
+
+define void @two_selects_in_gep_different_cond2(i1 %c1, i1 %c2, i64 %x) {
+entry:
+; CHECK-LABEL: Function: two_selects_in_gep_different_cond2
+; CHECK: MayAlias: i32* %arrayidx1, i32* %arrayidx2
+  %add1_ = add nsw i64 %x, 1
+  %add2_ = add nsw i64 %x, 2
+  %select1_ = select i1 %c1, i64 %x, i64 %add1_
+  %select2_ = select i1 %c2, i64 %x, i64 %add2_
+  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select1_
+  store i32 42, ptr %arrayidx1, align 4
+  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select2_
   store i32 43, ptr %arrayidx2, align 4
   ret void
 }

--- a/llvm/test/Analysis/BasicAA/non-equal-select.ll
+++ b/llvm/test/Analysis/BasicAA/non-equal-select.ll
@@ -46,38 +46,6 @@ entry:
   ret void
 }
 
-define void @two_selects_in_gep_opposite_cond1(i1 %c, i64 %x) {
-entry:
-; CHECK-LABEL: Function: two_selects_in_gep_opposite_cond1
-; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
-  %add1_ = add nsw i64 %x, 1
-  %add2_ = add nsw i64 %x, 2
-  %not_c = xor i1 %c, -1
-  %select1_ = select i1 %c, i64 %x, i64 %add1_
-  %select2_ = select i1 %not_c, i64 %x, i64 %add2_
-  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select1_
-  store i32 42, ptr %arrayidx1, align 4
-  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select2_
-  store i32 43, ptr %arrayidx2, align 4
-  ret void
-}
-
-define void @two_selects_in_gep_opposite_cond2(i1 %c, i64 %x) {
-entry:
-; CHECK-LABEL: Function: two_selects_in_gep_opposite_cond2
-; CHECK: NoAlias: i32* %arrayidx1, i32* %arrayidx2
-  %add1_ = add nsw i64 %x, 1
-  %add2_ = add nsw i64 %x, 2
-  %not_c = xor i1 %c, -1
-  %select1_ = select i1 %not_c, i64 %x, i64 %add1_
-  %select2_ = select i1 %c, i64 %x, i64 %add2_
-  %arrayidx1 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select1_
-  store i32 42, ptr %arrayidx1, align 4
-  %arrayidx2 = getelementptr inbounds [10 x i32], ptr @G, i64 0, i64 %select2_
-  store i32 43, ptr %arrayidx2, align 4
-  ret void
-}
-
 define void @two_selects_in_gep_different_cond1(i1 %c1, i1 %c2, i64 %x) {
 entry:
 ; CHECK-LABEL: Function: two_selects_in_gep_different_cond1


### PR DESCRIPTION
Basic way to recursively analyze `select` in `isKnownNonEqual`: `select %c, %t, %f` is non-equal to `%x` if `%t` is non-equal to `%x` and `%f` is non-equal to `%x`.