### PR TITLE
[libc++][mdspan] Fix extents CTAD

### DIFF
--- a/libcxx/include/__mdspan/extents.h
+++ b/libcxx/include/__mdspan/extents.h
@@ -456,7 +456,7 @@ using dextents = typename __mdspan_detail::__make_dextents<_IndexType, _Rank>::t
 
 // Deduction guide for extents
 template <class... _IndexTypes>
-extents(_IndexTypes...) -> extents<size_t, size_t((_IndexTypes(), dynamic_extent))...>;
+extents(_IndexTypes...) -> extents<size_t, size_t(((void)sizeof(_IndexTypes), dynamic_extent))...>;
 
 namespace __mdspan_detail {
 

--- a/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
@@ -21,6 +21,13 @@
 #include "../ConvertibleToIntegral.h"
 #include "test_macros.h"
 
+struct NoDefaultCtorIndex {
+  size_t value;
+  constexpr NoDefaultCtorIndex() = delete;
+  constexpr NoDefaultCtorIndex(size_t val) : value(val){};
+  constexpr operator size_t() const noexcept { return value; }
+};
+
 template <class E, class Expected>
 constexpr void test(E e, Expected expected) {
   ASSERT_SAME_TYPE(E, Expected);
@@ -35,6 +42,7 @@ constexpr bool test() {
   test(std::extents(1, 2u), std::extents<std::size_t, D, D>(1, 2u));
   test(std::extents(1, 2u, 3, 4, 5, 6, 7, 8, 9),
        std::extents<std::size_t, D, D, D, D, D, D, D, D, D>(1, 2u, 3, 4, 5, 6, 7, 8, 9));
+  test(std::extents(NoDefaultCtorIndex{1}, NoDefaultCtorIndex{2}), std::extents<std::size_t, D, D>(1, 2));
   return true;
 }
 


### PR DESCRIPTION
extents CTAD was requiring default constructibility of the extent arguments due to the way we implemented a pack expansion. This requirement is not in the standard.

Reported in issue #68671 https://github.com/llvm/llvm-project/issues/68671 by @hewillk.

Fixes #68671