### PR TITLE
[clang-format] Skip PP directives when determining brace kind

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -492,17 +492,16 @@ void UnwrappedLineParser::calculateBraceTypes(bool ExpectClassBody) {
   assert(Tok->is(tok::l_brace));
   do {
     // Get next non-comment, non-preprocessor token.
-    FormatToken *NextTok = Tokens->getNextToken();
-    while (NextTok->is(tok::comment) ||
-           (NextTok->is(tok::hash) && isOnNewLine(*NextTok))) {
-      while (NextTok->is(tok::comment))
+    FormatToken *NextTok;
+    do {
+      NextTok = Tokens->getNextToken();
+    } while (NextTok->is(tok::comment));
+    while (NextTok->is(tok::hash)) {
+      NextTok = Tokens->getNextToken();
+      do {
         NextTok = Tokens->getNextToken();
-      while (NextTok->is(tok::hash) && isOnNewLine(*NextTok)) {
-        ScopedMacroState MacroState(*Line, Tokens, NextTok);
-        do {
-          NextTok = Tokens->getNextToken();
-        } while (NextTok->isNot(tok::eof));
-      }
+      } while (NextTok->is(tok::comment) ||
+               (NextTok->NewlinesBefore == 0 && NextTok->isNot(tok::eof)));
     }
 
     switch (Tok->Tok.getKind()) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2134,6 +2134,7 @@ TEST_F(TokenAnnotatorTest, UnderstandConstructors) {
   EXPECT_TOKEN(Tokens[11], tok::l_paren, TT_Unknown);
   EXPECT_TOKEN(Tokens[12], tok::r_paren, TT_Unknown);
   EXPECT_TOKEN(Tokens[13], tok::l_brace, TT_FunctionLBrace);
+  EXPECT_BRACE_KIND(Tokens[13], BK_Block);
 
   Tokens = annotate("Class::Class() : BaseClass{}, Member{} {}");
   ASSERT_EQ(Tokens.size(), 16u) << Tokens;
@@ -2146,6 +2147,20 @@ TEST_F(TokenAnnotatorTest, UnderstandConstructors) {
   EXPECT_TOKEN(Tokens[11], tok::l_brace, TT_Unknown);
   EXPECT_TOKEN(Tokens[12], tok::r_brace, TT_Unknown);
   EXPECT_TOKEN(Tokens[13], tok::l_brace, TT_FunctionLBrace);
+  EXPECT_BRACE_KIND(Tokens[13], BK_Block);
+
+  Tokens = annotate("class Class {\n"
+                    "  Class() : BaseClass() {\n"
+                    "#if 0\n"
+                    "    // comment\n"
+                    "#endif\n"
+                    "  }\n"
+                    "  Class f();\n"
+                    "}");
+  ASSERT_EQ(Tokens.size(), 25u) << Tokens;
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_CtorInitializerColon);
+  EXPECT_TOKEN(Tokens[10], tok::l_brace, TT_FunctionLBrace);
+  EXPECT_BRACE_KIND(Tokens[10], BK_Block);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsConditionParens) {


### PR DESCRIPTION
Pull request #65409 changed the brace kind heuristic to not treat a preprocessor if directive as a in statement, however, this caused some regressions.

If the contents of a brace don't immediately determine the brace kind, the heuristic will look at the characters immediately before and after the closing brace to determine the brace type.

Unfortunately, if the closing brace was preceded by a preprocessor directive, for example `#endif`, the preceding token was `endif`, seen as just an identifier, so the braces were understood as a braced list.

This patch fixes this behaviour by skipping all preprocessor directives when calculating brace types. Comments were already being skipped, so now preprocessor lines are skipped alongside comments.

Fixes https://github.com/llvm/llvm-project/issues/68404