### PR TITLE
[libcxx][test] Fix empty.gen selftest on windows

### DIFF
--- a/libcxx/test/libcxx/selftest/gen.cpp/empty.gen.cpp
+++ b/libcxx/test/libcxx/selftest/gen.cpp/empty.gen.cpp
@@ -8,4 +8,4 @@
 
 // Make sure we can generate no tests at all
 
-// RUN: cd .
+// RUN: :

--- a/libcxx/test/libcxx/selftest/gen.cpp/empty.gen.cpp
+++ b/libcxx/test/libcxx/selftest/gen.cpp/empty.gen.cpp
@@ -8,4 +8,4 @@
 
 // Make sure we can generate no tests at all
 
-// RUN: true
+// RUN: cd .

--- a/libcxx/test/libcxx/selftest/sh.cpp/run-success.sh.cpp
+++ b/libcxx/test/libcxx/selftest/sh.cpp/run-success.sh.cpp
@@ -8,4 +8,4 @@
 
 // Make sure the test passes if it succeeds to run
 
-// RUN: true
+// RUN: :


### PR DESCRIPTION
Using `true` as a no-op unfortunately does not work on windows, which fails libcxx lit tests on windows. Using `cd .` is a good solution that should work across most platforms, but any suggestion is appreciated.