### PR TITLE
[clang] Language to String function

### DIFF
--- a/clang/include/clang/Basic/LangStandard.h
+++ b/clang/include/clang/Basic/LangStandard.h
@@ -43,6 +43,7 @@ enum class Language : uint8_t {
   HLSL,
   ///@}
 };
+const char *languageToString(Language L);
 
 enum LangFeatures {
   LineComment = (1 << 0),

--- a/clang/include/clang/Basic/LangStandard.h
+++ b/clang/include/clang/Basic/LangStandard.h
@@ -43,7 +43,7 @@ enum class Language : uint8_t {
   HLSL,
   ///@}
 };
-const char *languageToString(Language L);
+StringRef languageToString(Language L);
 
 enum LangFeatures {
   LineComment = (1 << 0),

--- a/clang/lib/Basic/LangStandards.cpp
+++ b/clang/lib/Basic/LangStandards.cpp
@@ -10,8 +10,48 @@
 #include "clang/Config/config.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/TargetParser/Triple.h"
 using namespace clang;
+
+const char *clang::languageToString(Language L) {
+  // I would like to make this function and the definition of Language
+  // in the .h file simply expand the contents of a .def file.
+  // However, in the .h the members of the enum have doxygen annotations
+  // and/or comments which would be lost.
+  switch (L) {
+  case Language::Unknown:
+    return "Unknown";
+  case Language::Asm:
+    return "Asm";
+  case Language::LLVM_IR:
+    return "LLVM_IR";
+  case Language::C:
+    return "C";
+  case Language::CXX:
+    return "CXX";
+  case Language::ObjC:
+    return "ObjC";
+  case Language::ObjCXX:
+    return "ObjCXX";
+  case Language::OpenCL:
+    return "OpenCL";
+  case Language::OpenCLCXX:
+    return "OpenCLCXX";
+  case Language::CUDA:
+    return "CUDA";
+  case Language::RenderScript:
+    return "RenderScript";
+  case Language::HIP:
+    return "HIP";
+  case Language::HLSL:
+    return "HLSL";
+  }
+
+  std::string msg = llvm::formatv(
+      "Unknown value ({0}) passed to languageToString", (unsigned int)L);
+  llvm_unreachable(msg.c_str());
+}
 
 #define LANGSTANDARD(id, name, lang, desc, features)                           \
   static const LangStandard Lang_##id = {name, desc, features, Language::lang};

--- a/clang/lib/Basic/LangStandards.cpp
+++ b/clang/lib/Basic/LangStandards.cpp
@@ -10,22 +10,17 @@
 #include "clang/Config/config.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "llvm/TargetParser/Triple.h"
 using namespace clang;
 
-const char *clang::languageToString(Language L) {
-  // I would like to make this function and the definition of Language
-  // in the .h file simply expand the contents of a .def file.
-  // However, in the .h the members of the enum have doxygen annotations
-  // and/or comments which would be lost.
+StringRef clang::languageToString(Language L) {
   switch (L) {
   case Language::Unknown:
     return "Unknown";
   case Language::Asm:
     return "Asm";
   case Language::LLVM_IR:
-    return "LLVM_IR";
+    return "LLVM IR";
   case Language::C:
     return "C";
   case Language::CXX:
@@ -48,9 +43,7 @@ const char *clang::languageToString(Language L) {
     return "HLSL";
   }
 
-  std::string msg = llvm::formatv(
-      "Unknown value ({0}) passed to languageToString", (unsigned int)L);
-  llvm_unreachable(msg.c_str());
+  llvm_unreachable("unhandled language kind");
 }
 
 #define LANGSTANDARD(id, name, lang, desc, features)                           \

--- a/clang/lib/Basic/LangStandards.cpp
+++ b/clang/lib/Basic/LangStandards.cpp
@@ -24,15 +24,15 @@ StringRef clang::languageToString(Language L) {
   case Language::C:
     return "C";
   case Language::CXX:
-    return "CXX";
+    return "C++";
   case Language::ObjC:
-    return "ObjC";
+    return "Objective-C";
   case Language::ObjCXX:
-    return "ObjCXX";
+    return "Objective-C++";
   case Language::OpenCL:
     return "OpenCL";
   case Language::OpenCLCXX:
-    return "OpenCLCXX";
+    return "OpenCLC++";
   case Language::CUDA:
     return "CUDA";
   case Language::RenderScript:


### PR DESCRIPTION
This PR adds a function which converts the language to string. This is intended to be used by the z/OS target, see the patch here: https://github.com/llvm/llvm-project/pull/68926