### PR TITLE
[LLDB] Fix type formatting empty c-strings

### DIFF
--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -81,9 +81,9 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
               WritableDataBufferSP buffer_sp(
                   new DataBufferHeap(max_len + 1, 0));
               Address address(valobj->GetPointerValue());
-              if (target_sp->ReadCStringFromMemory(
-                      address, (char *)buffer_sp->GetBytes(), max_len, error) &&
-                  error.Success())
+              target_sp->ReadCStringFromMemory(
+                  address, (char *)buffer_sp->GetBytes(), max_len, error);
+              if (error.Success())
                 data.SetData(buffer_sp);
             }
           }

--- a/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
+++ b/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
@@ -3,9 +3,9 @@ Tests the builtin formats of LLDB.
 """
 
 import lldb
+from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
@@ -19,6 +19,21 @@ class TestCase(TestBase):
         self.assertTrue(result.Succeeded(), result.GetError())
         return result.GetOutput()
 
+    @no_debug_info_test
+    @skipIfWindows
+    def testAllPlatforms(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+        # We can dump correctly non char* c-strings with explicit formatting.
+        self.assertIn(' = ""', self.getFormatted("c-string", "void_empty_cstring"));
+        self.assertIn(' = ""', self.getFormatted("c-string", "empty_cstring"));
+
+
+    # TODO: Move as many asserts as possible within this function to `testAllPlatforms`.
+    # Currently `arm` is being skipped even though many asserts would effectively
+    # pass.
     @no_debug_info_test
     @skipIfWindows
     # uint128_t not available on arm.

--- a/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
+++ b/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
@@ -30,7 +30,6 @@ class TestCase(TestBase):
         self.assertIn(' = ""', self.getFormatted("c-string", "void_empty_cstring"))
         self.assertIn(' = ""', self.getFormatted("c-string", "empty_cstring"))
 
-
     # TODO: Move as many asserts as possible within this function to `testAllPlatforms`.
     # Currently `arm` is being skipped even though many asserts would effectively
     # pass.

--- a/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
+++ b/lldb/test/API/functionalities/data-formatter/builtin-formats/TestBuiltinFormats.py
@@ -27,8 +27,8 @@ class TestCase(TestBase):
             self, "// break here", lldb.SBFileSpec("main.cpp")
         )
         # We can dump correctly non char* c-strings with explicit formatting.
-        self.assertIn(' = ""', self.getFormatted("c-string", "void_empty_cstring"));
-        self.assertIn(' = ""', self.getFormatted("c-string", "empty_cstring"));
+        self.assertIn(' = ""', self.getFormatted("c-string", "void_empty_cstring"))
+        self.assertIn(' = ""', self.getFormatted("c-string", "empty_cstring"))
 
 
     # TODO: Move as many asserts as possible within this function to `testAllPlatforms`.

--- a/lldb/test/API/functionalities/data-formatter/builtin-formats/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/builtin-formats/main.cpp
@@ -1,8 +1,10 @@
 #include <cstdint>
 
 const char cstring[15] = " \033\a\b\f\n\r\t\vaA09\0";
+const char *empty_cstring = "";
 
 int main() {
   int use = *cstring;
+  void *void_empty_cstring = (void *)empty_cstring;
   return use; // break here
 }


### PR DESCRIPTION
The type formatter code is effectively considering empty strings as read errors, which is wrong. The fix is very simple. We should rely on the error object and stop checking the size. I also added a test.
