### PR TITLE
[MLIR][Presburger] Add simplify function

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -326,7 +326,7 @@ public:
 
   /// Clear all constraints and add an invalid equation indicating that the set
   /// is empty.
-  void setEmpty();
+  void markSetEmpty();
 
   /// Sets the `values.size()` variables starting at `po`s to the specified
   /// values and removes them.
@@ -354,6 +354,9 @@ public:
   /// any equality, or if any invalid constraints are discovered on any row.
   /// Returns false otherwise.
   bool isEmpty() const;
+
+  /// Performs GCD checks and invalid constraint checks.
+  bool isPlainEmpty() const;
 
   /// Runs the GCD test on all equality constraints. Returns true if this test
   /// fails on any equality. Returns false otherwise.
@@ -549,9 +552,8 @@ public:
 
   void removeDuplicateDivs();
 
-  /// Attempts to simplify the constraints. The return value indicates whether
-  /// the set is empty.
-  bool simplify();
+  /// Attempts to simplify the constraints.
+  void simplify();
 
   /// Converts variables of kind srcKind in the range [varStart, varLimit) to
   /// variables of kind dstKind. If `pos` is given, the variables are placed at
@@ -733,9 +735,7 @@ protected:
   unsigned gaussianEliminateVars(unsigned posStart, unsigned posLimit);
 
   /// Perform a Gaussian elimination operation to reduce all equations to
-  /// standard form, and call setempty for cases that are clearly empty. the
-  /// return value indicates whether the number of constraints has been modified
-  /// or not.
+  /// standard form. The return value indicates if anything was modified.
   bool gaussianEliminate();
 
   /// Eliminates the variable at the specified position using Fourier-Motzkin
@@ -770,8 +770,7 @@ protected:
   bool isColZero(unsigned pos) const;
 
   /// Checks for identical inequalities and eliminates redundant inequalities.
-  /// The return value indicates whether the number of constraints has been
-  /// modified.
+  /// The return value indicates if anything has changed.
   bool removeDuplicateConstraints();
 
   /// Returns false if the fields corresponding to various variable counts, or

--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -91,6 +91,15 @@ public:
     return IntegerRelation(space);
   }
 
+  /// Return an empty system containing an invalid equation 0=1.
+  static IntegerRelation getEmpty(const PresburgerSpace &space) {
+    IntegerRelation relult(0, 1, space.getNumVars() + 1, space);
+    SmallVector<int64_t> eqeff(space.getNumVars() + 1, 0);
+    eqeff.back() = 1;
+    relult.addEquality(eqeff);
+    return relult;
+  }
+
   /// Return the kind of this IntegerRelation.
   virtual Kind getKind() const { return Kind::IntegerRelation; }
 
@@ -138,7 +147,7 @@ public:
   /// returns false. The equality check is performed in a plain manner, by
   /// comparing if all the equalities and inequalities in `this` and `other`
   /// are the same.
-  bool isPlainEqual(const IntegerRelation &other) const;
+  bool isObviouslyEqual(const IntegerRelation &other) const;
 
   /// Return whether this is a subset of the given IntegerRelation. This is
   /// integer-exact and somewhat expensive, since it uses the integer emptiness
@@ -324,10 +333,6 @@ public:
   /// Removes all equalities and inequalities.
   void clearConstraints();
 
-  /// Clear all constraints and add an invalid equation indicating that the set
-  /// is empty.
-  void markSetEmpty();
-
   /// Sets the `values.size()` variables starting at `po`s to the specified
   /// values and removes them.
   void setAndEliminate(unsigned pos, ArrayRef<MPInt> values);
@@ -356,7 +361,7 @@ public:
   bool isEmpty() const;
 
   /// Performs GCD checks and invalid constraint checks.
-  bool isPlainEmpty() const;
+  bool isObviouslyEmpty() const;
 
   /// Runs the GCD test on all equality constraints. Returns true if this test
   /// fails on any equality. Returns false otherwise.

