### PR TITLE
[Clang] Handle real and imaginary parts of complex lvalue in `APValue::printPretty`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -474,6 +474,8 @@ Bug Fixes in This Version
 - Clang now accepts anonymous members initialized with designated initializers
   inside templates.
   Fixes (`#65143 <https://github.com/llvm/llvm-project/issues/65143>`_)
+- Fix crash in formatting the real/imaginary part of a complex lvalue.
+  Fixes (`#69218 <https://github.com/llvm/llvm-project/issues/69218>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -841,6 +841,10 @@ void APValue::printPretty(raw_ostream &Out, const PrintingPolicy &Policy,
           Out << *VD;
           ElemTy = VD->getType();
         }
+      } else if (ElemTy->isAnyComplexType()) {
+        // The lvalue refers to a complex type
+        Out << (Path[I].getAsArrayIndex() == 0 ? ".real" : ".imag");
+        ElemTy = ElemTy->castAs<ComplexType>()->getElementType();
       } else {
         // The lvalue must refer to an array.
         Out << '[' << Path[I].getAsArrayIndex() << ']';

--- a/clang/test/CodeGen/complex.c
+++ b/clang/test/CodeGen/complex.c
@@ -113,3 +113,8 @@ void t92(void) {
   (0 ? (_Complex double) 2.0f : 2.0f);
 }
 
+// PR69218
+int t10(void) {
+  float _Complex a;
+  return (0 < &__real__ a) && (0 < &__imag__ a);
+}

--- a/clang/test/CodeGen/complex.c
+++ b/clang/test/CodeGen/complex.c
@@ -113,8 +113,3 @@ void t92(void) {
   (0 ? (_Complex double) 2.0f : 2.0f);
 }
 
-// PR69218
-int t10(void) {
-  float _Complex a;
-  return (0 < &__real__ a) && (0 < &__imag__ a);
-}

--- a/clang/test/Sema/complex-imag.c
+++ b/clang/test/Sema/complex-imag.c
@@ -27,3 +27,9 @@ void f4(void) {
   double *c = &__real a;
   double *d = &__imag a;
 }
+
+// PR69218
+int f5(void) {
+  float _Complex a;
+  return (0 < &__real__ a) && (0 < &__imag__ a);
+}


### PR DESCRIPTION
This patch handles formatting of real and imaginary parts of complex lvalue.
Fixes #69218.
