### PR TITLE
[Flang] Set address space during FIR pointer-like types lowering

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/include/flang/Optimizer/CodeGen/TypeConverter.h
@@ -101,7 +101,7 @@ public:
   }
 
   template <typename A> mlir::Type convertPointerLike(A &ty) const {
-    return mlir::LLVM::LLVMPointerType::get(ty.getContext());
+    return mlir::LLVM::LLVMPointerType::get(ty.getContext(), addressSpace);
   }
 
   // convert a front-end kind value to either a std or LLVM IR dialect type
@@ -127,6 +127,7 @@ private:
   KindMapping kindMapping;
   std::unique_ptr<CodeGenSpecifics> specifics;
   std::unique_ptr<TBAABuilder> tbaaBuilder;
+  unsigned addressSpace;
 };
 
 } // namespace fir

--- a/flang/lib/Optimizer/CodeGen/DescriptorModel.h
+++ b/flang/lib/Optimizer/CodeGen/DescriptorModel.h
@@ -31,7 +31,7 @@
 
 namespace fir {
 
-using TypeBuilderFunc = mlir::Type (*)(mlir::MLIRContext *);
+using TypeBuilderFunc = mlir::Type (*)(mlir::MLIRContext *, unsigned);
 
 /// Get the LLVM IR dialect model for building a particular C++ type, `T`.
 template <typename T>
@@ -39,64 +39,72 @@ TypeBuilderFunc getModel();
 
 template <>
 TypeBuilderFunc getModel<void *>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::LLVM::LLVMPointerType::get(context);
+  return [](mlir::MLIRContext *context, unsigned addressSpace) -> mlir::Type {
+    return mlir::LLVM::LLVMPointerType::get(context, addressSpace);
   };
 }
 template <>
 TypeBuilderFunc getModel<unsigned>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, sizeof(unsigned) * 8);
-  };
+  return
+      [](mlir::MLIRContext *context, unsigned /*addressSpace*/) -> mlir::Type {
+        return mlir::IntegerType::get(context, sizeof(unsigned) * 8);
+      };
 }
 template <>
 TypeBuilderFunc getModel<int>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, sizeof(int) * 8);
-  };
+  return
+      [](mlir::MLIRContext *context, unsigned /*addressSpace*/) -> mlir::Type {
+        return mlir::IntegerType::get(context, sizeof(int) * 8);
+      };
 }
 template <>
 TypeBuilderFunc getModel<unsigned long>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, sizeof(unsigned long) * 8);
-  };
+  return
+      [](mlir::MLIRContext *context, unsigned /*addressSpace*/) -> mlir::Type {
+        return mlir::IntegerType::get(context, sizeof(unsigned long) * 8);
+      };
 }
 template <>
 TypeBuilderFunc getModel<unsigned long long>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, sizeof(unsigned long long) * 8);
-  };
+  return
+      [](mlir::MLIRContext *context, unsigned /*addressSpace*/) -> mlir::Type {
+        return mlir::IntegerType::get(context, sizeof(unsigned long long) * 8);
+      };
 }
 template <>
 TypeBuilderFunc getModel<long long>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, sizeof(long long) * 8);
-  };
+  return
+      [](mlir::MLIRContext *context, unsigned /*addressSpace*/) -> mlir::Type {
+        return mlir::IntegerType::get(context, sizeof(long long) * 8);
+      };
 }
 template <>
 TypeBuilderFunc getModel<Fortran::ISO::CFI_rank_t>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
+  return [](mlir::MLIRContext *context,
+            unsigned /*addressSpace*/) -> mlir::Type {
     return mlir::IntegerType::get(context,
                                   sizeof(Fortran::ISO::CFI_rank_t) * 8);
   };
 }
 template <>
 TypeBuilderFunc getModel<Fortran::ISO::CFI_type_t>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
+  return [](mlir::MLIRContext *context,
+            unsigned /*addressSpace*/) -> mlir::Type {
     return mlir::IntegerType::get(context,
                                   sizeof(Fortran::ISO::CFI_type_t) * 8);
   };
 }
 template <>
 TypeBuilderFunc getModel<long>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, sizeof(long) * 8);
