### PR TITLE
[lldb] Add `SBModule.SetLocateDwoCallback`

### DIFF
--- a/lldb/bindings/python/python-typemaps.swig
+++ b/lldb/bindings/python/python-typemaps.swig
@@ -696,3 +696,55 @@ template <> bool SetNumberFromPyObject<double>(double &number, PyObject *obj) {
   $1 = $input == Py_None;
   $1 = $1 || PyCallable_Check(reinterpret_cast<PyObject *>($input));
 }
+
+// For lldb::SBModuleLocateDwoCallback
+// The `baton` is the actual Python function passed, and we invoke the `baton` via a SWIG function.
+%typemap(in) (lldb::SBModuleLocateDwoCallback callback,
+              void *baton) {
+  if (!($input == Py_None ||
+        PyCallable_Check(reinterpret_cast<PyObject *>($input)))) {
+    PyErr_SetString(PyExc_TypeError, "Need a callable object or None!");
+    SWIG_fail;
+  }
+
+  if ($input == Py_None) {
+    $1 = nullptr;
+    $2 = nullptr;
+  } else {
+    PythonCallable callable = Retain<PythonCallable>($input);
+    if (!callable.IsValid()) {
+      PyErr_SetString(PyExc_TypeError, "Need a valid callable object");
+      SWIG_fail;
+    }
+
+    llvm::Expected<PythonCallable::ArgInfo> arg_info = callable.GetArgInfo();
+    if (!arg_info) {
+      PyErr_SetString(PyExc_TypeError,
+                      ("Could not get arguments: " +
+                          llvm::toString(arg_info.takeError())).c_str());
+      SWIG_fail;
+    }
+
+    if (arg_info.get().max_positional_args != 5) {
+      PyErr_SetString(PyExc_TypeError, "Expected 5 argument callable object");
+      SWIG_fail;
+    }
+
+    // NOTE: When this is called multiple times, this will leak the Python
+    // callable object as other callbacks, because this does not call Py_DECREF
+    // the object. But it should be almost zero impact since this method is
+    // expected to be called only once.
+
+    // Don't lose the callback reference
+    Py_INCREF($input);
+
+    $1 = LLDBSwigPythonCallLocateDwoCallback;
+    $2 = $input;
+  }
+}
+
+%typemap(typecheck) (lldb::SBModuleLocateDwoCallback callback,
+                     void *baton) {
+  $1 = $input == Py_None;
+  $1 = $1 || PyCallable_Check(reinterpret_cast<PyObject *>($input));
+}

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -1168,4 +1168,58 @@ static SBError LLDBSwigPythonCallLocateModuleCallback(
 
   return *sb_error_ptr;
 }
+
+// `comp_dir` is allowed to be NULL. All other arguments must be valid values.
+static SBError LLDBSwigPythonCallLocateDwoCallback(
+    void *baton, const SBFileSpec &objfile_spec_sb,
+    const char *dwo_name, const char *comp_dir, const int64_t dwo_id, SBFileSpec &located_dwo_file_spec_sb) {
+  SWIG_Python_Thread_Block swig_thread_block;
+
+  PyErr_Cleaner py_err_cleaner(true);
+  if (dwo_name == NULL) {
+    return SBError("`dwo_name` is NULL. Expected a valid string.");
+  }
+  PythonString dwo_name_arg(dwo_name);
+  PythonObject comp_dir_arg(PyRefType::Borrowed, Py_None);
+  if (comp_dir != NULL) {
+    comp_dir_arg = PythonString(comp_dir);
+  }
+  PythonObject dwo_id_arg = PythonInteger(dwo_id);
+  PythonObject objfile_spec_arg = SWIGBridge::ToSWIGWrapper(
+      std::make_unique<SBFileSpec>(objfile_spec_sb));
+  PythonObject located_dwo_file_spec_arg = SWIGBridge::ToSWIGWrapper(
+      std::make_unique<SBFileSpec>(located_dwo_file_spec_sb));
+
+  PythonCallable callable =
+      Retain<PythonCallable>(reinterpret_cast<PyObject *>(baton));
+  if (!callable.IsValid()) {
+    return SBError("The callback callable is not valid.");
+  }
+
+  PythonObject result = callable(objfile_spec_arg,
+                                 dwo_name_arg,
+                                 comp_dir_arg,
+                                 dwo_id_arg,
+                                 located_dwo_file_spec_arg);
+
+  if (!result.IsAllocated())
+    return SBError("No result.");
+  lldb::SBError *sb_error_ptr = nullptr;
+  if (SWIG_ConvertPtr(result.get(), (void **)&sb_error_ptr,
+                      SWIGTYPE_p_lldb__SBError, 0) == -1) {
+    return SBError("Result is not SBError.");
+  }
+
+  if (sb_error_ptr->Success()) {
+    lldb::SBFileSpec *located_dwo_file_spec_ptr = nullptr;
+    if (SWIG_ConvertPtr(located_dwo_file_spec_arg.get(),
+                        (void **)&located_dwo_file_spec_ptr,
+                        SWIGTYPE_p_lldb__SBFileSpec, 0) == -1)
+      return SBError("located_dwo_file_spec is not SBFileSpec.");
+
+    located_dwo_file_spec_sb = *located_dwo_file_spec_ptr;
+  }
+
+  return *sb_error_ptr;
+}
 %}

