### PR TITLE
[llvm][CMake] Check dependency cxx source compiles

### DIFF
--- a/llvm/cmake/modules/FindFFI.cmake
+++ b/llvm/cmake/modules/FindFFI.cmake
@@ -40,7 +40,7 @@ if(FFI_LIBRARIES)
   include(CMakePushCheckState)
   cmake_push_check_state()
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${FFI_LIBRARIES})
-  set(SRC [=[
+  set(HAVE_FFI_CALL_SRC [=[
     #ifdef __cplusplus
     extern "C" {
     #endif
@@ -54,10 +54,10 @@ if(FFI_LIBRARIES)
     ]=])
   if(DEFINED CMAKE_C_COMPILER)
     include(CheckCSourceCompiles)
-    check_c_source_compiles("${SRC}" HAVE_FFI_CALL)
+    check_c_source_compiles("${HAVE_FFI_CALL_SRC}" HAVE_FFI_CALL)
   else()
     include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles("${SRC}" HAVE_FFI_CALL)
+    check_cxx_source_compiles("${HAVE_FFI_CALL_SRC}" HAVE_FFI_CALL)
   endif()
   cmake_pop_check_state()
 endif()

--- a/llvm/cmake/modules/FindFFI.cmake
+++ b/llvm/cmake/modules/FindFFI.cmake
@@ -38,15 +38,27 @@ find_library(FFI_LIBRARIES ffi PATHS ${FFI_LIBRARY_DIR})
 
 if(FFI_LIBRARIES)
   include(CMakePushCheckState)
-  include(CheckCSourceCompiles)
   cmake_push_check_state()
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${FFI_LIBRARIES})
-  check_c_source_compiles("
+  set(SRC [=[
+    #ifdef __cplusplus
+    extern "C" {
+    #endif
     struct ffi_cif;
     typedef struct ffi_cif ffi_cif;
     void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue);
-    int main(void) { ffi_call(0, 0, 0, 0); }"
-    HAVE_FFI_CALL)
+    #ifdef __cplusplus
+    }
+    #endif
+    int main(void) { ffi_call(0, 0, 0, 0); }
+    ]=])
+  if(DEFINED CMAKE_C_COMPILER)
+    include(CheckCSourceCompiles)
+    check_c_source_compiles("${SRC}" HAVE_FFI_CALL)
+  else()
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("${SRC}" HAVE_FFI_CALL)
+  endif()
   cmake_pop_check_state()
 endif()
 

--- a/llvm/cmake/modules/FindTerminfo.cmake
+++ b/llvm/cmake/modules/FindTerminfo.cmake
@@ -17,7 +17,7 @@ if(Terminfo_LIBRARIES)
   include(CMakePushCheckState)
   cmake_push_check_state()
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${Terminfo_LIBRARIES})
-  set(SRC [=[
+  set(Terminfo_LINKABLE_SRC [=[
     #ifdef __cplusplus
     extern "C" {
     #endif
@@ -29,10 +29,10 @@ if(Terminfo_LIBRARIES)
     ]=])
   if(DEFINED CMAKE_C_COMPILER)
     include(CheckCSourceCompiles)
-    check_c_source_compiles("${SRC}" Terminfo_LINKABLE)
+    check_c_source_compiles("${Terminfo_LINKABLE_SRC}" Terminfo_LINKABLE)
   else()
     include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles("${SRC}" Terminfo_LINKABLE)
+    check_cxx_source_compiles("${Terminfo_LINKABLE_SRC}" Terminfo_LINKABLE)
   endif()
   cmake_pop_check_state()
 endif()

--- a/llvm/cmake/modules/FindTerminfo.cmake
+++ b/llvm/cmake/modules/FindTerminfo.cmake
@@ -15,13 +15,25 @@ find_library(Terminfo_LIBRARIES NAMES terminfo tinfo curses ncurses ncursesw)
 
 if(Terminfo_LIBRARIES)
   include(CMakePushCheckState)
-  include(CheckCSourceCompiles)
   cmake_push_check_state()
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${Terminfo_LIBRARIES})
-  check_c_source_compiles("
+  set(SRC [=[
+    #ifdef __cplusplus
+    extern "C" {
+    #endif
     int setupterm(char *term, int filedes, int *errret);
-    int main(void) { return setupterm(0, 0, 0); }"
-    Terminfo_LINKABLE)
+    #ifdef __cplusplus
+    }
+    #endif
+    int main(void) { return setupterm(0, 0, 0); }
+    ]=])
+  if(DEFINED CMAKE_C_COMPILER)
+    include(CheckCSourceCompiles)
+    check_c_source_compiles("${SRC}" Terminfo_LINKABLE)
+  else()
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("${SRC}" Terminfo_LINKABLE)
+  endif()
   cmake_pop_check_state()
 endif()
 


### PR DESCRIPTION
If a CMake project doesn't enable the C language, then the CMake FFI and Terminfo find modules will fail their checks for compilation and linking.

This commit allows projects to enable only C++ by first checking if a C compiler is set before testing C source compilation; if not, it checks whether C++ compilation succeeds.

Fixes #53950