### PR TITLE
[clang] Add information about lld presence in RISCVToolchain.

### DIFF
--- a/clang/lib/Driver/ToolChains/RISCVToolchain.cpp
+++ b/clang/lib/Driver/ToolChains/RISCVToolchain.cpp
@@ -49,7 +49,9 @@ bool RISCVToolChain::hasGCCToolchain(const Driver &D,
 /// RISC-V Toolchain
 RISCVToolChain::RISCVToolChain(const Driver &D, const llvm::Triple &Triple,
                                const ArgList &Args)
-    : Generic_ELF(D, Triple, Args) {
+    : Generic_ELF(D, Triple, Args), UseLLD{Args.getLastArgValue(
+                                                   options::OPT_fuse_ld_EQ)
+                                               .equals_insensitive("lld")} {
   GCCInstallation.init(Triple, Args);
   if (GCCInstallation.isValid()) {
     Multilibs = GCCInstallation.getMultilibs();

--- a/clang/lib/Driver/ToolChains/RISCVToolchain.h
+++ b/clang/lib/Driver/ToolChains/RISCVToolchain.h
@@ -35,11 +35,14 @@ public:
   addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
                            llvm::opt::ArgStringList &CC1Args) const override;
 
+  bool HasNativeLLVMSupport() const override { return UseLLD; }
+
 protected:
   Tool *buildLinker() const override;
 
 private:
   std::string computeSysRoot() const override;
+  bool UseLLD;
 };
 
 } // end namespace toolchains

--- a/clang/test/Driver/riscv64-toolchain.c
+++ b/clang/test/Driver/riscv64-toolchain.c
@@ -121,6 +121,31 @@
 // C-RV64IMAC-BAREMETAL-MULTI-LP64: "--start-group" "-lc" "-lgloss" "--end-group" "-lgcc"
 // C-RV64IMAC-BAREMETAL-MULTI-LP64: "{{.*}}/Inputs/multilib_riscv_elf_sdk/lib/gcc/riscv64-unknown-elf/8.2.0/rv64imac/lp64/crtend.o"
 
+// Check that lto works in riscv-toolchain when explicitly specified lld as linker.
+// RUN: env "PATH=" %clang -### %s -fuse-ld=lld -flto \
+// RUN:   -B%S/Inputs/lld --target=riscv64-unknown-elf --rtlib=platform --sysroot= \
+// RUN:   -march=rv64imac -mabi=lp64\
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_elf_sdk 2>&1 \
+// RUN:   | FileCheck -check-prefix=C-RV64IMAC-BAREMETAL-LTO-LP64 %s
+
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "{{.*}}lld"
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "-m" "elf64lriscv"
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "{{.*}}/Inputs/multilib_riscv_elf_sdk/lib/gcc/riscv64-unknown-elf/8.2.0/../../../../riscv64-unknown-elf/lib/rv64imac/lp64/crt0.o"
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "{{.*}}/Inputs/multilib_riscv_elf_sdk/lib/gcc/riscv64-unknown-elf/8.2.0/rv64imac/lp64/crtbegin.o"
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "-L{{.*}}/Inputs/multilib_riscv_elf_sdk/lib/gcc/riscv64-unknown-elf/8.2.0"
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "-L{{.*}}/Inputs/multilib_riscv_elf_sdk/lib/gcc/riscv64-unknown-elf/8.2.0/../../../../riscv64-unknown-elf/lib"
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "--start-group" "-lc" "-lgloss" "--end-group" "-lgcc"
+// C-RV64IMAC-BAREMETAL-LTO-LP64: "{{.*}}/Inputs/multilib_riscv_elf_sdk/lib/gcc/riscv64-unknown-elf/8.2.0/rv64imac/lp64/crtend.o"
+
+// Check driver error when lto is used without specified lld linker.
+// RUN: not env "PATH=" %clang -### %s -flto \
+// RUN:   --target=riscv64-unknown-elf --rtlib=platform --sysroot= \
+// RUN:   -march=rv64imac -mabi=lp64\
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_elf_sdk 2>&1 \
+// RUN:   | FileCheck -check-prefix=C-RV64IMAC-BAREMETAL-LTO-FAIL-LP64 %s
+
+// C-RV64IMAC-BAREMETAL-LTO-FAIL-LP64: error: 'riscv64-unknown-unknown-elf': unable to pass LLVM bit-code files to linker
+
 // RUN: env "PATH=" %clang -### %s -fuse-ld=ld \
 // RUN:   --target=riscv64-unknown-elf --rtlib=platform --unwindlib=platform --sysroot= \
 // RUN:   -march=rv64imafdc -mabi=lp64d \


### PR DESCRIPTION
When compiling for target riscv64/32-uknown-elf clang assumes that it do not use lld linker even if explicitly told ('-fuse-ld=lld').