### PR TITLE
[BOLT][NFC] Add allocator id to createInstrIncMemory

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -504,9 +504,10 @@ public:
   }
 
   /// Create increment contents of target by 1 for Instrumentation
-  virtual InstructionListType
-  createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
-                       unsigned CodePointerSize) const {
+  virtual InstructionListType createInstrIncMemory(const MCSymbol *Target,
+                                                   MCContext *Ctx, bool IsLeaf,
+                                                   unsigned CodePointerSize,
+                                                   AllocatorIdTy AllocatorId) {
     llvm_unreachable("not implemented");
     return InstructionListType();
   }

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -504,10 +504,10 @@ public:
   }
 
   /// Create increment contents of target by 1 for Instrumentation
-  virtual InstructionListType createInstrIncMemory(const MCSymbol *Target,
-                                                   MCContext *Ctx, bool IsLeaf,
-                                                   unsigned CodePointerSize,
-                                                   AllocatorIdTy AllocatorId) {
+  virtual InstructionListType
+  createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
+                       unsigned CodePointerSize,
+                       AllocatorIdTy AllocatorId = 0) {
     llvm_unreachable("not implemented");
     return InstructionListType();
   }

--- a/bolt/include/bolt/Passes/Instrumentation.h
+++ b/bolt/include/bolt/Passes/Instrumentation.h
@@ -64,8 +64,9 @@ private:
   void createLeafNodeDescription(FunctionDescription &FuncDesc, uint32_t Node);
 
   /// Create the sequence of instructions to increment a counter
-  InstructionListType createInstrumentationSnippet(BinaryContext &BC,
-                                                   bool IsLeaf);
+  InstructionListType
+  createInstrumentationSnippet(BinaryContext &BC, bool IsLeaf,
+                               MCPlusBuilder::AllocatorIdTy AllocatorId);
 
   // Critical edges worklist
   // This worklist keeps track of CFG edges <From-To> that needs to be split.
@@ -81,19 +82,18 @@ private:
   /// if this is a local branch and null if it is a call. Return true if the
   /// location was instrumented with an explicit counter or false if it just
   /// created the description, but no explicit counters were necessary.
-  bool instrumentOneTarget(SplitWorklistTy &SplitWorklist,
-                           SplitInstrsTy &SplitInstrs,
-                           BinaryBasicBlock::iterator &Iter,
-                           BinaryFunction &FromFunction,
-                           BinaryBasicBlock &FromBB, uint32_t From,
-                           BinaryFunction &ToFunc, BinaryBasicBlock *TargetBB,
-                           uint32_t ToOffset, bool IsLeaf, bool IsInvoke,
-                           FunctionDescription *FuncDesc, uint32_t FromNodeID,
-                           uint32_t ToNodeID = 0);
+  bool instrumentOneTarget(
+      SplitWorklistTy &SplitWorklist, SplitInstrsTy &SplitInstrs,
+      BinaryBasicBlock::iterator &Iter, BinaryFunction &FromFunction,
+      BinaryBasicBlock &FromBB, uint32_t From, BinaryFunction &ToFunc,
+      BinaryBasicBlock *TargetBB, uint32_t ToOffset, bool IsLeaf, bool IsInvoke,
+      FunctionDescription *FuncDesc, uint32_t FromNodeID, uint32_t ToNodeID,
+      MCPlusBuilder::AllocatorIdTy AllocatorId);
 
   void instrumentLeafNode(BinaryBasicBlock &BB, BinaryBasicBlock::iterator Iter,
                           bool IsLeaf, FunctionDescription &FuncDesc,
-                          uint32_t Node);
+                          uint32_t Node,
+                          MCPlusBuilder::AllocatorIdTy AllocatorId);
 
   void instrumentIndirectTarget(BinaryBasicBlock &BB,
                                 BinaryBasicBlock::iterator &Iter,

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -1542,9 +1542,10 @@ public:
     return Insts;
   }
 
-  InstructionListType
-  createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
-                       unsigned CodePointerSize) const override {
+  InstructionListType createInstrIncMemory(const MCSymbol *Target,
+                                           MCContext *Ctx, bool IsLeaf,
+                                           unsigned CodePointerSize,
+                                           AllocatorIdTy AllocatorId) override {
     unsigned int I = 0;
     InstructionListType Instrs(IsLeaf ? 12 : 10);
 

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -3025,9 +3025,10 @@ public:
     Inst.clear();
   }
 
-  InstructionListType
-  createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
-                       unsigned CodePointerSize) const override {
+  InstructionListType createInstrIncMemory(const MCSymbol *Target,
+                                           MCContext *Ctx, bool IsLeaf,
+                                           unsigned CodePointerSize,
+                                           AllocatorIdTy AllocatorId) override {
     InstructionListType Instrs(IsLeaf ? 13 : 11);
     unsigned int I = 0;
 


### PR DESCRIPTION
On RISC-V, this function will have to insert `auipc`+`lw`/`sw` pairs where the `auipc` needs a label annotation (see #66395). In order to do this correctly within the context of `ParallelUtilities`, we need an allocator id when setting the label. This patch adds this allocator id argument and wires it through to all call sites.

Note that this function is also made non-const since `setLabel` is non-const.