### PR TITLE
[XCOFF] make related SD symbols as isFunction

### DIFF
--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -853,6 +853,9 @@ public:
   xcoff_symbol_iterator(const basic_symbol_iterator &B)
       : symbol_iterator(B) {}
 
+  xcoff_symbol_iterator(const XCOFFSymbolRef *Symbol)
+      : symbol_iterator(*Symbol) {}
+
   const XCOFFSymbolRef *operator->() const {
     return static_cast<const XCOFFSymbolRef *>(symbol_iterator::operator->());
   }

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1280,15 +1280,7 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
     if (!NextSym.isCsectSymbol())
       return true;
 
-    Expected<uint64_t> SymbolAddressOrErr = getAddress();
-    if (!SymbolAddressOrErr)
-      return false;
-
-    Expected<uint64_t> NextSymbolAddressOrErr = NextSym.getAddress();
-    if (!NextSymbolAddressOrErr)
-      return true;
-
-    if (SymbolAddressOrErr.get() != NextSymbolAddressOrErr.get())
+    if (cantFail(getAddress()) != cantFail(NextSym.getAddress()))
       return true;
 
     // Check next symbol is XTY_LD. If so, this symbol is not a function.

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1246,7 +1246,7 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
       CsectAuxRef.getStorageMappingClass() != XCOFF::XMC_GL)
     return false;
 
-  // A function definition should not be a common type symbol or a external
+  // A function definition should not be a common type symbol or an external
   // symbol.
   if (CsectAuxRef.getSymbolType() == XCOFF::XTY_CM ||
       CsectAuxRef.getSymbolType() == XCOFF::XTY_ER)

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1276,11 +1276,8 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
 
     // Check next symbol is XTY_LD. If so, this symbol is not a function.
     Expected<XCOFFCsectAuxRef> NextCsectAuxEnt = NextIt->getXCOFFCsectAuxRef();
-    if (!NextCsectAuxEnt) {
-      // If the next symbol has no aux entries, won't be a XTY_LD symbol.
-      consumeError(NextCsectAuxEnt.takeError());
-      return true;
-    }
+    if (!NextCsectAuxEnt)
+      return NextCsectAuxEnt.takeError();
 
     if (NextCsectAuxEnt.get().getSymbolType() == XCOFF::XTY_LD)
       return false;

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1288,7 +1288,7 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
   if (CsectAuxRef.getSymbolType() == XCOFF::XTY_LD)
     return true;
 
-  return false;
+  return createError("csect symbol has no valid symbol type.");
 }
 
 bool XCOFFSymbolRef::isCsectSymbol() const {

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1252,16 +1252,16 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
       CsectAuxRef.getSymbolType() == XCOFF::XTY_ER)
     return false;
 
-  // If the next symbol is an XTY_LD type symbol with same address, this XTY_SD
-  // symbol is not a function. Otherwise this is a function symbol for
+  // If the next symbol is an XTY_LD type symbol with the same address, this
+  // XTY_SD symbol is not a function. Otherwise this is a function symbol for
   // -ffunction-sections.
   if (CsectAuxRef.getSymbolType() == XCOFF::XTY_SD) {
     // If this is a csect with size 0, it won't be a function definition.
-    // This is used to hack situation that llvm always generates below symbol
-    // for -ffunction-sections:
-    // FIXME: remove or replace this meaningless symbol.
+    // This is used to work around the fact that LLVM always generates below
+    // symbol for -ffunction-sections:
     // m   0x00000000     .text     1  unamex                    **No Symbol**
     // a4  0x00000000       0    0     SD       PR    0    0
+    // FIXME: remove or replace this meaningless symbol.
     if (getSize() == 0)
       return false;
 

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1288,7 +1288,11 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
   if (CsectAuxRef.getSymbolType() == XCOFF::XTY_LD)
     return true;
 
-  return createError("csect symbol has no valid symbol type.");
+  return createError(
+      "Symbol csect aux entry with index " +
+      Twine(getObject()->getSymbolIndex(CsectAuxRef.getEntryAddress())) +
+      " has invalid symbol type " +
+      Twine::utohexstr(CsectAuxRef.getSymbolType()));
 }
 
 bool XCOFFSymbolRef::isCsectSymbol() const {

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1289,7 +1289,7 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
     return true;
 
   return createError(
-      "Symbol csect aux entry with index " +
+      "symbol csect aux entry with index " +
       Twine(getObject()->getSymbolIndex(CsectAuxRef.getEntryAddress())) +
       " has invalid symbol type " +
       Twine::utohexstr(CsectAuxRef.getSymbolType()));

--- a/llvm/test/CodeGen/PowerPC/aix-text.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-text.ll
@@ -17,13 +17,13 @@ entry:
   ret i32 2
 }
 
