### PR TITLE
[ValueTracking] Expand cmpExcludesZero to optionally work with non-constant RHS

### DIFF
--- a/llvm/test/Analysis/ValueTracking/phi-known-nonzero.ll
+++ b/llvm/test/Analysis/ValueTracking/phi-known-nonzero.ll
@@ -270,9 +270,7 @@ define i1 @phi_uge_non_zero_non_const(i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X:%.*]], [[YY]]
 ; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
 ; CHECK:       T:
-; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ; CHECK:       F:
 ; CHECK-NEXT:    br label [[T]]
 ;
@@ -320,9 +318,7 @@ define i1 @phi_slt_non_zero_non_const(i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[YY]], [[X:%.*]]
 ; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
 ; CHECK:       T:
-; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ; CHECK:       F:
 ; CHECK-NEXT:    br label [[T]]
 ;
@@ -424,9 +420,7 @@ define i1 @phi_eq_non_zero_non_const(i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i8 [[X:%.*]], [[YY]]
 ; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
 ; CHECK:       T:
-; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ; CHECK:       F:
 ; CHECK-NEXT:    br label [[T]]
 ;

--- a/llvm/test/Analysis/ValueTracking/phi-known-nonzero.ll
+++ b/llvm/test/Analysis/ValueTracking/phi-known-nonzero.ll
@@ -262,3 +262,207 @@ T:
 F:
   br label %T
 }
