### PR TITLE
[clang-tidy][modernize-return-braced-init-list]fix false-positives

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -272,8 +272,7 @@ Changes in existing checks
 - Improved :doc:`modernize-return-braced-init-list
   <clang-tidy/checks/modernize/return-braced-init-list>` check to ignore
   false-positives when constructing the container with ``count`` copies of
-  elements with value ``value``
-  (e.g., ``vector(size_type count, const T& value);``).
+  elements with value ``value``.
 
 - Improved :doc:`modernize-use-equals-delete
   <clang-tidy/checks/modernize/use-equals-delete>` check to ignore

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -269,6 +269,12 @@ Changes in existing checks
   <clang-tidy/checks/modernize/loop-convert>` to support for-loops with
   iterators initialized by free functions like ``begin``, ``end``, or ``size``.
 
+- Improved :doc:`modernize-return-braced-init-list
+  <clang-tidy/checks/modernize/return-braced-init-list>` check to ignore
+  false-positives when constructing the container with ``count`` copies of
+  elements with value ``value``
+  (e.g., ``vector(size_type count, const T& value);``).
+
 - Improved :doc:`modernize-use-equals-delete
   <clang-tidy/checks/modernize/use-equals-delete>` check to ignore
   false-positives when special member function is actually used or implicit.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
@@ -30,13 +30,16 @@ public:
 };
 
 template <typename T>
+struct allocator {};
+
+template <typename T, typename Allocator = ::std::allocator<T>>
 class vector {
 public:
   vector(T);
-  vector(size_t, T);
+  vector(size_t, T, const Allocator &alloc = Allocator());
   vector(std::initializer_list<T>);
 };
-}
+} // namespace std
 
 class Bar {};
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/return-braced-init-list.cpp
@@ -32,8 +32,9 @@ public:
 template <typename T>
 class vector {
 public:
-  vector(T) {}
-  vector(std::initializer_list<T>) {}
+  vector(T);
+  vector(size_t, T);
+  vector(std::initializer_list<T>);
 };
 }
 
@@ -98,11 +99,25 @@ Foo f6() {
   return Foo(b6, 1);
 }
 
-std::vector<int> f7() {
+std::vector<int> vectorWithOneParameter() {
   int i7 = 1;
   return std::vector<int>(i7);
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: avoid repeating the return type
 }
+
+std::vector<int> vectorIntWithTwoParameter() {
+  return std::vector<int>(1, 2);
+}
+
+std::vector<double> vectorDoubleWithTwoParameter() {
+  return std::vector<double>(1, 2.1);
+}
+struct A {};
+std::vector<A> vectorRecordWithTwoParameter() {
+  A a{};
+  return std::vector<A>(1, a);
+}
+
 
 Bar f8() {
   return {};


### PR DESCRIPTION
fix false-positives when constructing the container with ``count`` copies of elements with value ``value``
(e.g., ``vector(size_type count, const T& value);``).
Fixes: #68159