### PR TITLE
[mlir][docgen] Add option to enable Hugo Docs specific features

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -188,7 +188,8 @@ endfunction()
 # Generate Documentation
 function(add_mlir_doc doc_filename output_file output_directory command)
   set(LLVM_TARGET_DEFINITIONS ${doc_filename}.td)
-  tablegen(MLIR ${output_file}.md ${command} ${ARGN})
+  # The MLIR docs use Hugo, so we allow Hugo specific features here.
+  tablegen(MLIR ${output_file}.md ${command} -allow-hugo-specific-features ${ARGN})
   set(GEN_DOC_FILE ${MLIR_BINARY_DIR}/docs/${output_directory}${output_file}.md)
   add_custom_command(
           OUTPUT ${GEN_DOC_FILE}

--- a/mlir/tools/mlir-tblgen/OpDocGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDocGen.cpp
@@ -42,6 +42,10 @@ llvm::cl::opt<std::string>
     stripPrefix("strip-prefix",
                 llvm::cl::desc("Strip prefix of the fully qualified names"),
                 llvm::cl::init("::mlir::"), llvm::cl::cat(docCat));
+llvm::cl::opt<bool> allowHugoSpecificFeatures(
+    "allow-hugo-specific-features",
+    llvm::cl::desc("Allows using features specific to Hugo"),
+    llvm::cl::init(false), llvm::cl::cat(docCat));
 
 using namespace llvm;
 using namespace mlir;
@@ -213,7 +217,7 @@ static void emitOpDoc(const Operator &op, raw_ostream &os) {
       os << "<td><code>" << it.name << "</code></td><td>" << storageType
          << "</td><td>";
       StringRef description = resolveAttrDescription(it.attr);
-      if (!description.empty()) {
+      if (allowHugoSpecificFeatures && !description.empty()) {
         // Expandable description.
         // This appears as just the summary, but when clicked shows the full
         // description.
@@ -227,7 +231,7 @@ static void emitOpDoc(const Operator &op, raw_ostream &os) {
       }
       os << "</td></tr>\n";
     }
-    os << "<table>\n";
+    os << "</table>\n";
   }
 
   // Emit each of the operands.


### PR DESCRIPTION
This is set to off by default but enabled for the MLIR project, which uses Hugo Docs. Downstream projects can choose if they want to set this option or not.

Also fix an incorrectly closed `<table>` tag.