### PR TITLE
[ARM] Correctly handle .inst in IT and VPT blocks

### DIFF
--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -11981,6 +11981,8 @@ bool ARMAsmParser::parseDirectiveInst(SMLoc Loc, char Suffix) {
     }
 
     getTargetStreamer().emitInst(Value->getValue(), CurSuffix);
+    forwardITPosition();
+    forwardVPTPosition();
     return false;
   };
 

--- a/llvm/test/MC/ARM/inst-directive-it-vpt.s
+++ b/llvm/test/MC/ARM/inst-directive-it-vpt.s
@@ -1,0 +1,26 @@
+// RUN: llvm-mc %s -triple armv8m.main -mattr=+mve -filetype asm -o - | FileCheck %s
+
+  .thumb
+
+// CHECK: it      eq
+// CHECK: .inst.n 0x3001
+// CHECK: add.w r0, r0, #1
+  it eq
+  .inst.n 0x3001 // addeq r0, #1
+  add r0, #1
+
+// CHECK: vpst
+// CHECK: .inst.w 0xef220844
+// CHECK: vadd.i32 q0, q1, q2
+  vpst
+  .inst.w 0xef220844 // vaddt.i32 q0, q1, q2
+  vadd.i32 q0, q1, q2
+
+// CHECK: ite eq
+// CHECK: .inst.n 0x3001
+// CHECK: addne r0, #1
+// CHECK: add.w r0, r0, #1
+  ite eq
+  .inst.n 0x3001 // addeq r0, #1
+  addne r0, #1
+  add r0, #1


### PR DESCRIPTION
Advance the IT and VPT block state when parsing the .inst directive, so that it is possible to use them to emit conditional instructions. If we don't do this, then a later instruction inside or just after the block will have a mis-matched condition, so be incorrectly reported as an error.