### PR TITLE
[clang][driver] Support option '-r' for target AVR

### DIFF
--- a/clang/lib/Driver/ToolChains/AVR.cpp
+++ b/clang/lib/Driver/ToolChains/AVR.cpp
@@ -457,7 +457,8 @@ void AVR::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back(Output.getFilename());
 
   // Enable garbage collection of unused sections.
-  CmdArgs.push_back("--gc-sections");
+  if (!Args.hasArg(options::OPT_r))
+    CmdArgs.push_back("--gc-sections");
 
   // Add library search paths before we specify libraries.
   Args.AddAllArgs(CmdArgs, options::OPT_L);
@@ -471,7 +472,7 @@ void AVR::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Only add default libraries if the user hasn't explicitly opted out.
   bool LinkStdlib = false;
-  if (!Args.hasArg(options::OPT_nostdlib) &&
+  if (!Args.hasArg(options::OPT_nostdlib) && !Args.hasArg(options::OPT_r) &&
       !Args.hasArg(options::OPT_nodefaultlibs)) {
     if (!CPU.empty()) {
       if (!FamilyName) {
@@ -497,13 +498,17 @@ void AVR::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       D.Diag(diag::warn_drv_avr_stdlib_not_linked);
   }
 
-  if (SectionAddressData) {
-    CmdArgs.push_back(
-        Args.MakeArgString("--defsym=__DATA_REGION_ORIGIN__=0x" +
-                           Twine::utohexstr(*SectionAddressData)));
-  } else {
-    // We do not have an entry for this CPU in the address mapping table yet.
-    D.Diag(diag::warn_drv_avr_linker_section_addresses_not_implemented) << CPU;
+  if (!Args.hasArg(options::OPT_r)) {
+    if (SectionAddressData) {
+      CmdArgs.push_back(
+          Args.MakeArgString("--defsym=__DATA_REGION_ORIGIN__=0x" +
+                             Twine::utohexstr(*SectionAddressData)));
+    } else {
+      // We do not have an entry for this CPU in the address mapping table
+      // yet.
+      D.Diag(diag::warn_drv_avr_linker_section_addresses_not_implemented)
+          << CPU;
+    }
   }
 
   if (D.isUsingLTO()) {
@@ -554,16 +559,16 @@ void AVR::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
     if (Args.hasFlag(options::OPT_mrelax, options::OPT_mno_relax, true))
       CmdArgs.push_back("--relax");
-
-    // Specify the family name as the emulation mode to use.
-    // This is almost always required because otherwise avr-ld
-    // will assume 'avr2' and warn about the program being larger
-    // than the bare minimum supports.
-    if (Linker.find("avr-ld") != std::string::npos)
-      CmdArgs.push_back(Args.MakeArgString(std::string("-m") + *FamilyName));
   } else {
     AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
   }
+
+  // Specify the family name as the emulation mode to use.
+  // This is almost always required because otherwise avr-ld
+  // will assume 'avr2' and warn about the program being larger
+  // than the bare minimum supports.
+  if (Linker.find("avr-ld") != std::string::npos && FamilyName)
+    CmdArgs.push_back(Args.MakeArgString(std::string("-m") + *FamilyName));
 
   C.addCommand(std::make_unique<Command>(
       JA, *this, ResponseFileSupport::AtFileCurCP(), Args.MakeArgString(Linker),

--- a/clang/test/Driver/avr-ld.c
+++ b/clang/test/Driver/avr-ld.c
@@ -57,3 +57,31 @@
 // RUN: %clang -### --target=avr -mmcu=atmega328 -fuse-ld=lld -flto --sysroot %S/Inputs/basic_avr_tree %s 2>&1 | FileCheck -check-prefix LINKS %s
 // LINKS: {{".*ld.*"}} {{.*}} "--defsym=__DATA_REGION_ORIGIN__=0x800100" "-plugin-opt=mcpu=atmega328"
 // LINKS-NOT: "-plugin-opt=thinlto"
+
+// RUN: %clang -### -r --target=avr -mmcu=atmega328 --sysroot %S/Inputs/basic_avr_tree %s 2>&1 | FileCheck --check-prefix=LINKU %s
+// LINKU: {{".*ld.*"}} {{.*}} "-r" {{.*}} "-mavr5"
+// LINKU-NOT: "--gc-sections"
+// LINKU-NOT: "--defsym
+// LINKU-NOT: "-l
+
+// RUN: %clang -### -r --target=avr -mmcu=atmega328 -fuse-ld=lld --sysroot %S/Inputs/basic_avr_tree %s 2>&1 | FileCheck --check-prefix=LINKV %s
+// LINKV: {{".*ld.*"}} {{.*}} "-r"
+// LINKV-NOT: "--gc-sections"
+// LINKV-NOT: "--defsym
+// LINKV-NOT: "-l
+// LINKV-NOT: "-m
+
+// RUN: %clang -### -r --target=avr -mmcu=atmega328 -lm --sysroot %S/Inputs/basic_avr_tree %s 2>&1 | FileCheck --check-prefix=LINKW %s
+// LINKW: {{".*ld.*"}} {{.*}} "-r" "-lm" {{.*}} "-mavr5"
+// LINKW-NOT: "--gc-sections"
+// LINKW-NOT: "--defsym
+
+// RUN: %clang -### -r --target=avr --sysroot %S/Inputs/basic_avr_tree %s 2>&1 | FileCheck --check-prefix=LINKX %s
+// LINKX: warning: no target microcontroller specified
+// LINKX: {{".*ld.*"}} {{.*}} "-r" {{.*}}
+// LINKX-NOT: warning: {{.*}} standard library
+// LINKX-NOT: warning: {{.*}} data section address
+// LINKX-NOT: "--gc-sections"
+// LINKX-NOT: "--defsym
+// LINKX-NOT: "-l
+// LINKX-NOT: "-m


### PR DESCRIPTION
If '-r' is specified with target AVR:

1. Do not link to the avr-libc.
2. Do not emit some conflict options.
3. Do not emit any sub-target related address information/warning.