### PR TITLE
Fix __builtin_vectorelements tests with REQUIRES

### DIFF
--- a/clang/test/CodeGen/builtin_vectorelements.c
+++ b/clang/test/CodeGen/builtin_vectorelements.c
@@ -1,10 +1,17 @@
-// RUN: %clang_cc1 -O1 -triple aarch64 -target-feature +neon %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,NEON %s
-// RUN: %clang_cc1 -O1 -triple aarch64 -target-feature +sve  %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,SVE  %s
-// RUN: %clang_cc1 -O1 -triple riscv64 -target-feature +v    %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,RISCV  %s
+// RUN: %clang_cc1 -O1 -triple x86_64                        %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK       %s
 
-// Note that this does not make sense to check for x86 SIMD types, because
-// __m128i, __m256i, and __m512i do not specify the element type. There are no
-// "logical" number of elements in them.
+// REQUIRES: target=aarch64-{{.*}}
+// RUN: %clang_cc1 -O1 -triple aarch64 -target-feature +neon %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,NEON  %s
+
+// REQUIRES: target=aarch64-{{.*}}
+// RUN: %clang_cc1 -O1 -triple aarch64 -target-feature +sve  %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,SVE   %s
+
+// REQUIRES: target=riscv64{{.*}}
+// RUN: %clang_cc1 -O1 -triple riscv64 -target-feature +v    %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,RISCV %s
+
+/// Note that this does not make sense to check for x86 SIMD types, because
+/// __m128i, __m256i, and __m512i do not specify the element type. There are no
+/// "logical" number of elements in them.
 
 typedef int int1 __attribute__((vector_size(4)));
 typedef int int4 __attribute__((vector_size(16)));
@@ -55,7 +62,6 @@ int test_builtin_vectorelements_multiply_constant() {
   // CHECK: ret i32 32
   return __builtin_vectorelements(int16) * 2;
 }
-
 
 #if defined(__ARM_NEON)
 #include <arm_neon.h>

--- a/clang/test/SemaCXX/builtin_vectorelements.cpp
+++ b/clang/test/SemaCXX/builtin_vectorelements.cpp
@@ -1,3 +1,6 @@
+// RUN: %clang_cc1 -triple x86_64                       -std=c++20 -fsyntax-only -verify -disable-llvm-passes %s
+
+// REQUIRES: target=aarch64-{{.*}}
 // RUN: %clang_cc1 -triple aarch64 -target-feature +sve -std=c++20 -fsyntax-only -verify -disable-llvm-passes %s
 
 template <typename T>


### PR DESCRIPTION
Small fix for failing tests after merge of #69010. The tests need `REQUIRES` to ensure that the correct headers are available. I've also added a generic x86 build which does not need headers, so there is at least one run per test.

Side note: I'm still quite new to the LLVM test setup. _a)_ Is this the correct way to do this and _b)_ canI trigger the full tests before merging to main to avoid a second set of failed buildbots?