### PR TITLE
[LLD] [MinGW] Handle the --dll option

### DIFF
--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -203,6 +203,7 @@ def alias_Bdynamic_dy: Flag<["-"], "dy">, Alias<Bdynamic>;
 def alias_Bstatic_dn: Flag<["-"], "dn">, Alias<Bstatic>;
 def alias_Bstatic_non_shared: Flag<["-"], "non_shared">, Alias<Bstatic>;
 def alias_Bstatic_static: Flag<["-"], "static">, Alias<Bstatic>;
+def alias_dll: F<"dll">, Alias<shared>;
 def alias_entry_e: JoinedOrSeparate<["-"], "e">, Alias<entry>;
 def alias_no_dynamicbase: F<"no-dynamicbase">, Alias<disable_dynamicbase>;
 def alias_strip_s: Flag<["-"], "s">, Alias<strip_all>;

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -27,6 +27,7 @@ ARM64-SAME: foo.o
 
 RUN: ld.lld -### foo.o -m i386pep -shared 2>&1 | FileCheck -check-prefix=SHARED %s
 RUN: ld.lld -### foo.o -m i386pep --shared 2>&1 | FileCheck -check-prefix=SHARED %s
+RUN: ld.lld -### foo.o -m i386pep --dll 2>&1 | FileCheck -check-prefix=SHARED %s
 SHARED:      -out:a.dll
 SHARED-SAME: -dll
 


### PR DESCRIPTION
Treat this as an alias for the --shared option.

In practice in GNU ld, they aren't exact aliases but there are small subtle differences in what happens and what doesn't, when they are set, but those differences are probably not intended by users who might be using the --dll option (which gets passed by -mdll in the compiler driver), and the differences are within the area where small details differ between LLD and GNU ld anyway.