### PR TITLE
[NFC] Allow fragment expressions in extractIfOffset

### DIFF
--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -1673,18 +1673,21 @@ bool DIExpression::extractIfOffset(int64_t &Offset) const {
     return false;
   auto SingleLocElts = *SingleLocEltsOpt;
 
-  if (SingleLocElts.size() == 0) {
+  unsigned FragmentOpsCount = isFragment() ? 3 : 0;
+
+  if (SingleLocElts.size() == FragmentOpsCount) {
     Offset = 0;
     return true;
   }
 
-  if (SingleLocElts.size() == 2 &&
+  if (SingleLocElts.size() == 2 + FragmentOpsCount &&
       SingleLocElts[0] == dwarf::DW_OP_plus_uconst) {
     Offset = SingleLocElts[1];
     return true;
   }
 
-  if (SingleLocElts.size() == 3 && SingleLocElts[0] == dwarf::DW_OP_constu) {
+  if (SingleLocElts.size() == 3 + FragmentOpsCount &&
+      SingleLocElts[0] == dwarf::DW_OP_constu) {
     if (SingleLocElts[2] == dwarf::DW_OP_plus) {
       Offset = SingleLocElts[1];
       return true;


### PR DESCRIPTION
A fragment is part of the variable identity and should be ignored for the purposes of checking whether the expression contains an offset.

This NFC patch is required for a subsequent change that addresses #61981.