### PR TITLE
[libc++] Check formatting with clang-format 17

### DIFF
--- a/libcxx/include/__concepts/swappable.h
+++ b/libcxx/include/__concepts/swappable.h
@@ -92,7 +92,7 @@ struct __fn {
   // 2.3   Otherwise, if `E1` and `E2` are lvalues of the same type `T` that models...
   template <__exchangeable _Tp>
   _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Tp& __x, _Tp& __y) const
-      noexcept(is_nothrow_move_constructible_v<_Tp>&& is_nothrow_move_assignable_v<_Tp>) {
+      noexcept(is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>) {
     __y = _VSTD::exchange(__x, _VSTD::move(__y));
   }
 };

--- a/libcxx/include/__ranges/to.h
+++ b/libcxx/include/__ranges/to.h
@@ -207,13 +207,11 @@ _LIBCPP_NODISCARD_EXT _LIBCPP_HIDE_FROM_ABI constexpr auto to(_Args&&... __args)
   static_assert(
       !is_volatile_v<_Container>, "The target container cannot be volatile-qualified, please remove the volatile");
 
-  auto __to_func = []<input_range _Range, class... _Tail>(_Range && __range, _Tail && ... __tail)
+  auto __to_func = []<input_range _Range, class... _Tail>(_Range&& __range, _Tail&&... __tail)
     requires requires { //
       /**/ ranges::to<_Container>(std::forward<_Range>(__range), std::forward<_Tail>(__tail)...);
     }
-  {
-    return ranges::to<_Container>(std::forward<_Range>(__range), std::forward<_Tail>(__tail)...);
-  };
+  { return ranges::to<_Container>(std::forward<_Range>(__range), std::forward<_Tail>(__tail)...); };
 
   return __range_adaptor_closure_t(std::__bind_back(__to_func, std::forward<_Args>(__args)...));
 }

