### PR TITLE
[AST] Use explicit type erasure in TypeSourceInfo constructor

### DIFF
--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -243,7 +243,7 @@ private:
 
 inline TypeSourceInfo::TypeSourceInfo(QualType ty, size_t DataSize) : Ty(ty) {
   // Init data attached to the object. See getTypeLoc.
-  memset(this + 1, 0, DataSize);
+  memset(static_cast<void *>(this + 1), 0, DataSize);
 }
 
 /// Return the TypeLoc for a type source info.


### PR DESCRIPTION
When this file is included in a project compiled with GCC 13 `-Werror`, compilation fails with the following diagnostic:
<pre>
/usr/lib/llvm-17.0/include/clang/AST/TypeLoc.h: In constructor 'clang::TypeSourceInfo::TypeSourceInfo(clang::QualType, size_t)':
/usr/lib/llvm-17.0/include/clang/AST/TypeLoc.h:245:9: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'class clang::TypeSourceInfo'; use assignment instead [-Werror=class-memaccess]
  245 |   memset(this + 1, 0, DataSize);
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~

</pre>
To avoid this, we add an explicit type cast. The cast to `void*` makes sense, since other member functions of `TypeSourceInfo` also treat the buffer `(this + 1)` of length `DataSize` as opaque memory, and was likely left out by mistake.

Fixes: 4498663f3de0 ("[AST] Initialized data after TypeSourceInfo")

I also suggest to apply this to release/17.x if possible.