### PR TITLE
[clang] Correct end for the `CastOperation.OpRange`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -379,6 +379,25 @@ Improvements to Clang's diagnostics
   can sometimes lead to worse ordering.
 
 
+- When describing a warning/error in a function-style type conversion Clang underlines only until
+  the end of the expression we convert from. Now Clang underlines until the closing parenthesis.
+
+  Before:
+
+  .. code-block:: text
+
+    warning: cast from 'long (*)(const int &)' to 'decltype(fun_ptr)' (aka 'long (*)(int &)') converts to incompatible function type [-Wcast-function-type-strict]
+    24 | return decltype(fun_ptr)( f_ptr /*comment*/);
+       |        ^~~~~~~~~~~~~~~~~~~~~~~~
+
+  After:
+
+  .. code-block:: text
+
+    warning: cast from 'long (*)(const int &)' to 'decltype(fun_ptr)' (aka 'long (*)(int &)') converts to incompatible function type [-Wcast-function-type-strict]
+    24 | return decltype(fun_ptr)( f_ptr /*comment*/);
+       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Bug Fixes in This Version
 -------------------------
 - Fixed an issue where a class template specialization whose declaration is

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -3362,7 +3362,7 @@ ExprResult Sema::BuildCXXFunctionalCastExpr(TypeSourceInfo *CastTypeInfo,
   assert(LPLoc.isValid() && "List-initialization shouldn't get here.");
   CastOperation Op(*this, Type, CastExpr);
   Op.DestRange = CastTypeInfo->getTypeLoc().getSourceRange();
-  Op.OpRange = SourceRange(Op.DestRange.getBegin(), CastExpr->getEndLoc());
+  Op.OpRange = SourceRange(Op.DestRange.getBegin(), RPLoc);
 
   Op.CheckCXXCStyleCast(/*FunctionalCast=*/true, /*ListInit=*/false);
   if (Op.SrcExpr.isInvalid())

--- a/clang/test/Misc/misc-source-ranges.cpp
+++ b/clang/test/Misc/misc-source-ranges.cpp
@@ -1,7 +1,13 @@
-// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -Wcast-function-type-strict %s 2>&1 | FileCheck %s
 
 struct S {
   char a : 12 - 12;
 };
 // CHECK: misc-source-ranges.cpp:[[@LINE-2]]:8:{[[@LINE-2]]:12-[[@LINE-2]]:19}
 
+using fun = long(*)(int &);
+fun foo(){
+  long (*f_ptr)(const int &);
+  return fun(f_ptr);
+}
+// CHECK: misc-source-ranges.cpp:[[@LINE-2]]:10:{[[@LINE-2]]:10-[[@LINE-2]]:20}


### PR DESCRIPTION
Set the correct end for the CastOperation.OpRange in CXXFunctionalCastExpr. Now it is the closing bracket's location instead of the parameter's location.

This can lead to better highlight in the diagnostics. 
Similar to https://github.com/llvm/llvm-project/pull/66853
Example:
Before:
```
warning: cast from 'long (*)(const int &)' to 'decltype(fun_ptr)' (aka 'long (*)(int &)') converts to incompatible function type 
[-Wcast-function-type-strict]
   24 | return decltype(fun_ptr)( f_ptr /*comment*/);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~
```
After:
```
warning: cast from 'long (*)(const int &)' to 'decltype(fun_ptr)' (aka 'long (*)(int &)') converts to incompatible function type [-Wcast-function-type-strict]
   24 | return decltype(fun_ptr)( f_ptr /*comment*/);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```