--- a/libcxx/include/__type_traits/promote.h
+++ b/libcxx/include/__type_traits/promote.h
@@ -50,7 +50,7 @@ struct __numeric_type<void> {
 template <class _A1,
           class _A2 = void,
           class _A3 = void,
-          bool      = __numeric_type<_A1>::value&& __numeric_type<_A2>::value&& __numeric_type<_A3>::value>
+          bool      = __numeric_type<_A1>::value && __numeric_type<_A2>::value && __numeric_type<_A3>::value>
 class __promote_imp {
 public:
   static const bool value = false;

--- a/libcxx/test/std/strings/basic.string/string.cons/implicit_deduction_guides.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/implicit_deduction_guides.pass.cpp
@@ -48,15 +48,17 @@ using BStr = std::basic_string<T, std::char_traits<T>, Alloc>;
 TEST_CONSTEXPR_CXX20 bool test() {
   using TestSizeT = test_allocator<char>::size_type;
   {
-      // Testing (1)
-      // Nothing to do. Cannot deduce without any arguments.
-  } {
-      // Testing (2)
-      // This overload isn't compatible with implicit deduction guides as
-      // specified in the standard.
-      // const test_allocator<char> alloc{};
-      // std::basic_string s(alloc);
-  } { // Testing (3) w/o allocator
+    // Testing (1)
+    // Nothing to do. Cannot deduce without any arguments.
+  }
+  {
+    // Testing (2)
+    // This overload isn't compatible with implicit deduction guides as
+    // specified in the standard.
+    // const test_allocator<char> alloc{};
+    // std::basic_string s(alloc);
+  }
+  { // Testing (3) w/o allocator
     std::basic_string s(6ull, 'a');
     ASSERT_SAME_TYPE(decltype(s), std::string);
     assert(s == "aaaaaa");
@@ -187,162 +189,163 @@ TEST_CONSTEXPR_CXX20 bool test() {
     ASSERT_SAME_TYPE(decltype(s), std::string);
     assert(s == "abc");
   }
-  {// (8) w/ allocator
-   {using Expect = std::basic_string<char, std::char_traits<char>, test_allocator<char>>;
-  using It          = cpp17_input_iterator<const char*>;
-  const char* input = "abcdef";
-  std::basic_string s(It(input), It(input + 3), test_allocator<char>{});
-  ASSERT_SAME_TYPE(decltype(s), Expect);
-  assert(s == "abc");
-}
+  { // (8) w/ allocator
+    {
+      using Expect      = std::basic_string<char, std::char_traits<char>, test_allocator<char>>;
+      using It          = cpp17_input_iterator<const char*>;
+      const char* input = "abcdef";
+      std::basic_string s(It(input), It(input + 3), test_allocator<char>{});
+      ASSERT_SAME_TYPE(decltype(s), Expect);
+      assert(s == "abc");
+    }
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-{
-  using ExpectW        = std::basic_string<wchar_t, std::char_traits<wchar_t>, test_allocator<wchar_t>>;
-  using It             = cpp17_input_iterator<const wchar_t*>;
-  const wchar_t* input = L"abcdef";
-  std::basic_string s(It(input), It(input + 3), test_allocator<wchar_t>{});
-  ASSERT_SAME_TYPE(decltype(s), ExpectW);
-  assert(s == L"abc");
-}
+    {
+      using ExpectW        = std::basic_string<wchar_t, std::char_traits<wchar_t>, test_allocator<wchar_t>>;
+      using It             = cpp17_input_iterator<const wchar_t*>;
+      const wchar_t* input = L"abcdef";
+      std::basic_string s(It(input), It(input + 3), test_allocator<wchar_t>{});
+      ASSERT_SAME_TYPE(decltype(s), ExpectW);
+      assert(s == L"abc");
+    }
 #endif
-}
-{ // Testing (9)
-  const std::string sin("abc");
-  std::basic_string s(sin);
-  ASSERT_SAME_TYPE(decltype(s), std::string);
-  assert(s == "abc");
+  }
+  { // Testing (9)
+    const std::string sin("abc");
+    std::basic_string s(sin);
+    ASSERT_SAME_TYPE(decltype(s), std::string);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
-  const WStr win(L"abcdef");
-  std::basic_string w(win);
-  ASSERT_SAME_TYPE(decltype(w), WStr);
-  assert(w == L"abcdef");
+    using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
+    const WStr win(L"abcdef");
+    std::basic_string w(win);
+    ASSERT_SAME_TYPE(decltype(w), WStr);
+    assert(w == L"abcdef");
 #endif
-}
-{ // Testing (10)
-  const std::string sin("abc");
-  std::basic_string s(sin, std::allocator<char>{});
-  ASSERT_SAME_TYPE(decltype(s), std::string);
-  assert(s == "abc");
+  }
+  { // Testing (10)
+    const std::string sin("abc");
+    std::basic_string s(sin, std::allocator<char>{});
+    ASSERT_SAME_TYPE(decltype(s), std::string);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
-  const WStr win(L"abcdef");
-  std::basic_string w(win, test_allocator<wchar_t>{});
-  ASSERT_SAME_TYPE(decltype(w), WStr);
-  assert(w == L"abcdef");
+    using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
+    const WStr win(L"abcdef");
+    std::basic_string w(win, test_allocator<wchar_t>{});
+    ASSERT_SAME_TYPE(decltype(w), WStr);
+    assert(w == L"abcdef");
 #endif
-}
-{ // Testing (11)
-  std::string sin("abc");
-  std::basic_string s(std::move(sin));
-  ASSERT_SAME_TYPE(decltype(s), std::string);
-  assert(s == "abc");
+  }
+  { // Testing (11)
+    std::string sin("abc");
+    std::basic_string s(std::move(sin));
+    ASSERT_SAME_TYPE(decltype(s), std::string);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
-  WStr win(L"abcdef");
-  std::basic_string w(std::move(win));
-  ASSERT_SAME_TYPE(decltype(w), WStr);
-  assert(w == L"abcdef");
+    using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
+    WStr win(L"abcdef");
+    std::basic_string w(std::move(win));
+    ASSERT_SAME_TYPE(decltype(w), WStr);
+    assert(w == L"abcdef");
 #endif
-}
-{ // Testing (12)
-  std::string sin("abc");
-  std::basic_string s(std::move(sin), std::allocator<char>{});
-  ASSERT_SAME_TYPE(decltype(s), std::string);
-  assert(s == "abc");
+  }
+  { // Testing (12)
+    std::string sin("abc");
+    std::basic_string s(std::move(sin), std::allocator<char>{});
+    ASSERT_SAME_TYPE(decltype(s), std::string);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
-  WStr win(L"abcdef");
-  std::basic_string w(std::move(win), test_allocator<wchar_t>{});
-  ASSERT_SAME_TYPE(decltype(w), WStr);
-  assert(w == L"abcdef");
+    using WStr = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
+    WStr win(L"abcdef");
+    std::basic_string w(std::move(win), test_allocator<wchar_t>{});
+    ASSERT_SAME_TYPE(decltype(w), WStr);
+    assert(w == L"abcdef");
 #endif
-}
-{ // Testing (13) w/o allocator
-  std::basic_string s({'a', 'b', 'c'});
-  ASSERT_SAME_TYPE(decltype(s), std::string);
-  assert(s == "abc");
+  }
+  { // Testing (13) w/o allocator
+    std::basic_string s({'a', 'b', 'c'});
+    ASSERT_SAME_TYPE(decltype(s), std::string);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  std::basic_string w({L'a', L'b', L'c'});
-  ASSERT_SAME_TYPE(decltype(w), std::wstring);
-  assert(w == L"abc");
+    std::basic_string w({L'a', L'b', L'c'});
+    ASSERT_SAME_TYPE(decltype(w), std::wstring);
+    assert(w == L"abc");
 #endif
-}
-{ // Testing (13) w/ allocator
-  std::basic_string s({'a', 'b', 'c'}, test_allocator<char>{});
-  ASSERT_SAME_TYPE(decltype(s), BStr<char, test_allocator<char>>);
-  assert(s == "abc");
+  }
+  { // Testing (13) w/ allocator
+    std::basic_string s({'a', 'b', 'c'}, test_allocator<char>{});
+    ASSERT_SAME_TYPE(decltype(s), BStr<char, test_allocator<char>>);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  std::basic_string w({L'a', L'b', L'c'}, test_allocator<wchar_t>{});
-  ASSERT_SAME_TYPE(decltype(w), BStr<wchar_t, test_allocator<wchar_t>>);
-  assert(w == L"abc");
+    std::basic_string w({L'a', L'b', L'c'}, test_allocator<wchar_t>{});
+    ASSERT_SAME_TYPE(decltype(w), BStr<wchar_t, test_allocator<wchar_t>>);
+    assert(w == L"abc");
 #endif
-}
-{ // Testing (14) w/o allocator
-  std::string_view sv("abc");
-  std::basic_string s(sv);
-  ASSERT_SAME_TYPE(decltype(s), std::string);
-  assert(s == "abc");
+  }
+  { // Testing (14) w/o allocator
+    std::string_view sv("abc");
+    std::basic_string s(sv);
+    ASSERT_SAME_TYPE(decltype(s), std::string);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  using Expect = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>>;
-  std::basic_string_view<wchar_t, constexpr_char_traits<wchar_t>> BSV(L"abcdef");
-  std::basic_string w(BSV);
-  ASSERT_SAME_TYPE(decltype(w), Expect);
-  assert(w == L"abcdef");
+    using Expect = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>>;
+    std::basic_string_view<wchar_t, constexpr_char_traits<wchar_t>> BSV(L"abcdef");
+    std::basic_string w(BSV);
+    ASSERT_SAME_TYPE(decltype(w), Expect);
+    assert(w == L"abcdef");
 #endif
-}
-{ // Testing (14) w/ allocator
-  using ExpectS = std::basic_string<char, std::char_traits<char>, test_allocator<char>>;
-  std::string_view sv("abc");
-  std::basic_string s(sv, test_allocator<char>{});
-  ASSERT_SAME_TYPE(decltype(s), ExpectS);
-  assert(s == "abc");
+  }
+  { // Testing (14) w/ allocator
+    using ExpectS = std::basic_string<char, std::char_traits<char>, test_allocator<char>>;
+    std::string_view sv("abc");
+    std::basic_string s(sv, test_allocator<char>{});
+    ASSERT_SAME_TYPE(decltype(s), ExpectS);
+    assert(s == "abc");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  using ExpectW = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
-  std::basic_string_view<wchar_t, constexpr_char_traits<wchar_t>> BSV(L"abcdef");
-  std::basic_string w(BSV, test_allocator<wchar_t>{});
-  ASSERT_SAME_TYPE(decltype(w), ExpectW);
-  assert(w == L"abcdef");
+    using ExpectW = std::basic_string<wchar_t, constexpr_char_traits<wchar_t>, test_allocator<wchar_t>>;
+    std::basic_string_view<wchar_t, constexpr_char_traits<wchar_t>> BSV(L"abcdef");
+    std::basic_string w(BSV, test_allocator<wchar_t>{});
+    ASSERT_SAME_TYPE(decltype(w), ExpectW);
+    assert(w == L"abcdef");
 #endif
-}
-{ // Testing (15) w/o allocator
-  std::string s0("abc");
-  std::basic_string s(s0, 1, 1);
-  ASSERT_SAME_TYPE(decltype(s), std::string);
-  assert(s == "b");
+  }
+  { // Testing (15) w/o allocator
+    std::string s0("abc");
+    std::basic_string s(s0, 1, 1);
+    ASSERT_SAME_TYPE(decltype(s), std::string);
+    assert(s == "b");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  std::wstring w0(L"abcdef");
-  std::basic_string w(w0, 2, 2);
-  ASSERT_SAME_TYPE(decltype(w), std::wstring);
-  assert(w == L"cd");
+    std::wstring w0(L"abcdef");
+    std::basic_string w(w0, 2, 2);
+    ASSERT_SAME_TYPE(decltype(w), std::wstring);
+    assert(w == L"cd");
 #endif
-}
-{ // Testing (15) w/ allocator
-  using ExpectS = std::basic_string<char, std::char_traits<char>, test_allocator<char>>;
-  ExpectS s0("abc");
-  std::basic_string s(s0, 1, 1, test_allocator<char>{4});
-  ASSERT_SAME_TYPE(decltype(s), ExpectS);
-  assert(s == "b");
+  }
+  { // Testing (15) w/ allocator
+    using ExpectS = std::basic_string<char, std::char_traits<char>, test_allocator<char>>;
+    ExpectS s0("abc");
+    std::basic_string s(s0, 1, 1, test_allocator<char>{4});
+    ASSERT_SAME_TYPE(decltype(s), ExpectS);
+    assert(s == "b");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-  using ExpectW = std::basic_string<wchar_t, std::char_traits<wchar_t>, test_allocator<wchar_t>>;
-  ExpectW w0(L"abcdef");
-  std::basic_string w(w0, 2, 2, test_allocator<wchar_t>{6});
-  ASSERT_SAME_TYPE(decltype(w), ExpectW);
-  assert(w == L"cd");
+    using ExpectW = std::basic_string<wchar_t, std::char_traits<wchar_t>, test_allocator<wchar_t>>;
+    ExpectW w0(L"abcdef");
+    std::basic_string w(w0, 2, 2, test_allocator<wchar_t>{6});
+    ASSERT_SAME_TYPE(decltype(w), ExpectW);
+    assert(w == L"cd");
 #endif
-}
+  }
 
-return true;
+  return true;
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/strings/string.view/string.view.cons/implicit_deduction_guides.pass.cpp
+++ b/libcxx/test/std/strings/string.view/string.view.cons/implicit_deduction_guides.pass.cpp
@@ -27,9 +27,10 @@
 // (4)  basic_string_view(const CharT*)
 int main(int, char**) {
   {
-      // Testing (1)
-      // Nothing to do. Cannot deduce without any arguments.
-  } { // Testing (2)
+    // Testing (1)
+    // Nothing to do. Cannot deduce without any arguments.
+  }
+  { // Testing (2)
     const std::string_view sin("abc");
     std::basic_string_view s(sin);
     ASSERT_SAME_TYPE(decltype(s), std::string_view);

--- a/libcxx/test/support/counting_projection.h
+++ b/libcxx/test/support/counting_projection.h
@@ -26,7 +26,7 @@ public:
   constexpr counting_projection(Proj proj, int& count) : proj_(std::move(proj)), count_(&count) {}
 
   template <class T>
-  constexpr decltype(auto) operator()(T&& value) const {
+  constexpr decltype(auto) operator()(T && value) const {
     ++(*count_);
     return std::invoke(proj_, std::forward<T>(value));
   }

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -26,7 +26,7 @@ env:
     # LLVM POST-BRANCH bump version
     # LLVM POST-BRANCH add compiler test for ToT - 1, e.g. "Clang 17"
     # LLVM RELEASE bump remove compiler ToT - 3, e.g. "Clang 15"
-    LLVM_STABLE_VERSION: "16" # Used for tooling, update after the RELEASE.
+    LLVM_STABLE_VERSION: "17" # Used for tooling, update after the RELEASE.
     LLVM_HEAD_VERSION: "18"   # Used compiler, update POST-BRANCH.
     GCC_STABLE_VERSION: "13"
 steps:

--- a/libcxx/utils/data/ignore_format.txt
+++ b/libcxx/utils/data/ignore_format.txt
@@ -5265,7 +5265,6 @@ libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/ba
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/ctor.default.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/ctor.outer_iterator.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/equal.pass.cpp
-libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/increment.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/iter_move.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/iter_swap.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/types.compile.pass.cpp
@@ -5275,11 +5274,8 @@ libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/ct
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/equal.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/types.compile.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.default.pass.cpp
-libcxx/test/std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/view_interface.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.lazy.split/types.h
-libcxx/test/std/ranges/range.adaptors/range.lazy.split/view_interface.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.reverse/adaptor.pass.cpp
-libcxx/test/std/ranges/range.adaptors/range.reverse/base.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.reverse/begin.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.reverse/borrowing.compile.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.reverse/ctad.compile.pass.cpp
@@ -5300,7 +5296,6 @@ libcxx/test/std/ranges/range.adaptors/range.take/ctad.compile.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.take/ctor.default.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.take/range_concept_conformance.compile.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.take/sentinel/ctor.pass.cpp
-libcxx/test/std/ranges/range.adaptors/range.take/sentinel/eq.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.take/size.pass.cpp
 libcxx/test/std/ranges/range.adaptors/range.take/types.h
 libcxx/test/std/ranges/range.adaptors/range.take.while/adaptor.pass.cpp
@@ -5357,7 +5352,6 @@ libcxx/test/std/ranges/range.factories/range.iota.view/iterator/ctor.value.pass.
 libcxx/test/std/ranges/range.factories/range.iota.view/iterator/decrement.pass.cpp
 libcxx/test/std/ranges/range.factories/range.iota.view/iterator/increment.pass.cpp
 libcxx/test/std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass.cpp
-libcxx/test/std/ranges/range.factories/range.iota.view/iterator/minus.pass.cpp
 libcxx/test/std/ranges/range.factories/range.iota.view/iterator/star.pass.cpp
 libcxx/test/std/ranges/range.factories/range.iota.view/iterator/subscript.pass.cpp
 libcxx/test/std/ranges/range.factories/range.iota.view/range_concept_conformance.compile.pass.cpp


### PR DESCRIPTION
This updates the clang-format we use in libc++ to 17. This is necessary to start running the generated-files checks in GitHub Actions (in #68920). In fact this is a pre-existing issue regardless of #68920 -- right now our ignore_format.txt job disagrees with the LLVM-wide clang-format job.