### PR TITLE
[TableGen] Handle duplicate rules in combiners

### DIFF
--- a/llvm/test/TableGen/GlobalISelCombinerEmitter/misc/redundant-combine-in-list.td
+++ b/llvm/test/TableGen/GlobalISelCombinerEmitter/misc/redundant-combine-in-list.td
@@ -1,0 +1,30 @@
+// RUN: llvm-tblgen -I %p/../../../../include -gen-global-isel-combiner \
+// RUN:     -combiners=Combiner %s 2>&1 | FileCheck %s
+
+include "llvm/Target/Target.td"
+include "llvm/Target/GlobalISel/Combine.td"
+
+// Check we don't crash if a combine is present twice in the list.
+
+def MyTargetISA : InstrInfo;
+def MyTarget : Target { let InstructionSet = MyTargetISA; }
+
+def dummy;
+
+// CHECK: :[[@LINE+1]]:{{[0-9]+}}: warning: skipping rule 'Foo' because it has already been processed
+def Foo : GICombineRule<
+  (defs root:$root),
+  (match (G_ZEXT $root, $x)),
+  (apply (G_TRUNC $root, $x))>;
+
+def Bar : GICombineRule<
+  (defs root:$root),
+  (match (G_TRUNC $root, $x)),
+  (apply (G_ZEXT $root, $x))>;
+
+def FooBar : GICombineGroup<[ Foo, Bar ]>;
+
+def Combiner: GICombiner<"GenMyCombiner", [
+  FooBar,
+  Foo
+]>;

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -3637,14 +3637,16 @@ void GICombinerEmitter::gatherRules(
     }
 
     StringRef RuleName = Rec->getName();
-    if(!RulesSeen.insert(RuleName).second) {
-      PrintWarning(Rec->getLoc(), "skipping rule '" + Rec->getName() + "' because it has already been processed");
+    if (!RulesSeen.insert(RuleName).second) {
+      PrintWarning(Rec->getLoc(),
+                   "skipping rule '" + Rec->getName() +
+                       "' because it has already been processed");
       continue;
     }
 
     AllCombineRules.emplace_back(NextRuleID, Rec->getName().str());
     CombineRuleBuilder CRB(Target, SubtargetFeatures, *Rec, NextRuleID++,
-                            ActiveRules);
+                           ActiveRules);
 
     if (!CRB.parseAll()) {
       assert(ErrorsPrinted && "Parsing failed without errors!");


### PR DESCRIPTION
We would crash when a rule was accidentally added twice to a combiner. This patch adds a warning instead to skip the already-processed rules.