### PR TITLE
[flang][driver] support -dumpversion and -dumpmachine

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1375,9 +1375,13 @@ def dsym_dir : JoinedOrSeparate<["-"], "dsym-dir">,
 def dumpdir : Separate<["-"], "dumpdir">, Visibility<[ClangOption, CC1Option]>,
   MetaVarName<"<dumppfx>">,
   HelpText<"Use <dumpfpx> as a prefix to form auxiliary and dump file names">;
-def dumpmachine : Flag<["-"], "dumpmachine">;
+def dumpmachine : Flag<["-"], "dumpmachine">,
+  Visibility<[ClangOption, FlangOption]>,
+  HelpText<"Display the compiler's target processor">;
+def dumpversion : Flag<["-"], "dumpversion">,
+  Visibility<[ClangOption, FlangOption]>,
+  HelpText<"Display the version of the compiler">;
 def dumpspecs : Flag<["-"], "dumpspecs">, Flags<[Unsupported]>;
-def dumpversion : Flag<["-"], "dumpversion">;
 def dylib__file : Separate<["-"], "dylib_file">;
 def dylinker__install__name : JoinedOrSeparate<["-"], "dylinker_install_name">;
 def dylinker : Flag<["-"], "dylinker">;

--- a/flang/test/Driver/driver-help-hidden.f90
+++ b/flang/test/Driver/driver-help-hidden.f90
@@ -21,6 +21,8 @@
 ! CHECK-NEXT: -ccc-print-phases       Dump list of actions to perform
 ! CHECK-NEXT: -cpp                    Enable predefined and command line preprocessor macros
 ! CHECK-NEXT: -c                      Only run preprocess, compile, and assemble steps
+! CHECK-NEXT: -dumpmachine            Display the compiler's target processor
+! CHECK-NEXT: -dumpversion            Display the version of the compiler
 ! CHECK-NEXT: -D <macro>=<value>      Define <macro> to <value> (or 1 if <value> omitted)
 ! CHECK-NEXT: -emit-llvm              Use the LLVM representation for assembler and object files
 ! CHECK-NEXT: -E                      Only run the preprocessor

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -17,6 +17,8 @@
 ! HELP-NEXT: -###                    Print (but do not run) the commands to run for this compilation
 ! HELP-NEXT: -cpp                    Enable predefined and command line preprocessor macros
 ! HELP-NEXT: -c                      Only run preprocess, compile, and assemble steps
+! HELP-NEXT: -dumpmachine            Display the compiler's target processor
+! HELP-NEXT: -dumpversion            Display the version of the compiler
 ! HELP-NEXT: -D <macro>=<value>      Define <macro> to <value> (or 1 if <value> omitted)
 ! HELP-NEXT: -emit-llvm              Use the LLVM representation for assembler and object files
 ! HELP-NEXT: -E                      Only run the preprocessor

--- a/flang/test/Driver/dumpmachine.f90
+++ b/flang/test/Driver/dumpmachine.f90
@@ -1,0 +1,8 @@
+! Test that -dumpmachine prints the target triple.
+
+! Note: Debian GCC may omit "unknown-".
+! RUN: %flang --target=x86_64-linux-gnu -dumpmachine | FileCheck %s --check-prefix=X86_64
+! X86_64: x86_64-unknown-linux-gnu
+
+! RUN: %flang --target=xxx-pc-freebsd -dumpmachine | FileCheck %s --check-prefix=FREEBSD
+! FREEBSD: xxx-pc-freebsd

--- a/flang/test/Driver/immediate-options.f90
+++ b/flang/test/Driver/immediate-options.f90
@@ -1,0 +1,2 @@
+! RUN: %flang -dumpversion | FileCheck %s -check-prefix=DUMPVERSION
+! DUMPVERSION: {{[0-9]+\.[0-9.]+}}


### PR DESCRIPTION
Match GCC driver. GCC has -cc1/-fc1 support too, but this patch does not address that.