### PR TITLE
[docs] Improve README: point to office hours and online sync-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ the [Contributing to LLVM](https://llvm.org/docs/Contributing.html) guide.
 ## Getting in touch
 
 Join the [LLVM Discourse forums](https://discourse.llvm.org/), [Discord
-chat](https://discord.gg/xS7Z362), or #llvm IRC channel on
-[OFTC](https://oftc.net/).
+chat](https://discord.gg/xS7Z362),
+[LLVM Office Hours](https://llvm.org/docs/GettingInvolved.html#office-hours) or
+[Regular sync-ups](https://llvm.org/docs/GettingInvolved.html#online-sync-ups).
 
 The LLVM project has adopted a [code of conduct](https://llvm.org/docs/CodeOfConduct.html) for
 participants to all modes of communication within the project.


### PR DESCRIPTION
The main README.md should probably be kept pretty short and be used to point new-comers to the most essential ways to get started on or get involved with LLVM.

Therefore, this patch removes a pointer to IRC (not used very much these days), and does add pointers to office hours and online sync-ups.