### PR TITLE
[mlir][nvvm] Fix circular dependency in

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h"
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Support/LogicalResult.h"
 
 #define DEBUG_TYPE "ptx-builder"
@@ -27,6 +26,8 @@
 
 using namespace mlir;
 using namespace NVVM;
+
+static constexpr int64_t kSharedMemorySpace = 3;
 
 static char getRegisterType(Type type) {
   if (type.isInteger(1))
@@ -43,7 +44,7 @@ static char getRegisterType(Type type) {
     return 'd';
   if (auto ptr = type.dyn_cast<LLVM::LLVMPointerType>()) {
     // Shared address spaces is addressed with 32-bit pointers.
-    if (ptr.getAddressSpace() == NVVM::kSharedMemorySpace) {
+    if (ptr.getAddressSpace() == kSharedMemorySpace) {
       return 'r';
     }
     return 'l';


### PR DESCRIPTION
BasicPtxBuilder includes NVVMDialect and vice versa. Cmake appereantly forgives that, but this causes bazel build fails. This PR aims to fix that