### PR TITLE
[libc++] Fix UB in <expected> related to "has value" flag (#68552)

### DIFF
--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -934,14 +934,18 @@ private:
 
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Tp, _Err> __union_from_expected(const expected<_Up, _OtherErr>& __other) {
-    return __other.__has_val_ ? __union_t<_Tp, _Err>(std::in_place, __other.__union_.__val_)
-                              : __union_t<_Tp, _Err>(std::unexpect, __other.__union_.__unex_);
+    if (__other.__has_val_)
+      return __union_t<_Tp, _Err>(std::in_place, __other.__union_.__val_);
+    else
+      return __union_t<_Tp, _Err>(std::unexpect, __other.__union_.__unex_);
   }
 
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Tp, _Err> __union_from_expected(expected<_Up, _OtherErr>&& __other) {
-    return __other.__has_val_ ? __union_t<_Tp, _Err>(std::in_place, std::move(__other.__union_.__val_))
-                              : __union_t<_Tp, _Err>(std::unexpect, std::move(__other.__union_.__unex_));
+    if (__other.__has_val_)
+      return __union_t<_Tp, _Err>(std::in_place, std::move(__other.__union_.__val_));
+    else
+      return __union_t<_Tp, _Err>(std::unexpect, std::move(__other.__union_.__unex_));
   }
 
   _LIBCPP_NO_UNIQUE_ADDRESS __union_t<_Tp, _Err> __union_;
@@ -1527,14 +1531,18 @@ private:
 
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Err> __union_from_expected(const expected<_Up, _OtherErr>& __other) {
-    return __other.__has_val_ ? __union_t<_Err>()
-                              : __union_t<_Err>(std::unexpect, __other.__union_.__unex_);
+    if (__other.__has_val_)
+      return __union_t<_Err>();
+    else
+      return __union_t<_Err>(std::unexpect, __other.__union_.__unex_);
   }
 
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Err> __union_from_expected(expected<_Up, _OtherErr>&& __other) {
-    return __other.__has_val_ ? __union_t<_Err>()
-                              : __union_t<_Err>(std::unexpect, std::move(__other.__union_.__unex_));
+    if (__other.__has_val_)
+      return __union_t<_Err>();
+    else
+      return __union_t<_Err>(std::unexpect, std::move(__other.__union_.__unex_));
   }
 
   _LIBCPP_NO_UNIQUE_ADDRESS __union_t<_Err> __union_;

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -119,7 +119,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr expected()
     noexcept(is_nothrow_default_constructible_v<_Tp>) // strengthened
     requires is_default_constructible_v<_Tp>
-      : __union_(__construct_in_place_tag{}), __has_val_(true) {}
+      : __union_(std::in_place), __has_val_(true) {}
 
   _LIBCPP_HIDE_FROM_ABI constexpr expected(const expected&) = delete;
 
@@ -200,47 +200,47 @@ public:
              (!is_same_v<remove_cv_t<_Tp>, bool> || !__is_std_expected<remove_cvref_t<_Up>>::value))
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!is_convertible_v<_Up, _Tp>)
       expected(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>) // strengthened
