### PR TITLE
[flang][openacc] Warn for num_gangs, num_workers and vector_length on acc serial

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -541,7 +541,8 @@ void AccStructureChecker::Enter(const parser::AccClause::Gang &g) {
 void AccStructureChecker::Enter(const parser::AccClause::NumGangs &n) {
   CheckAllowed(llvm::acc::Clause::ACCC_num_gangs,
       /*warnInsteadOfError=*/GetContext().directive ==
-          llvm::acc::Directive::ACCD_serial);
+              llvm::acc::Directive::ACCD_serial ||
+          GetContext().directive == llvm::acc::Directive::ACCD_serial_loop);
 
   if (n.v.size() > 3)
     context_.Say(GetContext().clauseSource,
@@ -551,13 +552,15 @@ void AccStructureChecker::Enter(const parser::AccClause::NumGangs &n) {
 void AccStructureChecker::Enter(const parser::AccClause::NumWorkers &n) {
   CheckAllowed(llvm::acc::Clause::ACCC_num_workers,
       /*warnInsteadOfError=*/GetContext().directive ==
-          llvm::acc::Directive::ACCD_serial);
+              llvm::acc::Directive::ACCD_serial ||
+          GetContext().directive == llvm::acc::Directive::ACCD_serial_loop);
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::VectorLength &n) {
   CheckAllowed(llvm::acc::Clause::ACCC_vector_length,
       /*warnInsteadOfError=*/GetContext().directive ==
-          llvm::acc::Directive::ACCD_serial);
+              llvm::acc::Directive::ACCD_serial ||
+          GetContext().directive == llvm::acc::Directive::ACCD_serial_loop);
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::Reduction &reduction) {

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -380,14 +380,12 @@ CHECK_SIMPLE_CLAUSE(IfPresent, ACCC_if_present)
 CHECK_SIMPLE_CLAUSE(Independent, ACCC_independent)
 CHECK_SIMPLE_CLAUSE(NoCreate, ACCC_no_create)
 CHECK_SIMPLE_CLAUSE(Nohost, ACCC_nohost)
-CHECK_SIMPLE_CLAUSE(NumWorkers, ACCC_num_workers)
 CHECK_SIMPLE_CLAUSE(Private, ACCC_private)
 CHECK_SIMPLE_CLAUSE(Read, ACCC_read)
 CHECK_SIMPLE_CLAUSE(Seq, ACCC_seq)
 CHECK_SIMPLE_CLAUSE(Tile, ACCC_tile)
 CHECK_SIMPLE_CLAUSE(UseDevice, ACCC_use_device)
 CHECK_SIMPLE_CLAUSE(Vector, ACCC_vector)
-CHECK_SIMPLE_CLAUSE(VectorLength, ACCC_vector_length)
 CHECK_SIMPLE_CLAUSE(Wait, ACCC_wait)
 CHECK_SIMPLE_CLAUSE(Worker, ACCC_worker)
 CHECK_SIMPLE_CLAUSE(Write, ACCC_write)
@@ -541,11 +539,25 @@ void AccStructureChecker::Enter(const parser::AccClause::Gang &g) {
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::NumGangs &n) {
-  CheckAllowed(llvm::acc::Clause::ACCC_num_gangs);
+  CheckAllowed(llvm::acc::Clause::ACCC_num_gangs,
+      /*warnInsteadOfError=*/GetContext().directive ==
+          llvm::acc::Directive::ACCD_serial);
 
   if (n.v.size() > 3)
     context_.Say(GetContext().clauseSource,
         "NUM_GANGS clause accepts a maximum of 3 arguments"_err_en_US);
+}
+
+void AccStructureChecker::Enter(const parser::AccClause::NumWorkers &n) {
+  CheckAllowed(llvm::acc::Clause::ACCC_num_workers,
+      /*warnInsteadOfError=*/GetContext().directive ==
+          llvm::acc::Directive::ACCD_serial);
+}
+
+void AccStructureChecker::Enter(const parser::AccClause::VectorLength &n) {
+  CheckAllowed(llvm::acc::Clause::ACCC_vector_length,
+      /*warnInsteadOfError=*/GetContext().directive ==
+          llvm::acc::Directive::ACCD_serial);
 }
 
 void AccStructureChecker::Enter(const parser::AccClause::Reduction &reduction) {

--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -333,7 +333,7 @@ protected:
 
   void CheckRequireAtLeastOneOf(bool warnInsteadOfError = false);
 
-  void CheckAllowed(C clause);
+  void CheckAllowed(C clause, bool warnInsteadOfError = false);
 
   void CheckAtLeastOneClause();
 
@@ -452,15 +452,21 @@ std::string DirectiveStructureChecker<D, C, PC,
 // Check that clauses present on the directive are allowed clauses.
 template <typename D, typename C, typename PC, std::size_t ClauseEnumSize>
 void DirectiveStructureChecker<D, C, PC, ClauseEnumSize>::CheckAllowed(
-    C clause) {
+    C clause, bool warnInsteadOfError) {
   if (!GetContext().allowedClauses.test(clause) &&
       !GetContext().allowedOnceClauses.test(clause) &&
       !GetContext().allowedExclusiveClauses.test(clause) &&
       !GetContext().requiredClauses.test(clause)) {
-    context_.Say(GetContext().clauseSource,
-        "%s clause is not allowed on the %s directive"_err_en_US,
-        parser::ToUpperCaseLetters(getClauseName(clause).str()),
-        parser::ToUpperCaseLetters(GetContext().directiveSource.ToString()));
+    if (warnInsteadOfError)
+      context_.Say(GetContext().clauseSource,
+          "%s clause is not allowed on the %s directive and will be ignored"_warn_en_US,
+          parser::ToUpperCaseLetters(getClauseName(clause).str()),
+          parser::ToUpperCaseLetters(GetContext().directiveSource.ToString()));
+    else
+      context_.Say(GetContext().clauseSource,
+          "%s clause is not allowed on the %s directive"_err_en_US,
+          parser::ToUpperCaseLetters(getClauseName(clause).str()),
+          parser::ToUpperCaseLetters(GetContext().directiveSource.ToString()));
     return;
   }
   if ((GetContext().allowedOnceClauses.test(clause) ||

--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -459,7 +459,7 @@ void DirectiveStructureChecker<D, C, PC, ClauseEnumSize>::CheckAllowed(
       !GetContext().requiredClauses.test(clause)) {
     if (warnInsteadOfError)
       context_.Say(GetContext().clauseSource,
-          "%s clause is not allowed on the %s directive and will be ignored"_warn_en_US,
+          "%s clause is not allowed on the %s directive and will be ignored"_port_en_US,
           parser::ToUpperCaseLetters(getClauseName(clause).str()),
           parser::ToUpperCaseLetters(GetContext().directiveSource.ToString()));
     else

--- a/flang/test/Semantics/OpenACC/acc-serial.f90
+++ b/flang/test/Semantics/OpenACC/acc-serial.f90
@@ -77,15 +77,15 @@ program openacc_serial_validity
   !$acc serial wait(wait1) wait(wait2)
   !$acc end serial
 
-  !ERROR: NUM_GANGS clause is not allowed on the SERIAL directive
+  !PORTABILITY: NUM_GANGS clause is not allowed on the SERIAL directive and will be ignored
   !$acc serial num_gangs(8)
   !$acc end serial
 
-  !ERROR: NUM_WORKERS clause is not allowed on the SERIAL directive
+  !PORTABILITY: NUM_WORKERS clause is not allowed on the SERIAL directive and will be ignored
   !$acc serial num_workers(8)
   !$acc end serial
 
-  !ERROR: VECTOR_LENGTH clause is not allowed on the SERIAL directive
+  !PORTABILITY: VECTOR_LENGTH clause is not allowed on the SERIAL directive and will be ignored
   !$acc serial vector_length(128)
   !$acc end serial
 


### PR DESCRIPTION
For portability with other compilers, just issue a portability warning instead of a hard error when `num_gangs`, `num_workers` or `vector_length` are present on an `!$acc serial` directive