### PR TITLE
[libc] Mark operator== const to avoid ambiguity in C++20.

### DIFF
--- a/libc/src/stdio/printf_core/core_structs.h
+++ b/libc/src/stdio/printf_core/core_structs.h
@@ -53,7 +53,7 @@ struct FormatSection {
 
   // This operator is only used for testing and should be automatically
   // optimized out for release builds.
-  bool operator==(const FormatSection &other) {
+  bool operator==(const FormatSection &other) const {
     if (has_conv != other.has_conv)
       return false;
 


### PR DESCRIPTION
C++20 will automatically generate an operator== with reversed operand order, which is ambiguous with the written operator== when one argument is marked const and the other isn't.

This operator currently triggers -Wambiguous-reversed-operator at usage site libc/test/UnitTest/PrintfMatcher.cpp:28.