### PR TITLE
[clang-tidy][modernize-loop-convert]check isDependentSizedArrayType

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
@@ -753,6 +753,7 @@ void LoopConvertCheck::doConversion(
   bool IsCheapToCopy =
       !Descriptor.ElemType.isNull() &&
       Descriptor.ElemType.isTriviallyCopyableType(*Context) &&
+      !Descriptor.ElemType->isDependentSizedArrayType() &&
       // TypeInfo::Width is in bits.
       Context->getTypeInfo(Descriptor.ElemType).Width <= 8 * MaxCopySize;
   bool UseCopy = CanCopy && ((VarNameFromAlias && !AliasVarIsRef) ||

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -267,11 +267,8 @@ Changes in existing checks
 
 - Improved :doc:`modernize-loop-convert
   <clang-tidy/checks/modernize/loop-convert>` to support for-loops with
-  iterators initialized by free functions like ``begin``, ``end``, or ``size``.
-
-- Improved :doc:`modernize-loop-convert
-   <clang-tidy/checks/modernize/loop-convert>` to avoid crash dor dependent
-   array.
+  iterators initialized by free functions like ``begin``, ``end``, or ``size``
+  and avoid crash for array of dependent array.
 
 - Improved :doc:`modernize-return-braced-init-list
   <clang-tidy/checks/modernize/return-braced-init-list>` check to ignore

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -269,6 +269,10 @@ Changes in existing checks
   <clang-tidy/checks/modernize/loop-convert>` to support for-loops with
   iterators initialized by free functions like ``begin``, ``end``, or ``size``.
 
+- Improved :doc:`modernize-loop-convert
+   <clang-tidy/checks/modernize/loop-convert>` to avoid crash dor dependent
+   array.
+
 - Improved :doc:`modernize-return-braced-init-list
   <clang-tidy/checks/modernize/return-braced-init-list>` check to ignore
   false-positives when constructing the container with ``count`` copies of

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
@@ -939,15 +939,18 @@ void fundamentalTypesTest() {
   // CHECK-FIXES: for (double Double : Doubles)
 }
 
-template <unsigned int p> void test() {
-  unsigned int test[3][p];
-  // Initialize to zero
-  for (unsigned int i = 0; i < p; ++i)
-    for (unsigned int j = 0; j < 3; ++j)
-      test[j][i] = 0;
+template <unsigned  p> void _dependenceArrayTest() {
+  unsigned test[3][p];
+  for (unsigned i = 0; i < p; ++i)
+    for (unsigned j = 0; j < 3; ++j)
+      printf("%d", test[j][i]);
   // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: use range-based for loop instead
   // CHECK-FIXES: (auto & j : test)
-  // CHECK-FIXES: j[i] = 0;
+  // CHECK-FIXES: printf("%d", j[i]);
+}
+void dependenceArrayTest() {
+  _dependenceArrayTest<1>();
+  _dependenceArrayTest<2>();
 }
 
 } // namespace PseudoArray

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
@@ -939,4 +939,13 @@ void fundamentalTypesTest() {
   // CHECK-FIXES: for (double Double : Doubles)
 }
 
+template <unsigned int p> void test() {
+  unsigned int test[3][p];
+  // Initialize to zero
+  for (unsigned int i = 0; i < p; ++i)
+    for (unsigned int j = 0; j < 3; ++j) // CHECK-MESSAGES: warning: use range-based for loop instead
+  // CHECK-FIXES: (auto & j : test)
+      test[j][i] = 0;
+}
+
 } // namespace PseudoArray

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
@@ -943,9 +943,11 @@ template <unsigned int p> void test() {
   unsigned int test[3][p];
   // Initialize to zero
   for (unsigned int i = 0; i < p; ++i)
-    for (unsigned int j = 0; j < 3; ++j) // CHECK-MESSAGES: warning: use range-based for loop instead
-  // CHECK-FIXES: (auto & j : test)
+    for (unsigned int j = 0; j < 3; ++j)
       test[j][i] = 0;
+  // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: use range-based for loop instead
+  // CHECK-FIXES: (auto & j : test)
+  // CHECK-FIXES: j[i] = 0;
 }
 
 } // namespace PseudoArray


### PR DESCRIPTION
We cannot get element size only when type is `DependentSizedArrayType`.
So it should be treated as not cheap to copy and use element ref in loop.

Fixes: #68975