+
+define i1 @phi_uge_non_zero_non_const(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_uge_non_zero_non_const(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YY:%.*]] = add nuw i8 [[Y:%.*]], 32
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X:%.*]], [[YY]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+; CHECK:       F:
+; CHECK-NEXT:    br label [[T]]
+;
+entry:
+  %yy = add nuw i8 %y, 32
+  %cmp = icmp uge i8 %x, %yy
+  br i1 %cmp, label %T, label %F
+T:
+  %v = phi i8 [ %x, %entry], [-1, %F]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+F:
+  br label %T
+}
+
+define i1 @phi_uge_non_zero_non_const_fail(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_uge_non_zero_non_const_fail(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YY:%.*]] = add i8 [[Y:%.*]], 32
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X:%.*]], [[YY]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+; CHECK:       F:
+; CHECK-NEXT:    br label [[T]]
+;
+entry:
+  %yy = add i8 %y, 32
+  %cmp = icmp uge i8 %x, %yy
+  br i1 %cmp, label %T, label %F
+T:
+  %v = phi i8 [ %x, %entry], [-1, %F]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+F:
+  br label %T
+}
+
+define i1 @phi_slt_non_zero_non_const(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_slt_non_zero_non_const(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YY:%.*]] = and i8 [[Y:%.*]], 95
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[YY]], [[X:%.*]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+; CHECK:       F:
+; CHECK-NEXT:    br label [[T]]
+;
+entry:
+  %yy = and i8 %y, 95
+  %cmp = icmp slt i8 %yy, %x
+  br i1 %cmp, label %T, label %F
+T:
+  %v = phi i8 [ %x, %entry], [-1, %F]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+F:
+  br label %T
+}
+
+define i1 @phi_slt_non_zero_non_const_fail(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_slt_non_zero_non_const_fail(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YY:%.*]] = or i8 [[Y:%.*]], 32
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[YY]], [[X:%.*]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+; CHECK:       F:
+; CHECK-NEXT:    br label [[T]]
+;
+entry:
+  %yy = or i8 %y, 32
+  %cmp = icmp slt i8 %yy, %x
+  br i1 %cmp, label %T, label %F
+T:
+  %v = phi i8 [ %x, %entry], [-1, %F]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+F:
+  br label %T
+}
+
+define i1 @phi_sle_non_zero_non_const(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_sle_non_zero_non_const(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YYY:%.*]] = and i8 [[Y:%.*]], 95
+; CHECK-NEXT:    [[YY:%.*]] = add nuw i8 [[YYY]], 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i8 [[X:%.*]], [[YY]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    br label [[F]]
+; CHECK:       F:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[T]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+entry:
+  %yyy = and i8 %y, 95
+  %yy = add nuw i8 %yyy, 4
+  %cmp = icmp sle i8 %x, %yy
+  br i1 %cmp, label %T, label %F
+T:
+  br label %F
+F:
+  %v = phi i8 [ %x, %entry], [-1, %T]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+}
+
+define i1 @phi_sle_non_zero_non_const_fail(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_sle_non_zero_non_const_fail(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YYY:%.*]] = and i8 [[Y:%.*]], 95
+; CHECK-NEXT:    [[YY:%.*]] = add nuw i8 [[YYY]], 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i8 [[YY]], [[X:%.*]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    br label [[F]]
+; CHECK:       F:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[T]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+entry:
+  %yyy = and i8 %y, 95
+  %yy = add nuw i8 %yyy, 4
+  %cmp = icmp sle i8 %yy, %x
+  br i1 %cmp, label %T, label %F
+T:
+  br label %F
+F:
+  %v = phi i8 [ %x, %entry], [-1, %T]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+}
+
+define i1 @phi_eq_non_zero_non_const(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_eq_non_zero_non_const(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YY:%.*]] = or i8 [[Y:%.*]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i8 [[X:%.*]], [[YY]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[F]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+; CHECK:       F:
+; CHECK-NEXT:    br label [[T]]
+;
+entry:
+  %yy = or i8 %y, 1
+  %cmp = icmp eq i8 %x, %yy
+  br i1 %cmp, label %T, label %F
+T:
+  %v = phi i8 [ %x, %entry], [-1, %F]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+F:
+  br label %T
+}
+
+define i1 @phi_eq_non_zero_non_const_fail(i8 %x, i8 %y) {
+; CHECK-LABEL: @phi_eq_non_zero_non_const_fail(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[YY:%.*]] = or i8 [[Y:%.*]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i8 [[X:%.*]], [[YY]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[T:%.*]], label [[F:%.*]]
+; CHECK:       T:
+; CHECK-NEXT:    br label [[F]]
+; CHECK:       F:
+; CHECK-NEXT:    [[V:%.*]] = phi i8 [ [[X]], [[ENTRY:%.*]] ], [ -1, [[T]] ]
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[V]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+entry:
+  %yy = or i8 %y, 1
+  %cmp = icmp eq i8 %x, %yy
+  br i1 %cmp, label %T, label %F
+T:
+  br label %F
+F:
+  %v = phi i8 [ %x, %entry], [-1, %T]
+  %r = icmp eq i8 %v, 0
+  ret i1 %r
+}

--- a/llvm/test/Analysis/ValueTracking/select-known-non-zero.ll
+++ b/llvm/test/Analysis/ValueTracking/select-known-non-zero.ll
@@ -26,10 +26,7 @@ define i1 @select_v_eq_nz(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp ne i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i8 [[C]], [[V:%.*]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -47,10 +44,7 @@ define i1 @inv_select_v_ugt_nz(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp ne i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i8 [[C]], [[V:%.*]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[Y]], i8 [[V]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -89,10 +83,7 @@ define i1 @select_v_uge_nz(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp ne i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[V:%.*]], [[C]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -110,10 +101,7 @@ define i1 @select_v_sgt_nonneg(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp sge i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[V:%.*]], [[C]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -152,10 +140,7 @@ define i1 @inv_select_v_sgt_neg(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp slt i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[V:%.*]], [[C]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[Y]], i8 [[V]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -173,10 +158,7 @@ define i1 @inv_select_v_sgt_nonneg_nz(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp sgt i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[C]], [[V:%.*]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[Y]], i8 [[V]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -194,10 +176,7 @@ define i1 @select_v_slt_nonneg(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp sge i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[C]], [[V:%.*]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -236,10 +215,7 @@ define i1 @select_v_slt_neg(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp slt i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[V:%.*]], [[C]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -257,10 +233,7 @@ define i1 @select_v_sge_nonneg_nz(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp sgt i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i8 [[V:%.*]], [[C]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -278,10 +251,7 @@ define i1 @select_v_sge_neg(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp slt i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i8 [[C]], [[V:%.*]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -316,10 +286,7 @@ define i1 @select_v_sle_neg(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp slt i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i8 [[V:%.*]], [[C]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -337,10 +304,7 @@ define i1 @select_v_sle_nonneg_nz(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp sgt i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i8 [[C]], [[V:%.*]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[V]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)
@@ -379,10 +343,7 @@ define i1 @inv_select_v_sle_nonneg(i8 %v, i8 %C, i8 %y) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[YNZ]])
 ; CHECK-NEXT:    [[PCOND0:%.*]] = icmp sge i8 [[C:%.*]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[PCOND0]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sle i8 [[V:%.*]], [[C]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[CMP]], i8 [[Y]], i8 [[V]]
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[S]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %ynz = icmp ne i8 %y, 0
   call void @llvm.assume(i1 %ynz)


### PR DESCRIPTION
- [ValueTracking] Add tests for proving phi-nonzero based on ICmp without constants; NFC
- [ValueTracking] Expand `cmpExcludesZero` to optionally work with non-constant RHS
