### PR TITLE
[clang-tidy] Ignore deleted functions in cppcoreguidelines-rvalue-reference-param-not-moved

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/RvalueReferenceParamNotMovedCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/RvalueReferenceParamNotMovedCheck.cpp
@@ -62,33 +62,34 @@ void RvalueReferenceParamNotMovedCheck::registerMatchers(MatchFinder *Finder) {
               anyOf(isConstQualified(), substTemplateTypeParmType()))))),
           optionally(hasType(qualType(references(templateTypeParmType(
               hasDeclaration(templateTypeParmDecl().bind("template-type"))))))),
-          anyOf(hasAncestor(cxxConstructorDecl(
-                    ToParam, isDefinition(), unless(isMoveConstructor()),
-                    optionally(hasDescendant(MoveCallMatcher)))),
-                hasAncestor(functionDecl(
-                    unless(cxxConstructorDecl()), ToParam,
-                    unless(cxxMethodDecl(isMoveAssignmentOperator())),
-                    hasBody(optionally(hasDescendant(MoveCallMatcher))))))),
+          hasDeclContext(
+              functionDecl(
+                  isDefinition(), unless(isDeleted()), unless(isDefaulted()),
+                  unless(cxxConstructorDecl(isMoveConstructor())),
+                  unless(cxxMethodDecl(isMoveAssignmentOperator())), ToParam,
+                  anyOf(cxxConstructorDecl(
+                            optionally(hasDescendant(MoveCallMatcher))),
+                        functionDecl(unless(cxxConstructorDecl()),
+                                     optionally(hasBody(
+                                         hasDescendant(MoveCallMatcher))))))
+                  .bind("func"))),
       this);
 }
 
 void RvalueReferenceParamNotMovedCheck::check(
     const MatchFinder::MatchResult &Result) {
   const auto *Param = Result.Nodes.getNodeAs<ParmVarDecl>("param");
+  const auto *Function = Result.Nodes.getNodeAs<FunctionDecl>("func");
   const auto *TemplateType =
       Result.Nodes.getNodeAs<TemplateTypeParmDecl>("template-type");
 
-  if (!Param)
+  if (!Param || !Function)
     return;
 
   if (IgnoreUnnamedParams && Param->getName().empty())
     return;
 
   if (!Param->isUsed() && Param->hasAttr<UnusedAttr>())
-    return;
-
-  const auto *Function = dyn_cast<FunctionDecl>(Param->getDeclContext());
-  if (!Function)
     return;
 
   if (IgnoreNonDeducedTemplateTypes && TemplateType)

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -246,7 +246,8 @@ Changes in existing checks
 
 - Improved :doc:`cppcoreguidelines-rvalue-reference-param-not-moved
   <clang-tidy/checks/cppcoreguidelines/rvalue-reference-param-not-moved>` check
-  to ignore unused parameters when they are marked as unused.
+  to ignore unused parameters when they are marked as unused and parameters of
+  deleted functions and constructors.
 
 - Improved :doc:`llvm-namespace-comment
   <clang-tidy/checks/llvm/namespace-comment>` check to provide fixes for

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/rvalue-reference-param-not-moved.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/rvalue-reference-param-not-moved.cpp
@@ -334,8 +334,7 @@ void instantiate_a_class_template() {
   withObjRef.never_moves(o);
 }
 
-namespace gh68209
-{
+namespace gh68209 {
   void f1([[maybe_unused]] int&& x) {}
 
   void f2(__attribute__((unused)) int&& x) {}
@@ -358,3 +357,13 @@ namespace gh68209
   void f8(__attribute__((unused)) int&& x) { x += 1; }
   // CHECK-MESSAGES: :[[@LINE-1]]:41: warning: rvalue reference parameter 'x' is never moved from inside the function body [cppcoreguidelines-rvalue-reference-param-not-moved]
 } // namespace gh68209
+
+namespace gh69412 {
+  struct S
+  {
+      S(const int&);
+      S(int&&) = delete;
+
+      void foo(int&&) = delete;
+  };
+} // namespace gh69412


### PR DESCRIPTION
Ignore functions and constructors that are maked deleted or defaulted in cppcoreguidelines-rvalue-reference-param-not-moved check.

Fixes #69412 