### PR TITLE
[HWASAN] Mark built-ins as not built-ins to prevent optimizations

### DIFF
--- a/compiler-rt/test/hwasan/TestCases/memcmp.cpp
+++ b/compiler-rt/test/hwasan/TestCases/memcmp.cpp
@@ -11,8 +11,8 @@
 int main(int argc, char **argv) {
   __hwasan_enable_allocator_tagging();
   char a[] = {static_cast<char>(argc), 2, 3, 4};
-  volatile int size = sizeof(a);
-  char *volatile p = (char *)malloc(size);
+  int size = sizeof(a);
+  char *p = (char *)malloc(size);
   memcpy(p, a, size);
   free(p);
   return memcmp(p, a, size);

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Analysis/GlobalsModRef.h"
 #include "llvm/Analysis/PostDominators.h"
 #include "llvm/Analysis/StackSafetyAnalysis.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/BinaryFormat/ELF.h"
@@ -52,6 +53,7 @@
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizerCommon.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Transforms/Utils/MemoryTaggingSupport.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include "llvm/Transforms/Utils/PromoteMemToReg.h"
@@ -320,7 +322,8 @@ private:
                            LoopInfo *LI);
   bool ignoreAccess(Instruction *Inst, Value *Ptr);
   void getInterestingMemoryOperands(
-      Instruction *I, SmallVectorImpl<InterestingMemoryOperand> &Interesting);
+      Instruction *I, const TargetLibraryInfo &TLI,
+      SmallVectorImpl<InterestingMemoryOperand> &Interesting);
 
   void tagAlloca(IRBuilder<> &IRB, AllocaInst *AI, Value *Tag, size_t Size);
   Value *tagPointer(IRBuilder<> &IRB, Type *Ty, Value *PtrLong, Value *Tag);
@@ -779,7 +782,8 @@ bool HWAddressSanitizer::ignoreAccess(Instruction *Inst, Value *Ptr) {
 }
 
 void HWAddressSanitizer::getInterestingMemoryOperands(
-    Instruction *I, SmallVectorImpl<InterestingMemoryOperand> &Interesting) {
+    Instruction *I, const TargetLibraryInfo &TLI,
+    SmallVectorImpl<InterestingMemoryOperand> &Interesting) {
   // Skip memory accesses inserted by another instrumentation.
   if (I->hasMetadata(LLVMContext::MD_nosanitize))
     return;
@@ -817,6 +821,7 @@ void HWAddressSanitizer::getInterestingMemoryOperands(
       Type *Ty = CI->getParamByValType(ArgNo);
       Interesting.emplace_back(I, ArgNo, false, Ty, Align(1));
     }
+    maybeMarkSanitizerLibraryCallNoBuiltin(CI, &TLI);
   }
 }
 
@@ -1493,6 +1498,7 @@ void HWAddressSanitizer::sanitizeFunction(Function &F,
   SmallVector<InterestingMemoryOperand, 16> OperandsToInstrument;
   SmallVector<MemIntrinsic *, 16> IntrinToInstrument;
   SmallVector<Instruction *, 8> LandingPadVec;
+  const TargetLibraryInfo &TLI = FAM.getResult<TargetLibraryAnalysis>(F);
 
   memtag::StackInfoBuilder SIB(SSI);
   for (auto &Inst : instructions(F)) {
@@ -1503,7 +1509,7 @@ void HWAddressSanitizer::sanitizeFunction(Function &F,
     if (InstrumentLandingPads && isa<LandingPadInst>(Inst))
       LandingPadVec.push_back(&Inst);
 
-    getInterestingMemoryOperands(&Inst, OperandsToInstrument);
+    getInterestingMemoryOperands(&Inst, TLI, OperandsToInstrument);
 
     if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(&Inst))
       if (!ignoreMemIntrinsic(MI))

--- a/llvm/test/Instrumentation/HWAddressSanitizer/str-nobuiltin.ll
+++ b/llvm/test/Instrumentation/HWAddressSanitizer/str-nobuiltin.ll
@@ -1,0 +1,33 @@
+; Test marking string functions as nobuiltin in address sanitizer.
+;
+; RUN: opt < %s -passes=asan -S | FileCheck %s
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare ptr @memchr(ptr %a, i32 %b, i64 %c)
+declare i32 @memcmp(ptr %a, ptr %b, i64 %c)
+declare i32 @strcmp(ptr %a, ptr %b)
+declare ptr @strcpy(ptr %a, ptr %b)
+declare ptr @stpcpy(ptr %a, ptr %b)
+declare i64 @strlen(ptr %a)
+declare i64 @strnlen(ptr %a, i64 %b)
+
+; CHECK: call{{.*}}@memchr{{.*}} #[[ATTR:[0-9]+]]
+; CHECK: call{{.*}}@memcmp{{.*}} #[[ATTR]]
+; CHECK: call{{.*}}@strcmp{{.*}} #[[ATTR]]
+; CHECK: call{{.*}}@strcpy{{.*}} #[[ATTR]]
+; CHECK: call{{.*}}@stpcpy{{.*}} #[[ATTR]]
+; CHECK: call{{.*}}@strlen{{.*}} #[[ATTR]]
+; CHECK: call{{.*}}@strnlen{{.*}} #[[ATTR]]
+; attributes #[[ATTR]] = { nobuiltin }
+
+define void @f1(ptr %a, ptr %b) nounwind uwtable sanitize_address {
+  tail call ptr @memchr(ptr %a, i32 1, i64 12)
+  tail call i32 @memcmp(ptr %a, ptr %b, i64 12)
+  tail call i32 @strcmp(ptr %a, ptr %b)
+  tail call ptr @strcpy(ptr %a, ptr %b)
+  tail call ptr @stpcpy(ptr %a, ptr %b)
+  tail call i64 @strlen(ptr %a)
+  tail call i64 @strnlen(ptr %a, i64 12)
+  ret void
+}

--- a/llvm/test/Instrumentation/HWAddressSanitizer/str-nobuiltin.ll
+++ b/llvm/test/Instrumentation/HWAddressSanitizer/str-nobuiltin.ll
@@ -1,6 +1,6 @@
 ; Test marking string functions as nobuiltin in address sanitizer.
 ;
-; RUN: opt < %s -passes=asan -S | FileCheck %s
+; RUN: opt < %s -passes=hwasan -S | FileCheck %s
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-unknown-linux-gnu"
 
@@ -21,7 +21,7 @@ declare i64 @strnlen(ptr %a, i64 %b)
 ; CHECK: call{{.*}}@strnlen{{.*}} #[[ATTR]]
 ; attributes #[[ATTR]] = { nobuiltin }
 
-define void @f1(ptr %a, ptr %b) nounwind uwtable sanitize_address {
+define void @f1(ptr %a, ptr %b) nounwind uwtable sanitize_hwaddress {
   tail call ptr @memchr(ptr %a, i32 1, i64 12)
   tail call i32 @memcmp(ptr %a, ptr %b, i64 12)
   tail call i32 @strcmp(ptr %a, ptr %b)


### PR DESCRIPTION
The other 3 sanitizers (ASAN, TSAN and MSAN) all use maybeMarkSanitizerLibraryCallNoBuiltin to make disable optimizations which inline functions like memcmp for example. The lack of this optimization was allowing ExpandMemCmpPass to convert a memcmp call to inlined assembly and cause a false negative in HWASAN. 