### PR TITLE
[mlir][sparse] cleanup of COO

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/SparseTensor/COO.h
+++ b/mlir/include/mlir/ExecutionEngine/SparseTensor/COO.h
@@ -58,21 +58,13 @@ struct ElementLT final {
   const uint64_t rank;
 };
 
-/// The type of callback functions which receive an element.
-template <typename V>
-using ElementConsumer =
-    const std::function<void(const std::vector<uint64_t> &, V)> &;
-
 /// A memory-resident sparse tensor in coordinate-scheme representation
-/// (a collection of `Element`s).  This data structure is used as
-/// an intermediate representation; e.g., for reading sparse tensors
-/// from external formats into memory, or for certain conversions between
-/// different `SparseTensorStorage` formats.
+/// (a collection of `Element`s). This data structure is used as an
+/// intermediate representation, e.g., for reading sparse tensors from
+/// external formats into memory.
 template <typename V>
 class SparseTensorCOO final {
 public:
-  using const_iterator = typename std::vector<Element<V>>::const_iterator;
-
   /// Constructs a new coordinate-scheme sparse tensor with the given
   /// sizes and an optional initial storage capacity.
   explicit SparseTensorCOO(const std::vector<uint64_t> &dimSizes,
@@ -106,7 +98,7 @@ public:
   /// Returns the `operator<` closure object for the COO's element type.
   ElementLT<V> getElementLT() const { return ElementLT<V>(getRank()); }
 
-  /// Adds an element to the tensor. This method invalidates all iterators.
+  /// Adds an element to the tensor.
   void add(const std::vector<uint64_t> &dimCoords, V val) {
     const uint64_t *base = coordinates.data();
     const uint64_t size = coordinates.size();
@@ -135,12 +127,9 @@ public:
     elements.push_back(addedElem);
   }
 
-  const_iterator begin() const { return elements.cbegin(); }
-  const_iterator end() const { return elements.cend(); }
-
   /// Sorts elements lexicographically by coordinates. If a coordinate
   /// is mapped to multiple values, then the relative order of those
-  /// values is unspecified. This method invalidates all iterators.
+  /// values is unspecified.
   void sort() {
     if (isSorted)
       return;

--- a/mlir/include/mlir/ExecutionEngine/SparseTensor/Storage.h
+++ b/mlir/include/mlir/ExecutionEngine/SparseTensor/Storage.h
@@ -37,6 +37,11 @@
 namespace mlir {
 namespace sparse_tensor {
 
+/// The type of callback functions which receive an element.
+template <typename V>
+using ElementConsumer =
+    const std::function<void(const std::vector<uint64_t> &, V)> &;
+
 // Forward references.
 template <typename V>
 class SparseTensorEnumeratorBase;


### PR DESCRIPTION
Moves typedef to only file where it is used.
Removes some deadcode. Some minor doc changes.