### PR TITLE
Fix typos in Debug.h

### DIFF
--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -53,7 +53,7 @@ void setCurrentDebugType(const char *Type);
 void setCurrentDebugTypes(const char **Types, unsigned Count);
 
 /// DEBUG_WITH_TYPE macro - This macro should be used by passes to emit debug
-/// information.  In the '-debug' option is specified on the commandline, and if
+/// information.  If the '-debug' option is specified on the commandline, and if
 /// this is a debug build, then the code specified as the option to the macro
 /// will be executed.  Otherwise it will not be.  Example:
 ///
@@ -92,7 +92,7 @@ extern bool EnableDebugBuffering;
 raw_ostream &dbgs();
 
 // DEBUG macro - This macro should be used by passes to emit debug information.
-// In the '-debug' option is specified on the commandline, and if this is a
+// If the '-debug' option is specified on the commandline, and if this is a
 // debug build, then the code specified as the option to the macro will be
 // executed.  Otherwise it will not be.  Example:
 //


### PR DESCRIPTION
There were a couple of typos of "If" -> "In" in Debug.h