### PR TITLE
[libcxx] changes `__is_allocator` from a struct to a variable or concept

### DIFF
--- a/libcxx/include/__type_traits/is_allocator.h
+++ b/libcxx/include/__type_traits/is_allocator.h
@@ -21,13 +21,21 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
+#if _LIBCPP_STD_VER >= 20
+template <class _Alloc>
+concept __is_allocator = requires(_Alloc __a) {
+  typename _Alloc::value_type;
+  __a.allocate(size_t(0));
+};
+#else
 template <typename _Alloc, typename = void, typename = void>
-struct __is_allocator : false_type {};
+inline static const bool __is_allocator = false;
 
 template <typename _Alloc>
-struct __is_allocator<_Alloc,
-                      __void_t<typename _Alloc::value_type>,
-                      __void_t<decltype(std::declval<_Alloc&>().allocate(size_t(0)))> > : true_type {};
+inline static const bool __is_allocator<_Alloc,
+                                        __void_t<typename _Alloc::value_type>,
+                                        __void_t<decltype(std::declval<_Alloc&>().allocate(size_t(0)))> > = true;
+#endif
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -604,7 +604,7 @@ public:
 #endif
     _LIBCPP_HIDE_FROM_ABI deque(size_type __n, const value_type& __v);
 
-    template <class = __enable_if_t<__is_allocator<_Allocator>::value> >
+    template <class = __enable_if_t<__is_allocator<_Allocator> > >
     _LIBCPP_HIDE_FROM_ABI deque(size_type __n, const value_type& __v, const allocator_type& __a)
         : __map_(__pointer_allocator(__a)), __start_(0), __size_(0, __a)
     {
@@ -1314,7 +1314,7 @@ _LIBCPP_CONSTEXPR const typename allocator_traits<_Alloc>::difference_type deque
 template<class _InputIterator,
          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 deque(_InputIterator, _InputIterator)
   -> deque<__iter_value_type<_InputIterator>, _Alloc>;
@@ -1322,7 +1322,7 @@ deque(_InputIterator, _InputIterator)
 template<class _InputIterator,
          class _Alloc,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 deque(_InputIterator, _InputIterator, _Alloc)
   -> deque<__iter_value_type<_InputIterator>, _Alloc>;
@@ -1331,7 +1331,7 @@ deque(_InputIterator, _InputIterator, _Alloc)
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Alloc = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<__is_allocator<_Alloc>::value>
+          class = enable_if_t<__is_allocator<_Alloc> >
           >
 deque(from_range_t, _Range&&, _Alloc = _Alloc())
   -> deque<ranges::range_value_t<_Range>, _Alloc>;

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -736,7 +736,7 @@ public:
 #endif
     _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v);
 
-    template <class = __enable_if_t<__is_allocator<_Alloc>::value> >
+    template <class = __enable_if_t<__is_allocator<_Alloc> > >
     _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v, const allocator_type& __a) : base(__a)
     {
         insert_after(cbefore_begin(), __n, __v);
@@ -982,7 +982,7 @@ private:
 template<class _InputIterator,
          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 forward_list(_InputIterator, _InputIterator)
   -> forward_list<__iter_value_type<_InputIterator>, _Alloc>;
@@ -990,7 +990,7 @@ forward_list(_InputIterator, _InputIterator)
 template<class _InputIterator,
          class _Alloc,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 forward_list(_InputIterator, _InputIterator, _Alloc)
   -> forward_list<__iter_value_type<_InputIterator>, _Alloc>;
@@ -999,7 +999,7 @@ forward_list(_InputIterator, _InputIterator, _Alloc)
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Alloc = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<__is_allocator<_Alloc>::value>
+          class = enable_if_t<__is_allocator<_Alloc> >
           >
 forward_list(from_range_t, _Range&&, _Alloc = _Alloc())
   -> forward_list<ranges::range_value_t<_Range>, _Alloc>;

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -779,7 +779,7 @@ public:
     _LIBCPP_HIDE_FROM_ABI explicit list(size_type __n, const allocator_type& __a);
 #endif
     _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x);
