### PR TITLE
[flang][openacc] Avoid privatizing symbols during semantics

### DIFF
--- a/flang/test/Semantics/OpenACC/acc-symbols01.f90
+++ b/flang/test/Semantics/OpenACC/acc-symbols01.f90
@@ -14,11 +14,11 @@ program mm
   b = 2
  !$acc parallel present(c) firstprivate(b) private(a)
  !$acc loop
-  !DEF: /mm/OtherConstruct1/i (AccPrivate, AccPreDetermined) HostAssoc INTEGER(4)
+  !REF: /mm/i
   do i=1,10
-   !DEF: /mm/OtherConstruct1/a (AccPrivate) HostAssoc INTEGER(4)
-   !REF: /mm/OtherConstruct1/i
-   !DEF: /mm/OtherConstruct1/b (AccFirstPrivate) HostAssoc INTEGER(4)
+   !REF: /mm/a
+   !REF: /mm/i
+   !REF: /mm/b
    a(i) = b(i)
   end do
  !$acc end parallel


### PR DESCRIPTION
During flang handling of semantics of OpenACC private/firstprivate/ reduction clauses (including the implicitly private loop IV), a new scoped symbol was being created. This could lead to ambiguity in the lowered FIR - aka having multiple fir.declare for the same symbol. Because lowering of OpenACC does not materialize the meaning of the private clauses (by actually creating a scoped local symbol), it does not make sense to create a new symbol in semantics either.

I updated the acc-symbols01.f90 test to reflect this updated approach. Technically, the test could be removed, but it made sense to keep in place to highlight this intentional decision.