### PR TITLE
[flang][openacc] Accept scalar integer expression in the if clause

### DIFF
--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -21,3 +21,5 @@ local:
 * `!$acc end loop` does not trigger a parsing error and is just ignored.
 * The restriction on `!$acc data` required clauses is emitted as a portability
   warning instead of an error as other compiler accepts it.
+* The `if` clause accepts scalar integer expression in addition to scalar
+  logical expression.

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -376,7 +376,6 @@ CHECK_SIMPLE_CLAUSE(DeviceNum, ACCC_device_num)
 CHECK_SIMPLE_CLAUSE(Finalize, ACCC_finalize)
 CHECK_SIMPLE_CLAUSE(Firstprivate, ACCC_firstprivate)
 CHECK_SIMPLE_CLAUSE(Host, ACCC_host)
-CHECK_SIMPLE_CLAUSE(If, ACCC_if)
 CHECK_SIMPLE_CLAUSE(IfPresent, ACCC_if_present)
 CHECK_SIMPLE_CLAUSE(Independent, ACCC_independent)
 CHECK_SIMPLE_CLAUSE(NoCreate, ACCC_no_create)
@@ -658,6 +657,20 @@ void AccStructureChecker::Enter(const parser::AccClause::DeviceResident &x) {
 void AccStructureChecker::Enter(const parser::AccClause::Link &x) {
   CheckAllowed(llvm::acc::Clause::ACCC_link);
   CheckMultipleOccurrenceInDeclare(x.v, llvm::acc::Clause::ACCC_link);
+}
+
+void AccStructureChecker::Enter(const parser::AccClause::If &x) {
+  CheckAllowed(llvm::acc::Clause::ACCC_if);
+  if (const auto *expr{GetExpr(x.v)}) {
+    if (auto type{expr->GetType()}) {
+      if (type->category() == TypeCategory::Integer ||
+          type->category() == TypeCategory::Logical) {
+        return; // LOGICAL and INTEGER type supported for the if clause.
+      }
+    }
+  }
+  context_.Say(
+      GetContext().clauseSource, "Must have LOGICAL or INTEGER type"_err_en_US);
 }
 
 void AccStructureChecker::Enter(const parser::Module &) {

--- a/flang/test/Lower/OpenACC/acc-init.f90
+++ b/flang/test/Lower/OpenACC/acc-init.f90
@@ -5,6 +5,7 @@
 
 subroutine acc_init
   logical :: ifCondition = .TRUE.
+  integer :: ifInt = 1
 
   !$acc init
 !CHECK: acc.init{{ *}}{{$}}
@@ -27,5 +28,10 @@ subroutine acc_init
 !CHECK: [[DEVTYPE1:%.*]] = arith.constant 1 : i32
 !CHECK: [[DEVTYPE2:%.*]] = arith.constant 2 : i32
 !CHECK: acc.init device_type([[DEVTYPE1]], [[DEVTYPE2]] : i32, i32) device_num([[DEVNUM]] : i32){{$}}
+
+  !$acc init if(ifInt)
+!CHECK: %[[IFINT:.*]] = fir.load %{{.*}} : !fir.ref<i32>
+!CHECK: %[[CONV:.*]] = fir.convert %[[IFINT]] : (i32) -> i1
+!CHECK: acc.init if(%[[CONV]])
 
 end subroutine acc_init

--- a/flang/test/Semantics/OpenACC/acc-init-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-init-validity.f90
@@ -10,11 +10,14 @@ program openacc_init_validity
   integer :: i, j
   integer, parameter :: N = 256
   logical :: ifCondition = .TRUE.
+  integer :: ifInt
+  real :: ifReal
   real(8), dimension(N) :: a
 
   !$acc init
   !$acc init if(.TRUE.)
   !$acc init if(ifCondition)
+  !$acc init if(ifInt)
   !$acc init device_num(1)
   !$acc init device_num(i)
   !$acc init device_type(i)
@@ -92,5 +95,8 @@ program openacc_init_validity
 
   !ERROR: At most one DEVICE_TYPE clause can appear on the INIT directive
   !$acc init device_type(2) device_type(i, j)
+
+  !ERROR: Must have LOGICAL or INTEGER type
+  !$acc init if(ifReal)
 
 end program openacc_init_validity

--- a/llvm/include/llvm/Frontend/OpenACC/ACC.td
+++ b/llvm/include/llvm/Frontend/OpenACC/ACC.td
@@ -159,7 +159,7 @@ def ACCC_Host : Clause<"host"> {
 
 // 2.5.6
 def ACCC_If : Clause <"if"> {
-  let flangClass = "ScalarLogicalExpr";
+  let flangClass = "ScalarExpr";
 }
 
 // 2.14.4

--- a/llvm/utils/TableGen/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/DirectiveEmitter.cpp
@@ -736,6 +736,7 @@ static void GenerateFlangClausesParser(const DirectiveLanguage &DirLang,
             .Case("Name", "name")
             .Case("ScalarIntConstantExpr", "scalarIntConstantExpr")
             .Case("ScalarIntExpr", "scalarIntExpr")
+            .Case("ScalarExpr", "scalarExpr")
             .Case("ScalarLogicalExpr", "scalarLogicalExpr")
             .Default(("Parser<" + Clause.getFlangClass() + ">{}")
                          .toStringRef(Scratch));


### PR DESCRIPTION
Relax the parser to accept scalar integer expression in addition to scalar logical expression. The parser now accepts scalar expression and the semantic checks its type. 