### PR TITLE
[ELF] Merge copyLocalSymbols and demoteLocalSymbolsInDiscardedSections

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -613,7 +613,6 @@ void LinkerScript::processSectionCommands() {
         discard(*s);
       discardSynthetic(*osec);
       osec->commands.clear();
-      seenDiscard = true;
       return false;
     }
 

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -356,7 +356,6 @@ public:
 
   bool hasSectionsCommand = false;
   bool seenDataAlign = false;
-  bool seenDiscard = false;
   bool seenRelroEnd = false;
   bool errorOnMissingSection = false;
   std::string backwardDotErr;


### PR DESCRIPTION
Follow-up to #69295: In `Writer<ELFT>::run`, the symbol passes are flexible:
they can be placed almost everywhere before `scanRelocations`, with a constraint
that the `computeIsPreemptible` pass must be invoked for linker-defined
non-local symbols.

Merge copyLocalSymbols and demoteLocalSymbolsInDiscardedSections to simplify
code:

* Demoting local symbols can be made unconditional, not constrainted to /DISCARD/ uses due to performance concerns
* `includeInSymtab` can be made faster
* Make symbol passes close to each other
* Decrease data cache misses due to saving an iteration over local symbols

There is no speedup, likely due to the unconditional `dr->section` access in `demoteAndCopyLocalSymbols`.

`gc-sections-tls.s` no longer reports an error because the TLS symbol is
converted to an Undefined.