### PR TITLE
[X86] Enable bfloat type support in inline assembly constraints

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -56907,7 +56907,7 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
           return std::make_pair(0U, &X86::VR128XRegClass);
         return std::make_pair(0U, &X86::VR128RegClass);
       case MVT::v8bf16:
-        if (!Subtarget.hasBF16())
+        if (!Subtarget.hasBF16() || !Subtarget.hasVLX())
           break;
         if (VConstraint)
           return std::make_pair(0U, &X86::VR128XRegClass);
@@ -56930,7 +56930,7 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
           return std::make_pair(0U, &X86::VR256XRegClass);
         return std::make_pair(0U, &X86::VR256RegClass);
       case MVT::v16bf16:
-        if (!Subtarget.hasBF16())
+        if (!Subtarget.hasBF16() || !Subtarget.hasVLX())
           break;
         if (VConstraint)
           return std::make_pair(0U, &X86::VR256XRegClass);
@@ -57002,7 +57002,7 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
           break;
         return std::make_pair(X86::XMM0, &X86::VR128RegClass);
       case MVT::v8bf16:
-        if (!Subtarget.hasBF16())
+        if (!Subtarget.hasBF16() || !Subtarget.hasVLX())
           break;
         return std::make_pair(X86::XMM0, &X86::VR128RegClass);
       case MVT::f128:
@@ -57019,7 +57019,7 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
           break;
         return std::make_pair(X86::YMM0, &X86::VR256RegClass);
       case MVT::v16bf16:
-        if (!Subtarget.hasBF16())
+        if (!Subtarget.hasBF16() || !Subtarget.hasVLX())
           break;
         return std::make_pair(X86::YMM0, &X86::VR256RegClass);
       case MVT::v32i8:

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -56904,6 +56904,10 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
         if (!Subtarget.hasFP16())
           break;
         [[fallthrough]];
+      case MVT::v8bf16:
+        if (!Subtarget.hasBF16())
+          break;
+        [[fallthrough]];
       case MVT::f128:
       case MVT::v16i8:
       case MVT::v8i16:
@@ -56919,6 +56923,10 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
         if (!Subtarget.hasFP16())
           break;
         [[fallthrough]];
+      case MVT::v16bf16:
+        if (!Subtarget.hasBF16())
+          break;
+        [[fallthrough]];
       case MVT::v32i8:
       case MVT::v16i16:
       case MVT::v8i32:
@@ -56932,6 +56940,10 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
         break;
       case MVT::v32f16:
         if (!Subtarget.hasFP16())
+          break;
+        [[fallthrough]];
+      case MVT::v32bf16:
+        if (!Subtarget.hasBF16())
           break;
         [[fallthrough]];
       case MVT::v64i8:
@@ -56977,6 +56989,10 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
         if (!Subtarget.hasFP16())
           break;
         [[fallthrough]];
+      case MVT::v8bf16:
+        if (!Subtarget.hasBF16())
+          break;
+        [[fallthrough]];
       case MVT::f128:
       case MVT::v16i8:
       case MVT::v8i16:
@@ -56990,6 +57006,10 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
         if (!Subtarget.hasFP16())
           break;
         [[fallthrough]];
+      case MVT::v16bf16:
+        if (!Subtarget.hasBF16())
+          break;
+        [[fallthrough]];
       case MVT::v32i8:
       case MVT::v16i16:
       case MVT::v8i32:
@@ -57001,6 +57021,10 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
         break;
       case MVT::v32f16:
         if (!Subtarget.hasFP16())
+          break;
+        [[fallthrough]];
+      case MVT::v32bf16:
+        if (!Subtarget.hasBF16())
           break;
         [[fallthrough]];
       case MVT::v64i8:

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -56903,11 +56903,15 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       case MVT::v8f16:
         if (!Subtarget.hasFP16())
           break;
-        [[fallthrough]];
+        if (VConstraint)
+          return std::make_pair(0U, &X86::VR128XRegClass);
+        return std::make_pair(0U, &X86::VR128RegClass);
       case MVT::v8bf16:
         if (!Subtarget.hasBF16())
           break;
-        [[fallthrough]];
+        if (VConstraint)
+          return std::make_pair(0U, &X86::VR128XRegClass);
+        return std::make_pair(0U, &X86::VR128RegClass);
       case MVT::f128:
       case MVT::v16i8:
       case MVT::v8i16:
@@ -56922,11 +56926,15 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       case MVT::v16f16:
         if (!Subtarget.hasFP16())
           break;
-        [[fallthrough]];
+        if (VConstraint)
+          return std::make_pair(0U, &X86::VR256XRegClass);
+        return std::make_pair(0U, &X86::VR256RegClass);
       case MVT::v16bf16:
         if (!Subtarget.hasBF16())
           break;
-        [[fallthrough]];
+        if (VConstraint)
+          return std::make_pair(0U, &X86::VR256XRegClass);
+        return std::make_pair(0U, &X86::VR256RegClass);
       case MVT::v32i8:
       case MVT::v16i16:
       case MVT::v8i32:
