### PR TITLE
[SanitizerCommon] add null check for fopen64 interceptor

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
@@ -6145,7 +6145,7 @@ INTERCEPTOR(int, flopenat, int dirfd, const char *path, int flags, ...) {
 INTERCEPTOR(__sanitizer_FILE *, fopen64, const char *path, const char *mode) {
   void *ctx;
   COMMON_INTERCEPTOR_ENTER(ctx, fopen64, path, mode);
-  COMMON_INTERCEPTOR_READ_RANGE(ctx, path, internal_strlen(path) + 1);
+  if (path) COMMON_INTERCEPTOR_READ_RANGE(ctx, path, internal_strlen(path) + 1);
   COMMON_INTERCEPTOR_READ_RANGE(ctx, mode, internal_strlen(mode) + 1);
   __sanitizer_FILE *res = REAL(fopen64)(path, mode);
   COMMON_INTERCEPTOR_FILE_OPEN(ctx, res, path);

--- a/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
@@ -1,5 +1,5 @@
 // Check that fopen64(NULL, "r") is ok.
-// REQUIRES: linux
+// REQUIRES: linux, asan, glibc
 // RUN: %clang -O2 %s -o %t && %run %t
 #include <stdio.h>
 FILE *fopen64(const char *filename, const char *mode);

--- a/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
@@ -1,9 +1,9 @@
 // Check that fopen64(NULL, "r") is ok.
 // `-m32` and `-D_FILE_OFFSET_BITS=64` will make fopen() call fopen64()
 
-// REQUIRES: asan
-// RUN: %clang -m32 -D_FILE_OFFSET_BITS=64 -O2 %s -o %t && %run %t
+// REQUIRES: linux
 #include <stdio.h>
+FILE * fopen64 ( const char * filename, const char * mode );
 const char *fn = NULL;
 FILE *f;
-int main() { f = fopen(fn, "r"); }
+int main() { f = fopen64(fn, "r"); }

--- a/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
@@ -2,7 +2,7 @@
 
 // REQUIRES: linux
 #include <stdio.h>
-FILE * fopen64 ( const char * filename, const char * mode );
+FILE *fopen64(const char *filename, const char *mode);
 const char *fn = NULL;
 FILE *f;
 int main() { f = fopen64(fn, "r"); }

--- a/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
@@ -1,6 +1,6 @@
 // Check that fopen64(NULL, "r") is ok.
-
 // REQUIRES: linux
+// RUN: %clang -O2 %s -o %t && %run %t
 #include <stdio.h>
 FILE *fopen64(const char *filename, const char *mode);
 const char *fn = NULL;

--- a/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
@@ -1,5 +1,4 @@
 // Check that fopen64(NULL, "r") is ok.
-// `-m32` and `-D_FILE_OFFSET_BITS=64` will make fopen() call fopen64()
 
 // REQUIRES: linux
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/fopen64_nullptr.c
@@ -1,0 +1,9 @@
+// Check that fopen64(NULL, "r") is ok.
+// `-m32` and `-D_FILE_OFFSET_BITS=64` will make fopen() call fopen64()
+
+// REQUIRES: asan
+// RUN: %clang -m32 -D_FILE_OFFSET_BITS=64 -O2 %s -o %t && %run %t
+#include <stdio.h>
+const char *fn = NULL;
+FILE *f;
+int main() { f = fopen(fn, "r"); }


### PR DESCRIPTION
Currently, the interceptor for fopen64 will crash when path is null. Adding the same null check as `fopen()`.