### PR TITLE
[mlir][Interfaces][NFC] Change `getDpsInitsMutable` to return `MutableArrayRef`

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationOps.td
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizationOps.td
@@ -218,7 +218,8 @@ def Bufferization_MaterializeInDestinationOp
     : Bufferization_Op<"materialize_in_destination",
         [AllShapesMatch<["source", "dest"]>,
          AllElementTypesMatch<["source", "dest"]>,
-         BufferizableOpInterface, DestinationStyleOpInterface,
+         BufferizableOpInterface,
+         DeclareOpInterfaceMethods<DestinationStyleOpInterface>,
          DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
          DeclareOpInterfaceMethods<SubsetInsertionOpInterface,
             ["getSourceOperand", "getValuesNeededToBuildSubsetExtraction",
@@ -300,8 +301,6 @@ def Bufferization_MaterializeInDestinationOp
     RankedTensorType getType() {
       return ::llvm::cast<RankedTensorType>(getResult().getType());
     }
-
-    MutableOperandRange getDpsInitsMutable();
 
     bool isWritable(Value value, const AnalysisState &state);
   }];

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
@@ -149,7 +149,9 @@ def Linalg_SoftmaxOp : Linalg_Op<"softmax",
     int64_t getOutputOperandRank() {
       return getOutputOperandType().getRank();
     }
-    MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() {
+      return getOutputMutable();
+    }
   }];
   let hasVerifier = 1;
 }

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
@@ -208,7 +208,9 @@ def GenericOp : LinalgStructuredBase_Op<"generic", [
       return nullptr;
     }
 
-    MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() {
+      return getOutputsMutable();
+    }
   }];
 
   let hasCanonicalizer = 1;
@@ -281,7 +283,7 @@ def MapOp : LinalgStructuredBase_Op<"map", [
     }
 
     // Implement functions necessary for DestinationStyleOpInterface.
-    MutableOperandRange getDpsInitsMutable() { return getInitMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() { return getInitMutable(); }
 
     SmallVector<OpOperand *> getOpOperandsMatchingBBargs() {
       return getDpsInputOperands();
@@ -377,7 +379,9 @@ def ReduceOp : LinalgStructuredBase_Op<"reduce", [
     getRegionBuilder() {
       return nullptr;
     }
-    MutableOperandRange getDpsInitsMutable() { return getInitsMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() {
+      return getInitsMutable();
+    }
   }];
 
   let hasCustomAssemblyFormat = 1;
@@ -440,7 +444,7 @@ def TransposeOp : LinalgStructuredBase_Op<"transpose", [
     }
 
     // Implement functions necessary for DestinationStyleOpInterface.
-    MutableOperandRange getDpsInitsMutable() { return getInitMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() { return getInitMutable(); }
 
     static std::function<void(mlir::ImplicitLocOpBuilder &, mlir::Block &,
         mlir::ArrayRef<mlir::NamedAttribute>)>
@@ -508,7 +512,7 @@ def BroadcastOp : LinalgStructuredBase_Op<"broadcast", [
     }
 
     // Implement functions necessary for DestinationStyleOpInterface.
-    MutableOperandRange getDpsInitsMutable() { return getInitMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() { return getInitMutable(); }
 
     static std::function<void(mlir::ImplicitLocOpBuilder &, mlir::Block &,
         mlir::ArrayRef<mlir::NamedAttribute>)>

--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -635,7 +635,9 @@ def ForallOp : SCF_Op<"forall", [
     InParallelOp getTerminator();
 
     // Declare the shared_outs as inits/outs to DestinationStyleOpInterface.
-    MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() {
+      return getOutputsMutable();
+    }
   }];
 }
 

--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
@@ -750,7 +750,7 @@ def Tensor_InsertOp : Tensor_Op<"insert", [
   }];
 
   let extraClassDeclaration = [{
-    MutableOperandRange getDpsInitsMutable() { return getDestMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() { return getDestMutable(); }
   }];
 
   let hasFolder = 1;
@@ -890,7 +890,7 @@ def Tensor_InsertSliceOp : Tensor_OpWithOffsetSizesAndStrides<"insert_slice", [
     /// and `strides` operands.
     static unsigned getOffsetSizeAndStrideStartOperandIndex() { return 2; }
 
-    MutableOperandRange getDpsInitsMutable() { return getDestMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() { return getDestMutable(); }
   }];
 
   let hasCanonicalizer = 1;
@@ -1710,7 +1710,7 @@ class Tensor_RelayoutOp<string mnemonic, list<Trait> traits = []> :
     RankedTensorType getDestType() {
       return ::llvm::cast<RankedTensorType>(getDest().getType()); };
 
-    MutableOperandRange getDpsInitsMutable() { return getDestMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() { return getDestMutable(); }
 
     /// Interface method for ConditionallySpeculatable.
     Speculation::Speculatability getSpeculatability();

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1389,8 +1389,8 @@ def Vector_TransferReadOp :
     // MaskableOpInterface methods.
     bool supportsPassthru() { return true; }
 
-    MutableOperandRange getDpsInitsMutable() {
-      return MutableOperandRange(getOperation(), /*start=*/0, /*length=*/0);
+    MutableArrayRef<OpOperand> getDpsInitsMutable() {
+      return {};
     }
   }];
 
@@ -1553,7 +1553,9 @@ def Vector_TransferWriteOp :
     ///  ops of other dialects.
     Value getValue() { return getVector(); }
 
-    MutableOperandRange getDpsInitsMutable() { return getSourceMutable(); }
+    MutableArrayRef<OpOperand> getDpsInitsMutable() {
+      return getSourceMutable();
+    }
   }];
 
   let hasFolder = 1;

