### PR TITLE
[DebugInfo] Correctly report header parsing errors from DWARFContext::fixupIndex

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -91,10 +91,9 @@ void fixupIndexV4(DWARFContext &C, DWARFUnitIndex &Index) {
       DWARFUnitHeader Header;
       if (Error ExtractionErr = Header.extract(
               C, Data, &Offset, DWARFSectionKind::DW_SECT_INFO)) {
-        logAllUnhandledErrors(
+        C.getWarningHandler()(
             createError("Failed to parse CU header in DWP file: " +
-                        toString(std::move(ExtractionErr))),
-            errs());
+                        toString(std::move(ExtractionErr))));
         Map.clear();
         break;
       }
@@ -154,10 +153,9 @@ void fixupIndexV5(DWARFContext &C, DWARFUnitIndex &Index) {
       DWARFUnitHeader Header;
       if (Error ExtractionErr = Header.extract(
               C, Data, &Offset, DWARFSectionKind::DW_SECT_INFO)) {
-        logAllUnhandledErrors(
+        C.getWarningHandler()(
             createError("Failed to parse CU header in DWP file: " +
-                        toString(std::move(ExtractionErr))),
-            errs());
+                        toString(std::move(ExtractionErr))));
         break;
       }
       bool CU = Header.getUnitType() == DW_UT_split_compile;

--- a/llvm/test/tools/llvm-dwp/X86/cu_tu_units_manual_v5_invalid.s
+++ b/llvm/test/tools/llvm-dwp/X86/cu_tu_units_manual_v5_invalid.s
@@ -13,10 +13,10 @@
 # CHECK-NOT: .debug_info.dwo contents:
 
 # CHECK-DAG: .debug_cu_index contents:
-# CHECK: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 6, supported are 2-5
+# CHECK: warning: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 6, supported are 2-5
 
 # CHECK-DAG: .debug_tu_index contents:
-# CHECK: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 6, supported are 2-5
+# CHECK: warning: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 6, supported are 2-5
 
     .section	.debug_info.dwo,"e",@progbits
     .long	.Ldebug_info_dwo_end0-.Ldebug_info_dwo_start0 # Length of Unit


### PR DESCRIPTION
In ef762e5e7292, I shifted around where errors were reported when failing to parse and/or validate DWARFUnitHeaders. When we are doing so in DWARFContext::fixupIndex, the actual error message isn't prefixed with `warning:` like it would be elsewhere (because of the way `logAllUnhandledErrors` is implemented).