### PR TITLE
[AArch64][Windows] Add llvm-readobj support for ec_context unwind opcode

### DIFF
--- a/llvm/tools/llvm-readobj/ARMWinEHPrinter.cpp
+++ b/llvm/tools/llvm-readobj/ARMWinEHPrinter.cpp
@@ -171,6 +171,7 @@ const Decoder::RingEntry Decoder::Ring64[] = {
     {0xff, 0xe8, 1, &Decoder::opcode_trap_frame},
     {0xff, 0xe9, 1, &Decoder::opcode_machine_frame},
     {0xff, 0xea, 1, &Decoder::opcode_context},
+    {0xff, 0xeb, 1, &Decoder::opcode_ec_context},
     {0xff, 0xec, 1, &Decoder::opcode_clear_unwound_to_call},
     {0xff, 0xfc, 1, &Decoder::opcode_pac_sign_lr},
 };
@@ -965,6 +966,13 @@ bool Decoder::opcode_machine_frame(const uint8_t *OC, unsigned &Offset,
 bool Decoder::opcode_context(const uint8_t *OC, unsigned &Offset,
                              unsigned Length, bool Prologue) {
   SW.startLine() << format("0x%02x                ; context\n", OC[Offset]);
+  ++Offset;
+  return false;
+}
+
+bool Decoder::opcode_ec_context(const uint8_t *OC, unsigned &Offset,
+                                unsigned Length, bool Prologue) {
+  SW.startLine() << format("0x%02x                ; EC context\n", OC[Offset]);
   ++Offset;
   return false;
 }

--- a/llvm/tools/llvm-readobj/ARMWinEHPrinter.h
+++ b/llvm/tools/llvm-readobj/ARMWinEHPrinter.h
@@ -129,6 +129,8 @@ class Decoder {
                             unsigned Length, bool Prologue);
   bool opcode_context(const uint8_t *Opcodes, unsigned &Offset, unsigned Length,
                       bool Prologue);
+  bool opcode_ec_context(const uint8_t *Opcodes, unsigned &Offset,
+                         unsigned Length, bool Prologue);
   bool opcode_clear_unwound_to_call(const uint8_t *Opcodes, unsigned &Offset,
                                     unsigned Length, bool Prologue);
   bool opcode_pac_sign_lr(const uint8_t *Opcodes, unsigned &Offset,


### PR DESCRIPTION
ARM64EC uses the same CONTEXT structure as x86_64 as opposed to the regular ARM64 context, a [new unwind opcode](https://learn.microsoft.com/en-us/cpp/build/arm64-exception-handling?view=msvc-170) (MSFT_OP_EC_CONTEXT) is added to handle this.