### PR TITLE
[AIX] recognize vsr in inline asm for AIX

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -753,6 +753,8 @@ void PPCTargetInfo::setFeatureEnabled(llvm::StringMap<bool> &Features,
   }
 }
 
+// Make sure that registers are added in the correct array index which should be
+// the DWARF number for PPC registers.
 const char *const PPCTargetInfo::GCCRegNames[] = {
     "r0",  "r1",     "r2",   "r3",      "r4",      "r5",  "r6",  "r7",  "r8",
     "r9",  "r10",    "r11",  "r12",     "r13",     "r14", "r15", "r16", "r17",

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -807,6 +807,7 @@ ArrayRef<TargetInfo::GCCRegAlias> PPCTargetInfo::getGCCRegAliases() const {
 // PPC ELFABIv2 DWARF Definitoin "Table 2.26. Mappings of Common Registers".
 // vs0 ~ vs31 is mapping to 32 - 63,
 // vs32 ~ vs63 is mapping to 77 - 108.
+// And this mapping applies to all OSes which runs on powerpc.
 const TargetInfo::AddlRegName GCCAddlRegNames[] = {
     // Table of additional register names to use in user input.
     {{"vs0"}, 32},   {{"vs1"}, 33},   {{"vs2"}, 34},   {{"vs3"}, 35},
@@ -828,7 +829,7 @@ const TargetInfo::AddlRegName GCCAddlRegNames[] = {
 };
 
 ArrayRef<TargetInfo::AddlRegName> PPCTargetInfo::getGCCAddlRegNames() const {
-  if (ABI == "elfv2")
+  if (ABI == "elfv2" || ABI == "aix")
     return llvm::ArrayRef(GCCAddlRegNames);
   else
     return TargetInfo::getGCCAddlRegNames();

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -807,7 +807,7 @@ ArrayRef<TargetInfo::GCCRegAlias> PPCTargetInfo::getGCCRegAliases() const {
 // PPC ELFABIv2 DWARF Definitoin "Table 2.26. Mappings of Common Registers".
 // vs0 ~ vs31 is mapping to 32 - 63,
 // vs32 ~ vs63 is mapping to 77 - 108.
-// And this mapping applies to all OSes which runs on powerpc.
+// And this mapping applies to all OSes which run on powerpc.
 const TargetInfo::AddlRegName GCCAddlRegNames[] = {
     // Table of additional register names to use in user input.
     {{"vs0"}, 32},   {{"vs1"}, 33},   {{"vs2"}, 34},   {{"vs3"}, 35},
@@ -829,10 +829,7 @@ const TargetInfo::AddlRegName GCCAddlRegNames[] = {
 };
 
 ArrayRef<TargetInfo::AddlRegName> PPCTargetInfo::getGCCAddlRegNames() const {
-  if (ABI == "elfv2" || ABI == "aix")
-    return llvm::ArrayRef(GCCAddlRegNames);
-  else
-    return TargetInfo::getGCCAddlRegNames();
+  return llvm::ArrayRef(GCCAddlRegNames);
 }
 
 static constexpr llvm::StringLiteral ValidCPUNames[] = {

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -385,6 +385,7 @@ public:
       LongDoubleWidth = 64;
       LongDoubleAlign = DoubleAlign = 32;
       LongDoubleFormat = &llvm::APFloat::IEEEdouble();
+      ABI = "aix";
       break;
     default:
       break;
@@ -418,11 +419,11 @@ public:
     std::string DataLayout;
 
     if (Triple.isOSAIX()) {
-      // TODO: Set appropriate ABI for AIX platform.
       DataLayout = "E-m:a-Fi64-i64:64-n32:64";
       LongDoubleWidth = 64;
       LongDoubleAlign = DoubleAlign = 32;
       LongDoubleFormat = &llvm::APFloat::IEEEdouble();
+      ABI = "aix";
     } else if ((Triple.getArch() == llvm::Triple::ppc64le)) {
       DataLayout = "e-m:e-Fn32-i64:64-n32:64";
       ABI = "elfv2";

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -385,7 +385,6 @@ public:
       LongDoubleWidth = 64;
       LongDoubleAlign = DoubleAlign = 32;
       LongDoubleFormat = &llvm::APFloat::IEEEdouble();
-      ABI = "aix";
       break;
     default:
       break;
@@ -419,11 +418,11 @@ public:
     std::string DataLayout;
 
     if (Triple.isOSAIX()) {
+      // TODO: Set appropriate ABI for AIX platform.
       DataLayout = "E-m:a-Fi64-i64:64-n32:64";
       LongDoubleWidth = 64;
       LongDoubleAlign = DoubleAlign = 32;
       LongDoubleFormat = &llvm::APFloat::IEEEdouble();
-      ABI = "aix";
     } else if ((Triple.getArch() == llvm::Triple::ppc64le)) {
       DataLayout = "e-m:e-Fn32-i64:64-n32:64";
       ABI = "elfv2";

--- a/clang/test/CodeGen/PowerPC/inline-asm-matching-ppc-vsx.c
+++ b/clang/test/CodeGen/PowerPC/inline-asm-matching-ppc-vsx.c
@@ -2,6 +2,10 @@
 
 // RUN: %clang_cc1 -triple powerpc64le-unknown-linux-gnu -target-feature +vsx \
 // RUN:   -target-cpu pwr9 -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -target-feature +vsx \
+// RUN:   -target-cpu pwr9 -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple powerpc-ibm-aix -target-feature +vsx \
+// RUN:   -target-cpu pwr9 -emit-llvm %s -o - | FileCheck %s
 
 // This case is to test VSX register support in the clobbers list for inline asm.
 void testVSX (void) {

--- a/clang/test/CodeGen/PowerPC/inline-asm-matching-ppc-vsx.c
+++ b/clang/test/CodeGen/PowerPC/inline-asm-matching-ppc-vsx.c
@@ -2,6 +2,8 @@
 
 // RUN: %clang_cc1 -triple powerpc64le-unknown-linux-gnu -target-feature +vsx \
 // RUN:   -target-cpu pwr9 -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple powerpc64-unknown-linux-gnu -target-feature +vsx \
+// RUN:   -target-cpu pwr9 -emit-llvm %s -o - | FileCheck %s
 // RUN: %clang_cc1 -triple powerpc64-ibm-aix -target-feature +vsx \
 // RUN:   -target-cpu pwr9 -emit-llvm %s -o - | FileCheck %s
 // RUN: %clang_cc1 -triple powerpc-ibm-aix -target-feature +vsx \
@@ -13,12 +15,12 @@ void testVSX (void) {
   unsigned int *dbell=&a;
   int d;
   __asm__ __volatile__ (
-    "lxvw4x  %%vs32, 0, %2\n\t"
-    "stxvw4x %%vs32, 0, %1"
+    "lxvw4x  32, 0, %2\n\t"
+    "stxvw4x 32, 0, %1"
     : "=m"(*(volatile unsigned int*)(dbell))
     : "r" (dbell), "r" (&d)
     : "vs32"
   );
 }
 
-// CHECK: call void asm sideeffect "lxvw4x  %vs32, 0, $2\0A\09stxvw4x %vs32, 0, $1", "=*m,r,r,~{vs32}"
+// CHECK: call void asm sideeffect "lxvw4x  32, 0, $2\0A\09stxvw4x 32, 0, $1", "=*m,r,r,~{vs32}"


### PR DESCRIPTION
Extend `PPCTargetInfo::getGCCAddlRegNames()` to aix as well. The definition should be common between Linux PPC and AIX PPC.