### PR TITLE
[BOLT][RISCV] Handle EH_LABEL operands

### DIFF
--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -292,6 +292,7 @@ public:
     default:
       return false;
     case RISCV::C_J:
+    case TargetOpcode::EH_LABEL:
       OpNum = 0;
       return true;
     case RISCV::AUIPC:


### PR DESCRIPTION
Fixes the `runtime/exceptions-no-pie.cpp` test on RISC-V.