### PR TITLE
[clangd] Support square bracket escaping in Annotations

### DIFF
--- a/llvm/lib/Testing/Annotations/Annotations.cpp
+++ b/llvm/lib/Testing/Annotations/Annotations.cpp
@@ -60,6 +60,14 @@ Annotations::Annotations(llvm::StringRef Text) {
       OpenRanges.pop_back();
       continue;
     }
+    if (Text.consume_front("\\[")) {
+      Code.push_back('[');
+      continue;
+    }
+    if (Text.consume_front("\\]")) {
+      Code.push_back(']');
+      continue;
+    }
     if (Text.consume_front("$")) {
       Name =
           Text.take_while([](char C) { return llvm::isAlnum(C) || C == '_'; });


### PR DESCRIPTION
The `Annotations` class is not supporting C++ attributes `[[...]]` because the attributes are parsed as a selection. The proposed improvement allows `[`, `]` characters to be escaped (example: `\[\[nodiscard\]\]`), allowing attributes to be used.