### PR TITLE
[Kaleidoscope] Register new dependencies introduced by #69032.

### DIFF
--- a/llvm/examples/Kaleidoscope/Chapter4/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter4/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  Passes
   RuntimeDyld
   ScalarOpts
   Support

--- a/llvm/examples/Kaleidoscope/Chapter5/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter5/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  Passes
   RuntimeDyld
   ScalarOpts
   Support

--- a/llvm/examples/Kaleidoscope/Chapter6/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter6/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  Passes
   RuntimeDyld
   ScalarOpts
   Support

--- a/llvm/examples/Kaleidoscope/Chapter7/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter7/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   InstCombine
   Object
   OrcJIT
+  Passes
   RuntimeDyld
   ScalarOpts
   Support


### PR DESCRIPTION
Broke https://lab.llvm.org/buildbot/#/builders/181/builds/24470.

Could we build the example/tutorial code in the submit checks? This breakage wasn't caught at submit time.