### PR TITLE
[TargetParser][AMDGPU] Fix getArchEntry().

### DIFF
--- a/llvm/lib/TargetParser/TargetParser.cpp
+++ b/llvm/lib/TargetParser/TargetParser.cpp
@@ -133,7 +133,7 @@ const GPUInfo *getArchEntry(AMDGPU::GPUKind AK, ArrayRef<GPUInfo> Table) {
         return A.Kind < B.Kind;
       });
 
-  if (I == Table.end())
+  if (I == Table.end() || I->Kind != Search.Kind)
     return nullptr;
   return I;
 }


### PR DESCRIPTION
It's supposed to return null when an unknown target id is passed.