### PR TITLE
[llvm] Use XMACROS for MachO platforms.

### DIFF
--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -3954,7 +3954,7 @@ static unsigned getBaseMachOPlatformID(const llvm::Triple &TT) {
   case llvm::Triple::DriverKit:
     return llvm::MachO::PLATFORM_DRIVERKIT;
   default:
-    return /*Unknown platform*/ 0;
+    return llvm::MachO::PLATFORM_UNKNOWN;
   }
 }
 

--- a/llvm/include/llvm/BinaryFormat/MachO.def
+++ b/llvm/include/llvm/BinaryFormat/MachO.def
@@ -120,5 +120,21 @@ LOAD_COMMAND_STRUCT(fileset_entry_command)
 
 #endif
 
+#ifdef PLATFORM
+// PLATFORM(platform, id, name, build_name, target, tapi_target, marketing)
+PLATFORM(UNKNOWN, 0, unknown, unknown, unknown, unknown, unknown)
+PLATFORM(MACOS, 1, macos, macos, macos, macos, macOS)
+PLATFORM(IOS, 2, ios, ios, ios, ios, iOS)
+PLATFORM(TVOS, 3, tvos, tvos, tvos, tvos, tvOS)
+PLATFORM(WATCHOS, 4, watchos, watchos, watchos, watchos, watchOS)
+PLATFORM(BRIDGEOS, 5, bridgeos, bridgeos, bridgeos, bridgeos, bridgeOS)
+PLATFORM(MACCATALYST, 6, macCatalyst, macCatalyst, ios-macabi, maccatalyst, macCatalyst)
+PLATFORM(IOSSIMULATOR, 7, iossimulator, iossimulator, ios-simulator, ios-simulator, iOS Simulator)
+PLATFORM(TVOSSIMULATOR, 8, tvossimulator, tvossimulator, tvos-simulator, tvos-simulator, tvOS Simulator)
+PLATFORM(WATCHOSSIMULATOR, 9, watchossimulator, watchossimulator, watchos-simulator, watchos-simulator, watchOS Simulator)
+PLATFORM(DRIVERKIT, 10, driverkit, driverkit, driverkit, driverkit, DriverKit)
+#endif
+
 #undef HANDLE_LOAD_COMMAND
 #undef LOAD_COMMAND_STRUCT
