### PR TITLE
[Clang] Actually fix tests for __builtin_vectorelements

### DIFF
--- a/clang/test/CodeGen/builtin_vectorelements.c
+++ b/clang/test/CodeGen/builtin_vectorelements.c
@@ -1,12 +1,12 @@
 // RUN: %clang_cc1 -O1 -triple x86_64                        %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK       %s
 
-// REQUIRES: target=aarch64-{{.*}}
+// REQUIRES: aarch64-registered-target
 // RUN: %clang_cc1 -O1 -triple aarch64 -target-feature +neon %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,NEON  %s
 
-// REQUIRES: target=aarch64-{{.*}}
+// REQUIRES: aarch64-registered-target
 // RUN: %clang_cc1 -O1 -triple aarch64 -target-feature +sve  %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,SVE   %s
 
-// REQUIRES: target=riscv64{{.*}}
+// REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -O1 -triple riscv64 -target-feature +v    %s -emit-llvm -disable-llvm-passes -o - | FileCheck --check-prefixes=CHECK,RISCV %s
 
 /// Note that this does not make sense to check for x86 SIMD types, because

--- a/clang/test/SemaCXX/builtin_vectorelements.cpp
+++ b/clang/test/SemaCXX/builtin_vectorelements.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64                       -std=c++20 -fsyntax-only -verify -disable-llvm-passes %s
 
-// REQUIRES: target=aarch64-{{.*}}
+// REQUIRES: aarch64-registered-target
 // RUN: %clang_cc1 -triple aarch64 -target-feature +sve -std=c++20 -fsyntax-only -verify -disable-llvm-passes %s
 
 template <typename T>


### PR DESCRIPTION
In #69582, I accidentally disabled all tests for the changed introduced in #69010. This change should use the correct `REQUIRES` syntax to en-/disable target-specific tests.