### PR TITLE
[clang-tidy] Ignore unused parameters in `rvalue-reference-param-not-moved check`

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/RvalueReferenceParamNotMovedCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/RvalueReferenceParamNotMovedCheck.cpp
@@ -84,6 +84,9 @@ void RvalueReferenceParamNotMovedCheck::check(
   if (IgnoreUnnamedParams && Param->getName().empty())
     return;
 
+  if (!Param->isUsed() && Param->hasAttr<UnusedAttr>())
+    return;
+
   const auto *Function = dyn_cast<FunctionDecl>(Param->getDeclContext());
   if (!Function)
     return;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -237,6 +237,10 @@ Changes in existing checks
   <clang-tidy/checks/cppcoreguidelines/pro-type-vararg>` check to ignore
   false-positives in unevaluated context (e.g., ``decltype``, ``sizeof``, ...).
 
+- Improved :doc:`cppcoreguidelines-rvalue-reference-param-not-moved
+  <clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved>` check
+  to ignore unused parameters when they are marked as unused.
+
 - Improved :doc:`llvm-namespace-comment
   <clang-tidy/checks/llvm/namespace-comment>` check to provide fixes for
   ``inline`` namespaces in the same format as :program:`clang-format`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved.rst
@@ -18,6 +18,16 @@ Example:
     std::string Copy(Input); // Oops - forgot to std::move
   }
 
+Note that parameters that are unused and marked as such will not be diagnosed.
+
+Example:
+
+.. code-block:: c++
+
+  void conditional_use([[maybe_unused]] std::string&& Input) {
+    // No diagnostic here since Input is unused and marked as such
+  }
+
 Options
 -------
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/rvalue-reference-param-not-moved.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/rvalue-reference-param-not-moved.cpp
@@ -333,3 +333,28 @@ void instantiate_a_class_template() {
   AClassTemplate<Obj&> withObjRef(o);
   withObjRef.never_moves(o);
 }
+
+namespace gh68209
+{
+  void f1([[maybe_unused]] int&& x) {}
+
+  void f2(__attribute__((unused)) int&& x) {}
+
+  void f3(int&& x) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: rvalue reference parameter 'x' is never moved from inside the function body [cppcoreguidelines-rvalue-reference-param-not-moved]
+
+  template <typename T>
+  void f4([[maybe_unused]] T&& x) {}
+
+  template <typename T>
+  void f5(__attribute((unused)) T&& x) {}
+
+  template<typename T>
+  void f6(T&& x) {}
+
+  void f7([[maybe_unused]] int&& x) { x += 1; }
+  // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: rvalue reference parameter 'x' is never moved from inside the function body [cppcoreguidelines-rvalue-reference-param-not-moved]
+
+  void f8(__attribute__((unused)) int&& x) { x += 1; }
+  // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: rvalue reference parameter 'x' is never moved from inside the function body [cppcoreguidelines-rvalue-reference-param-not-moved]
+} // namespace gh68209


### PR DESCRIPTION
With this patch we no longer issue a warning for unused parameters which are marked as such.

This fixes #68209