### PR TITLE
[hwasan][test] Fix regex so deep-recursion.c is unsupported on aarch64 targets

### DIFF
--- a/compiler-rt/test/hwasan/TestCases/deep-recursion.c
+++ b/compiler-rt/test/hwasan/TestCases/deep-recursion.c
@@ -18,7 +18,7 @@
 // XFAIL: target=x86_64{{.*}}
 
 // Flaky on AArch64 Linux, see https://github.com/llvm/llvm-project/issues/69221.
-// UNSUPPORTED: target=aarch64-linux{{.*}}
+// UNSUPPORTED: target=aarch64{{.*}}
 
 #include <stdlib.h>
 // At least -O1 is needed for this function to not have a stack frame on


### PR DESCRIPTION
After 144c5b6d58803a2d4a0fe92a0fe331ff0347dc3b, we still see this test running in CI for aarch64-linux targets. This appears to be related to the triple being `aarch64-unknown-linux-gnu`, or similar.

The bot link below includes 144c5b6d58803a2d4a0fe92a0fe331ff0347dc3b, and fails the deep-recursion.c test, which should have been disabled. https://luci-milo.appspot.com/ui/p/fuchsia/builders/toolchain.ci/clang-linux-arm64/b8767065085790662609/overview