### PR TITLE
[RISCV] Add CompressPat for c.beqz/bnez with X0 in the first operand.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -956,7 +956,13 @@ def : CompressPat<(JAL X0, simm12_lsb0:$offset),
                   (C_J simm12_lsb0:$offset)>;
 def : CompressPat<(BEQ GPRC:$rs1, X0, simm9_lsb0:$imm),
                   (C_BEQZ GPRC:$rs1, simm9_lsb0:$imm)>;
+let isCompressOnly = true in
+def : CompressPat<(BEQ X0, GPRC:$rs1, simm9_lsb0:$imm),
+                  (C_BEQZ GPRC:$rs1, simm9_lsb0:$imm)>;
 def : CompressPat<(BNE GPRC:$rs1, X0, simm9_lsb0:$imm),
+                  (C_BNEZ GPRC:$rs1, simm9_lsb0:$imm)>;
+let isCompressOnly = true in
+def : CompressPat<(BNE X0, GPRC:$rs1, simm9_lsb0:$imm),
                   (C_BNEZ GPRC:$rs1, simm9_lsb0:$imm)>;
 } // Predicates = [HasStdExtCOrZca]
 

--- a/llvm/test/MC/RISCV/compress-rv32i.s
+++ b/llvm/test/MC/RISCV/compress-rv32i.s
@@ -154,15 +154,35 @@ jal zero, -2048
 # CHECK: # encoding: [0x01,0xd0]
 beq s0, zero, -256
 
+# CHECK-BYTES: 01 d0
+# CHECK-ALIASASM: beqz s0, -256
+# CHECK-ALIASOBJ32: beqz s0, 0xffffff2a
+# CHECK-ALIASOBJ64: beqz s0, 0xffffffffffffff2a
+# CHECK-INSTASM: c.beqz s0, -256
+# CHECK-INSTOBJ32: c.beqz s0, 0xffffff2a
+# CHECK-INSTOBJ64: c.beqz s0, 0xffffffffffffff2a
+# CHECK: # encoding: [0x01,0xd0]
+beq zero, s0, -256
+
 # CHECK-BYTES: 7d ec
 # CHECK-ALIASASM: bnez s0, 254
-# CHECK-ALIASOBJ32: bnez s0, 0x128
-# CHECK-ALIASOBJ64: bnez s0, 0x128
+# CHECK-ALIASOBJ32: bnez s0, 0x12a
+# CHECK-ALIASOBJ64: bnez s0, 0x12a
 # CHECK-INSTASM: c.bnez s0, 254
-# CHECK-INSTOBJ32: c.bnez s0, 0x128
-# CHECK-INSTOBJ64: c.bnez s0, 0x128
+# CHECK-INSTOBJ32: c.bnez s0, 0x12a
+# CHECK-INSTOBJ64: c.bnez s0, 0x12a
 # CHECK: # encoding: [0x7d,0xec]
 bne s0, zero, 254
+
+# CHECK-BYTES: 7d ec
+# CHECK-ALIASASM: bnez s0, 254
+# CHECK-ALIASOBJ32: bnez s0, 0x12c
+# CHECK-ALIASOBJ64: bnez s0, 0x12c
+# CHECK-INSTASM: c.bnez s0, 254
+# CHECK-INSTOBJ32: c.bnez s0, 0x12c
+# CHECK-INSTOBJ64: c.bnez s0, 0x12c
+# CHECK: # encoding: [0x7d,0xec]
+bne zero, s0, 254
 
 # CHECK-BYTES: 7e 04
 # CHECK-ALIAS: slli s0, s0, 31


### PR DESCRIPTION
Copy propagation during codegen can cause the first operand to become X0. We should be able to compress that.