### PR TITLE
[flang] Put ISO_Fortran_binding.h where it can be easily used

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -273,10 +273,10 @@ if (NOT(FLANG_DEFAULT_RTLIB STREQUAL ""))
       "Default runtime library to use (empty for platform default)" FORCE)
 endif()
 
-
-
 set(PACKAGE_VERSION "${LLVM_PACKAGE_VERSION}")
-
+if (NOT PACKAGE_VERSION)
+  set(PACKAGE_VERSION ${LLVM_VERSION_MAJOR})
+endif()
 
 if (NOT DEFINED FLANG_VERSION_MAJOR)
   set(FLANG_VERSION_MAJOR ${LLVM_VERSION_MAJOR})
@@ -490,3 +490,17 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     PATTERN "*.inc"
     )
 endif()
+
+# Put ISO_Fortran_binding.h into the include files of the build area now
+# so that we can run tests before installing
+include(GetClangResourceDir)
+get_clang_resource_dir(HEADER_BINARY_DIR PREFIX ${LLVM_LIBRARY_OUTPUT_INTDIR}/.. SUBDIR include)
+configure_file(
+  ${FLANG_SOURCE_DIR}/include/flang/ISO_Fortran_binding.h
+  ${HEADER_BINARY_DIR}/ISO_Fortran_binding.h)
+
+# And also install it into the install area
+get_clang_resource_dir(HEADER_INSTALL_DIR PREFIX ${CMAKE_INSTALL_PREFIX} SUBDIR include)
+install(
+  FILES ${CMAKE_INSTALL_PREFIX}/include/flang/ISO_Fortran_binding.h 
+  DESTINATION ${HEADER_INSTALL_DIR})

--- a/flang/test/Examples/ctofortran.f90
+++ b/flang/test/Examples/ctofortran.f90
@@ -1,0 +1,70 @@
+! UNSUPPORTED: system-windows
+! RUN: split-file %s %t
+! RUN: chmod +x %t/runtest.sh
+! RUN: %t/runtest.sh %t %flang $t/ffile.f90 $t/cfile.c | FileCheck %s
+
+!--- ffile.f90
+subroutine foo(a) bind(c)
+  integer :: a(:)
+  if (lbound(a, 1) .ne. 1) then
+     print *, 'FAIL expected 1 for lbound but got ',lbound(a, 1)
+     stop 1
+  endif
+
+  if (ubound(a, 1) .ne. 10) then
+     print *, 'FAIL expected 10 for ubound but got ',ubound(a, 1)
+     stop 1
+  endif
+
+  do i = lbound(a,1),ubound(a,1)
+     !print *, a(i)
+     if (a(i) .ne. i) then
+        print *, 'FAIL expected', i, ' for index ',i, ' but got ',a(i)
+        stop 1
+     endif
+  enddo
+  print *, 'PASS'
+end subroutine foo
+
+! CHECK: PASS
+!--- cfile.c
+#include <stdio.h>
+#include <stdlib.h>
+#include <ISO_Fortran_binding.h>
+
+void foo(CFI_cdesc_t*);
+
+int a[10];
+
+int main() {
+  int i, res;
+  static CFI_CDESC_T(1) r1;
+  CFI_cdesc_t *desc = (CFI_cdesc_t*)&r1;
+  CFI_index_t extent[1] = {10};
+
+  for(i=0; i<10; ++i) {
+    a[i] = i+1;
+  }
+
+  res = CFI_establish(desc, (void*)a, CFI_attribute_other, CFI_type_int32_t,
+                      sizeof(int), 1, extent);
+  if (res != 0) {
+    printf("FAIL CFI_establish returned %d instead of 0.\n",res);
+    exit(1);
+  }
+
+  foo(desc);
+  return 0;
+}
+!--- runtest.sh
+#!/bin/bash
+export CCOMP=`dirname $2`/clang
+if [ -x $CCOMP ]
+then
+  $CCOMP -c $1/$4 -o $1/cfile.o
+  $2 $1/$3 $1/cfile.o -o $1/ctofortran
+  $1/ctofortran # should print "PASS"
+else
+  # No clang compiler, just pass by default
+  echo "PASS"
+fi


### PR DESCRIPTION
The update stems from the discussion in
https://discourse.llvm.org/t/adding-flang-specific-header-files-to-clang/72442

This is my second attempt at this.  My first attempt was in pull request #68756.

I decided to put ISO_Fortran_binding.h in a place where it would be accessible with the include: "#include<ISO_Fortran_binding.h>" rather than "#include<fortran/ISO_Fortran_binding.h>" because this is what gfortran implements.

Note that the file is also installed into ".../include/flang", so if a user wanted to access the file from a compiler other than clang, it would be available.

I added a test in ".../flang/test/Examples".  To make the test work, I also needed to put ISO_Fortran_binding.h into the build area.

Although the flang project depends on clang, clang may not always be available in a flang build.  For example, when building just the "check-flang" target, the "clang" executable may not be available at the time the new test gets run. To account for this, I made the test's script check for the existence of the "clang" executable.  If "clang" is not available, it simply prints "PASS".  If it is available, it fully builds and executes the test.  On success, this will also print "PASS"