### PR TITLE
[PowerPC] Remove HTM instruction from P10 SchedModel

### DIFF
--- a/llvm/lib/Target/PowerPC/P10InstrResources.td
+++ b/llvm/lib/Target/PowerPC/P10InstrResources.td
@@ -825,9 +825,7 @@ def : InstRW<[P10W_F2_4C, P10W_DISP_ANY, P10F2_Read, P10F2_Read, P10F2_Read],
 def : InstRW<[P10W_F2_4C, P10W_DISP_EVEN, P10W_DISP_ANY, P10F2_Read],
       (instrs
     SRADI_rec,
-    SRAWI_rec,
-    TABORTDCI,
-    TABORTWCI
+    SRAWI_rec
 )>;
 
 // Single crack instructions
@@ -835,9 +833,7 @@ def : InstRW<[P10W_F2_4C, P10W_DISP_EVEN, P10W_DISP_ANY, P10F2_Read],
 def : InstRW<[P10W_F2_4C, P10W_DISP_EVEN, P10W_DISP_ANY, P10F2_Read, P10F2_Read],
       (instrs
     SRAD_rec,
-    SRAW_rec,
-    TABORTDC,
-    TABORTWC
+    SRAW_rec
 )>;
 
 // 2-way crack instructions
@@ -1130,10 +1126,7 @@ def : InstRW<[P10W_FX_3C, P10W_DISP_EVEN, P10W_DISP_ANY],
     MFFSCRNI,
     MFFSL,
     MFVSCR,
-    MTFSB0,
-    TBEGIN,
-    TRECHKPT,
-    TSR
+    MTFSB0
 )>;
 
 // Single crack instructions
@@ -1153,9 +1146,7 @@ def : InstRW<[P10W_FX_3C, P10W_DISP_EVEN, P10W_DISP_ANY, P10FX_Read],
     SUBFME8_rec, SUBFME_rec,
     SUBFME8O_rec, SUBFMEO_rec,
     SUBFZE8_rec, SUBFZE_rec,
-    SUBFZE8O_rec, SUBFZEO_rec,
-    TABORT,
-    TRECLAIM
+    SUBFZE8O_rec, SUBFZEO_rec
 )>;
 
 // Single crack instructions
@@ -1862,8 +1853,6 @@ def : InstRW<[P10W_ST_3C, P10W_DISP_EVEN, P10W_DISP_ANY],
     EnforceIEIO,
     MSGSYNC,
     SLBSYNC,
-    TCHECK,
-    TEND,
     TLBSYNC
 )>;
 

--- a/llvm/lib/Target/PowerPC/PPCScheduleP10.td
+++ b/llvm/lib/Target/PowerPC/PPCScheduleP10.td
@@ -29,8 +29,8 @@ def P10Model : SchedMachineModel {
   let LoopMicroOpBufferSize = 60;
   let CompleteModel = 1;
 
-  // Do not support SPE (Signal Procesing Engine) on Power 10.
-  let UnsupportedFeatures = [HasSPE, IsE500, IsBookE, IsISAFuture];
+  // Power 10 does not support instructions from SPE, Book E and HTM.
+  let UnsupportedFeatures = [HasSPE, IsE500, IsBookE, IsISAFuture, HasHTM];
 }
 
 let SchedModel = P10Model in {


### PR DESCRIPTION
Power10 does not support Hardware Transactional Memory instructions.
Remove to keep consistency.