### PR TITLE
[flang][openMP] skip CompilerDirective on ResolveOmpTopLevelParts.

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2228,7 +2228,9 @@ void ResolveOmpTopLevelParts(
       if (!std::holds_alternative<common::Indirection<parser::Module>>(
               unit.u) &&
           !std::holds_alternative<common::Indirection<parser::Submodule>>(
-              unit.u)) {
+              unit.u) &&
+          !std::holds_alternative<
+              common::Indirection<parser::CompilerDirective>>(unit.u)) {
         Symbol *symbol{common::visit(
             [&context](auto &x) {
               Scope *scope = GetScope(context, x.value());

--- a/flang/test/Semantics/OpenMP/compiler-directive.f90
+++ b/flang/test/Semantics/OpenMP/compiler-directive.f90
@@ -1,0 +1,8 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+! CompilerDirective with openmp tests
+
+!ERROR: !DIR$ IGNORE_TKR directive must appear in a subroutine or function
+!dir$ ignore_tkr
+
+program main
+end program main


### PR DESCRIPTION
Fixes #68966

should i copy and adjust flang/test/Semantics/ignore_tkr01.f90 to flang/test/Semantics/OpenMP/ignore_tkr01.f90 or just write a simple test for this case?

`flang-new -fopenmp fail.f90`

fail.f90:
``` 
!dir$ ignore_tkr
program main
end program main
```