### PR TITLE
[scudo] Improve the message of region exhaustion

### DIFF
--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -367,10 +367,9 @@ public:
       auto *TSD = TSDRegistry.getTSDAndLock(&UnlockRequired);
       TSD->assertLocked(/*BypassCheck=*/!UnlockRequired);
       Block = TSD->getCache().allocate(ClassId);
-      // If the allocation failed, the most likely reason with a 32-bit primary
-      // is the region being full. In that event, retry in each successively
-      // larger class until it fits. If it fails to fit in the largest class,
-      // fallback to the Secondary.
+      // If the allocation failed, retry in each successively larger class until
+      // it fits. If it fails to fit in the largest class, fallback to the
+      // Secondary.
       if (UNLIKELY(!Block)) {
         while (ClassId < SizeClassMap::LargestClassId && !Block)
           Block = TSD->getCache().allocate(++ClassId);
@@ -388,6 +387,7 @@ public:
     if (UNLIKELY(!Block)) {
       if (Options.get(OptionBit::MayReturnNull))
         return nullptr;
+      printStats();
       reportOutOfMemory(NeededSize);
     }
 


### PR DESCRIPTION
In this CL, we move the printing of allocator stats from primary.h to combined.h. This will also dump the secondary stats and reduce the log spam when an OOM happens

Also change the symbol `F` to `E` to indicate region pages exhausted. It means the region can't map more pages for blocks but it may still have free blocks to allocate. `F` may hint the failure of fatel error in the region. Also update the related comments.