--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -552,7 +552,9 @@ public:
 
   void removeDuplicateDivs();
 
-  /// Attempts to simplify the constraints.
+  /// Simplify iteratively attempt to remove redundant equations by Gaussian
+  /// elimination and attempt to remove duplicate inequalities until a fixed
+  /// point is reached.
   void simplify();
 
   /// Converts variables of kind srcKind in the range [varStart, varLimit) to

--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -776,7 +776,7 @@ protected:
   bool isColZero(unsigned pos) const;
 
   /// Checks for identical inequalities and eliminates redundant inequalities.
-  /// The return value indicates if anything has changed.
+  /// Returns whether the constraint system was modified.
   bool removeDuplicateConstraints();
 
   /// Returns false if the fields corresponding to various variable counts, or

--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -91,13 +91,13 @@ public:
     return IntegerRelation(space);
   }
 
-  /// Return an empty system containing an invalid equation 0=1.
+  /// Return an empty system containing an invalid equation 0 = 1.
   static IntegerRelation getEmpty(const PresburgerSpace &space) {
-    IntegerRelation relult(0, 1, space.getNumVars() + 1, space);
-    SmallVector<int64_t> eqeff(space.getNumVars() + 1, 0);
-    eqeff.back() = 1;
-    relult.addEquality(eqeff);
-    return relult;
+    IntegerRelation result(0, 1, space.getNumVars() + 1, space);
+    SmallVector<int64_t> invalidEq(space.getNumVars() + 1, 0);
+    invalidEq.back() = 1;
+    result.addEquality(invalidEq);
+    return result;
   }
 
   /// Return the kind of this IntegerRelation.
@@ -557,9 +557,8 @@ public:
 
   void removeDuplicateDivs();
 
-  /// Simplify iteratively attempt to remove redundant equations by Gaussian
-  /// elimination and attempt to remove duplicate inequalities until a fixed
-  /// point is reached.
+  /// Simplify the constraint system by removing canonicalizing constraints and
+  /// removing redundant constraints.
   void simplify();
 
   /// Converts variables of kind srcKind in the range [varStart, varLimit) to
@@ -742,7 +741,7 @@ protected:
   unsigned gaussianEliminateVars(unsigned posStart, unsigned posLimit);
 
   /// Perform a Gaussian elimination operation to reduce all equations to
-  /// standard form. The return value indicates if anything was modified.
+  /// standard form. Returns whether the constraint system was modified.
   bool gaussianEliminate();
 
   /// Eliminates the variable at the specified position using Fourier-Motzkin

--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -324,6 +324,10 @@ public:
   /// Removes all equalities and inequalities.
   void clearConstraints();
 
+  /// Clear all constraints and add an invalid equation indicating that the set
+  /// is empty.
+  void setEmpty();
+
   /// Sets the `values.size()` variables starting at `po`s to the specified
   /// values and removes them.
   void setAndEliminate(unsigned pos, ArrayRef<MPInt> values);
@@ -545,6 +549,10 @@ public:
 
   void removeDuplicateDivs();
 
+  /// Attempts to simplify the constraints. The return value indicates whether
+  /// the set is empty.
+  bool simplify();
+
   /// Converts variables of kind srcKind in the range [varStart, varLimit) to
   /// variables of kind dstKind. If `pos` is given, the variables are placed at
   /// position `pos` of dstKind, otherwise they are placed after all the other
@@ -724,6 +732,12 @@ protected:
   /// Returns the number of variables eliminated.
   unsigned gaussianEliminateVars(unsigned posStart, unsigned posLimit);
 
+  /// Perform a Gaussian elimination operation to reduce all equations to
+  /// standard form, and call setempty for cases that are clearly empty. the
+  /// return value indicates whether the number of constraints has been modified
+  /// or not.
+  bool gaussianEliminate();
+
   /// Eliminates the variable at the specified position using Fourier-Motzkin
   /// variable elimination, but uses Gaussian elimination if there is an
   /// equality involving that variable. If the result of the elimination is
