### PR TITLE
[Sanitizer][Docs] Improve docs on building Asan

### DIFF
--- a/clang/docs/AddressSanitizer.rst
+++ b/clang/docs/AddressSanitizer.rst
@@ -26,7 +26,16 @@ Typical slowdown introduced by AddressSanitizer is **2x**.
 How to build
 ============
 
-Build LLVM/Clang with `CMake <https://llvm.org/docs/CMake.html>`_.
+Build LLVM/Clang with `CMake <https://llvm.org/docs/CMake.html>` and enable
+the ``compiler-rt`` runtime. An example CMake configuration that will allow
+for the use/testing of AddressSanitizer:
+
+.. code-block:: console
+
+   cmake -DCMAKE_BUILD_TYPE=Release \
+     -DLLVM_ENABLE_PROJECTS="clang" \
+     -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
+     ../llvm
 
 Usage
 =====


### PR DESCRIPTION
Currently the documentation for building Asan doesn't specify that compiler-rt needs to be built as well. In addition, there's no minimal example for the LLVM CMake configuration. This patch addresses both of these issues.

The lack of specification about building compiler-rt has shown up on Discourse (e.g., https://discourse.llvm.org/t/enabling-address-sanitizer/73940/2).