--- a/mlir/include/mlir/IR/ValueRange.h
+++ b/mlir/include/mlir/IR/ValueRange.h
@@ -158,6 +158,9 @@ public:
   /// Allow implicit conversion to an OperandRange.
   operator OperandRange() const;
 
+  /// Allow implicit conversion to a MutableArrayRef.
+  operator MutableArrayRef<OpOperand>() const;
+
   /// Returns the owning operation.
   Operation *getOwner() const { return owner; }
 

--- a/mlir/include/mlir/Interfaces/DestinationStyleOpInterface.td
+++ b/mlir/include/mlir/Interfaces/DestinationStyleOpInterface.td
@@ -20,9 +20,9 @@ def DestinationStyleOpInterface : OpInterface<"DestinationStyleOpInterface"> {
     Init operands must be ranked tensors or ranked memrefs. Input operands can
     have any type. All non-init operands are DPS inputs.
 
-    The init operands of this op are specified by the MutableOperandRange that
-    the `getDpsInitsMutable` interface methods returns. This implies that the
-    init operands must be a consecutive range of operands.
+    The init operands of this op are specified by the OpOperands that
+    the `getDpsInitsMutable` interface methods returns. The init operands must
+    be a consecutive range of operands.
 
     If the op has "tensor semantics", then the input operands are either ranked
     tensors or other non-tensor/memref types ("scalars"). The init operands are
@@ -56,8 +56,8 @@ def DestinationStyleOpInterface : OpInterface<"DestinationStyleOpInterface"> {
 
   let methods = [
     InterfaceMethod<
-      /*desc=*/"Return start and end indices of the init operands range.",
-      /*retTy=*/"::mlir::MutableOperandRange",
+      /*desc=*/"Return the consecutive range of init operands.",
+      /*retTy=*/"::llvm::MutableArrayRef<::mlir::OpOperand>",
       /*methodName=*/"getDpsInitsMutable",
       /*args=*/(ins)
     >,
@@ -65,7 +65,13 @@ def DestinationStyleOpInterface : OpInterface<"DestinationStyleOpInterface"> {
 
   let extraSharedClassDeclaration = [{
     ::mlir::OperandRange getDpsInits() {
-      return $_op.getDpsInitsMutable();
+      auto initsMutable = $_op.getDpsInitsMutable();
+      if (initsMutable.empty())
+        return ::mlir::OperandRange($_op->operand_end(), $_op->operand_end());
+      unsigned firstOperandIndex = initsMutable.begin()->getOperandNumber();
+      return OperandRange(
+          $_op->operand_begin() + firstOperandIndex,
+          $_op->operand_begin() + firstOperandIndex + initsMutable.size());
     }
 
     /// Return the number of DPS inits.

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationOps.cpp
@@ -675,7 +675,7 @@ bool MaterializeInDestinationOp::isWritable(Value value,
   return isa<TensorType>(getDest().getType()) ? true : getWritable();
 }
 
-MutableOperandRange MaterializeInDestinationOp::getDpsInitsMutable() {
+MutableArrayRef<OpOperand> MaterializeInDestinationOp::getDpsInitsMutable() {
   return getDestMutable();
 }
 

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -502,6 +502,10 @@ MutableOperandRange::operator OperandRange() const {
   return owner->getOperands().slice(start, length);
 }
 
+MutableOperandRange::operator MutableArrayRef<OpOperand>() const {
+  return owner->getOpOperands().slice(start, length);
+}
+
 MutableOperandRangeRange
 MutableOperandRange::split(NamedAttribute segmentSizes) const {
   return MutableOperandRangeRange(*this, segmentSizes);
@@ -529,11 +533,11 @@ OpOperand &MutableOperandRange::operator[](unsigned index) const {
 }
 
 MutableArrayRef<OpOperand>::iterator MutableOperandRange::begin() const {
-  return owner->getOpOperands().slice(start, length).begin();
+  return static_cast<MutableArrayRef<OpOperand>>(*this).begin();
 }
 
 MutableArrayRef<OpOperand>::iterator MutableOperandRange::end() const {
-  return owner->getOpOperands().slice(start, length).end();
+  return static_cast<MutableArrayRef<OpOperand>>(*this).end();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2350,7 +2350,7 @@ def TestDestinationStyleOp :
   }];
 
   let extraClassDeclaration = [{
-    mlir::MutableOperandRange getDpsInitsMutable() {
+    mlir::MutableArrayRef<mlir::OpOperand> getDpsInitsMutable() {
       return getOutputsMutable();
     }
   }];
@@ -2411,7 +2411,7 @@ def TestLinalgConvOp :
       return "";
     }
 
-    mlir::MutableOperandRange getDpsInitsMutable() {
+    mlir::MutableArrayRef<mlir::OpOperand> getDpsInitsMutable() {
       return getOutputsMutable();
     }
   }];
@@ -2472,7 +2472,7 @@ def TestLinalgFillOp :
       return "";
     }
 
-    mlir::MutableOperandRange getDpsInitsMutable() {
+    mlir::MutableArrayRef<mlir::OpOperand> getDpsInitsMutable() {
       return getOutputsMutable();
     }
   }];


### PR DESCRIPTION
`getDpsInitsMutable` now returns a `MutableArrayRef`. This is so that ops can implement the `DestinationStyleOpInterface` even if they do not have any "inits". An example for such an op is `vector.transfer_read`. The current implementation returns a `MutableOperandRange` with range 0 and length 0. This is problematic because the API could be used to append operands, which would create an invalid op. `MutableArrayRef<OpOperand>` is a better abstraction, which does not allow users to change the number of operands.