### PR TITLE
[MLIR] Refactor FuncOpToLLVM to operate on FunctionOpInterface instead of FuncOp (NFC)

### DIFF
--- a/mlir/include/mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h
+++ b/mlir/include/mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h
@@ -14,12 +14,27 @@
 #ifndef MLIR_CONVERSION_FUNCTOLLVM_CONVERTFUNCTOLLVM_H
 #define MLIR_CONVERSION_FUNCTOLLVM_CONVERTFUNCTOLLVM_H
 
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LogicalResult.h"
+
 namespace mlir {
 
+namespace LLVM {
+class LLVMFuncOp;
+} // namespace LLVM
+
+class ConversionPatternRewriter;
 class DialectRegistry;
 class LLVMTypeConverter;
 class RewritePatternSet;
 class SymbolTable;
+
+/// Convert input FuncOp to LLVMFuncOp by using the provided LLVMTypeConverter.
+/// Returns failure if failed to so.
+FailureOr<LLVM::LLVMFuncOp>
+convertFuncOpToLLVMFuncOp(FunctionOpInterface funcOp,
+                          ConversionPatternRewriter &rewriter,
+                          const LLVMTypeConverter &converter);
 
 /// Collect the default pattern to convert a FuncOp to the LLVM dialect. If
 /// `emitCWrappers` is set, the pattern will also produce functions

--- a/mlir/include/mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h
+++ b/mlir/include/mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h
@@ -29,8 +29,8 @@ class LLVMTypeConverter;
 class RewritePatternSet;
 class SymbolTable;
 
-/// Convert input FuncOp to LLVMFuncOp by using the provided LLVMTypeConverter.
-/// Returns failure if failed to so.
+/// Convert input FunctionOpInterface operation to LLVMFuncOp by using the
+/// provided LLVMTypeConverter. Return failure if failed to so.
 FailureOr<LLVM::LLVMFuncOp>
 convertFuncOpToLLVMFuncOp(FunctionOpInterface funcOp,
                           ConversionPatternRewriter &rewriter,


### PR DESCRIPTION
* refactor `convertFuncOpToLLVMFuncOp` to accept a `FunctionOpInterface` instead of func::FuncOp
* move `convertFuncOpToLLVMFuncOp` to corresponding public header, making it available for downstream project.