### PR TITLE
[RISCV] Remove FrameIndex case in lui+addi MacroFusion

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.cpp
@@ -35,10 +35,6 @@ static bool isLUIADDI(const MachineInstr *FirstMI,
   if (FirstMI->getOpcode() != RISCV::LUI)
     return false;
 
-  // The first operand of ADDI might be a frame index.
-  if (!SecondMI.getOperand(1).isReg())
-    return false;
-
   Register FirstDest = FirstMI->getOperand(0).getReg();
 
   // Destination of LUI should be the ADDI(W) source register.


### PR DESCRIPTION
Correct me if I am wrong, if the first operand of ADDI is a frame
index, then it won't have data dependency of predecessor LUI. So
it is impossible to do the DAG mutation in these two instructions.