@@ -754,6 +768,11 @@ protected:
   /// Returns true if the pos^th column is all zero for both inequalities and
   /// equalities.
   bool isColZero(unsigned pos) const;
+
+  /// Checks for identical inequalities and eliminates redundant inequalities.
+  /// The return value indicates whether the number of constraints has been
+  /// modified.
+  bool removeDuplicateConstraints();
 
   /// Returns false if the fields corresponding to various variable counts, or
   /// equality/inequality buffer sizes aren't consistent; true otherwise. This

--- a/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
@@ -169,17 +169,17 @@ public:
   bool isIntegerEmpty() const;
 
   /// Return true if there is no disjunct, false otherwise.
-  bool isPlainEmpty() const;
+  bool isObviouslyEmpty() const;
 
   /// Return true if the set is known to have one unconstrained disjunct, false
   /// otherwise.
-  bool isPlainUniverse() const;
+  bool isObviouslyUniverse() const;
 
   /// Perform a quick equality check on `this` and `other`. The relations are
   /// equal if the check return true, but may or may not be equal if the check
   /// returns false. This is doing by directly comparing whether each internal
   /// disjunct is the same.
-  bool isPlainEqual(const PresburgerRelation &set) const;
+  bool isObviouslyEqual(const PresburgerRelation &set) const;
 
   /// Return true if the set is consist of a single disjunct, without any local
   /// variables, false otherwise.

--- a/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
@@ -213,6 +213,10 @@ public:
   /// also be a union of convex disjuncts.
   PresburgerRelation computeReprWithOnlyDivLocals() const;
 
+  /// Simplify each disjunct, if it is empty it will not be merged into the new
+  /// set.
+  PresburgerRelation simplify();
+
   /// Print the set's internal state.
   void print(raw_ostream &os) const;
   void dump() const;

--- a/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
@@ -213,9 +213,9 @@ public:
   /// also be a union of convex disjuncts.
   PresburgerRelation computeReprWithOnlyDivLocals() const;
 
-  /// Simplify each disjunct, if it is empty it will not be merged into the new
-  /// set.
-  PresburgerRelation simplify();
+  /// Simplify each disjunct, see IntegerRelation::simplify for details. If
+  /// disjunct is empty it will not be merged into the new set.
+  PresburgerRelation simplify() const;
 
   /// Print the set's internal state.
   void print(raw_ostream &os) const;

--- a/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
@@ -213,8 +213,8 @@ public:
   /// also be a union of convex disjuncts.
   PresburgerRelation computeReprWithOnlyDivLocals() const;
 
-  /// Simplify each disjunct, see IntegerRelation::simplify for details. If
-  /// disjunct is empty it will not be merged into the new set.
+  /// Simplify each disjunct, canonicalizing each disjunct and removing
+  /// redundencies.
   PresburgerRelation simplify() const;
 
   /// Print the set's internal state.

--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -80,7 +80,7 @@ bool IntegerRelation::isEqual(const IntegerRelation &other) const {
   return PresburgerRelation(*this).isEqual(PresburgerRelation(other));
 }
 
