### PR TITLE
[LLVM[NFC] Refactor to allow debug_names entries to conatain DIE offset

### DIFF
--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -176,6 +176,7 @@ public:
   uint32_t getBucketCount() const { return BucketCount; }
   uint32_t getUniqueHashCount() const { return UniqueHashCount; }
   uint32_t getUniqueNameCount() const { return Entries.size(); }
+  StringEntries &getEntries() { return Entries; }
 
 #ifndef NDEBUG
   void print(raw_ostream &OS) const;
@@ -259,13 +260,17 @@ public:
 #endif
 
   uint64_t getDieOffset() const {
-    if (const DIE *const *TDie = std::get_if<const DIE *>(&OffsetVal))
-      return (*TDie)->getOffset();
+    assert(std::holds_alternative<uint64_t>(OffsetVal) &&
+           "Accessing DIE Offset before normalizing.");
     return std::get<uint64_t>(OffsetVal);
   }
   unsigned getDieTag() const { return Tag; }
   unsigned getUnitID() const { return UnitID; }
-  void normalizeDIEToOffset() { OffsetVal = getDieOffset(); }
+  void normalizeDIEToOffset() {
+    assert(std::holds_alternative<const DIE *>(OffsetVal) &&
+           "Accessing offset after normalizing.");
+    OffsetVal = std::get<const DIE *>(OffsetVal)->getOffset();
+  }
 
 protected:
   std::variant<const DIE *, uint64_t> OffsetVal;

--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -283,7 +283,15 @@ protected:
 
 class DWARF5AccelTable : public AccelTable<DWARF5AccelTableData> {
 public:
-  StringEntries &getEntries() { return Entries; }
+  /// Convert DIE entries to explicit offset.
+  /// Needs to be called after DIE offsets are computed.
+  void convertDieToOffset() {
+    for (auto &Entry : Entries) {
+      for (AccelTableData *Value : Entry.second.Values) {
+        static_cast<DWARF5AccelTableData *>(Value)->normalizeDIEToOffset();
+      }
+    }
+  }
 };
 
 void emitAppleAccelTableImpl(AsmPrinter *Asm, AccelTableBase &Contents,

--- a/llvm/include/llvm/DWARFLinker/DWARFLinker.h
+++ b/llvm/include/llvm/DWARFLinker/DWARFLinker.h
@@ -119,8 +119,7 @@ public:
   virtual void emitLineStrings(const NonRelocatableStringpool &Pool) = 0;
 
   /// Emit DWARF debug names.
-  virtual void
-  emitDebugNames(AccelTable<DWARF5AccelTableStaticData> &Table) = 0;
+  virtual void emitDebugNames(DWARF5AccelTable &Table) = 0;
 
   /// Emit Apple namespaces accelerator table.
   virtual void
@@ -880,7 +879,7 @@ private:
   uint32_t LastCIEOffset = 0;
 
   /// Apple accelerator tables.
-  AccelTable<DWARF5AccelTableStaticData> DebugNames;
+  DWARF5AccelTable DebugNames;
   AccelTable<AppleAccelTableStaticOffsetData> AppleNames;
   AccelTable<AppleAccelTableStaticOffsetData> AppleNamespaces;
   AccelTable<AppleAccelTableStaticOffsetData> AppleObjc;

--- a/llvm/include/llvm/DWARFLinker/DWARFStreamer.h
+++ b/llvm/include/llvm/DWARFLinker/DWARFStreamer.h
@@ -163,7 +163,7 @@ public:
                StringRef Bytes) override;
 
   /// Emit DWARF debug names.
-  void emitDebugNames(AccelTable<DWARF5AccelTableStaticData> &Table) override;
+  void emitDebugNames(DWARF5AccelTable &Table) override;
 
   /// Emit Apple namespaces accelerator table.
   void emitAppleNamespaces(

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -219,10 +219,6 @@ class Dwarf5AccelTableWriter : public AccelTableWriter {
   MCSymbol *AbbrevEnd = Asm->createTempSymbol("names_abbrev_end");
   MCSymbol *EntryPool = Asm->createTempSymbol("names_entries");
 
-  /// Iterates over all the entries and if it contains a DIE replaces it with an
-  /// offset.
-  void normalizeOffsets();
-
   DenseSet<uint32_t> getUniqueTags() const;
 
   // Right now, we emit uniform attributes for all tags.
@@ -399,16 +395,6 @@ void Dwarf5AccelTableWriter<DataT>::Header::emit(Dwarf5AccelTableWriter &Ctx) {
 }
 
 template <typename DataT>
-void Dwarf5AccelTableWriter<DataT>::normalizeOffsets() {
-  for (auto &Bucket : Contents.getBuckets()) {
-    for (auto *Hash : Bucket) {
-      for (auto *Value : Hash->Values) {
-        static_cast<DataT *>(Value)->normalizeDIEToOffset();
-      }
-    }
-  }
-}
-template <typename DataT>
 DenseSet<uint32_t> Dwarf5AccelTableWriter<DataT>::getUniqueTags() const {
   DenseSet<uint32_t> UniqueTags;
   for (auto &Bucket : Contents.getBuckets()) {
@@ -537,7 +523,6 @@ Dwarf5AccelTableWriter<DataT>::Dwarf5AccelTableWriter(
       Header(CompUnits.size(), Contents.getBucketCount(),
              Contents.getUniqueNameCount()),
       CompUnits(CompUnits), getCUIndexForEntry(std::move(getCUIndexForEntry)) {
-  normalizeOffsets();
   DenseSet<uint32_t> UniqueTags = getUniqueTags();
   SmallVector<AttributeEncoding, 2> UniformAttributes = getUniformAttributes();
 

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -360,7 +360,7 @@ void AppleAccelTableWriter::emit() const {
 DWARF5AccelTableData::DWARF5AccelTableData(const DIE &Die,
                                            const DwarfCompileUnit &CU)
     : OffsetVal(&Die) {
-  Tag = Die.getTag();
+  DieTag = Die.getTag();
   UnitID = CU.getUniqueID();
 }
 
@@ -552,8 +552,8 @@ void llvm::emitAppleAccelTableImpl(AsmPrinter *Asm, AccelTableBase &Contents,
 }
 
 void llvm::emitDWARF5AccelTable(
-    AsmPrinter *Asm, AccelTable<DWARF5AccelTableData> &Contents,
-    const DwarfDebug &DD, ArrayRef<std::unique_ptr<DwarfCompileUnit>> CUs) {
+    AsmPrinter *Asm, DWARF5AccelTable &Contents, const DwarfDebug &DD,
+    ArrayRef<std::unique_ptr<DwarfCompileUnit>> CUs) {
   std::vector<std::variant<MCSymbol *, uint64_t>> CompUnits;
   SmallVector<unsigned, 1> CUIndex(CUs.size());
   int Count = 0;
@@ -588,13 +588,13 @@ void llvm::emitDWARF5AccelTable(
 }
 
 void llvm::emitDWARF5AccelTable(
-    AsmPrinter *Asm, AccelTable<DWARF5AccelTableStaticData> &Contents,
+    AsmPrinter *Asm, DWARF5AccelTable &Contents,
     ArrayRef<std::variant<MCSymbol *, uint64_t>> CUs,
-    llvm::function_ref<unsigned(const DWARF5AccelTableStaticData &)>
+    llvm::function_ref<unsigned(const DWARF5AccelTableData &)>
         getCUIndexForEntry) {
   Contents.finalize(Asm, "names");
-  Dwarf5AccelTableWriter<DWARF5AccelTableStaticData>(Asm, Contents, CUs,
-                                                     getCUIndexForEntry)
+  Dwarf5AccelTableWriter<DWARF5AccelTableData>(Asm, Contents, CUs,
+                                               getCUIndexForEntry)
       .emit();
 }
 
@@ -689,11 +689,6 @@ void AccelTableBase::print(raw_ostream &OS) const {
 }
 
 void DWARF5AccelTableData::print(raw_ostream &OS) const {
-  OS << "  Offset: " << getDieOffset() << "\n";
-  OS << "  Tag: " << dwarf::TagString(getDieTag()) << "\n";
-}
-
-void DWARF5AccelTableStaticData::print(raw_ostream &OS) const {
   OS << "  Offset: " << getDieOffset() << "\n";
   OS << "  Tag: " << dwarf::TagString(getDieTag()) << "\n";
 }

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -359,10 +359,7 @@ void AppleAccelTableWriter::emit() const {
 
 DWARF5AccelTableData::DWARF5AccelTableData(const DIE &Die,
                                            const DwarfCompileUnit &CU)
-    : OffsetVal(&Die) {
-  DieTag = Die.getTag();
-  UnitID = CU.getUniqueID();
-}
+    : OffsetVal(&Die), DieTag(Die.getTag()), UnitID(CU.getUniqueID()) {}
 
 template <typename DataT>
 void Dwarf5AccelTableWriter<DataT>::Header::emit(Dwarf5AccelTableWriter &Ctx) {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1246,6 +1246,14 @@ void DwarfDebug::finishSubprogramDefinitions() {
   }
 }
 
+void DwarfDebug::finalizeAccelerationTables() {
+  for (auto &Entry : AccelDebugNames.getEntries()) {
+    for (AccelTableData *Value : Entry.second.Values) {
+      static_cast<DWARF5AccelTableData *>(Value)->normalizeDIEToOffset();
+    }
+  }
+}
+
 void DwarfDebug::finalizeModuleInfo() {
   const TargetLoweringObjectFile &TLOF = Asm->getObjFileLowering();
 
@@ -1389,6 +1397,10 @@ void DwarfDebug::finalizeModuleInfo() {
   InfoHolder.computeSizeAndOffsets();
   if (useSplitDwarf())
     SkeletonHolder.computeSizeAndOffsets();
+
+  // Now that offsets are computed, can replace DIEs in debug_names Entry with
+  // an actual offset.
+  finalizeAccelerationTables();
 }
 
 // Emit all Dwarf sections that should come after the content.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -3547,9 +3547,11 @@ void DwarfDebug::addAccelNameImpl(const DICompileUnit &CU,
   case AccelTableKind::Apple:
     AppleAccel.addName(Ref, Die);
     break;
-  case AccelTableKind::Dwarf:
-    AccelDebugNames.addName(Ref, Die);
+  case AccelTableKind::Dwarf: {
+    DwarfCompileUnit *CU = lookupCU(Die.getUnitDie());
+    AccelDebugNames.addName(Ref, Die, *CU);
     break;
+  }
   case AccelTableKind::Default:
     llvm_unreachable("Default should have already been resolved.");
   case AccelTableKind::None:

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1246,7 +1246,10 @@ void DwarfDebug::finishSubprogramDefinitions() {
   }
 }
 
-void DwarfDebug::finalizeAccelerationTables() {
+/// Finalizes DWARF acceleration tables.
+/// Currently it converts DIE entries to offsets in .debu_names entry.
+static void
+finalizeDWARF5AccelerationTables(DWARF5AccelTable &AccelDebugNames) {
   for (auto &Entry : AccelDebugNames.getEntries()) {
     for (AccelTableData *Value : Entry.second.Values) {
       static_cast<DWARF5AccelTableData *>(Value)->normalizeDIEToOffset();
@@ -1400,7 +1403,7 @@ void DwarfDebug::finalizeModuleInfo() {
 
   // Now that offsets are computed, can replace DIEs in debug_names Entry with
   // an actual offset.
-  finalizeAccelerationTables();
+  finalizeDWARF5AccelerationTables(AccelDebugNames);
 }
 
 // Emit all Dwarf sections that should come after the content.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1246,17 +1246,6 @@ void DwarfDebug::finishSubprogramDefinitions() {
   }
 }
 
-/// Finalizes DWARF acceleration tables.
-/// Currently it converts DIE entries to offsets in .debu_names entry.
-static void
-finalizeDWARF5AccelerationTables(DWARF5AccelTable &AccelDebugNames) {
-  for (auto &Entry : AccelDebugNames.getEntries()) {
-    for (AccelTableData *Value : Entry.second.Values) {
-      static_cast<DWARF5AccelTableData *>(Value)->normalizeDIEToOffset();
-    }
-  }
-}
-
 void DwarfDebug::finalizeModuleInfo() {
   const TargetLoweringObjectFile &TLOF = Asm->getObjFileLowering();
 
@@ -1403,7 +1392,7 @@ void DwarfDebug::finalizeModuleInfo() {
 
   // Now that offsets are computed, can replace DIEs in debug_names Entry with
   // an actual offset.
-  finalizeDWARF5AccelerationTables(AccelDebugNames);
+  AccelDebugNames.convertDieToOffset();
 }
 
 // Emit all Dwarf sections that should come after the content.
@@ -3563,8 +3552,8 @@ void DwarfDebug::addAccelNameImpl(const DICompileUnit &CU,
     AppleAccel.addName(Ref, Die);
     break;
   case AccelTableKind::Dwarf: {
-    DwarfCompileUnit *CU = lookupCU(Die.getUnitDie());
-    AccelDebugNames.addName(Ref, Die, *CU);
+    DwarfCompileUnit *DCU = CUMap.lookup(&CU);
+    AccelDebugNames.addName(Ref, Die, *DCU);
     break;
   }
   case AccelTableKind::Default:

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -496,7 +496,7 @@ private:
   AddressPool AddrPool;
 
   /// Accelerator tables.
-  AccelTable<DWARF5AccelTableData> AccelDebugNames;
+  DWARF5AccelTable AccelDebugNames;
   AccelTable<AppleAccelTableOffsetData> AccelNames;
   AccelTable<AppleAccelTableOffsetData> AccelObjC;
   AccelTable<AppleAccelTableOffsetData> AccelNamespace;
@@ -541,10 +541,6 @@ private:
   void finishEntityDefinitions();
 
   void finishSubprogramDefinitions();
-
-  /// Finalizes DWARF acceleration tables.
-  /// Currently it converts DIE entries to offsets in .debu_names entry.
-  void finalizeAccelerationTables();
 
   /// Finish off debug information after all functions have been
   /// processed.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -542,6 +542,10 @@ private:
 
   void finishSubprogramDefinitions();
 
+  /// Finalizes DWARF acceleration tables.
+  /// Currently it converts DIE entries to offsets in .debu_names entry.
+  void finalizeAccelerationTables();
+
   /// Finish off debug information after all functions have been
   /// processed.
   void finalizeModuleInfo();

--- a/llvm/lib/DWARFLinker/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/DWARFStreamer.cpp
@@ -291,8 +291,7 @@ void DwarfStreamer::emitLineStrings(const NonRelocatableStringpool &Pool) {
   }
 }
 
-void DwarfStreamer::emitDebugNames(
-    AccelTable<DWARF5AccelTableStaticData> &Table) {
+void DwarfStreamer::emitDebugNames(DWARF5AccelTable &Table) {
   if (EmittedUnits.empty())
     return;
 
@@ -307,11 +306,10 @@ void DwarfStreamer::emitDebugNames(
   }
 
   Asm->OutStreamer->switchSection(MOFI->getDwarfDebugNamesSection());
-  emitDWARF5AccelTable(
-      Asm.get(), Table, CompUnits,
-      [&UniqueIdToCuMap](const DWARF5AccelTableStaticData &Entry) {
-        return UniqueIdToCuMap[Entry.getCUIndex()];
-      });
+  emitDWARF5AccelTable(Asm.get(), Table, CompUnits,
+                       [&UniqueIdToCuMap](const DWARF5AccelTableData &Entry) {
+                         return UniqueIdToCuMap[Entry.getUnitID()];
+                       });
 }
 
 void DwarfStreamer::emitAppleNamespaces(

--- a/llvm/lib/DWARFLinkerParallel/DWARFEmitterImpl.cpp
+++ b/llvm/lib/DWARFLinkerParallel/DWARFEmitterImpl.cpp
@@ -223,16 +223,16 @@ void DwarfEmitterImpl::emitDIE(DIE &Die) {
   DebugInfoSectionSize += Die.getSize();
 }
 
-void DwarfEmitterImpl::emitDebugNames(
-    AccelTable<DWARF5AccelTableStaticData> &Table,
-    DebugNamesUnitsOffsets &CUOffsets, CompUnitIDToIdx &CUidToIdx) {
+void DwarfEmitterImpl::emitDebugNames(DWARF5AccelTable &Table,
+                                      DebugNamesUnitsOffsets &CUOffsets,
+                                      CompUnitIDToIdx &CUidToIdx) {
   if (CUOffsets.empty())
     return;
 
   Asm->OutStreamer->switchSection(MOFI->getDwarfDebugNamesSection());
   emitDWARF5AccelTable(Asm.get(), Table, CUOffsets,
-                       [&CUidToIdx](const DWARF5AccelTableStaticData &Entry) {
-                         return CUidToIdx[Entry.getCUIndex()];
+                       [&CUidToIdx](const DWARF5AccelTableData &Entry) {
+                         return CUidToIdx[Entry.getUnitID()];
                        });
 }
 

--- a/llvm/lib/DWARFLinkerParallel/DWARFEmitterImpl.h
+++ b/llvm/lib/DWARFLinkerParallel/DWARFEmitterImpl.h
@@ -87,7 +87,7 @@ public:
   uint64_t getDebugInfoSectionSize() const { return DebugInfoSectionSize; }
 
   /// Emits .debug_names section according to the specified \p Table.
-  void emitDebugNames(AccelTable<DWARF5AccelTableStaticData> &Table,
+  void emitDebugNames(DWARF5AccelTable &Table,
                       DebugNamesUnitsOffsets &CUOffsets,
                       CompUnitIDToIdx &UnitIDToIdxMap);
 

--- a/llvm/lib/DWARFLinkerParallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinkerParallel/DWARFLinkerImpl.cpp
@@ -1129,7 +1129,7 @@ void DWARFLinkerImpl::emitAppleAcceleratorSections(const Triple &TargetTriple) {
 }
 
 void DWARFLinkerImpl::emitDWARFv5DebugNamesSection(const Triple &TargetTriple) {
-  std::unique_ptr<AccelTable<DWARF5AccelTableStaticData>> DebugNames;
+  std::unique_ptr<DWARF5AccelTable> DebugNames;
 
   DebugNamesUnitsOffsets CompUnits;
   CompUnitIDToIdx CUidToIdx;
@@ -1144,7 +1144,7 @@ void DWARFLinkerImpl::emitDWARFv5DebugNamesSection(const Triple &TargetTriple) {
 
     CU->AcceleratorRecords.forEach([&](const DwarfUnit::AccelInfo &Info) {
       if (DebugNames.get() == nullptr)
-        DebugNames = std::make_unique<AccelTable<DWARF5AccelTableStaticData>>();
+        DebugNames = std::make_unique<DWARF5AccelTable>();
 
       switch (Info.Type) {
       case DwarfUnit::AccelType::Name:


### PR DESCRIPTION
This is pre-cursor patch to enabling type units with DWARF5 acceleration tables.
With this change it allows for entries to contain offsets directly, this way type
units do not need to be preserved until .debug_names is written out.
