### PR TITLE
[CodeGen] Remove unused function isMSInlineAsm

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1365,12 +1365,6 @@ public:
            getOpcode() == TargetOpcode::INLINEASM_BR;
   }
 
-  /// FIXME: Seems like a layering violation that the AsmDialect, which is X86
-  /// specific, be attached to a generic MachineInstr.
-  bool isMSInlineAsm() const {
-    return isInlineAsm() && getInlineAsmDialect() == InlineAsm::AD_Intel;
-  }
-
   bool isStackAligningInlineAsm() const;
   InlineAsm::AsmDialect getInlineAsmDialect() const;
 


### PR DESCRIPTION
The last use was removed by:

  commit ee08897fb8d4b59b4609f6e837205e7a089b6fb7
  Author: Reid Kleckner <reid@kleckner.net>
  Date:   Tue Dec 10 18:27:32 2013 +0000
