### PR TITLE
[llvm-rc] Accept filenames provided as multiple string literals

### DIFF
--- a/llvm/test/tools/llvm-rc/Inputs/split-path.rc
+++ b/llvm/test/tools/llvm-rc/Inputs/split-path.rc
@@ -1,0 +1,2 @@
+100 ICON "subdir" "/icon-new.ico"
+101 24 "subdir" "/empty.manifest"

--- a/llvm/test/tools/llvm-rc/split-path.test
+++ b/llvm/test/tools/llvm-rc/split-path.test
@@ -1,0 +1,7 @@
+; RUN: rm -rf %t
+; RUN: mkdir %t
+; RUN: cd %t
+; RUN: mkdir subdir
+; RUN: cp %p/Inputs/icon-new.ico subdir
+; RUN: touch subdir/empty.manifest
+; RUN: llvm-windres --no-preprocess %p/Inputs/split-path.rc %t/split-path.res

--- a/llvm/tools/llvm-rc/ResourceScriptParser.h
+++ b/llvm/tools/llvm-rc/ResourceScriptParser.h
@@ -18,6 +18,7 @@
 #include "ResourceScriptToken.h"
 
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/StringSaver.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <system_error>
@@ -185,6 +186,9 @@ private:
   std::vector<RCToken> Tokens;
   LocIter CurLoc;
   const LocIter End;
+
+  BumpPtrAllocator Alloc;
+  StringSaver Saver{Alloc};
 };
 
 } // namespace rc


### PR DESCRIPTION
GNU windres supports this, while MS rc.exe doesn't.

MS rc.exe only supports treating consecutive string literals as if they were fused into one in a few fixed locations (most of which are already supported), while GNU windres supports this essentially anywhere in any string. See
b989fcbae6f179ad887d19ceef83ace1c00b87cc for one recent change that extended support for this in one specific resource.

A reasonable use case for multiple concatenated string literals that GNU windres accepts is `1 ICON DIR "/name.ico"`, where the directory is provided via the preprocessor, expanding to another string literal; this is https://github.com/llvm/llvm-project/issues/51286.

Extend the parser to try to consume all consecutive string tokens, whenever reading a filename. Adjust the handling of user data resources read from a file to use the readFilename() helper.

While this probably doesn't cover every single case where GNU windres might accept concatenated string literals, this is the primary missing case that has been reported so far.