### PR TITLE
[RISCV] Replace PostRAScheduler with PostMachineScheduler

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -248,6 +248,8 @@ class RISCVPassConfig : public TargetPassConfig {
 public:
   RISCVPassConfig(RISCVTargetMachine &TM, PassManagerBase &PM)
       : TargetPassConfig(TM, PM) {
+    if (TM.getOptLevel() != CodeGenOptLevel::None)
+      substitutePass(&PostRASchedulerID, &PostMachineSchedulerID);
     setEnableSinkAndFold(EnableSinkFold);
   }
 

--- a/llvm/test/CodeGen/RISCV/O3-pipeline.ll
+++ b/llvm/test/CodeGen/RISCV/O3-pipeline.ll
@@ -159,7 +159,7 @@
 ; CHECK-NEXT:       Insert KCFI indirect call checks
 ; CHECK-NEXT:       MachineDominator Tree Construction
 ; CHECK-NEXT:       Machine Natural Loop Construction
-; CHECK-NEXT:       Post RA top-down list latency scheduler
+; CHECK-NEXT:       PostRA Machine Instruction Scheduler
 ; CHECK-NEXT:       Analyze Machine Code For Garbage Collection
 ; CHECK-NEXT:       Machine Block Frequency Analysis
 ; CHECK-NEXT:       MachinePostDominator Tree Construction

--- a/llvm/test/CodeGen/RISCV/macro-fusion-lui-addi.ll
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-lui-addi.ll
@@ -25,8 +25,8 @@ define void @foo(i32 signext %0, i32 signext %1) {
 ;
 ; FUSION-POSTRA-LABEL: foo:
 ; FUSION-POSTRA:       # %bb.0:
-; FUSION-POSTRA-NEXT:    lui a0, %hi(.L.str)
 ; FUSION-POSTRA-NEXT:    fcvt.s.w fa0, a1
+; FUSION-POSTRA-NEXT:    lui a0, %hi(.L.str)
 ; FUSION-POSTRA-NEXT:    addi a0, a0, %lo(.L.str)
 ; FUSION-POSTRA-NEXT:    tail bar@plt
   %3 = sitofp i32 %1 to float


### PR DESCRIPTION
Just like what other targets have done.

And this will make DAG mutations like MacroFusion take effect.

This PR is stacked on #68692.

