### PR TITLE
[clang]Avoid diagnose invalid consteval call for invalid function decl

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -358,6 +358,8 @@ Bug Fixes in This Version
   Fixes (`#67690 <https://github.com/llvm/llvm-project/issues/67690>`_)
 - Fixes a ``clang-17`` regression where ``LLVM_UNREACHABLE_OPTIMIZE=OFF``
   cannot be used with ``Release`` mode builds. (`#68237 <https://github.com/llvm/llvm-project/issues/68237>`_).
+- Fix crash in evaluating ``constexpr`` value for invalid template function.
+  Fixes (`#68542 <https://github.com/llvm/llvm-project/issues/68542>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18406,9 +18406,10 @@ static void EvaluateAndDiagnoseImmediateInvocation(
       FD = Call->getConstructor();
     else if (auto *Cast = dyn_cast<CastExpr>(InnerExpr))
       FD = dyn_cast_or_null<FunctionDecl>(Cast->getConversionFunction());
-
     assert(FD && FD->isImmediateFunction() &&
            "could not find an immediate function in this expression");
+    if (FD->isInvalidDecl())
+      return;
     SemaRef.Diag(CE->getBeginLoc(), diag::err_invalid_consteval_call)
         << FD << FD->isConsteval();
     if (auto Context =

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -18406,6 +18406,7 @@ static void EvaluateAndDiagnoseImmediateInvocation(
       FD = Call->getConstructor();
     else if (auto *Cast = dyn_cast<CastExpr>(InnerExpr))
       FD = dyn_cast_or_null<FunctionDecl>(Cast->getConversionFunction());
+
     assert(FD && FD->isImmediateFunction() &&
            "could not find an immediate function in this expression");
     if (FD->isInvalidDecl())

--- a/clang/test/SemaCXX/PR68542.cpp
+++ b/clang/test/SemaCXX/PR68542.cpp
@@ -1,7 +1,5 @@
 // RUN: %clang_cc1 -verify -std=c++20 -fsyntax-only %s
 
-// expected-note@+2{{candidate constructor (the implicit move constructor) not viable: no known conversion from 'int' to 'S &&' for 1st argument}}
-// expected-note@+1{{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'int' to 'const S &' for 1st argument}}
 struct S {
     int e;
 };
@@ -16,5 +14,7 @@ constexpr S f(T) noexcept {
 	return get_format<T>(); // expected-error{{no viable conversion from returned value of type 'int' to function return type 'S'}}
 }
 
-// expected-note@+1{{in instantiation of function template specialization 'f<int>' requested here}}
 constexpr S x = f(0); // expected-error{{constexpr variable 'x' must be initialized by a constant expression}}
+// expected-note@-1{{in instantiation of function template specialization 'f<int>' requested here}}
+// expected-note@3{{candidate constructor (the implicit move constructor) not viable: no known conversion from 'int' to 'S &&' for 1st argument}}
+// expected-note@3{{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'int' to 'const S &' for 1st argument}}

--- a/clang/test/SemaCXX/PR68542.cpp
+++ b/clang/test/SemaCXX/PR68542.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -verify -std=c++20 -fsyntax-only %s
+
+// expected-note@+2{{candidate constructor (the implicit move constructor) not viable: no known conversion from 'int' to 'S &&' for 1st argument}}
+// expected-note@+1{{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'int' to 'const S &' for 1st argument}}
+struct S {
+    int e;
+};
+
+template<class T>
+consteval int get_format() {
+	return nullptr; // expected-error{{cannot initialize return object of type 'int' with an rvalue of type 'std::nullptr_t'}}
+}
+
+template<class T>
+constexpr S f(T) noexcept {
+	return get_format<T>(); // expected-error{{no viable conversion from returned value of type 'int' to function return type 'S'}}
+}
+
+// expected-note@+1{{in instantiation of function template specialization 'f<int>' requested here}}
+constexpr S x = f(0); // expected-error{{constexpr variable 'x' must be initialized by a constant expression}}


### PR DESCRIPTION
Fixes:#68542
It is meaningless to diagnose further error for a invalid function declaration.