### PR TITLE
[BasicAA] Remove NSW flags when merging scales

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -662,6 +662,7 @@ BasicAAResult::DecomposeGEPExpression(const Value *V, const DataLayout &DL,
         if (Decomposed.VarIndices[i].Val.V == LE.Val.V &&
             Decomposed.VarIndices[i].Val.hasSameCastsAs(LE.Val)) {
           Scale += Decomposed.VarIndices[i].Scale;
+          LE.IsNSW = false; // We cannot guarantee nsw for the merge.
           Decomposed.VarIndices.erase(Decomposed.VarIndices.begin() + i);
           break;
         }

--- a/llvm/test/Analysis/BasicAA/pr69096.ll
+++ b/llvm/test/Analysis/BasicAA/pr69096.ll
@@ -3,8 +3,8 @@
 target datalayout = "p:64:64:64"
 
 ; CHECK-LABEL: Function: pr69096
-; FIXME: This should be MayAlias. %p == %scevgep.i when %a == -1.
-; CHECK: NoAlias:     i8* %p, i16* %scevgep.i
+; %p == %scevgep.i when %a == -1.
+; CHECK: MayAlias:     i8* %p, i16* %scevgep.i
 
 define i32 @pr69096(i16 %a, ptr %p) {
 entry:


### PR DESCRIPTION
When merging scales of `LinearExpression` that have common index variables, we cannot guarantee the NSW flag still applies to the merged expression.

Fixes #69096.
