### PR TITLE
[lldb] Add SBType::FindDirectNestedType() function

### DIFF
--- a/lldb/bindings/interface/SBTypeDocstrings.i
+++ b/lldb/bindings/interface/SBTypeDocstrings.i
@@ -721,7 +721,7 @@ SBType supports the eq/ne operator. For example,::
 ) lldb::SBType::GetTypeFlags;
 
 %feature("docstring",
-    "Searches for a directly nested type that has provided name.
+    "Searches for a directly nested type that has the provided name.
 
     Returns the type if it was found.
     Returns invalid type if nothing was found.

--- a/lldb/bindings/interface/SBTypeDocstrings.i
+++ b/lldb/bindings/interface/SBTypeDocstrings.i
@@ -721,11 +721,12 @@ SBType supports the eq/ne operator. For example,::
 ) lldb::SBType::GetTypeFlags;
 
 %feature("docstring",
-    "Searches for a nested type that has provided name.
+    "Searches for a directly nested type that has provided name.
 
     Returns the type if it was found.
-    Returns invalid type if nothing was found."
-) lldb::SBType::FindNestedType;
+    Returns invalid type if nothing was found.
+    "
+) lldb::SBType::FindDirectNestedType;
 
 %feature("docstring",
 "Represents a list of :py:class:`SBType` s.

--- a/lldb/bindings/interface/SBTypeDocstrings.i
+++ b/lldb/bindings/interface/SBTypeDocstrings.i
@@ -721,6 +721,13 @@ SBType supports the eq/ne operator. For example,::
 ) lldb::SBType::GetTypeFlags;
 
 %feature("docstring",
+    "Searches for a nested type that has provided name.
+
+    Returns the type if it was found.
+    Returns invalid type if nothing was found."
+) lldb::SBType::FindNestedType;
+
+%feature("docstring",
 "Represents a list of :py:class:`SBType` s.
 
 The FindTypes() method of :py:class:`SBTarget`/:py:class:`SBModule` returns a SBTypeList.

--- a/lldb/include/lldb/API/SBType.h
+++ b/lldb/include/lldb/API/SBType.h
@@ -215,7 +215,7 @@ public:
   bool GetDescription(lldb::SBStream &description,
                       lldb::DescriptionLevel description_level);
 
-  lldb::SBType FindNestedType(const char *name);
+  lldb::SBType FindDirectNestedType(const char *name);
 
   lldb::SBType &operator=(const lldb::SBType &rhs);
 

--- a/lldb/include/lldb/API/SBType.h
+++ b/lldb/include/lldb/API/SBType.h
@@ -215,6 +215,8 @@ public:
   bool GetDescription(lldb::SBStream &description,
                       lldb::DescriptionLevel description_level);
 
+  lldb::SBType FindNestedType(const char *name);
+
   lldb::SBType &operator=(const lldb::SBType &rhs);
 
   bool operator==(lldb::SBType &rhs);

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -313,7 +313,7 @@ public:
   bool GetDescription(lldb_private::Stream &strm,
                       lldb::DescriptionLevel description_level);
 
-  CompilerType FindDirectNestedType(ConstString name);
+  CompilerType FindDirectNestedType(llvm::StringRef name);
 
 private:
   bool CheckModule(lldb::ModuleSP &module_sp) const;

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -313,7 +313,7 @@ public:
   bool GetDescription(lldb_private::Stream &strm,
                       lldb::DescriptionLevel description_level);
 
-  CompilerType FindNestedType(ConstString name);
+  CompilerType FindDirectNestedType(ConstString name);
 
 private:
   bool CheckModule(lldb::ModuleSP &module_sp) const;

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -313,6 +313,8 @@ public:
   bool GetDescription(lldb_private::Stream &strm,
                       lldb::DescriptionLevel description_level);
 
+  CompilerType FindNestedType(ConstString name);
+
 private:
   bool CheckModule(lldb::ModuleSP &module_sp) const;
   bool CheckExeModule(lldb::ModuleSP &module_sp) const;

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -135,8 +135,6 @@ public:
 
   virtual lldb::LanguageType DeclContextGetLanguage(void *opaque_decl_ctx) = 0;
 
-  // CompilerType functions
-
   /// Returns the direct parent context of specified type
   virtual CompilerDeclContext
   GetCompilerDeclContextForType(const CompilerType &type);

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -137,6 +137,7 @@ public:
 
   // CompilerType functions
 
+  /// Returns the direct parent context of specified type
   virtual CompilerDeclContext
   GetCompilerDeclContextForType(const CompilerType &type);
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -137,7 +137,8 @@ public:
 
   // CompilerType functions
 
-  virtual CompilerDeclContext GetCompilerDeclContextForType(const CompilerType& type);
+  virtual CompilerDeclContext
+  GetCompilerDeclContextForType(const CompilerType &type);
 
   // Tests
 #ifndef NDEBUG

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -135,6 +135,10 @@ public:
 
   virtual lldb::LanguageType DeclContextGetLanguage(void *opaque_decl_ctx) = 0;
 
+  // CompilerType functions
+
+  virtual CompilerDeclContext GetCompilerDeclContextForType(const CompilerType& type);
+
   // Tests
 #ifndef NDEBUG
   /// Verify the integrity of the type to catch CompilerTypes that mix

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -586,12 +586,12 @@ lldb::TemplateArgumentKind SBType::GetTemplateArgumentKind(uint32_t idx) {
   return eTemplateArgumentKindNull;
 }
 
-SBType SBType::FindNestedType(const char *name) {
+SBType SBType::FindDirectNestedType(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 
   if (!IsValid())
     return SBType();
-  auto ret = SBType(m_opaque_sp->FindNestedType(ConstString(name)));
+  auto ret = SBType(m_opaque_sp->FindDirectNestedType(ConstString(name)));
   return ret;
 }
 

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -591,8 +591,7 @@ SBType SBType::FindDirectNestedType(const char *name) {
 
   if (!IsValid())
     return SBType();
-  auto ret = SBType(m_opaque_sp->FindDirectNestedType(name));
-  return ret;
+  return SBType(m_opaque_sp->FindDirectNestedType(name));
 }
 
 SBTypeList::SBTypeList() : m_opaque_up(new TypeListImpl()) {

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -591,7 +591,7 @@ SBType SBType::FindDirectNestedType(const char *name) {
 
   if (!IsValid())
     return SBType();
-  auto ret = SBType(m_opaque_sp->FindDirectNestedType(ConstString(name)));
+  auto ret = SBType(m_opaque_sp->FindDirectNestedType(name));
   return ret;
 }
 

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -586,6 +586,15 @@ lldb::TemplateArgumentKind SBType::GetTemplateArgumentKind(uint32_t idx) {
   return eTemplateArgumentKindNull;
 }
 
+SBType SBType::FindNestedType(const char *name) {
+  LLDB_INSTRUMENT_VA(this);
+
+  if (!IsValid())
+    return SBType();
+  auto ret = SBType(m_opaque_sp->FindNestedType(ConstString(name)));
+  return ret;
+}
+
 SBTypeList::SBTypeList() : m_opaque_up(new TypeListImpl()) {
   LLDB_INSTRUMENT_VA(this);
 }

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -587,7 +587,7 @@ lldb::TemplateArgumentKind SBType::GetTemplateArgumentKind(uint32_t idx) {
 }
 
 SBType SBType::FindNestedType(const char *name) {
-  LLDB_INSTRUMENT_VA(this);
+  LLDB_INSTRUMENT_VA(this, name);
 
   if (!IsValid())
     return SBType();

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2638,7 +2638,9 @@ TypeSystemClang::GetDeclContextForType(const CompilerType &type) {
 
 CompilerDeclContext
 TypeSystemClang::GetCompilerDeclContextForType(const CompilerType &type) {
-  return CreateDeclContext(GetDeclContextForType(type));
+  if (auto *decl_context = GetDeclContextForType(type))
+    return CreateDeclContext(decl_context);
+  return CompilerDeclContext();
 }
 
 /// Aggressively desugar the provided type, skipping past various kinds of

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2636,6 +2636,10 @@ TypeSystemClang::GetDeclContextForType(const CompilerType &type) {
   return GetDeclContextForType(ClangUtil::GetQualType(type));
 }
 
+CompilerDeclContext TypeSystemClang::GetCompilerDeclContextForType(const CompilerType& type) {
+  return CreateDeclContext(GetDeclContextForType(type));
+}
+
 /// Aggressively desugar the provided type, skipping past various kinds of
 /// syntactic sugar and other constructs one typically wants to ignore.
 /// The \p mask argument allows one to skip certain kinds of simplifications,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2636,7 +2636,8 @@ TypeSystemClang::GetDeclContextForType(const CompilerType &type) {
   return GetDeclContextForType(ClangUtil::GetQualType(type));
 }
 
-CompilerDeclContext TypeSystemClang::GetCompilerDeclContextForType(const CompilerType& type) {
+CompilerDeclContext
+TypeSystemClang::GetCompilerDeclContextForType(const CompilerType &type) {
   return CreateDeclContext(GetDeclContextForType(type));
 }
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -219,7 +219,8 @@ public:
 
   static clang::DeclContext *GetDeclContextForType(const CompilerType &type);
 
-  CompilerDeclContext GetCompilerDeclContextForType(const CompilerType &type) override;
+  CompilerDeclContext
+  GetCompilerDeclContextForType(const CompilerType &type) override;
 
   uint32_t GetPointerByteSize() override;
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -219,6 +219,8 @@ public:
 
   static clang::DeclContext *GetDeclContextForType(const CompilerType &type);
 
+  CompilerDeclContext GetCompilerDeclContextForType(const CompilerType &type) override;
+
   uint32_t GetPointerByteSize() override;
 
   clang::TranslationUnitDecl *GetTranslationUnitDecl() {

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1082,8 +1082,8 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
   return true;
 }
 
-CompilerType TypeImpl::FindDirectNestedType(ConstString name) {
-  if (name.IsEmpty())
+CompilerType TypeImpl::FindDirectNestedType(llvm::StringRef name) {
+  if (name.empty())
     return CompilerType();
   auto type_system = GetTypeSystem(/*prefer_dynamic*/ false);
   auto *symbol_file = type_system->GetSymbolFile();
@@ -1092,7 +1092,7 @@ CompilerType TypeImpl::FindDirectNestedType(ConstString name) {
     return CompilerType();
   llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
   TypeMap search_result;
-  symbol_file->FindTypes(name, decl_context, /*max_matches*/ 1,
+  symbol_file->FindTypes(ConstString(name), decl_context, /*max_matches*/ 1,
                          searched_symbol_files, search_result);
   if (search_result.Empty())
     return CompilerType();

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1086,6 +1086,8 @@ CompilerType TypeImpl::FindNestedType(ConstString name) {
   auto type_system = GetTypeSystem(/*prefer_dynamic*/ false);
   auto *symbol_file = type_system->GetSymbolFile();
   auto decl_context = type_system->GetCompilerDeclContextForType(m_static_type);
+  if (!decl_context.IsValid())
+    return CompilerType();
   llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
   TypeMap search_result;
   symbol_file->FindTypes(name, decl_context, /*max_matches*/ 1,

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1082,7 +1082,7 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
   return true;
 }
 
-CompilerType TypeImpl::FindNestedType(ConstString name) {
+CompilerType TypeImpl::FindDirectNestedType(ConstString name) {
   if (name.IsEmpty())
     return CompilerType();
   auto type_system = GetTypeSystem(/*prefer_dynamic*/ false);

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1083,6 +1083,8 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
 }
 
 CompilerType TypeImpl::FindNestedType(ConstString name) {
+  if (name.IsEmpty())
+    return CompilerType();
   auto type_system = GetTypeSystem(/*prefer_dynamic*/ false);
   auto *symbol_file = type_system->GetSymbolFile();
   auto decl_context = type_system->GetCompilerDeclContextForType(m_static_type);

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1082,6 +1082,19 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
   return true;
 }
 
+CompilerType TypeImpl::FindNestedType(ConstString name) {
+  auto type_system = GetTypeSystem(false);
+  auto *symbol_file = type_system->GetSymbolFile();
+  auto decl_context = type_system->GetCompilerDeclContextForType(m_static_type);
+  llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
+  TypeMap search_result;
+  symbol_file->FindTypes(name, decl_context, /*max_matches*/ 1, searched_symbol_files, search_result);
+  if (search_result.Empty()) {
+    return CompilerType();
+  }
+  return search_result.GetTypeAtIndex(0)->GetFullCompilerType();
+}
+
 bool TypeMemberFunctionImpl::IsValid() {
   return m_type.IsValid() && m_kind != lldb::eMemberFunctionKindUnknown;
 }

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1083,15 +1083,14 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
 }
 
 CompilerType TypeImpl::FindNestedType(ConstString name) {
-  auto type_system = GetTypeSystem(false);
+  auto type_system = GetTypeSystem(/*prefer_dynamic*/ false);
   auto *symbol_file = type_system->GetSymbolFile();
   auto decl_context = type_system->GetCompilerDeclContextForType(m_static_type);
   llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
   TypeMap search_result;
   symbol_file->FindTypes(name, decl_context, /*max_matches*/ 1, searched_symbol_files, search_result);
-  if (search_result.Empty()) {
+  if (search_result.Empty())
     return CompilerType();
-  }
   return search_result.GetTypeAtIndex(0)->GetFullCompilerType();
 }
 

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1088,7 +1088,8 @@ CompilerType TypeImpl::FindNestedType(ConstString name) {
   auto decl_context = type_system->GetCompilerDeclContextForType(m_static_type);
   llvm::DenseSet<lldb_private::SymbolFile *> searched_symbol_files;
   TypeMap search_result;
-  symbol_file->FindTypes(name, decl_context, /*max_matches*/ 1, searched_symbol_files, search_result);
+  symbol_file->FindTypes(name, decl_context, /*max_matches*/ 1,
+                         searched_symbol_files, search_result);
   if (search_result.Empty())
     return CompilerType();
   return search_result.GetTypeAtIndex(0)->GetFullCompilerType();

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -186,7 +186,8 @@ std::optional<llvm::json::Value> TypeSystem::ReportStatistics() {
   return std::nullopt;
 }
 
-CompilerDeclContext TypeSystem::GetCompilerDeclContextForType(const CompilerType& type) {
+CompilerDeclContext
+TypeSystem::GetCompilerDeclContextForType(const CompilerType &type) {
   return CompilerDeclContext();
 }
 

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -186,6 +186,10 @@ std::optional<llvm::json::Value> TypeSystem::ReportStatistics() {
   return std::nullopt;
 }
 
+CompilerDeclContext TypeSystem::GetCompilerDeclContextForType(const CompilerType& type) {
+  return CompilerDeclContext();
+}
+
 #pragma mark TypeSystemMap
 
 TypeSystemMap::TypeSystemMap() : m_mutex(), m_map() {}

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -124,6 +124,10 @@ class TypeAndTypeListTestCase(TestBase):
         self.assertTrue(name_type)
         self.DebugSBType(name_type)
 
+        task_ptr_type = task_type.GetPointerType()
+        invalid_type = task_ptr_type.FindNestedType("name")
+        self.assertFalse(invalid_type.IsValid())
+
         # We'll now get the child member 'id' from 'task_head'.
         id = task_head.GetChildMemberWithName("id")
         self.DebugSBValue(id)

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -119,29 +119,29 @@ class TypeAndTypeListTestCase(TestBase):
 
         self.assertEqual(task_type, task_head_pointee_type)
 
-        # Check whether we can find a nested type by name
-        name_type = task_type.FindNestedType("name")
+        # Check whether we can find a directly nested type by name
+        name_type = task_type.FindDirectNestedType("name")
         self.assertTrue(name_type)
         self.DebugSBType(name_type)
 
-        enum_type = task_type.FindNestedType("E")
+        enum_type = task_type.FindDirectNestedType("E")
         self.assertTrue(enum_type)
         self.DebugSBType(enum_type)
 
-        union_type = task_type.FindNestedType("U")
+        union_type = task_type.FindDirectNestedType("U")
         self.assertTrue(union_type)
         self.DebugSBType(union_type)
 
-        # Check that FindNestedType handles types without DeclContext
+        # Check that FindDirectNestedType handles types without DeclContext
         # and other errorneous inputs
         task_ptr_type = task_type.GetPointerType()
-        invalid_type = task_ptr_type.FindNestedType("name")
+        invalid_type = task_ptr_type.FindDirectNestedType("name")
         self.assertFalse(invalid_type)
 
-        invalid_type = task_type.FindNestedType("")
+        invalid_type = task_type.FindDirectNestedType("")
         self.assertFalse(invalid_type)
 
-        invalid_type = task_type.FindNestedType(None)
+        invalid_type = task_type.FindDirectNestedType(None)
         self.assertFalse(invalid_type)
 
         # We'll now get the child member 'id' from 'task_head'.

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -124,6 +124,14 @@ class TypeAndTypeListTestCase(TestBase):
         self.assertTrue(name_type)
         self.DebugSBType(name_type)
 
+        enum_type = task_type.FindNestedType("E")
+        self.assertTrue(enum_type)
+        self.DebugSBType(enum_type)
+
+        union_type = task_type.FindNestedType("U")
+        self.assertTrue(union_type)
+        self.DebugSBType(union_type)
+
         task_ptr_type = task_type.GetPointerType()
         invalid_type = task_ptr_type.FindNestedType("name")
         self.assertFalse(invalid_type)

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -133,7 +133,6 @@ class TypeAndTypeListTestCase(TestBase):
         self.DebugSBType(union_type)
 
         # Check that we don't find indirectly nested types
-
         self.assertTrue(enum_type.size == 1)
 
         invalid_type = task_type.FindDirectNestedType("E2")

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -132,6 +132,13 @@ class TypeAndTypeListTestCase(TestBase):
         self.assertTrue(union_type)
         self.DebugSBType(union_type)
 
+        # Check that we don't find indirectly nested types
+
+        self.assertTrue(enum_type.size == 1)
+
+        invalid_type = task_type.FindDirectNestedType("E2")
+        self.assertFalse(invalid_type)
+
         # Check that FindDirectNestedType handles types without DeclContext
         # and other errorneous inputs
         task_ptr_type = task_type.GetPointerType()

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -126,7 +126,13 @@ class TypeAndTypeListTestCase(TestBase):
 
         task_ptr_type = task_type.GetPointerType()
         invalid_type = task_ptr_type.FindNestedType("name")
-        self.assertFalse(invalid_type.IsValid())
+        self.assertFalse(invalid_type)
+
+        invalid_type = task_type.FindNestedType("")
+        self.assertFalse(invalid_type)
+
+        invalid_type = task_type.FindNestedType(None)
+        self.assertFalse(invalid_type)
 
         # We'll now get the child member 'id' from 'task_head'.
         id = task_head.GetChildMemberWithName("id")

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -132,6 +132,8 @@ class TypeAndTypeListTestCase(TestBase):
         self.assertTrue(union_type)
         self.DebugSBType(union_type)
 
+        # Check that FindNestedType handles types without DeclContext
+        # and other errorneous inputs
         task_ptr_type = task_type.GetPointerType()
         invalid_type = task_ptr_type.FindNestedType("name")
         self.assertFalse(invalid_type)

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -119,6 +119,11 @@ class TypeAndTypeListTestCase(TestBase):
 
         self.assertEqual(task_type, task_head_pointee_type)
 
+        # Check whether we can find a nested type by name
+        name_type = task_type.FindNestedType("name")
+        self.assertTrue(name_type)
+        self.DebugSBType(name_type)
+
         # We'll now get the child member 'id' from 'task_head'.
         id = task_head.GetChildMemberWithName("id")
         self.DebugSBValue(id)

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -8,7 +8,7 @@ public:
         TASK_TYPE_1,
         TASK_TYPE_2
     } type;
-    enum E {} e;
+    enum E : unsigned char {} e;
     union U {
     } u;
     // This struct is anonymous b/c it does not have a name
@@ -24,6 +24,8 @@ public:
     } my_type_is_nameless;
     struct name {
       int x;
+      enum E : int {} e;
+      enum E2 {} e2;
     } my_type_is_named;
     Task(int i, Task *n):
         id(i),

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -8,6 +8,8 @@ public:
         TASK_TYPE_1,
         TASK_TYPE_2
     } type;
+    enum E {} e;
+    union U {} u;
     // This struct is anonymous b/c it does not have a name
     // and it is not unnamed class.
     // Anonymous classes are a GNU extension.

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -9,7 +9,8 @@ public:
         TASK_TYPE_2
     } type;
     enum E {} e;
-    union U {} u;
+    union U {
+    } u;
     // This struct is anonymous b/c it does not have a name
     // and it is not unnamed class.
     // Anonymous classes are a GNU extension.

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -8,9 +8,6 @@ public:
         TASK_TYPE_1,
         TASK_TYPE_2
     } type;
-    enum E : unsigned char {} e;
-    union U {
-    } u;
     // This struct is anonymous b/c it does not have a name
     // and it is not unnamed class.
     // Anonymous classes are a GNU extension.
@@ -27,6 +24,9 @@ public:
       enum E : int {} e;
       enum E2 {} e2;
     } my_type_is_named;
+    enum E : unsigned char {} e;
+    union U {
+    } u;
     Task(int i, Task *n):
         id(i),
         next(n),

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -186,6 +186,10 @@ Changes to LLDB
 
 * Methods in SBHostOS related to threads have had their implementations
   removed. These methods will return a value indicating failure.
+* ``SBType::FindDirectNestedType`` function is added. It's useful
+  for formatters to quickly find directly nested type when it's known
+  where to search for it, avoiding more expensive global search via
+  ``SBTarget::FindFirstType``.
 
 Changes to Sanitizers
 ---------------------


### PR DESCRIPTION
This patch adds a `SBType::FindDirectNestedType(name)` function which performs a non-recursive search in given class for a type with specified name. The intent is to perform a fast search in debug info, so that it can be used in formatters, and let them remain responsive.

This is driven by my work on formatters for Clang and LLVM types. In particular, by [`PointerIntPairInfo::MaskAndShiftConstants`](https://github.com/llvm/llvm-project/blob/cde9f9df79805a0850310870d6dcc64004292727/llvm/include/llvm/ADT/PointerIntPair.h#L174C16-L174C16), which is required to extract pointer and integer from `PointerIntPair`.

Related Discourse thread: https://discourse.llvm.org/t/traversing-member-types-of-a-type/72452