### PR TITLE
[clang] [Gnu] Improve GCCVersion parsing to match versions such as "10-win32"

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2027,7 +2027,7 @@ Generic_GCC::GCCVersion Generic_GCC::GCCVersion::Parse(StringRef VersionText) {
   // is stored in PatchSuffix. The third segment is allowed to not contain
   // a number at all.
 
-  auto HandleLastNumber = [&](StringRef Segment, int &Number,
+  auto TryParseLastNumber = [&](StringRef Segment, int &Number,
                               std::string &OutStr) -> bool {
     // Look for a number prefix and parse that, and split out any trailing
     // string into GoodVersion.PatchSuffix.
@@ -2042,7 +2042,7 @@ Generic_GCC::GCCVersion Generic_GCC::GCCVersion::Parse(StringRef VersionText) {
     }
     return false;
   };
-  auto HandleNumber = [](StringRef Segment, int &Number) -> bool {
+  auto TryParseNumber = [](StringRef Segment, int &Number) -> bool {
     if (Segment.getAsInteger(10, Number) || Number < 0)
       return false;
     return true;
@@ -2050,28 +2050,28 @@ Generic_GCC::GCCVersion Generic_GCC::GCCVersion::Parse(StringRef VersionText) {
 
   if (MinorStr.empty()) {
     // If no minor string, major is the last segment
-    if (!HandleLastNumber(MajorStr, GoodVersion.Major, GoodVersion.MajorStr))
+    if (!TryParseLastNumber(MajorStr, GoodVersion.Major, GoodVersion.MajorStr))
       return BadVersion;
     return GoodVersion;
   } else {
-    if (!HandleNumber(MajorStr, GoodVersion.Major))
+    if (!TryParseNumber(MajorStr, GoodVersion.Major))
       return BadVersion;
     GoodVersion.MajorStr = MajorStr;
   }
   if (PatchStr.empty()) {
     // If no patch string, minor is the last segment
-    if (!HandleLastNumber(MinorStr, GoodVersion.Minor, GoodVersion.MinorStr))
+    if (!TryParseLastNumber(MinorStr, GoodVersion.Minor, GoodVersion.MinorStr))
       return BadVersion;
     return GoodVersion;
   } else {
-    if (!HandleNumber(MinorStr, GoodVersion.Minor))
+    if (!TryParseNumber(MinorStr, GoodVersion.Minor))
       return BadVersion;
     GoodVersion.MinorStr = MinorStr;
   }
 
   // For the last segment, tolerate a missing number.
   std::string DummyStr;
-  HandleLastNumber(PatchStr, GoodVersion.Patch, DummyStr);
+  TryParseLastNumber(PatchStr, GoodVersion.Patch, DummyStr);
   return GoodVersion;
 }
 

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2028,7 +2028,7 @@ Generic_GCC::GCCVersion Generic_GCC::GCCVersion::Parse(StringRef VersionText) {
   // a number at all.
 
   auto TryParseLastNumber = [&](StringRef Segment, int &Number,
-                              std::string &OutStr) -> bool {
+                                std::string &OutStr) -> bool {
     // Look for a number prefix and parse that, and split out any trailing
     // string into GoodVersion.PatchSuffix.
 

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2007,45 +2007,71 @@ Generic_GCC::GCCVersion Generic_GCC::GCCVersion::Parse(StringRef VersionText) {
   std::pair<StringRef, StringRef> First = VersionText.split('.');
   std::pair<StringRef, StringRef> Second = First.second.split('.');
 
-  GCCVersion GoodVersion = {VersionText.str(), -1, -1, -1, "", "", ""};
-  if (First.first.getAsInteger(10, GoodVersion.Major) || GoodVersion.Major < 0)
-    return BadVersion;
-  GoodVersion.MajorStr = First.first.str();
-  if (First.second.empty())
-    return GoodVersion;
+  StringRef MajorStr = First.first;
   StringRef MinorStr = Second.first;
-  if (Second.second.empty()) {
-    if (size_t EndNumber = MinorStr.find_first_not_of("0123456789")) {
-      GoodVersion.PatchSuffix = std::string(MinorStr.substr(EndNumber));
-      MinorStr = MinorStr.slice(0, EndNumber);
-    }
-  }
-  if (MinorStr.getAsInteger(10, GoodVersion.Minor) || GoodVersion.Minor < 0)
-    return BadVersion;
-  GoodVersion.MinorStr = MinorStr.str();
+  StringRef PatchStr = Second.second;
 
-  // First look for a number prefix and parse that if present. Otherwise just
-  // stash the entire patch string in the suffix, and leave the number
-  // unspecified. This covers versions strings such as:
-  //   5        (handled above)
+  GCCVersion GoodVersion = {VersionText.str(), -1, -1, -1, "", "", ""};
+
+  // Parse version number strings such as:
+  //   5
   //   4.4
   //   4.4-patched
   //   4.4.0
   //   4.4.x
   //   4.4.2-rc4
   //   4.4.x-patched
-  // And retains any patch number it finds.
-  StringRef PatchText = Second.second;
-  if (!PatchText.empty()) {
-    if (size_t EndNumber = PatchText.find_first_not_of("0123456789")) {
-      // Try to parse the number and any suffix.
-      if (PatchText.slice(0, EndNumber).getAsInteger(10, GoodVersion.Patch) ||
-          GoodVersion.Patch < 0)
-        return BadVersion;
-      GoodVersion.PatchSuffix = std::string(PatchText.substr(EndNumber));
+  //   10-win32
+  // Split on '.', handle 1, 2 or 3 such segments. Each segment must contain
+  // purely a number, except for the last one, where a non-number suffix
+  // is stored in PatchSuffix. The third segment is allowed to not contain
+  // a number at all.
+
+  auto HandleLastNumber = [&](StringRef Segment, int &Number,
+                              std::string &OutStr) -> bool {
+    // Look for a number prefix and parse that, and split out any trailing
+    // string into GoodVersion.PatchSuffix.
+
+    if (size_t EndNumber = Segment.find_first_not_of("0123456789")) {
+      StringRef NumberStr = Segment.slice(0, EndNumber);
+      if (NumberStr.getAsInteger(10, Number) || Number < 0)
+        return false;
+      OutStr = NumberStr;
+      GoodVersion.PatchSuffix = Segment.substr(EndNumber);
+      return true;
     }
+    return false;
+  };
+  auto HandleNumber = [](StringRef Segment, int &Number) -> bool {
+    if (Segment.getAsInteger(10, Number) || Number < 0)
+      return false;
+    return true;
+  };
+
+  if (MinorStr.empty()) {
+    // If no minor string, major is the last segment
+    if (!HandleLastNumber(MajorStr, GoodVersion.Major, GoodVersion.MajorStr))
+      return BadVersion;
+    return GoodVersion;
+  } else {
+    if (!HandleNumber(MajorStr, GoodVersion.Major))
+      return BadVersion;
+    GoodVersion.MajorStr = MajorStr;
+  }
+  if (PatchStr.empty()) {
+    // If no patch string, minor is the last segment
+    if (!HandleLastNumber(MinorStr, GoodVersion.Minor, GoodVersion.MinorStr))
+      return BadVersion;
+    return GoodVersion;
+  } else {
+    if (!HandleNumber(MinorStr, GoodVersion.Minor))
+      return BadVersion;
+    GoodVersion.MinorStr = MinorStr;
   }
 
+  // For the last segment, tolerate a missing number.
+  std::string DummyStr;
+  HandleLastNumber(PatchStr, GoodVersion.Patch, DummyStr);
   return GoodVersion;
 }
 

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2053,21 +2053,22 @@ Generic_GCC::GCCVersion Generic_GCC::GCCVersion::Parse(StringRef VersionText) {
     if (!TryParseLastNumber(MajorStr, GoodVersion.Major, GoodVersion.MajorStr))
       return BadVersion;
     return GoodVersion;
-  } else {
-    if (!TryParseNumber(MajorStr, GoodVersion.Major))
-      return BadVersion;
-    GoodVersion.MajorStr = MajorStr;
   }
+
+  if (!TryParseNumber(MajorStr, GoodVersion.Major))
+    return BadVersion;
+  GoodVersion.MajorStr = MajorStr;
+
   if (PatchStr.empty()) {
     // If no patch string, minor is the last segment
     if (!TryParseLastNumber(MinorStr, GoodVersion.Minor, GoodVersion.MinorStr))
       return BadVersion;
     return GoodVersion;
-  } else {
-    if (!TryParseNumber(MinorStr, GoodVersion.Minor))
-      return BadVersion;
-    GoodVersion.MinorStr = MinorStr;
   }
+
+  if (!TryParseNumber(MinorStr, GoodVersion.Minor))
+    return BadVersion;
+  GoodVersion.MinorStr = MinorStr;
 
   // For the last segment, tolerate a missing number.
   std::string DummyStr;

--- a/clang/unittests/Driver/GCCVersionTest.cpp
+++ b/clang/unittests/Driver/GCCVersionTest.cpp
@@ -39,6 +39,7 @@ const VersionParseTest TestCases[] = {
     {"4.4.2-rc4", 4, 4, 2, "4", "4", "-rc4"},
     {"4.4.x-patched", 4, 4, -1, "4", "4", ""},
     {"not-a-version", -1, -1, -1, "", "", ""},
+    {"10-win32", 10, -1, -1, "10", "", "-win32"},
 };
 
 TEST(GCCVersionTest, Parse) {


### PR DESCRIPTION
In earlier GCC versions, the Debian/Ubuntu provided mingw toolchains were packaged in /usr/lib/gcc/<triple> with version strings such as "5.3-win32", which were matched and found since 6afcd64eb65fca233a7b173f88cffb2c2c9c114c. However in recent versions, they have stopped including the minor version number and only have version strings such as "10-win32" and "10-posix".

Generalize the parsing code to tolerate the patch suffix to be present on a version number with only a major number.

Refactor the string parsing code to highlight the overall structure of the parsing. This implementation should yield the same result as before, except for when there's only one segment and it has trailing, non-number contents.

This allows Clang to find the GCC libraries and headers in Debian/Ubuntu provided MinGW cross compilers.