-bool IntegerRelation::isPlainEqual(const IntegerRelation &other) const {
+bool IntegerRelation::isObviouslyEqual(const IntegerRelation &other) const {
   if (!space.isEqual(other.getSpace()))
     return false;
   if (getNumEqualities() != other.getNumEqualities())
@@ -445,14 +445,6 @@ void IntegerRelation::clearConstraints() {
   inequalities.resizeVertically(0);
 }
 
-void IntegerRelation::markSetEmpty() {
-  clearConstraints();
-  unsigned col = getNumCols();
-  SmallVector<int64_t> eqeff(col, 0);
-  eqeff.back() = 1;
-  addEquality(eqeff);
-}
-
 /// Gather all lower and upper bounds of the variable at `pos`, and
 /// optionally any equalities on it. In addition, the bounds are to be
 /// independent of variables in position range [`offset`, `offset` + `num`).
@@ -709,7 +701,7 @@ bool IntegerRelation::isEmpty() const {
   return false;
 }
 
-bool IntegerRelation::isPlainEmpty() const {
+bool IntegerRelation::isObviouslyEmpty() const {
   if (isEmptyByGCDTest() || hasInvalidConstraint())
     return true;
   return false;
@@ -1136,7 +1128,7 @@ bool IntegerRelation::gaussianEliminate() {
     if (atEq(i, vars) == 0)
       continue;
 
-    markSetEmpty();
+    *this = getEmpty(getSpace());
     return true;
   }
   // Rows that are confirmed to be all zeros can be eliminated.
@@ -1341,7 +1333,7 @@ void IntegerRelation::simplify() {
     changed = false;
     normalizeConstraintsByGCD();
     changed |= gaussianEliminate();
-    if (isPlainEmpty())
+    if (isObviouslyEmpty())
       return;
     changed |= removeDuplicateConstraints();
   }
@@ -2353,7 +2345,7 @@ bool IntegerRelation::removeDuplicateConstraints() {
       removeInequality(k);
       removeInequality(l);
     } else
-      markSetEmpty();
+      *this = getEmpty(getSpace());
     break;
   }
 

--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2338,18 +2338,20 @@ bool IntegerRelation::removeDuplicateConstraints() {
     // sum of their constant terms is positive.
     unsigned l = hashTable[nRow];
     auto sum = atIneq(l, cols - 1) + atIneq(k, cols - 1);
-    if (sum > 0)
+    if (sum > 0 || l == k)
       continue;
 
     // A sum of constant terms equal to zero combines two inequalities into one
     // equation, less than zero means the set is empty.
     negChanged = true;
     changed = true;
+    if (k < l)
+      std::swap(l, k);
     if (sum == 0) {
       addEquality(getInequality(k));
       removeInequality(ineqs);
-      removeInequality(l);
       removeInequality(k);
+      removeInequality(l);
     } else
       markSetEmpty();
     break;

--- a/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
@@ -1015,6 +1015,15 @@ bool PresburgerRelation::hasOnlyDivLocals() const {
   });
 }
 
+PresburgerRelation PresburgerRelation::simplify() {
+  PresburgerRelation rel = PresburgerRelation(getSpace());
+  for (IntegerRelation &disjunct : disjuncts) {
+    if (disjunct.simplify())
+      rel.unionInPlace(disjunct);
+  }
+  return rel;
+}
+
 void PresburgerRelation::print(raw_ostream &os) const {
   os << "Number of Disjuncts: " << getNumDisjuncts() << "\n";
   for (const IntegerRelation &disjunct : disjuncts) {

--- a/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
@@ -1018,7 +1018,8 @@ bool PresburgerRelation::hasOnlyDivLocals() const {
 PresburgerRelation PresburgerRelation::simplify() {
   PresburgerRelation rel = PresburgerRelation(getSpace());
   for (IntegerRelation &disjunct : disjuncts) {
-    if (disjunct.simplify())
+    disjunct.simplify();
+    if (!disjunct.isPlainEmpty())
       rel.unionInPlace(disjunct);
   }
   return rel;

--- a/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
@@ -576,6 +576,9 @@ static PresburgerRelation getSetDifference(IntegerRelation b,
     }
   }
 
+  // Try to simplify the results.
+  result = result.simplify();
+
   return result;
 }
 
@@ -1015,14 +1018,15 @@ bool PresburgerRelation::hasOnlyDivLocals() const {
   });
 }
 
-PresburgerRelation PresburgerRelation::simplify() {
-  PresburgerRelation rel = PresburgerRelation(getSpace());
-  for (IntegerRelation &disjunct : disjuncts) {
+PresburgerRelation PresburgerRelation::simplify() const {
+  PresburgerRelation origin = *this;
+  PresburgerRelation result = PresburgerRelation(getSpace());
+  for (IntegerRelation &disjunct : origin.disjuncts) {
     disjunct.simplify();
     if (!disjunct.isPlainEmpty())
-      rel.unionInPlace(disjunct);
+      result.unionInPlace(disjunct);
   }
-  return rel;
+  return result;
 }
 
 void PresburgerRelation::print(raw_ostream &os) const {

--- a/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
@@ -639,7 +639,7 @@ bool PresburgerRelation::isObviouslyEqual(const PresburgerRelation &set) const {
 /// one unconstrained disjunct, indicating the absence of constraints or
 /// conditions.
 bool PresburgerRelation::isObviouslyUniverse() const {
-  for (auto &disjunct : getAllDisjuncts()) {
+  for (const IntegerRelation &disjunct : getAllDisjuncts()) {
     if (disjunct.getNumConstraints() == 0)
       return true;
   }


### PR DESCRIPTION
Added the simplify function to reduce the size of the constraint system, referencing the ISL implementation.

Tested it on a simple Benchmark implemented by myself, calling SImplify before the operation and calling Simplify on the result after Subtract were tested, respectively.

The Benchmark can be found here: [benchmark](https://github.com/gilsaia/llvm-project-test-fpl/blob/develop_benchmark/mlir/benchmark/presburger/Benchmark.cpp)

For the case of calling Simplify before each operation, the overall result is shown in the following figure.
![image](https://github.com/llvm/llvm-project/assets/38588948/7099286e-b9a2-42e0-bc2a-1ed6627ead00)

A comparison of the constraint system sizes and time for each operation is as follows
![image](https://github.com/llvm/llvm-project/assets/38588948/e5d0e488-f76e-4438-b19e-f6163699c526)
![image](https://github.com/llvm/llvm-project/assets/38588948/119a08de-4ee1-4cde-886c-50a91b502d93)
![image](https://github.com/llvm/llvm-project/assets/38588948/7a8b69ac-6cdb-41ab-9a75-cd016664fa5a)
![image](https://github.com/llvm/llvm-project/assets/38588948/c84b6eb1-62dc-4bae-a771-67d97ebf514a)
![image](https://github.com/llvm/llvm-project/assets/38588948/cdbfa3ed-0155-481e-9273-9d6dba3a2d7b)
![image](https://github.com/llvm/llvm-project/assets/38588948/8c945cff-a0a4-472a-a178-6b6a70a1b16a)
![image](https://github.com/llvm/llvm-project/assets/38588948/0bfe3a2b-3568-4d31-bebf-bd1b3c4e734e)
![image](https://github.com/llvm/llvm-project/assets/38588948/f1a99d56-edf5-45de-a506-512c0584f1d8)
![image](https://github.com/llvm/llvm-project/assets/38588948/ffef3312-6c99-494c-bb52-73aa8df275bb)
![image](https://github.com/llvm/llvm-project/assets/38588948/3e5924a7-8e1f-49d1-bd27-02a2e10a5cc4)
![image](https://github.com/llvm/llvm-project/assets/38588948/cec8be0e-dd19-46fa-88b4-2585d4031c9e)
![image](https://github.com/llvm/llvm-project/assets/38588948/3cb68e89-82c7-4cd2-b6bc-70f15e495ce8)

For the case of calling Simplify on the result after Subtract, the overall results are as follows
![image](https://github.com/llvm/llvm-project/assets/38588948/be5b9c50-7417-42c8-abbf-8a50f093c3f5)

A comparison of the constraint system sizes and time for subtract is as follows
![image](https://github.com/llvm/llvm-project/assets/38588948/fafe10ba-f8bd-43cd-b281-aaebf09af0af)
![image](https://github.com/llvm/llvm-project/assets/38588948/24662b40-42fc-47ee-a0a3-1b8b8f5778d2)

