### PR TITLE
clarify NaN propagation in fptrunc

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -11311,7 +11311,10 @@ environment <floatenv>`.
 NaN values follow the usual :ref:`NaN behaviors <floatnan>`, except that _if_ a
 NaN payload is propagated from the input ("Quieting NaN propagation" or
 "Unchanged NaN propagation" cases), then the low order bits of the NaN payload
-which cannot fit in the resulting type are discarded.
+which cannot fit in the resulting type are discarded. Note that if discarding
+the low order bits leads to an all-0 payload, this cannot be represented as a
+signaling NaN (it would represent an infinity instead), so in that case
+"Unchanged NaN propagation" is not possible.
 
 Example:
 """"""""


### PR DESCRIPTION
Follow-up to https://github.com/llvm/llvm-project/pull/66579: while implementing those semantics in Miri I realized there's a special case to be considered in truncating float casts.

Cc @nunoplopes @nikic @jyknight @jcranmer-intel 