### PR TITLE
[BOLT][RISCV] Recognize mapping syms with encoded ISA

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1803,6 +1803,10 @@ MarkerSymType BinaryContext::getMarkerType(const SymbolRef &Symbol) const {
   if (*NameOrError == "$x" || NameOrError->startswith("$x."))
     return MarkerSymType::CODE;
 
+  // $x<ISA>
+  if (isRISCV() && NameOrError->startswith("$x"))
+    return MarkerSymType::CODE;
+
   if (*NameOrError == "$d" || NameOrError->startswith("$d."))
     return MarkerSymType::DATA;
 

--- a/bolt/test/RISCV/Inputs/mapping-syms-isa.yaml
+++ b/bolt/test/RISCV/Inputs/mapping-syms-isa.yaml
@@ -1,0 +1,47 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_RISCV
+  Flags:           [ EF_RISCV_RVC, EF_RISCV_FLOAT_ABI_DOUBLE ]
+  Entry:           0x100B0
+ProgramHeaders:
+  - Type:            0x70000003
+    Flags:           [ PF_R ]
+    FirstSec:        .riscv.attributes
+    LastSec:         .riscv.attributes
+    Offset:          0xB8
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    FirstSec:        .text
+    LastSec:         .text
+    VAddr:           0x10000
+    Align:           0x1000
+    Offset:          0x0
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x100B0
+    AddressAlign:    0x2
+    Content:         '0100000000008280'
+  - Name:            .riscv.attributes
+    Type:            SHT_RISCV_ATTRIBUTES
+    AddressAlign:    0x1
+    Content:         4144000000726973637600013A0000000572763634693270315F6D3270305F613270315F663270325F643270325F633270305F7A696373723270305F7A6D6D756C31703000
+Symbols:
+  - Name:            '_start'
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Value:           0x100B0
+  - Name:            '$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zmmul1p0'
+    Section:         .text
+    Value:           0x100B0
+  - Name:            '$d'
+    Section:         .text
+    Value:           0x100B2
+  - Name:            '$x'
+    Section:         .text
+    Value:           0x100B6
+...

--- a/bolt/test/RISCV/mapping-syms-isa.test
+++ b/bolt/test/RISCV/mapping-syms-isa.test
@@ -1,0 +1,18 @@
+# Test that BOLT handles mapping syms that include ISA strings: $x<isa>
+
+RUN: yaml2obj -o %t %p/Inputs/mapping-syms-isa.yaml
+RUN: llvm-bolt --print-cfg --print-only=_start -o %t.bolt %t 2>&1 | FileCheck %s
+RUN: llvm-objdump -d %t.bolt | FileCheck --check-prefix=CHECK-OBJDUMP %s
+
+CHECK-NOT: BOLT-WARNING
+
+# Check that .word is not disassembled by BOLT
+CHECK: 00000000: nop
+CHECK: 00000002: ret
+
+# Check .word is still present in output
+CHECK-OBJDUMP: <_start>:
+CHECK-OBJDUMP-NEXT: nop
+CHECK-OBJDUMP-NEXT: unimp
+CHECK-OBJDUMP-NEXT: unimp
+CHECK-OBJDUMP-NEXT: ret


### PR DESCRIPTION
RISC-V supports mapping syms for code that encode the exact ISA for which the code is valid. They have the form `$x<ISA>` where `<ISA>` is the textual encoding of an ISA specification.

BOLT currently doesn't recognize these mapping symbols causing many binaries compiled with newer versions of GCC (which emits them) to not be properly processed. This patch makes sure BOLT recognizes them as code markers.

Note that LLVM does not emit these kinds of mapping symbols yet so the test is based on a binary produced by GCC.