### PR TITLE
[clang-tidy] add namespace qualifier NFC

### DIFF
--- a/clang-tools-extra/clang-tidy/llvmlibc/NamespaceConstants.h
+++ b/clang-tools-extra/clang-tidy/llvmlibc/NamespaceConstants.h
@@ -10,7 +10,7 @@
 
 namespace clang::tidy::llvm_libc {
 
-const static StringRef RequiredNamespaceStart = "__llvm_libc";
-const static StringRef RequiredNamespaceMacroName = "LIBC_NAMESPACE";
+const static llvm::StringRef RequiredNamespaceStart = "__llvm_libc";
+const static llvm::StringRef RequiredNamespaceMacroName = "LIBC_NAMESPACE";
 
 } // namespace clang::tidy::llvm_libc


### PR DESCRIPTION
for daca97216cf132d733513f992d49e3c722aabf40 #68134 adds a namespace as we are not using llvm::StringRef yet