### PR TITLE
[CMake] Avoid build spam by switching to Debug message

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1530,7 +1530,7 @@ endmacro(add_llvm_tool_subdirectory)
 
 macro(add_custom_linker_flags name)
   if (LLVM_${name}_LINKER_FLAGS)
-    message(STATUS "Applying ${LLVM_${name}_LINKER_FLAGS} to ${name}")
+    message(DEBUG "Applying ${LLVM_${name}_LINKER_FLAGS} to ${name}")
     target_link_options(${name} PRIVATE ${LLVM_${name}_LINKER_FLAGS})
   endif()
 endmacro()


### PR DESCRIPTION
This is primarily only useful when debugging. It's generally assumed that users
will have their custom flags applied if it's specified in their CMake cache files.

Addresses https://github.com/llvm/llvm-project/pull/68393#discussion_r1363399029