### PR TITLE
[Github] Add PR author name to subscription email

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -82,6 +82,8 @@ class IssueSubscriber:
         comment = f"""
 @llvm/{team.slug}
 
+Author: {self.issue.user.name} ({self.issue.user.login})
+
 <details>
 {body}
 </details>
@@ -165,7 +167,7 @@ class PRSubscriber:
 {self.COMMENT_TAG}
 {team_mention}
 
-Author: {self.pr._user.name} ({self.pr._user.login})
+Author: {self.pr.user.name} ({self.pr.user.login})
 
 <details>
 <summary>Changes</summary>

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -165,6 +165,8 @@ class PRSubscriber:
 {self.COMMENT_TAG}
 {team_mention}
 
+Author: {self.pr._user.name} ({self.pr._user.login})
+
 <details>
 <summary>Changes</summary>
 


### PR DESCRIPTION
Currently the email that gets sent out to people subscribing to a label that the bot tags on the PR doesn't include any authorship information which some people are interested in having. This patch adds an author field to the message with the relevant information.