### PR TITLE
[Docs][Clang] Missing DR status for C++23-era papers in cxx_status.html

### DIFF
--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -247,7 +247,7 @@ C++23, informally referred to as C++26.</p>
     </tr>
     <tr>
       <td>Allow duplicate attributes</td>
-      <td><a href="https://wg21.link/P2156R1">P2156R1</a></td>
+      <td><a href="https://wg21.link/P2156R1">P2156R1</a> (<a href="#dr">DR</a>)</td>
       <td class="full" align="center">Clang 13</td>
     </tr>
     <tr>
@@ -267,7 +267,7 @@ C++23, informally referred to as C++26.</p>
     </tr>
     <tr>
       <td>C++ identifier syntax using UAX 31</td>
-      <td><a href="https://wg21.link/P1949R7">P1949R7</a></td>
+      <td><a href="https://wg21.link/P1949R7">P1949R7</a> (<a href="#dr">DR</a>)</td>
       <td class="full" align="center">Clang 14</td>
     </tr>
     <tr>
@@ -287,11 +287,11 @@ C++23, informally referred to as C++26.</p>
     </tr>
     <tr>
       <td rowspan=2>Change scope of lambda trailing-return-type</td>
-      <td><a href="https://wg21.link/P2036R3">P2036R3</a></td>
+      <td><a href="https://wg21.link/P2036R3">P2036R3</a> (<a href="#dr">DR</a>)</td>
       <td rowspan=2 class="full" align="center">Clang 17</td>
     </tr>
     <tr>
-      <td><a href="https://wg21.link/P2579R0">P2579R0</a></td>
+      <td><a href="https://wg21.link/P2579R0">P2579R0</a> (<a href="#dr">DR</a>)</td>
     </tr>
     <tr>
       <td>Multidimensional subscript operator</td>
@@ -352,12 +352,12 @@ C++23, informally referred to as C++26.</p>
     <!-- July 2022 papers -->
     <tr>
       <td>The Equality Operator You Are Looking For</td>
-      <td><a href="https://wg21.link/P2468R2">P2468R2</a></td>
+      <td><a href="https://wg21.link/P2468R2">P2468R2</a> (<a href="#dr">DR</a>)</td>
       <td class="full" align="center">Clang 16</td>
     </tr>
     <tr>
       <td>De-deprecating volatile compound operations</td>
-      <td><a href="https://wg21.link/P2327R1">P2327R1</a></td>
+      <td><a href="https://wg21.link/P2327R1">P2327R1</a> (<a href="#dr">DR</a>)</td>
       <td class="full" align="center">Clang 15</td>
     </tr>
     <tr>
@@ -422,12 +422,12 @@ C++23, informally referred to as C++26.</p>
     </tr>
     <tr>
       <td><code>char8_t</code> Compatibility and Portability Fix</td>
-      <td><a href="https://wg21.link/P2513R3">P2513R3</a></td>
+      <td><a href="https://wg21.link/P2513R3">P2513R3</a> (<a href="#dr">DR</a>)</td>
       <td class="full" align="center">Clang 16</td>
     </tr>
     <tr>
       <td>Relax requirements on <code>wchar_t</code> to match existing practices</td>
-      <td><a href="https://wg21.link/P2460R2">P2460R2</a></td>
+      <td><a href="https://wg21.link/P2460R2">P2460R2</a> (<a href="#dr">DR</a>)</td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
@@ -563,7 +563,7 @@ C++23, informally referred to as C++26.</p>
         <td><a href="https://wg21.link/p2103r0">P2103R0</a></td>
       </tr>
       <tr> <!-- from February 2022 -->
-        <td><a href="https://wg21.link/p2493r0">P2493R0</a></td>
+        <td><a href="https://wg21.link/p2493r0">P2493R0</a> (<a href="#dr">DR</a>)</td>
       </tr>
       <tr>
         <td><a href="https://wg21.link/p2092r0">P2092R0</a></td>


### PR DESCRIPTION
List the following C++23-era WG21 papers as Defect Reports in cxx_status.html as per WG21 meeting minutes.

 - [P1949R7](https://wg21.link/p1949r7) (C++ Identifier Syntax using Unicode Standard Annex 31)
 - [P2156R1](https://wg21.link/p2156r1) (Allow Duplicate Attributes)
 - [P2036R3](https://wg21.link/p2036r3) (Change scope of lambda _trailing-return-type_)
 - [P2468R2](https://wg21.link/p2468r2) (The Equality Operator You Are Looking For)
 - [P2327R1](https://wg21.link/p2327r1) (De-deprecating `volatile` compound operations)
 - [P2493R0](https://wg21.link/p2493r0) (Missing feature test macros for C++20 core papers)
 - [P2513R3](https://wg21.link/p2513r3) (`char8_t` Compatibility and Portability Fix)
 - [P2460R2](https://wg21.link/p2460r2) (Relax requirements on `wchar_t` to match existing practices)
 - [P2579R0](https://wg21.link/p2579r0) (Mitigation strategies for [P2036](https://wg21.link/p2036) ”Changing scope for lambda _trailing-return-type_”)