### PR TITLE
[mlir][sparse] Update verifier for block sparsity and singleton

### DIFF
--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
@@ -173,6 +173,14 @@ AffineMap inferLvlToDim(AffineMap dimToLvl, MLIRContext *context);
 /// Asserts on failure (so only use when known to succeed).
 AffineMap inverseBlockSparsity(AffineMap dimToLvl, MLIRContext *context);
 
+/// Given the dimToLvl map, returns the block size in vector.
+/// For instance, a 2x3 block will return [2, 3].
+/// Only valid block sparsity will be accepted.
+SmallVector<unsigned> getBlockSize(AffineMap dimToLvl);
+
+/// Given the dimToLvl map, returns if it's block sparsity.
+bool isBlockSparsity(AffineMap dimToLvl);
+
 //
 // Reordering.
 //

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
@@ -173,7 +173,7 @@ AffineMap inferLvlToDim(AffineMap dimToLvl, MLIRContext *context);
 /// Asserts on failure (so only use when known to succeed).
 AffineMap inverseBlockSparsity(AffineMap dimToLvl, MLIRContext *context);
 
-/// Given the dimToLvl map, returns the block size in vector.
+/// Given the dimToLvl map, returns the block size in a vector.
 /// For instance, a 2x3 block will return [2, 3].
 /// Only valid block sparsity will be accepted.
 SmallVector<unsigned> getBlockSize(AffineMap dimToLvl);

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
@@ -173,8 +173,15 @@ AffineMap inferLvlToDim(AffineMap dimToLvl, MLIRContext *context);
 /// Asserts on failure (so only use when known to succeed).
 AffineMap inverseBlockSparsity(AffineMap dimToLvl, MLIRContext *context);
 
-/// Given the dimToLvl map, returns the block size in a vector.
-/// For instance, a 2x3 block will return [2, 3].
+/// Given the dimToLvl map, returns the block sizes in a vector.
+/// For instance, a 2x3 block will return [2, 3]. Unblocked dimension i
+/// will return 0, and i floordiv 1, i mod 1 will return 1. Therefore,
+/// the example below will return [0, 1].
+/// map = ( i, j ) ->
+///       ( i : dense,
+///         j floordiv 1 : compressed,
+///         j mod 1      : dense
+///       )
 /// Only valid block sparsity will be accepted.
 SmallVector<unsigned> getBlockSize(AffineMap dimToLvl);
 

--- a/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMap.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMap.cpp
@@ -359,15 +359,12 @@ AffineMap DimLvlMap::getLvlToDimMap(MLIRContext *context) const {
   for (const auto &dimSpec : dimSpecs) {
     auto expr = dimSpec.getExpr().getAffineExpr();
     if (expr) {
-      auto exprTuple = dimSpec.getExpr().unpackBinop();
-      if (std::get<1>(exprTuple) == AffineExprKind::FloorDiv ||
-          std::get<1>(exprTuple) == AffineExprKind::Mod) {
-        dimAffines.push_back(expr);
-      }
+      dimAffines.push_back(expr);
     }
   }
   auto map = AffineMap::get(getLvlRank(), getSymRank(), dimAffines, context);
-  if (dimAffines.empty() || map.isIdentity()) return AffineMap();
+  if (dimAffines.empty() || map.isIdentity())
+    return AffineMap();
   return map;
 }
 

--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -835,7 +835,7 @@ SmallVector<unsigned> mlir::sparse_tensor::getBlockSize(AffineMap dimToLvl) {
             binOp.getRHS().dyn_cast<AffineConstantExpr>().getValue());
       }
     } else {
-      blockSize.push_back(1);
+      blockSize.push_back(0);
     }
   }
   return blockSize;

--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -694,12 +694,10 @@ SparseTensorEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
              << dimToLvl.getNumResults() << " != " << lvlRank;
     auto inferRes = inferLvlToDim(dimToLvl, dimToLvl.getContext());
     // Symbols can't be inferred but are acceptable.
-    if (!inferRes && dimToLvl.getNumSymbols() == 0) {
+    if (!inferRes && dimToLvl.getNumSymbols() == 0)
       return emitError() << "failed to infer lvlToDim from dimToLvl";
-    }
-    if (lvlToDim && (inferRes != lvlToDim)) {
+    if (lvlToDim && (inferRes != lvlToDim))
       return emitError() << "expected lvlToDim to be an inverse of dimToLvl";
-    }
     if (dimRank > lvlRank)
       return emitError() << "unexpected dimToLvl mapping from " << dimRank
                          << " to " << lvlRank;

--- a/mlir/test/Dialect/SparseTensor/invalid_encoding.mlir
+++ b/mlir/test/Dialect/SparseTensor/invalid_encoding.mlir
@@ -60,7 +60,7 @@ func.func private @tensor_sizes_mismatch(%arg0: tensor<8xi32, #a>) -> ()
 
 // -----
 
-// expected-error@+1 {{unexpected dimToLvl mapping from 2 to 1}}
+// expected-error@+1 {{failed to infer lvlToDim from dimToLvl}}
 #a = #sparse_tensor.encoding<{map = (d0, d1) -> (d0 : dense)}>
 func.func private @tensor_sizes_mismatch(%arg0: tensor<8xi32, #a>) -> ()
 
@@ -119,7 +119,7 @@ func.func private @tensor_dimtolvl_mismatch(%arg0: tensor<8xi32, #a>) -> ()
 
 // -----
 
-// expected-error@+1 {{expected a permutation affine map for dimToLvl}}
+// expected-error@+1 {{failed to infer lvlToDim from dimToLvl}}
 #a = #sparse_tensor.encoding<{map = (d0, d1) -> (d0 : dense, d0 : compressed)}>
 func.func private @tensor_no_permutation(%arg0: tensor<16x32xf32, #a>) -> ()
 
@@ -249,5 +249,24 @@ func.func private @too_few_lvl_decl(%arg0: tensor<?x?xf64, #TooFewLvlDecl>) {
   map = {l1, l0} (d0, d1) -> (l0 = d0 : dense, l1 = d1 : compressed)
 }>
 func.func private @wrong_order_lvl_decl(%arg0: tensor<?x?xf64, #WrongOrderLvlDecl>) {
+  return
+}
+
+// -----
+
+// expected-error@+1 {{expected lvlToDim to be an inverse of dimToLvl}}
+#BSR_explicit = #sparse_tensor.encoding<{
+  map =
+  {il, jl, ii, jj}
+  ( i = il * 3 + ii,
+    j = jl * 2 + jj
+  ) ->
+  ( il = i floordiv 2 : dense,
+    jl = j floordiv 3 : compressed,
+    ii = i mod 2      : dense,
+    jj = j mod 3      : dense
+  )
+}>
+func.func private @BSR_explicit(%arg0: tensor<?x?xf64, #BSR_explicit>) {
   return
 }


### PR DESCRIPTION
Updates:
1. Verification of block sparsity.
2. Verification of singleton level type can only follow compressed or loose_compressed levels. And all level types after singleton should be singleton.
3. Added getBlockSize function.
4. Added an invalid encoding test for an incorrect lvlToDim map that user provides.