### PR TITLE
[LangRef] "cc 10" -> "ghccc"

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -309,7 +309,7 @@ added in the future:
     prototype of all callees to exactly match the prototype of the
     function definition. Furthermore the inliner doesn't consider such function
     calls for inlining.
-"``cc 10``" - GHC convention
+"``ghccc``" - GHC convention
     This calling convention has been implemented specifically for use by
     the `Glasgow Haskell Compiler (GHC) <http://www.haskell.org/ghc>`_.
     It passes everything in registers, going to extremes to achieve this


### PR DESCRIPTION
The change to print this was made in 2014 in 35fc363ce8f04c7a74ce3848ce25d90b1a5bd556 but apparently the LangRef was never updated.
