### PR TITLE
[utils] Add an alias name --cc for --clang

### DIFF
--- a/llvm/utils/update_cc_test_checks.py
+++ b/llvm/utils/update_cc_test_checks.py
@@ -173,7 +173,7 @@ def config():
     )
     parser.add_argument("--llvm-bin", help="llvm $prefix/bin path")
     parser.add_argument(
-        "--clang", help='"clang" executable, defaults to $llvm_bin/clang'
+        "--cc", "--clang", help='"clang" executable, defaults to $llvm_bin/clang'
     )
     parser.add_argument(
         "--clang-args",

--- a/llvm/utils/update_cc_test_checks.py
+++ b/llvm/utils/update_cc_test_checks.py
@@ -173,7 +173,7 @@ def config():
     )
     parser.add_argument("--llvm-bin", help="llvm $prefix/bin path")
     parser.add_argument(
-        "--cc", "--clang", help='"clang" executable, defaults to $llvm_bin/clang'
+        "--clang", "--cc", help='"clang" executable, defaults to $llvm_bin/clang'
     )
     parser.add_argument(
         "--clang-args",


### PR DESCRIPTION
When using `update_cc_test_checks.py`, it is easy to mistakenly use the `--cc` option instead of `--clang` based on the name. It wouldn't have any negative impact if it's added as well, so I think it can be more convenient.