### PR TITLE
[clang][C2x] Remove confusing diagnostic auto storage class specifier

### DIFF
--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4042,7 +4042,7 @@ void Parser::ParseDeclarationSpecifiers(
         if (isKnownToBeTypeSpecifier(GetLookAheadToken(1))) {
           isInvalid = DS.SetStorageClassSpec(Actions, DeclSpec::SCS_auto, Loc,
                                              PrevSpec, DiagID, Policy);
-          if (!isInvalid)
+          if (!isInvalid && !getLangOpts().C23)
             Diag(Tok, diag::ext_auto_storage_class)
               << FixItHint::CreateRemoval(DS.getStorageClassSpecLoc());
         } else

--- a/clang/test/C/C2x/n3007.c
+++ b/clang/test/C/C2x/n3007.c
@@ -3,6 +3,10 @@
 /* WG14 N3007: Yes
  * Type Inference for object definitions
  */
+void test_auto_int(void) {
+  auto int auto_int = 12;
+}
+
 void test_qualifiers(int x, const int y, int * restrict z) {
   const auto a = x;
   auto b = y;

--- a/clang/test/Sema/c2x-auto.c
+++ b/clang/test/Sema/c2x-auto.c
@@ -4,6 +4,7 @@ void test_basic_types(void) {
   auto undefined;     // expected-error {{declaration of variable 'undefined' with deduced type 'auto' requires an initializer}}
   auto auto_int = 4;
   auto auto_long = 4UL;
+  auto int auto_int_ts = 12;
   signed auto a = 1L; // expected-error {{'auto' cannot be signed or unsigned}}
 
   _Static_assert(_Generic(auto_int, int : 1));


### PR DESCRIPTION
When declaring `auto int` at local or file scope, we emit a warning intended for C++11 and later, which is incorrect and confusing in C23.
See [Godbolt example](https://godbolt.org/z/j1acGhecd).
Now this diagnostic does not show up in C23.