### PR TITLE
[clang] Fixes compile error that double colon operator cannot resolve macro with parentheses.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -651,6 +651,8 @@ Bug Fixes in This Version
 - Fixed false positive error emitted by clang when performing qualified name
   lookup and the current class instantiation has dependent bases.
   Fixes (`#13826 <https://github.com/llvm/llvm-project/issues/13826>`_)
+- Fixes compile error that double colon operator cannot resolve macro with parentheses.
+  Fixes (`#64467 <https://github.com/llvm/llvm-project/issues/64467>`_)- Clang now properly diagnoses use of stand-alone OpenMP directives after a
 - Clang's ``-Wchar-subscripts`` no longer warns on chars whose values are known non-negative constants.
   Fixes (`#18763 <https://github.com/llvm/llvm-project/issues/18763>`_)
 

--- a/clang/lib/Headers/bmiintrin.h
+++ b/clang/lib/Headers/bmiintrin.h
@@ -19,7 +19,7 @@
    to use it as a potentially faster version of BSF. */
 #define __RELAXED_FN_ATTRS __attribute__((__always_inline__, __nodebug__))
 
-#define _tzcnt_u16(a)     (__tzcnt_u16((a)))
+#define _tzcnt_u16 __tzcnt_u16
 
 /// Counts the number of trailing zero bits in the operand.
 ///
@@ -71,7 +71,7 @@ _mm_tzcnt_32(unsigned int __X)
   return (int)__builtin_ia32_tzcnt_u32(__X);
 }
 
-#define _tzcnt_u32(a)     (__tzcnt_u32((a)))
+#define _tzcnt_u32 __tzcnt_u32
 
 #ifdef __x86_64__
 
@@ -109,7 +109,7 @@ _mm_tzcnt_64(unsigned long long __X)
   return (long long)__builtin_ia32_tzcnt_u64(__X);
 }
 
-#define _tzcnt_u64(a)     (__tzcnt_u64((a)))
+#define _tzcnt_u64 __tzcnt_u64
 
 #endif /* __x86_64__ */
 
@@ -121,14 +121,14 @@ _mm_tzcnt_64(unsigned long long __X)
 /* Define the default attributes for the functions in this file. */
 #define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, __nodebug__, __target__("bmi")))
 
-#define _andn_u32(a, b)   (__andn_u32((a), (b)))
+#define _andn_u32 __andn_u32
 
 /* _bextr_u32 != __bextr_u32 */
-#define _blsi_u32(a)      (__blsi_u32((a)))
+#define _blsi_u32 __blsi_u32
 
-#define _blsmsk_u32(a)    (__blsmsk_u32((a)))
+#define _blsmsk_u32 __blsmsk_u32
 
-#define _blsr_u32(a)      (__blsr_u32((a)))
+#define _blsr_u32 __blsr_u32
 
 /// Performs a bitwise AND of the second operand with the one's
 ///    complement of the first operand.
@@ -272,14 +272,14 @@ __blsr_u32(unsigned int __X)
 
 #ifdef __x86_64__
 
-#define _andn_u64(a, b)   (__andn_u64((a), (b)))
+#define _andn_u64 __andn_u64
 
 /* _bextr_u64 != __bextr_u64 */
-#define _blsi_u64(a)      (__blsi_u64((a)))
+#define _blsi_u64 __blsi_u64
 
-#define _blsmsk_u64(a)    (__blsmsk_u64((a)))
+#define _blsmsk_u64 __blsmsk_u64
 
-#define _blsr_u64(a)      (__blsr_u64((a)))
+#define _blsr_u64 __blsr_u64
 
 /// Performs a bitwise AND of the second operand with the one's
 ///    complement of the first operand.


### PR DESCRIPTION

Error message:
```
In file included from ../src/amd/addrlib/src/core/addrobject.h:21:
../src/amd/addrlib/src/core/addrcommon.h:343:13: error: expected unqualified-id
    out = ::_tzcnt_u32(mask);
            ^
/usr/lib/llvm-15/lib/clang/15.0.6/include/bmiintrin.h:74:27: note: expanded from macro '_tzcnt_u32'
#define _tzcnt_u32(a)     (__tzcnt_u32((a)))
```

This is because both GCC/Clang doesn't support compiling the following code:
```
#ifdef _MSC_VER
#include <intrin.h>
#else
#include <x86intrin.h>
#endif

int f(int a) {
    return ::(_tzcnt_u32)(a);
}
```

This is because the return statement expects an expression or braced init list: http://eel.is/c++draft/stmt.jump#general-1 but we really only need to care about the expression form (there's no braces in sight). Grammatically, the leading :: will parse as a qualified-id because it matches the production for nested-name-specifier: http://eel.is/c++draft/expr.prim.id.qual#nt:qualified-id That needs to be followed by an unqualified-id (http://eel.is/c++draft/expr.prim.id.unqual#nt:unqualified-id), but the open paren does not match any of the grammar productions, so this is a syntax error.

Closes: https://github.com/llvm/llvm-project/issues/64467