### PR TITLE
[VP] Use the interface of 'getFunctionalIntrinsicID' to get the non-p…

### DIFF
--- a/llvm/lib/CodeGen/ExpandVectorPredication.cpp
+++ b/llvm/lib/CodeGen/ExpandVectorPredication.cpp
@@ -479,7 +479,7 @@ Value *CachingVPExpander::expandPredicationToCastIntrinsic(IRBuilder<> &Builder,
   Value *CastOp = nullptr;
   switch (VPI.getIntrinsicID()) {
   default:
-    llvm_unreachable("Not a VP memory intrinsic");
+    llvm_unreachable("Not a VP cast intrinsic");
   case Intrinsic::vp_sext:
     CastOp =
         Builder.CreateSExt(VPI.getOperand(0), VPI.getType(), VPI.getName());
@@ -705,23 +705,18 @@ Value *CachingVPExpander::expandPredication(VPIntrinsic &VPI) {
     return NewNegOp;  
   }
   case Intrinsic::vp_abs:
-    return expandPredicationToIntCall(Builder, VPI, Intrinsic::abs);
   case Intrinsic::vp_smax:
-    return expandPredicationToIntCall(Builder, VPI, Intrinsic::smax);
   case Intrinsic::vp_smin:
-    return expandPredicationToIntCall(Builder, VPI, Intrinsic::smin);
   case Intrinsic::vp_umax:
-    return expandPredicationToIntCall(Builder, VPI, Intrinsic::umax);
   case Intrinsic::vp_umin:
-    return expandPredicationToIntCall(Builder, VPI, Intrinsic::umin);
+    return expandPredicationToIntCall(Builder, VPI,
+                                      VPI.getFunctionalIntrinsicID().value());
   case Intrinsic::vp_fabs:
-    return expandPredicationToFPCall(Builder, VPI, Intrinsic::fabs);
   case Intrinsic::vp_sqrt:
-    return expandPredicationToFPCall(Builder, VPI, Intrinsic::sqrt);
   case Intrinsic::vp_maxnum:
-    return expandPredicationToFPCall(Builder, VPI, Intrinsic::maxnum);
   case Intrinsic::vp_minnum:
-    return expandPredicationToFPCall(Builder, VPI, Intrinsic::minnum);
+    return expandPredicationToFPCall(Builder, VPI,
+                                     VPI.getFunctionalIntrinsicID().value());
   case Intrinsic::vp_load:
   case Intrinsic::vp_store:
   case Intrinsic::vp_gather:


### PR DESCRIPTION
Use the interface of 'getFunctionalIntrinsicID' to get the non-predicated Intrinsic ID