### PR TITLE
[TableGen] Update editor modes for new keywords and bang operators.

### DIFF
--- a/llvm/utils/emacs/tablegen-mode.el
+++ b/llvm/utils/emacs/tablegen-mode.el
@@ -19,7 +19,7 @@
 (defvar tablegen-font-lock-keywords
   (let ((kw (regexp-opt '("class" "defm" "def" "field" "include" "in"
                          "let" "multiclass" "foreach" "if" "then" "else"
-                         "defvar" "defset")
+                         "defvar" "defset" "dump" "assert")
                         'words))
         (type-kw (regexp-opt '("bit" "bits" "code" "dag" "int" "list" "string")
                              'words))

--- a/llvm/utils/kate/llvm-tablegen.xml
+++ b/llvm/utils/kate/llvm-tablegen.xml
@@ -44,6 +44,7 @@
       <item> !ne </item>
       <item> !tolower </item>
       <item> !toupper </item>
+      <item> !repr </item>
     </list>
     <list name="objects">
       <item> class </item>
@@ -53,6 +54,8 @@
       <item> let </item>
       <item> defvar </item>
       <item> multiclass </item>
+      <item> assert </item>
+      <item> dump </item>
     </list>
     <list name="class-like">
       <item> class </item>

--- a/llvm/utils/vim/syntax/tablegen.vim
+++ b/llvm/utils/vim/syntax/tablegen.vim
@@ -14,7 +14,7 @@ syntax sync minlines=100
 
 syn case match
 
-syn keyword tgKeyword   def let in code dag field include defm foreach defset defvar if then else
+syn keyword tgKeyword   def let in code dag field include defm foreach defset defvar if then else assert dump
 syn keyword tgType      class int string list bit bits multiclass
 
 syn match   tgNumber    /\<\d\+\>/

--- a/llvm/utils/vscode/llvm/syntaxes/TableGen.tmLanguage
+++ b/llvm/utils/vscode/llvm/syntaxes/TableGen.tmLanguage
@@ -18,7 +18,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(def|let|in|code|dag|string|list|bits|bit|field|include|defm|foreach|class|multiclass|int|defvar|defset|if|then|else)\b</string>
+			<string>\b(def|let|in|code|dag|string|list|bits|bit|field|include|defm|foreach|class|multiclass|int|defvar|defset|if|then|else|assert|dump)\b</string>
 			<key>name</key>
 			<string>keyword.control.tablegen</string>
 		</dict>


### PR DESCRIPTION
* `dump`, added in https://github.com/llvm/llvm-project/pull/68793
* `!repr`, added in https://github.com/llvm/llvm-project/pull/68716

The keyword `assert` was missing, so I have added that too.