### PR TITLE
[mlir][doc] Trim summary text during DocGen

### DIFF
--- a/mlir/tools/mlir-tblgen/OpDocGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDocGen.cpp
@@ -50,6 +50,7 @@ using mlir::tblgen::Operator;
 
 void mlir::tblgen::emitSummary(StringRef summary, raw_ostream &os) {
   if (!summary.empty()) {
+    summary = summary.trim();
     char first = std::toupper(summary.front());
     llvm::StringRef rest = summary.drop_front();
     os << "\n_" << first << rest << "_\n\n";

--- a/mlir/tools/mlir-tblgen/OpDocGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDocGen.cpp
@@ -50,9 +50,9 @@ using mlir::tblgen::Operator;
 
 void mlir::tblgen::emitSummary(StringRef summary, raw_ostream &os) {
   if (!summary.empty()) {
-    summary = summary.trim();
-    char first = std::toupper(summary.front());
-    llvm::StringRef rest = summary.drop_front();
+    llvm::StringRef trimmed = summary.trim();
+    char first = std::toupper(trimmed.front());
+    llvm::StringRef rest = trimmed.drop_front();
     os << "\n_" << first << rest << "_\n\n";
   }
 }


### PR DESCRIPTION
When defining a multi-line string in tblgen, the output in the Markdown file currently contains too much whitespace and newlines for Hugo's Markdown parser. For example, for `arith.addui_extended` the tblgen
```tblgen
let summary = [{
  extended unsigned integer addition operation returning sum and overflow bit
}];
```
is currently converted to
```markdown
_
    extended unsigned integer addition operation returning sum and overflow bit
  _
```
which causes the text to not be italicized (as can be seen at https://mlir.llvm.org/docs/Dialects/ArithOps/#arithaddui_extended-arithadduiextendedop). After this PR, the output becomes
```
_Extended unsigned integer addition operation returning sum and overflow bit_
```