### PR TITLE
[llvm][llvm-readobj] Add AArch64 Tagged Address note type

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1611,6 +1611,7 @@ enum : unsigned {
   NT_ARM_HW_WATCH = 0x403,
   NT_ARM_SVE = 0x405,
   NT_ARM_PAC_MASK = 0x406,
+  NT_ARM_TAGGED_ADDR_CTRL = 0x409,
   NT_ARM_SSVE = 0x40b,
   NT_ARM_ZA = 0x40c,
   NT_ARM_ZT = 0x40d,

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -131,6 +131,7 @@ void ScalarEnumerationTraits<ELFYAML::ELF_NT>::enumeration(
   ECase(NT_ARM_HW_WATCH);
   ECase(NT_ARM_SVE);
   ECase(NT_ARM_PAC_MASK);
+  ECase(NT_ARM_TAGGED_ADDR_CTRL);
   ECase(NT_ARM_SSVE);
   ECase(NT_ARM_ZA);
   ECase(NT_ARM_ZT);

--- a/llvm/test/tools/llvm-readobj/ELF/note-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core.test
@@ -240,40 +240,45 @@
 # RUN: llvm-readelf --notes %t48.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_PAC_MASK (AArch64 Pointer Authentication code masks)"
 # RUN: llvm-readobj --notes %t48.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_PAC_MASK (AArch64 Pointer Authentication code masks)"
 
+## Check ELF::NT_ARM_TAGGED_ADDR_CTRL
+# RUN: yaml2obj %s -DTYPE=0x409 -o %t49.o
+# RUN: llvm-readelf --notes %t49.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_TAGGED_ADDR_CTRL (AArch64 Tagged Address Control)"
+# RUN: llvm-readobj --notes %t49.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_TAGGED_ADDR_CTRL (AArch64 Tagged Address Control)"
+
 ## Check ELF::NT_ARM_SSVE
-# RUN: yaml2obj %s -DTYPE=0x40b -o %t49.o
-# RUN: llvm-readelf --notes %t49.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_SSVE (AArch64 Streaming SVE registers)"
-# RUN: llvm-readobj --notes %t49.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_SSVE (AArch64 Streaming SVE registers)"
+# RUN: yaml2obj %s -DTYPE=0x40b -o %t50.o
+# RUN: llvm-readelf --notes %t50.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_SSVE (AArch64 Streaming SVE registers)"
+# RUN: llvm-readobj --notes %t50.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_SSVE (AArch64 Streaming SVE registers)"
 
 ## Check ELF::NT_ARM_ZA
-# RUN: yaml2obj %s -DTYPE=0x40c -o %t50.o
-# RUN: llvm-readelf --notes %t50.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_ZA (AArch64 SME ZA registers)"
-# RUN: llvm-readobj --notes %t50.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_ZA (AArch64 SME ZA registers)"
+# RUN: yaml2obj %s -DTYPE=0x40c -o %t51.o
+# RUN: llvm-readelf --notes %t51.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_ZA (AArch64 SME ZA registers)"
+# RUN: llvm-readobj --notes %t51.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_ZA (AArch64 SME ZA registers)"
 
 ## Check ELF::NT_ARM_ZT
-# RUN: yaml2obj %s -DTYPE=0x40d -o %t51.o
-# RUN: llvm-readelf --notes %t51.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_ZT (AArch64 SME ZT registers)"
-# RUN: llvm-readobj --notes %t51.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_ZT (AArch64 SME ZT registers)"
+# RUN: yaml2obj %s -DTYPE=0x40d -o %t52.o
+# RUN: llvm-readelf --notes %t52.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_ZT (AArch64 SME ZT registers)"
+# RUN: llvm-readobj --notes %t52.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_ZT (AArch64 SME ZT registers)"
 
 ## Check ELF::NT_FILE.
-# RUN: yaml2obj %s -DTYPE=0x46494c45 -o %t52.o
-# RUN: llvm-readelf --notes %t52.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_FILE (mapped files)"
-# RUN: llvm-readobj --notes %t52.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_FILE (mapped files)"
+# RUN: yaml2obj %s -DTYPE=0x46494c45 -o %t53.o
+# RUN: llvm-readelf --notes %t53.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_FILE (mapped files)"
+# RUN: llvm-readobj --notes %t53.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_FILE (mapped files)"
 
 ## Check ELF::NT_PRXFPREG.
-# RUN: yaml2obj %s -DTYPE=0x46e62b7f -o %t53.o
-# RUN: llvm-readelf --notes %t53.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_PRXFPREG (user_xfpregs structure)"
-# RUN: llvm-readobj --notes %t53.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_PRXFPREG (user_xfpregs structure)"
+# RUN: yaml2obj %s -DTYPE=0x46e62b7f -o %t54.o
+# RUN: llvm-readelf --notes %t54.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_PRXFPREG (user_xfpregs structure)"
+# RUN: llvm-readobj --notes %t54.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_PRXFPREG (user_xfpregs structure)"
 
 ## Check ELF::NT_SIGINFO.
-# RUN: yaml2obj %s -DTYPE=0x53494749 -o %t54.o
-# RUN: llvm-readelf --notes %t54.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_SIGINFO (siginfo_t data)"
-# RUN: llvm-readobj --notes %t54.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_SIGINFO (siginfo_t data)"
+# RUN: yaml2obj %s -DTYPE=0x53494749 -o %t55.o
+# RUN: llvm-readelf --notes %t55.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_SIGINFO (siginfo_t data)"
+# RUN: llvm-readobj --notes %t55.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_SIGINFO (siginfo_t data)"
 
 ## Check an arbitrary unknown type.
-# RUN: yaml2obj %s -DTYPE=0x12345678 -o %t55.o
-# RUN: llvm-readelf --notes %t55.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="Unknown note type: (0x12345678)"
-# RUN: llvm-readobj --notes %t55.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="Unknown (0x12345678)"
+# RUN: yaml2obj %s -DTYPE=0x12345678 -o %t56.o
+# RUN: llvm-readelf --notes %t56.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="Unknown note type: (0x12345678)"
+# RUN: llvm-readobj --notes %t56.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="Unknown (0x12345678)"
 
 # CHECK-GNU:      Owner Data size  Description
 # CHECK-GNU-NEXT: CORE  0x00000000 [[DESC]]

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -5806,6 +5806,8 @@ const NoteType CoreNoteTypes[] = {
     {ELF::NT_ARM_SVE, "NT_ARM_SVE (AArch64 SVE registers)"},
     {ELF::NT_ARM_PAC_MASK,
      "NT_ARM_PAC_MASK (AArch64 Pointer Authentication code masks)"},
+    {ELF::NT_ARM_TAGGED_ADDR_CTRL,
+     "NT_ARM_TAGGED_ADDR_CTRL (AArch64 Tagged Address Control)"},
     {ELF::NT_ARM_SSVE, "NT_ARM_SSVE (AArch64 Streaming SVE registers)"},
     {ELF::NT_ARM_ZA, "NT_ARM_ZA (AArch64 SME ZA registers)"},
     {ELF::NT_ARM_ZT, "NT_ARM_ZT (AArch64 SME ZT registers)"},


### PR DESCRIPTION
On Linux this contains a single register that determines memory tagging and tagged address ABI settings.