### PR TITLE
[IR][NFC] Assert that FunctionType::getParamType is in-bounds

### DIFF
--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -132,7 +132,10 @@ public:
   }
 
   /// Parameter type accessors.
-  Type *getParamType(unsigned i) const { return ContainedTys[i+1]; }
+  Type *getParamType(unsigned i) const {
+    assert(i < getNumParams() && "getParamType() out of range!");
+    return ContainedTys[i + 1];
+  }
 
   /// Return the number of fixed parameters this function type requires.
   /// This does not consider varargs.


### PR DESCRIPTION
Like for Function::getArg, assert that the fetched argument is in-range and not out-of-bounds.