-; CHECKFS32: 00000000 l       .text  00000000 (idx: {{[[:digit:]]*}}) [PR]
-; CHECKFS32-NEXT: 00000000 g       .text  {{([[:xdigit:]]{8})}} (idx: {{[[:digit:]]*}}) .text[PR]
-; CHECKFS32-NEXT: {{([[:xdigit:]]{8})}} g       .text  {{([[:xdigit:]]{8})}} (idx: {{[[:digit:]]*}}) .text2[PR]
+; CHECKFS32: 00000000 l        .text  00000000 (idx: {{[[:digit:]]*}}) [PR]
+; CHECKFS32-NEXT: 00000000 g      F .text  {{([[:xdigit:]]{8})}} (idx: {{[[:digit:]]*}}) .text[PR]
+; CHECKFS32-NEXT: {{([[:xdigit:]]{8})}} g      F .text  {{([[:xdigit:]]{8})}} (idx: {{[[:digit:]]*}}) .text2[PR]
 
-; CHECKFS64: 0000000000000000 l       .text  0000000000000000 
-; CHECKFS64-NEXT: 0000000000000000 g       .text  {{([[:xdigit:]]{16})}} (idx: {{[[:digit:]]*}}) .text[PR]
-; CHECKFS64-NEXT: {{([[:xdigit:]]{16})}} g       .text  {{([[:xdigit:]]{16})}} (idx: {{[[:digit:]]*}}) .text2[PR]
+; CHECKFS64: 0000000000000000 l      .text  0000000000000000
+; CHECKFS64-NEXT: 0000000000000000 g      F .text  {{([[:xdigit:]]{16})}} (idx: {{[[:digit:]]*}}) .text[PR]
+; CHECKFS64-NEXT: {{([[:xdigit:]]{16})}} g      F .text  {{([[:xdigit:]]{16})}} (idx: {{[[:digit:]]*}}) .text2[PR]
 
 ; CHECK32: 00000000 l       .text  {{([[:xdigit:]]{8})}} (idx: {{[[:digit:]]*}}) [PR]
 ; CHECK32-NEXT: {{([[:xdigit:]]{8})}} g     F .text (csect: (idx: {{[[:digit:]]*}}) [PR])   00000000 (idx: {{[[:digit:]]*}}) .text

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
@@ -117,9 +117,9 @@ entry:
 ; XCOFF32-NEXT: 00000000 l       .text	00000000 (idx: 5) [PR]
 ; XCOFF32-NEXT: 00000000 g       .text	00000019 (idx: 7) .foo[PR]
 ; XCOFF32-NEXT: 00000000 g     F .text (csect: (idx: 7) .foo[PR]) 	00000000 (idx: 9) .alias_foo
-; XCOFF32-NEXT: 00000020 g       .text	00000020 .hidden (idx: 11) .hidden_foo[PR]
-; XCOFF32-NEXT: 00000040 g       .text	00000059 (idx: 13) .bar[PR]
-; XCOFF32-NEXT: 000000c0 l       .text	0000002a (idx: 15) .static_overalign_foo[PR]
+; XCOFF32-NEXT: 00000020 g     F .text	00000020 .hidden (idx: 11) .hidden_foo[PR]
+; XCOFF32-NEXT: 00000040 g     F .text	00000059 (idx: 13) .bar[PR]
+; XCOFF32-NEXT: 000000c0 l     F .text	0000002a (idx: 15) .static_overalign_foo[PR]
 ; XCOFF32-NEXT: 000000ec g     O .data	0000000c (idx: 17) foo[DS]
 ; XCOFF32-NEXT: 000000ec g     O .data (csect: (idx: 17) foo[DS]) 	00000000 (idx: 19) alias_foo
 ; XCOFF32-NEXT: 000000f8 g     O .data	0000000c .hidden (idx: 21) hidden_foo[DS]
