### PR TITLE
[lldb][lldb-vscode] Add example configuration for connecting to a remote gdbserver

### DIFF
--- a/lldb/tools/lldb-vscode/README.md
+++ b/lldb/tools/lldb-vscode/README.md
@@ -222,9 +222,9 @@ locally on port `2345`.
 {
   "name": "Local Debug Server",
   "type": "lldb-vscode",
-  "request": "launch",
+  "request": "attach",
   "program": "/tmp/a.out",
-  "launchCommands": ["gdb-remote 2345"],
+  "attachCommands": ["gdb-remote 2345"],
 }
 ```
 
@@ -238,9 +238,9 @@ port `5678` of that other machine.
 {
   "name": "Remote Debug Server",
   "type": "lldb-vscode",
-  "request": "launch",
+  "request": "attach",
   "program": "/tmp/a.out",
-  "launchCommands": ["gdb-remote hostname:5678"],
+  "attachCommands": ["gdb-remote hostname:5678"],
 }
 ```
 

--- a/lldb/tools/lldb-vscode/README.md
+++ b/lldb/tools/lldb-vscode/README.md
@@ -212,10 +212,27 @@ This loads the coredump file `/cores/123.core` associated with the program
 }
 ```
 
-### Connect to a Remote Debug Server
+### Connect to a Debug Server on the Current Machine
 
-This connects to a debug server (e.g. `lldb-server`, `gdbserver`) that is
-debugging the program `/tmp/a.out` and listening locally on port `2345`.
+This connects to a debug server (e.g. `lldb-server`, `gdbserver`) on
+the current machine, that is debugging the program `/tmp/a.out` and listening
+locally on port `2345`.
+
+```javascript
+{
+  "name": "Local Debug Server",
+  "type": "lldb-vscode",
+  "request": "launch",
+  "program": "/tmp/a.out",
+  "launchCommands": ["gdb-remote 2345"],
+}
+```
+
+### Connect to a Debug Server on Another Machine
+
+This connects to a debug server running on another machine with hostname
+`hostnmame`. Which is debugging the program `/tmp/a.out` and listening on
+port `5678` of that other machine.
 
 ```javascript
 {
@@ -223,7 +240,7 @@ debugging the program `/tmp/a.out` and listening locally on port `2345`.
   "type": "lldb-vscode",
   "request": "launch",
   "program": "/tmp/a.out",
-  "launchCommands": ["gdb-remote 2345"],
+  "launchCommands": ["gdb-remote hostname:5678"],
 }
 ```
 

--- a/lldb/tools/lldb-vscode/README.md
+++ b/lldb/tools/lldb-vscode/README.md
@@ -212,6 +212,21 @@ This loads the coredump file `/cores/123.core` associated with the program
 }
 ```
 
+### Connect to a Remote Debug Server
+
+This connects to a debug server (e.g. `lldb-server`, `gdbserver`) that is
+debugging the program `/tmp/a.out` and listening locally on port `2345`.
+
+```javascript
+{
+  "name": "Remote Debug Server",
+  "type": "lldb-vscode",
+  "request": "launch",
+  "program": "/tmp/a.out",
+  "launchCommands": ["gdb-remote 2345"],
+}
+```
+
 # Custom debugger commands
 
 The `lldb-vscode` tool includes additional custom commands to support the Debug


### PR DESCRIPTION
This can be used to have VS Code debug various emulators, remote systems, hardware probes, etc.

In my case I was doing this for the Gameboy Advance, https://github.com/stuij/gba-llvm-devkit/blob/main/docs/Debugging.md#debugging-using-visual-studio-code.

It's not very complex if you know LLDB well, but when using another plugin, CodeLLDB, I was very glad that they had an example for it. So we should have one too.