### PR TITLE
[lldb][test] Temporarily disable TestQueueFromStdModule.py

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 class TestQueue(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(compiler="clang", compiler_version=[">", "16.0"], bugnumber="https://github.com/llvm/llvm-project/issues/68968")
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
@@ -10,7 +10,11 @@ from lldbsuite.test import lldbutil
 class TestQueue(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
-    @skipIf(compiler="clang", compiler_version=[">", "16.0"], bugnumber="https://github.com/llvm/llvm-project/issues/68968")
+    @skipIf(
+        compiler="clang",
+        compiler_version=[">", "16.0"],
+        bugnumber="https://github.com/llvm/llvm-project/issues/68968",
+    )
     def test(self):
         self.build()
 


### PR DESCRIPTION
Started failing since D101206, but root-cause is unclear. It's definitely not an issue with th libc++ patch itself however. So disable the test until we know what's going on.