@@ -152,9 +152,9 @@ entry:
 ; XCOFF64-NEXT: 0000000000000000 l       .text	0000000000000000 (idx: 5) [PR]
 ; XCOFF64-NEXT: 0000000000000000 g       .text	0000000000000019 (idx: 7) .foo[PR]
 ; XCOFF64-NEXT: 0000000000000000 g     F .text (csect: (idx: 7) .foo[PR]) 	0000000000000000 (idx: 9) .alias_foo
-; XCOFF64-NEXT: 0000000000000020 g       .text	0000000000000020 .hidden (idx: 11) .hidden_foo[PR]
-; XCOFF64-NEXT: 0000000000000040 g       .text	0000000000000059 (idx: 13) .bar[PR]
-; XCOFF64-NEXT: 00000000000000c0 l       .text	000000000000002a (idx: 15) .static_overalign_foo[PR]
+; XCOFF64-NEXT: 0000000000000020 g     F .text	0000000000000020 .hidden (idx: 11) .hidden_foo[PR]
+; XCOFF64-NEXT: 0000000000000040 g     F .text	0000000000000059 (idx: 13) .bar[PR]
+; XCOFF64-NEXT: 00000000000000c0 l     F .text	000000000000002a (idx: 15) .static_overalign_foo[PR]
 ; XCOFF64-NEXT: 00000000000000f0 g     O .data	0000000000000018 (idx: 17) foo[DS]
 ; XCOFF64-NEXT: 00000000000000f0 g     O .data (csect: (idx: 17) foo[DS]) 	0000000000000000 (idx: 19) alias_foo
 ; XCOFF64-NEXT: 0000000000000108 g     O .data	0000000000000018 .hidden (idx: 21) hidden_foo[DS]

--- a/llvm/test/tools/llvm-objdump/XCOFF/aux-entry-invalid-type.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/aux-entry-invalid-type.test
@@ -2,41 +2,18 @@
 ## the symbol type in the csect aux entry of a symbol is not valid.
 
 ## Check XCOFF32
-# RUN: yaml2obj --docnum=1 %s -o %t1
-# RUN: not llvm-objdump --syms %t1 2>&1 | FileCheck %s -DOBJ=%t1 --check-prefix=XCOFF32
-
-# XCOFF32: error: '[[OBJ]]': Symbol csect aux entry with index 2 has invalid symbol type 5
-
---- !XCOFF
-FileHeader:
-  MagicNumber:       0x1DF
-Sections:
-  - Name:                    .text
-    Flags:           [ STYP_TEXT ]
-Symbols:
-  - Name:            .file
-    Section:         N_DEBUG
-    NumberOfAuxEntries: 0
-    Type:            0x0
-    StorageClass:       C_FILE
-  - Name:             test
-    Section:         .text
-    NumberOfAuxEntries: 1
-    StorageClass:       C_EXT
-    AuxEntries:
-      - Type:                   AUX_CSECT
-        SymbolAlignmentAndType: 5
-        StorageMappingClass:    XMC_PR
+# RUN: yaml2obj -DMAGICNUMBER=0x1DF %s -o %t1
+# RUN: not llvm-objdump --syms %t1 2>&1 | FileCheck %s -DOBJ=%t1
 
 ## Check XCOFF64
-# RUN: yaml2obj --docnum=2 %s -o %t2
-# RUN: not llvm-objdump --syms %t2 2>&1 | FileCheck %s -DOBJ=%t2 --check-prefix=XCOFF64
+# RUN: yaml2obj -DMAGICNUMBER=0x1F7 %s -o %t2
+# RUN: not llvm-objdump --syms %t2 2>&1 | FileCheck %s -DOBJ=%t2
 
