### PR TITLE
[lldb][DataFormatter] VectorType: fix format for arrays with size not a power-of-2

### DIFF
--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -169,14 +169,12 @@ static lldb::Format GetItemFormatForFormat(lldb::Format format,
   }
 }
 
-static size_t CalculateNumChildren(
-    CompilerType container_type, CompilerType element_type,
-    lldb_private::ExecutionContextScope *exe_scope =
-        nullptr // does not matter here because all we trade in are basic types
-    ) {
+static size_t CalculateNumChildren(CompilerType container_type,
+                                   CompilerType element_type) {
   std::optional<uint64_t> container_size =
-      container_type.GetByteSize(exe_scope);
-  std::optional<uint64_t> element_size = element_type.GetByteSize(exe_scope);
+      container_type.GetByteSize(/* exe_scope */ nullptr);
+  std::optional<uint64_t> element_size =
+      element_type.GetByteSize(/* exe_scope */ nullptr);
 
   if (container_size && element_size && *element_size) {
     if (*container_size % *element_size)

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -169,8 +169,8 @@ static lldb::Format GetItemFormatForFormat(lldb::Format format,
   }
 }
 
-/// The number of elements stored in a container (with element
-/// type 'container_elem_type') as if it had elements of type
+/// Calculates the number of elements stored in a container (with
+/// element type 'container_elem_type') as if it had elements of type
 /// 'element_type'.
 ///
 /// For example, a container of type
@@ -193,10 +193,9 @@ static lldb::Format GetItemFormatForFormat(lldb::Format format,
 /// type 'element_type'. Returns a std::nullopt if the
 /// size of the container is not a multiple of 'element_type'
 /// or if an error occurs.
-static std::optional<size_t> CalculateNumChildren(
-        CompilerType container_elem_type,
-        uint64_t num_elements,
-        CompilerType element_type) {
+static std::optional<size_t>
+CalculateNumChildren(CompilerType container_elem_type, uint64_t num_elements,
+                     CompilerType element_type) {
   std::optional<uint64_t> container_elem_size =
       container_elem_type.GetByteSize(/* exe_scope */ nullptr);
   if (!container_elem_size)
@@ -256,7 +255,8 @@ public:
         m_parent_format, element_type,
         parent_type.GetTypeSystem().GetSharedPointer());
     m_num_children =
-        ::CalculateNumChildren(element_type, num_elements, m_child_type).value_or(0);
+        ::CalculateNumChildren(element_type, num_elements, m_child_type)
+            .value_or(0);
     m_item_format = GetItemFormatForFormat(m_parent_format, m_child_type);
     return false;
   }

--- a/lldb/test/API/functionalities/data-formatter/vector-types/TestVectorTypesFormatting.py
+++ b/lldb/test/API/functionalities/data-formatter/vector-types/TestVectorTypesFormatting.py
@@ -86,3 +86,10 @@ class VectorTypesFormattingTestCase(TestBase):
         v.SetFormat(lldb.eFormatVectorOfFloat32)
         oldValueAgain = v.GetChildAtIndex(0).GetValue()
         self.assertEqual(oldValue, oldValueAgain, "same format but different values")
+
+        # Test formatter for vector types whose size is not a power-of-2
+        f3 = self.frame().FindVariable("f3")
+        self.assertEqual(f3.GetNumChildren(), 3)
+        self.assertEqual(f3.GetChildAtIndex(0).GetData().float[0], 1.25)
+        self.assertEqual(f3.GetChildAtIndex(1).GetData().float[0], 2.50)
+        self.assertEqual(f3.GetChildAtIndex(2).GetData().float[0], 2.50)

--- a/lldb/test/API/functionalities/data-formatter/vector-types/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/vector-types/main.cpp
@@ -1,8 +1,10 @@
 typedef float float4 __attribute__((ext_vector_type(4)));
-typedef  unsigned char vec __attribute__((ext_vector_type(16)));
+typedef unsigned char vec __attribute__((ext_vector_type(16)));
+typedef float float3 __attribute__((ext_vector_type(3)));
 
 int main() {
     float4 f4 = {1.25, 1.25, 2.50, 2.50};
     vec v = (vec)f4;
+    float3 f3 = f4.gba;
     return 0; // break here
 }


### PR DESCRIPTION
To get the number of children for a VectorType (i.e.,
a type declared with a `vector_size`/`ext_vector_type` attribute)
LLDB previously did following calculation:
1. Get byte-size of the vector container from Clang (`getTypeInfo`).
2. Get byte-size of the element type we want to interpret the array as.
   (e.g., sometimes we want to interpret an `unsigned char vec[16]`
   as a `float32[]`).
3. `numChildren = containerSize / reinterpretedElementSize`

However, for step 1, clang will return us the *aligned* container byte-size.
So for a type such as `float __attribute__((ext_vector_type(3)))`
(which is an array of 3 4-byte floats), clang will round up the
byte-width of the array to `16`.
(see [here](https://github.com/llvm/llvm-project/blob/ab6a66dbec61654d0962f6abf6d6c5b776937584/clang/lib/AST/ASTContext.cpp#L1987-L1992))

This means that for vectors where the size isn't a power-of-2, LLDB
will miscalculate the number of elements.

**Solution**

This patch changes step 1 such that we calculate the container size
as `numElementsInSource * byteSizeOfElement`.