### PR TITLE
[clang]Avoid to check created local variable multiple time when evaluating

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -393,6 +393,9 @@ Bug Fixes in This Version
   operator in C. No longer issuing a confusing diagnostic along the lines of
   "incompatible operand types ('foo' and 'foo')" with extensions such as matrix
   types. Fixes (`#69008 <https://github.com/llvm/llvm-project/issues/69008>`_)
+- Fix a crash when evaluating comparasion between the field from the same variable
+  which initialized from compound literals in C. Fixes
+  (`#69065 <https://github.com/llvm/llvm-project/issues/69065>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -393,7 +393,7 @@ Bug Fixes in This Version
   operator in C. No longer issuing a confusing diagnostic along the lines of
   "incompatible operand types ('foo' and 'foo')" with extensions such as matrix
   types. Fixes (`#69008 <https://github.com/llvm/llvm-project/issues/69008>`_)
-- Fix a crash when evaluating comparasion between the field from the same variable
+- Fix a crash when evaluating comparison between the field from the same variable
   which initialized from compound literals in C. Fixes
   (`#69065 <https://github.com/llvm/llvm-project/issues/69065>`_)
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -1912,7 +1912,6 @@ APValue &CallStackFrame::createLocal(APValue::LValueBase Base, const void *Key,
   assert(Base.getCallIndex() == Index && "lvalue for wrong frame");
   unsigned Version = Base.getVersion();
   APValue &Result = Temporaries[MapKeyTy(Key, Version)];
-  assert(Result.isAbsent() && "local created multiple times");
 
   // If we're creating a local immediately in the operand of a speculative
   // evaluation, don't register a cleanup to be run outside the speculative

--- a/clang/test/AST/issue69065.c
+++ b/clang/test/AST/issue69065.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -fsyntax-only %s -verify
+// expected-no-diagnostics
+
+struct A {
+  int i;
+};
+struct B {
+  struct A *a;
+};
+const struct B c = {&(struct A){1}};
+
+int main(void) {
+  if ((c.a->i != 1) || (c.a->i)) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
When evaluating variable initialized from compound literal multiple times, it will be converted to evaluting the compound literal itself multiple times, which causes clang crash in assertions.
Further evaluating is not rely on this assertion.

Fixes: #69065