+#undef PLATFORM

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -497,17 +497,10 @@ enum { VM_PROT_READ = 0x1, VM_PROT_WRITE = 0x2, VM_PROT_EXECUTE = 0x4 };
 
 // Values for platform field in build_version_command.
 enum PlatformType {
-  PLATFORM_UNKNOWN = 0,
-  PLATFORM_MACOS = 1,
-  PLATFORM_IOS = 2,
-  PLATFORM_TVOS = 3,
-  PLATFORM_WATCHOS = 4,
-  PLATFORM_BRIDGEOS = 5,
-  PLATFORM_MACCATALYST = 6,
-  PLATFORM_IOSSIMULATOR = 7,
-  PLATFORM_TVOSSIMULATOR = 8,
-  PLATFORM_WATCHOSSIMULATOR = 9,
-  PLATFORM_DRIVERKIT = 10,
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  PLATFORM_##platform = id,
+#include "MachO.def"
 };
 
 // Values for tools enum in build_tool_version.

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -789,16 +789,11 @@ public:
 
   static std::string getBuildPlatform(uint32_t platform) {
     switch (platform) {
-    case MachO::PLATFORM_MACOS: return "macos";
-    case MachO::PLATFORM_IOS: return "ios";
-    case MachO::PLATFORM_TVOS: return "tvos";
-    case MachO::PLATFORM_WATCHOS: return "watchos";
-    case MachO::PLATFORM_BRIDGEOS: return "bridgeos";
-    case MachO::PLATFORM_MACCATALYST: return "macCatalyst";
-    case MachO::PLATFORM_IOSSIMULATOR: return "iossimulator";
-    case MachO::PLATFORM_TVOSSIMULATOR: return "tvossimulator";
-    case MachO::PLATFORM_WATCHOSSIMULATOR: return "watchossimulator";
-    case MachO::PLATFORM_DRIVERKIT: return "driverkit";
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  case MachO::PLATFORM_##platform:                                             \
+    return #name;
+#include "llvm/BinaryFormat/MachO.def"
     default:
       std::string ret;
       raw_string_ostream ss(ret);

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -629,18 +629,11 @@ void MCAsmStreamer::emitVersionMin(MCVersionMinType Type, unsigned Major,
 
 static const char *getPlatformName(MachO::PlatformType Type) {
   switch (Type) {
-  case MachO::PLATFORM_UNKNOWN: /* silence warning*/
-    break;
-  case MachO::PLATFORM_MACOS:            return "macos";
-  case MachO::PLATFORM_IOS:              return "ios";
-  case MachO::PLATFORM_TVOS:             return "tvos";
-  case MachO::PLATFORM_WATCHOS:          return "watchos";
-  case MachO::PLATFORM_BRIDGEOS:         return "bridgeos";
-  case MachO::PLATFORM_MACCATALYST:      return "macCatalyst";
-  case MachO::PLATFORM_IOSSIMULATOR:     return "iossimulator";
-  case MachO::PLATFORM_TVOSSIMULATOR:    return "tvossimulator";
-  case MachO::PLATFORM_WATCHOSSIMULATOR: return "watchossimulator";
-  case MachO::PLATFORM_DRIVERKIT:        return "driverkit";
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  case MachO::PLATFORM_##platform:                                             \
+    return #build_name;
+#include "llvm/BinaryFormat/MachO.def"
   }
   llvm_unreachable("Invalid Mach-O platform type");
 }

--- a/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
@@ -1167,14 +1167,13 @@ bool DarwinAsmParser::parseBuildVersion(StringRef Directive, SMLoc Loc) {
     return TokError("platform name expected");
 
   unsigned Platform = StringSwitch<unsigned>(PlatformName)
-    .Case("macos", MachO::PLATFORM_MACOS)
-    .Case("ios", MachO::PLATFORM_IOS)
-    .Case("tvos", MachO::PLATFORM_TVOS)
-    .Case("watchos", MachO::PLATFORM_WATCHOS)
-    .Case("macCatalyst", MachO::PLATFORM_MACCATALYST)
-    .Case("driverkit", MachO::PLATFORM_DRIVERKIT)
-    .Default(0);
-  if (Platform == 0)
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  .Case(#build_name, MachO::PLATFORM_##platform)
+#include "llvm/BinaryFormat/MachO.def"
+                          .Default(MachO::PLATFORM_UNKNOWN);
+
+  if (Platform == MachO::PLATFORM_UNKNOWN)
     return Error(PlatformLoc, "unknown platform name");
 
   if (getLexer().isNot(AsmToken::Comma))

--- a/llvm/lib/TextAPI/Platform.cpp
+++ b/llvm/lib/TextAPI/Platform.cpp
@@ -62,28 +62,11 @@ PlatformSet mapToPlatformSet(ArrayRef<Triple> Targets) {
 
 StringRef getPlatformName(PlatformType Platform) {
   switch (Platform) {
-  case PLATFORM_UNKNOWN:
-    return "unknown";
-  case PLATFORM_MACOS:
-    return "macOS";
-  case PLATFORM_IOS:
-    return "iOS";
-  case PLATFORM_TVOS:
-    return "tvOS";
-  case PLATFORM_WATCHOS:
-    return "watchOS";
-  case PLATFORM_BRIDGEOS:
-    return "bridgeOS";
-  case PLATFORM_MACCATALYST:
-    return "macCatalyst";
-  case PLATFORM_IOSSIMULATOR:
-    return "iOS Simulator";
-  case PLATFORM_TVOSSIMULATOR:
-    return "tvOS Simulator";
-  case PLATFORM_WATCHOSSIMULATOR:
-    return "watchOS Simulator";
-  case PLATFORM_DRIVERKIT:
-    return "DriverKit";
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  case PLATFORM_##platform:                                                    \
+    return #marketing;
+#include "llvm/BinaryFormat/MachO.def"
   }
   llvm_unreachable("Unknown llvm::MachO::PlatformType enum");
 }
@@ -91,16 +74,10 @@ StringRef getPlatformName(PlatformType Platform) {
 PlatformType getPlatformFromName(StringRef Name) {
   return StringSwitch<PlatformType>(Name)
       .Case("osx", PLATFORM_MACOS)
-      .Case("macos", PLATFORM_MACOS)
-      .Case("ios", PLATFORM_IOS)
-      .Case("tvos", PLATFORM_TVOS)
-      .Case("watchos", PLATFORM_WATCHOS)
-      .Case("bridgeos", PLATFORM_BRIDGEOS)
-      .Case("ios-macabi", PLATFORM_MACCATALYST)
-      .Case("ios-simulator", PLATFORM_IOSSIMULATOR)
-      .Case("tvos-simulator", PLATFORM_TVOSSIMULATOR)
-      .Case("watchos-simulator", PLATFORM_WATCHOSSIMULATOR)
-      .Case("driverkit", PLATFORM_DRIVERKIT)
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  .Case(#tapi_target, PLATFORM_##platform)
+#include "llvm/BinaryFormat/MachO.def"
       .Default(PLATFORM_UNKNOWN);
 }
 

--- a/llvm/lib/TextAPI/Target.cpp
+++ b/llvm/lib/TextAPI/Target.cpp
@@ -21,16 +21,10 @@ Expected<Target> Target::create(StringRef TargetValue) {
   auto PlatformStr = Result.second;
   PlatformType Platform;
   Platform = StringSwitch<PlatformType>(PlatformStr)
-                 .Case("macos", PLATFORM_MACOS)
-                 .Case("ios", PLATFORM_IOS)
-                 .Case("tvos", PLATFORM_TVOS)
-                 .Case("watchos", PLATFORM_WATCHOS)
-                 .Case("bridgeos", PLATFORM_BRIDGEOS)
-                 .Case("maccatalyst", PLATFORM_MACCATALYST)
-                 .Case("ios-simulator", PLATFORM_IOSSIMULATOR)
-                 .Case("tvos-simulator", PLATFORM_TVOSSIMULATOR)
-                 .Case("watchos-simulator", PLATFORM_WATCHOSSIMULATOR)
-                 .Case("driverkit", PLATFORM_DRIVERKIT)
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  .Case(#tapi_target, PLATFORM_##platform)
+#include "llvm/BinaryFormat/MachO.def"
                  .Default(PLATFORM_UNKNOWN);
 
   if (Platform == PLATFORM_UNKNOWN) {

--- a/llvm/lib/TextAPI/TextStub.cpp
+++ b/llvm/lib/TextAPI/TextStub.cpp
@@ -367,39 +367,12 @@ template <> struct ScalarTraits<Target> {
   static void output(const Target &Value, void *, raw_ostream &OS) {
     OS << Value.Arch << "-";
     switch (Value.Platform) {
-    default:
-      OS << "unknown";
-      break;
-    case PLATFORM_MACOS:
-      OS << "macos";
-      break;
-    case PLATFORM_IOS:
-      OS << "ios";
-      break;
-    case PLATFORM_TVOS:
-      OS << "tvos";
-      break;
-    case PLATFORM_WATCHOS:
-      OS << "watchos";
-      break;
-    case PLATFORM_BRIDGEOS:
-      OS << "bridgeos";
-      break;
-    case PLATFORM_MACCATALYST:
-      OS << "maccatalyst";
-      break;
-    case PLATFORM_IOSSIMULATOR:
-      OS << "ios-simulator";
-      break;
-    case PLATFORM_TVOSSIMULATOR:
-      OS << "tvos-simulator";
-      break;
-    case PLATFORM_WATCHOSSIMULATOR:
-      OS << "watchos-simulator";
-      break;
-    case PLATFORM_DRIVERKIT:
-      OS << "driverkit";
-      break;
+#define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
+                 marketing)                                                    \
+  case PLATFORM_##platform:                                                    \
+    OS << #tapi_target;                                                        \
+    break;
+#include "llvm/BinaryFormat/MachO.def"
     }
   }
 


### PR DESCRIPTION
This change adds the PLATFORM XMACRO to simplify the addition of new MachO
platforms and reduce the number of required changes. Many of the changes needed
for adding a new platform are mechanical, such as adding new cases to a switch
statement. This will help streamline the process by consolidating much of the
necessary information into the MachO.def file.
