### PR TITLE
[Libomptarget] Add a test for the `libc` implementation of assert

### DIFF
--- a/openmp/libomptarget/test/libc/assert.c
+++ b/openmp/libomptarget/test/libc/assert.c
@@ -1,0 +1,21 @@
+// RUN: %libomptarget-compile-generic && %libomptarget-run-fail-generic 2>&1 | \
+// RUN:   %fcheck-generic --check-prefix=CHECK
+
+// REQUIRES: libc
+
+// UNSUPPORTED: powerpc64-ibm-linux-gnu
+// UNSUPPORTED: powerpc64-ibm-linux-gnu-LTO
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+// UNSUPPORTED: x86_64-pc-linux-gnu
+// UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+
+#include <assert.h>
+
+int main() {
+  // CHECK: Assertion failed: '0 && "Trivial failure"' in function: 'int main()'
+  // CHECK-NOT: Assertion failed:
+#pragma omp target
+#pragma omp parallel
+  { assert(0 && "Trivial failure"); }
+}


### PR DESCRIPTION
Summary:
The `libcgpu.a` file provides its own implementation of `__assert_fail`.
This adds a test to make sure it's usable in OpenMP offloading as
expected. Currently this requires linking `libcgpu.a` before the OpenMP
device RTL however. We also disable the test on the CPU as the format of
the string will be different.
