### PR TITLE
[Clang] Fill in documentation gaps for some attributes

### DIFF
--- a/llvm/docs/BitCodeFormat.rst
+++ b/llvm/docs/BitCodeFormat.rst
@@ -1085,6 +1085,14 @@ The integer codes are mapped to well-known attributes as follows.
 * code 77: ``elementtype``
 * code 78: ``disable_sanitizer_instrumentation``
 * code 79: ``nosanitize_bounds``
+* code 80: ``allocalign``
+* code 81: ``allocptr``
+* code 82: ``allockind``
+* code 83: ``presplitcoroutine``
+* code 84: ``fn_ret_thunk_extern``
+* code 85: ``skipprofile``
+* code 86: ``memory``
+* code 87: ``nofpclass``
 
 .. note::
   The ``allocsize`` attribute has a special encoding for its arguments. Its two

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1872,6 +1872,7 @@ example:
     passes make choices that keep the code size of this function as small
     as possible and perform optimizations that may sacrifice runtime
     performance in order to minimize the size of the generated code.
+    This attribute is incompatible with the ``optnone`` attribute.
 ``naked``
     This attribute disables prologue / epilogue emission for the
     function. This can have very system-specific consequences.
@@ -2044,6 +2045,7 @@ example:
     passes make choices that keep the code size of this function low,
     and otherwise do optimizations specifically to reduce code size as
     long as they do not significantly impact runtime performance.
+    This attribute is incompatible with the ``optnone`` attribute.
 ``"patchable-function"``
     This attribute tells the code generator that the code
     generated for this function needs to follow certain conventions that


### PR DESCRIPTION
This patch adds some missing documentation for some attributes in BitCodeFormat, where the integer code mappings for attributes after code 79 were not listed, and in LangRef where the incompatibility between minsize/optsize and optnone was not mentioned.