### PR TITLE
[TableGen][NFC] Remove MultiClass argument and Scoper in QualifyName

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -143,8 +143,8 @@ Init *TGVarScope::getVar(RecordKeeper &Records, MultiClass *ParsingMultiClass,
   if (It != Vars.end())
     return It->second;
 
-  std::function<Init *(Record *, StringInit *, bool)> FindValueInArgs =
-      [&](Record *Rec, StringInit *Name, bool IsMC) -> Init * {
+  auto FindValueInArgs = [&](Record *Rec, StringInit *Name,
+                             bool IsMC) -> Init * {
     if (!Rec)
       return nullptr;
     Init *ArgName = QualifyName(*Rec, Name, IsMC);


### PR DESCRIPTION
MultiClass argument is not used any more since aa84326.

Besides, for maintainability, we should put the implementation of
qualifying name in one place (that is `QualifyName` function), so
`Scoper` is removed and we use `IsMC` to indicate that we are in a
multiclass.
