### PR TITLE
[libc] Add simple features.h with implementation macro

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -2,6 +2,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.assert
     libc.include.ctype
     libc.include.errno
+    libc.include.features
     libc.include.fenv
     libc.include.inttypes
     libc.include.math

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -4,6 +4,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.dirent
     libc.include.errno
     libc.include.fcntl
+    libc.include.features
     libc.include.fenv
     libc.include.inttypes
     libc.include.math

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -4,6 +4,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.dirent
     libc.include.errno
     libc.include.fcntl
+    libc.include.features
     libc.include.fenv
     libc.include.inttypes
     libc.include.math

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -47,6 +47,15 @@ add_gen_header(
 )
 
 add_gen_header(
+  features
+  DEF_FILE features.h.def
+  GEN_HDR features.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.features_macros
+)
+
+add_gen_header(
   fenv
   DEF_FILE fenv.h.def
   GEN_HDR fenv.h

--- a/libc/include/features.h.def
+++ b/libc/include/features.h.def
@@ -1,0 +1,17 @@
+//===-- C standard library header features.h -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_FEATURES_H
+#define LLVM_LIBC_FEATURES_H
+
+#include <__llvm-libc-common.h>
+#include <llvm-libc-macros/features-macros.h>
+
+%%public_api()
+
+#endif // LLVM_LIBC_FEATURES_H

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -47,6 +47,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  features_macros
+  HDR
+    features-macros.h
+)
+
+add_macro_header(
   fenv_macros
   HDR
     fenv-macros.h

--- a/libc/include/llvm-libc-macros/features-macros.h
+++ b/libc/include/llvm-libc-macros/features-macros.h
@@ -1,0 +1,14 @@
+//===-- Definition of macros from features.h ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __LLVM_LIBC_MACROS_FEATURES_MACROS_H
+#define __LLVM_LIBC_MACROS_FEATURES_MACROS_H
+
+#define __LLVM_LIBC__ 1
+
+#endif // __LLVM_LIBC_MACROS_FEATURES_MACROS_H


### PR DESCRIPTION
In the future this should probably be autogenerated so it defines library version.

Only added config/linux/* at the moment with an
if(LLVM_LIBC_FULL_BUILD) statement as I don't think this makes sense for overlay builds.

See: Discussion in #libc https://discord.com/channels/636084430946959380/636732994891284500/1163979080979460176

@michaelrj-google