### PR TITLE
[mlir] Fix distinct attr mismatch error reporting

### DIFF
--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -1225,6 +1225,7 @@ Attribute Parser::parseStridedLayoutAttr() {
 ///                         `[` integer-literal `]<` attribute-value `>`
 ///
 Attribute Parser::parseDistinctAttr(Type type) {
+  SMLoc loc = getToken().getLoc();
   consumeToken(Token::kw_distinct);
   if (parseToken(Token::l_square, "expected '[' after 'distinct'"))
     return {};
@@ -1269,7 +1270,7 @@ Attribute Parser::parseDistinctAttr(Type type) {
     DistinctAttr distinctAttr = DistinctAttr::create(referencedAttr);
     it = distinctAttrs.try_emplace(*value, distinctAttr).first;
   } else if (it->getSecond().getReferencedAttr() != referencedAttr) {
-    emitError("referenced attribute does not match previous definition: ")
+    emitError(loc, "referenced attribute does not match previous definition: ")
         << it->getSecond().getReferencedAttr();
     return {};
   }

--- a/mlir/test/IR/invalid-builtin-attributes.mlir
+++ b/mlir/test/IR/invalid-builtin-attributes.mlir
@@ -587,3 +587,5 @@ func.func @duplicate_dictionary_attr_key() {
 #attr = distinct[0]<42 : i32>
 // expected-error@below {{referenced attribute does not match previous definition: 42 : i32}}
 #attr1 = distinct[0]<43 : i32>
+
+// -----


### PR DESCRIPTION
Previously the error reported location would not be where expected. E.g., it would fail in the existing test if it wasn't the last in the file.