### PR TITLE
[llvm][Tablegen][llvm-tblgen] Added keyword #undef to llvm-tblgen

### DIFF
--- a/llvm/lib/TableGen/TGLexer.h
+++ b/llvm/lib/TableGen/TGLexer.h
@@ -72,6 +72,7 @@ enum TokKind {
   Else,
   Endif,
   Define,
+  Undef,
 
   // Reserved keywords. ('ElseKW' is named to distinguish it from the
   // existing 'Else' that means the preprocessor #else.)

--- a/llvm/test/TableGen/prep-undef-1.td
+++ b/llvm/test/TableGen/prep-undef-1.td
@@ -1,0 +1,9 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+
+// CHECK: def TEST_MACRONAME
+#define MACRONAME
+#undef MACRONAME
+
+#ifndef MACRONAME
+def TEST_MACRONAME;
+#endif

--- a/llvm/test/TableGen/prep-undef-2.td
+++ b/llvm/test/TableGen/prep-undef-2.td
@@ -1,0 +1,8 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+
+// CHECK: def TEST_MACRONAME
+#undef MACRONAME
+#define MACRONAME
+#ifdef MACRONAME
+def TEST_MACRONAME;
+#endif

--- a/llvm/test/TableGen/prep-undef-3.td
+++ b/llvm/test/TableGen/prep-undef-3.td
@@ -1,0 +1,9 @@
+// RUN: llvm-tblgen -I %p %s 2>&1 | FileCheck %s 
+
+// CHECK: def DEF_A
+#define FILE_A
+include "prep-undef-included-file.inc"
+
+// CHECK: def DEF_B
+#define FILE_B
+include "prep-undef-included-file.inc"

--- a/llvm/test/TableGen/prep-undef-diag-1.td
+++ b/llvm/test/TableGen/prep-undef-diag-1.td
@@ -1,0 +1,4 @@
+// // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
+
+// CHECK: error: Expected macro name after #undef
+#undef 1

--- a/llvm/test/TableGen/prep-undef-diag-2.td
+++ b/llvm/test/TableGen/prep-undef-diag-2.td
@@ -1,0 +1,4 @@
+// // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
+
+// CHECK: error: Only comments are supported after #undef NAME
+#undef MACRO 42

--- a/llvm/test/TableGen/prep-undef-included-file.inc
+++ b/llvm/test/TableGen/prep-undef-included-file.inc
@@ -1,0 +1,9 @@
+#ifdef FILE_A
+#undef FILE_A
+def DEF_A;
+#endif
+
+#ifdef FILE_B
+#undef FILE_B
+def DEF_B;
+#endif


### PR DESCRIPTION
### Motivation introduction

I want a td file to contain part of other td files instead of the entire file, so when using macros to implement it, I found that llvm-tblgen provides #define, #ifdef, #ifndef, #endif but does not provide #undef, so this PR The main purpose is to provide #undef support in llvm-tblgen, and when I was debugging, I found that if a td file ends with #endif, a td syntax error will occur, so I added a line to correct this bug. If there are any deficiencies, please point out

### bug in llvm-tblgen

If you remove a lot of spaces in the last line of the test file for testing the llvm-tblgen macro, you will find that a compilation error will occur.
ex: llvm/test/TableGen/prep-ifndef.td
```
// RUN: llvm-tblgen %s -DMACRO | FileCheck %s
// RUN: llvm-tblgen %s | FileCheck %s --check-prefix=CHECK-NOMACRO

#ifndef MACRO
// CHECK-NOMACRO: def nomacro
def nomacro;
#else
// CHECK: def macro
def macro;
#endif

```