### PR TITLE
[CodeGen] Sort .ctors in reverse on MinGW just like on other platforms

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2807,7 +2807,11 @@ void AsmPrinter::emitXXStructorList(const DataLayout &DL, const Constant *List,
 
   // Emit the structors in reverse order if we are using the .ctor/.dtor
   // initialization scheme.
-  if (!TM.Options.UseInitArray)
+  bool UseCtorSection = !TM.Options.UseInitArray;
+  // MinGW targets always use the .ctors section.
+  if (TM.getTargetTriple().isWindowsGNUEnvironment())
+    UseCtorSection = true;
+  if (UseCtorSection)
     std::reverse(Structors.begin(), Structors.end());
 
   const Align Align = DL.getPointerPrefAlignment();

--- a/llvm/test/CodeGen/X86/constructor.ll
+++ b/llvm/test/CodeGen/X86/constructor.ll
@@ -77,14 +77,14 @@ entry:
 ; MCU-CTORS:         .section        .ctors,"aw",@progbits
 ; MCU-INIT-ARRAY:    .section        .init_array,"aw",@init_array
 
-; COFF-CTOR:		.section	.ctors.65520,"dw",associative,v
+; COFF-CTOR:		.section	.ctors,"dw"
 ; COFF-CTOR-NEXT:	.p2align	3
-; COFF-CTOR-NEXT:	.quad	g
+; COFF-CTOR-NEXT:	.quad	j
+; COFF-CTOR-NEXT:	.quad	i
+; COFF-CTOR-NEXT:	.quad	f
 ; COFF-CTOR-NEXT:	.section	.ctors.09980,"dw",associative,v
 ; COFF-CTOR-NEXT:	.p2align	3
 ; COFF-CTOR-NEXT:	.quad	h
-; COFF-CTOR-NEXT:	.section	.ctors,"dw"
+; COFF-CTOR-NEXT:	.section	.ctors.65520,"dw",associative,v
 ; COFF-CTOR-NEXT:	.p2align	3
-; COFF-CTOR-NEXT:	.quad	f
-; COFF-CTOR-NEXT:	.quad	i
-; COFF-CTOR-NEXT:	.quad	j
+; COFF-CTOR-NEXT:	.quad	g

--- a/llvm/test/MC/COFF/global_ctors_dtors.ll
+++ b/llvm/test/MC/COFF/global_ctors_dtors.ll
@@ -56,10 +56,10 @@ define i32 @main() nounwind {
 ; WIN32-NOT: c_global_ctor
 ; WIN32: .section .CRT$XTX,"dr"
 ; WIN32: a_global_dtor
-; MINGW32: .section .ctors,"dw"
-; MINGW32: a_global_ctor
 ; MINGW32: .section .ctors,"dw",associative,{{_?}}b
 ; MINGW32: b_global_ctor
 ; MINGW32-NOT: c_global_ctor
+; MINGW32: .section .ctors,"dw"
+; MINGW32: a_global_ctor
 ; MINGW32: .section .dtors,"dw"
 ; MINGW32: a_global_dtor


### PR DESCRIPTION
On MinGW targets, the .ctors section is always used (as opposed to on ELF platforms, where .init_section is the default but one can select using .ctors, with the -use-ctors option, or the UseInitArray field in TargetOptions).

Apply the reverse ordering regardless of whether the caller has set the UseInitArray flag for this target, as this target unconditionally uses the .ctors section anyway.

For the CodeGen/X86/constructor.ll testcase, note how this now produces the same output ordering as for ELF targets with -use-ctors.

This fixes https://github.com/llvm/llvm-project/issues/55938.