### PR TITLE
[scudo] Disable ring buffer in Trusty

### DIFF
--- a/compiler-rt/lib/scudo/standalone/flags.inc
+++ b/compiler-rt/lib/scudo/standalone/flags.inc
@@ -46,5 +46,5 @@ SCUDO_FLAG(int, release_to_os_interval_ms, SCUDO_ANDROID ? INT32_MIN : 5000,
            "Interval (in milliseconds) at which to attempt release of unused "
            "memory to the OS. Negative values disable the feature.")
 
-SCUDO_FLAG(int, allocation_ring_buffer_size, 32768,
+SCUDO_FLAG(int, allocation_ring_buffer_size, SCUDO_TRUSTY ? 0 : 32768,
            "Entries to keep in the allocation ring buffer for scudo.")


### PR DESCRIPTION
The allocation ringbuffer has a size of 32768 entries by default,
totalling over a megabyte. In addition, a recent change moved
this buffer from .bss to being dynamically allocated, which means
it counts against the min_heap setting in the app manifest.
Upstreamed from https://r.android.com/2395872 and
https://r.android.com/2480217.
