### PR TITLE
[libc++] Fix _CopySegment helper in ranges::copy(join_view, out) when called in a static assertion context

### DIFF
--- a/libcxx/include/__algorithm/copy.h
+++ b/libcxx/include/__algorithm/copy.h
@@ -51,9 +51,10 @@ struct __copy_loop {
 
     _OutIter& __result_;
 
-    _LIBCPP_HIDE_FROM_ABI _CopySegment(_OutIter& __result) : __result_(__result) {}
+    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit _CopySegment(_OutIter& __result)
+        : __result_(__result) {}
 
-    _LIBCPP_HIDE_FROM_ABI void
+    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
     operator()(typename _Traits::__local_iterator __lfirst, typename _Traits::__local_iterator __llast) {
       __result_ = std::__copy<_AlgPolicy>(__lfirst, __llast, std::move(__result_)).second;
     }

--- a/libcxx/include/__algorithm/move.h
+++ b/libcxx/include/__algorithm/move.h
@@ -52,9 +52,10 @@ struct __move_loop {
 
     _OutIter& __result_;
 
-    _LIBCPP_HIDE_FROM_ABI _MoveSegment(_OutIter& __result) : __result_(__result) {}
+    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit _MoveSegment(_OutIter& __result)
+        : __result_(__result) {}
 
-    _LIBCPP_HIDE_FROM_ABI void
+    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
     operator()(typename _Traits::__local_iterator __lfirst, typename _Traits::__local_iterator __llast) {
       __result_ = std::__move<_AlgPolicy>(__lfirst, __llast, std::move(__result_)).second;
     }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp
@@ -31,18 +31,18 @@ constexpr void test_containers() {
     OutContainer out(4);
 
     std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret =
-        std::ranges::copy(in.begin(), in.end(), out.begin());
+        std::ranges::copy_backward(in.begin(), in.end(), out.end());
     assert(std::ranges::equal(in, out));
     assert(ret.in == in.end());
-    assert(ret.out == out.end());
+    assert(ret.out == out.begin());
   }
   {
     InContainer in{1, 2, 3, 4};
     OutContainer out(4);
-    std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret = std::ranges::copy(in, out.begin());
+    std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret = std::ranges::copy_backward(in, out.end());
     assert(std::ranges::equal(in, out));
     assert(ret.in == in.end());
-    assert(ret.out == out.end());
+    assert(ret.out == out.begin());
   }
 }
 
@@ -58,7 +58,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 0> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::copy_backward(subrange_vector | std::views::join, arr.end());
     assert(std::ranges::equal(arr, std::array<int, 0>{}));
   }
   { // segmented -> contiguous
@@ -67,7 +67,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 10> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::copy_backward(subrange_vector | std::views::join, arr.end());
     assert(std::ranges::equal(arr, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // contiguous -> segmented
@@ -76,7 +76,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array arr = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    std::ranges::copy(arr, (subrange_vector | std::views::join).begin());
+    std::ranges::copy_backward(arr, (subrange_vector | std::views::join).end());
     assert(std::ranges::equal(subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // segmented -> segmented
@@ -87,7 +87,7 @@ constexpr void test_join_view() {
     auto range2                              = to_vectors | to_subranges;
     std::vector<std::ranges::subrange<Iter, Sent>> to_subrange_vector(range2.begin(), range2.end());
 
-    std::ranges::copy(subrange_vector | std::views::join, (to_subrange_vector | std::views::join).begin());
+    std::ranges::copy_backward(subrange_vector | std::views::join, (to_subrange_vector | std::views::join).end());
     assert(std::ranges::equal(to_subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
 }
@@ -95,11 +95,7 @@ constexpr void test_join_view() {
 constexpr bool test_constexpr() {
   test_containers<std::vector<int>, std::vector<int>>();
 
-  types::for_each(types::forward_iterator_list<int*>{}, []<class Iter> {
-    test_join_view<Iter, Iter>();
-    test_join_view<Iter, sentinel_wrapper<Iter>>();
-    test_join_view<Iter, sized_sentinel<Iter>>();
-  });
+  types::for_each(types::bidirectional_iterator_list<int*>{}, []<class Iter> { test_join_view<Iter, Iter>(); });
   return true;
 }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp
@@ -31,15 +31,7 @@ constexpr void test_containers() {
     OutContainer out(4);
 
     std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret =
-        std::ranges::copy(in.begin(), in.end(), out.begin());
-    assert(std::ranges::equal(in, out));
-    assert(ret.in == in.end());
-    assert(ret.out == out.end());
-  }
-  {
-    InContainer in{1, 2, 3, 4};
-    OutContainer out(4);
-    std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret = std::ranges::copy(in, out.begin());
+        std::ranges::copy_n(in.begin(), in.size(), out.begin());
     assert(std::ranges::equal(in, out));
     assert(ret.in == in.end());
     assert(ret.out == out.end());
@@ -58,7 +50,9 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 0> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::copy_n((subrange_vector | std::views::join).begin(),
+                        std::ranges::distance(subrange_vector | std::views::join),
+                        arr.begin());
     assert(std::ranges::equal(arr, std::array<int, 0>{}));
   }
   { // segmented -> contiguous
@@ -67,7 +61,9 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 10> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::copy_n((subrange_vector | std::views::join).begin(),
+                        std::ranges::distance(subrange_vector | std::views::join),
+                        arr.begin());
     assert(std::ranges::equal(arr, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // contiguous -> segmented
@@ -76,7 +72,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array arr = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    std::ranges::copy(arr, (subrange_vector | std::views::join).begin());
+    std::ranges::copy_n(arr.begin(), arr.size(), (subrange_vector | std::views::join).begin());
     assert(std::ranges::equal(subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // segmented -> segmented
@@ -87,7 +83,9 @@ constexpr void test_join_view() {
     auto range2                              = to_vectors | to_subranges;
     std::vector<std::ranges::subrange<Iter, Sent>> to_subrange_vector(range2.begin(), range2.end());
 
-    std::ranges::copy(subrange_vector | std::views::join, (to_subrange_vector | std::views::join).begin());
+    std::ranges::copy_n((subrange_vector | std::views::join).begin(),
+                        std::ranges::distance(subrange_vector | std::views::join),
+                        (to_subrange_vector | std::views::join).begin());
     assert(std::ranges::equal(to_subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
 }
@@ -95,6 +93,7 @@ constexpr void test_join_view() {
 constexpr bool test_constexpr() {
   test_containers<std::vector<int>, std::vector<int>>();
 
+  // TODO: this should be cpp20_input_iterator_list, not forward_iterator_list
   types::for_each(types::forward_iterator_list<int*>{}, []<class Iter> {
     test_join_view<Iter, Iter>();
     test_join_view<Iter, sentinel_wrapper<Iter>>();

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp
@@ -31,7 +31,7 @@ constexpr void test_containers() {
     OutContainer out(4);
 
     std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret =
-        std::ranges::copy(in.begin(), in.end(), out.begin());
+        std::ranges::move(in.begin(), in.end(), out.begin());
     assert(std::ranges::equal(in, out));
     assert(ret.in == in.end());
     assert(ret.out == out.end());
@@ -39,7 +39,7 @@ constexpr void test_containers() {
   {
     InContainer in{1, 2, 3, 4};
     OutContainer out(4);
-    std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret = std::ranges::copy(in, out.begin());
+    std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret = std::ranges::move(in, out.begin());
     assert(std::ranges::equal(in, out));
     assert(ret.in == in.end());
     assert(ret.out == out.end());
@@ -58,7 +58,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 0> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::move(subrange_vector | std::views::join, arr.begin());
     assert(std::ranges::equal(arr, std::array<int, 0>{}));
   }
   { // segmented -> contiguous
@@ -67,7 +67,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 10> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::move(subrange_vector | std::views::join, arr.begin());
     assert(std::ranges::equal(arr, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // contiguous -> segmented
@@ -76,7 +76,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array arr = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    std::ranges::copy(arr, (subrange_vector | std::views::join).begin());
+    std::ranges::move(arr, (subrange_vector | std::views::join).begin());
     assert(std::ranges::equal(subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // segmented -> segmented
@@ -87,7 +87,7 @@ constexpr void test_join_view() {
     auto range2                              = to_vectors | to_subranges;
     std::vector<std::ranges::subrange<Iter, Sent>> to_subrange_vector(range2.begin(), range2.end());
 
-    std::ranges::copy(subrange_vector | std::views::join, (to_subrange_vector | std::views::join).begin());
+    std::ranges::move(subrange_vector | std::views::join, (to_subrange_vector | std::views::join).begin());
     assert(std::ranges::equal(to_subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
 }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp
@@ -31,18 +31,18 @@ constexpr void test_containers() {
     OutContainer out(4);
 
     std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret =
-        std::ranges::copy(in.begin(), in.end(), out.begin());
+        std::ranges::move_backward(in.begin(), in.end(), out.end());
     assert(std::ranges::equal(in, out));
     assert(ret.in == in.end());
-    assert(ret.out == out.end());
+    assert(ret.out == out.begin());
   }
   {
     InContainer in{1, 2, 3, 4};
     OutContainer out(4);
-    std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret = std::ranges::copy(in, out.begin());
+    std::same_as<std::ranges::in_out_result<InIter, OutIter>> auto ret = std::ranges::move_backward(in, out.end());
     assert(std::ranges::equal(in, out));
     assert(ret.in == in.end());
-    assert(ret.out == out.end());
+    assert(ret.out == out.begin());
   }
 }
 
@@ -58,7 +58,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 0> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::move_backward(subrange_vector | std::views::join, arr.end());
     assert(std::ranges::equal(arr, std::array<int, 0>{}));
   }
   { // segmented -> contiguous
@@ -67,7 +67,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array<int, 10> arr;
 
-    std::ranges::copy(subrange_vector | std::views::join, arr.begin());
+    std::ranges::move_backward(subrange_vector | std::views::join, arr.end());
     assert(std::ranges::equal(arr, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // contiguous -> segmented
@@ -76,7 +76,7 @@ constexpr void test_join_view() {
     std::vector<std::ranges::subrange<Iter, Sent>> subrange_vector(range.begin(), range.end());
     std::array arr = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    std::ranges::copy(arr, (subrange_vector | std::views::join).begin());
+    std::ranges::move_backward(arr, (subrange_vector | std::views::join).end());
     assert(std::ranges::equal(subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
   { // segmented -> segmented
@@ -87,7 +87,7 @@ constexpr void test_join_view() {
     auto range2                              = to_vectors | to_subranges;
     std::vector<std::ranges::subrange<Iter, Sent>> to_subrange_vector(range2.begin(), range2.end());
 
-    std::ranges::copy(subrange_vector | std::views::join, (to_subrange_vector | std::views::join).begin());
+    std::ranges::move_backward(subrange_vector | std::views::join, (to_subrange_vector | std::views::join).end());
     assert(std::ranges::equal(to_subrange_vector | std::views::join, std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
   }
 }
@@ -95,11 +95,7 @@ constexpr void test_join_view() {
 constexpr bool test_constexpr() {
   test_containers<std::vector<int>, std::vector<int>>();
 
-  types::for_each(types::forward_iterator_list<int*>{}, []<class Iter> {
-    test_join_view<Iter, Iter>();
-    test_join_view<Iter, sentinel_wrapper<Iter>>();
-    test_join_view<Iter, sized_sentinel<Iter>>();
-  });
+  types::for_each(types::bidirectional_iterator_list<int*>{}, []<class Iter> { test_join_view<Iter, Iter>(); });
   return true;
 }
 


### PR DESCRIPTION
Resolves Issue #69083

The `_CopySegment` helper for `ranges::copy(join_view, out)` is not `constexpr` causing rejection in `libc++` in a static assertion context as in the issue snippet.