-      : __union_(__construct_in_place_tag{}, std::forward<_Up>(__u)), __has_val_(true) {}
+      : __union_(std::in_place, std::forward<_Up>(__u)), __has_val_(true) {}
 
   template <class _OtherErr>
     requires is_constructible_v<_Err, const _OtherErr&>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!is_convertible_v<const _OtherErr&, _Err>)
   expected(const unexpected<_OtherErr>& __unex)
     noexcept(is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
-      : __union_(__construct_unexpected_tag{}, __unex.error()), __has_val_(false) {}
+      : __union_(std::unexpect, __unex.error()), __has_val_(false) {}
 
   template <class _OtherErr>
     requires is_constructible_v<_Err, _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!is_convertible_v<_OtherErr, _Err>)
   expected(unexpected<_OtherErr>&& __unex)
     noexcept(is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
-      : __union_(__construct_unexpected_tag{}, std::move(__unex.error())), __has_val_(false) {}
+      : __union_(std::unexpect, std::move(__unex.error())), __has_val_(false) {}
 
   template <class... _Args>
     requires is_constructible_v<_Tp, _Args...>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit expected(in_place_t, _Args&&... __args)
     noexcept(is_nothrow_constructible_v<_Tp, _Args...>) // strengthened
-      : __union_(__construct_in_place_tag{}, std::forward<_Args>(__args)...), __has_val_(true) {}
+      : __union_(std::in_place, std::forward<_Args>(__args)...), __has_val_(true) {}
 
   template <class _Up, class... _Args>
     requires is_constructible_v< _Tp, initializer_list<_Up>&, _Args... >
   _LIBCPP_HIDE_FROM_ABI constexpr explicit
   expected(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
     noexcept(is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>) // strengthened
-      : __union_(__construct_in_place_tag{}, __il, std::forward<_Args>(__args)...), __has_val_(true) {}
+      : __union_(std::in_place, __il, std::forward<_Args>(__args)...), __has_val_(true) {}
 
   template <class... _Args>
     requires is_constructible_v<_Err, _Args...>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit expected(unexpect_t, _Args&&... __args)
     noexcept(is_nothrow_constructible_v<_Err, _Args...>) // strengthened
-      : __union_(__construct_unexpected_tag{}, std::forward<_Args>(__args)...), __has_val_(false) {}
+      : __union_(std::unexpect, std::forward<_Args>(__args)...), __has_val_(false) {}
 
   template <class _Up, class... _Args>
     requires is_constructible_v< _Err, initializer_list<_Up>&, _Args... >
   _LIBCPP_HIDE_FROM_ABI constexpr explicit
   expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args)
     noexcept(is_nothrow_constructible_v<_Err, initializer_list<_Up>&, _Args...>) // strengthened
-      : __union_(__construct_unexpected_tag{}, __il, std::forward<_Args>(__args)...), __has_val_(false) {}
+      : __union_(std::unexpect, __il, std::forward<_Args>(__args)...), __has_val_(false) {}
 
   // [expected.object.dtor], destructor
 
@@ -855,19 +855,17 @@ public:
 
 private:
   struct __empty_t {};
-  struct __construct_in_place_tag {};
-  struct __construct_unexpected_tag {};
 
   template <class _ValueType, class _ErrorType>
   union __union_t {
     _LIBCPP_HIDE_FROM_ABI constexpr __union_t() {}
 
     template <class... _Args>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(__construct_in_place_tag, _Args&&... __args)
+    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(std::in_place_t, _Args&&... __args)
         : __val_(std::forward<_Args>(__args)...) {}
 
     template <class... _Args>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(__construct_unexpected_tag, _Args&&... __args)
+    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(std::unexpect_t, _Args&&... __args)
         : __unex_(std::forward<_Args>(__args)...) {}
 
     template <class _Func, class... _Args>
@@ -903,11 +901,11 @@ private:
     _LIBCPP_HIDE_FROM_ABI constexpr __union_t& operator=(const __union_t&) = default;
 
     template <class... _Args>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(__construct_in_place_tag, _Args&&... __args)
+    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(std::in_place_t, _Args&&... __args)
         : __val_(std::forward<_Args>(__args)...) {}
 
     template <class... _Args>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(__construct_unexpected_tag, _Args&&... __args)
+    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(std::unexpect_t, _Args&&... __args)
         : __unex_(std::forward<_Args>(__args)...) {}
 
     template <class _Func, class... _Args>
@@ -936,14 +934,14 @@ private:
 
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Tp, _Err> __union_from_expected(const expected<_Up, _OtherErr>& __other) {
-    return __other.__has_val_ ? __union_t<_Tp, _Err>(__construct_in_place_tag{}, __other.__union_.__val_)
-                              : __union_t<_Tp, _Err>(__construct_unexpected_tag{}, __other.__union_.__unex_);
+    return __other.__has_val_ ? __union_t<_Tp, _Err>(std::in_place, __other.__union_.__val_)
+                              : __union_t<_Tp, _Err>(std::unexpect, __other.__union_.__unex_);
   }
 
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Tp, _Err> __union_from_expected(expected<_Up, _OtherErr>&& __other) {
-    return __other.__has_val_ ? __union_t<_Tp, _Err>(__construct_in_place_tag{}, std::move(__other.__union_.__val_))
-                              : __union_t<_Tp, _Err>(__construct_unexpected_tag{}, std::move(__other.__union_.__unex_));
+    return __other.__has_val_ ? __union_t<_Tp, _Err>(std::in_place, std::move(__other.__union_.__val_))
+                              : __union_t<_Tp, _Err>(std::unexpect, std::move(__other.__union_.__unex_));
   }
 
   _LIBCPP_NO_UNIQUE_ADDRESS __union_t<_Tp, _Err> __union_;
@@ -1019,14 +1017,14 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!is_convertible_v<const _OtherErr&, _Err>)
   expected(const unexpected<_OtherErr>& __unex)
     noexcept(is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
-      : __union_(__construct_unexpected_tag{}, __unex.error()), __has_val_(false) {}
+      : __union_(std::unexpect, __unex.error()), __has_val_(false) {}
 
   template <class _OtherErr>
     requires is_constructible_v<_Err, _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!is_convertible_v<_OtherErr, _Err>)
   expected(unexpected<_OtherErr>&& __unex)
     noexcept(is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
-      : __union_(__construct_unexpected_tag{}, std::move(__unex.error())), __has_val_(false) {}
+      : __union_(std::unexpect, std::move(__unex.error())), __has_val_(false) {}
 
   _LIBCPP_HIDE_FROM_ABI constexpr explicit expected(in_place_t) noexcept : __has_val_(true) {}
 
@@ -1034,13 +1032,13 @@ public:
     requires is_constructible_v<_Err, _Args...>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit expected(unexpect_t, _Args&&... __args)
     noexcept(is_nothrow_constructible_v<_Err, _Args...>) // strengthened
-      : __union_(__construct_unexpected_tag{}, std::forward<_Args>(__args)...), __has_val_(false) {}
+      : __union_(std::unexpect, std::forward<_Args>(__args)...), __has_val_(false) {}
 
   template <class _Up, class... _Args>
     requires is_constructible_v< _Err, initializer_list<_Up>&, _Args... >
   _LIBCPP_HIDE_FROM_ABI constexpr explicit expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args)
     noexcept(is_nothrow_constructible_v<_Err, initializer_list<_Up>&, _Args...>) // strengthened
-      : __union_(__construct_unexpected_tag{}, __il, std::forward<_Args>(__args)...), __has_val_(false) {}
+      : __union_(std::unexpect, __il, std::forward<_Args>(__args)...), __has_val_(false) {}
 
 private:
   template <class _Func>
@@ -1469,14 +1467,13 @@ public:
 
 private:
   struct __empty_t {};
-  struct __construct_unexpected_tag {};
 
   template <class _ErrorType>
   union __union_t {
     _LIBCPP_HIDE_FROM_ABI constexpr __union_t() : __empty_() {}
 
     template <class... _Args>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(__construct_unexpected_tag, _Args&&... __args)
+    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(std::unexpect_t, _Args&&... __args)
         : __unex_(std::forward<_Args>(__args)...) {}
 
     template <class _Func, class... _Args>
@@ -1507,7 +1504,7 @@ private:
     _LIBCPP_HIDE_FROM_ABI constexpr __union_t& operator=(const __union_t&) = default;
 
     template <class... _Args>
-    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(__construct_unexpected_tag, _Args&&... __args)
+    _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(std::unexpect_t, _Args&&... __args)
         : __unex_(std::forward<_Args>(__args)...) {}
 
     template <class _Func, class... _Args>
@@ -1531,13 +1528,13 @@ private:
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Err> __union_from_expected(const expected<_Up, _OtherErr>& __other) {
     return __other.__has_val_ ? __union_t<_Err>()
-                              : __union_t<_Err>(__construct_unexpected_tag{}, __other.__union_.__unex_);
+                              : __union_t<_Err>(std::unexpect, __other.__union_.__unex_);
   }
 
   template <class _Up, class _OtherErr>
   _LIBCPP_HIDE_FROM_ABI constexpr __union_t<_Err> __union_from_expected(expected<_Up, _OtherErr>&& __other) {
     return __other.__has_val_ ? __union_t<_Err>()
-                              : __union_t<_Err>(__construct_unexpected_tag{}, std::move(__other.__union_.__unex_));
+                              : __union_t<_Err>(std::unexpect, std::move(__other.__union_.__unex_));
   }
 
   _LIBCPP_NO_UNIQUE_ADDRESS __union_t<_Err> __union_;

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -402,7 +402,7 @@ public:
     }
     std::construct_at(std::addressof(__union_.__val_), std::forward<_Args>(__args)...);
     __has_val_ = true;
-    return *std::addressof(__union_.__val_);
+    return __union_.__val_;
   }
 
   template <class _Up, class... _Args>
@@ -415,7 +415,7 @@ public:
     }
     std::construct_at(std::addressof(__union_.__val_), __il, std::forward<_Args>(__args)...);
     __has_val_ = true;
-    return *std::addressof(__union_.__val_);
+    return __union_.__val_;
   }
 
 

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -881,9 +881,9 @@ private:
     template <class _Union>
     _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(bool __has_val, _Union&& __other) {
       if (__has_val)
-        std::construct_at(this, std::in_place, std::forward<_Union>(__other).__val_);
+        std::construct_at(std::addressof(__val_), std::forward<_Union>(__other).__val_);
       else
-        std::construct_at(this, std::unexpect, std::forward<_Union>(__other).__unex_);
+        std::construct_at(std::addressof(__unex_), std::forward<_Union>(__other).__unex_);
     }
 
     _LIBCPP_HIDE_FROM_ABI constexpr ~__union_t()
