### PR TITLE
[ModuleInliner] use std::make_heap to construct the heap after element updated

### DIFF
--- a/llvm/lib/Analysis/InlineOrder.cpp
+++ b/llvm/lib/Analysis/InlineOrder.cpp
@@ -219,13 +219,12 @@ class PriorityInlineOrder : public InlineOrder<std::pair<CallBase *, int>> {
   // growth from prior inlining into the callee. This method is used to lazily
   // update the desirability of a call site if it's decreasing. It is only
   // called on pop() or front(), not every time the desirability changes. When
-  // the desirability of the front call site decreases, an updated one would be
-  // pushed right back into the heap. For simplicity, those cases where
-  // the desirability of a call site increases are ignored here.
+  // the desirability of the front call site decreases, the heap is re-constructed
+  // by std::make_heap. For simplicity, those cases where the desirability of
+  // a call site increases are ignored here.
   void adjust() {
     while (updateAndCheckDecreased(Heap.front())) {
-      std::pop_heap(Heap.begin(), Heap.end(), isLess);
-      std::push_heap(Heap.begin(), Heap.end(), isLess);
+      std::make_heap(Heap.begin(), Heap.end(), isLess);
     }
   }
 


### PR DESCRIPTION
After `updateAndCheckDecreased`, some element may be updated and the range(Heap.begin(), Heap.end()) is not a valid heap.
Use std::make_heap to make sure the heap is valid.