### PR TITLE
[gitattributes] Don't mark all llvm-rc test Inputs as binary

### DIFF
--- a/llvm/.gitattributes
+++ b/llvm/.gitattributes
@@ -11,7 +11,9 @@ test/tools/dsymutil/Inputs/*.swiftmodule binary
 test/tools/llvm-ar/Inputs/*.lib binary
 test/tools/llvm-ar/Inputs/*.a binary
 test/tools/llvm-objdump/Inputs/*.a binary
-test/tools/llvm-rc/Inputs/* binary
+test/tools/llvm-rc/Inputs/*.bmp binary
+test/tools/llvm-rc/Inputs/*.cur binary
+test/tools/llvm-rc/Inputs/*.ico binary
 test/tools/llvm-strings/Inputs/numbers binary
 test/MC/AsmParser/incbin_abcd binary
 test/YAMLParser/spec-09-02.test binary


### PR DESCRIPTION
This allows tooling to properly show diffs for files in the llvm/test/tools/llvm-rc/Inputs directory.

Keep the actual icon/cursor/bitmap files marked as binary.