### PR TITLE
[AArch64] Fix tryMergeAdjacentSTG function in PrologEpilog pass

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3767,19 +3767,19 @@ MachineBasicBlock::iterator tryMergeAdjacentSTG(MachineBasicBlock::iterator II,
   // flag is live at the point where we are trying to insert. Otherwise
   // the nzcv flag might get clobbered if any stg loops are present.
 
-  // FIXME : This approach of bailing out from merge is also conservative
-  // in some ways like even if stg loops are not present after merge in
-  // the insert list, this liveness check is done (which is not needed).
-  LivePhysRegs LR(*(MBB->getParent()->getSubtarget().getRegisterInfo()));
-  LR.addLiveOuts(*MBB);
+  // FIXME : This approach of bailing out from merge is conservative in
+  // some ways like even if stg loops are not present after merge the
+  // insert list, this liveness check is done (which is not needed).
+  LivePhysRegs LiveRegs(*(MBB->getParent()->getSubtarget().getRegisterInfo()));
+  LiveRegs.addLiveOuts(*MBB);
   for (auto I = MBB->rbegin();; ++I) {
-    MachineInstr &MIns = *I;
-    if (MIns == InsertI)
+    MachineInstr &MI = *I;
+    if (MI == InsertI)
       break;
-    LR.stepBackward(*I);
+    LiveRegs.stepBackward(*I);
   }
   InsertI++;
-  if (LR.contains(AArch64::NZCV))
+  if (LiveRegs.contains(AArch64::NZCV))
     return InsertI;
 
   llvm::stable_sort(Instrs,

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3703,17 +3703,6 @@ bool isMergeableStackTaggingInstruction(MachineInstr &MI, int64_t &Offset,
   return true;
 }
 
-bool isNZCVLiveOut(MachineBasicBlock &MBB) {
-  // Loop over all of the successors of the basic block, checking to see if
-  // the value is either live in the block, or if it is killed in the block.
-  // We are checking for LiveIns alone
-  for (MachineBasicBlock *SuccMBB : MBB.successors()) {
-    if (SuccMBB->isLiveIn(AArch64::NZCV))
-      return true;
-  }
-  return false;
-}
-
 // Detect a run of memory tagging instructions for adjacent stack frame slots,
 // and replace them with a shorter instruction sequence:
 // * replace STG + STG with ST2G
@@ -3772,33 +3761,25 @@ MachineBasicBlock::iterator tryMergeAdjacentSTG(MachineBasicBlock::iterator II,
 
   // New code will be inserted after the last tagging instruction we've found.
   MachineBasicBlock::iterator InsertI = Instrs.back().MI;
-  InsertI++;
 
   // All the gathered stack tag instructions are merged and placed after
   // last tag store in the list. The check should be made if the nzcv
-  // flag that we might be overriding will affect upcoming instructions
-  // that reads the flag(Here NZCV) or if the register is live out. If
-  // the flag is defined again we don't have this problem as the flag
-  // is anyway subject to modification.
-  // Though there could be different ways to curb this maltransformation,
-  // this seems to be simple and straight forward without changing
-  // existing algorithm.
+  // flag is live at the point where we are trying to insert. Otherwise
+  // the nzcv flag might get clobbered if any stg loops are present.
+
   // FIXME : This approach of bailing out from merge is also conservative
-  // in some ways like even if stg loops are not present after merge
-  // these checks are done (which are not needed).
-  bool modifiesFirst = false, readsFirst = false;
-  for (MachineBasicBlock::iterator I = InsertI, E = MBB->end(); I != E; I++) {
-    MachineInstr &MI = *I;
-    if (MI.readsRegister(AArch64::NZCV)) {
-      readsFirst = true;
+  // in some ways like even if stg loops are not present after merge in
+  // the insert list, this liveness check is done (which is not needed).
+  LivePhysRegs LR(*(MBB->getParent()->getSubtarget().getRegisterInfo()));
+  LR.addLiveOuts(*MBB);
+  for (auto I = MBB->rbegin(); ; ++I) {
+    MachineInstr &MIns = *I;
+    if (MIns == InsertI)
       break;
-    }
-    if (MI.modifiesRegister(AArch64::NZCV)) {
-      modifiesFirst = true;
-      break;
-    }
+    LR.stepBackward(*I);
   }
-  if (!modifiesFirst && (readsFirst || isNZCVLiveOut(*MBB)))
+  InsertI++;
+  if (LR.contains(AArch64::NZCV))
     return InsertI;
 
   llvm::stable_sort(Instrs,

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3772,7 +3772,7 @@ MachineBasicBlock::iterator tryMergeAdjacentSTG(MachineBasicBlock::iterator II,
   // the insert list, this liveness check is done (which is not needed).
   LivePhysRegs LR(*(MBB->getParent()->getSubtarget().getRegisterInfo()));
   LR.addLiveOuts(*MBB);
-  for (auto I = MBB->rbegin(); ; ++I) {
+  for (auto I = MBB->rbegin();; ++I) {
     MachineInstr &MIns = *I;
     if (MIns == InsertI)
       break;

--- a/llvm/test/CodeGen/AArch64/settag-merge.ll
+++ b/llvm/test/CodeGen/AArch64/settag-merge.ll
@@ -299,9 +299,9 @@ declare i32 @printf(ptr, ...) #0
 ; Insert point of stg merge is followed by nzcv read
 ; Don't merge in this case
 
-define i32 @stg_no_merge(i32 %in) {
+define i32 @nzcv_clobber(i32 %in) {
 entry:
-; CHECK-LABEL: stg_no_merge:
+; CHECK-LABEL: nzcv_clobber:
 ; CHECK: stg sp, [sp, #528]
 ; CHECK-NEXT: .LBB10_1:
 ; CHECK: st2g x9, [x9], #32
@@ -333,9 +333,9 @@ return1:
 ; Insert point of stg merge is not followed by nzcv read
 ; Merge in this case
 
-define i32 @stg_merge(i32 %in) {
+define i32 @nzcv_no_clobber(i32 %in) {
 entry:
-; CHECK-LABEL: stg_merge:
+; CHECK-LABEL: nzcv_no_clobber:
 ; CHECK: mov x8, #544
 ; CHECK-NEXT: .LBB11_1:
 ; CHECK: st2g sp, [sp], #32


### PR DESCRIPTION
The tryMergeAdjacentSTG function tries to merge multiple stg/st2g/stg_loop instructions. It doesn't verify the liveness of NZCV flag before moving around STGloop which also alters NZCV flags. This was not issue before the patch 5e612bc291347d364f1d47c37f0d34eb6474b9b5 as these stack tag stores does not alter the NZCV flags. But after the change, this merge function leads to miscompilation because of control flow change in instructions. Added the check to to see if the first instruction after insert point reads or writes to NZCV flag and it's liveout state. This check happens after the filling of merge list just before merge and bails out if necessary.