### PR TITLE
[BOLT] Filter itrace from perf script mmap & task events

### DIFF
--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -183,12 +183,12 @@ void DataAggregator::start() {
 
   launchPerfProcess("process events",
                     MMapEventsPPI,
-                    "script --show-mmap-events",
+                    "script --show-mmap-events --no-itrace",
                     /*Wait = */false);
 
   launchPerfProcess("task events",
                     TaskEventsPPI,
-                    "script --show-task-events",
+                    "script --show-task-events --no-itrace",
                     /*Wait = */false);
 }
 

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -181,15 +181,13 @@ void DataAggregator::start() {
                     "script -F pid,event,addr,ip",
                     /*Wait = */false);
 
-  launchPerfProcess("process events",
-                    MMapEventsPPI,
+  launchPerfProcess("process events", MMapEventsPPI,
                     "script --show-mmap-events --no-itrace",
-                    /*Wait = */false);
+                    /*Wait = */ false);
 
-  launchPerfProcess("task events",
-                    TaskEventsPPI,
+  launchPerfProcess("task events", TaskEventsPPI,
                     "script --show-task-events --no-itrace",
-                    /*Wait = */false);
+                    /*Wait = */ false);
 }
 
 void DataAggregator::abort() {


### PR DESCRIPTION
perf2bolt launches a few perf script commands and stores the output in temporary files before processing the output and cleaning them up before it exits.

The command `perf script --show-mmap-events` outputs PERF_RECORD_MMAP2 and instruction tracing data but when processed it only looks for PERF_RECORD_MMAP2 and the instruction tracing data is ignored. This is fine for small amounts of instruction trace data but when I've recorded Arm ETM or Intel PT AUX I get lots of it

By adding `--no-itrace` is will just show the PERF_RECORD_MMAP2 records and will save on time running the `perf script`, disk space storing the output & time parsing the output.

It is the same for `perf script --show-task-events` where BOLT is only interested in the PERF_RECORD_COMM & PERF_RECORD_FORK records.

### Data

| Perf Record | Perf Data Size  | MMap Size | MMap No Itrace Size |
|---|---|---|---|
| perf record -e cs_etm/@tmc_etr0/u | 137K | 4468K | 0.632K |
| perf record -e intel_pt//u | 890K | 33378K | 0.673K |
