### PR TITLE
[SystemZ] Support builtin_{frame,return}_address() with non-zero argument

### DIFF
--- a/llvm/test/CodeGen/SystemZ/frameaddr-01.ll
+++ b/llvm/test/CodeGen/SystemZ/frameaddr-01.ll
@@ -25,4 +25,25 @@ entry:
   ret ptr %1
 }
 
+; Check the caller's frame address.
+define ptr @fpcaller() nounwind "backchain" {
+entry:
+; CHECK-LABEL: fpcaller:
+; CHECK: lg   %r2, 0(%r15)
+; CHECK: br   %r14
+  %0 = tail call ptr @llvm.frameaddress(i32 1)
+  ret ptr %0
+}
+
+; Check the caller's frame address.
+define ptr @fpcallercaller() nounwind "backchain" {
+entry:
+; CHECK-LABEL: fpcallercaller:
+; CHECK: lg   %r1, 0(%r15)
+; CHECK: lg   %r2, 0(%r1)
+; CHECK: br   %r14
+  %0 = tail call ptr @llvm.frameaddress(i32 2)
+  ret ptr %0
+}
+
 declare ptr @llvm.frameaddress(i32) nounwind readnone

--- a/llvm/test/CodeGen/SystemZ/frameaddr-02.ll
+++ b/llvm/test/CodeGen/SystemZ/frameaddr-02.ll
@@ -27,6 +27,29 @@ entry:
   ret ptr %1
 }
 
+; Check the caller's frame address.
+define ptr @fpcaller() #0 {
+entry:
+; CHECK-LABEL: fpcaller:
+; CHECK: lghi %r2, 152
+; CHECK: ag   %r2, 152(%r15)
+; CHECK: br   %r14
+  %0 = tail call ptr @llvm.frameaddress(i32 1)
+  ret ptr %0
+}
+
+; Check the caller's caller's frame address.
+define ptr @fpcallercaller() #0 {
+entry:
+; CHECK-LABEL: fpcallercaller:
+; CHECK: lg   %r1, 152(%r15)
+; CHECK: lghi %r2, 152
+; CHECK: ag   %r2, 152(%r1)
+; CHECK: br   %r14
+  %0 = tail call ptr @llvm.frameaddress(i32 2)
+  ret ptr %0
+}
+
 ; Without back chain
 
 attributes #1 = { nounwind "packed-stack" }

--- a/llvm/test/CodeGen/SystemZ/ret-addr-02.ll
+++ b/llvm/test/CodeGen/SystemZ/ret-addr-02.ll
@@ -1,9 +1,10 @@
-; Test support for the llvm.returnaddress intrinsic.
-; 
+; Test support for the llvm.returnaddress intrinsic with packed-stack.
+
 ; RUN: llc < %s -mtriple=s390x-linux-gnu | FileCheck %s
 
 ; The current function's return address is in the link register.
-define ptr @rt0() norecurse nounwind readnone {
+attributes #0 = { nounwind "packed-stack" "backchain" "use-soft-float"="true" }
+define ptr @rt0() #0 {
 entry:
 ; CHECK-LABEL: rt0:
 ; CHECK: lgr  %r2, %r14
@@ -13,23 +14,23 @@ entry:
 }
 
 ; Check the caller's return address.
-define ptr @rtcaller() nounwind "backchain" {
+define ptr @rtcaller() #0 {
 entry:
 ; CHECK-LABEL: rtcaller:
-; CHECK: lg   %r1, 0(%r15)
-; CHECK  lg   %r2, 112(%r1)
+; CHECK: lg   %r1, 152(%r15)
+; CHECK  lg   %r2, 136(%r1)
 ; CHECK: br   %r14
   %0 = tail call ptr @llvm.returnaddress(i32 1)
   ret ptr %0
 }
 
 ; Check the caller's caller's return address.
-define ptr @rtcallercaller() nounwind "backchain" {
+define ptr @rtcallercaller() #0 {
 entry:
 ; CHECK-LABEL: rtcallercaller:
-; CHECK: lg   %r1, 0(%r15)
-; CHECK: lg   %r1, 0(%r1)
-; CHECK  lg   %r2, 112(%r1)
+; CHECK: lg   %r1, 152(%r15)
+; CHECK: lg   %r1, 152(%r1)
+; CHECK  lg   %r2, 136(%r1)
 ; CHECK: br   %r14
   %0 = tail call ptr @llvm.returnaddress(i32 2)
   ret ptr %0


### PR DESCRIPTION
When the code is built with -mbackchain, it is possible to retrieve the caller's frame and return addresses. GCC already can do this, add this support to Clang as well. Use RISCVTargetLowering and GCC's s390_return_addr_rtx() as inspiration. Add tests based on what GCC is emitting.