### PR TITLE
[libc++][Android] Enable Android testing in BuildKite CI

### DIFF
--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -130,6 +130,7 @@ Target platform Target architecture       Notes
 macOS 10.9+     i386, x86_64, arm64       Building the shared library itself requires targetting macOS 10.13+
 FreeBSD 12+     i386, x86_64, arm
 Linux           i386, x86_64, arm, arm64  Only glibc-2.24 and later and no other libc is officially supported
+Android 5.0+    i386, x86_64, arm, arm64
 Windows         i386, x86_64              Both MSVC and MinGW style environments, ABI in MSVC environments is :doc:`unstable <DesignDocs/ABIVersioning>`
 AIX 7.2TL5+     powerpc, powerpc64
 =============== ========================= ============================

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -1116,3 +1116,33 @@ steps:
           - exit_status: -1  # Agent was lost
             limit: 2
       timeout_in_minutes: 120
+
+  - group: ":android: Android"
+    steps:
+    - label: "Android 5.0, x86 NDK"
+      command: "libcxx/utils/ci/run-buildbot android-ndk-21-def-x86"
+      artifact_paths:
+        - "**/test-results.xml"
+        - "**/*.abilist"
+      agents:
+        queue: "libcxx-builders"
+        os: "android"
+      retry:
+        automatic:
+          - exit_status: -1  # Agent was lost
+            limit: 2
+      timeout_in_minutes: 120
+
+    - label: "Android 13, x86_64 NDK"
+      command: "libcxx/utils/ci/run-buildbot android-ndk-33-goog-x86_64"
+      artifact_paths:
+        - "**/test-results.xml"
+        - "**/*.abilist"
+      agents:
+        queue: "libcxx-builders"
+        os: "android"
+      retry:
+        automatic:
+          - exit_status: -1  # Agent was lost
+            limit: 2
+      timeout_in_minutes: 120

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -1131,6 +1131,7 @@ steps:
         automatic:
           - exit_status: -1  # Agent was lost
             limit: 2
+      soft_fail: true
       timeout_in_minutes: 120
 
     - label: "Android 13, x86_64 NDK"
@@ -1145,4 +1146,5 @@ steps:
         automatic:
           - exit_status: -1  # Agent was lost
             limit: 2
+      soft_fail: true
       timeout_in_minutes: 120


### PR DESCRIPTION
Enable testing for two NDK configurations:
 - android-ndk-21-def-x86
 - android-ndk-33-goog-x86_64

Fixes: https://github.com/llvm/llvm-project/issues/69270