### PR TITLE
[hwasan] Fix rare false negative (zero tag) in two more test cases

### DIFF
--- a/compiler-rt/test/hwasan/TestCases/stack-history-length.c
+++ b/compiler-rt/test/hwasan/TestCases/stack-history-length.c
@@ -11,6 +11,8 @@
 // Stack histories are currently not recorded on x86.
 // XFAIL: target=x86_64{{.*}}
 
+#include <assert.h>
+#include <sanitizer/hwasan_interface.h>
 #include <stdlib.h>
 
 void USE(void *x) { // pretend_to_do_something(void *x)
@@ -20,7 +22,24 @@ void USE(void *x) { // pretend_to_do_something(void *x)
 volatile int four = 4;
 __attribute__((noinline)) void FUNC0() { int x[4]; USE(&x[0]); }
 __attribute__((noinline)) void FUNC() { int x[4]; USE(&x[0]); }
-__attribute__((noinline)) void OOB() { int x[4]; x[four] = 0; USE(&x[0]); }
+__attribute__((noinline)) void OOB() {
+  int x[4];
+  int y[4];
+  // With -hwasan-generate-tags-with-calls=false, stack tags can occasionally
+  // be zero, leading to a false negative
+  // (https://github.com/llvm/llvm-project/issues/69221). Work around it by
+  // using the neighboring variable, which is guaranteed by
+  // -hwasan-generate-tags-with-calls=false to have a different (hence
+  // non-zero) tag.
+  if (__hwasan_tag_pointer(x, 0) == x) {
+    assert(__hwasan_tag_pointer(y, 0) != y);
+    y[four] = 0;
+  } else {
+    x[four] = 0;
+  }
+  USE(&x[0]);
+  USE(&y[0]);
+}
 
 int main(int argc, char **argv) {
   int X = argc == 2 ? atoi(argv[1]) : 10;


### PR DESCRIPTION
stack-uas.c and stack-history-length.c both have
-hwasan-record-stack-history=libcall, which makes the stack base
tag fully randomized. They may therefore sometimes have a zero tag
for a stack allocated variable, resulting in a false negative
(https://github.com/llvm/llvm-project/issues/69221#issuecomment-1767322411).

This patch applies the same workaround as used for deep-recursion.c
(https://github.com/llvm/llvm-project/commit/aa4dfd3736dd1c2e0263eacd09bd613c5784ea73)
and stack-uar.c
(https://github.com/llvm/llvm-project/commit/ddf1de20a3f7db3bca1ef6ba7e6cbb90aac5fd2d):
have two adjacent stack-allocated variables, and use whichever is not
zero-tagged.

These are the last remaining test cases that use -hwasan-record-stack-history=libcall.

stack-uas flakiness spotted in the wild: https://lab.llvm.org/buildbot/#/builders/269/builds/549/steps/11/logs/stdio
stack-history-length: https://lab.llvm.org/buildbot/#/builders/269/builds/537
