### PR TITLE
[libc] Fix accidental LIBC_NAMESPACE_syscall definition

### DIFF
--- a/libc/src/unistd/linux/syscall.cpp
+++ b/libc/src/unistd/linux/syscall.cpp
@@ -16,7 +16,7 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(long, LIBC_NAMESPACE_syscall,
+LLVM_LIBC_FUNCTION(long, __llvm_libc_syscall,
                    (long number, long arg1, long arg2, long arg3, long arg4,
                     long arg5, long arg6)) {
   long ret = LIBC_NAMESPACE::syscall_impl<long>(number, arg1, arg2, arg3, arg4,

--- a/libc/src/unistd/syscall.h
+++ b/libc/src/unistd/syscall.h
@@ -14,8 +14,8 @@
 
 namespace LIBC_NAMESPACE {
 
-long LIBC_NAMESPACE_syscall(long number, long arg1, long arg2, long arg3,
-                            long arg4, long arg5, long arg6);
+long __llvm_libc_syscall(long number, long arg1, long arg2, long arg3,
+                         long arg4, long arg5, long arg6);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -414,7 +414,7 @@ add_libc_unittest(
     libc.include.unistd
     libc.include.fcntl
     libc.include.sys_syscall
-    libc.src.unistd.LIBC_NAMESPACE_syscall
+    libc.src.unistd.__llvm_libc_syscall
     libc.test.errno_setter_matcher
 )
 

--- a/libc/test/src/unistd/syscall_test.cpp
+++ b/libc/test/src/unistd/syscall_test.cpp
@@ -24,7 +24,7 @@ using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 // There is no function named "syscall" in llvm-libc, we instead use a macro to
 // set up the arguments properly. We still need to specify the namespace though
 // because the macro generates a call to the actual internal function
-// (LIBC_NAMESPACE_syscall) which is inside the namespace.
+// (__llvm_libc_syscall) which is inside the namespace.
 TEST(LlvmLibcSyscallTest, TrivialCall) {
   libc_errno = 0;
 


### PR DESCRIPTION
Building helloworld.c currently errors with "undefined symbol: __llvm_libc_syscall"

See: https://github.com/llvm/llvm-project/pull/67032

@gchatelet