-# XCOFF64: error: '[[OBJ]]': Symbol csect aux entry with index 2 has invalid symbol type 5
+# CHECK: error: '[[OBJ]]': symbol csect aux entry with index 2 has invalid symbol type 5
 
 --- !XCOFF
 FileHeader:
-  MagicNumber:       0x1F7
+  MagicNumber:       [[MAGICNUMBER]]
 Sections:
   - Name:                    .text
     Flags:           [ STYP_TEXT ]
@@ -54,3 +31,4 @@ Symbols:
       - Type:                   AUX_CSECT
         SymbolAlignmentAndType: 5
         StorageMappingClass:    XMC_PR
+

--- a/llvm/test/tools/llvm-objdump/XCOFF/aux-entry-invalid-type.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/aux-entry-invalid-type.test
@@ -31,4 +31,3 @@ Symbols:
       - Type:                   AUX_CSECT
         SymbolAlignmentAndType: 5
         StorageMappingClass:    XMC_PR
-

--- a/llvm/test/tools/llvm-objdump/XCOFF/aux-entry-invalid-type.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/aux-entry-invalid-type.test
@@ -1,0 +1,56 @@
+## Check that llvm-objdump --syms reports an error when
+## the symbol type in the csect aux entry of a symbol is not valid.
+
+## Check XCOFF32
+# RUN: yaml2obj --docnum=1 %s -o %t1
+# RUN: not llvm-objdump --syms %t1 2>&1 | FileCheck %s -DOBJ=%t1 --check-prefix=XCOFF32
+
+# XCOFF32: error: '[[OBJ]]': Symbol csect aux entry with index 2 has invalid symbol type 5
+
+--- !XCOFF
+FileHeader:
+  MagicNumber:       0x1DF
+Sections:
+  - Name:                    .text
+    Flags:           [ STYP_TEXT ]
+Symbols:
+  - Name:            .file
+    Section:         N_DEBUG
+    NumberOfAuxEntries: 0
+    Type:            0x0
+    StorageClass:       C_FILE
+  - Name:             test
+    Section:         .text
+    NumberOfAuxEntries: 1
+    StorageClass:       C_EXT
+    AuxEntries:
+      - Type:                   AUX_CSECT
+        SymbolAlignmentAndType: 5
+        StorageMappingClass:    XMC_PR
+
+## Check XCOFF64
+# RUN: yaml2obj --docnum=2 %s -o %t2
+# RUN: not llvm-objdump --syms %t2 2>&1 | FileCheck %s -DOBJ=%t2 --check-prefix=XCOFF64
+
+# XCOFF64: error: '[[OBJ]]': Symbol csect aux entry with index 2 has invalid symbol type 5
+
+--- !XCOFF
+FileHeader:
+  MagicNumber:       0x1F7
+Sections:
+  - Name:                    .text
+    Flags:           [ STYP_TEXT ]
+Symbols:
+  - Name:            .file
+    Section:         N_DEBUG
+    NumberOfAuxEntries: 0
+    Type:            0x0
+    StorageClass:       C_FILE
+  - Name:             test
+    Section:         .text
+    NumberOfAuxEntries: 1
+    StorageClass:       C_EXT
+    AuxEntries:
+      - Type:                   AUX_CSECT
+        SymbolAlignmentAndType: 5
+        StorageMappingClass:    XMC_PR

--- a/llvm/test/tools/llvm-symbolizer/xcoff-sd-symbol.ll
+++ b/llvm/test/tools/llvm-symbolizer/xcoff-sd-symbol.ll
@@ -16,10 +16,10 @@ entry:
   ret void
 }
 
-; CHECK: ??
+; CHECK: .foo
 ; CHECK: ??:0:0
 ; CHECK-EMPTY:
 
-; CHECK: ??
+; CHECK: .foo1
 ; CHECK: ??:0:0
 ; CHECK-EMPTY:


### PR DESCRIPTION
This will help tools like llvm-symbolizer recognizes more functions.