### PR TITLE
[OCaml][test] Use correct data layout string.

### DIFF
--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -71,11 +71,11 @@ let test_target () =
   end;
 
   begin group "layout";
-    let layout = "e" in
+    let layout = "e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:128-n8:16:32-S128" in
     set_data_layout layout m;
     insist (layout = data_layout m)
   end
-  (* CHECK: target datalayout = "e"
+  (* CHECK: target datalayout = "e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:128-n8:16:32-S128"
    * CHECK: target triple = "i686-apple-darwin8"
    *)
 


### PR DESCRIPTION
core.ml would previously set a data layout string of "e" and check that it remained "e". This is fragile when we have the data layout string auto-upgrade facility, and indeed broke when D86310 upgraded this one. As the auto-upgrade logic is not what is being tested here, it seems easier to just use the data layout string that the target expects.