### PR TITLE
[lld] Align EC code region boundaries.

### DIFF
--- a/lld/test/COFF/arm64ec-codemap.test
+++ b/lld/test/COFF/arm64ec-codemap.test
@@ -93,7 +93,7 @@ RUN:          codemap3.obj loadconfig-arm64ec.obj -dll -noentry -merge:test=.tex
 RUN: llvm-readobj --coff-load-config testm.dll | FileCheck -check-prefix=CODEMAPM %s
 CODEMAPM:      CodeMap [
 CODEMAPM-NEXT:   0x1000 - 0x1010  ARM64EC
-CODEMAPM-NEXT:   0x2000 - 0x3004  X64
+CODEMAPM-NEXT:   0x2000 - 0x200E  X64
 CODEMAPM-NEXT: ]
 
 RUN: llvm-objdump -d testm.dll | FileCheck -check-prefix=DISASMM %s
@@ -107,9 +107,9 @@ DISASMM-NEXT: 18000100c: d65f03c0     ret
 DISASMM-NEXT:                 ...
 DISASMM-NEXT: 180002000: b8 03 00 00 00               movl    $0x3, %eax
 DISASMM-NEXT: 180002005: c3                           retq
-DISASMM-NEXT:                 ...
-DISASMM-NEXT: 180002ffe: 00 00                        addb    %al, (%rax)
-DISASMM-NEXT: 180003000: b8 06 00 00 00               movl    $0x6, %eax
+DISASMM-NEXT: 180002006: 00 00                        addb    %al, (%rax)
+DISASMM-NEXT: 180002008: b8 06 00 00 00               movl    $0x6, %eax
+DISASMM-NEXT: 18000200d: c3                           retq
 
 Merging data sections into code sections causes data to be separated from the code when sorting chunks.
 
@@ -120,8 +120,8 @@ RUN: llvm-readobj --coff-load-config testdm.dll | FileCheck -check-prefix=CODEMA
 CODEMAPDM:      CodeMap [
 CODEMAPDM-NEXT:     0x2000 - 0x2008  ARM64EC
 CODEMAPDM-NEXT:     0x3000 - 0x3006  X64
-CODEMAPDM-NEXT:     0x5200 - 0x5208  ARM64EC
-CODEMAPDM-NEXT:     0x6000 - 0x6006  X64
+CODEMAPDM-NEXT:     0x6000 - 0x6008  ARM64EC
+CODEMAPDM-NEXT:     0x7000 - 0x7006  X64
 CODEMAPDM-NEXT: ]
 
 RUN: llvm-objdump -d testdm.dll | FileCheck -check-prefix=DISASMDM %s
@@ -139,11 +139,11 @@ DISASMDM-EMPTY:
 DISASMDM-NEXT: Disassembly of section test:
 DISASMDM-EMPTY:
 DISASMDM-NEXT: 0000000180005000 <test>:
-DISASMDM:      180005200: 528000a0     mov     w0, #0x5
-DISASMDM-NEXT: 180005204: d65f03c0     ret
+DISASMDM:      180006000: 528000a0     mov     w0, #0x5
+DISASMDM-NEXT: 180006004: d65f03c0     ret
 DISASMDM-NEXT:                 ...
-DISASMDM-NEXT: 180006000: b8 06 00 00 00               movl    $0x6, %eax
-DISASMDM-NEXT: 180006005: c3                           retq
+DISASMDM-NEXT: 180007000: b8 06 00 00 00               movl    $0x6, %eax
+DISASMDM-NEXT: 180007005: c3                           retq
 
 #--- arm64-func-sym.s
     .text
@@ -156,7 +156,7 @@ arm64_func_sym:
 #--- arm64ec-func-sym.s
     .text
     .globl arm64ec_func_sym
-    .p2align 12, 0x0
+    .p2align 2, 0x0
 arm64ec_func_sym:
     mov w0, #2
     ret
@@ -171,14 +171,14 @@ arm64ec_func_sym2:
 #--- x86_64-func-sym.s
     .text
     .globl x86_64_func_sym
-    .p2align 12, 0x0
+    .p2align 2, 0x0
 x86_64_func_sym:
     movl $3, %eax
     retq
 
     .section test, "xr"
     .globl x86_64_func_sym2
-    .p2align 12, 0x0
+    .p2align 2, 0x0
 x86_64_func_sym2:
     movl $6, %eax
     retq
@@ -228,7 +228,7 @@ code_map:
     .rva arm64ec_func_sym + 1
     .word 16
     .rva x86_64_func_sym + 2
-    .word 0x1004
+    .word 14
 
     .globl code_map_count
 code_map_count = 2


### PR DESCRIPTION
This is a refreshed version of https://reviews.llvm.org/D157142 and depends on #69099.

Boundaries between code chunks of different architecture are always aligned. 0x1000 seems to be a constant, this does not seem to be affected by any command line alignment argument.

More info about my findings is here: https://wiki.winehq.org/ARM64ECToolchain#Code_layout This is compatible with MSVC and I suspect that it is motivated by emulator needing to watch for x86_64 code writes to invalidate JIT code.

cc @bylaws 