### PR TITLE
workflows/release-lit: Fix dev suffix removal

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           cd llvm/utils/lit
           # Remove 'dev' suffix from lit version.
-          sed -i "s/ + 'dev'//g" lit/__init__.py
+          sed -i 's/ + "dev"//g' lit/__init__.py
           python3 setup.py sdist
 
       - name: Upload lit to test.pypi.org


### PR DESCRIPTION
This was broken by b71edfaa4ec3c998aadb35255ce2f60bba2940b0.