### PR TITLE
[GlobalISel] Remove unused function narrowToSmallerAndWidenToSmallest

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegacyLegalizerInfo.h
@@ -240,16 +240,6 @@ public:
                                                        Unsupported);
   }
 
-  static SizeAndActionsVec
-  narrowToSmallerAndWidenToSmallest(const SizeAndActionsVec &v) {
-    using namespace LegacyLegalizeActions;
-    assert(v.size() > 0 &&
-           "At least one size that can be legalized towards is needed"
-           " for this SizeChangeStrategy");
-    return decreaseToSmallerTypesAndIncreaseToSmallest(v, NarrowScalar,
-                                                       WidenScalar);
-  }
-
   /// A SizeChangeStrategy for the common case where legalization for a
   /// particular vector operation consists of having more elements in the
   /// vector, to a type that is legal. Unless there is no such type and then


### PR DESCRIPTION
The last use was removed by:

  commit b163efae3312abe1227cff1d7704325138b4e538
  Author: Simon Pilgrim <llvm-dev@redking.me.uk>
  Date:   Thu Jun 15 13:56:53 2023 +0100
