### PR TITLE
[libcxx] [docs] Remove mention of a MSVC/Debug mode caveat

### DIFF
--- a/libcxx/docs/BuildingLibcxx.rst
+++ b/libcxx/docs/BuildingLibcxx.rst
@@ -145,9 +145,6 @@ should add e.g. ``-DCMAKE_CXX_COMPILER_TARGET=x86_64-windows-msvc`` (replacing
 line above. This will instruct ``check-cxx`` to use the right target triple
 when invoking ``clang++``.
 
-Also note that if not building in Release mode, a failed assert in the tests
-pops up a blocking dialog box, making it hard to run a larger number of tests.
-
 CMake + ninja (MinGW)
 ---------------------
 


### PR DESCRIPTION
Since e346fd8a60d4969b29bdd1740a89b1ea43635331 and cd1b8be8de91bc1c43bac3eea7ebf3b5643b031c, the tests should run fine in Debug mode, with failed asserts not popping up blocking dialog boxes.