### PR TITLE
[test] Align behavior of interrupts.test on different platforms

### DIFF
--- a/llvm/test/Support/interrupts.test
+++ b/llvm/test/Support/interrupts.test
@@ -10,7 +10,8 @@ import sys
 import time
 
 def run_symbolizer():
-    proc = subprocess.Popen([sys.argv[2]], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    proc = subprocess.Popen([sys.argv[2]], stdout=subprocess.PIPE,
+                            stdin=subprocess.PIPE, stderr=sys.stderr)
     # Write then read some output to ensure the process has started fully.
     proc.stdin.write(b'foo bar\n')
     proc.stdin.flush()
@@ -34,8 +35,8 @@ def run_wrapper():
                                 startupinfo=startupinfo,
                                 creationflags=subprocess.CREATE_NEW_CONSOLE)
     else:
-        proc = subprocess.Popen(args,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(args, stderr=sys.stderr)
+        proc.wait()
 
 if sys.argv[1] == 'wrapper':
     run_wrapper()

--- a/llvm/test/Support/interrupts.test
+++ b/llvm/test/Support/interrupts.test
@@ -30,13 +30,10 @@ def run_wrapper():
     if os.name == 'nt':
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        proc = subprocess.Popen(args,
-                                stderr=sys.stderr,
-                                startupinfo=startupinfo,
-                                creationflags=subprocess.CREATE_NEW_CONSOLE)
+        subprocess.run(args, stderr=sys.stderr, startupinfo=startupinfo,
+                       creationflags=subprocess.CREATE_NEW_CONSOLE)
     else:
-        proc = subprocess.Popen(args, stderr=sys.stderr)
-        proc.wait()
+        subprocess.run(args, stderr=sys.stderr)
 
 if sys.argv[1] == 'wrapper':
     run_wrapper()


### PR DESCRIPTION
The test llvm/Support/interrupts.test behaves differently on Linux and Windows. On Linux the function 'run_wrapper' runs process with stderr connected to pipe, while on Windows stderr is mapped to stderr of the running script.

When no output was made to stderr, this difference was not observable. The new version of llvm-symbolizer (https://reviews.llvm.org/D149759) complains about missing binary file, so stderr is not empty anymore and the test fails on Windows and passes on Linux.

With this change pipes are used on all operating systems.