### PR TITLE
[clang] [MinGW] Explicitly always pass the -fno-use-init-array

### DIFF
--- a/clang/lib/Driver/ToolChains/MinGW.cpp
+++ b/clang/lib/Driver/ToolChains/MinGW.cpp
@@ -709,6 +709,8 @@ void toolchains::MinGW::addClangTargetOptions(
     }
   }
 
+  CC1Args.push_back("-fno-use-init-array");
+
   for (auto Opt : {options::OPT_mthreads, options::OPT_mwindows,
                    options::OPT_mconsole, options::OPT_mdll}) {
     if (Arg *A = DriverArgs.getLastArgNoClaim(Opt))

--- a/clang/test/Driver/mingw.cpp
+++ b/clang/test/Driver/mingw.cpp
@@ -77,3 +77,6 @@
 // CHECK_NO_SUBSYS-NOT: "--subsystem"
 // CHECK_SUBSYS_CONSOLE: "--subsystem" "console"
 // CHECK_SUBSYS_WINDOWS: "--subsystem" "windows"
+
+// RUN: %clang -target i686-windows-gnu -### %s 2>&1 | FileCheck -check-prefix=CHECK_NO_INIT_ARRAY %s
+// CHECK_NO_INIT_ARRAY: "-fno-use-init-array"


### PR DESCRIPTION
On MinGW targets, the .ctors section is always used for constructors.

Make sure that all layers of code generation is aware of this, wherever it matters, by passing the -fno-use-init-array option, setting the TargetOptions field UseInitArray to false.

This fixes https://github.com/llvm/llvm-project/issues/55938.