-  };
+  return
+      [](mlir::MLIRContext *context, unsigned /*addressSpace*/) -> mlir::Type {
+        return mlir::IntegerType::get(context, sizeof(long) * 8);
+      };
 }
 template <>
 TypeBuilderFunc getModel<Fortran::ISO::CFI_dim_t>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    auto indexTy = getModel<Fortran::ISO::CFI_index_t>()(context);
+  return [](mlir::MLIRContext *context, unsigned addressSpace) -> mlir::Type {
+    auto indexTy = getModel<Fortran::ISO::CFI_index_t>()(context, addressSpace);
     return mlir::LLVM::LLVMArrayType::get(indexTy, 3);
   };
 }

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.cpp
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.cpp
@@ -35,7 +35,13 @@ LLVMTypeConverter::LLVMTypeConverter(mlir::ModuleOp module, bool applyTBAA,
                                       getTargetTriple(module),
                                       getKindMapping(module), dl)),
       tbaaBuilder(std::make_unique<TBAABuilder>(module->getContext(), applyTBAA,
-                                                forceUnifiedTBAATree)) {
+                                                forceUnifiedTBAATree)),
+      addressSpace(0) {
+  // Get default alloca address space for the current target
+  if (mlir::Attribute addrSpace =
+          mlir::DataLayout(module).getAllocaMemorySpace())
+    addressSpace = addrSpace.cast<mlir::IntegerAttr>().getUInt();
+
   LLVM_DEBUG(llvm::dbgs() << "FIR type converter\n");
 
   // Each conversion should return a value of type mlir::Type.

--- a/flang/test/Fir/alloca-addrspace-2.fir
+++ b/flang/test/Fir/alloca-addrspace-2.fir
@@ -5,7 +5,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_mem
   // CHECK-LABEL: llvm.func @set_addrspace
   func.func @set_addrspace() {
     // CHECK: llvm.alloca {{.*}} x i32
-    // CHECK-SAME: -> !llvm.ptr<i32, 5>
+    // CHECK-SAME: -> !llvm.ptr<5>
     %0 = fir.alloca i32
     return
   }

--- a/flang/test/Fir/alloca-addrspace-2.fir
+++ b/flang/test/Fir/alloca-addrspace-2.fir
@@ -1,0 +1,12 @@
+// RUN: fir-opt --fir-to-llvm-ir %s | FileCheck %s
+// RUN: tco --fir-to-llvm-ir %s | FileCheck %s
+
+module attributes { dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_memory_space", 5 : ui32>> } {
+  // CHECK-LABEL: llvm.func @set_addrspace
+  func.func @set_addrspace() {
+    // CHECK: llvm.alloca {{.*}} x i32
+    // CHECK-SAME: -> !llvm.ptr<i32, 5>
+    %0 = fir.alloca i32
+    return
+  }
+}

--- a/flang/test/Fir/alloca-addrspace.fir
+++ b/flang/test/Fir/alloca-addrspace.fir
@@ -1,0 +1,12 @@
+// RUN: fir-opt --fir-to-llvm-ir %s | FileCheck %s
+// RUN: tco --fir-to-llvm-ir %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: llvm.func @default_addrspace
+  func.func @default_addrspace() {
+    // CHECK: llvm.alloca {{.*}} x i32
+    // CHECK-SAME: -> !llvm.ptr<i32>
+    %0 = fir.alloca i32
+    return
+  }
+}

--- a/flang/test/Fir/alloca-addrspace.fir
+++ b/flang/test/Fir/alloca-addrspace.fir
@@ -5,7 +5,7 @@ module {
   // CHECK-LABEL: llvm.func @default_addrspace
   func.func @default_addrspace() {
     // CHECK: llvm.alloca {{.*}} x i32
-    // CHECK-SAME: -> !llvm.ptr<i32>
+    // CHECK-SAME: -> !llvm.ptr
     %0 = fir.alloca i32
     return
   }


### PR DESCRIPTION
This patch modifies FIR pointer-like types lowering to LLVM dialect to use the address space stated in the module's data layout.