### PR TITLE
[BOLT] Fix reorder data test for RISC-V

### DIFF
--- a/bolt/test/reorder-data-writable-ptload.c
+++ b/bolt/test/reorder-data-writable-ptload.c
@@ -1,7 +1,8 @@
 // This test checks that reorder-data pass puts new hot .data section
 // to the writable segment.
 
-// RUN: %clang %cflags -O3 -nostdlib -Wl,-q %s -o %t.exe
+// RUN: %clang %cflags %if target=riscv64{{.*}} %{ -msmall-data-limit=0 %} \
+// RUN:     -O3 -nostdlib -Wl,-q %s -o %t.exe
 // RUN: llvm-bolt %t.exe -o %t.bolt --reorder-data=".data" \
 // RUN:   -data %S/Inputs/reorder-data-writable-ptload.fdata
 // RUN: llvm-readelf -SlW %t.bolt | FileCheck %s

--- a/bolt/test/reorder-data-writable-ptload.c
+++ b/bolt/test/reorder-data-writable-ptload.c
@@ -1,8 +1,9 @@
 // This test checks that reorder-data pass puts new hot .data section
 // to the writable segment.
 
-// RUN: %clang %cflags %if target=riscv64{{.*}} %{ -msmall-data-limit=0 %} \
-// RUN:     -O3 -nostdlib -Wl,-q %s -o %t.exe
+// Use -fPIC -pie to prevent the globals being put in .sdata instead of .data on
+// RISC-V.
+// RUN: %clang %cflags -fPIC -pie -O3 -nostdlib -Wl,-q %s -o %t.exe
 // RUN: llvm-bolt %t.exe -o %t.bolt --reorder-data=".data" \
 // RUN:   -data %S/Inputs/reorder-data-writable-ptload.fdata
 // RUN: llvm-readelf -SlW %t.bolt | FileCheck %s


### PR DESCRIPTION
On RISC-V, small data objects are put in the `.sdata` section by default. This causes the `reorder-data-writable-ptload.c` test to fail since it hard-codes the section to optimize to `.data`.

This patch passes the `-fPIC -pie` flags to clang to ensure the objects are added to `.data` on RISC-V.