### PR TITLE
[analyzer] Fix note for member reference

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -177,8 +177,7 @@ static const MemRegion *
 getLocationRegionIfReference(const Expr *E, const ExplodedNode *N,
                              bool LookingForReference = true) {
   if (const auto *ME = dyn_cast<MemberExpr>(E)) {
-    // This handles other kinds of null references,
-    // for example, references from FieldRegions:
+    // This handles null references from FieldRegions, for example:
     //   struct Wrapper { int &ref; };
     //   Wrapper w = { *(int *)0 };
     //   w.ref = 1;

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -133,7 +133,7 @@ const Expr *bugreporter::getDerefExpr(const Stmt *S) {
     // Pattern match for a few useful cases: a[0], p->f, *p etc.
     else if (const auto *ME = dyn_cast<MemberExpr>(E)) {
       // This handles the case when the dereferencing of a member reference
-      // happens. This is needed, because the ast for dereferencing of a
+      // happens. This is needed, because the AST for dereferencing a
       // member reference looks like the following:
       // |-MemberExpr
       //  `-DeclRefExpr

--- a/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporterVisitors.cpp
@@ -137,11 +137,9 @@ const Expr *bugreporter::getDerefExpr(const Stmt *S) {
       // member reference looks like the following:
       // |-MemberExpr
       //  `-DeclRefExpr
-      // This branch without the special case just takes out the DeclRefExpr
-      // of the struct, class or union.
-      // This is wrong, because this DeclRefExpr will be passed
-      // to the bug reporting and the notes will refer to wrong variable
-      // (the struct instead of the member).
+      // Without this special case the notes would refer to the whole object
+      // (struct, class or union variable) instead of just the relevant member.
+
       if (ME->getMemberDecl()->getType()->isReferenceType())
         break;
       E = ME->getBase();

--- a/clang/test/Analysis/diagnostics/deref-track-symbolic-region.cpp
+++ b/clang/test/Analysis/diagnostics/deref-track-symbolic-region.cpp
@@ -65,7 +65,7 @@ void testReferenceToPointerWithNullptr() {
                                       // expected-note@-1 {{Dereference of null pointer}}
 }
 
-void aaa() {
+void testNullReferenceToPointer() {
   struct Wrapper {char c; int *&a;};
   Wrapper w {'c', *(int **)0 };           // expected-note{{'w.a' initialized to a null pointer value}}
                                           // expected-warning@-1 {{binding dereferenced null pointer to reference has undefined behavior}}

--- a/clang/test/Analysis/diagnostics/deref-track-symbolic-region.cpp
+++ b/clang/test/Analysis/diagnostics/deref-track-symbolic-region.cpp
@@ -41,3 +41,34 @@ int testRefToNullPtr2() {
   return *p2;         //expected-warning {{Dereference of null pointer}}
                       // expected-note@-1{{Dereference of null pointer}}
 }
+
+void testMemberNullPointerDeref() {
+  struct Wrapper {char c; int *ptr; };  
+  Wrapper w = {'a', nullptr};           // expected-note {{'w.ptr' initialized to a null pointer value}}
+  *w.ptr = 1;                           //expected-warning {{Dereference of null pointer}}
+                                        // expected-note@-1{{Dereference of null pointer}}
+}
+
+void testMemberNullReferenceDeref() {
+  struct Wrapper {char c; int &ref; };
+  Wrapper w = {.c = 'a', .ref = *(int *)0 }; // expected-note {{'w.ref' initialized to a null pointer value}}
+                                             // expected-warning@-1 {{binding dereferenced null pointer to reference has undefined behavior}}
+  w.ref = 1;                                 //expected-warning {{Dereference of null pointer}}
+                                             // expected-note@-1{{Dereference of null pointer}}
+}
+
+void testReferenceToPointerWithNullptr() {
+  int *i = nullptr;                   // expected-note {{'i' initialized to a null pointer value}}
+  struct Wrapper {char c; int *&a;};
+  Wrapper w {'c', i};                 // expected-note{{'w.a' initialized here}}
+  *(w.a) = 25;                        // expected-warning {{Dereference of null pointer}}
+                                      // expected-note@-1 {{Dereference of null pointer}}
+}
+
+void aaa() {
+  struct Wrapper {char c; int *&a;};
+  Wrapper w {'c', *(int **)0 };           // expected-note{{'w.a' initialized to a null pointer value}}
+                                          // expected-warning@-1 {{binding dereferenced null pointer to reference has undefined behavior}}
+  w.a = nullptr;                          // expected-warning {{Dereference of null pointer}}
+                                          // expected-note@-1 {{Dereference of null pointer}}
+}


### PR DESCRIPTION
In the following code:
```cpp
int main() {
    struct Wrapper {char c; int &ref; };
    Wrapper w = {.c = 'a', .ref = *(int *)0 };
    w.ref = 1;
}
```

The clang static analyzer will produce the following warnings and notes:
```
test.cpp:12:11: warning: Dereference of null pointer [core.NullDereference]
   12 |     w.ref = 1;
      |     ~~~~~~^~~
test.cpp:11:5: note: 'w' initialized here
   11 |     Wrapper w = {.c = 'a', .ref = *(int *)0 };
      |     ^~~~~~~~~
test.cpp:12:11: note: Dereference of null pointer
   12 |     w.ref = 1;
      |     ~~~~~~^~~
1 warning generated.
```
In the line where `w` is created, the note gives information about the initialization of `w` instead of `w.ref`. Let's compare it to a similar case where a null pointer dereference happens to a pointer member:

```cpp
int main() {
     struct Wrapper {char c; int *ptr; };
     Wrapper w = {.c = 'a', .ptr = nullptr };
     *w.ptr = 1;
}
```

Here the following error and notes are seen:
```
test.cpp:18:12: warning: Dereference of null pointer (loaded from field 'ptr') [core.NullDereference]
   18 |     *w.ptr = 1;
      |        ~~~ ^
test.cpp:17:5: note: 'w.ptr' initialized to a null pointer value
   17 |     Wrapper w = {.c = 'a', .ptr = nullptr };
      |     ^~~~~~~~~
test.cpp:18:12: note: Dereference of null pointer (loaded from field 'ptr')
   18 |     *w.ptr = 1;
      |        ~~~ ^
1 warning generated.
```
Here the note that shows the initialization the initialization of `w.ptr` in shown instead of `w`.

This commit is here to achieve similar notes for member reference as the notes of member pointers, so the report looks like the following:

```
test.cpp:12:11: warning: Dereference of null pointer [core.NullDereference]
   12 |     w.ref = 1;
      |     ~~~~~~^~~
test.cpp:11:5: note: 'w.ref' initialized to a null pointer value
   11 |     Wrapper w = {.c = 'a', .ref = *(int *)0 };
      |     ^~~~~~~~~
test.cpp:12:11: note: Dereference of null pointer
   12 |     w.ref = 1;
      |     ~~~~~~^~~
1 warning generated.
```
Here the initialization of `w.ref` is shown instead of `w`.