-    template <class = __enable_if_t<__is_allocator<_Alloc>::value> >
+    template <class = __enable_if_t<__is_allocator<_Alloc> > >
     _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x, const allocator_type& __a) : base(__a)
     {
         for (; __n > 0; --__n)
@@ -1075,7 +1075,7 @@ private:
 template<class _InputIterator,
          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 list(_InputIterator, _InputIterator)
   -> list<__iter_value_type<_InputIterator>, _Alloc>;
@@ -1083,7 +1083,7 @@ list(_InputIterator, _InputIterator)
 template<class _InputIterator,
          class _Alloc,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 list(_InputIterator, _InputIterator, _Alloc)
   -> list<__iter_value_type<_InputIterator>, _Alloc>;
@@ -1092,7 +1092,7 @@ list(_InputIterator, _InputIterator, _Alloc)
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Alloc = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<__is_allocator<_Alloc>::value>
+          class = enable_if_t<__is_allocator<_Alloc> >
           >
 list(from_range_t, _Range&&, _Alloc = _Alloc())
   -> list<ranges::range_value_t<_Range>, _Alloc>;

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -1630,43 +1630,43 @@ private:
 template<class _InputIterator, class _Compare = less<__iter_key_type<_InputIterator>>,
          class _Allocator = allocator<__iter_to_alloc_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<!__is_allocator<_Compare> , void>,
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 map(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
   -> map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>, _Compare, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Compare = less<__range_key_type<_Range>>,
           class _Allocator = allocator<__range_to_alloc_type<_Range>>,
-          class = enable_if_t<!__is_allocator<_Compare>::value, void>,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+          class = enable_if_t<!__is_allocator<_Compare> , void>,
+          class = enable_if_t<__is_allocator<_Allocator> , void>>
 map(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
   -> map<__range_key_type<_Range>, __range_mapped_type<_Range>, _Compare, _Allocator>;
 #endif
 
 template<class _Key, class _Tp, class _Compare = less<remove_const_t<_Key>>,
          class _Allocator = allocator<pair<const _Key, _Tp>>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<!__is_allocator<_Compare> , void>,
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 map(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
   -> map<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 map(_InputIterator, _InputIterator, _Allocator)
   -> map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
          less<__iter_key_type<_InputIterator>>, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+          class = enable_if_t<__is_allocator<_Allocator> , void>>
 map(from_range_t, _Range&&, _Allocator)
   -> map<__range_key_type<_Range>, __range_mapped_type<_Range>, less<__range_key_type<_Range>>, _Allocator>;
 #endif
 
 template<class _Key, class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 map(initializer_list<pair<_Key, _Tp>>, _Allocator)
   -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #endif
@@ -2360,43 +2360,43 @@ private:
 template<class _InputIterator, class _Compare = less<__iter_key_type<_InputIterator>>,
          class _Allocator = allocator<__iter_to_alloc_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<!__is_allocator<_Compare> , void>,
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 multimap(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
   -> multimap<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>, _Compare, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Compare = less<__range_key_type<_Range>>,
           class _Allocator = allocator<__range_to_alloc_type<_Range>>,
-          class = enable_if_t<!__is_allocator<_Compare>::value, void>,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+          class = enable_if_t<!__is_allocator<_Compare> , void>,
+          class = enable_if_t<__is_allocator<_Allocator> , void>>
 multimap(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
   -> multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, _Compare, _Allocator>;
 #endif
 
 template<class _Key, class _Tp, class _Compare = less<remove_const_t<_Key>>,
          class _Allocator = allocator<pair<const _Key, _Tp>>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<!__is_allocator<_Compare> , void>,
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 multimap(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
   -> multimap<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 multimap(_InputIterator, _InputIterator, _Allocator)
   -> multimap<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
          less<__iter_key_type<_InputIterator>>, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+          class = enable_if_t<__is_allocator<_Allocator> , void>>
 multimap(from_range_t, _Range&&, _Allocator)
   -> multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, less<__range_key_type<_Range>>, _Allocator>;
 #endif
 
 template<class _Key, class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 multimap(initializer_list<pair<_Key, _Tp>>, _Allocator)
   -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #endif

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -468,14 +468,14 @@ public:
 
 #if _LIBCPP_STD_VER >= 17
 template<class _Container,
-         class = enable_if_t<!__is_allocator<_Container>::value>
+         class = enable_if_t<!__is_allocator<_Container> >
 >
 queue(_Container)
     -> queue<typename _Container::value_type, _Container>;
 
 template<class _Container,
          class _Alloc,
-         class = enable_if_t<!__is_allocator<_Container>::value>,
+         class = enable_if_t<!__is_allocator<_Container> >,
          class = enable_if_t<uses_allocator<_Container, _Alloc>::value>
 >
 queue(_Container, _Alloc)
@@ -495,13 +495,13 @@ queue(from_range_t, _Range&&)
 template <class _InputIterator,
           class _Alloc,
           class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-          class = __enable_if_t<__is_allocator<_Alloc>::value>>
+          class = __enable_if_t<__is_allocator<_Alloc> >>
 queue(_InputIterator, _InputIterator, _Alloc)
     -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range,
           class _Alloc,
-          class = __enable_if_t<__is_allocator<_Alloc>::value>>
+          class = __enable_if_t<__is_allocator<_Alloc> >>
 queue(from_range_t, _Range&&, _Alloc)
     -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 #endif
@@ -784,8 +784,8 @@ public:
 #if _LIBCPP_STD_VER >= 17
 template <class _Compare,
           class _Container,
-          class = enable_if_t<!__is_allocator<_Compare>::value>,
-          class = enable_if_t<!__is_allocator<_Container>::value>
+          class = enable_if_t<!__is_allocator<_Compare> >,
+          class = enable_if_t<!__is_allocator<_Container> >
 >
 priority_queue(_Compare, _Container)
     -> priority_queue<typename _Container::value_type, _Container, _Compare>;
@@ -794,8 +794,8 @@ template<class _InputIterator,
          class _Compare = less<__iter_value_type<_InputIterator>>,
          class _Container = vector<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Compare>::value>,
-         class = enable_if_t<!__is_allocator<_Container>::value>
+         class = enable_if_t<!__is_allocator<_Compare> >,
+         class = enable_if_t<!__is_allocator<_Container> >
 >
 priority_queue(_InputIterator, _InputIterator, _Compare = _Compare(), _Container = _Container())
     -> priority_queue<__iter_value_type<_InputIterator>, _Container, _Compare>;
@@ -803,8 +803,8 @@ priority_queue(_InputIterator, _InputIterator, _Compare = _Compare(), _Container
 template<class _Compare,
          class _Container,
          class _Alloc,
-         class = enable_if_t<!__is_allocator<_Compare>::value>,
-         class = enable_if_t<!__is_allocator<_Container>::value>,
+         class = enable_if_t<!__is_allocator<_Compare> >,
+         class = enable_if_t<!__is_allocator<_Container> >,
          class = enable_if_t<uses_allocator<_Container, _Alloc>::value>
 >
 priority_queue(_Compare, _Container, _Alloc)
@@ -812,7 +812,7 @@ priority_queue(_Compare, _Container, _Alloc)
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>
+         class = enable_if_t<__is_allocator<_Allocator> >
 >
 priority_queue(_InputIterator, _InputIterator, _Allocator)
     -> priority_queue<__iter_value_type<_InputIterator>,
@@ -821,8 +821,8 @@ priority_queue(_InputIterator, _InputIterator, _Allocator)
 
 template<class _InputIterator, class _Compare, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Compare>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>
+         class = enable_if_t<!__is_allocator<_Compare> >,
+         class = enable_if_t<__is_allocator<_Allocator> >
 >
 priority_queue(_InputIterator, _InputIterator, _Compare, _Allocator)
     -> priority_queue<__iter_value_type<_InputIterator>,
@@ -830,8 +830,8 @@ priority_queue(_InputIterator, _InputIterator, _Compare, _Allocator)
 
 template<class _InputIterator, class _Compare, class _Container, class _Alloc,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Compare>::value>,
-         class = enable_if_t<!__is_allocator<_Container>::value>,
+         class = enable_if_t<!__is_allocator<_Compare> >,
+         class = enable_if_t<!__is_allocator<_Container> >,
          class = enable_if_t<uses_allocator<_Container, _Alloc>::value>
 >
 priority_queue(_InputIterator, _InputIterator, _Compare, _Container, _Alloc)
@@ -842,22 +842,22 @@ priority_queue(_InputIterator, _InputIterator, _Compare, _Container, _Alloc)
 
 template <ranges::input_range _Range,
           class _Compare = less<ranges::range_value_t<_Range>>,
-          class = enable_if_t<!__is_allocator<_Compare>::value>>
+          class = enable_if_t<!__is_allocator<_Compare> >>
 priority_queue(from_range_t, _Range&&, _Compare = _Compare())
     -> priority_queue<ranges::range_value_t<_Range>, vector<ranges::range_value_t<_Range>>, _Compare>;
 
 template <ranges::input_range _Range,
           class _Compare,
           class _Alloc,
-          class = enable_if_t<!__is_allocator<_Compare>::value>,
-          class = enable_if_t<__is_allocator<_Alloc>::value>>
+          class = enable_if_t<!__is_allocator<_Compare> >,
+          class = enable_if_t<__is_allocator<_Alloc> >>
 priority_queue(from_range_t, _Range&&, _Compare, _Alloc)
     -> priority_queue<ranges::range_value_t<_Range>, vector<ranges::range_value_t<_Range>, _Alloc>,
                         _Compare>;
 
 template <ranges::input_range _Range,
           class _Alloc,
-          class = enable_if_t<__is_allocator<_Alloc>::value>>
+          class = enable_if_t<__is_allocator<_Alloc> >>
 priority_queue(from_range_t, _Range&&, _Alloc)
     -> priority_queue<ranges::range_value_t<_Range>, vector<ranges::range_value_t<_Range>, _Alloc>>;
 

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -1007,43 +1007,43 @@ template<class _InputIterator,
          class _Compare = less<__iter_value_type<_InputIterator>>,
          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>,
+         class = enable_if_t<!__is_allocator<_Compare> , void>>
 set(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
   -> set<__iter_value_type<_InputIterator>, _Compare, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Compare = less<ranges::range_value_t<_Range>>,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>,
-          class = enable_if_t<!__is_allocator<_Compare>::value, void>>
+          class = enable_if_t<__is_allocator<_Allocator> , void>,
+          class = enable_if_t<!__is_allocator<_Compare> , void>>
 set(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
   -> set<ranges::range_value_t<_Range>, _Compare, _Allocator>;
 #endif
 
 template<class _Key, class _Compare = less<_Key>,
          class _Allocator = allocator<_Key>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<!__is_allocator<_Compare> , void>,
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 set(initializer_list<_Key>, _Compare = _Compare(), _Allocator = _Allocator())
   -> set<_Key, _Compare, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 set(_InputIterator, _InputIterator, _Allocator)
   -> set<__iter_value_type<_InputIterator>,
          less<__iter_value_type<_InputIterator>>, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+          class = enable_if_t<__is_allocator<_Allocator> , void>>
 set(from_range_t, _Range&&, _Allocator)
   -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #endif
 
 template<class _Key, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 set(initializer_list<_Key>, _Allocator)
   -> set<_Key, less<_Key>, _Allocator>;
 #endif
@@ -1598,43 +1598,43 @@ template<class _InputIterator,
          class _Compare = less<__iter_value_type<_InputIterator>>,
          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>,
+         class = enable_if_t<!__is_allocator<_Compare> , void>>
 multiset(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
   -> multiset<__iter_value_type<_InputIterator>, _Compare, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Compare = less<ranges::range_value_t<_Range>>,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>,
-          class = enable_if_t<!__is_allocator<_Compare>::value, void>>
+          class = enable_if_t<__is_allocator<_Allocator> , void>,
+          class = enable_if_t<!__is_allocator<_Compare> , void>>
 multiset(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
   -> multiset<ranges::range_value_t<_Range>, _Compare, _Allocator>;
 #endif
 
 template<class _Key, class _Compare = less<_Key>,
          class _Allocator = allocator<_Key>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>,
-         class = enable_if_t<!__is_allocator<_Compare>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>,
+         class = enable_if_t<!__is_allocator<_Compare> , void>>
 multiset(initializer_list<_Key>, _Compare = _Compare(), _Allocator = _Allocator())
   -> multiset<_Key, _Compare, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 multiset(_InputIterator, _InputIterator, _Allocator)
   -> multiset<__iter_value_type<_InputIterator>,
          less<__iter_value_type<_InputIterator>>, _Allocator>;
 
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+          class = enable_if_t<__is_allocator<_Allocator> , void>>
 multiset(from_range_t, _Range&&, _Allocator)
   -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #endif
 
 template<class _Key, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value, void>>
+         class = enable_if_t<__is_allocator<_Allocator> , void>>
 multiset(initializer_list<_Key>, _Allocator)
   -> multiset<_Key, less<_Key>, _Allocator>;
 #endif

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -413,7 +413,7 @@ public:
 
 #if _LIBCPP_STD_VER >= 20
     template <class _SAlloc>
-      requires __is_allocator<_SAlloc>::value
+      requires __is_allocator<_SAlloc>
     _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
         return basic_string<_CharT, _Traits, _SAlloc>(view(), __sa);
     }
@@ -914,7 +914,7 @@ public:
 
 #if _LIBCPP_STD_VER >= 20
     template <class _SAlloc>
-      requires __is_allocator<_SAlloc>::value
+      requires __is_allocator<_SAlloc>
     _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
         return __sb_.str(__sa);
     }
@@ -1039,7 +1039,7 @@ public:
 
 #if _LIBCPP_STD_VER >= 20
     template <class _SAlloc>
-      requires __is_allocator<_SAlloc>::value
+      requires __is_allocator<_SAlloc>
     _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
         return __sb_.str(__sa);
     }
@@ -1163,7 +1163,7 @@ public:
 
 #if _LIBCPP_STD_VER >= 20
     template <class _SAlloc>
-      requires __is_allocator<_SAlloc>::value
+      requires __is_allocator<_SAlloc>
     _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
         return __sb_.str(__sa);
     }

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -317,14 +317,14 @@ public:
 
 #if _LIBCPP_STD_VER >= 17
 template<class _Container,
-         class = enable_if_t<!__is_allocator<_Container>::value>
+         class = enable_if_t<!__is_allocator<_Container> >
 >
 stack(_Container)
     -> stack<typename _Container::value_type, _Container>;
 
 template<class _Container,
          class _Alloc,
-         class = enable_if_t<!__is_allocator<_Container>::value>,
+         class = enable_if_t<!__is_allocator<_Container> >,
          class = enable_if_t<uses_allocator<_Container, _Alloc>::value>
          >
 stack(_Container, _Alloc)
@@ -343,13 +343,13 @@ stack(from_range_t, _Range&&) -> stack<ranges::range_value_t<_Range>>;
 template<class _InputIterator,
          class _Alloc,
          class = __enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = __enable_if_t<__is_allocator<_Alloc>::value>>
+         class = __enable_if_t<__is_allocator<_Alloc> >>
 stack(_InputIterator, _InputIterator, _Alloc)
     -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range,
           class _Alloc,
-          class = __enable_if_t<__is_allocator<_Alloc>::value>>
+          class = __enable_if_t<__is_allocator<_Alloc> >>
 stack(from_range_t, _Range&&, _Alloc)
   -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -933,14 +933,14 @@ public:
   }
 #endif // _LIBCPP_CXX03_LANG
 
-  template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
+  template <__enable_if_t<__is_allocator<_Allocator> , int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(const _CharT* __s)
       : __r_(__default_init_tag(), __default_init_tag()) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__s != nullptr, "basic_string(const char*) detected nullptr");
     __init(__s, traits_type::length(__s));
   }
 
-  template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
+  template <__enable_if_t<__is_allocator<_Allocator> , int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(const _CharT* __s, const _Allocator& __a)
       : __r_(__default_init_tag(), __a) {
     _LIBCPP_ASSERT_UNCATEGORIZED(__s != nullptr, "basic_string(const char*, allocator) detected nullptr");
@@ -996,7 +996,7 @@ public:
   }
 #endif
 
-  template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
+  template <__enable_if_t<__is_allocator<_Allocator> , int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(size_type __n, _CharT __c, const _Allocator& __a)
       : __r_(__default_init_tag(), __a) {
     __init(__n, __c);
@@ -2081,7 +2081,7 @@ template<class _InputIterator,
          class _CharT = __iter_value_type<_InputIterator>,
          class _Allocator = allocator<_CharT>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>
+         class = enable_if_t<__is_allocator<_Allocator> >
          >
 basic_string(_InputIterator, _InputIterator, _Allocator = _Allocator())
   -> basic_string<_CharT, char_traits<_CharT>, _Allocator>;
@@ -2089,7 +2089,7 @@ basic_string(_InputIterator, _InputIterator, _Allocator = _Allocator())
 template<class _CharT,
          class _Traits,
          class _Allocator = allocator<_CharT>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>
+         class = enable_if_t<__is_allocator<_Allocator> >
          >
 explicit basic_string(basic_string_view<_CharT, _Traits>, const _Allocator& = _Allocator())
   -> basic_string<_CharT, _Traits, _Allocator>;
@@ -2097,7 +2097,7 @@ explicit basic_string(basic_string_view<_CharT, _Traits>, const _Allocator& = _A
 template<class _CharT,
          class _Traits,
          class _Allocator = allocator<_CharT>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>,
+         class = enable_if_t<__is_allocator<_Allocator> >,
          class _Sz = typename allocator_traits<_Allocator>::size_type
          >
 basic_string(basic_string_view<_CharT, _Traits>, _Sz, _Sz, const _Allocator& = _Allocator())
@@ -2107,7 +2107,7 @@ basic_string(basic_string_view<_CharT, _Traits>, _Sz, _Sz, const _Allocator& = _
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>
+          class = enable_if_t<__is_allocator<_Allocator> >
           >
 basic_string(from_range_t, _Range&&, _Allocator = _Allocator())
   -> basic_string<ranges::range_value_t<_Range>, char_traits<ranges::range_value_t<_Range>>, _Allocator>;

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -1631,10 +1631,10 @@ template<class _InputIterator,
          class _Pred = equal_to<__iter_key_type<_InputIterator>>,
          class _Allocator = allocator<__iter_to_alloc_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>, _Hash, _Pred, _Allocator>;
@@ -1644,10 +1644,10 @@ template <ranges::input_range _Range,
           class _Hash = hash<__range_key_type<_Range>>,
           class _Pred = equal_to<__range_key_type<_Range>>,
           class _Allocator = allocator<__range_to_alloc_type<_Range>>,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<!__is_allocator<_Pred>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<!__is_allocator<_Pred> >,
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_map<__range_key_type<_Range>, __range_mapped_type<_Range>, _Hash, _Pred, _Allocator>; // C++23
@@ -1656,33 +1656,33 @@ unordered_map(from_range_t, _Range&&, typename allocator_traits<_Allocator>::siz
 template<class _Key, class _Tp, class _Hash = hash<remove_const_t<_Key>>,
          class _Pred = equal_to<remove_const_t<_Key>>,
          class _Allocator = allocator<pair<const _Key, _Tp>>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_map<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
                    hash<__iter_key_type<_InputIterator>>, equal_to<__iter_key_type<_InputIterator>>, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(_InputIterator, _InputIterator, _Allocator)
   -> unordered_map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
                    hash<__iter_key_type<_InputIterator>>, equal_to<__iter_key_type<_InputIterator>>, _Allocator>;
 
 template<class _InputIterator, class _Hash, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
                    _Hash, equal_to<__iter_key_type<_InputIterator>>, _Allocator>;
@@ -1690,21 +1690,21 @@ unordered_map(_InputIterator, _InputIterator, typename allocator_traits<_Allocat
 #if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_map<__range_key_type<_Range>, __range_mapped_type<_Range>, hash<__range_key_type<_Range>>,
                    equal_to<__range_key_type<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(from_range_t, _Range&&, _Allocator)
   -> unordered_map<__range_key_type<_Range>, __range_mapped_type<_Range>, hash<__range_key_type<_Range>>,
                    equal_to<__range_key_type<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Hash, class _Allocator,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_map<__range_key_type<_Range>, __range_mapped_type<_Range>, _Hash,
                    equal_to<__range_key_type<_Range>>, _Allocator>;
@@ -1712,23 +1712,23 @@ unordered_map(from_range_t, _Range&&, typename allocator_traits<_Allocator>::siz
 #endif
 
 template<class _Key, class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_map<remove_const_t<_Key>, _Tp,
                    hash<remove_const_t<_Key>>,
                    equal_to<remove_const_t<_Key>>, _Allocator>;
 
 template<class _Key, class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(initializer_list<pair<_Key, _Tp>>, _Allocator)
   -> unordered_map<remove_const_t<_Key>, _Tp,
                    hash<remove_const_t<_Key>>,
                    equal_to<remove_const_t<_Key>>, _Allocator>;
 
 template<class _Key, class _Tp, class _Hash, class _Allocator,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_map(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_map<remove_const_t<_Key>, _Tp, _Hash,
                    equal_to<remove_const_t<_Key>>, _Allocator>;
@@ -2455,10 +2455,10 @@ template<class _InputIterator,
          class _Pred = equal_to<__iter_key_type<_InputIterator>>,
          class _Allocator = allocator<__iter_to_alloc_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type = 0,
                    _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_multimap<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>, _Hash, _Pred, _Allocator>;
@@ -2468,10 +2468,10 @@ template <ranges::input_range _Range,
           class _Hash = hash<__range_key_type<_Range>>,
           class _Pred = equal_to<__range_key_type<_Range>>,
           class _Allocator = allocator<__range_to_alloc_type<_Range>>,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<!__is_allocator<_Pred>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<!__is_allocator<_Pred> >,
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, _Hash, _Pred, _Allocator>;
@@ -2480,33 +2480,33 @@ unordered_multimap(from_range_t, _Range&&, typename allocator_traits<_Allocator>
 template<class _Key, class _Tp, class _Hash = hash<remove_const_t<_Key>>,
          class _Pred = equal_to<remove_const_t<_Key>>,
          class _Allocator = allocator<pair<const _Key, _Tp>>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type = 0,
                    _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_multimap<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
                         hash<__iter_key_type<_InputIterator>>, equal_to<__iter_key_type<_InputIterator>>, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(_InputIterator, _InputIterator, _Allocator)
   -> unordered_multimap<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
                         hash<__iter_key_type<_InputIterator>>, equal_to<__iter_key_type<_InputIterator>>, _Allocator>;
 
 template<class _InputIterator, class _Hash, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_multimap<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>,
                         _Hash, equal_to<__iter_key_type<_InputIterator>>, _Allocator>;
@@ -2514,21 +2514,21 @@ unordered_multimap(_InputIterator, _InputIterator, typename allocator_traits<_Al
 #if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, hash<__range_key_type<_Range>>,
                    equal_to<__range_key_type<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(from_range_t, _Range&&, _Allocator)
   -> unordered_multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, hash<__range_key_type<_Range>>,
                    equal_to<__range_key_type<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Hash, class _Allocator,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, _Hash,
                    equal_to<__range_key_type<_Range>>, _Allocator>;
@@ -2536,23 +2536,23 @@ unordered_multimap(from_range_t, _Range&&, typename allocator_traits<_Allocator>
 #endif
 
 template<class _Key, class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_multimap<remove_const_t<_Key>, _Tp,
                         hash<remove_const_t<_Key>>,
                         equal_to<remove_const_t<_Key>>, _Allocator>;
 
 template<class _Key, class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(initializer_list<pair<_Key, _Tp>>, _Allocator)
   -> unordered_multimap<remove_const_t<_Key>, _Tp,
                         hash<remove_const_t<_Key>>,
                         equal_to<remove_const_t<_Key>>, _Allocator>;
 
 template<class _Key, class _Tp, class _Hash, class _Allocator,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multimap(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash,
                         equal_to<remove_const_t<_Key>>, _Allocator>;

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -968,10 +968,10 @@ template<class _InputIterator,
          class _Pred = equal_to<__iter_value_type<_InputIterator>>,
          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_set<__iter_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
@@ -981,10 +981,10 @@ template <ranges::input_range _Range,
           class _Hash = hash<ranges::range_value_t<_Range>>,
           class _Pred = equal_to<ranges::range_value_t<_Range>>,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<!__is_allocator<_Pred>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<!__is_allocator<_Pred> >,
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
@@ -993,17 +993,17 @@ unordered_set(from_range_t, _Range&&, typename allocator_traits<_Allocator>::siz
 template<class _Tp, class _Hash = hash<_Tp>,
          class _Pred = equal_to<_Tp>,
          class _Allocator = allocator<_Tp>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_set<_Tp, _Hash, _Pred, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(_InputIterator, _InputIterator,
               typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_set<__iter_value_type<_InputIterator>,
@@ -1013,9 +1013,9 @@ unordered_set(_InputIterator, _InputIterator,
 
 template<class _InputIterator, class _Hash, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(_InputIterator, _InputIterator,
               typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_set<__iter_value_type<_InputIterator>, _Hash,
@@ -1025,35 +1025,35 @@ unordered_set(_InputIterator, _InputIterator,
 #if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_set<ranges::range_value_t<_Range>, hash<ranges::range_value_t<_Range>>,
                    equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(from_range_t, _Range&&, _Allocator)
   -> unordered_set<ranges::range_value_t<_Range>, hash<ranges::range_value_t<_Range>>,
                    equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Hash, class _Allocator,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_set<ranges::range_value_t<_Range>, _Hash, equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
 #endif
 
 template<class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_set<_Tp, hash<_Tp>, equal_to<_Tp>, _Allocator>;
 
 template<class _Tp, class _Hash, class _Allocator,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_set(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_set<_Tp, _Hash, equal_to<_Tp>, _Allocator>;
 #endif
@@ -1654,10 +1654,10 @@ template<class _InputIterator,
          class _Pred = equal_to<__iter_value_type<_InputIterator>>,
          class _Allocator = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_multiset<__iter_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
@@ -1667,10 +1667,10 @@ template <ranges::input_range _Range,
           class _Hash = hash<ranges::range_value_t<_Range>>,
           class _Pred = equal_to<ranges::range_value_t<_Range>>,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<!__is_allocator<_Pred>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<!__is_allocator<_Pred> >,
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_multiset<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
@@ -1678,17 +1678,17 @@ unordered_multiset(from_range_t, _Range&&, typename allocator_traits<_Allocator>
 
 template<class _Tp, class _Hash = hash<_Tp>,
          class _Pred = equal_to<_Tp>, class _Allocator = allocator<_Tp>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<!__is_allocator<_Pred>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<!__is_allocator<_Pred> >,
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type = 0,
               _Hash = _Hash(), _Pred = _Pred(), _Allocator = _Allocator())
   -> unordered_multiset<_Tp, _Hash, _Pred, _Allocator>;
 
 template<class _InputIterator, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_multiset<__iter_value_type<_InputIterator>,
                    hash<__iter_value_type<_InputIterator>>,
@@ -1697,9 +1697,9 @@ unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Al
 
 template<class _InputIterator, class _Hash, class _Allocator,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type,
               _Hash, _Allocator)
   -> unordered_multiset<__iter_value_type<_InputIterator>, _Hash,
@@ -1709,35 +1709,35 @@ unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Al
 #if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_multiset<ranges::range_value_t<_Range>, hash<ranges::range_value_t<_Range>>,
                    equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Allocator,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(from_range_t, _Range&&, _Allocator)
   -> unordered_multiset<ranges::range_value_t<_Range>, hash<ranges::range_value_t<_Range>>,
                    equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
 template <ranges::input_range _Range, class _Hash, class _Allocator,
-          class = enable_if_t<!__is_allocator<_Hash>::value>,
+          class = enable_if_t<!__is_allocator<_Hash> >,
           class = enable_if_t<!is_integral<_Hash>::value>,
-          class = enable_if_t<__is_allocator<_Allocator>::value>>
+          class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_multiset<ranges::range_value_t<_Range>, _Hash, equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
 #endif
 
 template<class _Tp, class _Allocator,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Allocator)
   -> unordered_multiset<_Tp, hash<_Tp>, equal_to<_Tp>, _Allocator>;
 
 template<class _Tp, class _Hash, class _Allocator,
-         class = enable_if_t<!__is_allocator<_Hash>::value>,
+         class = enable_if_t<!__is_allocator<_Hash> >,
          class = enable_if_t<!is_integral<_Hash>::value>,
-         class = enable_if_t<__is_allocator<_Allocator>::value>>
+         class = enable_if_t<__is_allocator<_Allocator> >>
 unordered_multiset(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
   -> unordered_multiset<_Tp, _Hash, equal_to<_Tp>, _Allocator>;
 #endif

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -427,7 +427,7 @@ public:
 #endif
     _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI vector(size_type __n, const value_type& __x);
 
-    template <class = __enable_if_t<__is_allocator<_Allocator>::value> >
+    template <class = __enable_if_t<__is_allocator<_Allocator> > >
     _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
     vector(size_type __n, const value_type& __x, const allocator_type& __a)
         : __end_cap_(nullptr, __a)
@@ -1002,7 +1002,7 @@ private:
 template<class _InputIterator,
          class _Alloc = allocator<__iter_value_type<_InputIterator>>,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 vector(_InputIterator, _InputIterator)
   -> vector<__iter_value_type<_InputIterator>, _Alloc>;
@@ -1010,7 +1010,7 @@ vector(_InputIterator, _InputIterator)
 template<class _InputIterator,
          class _Alloc,
          class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
-         class = enable_if_t<__is_allocator<_Alloc>::value>
+         class = enable_if_t<__is_allocator<_Alloc> >
          >
 vector(_InputIterator, _InputIterator, _Alloc)
   -> vector<__iter_value_type<_InputIterator>, _Alloc>;
@@ -1019,7 +1019,7 @@ vector(_InputIterator, _InputIterator, _Alloc)
 #if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Alloc = allocator<ranges::range_value_t<_Range>>,
-          class = enable_if_t<__is_allocator<_Alloc>::value>
+          class = enable_if_t<__is_allocator<_Alloc> >
           >
 vector(from_range_t, _Range&&, _Alloc = _Alloc())
   -> vector<ranges::range_value_t<_Range>, _Alloc>;

--- a/libcxx/test/libcxx/memory/is_allocator.pass.cpp
+++ b/libcxx/test/libcxx/memory/is_allocator.pass.cpp
@@ -25,10 +25,10 @@
 template <typename T>
 void test_allocators()
 {
-    static_assert(!std::__is_allocator<T>::value, "" );
-    static_assert( std::__is_allocator<std::allocator<T>>::value, "" );
-    static_assert( std::__is_allocator<test_allocator<T>>::value, "" );
-    static_assert( std::__is_allocator<min_allocator<T>>::value, "" );
+    static_assert(!std::__is_allocator<T>, "" );
+    static_assert( std::__is_allocator<std::allocator<T>>, "" );
+    static_assert( std::__is_allocator<test_allocator<T>>, "" );
+    static_assert( std::__is_allocator<min_allocator<T>>, "" );
 }
 
 

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -57,6 +57,8 @@ _warningFlags = [
     # Disable warnings for extensions used in C++03
     "-Wno-local-type-template-args",
     "-Wno-c++11-extensions",
+    "-Wno-c++14-extensions",
+    "-Wno-c++17-extensions",
 
     # TODO(philnik) This fails with the PSTL.
     "-Wno-unknown-pragmas",


### PR DESCRIPTION
Having `__is_allocator` be a concept when concepts are available is advantageous for diagnostic quality. Since libc++ doesn't use `__is_allocator` as a struct, we can turn it into an inline bool whenever concepts aren't available and retain the same syntax.

This change requires disabling warnings for C++14 and C++17 extensions (template variables and inline variables, respectively), but these ones are both supported in GCC anyway (see https://godbolt.org/z/M5frbxefP).