### PR TITLE
[MachineBasicBlock] Fix use after free in SplitCriticalEdge

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -107,16 +107,6 @@ public:
         : PhysReg(PhysReg), LaneMask(LaneMask) {}
   };
 
-  class Delegate {
-    virtual void anchor();
-
-  public:
-    virtual ~Delegate() = default;
-
-    virtual void MBB_NoteInsertion(MachineInstr &MI) = 0;
-    virtual void MBB_NoteRemoval(MachineInstr &MI) = 0;
-  };
-
 private:
   using Instructions = ilist<MachineInstr, ilist_sentinel_tracking<true>>;
 
@@ -243,9 +233,6 @@ public:
 
   /// Return a formatted string to identify this block and its parent function.
   std::string getFullName() const;
-
-  /// Delegates to inform of instruction addition and removal.
-  SmallPtrSet<Delegate *, 1> TheDelegates;
 
   /// Test whether this block is used as something other than the target
   /// of a terminator, exception-handling target, or jump table. This is
@@ -1197,29 +1184,6 @@ public:
   /// NOT be called directly, but by using getEdgeProbability method from
   /// MachineBranchProbabilityInfo class.
   BranchProbability getSuccProbability(const_succ_iterator Succ) const;
-
-  void resetDelegate(Delegate *delegate) {
-    assert(TheDelegates.count(delegate) &&
-           "Only an existing delegate can perform reset!");
-    TheDelegates.erase(delegate);
-  }
-
-  void addDelegate(Delegate *delegate) {
-    assert(delegate && !TheDelegates.count(delegate) &&
-           "Attempted to add null delegate, or to change it without "
-           "first resetting it!");
-    TheDelegates.insert(delegate);
-  }
-
-  void noteInsertion(MachineInstr &MI) {
-    for (auto *TheDelegate : TheDelegates)
-      TheDelegate->MBB_NoteInsertion(MI);
-  }
-
-  void noteRemoval(MachineInstr &MI) {
-    for (auto *TheDelegate : TheDelegates)
-      TheDelegate->MBB_NoteRemoval(MI);
-  }
 
 private:
   /// Return probability iterator corresponding to the I successor iterator.

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -14,7 +14,6 @@
 #define LLVM_CODEGEN_MACHINEBASICBLOCK_H
 
 #include "llvm/ADT/GraphTraits.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SparseBitVector.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/iterator_range.h"


### PR DESCRIPTION
Remove use after free when attempting to update SlotIndexes in MachineBasicBlock::SplitCriticalEdge.

Add delegate mechanism for MachineBasicBlock to observe instructions added or removed when calling target specific functions for updating branches and update SlotIndexes appropriately.