--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -139,6 +139,13 @@ typedef void (*SBDebuggerDestroyCallback)(lldb::user_id_t debugger_id,
 typedef SBError (*SBPlatformLocateModuleCallback)(
     void *baton, const SBModuleSpec &module_spec, SBFileSpec &module_file_spec,
     SBFileSpec &symbol_file_spec);
+
+typedef SBError (*SBModuleLocateDwoCallback)(void *baton,
+                                             const SBFileSpec &objfile_spec,
+                                             const char *dwo_name,
+                                             const char *comp_dir,
+                                             const int64_t dwo_id,
+                                             SBFileSpec &located_dwo_file_spec);
 }
 
 #endif // LLDB_API_SBDEFINES_H

--- a/lldb/include/lldb/API/SBError.h
+++ b/lldb/include/lldb/API/SBError.h
@@ -91,6 +91,7 @@ protected:
   friend class SBValue;
   friend class SBValueList;
   friend class SBWatchpoint;
+  friend class SBModule;
 
   friend class lldb_private::ScriptInterpreter;
   friend class lldb_private::python::SWIGBridge;

--- a/lldb/include/lldb/API/SBModule.h
+++ b/lldb/include/lldb/API/SBModule.h
@@ -296,6 +296,20 @@ public:
   /// Remove any global modules which are no longer needed.
   static void GarbageCollectAllocatedModules();
 
+  /// Set a callback which is called to find separate DWARF DWO debug info
+  /// files.
+  ///
+  /// This is useful when DWO files have been moved, or when the symbol file
+  /// contains relative paths to the DWO files.
+  ///
+  /// If the callback fails to
+  /// find the DWO file (`located_dwo_file_spec` is unset), then LLDB will fall
+  /// back to the default search locations. The callback will be cleared if
+  /// `nullptr` is set.
+  /// `comp_dir` may be `nullptr`.
+  static void SetLocateDwoCallback(lldb::SBModuleLocateDwoCallback callback,
+                                   void *baton);
+
 private:
   friend class SBAddress;
   friend class SBFrame;

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -68,6 +68,7 @@ public:
   uint64_t GetLLDBIndexCacheExpirationDays();
   FileSpec GetLLDBIndexCachePath() const;
   bool SetLLDBIndexCachePath(const FileSpec &path);
+  FileSpec GetLocateDwoScriptPath() const;
 
   bool GetLoadSymbolOnDemand();
 

--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -77,6 +77,15 @@ public:
 
   static SymbolFile *FindPlugin(lldb::ObjectFileSP objfile_sp);
 
+  typedef std::function<Status(
+      const FileSpec &objfile_spec, const char *dwo_name, const char *comp_dir,
+      const uint64_t dwo_id, FileSpec &located_dwo_file_spec)>
+      LocateDwoCallback;
+
+  static void SetLocateDwoCallback(LocateDwoCallback callback);
+
+  static LocateDwoCallback GetLocateDwoCallback();
+
   // Constructors and Destructors
   SymbolFile() = default;
 
