### PR TITLE
[flang][openacc] Warn about misplaced end loop directive and ignore it

### DIFF
--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -568,6 +568,7 @@ public:
   NODE(parser, OpenACCCombinedConstruct)
   NODE(parser, OpenACCConstruct)
   NODE(parser, OpenACCDeclarativeConstruct)
+  NODE(parser, OpenACCEndConstruct)
   NODE(parser, OpenACCLoopConstruct)
   NODE(parser, OpenACCRoutineConstruct)
   NODE(parser, OpenACCStandaloneDeclarativeConstruct)

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -4257,6 +4257,11 @@ struct OpenACCLoopConstruct {
       t;
 };
 
+struct OpenACCEndConstruct {
+  WRAPPER_CLASS_BOILERPLATE(OpenACCEndConstruct, llvm::acc::Directive);
+  CharBlock source;
+};
+
 struct OpenACCStandaloneConstruct {
   TUPLE_CLASS_BOILERPLATE(OpenACCStandaloneConstruct);
   CharBlock source;
@@ -4267,7 +4272,7 @@ struct OpenACCConstruct {
   UNION_CLASS_BOILERPLATE(OpenACCConstruct);
   std::variant<OpenACCBlockConstruct, OpenACCCombinedConstruct,
       OpenACCLoopConstruct, OpenACCStandaloneConstruct, OpenACCCacheConstruct,
-      OpenACCWaitConstruct, OpenACCAtomicConstruct>
+      OpenACCWaitConstruct, OpenACCAtomicConstruct, OpenACCEndConstruct>
       u;
 };
 

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -3358,6 +3358,9 @@ void Fortran::lower::genOpenACCConstruct(
           [&](const Fortran::parser::OpenACCAtomicConstruct &atomicConstruct) {
             genACC(converter, eval, atomicConstruct);
           },
+          [&](const Fortran::parser::OpenACCEndConstruct &) {
+            // No op
+          },
       },
       accConstruct.u);
 }

--- a/flang/lib/Parser/openacc-parsers.cpp
+++ b/flang/lib/Parser/openacc-parsers.cpp
@@ -235,6 +235,9 @@ TYPE_PARSER(startAccLine >>
             sourced(construct<OpenACCDeclarativeConstruct>(
                 Parser<OpenACCRoutineConstruct>{})))))
 
+TYPE_PARSER(sourced(construct<OpenACCEndConstruct>(
+    "END"_tok >> "LOOP"_tok >> pure(llvm::acc::Directive::ACCD_loop))))
+
 // OpenACC constructs
 TYPE_CONTEXT_PARSER("OpenACC construct"_en_US,
     startAccLine >>
@@ -246,7 +249,8 @@ TYPE_CONTEXT_PARSER("OpenACC construct"_en_US,
                     Parser<OpenACCStandaloneConstruct>{}),
                 construct<OpenACCConstruct>(Parser<OpenACCCacheConstruct>{}),
                 construct<OpenACCConstruct>(Parser<OpenACCWaitConstruct>{}),
-                construct<OpenACCConstruct>(Parser<OpenACCAtomicConstruct>{}))))
+                construct<OpenACCConstruct>(Parser<OpenACCAtomicConstruct>{}),
+                construct<OpenACCConstruct>(Parser<OpenACCEndConstruct>{}))))
 
 TYPE_PARSER(startAccLine >>
     sourced(construct<AccEndCombinedDirective>(sourced("END"_tok >>

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -673,6 +673,10 @@ void AccStructureChecker::Enter(const parser::AccClause::If &x) {
       GetContext().clauseSource, "Must have LOGICAL or INTEGER type"_err_en_US);
 }
 
+void AccStructureChecker::Enter(const parser::OpenACCEndConstruct &x) {
+  context_.Say(x.source, "Misplaced OpenACC end directive"_warn_en_US);
+}
+
 void AccStructureChecker::Enter(const parser::Module &) {
   declareSymbols.clear();
 }

--- a/flang/lib/Semantics/check-acc-structure.h
+++ b/flang/lib/Semantics/check-acc-structure.h
@@ -63,6 +63,7 @@ public:
   void Enter(const parser::OpenACCCacheConstruct &);
   void Leave(const parser::OpenACCCacheConstruct &);
   void Enter(const parser::AccAtomicUpdate &);
+  void Enter(const parser::OpenACCEndConstruct &);
 
   // Clauses
   void Leave(const parser::AccClauseList &);

--- a/flang/test/Semantics/OpenACC/acc-error.f90
+++ b/flang/test/Semantics/OpenACC/acc-error.f90
@@ -13,3 +13,17 @@ subroutine test(a, n)
     !ERROR: expected OpenACC directive
     !$acc p
   end subroutine
+
+subroutine test2(a, n)
+  integer :: a(n)
+  integer :: i
+
+  !$acc parallel
+  !$acc loop
+  DO i = 1, n
+  END DO
+  !$acc end parallel
+  !WARN: Misplaced OpenACC end directive
+  !$acc end loop
+
+end subroutine


### PR DESCRIPTION
Instead of raising an error for a misplaced `end loop directive`, just warn about it and ignore it. This directive is an extension and is optional.