### PR TITLE
[BOLT][NFC] Add allocator id to MCPlusBuilder::setLabel

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -1185,7 +1185,7 @@ public:
 
   /// Set the label of \p Inst. This label will be emitted right before \p Inst
   /// is emitted to MCStreamer.
-  bool setLabel(MCInst &Inst, MCSymbol *Label);
+  bool setLabel(MCInst &Inst, MCSymbol *Label, AllocatorIdTy AllocatorId = 0);
 
   /// Return MCSymbol that represents a target of this instruction at a given
   /// operand number \p OpNum. If there's no symbol associated with

--- a/bolt/lib/Core/MCPlusBuilder.cpp
+++ b/bolt/lib/Core/MCPlusBuilder.cpp
@@ -274,8 +274,10 @@ std::optional<MCSymbol *> MCPlusBuilder::getLabel(const MCInst &Inst) const {
   return std::nullopt;
 }
 
-bool MCPlusBuilder::setLabel(MCInst &Inst, MCSymbol *Label) {
-  getOrCreateAnnotationAs<MCSymbol *>(Inst, MCAnnotation::kLabel) = Label;
+bool MCPlusBuilder::setLabel(MCInst &Inst, MCSymbol *Label,
+                             AllocatorIdTy AllocatorId) {
+  getOrCreateAnnotationAs<MCSymbol *>(Inst, MCAnnotation::kLabel, AllocatorId) =
+      Label;
   return true;
 }
 


### PR DESCRIPTION
This will be needed for some RISC-V instrumentation functions and is also consistent with other annotation setters.