@@ -475,6 +484,8 @@ protected:
 private:
   SymbolFile(const SymbolFile &) = delete;
   const SymbolFile &operator=(const SymbolFile &) = delete;
+
+  static LocateDwoCallback LOCATE_DWO_CALLBACK;
 };
 
 /// Containing protected virtual methods for child classes to override.

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -28,6 +28,7 @@ using namespace lldb;
 
 char SymbolFile::ID;
 char SymbolFileCommon::ID;
+SymbolFile::LocateDwoCallback SymbolFile::LOCATE_DWO_CALLBACK;
 
 void SymbolFile::PreloadSymbols() {
   // No-op for most implementations.
@@ -103,6 +104,14 @@ SymbolFile *SymbolFile::FindPlugin(ObjectFileSP objfile_sp) {
     }
   }
   return best_symfile_up.release();
+}
+
+void SymbolFile::SetLocateDwoCallback(LocateDwoCallback callback) {
+  LOCATE_DWO_CALLBACK = callback;
+}
+
+SymbolFile::LocateDwoCallback SymbolFile::GetLocateDwoCallback() {
+  return LOCATE_DWO_CALLBACK;
 }
 
 uint32_t

--- a/lldb/test/API/python_api/sbmodule/locate_dwo_callback/Makefile
+++ b/lldb/test/API/python_api/sbmodule/locate_dwo_callback/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp foo.cpp
+CFLAGS_EXTRAS := -g -gsplit-dwarf
+
+include Makefile.rules

