### PR TITLE
[lldb] Fix `po` alias by printing fix-its to the console.

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -172,8 +172,19 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
   {
     auto *exe_scope = m_exe_ctx.GetBestExecutionContextScope();
     ValueObjectSP valobj_sp;
-    ExpressionResults expr_result =
-        target.EvaluateExpression(expr, exe_scope, valobj_sp, eval_options);
+    std::string fixed_expression;
+
+    ExpressionResults expr_result = target.EvaluateExpression(
+        expr, exe_scope, valobj_sp, eval_options, &fixed_expression);
+
+    // Only mention Fix-Its if the expression evaluator applied them.
+    // Compiler errors refer to the final expression after applying Fix-It(s).
+    if (!fixed_expression.empty() && target.GetEnableNotifyAboutFixIts()) {
+      Stream &error_stream = result.GetErrorStream();
+      error_stream << "  Evaluated this expression after applying Fix-It(s):\n";
+      error_stream << "    " << fixed_expression << "\n";
+    }
+
     if (expr_result == eExpressionCompleted) {
       if (verbosity != eDWIMPrintVerbosityNone) {
         StringRef flags;

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -439,11 +439,11 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
   ExpressionResults success = target.EvaluateExpression(
       expr, frame, result_valobj_sp, eval_options, &m_fixed_expression);
 
-  // We only tell you about the FixIt if we applied it.  The compiler errors
-  // will suggest the FixIt if it parsed.
+  // Only mention Fix-Its if the expression evaluator applied them.
+  // Compiler errors refer to the final expression after applying Fix-It(s).
   if (!m_fixed_expression.empty() && target.GetEnableNotifyAboutFixIts()) {
-    error_stream.Printf("  Fix-it applied, fixed expression was: \n    %s\n",
-                        m_fixed_expression.c_str());
+    error_stream << "  Evaluated this expression after applying Fix-It(s):\n";
+    error_stream << "    " << m_fixed_expression << "\n";
   }
 
   if (result_valobj_sp) {

--- a/lldb/test/API/commands/expression/fixits/TestFixIts.py
+++ b/lldb/test/API/commands/expression/fixits/TestFixIts.py
@@ -22,7 +22,9 @@ class ExprCommandWithFixits(TestBase):
         self.assertEqual(
             result, lldb.eReturnStatusSuccessFinishResult, ret_val.GetError()
         )
-        self.assertIn("Fix-it applied", ret_val.GetError())
+        self.assertIn(
+            "Evaluated this expression after applying Fix-It(s):", ret_val.GetError()
+        )
 
     def test_with_target(self):
         """Test calling expressions with errors that can be fixed by the FixIts."""
@@ -99,7 +101,9 @@ class ExprCommandWithFixits(TestBase):
         )
         self.assertEqual(result, lldb.eReturnStatusFailed, ret_val.GetError())
 
-        self.assertIn("Fix-it applied, fixed expression was:", ret_val.GetError())
+        self.assertIn(
+            "Evaluated this expression after applying Fix-It(s):", ret_val.GetError()
+        )
         self.assertIn("null_pointer->first", ret_val.GetError())
 
     # The final function call runs into SIGILL on aarch64-linux.

--- a/lldb/test/API/lang/cpp/fixits/Makefile
+++ b/lldb/test/API/lang/cpp/fixits/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/fixits/TestCppFixIts.py
+++ b/lldb/test/API/lang/cpp/fixits/TestCppFixIts.py
@@ -1,0 +1,44 @@
+"""
+Tests a C++ fixit for the `expr` command and
+`po` alias (aka DWIM aka "do what I mean") alias.
+"""
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test_fixit_with_dwim(self):
+        """Confirms `po` shows an expression after applying Fix-It(s)."""
+
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        self.expect(
+            "dwim-print -O -- class C { int i; void f() { []() { ++i; }(); } }; 42",
+            error=True,
+            substrs=[
+                "Evaluated this expression after applying Fix-It(s)",
+                "class C { int i; void f() { [this]() { ++i; }(); } }",
+            ],
+        )
+
+    def test_fixit_with_expression(self):
+        """Confirms `expression` shows an expression after applying Fix-It(s)."""
+
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        self.expect(
+            "expr class C { int i; void f() { []() { ++i; }(); } }; 42",
+            error=True,
+            substrs=[
+                "Evaluated this expression after applying Fix-It(s)",
+                "class C { int i; void f() { [this]() { ++i; }(); } }",
+            ],
+        )

--- a/lldb/test/API/lang/cpp/fixits/main.cpp
+++ b/lldb/test/API/lang/cpp/fixits/main.cpp
@@ -1,0 +1,5 @@
+int main() {
+  long foo = 1234;
+
+  return 0; // break here
+}


### PR DESCRIPTION
The `po` alias now matches the behavior of the `expression` command when the it can apply a Fix-It to an expression.
Modifications

- Add has `m_fixed_expression` to the `CommandObjectDWIMPrint` class a `protected` member that stores the post Fix-It expression, just like the `CommandObjectExpression` class.
- Converted messages to present tense.
- Add test cases that confirms a Fix-It for a C++ expression for both `po` and `expressions`

rdar://115317419