@@ -56941,11 +56949,15 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       case MVT::v32f16:
         if (!Subtarget.hasFP16())
           break;
-        [[fallthrough]];
+        if (VConstraint)
+          return std::make_pair(0U, &X86::VR512RegClass);
+        return std::make_pair(0U, &X86::VR512_0_15RegClass);
       case MVT::v32bf16:
         if (!Subtarget.hasBF16())
           break;
-        [[fallthrough]];
+        if (VConstraint)
+          return std::make_pair(0U, &X86::VR512RegClass);
+        return std::make_pair(0U, &X86::VR512_0_15RegClass);
       case MVT::v64i8:
       case MVT::v32i16:
       case MVT::v8f64:
@@ -56988,11 +57000,11 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       case MVT::v8f16:
         if (!Subtarget.hasFP16())
           break;
-        [[fallthrough]];
+        return std::make_pair(X86::XMM0, &X86::VR128RegClass);
       case MVT::v8bf16:
         if (!Subtarget.hasBF16())
           break;
-        [[fallthrough]];
+        return std::make_pair(X86::XMM0, &X86::VR128RegClass);
       case MVT::f128:
       case MVT::v16i8:
       case MVT::v8i16:
@@ -57005,11 +57017,11 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       case MVT::v16f16:
         if (!Subtarget.hasFP16())
           break;
-        [[fallthrough]];
+        return std::make_pair(X86::YMM0, &X86::VR256RegClass);
       case MVT::v16bf16:
         if (!Subtarget.hasBF16())
           break;
-        [[fallthrough]];
+        return std::make_pair(X86::YMM0, &X86::VR256RegClass);
       case MVT::v32i8:
       case MVT::v16i16:
       case MVT::v8i32:
@@ -57022,11 +57034,11 @@ X86TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       case MVT::v32f16:
         if (!Subtarget.hasFP16())
           break;
-        [[fallthrough]];
+        return std::make_pair(X86::ZMM0, &X86::VR512_0_15RegClass);
       case MVT::v32bf16:
         if (!Subtarget.hasBF16())
           break;
-        [[fallthrough]];
+        return std::make_pair(X86::ZMM0, &X86::VR512_0_15RegClass);
       case MVT::v64i8:
       case MVT::v32i16:
       case MVT::v8f64:

--- a/llvm/test/CodeGen/X86/inline-asm-avx512f-x-constraint.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-avx512f-x-constraint.ll
@@ -1,7 +1,7 @@
 ; RUN: not llc < %s -mtriple=x86_64-unknown-unknown -mattr=avx512f -stop-after=finalize-isel > %t 2> %t.err
 ; RUN: FileCheck < %t %s
 ; RUN: FileCheck --check-prefix=CHECK-STDERR < %t.err %s
-; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=avx512fp16 -stop-after=finalize-isel | FileCheck --check-prefixes=CHECK,FP16 %s
+; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=avx512bf16,avx512fp16 -stop-after=finalize-isel | FileCheck --check-prefixes=CHECK,FP16 %s
 
 ; CHECK-LABEL: name: mask_Yk_i8
 ; CHECK: %[[REG1:.*]]:vr512_0_15 = COPY %1
@@ -23,4 +23,15 @@ define <32 x half> @mask_Yk_f16(i8 signext %msk, <32 x half> %x, <32 x half> %y)
 entry:
   %0 = tail call <32 x half> asm "vaddph\09$3, $2, $0 {$1}", "=x,^Yk,x,x,~{dirflag},~{fpsr},~{flags}"(i8 %msk, <32 x half> %x, <32 x half> %y)
   ret <32 x half> %0
+}
+
+; FP16-LABEL: name: mask_Yk_bf16
+; FP16: %[[REG1:.*]]:vr512_0_15 = COPY %1
+; FP16: %[[REG2:.*]]:vr512_0_15 = COPY %2
+; FP16: INLINEASM &"vaddph\09$3, $2, $0 {$1}", 0 /* attdialect */, {{.*}}, def %{{.*}}, {{.*}}, %{{.*}}, {{.*}}, %[[REG1]], {{.*}}, %[[REG2]], 12 /* clobber */, implicit-def early-clobber $df, 12 /* clobber */, implicit-def early-clobber $fpsw, 12 /* clobber */, implicit-def early-clobber $eflags
+; CHECK-STDERR: couldn't allocate output register for constraint 'x'
+define <32 x bfloat> @mask_Yk_bf16(i8 signext %msk, <32 x bfloat> %x, <32 x bfloat> %y) {
+entry:
+  %0 = tail call <32 x bfloat> asm "vaddph\09$3, $2, $0 {$1}", "=x,^Yk,x,x,~{dirflag},~{fpsr},~{flags}"(i8 %msk, <32 x bfloat> %x, <32 x bfloat> %y)
+  ret <32 x bfloat> %0
 }


### PR DESCRIPTION
Similar to FP16 but we don't have native scalar instruction support, so limit it to vector types only.

Fixes #68149