--- a/lldb/test/API/python_api/sbmodule/locate_dwo_callback/TestLocateDwoCallback.py
+++ b/lldb/test/API/python_api/sbmodule/locate_dwo_callback/TestLocateDwoCallback.py
@@ -1,0 +1,119 @@
+"""
+Test module locate dwo callback functionality
+"""
+
+import ctypes
+import shutil
+from lldbsuite.test.decorators import *
+import lldb
+from lldbsuite.test import lldbtest, lldbutil
+
+
+class LocateDwoCallbackTestCase(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def setUp(self):
+        lldbtest.TestBase.setUp(self)
+
+        self.build()
+        self.exe = self.getBuildArtifact("a.out")
+        self.dwos = [
+         self.getBuildArtifact("main.dwo"),
+         self.getBuildArtifact("foo.dwo")
+        ]
+
+    def run_program(self):
+        # Set a breakpoint at main
+        target = self.dbg.CreateTarget(self.exe)
+        self.assertTrue(target, lldbtest.VALID_TARGET)
+        lldbutil.run_break_set_by_symbol(self, "main")
+
+        # Now launch the process, and do not stop at entry point.
+        self.process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertTrue(self.process, lldbtest.PROCESS_IS_VALID)
+
+    def check_symbolicated(self):
+        thread = self.process.GetSelectedThread()
+        frame = thread.GetSelectedFrame()
+        self.assertEquals(len(frame.get_arguments()), 2)
+
+    def check_not_symbolicated(self):
+        thread = self.process.GetSelectedThread()
+        frame = thread.GetSelectedFrame()
+        self.assertNotEquals(len(frame.get_arguments()), 2)
+
+    def moveDwos(self):
+        """Move the dwos to a subdir in the build dir"""
+        dwo_folder = os.path.join(self.getBuildDir(), "dwos")
+        lldbutil.mkdir_p(dwo_folder)
+        for dwo in self.dwos:
+            shutil.move(dwo, dwo_folder)
+
+    @skipIfWindows
+    @skipIfDarwin
+    def test_set_non_callable(self):
+        with self.assertRaises(TypeError):
+            lldb.SBModule.SetLocateDwoCallback("a")
+
+    @skipIfWindows
+    @skipIfDarwin
+    def test_set_wrong_args(self):
+        def test_args_less_than_5(a, b, c, d):
+            pass
+        with self.assertRaises(TypeError):
+            lldb.SBModule.SetLocateDwoCallback(test_args_less_than_5)
+
+    @skipIfWindows
+    @skipIfDarwin
+    def test_default_succeeds(self):
+        lldb.SBModule.SetLocateDwoCallback(None)
+
+        self.moveDwos()
+        self.run_program()
+        self.check_not_symbolicated()
+
+    @skipIfWindows
+    @skipIfDarwin
+    def test_default_fails_when_dwos_moved(self):
+        lldb.SBModule.SetLocateDwoCallback(None)
+
+        self.moveDwos()
+        self.run_program()
+        self.check_not_symbolicated()
+
+    @skipIfWindows
+    @skipIfDarwin
+    def test_callback_finds_dwos(self):
+        lldb.SBModule.SetLocateDwoCallback(locate_dwo_callback)
+
+        self.moveDwos()
+        self.run_program()
+        self.check_symbolicated()
+
+        # We don't want to interfere with other tests, so we unset it here.
+        lldb.SBModule.SetLocateDwoCallback(None)
+
+    @skipIfWindows
+    @skipIfDarwin
+    def test_falls_back_when_dwo_fails(self):
+        # Note that we *don't* move the dwo files here, so the callback
+        # *shouldn't* actually find the files.
+        lldb.SBModule.SetLocateDwoCallback(locate_dwo_callback)
+
+        self.run_program()
+
+        # We should properly fall back to the default.
+        self.check_symbolicated()
+
+        # We don't want to interfere with other tests, so we unset it here.
+        lldb.SBModule.SetLocateDwoCallback(None)
+
+def locate_dwo_callback(objfile, dwo_name, comp_dir, dwo_id, result_file_spec):
+    import os
+    dwo_dir_after_move = os.path.join(comp_dir, "dwos")
+
+    if os.path.exists(os.path.join(dwo_dir_after_move, dwo_name)):
+        result_file_spec.SetDirectory(dwo_dir_after_move)
+        result_file_spec.SetFilename(dwo_name)
+
+    return lldb.SBError()

--- a/lldb/test/API/python_api/sbmodule/locate_dwo_callback/foo.cpp
+++ b/lldb/test/API/python_api/sbmodule/locate_dwo_callback/foo.cpp
@@ -1,0 +1,3 @@
+#include "foo.h"
+
+int foo() { return 1; }

--- a/lldb/test/API/python_api/sbmodule/locate_dwo_callback/foo.h
+++ b/lldb/test/API/python_api/sbmodule/locate_dwo_callback/foo.h
@@ -1,0 +1,6 @@
+#ifndef FOO_H
+#define FOO_H
+
+int foo();
+
+#endif

--- a/lldb/test/API/python_api/sbmodule/locate_dwo_callback/main.cpp
+++ b/lldb/test/API/python_api/sbmodule/locate_dwo_callback/main.cpp
@@ -1,0 +1,3 @@
+#include "foo.h"
+
+int main(int argc, char **argv) { return foo(); }


### PR DESCRIPTION
Add a way to set a *static* callback to locate DWO files in `SBModule`.
```
SBError SBLocateDwoCallback(void *baton, const SBFileSpec &objfile_spec, const char *dwo_name, const char *comp_dir, const int64_t dwo_id, SBFileSpec &located_dwo_file_spec);
```
where `located_dwo_file_spec` is the output of the function.

This is more powerful than using a list of search directories via `target.debug-file-search-paths`; for example, we could write a callback that traverses up the object file path and searches for some expected folder name. The callback supplements the existing search paths for dwo files. If there is no callback or the callback fails, we fall back to other ways of finding dwos.

On `Python`, the callback arguments are just `objfile_spec`, `dwo_name`, `comp_dir`, `dwo_id`, and `located_dwo_file_spec`, no `baton`. See `TestLocateDwoCallback.py` for examples.

To implement this, I pretty religiously followed the pattern set by Kazuki in his OSS RFC
https://discourse.llvm.org/t/rfc-python-callback-for-target-get-module/71580.

# Testing
Tested manually, and with
```
ninja check-lldb-shell-symbolfile-dwarf
```
and 
```
lldb-dotest -p TestLocateDwoCallback
```