### PR TITLE
[Clang][Frontend] Fix a crash when -Wdocumentation is used

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -344,6 +344,9 @@ RawComment *ASTContext::getRawCommentForDeclNoCacheImpl(
   if (Invalid)
     return nullptr;
 
+  if (DeclLocDecomp.second < CommentEndOffset)
+    return nullptr;
+
   // Extract text between the comment and declaration.
   StringRef Text(Buffer + CommentEndOffset,
                  DeclLocDecomp.second - CommentEndOffset);


### PR DESCRIPTION
This commit resolves a crash issue in Clang's frontend caused while using the `-Wdocumentation` compiler flag.

The flaw was due to the lack of necessary checks before the extraction of text between the comment and the declaration in the `ASTContext.cpp` file. Specifically, there was no verification to ensure that the second component of the declaration location's decomposition is not less than the comment's end offset.

This could lead to an invalid length being passed to the `StringRef` constructor, triggering the crash. I have added a check to prevent this crash from occurring.

Fixes #68524.