### PR TITLE
[Windows] Add git-clang-format wrapper bat file

### DIFF
--- a/clang/tools/clang-format/CMakeLists.txt
+++ b/clang/tools/clang-format/CMakeLists.txt
@@ -38,3 +38,9 @@ install(FILES clang-format.py
 install(PROGRAMS git-clang-format
   DESTINATION "${CMAKE_INSTALL_BINDIR}"
   COMPONENT clang-format)
+
+if (WIN32 AND NOT CYGWIN)
+  install(PROGRAMS git-clang-format.bat
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT clang-format)
+endif()

--- a/clang/tools/clang-format/git-clang-format.bat
+++ b/clang/tools/clang-format/git-clang-format.bat
@@ -1,0 +1,1 @@
+py -3 git-clang-format %*


### PR DESCRIPTION
This allows git-clang-format to be used on a Windows terminal without manually needing to find the path and invoke the python interpreter. We have a similar script for `scan-build`.

Fixes #69643