### PR TITLE
[IPO] Remove unused function getAndUpdateAAFor

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1541,18 +1541,6 @@ struct Attributor {
                                     /* ForceUpdate */ false);
   }
 
-  /// Similar to getAAFor but the return abstract attribute will be updated (via
-  /// `AbstractAttribute::update`) even if it is found in the cache. This is
-  /// especially useful for AAIsDead as changes in liveness can make updates
-  /// possible/useful that were not happening before as the abstract attribute
-  /// was assumed dead.
-  template <typename AAType>
-  const AAType *getAndUpdateAAFor(const AbstractAttribute &QueryingAA,
-                                  const IRPosition &IRP, DepClassTy DepClass) {
-    return getOrCreateAAFor<AAType>(IRP, &QueryingAA, DepClass,
-                                    /* ForceUpdate */ true);
-  }
-
   /// The version of getAAFor that allows to omit a querying abstract
   /// attribute. Using this after Attributor started running is restricted to
   /// only the Attributor itself. Initial seeding of AAs can be done via this


### PR DESCRIPTION
The last use was removed by:

  commit 18d9f7ebbaa6022fb924c1607a0edc7ebe6ec8b8
  Author: Johannes Doerfert <johannes@jdoerfert.de>
  Date:   Wed Jul 5 15:35:24 2023 -0700
