### PR TITLE
Remove warnings from -Wchar-subscripts for known positive constants

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -651,6 +651,8 @@ Bug Fixes in This Version
 - Fixed false positive error emitted by clang when performing qualified name
   lookup and the current class instantiation has dependent bases.
   Fixes (`#13826 <https://github.com/llvm/llvm-project/issues/13826>`_)
+- Clang's ``-Wchar-subscripts`` no longer warns on chars whose values are known non-negative constants.
+  Fixes (`#18763 <https://github.com/llvm/llvm-project/issues/18763>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6053,9 +6053,14 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
                      << IndexExpr->getSourceRange());
 
   if ((IndexExpr->getType()->isSpecificBuiltinType(BuiltinType::Char_S) ||
-       IndexExpr->getType()->isSpecificBuiltinType(BuiltinType::Char_U))
-         && !IndexExpr->isTypeDependent())
-    Diag(LLoc, diag::warn_subscript_is_char) << IndexExpr->getSourceRange();
+       IndexExpr->getType()->isSpecificBuiltinType(BuiltinType::Char_U)) &&
+      !IndexExpr->isTypeDependent()) {
+    std::optional<llvm::APSInt> IntegerContantExpr =
+        IndexExpr->getIntegerConstantExpr(getASTContext());
+    if (!IntegerContantExpr.has_value() ||
+        IntegerContantExpr.value().isNegative())
+      Diag(LLoc, diag::warn_subscript_is_char) << IndexExpr->getSourceRange();
+  }
 
   // C99 6.5.2.1p1: "shall have type "pointer to *object* type". Similarly,
   // C++ [expr.sub]p1: The type "T" shall be a completely-defined object

--- a/clang/test/Sema/warn-char-subscripts.cpp
+++ b/clang/test/Sema/warn-char-subscripts.cpp
@@ -77,12 +77,26 @@ void t12(void) {
 void t13(void) {
   int array[256] = { 0 };
   const char b = 'a';
-  int val = array[b]; // expected-warning{{array subscript is of type 'char'}}
+  int val = array[b]; // no warning for char with known positive value
 }
 
 void t14(void) {
+  int array[256] = { 0 };
+  constexpr char b = 'a';
+  int val = array[b]; // no warning for char with known positive value
+}
+
+void t15(void) {
   int array[256] = { 0 }; // expected-note {{array 'array' declared here}}
   const char b = -1;
+  // expected-warning@+2 {{array subscript is of type 'char'}}
+  // expected-warning@+1 {{array index -1 is before the beginning of the array}}
+  int val = array[b];
+}
+
+void t16(void) {
+  int array[256] = { 0 }; // expected-note {{array 'array' declared here}}
+  constexpr char b = -1;
   // expected-warning@+2 {{array subscript is of type 'char'}}
   // expected-warning@+1 {{array index -1 is before the beginning of the array}}
   int val = array[b];


### PR DESCRIPTION
This is to address https://github.com/llvm/llvm-project/issues/18763

it removes warnings from using a signed char as an array bound if the char is a known positives constant.

This goes one step farther than gcc does.

For example given the following code
```c++
char upper[300];

int main() {
  upper['a'] = 'A';
  char b = 'a';
  upper[b] = 'A';
  const char c = 'a';
  upper[c] = 'A';
  constexpr char d = 'a';
  upper[d] = 'A';
  char e = -1;
  upper[e] = 'A';
  const char f = -1;
  upper[f] = 'A';
  constexpr char g = -1;
  upper[g] = 'A';
  return 1;
}
```

clang currently gives warnings for all cases, while gcc gives warnings for all cases except for 'a' (https://godbolt.org/z/5ahjETTv3)

with the change there is no longer any warning for 'a', 'c', or 'd'.

```
../test.cpp:7:8: warning: array subscript is of type 'char' [-Wchar-subscripts]
    7 |   upper[b] = 'A';
      |        ^~
../test.cpp:13:8: warning: array subscript is of type 'char' [-Wchar-subscripts]
   13 |   upper[e] = 'A';
      |        ^~
../test.cpp:15:8: warning: array subscript is of type 'char' [-Wchar-subscripts]
   15 |   upper[f] = 'A';
      |        ^~
../test.cpp:17:8: warning: array subscript is of type 'char' [-Wchar-subscripts]
   17 |   upper[g] = 'A';
      |        ^~
../test.cpp:15:3: warning: array index -1 is before the beginning of the array [-Warray-bounds]
   15 |   upper[f] = 'A';
      |   ^     ~
../test.cpp:1:1: note: array 'upper' declared here
    1 | char upper[300];
      | ^
../test.cpp:17:3: warning: array index -1 is before the beginning of the array [-Warray-bounds]
   17 |   upper[g] = 'A';
      |   ^     ~
../test.cpp:1:1: note: array 'upper' declared here
    1 | char upper[300];
      | ^
6 warnings generated.
```

This pull request is my first change and I would appreciate any comments or suggestions.