### PR TITLE
[run-clang-tidy,clang-tidy-diff] Accept directory as value for -export-fixes

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -308,10 +308,12 @@ def main():
     if yaml:
         parser.add_argument(
             "-export-fixes",
-            metavar="filename",
+            metavar="file_or_directory",
             dest="export_fixes",
-            help="Create a yaml file to store suggested fixes in, "
-            "which can be applied with clang-apply-replacements.",
+            help="A directory or a yaml file to store suggested fixes in, "
+            "which can be applied with clang-apply-replacements. If the "
+            "parameter is a directory, the fixes of each compilation unit are "
+            "stored in individual yaml files in the directory.",
         )
     parser.add_argument(
         "-j",
@@ -384,14 +386,30 @@ def main():
 
     clang_tidy_binary = find_binary(args.clang_tidy_binary, "clang-tidy", build_path)
 
-    tmpdir = None
     if args.fix:
         clang_apply_replacements_binary = find_binary(
             args.clang_apply_replacements_binary, "clang-apply-replacements", build_path
         )
 
-    if args.fix or (yaml and args.export_fixes):
-        tmpdir = tempfile.mkdtemp()
+    combine_fixes = False
+    export_fixes_dir = None
+    delete_fixes_dir = False
+    if args.export_fixes is not None:
+        # if a directory is given, create it if it does not exist
+        if args.export_fixes.endswith(os.path.sep) and not os.path.isdir(
+            args.export_fixes
+        ):
+            os.makedirs(args.export_fixes)
+
+        if not os.path.isdir(args.export_fixes) and yaml:
+            combine_fixes = True
+
+        if os.path.isdir(args.export_fixes):
+            export_fixes_dir = args.export_fixes
+
+    if export_fixes_dir is None and (args.fix or combine_fixes):
+        export_fixes_dir = tempfile.mkdtemp()
+        delete_fixes_dir = True
 
     try:
         invocation = get_tidy_invocation(
@@ -450,7 +468,7 @@ def main():
                 args=(
                     args,
                     clang_tidy_binary,
-                    tmpdir,
+                    export_fixes_dir,
                     build_path,
                     task_queue,
                     lock,
@@ -474,14 +492,14 @@ def main():
         # This is a sad hack. Unfortunately subprocess goes
         # bonkers with ctrl-c and we start forking merrily.
         print("\nCtrl-C detected, goodbye.")
-        if tmpdir:
-            shutil.rmtree(tmpdir)
+        if delete_fixes_dir:
+            shutil.rmtree(export_fixes_dir)
         os.kill(0, 9)
 
-    if yaml and args.export_fixes:
+    if combine_fixes:
         print("Writing fixes to " + args.export_fixes + " ...")
         try:
-            merge_replacement_files(tmpdir, args.export_fixes)
+            merge_replacement_files(export_fixes_dir, args.export_fixes)
         except:
             print("Error exporting fixes.\n", file=sys.stderr)
             traceback.print_exc()
@@ -490,14 +508,14 @@ def main():
     if args.fix:
         print("Applying fixes ...")
         try:
-            apply_fixes(args, clang_apply_replacements_binary, tmpdir)
+            apply_fixes(args, clang_apply_replacements_binary, export_fixes_dir)
         except:
             print("Error applying fixes.\n", file=sys.stderr)
             traceback.print_exc()
             return_code = 1
 
-    if tmpdir:
-        shutil.rmtree(tmpdir)
+    if delete_fixes_dir:
+        shutil.rmtree(export_fixes_dir)
     sys.exit(return_code)
 
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -120,7 +120,8 @@ Improvements to clang-tidy
 
 - Improved :program:`clang-tidy-diff.py` script. It now returns exit code `1`
   if any :program:`clang-tidy` subprocess exits with a non-zero code or if
-  exporting fixes fails.
+  exporting fixes fails. It now accepts a directory as a value for
+  `-export-fixes` to export individual yaml files for each compilation unit.
 
 - Improved :program:`run-clang-tidy.py` script. It now accepts a directory
   as a value for `-export-fixes` to export individual yaml files for each

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -122,6 +122,10 @@ Improvements to clang-tidy
   if any :program:`clang-tidy` subprocess exits with a non-zero code or if
   exporting fixes fails.
 
+- Improved :program:`run-clang-tidy.py` script. It now accepts a directory
+  as a value for `-export-fixes` to export individual yaml files for each
+  compilation unit.
+
 New checks
 ^^^^^^^^^^
 


### PR DESCRIPTION
Adding an additional parameter to run_clang_tidy.py to accept a directory where the clang-tidy fixes are saved to. This directory can then be used to run `clang-apply-replacements`.

Closes #69450 