### PR TITLE
[CI] Add Github actions job to build LLVM documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 1
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@
 
 name: "Test documentation build"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+# LLVM Documentation CI
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: "Test documentation build"
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'llvm/docs/**'
+  pull_request:
+    paths:
+      - 'llvm/docs/**'
+
+jobs:
+  check-docs-build:
+    name: "Test documentation build"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch LLVM sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Setup Python env
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'llvm/docs/requirements.txt'
+      - name: Install python dependencies
+        run: pip install -r llvm/docs/requirements.txt
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y cmake ninja-build
+      - name: Build docs
+        run: |
+          mkdir build
+          cd build
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON -DSPHINX_OUTPUT_MAN=ON ../llvm
+          TZ=UTC ninja docs-llvm-html docs-llvm-man
+


### PR DESCRIPTION
This patch adds in support for building the LLVM documentation through a Github actions job. This enables catching documentation build failures earlier and also more easily as the job failure will show up directly on pull requests. The job currently only builds the documentation for LLVM, but the plan is to extend it to also build the documentation for other subprojects when appropriate (i.e., the docs files have changed), starting with clang.