### PR TITLE
[Github] Make PR formatting job only run with C/C++ changes

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -1,10 +1,19 @@
 name: "Check code formatting"
-on: pull_request_target
+
+on:
+  pull_request_target:
+    paths:
+      - '**/*.cpp'
+      - '**/*.c'
+      - '**/*.h'
+      - '**/*.inc'
+
 permissions:
   pull-requests: write
 
 jobs:
-  code_formatter:
+  cpp_code_formatter:
+    name: "Check C++ Formatting"
     runs-on: ubuntu-latest
     steps:
       - name: Fetch LLVM sources


### PR DESCRIPTION
Currently the PR formatting job only runs clang-format. There isn't a lot of utility in running it if there aren't any C/C++ changes as there will be nothing to format. This isn't super noisy currently as the job doesn't fail if there aren't any C/C++ changes, but it's a bit of a waste.

In addition, this patch names the code formatting job "Check C++ Formatting" to make it clear that this job only checks C/C++ formatting rather than Python formatting/other languages.