### PR TITLE
[mlir] Use the process (host) triple in MLIRTargetLLVMTests

### DIFF
--- a/mlir/unittests/Target/LLVM/SerializeToLLVMBitcode.cpp
+++ b/mlir/unittests/Target/LLVM/SerializeToLLVMBitcode.cpp
@@ -55,7 +55,7 @@ TEST_F(MLIRTargetLLVM, SKIP_WITHOUT_NATIVE(SerializeToLLVMBitcode)) {
   ASSERT_TRUE(!!module);
 
   // Serialize the module.
-  std::string targetTriple = llvm::sys::getDefaultTargetTriple();
+  std::string targetTriple = llvm::sys::getProcessTriple();
   LLVM::ModuleToObject serializer(*(module->getOperation()), targetTriple, "",
                                   "");
   std::optional<SmallVector<char, 0>> serializedModule = serializer.run();


### PR DESCRIPTION
The test is meant to execute on the native target and only initializes the native target. However, it then gets the default target triple instead of the process (host) triple. This fails in cases where the native target and the default target are not the same.

The test was added here: https://reviews.llvm.org/D154100