### PR TITLE
[clang][Interp] Implement inc/dec for IntegralAP

### DIFF
--- a/clang/lib/AST/Interp/IntegralAP.h
+++ b/clang/lib/AST/Interp/IntegralAP.h
@@ -182,17 +182,13 @@ public:
   }
 
   static bool increment(IntegralAP A, IntegralAP *R) {
-    // FIXME: Implement.
-    assert(false);
-    *R = IntegralAP(A.V - 1);
-    return false;
+    IntegralAP<Signed> One(1, A.bitWidth());
+    return add(A, One, A.bitWidth() + 1, R);
   }
 
   static bool decrement(IntegralAP A, IntegralAP *R) {
-    // FIXME: Implement.
-    assert(false);
-    *R = IntegralAP(A.V - 1);
-    return false;
+    IntegralAP<Signed> One(1, A.bitWidth());
+    return sub(A, One, A.bitWidth() + 1, R);
   }
 
   static bool add(IntegralAP A, IntegralAP B, unsigned OpBits, IntegralAP *R) {


### PR DESCRIPTION
The tests are commented out and I can't merge this yet, since it creates memory leaks when the interpretation is aborted midway through.

This problem also exists with floating-point values:

```c++
constexpr long double a() {
  long double A = __LDBL_MAX__;
  throw;
  return A;
}
```

We will allocate a `APFloat` into the stack frame and not call its destructor later.
