### PR TITLE
[mlir][affine] Add `AffineScope` trait to `scf.index_switch`

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -1101,7 +1101,7 @@ def WhileOp : SCF_Op<"while",
 // IndexSwitchOp
 //===----------------------------------------------------------------------===//
 
-def IndexSwitchOp : SCF_Op<"index_switch", [RecursiveMemoryEffects,
+def IndexSwitchOp : SCF_Op<"index_switch", [RecursiveMemoryEffects, AffineScope,
     SingleBlockImplicitTerminator<"scf::YieldOp">,
     DeclareOpInterfaceMethods<RegionBranchOpInterface,
                               ["getRegionInvocationBounds",

--- a/mlir/test/Dialect/Affine/parallelize.mlir
+++ b/mlir/test/Dialect/Affine/parallelize.mlir
@@ -323,3 +323,22 @@ func.func @iter_arg_memrefs(%in: memref<10xf32>) {
   }
   return
 }
+
+// CHECK-LABEL: @scf_affine_scope
+func.func @scf_affine_scope() {
+  %c0 = arith.constant 0 : index
+  %0 = tensor.empty(%c0) : tensor<?xi1>
+  %1 = bufferization.to_memref %0 : memref<?xi1>
+  %alloc = memref.alloc(%c0) : memref<?xi1>
+  %2 = scf.index_switch %c0 -> tensor<?x31x6xf16>
+  default {
+    %dim = memref.dim %1, %c0 : memref<?xi1>
+    affine.for %arg0 = 0 to %dim {
+      %3 = affine.load %1[%arg0] : memref<?xi1>
+      affine.store %3, %alloc[%arg0] : memref<?xi1>
+    }
+    %3 = tensor.empty(%c0) : tensor<?x31x6xf16>
+    scf.yield %3 : tensor<?x31x6xf16>
+  } 
+  return
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/64287

The code in AffineStructures.cpp:FlatAffineValueConstraints' assert statement checks that the loop bound (i.e. val) isTopLevelValue or isForInductionVar. In this case, `%dim = memref.dim %20, %c0 : memref<?x?x6xi1>` is neither, since it is inside `scf.index_switch`, which is not a part of `AffineScope`. Thus, the assert is triggered.

However, `%dim = memref.dim %20, %c0 : memref<?x?x6xi1>` is an invariant in the scope of the `scf.index_switch`. If it was a loop,  a invariant code motion could have hoisted it to be outside the `scf` scope, making it a valid `TopLevelValue`.

Adding the `AffineScope` trait to `scf.index_switch` solves the issue. This defines a new top level scope for symbols, which proves highly practical as it enables a broader range of things to be represented as sequences of affine loop nests.
I even suggest that we add this trait to other SCF operations like `scf.for`, `scf.while` as well, as that will be very useful, and should not have any major issues that we cannot solve.
