### PR TITLE
[RecursiveASTVisitor] Fix RecursiveASTVisitor (RAV) fails to visit the initializer of a bitfield

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -650,7 +650,7 @@ Bug Fixes to AST Handling
   `Issue 64170 <https://github.com/llvm/llvm-project/issues/64170>`_
 - Fixed ``hasAnyBase`` not binding nodes in its submatcher.
   (`#65421 <https://github.com/llvm/llvm-project/issues/65421>`_)
-- Fixed a bug where RecursiveASTVisitor (RAV) fails to visit the
+- Fixed a bug where RecursiveASTVisitor fails to visit the
   initializer of a bitfield.
   `Issue 64916 <https://github.com/llvm/llvm-project/issues/64916>`_
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -650,6 +650,9 @@ Bug Fixes to AST Handling
   `Issue 64170 <https://github.com/llvm/llvm-project/issues/64170>`_
 - Fixed ``hasAnyBase`` not binding nodes in its submatcher.
   (`#65421 <https://github.com/llvm/llvm-project/issues/65421>`_)
+- Fixed a bug where RecursiveASTVisitor (RAV) fails to visit the
+  initializer of a bitfield.
+  `Issue 64916 <https://github.com/llvm/llvm-project/issues/64916>`_
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2103,7 +2103,7 @@ DEF_TRAVERSE_DECL(FieldDecl, {
   TRY_TO(TraverseDeclaratorHelper(D));
   if (D->isBitField())
     TRY_TO(TraverseStmt(D->getBitWidth()));
-  else if (D->hasInClassInitializer())
+  if (D->hasInClassInitializer())
     TRY_TO(TraverseStmt(D->getInClassInitializer()));
 })
 

--- a/clang/unittests/Tooling/CMakeLists.txt
+++ b/clang/unittests/Tooling/CMakeLists.txt
@@ -25,6 +25,7 @@ add_clang_unittest(ToolingTests
   QualTypeNamesTest.cpp
   RangeSelectorTest.cpp
   RecursiveASTVisitorTests/Attr.cpp
+  RecursiveASTVisitorTests/BitfieldInitializer.cpp
   RecursiveASTVisitorTests/CallbacksLeaf.cpp
   RecursiveASTVisitorTests/CallbacksUnaryOperator.cpp
   RecursiveASTVisitorTests/CallbacksBinaryOperator.cpp

--- a/clang/unittests/Tooling/RecursiveASTVisitorTests/BitfieldInitializer.cpp
+++ b/clang/unittests/Tooling/RecursiveASTVisitorTests/BitfieldInitializer.cpp
@@ -14,7 +14,8 @@ using namespace clang;
 namespace {
 
 // Check to ensure that bitfield initializers are visited.
-class BitfieldInitializerVisitor : public ExpectedLocationVisitor<BitfieldInitializerVisitor> {
+class BitfieldInitializerVisitor
+    : public ExpectedLocationVisitor<BitfieldInitializerVisitor> {
 public:
   bool VisitIntegerLiteral(IntegerLiteral *IL) {
     Match(std::to_string(IL->getValue().getSExtValue()), IL->getLocation());
@@ -24,11 +25,10 @@ public:
 
 TEST(RecursiveASTVisitor, BitfieldInitializerIsVisited) {
   BitfieldInitializerVisitor Visitor;
-  Visitor.ExpectMatch("123", 2, 15); 
-  EXPECT_TRUE(Visitor.runOver(
-    "struct S {\n"
-    "  int x : 8 = 123;\n"
-    "};\n"));
+  Visitor.ExpectMatch("123", 2, 15);
+  EXPECT_TRUE(Visitor.runOver("struct S {\n"
+                              "  int x : 8 = 123;\n"
+                              "};\n"));
 }
 
 } // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTVisitorTests/BitfieldInitializer.cpp
+++ b/clang/unittests/Tooling/RecursiveASTVisitorTests/BitfieldInitializer.cpp
@@ -1,0 +1,34 @@
+//===- unittest/Tooling/RecursiveASTVisitorTests/BitfieldInitializer.cpp -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include <string>
+
+using namespace clang;
+
+namespace {
+
+// Check to ensure that bitfield initializers are visited.
+class BitfieldInitializerVisitor : public ExpectedLocationVisitor<BitfieldInitializerVisitor> {
+public:
+  bool VisitIntegerLiteral(IntegerLiteral *IL) {
+    Match(std::to_string(IL->getValue().getSExtValue()), IL->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTVisitor, BitfieldInitializerIsVisited) {
+  BitfieldInitializerVisitor Visitor;
+  Visitor.ExpectMatch("123", 2, 15); 
+  EXPECT_TRUE(Visitor.runOver(
+    "struct S {\n"
+    "  int x : 8 = 123;\n"
+    "};\n"));
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
The problem was introduced in commit https://github.com/llvm/llvm-project/commit/6b8e3c02ca44fb6c3738bb0c75859c11a03e30ed when the possibility of initialized bitfields was added, but the logic in RecursiveASTVisitor was not updated.

This fixes https://github.com/llvm/llvm-project/issues/64916.

Patch by Scott McPeak