### PR TITLE
[BOLT][RISCV] Don't create function entry points for unnamed symbols

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1582,6 +1582,12 @@ void RewriteInstance::adjustFunctionBoundaries() {
       if (!Function.isSymbolValidInScope(Symbol, SymbolSize))
         break;
 
+      // Ignore unnamed symbols. Used, for example, by debugging info on RISC-V.
+      if (cantFail(Symbol.getName()).empty()) {
+        ++NextSymRefI;
+        continue;
+      }
+
       // Skip basic block labels. This happens on RISC-V with linker relaxation
       // enabled because every branch needs a relocation and corresponding
       // symbol. We don't want to add such symbols as entry points.

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1583,7 +1583,7 @@ void RewriteInstance::adjustFunctionBoundaries() {
         break;
 
       // Ignore unnamed symbols. Used, for example, by debugging info on RISC-V.
-      if (cantFail(Symbol.getName()).empty()) {
+      if (BC->isRISCV() && cantFail(Symbol.getName()).empty()) {
         ++NextSymRefI;
         continue;
       }

--- a/bolt/test/RISCV/unnamed-sym-no-entry.c
+++ b/bolt/test/RISCV/unnamed-sym-no-entry.c
@@ -1,0 +1,16 @@
+/// Verify that unnamed symbols are not added as function entry points. Such
+/// symbols are used by relocations in debugging sections.
+
+// RUN: %clang %cflags -g -Wl,-q -o %t %s
+
+/// Verify that the binary indeed contains an unnamed symbol at _start
+// RUN: llvm-readelf -s %t | FileCheck %s --check-prefix=CHECK-ELF
+// CHECK-ELF-DAG: [[#%x,START:]] {{.*}} FUNC GLOBAL DEFAULT [[#%d,SECTION:]] _start{{$}}
+// CHECK-ELF-DAG: [[#%x,START]] {{.*}} NOTYPE LOCAL DEFAULT [[#SECTION]] {{$}}
+
+/// Verify that BOLT did not create an extra entry point for the unnamed symbol
+// RUN: llvm-bolt -o %t.bolt %t --print-cfg | FileCheck %s
+// CHECK: Binary Function "_start" after building cfg {
+// CHECK:  IsMultiEntry: 0
+
+void _start() {}

--- a/bolt/test/RISCV/unnamed-sym-no-entry.c
+++ b/bolt/test/RISCV/unnamed-sym-no-entry.c
@@ -1,6 +1,8 @@
 /// Verify that unnamed symbols are not added as function entry points. Such
 /// symbols are used by relocations in debugging sections.
 
+// clang-format off
+
 // RUN: %clang %cflags -g -Wl,-q -o %t %s
 
 /// Verify that the binary indeed contains an unnamed symbol at _start


### PR DESCRIPTION
Unnamed symbols are used, for example, for debug info related relocations on RISC-V.