### PR TITLE
[Docs] Fix broken LLVM doc pages

### DIFF
--- a/llvm/docs/GitRepositoryPolicy.md
+++ b/llvm/docs/GitRepositoryPolicy.md
@@ -20,7 +20,7 @@ Requirements for *new* repositories as part of the
 
 If you want to integrate your project as part of the Monorepo, please take a
 look at the
-[Developer Policy](DeveloperPolicy.html#adding-an-established-project-to-the-llvm-monorepo>).
+[Developer Policy](project:DeveloperPolicy.rst#Adding an Established Project To the LLVM Monorepo).
 
 To request a new repository, please create an issue with the
 [Infrastructure Working Group](https://github.com/llvm/llvm-iwg/issues).

--- a/llvm/docs/InstrRefDebugInfo.md
+++ b/llvm/docs/InstrRefDebugInfo.md
@@ -191,4 +191,4 @@ instruction number of any cloned instruction, to avoid duplicate numbers
 appearing to `LiveDebugValues`. Dealing with duplicated instructions is a
 natural extension to instruction referencing that's currently unimplemented.
 
-[LiveDebugValues]: SourceLevelDebugging.html#livedebugvalues-expansion-of-variable-locations
+[LiveDebugValues]: project:SourceLevelDebugging.rst#LiveDebugValues expansion of variable locations

--- a/llvm/docs/MarkdownQuickstartTemplate.md
+++ b/llvm/docs/MarkdownQuickstartTemplate.md
@@ -158,4 +158,4 @@ integration documentation can be found in the [myst-parser docs].
 
 ## Generating the documentation
 
-see [Sphinx Quickstart Template](SphinxQuickstartTemplate.html#generating-the-documentation)
+see [Sphinx Quickstart Template](project:SphinxQuickstartTemplate.rst#Generating the documentation)

--- a/llvm/docs/PointerAuth.md
+++ b/llvm/docs/PointerAuth.md
@@ -303,8 +303,7 @@ instructions as such:
 
 #### Assembly Representation
 
-At the assembly level,
-[Authenticated Relocations](#authenticated-global-relocation) are represented
+At the assembly level, authenticated relocations are represented
 using the `@AUTH` modifier:
 
 ```asm
@@ -328,8 +327,7 @@ For example:
 
 #### ELF Object File Representation
 
-At the object file level,
-[Authenticated Relocations](#authenticated-global-relocation) are represented
+At the object file level, authenticated relocations are represented
 using the `R_AARCH64_AUTH_ABS64` relocation kind (with value `0xE100`).
 
 The signing schema is encoded in the place of relocation to be applied


### PR DESCRIPTION
These pages have warnings due to the links not being moved during the myst transition and maybe some breakages afterwards. This causes the docs build to fail as warnings are treated as errors by default. This patch fixes these issues for llvm/*.