### PR TITLE
[libc][bazel] Define libc namespace in a separate file and drop the `release` flag

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -10,9 +10,9 @@ load(
     "libc_support_library",
 )
 load(":platforms.bzl", "PLATFORM_CPU_ARM64", "PLATFORM_CPU_X86_64")
+load(":libc_namespace.bzl", "LIBC_NAMESPACE")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
-load("//:vars.bzl", "LLVM_VERSION_MAJOR", "LLVM_VERSION_MINOR", "LLVM_VERSION_PATCH")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -63,23 +63,6 @@ config_setting(
     flag_values = {":mpfr": "system"},
 )
 
-default_libc_namespace = "__llvm_libc_{}_{}_{}_git".format(LLVM_VERSION_MAJOR, LLVM_VERSION_MINOR, LLVM_VERSION_PATCH)
-
-release_libc_namespace = "__llvm_libc"
-
-# When set, The ':libc_root' target below will define 'LIBC_NAMESPACE' to
-# 'release_libc_namespace' instead of 'default_libc_namespace'.
-# Usage: `--@llvm-project//libc:release`.
-bool_flag(
-    name = "release",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "use_release_namespace",
-    flag_values = {":release": "true"},
-)
-
 # This empty root library helps us add an include path to this directory
 # using the 'includes' attribute. The strings listed in the includes attribute
 # are relative paths wrt this library but are inherited by the dependents
@@ -87,10 +70,7 @@ config_setting(
 # paths of the kind "../../" to other libc targets.
 cc_library(
     name = "libc_root",
-    defines = select({
-        ":use_release_namespace": ["LIBC_NAMESPACE=" + release_libc_namespace],
-        "//conditions:default": ["LIBC_NAMESPACE=" + default_libc_namespace],
-    }),
+    defines = ["LIBC_NAMESPACE=" + LIBC_NAMESPACE],
     includes = ["."],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/libc_namespace.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_namespace.bzl
@@ -1,0 +1,4 @@
+load("//:vars.bzl", "LLVM_VERSION_MAJOR", "LLVM_VERSION_MINOR", "LLVM_VERSION_PATCH")
+
+# The default libc namespace that encloses all functions.
+LIBC_NAMESPACE = "__llvm_libc_{}_{}_{}_git".format(LLVM_VERSION_MAJOR, LLVM_VERSION_MINOR, LLVM_VERSION_PATCH)


### PR DESCRIPTION
The `release` flag is misleading and its semantics are not well defined. Originally this was meant to allow for different `LIBC_NAMESPACE` depending on whether the code was considered stabled and released or unstable. It appears that we may have a canary environment that is neither released or dev. As a consequence we move the `LIBC_NAMESPACE` definition to its own file and each environment can override this file with whatever makes sense.