### PR TITLE
[flang] Put ISO_Fortran_binding.h where it can be easily used

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -273,10 +273,10 @@ if (NOT(FLANG_DEFAULT_RTLIB STREQUAL ""))
       "Default runtime library to use (empty for platform default)" FORCE)
 endif()
 
-
-
 set(PACKAGE_VERSION "${LLVM_PACKAGE_VERSION}")
-
+if (NOT PACKAGE_VERSION)
+  set(PACKAGE_VERSION ${LLVM_VERSION_MAJOR})
+endif()
 
 if (NOT DEFINED FLANG_VERSION_MAJOR)
   set(FLANG_VERSION_MAJOR ${LLVM_VERSION_MAJOR})
@@ -490,3 +490,17 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     PATTERN "*.inc"
     )
 endif()
+
+# Put ISO_Fortran_binding.h into the include files of the build area now
+# so that we can run tests before installing
+include(GetClangResourceDir)
+get_clang_resource_dir(HEADER_BINARY_DIR PREFIX ${LLVM_LIBRARY_OUTPUT_INTDIR}/.. SUBDIR include)
+configure_file(
+  ${FLANG_SOURCE_DIR}/include/flang/ISO_Fortran_binding.h
+  ${HEADER_BINARY_DIR}/ISO_Fortran_binding.h)
+
+# And also install it into the install area
+get_clang_resource_dir(HEADER_INSTALL_DIR PREFIX ${CMAKE_INSTALL_PREFIX} SUBDIR include)
+install(
+  FILES ${CMAKE_INSTALL_PREFIX}/include/flang/ISO_Fortran_binding.h 
+  DESTINATION ${HEADER_INSTALL_DIR})

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -64,7 +64,6 @@ set(FLANG_TEST_DEPENDS
   FortranRuntime
   Fortran_main
   FortranDecimal
-  clang
 )
 if (LLVM_ENABLE_PLUGINS AND NOT WIN32)
   list(APPEND FLANG_TEST_DEPENDS Bye)

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -64,6 +64,7 @@ set(FLANG_TEST_DEPENDS
   FortranRuntime
   Fortran_main
   FortranDecimal
+  clang
 )
 if (LLVM_ENABLE_PLUGINS AND NOT WIN32)
   list(APPEND FLANG_TEST_DEPENDS Bye)

--- a/flang/test/Examples/ctofortran.f90
+++ b/flang/test/Examples/ctofortran.f90
@@ -1,8 +1,8 @@
 ! UNSUPPORTED: system-windows
 ! RUN: split-file %s %t
 ! RUN: %clang -c %t/cfile.c
-! RUN: %flang -flang-experimental-hlfir cfile.o %t/src.f90 -o ctofortran
-! RUN: ./ctofortran | FileCheck %s
+! RUN: %flang -flang-experimental-hlfir cfile.o %t/src.f90 -o %t/ctofortran
+! RUN: %t/ctofortran | FileCheck %s
 
 !--- src.f90
 subroutine foo(a) bind(c)

--- a/flang/test/Examples/ctofortran.f90
+++ b/flang/test/Examples/ctofortran.f90
@@ -1,4 +1,5 @@
 ! UNSUPPORTED: system-windows
+! REQUIRES: clang
 ! RUN: split-file %s %t
 ! RUN: %clang -c %t/cfile.c
 ! RUN: %flang -flang-experimental-hlfir cfile.o %t/src.f90 -o %t/ctofortran

--- a/flang/test/Examples/ctofortran.f90
+++ b/flang/test/Examples/ctofortran.f90
@@ -1,8 +1,8 @@
 ! UNSUPPORTED: system-windows
 ! RUN: split-file %s %t
 ! RUN: %clang -c %t/cfile.c
-! RUN: %flang -flang-experimental-hlfir cfile.o %t/src.f90
-! RUN: a.out | FileCheck %s
+! RUN: %flang -flang-experimental-hlfir cfile.o %t/src.f90 -o ctofortran
+! RUN: ./ctofortran | FileCheck %s
 
 !--- src.f90
 subroutine foo(a) bind(c)

--- a/flang/test/Examples/ctofortran.f90
+++ b/flang/test/Examples/ctofortran.f90
@@ -1,0 +1,59 @@
+! UNSUPPORTED: system-windows
+! RUN: split-file %s %t
+! RUN: %clang -c %t/cfile.c
+! RUN: %flang -flang-experimental-hlfir cfile.o %t/src.f90
+! RUN: a.out | FileCheck %s
+
+!--- src.f90
+subroutine foo(a) bind(c)
+  integer :: a(:)
+  if (lbound(a, 1) .ne. 1) then
+     print *, 'FAIL expected 1 for lbound but got ',lbound(a, 1)
+     stop 1
+  endif
+  
+  if (ubound(a, 1) .ne. 10) then
+     print *, 'FAIL expected 10 for ubound but got ',ubound(a, 1)
+     stop 1
+  endif
+  
+  do i = lbound(a,1),ubound(a,1)
+     !print *, a(i)
+     if (a(i) .ne. i) then
+        print *, 'FAIL expected', i, ' for index ',i, ' but got ',a(i)
+        stop 1
+     endif
+  enddo
+  print *, 'PASS'
+end subroutine foo
+
+! CHECK: PASS
+!--- cfile.c
+#include <stdio.h>
+#include <stdlib.h>
+#include <ISO_Fortran_binding.h>
+
+void foo(CFI_cdesc_t*);
+
+int a[10];
+
+int main() {
+  int i, res;
+  static CFI_CDESC_T(1) r1;
+  CFI_cdesc_t *desc = (CFI_cdesc_t*)&r1;
+  CFI_index_t extent[1] = {10};
+
+  for(i=0; i<10; ++i) {
+    a[i] = i+1;
+  }
+
+  res = CFI_establish(desc, (void*)a, CFI_attribute_other, CFI_type_int32_t, 
+                      sizeof(int), 1, extent);
+  if (res != 0) {
+    printf("FAIL CFI_establish returned %d instead of 0.\n",res);
+    exit(1);
+  }
+
+  foo(desc);
+  return 0;
+}

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -121,6 +121,7 @@ if config.flang_standalone_build:
 # For each occurrence of a flang tool name, replace it with the full path to
 # the build directory holding that tool.
 tools = [
+    ToolSubst("%clang", command=FindTool("clang"), unresolved="fatal"),
     ToolSubst("%flang", command=FindTool("flang-new"), unresolved="fatal"),
     ToolSubst(
         "%flang_fc1",


### PR DESCRIPTION
The update stems from the discussion in
https://discourse.llvm.org/t/adding-flang-specific-header-files-to-clang/72442

I decided to put ISO_Fortran_binding.h in a place where it would be accessible with the include: "#include<ISO_Fortran_binding.h>" rather than "#include<fortran/ISO_Fortran_binding.h>" because this is what gfortran does.

The changes to put the header file into the build and install areas are in .../flang/CMakeLists.txt.  This code  calls "get_clang_resource_dir", which requires "PACKAGE_VERSION" to be defined, so I added code to define it.

Note that the file is also installed into ".../include/flang", so if a user wanted to access the file from a compiler other than clang, it would be available.

I added a test in ".../flang/test/Examples".  Since the flang project depends on clang, clang will always be available in a flang build.  To make the test work, I also needed to put ISO_Fortran_binding.h into the build area.