### PR TITLE
[MLIR][TOSA] Add tosa.slice operation conversion failure scenario

### DIFF
--- a/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
+++ b/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
@@ -243,6 +243,10 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = sliceOp.getLoc();
     Value input = adaptor.getInput();
+    ShapedType resultType = cast<ShapedType>(sliceOp.getType());
+    if (llvm::isa<UnrankedTensorType>(resultType) ||
+        resultType.getRank() != static_cast<int64_t>(sliceOp.getSize().size()))
+      return failure();
     SmallVector<int64_t> strides, sizes;
     ArrayRef<int64_t> starts = sliceOp.getStart();
     strides.resize(cast<ShapedType>(sliceOp.getType()).getRank(), 1);

--- a/mlir/test/Conversion/TosaToTensor/tosa-to-tensor-invalid.mlir
+++ b/mlir/test/Conversion/TosaToTensor/tosa-to-tensor-invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt --split-input-file -pass-pipeline="builtin.module(func.func(tosa-to-tensor))" %s -verify-diagnostics
+
+// CHECK-LABEL:  @slice_resultType_unranked
+func.func @slice_resultType_unranked(%arg0: tensor<?xf32>) -> (tensor<*xf32>) {
+  // expected-error@+1 {{failed to legalize operation 'tosa.slice'}}
+  %0 = "tosa.slice"(%arg0) {start = array<i64: 2>, size = array<i64: 0>} : (tensor<?xf32>)  -> (tensor<*xf32>)
+  return %0 : tensor<*xf32>
+}
+
+// CHECK-LABEL:  @slice_resultRank_neq_opSize
+func.func @slice_resultRank_neq_opSize(%arg0: tensor<12xf32>) -> (tensor<2xf32>) {
+  // expected-error@+1 {{failed to legalize operation 'tosa.slice'}}
+  %0 = "tosa.slice"(%arg0) {start = array<i64: 2>, size = array<i64: 2, 3>} : (tensor<12xf32>)  -> (tensor<2xf32>)
+  return %0 : tensor<2xf32>
+}


### PR DESCRIPTION
  Fixes #68481, In the following scenario, the conversion fails:
    1. resultType of tosa.slice is UnrankedTensorType
    2. tosa.slice.getsize().size() != resultType.getRank()