### PR TITLE
Detect against invalid variant index for LibStdC++ std::variant data formatters

### DIFF
--- a/lldb/examples/synthetic/gnu_libstdcpp.py
+++ b/lldb/examples/synthetic/gnu_libstdcpp.py
@@ -914,6 +914,11 @@ def VariantSummaryProvider(valobj, dict):
     if index == npos_value:
         return " No Value"
 
+    # Invalid index can happen when the variant is not initialized yet.
+    template_arg_count = data_obj.GetType().GetNumberOfTemplateArguments()
+    if index >= template_arg_count:
+        return " <Invalid>"
+
     active_type = data_obj.GetType().GetTemplateArgumentType(index)
     return f" Active Type = {active_type.GetDisplayTypeName()} "
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7173,6 +7173,9 @@ GetNthTemplateArgument(const clang::ClassTemplateSpecializationDecl *decl,
   if (idx < last_idx)
     return &args[idx];
 
+  if (idx >= args.size())
+    return nullptr;
+
   // We're asked for the last template argument but we don't want/need to
   // expand it.
   if (!expand_pack || args[last_idx].getKind() != clang::TemplateArgument::Pack)

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -7173,9 +7173,6 @@ GetNthTemplateArgument(const clang::ClassTemplateSpecializationDecl *decl,
   if (idx < last_idx)
     return &args[idx];
 
-  if (idx >= args.size())
-    return nullptr;
-
   // We're asked for the last template argument but we don't want/need to
   // expand it.
   if (!expand_pack || args[last_idx].getKind() != clang::TemplateArgument::Pack)
@@ -7185,6 +7182,9 @@ GetNthTemplateArgument(const clang::ClassTemplateSpecializationDecl *decl,
   // Note that 'idx' counts from the beginning of all template arguments
   // (including the ones preceding the parameter pack).
   const auto &pack = args[last_idx];
+  if (idx >= pack.pack_size())
+    return nullptr;
+
   const size_t pack_idx = idx - last_idx;
   assert(pack_idx < pack.pack_size() && "parameter pack index out-of-bounds");
   return &pack.pack_elements()[pack_idx];

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
@@ -71,3 +71,29 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
             substrs=["v_many_types_no_value =  No Value"],
         )
         """
+
+    @add_test_categories(["libstdcxx"])
+    def test_invalid_variant_index(self):
+        """Test LibStdC++ data formatter for std::variant with invalid index."""
+        self.build()
+
+        (self.target, self.process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        lldbutil.continue_to_breakpoint(self.process, bkpt)
+
+        self.expect(
+            "frame variable v1",
+            substrs=["v1 =  Active Type = int  {", "Value = 12", "}"],
+        )
+
+        var_v1 = thread.frames[0].FindVariable("v1")
+        var_v1_raw_obj = var_v1.GetNonSyntheticValue()
+        index_obj = var_v1_raw_obj.GetChildMemberWithName("_M_index")
+        self.assertTrue(index_obj and index_obj.IsValid())
+
+        INVALID_INDEX = 100
+        index_obj.SetValueFromCString(INVALID_INDEX)
+
+        self.expect("frame variable v1", substrs=["v1 =  <Invalid>"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
@@ -93,7 +93,7 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
         index_obj = var_v1_raw_obj.GetChildMemberWithName("_M_index")
         self.assertTrue(index_obj and index_obj.IsValid())
 
-        INVALID_INDEX = 100
+        INVALID_INDEX = "100"
         index_obj.SetValueFromCString(INVALID_INDEX)
 
         self.expect("frame variable v1", substrs=["v1 =  <Invalid>"])


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/68012/files added new data formatters for LibStdC++ std::variant. 

However, this formatter can crash if std::variant's index field has invalid value (exceeds the number of template arguments). 
This can happen if the current IP stops at a place std::variant is not initialized yet. 

This patch fixes the crash by ensuring the index is a valid value. 