### PR TITLE
[clangd] Disable crashy unchecked-optional-access tidy check

### DIFF
--- a/clang-tools-extra/clangd/TidyProvider.cpp
+++ b/clang-tools-extra/clangd/TidyProvider.cpp
@@ -219,6 +219,9 @@ TidyProvider disableUnusableChecks(llvm::ArrayRef<std::string> ExtraBadChecks) {
       "-bugprone-use-after-move",
       // Alias for bugprone-use-after-move.
       "-hicpp-invalid-access-moved",
+      // Check uses dataflow analysis, which might hang/crash unexpectedly on
+      // incomplete code.
+      "-bugprone-unchecked-optional-access",
 
       // ----- Performance problems -----
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/69369.
Fixes https://github.com/clangd/clangd/issues/1700.
