### PR TITLE
[PowerPC] Use zext instead of anyext in custom and combine

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15588,7 +15588,7 @@ SDValue PPCTargetLowering::PerformDAGCombine(SDNode *N,
       break;
     SDValue ConstOp = DAG.getConstant(Imm, dl, MVT::i32);
     SDValue NarrowAnd = DAG.getNode(ISD::AND, dl, MVT::i32, NarrowOp, ConstOp);
-    return DAG.getAnyExtOrTrunc(NarrowAnd, dl, N->getValueType(0));
+    return DAG.getZExtOrTrunc(NarrowAnd, dl, N->getValueType(0));
   }
   case ISD::SHL:
     return combineSHL(N, DCI);

--- a/llvm/test/CodeGen/PowerPC/and-extend-combine.ll
+++ b/llvm/test/CodeGen/PowerPC/and-extend-combine.ll
@@ -23,11 +23,12 @@ bb:
   ret ptr %i8
 }
 
-; FIXME: This is a miscompile.
 define void @pr68783(i32 %x, ptr %p) {
 ; CHECK-LABEL: pr68783:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    rlwinm r3, r3, 31, 24, 31
+; CHECK-NEXT:    li r5, 0
+; CHECK-NEXT:    sth r5, 4(r4)
 ; CHECK-NEXT:    stw r3, 0(r4)
 ; CHECK-NEXT:    blr
   %lshr = lshr i32 %x, 1


### PR DESCRIPTION
This custom combine currently converts `and(anyext(x),c)` into `anyext(and(x,c))`. This is not correct, because the original expression guaranteed that the high bits are zero, while the new one sets them to undef.

Emit `zext(and(x,c))` instead.

Fixes https://github.com/llvm/llvm-project/issues/68783.