### PR TITLE
[Support] Better error msg when cache dir can't be created.

### DIFF
--- a/lld/test/COFF/lto-cache-errors.ll
+++ b/lld/test/COFF/lto-cache-errors.ll
@@ -6,7 +6,7 @@
 ; RUN: chmod 444 %t.cache
 
 ;; Check emit warnings when we can't create the cache dir, note that this test will pass if there is a o: drive.
-; RUN: not lld-link /lldltocache:%t.cache/cache /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
+; RUN: not --crash lld-link /lldltocache:%t.cache/cache /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
 ; CHECK: LLVM ERROR: Can't create cache directory
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"

--- a/lld/test/COFF/lto-cache-errors.ll
+++ b/lld/test/COFF/lto-cache-errors.ll
@@ -9,7 +9,7 @@
 
 ;; Check emit warnings when we can't create the cache dir, note that this test will pass if there is a o: drive.
 ; RUN: not --crash lld-link /lldltocache:%t.cache/cache /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
-; CHECK: LLVM ERROR: Can't create cache directory
+; CHECK: LLVM ERROR: can't create cache directory
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc"

--- a/lld/test/COFF/lto-cache-errors.ll
+++ b/lld/test/COFF/lto-cache-errors.ll
@@ -1,0 +1,18 @@
+; REQUIRES: x86
+
+; RUN: opt -module-hash -module-summary %s -o %t.o
+; RUN: opt -module-hash -module-summary %p/Inputs/lto-cache.ll -o %t2.o
+; RUN: rm -Rf %t.cache && mkdir %t.cache
+; RUN: chmod 444 %t.cache
+
+;; Check emit warnings when we can't create the cache dir, note that this test will pass if there is a o: drive.
+; RUN: not lld-link /lldltocache:%t.cache/cache /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
+; CHECK: LLVM ERROR: Can't create cache directory
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+define void @globalfunc() #0 {
+entry:
+  ret void
+}

--- a/lld/test/COFF/lto-cache-errors.ll
+++ b/lld/test/COFF/lto-cache-errors.ll
@@ -7,7 +7,7 @@
 ; RUN: rm -Rf %t.cache && mkdir %t.cache
 ; RUN: chmod 444 %t.cache
 
-;; Check emit warnings when we can't create the cache dir, note that this test will pass if there is a o: drive.
+;; Check emit warnings when we can't create the cache dir
 ; RUN: not --crash lld-link /lldltocache:%t.cache/cache /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
 ; CHECK: LLVM ERROR: can't create cache directory
 

--- a/lld/test/COFF/lto-cache-errors.ll
+++ b/lld/test/COFF/lto-cache-errors.ll
@@ -1,4 +1,6 @@
 ; REQUIRES: x86
+;; Not supported on windows since we use permissions to deny the creation
+; UNSUPPORTED: system-windows
 
 ; RUN: opt -module-hash -module-summary %s -o %t.o
 ; RUN: opt -module-hash -module-summary %p/Inputs/lto-cache.ll -o %t2.o

--- a/lld/test/COFF/lto-cache-errors.ll
+++ b/lld/test/COFF/lto-cache-errors.ll
@@ -8,8 +8,8 @@
 ; RUN: chmod 444 %t.cache
 
 ;; Check emit warnings when we can't create the cache dir
-; RUN: not --crash lld-link /lldltocache:%t.cache/cache /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
-; CHECK: LLVM ERROR: can't create cache directory
+; RUN: not --crash lld-link /lldltocache:%t.cache/nonexistant/ /out:%t3 /entry:main %t2.o %t.o 2>&1 | FileCheck %s
+; CHECK: LLVM ERROR: can't create cache directory {{.*}}/nonexistant/: Permission denied
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc"

--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -145,7 +145,7 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
       // ensures the filesystem isn't mutated until the cache is.
       if (std::error_code EC = sys::fs::create_directories(
               CacheDirectoryPath, /*IgnoreExisting=*/true))
-        return errorCodeToError(EC);
+        return createStringError(EC, Twine("Can't create cache directory: ") + CacheDirectoryPath);
 
       // Write to a temporary to avoid race condition
       SmallString<64> TempFilenameModel;

--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -145,8 +145,8 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
       // ensures the filesystem isn't mutated until the cache is.
       if (std::error_code EC = sys::fs::create_directories(
               CacheDirectoryPath, /*IgnoreExisting=*/true))
-        return createStringError(EC, Twine("Can't create cache directory: ") +
-                                         CacheDirectoryPath);
+        return createStringError(EC, Twine("Can't create cache directory ") +
+                                         CacheDirectoryPath + ": " + EC.message());
 
       // Write to a temporary to avoid race condition
       SmallString<64> TempFilenameModel;

--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -146,7 +146,8 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
       if (std::error_code EC = sys::fs::create_directories(
               CacheDirectoryPath, /*IgnoreExisting=*/true))
         return createStringError(EC, Twine("Can't create cache directory ") +
-                                         CacheDirectoryPath + ": " + EC.message());
+                                         CacheDirectoryPath + ": " +
+                                         EC.message());
 
       // Write to a temporary to avoid race condition
       SmallString<64> TempFilenameModel;

--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -145,7 +145,8 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
       // ensures the filesystem isn't mutated until the cache is.
       if (std::error_code EC = sys::fs::create_directories(
               CacheDirectoryPath, /*IgnoreExisting=*/true))
-        return createStringError(EC, Twine("Can't create cache directory: ") + CacheDirectoryPath);
+        return createStringError(EC, Twine("Can't create cache directory: ") +
+                                         CacheDirectoryPath);
 
       // Write to a temporary to avoid race condition
       SmallString<64> TempFilenameModel;

--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -145,7 +145,7 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
       // ensures the filesystem isn't mutated until the cache is.
       if (std::error_code EC = sys::fs::create_directories(
               CacheDirectoryPath, /*IgnoreExisting=*/true))
-        return createStringError(EC, Twine("Can't create cache directory ") +
+        return createStringError(EC, Twine("can't create cache directory ") +
                                          CacheDirectoryPath + ": " +
                                          EC.message());
 


### PR DESCRIPTION
On windows if you passed /lldltocache:D:\tmp to lld and you didn't have D: mounted it fail to create the cache dir D:\tmp, but the error message is pretty hard to understand:

```
c:\code\llvm\llvm-project\out\debug>bin\lld-link.exe /lldltocache:D:\tmp
hello.obj
LLVM ERROR: no such file or directory

PLEASE submit a bug report to
https://github.com/llvm/llvm-project/issues/ and include the crash
backtrace.
Exception Code: 0xC000001D
```

Which lead one of our users to report this as a crash. I have just added a bit better message so it now says:

```
c:\code\llvm\llvm-project\out\debug>bin\lld-link.exe /lldltocache:D:\tmp
hello.obj
LLVM ERROR: Can't create cache directory: D:\tmp

PLEASE submit a bug report to
https://github.com/llvm/llvm-project/issues/ and include the crash
backtrace.
```

I am not sure this is a fatal error because it's not something that really should be reported as a bug to LLVM. But at least this gives a bit more visibility on what to change.