### PR TITLE
[lldb][DataFormatter] unordered_map: account for new libc++ __hash_node layout

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -168,7 +168,10 @@ lldb::ValueObjectSP lldb_private::formatters::
 
       value_sp = node_sp->GetChildMemberWithName("__value_");
       if (!value_sp) {
-        // Newer libc++ versions wrap the `__value_` in an anonymous union.
+        // Since D101206, libc++ wraps the `__value_` in an anonymous union.
+        // Child 0: __hash_node_base base class
+        // Child 1: __hash_
+        // Child 2: anonymous union
         auto anon_union_sp = node_sp->GetChildAtIndex(2);
         if (!anon_union_sp)
           return nullptr;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -168,10 +168,13 @@ lldb::ValueObjectSP lldb_private::formatters::
 
       value_sp = node_sp->GetChildMemberWithName("__value_");
       if (!value_sp) {
-        // Since D101206 (ba79fb2e1f), libc++ wraps the `__value_` in an anonymous union.
+        // clang-format off
+        // Since D101206 (ba79fb2e1f), libc++ wraps the `__value_` in an
+        // anonymous union.
         // Child 0: __hash_node_base base class
         // Child 1: __hash_
         // Child 2: anonymous union
+        // clang-format on
         auto anon_union_sp = node_sp->GetChildAtIndex(2);
         if (!anon_union_sp)
           return nullptr;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -168,7 +168,7 @@ lldb::ValueObjectSP lldb_private::formatters::
 
       value_sp = node_sp->GetChildMemberWithName("__value_");
       if (!value_sp) {
-        // Since D101206, libc++ wraps the `__value_` in an anonymous union.
+        // Since D101206 (ba79fb2e1f), libc++ wraps the `__value_` in an anonymous union.
         // Child 0: __hash_node_base base class
         // Child 1: __hash_
         // Child 2: anonymous union


### PR DESCRIPTION
Since D101206 the `__hash_node::__value_` member is wrapped in an anonymous union. `ValueObject::GetChildMemberWithName` doesn't see through the union.

This patch accounts for this possible new layout by getting a handle to the union before doing the by-name `__value_` lookup.