### PR TITLE
[libclang/python] Add missing concept declaration CursorKind

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -1403,6 +1403,8 @@ CursorKind.TYPE_ALIAS_TEMPLATE_DECL = CursorKind(601)
 CursorKind.STATIC_ASSERT = CursorKind(602)
 # A friend declaration
 CursorKind.FRIEND_DECL = CursorKind(603)
+# A concept declaration
+CursorKind.CONCEPT_DECL = CursorKind(604)
 
 # A code completion overload candidate.
 CursorKind.OVERLOAD_CANDIDATE = CursorKind(700)


### PR DESCRIPTION
Maps to [`CXCursor_ConceptDecl`](https://github.com/llvm/llvm-project/blob/ee8524087c78a673fcf5486ded69ee597a85e0f1/clang/include/clang-c/Index.h#L2716), added in ee8524087c78a673fcf5486ded69ee597a85e0f1.

Without this I get this error on my codebase which uses C++20 concept decls:
```
ValueError: Unknown template argument kind 604
```