### PR TITLE
[flang][OpenMP] Fix threadprivate common blocks

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1944,17 +1944,18 @@ void OmpAttributeVisitor::ResolveOmpNameList(
 
 Symbol *OmpAttributeVisitor::ResolveOmpCommonBlockName(
     const parser::Name *name) {
-  if (auto *prev{name
-              ? GetContext().scope.parent().FindCommonBlock(name->source)
-              : nullptr}) {
+  if (!name) {
+    return nullptr;
+  }
+  // First check if the Common Block is declared in the current scope
+  if (auto *cur{GetContext().scope.FindCommonBlock(name->source)}) {
+    name->symbol = cur;
+    return cur;
+  }
+  // Then check parent scope
+  if (auto *prev{GetContext().scope.parent().FindCommonBlock(name->source)}) {
     name->symbol = prev;
     return prev;
-  }
-  // Check if the Common Block is declared in the current scope
-  if (auto *commonBlockSymbol{
-          name ? GetContext().scope.FindCommonBlock(name->source) : nullptr}) {
-    name->symbol = commonBlockSymbol;
-    return commonBlockSymbol;
   }
   return nullptr;
 }

--- a/flang/test/Semantics/OpenMP/threadprivate06.f90
+++ b/flang/test/Semantics/OpenMP/threadprivate06.f90
@@ -1,0 +1,30 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+! OpenMP Version 5.1
+! Check OpenMP construct validity for the following directives:
+! 2.21.2 Threadprivate Directive
+
+program main
+  call sub1()
+  print *, 'pass'
+end program main
+
+subroutine sub1()
+  common /c/ a
+  !$omp threadprivate(/c/)
+  integer :: a
+
+  a = 100
+  call sub2()
+  if (a .ne. 101) print *, 'err'
+
+contains
+  subroutine sub2()
+    common /c/ a
+    !$omp threadprivate(/c/)
+    integer :: a
+
+    !$omp parallel copyin(/c/)
+      a = a + 1
+    !$omp end parallel
+  end subroutine
+end subroutine


### PR DESCRIPTION
Using a threadprivate common block within a nested scope resulted
in compilation errors.

This happened because common block names were being first resolved
to those in the parent scope. Because of this, in a nested scope,
an inner threadprivate directive would be applied to the outter
common block. This caused a 'common_block appears in more than one
data-sharing clause' error.

Also, when a copyin clause in a parallel region tried to use the
common block, getting the inner version of it, their objects would
be missing the threadprivate attribute, causing a 'Non-THREADPRIVATE
object in COPYIN clause' error.

Fixes https://github.com/llvm/llvm-project/issues/61200
