### PR TITLE
[mlir][test] Update tests to use vector.print str (NFC)

### DIFF
--- a/mlir/test/Integration/Dialect/Arith/CPU/test-wide-int-emulation-compare-results-i16.mlir
+++ b/mlir/test/Integration/Dialect/Arith/CPU/test-wide-int-emulation-compare-results-i16.mlir
@@ -15,18 +15,6 @@
 // Common Utility Functions
 //===----------------------------------------------------------------------===//
 
-llvm.mlir.global internal constant @str_mismatch("Mismatch\0A")
-func.func private @printCString(!llvm.ptr<i8>) -> ()
-// Prints 'Mismatch' to stdout.
-func.func @printMismatch() -> () {
-  %0 = llvm.mlir.addressof @str_mismatch : !llvm.ptr<array<9 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<9 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  func.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 // Prints both binary op operands and the first result. If the second result
 // does not match, prints the second result and a 'Mismatch' message.
 func.func @check_results(%lhs : i16, %rhs : i16, %res0 : i16, %res1 : i16) -> () {
@@ -38,7 +26,7 @@ func.func @check_results(%lhs : i16, %rhs : i16, %res0 : i16, %res1 : i16) -> ()
   %mismatch = arith.cmpi ne, %res0, %res1 : i16
   scf.if %mismatch -> () {
     vector.print %res1 : i16
-    func.call @printMismatch() : () -> ()
+    vector.print str "Mismatch"
   }
   return
 }

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/fill-2d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSME/fill-2d.mlir
@@ -13,15 +13,6 @@
 // RUN:   -shared-libs=%mlir_runner_utils,%mlir_c_runner_utils | \
 // RUN: FileCheck %s
 
-func.func @printTestEnd() {
-  %0 = llvm.mlir.addressof @str_sme_end : !llvm.ptr<array<24 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<24 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 func.func @entry() {
   %c0 = arith.constant 0 : index
   %c4 = arith.constant 4 : index
@@ -104,7 +95,7 @@ func.func @entry() {
   }
 
   // CHECK: SME: END OF TEST OUTPUT
-  func.call @printTestEnd() : () -> ()
+  vector.print str "SME: END OF TEST OUTPUT"
 
   return
 }
@@ -114,6 +105,3 @@ transform.sequence failures(propagate) {
   %0 = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!transform.any_op) -> !transform.any_op
   transform.structured.vectorize %0 vector_sizes [[4], [4]] : !transform.any_op
 }
-
-llvm.func @printCString(!llvm.ptr<i8>)
-llvm.mlir.global internal constant @str_sme_end("SME: END OF TEST OUTPUT\0A")

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/fill-1d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/fill-1d.mlir
@@ -2,15 +2,6 @@
 // RUN: %mcr_aarch64_cmd -e=entry -entry-point-result=void --march=aarch64 --mattr="+sve" -shared-libs=%mlir_runner_utils,%mlir_c_runner_utils | \
 // RUN: FileCheck %s
 
-func.func @printTestEnd() {
-  %0 = llvm.mlir.addressof @str_sve_end : !llvm.ptr<array<24 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<24 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 func.func @entry() {
   %c4 = arith.constant 4 : index
   %c0 = arith.constant 0 : index
@@ -41,7 +32,7 @@ func.func @entry() {
   }
 
   // CHECK: SVE: END OF TEST OUTPUT
-  func.call @printTestEnd() : () -> ()
+  vector.print str "SVE: END OF TEST OUTPUT"
 
   return
 }
@@ -51,6 +42,3 @@ transform.sequence failures(propagate) {
   %0 = transform.structured.match ops{["linalg.fill"]} in %arg1 : (!transform.any_op) -> !transform.any_op
   transform.structured.vectorize %0 vector_sizes [[4]] : !transform.any_op
 }
-
-llvm.func @printCString(!llvm.ptr<i8>)
-llvm.mlir.global internal constant @str_sve_end("SVE: END OF TEST OUTPUT\0A")

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-store-128-bit-tile.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/load-store-128-bit-tile.mlir
@@ -29,16 +29,6 @@ func.func @print_i8s(%bytes: memref<?xi8>, %len: index) {
   return
 }
 
-llvm.func @printCString(!llvm.ptr<i8>)
-
-func.func @print_str(%str: !llvm.ptr<array<17 x i8>>) {
-  %c0 = llvm.mlir.constant(0 : index) : i64
-  %str_bytes = llvm.getelementptr %str[%c0, %c0]
-    : (!llvm.ptr<array<17 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%str_bytes) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 func.func @vector_copy_i128(%src: memref<?x?xi128>, %dst: memref<?x?xi128>) {
   %c0 = arith.constant 0 : index
   %tile = vector.load %src[%c0, %c0] : memref<?x?xi128>, vector<[1]x[1]xi128>
@@ -80,13 +70,13 @@ func.func @test_load_store_zaq0() {
 
   // CHECK-LABEL: INITIAL TILE A:
   // CHECK: ( 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7 )
-  func.call @print_str(%init_a_str) : (!llvm.ptr<array<17 x i8>>) -> ()
+  vector.print str "INITIAL TILE A:"
   func.call @print_i8s(%tile_a_bytes, %zaq_size_bytes) : (memref<?xi8>, index) -> ()
   vector.print punctuation <newline>
 
   // CHECK-LABEL: INITIAL TILE B:
   // CHECK: ( 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64 )
-  func.call @print_str(%init_b_str) : (!llvm.ptr<array<17 x i8>>) -> ()
+  vector.print str "INITIAL TILE B:"
   func.call @print_i8s(%tile_b_bytes, %zaq_size_bytes) : (memref<?xi8>, index) -> ()
   vector.print punctuation <newline>
 
@@ -95,19 +85,14 @@ func.func @test_load_store_zaq0() {
 
   // CHECK-LABEL: FINAL TILE A:
   // CHECK: ( 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7 )
-  func.call @print_str(%final_a_str) : (!llvm.ptr<array<17 x i8>>) -> ()
+  vector.print str "FINAL TILE A:"
   func.call @print_i8s(%tile_a_bytes, %zaq_size_bytes) : (memref<?xi8>, index) -> ()
   vector.print punctuation <newline>
 
   // CHECK-LABEL: FINAL TILE B:
   // CHECK: ( 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7 )
-  func.call @print_str(%final_b_str) : (!llvm.ptr<array<17 x i8>>) -> ()
+  vector.print str "FINAL TILE B:"
   func.call @print_i8s(%tile_b_bytes, %zaq_size_bytes) : (memref<?xi8>, index) -> ()
 
   return
 }
-
-llvm.mlir.global internal constant @init_tile_a ("INITIAL TILE A:\0A\00")
-llvm.mlir.global internal constant @init_tile_b ("INITIAL TILE B:\0A\00")
-llvm.mlir.global internal constant @final_tile_a("  FINAL TILE A:\0A\00")
-llvm.mlir.global internal constant @final_tile_b("  FINAL TILE B:\0A\00")

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-outerproduct-f32.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-outerproduct-f32.mlir
@@ -14,26 +14,6 @@
 // REDEFINE: %{entry_point} = test_outerproduct_with_accumulator_4x4xf32
 // RUN: %{compile} | %{run} | FileCheck %s --check-prefix=WITH-ACC
 
-llvm.func @printCString(!llvm.ptr<i8>)
-
-func.func @printTileBegin() attributes { enable_arm_streaming_ignore } {
-  %0 = llvm.mlir.addressof @str_tile_begin : !llvm.ptr<array<11 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<11 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
-func.func @printTileEnd() attributes { enable_arm_streaming_ignore } {
-  %0 = llvm.mlir.addressof @str_tile_end : !llvm.ptr<array<9 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<9 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 func.func @test_outerproduct_no_accumulator_4x4xf32() {
   %c0 = arith.constant 0 : index
 
@@ -50,9 +30,9 @@ func.func @test_outerproduct_no_accumulator_4x4xf32() {
   // WITHOUT-ACC-NEXT: ( 0, 2, 4, 6
   // WITHOUT-ACC-NEXT: ( 0, 3, 6, 9
   // WITHOUT-ACC:      TILE END
-  func.call @printTileBegin() : () -> ()
+  vector.print str "TILE BEGIN"
   vector.print %tile : vector<[4]x[4]xf32>
-  func.call @printTileEnd() : () -> ()
+  vector.print str "TILE END"
 
   return
 }
@@ -75,12 +55,9 @@ func.func @test_outerproduct_with_accumulator_4x4xf32() {
   // WITH-ACC-NEXT: ( 10, 12, 14, 16
   // WITH-ACC-NEXT: ( 10, 13, 16, 19
   // WITH-ACC:      TILE END
-  func.call @printTileBegin() : () -> ()
+  vector.print str "TILE BEGIN"
   vector.print %tile : vector<[4]x[4]xf32>
-  func.call @printTileEnd() : () -> ()
+  vector.print str "TILE END"
 
   return
 }
-
-llvm.mlir.global internal constant @str_tile_begin("TILE BEGIN\0A")
-llvm.mlir.global internal constant @str_tile_end("TILE END\0A")

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-outerproduct-f64.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-outerproduct-f64.mlir
@@ -11,26 +11,6 @@
 
 // RUN: %{compile} | %{run} | FileCheck %s
 
-llvm.func @printCString(!llvm.ptr<i8>)
-
-func.func @printTileBegin() attributes { enable_arm_streaming_ignore } {
-  %0 = llvm.mlir.addressof @str_tile_begin : !llvm.ptr<array<11 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<11 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
-func.func @printTileEnd() attributes { enable_arm_streaming_ignore } {
-  %0 = llvm.mlir.addressof @str_tile_end : !llvm.ptr<array<9 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<9 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 func.func @test_outerproduct_with_accumulator_2x2xf64() {
   %f1 = arith.constant 1.0 : f64
   %f2 = arith.constant 2.0 : f64
@@ -50,12 +30,9 @@ func.func @test_outerproduct_with_accumulator_2x2xf64() {
   // CHECK-NEXT: ( 12, 12
   // CHECK-NEXT: ( 12, 12
   // CHECK:      TILE END
-  func.call @printTileBegin() : () -> ()
+  vector.print str "TILE BEGIN"
   vector.print %tile : vector<[2]x[2]xf64>
-  func.call @printTileEnd() : () -> ()
+  vector.print str "TILE END"
 
   return
 }
-
-llvm.mlir.global internal constant @str_tile_begin("TILE BEGIN\0A")
-llvm.mlir.global internal constant @str_tile_end("TILE END\0A")

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-transpose.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-transpose.mlir
@@ -11,26 +11,6 @@
 
 // RUN: %{compile} | %{run} | FileCheck %s
 
-llvm.func @printCString(!llvm.ptr<i8>)
-
-func.func @printTileBegin() attributes { enable_arm_streaming_ignore }  {
-  %0 = llvm.mlir.addressof @str_tile_begin : !llvm.ptr<array<11 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<11 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
-func.func @printTileEnd() attributes { enable_arm_streaming_ignore } {
-  %0 = llvm.mlir.addressof @str_tile_end : !llvm.ptr<array<9 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<9 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 func.func @entry() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -77,9 +57,9 @@ func.func @entry() {
   // CHECK-NEXT: ( 2, 2, 2, 2
   // CHECK-NEXT: ( 3, 3, 3, 3
   // CHECK:      TILE END
-  func.call @printTileBegin() : () -> ()
+  vector.print str "TILE BEGIN"
   vector.print %tile : vector<[4]x[4]xi32>
-  func.call @printTileEnd() : () -> ()
+  vector.print str "TILE END"
 
   // Dump the transposed tile. The smallest SVL is 128-bits so the tile will be
   // at least 4x4xi32.
@@ -90,12 +70,9 @@ func.func @entry() {
   // CHECK-NEXT: ( 0, 1, 2, 3
   // CHECK-NEXT: ( 0, 1, 2, 3
   // CHECK:      TILE END
-  func.call @printTileBegin() : () -> ()
+  vector.print str "TILE BEGIN"
   vector.print %transposed_tile : vector<[4]x[4]xi32>
-  func.call @printTileEnd() : () -> ()
+  vector.print str "TILE END"
 
   return
 }
-
-llvm.mlir.global internal constant @str_tile_begin("TILE BEGIN\0A")
-llvm.mlir.global internal constant @str_tile_end("TILE END\0A")

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/tile_fill.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/tile_fill.mlir
@@ -11,26 +11,6 @@
 // Integration test demonstrating filling a 32-bit element ZA tile with a
 // non-zero constant via vector to tile (MOVA) ops.
 
-llvm.func @printCString(!llvm.ptr<i8>)
-
-func.func @printTileBegin() attributes { enable_arm_streaming_ignore } {
-  %0 = llvm.mlir.addressof @str_tile_begin : !llvm.ptr<array<11 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<11 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
-func.func @printTileEnd() attributes { enable_arm_streaming_ignore } {
-  %0 = llvm.mlir.addressof @str_tile_end : !llvm.ptr<array<9 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<9 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 func.func @entry() -> i32 {
   // Fill a tile with '123'. This will get lowered to a 1-d vector splat of
   // '123' and a loop that writes this vector to each tile slice in the ZA
@@ -46,13 +26,10 @@ func.func @entry() -> i32 {
   // CHECK-NEXT: ( 123, 123, 123, 123
   // CHECK-NEXT: ( 123, 123, 123, 123
   // CHECK:      TILE END
-  func.call @printTileBegin() : () -> ()
+  vector.print str "TILE BEGIN"
   vector.print %tile : vector<[4]x[4]xi32>
-  func.call @printTileEnd() : () -> ()
+  vector.print str "TILE END"
 
   %c0_i32 = arith.constant 0 : i32
   return %c0_i32 : i32
 }
-
-llvm.mlir.global internal constant @str_tile_begin("TILE BEGIN\0A")
-llvm.mlir.global internal constant @str_tile_end("TILE END\0A")

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/vector-load-store.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/vector-load-store.mlir
@@ -16,8 +16,6 @@
 
 // Integration tests demonstrating load/store to/from SME ZA tile.
 
-llvm.func @printCString(!llvm.ptr<i8>)
-
 // This test verifies a 64-bit element ZA with FP64 data is correctly
 // loaded/stored to/from memory.
 func.func @za0_d_f64() -> i32 {
@@ -160,24 +158,6 @@ func.func @za0_d_f64() -> i32 {
   return %c0_i32 : i32
 }
 
-func.func @printTileBegin() {
-  %0 = llvm.mlir.addressof @str_tile_begin : !llvm.ptr<array<11 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<11 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
-func.func @printTileEnd() {
-  %0 = llvm.mlir.addressof @str_tile_end : !llvm.ptr<array<9 x i8>>
-  %1 = llvm.mlir.constant(0 : index) : i64
-  %2 = llvm.getelementptr %0[%1, %1]
-    : (!llvm.ptr<array<9 x i8>>, i64, i64) -> !llvm.ptr<i8>
-  llvm.call @printCString(%2) : (!llvm.ptr<i8>) -> ()
-  return
-}
-
 // This test loads two 32-bit element ZA tiles from memory and stores them back
 // to memory in reverse order. This verifies the memref indices for the vector
 // load and store are correctly preserved since the second tile is offset from
@@ -285,7 +265,7 @@ func.func @load_store_two_za_s_tiles() -> i32 {
   // CHECK-NEXT: ( 1, 1, 1, 1
   // CHECK-NEXT: ( 1, 1, 1, 1
   // CHECK:      TILE END
-  func.call @printTileBegin() : () -> ()
+  vector.print str "TILE BEGIN"
   scf.for %i = %c0 to %size_of_two_tiles step %svl_s {
     %av = vector.load %mem2[%i] : memref<?xi32>, vector<[4]xi32>
     vector.print %av : vector<[4]xi32>
@@ -293,14 +273,12 @@ func.func @load_store_two_za_s_tiles() -> i32 {
     %tileSizeMinusStep = arith.subi %size_of_tile, %svl_s : index
     %isNextTile = arith.cmpi eq, %i, %tileSizeMinusStep : index
     scf.if %isNextTile {
-      func.call @printTileEnd() : () -> ()
-      func.call @printTileBegin() : () -> ()
+      vector.print str "TILE END"
+      vector.print str "TILE BEGIN"
     }
   }
-  func.call @printTileEnd() : () -> ()
+  vector.print str "TILE END"
 
   return %c0_i32 : i32
 }
 
-llvm.mlir.global internal constant @str_tile_begin("TILE BEGIN\0A")
-llvm.mlir.global internal constant @str_tile_end("TILE END\0A")


### PR DESCRIPTION
This cuts down on a fair amount of boilerplate.

Depends on: #68695