### PR TITLE
Enable v for RISCV64 Android

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -309,7 +309,7 @@ StringRef riscv::getRISCVArch(const llvm::opt::ArgList &Args,
       return "rv32imafdc";
     else if (MABI.starts_with_insensitive("lp64")) {
       if (Triple.isAndroid())
-        return "rv64imafdc_zba_zbb_zbs";
+        return "rv64imafdcv_zba_zbb_zbs";
 
       return "rv64imafdc";
     }
@@ -329,7 +329,7 @@ StringRef riscv::getRISCVArch(const llvm::opt::ArgList &Args,
     if (Triple.getOS() == llvm::Triple::UnknownOS)
       return "rv64imac";
     else if (Triple.isAndroid())
-      return "rv64imafdc_zba_zbb_zbs";
+      return "rv64imafdcv_zba_zbb_zbs";
     else
       return "rv64imafdc";
   }

--- a/clang/test/Driver/riscv-features.c
+++ b/clang/test/Driver/riscv-features.c
@@ -10,6 +10,7 @@
 // RUN: %clang --target=riscv32-unknown-elf -### %s -mrelax 2>&1 | FileCheck %s -check-prefix=RELAX
 // RUN: %clang --target=riscv32-unknown-elf -### %s -mno-relax 2>&1 | FileCheck %s -check-prefix=NO-RELAX
 
+// ANDROID: "-target-feature" "+v"
 // ANDROID: "-target-feature" "+zba"
 // ANDROID: "-target-feature" "+zbb"
 // ANDROID: "-target-feature" "+zbs"


### PR DESCRIPTION
Android has already enabled V by default for aosp: https://android-review.googlesource.com/c/platform/build/soong/+/2752805 four weeks back.