### PR TITLE
[CodeGen] Remove LiveVariables::{isPHIJoin,setPHIJoin}

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveVariables.h
+++ b/llvm/include/llvm/CodeGen/LiveVariables.h
@@ -118,11 +118,6 @@ private:
   ///
   IndexedMap<VarInfo, VirtReg2IndexFunctor> VirtRegInfo;
 
-  /// PHIJoins - list of virtual registers that are PHI joins. These registers
-  /// may have multiple definitions, and they require special handling when
-  /// building live intervals.
-  SparseBitVector<> PHIJoins;
-
 private:   // Intermediate data structures
   MachineFunction *MF = nullptr;
 
@@ -302,12 +297,6 @@ public:
                    MachineBasicBlock *DomBB,
                    MachineBasicBlock *SuccBB,
                    std::vector<SparseBitVector<>> &LiveInSets);
-
-  /// isPHIJoin - Return true if Reg is a phi join register.
-  bool isPHIJoin(Register Reg) { return PHIJoins.test(Reg.id()); }
-
-  /// setPHIJoin - Mark Reg as a phi join register.
-  void setPHIJoin(Register Reg) { PHIJoins.set(Reg.id()); }
 };
 
 } // End llvm namespace

--- a/llvm/lib/CodeGen/LiveVariables.cpp
+++ b/llvm/lib/CodeGen/LiveVariables.cpp
@@ -601,7 +601,6 @@ bool LiveVariables::runOnMachineFunction(MachineFunction &mf) {
   PhysRegDef.assign(NumRegs, nullptr);
   PhysRegUse.assign(NumRegs, nullptr);
   PHIVarInfo.resize(MF->getNumBlockIDs());
-  PHIJoins.clear();
 
   // FIXME: LiveIntervals will be updated to remove its dependence on
   // LiveVariables to improve compilation time and eliminate bizarre pass

--- a/llvm/lib/CodeGen/PHIElimination.cpp
+++ b/llvm/lib/CodeGen/PHIElimination.cpp
@@ -330,9 +330,6 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
     if (IncomingReg) {
       LiveVariables::VarInfo &VI = LV->getVarInfo(IncomingReg);
 
-      // Increment use count of the newly created virtual register.
-      LV->setPHIJoin(IncomingReg);
-
       MachineInstr *OldKill = nullptr;
       bool IsPHICopyAfterOldKill = false;
 


### PR DESCRIPTION
The last use of isPHIJoin was removed by:

  commit fac770b865f59cbe615241dad153ad20d5138b9e
  Author: Jakob Stoklund Olesen <stoklund@2pi.dk>
  Date:   Sat Feb 9 00:04:07 2013 +0000

so there is no reason to maintain PHIJoins.
