### PR TITLE
[VPlan] Add initial anlysis to infer scalar type of VPValues.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/CMakeLists.txt
+++ b/llvm/lib/Transforms/Vectorize/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_component_library(LLVMVectorize
   Vectorize.cpp
   VectorCombine.cpp
   VPlan.cpp
+  VPlanAnalysis.cpp
   VPlanHCFGBuilder.cpp
   VPlanRecipes.cpp
   VPlanSLP.cpp

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -2709,8 +2709,7 @@ void InnerLoopVectorizer::scalarizeInstruction(const Instruction *Instr,
     // Verify that VPlan type inference results agree with the type of the
     // generated values.
     VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
-    assert(A.inferScalarType(RepRecipe->getVPSingleValue()) ==
-               Cloned->getType() &&
+    assert(A.inferScalarType(RepRecipe) == Cloned->getType() &&
            "inferred type and type from generated instructions do not match");
 #endif
   }

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -2711,7 +2711,7 @@ void InnerLoopVectorizer::scalarizeInstruction(const Instruction *Instr,
     VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
     assert(A.inferScalarType(RepRecipe->getVPSingleValue()) ==
                Cloned->getType() &&
-           "infered type and type from generated instructions do not match");
+           "inferred type and type from generated instructions do not match");
 #endif
   }
 

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -2708,8 +2708,7 @@ void InnerLoopVectorizer::scalarizeInstruction(const Instruction *Instr,
 #if !defined(NDEBUG)
     // Verify that VPlan type inference results agree with the type of the
     // generated values.
-    VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
-    assert(A.inferScalarType(RepRecipe) == Cloned->getType() &&
+    assert(State.TypeAnalysis.inferScalarType(RepRecipe) == Cloned->getType() &&
            "inferred type and type from generated instructions do not match");
 #endif
   }
@@ -7698,7 +7697,8 @@ SCEV2ValueTy LoopVectorizationPlanner::executePlan(
     VPlanTransforms::optimizeForVFAndUF(BestVPlan, BestVF, BestUF, PSE);
 
   // Perform the actual loop transformation.
-  VPTransformState State{BestVF, BestUF, LI, DT, ILV.Builder, &ILV, &BestVPlan};
+  VPTransformState State(BestVF, BestUF, LI, DT, ILV.Builder, &ILV, &BestVPlan,
+                         OrigLoop->getHeader()->getContext());
 
   // 0. Generate SCEV-dependent code into the preheader, including TripCount,
   // before making any changes to the CFG.

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1167,6 +1167,8 @@ public:
   /// Produce widened copies of all Ingredients.
   void execute(VPTransformState &State) override;
 
+  unsigned getOpcode() const { return Opcode; }
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void print(raw_ostream &O, const Twine &Indent,
@@ -1458,7 +1460,7 @@ public:
   bool isCanonical() const;
 
   /// Returns the scalar type of the induction.
-  const Type *getScalarType() const {
+  Type *getScalarType() const {
     return Trunc ? Trunc->getType() : IV->getType();
   }
 };
@@ -2080,7 +2082,7 @@ public:
 #endif
 
   /// Returns the scalar type of the induction.
-  const Type *getScalarType() const {
+  Type *getScalarType() const {
     return getOperand(0)->getLiveInIRValue()->getType();
   }
 
@@ -2149,7 +2151,7 @@ public:
 #endif
 
   /// Returns the scalar type of the induction.
-  const Type *getScalarType() const {
+  Type *getScalarType() const {
     return cast<VPCanonicalIVPHIRecipe>(getOperand(0)->getDefiningRecipe())
         ->getScalarType();
   }

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -2083,7 +2083,7 @@ public:
 
   /// Returns the scalar type of the induction.
   Type *getScalarType() const {
-    return getOperand(0)->getLiveInIRValue()->getType();
+    return getStartValue()->getLiveInIRValue()->getType();
   }
 
   /// Returns true if the recipe only uses the first lane of operand \p Op.
@@ -2151,7 +2151,7 @@ public:
 #endif
 
   /// Returns the scalar type of the induction.
-  Type *getScalarType() const {
+  const Type *getScalarType() const {
     return cast<VPCanonicalIVPHIRecipe>(getOperand(0)->getDefiningRecipe())
         ->getScalarType();
   }

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -2194,6 +2194,8 @@ public:
              VPSlotTracker &SlotTracker) const override;
 #endif
 
+  Type *getScalarType() const { return TruncResultTy; }
+
   VPValue *getStartValue() const { return getOperand(0); }
   VPValue *getCanonicalIV() const { return getOperand(1); }
   VPValue *getStepValue() const { return getOperand(2); }

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -2194,7 +2194,10 @@ public:
              VPSlotTracker &SlotTracker) const override;
 #endif
 
-  Type *getScalarType() const { return TruncResultTy; }
+  Type *getScalarType() const {
+    return TruncResultTy ? TruncResultTy
+                         : getStartValue()->getLiveInIRValue()->getType();
+  }
 
   VPValue *getStartValue() const { return getOperand(0); }
   VPValue *getCanonicalIV() const { return getOperand(1); }

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -23,6 +23,7 @@
 #ifndef LLVM_TRANSFORMS_VECTORIZE_VPLAN_H
 #define LLVM_TRANSFORMS_VECTORIZE_VPLAN_H
 
+#include "VPlanAnalysis.h"
 #include "VPlanValue.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
@@ -233,9 +234,9 @@ struct VPIteration {
 struct VPTransformState {
   VPTransformState(ElementCount VF, unsigned UF, LoopInfo *LI,
                    DominatorTree *DT, IRBuilderBase &Builder,
-                   InnerLoopVectorizer *ILV, VPlan *Plan)
+                   InnerLoopVectorizer *ILV, VPlan *Plan, LLVMContext &Ctx)
       : VF(VF), UF(UF), LI(LI), DT(DT), Builder(Builder), ILV(ILV), Plan(Plan),
-        LVer(nullptr) {}
+        LVer(nullptr), TypeAnalysis(Ctx) {}
 
   /// The chosen Vectorization and Unroll Factors of the loop being vectorized.
   ElementCount VF;
@@ -413,6 +414,9 @@ struct VPTransformState {
   /// Map SCEVs to their expanded values. Populated when executing
   /// VPExpandSCEVRecipes.
   DenseMap<const SCEV *, Value *> ExpandedSCEVs;
+
+  /// VPlan-based type analysis.
+  VPTypeAnalysis TypeAnalysis;
 };
 
 /// VPBlockBase is the building block of the Hierarchical Control-Flow Graph.

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -143,10 +143,6 @@ Type *VPTypeAnalysis::inferType(const VPReplicateRecipe *R) {
     return inferType(R->getOperand(0));
   case Instruction::Load:
     return cast<LoadInst>(R->getUnderlyingInstr())->getType();
-  case Instruction::Store:
-    return cast<StoreInst>(R->getUnderlyingInstr())
-        ->getValueOperand()
-        ->getType();
   default:
     llvm_unreachable("Unhandled instruction");
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -1,0 +1,225 @@
+//===- VPlanAnalysis.cpp - Various Analyses working on VPlan ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "VPlanAnalysis.h"
+#include "VPlan.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "vplan"
+
+Type *VPTypeAnalysis::inferType(const VPBlendRecipe *R) {
+  return inferType(R->getIncomingValue(0));
+}
+
+Type *VPTypeAnalysis::inferType(const VPInstruction *R) {
+  switch (R->getOpcode()) {
+  case Instruction::Select:
+    return inferType(R->getOperand(1));
+  case VPInstruction::FirstOrderRecurrenceSplice:
+    return inferType(R->getOperand(0));
+  default:
+    llvm_unreachable("Unhandled instruction!");
+  }
+}
+
+Type *VPTypeAnalysis::inferType(const VPInterleaveRecipe *R) { return nullptr; }
+
+Type *VPTypeAnalysis::inferType(const VPReductionPHIRecipe *R) {
+  return R->getOperand(0)->getLiveInIRValue()->getType();
+}
+
+Type *VPTypeAnalysis::inferType(const VPWidenRecipe *R) {
+  unsigned Opcode = R->getOpcode();
+  switch (Opcode) {
+  case Instruction::ICmp:
+  case Instruction::FCmp:
+    return IntegerType::get(Ctx, 1);
+  case Instruction::UDiv:
+  case Instruction::SDiv:
+  case Instruction::SRem:
+  case Instruction::URem:
+  case Instruction::Add:
+  case Instruction::FAdd:
+  case Instruction::Sub:
+  case Instruction::FSub:
+  case Instruction::FNeg:
+  case Instruction::Mul:
+  case Instruction::FMul:
+  case Instruction::FDiv:
+  case Instruction::FRem:
+  case Instruction::Shl:
+  case Instruction::LShr:
+  case Instruction::AShr:
+  case Instruction::And:
+  case Instruction::Or:
+  case Instruction::Xor: {
+    Type *ResTy = inferType(R->getOperand(0));
+    if (Opcode != Instruction::FNeg) {
+      assert(ResTy == inferType(R->getOperand(1)));
+      CachedTypes[R->getOperand(1)] = ResTy;
+    }
+    return ResTy;
+  }
+  case Instruction::Freeze:
+    return inferType(R->getOperand(0));
+  default:
+    // This instruction is not vectorized by simple widening.
+    //    LLVM_DEBUG(dbgs() << "LV: Found an unhandled instruction: " << I);
+    llvm_unreachable("Unhandled instruction!");
+  }
+
+  return nullptr;
+}
+
+Type *VPTypeAnalysis::inferType(const VPWidenCallRecipe *R) {
+  auto &CI = *cast<CallInst>(R->getUnderlyingInstr());
+  return CI.getType();
+}
+
+Type *VPTypeAnalysis::inferType(const VPWidenIntOrFpInductionRecipe *R) {
+  return R->getScalarType();
+}
+
+Type *VPTypeAnalysis::inferType(const VPWidenMemoryInstructionRecipe *R) {
+  if (R->isStore())
+    return cast<StoreInst>(&R->getIngredient())->getValueOperand()->getType();
+
+  return cast<LoadInst>(&R->getIngredient())->getType();
+}
+
+Type *VPTypeAnalysis::inferType(const VPWidenSelectRecipe *R) {
+  return inferType(R->getOperand(1));
+}
+
+Type *VPTypeAnalysis::inferType(const VPReplicateRecipe *R) {
+  switch (R->getUnderlyingInstr()->getOpcode()) {
+  case Instruction::Call: {
+    unsigned CallIdx = R->getNumOperands() - (R->isPredicated() ? 2 : 1);
+    return cast<Function>(R->getOperand(CallIdx)->getLiveInIRValue())
+        ->getReturnType();
+  }
+  case Instruction::UDiv:
+  case Instruction::SDiv:
+  case Instruction::SRem:
+  case Instruction::URem:
+  case Instruction::Add:
+  case Instruction::FAdd:
+  case Instruction::Sub:
+  case Instruction::FSub:
+  case Instruction::FNeg:
+  case Instruction::Mul:
+  case Instruction::FMul:
+  case Instruction::FDiv:
+  case Instruction::FRem:
+  case Instruction::Shl:
+  case Instruction::LShr:
+  case Instruction::AShr:
+  case Instruction::And:
+  case Instruction::Or:
+  case Instruction::Xor:
+  case Instruction::ICmp:
+  case Instruction::FCmp: {
+    Type *ResTy = inferType(R->getOperand(0));
+    assert(ResTy == inferType(R->getOperand(1)));
+    CachedTypes[R->getOperand(1)] = ResTy;
+    return ResTy;
+  }
+  case Instruction::Trunc:
+  case Instruction::SExt:
+  case Instruction::ZExt:
+  case Instruction::FPExt:
+  case Instruction::FPTrunc:
+    return R->getUnderlyingInstr()->getType();
+  case Instruction::ExtractValue: {
+    return R->getUnderlyingValue()->getType();
+  }
+  case Instruction::Freeze:
+    return inferType(R->getOperand(0));
+  case Instruction::Load:
+    return cast<LoadInst>(R->getUnderlyingInstr())->getType();
+  case Instruction::Store:
+    return cast<StoreInst>(R->getUnderlyingInstr())
+        ->getValueOperand()
+        ->getType();
+  default:
+    llvm_unreachable("Unhandled instruction");
+  }
+
+  return nullptr;
+}
+
+Type *VPTypeAnalysis::inferType(const VPValue *V) {
+  auto Iter = CachedTypes.find(V);
+  if (Iter != CachedTypes.end())
+    return Iter->second;
+
+  Type *ResultTy = nullptr;
+  if (V->isLiveIn())
+    ResultTy = V->getLiveInIRValue()->getType();
+  else {
+    const VPRecipeBase *Def = V->getDefiningRecipe();
+    switch (Def->getVPDefID()) {
+    case VPDef::VPBlendSC:
+      ResultTy = inferType(cast<VPBlendRecipe>(Def));
+      break;
+    case VPDef::VPCanonicalIVPHISC:
+      ResultTy = cast<VPCanonicalIVPHIRecipe>(Def)->getScalarType();
+      break;
+    case VPDef::VPFirstOrderRecurrencePHISC:
+      ResultTy = Def->getOperand(0)->getLiveInIRValue()->getType();
+      break;
+    case VPDef::VPInstructionSC:
+      ResultTy = inferType(cast<VPInstruction>(Def));
+      break;
+    case VPDef::VPInterleaveSC:
+      ResultTy = V->getUnderlyingValue()
+                     ->getType(); // inferType(cast<VPInterleaveRecipe>(Def));
+      break;
+    case VPDef::VPPredInstPHISC:
+      ResultTy = inferType(Def->getOperand(0));
+      break;
+    case VPDef::VPReductionPHISC:
+      ResultTy = inferType(cast<VPReductionPHIRecipe>(Def));
+      break;
+    case VPDef::VPReplicateSC:
+      ResultTy = inferType(cast<VPReplicateRecipe>(Def));
+      break;
+    case VPDef::VPScalarIVStepsSC:
+      return inferType(Def->getOperand(0));
+      break;
+    case VPDef::VPWidenSC:
+      ResultTy = inferType(cast<VPWidenRecipe>(Def));
+      break;
+    case VPDef::VPWidenPHISC:
+      return inferType(Def->getOperand(0));
+    case VPDef::VPWidenPointerInductionSC:
+      return inferType(Def->getOperand(0));
+    case VPDef::VPWidenCallSC:
+      ResultTy = inferType(cast<VPWidenCallRecipe>(Def));
+      break;
+    case VPDef::VPWidenCastSC:
+      ResultTy = cast<VPWidenCastRecipe>(Def)->getResultType();
+      break;
+    case VPDef::VPWidenGEPSC:
+      ResultTy = PointerType::get(Ctx, 0);
+      break;
+    case VPDef::VPWidenIntOrFpInductionSC:
+      ResultTy = inferType(cast<VPWidenIntOrFpInductionRecipe>(Def));
+      break;
+    case VPDef::VPWidenMemoryInstructionSC:
+      ResultTy = inferType(cast<VPWidenMemoryInstructionRecipe>(Def));
+      break;
+    case VPDef::VPWidenSelectSC:
+      ResultTy = inferType(cast<VPWidenSelectRecipe>(Def));
+      break;
+    }
+  }
+  CachedTypes[V] = ResultTy;
+  return ResultTy;
+}

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -172,40 +172,40 @@ Type *VPTypeAnalysis::inferScalarType(const VPValue *V) {
     case VPDef::VPFirstOrderRecurrencePHISC:
     case VPDef::VPReductionPHISC:
     case VPDef::VPWidenPointerInductionSC:
-    // Handle header phi recipes, except VPWienIntOrFpInduction which needs
-    // special handling due it being possibly truncated.
-    ResultTy = cast<VPHeaderPHIRecipe>(Def)
-                   ->getStartValue()
-                   ->getLiveInIRValue()
-                   ->getType();
-    break;
+      // Handle header phi recipes, except VPWienIntOrFpInduction which needs
+      // special handling due it being possibly truncated.
+      ResultTy = cast<VPHeaderPHIRecipe>(Def)
+                     ->getStartValue()
+                     ->getLiveInIRValue()
+                     ->getType();
+      break;
     case VPDef::VPWidenIntOrFpInductionSC:
-    ResultTy = cast<VPWidenIntOrFpInductionRecipe>(Def)->getScalarType();
-    break;
+      ResultTy = cast<VPWidenIntOrFpInductionRecipe>(Def)->getScalarType();
+      break;
     case VPDef::VPPredInstPHISC:
     case VPDef::VPScalarIVStepsSC:
     case VPDef::VPWidenPHISC:
-    ResultTy = inferScalarType(Def->getOperand(0));
-    break;
+      ResultTy = inferScalarType(Def->getOperand(0));
+      break;
     case VPDef::VPBlendSC:
-    ResultTy = inferScalarType(cast<VPBlendRecipe>(Def));
-    break;
+      ResultTy = inferScalarType(cast<VPBlendRecipe>(Def));
+      break;
     case VPDef::VPInstructionSC:
-    ResultTy = inferScalarType(cast<VPInstruction>(Def));
-    break;
+      ResultTy = inferScalarType(cast<VPInstruction>(Def));
+      break;
     case VPDef::VPInterleaveSC:
-    // TODO: Use info from interleave group.
-    ResultTy = V->getUnderlyingValue()->getType();
-    break;
+      // TODO: Use info from interleave group.
+      ResultTy = V->getUnderlyingValue()->getType();
+      break;
     case VPDef::VPReplicateSC:
-    ResultTy = inferScalarType(cast<VPReplicateRecipe>(Def));
-    break;
+      ResultTy = inferScalarType(cast<VPReplicateRecipe>(Def));
+      break;
     case VPDef::VPWidenSC:
-    ResultTy = inferScalarType(cast<VPWidenRecipe>(Def));
-    break;
+      ResultTy = inferScalarType(cast<VPWidenRecipe>(Def));
+      break;
     case VPDef::VPWidenCallSC:
-    ResultTy = inferScalarType(cast<VPWidenCallRecipe>(Def));
-    break;
+      ResultTy = inferScalarType(cast<VPWidenCallRecipe>(Def));
+      break;
     case VPDef::VPWidenCastSC:
       ResultTy = cast<VPWidenCastRecipe>(Def)->getResultType();
       break;

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -91,9 +91,7 @@ Type *VPTypeAnalysis::inferScalarType(const VPWidenCallRecipe *R) {
 }
 
 Type *VPTypeAnalysis::inferScalarType(const VPWidenMemoryInstructionRecipe *R) {
-  if (R->isStore())
-    return cast<StoreInst>(&R->getIngredient())->getValueOperand()->getType();
-
+  assert(!R->isStore() && "Store recipes should not define any values");
   return cast<LoadInst>(&R->getIngredient())->getType();
 }
 

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -80,7 +80,7 @@ Type *VPTypeAnalysis::inferScalarType(const VPWidenRecipe *R) {
     break;
   }
 
-  // Type inferrence not implemented for opcode.
+  // Type inference not implemented for opcode.
   LLVM_DEBUG(dbgs() << "LV: Found unhandled opcode: "
                     << Instruction::getOpcodeName(Opcode));
   llvm_unreachable("Unhandled opcode!");
@@ -194,8 +194,7 @@ Type *VPTypeAnalysis::inferScalarType(const VPValue *V) {
               })
           .Case<VPDerivedIVRecipe>([this](const VPDerivedIVRecipe *R) {
             // VPDerivedIV may truncate the IV to a specified scalar type or use
-            // the
-            // type of the first operand (the step).
+            // the type of the first operand (the start).
             Type *T = R->getScalarType();
             return T ? T : inferScalarType(R->getOperand(0));
           })

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -46,6 +46,11 @@ Type *VPTypeAnalysis::inferScalarTypeForRecipe(const VPInstruction *R) {
   default:
     break;
   }
+  // Type inference not implemented for opcode.
+  LLVM_DEBUG({
+    dbgs() << "LV: Found unhandled opcode for: ";
+    R->getVPSingleValue()->dump();
+  });
   llvm_unreachable("Unhandled opcode!");
 }
 
@@ -87,8 +92,10 @@ Type *VPTypeAnalysis::inferScalarTypeForRecipe(const VPWidenRecipe *R) {
   }
 
   // Type inference not implemented for opcode.
-  LLVM_DEBUG(dbgs() << "LV: Found unhandled opcode: "
-                    << Instruction::getOpcodeName(Opcode));
+  LLVM_DEBUG({
+    dbgs() << "LV: Found unhandled opcode for: ";
+    R->getVPSingleValue()->dump();
+  });
   llvm_unreachable("Unhandled opcode!");
 }
 
@@ -177,8 +184,12 @@ Type *VPTypeAnalysis::inferScalarTypeForRecipe(const VPReplicateRecipe *R) {
   default:
     break;
   }
-
-  llvm_unreachable("Unhandled instruction");
+  // Type inference not implemented for opcode.
+  LLVM_DEBUG({
+    dbgs() << "LV: Found unhandled opcode for: ";
+    R->getVPSingleValue()->dump();
+  });
+  llvm_unreachable("Unhandled opcode");
 }
 
 Type *VPTypeAnalysis::inferScalarType(const VPValue *V) {
@@ -195,6 +206,8 @@ Type *VPTypeAnalysis::inferScalarType(const VPValue *V) {
               [this](const auto *R) {
                 // Handle header phi recipes, except VPWienIntOrFpInduction
                 // which needs special handling due it being possibly truncated.
+                // TODO: consider inferring/caching type of siblings, e.g.,
+                // backedge value, here and in cases below.
                 return inferScalarType(R->getStartValue());
               })
           .Case<VPWidenIntOrFpInductionRecipe, VPDerivedIVRecipe>(

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -1,0 +1,56 @@
+//===- VPlanAnalysis.h - Various Analyses working on VPlan ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORMS_VECTORIZE_VPLANANALYSIS_H
+#define LLVM_TRANSFORMS_VECTORIZE_VPLANANALYSIS_H
+
+#include "llvm/ADT/DenseMap.h"
+
+namespace llvm {
+
+class LLVMContext;
+class VPValue;
+class VPBlendRecipe;
+class VPInterleaveRecipe;
+class VPInstruction;
+class VPReductionPHIRecipe;
+class VPWidenRecipe;
+class VPWidenCallRecipe;
+class VPWidenCastRecipe;
+class VPWidenIntOrFpInductionRecipe;
+class VPWidenMemoryInstructionRecipe;
+struct VPWidenSelectRecipe;
+class VPReplicateRecipe;
+class Type;
+
+/// An analysis for type-inferrence for VPValues.
+class VPTypeAnalysis {
+  DenseMap<const VPValue *, Type *> CachedTypes;
+  LLVMContext &Ctx;
+
+  Type *inferType(const VPBlendRecipe *R);
+  Type *inferType(const VPInstruction *R);
+  Type *inferType(const VPInterleaveRecipe *R);
+  Type *inferType(const VPWidenCallRecipe *R);
+  Type *inferType(const VPReductionPHIRecipe *R);
+  Type *inferType(const VPWidenRecipe *R);
+  Type *inferType(const VPWidenIntOrFpInductionRecipe *R);
+  Type *inferType(const VPWidenMemoryInstructionRecipe *R);
+  Type *inferType(const VPWidenSelectRecipe *R);
+  Type *inferType(const VPReplicateRecipe *R);
+
+public:
+  VPTypeAnalysis(LLVMContext &Ctx) : Ctx(Ctx) {}
+
+  /// Infer the type of \p V. Returns the scalar type of \p V.
+  Type *inferType(const VPValue *V);
+};
+
+} // end namespace llvm
+
+#endif // LLVM_TRANSFORMS_VECTORIZE_VPLANANALYSIS_H

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -33,6 +33,9 @@ class Type;
 /// through defining recipes until root nodes with known types are reached (e.g.
 /// live-ins or memory recipes). The types are then propagated top down through
 /// operations.
+/// Note that the analysis caches the infered types. A new analysis object must
+/// be constructed once a VPlan has been modified in a way that invalidates any
+/// of the previously infered types.
 class VPTypeAnalysis {
   DenseMap<const VPValue *, Type *> CachedTypes;
   LLVMContext &Ctx;

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -29,26 +29,28 @@ class VPReplicateRecipe;
 class Type;
 
 /// An analysis for type-inference for VPValues.
+/// It infers the scalar type for a given VPValue by bottom-up traversing
+/// through defining recipes until root nodes with known types are reached (e.g.
+/// live-ins or memory recipes). The types are then propagated top down through
+/// operations.
 class VPTypeAnalysis {
   DenseMap<const VPValue *, Type *> CachedTypes;
   LLVMContext &Ctx;
 
-  Type *inferType(const VPBlendRecipe *R);
-  Type *inferType(const VPInstruction *R);
-  Type *inferType(const VPInterleaveRecipe *R);
-  Type *inferType(const VPWidenCallRecipe *R);
-  Type *inferType(const VPReductionPHIRecipe *R);
-  Type *inferType(const VPWidenRecipe *R);
-  Type *inferType(const VPWidenIntOrFpInductionRecipe *R);
-  Type *inferType(const VPWidenMemoryInstructionRecipe *R);
-  Type *inferType(const VPWidenSelectRecipe *R);
-  Type *inferType(const VPReplicateRecipe *R);
+  Type *inferScalarType(const VPBlendRecipe *R);
+  Type *inferScalarType(const VPInstruction *R);
+  Type *inferScalarType(const VPWidenCallRecipe *R);
+  Type *inferScalarType(const VPWidenRecipe *R);
+  Type *inferScalarType(const VPWidenIntOrFpInductionRecipe *R);
+  Type *inferScalarType(const VPWidenMemoryInstructionRecipe *R);
+  Type *inferScalarType(const VPWidenSelectRecipe *R);
+  Type *inferScalarType(const VPReplicateRecipe *R);
 
 public:
   VPTypeAnalysis(LLVMContext &Ctx) : Ctx(Ctx) {}
 
   /// Infer the type of \p V. Returns the scalar type of \p V.
-  Type *inferType(const VPValue *V);
+  Type *inferScalarType(const VPValue *V);
 };
 
 } // end namespace llvm

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -28,7 +28,7 @@ struct VPWidenSelectRecipe;
 class VPReplicateRecipe;
 class Type;
 
-/// An analysis for type-inferrence for VPValues.
+/// An analysis for type-inference for VPValues.
 class VPTypeAnalysis {
   DenseMap<const VPValue *, Type *> CachedTypes;
   LLVMContext &Ctx;

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -31,11 +31,11 @@ class Type;
 /// An analysis for type-inference for VPValues.
 /// It infers the scalar type for a given VPValue by bottom-up traversing
 /// through defining recipes until root nodes with known types are reached (e.g.
-/// live-ins or memory recipes). The types are then propagated top down through
+/// live-ins or load recipes). The types are then propagated top down through
 /// operations.
-/// Note that the analysis caches the infered types. A new analysis object must
+/// Note that the analysis caches the inferred types. A new analysis object must
 /// be constructed once a VPlan has been modified in a way that invalidates any
-/// of the previously infered types.
+/// of the previously inferred types.
 class VPTypeAnalysis {
   DenseMap<const VPValue *, Type *> CachedTypes;
   LLVMContext &Ctx;

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -40,14 +40,14 @@ class VPTypeAnalysis {
   DenseMap<const VPValue *, Type *> CachedTypes;
   LLVMContext &Ctx;
 
-  Type *inferScalarType(const VPBlendRecipe *R);
-  Type *inferScalarType(const VPInstruction *R);
-  Type *inferScalarType(const VPWidenCallRecipe *R);
-  Type *inferScalarType(const VPWidenRecipe *R);
-  Type *inferScalarType(const VPWidenIntOrFpInductionRecipe *R);
-  Type *inferScalarType(const VPWidenMemoryInstructionRecipe *R);
-  Type *inferScalarType(const VPWidenSelectRecipe *R);
-  Type *inferScalarType(const VPReplicateRecipe *R);
+  Type *inferScalarTypeForRecipe(const VPBlendRecipe *R);
+  Type *inferScalarTypeForRecipe(const VPInstruction *R);
+  Type *inferScalarTypeForRecipe(const VPWidenCallRecipe *R);
+  Type *inferScalarTypeForRecipe(const VPWidenRecipe *R);
+  Type *inferScalarTypeForRecipe(const VPWidenIntOrFpInductionRecipe *R);
+  Type *inferScalarTypeForRecipe(const VPWidenMemoryInstructionRecipe *R);
+  Type *inferScalarTypeForRecipe(const VPWidenSelectRecipe *R);
+  Type *inferScalarTypeForRecipe(const VPReplicateRecipe *R);
 
 public:
   VPTypeAnalysis(LLVMContext &Ctx) : Ctx(Ctx) {}

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "VPlan.h"
+#include "VPlanAnalysis.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
@@ -738,7 +739,18 @@ void VPWidenRecipe::execute(VPTransformState &State) {
                       << Instruction::getOpcodeName(Opcode));
     llvm_unreachable("Unhandled instruction!");
   } // end of switch.
+
+#if !defined(NDEBUG)
+  // Verify that VPlan type infererrence results agree with the type of the
+  // generated values.
+  VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
+  for (unsigned Part = 0; Part < State.UF; ++Part) {
+    assert(VectorType::get(A.inferType(getVPSingleValue()), State.VF) ==
+           State.get(this, Part)->getType());
+  }
+#endif
 }
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenRecipe::print(raw_ostream &O, const Twine &Indent,
                           VPSlotTracker &SlotTracker) const {

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -741,7 +741,7 @@ void VPWidenRecipe::execute(VPTransformState &State) {
   } // end of switch.
 
 #if !defined(NDEBUG)
-  // Verify that VPlan type infererrence results agree with the type of the
+  // Verify that VPlan type inference results agree with the type of the
   // generated values.
   VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
   for (unsigned Part = 0; Part < State.UF; ++Part) {

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -746,7 +746,8 @@ void VPWidenRecipe::execute(VPTransformState &State) {
   VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
   for (unsigned Part = 0; Part < State.UF; ++Part) {
     assert(VectorType::get(A.inferScalarType(getVPSingleValue()), State.VF) ==
-           State.get(this, Part)->getType());
+               State.get(this, Part)->getType() &&
+           "infered type and type from generated instructions do not match");
   }
 #endif
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -745,7 +745,7 @@ void VPWidenRecipe::execute(VPTransformState &State) {
   // generated values.
   VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
   for (unsigned Part = 0; Part < State.UF; ++Part) {
-    assert(VectorType::get(A.inferType(getVPSingleValue()), State.VF) ==
+    assert(VectorType::get(A.inferScalarType(getVPSingleValue()), State.VF) ==
            State.get(this, Part)->getType());
   }
 #endif

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -747,7 +747,7 @@ void VPWidenRecipe::execute(VPTransformState &State) {
   for (unsigned Part = 0; Part < State.UF; ++Part) {
     assert(VectorType::get(A.inferScalarType(getVPSingleValue()), State.VF) ==
                State.get(this, Part)->getType() &&
-           "infered type and type from generated instructions do not match");
+           "inferred type and type from generated instructions do not match");
   }
 #endif
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -745,7 +745,7 @@ void VPWidenRecipe::execute(VPTransformState &State) {
   // generated values.
   VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
   for (unsigned Part = 0; Part < State.UF; ++Part) {
-    assert(VectorType::get(A.inferScalarType(getVPSingleValue()), State.VF) ==
+    assert(VectorType::get(A.inferScalarType(this), State.VF) ==
                State.get(this, Part)->getType() &&
            "inferred type and type from generated instructions do not match");
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -743,10 +743,9 @@ void VPWidenRecipe::execute(VPTransformState &State) {
 #if !defined(NDEBUG)
   // Verify that VPlan type inference results agree with the type of the
   // generated values.
-  VPTypeAnalysis A(State.Builder.GetInsertBlock()->getContext());
   for (unsigned Part = 0; Part < State.UF; ++Part) {
-    assert(VectorType::get(A.inferScalarType(this), State.VF) ==
-               State.get(this, Part)->getType() &&
+    assert(VectorType::get(State.TypeAnalysis.inferScalarType(this),
+                           State.VF) == State.get(this, Part)->getType() &&
            "inferred type and type from generated instructions do not match");
   }
 #endif


### PR DESCRIPTION
This patch adds initial type inferrence for VPValues. It infers the scalar type of a VPValue, by bottom-up traversing through defining recipes until root nodes with known types are reached (e.g. live-ins or memory recipes). The types are then propagated top down through operations.

This is intended as building block for a VPlan-based cost model, which will need access to type information for VPValues/recipes.

Initial testing is done by asserting the inferred type matches the type of the result value generated for a widen recipe.