### PR TITLE
[libc++] Introduce make_test_jthread for jthread tests

### DIFF
--- a/libcxx/test/std/thread/thread.jthread/cons.move.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/cons.move.pass.cpp
@@ -19,6 +19,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 static_assert(std::is_nothrow_move_constructible_v<std::jthread>);
@@ -27,8 +28,8 @@ int main(int, char**) {
   {
     // x.get_id() == id() and get_id() returns the value of x.get_id() prior
     // to the start of construction.
-    std::jthread j1{[] {}};
-    auto id1 = j1.get_id();
+    std::jthread j1 = support::make_test_jthread([] {});
+    auto id1        = j1.get_id();
 
     std::jthread j2(std::move(j1));
     assert(j1.get_id() == std::jthread::id());
@@ -38,8 +39,8 @@ int main(int, char**) {
   {
     // ssource has the value of x.ssource prior to the start of construction
     // and x.ssource.stop_possible() is false.
-    std::jthread j1{[] {}};
-    auto ss1 = j1.get_stop_source();
+    std::jthread j1 = support::make_test_jthread([] {});
+    auto ss1        = j1.get_stop_source();
 
     std::jthread j2(std::move(j1));
     assert(ss1 == j2.get_stop_source());

--- a/libcxx/test/std/thread/thread.jthread/detach.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/detach.pass.cpp
@@ -23,6 +23,7 @@
 #include <thread>
 #include <type_traits>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 int main(int, char**) {
@@ -30,10 +31,10 @@ int main(int, char**) {
   {
     std::atomic_bool start{false};
     std::atomic_bool done{false};
-    std::optional<std::jthread> jt{[&start, &done] {
+    std::optional<std::jthread> jt = support::make_test_jthread([&start, &done] {
       start.wait(false);
       done = true;
-    }};
+    });
 
     // If it blocks, it will deadlock here
     jt->detach();
@@ -49,7 +50,7 @@ int main(int, char**) {
 
   // Postconditions: get_id() == id().
   {
-    std::jthread jt{[] {}};
+    std::jthread jt = support::make_test_jthread([] {});
     assert(jt.get_id() != std::jthread::id());
     jt.detach();
     assert(jt.get_id() == std::jthread::id());

--- a/libcxx/test/std/thread/thread.jthread/dtor.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/dtor.pass.cpp
@@ -20,6 +20,8 @@
 #include <thread>
 #include <type_traits>
 #include <vector>
+
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 int main(int, char**) {
@@ -32,8 +34,8 @@ int main(int, char**) {
   // If joinable() is true, calls request_stop() and then join().
   // request_stop is called
   {
-    std::optional<std::jthread> jt([] {});
-    bool called = false;
+    std::optional<std::jthread> jt = support::make_test_jthread([] {});
+    bool called                    = false;
     std::stop_callback cb(jt->get_stop_token(), [&called] { called = true; });
     jt.reset();
     assert(called);
@@ -48,10 +50,10 @@ int main(int, char**) {
     constexpr auto numberOfThreads = 10u;
     jts.reserve(numberOfThreads);
     for (auto i = 0u; i < numberOfThreads; ++i) {
-      jts.emplace_back([&calledTimes] {
+      jts.emplace_back(support::make_test_jthread([&calledTimes] {
         std::this_thread::sleep_for(std::chrono::milliseconds{2});
         calledTimes.fetch_add(1, std::memory_order_relaxed);
-      });
+      }));
     }
     jts.clear();
 

--- a/libcxx/test/std/thread/thread.jthread/get_id.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/get_id.pass.cpp
@@ -18,6 +18,7 @@
 #include <thread>
 #include <type_traits>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 static_assert(noexcept(std::declval<const std::jthread&>().get_id()));
@@ -32,7 +33,7 @@ int main(int, char**) {
 
   // Represents a thread
   {
-    const std::jthread jt{[] {}};
+    const std::jthread jt                                = support::make_test_jthread([] {});
     std::same_as<std::jthread::id> decltype(auto) result = jt.get_id();
     assert(result != std::jthread::id());
   }

--- a/libcxx/test/std/thread/thread.jthread/get_stop_source.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/get_stop_source.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <type_traits>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 static_assert(noexcept(std::declval<std::jthread&>().get_stop_source()));
@@ -26,7 +27,7 @@ static_assert(noexcept(std::declval<std::jthread&>().get_stop_source()));
 int main(int, char**) {
   // Represents a thread
   {
-    std::jthread jt{[] {}};
+    std::jthread jt                                      = support::make_test_jthread([] {});
     std::same_as<std::stop_source> decltype(auto) result = jt.get_stop_source();
     assert(result.stop_possible());
   }

--- a/libcxx/test/std/thread/thread.jthread/get_stop_token.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/get_stop_token.pass.cpp
@@ -20,6 +20,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 static_assert(noexcept(std::declval<const std::jthread&>().get_stop_token()));
@@ -27,7 +28,7 @@ static_assert(noexcept(std::declval<const std::jthread&>().get_stop_token()));
 int main(int, char**) {
   // Represents a thread
   {
-    std::jthread jt{[] {}};
+    std::jthread jt                                 = support::make_test_jthread([] {});
     auto ss                                         = jt.get_stop_source();
     std::same_as<std::stop_token> decltype(auto) st = std::as_const(jt).get_stop_token();
 

--- a/libcxx/test/std/thread/thread.jthread/join.deadlock.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/join.deadlock.pass.cpp
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 int main(int, char**) {
@@ -40,12 +41,12 @@ int main(int, char**) {
     std::atomic_bool start = false;
     std::atomic_bool done  = false;
 
-    std::jthread jt{[&] {
+    std::jthread jt = support::make_test_jthread([&] {
       start.wait(false);
       f();
       done = true;
       done.notify_all();
-    }};
+    });
 
     f = [&] {
       try {

--- a/libcxx/test/std/thread/thread.jthread/joinable.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/joinable.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <type_traits>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 static_assert(noexcept(std::declval<const std::jthread&>().joinable()));
@@ -33,7 +34,7 @@ int main(int, char**) {
 
   // Non-default constructed
   {
-    const std::jthread jt{[] {}};
+    const std::jthread jt                    = support::make_test_jthread([] {});
     std::same_as<bool> decltype(auto) result = jt.joinable();
     assert(result);
   }
@@ -41,8 +42,8 @@ int main(int, char**) {
   // Non-default constructed
   // the thread of execution has not finished
   {
-    std::atomic_bool done = false;
-    const std::jthread jt{[&done] { done.wait(false); }};
+    std::atomic_bool done                    = false;
+    const std::jthread jt                    = support::make_test_jthread([&done] { done.wait(false); });
     std::same_as<bool> decltype(auto) result = jt.joinable();
     done                                     = true;
     done.notify_all();

--- a/libcxx/test/std/thread/thread.jthread/request_stop.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/request_stop.pass.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <type_traits>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 static_assert(noexcept(std::declval<std::jthread&>().request_stop()));
@@ -26,8 +27,8 @@ static_assert(noexcept(std::declval<std::jthread&>().request_stop()));
 int main(int, char**) {
   // Represents a thread
   {
-    std::jthread jt{[] {}};
-    auto st = jt.get_stop_token();
+    std::jthread jt = support::make_test_jthread([] {});
+    auto st         = jt.get_stop_token();
     assert(!st.stop_requested());
     std::same_as<bool> decltype(auto) result = jt.request_stop();
     assert(result);

--- a/libcxx/test/std/thread/thread.jthread/swap.free.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/swap.free.pass.cpp
@@ -17,6 +17,7 @@
 #include <thread>
 #include <type_traits>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 template <class T>
@@ -30,7 +31,7 @@ int main(int, char**) {
   // x is default constructed
   {
     std::jthread t1;
-    std::jthread t2{[] {}};
+    std::jthread t2        = support::make_test_jthread([] {});
     const auto originalId2 = t2.get_id();
     swap(t1, t2);
 
@@ -40,7 +41,7 @@ int main(int, char**) {
 
   // y is default constructed
   {
-    std::jthread t1([] {});
+    std::jthread t1 = support::make_test_jthread([] {});
     std::jthread t2{};
     const auto originalId1 = t1.get_id();
     swap(t1, t2);
@@ -51,8 +52,8 @@ int main(int, char**) {
 
   // both not default constructed
   {
-    std::jthread t1([] {});
-    std::jthread t2{[] {}};
+    std::jthread t1        = support::make_test_jthread([] {});
+    std::jthread t2        = support::make_test_jthread([] {});
     const auto originalId1 = t1.get_id();
     const auto originalId2 = t2.get_id();
     swap(t1, t2);

--- a/libcxx/test/std/thread/thread.jthread/swap.member.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/swap.member.pass.cpp
@@ -17,6 +17,7 @@
 #include <thread>
 #include <type_traits>
 
+#include "make_test_thread.h"
 #include "test_macros.h"
 
 template <class T>
@@ -30,7 +31,7 @@ int main(int, char**) {
   // this is default constructed
   {
     std::jthread t1;
-    std::jthread t2{[] {}};
+    std::jthread t2        = support::make_test_jthread([] {});
     const auto originalId2 = t2.get_id();
     t1.swap(t2);
 
@@ -40,7 +41,7 @@ int main(int, char**) {
 
   // that is default constructed
   {
-    std::jthread t1([] {});
+    std::jthread t1 = support::make_test_jthread([] {});
     std::jthread t2{};
     const auto originalId1 = t1.get_id();
     t1.swap(t2);
@@ -51,8 +52,8 @@ int main(int, char**) {
 
   // both not default constructed
   {
-    std::jthread t1([] {});
-    std::jthread t2{[] {}};
+    std::jthread t1        = support::make_test_jthread([] {});
+    std::jthread t2        = support::make_test_jthread([] {});
     const auto originalId1 = t1.get_id();
     const auto originalId2 = t2.get_id();
     t1.swap(t2);

--- a/libcxx/test/support/make_test_thread.h
+++ b/libcxx/test/support/make_test_thread.h
@@ -34,9 +34,15 @@ std::thread make_test_thread(F&& f, Args&& ...args) {
 }
 
 #if TEST_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN)
-template <class F, class ...Args>
-std::jthread make_test_jthread(F&& f, Args&& ...args) {
-    return std::jthread(std::forward<F>(f), std::forward<Args>(args)...);
+#  ifdef _LIBCPP_VERSION
+#    define TEST_AVAILABILITY_SYNC _LIBCPP_AVAILABILITY_SYNC
+#  else
+#    define TEST_AVAILABILITY_SYNC
+#  endif
+
+template <class F, class... Args>
+TEST_AVAILABILITY_SYNC std::jthread make_test_jthread(F&& f, Args&&... args) {
+  return std::jthread(std::forward<F>(f), std::forward<Args>(args)...);
 }
 #endif
 

--- a/libcxx/test/support/make_test_thread.h
+++ b/libcxx/test/support/make_test_thread.h
@@ -12,12 +12,33 @@
 #include <thread>
 #include <utility>
 
+#include "test_macros.h"
+
 namespace support {
+
+// These functions are used to mock the creation of threads within the test suite.
+//
+// This provides a vendor-friendly way of making the test suite work even on platforms
+// where the standard thread constructors don't work (e.g. embedded environments where
+// creating a thread requires additional information like setting attributes).
+//
+// Vendors can keep a downstream diff in this file to create threads however they
+// need on their platform, and the majority of the test suite will work out of the
+// box. Of course, tests that exercise the standard thread constructors won't work,
+// but any other test that only creates threads as a side effect of testing should
+// work if they use the utilities in this file.
 
 template <class F, class ...Args>
 std::thread make_test_thread(F&& f, Args&& ...args) {
     return std::thread(std::forward<F>(f), std::forward<Args>(args)...);
 }
+
+#if TEST_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_STOP_TOKEN)
+template <class F, class ...Args>
+std::jthread make_test_jthread(F&& f, Args&& ...args) {
+    return std::jthread(std::forward<F>(f), std::forward<Args>(args)...);
+}
+#endif
 
 } // end namespace support
 


### PR DESCRIPTION
This patch introduces the support::make_test_jthread utility which is basically the same as support::make_test_thread but for std::jthread. It allows vendors to maintain a downstream way to create threads for use within the test suite, which is especially useful for embedded platforms.