### PR TITLE
Fix typos and formatting in GettingStarted.md

### DIFF
--- a/flang/docs/GettingStarted.md
+++ b/flang/docs/GettingStarted.md
@@ -53,6 +53,7 @@ First, create the root directory and `cd` into it.
 ```bash
 mkdir root
 cd root
+```
 
 Now clone the source:
 ```bash
@@ -233,6 +234,7 @@ cmake \
   -DCMAKE_CUDA_COMPILER=nvcc \
   -DCMAKE_CUDA_HOST_COMPILER=clang++ \
   ../runtime/
+
 make -j FortranRuntime
 ```
 
@@ -275,7 +277,7 @@ Normal `make -j check-flang` will work with such CMake configuration.
 ##### OpenMP target offload build
 Only Clang compiler is currently supported.
 
-```
+```bash
 cd llvm-project/flang
 rm -rf build_flang_runtime
 mkdir build_flang_runtime
@@ -287,6 +289,7 @@ cmake \
   -DCMAKE_CXX_COMPILER=clang++ \
   -DFLANG_OMP_DEVICE_ARCHITECTURES="all" \
   ../runtime/
+
 make -j FortranRuntime
 ```
 
@@ -338,6 +341,7 @@ and the GCC library and tools that were used to build clang++.
 
 CXX should include the full path to clang++
 or clang++ should be found on your PATH.
+
 ```bash
 export CXX=clang++
 ```


### PR DESCRIPTION
Not too much to change here. Just found some issues with the flang GettingStarted.md file and wanted to sort it out.