### PR TITLE
[libc] Remove the optional arguments for NVPTX constructors

### DIFF
--- a/libc/startup/gpu/nvptx/start.cpp
+++ b/libc/startup/gpu/nvptx/start.cpp
@@ -24,13 +24,15 @@ uintptr_t *__fini_array_start [[gnu::visibility("protected")]];
 uintptr_t *__fini_array_end [[gnu::visibility("protected")]];
 }
 
-using InitCallback = void(int, char **, char **);
+// Nvidia requires that the signature of the function pointers match. This means
+// we cannot support the extended constructor arguments.
+using InitCallback = void(void);
 using FiniCallback = void(void);
 
-static void call_init_array_callbacks(int argc, char **argv, char **env) {
+static void call_init_array_callbacks(int, char **, char **) {
   size_t init_array_size = __init_array_end - __init_array_start;
   for (size_t i = 0; i < init_array_size; ++i)
-    reinterpret_cast<InitCallback *>(__init_array_start[i])(argc, argv, env);
+    reinterpret_cast<InitCallback *>(__init_array_start[i])();
 }
 
 static void call_fini_array_callbacks() {

--- a/libc/test/integration/startup/gpu/init_fini_array_test.cpp
+++ b/libc/test/integration/startup/gpu/init_fini_array_test.cpp
@@ -37,11 +37,11 @@ A global(GLOBAL_INDEX, INITVAL_INITIALIZER);
 int initval = 0;
 int before = 0;
 
-__attribute__((constructor(101))) void run_before(int, char **, char **) {
+__attribute__((constructor(101))) void run_before() {
   before = BEFORE_INITIALIZER;
 }
 
-__attribute__((constructor(65535))) void run_after(int, char **, char **) {
+__attribute__((constructor(65535))) void run_after() {
   ASSERT_EQ(before, BEFORE_INITIALIZER);
 }
 


### PR DESCRIPTION
Summary:
We call the global constructors by function pointer. For whatever reason
the NVPTX architecture relies very specifically on the arguments to the
function pointer invocation matching what the function is implemented
as. This is problematic as most of these constructors are generated
with no arguments. This patch removes the extended arguments that GNU
and LLVM use for the constructors optionally so that it can support the
common case.
