### PR TITLE
[flang] Reduce implicit interface compatibility warnings due to length

### DIFF
--- a/flang/test/Semantics/call35.f90
+++ b/flang/test/Semantics/call35.f90
@@ -1,11 +1,13 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror
 subroutine s1
   call ext(1, 2)
+  call myerror('abc')
 end
 
 subroutine s2
   !WARNING: Reference to the procedure 'ext' has an implicit interface that is distinct from another reference: distinct numbers of dummy arguments
   call ext(1.)
+  call myerror('abcd') ! don't warn about distinct lengths
 end
 
 subroutine s3


### PR DESCRIPTION
When a procedure with an implicit interface is called from two call sites with distinct argument types, we emit a warning.  This can lead to a lot of output when the actual argument types are differing-length character, and the warnings are less important since the procedure may well have been defined with assumed-length character dummy arguments. So let cases like CALL MYERROR('ab'); CALL MYERROR('abc') slide by without a warning.