### PR TITLE
[TableGen] SubtargetEmitter must use std::nullopt

### DIFF
--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1935,7 +1935,7 @@ void SubtargetEmitter::run(raw_ostream &OS) {
   if (NumProcs)
     OS << Target << "SubTypeKV, ";
   else
-    OS << "None, ";
+    OS << "std::nullopt, ";
   OS << '\n'; OS.indent(22);
   OS << Target << "WriteProcResTable, "
      << Target << "WriteLatencyTable, "
@@ -2028,7 +2028,7 @@ void SubtargetEmitter::run(raw_ostream &OS) {
   if (NumProcs)
     OS << "ArrayRef(" << Target << "SubTypeKV, " << NumProcs << "), ";
   else
-    OS << "None, ";
+    OS << "std::nullopt, ";
   OS << '\n'; OS.indent(24);
   OS << Target << "WriteProcResTable, "
      << Target << "WriteLatencyTable, "


### PR DESCRIPTION
Use of llvm::Optional was migrated to std::optional. This included a change in the constructor of ArrayRef.
However, there are still 2 places in the SubtargetEmitter which uses llvm::None, causing a compile error when emitted.