### PR TITLE
[mlir] ADTExtras: include mlir/Support/LLVM.h

### DIFF
--- a/mlir/include/mlir/Support/ADTExtras.h
+++ b/mlir/include/mlir/Support/ADTExtras.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_SUPPORT_ADTEXTRAS_H
 #define MLIR_SUPPORT_ADTEXTRAS_H
 
+#include "mlir/Support/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 


### PR DESCRIPTION
To forward-declare LLVM's support types.