### PR TITLE
[DIAG][msan] fix libc check string for dladdr1 call

### DIFF
--- a/compiler-rt/test/msan/dladdr1_test.c
+++ b/compiler-rt/test/msan/dladdr1_test.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
       fflush(stdout);
       map_ptr = map_ptr->l_next;
     }
-    // CHECK: libc.so
+    // CHECK: libc{{[\-]*.*}}.so
     // CHECK: dladdr1_test
   }
 


### PR DESCRIPTION
The check for dladdr1 for shared libc is too strict. Depending on how the system is setup we sometimes pick up the none generic lib name with the version string in it.

Update check to for libc to account for version string.