@@ -929,9 +929,9 @@ private:
     template <class _Union>
     _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(bool __has_val, _Union&& __other) {
       if (__has_val)
-        std::construct_at(this, std::in_place, std::forward<_Union>(__other).__val_);
+        std::construct_at(std::addressof(__val_), std::forward<_Union>(__other).__val_);
       else
-        std::construct_at(this, std::unexpect, std::forward<_Union>(__other).__unex_);
+        std::construct_at(std::addressof(__unex_), std::forward<_Union>(__other).__unex_);
     }
 
     _LIBCPP_HIDE_FROM_ABI constexpr ~__union_t()
@@ -1488,9 +1488,9 @@ private:
     template <class _Union>
     _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(bool __has_val, _Union&& __other) {
       if (__has_val)
-        std::construct_at(this);
+        std::construct_at(std::addressof(__empty_));
       else
-        std::construct_at(this, std::unexpect, std::forward<_Union>(__other).__unex_);
+        std::construct_at(std::addressof(__unex_), std::forward<_Union>(__other).__unex_);
     }
 
     _LIBCPP_HIDE_FROM_ABI constexpr ~__union_t()
@@ -1527,9 +1527,9 @@ private:
     template <class _Union>
     _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(bool __has_val, _Union&& __other) {
       if (__has_val)
-        std::construct_at(this);
+        std::construct_at(std::addressof(__empty_));
       else
-        std::construct_at(this, std::unexpect, std::forward<_Union>(__other).__unex_);
+        std::construct_at(std::addressof(__unex_), std::forward<_Union>(__other).__unex_);
     }
 
     _LIBCPP_HIDE_FROM_ABI constexpr ~__union_t()

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -854,12 +854,8 @@ public:
   }
 
 private:
-  struct __empty_t {};
-
   template <class _ValueType, class _ErrorType>
   union __union_t {
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t() {}
-
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(std::in_place_t, _Args&&... __args)
         : __val_(std::forward<_Args>(__args)...) {}
@@ -904,7 +900,6 @@ private:
   template <class _ValueType, class _ErrorType>
     requires(is_trivially_move_constructible_v<_ValueType> && is_trivially_move_constructible_v<_ErrorType>)
   union __union_t<_ValueType, _ErrorType> {
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t() : __empty_() {}
     _LIBCPP_HIDE_FROM_ABI constexpr __union_t(const __union_t&) = default;
     _LIBCPP_HIDE_FROM_ABI constexpr __union_t& operator=(const __union_t&) = default;
 
@@ -943,7 +938,6 @@ private:
       requires(!is_trivially_destructible_v<_ValueType> || !is_trivially_destructible_v<_ErrorType>)
     {}
 
-    _LIBCPP_NO_UNIQUE_ADDRESS __empty_t __empty_;
     _LIBCPP_NO_UNIQUE_ADDRESS _ValueType __val_;
     _LIBCPP_NO_UNIQUE_ADDRESS _ErrorType __unex_;
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.intializer_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.intializer_list.pass.cpp
@@ -81,6 +81,14 @@ constexpr bool test() {
     assert(e.value().i == 10);
   }
 
+  // TailClobberer
+  {
+    std::expected<TailClobberer<0>, bool> e(std::unexpect);
+    auto list = {4, 5, 6};
+    e.emplace(list);
+    assert(e.has_value());
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.pass.cpp
@@ -73,6 +73,13 @@ constexpr bool test() {
     assert(e.value() == 10);
   }
 
+  // TailClobberer
+  {
+    std::expected<TailClobberer<0>, bool> e(std::unexpect);
+    e.emplace();
+    assert(e.has_value());
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.copy.pass.cpp
@@ -175,8 +175,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct ThrowingInt {
     ThrowingInt(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.copy.pass.cpp
@@ -45,6 +45,7 @@
 #include <utility>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 template <class T1, class Err1, class T2, class Err2>
@@ -159,6 +160,14 @@ constexpr bool test() {
     assert(e2.error().i == 5);
     assert(!e1.has_value());
     assert(e1.error() == 5);
+  }
+
+  // convert TailClobberer
+  {
+    const std::expected<TailClobbererNonTrivialMove<0>, char> e1;
+    std::expected<TailClobberer<0>, char> e2 = e1;
+    assert(e2.has_value());
+    assert(e1.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.move.pass.cpp
@@ -174,8 +174,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct ThrowingInt {
     ThrowingInt(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.convert.move.pass.cpp
@@ -46,6 +46,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 template <class T1, class Err1, class T2, class Err2>
@@ -158,6 +159,14 @@ constexpr bool test() {
     assert(e2.error().data.get() == 5);
     assert(!e1.has_value());
     assert(e1.error().get() == 0);
+  }
+
+  // convert TailClobberer
+  {
+    std::expected<TailClobbererNonTrivialMove<0>, char> e1;
+    std::expected<TailClobberer<0>, char> e2 = std::move(e1);
+    assert(e2.has_value());
+    assert(e1.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.copy.pass.cpp
@@ -114,8 +114,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing() = default;
     Throwing(const Throwing&) { throw Except{}; }

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.copy.pass.cpp
@@ -30,6 +30,7 @@
 #include <utility>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 struct NonCopyable {
   NonCopyable(const NonCopyable&) = delete;
@@ -93,6 +94,21 @@ constexpr bool test() {
     assert(!e2.has_value());
     assert(e2.error() == 5);
   }
+
+  // copy TailClobberer as value
+  {
+    const std::expected<TailClobberer<0>, bool> e1;
+    auto e2 = e1;
+    assert(e2.has_value());
+  }
+
+  // copy TailClobberer as error
+  {
+    const std::expected<bool, TailClobberer<1>> e1(std::unexpect);
+    auto e2 = e1;
+    assert(!e2.has_value());
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.default.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.default.pass.cpp
@@ -60,8 +60,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing() { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.default.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.default.pass.cpp
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 struct NoDedefaultCtor {
   NoDedefaultCtor() = delete;
@@ -45,6 +46,7 @@ constexpr void testDefaultCtor() {
 
 template <class T>
 constexpr void testTypes() {
+  testDefaultCtor<T, bool>();
   testDefaultCtor<T, int>();
   testDefaultCtor<T, NoDedefaultCtor>();
 }
@@ -52,6 +54,7 @@ constexpr void testTypes() {
 constexpr bool test() {
   testTypes<int>();
   testTypes<MyInt>();
+  testTypes<TailClobberer<0>>();
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace.pass.cpp
@@ -26,6 +26,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 static_assert(std::is_constructible_v<std::expected<int, int>, std::in_place_t>);
@@ -54,24 +55,24 @@ struct CopyOnly {
   friend constexpr bool operator==(const CopyOnly& mi, int ii) { return mi.i == ii; }
 };
 
-template <class T>
+template <class T, class E = int>
 constexpr void testInt() {
-  std::expected<T, int> e(std::in_place, 5);
+  std::expected<T, E> e(std::in_place, 5);
   assert(e.has_value());
   assert(e.value() == 5);
 }
 
-template <class T>
+template <class T, class E = int>
 constexpr void testLValue() {
   T t(5);
-  std::expected<T, int> e(std::in_place, t);
+  std::expected<T, E> e(std::in_place, t);
   assert(e.has_value());
   assert(e.value() == 5);
 }
 
-template <class T>
+template <class T, class E = int>
 constexpr void testRValue() {
-  std::expected<T, int> e(std::in_place, T(5));
+  std::expected<T, E> e(std::in_place, T(5));
   assert(e.has_value());
   assert(e.value() == 5);
 }
@@ -80,10 +81,13 @@ constexpr bool test() {
   testInt<int>();
   testInt<CopyOnly>();
   testInt<MoveOnly>();
+  testInt<TailClobberer<0>, bool>();
   testLValue<int>();
   testLValue<CopyOnly>();
+  testLValue<TailClobberer<0>, bool>();
   testRValue<int>();
   testRValue<MoveOnly>();
+  testRValue<TailClobberer<0>, bool>();
 
   // no arg
   {

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace.pass.cpp
@@ -115,8 +115,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
@@ -28,6 +28,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 static_assert(
@@ -88,6 +89,12 @@ constexpr bool test() {
     assert(&std::get<1>(e.value().tuple_) == &j);
     assert(std::get<2>(e.value().tuple_) == 7);
     assert(m.get() == 0);
+  }
+
+  // TailClobberer
+  {
+    std::expected<TailClobberer<0>, bool> e(std::in_place, {1, 2, 3});
+    assert(e.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
@@ -102,8 +102,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(std::initializer_list<int>, int) { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.move.pass.cpp
@@ -32,6 +32,7 @@
 #include <utility>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 struct NonMovable {
   NonMovable(NonMovable&&) = delete;
@@ -112,6 +113,21 @@ constexpr bool test() {
     assert(e2.error() == 5);
     assert(!e1.has_value());
   }
+
+  // move TailClobbererNonTrivialMove as value
+  {
+    std::expected<TailClobbererNonTrivialMove<0>, bool> e1;
+    auto e2 = std::move(e1);
+    assert(e2.has_value());
+  }
+
+  // move TailClobbererNonTrivialMove as error
+  {
+    std::expected<bool, TailClobbererNonTrivialMove<1>> e1(std::unexpect);
+    auto e2 = std::move(e1);
+    assert(!e2.has_value());
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.move.pass.cpp
@@ -119,6 +119,7 @@ constexpr bool test() {
     std::expected<TailClobbererNonTrivialMove<0>, bool> e1;
     auto e2 = std::move(e1);
     assert(e2.has_value());
+    assert(e1.has_value());
   }
 
   // move TailClobbererNonTrivialMove as error
@@ -126,6 +127,7 @@ constexpr bool test() {
     std::expected<bool, TailClobbererNonTrivialMove<1>> e1(std::unexpect);
     auto e2 = std::move(e1);
     assert(!e2.has_value());
+    assert(!e1.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.move.pass.cpp
@@ -135,8 +135,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing() = default;
     Throwing(Throwing&&) { throw Except{}; }

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.u.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.u.pass.cpp
@@ -29,6 +29,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 static_assert(std::is_constructible_v<std::expected<int, int>, int>);
@@ -70,24 +71,24 @@ struct CopyOnly {
 struct BaseError {};
 struct DerivedError : BaseError {};
 
-template <class T>
+template <class T, class E = int>
 constexpr void testInt() {
-  std::expected<T, int> e(5);
+  std::expected<T, E> e(5);
   assert(e.has_value());
   assert(e.value() == 5);
 }
 
-template <class T>
+template <class T, class E = int>
 constexpr void testLValue() {
   T t(5);
-  std::expected<T, int> e(t);
+  std::expected<T, E> e(t);
   assert(e.has_value());
   assert(e.value() == 5);
 }
 
-template <class T>
+template <class T, class E = int>
 constexpr void testRValue() {
-  std::expected<T, int> e(T(5));
+  std::expected<T, E> e(T(5));
   assert(e.has_value());
   assert(e.value() == 5);
 }
@@ -96,10 +97,13 @@ constexpr bool test() {
   testInt<int>();
   testInt<CopyOnly>();
   testInt<MoveOnly>();
+  testInt<TailClobberer<0>, bool>();
   testLValue<int>();
   testLValue<CopyOnly>();
+  testLValue<TailClobberer<0>, bool>();
   testRValue<int>();
   testRValue<MoveOnly>();
+  testRValue<TailClobberer<0>, bool>();
 
   // Test default template argument.
   // Without it, the template parameter cannot be deduced from an initializer list

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.u.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.u.pass.cpp
@@ -157,8 +157,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect.pass.cpp
@@ -26,6 +26,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 static_assert(std::is_constructible_v<std::expected<int, int>, std::unexpect_t>);
@@ -54,24 +55,24 @@ struct CopyOnly {
   friend constexpr bool operator==(const CopyOnly& mi, int ii) { return mi.i == ii; }
 };
 
-template <class T>
+template <class T, class V = int>
 constexpr void testInt() {
-  std::expected<int, T> e(std::unexpect, 5);
+  std::expected<V, T> e(std::unexpect, 5);
   assert(!e.has_value());
   assert(e.error() == 5);
 }
 
-template <class T>
+template <class T, class V = int>
 constexpr void testLValue() {
   T t(5);
-  std::expected<int, T> e(std::unexpect, t);
+  std::expected<V, T> e(std::unexpect, t);
   assert(!e.has_value());
   assert(e.error() == 5);
 }
 
-template <class T>
+template <class T, class V = int>
 constexpr void testRValue() {
-  std::expected<int, T> e(std::unexpect, T(5));
+  std::expected<V, T> e(std::unexpect, T(5));
   assert(!e.has_value());
   assert(e.error() == 5);
 }
@@ -80,10 +81,13 @@ constexpr bool test() {
   testInt<int>();
   testInt<CopyOnly>();
   testInt<MoveOnly>();
+  testInt<TailClobberer<1>, bool>();
   testLValue<int>();
   testLValue<CopyOnly>();
+  testLValue<TailClobberer<1>, bool>();
   testRValue<int>();
   testRValue<MoveOnly>();
+  testRValue<TailClobberer<1>, bool>();
 
   // no arg
   {

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect.pass.cpp
@@ -115,8 +115,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
@@ -28,6 +28,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 static_assert(
@@ -88,6 +89,12 @@ constexpr bool test() {
     assert(&std::get<1>(e.error().tuple_) == &j);
     assert(std::get<2>(e.error().tuple_) == 7);
     assert(m.get() == 0);
+  }
+
+  // TailClobberer
+  {
+    std::expected<bool, TailClobberer<1>> e(std::unexpect, {1, 2, 3});
+    assert(!e.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
@@ -102,8 +102,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(std::initializer_list<int>, int) { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.copy.pass.cpp
@@ -67,8 +67,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.copy.pass.cpp
@@ -27,6 +27,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints
 static_assert(std::is_constructible_v<std::expected<int, int>, const std::unexpected<int>&>);
@@ -49,10 +50,10 @@ struct MyInt {
   friend constexpr bool operator==(const MyInt&, const MyInt&) = default;
 };
 
-template <class T>
+template <class T, class V = int>
 constexpr void testUnexpected() {
   const std::unexpected<int> u(5);
-  std::expected<int, T> e(u);
+  std::expected<V, T> e(u);
   assert(!e.has_value());
   assert(e.error() == 5);
 }
@@ -60,6 +61,7 @@ constexpr void testUnexpected() {
 constexpr bool test() {
   testUnexpected<int>();
   testUnexpected<MyInt>();
+  testUnexpected<TailClobberer<1>, bool>();
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.move.pass.cpp
@@ -27,6 +27,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints
 static_assert(std::is_constructible_v<std::expected<int, int>, std::unexpected<int>>);
@@ -49,10 +50,10 @@ struct MyInt {
   friend constexpr bool operator==(const MyInt&, const MyInt&) = default;
 };
 
-template <class Err>
+template <class Err, class V = int>
 constexpr void testInt() {
   std::unexpected<int> u(5);
-  std::expected<int, Err> e(std::move(u));
+  std::expected<V, Err> e(std::move(u));
   assert(!e.has_value());
   assert(e.error() == 5);
 }
@@ -69,6 +70,7 @@ constexpr bool test() {
   testInt<int>();
   testInt<MyInt>();
   testInt<MoveOnly>();
+  testInt<TailClobberer<1>, bool>();
   testMoveOnly();
   return true;
 }

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.unexpected.move.pass.cpp
@@ -77,8 +77,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
@@ -39,8 +39,6 @@ template <int c>
 struct tail_clobberer {
   constexpr tail_clobberer() {
     if (!std::is_constant_evaluated()) {
-      // This `memset` might actually be UB (?) but suffices to reproduce bugs
-      // related to the "has value" flag.
       std::memset(this, c, sizeof(*this));
     }
   }

--- a/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <concepts>
 #include <expected>
+#include <optional>
 #include <type_traits>
 #include <utility>
 
@@ -30,6 +31,22 @@ static_assert(!HasValueNoexcept<Foo>);
 static_assert(HasValueNoexcept<std::expected<int, int>>);
 static_assert(HasValueNoexcept<const std::expected<int, int>>);
 
+// This type has one byte of tail padding where `std::expected` will put its
+// "has value" flag. The constructor will clobber all bytes including the
+// tail padding. With this type we can check that `std::expected` will set
+// its "has value" flag _after_ the value/error object is constructed.
+template <int c>
+struct tail_clobberer {
+  constexpr tail_clobberer() {
+    if (!std::is_constant_evaluated()) {
+      // This `memset` might actually be UB (?) but suffices to reproduce bugs
+      // related to the "has value" flag.
+      std::memset(this, c, sizeof(*this));
+    }
+  }
+  alignas(2) bool b;
+};
+
 constexpr bool test() {
   // has_value
   {
@@ -40,6 +57,28 @@ constexpr bool test() {
   // !has_value
   {
     const std::expected<int, int> e(std::unexpect, 5);
+    assert(!e.has_value());
+  }
+
+  // See https://github.com/llvm/llvm-project/issues/68552
+  {
+    static constexpr auto f1 = [] -> std::expected<std::optional<int>, long> { return 0; };
+
+    static constexpr auto f2 = [] -> std::expected<std::optional<int>, int> {
+      return f1().transform_error([](auto) { return 0; });
+    };
+
+    auto e = f2();
+    assert(e.has_value());
+  }
+  {
+    const std::expected<tail_clobberer<0>, bool> e = {};
+    static_assert(sizeof(tail_clobberer<0>) == sizeof(e));
+    assert(e.has_value());
+  }
+  {
+    const std::expected<void, tail_clobberer<1>> e(std::unexpect);
+    static_assert(sizeof(tail_clobberer<1>) == sizeof(e));
     assert(!e.has_value());
   }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
@@ -60,7 +60,17 @@ constexpr bool test() {
     assert(!e.has_value());
   }
 
-  // See https://github.com/llvm/llvm-project/issues/68552
+  // The following tests check that the "has_value" flag is not overwritten
+  // by the constructor of the value. This could happen because the flag is
+  // stored in the tail padding of the value.
+  //
+  // The first test is a simplified version of the real code where this was
+  // first observed.
+  //
+  // The other tests use a synthetic struct that clobbers its tail padding
+  // on construction, making the issue easier to reproduce.
+  //
+  // See https://github.com/llvm/llvm-project/issues/68552 and the linked PR.
   {
     static constexpr auto f1 = [] -> std::expected<std::optional<int>, long> { return 0; };
 

--- a/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
@@ -57,6 +57,7 @@ constexpr bool test() {
   //
   // See https://github.com/llvm/llvm-project/issues/68552 and the linked PR.
   {
+#if !defined(TEST_COMPILER_CLANG) || TEST_CLANG_VER >= 1600
     static constexpr auto f1 = [] -> std::expected<std::optional<int>, long> { return 0; };
 
     static constexpr auto f2 = [] -> std::expected<std::optional<int>, int> {
@@ -65,10 +66,14 @@ constexpr bool test() {
 
     auto e = f2();
     assert(e.has_value());
+#endif
   }
   {
     const std::expected<TailClobberer<0>, bool> e = {};
+    // clang-cl does not support [[no_unique_address]] yet.
+#if !(defined(TEST_COMPILER_CLANG) && defined(_MSC_VER))
     static_assert(sizeof(TailClobberer<0>) == sizeof(e));
+#endif
     assert(e.has_value());
   }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
@@ -57,16 +57,14 @@ constexpr bool test() {
   //
   // See https://github.com/llvm/llvm-project/issues/68552 and the linked PR.
   {
-#if !defined(TEST_COMPILER_CLANG) || TEST_CLANG_VER >= 1600
-    static constexpr auto f1 = [] -> std::expected<std::optional<int>, long> { return 0; };
+    auto f1 = [] -> std::expected<std::optional<int>, long> { return 0; };
 
-    static constexpr auto f2 = [] -> std::expected<std::optional<int>, int> {
+    auto f2 = [&f1] -> std::expected<std::optional<int>, int> {
       return f1().transform_error([](auto) { return 0; });
     };
 
     auto e = f2();
     assert(e.has_value());
-#endif
   }
   {
     const std::expected<TailClobberer<0>, bool> e = {};

--- a/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
@@ -70,7 +70,7 @@ constexpr bool test() {
     const std::expected<TailClobberer<0>, bool> e = {};
     // clang-cl does not support [[no_unique_address]] yet.
 #if !(defined(TEST_COMPILER_CLANG) && defined(_MSC_VER))
-    static_assert(sizeof(TailClobberer<0>) == sizeof(e));
+    LIBCPP_STATIC_ASSERT(sizeof(TailClobberer<0>) == sizeof(e));
 #endif
     assert(e.has_value());
   }

--- a/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
@@ -129,7 +129,7 @@ constexpr bool test() {
     std::expected<TrackedMove<true>, TrackedMove<false>> e1(std::in_place, 5);
     std::expected<TrackedMove<true>, TrackedMove<false>> e2(std::unexpect, 10);
 
-    e1.swap(e2);
+    swap(e1, e2);
 
     assert(!e1.has_value());
     assert(e1.error().i == 10);

--- a/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
@@ -180,6 +180,35 @@ constexpr bool test() {
     assert(!e2.error().swapCalled);
   }
 
+  // TailClobberer
+  {
+    // is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, true>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, true>> y(std::unexpect);
+
+      swap(x, y);
+
+      // Both of these would fail if adjusting the "has value" flags happened
+      // _before_ constructing the member objects inside the `swap`.
+      assert(!x.has_value());
+      assert(y.has_value());
+    }
+
+    // !is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, false>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, false>> y(std::unexpect);
+
+      swap(x, y);
+
+      // Both of these would fail if adjusting the "has value" flags happened
+      // _before_ constructing the member objects inside the `swap`.
+      assert(!x.has_value());
+      assert(y.has_value());
+    }
+  }
+
   return true;
 }
 
@@ -208,6 +237,39 @@ void testException() {
     } catch (Except) {
       assert(e1.has_value());
       assert(*e1 == 5);
+    }
+  }
+
+  // TailClobberer
+  {
+    // is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0, false, true>, TailClobbererNonTrivialMove<1>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0, false, true>, TailClobbererNonTrivialMove<1>> y(std::unexpect);
+      try {
+        swap(x, y);
+        assert(false);
+      } catch (Except) {
+        assert(x.has_value());
+        // This would fail if `TailClobbererNonTrivialMove<1>` clobbered the
+        // flag when rolling back the swap.
+        assert(!y.has_value());
+      }
+    }
+
+    // !is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0>, TailClobbererNonTrivialMove<1, false, true>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0>, TailClobbererNonTrivialMove<1, false, true>> y(std::unexpect);
+      try {
+        swap(x, y);
+        assert(false);
+      } catch (Except) {
+        // This would fail if `TailClobbererNonTrivialMove<0>` clobbered the
+        // flag when rolling back the swap.
+        assert(x.has_value());
+        assert(!y.has_value());
+      }
     }
   }
 #endif // TEST_HAS_NO_EXCEPTIONS

--- a/libcxx/test/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
@@ -198,6 +198,35 @@ constexpr bool test() {
     assert(!e2.error().swapCalled);
   }
 
+  // TailClobberer
+  {
+    // is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, true>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, true>> y(std::unexpect);
+
+      x.swap(y);
+
+      // Both of these would fail if adjusting the "has value" flags happened
+      // _before_ constructing the member objects inside the `swap`.
+      assert(!x.has_value());
+      assert(y.has_value());
+    }
+
+    // !is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, false>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0, true>, TailClobbererNonTrivialMove<1, false>> y(std::unexpect);
+
+      x.swap(y);
+
+      // Both of these would fail if adjusting the "has value" flags happened
+      // _before_ constructing the member objects inside the `swap`.
+      assert(!x.has_value());
+      assert(y.has_value());
+    }
+  }
+
   return true;
 }
 
@@ -226,6 +255,39 @@ void testException() {
     } catch (Except) {
       assert(e1.has_value());
       assert(*e1 == 5);
+    }
+  }
+
+  // TailClobberer
+  {
+    // is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0, false, true>, TailClobbererNonTrivialMove<1>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0, false, true>, TailClobbererNonTrivialMove<1>> y(std::unexpect);
+      try {
+        x.swap(y);
+        assert(false);
+      } catch (Except) {
+        assert(x.has_value());
+        // This would fail if `TailClobbererNonTrivialMove<1>` clobbered the
+        // flag when rolling back the swap.
+        assert(!y.has_value());
+      }
+    }
+
+    // !is_nothrow_move_constructible_v<E>
+    {
+      std::expected<TailClobbererNonTrivialMove<0>, TailClobbererNonTrivialMove<1, false, true>> x(std::in_place);
+      std::expected<TailClobbererNonTrivialMove<0>, TailClobbererNonTrivialMove<1, false, true>> y(std::unexpect);
+      try {
+        x.swap(y);
+        assert(false);
+      } catch (Except) {
+        // This would fail if `TailClobbererNonTrivialMove<0>` clobbered the
+        // flag when rolling back the swap.
+        assert(x.has_value());
+        assert(!y.has_value());
+      }
     }
   }
 #endif // TEST_HAS_NO_EXCEPTIONS

--- a/libcxx/test/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
@@ -70,7 +70,7 @@ static_assert(!HasMemberSwap<MoveMayThrow, MoveMayThrow>);
 
 // Test noexcept
 template <class T, class E>
-concept MemberSwapNoexcept =
+concept MemberSwapNoexcept = //
     requires(std::expected<T, E> x, std::expected<T, E> y) {
       { x.swap(y) } noexcept;
     };

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
@@ -33,6 +33,7 @@
 #include <utility>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 template <class T1, class Err1, class T2, class Err2>
@@ -95,6 +96,14 @@ constexpr bool test() {
     assert(e2.error().i == 5);
     assert(!e1.has_value());
     assert(e1.error() == 5);
+  }
+
+  // convert TailClobberer
+  {
+    const std::expected<void, TailClobbererNonTrivialMove<1>> e1;
+    std::expected<void, TailClobberer<1>> e2 = e1;
+    assert(!e2.has_value());
+    assert(!e1.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
@@ -111,8 +111,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct ThrowingInt {
     ThrowingInt(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
@@ -100,7 +100,7 @@ constexpr bool test() {
 
   // convert TailClobberer
   {
-    const std::expected<void, TailClobbererNonTrivialMove<1>> e1;
+    const std::expected<void, TailClobbererNonTrivialMove<1>> e1(std::unexpect);
     std::expected<void, TailClobberer<1>> e2 = e1;
     assert(!e2.has_value());
     assert(!e1.has_value());

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
@@ -112,8 +112,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct ThrowingInt {
     ThrowingInt(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
@@ -101,7 +101,7 @@ constexpr bool test() {
 
   // convert TailClobberer
   {
-    std::expected<void, TailClobbererNonTrivialMove<1>> e1;
+    std::expected<void, TailClobbererNonTrivialMove<1>> e1(std::unexpect);
     std::expected<void, TailClobberer<1>> e2 = std::move(e1);
     assert(!e2.has_value());
     assert(!e1.has_value());

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
@@ -34,6 +34,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 template <class T1, class Err1, class T2, class Err2>
@@ -96,6 +97,14 @@ constexpr bool test() {
     assert(e2.error().data.get() == 5);
     assert(!e1.has_value());
     assert(e1.error().get() == 0);
+  }
+
+  // convert TailClobberer
+  {
+    std::expected<void, TailClobbererNonTrivialMove<1>> e1;
+    std::expected<void, TailClobberer<1>> e2 = std::move(e1);
+    assert(!e2.has_value());
+    assert(!e1.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.copy.pass.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 struct NonCopyable {
   NonCopyable(const NonCopyable&) = delete;

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.copy.pass.cpp
@@ -76,8 +76,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing() = default;
     Throwing(const Throwing&) { throw Except{}; }

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.copy.pass.cpp
@@ -62,6 +62,14 @@ constexpr bool test() {
     assert(!e2.has_value());
     assert(e2.error() == 5);
   }
+
+  // copy TailClobberer as error
+  {
+    const std::expected<void, TailClobberer<1>> e1(std::unexpect);
+    auto e2 = e1;
+    assert(!e2.has_value());
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.move.pass.cpp
@@ -91,8 +91,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing() = default;
     Throwing(Throwing&&) { throw Except{}; }

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.move.pass.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 struct NonMovable {
   NonMovable(NonMovable&&) = delete;

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.move.pass.cpp
@@ -76,6 +76,15 @@ constexpr bool test() {
     assert(e2.error() == 5);
     assert(!e1.has_value());
   }
+
+  // move TailClobbererNonTrivialMove as error
+  {
+    std::expected<void, TailClobbererNonTrivialMove<1>> e1(std::unexpect);
+    auto e2 = std::move(e1);
+    assert(!e2.has_value());
+    assert(!e1.has_value());
+  }
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect.pass.cpp
@@ -26,6 +26,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 static_assert(std::is_constructible_v<std::expected<void, int>, std::unexpect_t>);
@@ -80,10 +81,13 @@ constexpr bool test() {
   testInt<int>();
   testInt<CopyOnly>();
   testInt<MoveOnly>();
+  testInt<TailClobberer<1>>();
   testLValue<int>();
   testLValue<CopyOnly>();
+  testLValue<TailClobberer<1>>();
   testRValue<int>();
   testRValue<MoveOnly>();
+  testRValue<TailClobberer<1>>();
 
   // no arg
   {

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect.pass.cpp
@@ -115,8 +115,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
@@ -28,6 +28,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints:
 static_assert(
@@ -87,6 +88,12 @@ constexpr bool test() {
     assert(&std::get<1>(e.error().tuple_) == &j);
     assert(std::get<2>(e.error().tuple_) == 7);
     assert(m.get() == 0);
+  }
+
+  // TailClobberer
+  {
+    std::expected<void, TailClobberer<1>> e(std::unexpect, {1, 2, 3});
+    assert(!e.has_value());
   }
 
   return true;

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpect_init_list.pass.cpp
@@ -101,8 +101,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(std::initializer_list<int>, int) { throw Except{}; };
   };

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.copy.pass.cpp
@@ -67,8 +67,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.copy.pass.cpp
@@ -27,6 +27,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints
 static_assert(std::is_constructible_v<std::expected<void, int>, const std::unexpected<int>&>);
@@ -60,6 +61,7 @@ constexpr void testUnexpected() {
 constexpr bool test() {
   testUnexpected<int>();
   testUnexpected<MyInt>();
+  testUnexpected<TailClobberer<1>>();
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.move.pass.cpp
@@ -27,6 +27,7 @@
 
 #include "MoveOnly.h"
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test Constraints
 static_assert(std::is_constructible_v<std::expected<void, int>, std::unexpected<int>>);
@@ -69,6 +70,7 @@ constexpr bool test() {
   testInt<int>();
   testInt<MyInt>();
   testInt<MoveOnly>();
+  testInt<TailClobberer<1>>();
   testMoveOnly();
   return true;
 }

--- a/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.move.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/ctor/ctor.unexpected.move.pass.cpp
@@ -77,8 +77,6 @@ constexpr bool test() {
 
 void testException() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-  struct Except {};
-
   struct Throwing {
     Throwing(int) { throw Except{}; }
   };

--- a/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
@@ -50,7 +50,7 @@ constexpr bool test() {
     const std::expected<void, TailClobberer<1>> e(std::unexpect);
     // clang-cl does not support [[no_unique_address]] yet.
 #if !(defined(TEST_COMPILER_CLANG) && defined(_MSC_VER))
-    static_assert(sizeof(TailClobberer<1>) == sizeof(e));
+    LIBCPP_STATIC_ASSERT(sizeof(TailClobberer<1>) == sizeof(e));
 #endif
     assert(!e.has_value());
   }

--- a/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
@@ -47,7 +47,10 @@ constexpr bool test() {
   // See comments of the corresponding test in "expected.expected".
   {
     const std::expected<void, TailClobberer<1>> e(std::unexpect);
+    // clang-cl does not support [[no_unique_address]] yet.
+#if !(defined(TEST_COMPILER_CLANG) && defined(_MSC_VER))
     static_assert(sizeof(TailClobberer<1>) == sizeof(e));
+#endif
     assert(!e.has_value());
   }
 

--- a/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
@@ -44,7 +44,8 @@ constexpr bool test() {
     assert(!e.has_value());
   }
 
-  // See comments of the corresponding test in "expected.expected".
+  // See comments of the corresponding test in
+  // "expected.expected/observers/has_value.pass.cpp".
   {
     const std::expected<void, TailClobberer<1>> e(std::unexpect);
     // clang-cl does not support [[no_unique_address]] yet.

--- a/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/observers/has_value.pass.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include "test_macros.h"
+#include "../../types.h"
 
 // Test noexcept
 template <class T>
@@ -40,6 +41,13 @@ constexpr bool test() {
   // !has_value
   {
     const std::expected<void, int> e(std::unexpect, 5);
+    assert(!e.has_value());
+  }
+
+  // See comments of the corresponding test in "expected.expected".
+  {
+    const std::expected<void, TailClobberer<1>> e(std::unexpect);
+    static_assert(sizeof(TailClobberer<1>) == sizeof(e));
     assert(!e.has_value());
   }
 

--- a/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
@@ -117,6 +117,19 @@ constexpr bool test() {
     assert(s.dtorCalled);
   }
 
+  // TailClobberer
+  {
+    std::expected<void, TailClobbererNonTrivialMove<1>> x(std::in_place);
+    std::expected<void, TailClobbererNonTrivialMove<1>> y(std::unexpect);
+
+    swap(x, y);
+
+    // The next line would fail if adjusting the "has value" flag happened
+    // _before_ constructing the member object inside the `swap`.
+    assert(!x.has_value());
+    assert(y.has_value());
+  }
+
   return true;
 }
 
@@ -149,6 +162,21 @@ void testException() {
       assert(e1.has_value());
       assert(!e2.has_value());
       assert(!e2Destroyed);
+    }
+  }
+
+  // TailClobberer
+  {
+    std::expected<void, TailClobbererNonTrivialMove<0, false, true>> x(std::in_place);
+    std::expected<void, TailClobbererNonTrivialMove<0, false, true>> y(std::unexpect);
+    try {
+      swap(x, y);
+      assert(false);
+    } catch (Except) {
+      // This would fail if `TailClobbererNonTrivialMove<0, false, true>`
+      // clobbered the flag before throwing the exception.
+      assert(x.has_value());
+      assert(!y.has_value());
     }
   }
 #endif // TEST_HAS_NO_EXCEPTIONS

--- a/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
@@ -91,7 +91,7 @@ constexpr bool test() {
     std::expected<void, Traced> e1(std::in_place);
     std::expected<void, Traced> e2(std::unexpect, s, 10);
 
-    e1.swap(e2);
+    swap(e1, e2);
 
     assert(!e1.has_value());
     assert(e1.error().data_ == 10);
@@ -107,7 +107,7 @@ constexpr bool test() {
     std::expected<void, Traced> e1(std::unexpect, s, 10);
     std::expected<void, Traced> e2(std::in_place);
 
-    e1.swap(e2);
+    swap(e1, e2);
 
     assert(e1.has_value());
     assert(!e2.has_value());

--- a/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
@@ -52,7 +52,7 @@ struct MoveMayThrow {
 };
 
 template <class E>
-concept MemberSwapNoexcept =
+concept MemberSwapNoexcept = //
     requires(std::expected<void, E> x, std::expected<void, E> y) {
       { x.swap(y) } noexcept;
     };

--- a/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
@@ -126,6 +126,19 @@ constexpr bool test() {
     assert(s.dtorCalled);
   }
 
+  // TailClobberer
+  {
+    std::expected<void, TailClobbererNonTrivialMove<1>> x(std::in_place);
+    std::expected<void, TailClobbererNonTrivialMove<1>> y(std::unexpect);
+
+    x.swap(y);
+
+    // The next line would fail if adjusting the "has value" flag happened
+    // _before_ constructing the member object inside the `swap`.
+    assert(!x.has_value());
+    assert(y.has_value());
+  }
+
   return true;
 }
 
@@ -158,6 +171,21 @@ void testException() {
       assert(e1.has_value());
       assert(!e2.has_value());
       assert(!e2Destroyed);
+    }
+  }
+
+  // TailClobberer
+  {
+    std::expected<void, TailClobbererNonTrivialMove<0, false, true>> x(std::in_place);
+    std::expected<void, TailClobbererNonTrivialMove<0, false, true>> y(std::unexpect);
+    try {
+      x.swap(y);
+      assert(false);
+    } catch (Except) {
+      // This would fail if `TailClobbererNonTrivialMove<0, false, true>`
+      // clobbered the flag before throwing the exception.
+      assert(x.has_value());
+      assert(!y.has_value());
     }
   }
 #endif // TEST_HAS_NO_EXCEPTIONS

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -104,10 +104,12 @@ struct TrackedMove {
   }
 };
 
-// This type has one byte of tail padding where `std::expected` will put its
+// This type has one byte of tail padding where `std::expected` may put its
 // "has value" flag. The constructor will clobber all bytes including the
-// tail padding. With this type we can check that `std::expected` will set
-// its "has value" flag _after_ the value/error object is constructed.
+// tail padding. With this type we can check that `std::expected` handles
+// the case where the "has value" flag is an overlapping subobject correctly.
+//
+// See https://github.com/llvm/llvm-project/issues/68552 for details.
 template <int c>
 struct TailClobberer {
   constexpr TailClobberer() {

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -9,7 +9,9 @@
 #ifndef TEST_STD_UTILITIES_EXPECTED_TYPES_H
 #define TEST_STD_UTILITIES_EXPECTED_TYPES_H
 
+#include <cstring>
 #include <utility>
+#include <type_traits>
 #include "test_macros.h"
 
 template <bool copyMoveNoexcept, bool convertNoexcept = true>
@@ -100,6 +102,20 @@ struct TrackedMove {
     x.swapCalled = true;
     y.swapCalled = true;
   }
+};
+
+// This type has one byte of tail padding where `std::expected` will put its
+// "has value" flag. The constructor will clobber all bytes including the
+// tail padding. With this type we can check that `std::expected` will set
+// its "has value" flag _after_ the value/error object is constructed.
+template <int c>
+struct TailClobberer {
+  constexpr TailClobberer() {
+    if (!std::is_constant_evaluated()) {
+      std::memset(this, c, sizeof(*this));
+    }
+  }
+  alignas(2) bool b;
 };
 
 #ifndef TEST_HAS_NO_EXCEPTIONS

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -114,7 +114,7 @@ template <int constant>
 struct TailClobberer {
   constexpr TailClobberer() {
     if (!std::is_constant_evaluated()) {
-      std::memset(this, c, sizeof(*this));
+      std::memset(this, constant, sizeof(*this));
     }
   }
   alignas(2) bool b;

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -188,7 +188,7 @@ struct TailClobbererNonTrivialMove : TailClobberer<Constant> {
   using TailClobberer<Constant>::TailClobberer;
   constexpr TailClobbererNonTrivialMove(TailClobbererNonTrivialMove&&) noexcept(Noexcept) : TailClobberer<Constant>() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    if (!Noexcept && ThrowOnMove)
+    if constexpr (!Noexcept && ThrowOnMove)
       throw Except{};
 #endif
   }

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -188,7 +188,7 @@ struct TailClobbererNonTrivialMove : TailClobberer<Constant> {
   using TailClobberer<Constant>::TailClobberer;
   constexpr TailClobbererNonTrivialMove(TailClobbererNonTrivialMove&&) noexcept(Noexcept) : TailClobberer<Constant>() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    if (ThrowOnMove)
+    if (!Noexcept && ThrowOnMove)
       throw Except{};
 #endif
   }

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -110,7 +110,7 @@ struct TrackedMove {
 // the case where the "has value" flag is an overlapping subobject correctly.
 //
 // See https://github.com/llvm/llvm-project/issues/68552 for details.
-template <int c>
+template <int constant>
 struct TailClobberer {
   constexpr TailClobberer() {
     if (!std::is_constant_evaluated()) {


### PR DESCRIPTION
The calls to `std::construct_at` might overwrite the previously set `__has_value_` flag, so reverse the order everywhere.

Fixes: #68552