### PR TITLE
[Clang] Check features of tune CPU against target CPU

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -278,6 +278,9 @@ def err_builtin_needs_feature : Error<"%0 needs target feature %1">;
 def err_function_needs_feature : Error<
   "always_inline function %1 requires target feature '%2', but would "
   "be inlined into function %0 that is compiled without support for '%2'">;
+def warn_tune_cpu_feature_unavailable : Warning<
+  "instructions of current target may not be supported by tune CPU '%0'">,
+  InGroup<UnsupportedTargetOpt>;
 
 def warn_avx_calling_convention
     : Warning<"AVX vector %select{return|argument}0 of type %1 without '%2' "

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -976,6 +976,12 @@ public:
   /// with this target.
   virtual BuiltinVaListKind getBuiltinVaListKind() const = 0;
 
+  /// Return whether a feature matters for tune CPU. If true, present in
+  /// current target but missing in tune CPU triggers a warning.
+  virtual bool isFeatureConsumedByTuneCPU(StringRef Feature) const {
+    return false;
+  }
+
   /// Returns whether or not type \c __builtin_ms_va_list type is
   /// available on this target.
   bool hasBuiltinMSVaList() const { return HasBuiltinMSVaList; }

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -187,6 +187,14 @@ public:
                  StringRef CPU,
                  const std::vector<std::string> &FeaturesVec) const override;
 
+  bool isFeatureConsumedByTuneCPU(StringRef Feature) const override {
+    // FIXME: Ignore htm to avoid unnecessary warning on cpu=pwr8/tune=pwr10,
+    // once clang can analyze function features with granularity, remove it.
+    return Feature != "aix-small-local-exec-tls" && Feature != "rop-protect" &&
+           Feature != "pcrelative-memops" && Feature != "quadword-atomics" &&
+           Feature != "htm";
+  }
+
   void addP10SpecificFeatures(llvm::StringMap<bool> &Features) const;
   void addFutureSpecificFeatures(llvm::StringMap<bool> &Features) const;
 

--- a/clang/test/Frontend/tune-cpu-features.c
+++ b/clang/test/Frontend/tune-cpu-features.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -triple powerpc64le-unknown-linux-gnu -target-cpu pwr10 -tune-cpu pwr8 %s 2>&1 | FileCheck --check-prefix=P8 %s
+// RUN: %clang_cc1 -triple powerpc64le-unknown-linux-gnu -target-cpu pwr9 -tune-cpu pwr8 %s 2>&1 | FileCheck --check-prefix=P8 %s
+// RUN: %clang_cc1 -triple powerpc64le-unknown-linux-gnu -target-cpu g5 -tune-cpu pwr8 %s 2>&1 | FileCheck --check-prefix=NONE --allow-empty %s
+// RUN: %clang_cc1 -triple powerpc64le-unknown-linux-gnu -target-cpu pwr8 -tune-cpu pwr9 %s 2>&1 | FileCheck --check-prefix=NONE --allow-empty %s
+// RUN: %clang_cc1 -triple powerpc64le-unknown-linux-gnu -target-cpu pwr8 -tune-cpu pwr10 %s 2>&1 | FileCheck --check-prefix=NONE --allow-empty %s
+
+// P8: instructions of current target may not be supported by tune CPU 'pwr8'
+// NONE-NOT: instructions of current target may not be supported by tune CPU


### PR DESCRIPTION
Tune CPU relies on model of instruction sets. Compiler should warn if not all instruction sets of current target CPU are supported by tune CPU. Although there is limitation that Clang cannot analyze actual required features of a function.

This is enabled to PowerPC only, because feature lists of targets are complex.