### PR TITLE
[sanitizer_common] Use 38-bit mmap range for Fuchsia

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
@@ -303,7 +303,15 @@
 #    define SANITIZER_MMAP_RANGE_SIZE FIRST_32_SECOND_64(1ULL << 32, 1ULL << 40)
 #  endif
 #elif SANITIZER_RISCV64
-#  define SANITIZER_MMAP_RANGE_SIZE FIRST_32_SECOND_64(1ULL << 32, 1ULL << 47)
+// FIXME: Rather than hardcoding the VMA here, we should rely on
+// GetMaxUserVirtualAddress(). This will require some refactoring though since
+// many places either hardcode some value or SANITIZER_MMAP_RANGE_SIZE is
+// assumed to be some constant integer.
+#  if SANITIZER_FUCHSIA
+#    define SANITIZER_MMAP_RANGE_SIZE (1ULL << 38)
+#  else
+#    define SANITIZER_MMAP_RANGE_SIZE FIRST_32_SECOND_64(1ULL << 32, 1ULL << 47)
+#  endif
 #elif defined(__aarch64__)
 #  if SANITIZER_APPLE
 #    if SANITIZER_OSX || SANITIZER_IOSSIM


### PR DESCRIPTION
46cb8d9a325233ac11ed5e90367c43774294d87e unconditionally changed the mmap range to 2^48 for all riscv sanitizers. This changes the allocator tunings for the 32-bit allocator for riscv and led to a severe performance regression for our lsan tests. This effectively revers the tuning change but only for Fuchsia.

Once we enable the 64-bit allocator for everything riscv, this value will be irrelevant since it's only relevant for the 32-bit allocator.