### PR TITLE
[llvm-readtapi] Fix bad symlink with readtapi tool

### DIFF
--- a/llvm/tools/llvm-readtapi/CMakeLists.txt
+++ b/llvm/tools/llvm-readtapi/CMakeLists.txt
@@ -9,4 +9,6 @@ add_llvm_tool(llvm-readtapi
   DiffEngine.cpp
   )
 
-add_llvm_tool_symlink(readtapi llvm-readtapi)
+if(LLVM_INSTALL_BINUTILS_SYMLINKS)
+  add_llvm_tool_symlink(readtapi llvm-readtapi)
+endif()

--- a/llvm/utils/gn/secondary/llvm/tools/llvm-readtapi/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/tools/llvm-readtapi/BUILD.gn
@@ -1,3 +1,22 @@
+import("//llvm/tools/binutils_symlinks.gni")
+import("//llvm/utils/gn/build/symlink_or_copy.gni")
+
+if (llvm_install_binutils_symlinks) {
+  symlink_or_copy("readtapi") {
+    deps = [ ":llvm-readtapi" ]
+    source = "llvm-readtapi"
+    output = "$root_out_dir/bin/readtapi"
+  }
+}
+
+# //:llvm-readtapi depends on this symlink target, see comment in //BUILD.gn.
+group("symlinks") {
+  deps = [ ":llvm-readtapi" ]
+  if (llvm_install_binutils_symlinks) {
+    deps += [ ":readtapi" ]
+  }
+}
+
 executable("llvm-readtapi") {
   deps = [
     "//llvm/lib/Object",


### PR DESCRIPTION
A buildbot is currently failing at the set directory permission due to a bad symlink caused by this [commit](https://github.ibm.com/compiler/llvm-project/commit/a54f31fabd55ab111484b1e094e3d2c6b29c4715). This change is creating the additional symlink `readtapi -> llvm-readtapi` which causes it to appear in the install directory. 

After some investigation, it looks like `readtapi` is the only tool that is getting symlinked that is not guarded by the `LLVM_INSTALL_BINUTILS_SYMLINKS` macro. For example:

1. `llvm/tools/llvm-objcopy/CMakeLists.txt`

```
if(LLVM_INSTALL_BINUTILS_SYMLINKS)
  add_llvm_tool_symlink(objcopy llvm-objcopy)
endif()
```

2. `llvm/tools/llvm-dwp/CMakeLists.txt`
```
if(LLVM_INSTALL_BINUTILS_SYMLINKS)
  add_llvm_tool_symlink(dwp llvm-dwp)
endif()
```