### PR TITLE
[Github] Add steps to build clang docs to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,15 +53,11 @@ jobs:
       - name: Build LLVM docs
         if: steps.docs-changed-subprojects.outputs.llvm_any_changed == 'true'
         run: |
-          mkdir llvm-build
-          cd llvm-build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON -DSPHINX_OUTPUT_MAN=ON ../llvm
-          TZ=UTC ninja docs-llvm-html docs-llvm-man
+          cmake -B llvm-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON -DSPHINX_OUTPUT_MAN=ON ./llvm
+          TZ=UTC ninja -C llvm-build docs-llvm-html docs-llvm-man
       - name: Build Clang docs
         if: steps.docs-changed-subprojects.outputs.clang_any_changed == 'true'
         run: |
-          mkdir clang-build
-          cd clang-build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON -DSPHINX_OUTPUT_MAN=ON ../llvm
-          TZ=UTC ninja docs-clang-html docs-clang-man
+          cmake -B clang-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON -DSPHINX_OUTPUT_MAN=ON ./llvm
+          TZ=UTC ninja -C clang-build docs-clang-html docs-clang-man
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,11 @@ on:
       - 'main'
     paths:
       - 'llvm/docs/**'
+      - 'clang/docs/**'
   pull_request:
     paths:
       - 'llvm/docs/**'
+      - 'clang/docs/**'
 
 jobs:
   check-docs-build:
@@ -39,10 +41,27 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build
-      - name: Build docs
+      - name: Get subprojects that have doc changes
+        id: docs-changed-subprojects
+        uses: tj-actions/changed-files@v39
+        with:
+          files_yaml: |
+            llvm:
+              - 'llvm/docs/**'
+            clang:
+              - 'clang/docs/**'
+      - name: Build LLVM docs
+        if: steps.docs-changed-subprojects.outputs.llvm_any_changed == 'true'
         run: |
-          mkdir build
-          cd build
+          mkdir llvm-build
+          cd llvm-build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON -DSPHINX_OUTPUT_MAN=ON ../llvm
           TZ=UTC ninja docs-llvm-html docs-llvm-man
+      - name: Build Clang docs
+        if: steps.docs-changed-subprojects.outputs.clang_any_changed == 'true'
+        run: |
+          mkdir clang-build
+          cd clang-build
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON -DSPHINX_OUTPUT_MAN=ON ../llvm
+          TZ=UTC ninja docs-clang-html docs-clang-man
 


### PR DESCRIPTION
Recently, support for building the LLVM documentation within Github actions landed, allowing for easy testing of the docs both pre and post landing. This patch extends that functionality to clang and adds in additional support to the docs Github workflow to only build the docs for the subproject whose documentation has been touched.