### PR TITLE
[ThinLTOBitcodeWriter] Do not crash on a typed declaration

### DIFF
--- a/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
+++ b/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
@@ -329,7 +329,7 @@ void splitAndWriteThinLTOBitcode(
   // comdat in MergedM to keep the comdat together.
   DenseSet<const Comdat *> MergedMComdats;
   for (GlobalVariable &GV : M.globals())
-    if (HasTypeMetadata(&GV)) {
+    if (!GV.isDeclaration() && HasTypeMetadata(&GV)) {
       if (const auto *C = GV.getComdat())
         MergedMComdats.insert(C);
       forEachVirtualFunction(GV.getInitializer(), [&](Function *F) {

--- a/llvm/test/Transforms/ThinLTOBitcodeWriter/split-typed-decl.ll
+++ b/llvm/test/Transforms/ThinLTOBitcodeWriter/split-typed-decl.ll
@@ -1,0 +1,12 @@
+;; Generating bitcode files with split LTO modules should not crash if there are
+;; typed declarations in sources.
+
+; RUN: opt --thinlto-bc --thinlto-split-lto-unit -o - %s
+
+@_ZTV3Foo = external constant { [3 x ptr] }, !type !0
+
+define void @Bar() {
+  ret void
+}
+
+!0 = !{i64 16, !"_ZTS3Foo"}


### PR DESCRIPTION
This fixes a crash when `splitAndWriteThinLTOBitcode()` hits a declaration with type metadata. For example, such declarations can be generated by the `EliminateAvailableExternally` pass.