### PR TITLE
[ASan][Windows] Add __cdecl to public sanitizer functions

### DIFF
--- a/compiler-rt/include/sanitizer/allocator_interface.h
+++ b/compiler-rt/include/sanitizer/allocator_interface.h
@@ -11,86 +11,89 @@
 #ifndef SANITIZER_ALLOCATOR_INTERFACE_H
 #define SANITIZER_ALLOCATOR_INTERFACE_H
 
+#include <sanitizer/common_interface_defs.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-  /* Returns the estimated number of bytes that will be reserved by allocator
-     for request of "size" bytes. If allocator can't allocate that much
-     memory, returns the maximal possible allocation size, otherwise returns
-     "size". */
-  size_t __sanitizer_get_estimated_allocated_size(size_t size);
+/* Returns the estimated number of bytes that will be reserved by allocator
+   for request of "size" bytes. If allocator can't allocate that much
+   memory, returns the maximal possible allocation size, otherwise returns
+   "size". */
+size_t __sanitizer_cdecl __sanitizer_get_estimated_allocated_size(size_t size);
 
-  /* Returns true if p was returned by the allocator and
-     is not yet freed. */
-  int __sanitizer_get_ownership(const volatile void *p);
+/* Returns true if p was returned by the allocator and
+   is not yet freed. */
+int __sanitizer_cdecl __sanitizer_get_ownership(const volatile void *p);
 
-  /* If a pointer lies within an allocation, it will return the start address
-     of the allocation. Otherwise, it returns nullptr. */
-  const void *__sanitizer_get_allocated_begin(const void *p);
+/* If a pointer lies within an allocation, it will return the start address
+   of the allocation. Otherwise, it returns nullptr. */
+const void *__sanitizer_cdecl __sanitizer_get_allocated_begin(const void *p);
 
-  /* Returns the number of bytes reserved for the pointer p.
-     Requires (get_ownership(p) == true) or (p == 0). */
-  size_t __sanitizer_get_allocated_size(const volatile void *p);
+/* Returns the number of bytes reserved for the pointer p.
+   Requires (get_ownership(p) == true) or (p == 0). */
+size_t __sanitizer_cdecl __sanitizer_get_allocated_size(const volatile void *p);
 
-  /* Returns the number of bytes reserved for the pointer p.
-     Requires __sanitizer_get_allocated_begin(p) == p. */
-  size_t __sanitizer_get_allocated_size_fast(const volatile void *p);
+/* Returns the number of bytes reserved for the pointer p.
+   Requires __sanitizer_get_allocated_begin(p) == p. */
+size_t __sanitizer_cdecl
+__sanitizer_get_allocated_size_fast(const volatile void *p);
 
-  /* Number of bytes, allocated and not yet freed by the application. */
-  size_t __sanitizer_get_current_allocated_bytes(void);
+/* Number of bytes, allocated and not yet freed by the application. */
+size_t __sanitizer_cdecl __sanitizer_get_current_allocated_bytes(void);
 
-  /* Number of bytes, mmaped by the allocator to fulfill allocation requests.
-     Generally, for request of X bytes, allocator can reserve and add to free
-     lists a large number of chunks of size X to use them for future requests.
-     All these chunks count toward the heap size. Currently, allocator never
-     releases memory to OS (instead, it just puts freed chunks to free
-     lists). */
-  size_t __sanitizer_get_heap_size(void);
+/* Number of bytes, mmaped by the allocator to fulfill allocation requests.
+   Generally, for request of X bytes, allocator can reserve and add to free
+   lists a large number of chunks of size X to use them for future requests.
+   All these chunks count toward the heap size. Currently, allocator never
+   releases memory to OS (instead, it just puts freed chunks to free
+   lists). */
+size_t __sanitizer_cdecl __sanitizer_get_heap_size(void);
 
-  /* Number of bytes, mmaped by the allocator, which can be used to fulfill
-     allocation requests. When a user program frees memory chunk, it can first
-     fall into quarantine and will count toward __sanitizer_get_free_bytes()
-     later. */
-  size_t __sanitizer_get_free_bytes(void);
+/* Number of bytes, mmaped by the allocator, which can be used to fulfill
+   allocation requests. When a user program frees memory chunk, it can first
+   fall into quarantine and will count toward __sanitizer_get_free_bytes()
+   later. */
+size_t __sanitizer_cdecl __sanitizer_get_free_bytes(void);
 
-  /* Number of bytes in unmapped pages, that are released to OS. Currently,
-     always returns 0. */
-  size_t __sanitizer_get_unmapped_bytes(void);
+/* Number of bytes in unmapped pages, that are released to OS. Currently,
+   always returns 0. */
+size_t __sanitizer_cdecl __sanitizer_get_unmapped_bytes(void);
 
-  /* Malloc hooks that may be optionally provided by user.
-     __sanitizer_malloc_hook(ptr, size) is called immediately after
-       allocation of "size" bytes, which returned "ptr".
-     __sanitizer_free_hook(ptr) is called immediately before
-       deallocation of "ptr". */
-  void __sanitizer_malloc_hook(const volatile void *ptr, size_t size);
-  void __sanitizer_free_hook(const volatile void *ptr);
+/* Malloc hooks that may be optionally provided by user.
+   __sanitizer_malloc_hook(ptr, size) is called immediately after
+     allocation of "size" bytes, which returned "ptr".
+   __sanitizer_free_hook(ptr) is called immediately before
+     deallocation of "ptr". */
+void __sanitizer_cdecl __sanitizer_malloc_hook(const volatile void *ptr,
+                                               size_t size);
+void __sanitizer_cdecl __sanitizer_free_hook(const volatile void *ptr);
 
-  /* Installs a pair of hooks for malloc/free.
-     Several (currently, 5) hook pairs may be installed, they are executed
-     in the order they were installed and after calling
-     __sanitizer_malloc_hook/__sanitizer_free_hook.
-     Unlike __sanitizer_malloc_hook/__sanitizer_free_hook these hooks can be
-     chained and do not rely on weak symbols working on the platform, but
-     require __sanitizer_install_malloc_and_free_hooks to be called at startup
-     and thus will not be called on malloc/free very early in the process.
-     Returns the number of hooks currently installed or 0 on failure.
-     Not thread-safe, should be called in the main thread before starting
-     other threads.
-  */
-  int __sanitizer_install_malloc_and_free_hooks(
-      void (*malloc_hook)(const volatile void *, size_t),
-      void (*free_hook)(const volatile void *));
+/* Installs a pair of hooks for malloc/free.
+   Several (currently, 5) hook pairs may be installed, they are executed
+   in the order they were installed and after calling
+   __sanitizer_malloc_hook/__sanitizer_free_hook.
+   Unlike __sanitizer_malloc_hook/__sanitizer_free_hook these hooks can be
+   chained and do not rely on weak symbols working on the platform, but
+   require __sanitizer_install_malloc_and_free_hooks to be called at startup
+   and thus will not be called on malloc/free very early in the process.
+   Returns the number of hooks currently installed or 0 on failure.
+   Not thread-safe, should be called in the main thread before starting
+   other threads.
+*/
+int __sanitizer_cdecl __sanitizer_install_malloc_and_free_hooks(
+    void (*__sanitizer_cdecl malloc_hook)(const volatile void *, size_t),
+    void (*__sanitizer_cdecl free_hook)(const volatile void *));
 
-  /* Drains allocator quarantines (calling thread's and global ones), returns
-     freed memory back to OS and releases other non-essential internal allocator
-     resources in attempt to reduce process RSS.
-     Currently available with ASan only.
-  */
-  void __sanitizer_purge_allocator(void);
+/* Drains allocator quarantines (calling thread's and global ones), returns
+   freed memory back to OS and releases other non-essential internal allocator
+   resources in attempt to reduce process RSS.
+   Currently available with ASan only.
+*/
+void __sanitizer_cdecl __sanitizer_purge_allocator(void);
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif

--- a/compiler-rt/include/sanitizer/allocator_interface.h
+++ b/compiler-rt/include/sanitizer/allocator_interface.h
@@ -67,7 +67,7 @@ size_t SANITIZER_CDECL __sanitizer_get_unmapped_bytes(void);
    __sanitizer_free_hook(ptr) is called immediately before
      deallocation of "ptr". */
 void SANITIZER_CDECL __sanitizer_malloc_hook(const volatile void *ptr,
-                                               size_t size);
+                                             size_t size);
 void SANITIZER_CDECL __sanitizer_free_hook(const volatile void *ptr);
 
 /* Installs a pair of hooks for malloc/free.

--- a/compiler-rt/include/sanitizer/allocator_interface.h
+++ b/compiler-rt/include/sanitizer/allocator_interface.h
@@ -21,27 +21,27 @@ extern "C" {
    for request of "size" bytes. If allocator can't allocate that much
    memory, returns the maximal possible allocation size, otherwise returns
    "size". */
-size_t __sanitizer_cdecl __sanitizer_get_estimated_allocated_size(size_t size);
+size_t SANITIZER_CDECL __sanitizer_get_estimated_allocated_size(size_t size);
 
 /* Returns true if p was returned by the allocator and
    is not yet freed. */
-int __sanitizer_cdecl __sanitizer_get_ownership(const volatile void *p);
+int SANITIZER_CDECL __sanitizer_get_ownership(const volatile void *p);
 
 /* If a pointer lies within an allocation, it will return the start address
    of the allocation. Otherwise, it returns nullptr. */
-const void *__sanitizer_cdecl __sanitizer_get_allocated_begin(const void *p);
+const void *SANITIZER_CDECL __sanitizer_get_allocated_begin(const void *p);
 
 /* Returns the number of bytes reserved for the pointer p.
    Requires (get_ownership(p) == true) or (p == 0). */
-size_t __sanitizer_cdecl __sanitizer_get_allocated_size(const volatile void *p);
+size_t SANITIZER_CDECL __sanitizer_get_allocated_size(const volatile void *p);
 
 /* Returns the number of bytes reserved for the pointer p.
    Requires __sanitizer_get_allocated_begin(p) == p. */
-size_t __sanitizer_cdecl
+size_t SANITIZER_CDECL
 __sanitizer_get_allocated_size_fast(const volatile void *p);
 
 /* Number of bytes, allocated and not yet freed by the application. */
-size_t __sanitizer_cdecl __sanitizer_get_current_allocated_bytes(void);
+size_t SANITIZER_CDECL __sanitizer_get_current_allocated_bytes(void);
 
 /* Number of bytes, mmaped by the allocator to fulfill allocation requests.
    Generally, for request of X bytes, allocator can reserve and add to free
@@ -49,26 +49,26 @@ size_t __sanitizer_cdecl __sanitizer_get_current_allocated_bytes(void);
    All these chunks count toward the heap size. Currently, allocator never
    releases memory to OS (instead, it just puts freed chunks to free
    lists). */
-size_t __sanitizer_cdecl __sanitizer_get_heap_size(void);
+size_t SANITIZER_CDECL __sanitizer_get_heap_size(void);
 
 /* Number of bytes, mmaped by the allocator, which can be used to fulfill
    allocation requests. When a user program frees memory chunk, it can first
    fall into quarantine and will count toward __sanitizer_get_free_bytes()
    later. */
-size_t __sanitizer_cdecl __sanitizer_get_free_bytes(void);
+size_t SANITIZER_CDECL __sanitizer_get_free_bytes(void);
 
 /* Number of bytes in unmapped pages, that are released to OS. Currently,
    always returns 0. */
-size_t __sanitizer_cdecl __sanitizer_get_unmapped_bytes(void);
+size_t SANITIZER_CDECL __sanitizer_get_unmapped_bytes(void);
 
 /* Malloc hooks that may be optionally provided by user.
    __sanitizer_malloc_hook(ptr, size) is called immediately after
      allocation of "size" bytes, which returned "ptr".
    __sanitizer_free_hook(ptr) is called immediately before
      deallocation of "ptr". */
-void __sanitizer_cdecl __sanitizer_malloc_hook(const volatile void *ptr,
+void SANITIZER_CDECL __sanitizer_malloc_hook(const volatile void *ptr,
                                                size_t size);
-void __sanitizer_cdecl __sanitizer_free_hook(const volatile void *ptr);
+void SANITIZER_CDECL __sanitizer_free_hook(const volatile void *ptr);
 
 /* Installs a pair of hooks for malloc/free.
    Several (currently, 5) hook pairs may be installed, they are executed
@@ -82,16 +82,16 @@ void __sanitizer_cdecl __sanitizer_free_hook(const volatile void *ptr);
    Not thread-safe, should be called in the main thread before starting
    other threads.
 */
-int __sanitizer_cdecl __sanitizer_install_malloc_and_free_hooks(
-    void (*__sanitizer_cdecl malloc_hook)(const volatile void *, size_t),
-    void (*__sanitizer_cdecl free_hook)(const volatile void *));
+int SANITIZER_CDECL __sanitizer_install_malloc_and_free_hooks(
+    void (*SANITIZER_CDECL malloc_hook)(const volatile void *, size_t),
+    void (*SANITIZER_CDECL free_hook)(const volatile void *));
 
 /* Drains allocator quarantines (calling thread's and global ones), returns
    freed memory back to OS and releases other non-essential internal allocator
    resources in attempt to reduce process RSS.
    Currently available with ASan only.
 */
-void __sanitizer_cdecl __sanitizer_purge_allocator(void);
+void SANITIZER_CDECL __sanitizer_purge_allocator(void);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/compiler-rt/include/sanitizer/asan_interface.h
+++ b/compiler-rt/include/sanitizer/asan_interface.h
@@ -31,7 +31,7 @@ extern "C" {
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-void __sanitizer_cdecl __asan_poison_memory_region(void const volatile *addr,
+void SANITIZER_CDECL __asan_poison_memory_region(void const volatile *addr,
                                                    size_t size);
 
 /// Marks a memory region (<c>[addr, addr+size)</c>) as addressable.
@@ -46,7 +46,7 @@ void __sanitizer_cdecl __asan_poison_memory_region(void const volatile *addr,
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-void __sanitizer_cdecl __asan_unpoison_memory_region(void const volatile *addr,
+void SANITIZER_CDECL __asan_unpoison_memory_region(void const volatile *addr,
                                                      size_t size);
 
 // Macros provided for convenience.
@@ -85,7 +85,7 @@ void __sanitizer_cdecl __asan_unpoison_memory_region(void const volatile *addr,
 ///
 /// \retval 1 Address is poisoned.
 /// \retval 0 Address is not poisoned.
-int __sanitizer_cdecl __asan_address_is_poisoned(void const volatile *addr);
+int SANITIZER_CDECL __asan_address_is_poisoned(void const volatile *addr);
 
 /// Checks if a region is poisoned.
 ///
@@ -95,14 +95,14 @@ int __sanitizer_cdecl __asan_address_is_poisoned(void const volatile *addr);
 /// \param beg Start of memory region.
 /// \param size Start of memory region.
 /// \returns Address of first poisoned byte.
-void *__sanitizer_cdecl __asan_region_is_poisoned(void *beg, size_t size);
+void *SANITIZER_CDECL __asan_region_is_poisoned(void *beg, size_t size);
 
 /// Describes an address (useful for calling from the debugger).
 ///
 /// Prints the description of <c><i>addr</i></c>.
 ///
 /// \param addr Address to describe.
-void __sanitizer_cdecl __asan_describe_address(void *addr);
+void SANITIZER_CDECL __asan_describe_address(void *addr);
 
 /// Checks if an error has been or is being reported (useful for calling from
 /// the debugger to get information about an ASan error).
@@ -111,7 +111,7 @@ void __sanitizer_cdecl __asan_describe_address(void *addr);
 ///
 /// \returns 1 if an error has been (or is being) reported. Otherwise returns
 /// 0.
-int __sanitizer_cdecl __asan_report_present(void);
+int SANITIZER_CDECL __asan_report_present(void);
 
 /// Gets the PC (program counter) register value of an ASan error (useful for
 /// calling from the debugger).
@@ -120,7 +120,7 @@ int __sanitizer_cdecl __asan_report_present(void);
 /// Otherwise returns 0.
 ///
 /// \returns PC value.
-void *__sanitizer_cdecl __asan_get_report_pc(void);
+void *SANITIZER_CDECL __asan_get_report_pc(void);
 
 /// Gets the BP (base pointer) register value of an ASan error (useful for
 /// calling from the debugger).
@@ -129,7 +129,7 @@ void *__sanitizer_cdecl __asan_get_report_pc(void);
 /// Otherwise returns 0.
 ///
 /// \returns BP value.
-void *__sanitizer_cdecl __asan_get_report_bp(void);
+void *SANITIZER_CDECL __asan_get_report_bp(void);
 
 /// Gets the SP (stack pointer) register value of an ASan error (useful for
 /// calling from the debugger).
@@ -138,7 +138,7 @@ void *__sanitizer_cdecl __asan_get_report_bp(void);
 /// Otherwise returns 0.
 ///
 /// \returns SP value.
-void *__sanitizer_cdecl __asan_get_report_sp(void);
+void *SANITIZER_CDECL __asan_get_report_sp(void);
 
 /// Gets the address of the report buffer of an ASan error (useful for calling
 /// from the debugger).
@@ -147,7 +147,7 @@ void *__sanitizer_cdecl __asan_get_report_sp(void);
 /// reported. Otherwise returns 0.
 ///
 /// \returns Address of report buffer.
-void *__sanitizer_cdecl __asan_get_report_address(void);
+void *SANITIZER_CDECL __asan_get_report_address(void);
 
 /// Gets access type of an ASan error (useful for calling from the debugger).
 ///
@@ -155,7 +155,7 @@ void *__sanitizer_cdecl __asan_get_report_address(void);
 /// reported. Otherwise returns 0.
 ///
 /// \returns Access type (0 = read, 1 = write).
-int __sanitizer_cdecl __asan_get_report_access_type(void);
+int SANITIZER_CDECL __asan_get_report_access_type(void);
 
 /// Gets access size of an ASan error (useful for calling from the debugger).
 ///
@@ -163,7 +163,7 @@ int __sanitizer_cdecl __asan_get_report_access_type(void);
 /// returns 0.
 ///
 /// \returns Access size in bytes.
-size_t __sanitizer_cdecl __asan_get_report_access_size(void);
+size_t SANITIZER_CDECL __asan_get_report_access_size(void);
 
 /// Gets the bug description of an ASan error (useful for calling from a
 /// debugger).
@@ -171,7 +171,7 @@ size_t __sanitizer_cdecl __asan_get_report_access_size(void);
 /// \returns Returns a bug description if an error has been (or is being)
 /// reported - for example, "heap-use-after-free". Otherwise returns an empty
 /// string.
-const char *__sanitizer_cdecl __asan_get_report_description(void);
+const char *SANITIZER_CDECL __asan_get_report_description(void);
 
 /// Gets information about a pointer (useful for calling from the debugger).
 ///
@@ -192,7 +192,7 @@ const char *__sanitizer_cdecl __asan_get_report_description(void);
 /// \param[out] region_size Size of the region in bytes.
 ///
 /// \returns Returns the category of the given pointer as a constant string.
-const char *__sanitizer_cdecl __asan_locate_address(void *addr, char *name,
+const char *SANITIZER_CDECL __asan_locate_address(void *addr, char *name,
                                                     size_t name_size,
                                                     void **region_address,
                                                     size_t *region_size);
@@ -209,7 +209,7 @@ const char *__sanitizer_cdecl __asan_locate_address(void *addr, char *name,
 /// \param[out] thread_id The thread ID of the address.
 ///
 /// \returns Returns the number of stored frames or 0 on error.
-size_t __sanitizer_cdecl __asan_get_alloc_stack(void *addr, void **trace,
+size_t SANITIZER_CDECL __asan_get_alloc_stack(void *addr, void **trace,
                                                 size_t size, int *thread_id);
 
 /// Gets the free stack trace and thread ID for a heap address (useful for
@@ -224,7 +224,7 @@ size_t __sanitizer_cdecl __asan_get_alloc_stack(void *addr, void **trace,
 /// \param[out] thread_id The thread ID of the address.
 ///
 /// \returns Returns the number of stored frames or 0 on error.
-size_t __sanitizer_cdecl __asan_get_free_stack(void *addr, void **trace,
+size_t SANITIZER_CDECL __asan_get_free_stack(void *addr, void **trace,
                                                size_t size, int *thread_id);
 
 /// Gets the current shadow memory mapping (useful for calling from the
@@ -232,7 +232,7 @@ size_t __sanitizer_cdecl __asan_get_free_stack(void *addr, void **trace,
 ///
 /// \param[out] shadow_scale Shadow scale value.
 /// \param[out] shadow_offset Offset value.
-void __sanitizer_cdecl __asan_get_shadow_mapping(size_t *shadow_scale,
+void SANITIZER_CDECL __asan_get_shadow_mapping(size_t *shadow_scale,
                                                  size_t *shadow_offset);
 
 /// This is an internal function that is called to report an error. However,
@@ -245,19 +245,19 @@ void __sanitizer_cdecl __asan_get_shadow_mapping(size_t *shadow_scale,
 /// \param addr Address of the ASan error.
 /// \param is_write True if the error is a write error; false otherwise.
 /// \param access_size Size of the memory access of the ASan error.
-void __sanitizer_cdecl __asan_report_error(void *pc, void *bp, void *sp,
+void SANITIZER_CDECL __asan_report_error(void *pc, void *bp, void *sp,
                                            void *addr, int is_write,
                                            size_t access_size);
 
 // Deprecated. Call __sanitizer_set_death_callback instead.
-void __sanitizer_cdecl __asan_set_death_callback(void (*callback)(void));
+void SANITIZER_CDECL __asan_set_death_callback(void (*callback)(void));
 
 /// Sets the callback function to be called during ASan error reporting.
 ///
 /// The callback provides a string pointer to the report.
 ///
 /// \param callback User-provided function.
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 __asan_set_error_report_callback(void (*callback)(const char *));
 
 /// User-provided callback on ASan errors.
@@ -265,11 +265,11 @@ __asan_set_error_report_callback(void (*callback)(const char *));
 /// You can provide a function that would be called immediately when ASan
 /// detects an error. This is useful in cases when ASan detects an error but
 /// your program crashes before the ASan report is printed.
-void __sanitizer_cdecl __asan_on_error(void);
+void SANITIZER_CDECL __asan_on_error(void);
 
 /// Prints accumulated statistics to <c>stderr</c> (useful for calling from the
 /// debugger).
-void __sanitizer_cdecl __asan_print_accumulated_stats(void);
+void SANITIZER_CDECL __asan_print_accumulated_stats(void);
 
 /// User-provided default option settings.
 ///
@@ -278,7 +278,7 @@ void __sanitizer_cdecl __asan_print_accumulated_stats(void);
 /// <c>verbosity=1:halt_on_error=0</c>).
 ///
 /// \returns Default options string.
-const char *__sanitizer_cdecl __asan_default_options(void);
+const char *SANITIZER_CDECL __asan_default_options(void);
 
 // The following two functions facilitate garbage collection in presence of
 // ASan's fake stack.
@@ -290,7 +290,7 @@ const char *__sanitizer_cdecl __asan_default_options(void);
 /// does not have a fake stack.
 ///
 /// \returns An opaque handler to the fake stack or NULL.
-void *__sanitizer_cdecl __asan_get_current_fake_stack(void);
+void *SANITIZER_CDECL __asan_get_current_fake_stack(void);
 
 /// Checks if an address belongs to a given fake stack.
 ///
@@ -310,7 +310,7 @@ void *__sanitizer_cdecl __asan_get_current_fake_stack(void);
 /// \param[out] beg Beginning of fake frame.
 /// \param[out] end End of fake frame.
 /// \returns Stack address or NULL.
-void *__sanitizer_cdecl __asan_addr_is_in_fake_stack(void *fake_stack,
+void *SANITIZER_CDECL __asan_addr_is_in_fake_stack(void *fake_stack,
                                                      void *addr, void **beg,
                                                      void **end);
 
@@ -319,11 +319,11 @@ void *__sanitizer_cdecl __asan_addr_is_in_fake_stack(void *fake_stack,
 ///
 /// To avoid false positives on the stack, must be called before no-return
 /// functions like <c>_exit()</c> and <c>execl()</c>.
-void __sanitizer_cdecl __asan_handle_no_return(void);
+void SANITIZER_CDECL __asan_handle_no_return(void);
 
 /// Update allocation stack trace for the given allocation to the current stack
 /// trace. Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __asan_update_allocation_context(void *addr);
+int SANITIZER_CDECL __asan_update_allocation_context(void *addr);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/asan_interface.h
+++ b/compiler-rt/include/sanitizer/asan_interface.h
@@ -32,7 +32,7 @@ extern "C" {
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
 void SANITIZER_CDECL __asan_poison_memory_region(void const volatile *addr,
-                                                   size_t size);
+                                                 size_t size);
 
 /// Marks a memory region (<c>[addr, addr+size)</c>) as addressable.
 ///
@@ -47,7 +47,7 @@ void SANITIZER_CDECL __asan_poison_memory_region(void const volatile *addr,
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
 void SANITIZER_CDECL __asan_unpoison_memory_region(void const volatile *addr,
-                                                     size_t size);
+                                                   size_t size);
 
 // Macros provided for convenience.
 #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
@@ -193,9 +193,9 @@ const char *SANITIZER_CDECL __asan_get_report_description(void);
 ///
 /// \returns Returns the category of the given pointer as a constant string.
 const char *SANITIZER_CDECL __asan_locate_address(void *addr, char *name,
-                                                    size_t name_size,
-                                                    void **region_address,
-                                                    size_t *region_size);
+                                                  size_t name_size,
+                                                  void **region_address,
+                                                  size_t *region_size);
 
 /// Gets the allocation stack trace and thread ID for a heap address (useful
 /// for calling from the debugger).
@@ -210,7 +210,7 @@ const char *SANITIZER_CDECL __asan_locate_address(void *addr, char *name,
 ///
 /// \returns Returns the number of stored frames or 0 on error.
 size_t SANITIZER_CDECL __asan_get_alloc_stack(void *addr, void **trace,
-                                                size_t size, int *thread_id);
+                                              size_t size, int *thread_id);
 
 /// Gets the free stack trace and thread ID for a heap address (useful for
 /// calling from the debugger).
@@ -225,7 +225,7 @@ size_t SANITIZER_CDECL __asan_get_alloc_stack(void *addr, void **trace,
 ///
 /// \returns Returns the number of stored frames or 0 on error.
 size_t SANITIZER_CDECL __asan_get_free_stack(void *addr, void **trace,
-                                               size_t size, int *thread_id);
+                                             size_t size, int *thread_id);
 
 /// Gets the current shadow memory mapping (useful for calling from the
 /// debugger).
@@ -233,7 +233,7 @@ size_t SANITIZER_CDECL __asan_get_free_stack(void *addr, void **trace,
 /// \param[out] shadow_scale Shadow scale value.
 /// \param[out] shadow_offset Offset value.
 void SANITIZER_CDECL __asan_get_shadow_mapping(size_t *shadow_scale,
-                                                 size_t *shadow_offset);
+                                               size_t *shadow_offset);
 
 /// This is an internal function that is called to report an error. However,
 /// it is still a part of the interface because you might want to set a
@@ -246,8 +246,8 @@ void SANITIZER_CDECL __asan_get_shadow_mapping(size_t *shadow_scale,
 /// \param is_write True if the error is a write error; false otherwise.
 /// \param access_size Size of the memory access of the ASan error.
 void SANITIZER_CDECL __asan_report_error(void *pc, void *bp, void *sp,
-                                           void *addr, int is_write,
-                                           size_t access_size);
+                                         void *addr, int is_write,
+                                         size_t access_size);
 
 // Deprecated. Call __sanitizer_set_death_callback instead.
 void SANITIZER_CDECL __asan_set_death_callback(void (*callback)(void));
@@ -310,9 +310,8 @@ void *SANITIZER_CDECL __asan_get_current_fake_stack(void);
 /// \param[out] beg Beginning of fake frame.
 /// \param[out] end End of fake frame.
 /// \returns Stack address or NULL.
-void *SANITIZER_CDECL __asan_addr_is_in_fake_stack(void *fake_stack,
-                                                     void *addr, void **beg,
-                                                     void **end);
+void *SANITIZER_CDECL __asan_addr_is_in_fake_stack(void *fake_stack, void *addr,
+                                                   void **beg, void **end);
 
 /// Performs shadow memory cleanup of the current thread's stack before a
 /// function marked with the <c>[[noreturn]]</c> attribute is called.

--- a/compiler-rt/include/sanitizer/asan_interface.h
+++ b/compiler-rt/include/sanitizer/asan_interface.h
@@ -31,7 +31,8 @@ extern "C" {
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-void __asan_poison_memory_region(void const volatile *addr, size_t size);
+void __sanitizer_cdecl __asan_poison_memory_region(void const volatile *addr,
+                                                   size_t size);
 
 /// Marks a memory region (<c>[addr, addr+size)</c>) as addressable.
 ///
@@ -45,7 +46,8 @@ void __asan_poison_memory_region(void const volatile *addr, size_t size);
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
+void __sanitizer_cdecl __asan_unpoison_memory_region(void const volatile *addr,
+                                                     size_t size);
 
 // Macros provided for convenience.
 #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
@@ -56,7 +58,7 @@ void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-#define ASAN_POISON_MEMORY_REGION(addr, size) \
+#define ASAN_POISON_MEMORY_REGION(addr, size)                                  \
   __asan_poison_memory_region((addr), (size))
 
 /// Marks a memory region as addressable.
@@ -66,13 +68,11 @@ void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size)                                \
   __asan_unpoison_memory_region((addr), (size))
 #else
-#define ASAN_POISON_MEMORY_REGION(addr, size) \
-  ((void)(addr), (void)(size))
-#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
-  ((void)(addr), (void)(size))
+#define ASAN_POISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
 #endif
 
 /// Checks if an address is poisoned.
@@ -85,7 +85,7 @@ void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
 ///
 /// \retval 1 Address is poisoned.
 /// \retval 0 Address is not poisoned.
-int __asan_address_is_poisoned(void const volatile *addr);
+int __sanitizer_cdecl __asan_address_is_poisoned(void const volatile *addr);
 
 /// Checks if a region is poisoned.
 ///
@@ -95,14 +95,14 @@ int __asan_address_is_poisoned(void const volatile *addr);
 /// \param beg Start of memory region.
 /// \param size Start of memory region.
 /// \returns Address of first poisoned byte.
-void *__asan_region_is_poisoned(void *beg, size_t size);
+void *__sanitizer_cdecl __asan_region_is_poisoned(void *beg, size_t size);
 
 /// Describes an address (useful for calling from the debugger).
 ///
 /// Prints the description of <c><i>addr</i></c>.
 ///
 /// \param addr Address to describe.
-void __asan_describe_address(void *addr);
+void __sanitizer_cdecl __asan_describe_address(void *addr);
 
 /// Checks if an error has been or is being reported (useful for calling from
 /// the debugger to get information about an ASan error).
@@ -111,7 +111,7 @@ void __asan_describe_address(void *addr);
 ///
 /// \returns 1 if an error has been (or is being) reported. Otherwise returns
 /// 0.
-int __asan_report_present(void);
+int __sanitizer_cdecl __asan_report_present(void);
 
 /// Gets the PC (program counter) register value of an ASan error (useful for
 /// calling from the debugger).
@@ -120,7 +120,7 @@ int __asan_report_present(void);
 /// Otherwise returns 0.
 ///
 /// \returns PC value.
-void *__asan_get_report_pc(void);
+void *__sanitizer_cdecl __asan_get_report_pc(void);
 
 /// Gets the BP (base pointer) register value of an ASan error (useful for
 /// calling from the debugger).
@@ -129,7 +129,7 @@ void *__asan_get_report_pc(void);
 /// Otherwise returns 0.
 ///
 /// \returns BP value.
-void *__asan_get_report_bp(void);
+void *__sanitizer_cdecl __asan_get_report_bp(void);
 
 /// Gets the SP (stack pointer) register value of an ASan error (useful for
 /// calling from the debugger).
@@ -138,7 +138,7 @@ void *__asan_get_report_bp(void);
 /// Otherwise returns 0.
 ///
 /// \returns SP value.
-void *__asan_get_report_sp(void);
+void *__sanitizer_cdecl __asan_get_report_sp(void);
 
 /// Gets the address of the report buffer of an ASan error (useful for calling
 /// from the debugger).
@@ -147,7 +147,7 @@ void *__asan_get_report_sp(void);
 /// reported. Otherwise returns 0.
 ///
 /// \returns Address of report buffer.
-void *__asan_get_report_address(void);
+void *__sanitizer_cdecl __asan_get_report_address(void);
 
 /// Gets access type of an ASan error (useful for calling from the debugger).
 ///
@@ -155,7 +155,7 @@ void *__asan_get_report_address(void);
 /// reported. Otherwise returns 0.
 ///
 /// \returns Access type (0 = read, 1 = write).
-int __asan_get_report_access_type(void);
+int __sanitizer_cdecl __asan_get_report_access_type(void);
 
 /// Gets access size of an ASan error (useful for calling from the debugger).
 ///
@@ -163,7 +163,7 @@ int __asan_get_report_access_type(void);
 /// returns 0.
 ///
 /// \returns Access size in bytes.
-size_t __asan_get_report_access_size(void);
+size_t __sanitizer_cdecl __asan_get_report_access_size(void);
 
 /// Gets the bug description of an ASan error (useful for calling from a
 /// debugger).
@@ -171,7 +171,7 @@ size_t __asan_get_report_access_size(void);
 /// \returns Returns a bug description if an error has been (or is being)
 /// reported - for example, "heap-use-after-free". Otherwise returns an empty
 /// string.
-const char *__asan_get_report_description(void);
+const char *__sanitizer_cdecl __asan_get_report_description(void);
 
 /// Gets information about a pointer (useful for calling from the debugger).
 ///
@@ -192,8 +192,10 @@ const char *__asan_get_report_description(void);
 /// \param[out] region_size Size of the region in bytes.
 ///
 /// \returns Returns the category of the given pointer as a constant string.
-const char *__asan_locate_address(void *addr, char *name, size_t name_size,
-                                  void **region_address, size_t *region_size);
+const char *__sanitizer_cdecl __asan_locate_address(void *addr, char *name,
+                                                    size_t name_size,
+                                                    void **region_address,
+                                                    size_t *region_size);
 
 /// Gets the allocation stack trace and thread ID for a heap address (useful
 /// for calling from the debugger).
@@ -207,8 +209,8 @@ const char *__asan_locate_address(void *addr, char *name, size_t name_size,
 /// \param[out] thread_id The thread ID of the address.
 ///
 /// \returns Returns the number of stored frames or 0 on error.
-size_t __asan_get_alloc_stack(void *addr, void **trace, size_t size,
-                              int *thread_id);
+size_t __sanitizer_cdecl __asan_get_alloc_stack(void *addr, void **trace,
+                                                size_t size, int *thread_id);
 
 /// Gets the free stack trace and thread ID for a heap address (useful for
 /// calling from the debugger).
@@ -222,15 +224,16 @@ size_t __asan_get_alloc_stack(void *addr, void **trace, size_t size,
 /// \param[out] thread_id The thread ID of the address.
 ///
 /// \returns Returns the number of stored frames or 0 on error.
-size_t __asan_get_free_stack(void *addr, void **trace, size_t size,
-                             int *thread_id);
+size_t __sanitizer_cdecl __asan_get_free_stack(void *addr, void **trace,
+                                               size_t size, int *thread_id);
 
 /// Gets the current shadow memory mapping (useful for calling from the
 /// debugger).
 ///
 /// \param[out] shadow_scale Shadow scale value.
 /// \param[out] shadow_offset Offset value.
-void __asan_get_shadow_mapping(size_t *shadow_scale, size_t *shadow_offset);
+void __sanitizer_cdecl __asan_get_shadow_mapping(size_t *shadow_scale,
+                                                 size_t *shadow_offset);
 
 /// This is an internal function that is called to report an error. However,
 /// it is still a part of the interface because you might want to set a
@@ -242,29 +245,31 @@ void __asan_get_shadow_mapping(size_t *shadow_scale, size_t *shadow_offset);
 /// \param addr Address of the ASan error.
 /// \param is_write True if the error is a write error; false otherwise.
 /// \param access_size Size of the memory access of the ASan error.
-void __asan_report_error(void *pc, void *bp, void *sp,
-                         void *addr, int is_write, size_t access_size);
+void __sanitizer_cdecl __asan_report_error(void *pc, void *bp, void *sp,
+                                           void *addr, int is_write,
+                                           size_t access_size);
 
 // Deprecated. Call __sanitizer_set_death_callback instead.
-void __asan_set_death_callback(void (*callback)(void));
+void __sanitizer_cdecl __asan_set_death_callback(void (*callback)(void));
 
 /// Sets the callback function to be called during ASan error reporting.
 ///
 /// The callback provides a string pointer to the report.
 ///
 /// \param callback User-provided function.
-void __asan_set_error_report_callback(void (*callback)(const char *));
+void __sanitizer_cdecl
+__asan_set_error_report_callback(void (*callback)(const char *));
 
 /// User-provided callback on ASan errors.
 ///
 /// You can provide a function that would be called immediately when ASan
 /// detects an error. This is useful in cases when ASan detects an error but
 /// your program crashes before the ASan report is printed.
-void __asan_on_error(void);
+void __sanitizer_cdecl __asan_on_error(void);
 
 /// Prints accumulated statistics to <c>stderr</c> (useful for calling from the
 /// debugger).
-void __asan_print_accumulated_stats(void);
+void __sanitizer_cdecl __asan_print_accumulated_stats(void);
 
 /// User-provided default option settings.
 ///
@@ -273,7 +278,7 @@ void __asan_print_accumulated_stats(void);
 /// <c>verbosity=1:halt_on_error=0</c>).
 ///
 /// \returns Default options string.
-const char* __asan_default_options(void);
+const char *__sanitizer_cdecl __asan_default_options(void);
 
 // The following two functions facilitate garbage collection in presence of
 // ASan's fake stack.
@@ -285,7 +290,7 @@ const char* __asan_default_options(void);
 /// does not have a fake stack.
 ///
 /// \returns An opaque handler to the fake stack or NULL.
-void *__asan_get_current_fake_stack(void);
+void *__sanitizer_cdecl __asan_get_current_fake_stack(void);
 
 /// Checks if an address belongs to a given fake stack.
 ///
@@ -305,22 +310,23 @@ void *__asan_get_current_fake_stack(void);
 /// \param[out] beg Beginning of fake frame.
 /// \param[out] end End of fake frame.
 /// \returns Stack address or NULL.
-void *__asan_addr_is_in_fake_stack(void *fake_stack, void *addr, void **beg,
-                                   void **end);
+void *__sanitizer_cdecl __asan_addr_is_in_fake_stack(void *fake_stack,
+                                                     void *addr, void **beg,
+                                                     void **end);
 
 /// Performs shadow memory cleanup of the current thread's stack before a
 /// function marked with the <c>[[noreturn]]</c> attribute is called.
 ///
 /// To avoid false positives on the stack, must be called before no-return
 /// functions like <c>_exit()</c> and <c>execl()</c>.
-void __asan_handle_no_return(void);
+void __sanitizer_cdecl __asan_handle_no_return(void);
 
 /// Update allocation stack trace for the given allocation to the current stack
 /// trace. Returns 1 if successful, 0 if not.
-int __asan_update_allocation_context(void* addr);
+int __sanitizer_cdecl __asan_update_allocation_context(void *addr);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // SANITIZER_ASAN_INTERFACE_H
+#endif // SANITIZER_ASAN_INTERFACE_H

--- a/compiler-rt/include/sanitizer/common_interface_defs.h
+++ b/compiler-rt/include/sanitizer/common_interface_defs.h
@@ -20,6 +20,14 @@
 #define __has_feature(x) 0
 #endif
 
+// Windows allows a user to set their default calling convention, but we always
+// use __cdecl
+#ifdef _WIN32
+#define __sanitizer_cdecl __cdecl
+#else
+#define __sanitizer_cdecl
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -39,71 +47,73 @@ typedef struct {
 } __sanitizer_sandbox_arguments;
 
 // Tell the tools to write their reports to "path.<pid>" instead of stderr.
-void __sanitizer_set_report_path(const char *path);
+void __sanitizer_cdecl __sanitizer_set_report_path(const char *path);
 // Tell the tools to write their reports to the provided file descriptor
 // (casted to void *).
-void __sanitizer_set_report_fd(void *fd);
+void __sanitizer_cdecl __sanitizer_set_report_fd(void *fd);
 // Get the current full report file path, if a path was specified by
 // an earlier call to __sanitizer_set_report_path. Returns null otherwise.
-const char *__sanitizer_get_report_path();
+const char *__sanitizer_cdecl __sanitizer_get_report_path();
 
 // Notify the tools that the sandbox is going to be turned on. The reserved
 // parameter will be used in the future to hold a structure with functions
 // that the tools may call to bypass the sandbox.
-void __sanitizer_sandbox_on_notify(__sanitizer_sandbox_arguments *args);
+void __sanitizer_cdecl
+__sanitizer_sandbox_on_notify(__sanitizer_sandbox_arguments *args);
 
 // This function is called by the tool when it has just finished reporting
 // an error. 'error_summary' is a one-line string that summarizes
 // the error message. This function can be overridden by the client.
-void __sanitizer_report_error_summary(const char *error_summary);
+void __sanitizer_cdecl
+__sanitizer_report_error_summary(const char *error_summary);
 
 // Some of the sanitizers (for example ASan/TSan) could miss bugs that happen
 // in unaligned loads/stores. To find such bugs reliably, you need to replace
 // plain unaligned loads/stores with these calls.
 
 /// Loads a 16-bit unaligned value.
-///
+//
 /// \param p Pointer to unaligned memory.
 ///
 /// \returns Loaded value.
-uint16_t __sanitizer_unaligned_load16(const void *p);
+uint16_t __sanitizer_cdecl __sanitizer_unaligned_load16(const void *p);
 
 /// Loads a 32-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 ///
 /// \returns Loaded value.
-uint32_t __sanitizer_unaligned_load32(const void *p);
+uint32_t __sanitizer_cdecl __sanitizer_unaligned_load32(const void *p);
 
 /// Loads a 64-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 ///
 /// \returns Loaded value.
-uint64_t __sanitizer_unaligned_load64(const void *p);
+uint64_t __sanitizer_cdecl __sanitizer_unaligned_load64(const void *p);
 
 /// Stores a 16-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 /// \param x 16-bit value to store.
-void __sanitizer_unaligned_store16(void *p, uint16_t x);
+void __sanitizer_cdecl __sanitizer_unaligned_store16(void *p, uint16_t x);
 
 /// Stores a 32-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 /// \param x 32-bit value to store.
-void __sanitizer_unaligned_store32(void *p, uint32_t x);
+void __sanitizer_cdecl __sanitizer_unaligned_store32(void *p, uint32_t x);
 
 /// Stores a 64-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 /// \param x 64-bit value to store.
-void __sanitizer_unaligned_store64(void *p, uint64_t x);
+void __sanitizer_cdecl __sanitizer_unaligned_store64(void *p, uint64_t x);
 
 // Returns 1 on the first call, then returns 0 thereafter.  Called by the tool
 // to ensure only one report is printed when multiple errors occur
 // simultaneously.
-int __sanitizer_acquire_crash_state();
+int __sanitizer_cdecl __sanitizer_acquire_crash_state();
 
 /// Annotates the current state of a contiguous container, such as
 /// <c>std::vector</c>, <c>std::string</c>, or similar.
@@ -151,10 +161,8 @@ int __sanitizer_acquire_crash_state();
 /// \param end End of memory region.
 /// \param old_mid Old middle of memory region.
 /// \param new_mid New middle of memory region.
-void __sanitizer_annotate_contiguous_container(const void *beg,
-                                               const void *end,
-                                               const void *old_mid,
-                                               const void *new_mid);
+void __sanitizer_cdecl __sanitizer_annotate_contiguous_container(
+    const void *beg, const void *end, const void *old_mid, const void *new_mid);
 
 /// Similar to <c>__sanitizer_annotate_contiguous_container</c>.
 ///
@@ -185,7 +193,7 @@ void __sanitizer_annotate_contiguous_container(const void *beg,
 /// \param old_container_end End of used region.
 /// \param new_container_beg New beginning of used region.
 /// \param new_container_end New end of used region.
-void __sanitizer_annotate_double_ended_contiguous_container(
+void __sanitizer_cdecl __sanitizer_annotate_double_ended_contiguous_container(
     const void *storage_beg, const void *storage_end,
     const void *old_container_beg, const void *old_container_end,
     const void *new_container_beg, const void *new_container_end);
@@ -206,8 +214,9 @@ void __sanitizer_annotate_double_ended_contiguous_container(
 ///
 /// \returns True if the contiguous container <c>[beg, end)</c> is properly
 ///  poisoned.
-int __sanitizer_verify_contiguous_container(const void *beg, const void *mid,
-                                            const void *end);
+int __sanitizer_cdecl __sanitizer_verify_contiguous_container(const void *beg,
+                                                              const void *mid,
+                                                              const void *end);
 
 /// Returns true if the double ended contiguous
 /// container <c>[storage_beg, storage_end)</c> is properly poisoned.
@@ -230,7 +239,7 @@ int __sanitizer_verify_contiguous_container(const void *beg, const void *mid,
 /// \returns True if the double-ended contiguous container <c>[storage_beg,
 /// container_beg, container_end, end)</c> is properly poisoned - only
 /// [container_beg; container_end) is addressable.
-int __sanitizer_verify_double_ended_contiguous_container(
+int __sanitizer_cdecl __sanitizer_verify_double_ended_contiguous_container(
     const void *storage_beg, const void *container_beg,
     const void *container_end, const void *storage_end);
 
@@ -244,9 +253,8 @@ int __sanitizer_verify_double_ended_contiguous_container(
 /// \param end Old end of memory region.
 ///
 /// \returns The bad address or NULL.
-const void *__sanitizer_contiguous_container_find_bad_address(const void *beg,
-                                                              const void *mid,
-                                                              const void *end);
+const void *__sanitizer_cdecl __sanitizer_contiguous_container_find_bad_address(
+    const void *beg, const void *mid, const void *end);
 
 /// returns the address of the first improperly poisoned byte.
 ///
@@ -258,13 +266,14 @@ const void *__sanitizer_contiguous_container_find_bad_address(const void *beg,
 /// \param storage_end End of memory region.
 ///
 /// \returns The bad address or NULL.
-const void *__sanitizer_double_ended_contiguous_container_find_bad_address(
+const void *__sanitizer_cdecl
+__sanitizer_double_ended_contiguous_container_find_bad_address(
     const void *storage_beg, const void *container_beg,
     const void *container_end, const void *storage_end);
 
 /// Prints the stack trace leading to this call (useful for calling from the
 /// debugger).
-void __sanitizer_print_stack_trace(void);
+void __sanitizer_cdecl __sanitizer_print_stack_trace(void);
 
 // Symbolizes the supplied 'pc' using the format string 'fmt'.
 // Outputs at most 'out_buf_size' bytes into 'out_buf'.
@@ -276,17 +285,20 @@ void __sanitizer_print_stack_trace(void);
 // Inlined frames can be removed with 'symbolize_inline_frames=0'.
 // The format syntax is described in
 // lib/sanitizer_common/sanitizer_stacktrace_printer.h.
-void __sanitizer_symbolize_pc(void *pc, const char *fmt, char *out_buf,
-                              size_t out_buf_size);
+void __sanitizer_cdecl __sanitizer_symbolize_pc(void *pc, const char *fmt,
+                                                char *out_buf,
+                                                size_t out_buf_size);
 // Same as __sanitizer_symbolize_pc, but for data section (i.e. globals).
-void __sanitizer_symbolize_global(void *data_ptr, const char *fmt,
-                                  char *out_buf, size_t out_buf_size);
+void __sanitizer_cdecl __sanitizer_symbolize_global(void *data_ptr,
+                                                    const char *fmt,
+                                                    char *out_buf,
+                                                    size_t out_buf_size);
 // Determine the return address.
 #if !defined(_MSC_VER) || defined(__clang__)
 #define __sanitizer_return_address()                                           \
   __builtin_extract_return_addr(__builtin_return_address(0))
 #else
-extern "C" void *_ReturnAddress(void);
+extern "C" void *__sanitizer_cdecl _ReturnAddress(void);
 #pragma intrinsic(_ReturnAddress)
 #define __sanitizer_return_address() _ReturnAddress()
 #endif
@@ -296,8 +308,7 @@ extern "C" void *_ReturnAddress(void);
 /// Passing 0 will unset the callback.
 ///
 /// \param callback User-provided callback.
-void __sanitizer_set_death_callback(void (*callback)(void));
-
+void __sanitizer_cdecl __sanitizer_set_death_callback(void (*callback)(void));
 
 // Interceptor hooks.
 // Whenever a libc function interceptor is called, it checks if the
@@ -313,8 +324,10 @@ void __sanitizer_set_death_callback(void (*callback)(void));
 /// \param s2 Pointer to block of memory.
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_weak_hook_memcmp(void *called_pc, const void *s1,
-                                  const void *s2, size_t n, int result);
+void __sanitizer_cdecl __sanitizer_weak_hook_memcmp(void *called_pc,
+                                                    const void *s1,
+                                                    const void *s2, size_t n,
+                                                    int result);
 
 /// Interceptor hook for <c>strncmp()</c>.
 ///
@@ -323,8 +336,10 @@ void __sanitizer_weak_hook_memcmp(void *called_pc, const void *s1,
 /// \param s2 Pointer to block of memory.
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_weak_hook_strncmp(void *called_pc, const char *s1,
-                                  const char *s2, size_t n, int result);
+void __sanitizer_cdecl __sanitizer_weak_hook_strncmp(void *called_pc,
+                                                     const char *s1,
+                                                     const char *s2, size_t n,
+                                                     int result);
 
 /// Interceptor hook for <c>strncasecmp()</c>.
 ///
@@ -333,8 +348,10 @@ void __sanitizer_weak_hook_strncmp(void *called_pc, const char *s1,
 /// \param s2 Pointer to block of memory.
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_weak_hook_strncasecmp(void *called_pc, const char *s1,
-                                       const char *s2, size_t n, int result);
+void __sanitizer_cdecl __sanitizer_weak_hook_strncasecmp(void *called_pc,
+                                                         const char *s1,
+                                                         const char *s2,
+                                                         size_t n, int result);
 
 /// Interceptor hook for <c>strcmp()</c>.
 ///
@@ -342,8 +359,9 @@ void __sanitizer_weak_hook_strncasecmp(void *called_pc, const char *s1,
 /// \param s1 Pointer to block of memory.
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_weak_hook_strcmp(void *called_pc, const char *s1,
-                                  const char *s2, int result);
+void __sanitizer_cdecl __sanitizer_weak_hook_strcmp(void *called_pc,
+                                                    const char *s1,
+                                                    const char *s2, int result);
 
 /// Interceptor hook for <c>strcasecmp()</c>.
 ///
@@ -351,8 +369,10 @@ void __sanitizer_weak_hook_strcmp(void *called_pc, const char *s1,
 /// \param s1 Pointer to block of memory.
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_weak_hook_strcasecmp(void *called_pc, const char *s1,
-                                      const char *s2, int result);
+void __sanitizer_cdecl __sanitizer_weak_hook_strcasecmp(void *called_pc,
+                                                        const char *s1,
+                                                        const char *s2,
+                                                        int result);
 
 /// Interceptor hook for <c>strstr()</c>.
 ///
@@ -360,23 +380,28 @@ void __sanitizer_weak_hook_strcasecmp(void *called_pc, const char *s1,
 /// \param s1 Pointer to block of memory.
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_weak_hook_strstr(void *called_pc, const char *s1,
-                                  const char *s2, char *result);
+void __sanitizer_cdecl __sanitizer_weak_hook_strstr(void *called_pc,
+                                                    const char *s1,
+                                                    const char *s2,
+                                                    char *result);
 
-void __sanitizer_weak_hook_strcasestr(void *called_pc, const char *s1,
-                                      const char *s2, char *result);
+void __sanitizer_cdecl __sanitizer_weak_hook_strcasestr(void *called_pc,
+                                                        const char *s1,
+                                                        const char *s2,
+                                                        char *result);
 
-void __sanitizer_weak_hook_memmem(void *called_pc,
-                                  const void *s1, size_t len1,
-                                  const void *s2, size_t len2, void *result);
+void __sanitizer_cdecl __sanitizer_weak_hook_memmem(void *called_pc,
+                                                    const void *s1, size_t len1,
+                                                    const void *s2, size_t len2,
+                                                    void *result);
 
 // Prints stack traces for all live heap allocations ordered by total
 // allocation size until top_percent of total live heap is shown. top_percent
 // should be between 1 and 100. At most max_number_of_contexts contexts
 // (stack traces) are printed.
 // Experimental feature currently available only with ASan on Linux/x86_64.
-void __sanitizer_print_memory_profile(size_t top_percent,
-                                      size_t max_number_of_contexts);
+void __sanitizer_cdecl __sanitizer_print_memory_profile(
+    size_t top_percent, size_t max_number_of_contexts);
 
 /// Notify ASan that a fiber switch has started (required only if implementing
 /// your own fiber library).
@@ -405,8 +430,9 @@ void __sanitizer_print_memory_profile(size_t top_percent,
 /// \param[out] fake_stack_save Fake stack save location.
 /// \param bottom Bottom address of stack.
 /// \param size Size of stack in bytes.
-void __sanitizer_start_switch_fiber(void **fake_stack_save,
-                                    const void *bottom, size_t size);
+void __sanitizer_cdecl __sanitizer_start_switch_fiber(void **fake_stack_save,
+                                                      const void *bottom,
+                                                      size_t size);
 
 /// Notify ASan that a fiber switch has completed (required only if
 /// implementing your own fiber library).
@@ -419,18 +445,17 @@ void __sanitizer_start_switch_fiber(void **fake_stack_save,
 /// \param fake_stack_save Fake stack save location.
 /// \param[out] bottom_old Bottom address of old stack.
 /// \param[out] size_old Size of old stack in bytes.
-void __sanitizer_finish_switch_fiber(void *fake_stack_save,
-                                     const void **bottom_old,
-                                     size_t *size_old);
+void __sanitizer_cdecl __sanitizer_finish_switch_fiber(void *fake_stack_save,
+                                                       const void **bottom_old,
+                                                       size_t *size_old);
 
 // Get full module name and calculate pc offset within it.
 // Returns 1 if pc belongs to some module, 0 if module was not found.
-int __sanitizer_get_module_and_offset_for_pc(void *pc, char *module_path,
-                                             size_t module_path_len,
-                                             void **pc_offset);
+int __sanitizer_cdecl __sanitizer_get_module_and_offset_for_pc(
+    void *pc, char *module_path, size_t module_path_len, void **pc_offset);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // SANITIZER_COMMON_INTERFACE_DEFS_H
+#endif // SANITIZER_COMMON_INTERFACE_DEFS_H

--- a/compiler-rt/include/sanitizer/common_interface_defs.h
+++ b/compiler-rt/include/sanitizer/common_interface_defs.h
@@ -23,9 +23,9 @@
 // Windows allows a user to set their default calling convention, but we always
 // use __cdecl
 #ifdef _WIN32
-#define __sanitizer_cdecl __cdecl
+#define SANITIZER_CDECL __cdecl
 #else
-#define __sanitizer_cdecl
+#define SANITIZER_CDECL
 #endif
 
 #ifdef __cplusplus
@@ -47,24 +47,24 @@ typedef struct {
 } __sanitizer_sandbox_arguments;
 
 // Tell the tools to write their reports to "path.<pid>" instead of stderr.
-void __sanitizer_cdecl __sanitizer_set_report_path(const char *path);
+void SANITIZER_CDECL __sanitizer_set_report_path(const char *path);
 // Tell the tools to write their reports to the provided file descriptor
 // (casted to void *).
-void __sanitizer_cdecl __sanitizer_set_report_fd(void *fd);
+void SANITIZER_CDECL __sanitizer_set_report_fd(void *fd);
 // Get the current full report file path, if a path was specified by
 // an earlier call to __sanitizer_set_report_path. Returns null otherwise.
-const char *__sanitizer_cdecl __sanitizer_get_report_path();
+const char *SANITIZER_CDECL __sanitizer_get_report_path();
 
 // Notify the tools that the sandbox is going to be turned on. The reserved
 // parameter will be used in the future to hold a structure with functions
 // that the tools may call to bypass the sandbox.
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 __sanitizer_sandbox_on_notify(__sanitizer_sandbox_arguments *args);
 
 // This function is called by the tool when it has just finished reporting
 // an error. 'error_summary' is a one-line string that summarizes
 // the error message. This function can be overridden by the client.
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 __sanitizer_report_error_summary(const char *error_summary);
 
 // Some of the sanitizers (for example ASan/TSan) could miss bugs that happen
@@ -76,44 +76,44 @@ __sanitizer_report_error_summary(const char *error_summary);
 /// \param p Pointer to unaligned memory.
 ///
 /// \returns Loaded value.
-uint16_t __sanitizer_cdecl __sanitizer_unaligned_load16(const void *p);
+uint16_t SANITIZER_CDECL __sanitizer_unaligned_load16(const void *p);
 
 /// Loads a 32-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 ///
 /// \returns Loaded value.
-uint32_t __sanitizer_cdecl __sanitizer_unaligned_load32(const void *p);
+uint32_t SANITIZER_CDECL __sanitizer_unaligned_load32(const void *p);
 
 /// Loads a 64-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 ///
 /// \returns Loaded value.
-uint64_t __sanitizer_cdecl __sanitizer_unaligned_load64(const void *p);
+uint64_t SANITIZER_CDECL __sanitizer_unaligned_load64(const void *p);
 
 /// Stores a 16-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 /// \param x 16-bit value to store.
-void __sanitizer_cdecl __sanitizer_unaligned_store16(void *p, uint16_t x);
+void SANITIZER_CDECL __sanitizer_unaligned_store16(void *p, uint16_t x);
 
 /// Stores a 32-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 /// \param x 32-bit value to store.
-void __sanitizer_cdecl __sanitizer_unaligned_store32(void *p, uint32_t x);
+void SANITIZER_CDECL __sanitizer_unaligned_store32(void *p, uint32_t x);
 
 /// Stores a 64-bit unaligned value.
 ///
 /// \param p Pointer to unaligned memory.
 /// \param x 64-bit value to store.
-void __sanitizer_cdecl __sanitizer_unaligned_store64(void *p, uint64_t x);
+void SANITIZER_CDECL __sanitizer_unaligned_store64(void *p, uint64_t x);
 
 // Returns 1 on the first call, then returns 0 thereafter.  Called by the tool
 // to ensure only one report is printed when multiple errors occur
 // simultaneously.
-int __sanitizer_cdecl __sanitizer_acquire_crash_state();
+int SANITIZER_CDECL __sanitizer_acquire_crash_state();
 
 /// Annotates the current state of a contiguous container, such as
 /// <c>std::vector</c>, <c>std::string</c>, or similar.
@@ -161,7 +161,7 @@ int __sanitizer_cdecl __sanitizer_acquire_crash_state();
 /// \param end End of memory region.
 /// \param old_mid Old middle of memory region.
 /// \param new_mid New middle of memory region.
-void __sanitizer_cdecl __sanitizer_annotate_contiguous_container(
+void SANITIZER_CDECL __sanitizer_annotate_contiguous_container(
     const void *beg, const void *end, const void *old_mid, const void *new_mid);
 
 /// Similar to <c>__sanitizer_annotate_contiguous_container</c>.
@@ -193,7 +193,7 @@ void __sanitizer_cdecl __sanitizer_annotate_contiguous_container(
 /// \param old_container_end End of used region.
 /// \param new_container_beg New beginning of used region.
 /// \param new_container_end New end of used region.
-void __sanitizer_cdecl __sanitizer_annotate_double_ended_contiguous_container(
+void SANITIZER_CDECL __sanitizer_annotate_double_ended_contiguous_container(
     const void *storage_beg, const void *storage_end,
     const void *old_container_beg, const void *old_container_end,
     const void *new_container_beg, const void *new_container_end);
@@ -214,7 +214,7 @@ void __sanitizer_cdecl __sanitizer_annotate_double_ended_contiguous_container(
 ///
 /// \returns True if the contiguous container <c>[beg, end)</c> is properly
 ///  poisoned.
-int __sanitizer_cdecl __sanitizer_verify_contiguous_container(const void *beg,
+int SANITIZER_CDECL __sanitizer_verify_contiguous_container(const void *beg,
                                                               const void *mid,
                                                               const void *end);
 
@@ -239,7 +239,7 @@ int __sanitizer_cdecl __sanitizer_verify_contiguous_container(const void *beg,
 /// \returns True if the double-ended contiguous container <c>[storage_beg,
 /// container_beg, container_end, end)</c> is properly poisoned - only
 /// [container_beg; container_end) is addressable.
-int __sanitizer_cdecl __sanitizer_verify_double_ended_contiguous_container(
+int SANITIZER_CDECL __sanitizer_verify_double_ended_contiguous_container(
     const void *storage_beg, const void *container_beg,
     const void *container_end, const void *storage_end);
 
@@ -253,7 +253,7 @@ int __sanitizer_cdecl __sanitizer_verify_double_ended_contiguous_container(
 /// \param end Old end of memory region.
 ///
 /// \returns The bad address or NULL.
-const void *__sanitizer_cdecl __sanitizer_contiguous_container_find_bad_address(
+const void *SANITIZER_CDECL __sanitizer_contiguous_container_find_bad_address(
     const void *beg, const void *mid, const void *end);
 
 /// returns the address of the first improperly poisoned byte.
@@ -266,14 +266,14 @@ const void *__sanitizer_cdecl __sanitizer_contiguous_container_find_bad_address(
 /// \param storage_end End of memory region.
 ///
 /// \returns The bad address or NULL.
-const void *__sanitizer_cdecl
+const void *SANITIZER_CDECL
 __sanitizer_double_ended_contiguous_container_find_bad_address(
     const void *storage_beg, const void *container_beg,
     const void *container_end, const void *storage_end);
 
 /// Prints the stack trace leading to this call (useful for calling from the
 /// debugger).
-void __sanitizer_cdecl __sanitizer_print_stack_trace(void);
+void SANITIZER_CDECL __sanitizer_print_stack_trace(void);
 
 // Symbolizes the supplied 'pc' using the format string 'fmt'.
 // Outputs at most 'out_buf_size' bytes into 'out_buf'.
@@ -285,11 +285,11 @@ void __sanitizer_cdecl __sanitizer_print_stack_trace(void);
 // Inlined frames can be removed with 'symbolize_inline_frames=0'.
 // The format syntax is described in
 // lib/sanitizer_common/sanitizer_stacktrace_printer.h.
-void __sanitizer_cdecl __sanitizer_symbolize_pc(void *pc, const char *fmt,
+void SANITIZER_CDECL __sanitizer_symbolize_pc(void *pc, const char *fmt,
                                                 char *out_buf,
                                                 size_t out_buf_size);
 // Same as __sanitizer_symbolize_pc, but for data section (i.e. globals).
-void __sanitizer_cdecl __sanitizer_symbolize_global(void *data_ptr,
+void SANITIZER_CDECL __sanitizer_symbolize_global(void *data_ptr,
                                                     const char *fmt,
                                                     char *out_buf,
                                                     size_t out_buf_size);
@@ -298,7 +298,7 @@ void __sanitizer_cdecl __sanitizer_symbolize_global(void *data_ptr,
 #define __sanitizer_return_address()                                           \
   __builtin_extract_return_addr(__builtin_return_address(0))
 #else
-extern "C" void *__sanitizer_cdecl _ReturnAddress(void);
+extern "C" void *SANITIZER_CDECL _ReturnAddress(void);
 #pragma intrinsic(_ReturnAddress)
 #define __sanitizer_return_address() _ReturnAddress()
 #endif
@@ -308,7 +308,7 @@ extern "C" void *__sanitizer_cdecl _ReturnAddress(void);
 /// Passing 0 will unset the callback.
 ///
 /// \param callback User-provided callback.
-void __sanitizer_cdecl __sanitizer_set_death_callback(void (*callback)(void));
+void SANITIZER_CDECL __sanitizer_set_death_callback(void (*callback)(void));
 
 // Interceptor hooks.
 // Whenever a libc function interceptor is called, it checks if the
@@ -324,7 +324,7 @@ void __sanitizer_cdecl __sanitizer_set_death_callback(void (*callback)(void));
 /// \param s2 Pointer to block of memory.
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_cdecl __sanitizer_weak_hook_memcmp(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_memcmp(void *called_pc,
                                                     const void *s1,
                                                     const void *s2, size_t n,
                                                     int result);
@@ -336,7 +336,7 @@ void __sanitizer_cdecl __sanitizer_weak_hook_memcmp(void *called_pc,
 /// \param s2 Pointer to block of memory.
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_cdecl __sanitizer_weak_hook_strncmp(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_strncmp(void *called_pc,
                                                      const char *s1,
                                                      const char *s2, size_t n,
                                                      int result);
@@ -348,7 +348,7 @@ void __sanitizer_cdecl __sanitizer_weak_hook_strncmp(void *called_pc,
 /// \param s2 Pointer to block of memory.
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_cdecl __sanitizer_weak_hook_strncasecmp(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_strncasecmp(void *called_pc,
                                                          const char *s1,
                                                          const char *s2,
                                                          size_t n, int result);
@@ -359,7 +359,7 @@ void __sanitizer_cdecl __sanitizer_weak_hook_strncasecmp(void *called_pc,
 /// \param s1 Pointer to block of memory.
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_cdecl __sanitizer_weak_hook_strcmp(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_strcmp(void *called_pc,
                                                     const char *s1,
                                                     const char *s2, int result);
 
@@ -369,7 +369,7 @@ void __sanitizer_cdecl __sanitizer_weak_hook_strcmp(void *called_pc,
 /// \param s1 Pointer to block of memory.
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_cdecl __sanitizer_weak_hook_strcasecmp(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_strcasecmp(void *called_pc,
                                                         const char *s1,
                                                         const char *s2,
                                                         int result);
@@ -380,17 +380,17 @@ void __sanitizer_cdecl __sanitizer_weak_hook_strcasecmp(void *called_pc,
 /// \param s1 Pointer to block of memory.
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
-void __sanitizer_cdecl __sanitizer_weak_hook_strstr(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_strstr(void *called_pc,
                                                     const char *s1,
                                                     const char *s2,
                                                     char *result);
 
-void __sanitizer_cdecl __sanitizer_weak_hook_strcasestr(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_strcasestr(void *called_pc,
                                                         const char *s1,
                                                         const char *s2,
                                                         char *result);
 
-void __sanitizer_cdecl __sanitizer_weak_hook_memmem(void *called_pc,
+void SANITIZER_CDECL __sanitizer_weak_hook_memmem(void *called_pc,
                                                     const void *s1, size_t len1,
                                                     const void *s2, size_t len2,
                                                     void *result);
@@ -400,7 +400,7 @@ void __sanitizer_cdecl __sanitizer_weak_hook_memmem(void *called_pc,
 // should be between 1 and 100. At most max_number_of_contexts contexts
 // (stack traces) are printed.
 // Experimental feature currently available only with ASan on Linux/x86_64.
-void __sanitizer_cdecl __sanitizer_print_memory_profile(
+void SANITIZER_CDECL __sanitizer_print_memory_profile(
     size_t top_percent, size_t max_number_of_contexts);
 
 /// Notify ASan that a fiber switch has started (required only if implementing
@@ -430,7 +430,7 @@ void __sanitizer_cdecl __sanitizer_print_memory_profile(
 /// \param[out] fake_stack_save Fake stack save location.
 /// \param bottom Bottom address of stack.
 /// \param size Size of stack in bytes.
-void __sanitizer_cdecl __sanitizer_start_switch_fiber(void **fake_stack_save,
+void SANITIZER_CDECL __sanitizer_start_switch_fiber(void **fake_stack_save,
                                                       const void *bottom,
                                                       size_t size);
 
@@ -445,13 +445,13 @@ void __sanitizer_cdecl __sanitizer_start_switch_fiber(void **fake_stack_save,
 /// \param fake_stack_save Fake stack save location.
 /// \param[out] bottom_old Bottom address of old stack.
 /// \param[out] size_old Size of old stack in bytes.
-void __sanitizer_cdecl __sanitizer_finish_switch_fiber(void *fake_stack_save,
+void SANITIZER_CDECL __sanitizer_finish_switch_fiber(void *fake_stack_save,
                                                        const void **bottom_old,
                                                        size_t *size_old);
 
 // Get full module name and calculate pc offset within it.
 // Returns 1 if pc belongs to some module, 0 if module was not found.
-int __sanitizer_cdecl __sanitizer_get_module_and_offset_for_pc(
+int SANITIZER_CDECL __sanitizer_get_module_and_offset_for_pc(
     void *pc, char *module_path, size_t module_path_len, void **pc_offset);
 
 #ifdef __cplusplus

--- a/compiler-rt/include/sanitizer/common_interface_defs.h
+++ b/compiler-rt/include/sanitizer/common_interface_defs.h
@@ -215,8 +215,8 @@ void SANITIZER_CDECL __sanitizer_annotate_double_ended_contiguous_container(
 /// \returns True if the contiguous container <c>[beg, end)</c> is properly
 ///  poisoned.
 int SANITIZER_CDECL __sanitizer_verify_contiguous_container(const void *beg,
-                                                              const void *mid,
-                                                              const void *end);
+                                                            const void *mid,
+                                                            const void *end);
 
 /// Returns true if the double ended contiguous
 /// container <c>[storage_beg, storage_end)</c> is properly poisoned.
@@ -286,13 +286,13 @@ void SANITIZER_CDECL __sanitizer_print_stack_trace(void);
 // The format syntax is described in
 // lib/sanitizer_common/sanitizer_stacktrace_printer.h.
 void SANITIZER_CDECL __sanitizer_symbolize_pc(void *pc, const char *fmt,
-                                                char *out_buf,
-                                                size_t out_buf_size);
+                                              char *out_buf,
+                                              size_t out_buf_size);
 // Same as __sanitizer_symbolize_pc, but for data section (i.e. globals).
 void SANITIZER_CDECL __sanitizer_symbolize_global(void *data_ptr,
-                                                    const char *fmt,
-                                                    char *out_buf,
-                                                    size_t out_buf_size);
+                                                  const char *fmt,
+                                                  char *out_buf,
+                                                  size_t out_buf_size);
 // Determine the return address.
 #if !defined(_MSC_VER) || defined(__clang__)
 #define __sanitizer_return_address()                                           \
@@ -325,9 +325,9 @@ void SANITIZER_CDECL __sanitizer_set_death_callback(void (*callback)(void));
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
 void SANITIZER_CDECL __sanitizer_weak_hook_memcmp(void *called_pc,
-                                                    const void *s1,
-                                                    const void *s2, size_t n,
-                                                    int result);
+                                                  const void *s1,
+                                                  const void *s2, size_t n,
+                                                  int result);
 
 /// Interceptor hook for <c>strncmp()</c>.
 ///
@@ -337,9 +337,9 @@ void SANITIZER_CDECL __sanitizer_weak_hook_memcmp(void *called_pc,
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
 void SANITIZER_CDECL __sanitizer_weak_hook_strncmp(void *called_pc,
-                                                     const char *s1,
-                                                     const char *s2, size_t n,
-                                                     int result);
+                                                   const char *s1,
+                                                   const char *s2, size_t n,
+                                                   int result);
 
 /// Interceptor hook for <c>strncasecmp()</c>.
 ///
@@ -349,9 +349,9 @@ void SANITIZER_CDECL __sanitizer_weak_hook_strncmp(void *called_pc,
 /// \param n Number of bytes to compare.
 /// \param result Value returned by the intercepted function.
 void SANITIZER_CDECL __sanitizer_weak_hook_strncasecmp(void *called_pc,
-                                                         const char *s1,
-                                                         const char *s2,
-                                                         size_t n, int result);
+                                                       const char *s1,
+                                                       const char *s2, size_t n,
+                                                       int result);
 
 /// Interceptor hook for <c>strcmp()</c>.
 ///
@@ -360,8 +360,8 @@ void SANITIZER_CDECL __sanitizer_weak_hook_strncasecmp(void *called_pc,
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
 void SANITIZER_CDECL __sanitizer_weak_hook_strcmp(void *called_pc,
-                                                    const char *s1,
-                                                    const char *s2, int result);
+                                                  const char *s1,
+                                                  const char *s2, int result);
 
 /// Interceptor hook for <c>strcasecmp()</c>.
 ///
@@ -370,9 +370,9 @@ void SANITIZER_CDECL __sanitizer_weak_hook_strcmp(void *called_pc,
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
 void SANITIZER_CDECL __sanitizer_weak_hook_strcasecmp(void *called_pc,
-                                                        const char *s1,
-                                                        const char *s2,
-                                                        int result);
+                                                      const char *s1,
+                                                      const char *s2,
+                                                      int result);
 
 /// Interceptor hook for <c>strstr()</c>.
 ///
@@ -381,19 +381,18 @@ void SANITIZER_CDECL __sanitizer_weak_hook_strcasecmp(void *called_pc,
 /// \param s2 Pointer to block of memory.
 /// \param result Value returned by the intercepted function.
 void SANITIZER_CDECL __sanitizer_weak_hook_strstr(void *called_pc,
-                                                    const char *s1,
-                                                    const char *s2,
-                                                    char *result);
+                                                  const char *s1,
+                                                  const char *s2, char *result);
 
 void SANITIZER_CDECL __sanitizer_weak_hook_strcasestr(void *called_pc,
-                                                        const char *s1,
-                                                        const char *s2,
-                                                        char *result);
+                                                      const char *s1,
+                                                      const char *s2,
+                                                      char *result);
 
 void SANITIZER_CDECL __sanitizer_weak_hook_memmem(void *called_pc,
-                                                    const void *s1, size_t len1,
-                                                    const void *s2, size_t len2,
-                                                    void *result);
+                                                  const void *s1, size_t len1,
+                                                  const void *s2, size_t len2,
+                                                  void *result);
 
 // Prints stack traces for all live heap allocations ordered by total
 // allocation size until top_percent of total live heap is shown. top_percent
@@ -431,8 +430,8 @@ void SANITIZER_CDECL __sanitizer_print_memory_profile(
 /// \param bottom Bottom address of stack.
 /// \param size Size of stack in bytes.
 void SANITIZER_CDECL __sanitizer_start_switch_fiber(void **fake_stack_save,
-                                                      const void *bottom,
-                                                      size_t size);
+                                                    const void *bottom,
+                                                    size_t size);
 
 /// Notify ASan that a fiber switch has completed (required only if
 /// implementing your own fiber library).
@@ -446,8 +445,8 @@ void SANITIZER_CDECL __sanitizer_start_switch_fiber(void **fake_stack_save,
 /// \param[out] bottom_old Bottom address of old stack.
 /// \param[out] size_old Size of old stack in bytes.
 void SANITIZER_CDECL __sanitizer_finish_switch_fiber(void *fake_stack_save,
-                                                       const void **bottom_old,
-                                                       size_t *size_old);
+                                                     const void **bottom_old,
+                                                     size_t *size_old);
 
 // Get full module name and calculate pc offset within it.
 // Returns 1 if pc belongs to some module, 0 if module was not found.

--- a/compiler-rt/include/sanitizer/coverage_interface.h
+++ b/compiler-rt/include/sanitizer/coverage_interface.h
@@ -27,7 +27,7 @@ void SANITIZER_CDECL __sanitizer_cov_reset(void);
 // Dump collected coverage info. Sorts pcs by module into individual .sancov
 // files.
 void SANITIZER_CDECL __sanitizer_dump_coverage(const uintptr_t *pcs,
-                                                 uintptr_t len);
+                                               uintptr_t len);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/coverage_interface.h
+++ b/compiler-rt/include/sanitizer/coverage_interface.h
@@ -19,14 +19,14 @@ extern "C" {
 #endif
 
 // Record and dump coverage info.
-void __sanitizer_cdecl __sanitizer_cov_dump(void);
+void SANITIZER_CDECL __sanitizer_cov_dump(void);
 
 // Clear collected coverage info.
-void __sanitizer_cdecl __sanitizer_cov_reset(void);
+void SANITIZER_CDECL __sanitizer_cov_reset(void);
 
 // Dump collected coverage info. Sorts pcs by module into individual .sancov
 // files.
-void __sanitizer_cdecl __sanitizer_dump_coverage(const uintptr_t *pcs,
+void SANITIZER_CDECL __sanitizer_dump_coverage(const uintptr_t *pcs,
                                                  uintptr_t len);
 
 #ifdef __cplusplus

--- a/compiler-rt/include/sanitizer/coverage_interface.h
+++ b/compiler-rt/include/sanitizer/coverage_interface.h
@@ -18,18 +18,19 @@
 extern "C" {
 #endif
 
-  // Record and dump coverage info.
-  void __sanitizer_cov_dump(void);
+// Record and dump coverage info.
+void __sanitizer_cdecl __sanitizer_cov_dump(void);
 
-  // Clear collected coverage info.
-  void __sanitizer_cov_reset(void);
+// Clear collected coverage info.
+void __sanitizer_cdecl __sanitizer_cov_reset(void);
 
-  // Dump collected coverage info. Sorts pcs by module into individual .sancov
-  // files.
-  void __sanitizer_dump_coverage(const uintptr_t *pcs, uintptr_t len);
+// Dump collected coverage info. Sorts pcs by module into individual .sancov
+// files.
+void __sanitizer_cdecl __sanitizer_dump_coverage(const uintptr_t *pcs,
+                                                 uintptr_t len);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // SANITIZER_COVERAG_INTERFACE_H
+#endif // SANITIZER_COVERAG_INTERFACE_H

--- a/compiler-rt/include/sanitizer/dfsan_interface.h
+++ b/compiler-rt/include/sanitizer/dfsan_interface.h
@@ -25,9 +25,8 @@ typedef uint8_t dfsan_label;
 typedef uint32_t dfsan_origin;
 
 /// Signature of the callback argument to dfsan_set_write_callback().
-typedef void (*SANITIZER_CDECL dfsan_write_callback_t)(int fd,
-                                                         const void *buf,
-                                                         size_t count);
+typedef void (*SANITIZER_CDECL dfsan_write_callback_t)(int fd, const void *buf,
+                                                       size_t count);
 
 /// Signature of the callback argument to dfsan_set_conditional_callback().
 typedef void (*SANITIZER_CDECL dfsan_conditional_callback_t)(
@@ -44,12 +43,12 @@ dfsan_label SANITIZER_CDECL dfsan_union(dfsan_label l1, dfsan_label l2);
 
 /// Sets the label for each address in [addr,addr+size) to \c label.
 void SANITIZER_CDECL dfsan_set_label(dfsan_label label, void *addr,
-                                       size_t size);
+                                     size_t size);
 
 /// Sets the label for each address in [addr,addr+size) to the union of the
 /// current label for that address and \c label.
 void SANITIZER_CDECL dfsan_add_label(dfsan_label label, void *addr,
-                                       size_t size);
+                                     size_t size);
 
 /// Retrieves the label associated with the given data.
 ///
@@ -70,8 +69,8 @@ dfsan_label SANITIZER_CDECL dfsan_read_label(const void *addr, size_t size);
 
 /// Return the origin associated with the first taint byte in the size bytes
 /// from the address addr.
-dfsan_origin SANITIZER_CDECL
-dfsan_read_origin_of_first_taint(const void *addr, size_t size);
+dfsan_origin SANITIZER_CDECL dfsan_read_origin_of_first_taint(const void *addr,
+                                                              size_t size);
 
 /// Returns whether the given label contains the label elem.
 int SANITIZER_CDECL dfsan_has_label(dfsan_label label, dfsan_label elem);
@@ -123,21 +122,21 @@ dfsan_label SANITIZER_CDECL dfsan_get_labels_in_signal_reaches_function();
 /// needs to see the parameters of the function and the labels.
 /// FIXME: implement more hooks.
 void SANITIZER_CDECL dfsan_weak_hook_memcmp(void *caller_pc, const void *s1,
-                                              const void *s2, size_t n,
-                                              dfsan_label s1_label,
-                                              dfsan_label s2_label,
-                                              dfsan_label n_label);
+                                            const void *s2, size_t n,
+                                            dfsan_label s1_label,
+                                            dfsan_label s2_label,
+                                            dfsan_label n_label);
 void SANITIZER_CDECL dfsan_weak_hook_strncmp(void *caller_pc, const char *s1,
-                                               const char *s2, size_t n,
-                                               dfsan_label s1_label,
-                                               dfsan_label s2_label,
-                                               dfsan_label n_label);
+                                             const char *s2, size_t n,
+                                             dfsan_label s1_label,
+                                             dfsan_label s2_label,
+                                             dfsan_label n_label);
 
 /// Prints the origin trace of the label at the address addr to stderr. It also
 /// prints description at the beginning of the trace. If origin tracking is not
 /// on, or the address is not labeled, it prints nothing.
 void SANITIZER_CDECL dfsan_print_origin_trace(const void *addr,
-                                                const char *description);
+                                              const char *description);
 /// As above, but use an origin id from dfsan_get_origin() instead of address.
 /// Does not include header line with taint label and address information.
 void SANITIZER_CDECL dfsan_print_origin_id_trace(dfsan_origin origin);
@@ -177,14 +176,14 @@ void SANITIZER_CDECL dfsan_print_origin_id_trace(dfsan_origin origin);
 /// (not including trailing null byte '\0'). Thus, the string is truncated iff
 /// return value is not less than \p out_buf_size.
 size_t SANITIZER_CDECL dfsan_sprint_origin_trace(const void *addr,
-                                                   const char *description,
-                                                   char *out_buf,
-                                                   size_t out_buf_size);
+                                                 const char *description,
+                                                 char *out_buf,
+                                                 size_t out_buf_size);
 /// As above, but use an origin id from dfsan_get_origin() instead of address.
 /// Does not include header line with taint label and address information.
 size_t SANITIZER_CDECL dfsan_sprint_origin_id_trace(dfsan_origin origin,
-                                                      char *out_buf,
-                                                      size_t out_buf_size);
+                                                    char *out_buf,
+                                                    size_t out_buf_size);
 
 /// Prints the stack trace leading to this call to a pre-allocated output
 /// buffer.
@@ -198,7 +197,7 @@ size_t SANITIZER_CDECL dfsan_sprint_origin_id_trace(dfsan_origin origin,
 /// (not including trailing null byte '\0'). Thus, the string is truncated iff
 /// return value is not less than \p out_buf_size.
 size_t SANITIZER_CDECL dfsan_sprint_stack_trace(char *out_buf,
-                                                  size_t out_buf_size);
+                                                size_t out_buf_size);
 
 /// Retrieves the very first origin associated with the data at the given
 /// address.

--- a/compiler-rt/include/sanitizer/dfsan_interface.h
+++ b/compiler-rt/include/sanitizer/dfsan_interface.h
@@ -13,9 +13,9 @@
 #ifndef DFSAN_INTERFACE_H
 #define DFSAN_INTERFACE_H
 
+#include <sanitizer/common_interface_defs.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sanitizer/common_interface_defs.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,29 +25,31 @@ typedef uint8_t dfsan_label;
 typedef uint32_t dfsan_origin;
 
 /// Signature of the callback argument to dfsan_set_write_callback().
-typedef void (*dfsan_write_callback_t)(int fd, const void *buf, size_t count);
+typedef void (*__sanitizer_cdecl dfsan_write_callback_t)(int fd,
+                                                         const void *buf,
+                                                         size_t count);
 
 /// Signature of the callback argument to dfsan_set_conditional_callback().
-typedef void (*dfsan_conditional_callback_t)(dfsan_label label,
-                                             dfsan_origin origin);
+typedef void (*__sanitizer_cdecl dfsan_conditional_callback_t)(
+    dfsan_label label, dfsan_origin origin);
 
 /// Signature of the callback argument to dfsan_set_reaches_function_callback().
 /// The description is intended to hold the name of the variable.
-typedef void (*dfsan_reaches_function_callback_t)(dfsan_label label,
-                                                  dfsan_origin origin,
-                                                  const char *file,
-                                                  unsigned int line,
-                                                  const char *function);
+typedef void (*__sanitizer_cdecl dfsan_reaches_function_callback_t)(
+    dfsan_label label, dfsan_origin origin, const char *file, unsigned int line,
+    const char *function);
 
 /// Computes the union of \c l1 and \c l2, resulting in a union label.
-dfsan_label dfsan_union(dfsan_label l1, dfsan_label l2);
+dfsan_label __sanitizer_cdecl dfsan_union(dfsan_label l1, dfsan_label l2);
 
 /// Sets the label for each address in [addr,addr+size) to \c label.
-void dfsan_set_label(dfsan_label label, void *addr, size_t size);
+void __sanitizer_cdecl dfsan_set_label(dfsan_label label, void *addr,
+                                       size_t size);
 
 /// Sets the label for each address in [addr,addr+size) to the union of the
 /// current label for that address and \c label.
-void dfsan_add_label(dfsan_label label, void *addr, size_t size);
+void __sanitizer_cdecl dfsan_add_label(dfsan_label label, void *addr,
+                                       size_t size);
 
 /// Retrieves the label associated with the given data.
 ///
@@ -55,23 +57,24 @@ void dfsan_add_label(dfsan_label label, void *addr, size_t size);
 /// which can be truncated or extended (implicitly or explicitly) as necessary.
 /// The truncation/extension operations will preserve the label of the original
 /// value.
-dfsan_label dfsan_get_label(long data);
+dfsan_label __sanitizer_cdecl dfsan_get_label(long data);
 
 /// Retrieves the immediate origin associated with the given data. The returned
 /// origin may point to another origin.
 ///
 /// The type of 'data' is arbitrary.
-dfsan_origin dfsan_get_origin(long data);
+dfsan_origin __sanitizer_cdecl dfsan_get_origin(long data);
 
 /// Retrieves the label associated with the data at the given address.
-dfsan_label dfsan_read_label(const void *addr, size_t size);
+dfsan_label __sanitizer_cdecl dfsan_read_label(const void *addr, size_t size);
 
 /// Return the origin associated with the first taint byte in the size bytes
 /// from the address addr.
-dfsan_origin dfsan_read_origin_of_first_taint(const void *addr, size_t size);
+dfsan_origin __sanitizer_cdecl
+dfsan_read_origin_of_first_taint(const void *addr, size_t size);
 
 /// Returns whether the given label contains the label elem.
-int dfsan_has_label(dfsan_label label, dfsan_label elem);
+int __sanitizer_cdecl dfsan_has_label(dfsan_label label, dfsan_label elem);
 
 /// Flushes the DFSan shadow, i.e. forgets about all labels currently associated
 /// with the application memory.  Use this call to start over the taint tracking
@@ -79,37 +82,39 @@ int dfsan_has_label(dfsan_label label, dfsan_label elem);
 ///
 /// Note: If another thread is working with tainted data during the flush, that
 /// taint could still be written to shadow after the flush.
-void dfsan_flush(void);
+void __sanitizer_cdecl dfsan_flush(void);
 
 /// Sets a callback to be invoked on calls to write().  The callback is invoked
 /// before the write is done.  The write is not guaranteed to succeed when the
 /// callback executes.  Pass in NULL to remove any callback.
-void dfsan_set_write_callback(dfsan_write_callback_t labeled_write_callback);
+void __sanitizer_cdecl
+dfsan_set_write_callback(dfsan_write_callback_t labeled_write_callback);
 
 /// Sets a callback to be invoked on any conditional expressions which have a
 /// taint label set. This can be used to find where tainted data influences
 /// the behavior of the program.
 /// These callbacks will only be added when -dfsan-conditional-callbacks=true.
-void dfsan_set_conditional_callback(dfsan_conditional_callback_t callback);
+void __sanitizer_cdecl
+dfsan_set_conditional_callback(dfsan_conditional_callback_t callback);
 
 /// Conditional expressions occur during signal handlers.
 /// Making callbacks that handle signals well is tricky, so when
 /// -dfsan-conditional-callbacks=true, conditional expressions used in signal
 /// handlers will add the labels they see into a global (bitwise-or together).
 /// This function returns all label bits seen in signal handler conditions.
-dfsan_label dfsan_get_labels_in_signal_conditional();
+dfsan_label __sanitizer_cdecl dfsan_get_labels_in_signal_conditional();
 
 /// Sets a callback to be invoked when tainted data reaches a function.
 /// This could occur at function entry, or at a load instruction.
 /// These callbacks will only be added if -dfsan-reaches-function-callbacks=1.
-void dfsan_set_reaches_function_callback(
-    dfsan_reaches_function_callback_t callback);
+void __sanitizer_cdecl
+dfsan_set_reaches_function_callback(dfsan_reaches_function_callback_t callback);
 
 /// Making callbacks that handle signals well is tricky, so when
 /// -dfsan-reaches-function-callbacks=true, functions reached in signal
 /// handlers will add the labels they see into a global (bitwise-or together).
 /// This function returns all label bits seen during signal handlers.
-dfsan_label dfsan_get_labels_in_signal_reaches_function();
+dfsan_label __sanitizer_cdecl dfsan_get_labels_in_signal_reaches_function();
 
 /// Interceptor hooks.
 /// Whenever a dfsan's custom function is called the corresponding
@@ -117,20 +122,25 @@ dfsan_label dfsan_get_labels_in_signal_reaches_function();
 /// The primary use case is taint-guided fuzzing, where the fuzzer
 /// needs to see the parameters of the function and the labels.
 /// FIXME: implement more hooks.
-void dfsan_weak_hook_memcmp(void *caller_pc, const void *s1, const void *s2,
-                            size_t n, dfsan_label s1_label,
-                            dfsan_label s2_label, dfsan_label n_label);
-void dfsan_weak_hook_strncmp(void *caller_pc, const char *s1, const char *s2,
-                             size_t n, dfsan_label s1_label,
-                             dfsan_label s2_label, dfsan_label n_label);
+void __sanitizer_cdecl dfsan_weak_hook_memcmp(void *caller_pc, const void *s1,
+                                              const void *s2, size_t n,
+                                              dfsan_label s1_label,
+                                              dfsan_label s2_label,
+                                              dfsan_label n_label);
+void __sanitizer_cdecl dfsan_weak_hook_strncmp(void *caller_pc, const char *s1,
+                                               const char *s2, size_t n,
+                                               dfsan_label s1_label,
+                                               dfsan_label s2_label,
+                                               dfsan_label n_label);
 
 /// Prints the origin trace of the label at the address addr to stderr. It also
 /// prints description at the beginning of the trace. If origin tracking is not
 /// on, or the address is not labeled, it prints nothing.
-void dfsan_print_origin_trace(const void *addr, const char *description);
+void __sanitizer_cdecl dfsan_print_origin_trace(const void *addr,
+                                                const char *description);
 /// As above, but use an origin id from dfsan_get_origin() instead of address.
 /// Does not include header line with taint label and address information.
-void dfsan_print_origin_id_trace(dfsan_origin origin);
+void __sanitizer_cdecl dfsan_print_origin_id_trace(dfsan_origin origin);
 
 /// Prints the origin trace of the label at the address \p addr to a
 /// pre-allocated output buffer. If origin tracking is not on, or the address is
@@ -166,12 +176,15 @@ void dfsan_print_origin_id_trace(dfsan_origin origin);
 /// \returns The number of symbols that should have been written to \p out_buf
 /// (not including trailing null byte '\0'). Thus, the string is truncated iff
 /// return value is not less than \p out_buf_size.
-size_t dfsan_sprint_origin_trace(const void *addr, const char *description,
-                                 char *out_buf, size_t out_buf_size);
+size_t __sanitizer_cdecl dfsan_sprint_origin_trace(const void *addr,
+                                                   const char *description,
+                                                   char *out_buf,
+                                                   size_t out_buf_size);
 /// As above, but use an origin id from dfsan_get_origin() instead of address.
 /// Does not include header line with taint label and address information.
-size_t dfsan_sprint_origin_id_trace(dfsan_origin origin, char *out_buf,
-                                    size_t out_buf_size);
+size_t __sanitizer_cdecl dfsan_sprint_origin_id_trace(dfsan_origin origin,
+                                                      char *out_buf,
+                                                      size_t out_buf_size);
 
 /// Prints the stack trace leading to this call to a pre-allocated output
 /// buffer.
@@ -184,19 +197,20 @@ size_t dfsan_sprint_origin_id_trace(dfsan_origin origin, char *out_buf,
 /// \returns The number of symbols that should have been written to \p out_buf
 /// (not including trailing null byte '\0'). Thus, the string is truncated iff
 /// return value is not less than \p out_buf_size.
-size_t dfsan_sprint_stack_trace(char *out_buf, size_t out_buf_size);
+size_t __sanitizer_cdecl dfsan_sprint_stack_trace(char *out_buf,
+                                                  size_t out_buf_size);
 
 /// Retrieves the very first origin associated with the data at the given
 /// address.
-dfsan_origin dfsan_get_init_origin(const void *addr);
+dfsan_origin __sanitizer_cdecl dfsan_get_init_origin(const void *addr);
 
 /// Returns the value of -dfsan-track-origins.
 /// * 0: do not track origins.
 /// * 1: track origins at memory store operations.
 /// * 2: track origins at memory load and store operations.
-int dfsan_get_track_origins(void);
+int __sanitizer_cdecl dfsan_get_track_origins(void);
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 
 template <typename T> void dfsan_set_label(dfsan_label label, T &data) {
   dfsan_set_label(label, (void *)&data, sizeof(T));
@@ -204,4 +218,4 @@ template <typename T> void dfsan_set_label(dfsan_label label, T &data) {
 
 #endif
 
-#endif  // DFSAN_INTERFACE_H
+#endif // DFSAN_INTERFACE_H

--- a/compiler-rt/include/sanitizer/dfsan_interface.h
+++ b/compiler-rt/include/sanitizer/dfsan_interface.h
@@ -25,30 +25,30 @@ typedef uint8_t dfsan_label;
 typedef uint32_t dfsan_origin;
 
 /// Signature of the callback argument to dfsan_set_write_callback().
-typedef void (*__sanitizer_cdecl dfsan_write_callback_t)(int fd,
+typedef void (*SANITIZER_CDECL dfsan_write_callback_t)(int fd,
                                                          const void *buf,
                                                          size_t count);
 
 /// Signature of the callback argument to dfsan_set_conditional_callback().
-typedef void (*__sanitizer_cdecl dfsan_conditional_callback_t)(
+typedef void (*SANITIZER_CDECL dfsan_conditional_callback_t)(
     dfsan_label label, dfsan_origin origin);
 
 /// Signature of the callback argument to dfsan_set_reaches_function_callback().
 /// The description is intended to hold the name of the variable.
-typedef void (*__sanitizer_cdecl dfsan_reaches_function_callback_t)(
+typedef void (*SANITIZER_CDECL dfsan_reaches_function_callback_t)(
     dfsan_label label, dfsan_origin origin, const char *file, unsigned int line,
     const char *function);
 
 /// Computes the union of \c l1 and \c l2, resulting in a union label.
-dfsan_label __sanitizer_cdecl dfsan_union(dfsan_label l1, dfsan_label l2);
+dfsan_label SANITIZER_CDECL dfsan_union(dfsan_label l1, dfsan_label l2);
 
 /// Sets the label for each address in [addr,addr+size) to \c label.
-void __sanitizer_cdecl dfsan_set_label(dfsan_label label, void *addr,
+void SANITIZER_CDECL dfsan_set_label(dfsan_label label, void *addr,
                                        size_t size);
 
 /// Sets the label for each address in [addr,addr+size) to the union of the
 /// current label for that address and \c label.
-void __sanitizer_cdecl dfsan_add_label(dfsan_label label, void *addr,
+void SANITIZER_CDECL dfsan_add_label(dfsan_label label, void *addr,
                                        size_t size);
 
 /// Retrieves the label associated with the given data.
@@ -57,24 +57,24 @@ void __sanitizer_cdecl dfsan_add_label(dfsan_label label, void *addr,
 /// which can be truncated or extended (implicitly or explicitly) as necessary.
 /// The truncation/extension operations will preserve the label of the original
 /// value.
-dfsan_label __sanitizer_cdecl dfsan_get_label(long data);
+dfsan_label SANITIZER_CDECL dfsan_get_label(long data);
 
 /// Retrieves the immediate origin associated with the given data. The returned
 /// origin may point to another origin.
 ///
 /// The type of 'data' is arbitrary.
-dfsan_origin __sanitizer_cdecl dfsan_get_origin(long data);
+dfsan_origin SANITIZER_CDECL dfsan_get_origin(long data);
 
 /// Retrieves the label associated with the data at the given address.
-dfsan_label __sanitizer_cdecl dfsan_read_label(const void *addr, size_t size);
+dfsan_label SANITIZER_CDECL dfsan_read_label(const void *addr, size_t size);
 
 /// Return the origin associated with the first taint byte in the size bytes
 /// from the address addr.
-dfsan_origin __sanitizer_cdecl
+dfsan_origin SANITIZER_CDECL
 dfsan_read_origin_of_first_taint(const void *addr, size_t size);
 
 /// Returns whether the given label contains the label elem.
-int __sanitizer_cdecl dfsan_has_label(dfsan_label label, dfsan_label elem);
+int SANITIZER_CDECL dfsan_has_label(dfsan_label label, dfsan_label elem);
 
 /// Flushes the DFSan shadow, i.e. forgets about all labels currently associated
 /// with the application memory.  Use this call to start over the taint tracking
@@ -82,19 +82,19 @@ int __sanitizer_cdecl dfsan_has_label(dfsan_label label, dfsan_label elem);
 ///
 /// Note: If another thread is working with tainted data during the flush, that
 /// taint could still be written to shadow after the flush.
-void __sanitizer_cdecl dfsan_flush(void);
+void SANITIZER_CDECL dfsan_flush(void);
 
 /// Sets a callback to be invoked on calls to write().  The callback is invoked
 /// before the write is done.  The write is not guaranteed to succeed when the
 /// callback executes.  Pass in NULL to remove any callback.
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 dfsan_set_write_callback(dfsan_write_callback_t labeled_write_callback);
 
 /// Sets a callback to be invoked on any conditional expressions which have a
 /// taint label set. This can be used to find where tainted data influences
 /// the behavior of the program.
 /// These callbacks will only be added when -dfsan-conditional-callbacks=true.
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 dfsan_set_conditional_callback(dfsan_conditional_callback_t callback);
 
 /// Conditional expressions occur during signal handlers.
@@ -102,19 +102,19 @@ dfsan_set_conditional_callback(dfsan_conditional_callback_t callback);
 /// -dfsan-conditional-callbacks=true, conditional expressions used in signal
 /// handlers will add the labels they see into a global (bitwise-or together).
 /// This function returns all label bits seen in signal handler conditions.
-dfsan_label __sanitizer_cdecl dfsan_get_labels_in_signal_conditional();
+dfsan_label SANITIZER_CDECL dfsan_get_labels_in_signal_conditional();
 
 /// Sets a callback to be invoked when tainted data reaches a function.
 /// This could occur at function entry, or at a load instruction.
 /// These callbacks will only be added if -dfsan-reaches-function-callbacks=1.
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 dfsan_set_reaches_function_callback(dfsan_reaches_function_callback_t callback);
 
 /// Making callbacks that handle signals well is tricky, so when
 /// -dfsan-reaches-function-callbacks=true, functions reached in signal
 /// handlers will add the labels they see into a global (bitwise-or together).
 /// This function returns all label bits seen during signal handlers.
-dfsan_label __sanitizer_cdecl dfsan_get_labels_in_signal_reaches_function();
+dfsan_label SANITIZER_CDECL dfsan_get_labels_in_signal_reaches_function();
 
 /// Interceptor hooks.
 /// Whenever a dfsan's custom function is called the corresponding
@@ -122,12 +122,12 @@ dfsan_label __sanitizer_cdecl dfsan_get_labels_in_signal_reaches_function();
 /// The primary use case is taint-guided fuzzing, where the fuzzer
 /// needs to see the parameters of the function and the labels.
 /// FIXME: implement more hooks.
-void __sanitizer_cdecl dfsan_weak_hook_memcmp(void *caller_pc, const void *s1,
+void SANITIZER_CDECL dfsan_weak_hook_memcmp(void *caller_pc, const void *s1,
                                               const void *s2, size_t n,
                                               dfsan_label s1_label,
                                               dfsan_label s2_label,
                                               dfsan_label n_label);
-void __sanitizer_cdecl dfsan_weak_hook_strncmp(void *caller_pc, const char *s1,
+void SANITIZER_CDECL dfsan_weak_hook_strncmp(void *caller_pc, const char *s1,
                                                const char *s2, size_t n,
                                                dfsan_label s1_label,
                                                dfsan_label s2_label,
@@ -136,11 +136,11 @@ void __sanitizer_cdecl dfsan_weak_hook_strncmp(void *caller_pc, const char *s1,
 /// Prints the origin trace of the label at the address addr to stderr. It also
 /// prints description at the beginning of the trace. If origin tracking is not
 /// on, or the address is not labeled, it prints nothing.
-void __sanitizer_cdecl dfsan_print_origin_trace(const void *addr,
+void SANITIZER_CDECL dfsan_print_origin_trace(const void *addr,
                                                 const char *description);
 /// As above, but use an origin id from dfsan_get_origin() instead of address.
 /// Does not include header line with taint label and address information.
-void __sanitizer_cdecl dfsan_print_origin_id_trace(dfsan_origin origin);
+void SANITIZER_CDECL dfsan_print_origin_id_trace(dfsan_origin origin);
 
 /// Prints the origin trace of the label at the address \p addr to a
 /// pre-allocated output buffer. If origin tracking is not on, or the address is
@@ -176,13 +176,13 @@ void __sanitizer_cdecl dfsan_print_origin_id_trace(dfsan_origin origin);
 /// \returns The number of symbols that should have been written to \p out_buf
 /// (not including trailing null byte '\0'). Thus, the string is truncated iff
 /// return value is not less than \p out_buf_size.
-size_t __sanitizer_cdecl dfsan_sprint_origin_trace(const void *addr,
+size_t SANITIZER_CDECL dfsan_sprint_origin_trace(const void *addr,
                                                    const char *description,
                                                    char *out_buf,
                                                    size_t out_buf_size);
 /// As above, but use an origin id from dfsan_get_origin() instead of address.
 /// Does not include header line with taint label and address information.
-size_t __sanitizer_cdecl dfsan_sprint_origin_id_trace(dfsan_origin origin,
+size_t SANITIZER_CDECL dfsan_sprint_origin_id_trace(dfsan_origin origin,
                                                       char *out_buf,
                                                       size_t out_buf_size);
 
@@ -197,18 +197,18 @@ size_t __sanitizer_cdecl dfsan_sprint_origin_id_trace(dfsan_origin origin,
 /// \returns The number of symbols that should have been written to \p out_buf
 /// (not including trailing null byte '\0'). Thus, the string is truncated iff
 /// return value is not less than \p out_buf_size.
-size_t __sanitizer_cdecl dfsan_sprint_stack_trace(char *out_buf,
+size_t SANITIZER_CDECL dfsan_sprint_stack_trace(char *out_buf,
                                                   size_t out_buf_size);
 
 /// Retrieves the very first origin associated with the data at the given
 /// address.
-dfsan_origin __sanitizer_cdecl dfsan_get_init_origin(const void *addr);
+dfsan_origin SANITIZER_CDECL dfsan_get_init_origin(const void *addr);
 
 /// Returns the value of -dfsan-track-origins.
 /// * 0: do not track origins.
 /// * 1: track origins at memory store operations.
 /// * 2: track origins at memory load and store operations.
-int __sanitizer_cdecl dfsan_get_track_origins(void);
+int SANITIZER_CDECL dfsan_get_track_origins(void);
 #ifdef __cplusplus
 } // extern "C"
 

--- a/compiler-rt/include/sanitizer/hwasan_interface.h
+++ b/compiler-rt/include/sanitizer/hwasan_interface.h
@@ -38,11 +38,11 @@ void SANITIZER_CDECL __hwasan_disable_allocator_tagging(void);
 // Mark region of memory with the given tag. Both address and size need to be
 // 16-byte aligned.
 void SANITIZER_CDECL __hwasan_tag_memory(const volatile void *p,
-                                           unsigned char tag, size_t size);
+                                         unsigned char tag, size_t size);
 
 /// Set pointer tag. Previous tag is lost.
 void *SANITIZER_CDECL __hwasan_tag_pointer(const volatile void *p,
-                                             unsigned char tag);
+                                           unsigned char tag);
 
 // Set memory tag from the current SP address to the given address to zero.
 // This is meant to annotate longjmp and other non-local jumps.
@@ -65,8 +65,7 @@ void SANITIZER_CDECL __hwasan_thread_exit();
 
 // Print shadow and origin for the memory range to stderr in a human-readable
 // format.
-void SANITIZER_CDECL __hwasan_print_shadow(const volatile void *x,
-                                             size_t size);
+void SANITIZER_CDECL __hwasan_print_shadow(const volatile void *x, size_t size);
 
 // Print one-line report about the memory usage of the current process.
 void SANITIZER_CDECL __hwasan_print_memory_usage();
@@ -74,19 +73,18 @@ void SANITIZER_CDECL __hwasan_print_memory_usage();
 /* Returns the offset of the first byte in the memory range that can not be
  * accessed through the pointer in x, or -1 if the whole range is good. */
 intptr_t SANITIZER_CDECL __hwasan_test_shadow(const volatile void *x,
-                                                size_t size);
+                                              size_t size);
 
 /* Sets the callback function to be called during HWASan error reporting. */
 void SANITIZER_CDECL
 __hwasan_set_error_report_callback(void (*callback)(const char *));
 
-int SANITIZER_CDECL __sanitizer_posix_memalign(void **memptr,
-                                                 size_t alignment, size_t size);
+int SANITIZER_CDECL __sanitizer_posix_memalign(void **memptr, size_t alignment,
+                                               size_t size);
 void *SANITIZER_CDECL __sanitizer_memalign(size_t alignment, size_t size);
-void *SANITIZER_CDECL __sanitizer_aligned_alloc(size_t alignment,
-                                                  size_t size);
+void *SANITIZER_CDECL __sanitizer_aligned_alloc(size_t alignment, size_t size);
 void *SANITIZER_CDECL __sanitizer___libc_memalign(size_t alignment,
-                                                    size_t size);
+                                                  size_t size);
 void *SANITIZER_CDECL __sanitizer_valloc(size_t size);
 void *SANITIZER_CDECL __sanitizer_pvalloc(size_t size);
 void SANITIZER_CDECL __sanitizer_free(void *ptr);
@@ -98,7 +96,7 @@ void SANITIZER_CDECL __sanitizer_malloc_stats(void);
 void *SANITIZER_CDECL __sanitizer_calloc(size_t nmemb, size_t size);
 void *SANITIZER_CDECL __sanitizer_realloc(void *ptr, size_t size);
 void *SANITIZER_CDECL __sanitizer_reallocarray(void *ptr, size_t nmemb,
-                                                 size_t size);
+                                               size_t size);
 void *SANITIZER_CDECL __sanitizer_malloc(size_t size);
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/hwasan_interface.h
+++ b/compiler-rt/include/sanitizer/hwasan_interface.h
@@ -18,82 +18,90 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  // Libc hook for program startup in statically linked executables.
-  // Initializes enough of the runtime to run instrumented code. This function
-  // should only be called in statically linked executables because it modifies
-  // the GOT, which won't work in regular binaries because RELRO will already
-  // have been applied by the time the function is called. This also means that
-  // the function should be called before libc applies RELRO.
-  // Does not call libc unless there is an error.
-  // Can be called multiple times.
-  void __hwasan_init_static(void);
+// Libc hook for program startup in statically linked executables.
+// Initializes enough of the runtime to run instrumented code. This function
+// should only be called in statically linked executables because it modifies
+// the GOT, which won't work in regular binaries because RELRO will already
+// have been applied by the time the function is called. This also means that
+// the function should be called before libc applies RELRO.
+// Does not call libc unless there is an error.
+// Can be called multiple times.
+void __sanitizer_cdecl __hwasan_init_static(void);
 
-  // This function may be optionally provided by user and should return
-  // a string containing HWASan runtime options. See asan_flags.h for details.
-  const char* __hwasan_default_options(void);
+// This function may be optionally provided by user and should return
+// a string containing HWASan runtime options. See asan_flags.h for details.
+const char *__sanitizer_cdecl __hwasan_default_options(void);
 
-  void __hwasan_enable_allocator_tagging(void);
-  void __hwasan_disable_allocator_tagging(void);
+void __sanitizer_cdecl __hwasan_enable_allocator_tagging(void);
+void __sanitizer_cdecl __hwasan_disable_allocator_tagging(void);
 
-  // Mark region of memory with the given tag. Both address and size need to be
-  // 16-byte aligned.
-  void __hwasan_tag_memory(const volatile void *p, unsigned char tag,
-                           size_t size);
+// Mark region of memory with the given tag. Both address and size need to be
+// 16-byte aligned.
+void __sanitizer_cdecl __hwasan_tag_memory(const volatile void *p,
+                                           unsigned char tag, size_t size);
 
-  /// Set pointer tag. Previous tag is lost.
-  void *__hwasan_tag_pointer(const volatile void *p, unsigned char tag);
+/// Set pointer tag. Previous tag is lost.
+void *__sanitizer_cdecl __hwasan_tag_pointer(const volatile void *p,
+                                             unsigned char tag);
 
-  // Set memory tag from the current SP address to the given address to zero.
-  // This is meant to annotate longjmp and other non-local jumps.
-  // This function needs to know the (almost) exact destination frame address;
-  // clearing shadow for the entire thread stack like __asan_handle_no_return
-  // does would cause false reports.
-  void __hwasan_handle_longjmp(const void *sp_dst);
+// Set memory tag from the current SP address to the given address to zero.
+// This is meant to annotate longjmp and other non-local jumps.
+// This function needs to know the (almost) exact destination frame address;
+// clearing shadow for the entire thread stack like __asan_handle_no_return
+// does would cause false reports.
+void __sanitizer_cdecl __hwasan_handle_longjmp(const void *sp_dst);
 
-  // Set memory tag for the part of the current thread stack below sp_dst to
-  // zero. Call this in vfork() before returning in the parent process.
-  void __hwasan_handle_vfork(const void *sp_dst);
+// Set memory tag for the part of the current thread stack below sp_dst to
+// zero. Call this in vfork() before returning in the parent process.
+void __sanitizer_cdecl __hwasan_handle_vfork(const void *sp_dst);
 
-  // Libc hook for thread creation. Should be called in the child thread before
-  // any instrumented code.
-  void __hwasan_thread_enter();
+// Libc hook for thread creation. Should be called in the child thread before
+// any instrumented code.
+void __sanitizer_cdecl __hwasan_thread_enter();
 
-  // Libc hook for thread destruction. No instrumented code should run after
-  // this call.
-  void __hwasan_thread_exit();
+// Libc hook for thread destruction. No instrumented code should run after
+// this call.
+void __sanitizer_cdecl __hwasan_thread_exit();
 
-  // Print shadow and origin for the memory range to stderr in a human-readable
-  // format.
-  void __hwasan_print_shadow(const volatile void *x, size_t size);
+// Print shadow and origin for the memory range to stderr in a human-readable
+// format.
+void __sanitizer_cdecl __hwasan_print_shadow(const volatile void *x,
+                                             size_t size);
 
-  // Print one-line report about the memory usage of the current process.
-  void __hwasan_print_memory_usage();
+// Print one-line report about the memory usage of the current process.
+void __sanitizer_cdecl __hwasan_print_memory_usage();
 
-  /* Returns the offset of the first byte in the memory range that can not be
-   * accessed through the pointer in x, or -1 if the whole range is good. */
-  intptr_t __hwasan_test_shadow(const volatile void *x, size_t size);
+/* Returns the offset of the first byte in the memory range that can not be
+ * accessed through the pointer in x, or -1 if the whole range is good. */
+intptr_t __sanitizer_cdecl __hwasan_test_shadow(const volatile void *x,
+                                                size_t size);
 
-  /* Sets the callback function to be called during HWASan error reporting. */
-  void __hwasan_set_error_report_callback(void (*callback)(const char *));
+/* Sets the callback function to be called during HWASan error reporting. */
+void __sanitizer_cdecl
+__hwasan_set_error_report_callback(void (*callback)(const char *));
 
-  int __sanitizer_posix_memalign(void **memptr, size_t alignment, size_t size);
-  void * __sanitizer_memalign(size_t alignment, size_t size);
-  void * __sanitizer_aligned_alloc(size_t alignment, size_t size);
-  void * __sanitizer___libc_memalign(size_t alignment, size_t size);
-  void * __sanitizer_valloc(size_t size);
-  void * __sanitizer_pvalloc(size_t size);
-  void __sanitizer_free(void *ptr);
-  void __sanitizer_cfree(void *ptr);
-  size_t __sanitizer_malloc_usable_size(const void *ptr);
-  struct mallinfo __sanitizer_mallinfo();
-  int __sanitizer_mallopt(int cmd, int value);
-  void __sanitizer_malloc_stats(void);
-  void * __sanitizer_calloc(size_t nmemb, size_t size);
-  void * __sanitizer_realloc(void *ptr, size_t size);
-  void * __sanitizer_reallocarray(void *ptr, size_t nmemb, size_t size);
-  void * __sanitizer_malloc(size_t size);
+int __sanitizer_cdecl __sanitizer_posix_memalign(void **memptr,
+                                                 size_t alignment, size_t size);
+void *__sanitizer_cdecl __sanitizer_memalign(size_t alignment, size_t size);
+void *__sanitizer_cdecl __sanitizer_aligned_alloc(size_t alignment,
+                                                  size_t size);
+void *__sanitizer_cdecl __sanitizer___libc_memalign(size_t alignment,
+                                                    size_t size);
+void *__sanitizer_cdecl __sanitizer_valloc(size_t size);
+void *__sanitizer_cdecl __sanitizer_pvalloc(size_t size);
+void __sanitizer_cdecl __sanitizer_free(void *ptr);
+void __sanitizer_cdecl __sanitizer_cfree(void *ptr);
+size_t __sanitizer_cdecl __sanitizer_malloc_usable_size(const void *ptr);
+struct mallinfo __sanitizer_cdecl __sanitizer_mallinfo();
+int __sanitizer_cdecl __sanitizer_mallopt(int cmd, int value);
+void __sanitizer_cdecl __sanitizer_malloc_stats(void);
+void *__sanitizer_cdecl __sanitizer_calloc(size_t nmemb, size_t size);
+void *__sanitizer_cdecl __sanitizer_realloc(void *ptr, size_t size);
+void *__sanitizer_cdecl __sanitizer_reallocarray(void *ptr, size_t nmemb,
+                                                 size_t size);
+void *__sanitizer_cdecl __sanitizer_malloc(size_t size);
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // SANITIZER_HWASAN_INTERFACE_H
+#endif // SANITIZER_HWASAN_INTERFACE_H

--- a/compiler-rt/include/sanitizer/hwasan_interface.h
+++ b/compiler-rt/include/sanitizer/hwasan_interface.h
@@ -26,22 +26,22 @@ extern "C" {
 // the function should be called before libc applies RELRO.
 // Does not call libc unless there is an error.
 // Can be called multiple times.
-void __sanitizer_cdecl __hwasan_init_static(void);
+void SANITIZER_CDECL __hwasan_init_static(void);
 
 // This function may be optionally provided by user and should return
 // a string containing HWASan runtime options. See asan_flags.h for details.
-const char *__sanitizer_cdecl __hwasan_default_options(void);
+const char *SANITIZER_CDECL __hwasan_default_options(void);
 
-void __sanitizer_cdecl __hwasan_enable_allocator_tagging(void);
-void __sanitizer_cdecl __hwasan_disable_allocator_tagging(void);
+void SANITIZER_CDECL __hwasan_enable_allocator_tagging(void);
+void SANITIZER_CDECL __hwasan_disable_allocator_tagging(void);
 
 // Mark region of memory with the given tag. Both address and size need to be
 // 16-byte aligned.
-void __sanitizer_cdecl __hwasan_tag_memory(const volatile void *p,
+void SANITIZER_CDECL __hwasan_tag_memory(const volatile void *p,
                                            unsigned char tag, size_t size);
 
 /// Set pointer tag. Previous tag is lost.
-void *__sanitizer_cdecl __hwasan_tag_pointer(const volatile void *p,
+void *SANITIZER_CDECL __hwasan_tag_pointer(const volatile void *p,
                                              unsigned char tag);
 
 // Set memory tag from the current SP address to the given address to zero.
@@ -49,57 +49,57 @@ void *__sanitizer_cdecl __hwasan_tag_pointer(const volatile void *p,
 // This function needs to know the (almost) exact destination frame address;
 // clearing shadow for the entire thread stack like __asan_handle_no_return
 // does would cause false reports.
-void __sanitizer_cdecl __hwasan_handle_longjmp(const void *sp_dst);
+void SANITIZER_CDECL __hwasan_handle_longjmp(const void *sp_dst);
 
 // Set memory tag for the part of the current thread stack below sp_dst to
 // zero. Call this in vfork() before returning in the parent process.
-void __sanitizer_cdecl __hwasan_handle_vfork(const void *sp_dst);
+void SANITIZER_CDECL __hwasan_handle_vfork(const void *sp_dst);
 
 // Libc hook for thread creation. Should be called in the child thread before
 // any instrumented code.
-void __sanitizer_cdecl __hwasan_thread_enter();
+void SANITIZER_CDECL __hwasan_thread_enter();
 
 // Libc hook for thread destruction. No instrumented code should run after
 // this call.
-void __sanitizer_cdecl __hwasan_thread_exit();
+void SANITIZER_CDECL __hwasan_thread_exit();
 
 // Print shadow and origin for the memory range to stderr in a human-readable
 // format.
-void __sanitizer_cdecl __hwasan_print_shadow(const volatile void *x,
+void SANITIZER_CDECL __hwasan_print_shadow(const volatile void *x,
                                              size_t size);
 
 // Print one-line report about the memory usage of the current process.
-void __sanitizer_cdecl __hwasan_print_memory_usage();
+void SANITIZER_CDECL __hwasan_print_memory_usage();
 
 /* Returns the offset of the first byte in the memory range that can not be
  * accessed through the pointer in x, or -1 if the whole range is good. */
-intptr_t __sanitizer_cdecl __hwasan_test_shadow(const volatile void *x,
+intptr_t SANITIZER_CDECL __hwasan_test_shadow(const volatile void *x,
                                                 size_t size);
 
 /* Sets the callback function to be called during HWASan error reporting. */
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 __hwasan_set_error_report_callback(void (*callback)(const char *));
 
-int __sanitizer_cdecl __sanitizer_posix_memalign(void **memptr,
+int SANITIZER_CDECL __sanitizer_posix_memalign(void **memptr,
                                                  size_t alignment, size_t size);
-void *__sanitizer_cdecl __sanitizer_memalign(size_t alignment, size_t size);
-void *__sanitizer_cdecl __sanitizer_aligned_alloc(size_t alignment,
+void *SANITIZER_CDECL __sanitizer_memalign(size_t alignment, size_t size);
+void *SANITIZER_CDECL __sanitizer_aligned_alloc(size_t alignment,
                                                   size_t size);
-void *__sanitizer_cdecl __sanitizer___libc_memalign(size_t alignment,
+void *SANITIZER_CDECL __sanitizer___libc_memalign(size_t alignment,
                                                     size_t size);
-void *__sanitizer_cdecl __sanitizer_valloc(size_t size);
-void *__sanitizer_cdecl __sanitizer_pvalloc(size_t size);
-void __sanitizer_cdecl __sanitizer_free(void *ptr);
-void __sanitizer_cdecl __sanitizer_cfree(void *ptr);
-size_t __sanitizer_cdecl __sanitizer_malloc_usable_size(const void *ptr);
-struct mallinfo __sanitizer_cdecl __sanitizer_mallinfo();
-int __sanitizer_cdecl __sanitizer_mallopt(int cmd, int value);
-void __sanitizer_cdecl __sanitizer_malloc_stats(void);
-void *__sanitizer_cdecl __sanitizer_calloc(size_t nmemb, size_t size);
-void *__sanitizer_cdecl __sanitizer_realloc(void *ptr, size_t size);
-void *__sanitizer_cdecl __sanitizer_reallocarray(void *ptr, size_t nmemb,
+void *SANITIZER_CDECL __sanitizer_valloc(size_t size);
+void *SANITIZER_CDECL __sanitizer_pvalloc(size_t size);
+void SANITIZER_CDECL __sanitizer_free(void *ptr);
+void SANITIZER_CDECL __sanitizer_cfree(void *ptr);
+size_t SANITIZER_CDECL __sanitizer_malloc_usable_size(const void *ptr);
+struct mallinfo SANITIZER_CDECL __sanitizer_mallinfo();
+int SANITIZER_CDECL __sanitizer_mallopt(int cmd, int value);
+void SANITIZER_CDECL __sanitizer_malloc_stats(void);
+void *SANITIZER_CDECL __sanitizer_calloc(size_t nmemb, size_t size);
+void *SANITIZER_CDECL __sanitizer_realloc(void *ptr, size_t size);
+void *SANITIZER_CDECL __sanitizer_reallocarray(void *ptr, size_t nmemb,
                                                  size_t size);
-void *__sanitizer_cdecl __sanitizer_malloc(size_t size);
+void *SANITIZER_CDECL __sanitizer_malloc(size_t size);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/compiler-rt/include/sanitizer/lsan_interface.h
+++ b/compiler-rt/include/sanitizer/lsan_interface.h
@@ -20,11 +20,11 @@ extern "C" {
 #endif
 // Allocations made between calls to __lsan_disable() and __lsan_enable() will
 // be treated as non-leaks. Disable/enable pairs may be nested.
-void __sanitizer_cdecl __lsan_disable(void);
-void __sanitizer_cdecl __lsan_enable(void);
+void SANITIZER_CDECL __lsan_disable(void);
+void SANITIZER_CDECL __lsan_enable(void);
 
 // The heap object into which p points will be treated as a non-leak.
-void __sanitizer_cdecl __lsan_ignore_object(const void *p);
+void SANITIZER_CDECL __lsan_ignore_object(const void *p);
 
 // Memory regions registered through this interface will be treated as sources
 // of live pointers during leak checking. Useful if you store pointers in
@@ -37,8 +37,8 @@ void __sanitizer_cdecl __lsan_ignore_object(const void *p);
 // register the entire large region.
 // - the implementation is not optimized for performance. This interface is
 // intended to be used for a small number of relatively static regions.
-void __sanitizer_cdecl __lsan_register_root_region(const void *p, size_t size);
-void __sanitizer_cdecl __lsan_unregister_root_region(const void *p,
+void SANITIZER_CDECL __lsan_register_root_region(const void *p, size_t size);
+void SANITIZER_CDECL __lsan_unregister_root_region(const void *p,
                                                      size_t size);
 
 // Check for leaks now. This function behaves identically to the default
@@ -49,7 +49,7 @@ void __sanitizer_cdecl __lsan_unregister_root_region(const void *p,
 // the time of first invocation of this function.
 // By calling this function early during process shutdown, you can instruct
 // LSan to ignore shutdown-only leaks which happen later on.
-void __sanitizer_cdecl __lsan_do_leak_check(void);
+void SANITIZER_CDECL __lsan_do_leak_check(void);
 
 // Check for leaks now. Returns zero if no leaks have been found or if leak
 // detection is disabled, non-zero otherwise.
@@ -58,7 +58,7 @@ void __sanitizer_cdecl __lsan_do_leak_check(void);
 // terminate the process. It does not affect the behavior of
 // __lsan_do_leak_check() or the end-of-process leak check, and is not
 // affected by them.
-int __sanitizer_cdecl __lsan_do_recoverable_leak_check(void);
+int SANITIZER_CDECL __lsan_do_recoverable_leak_check(void);
 
 // The user may optionally provide this function to disallow leak checking
 // for the program it is linked into (if the return value is non-zero). This
@@ -66,15 +66,15 @@ int __sanitizer_cdecl __lsan_do_recoverable_leak_check(void);
 // that is unsupported.
 // To avoid dead stripping, you may need to define this function with
 // __attribute__((used))
-int __sanitizer_cdecl __lsan_is_turned_off(void);
+int SANITIZER_CDECL __lsan_is_turned_off(void);
 
 // This function may be optionally provided by user and should return
 // a string containing LSan runtime options. See lsan_flags.inc for details.
-const char *__sanitizer_cdecl __lsan_default_options(void);
+const char *SANITIZER_CDECL __lsan_default_options(void);
 
 // This function may be optionally provided by the user and should return
 // a string containing LSan suppressions.
-const char *__sanitizer_cdecl __lsan_default_suppressions(void);
+const char *SANITIZER_CDECL __lsan_default_suppressions(void);
 #ifdef __cplusplus
 } // extern "C"
 

--- a/compiler-rt/include/sanitizer/lsan_interface.h
+++ b/compiler-rt/include/sanitizer/lsan_interface.h
@@ -38,8 +38,7 @@ void SANITIZER_CDECL __lsan_ignore_object(const void *p);
 // - the implementation is not optimized for performance. This interface is
 // intended to be used for a small number of relatively static regions.
 void SANITIZER_CDECL __lsan_register_root_region(const void *p, size_t size);
-void SANITIZER_CDECL __lsan_unregister_root_region(const void *p,
-                                                     size_t size);
+void SANITIZER_CDECL __lsan_unregister_root_region(const void *p, size_t size);
 
 // Check for leaks now. This function behaves identically to the default
 // end-of-process leak check. In particular, it will terminate the process if

--- a/compiler-rt/include/sanitizer/lsan_interface.h
+++ b/compiler-rt/include/sanitizer/lsan_interface.h
@@ -18,72 +18,73 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  // Allocations made between calls to __lsan_disable() and __lsan_enable() will
-  // be treated as non-leaks. Disable/enable pairs may be nested.
-  void __lsan_disable(void);
-  void __lsan_enable(void);
+// Allocations made between calls to __lsan_disable() and __lsan_enable() will
+// be treated as non-leaks. Disable/enable pairs may be nested.
+void __sanitizer_cdecl __lsan_disable(void);
+void __sanitizer_cdecl __lsan_enable(void);
 
-  // The heap object into which p points will be treated as a non-leak.
-  void __lsan_ignore_object(const void *p);
+// The heap object into which p points will be treated as a non-leak.
+void __sanitizer_cdecl __lsan_ignore_object(const void *p);
 
-  // Memory regions registered through this interface will be treated as sources
-  // of live pointers during leak checking. Useful if you store pointers in
-  // mapped memory.
-  // Points of note:
-  // - __lsan_unregister_root_region() must be called with the same pointer and
-  // size that have earlier been passed to __lsan_register_root_region()
-  // - LSan will skip any inaccessible memory when scanning a root region. E.g.,
-  // if you map memory within a larger region that you have mprotect'ed, you can
-  // register the entire large region.
-  // - the implementation is not optimized for performance. This interface is
-  // intended to be used for a small number of relatively static regions.
-  void __lsan_register_root_region(const void *p, size_t size);
-  void __lsan_unregister_root_region(const void *p, size_t size);
+// Memory regions registered through this interface will be treated as sources
+// of live pointers during leak checking. Useful if you store pointers in
+// mapped memory.
+// Points of note:
+// - __lsan_unregister_root_region() must be called with the same pointer and
+// size that have earlier been passed to __lsan_register_root_region()
+// - LSan will skip any inaccessible memory when scanning a root region. E.g.,
+// if you map memory within a larger region that you have mprotect'ed, you can
+// register the entire large region.
+// - the implementation is not optimized for performance. This interface is
+// intended to be used for a small number of relatively static regions.
+void __sanitizer_cdecl __lsan_register_root_region(const void *p, size_t size);
+void __sanitizer_cdecl __lsan_unregister_root_region(const void *p,
+                                                     size_t size);
 
-  // Check for leaks now. This function behaves identically to the default
-  // end-of-process leak check. In particular, it will terminate the process if
-  // leaks are found and the exitcode runtime flag is non-zero.
-  // Subsequent calls to this function will have no effect and end-of-process
-  // leak check will not run. Effectively, end-of-process leak check is moved to
-  // the time of first invocation of this function.
-  // By calling this function early during process shutdown, you can instruct
-  // LSan to ignore shutdown-only leaks which happen later on.
-  void __lsan_do_leak_check(void);
+// Check for leaks now. This function behaves identically to the default
+// end-of-process leak check. In particular, it will terminate the process if
+// leaks are found and the exitcode runtime flag is non-zero.
+// Subsequent calls to this function will have no effect and end-of-process
+// leak check will not run. Effectively, end-of-process leak check is moved to
+// the time of first invocation of this function.
+// By calling this function early during process shutdown, you can instruct
+// LSan to ignore shutdown-only leaks which happen later on.
+void __sanitizer_cdecl __lsan_do_leak_check(void);
 
-  // Check for leaks now. Returns zero if no leaks have been found or if leak
-  // detection is disabled, non-zero otherwise.
-  // This function may be called repeatedly, e.g. to periodically check a
-  // long-running process. It prints a leak report if appropriate, but does not
-  // terminate the process. It does not affect the behavior of
-  // __lsan_do_leak_check() or the end-of-process leak check, and is not
-  // affected by them.
-  int __lsan_do_recoverable_leak_check(void);
+// Check for leaks now. Returns zero if no leaks have been found or if leak
+// detection is disabled, non-zero otherwise.
+// This function may be called repeatedly, e.g. to periodically check a
+// long-running process. It prints a leak report if appropriate, but does not
+// terminate the process. It does not affect the behavior of
+// __lsan_do_leak_check() or the end-of-process leak check, and is not
+// affected by them.
+int __sanitizer_cdecl __lsan_do_recoverable_leak_check(void);
 
-  // The user may optionally provide this function to disallow leak checking
-  // for the program it is linked into (if the return value is non-zero). This
-  // function must be defined as returning a constant value; any behavior beyond
-  // that is unsupported.
-  // To avoid dead stripping, you may need to define this function with
-  // __attribute__((used))
-  int __lsan_is_turned_off(void);
+// The user may optionally provide this function to disallow leak checking
+// for the program it is linked into (if the return value is non-zero). This
+// function must be defined as returning a constant value; any behavior beyond
+// that is unsupported.
+// To avoid dead stripping, you may need to define this function with
+// __attribute__((used))
+int __sanitizer_cdecl __lsan_is_turned_off(void);
 
-  // This function may be optionally provided by user and should return
-  // a string containing LSan runtime options. See lsan_flags.inc for details.
-  const char *__lsan_default_options(void);
+// This function may be optionally provided by user and should return
+// a string containing LSan runtime options. See lsan_flags.inc for details.
+const char *__sanitizer_cdecl __lsan_default_options(void);
 
-  // This function may be optionally provided by the user and should return
-  // a string containing LSan suppressions.
-  const char *__lsan_default_suppressions(void);
+// This function may be optionally provided by the user and should return
+// a string containing LSan suppressions.
+const char *__sanitizer_cdecl __lsan_default_suppressions(void);
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 
 namespace __lsan {
 class ScopedDisabler {
- public:
+public:
   ScopedDisabler() { __lsan_disable(); }
   ~ScopedDisabler() { __lsan_enable(); }
 };
-}  // namespace __lsan
+} // namespace __lsan
 #endif
 
-#endif  // SANITIZER_LSAN_INTERFACE_H
+#endif // SANITIZER_LSAN_INTERFACE_H

--- a/compiler-rt/include/sanitizer/memprof_interface.h
+++ b/compiler-rt/include/sanitizer/memprof_interface.h
@@ -25,7 +25,7 @@ extern "C" {
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
 void SANITIZER_CDECL __memprof_record_access_range(void const volatile *addr,
-                                                     size_t size);
+                                                   size_t size);
 
 /// Records access to a memory address <c><i>addr</i></c>.
 ///

--- a/compiler-rt/include/sanitizer/memprof_interface.h
+++ b/compiler-rt/include/sanitizer/memprof_interface.h
@@ -24,25 +24,26 @@ extern "C" {
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-void __memprof_record_access_range(void const volatile *addr, size_t size);
+void __sanitizer_cdecl __memprof_record_access_range(void const volatile *addr,
+                                                     size_t size);
 
 /// Records access to a memory address <c><i>addr</i></c>.
 ///
 /// This memory must be previously allocated by your program.
 ///
 /// \param addr Accessed memory address
-void __memprof_record_access(void const volatile *addr);
+void __sanitizer_cdecl __memprof_record_access(void const volatile *addr);
 
 /// User-provided callback on MemProf errors.
 ///
 /// You can provide a function that would be called immediately when MemProf
 /// detects an error. This is useful in cases when MemProf detects an error but
 /// your program crashes before the MemProf report is printed.
-void __memprof_on_error(void);
+void __sanitizer_cdecl __memprof_on_error(void);
 
 /// Prints accumulated statistics to <c>stderr</c> (useful for calling from the
 /// debugger).
-void __memprof_print_accumulated_stats(void);
+void __sanitizer_cdecl __memprof_print_accumulated_stats(void);
 
 /// User-provided default option settings.
 ///
@@ -51,12 +52,12 @@ void __memprof_print_accumulated_stats(void);
 /// <c>verbosity=1:print_stats=1</c>).
 ///
 /// \returns Default options string.
-const char *__memprof_default_options(void);
+const char *__sanitizer_cdecl __memprof_default_options(void);
 
 /// Prints the memory profile to the current profile file.
 ///
 /// \returns 0 on success.
-int __memprof_profile_dump(void);
+int __sanitizer_cdecl __memprof_profile_dump(void);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/memprof_interface.h
+++ b/compiler-rt/include/sanitizer/memprof_interface.h
@@ -24,7 +24,7 @@ extern "C" {
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-void __sanitizer_cdecl __memprof_record_access_range(void const volatile *addr,
+void SANITIZER_CDECL __memprof_record_access_range(void const volatile *addr,
                                                      size_t size);
 
 /// Records access to a memory address <c><i>addr</i></c>.
@@ -32,18 +32,18 @@ void __sanitizer_cdecl __memprof_record_access_range(void const volatile *addr,
 /// This memory must be previously allocated by your program.
 ///
 /// \param addr Accessed memory address
-void __sanitizer_cdecl __memprof_record_access(void const volatile *addr);
+void SANITIZER_CDECL __memprof_record_access(void const volatile *addr);
 
 /// User-provided callback on MemProf errors.
 ///
 /// You can provide a function that would be called immediately when MemProf
 /// detects an error. This is useful in cases when MemProf detects an error but
 /// your program crashes before the MemProf report is printed.
-void __sanitizer_cdecl __memprof_on_error(void);
+void SANITIZER_CDECL __memprof_on_error(void);
 
 /// Prints accumulated statistics to <c>stderr</c> (useful for calling from the
 /// debugger).
-void __sanitizer_cdecl __memprof_print_accumulated_stats(void);
+void SANITIZER_CDECL __memprof_print_accumulated_stats(void);
 
 /// User-provided default option settings.
 ///
@@ -52,12 +52,12 @@ void __sanitizer_cdecl __memprof_print_accumulated_stats(void);
 /// <c>verbosity=1:print_stats=1</c>).
 ///
 /// \returns Default options string.
-const char *__sanitizer_cdecl __memprof_default_options(void);
+const char *SANITIZER_CDECL __memprof_default_options(void);
 
 /// Prints the memory profile to the current profile file.
 ///
 /// \returns 0 on success.
-int __sanitizer_cdecl __memprof_profile_dump(void);
+int SANITIZER_CDECL __memprof_profile_dump(void);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/msan_interface.h
+++ b/compiler-rt/include/sanitizer/msan_interface.h
@@ -18,109 +18,121 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  /* Set raw origin for the memory range. */
-  void __msan_set_origin(const volatile void *a, size_t size, uint32_t origin);
+/* Set raw origin for the memory range. */
+void __sanitizer_cdecl __msan_set_origin(const volatile void *a, size_t size,
+                                         uint32_t origin);
 
-  /* Get raw origin for an address. */
-  uint32_t __msan_get_origin(const volatile void *a);
+/* Get raw origin for an address. */
+uint32_t __sanitizer_cdecl __msan_get_origin(const volatile void *a);
 
-  /* Test that this_id is a descendant of prev_id (or they are simply equal).
-   * "descendant" here means they are part of the same chain, created with
-   * __msan_chain_origin. */
-  int __msan_origin_is_descendant_or_same(uint32_t this_id, uint32_t prev_id);
+/* Test that this_id is a descendant of prev_id (or they are simply equal).
+ * "descendant" here means they are part of the same chain, created with
+ * __msan_chain_origin. */
+int __sanitizer_cdecl __msan_origin_is_descendant_or_same(uint32_t this_id,
+                                                          uint32_t prev_id);
 
-  /* Returns non-zero if tracking origins. */
-  int __msan_get_track_origins(void);
+/* Returns non-zero if tracking origins. */
+int __sanitizer_cdecl __msan_get_track_origins(void);
 
-  /* Returns the origin id of the latest UMR in the calling thread. */
-  uint32_t __msan_get_umr_origin(void);
+/* Returns the origin id of the latest UMR in the calling thread. */
+uint32_t __sanitizer_cdecl __msan_get_umr_origin(void);
 
-  /* Make memory region fully initialized (without changing its contents). */
-  void __msan_unpoison(const volatile void *a, size_t size);
+/* Make memory region fully initialized (without changing its contents). */
+void __sanitizer_cdecl __msan_unpoison(const volatile void *a, size_t size);
 
-  /* Make a null-terminated string fully initialized (without changing its
-     contents). */
-  void __msan_unpoison_string(const volatile char *a);
+/* Make a null-terminated string fully initialized (without changing its
+   contents). */
+void __sanitizer_cdecl __msan_unpoison_string(const volatile char *a);
 
-  /* Make first n parameters of the next function call fully initialized. */
-  void __msan_unpoison_param(size_t n);
+/* Make first n parameters of the next function call fully initialized. */
+void __sanitizer_cdecl __msan_unpoison_param(size_t n);
 
-  /* Make memory region fully uninitialized (without changing its contents).
-     This is a legacy interface that does not update origin information. Use
-     __msan_allocated_memory() instead. */
-  void __msan_poison(const volatile void *a, size_t size);
+/* Make memory region fully uninitialized (without changing its contents).
+   This is a legacy interface that does not update origin information. Use
+   __msan_allocated_memory() instead. */
+void __sanitizer_cdecl __msan_poison(const volatile void *a, size_t size);
 
-  /* Make memory region partially uninitialized (without changing its contents).
-   */
-  void __msan_partial_poison(const volatile void *data, void *shadow,
-                             size_t size);
+/* Make memory region partially uninitialized (without changing its contents).
+ */
+void __sanitizer_cdecl __msan_partial_poison(const volatile void *data,
+                                             void *shadow, size_t size);
 
-  /* Returns the offset of the first (at least partially) poisoned byte in the
-     memory range, or -1 if the whole range is good. */
-  intptr_t __msan_test_shadow(const volatile void *x, size_t size);
+/* Returns the offset of the first (at least partially) poisoned byte in the
+   memory range, or -1 if the whole range is good. */
+intptr_t __sanitizer_cdecl __msan_test_shadow(const volatile void *x,
+                                              size_t size);
 
-  /* Checks that memory range is fully initialized, and reports an error if it
-   * is not. */
-  void __msan_check_mem_is_initialized(const volatile void *x, size_t size);
+/* Checks that memory range is fully initialized, and reports an error if it
+ * is not. */
+void __sanitizer_cdecl __msan_check_mem_is_initialized(const volatile void *x,
+                                                       size_t size);
 
-  /* For testing:
-     __msan_set_expect_umr(1);
-     ... some buggy code ...
-     __msan_set_expect_umr(0);
-     The last line will verify that a UMR happened. */
-  void __msan_set_expect_umr(int expect_umr);
+/* For testing:
+   __msan_set_expect_umr(1);
+   ... some buggy code ...
+   __msan_set_expect_umr(0);
+   The last line will verify that a UMR happened. */
+void __sanitizer_cdecl __msan_set_expect_umr(int expect_umr);
 
-  /* Change the value of keep_going flag. Non-zero value means don't terminate
-     program execution when an error is detected. This will not affect error in
-     modules that were compiled without the corresponding compiler flag. */
-  void __msan_set_keep_going(int keep_going);
+/* Change the value of keep_going flag. Non-zero value means don't terminate
+   program execution when an error is detected. This will not affect error in
+   modules that were compiled without the corresponding compiler flag. */
+void __sanitizer_cdecl __msan_set_keep_going(int keep_going);
 
-  /* Print shadow and origin for the memory range to stderr in a human-readable
-     format. */
-  void __msan_print_shadow(const volatile void *x, size_t size);
+/* Print shadow and origin for the memory range to stderr in a human-readable
+   format. */
+void __sanitizer_cdecl __msan_print_shadow(const volatile void *x, size_t size);
 
-  /* Print shadow for the memory range to stderr in a minimalistic
-     human-readable format. */
-  void __msan_dump_shadow(const volatile void *x, size_t size);
+/* Print shadow for the memory range to stderr in a minimalistic
+   human-readable format. */
+void __sanitizer_cdecl __msan_dump_shadow(const volatile void *x, size_t size);
 
-  /* Returns true if running under a dynamic tool (DynamoRio-based). */
-  int  __msan_has_dynamic_component(void);
+/* Returns true if running under a dynamic tool (DynamoRio-based). */
+int __sanitizer_cdecl __msan_has_dynamic_component(void);
 
-  /* Tell MSan about newly allocated memory (ex.: custom allocator).
-     Memory will be marked uninitialized, with origin at the call site. */
-  void __msan_allocated_memory(const volatile void* data, size_t size);
+/* Tell MSan about newly allocated memory (ex.: custom allocator).
+   Memory will be marked uninitialized, with origin at the call site. */
+void __sanitizer_cdecl __msan_allocated_memory(const volatile void *data,
+                                               size_t size);
 
-  /* Tell MSan about newly destroyed memory. Mark memory as uninitialized. */
-  void __sanitizer_dtor_callback(const volatile void* data, size_t size);
-  void __sanitizer_dtor_callback_fields(const volatile void *data, size_t size);
-  void __sanitizer_dtor_callback_vptr(const volatile void *data);
+/* Tell MSan about newly destroyed memory. Mark memory as uninitialized. */
+void __sanitizer_cdecl __sanitizer_dtor_callback(const volatile void *data,
+                                                 size_t size);
+void __sanitizer_cdecl
+__sanitizer_dtor_callback_fields(const volatile void *data, size_t size);
+void __sanitizer_cdecl
+__sanitizer_dtor_callback_vptr(const volatile void *data);
 
-  /* This function may be optionally provided by user and should return
-     a string containing Msan runtime options. See msan_flags.h for details. */
-  const char* __msan_default_options(void);
+/* This function may be optionally provided by user and should return
+   a string containing Msan runtime options. See msan_flags.h for details. */
+const char *__sanitizer_cdecl __msan_default_options(void);
 
-  /* Deprecated. Call __sanitizer_set_death_callback instead. */
-  void __msan_set_death_callback(void (*callback)(void));
+/* Deprecated. Call __sanitizer_set_death_callback instead. */
+void __sanitizer_cdecl
+__msan_set_death_callback(void (*__sanitizer_cdecl callback)(void));
 
-  /* Update shadow for the application copy of size bytes from src to dst.
-     Src and dst are application addresses. This function does not copy the
-     actual application memory, it only updates shadow and origin for such
-     copy. Source and destination regions can overlap. */
-  void __msan_copy_shadow(const volatile void *dst, const volatile void *src,
-                          size_t size);
+/* Update shadow for the application copy of size bytes from src to dst.
+   Src and dst are application addresses. This function does not copy the
+   actual application memory, it only updates shadow and origin for such
+   copy. Source and destination regions can overlap. */
+void __sanitizer_cdecl __msan_copy_shadow(const volatile void *dst,
+                                          const volatile void *src,
+                                          size_t size);
 
-  /* Disables uninitialized memory checks in interceptors. */
-  void __msan_scoped_disable_interceptor_checks(void);
+/* Disables uninitialized memory checks in interceptors. */
+void __sanitizer_cdecl __msan_scoped_disable_interceptor_checks(void);
 
-  /* Re-enables uninitialized memory checks in interceptors after a previous
-     call to __msan_scoped_disable_interceptor_checks. */
-  void __msan_scoped_enable_interceptor_checks(void);
+/* Re-enables uninitialized memory checks in interceptors after a previous
+   call to __msan_scoped_disable_interceptor_checks. */
+void __sanitizer_cdecl __msan_scoped_enable_interceptor_checks(void);
 
-  void __msan_start_switch_fiber(const void *bottom, size_t size);
-  void __msan_finish_switch_fiber(const void **bottom_old, size_t *size_old);
+void __sanitizer_cdecl __msan_start_switch_fiber(const void *bottom,
+                                                 size_t size);
+void __sanitizer_cdecl __msan_finish_switch_fiber(const void **bottom_old,
+                                                  size_t *size_old);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif

--- a/compiler-rt/include/sanitizer/msan_interface.h
+++ b/compiler-rt/include/sanitizer/msan_interface.h
@@ -20,7 +20,7 @@ extern "C" {
 #endif
 /* Set raw origin for the memory range. */
 void SANITIZER_CDECL __msan_set_origin(const volatile void *a, size_t size,
-                                         uint32_t origin);
+                                       uint32_t origin);
 
 /* Get raw origin for an address. */
 uint32_t SANITIZER_CDECL __msan_get_origin(const volatile void *a);
@@ -29,7 +29,7 @@ uint32_t SANITIZER_CDECL __msan_get_origin(const volatile void *a);
  * "descendant" here means they are part of the same chain, created with
  * __msan_chain_origin. */
 int SANITIZER_CDECL __msan_origin_is_descendant_or_same(uint32_t this_id,
-                                                          uint32_t prev_id);
+                                                        uint32_t prev_id);
 
 /* Returns non-zero if tracking origins. */
 int SANITIZER_CDECL __msan_get_track_origins(void);
@@ -55,17 +55,17 @@ void SANITIZER_CDECL __msan_poison(const volatile void *a, size_t size);
 /* Make memory region partially uninitialized (without changing its contents).
  */
 void SANITIZER_CDECL __msan_partial_poison(const volatile void *data,
-                                             void *shadow, size_t size);
+                                           void *shadow, size_t size);
 
 /* Returns the offset of the first (at least partially) poisoned byte in the
    memory range, or -1 if the whole range is good. */
 intptr_t SANITIZER_CDECL __msan_test_shadow(const volatile void *x,
-                                              size_t size);
+                                            size_t size);
 
 /* Checks that memory range is fully initialized, and reports an error if it
  * is not. */
 void SANITIZER_CDECL __msan_check_mem_is_initialized(const volatile void *x,
-                                                       size_t size);
+                                                     size_t size);
 
 /* For testing:
    __msan_set_expect_umr(1);
@@ -93,15 +93,14 @@ int SANITIZER_CDECL __msan_has_dynamic_component(void);
 /* Tell MSan about newly allocated memory (ex.: custom allocator).
    Memory will be marked uninitialized, with origin at the call site. */
 void SANITIZER_CDECL __msan_allocated_memory(const volatile void *data,
-                                               size_t size);
+                                             size_t size);
 
 /* Tell MSan about newly destroyed memory. Mark memory as uninitialized. */
 void SANITIZER_CDECL __sanitizer_dtor_callback(const volatile void *data,
-                                                 size_t size);
-void SANITIZER_CDECL
-__sanitizer_dtor_callback_fields(const volatile void *data, size_t size);
-void SANITIZER_CDECL
-__sanitizer_dtor_callback_vptr(const volatile void *data);
+                                               size_t size);
+void SANITIZER_CDECL __sanitizer_dtor_callback_fields(const volatile void *data,
+                                                      size_t size);
+void SANITIZER_CDECL __sanitizer_dtor_callback_vptr(const volatile void *data);
 
 /* This function may be optionally provided by user and should return
    a string containing Msan runtime options. See msan_flags.h for details. */
@@ -116,8 +115,7 @@ __msan_set_death_callback(void (*SANITIZER_CDECL callback)(void));
    actual application memory, it only updates shadow and origin for such
    copy. Source and destination regions can overlap. */
 void SANITIZER_CDECL __msan_copy_shadow(const volatile void *dst,
-                                          const volatile void *src,
-                                          size_t size);
+                                        const volatile void *src, size_t size);
 
 /* Disables uninitialized memory checks in interceptors. */
 void SANITIZER_CDECL __msan_scoped_disable_interceptor_checks(void);
@@ -126,10 +124,9 @@ void SANITIZER_CDECL __msan_scoped_disable_interceptor_checks(void);
    call to __msan_scoped_disable_interceptor_checks. */
 void SANITIZER_CDECL __msan_scoped_enable_interceptor_checks(void);
 
-void SANITIZER_CDECL __msan_start_switch_fiber(const void *bottom,
-                                                 size_t size);
+void SANITIZER_CDECL __msan_start_switch_fiber(const void *bottom, size_t size);
 void SANITIZER_CDECL __msan_finish_switch_fiber(const void **bottom_old,
-                                                  size_t *size_old);
+                                                size_t *size_old);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/msan_interface.h
+++ b/compiler-rt/include/sanitizer/msan_interface.h
@@ -19,52 +19,52 @@
 extern "C" {
 #endif
 /* Set raw origin for the memory range. */
-void __sanitizer_cdecl __msan_set_origin(const volatile void *a, size_t size,
+void SANITIZER_CDECL __msan_set_origin(const volatile void *a, size_t size,
                                          uint32_t origin);
 
 /* Get raw origin for an address. */
-uint32_t __sanitizer_cdecl __msan_get_origin(const volatile void *a);
+uint32_t SANITIZER_CDECL __msan_get_origin(const volatile void *a);
 
 /* Test that this_id is a descendant of prev_id (or they are simply equal).
  * "descendant" here means they are part of the same chain, created with
  * __msan_chain_origin. */
-int __sanitizer_cdecl __msan_origin_is_descendant_or_same(uint32_t this_id,
+int SANITIZER_CDECL __msan_origin_is_descendant_or_same(uint32_t this_id,
                                                           uint32_t prev_id);
 
 /* Returns non-zero if tracking origins. */
-int __sanitizer_cdecl __msan_get_track_origins(void);
+int SANITIZER_CDECL __msan_get_track_origins(void);
 
 /* Returns the origin id of the latest UMR in the calling thread. */
-uint32_t __sanitizer_cdecl __msan_get_umr_origin(void);
+uint32_t SANITIZER_CDECL __msan_get_umr_origin(void);
 
 /* Make memory region fully initialized (without changing its contents). */
-void __sanitizer_cdecl __msan_unpoison(const volatile void *a, size_t size);
+void SANITIZER_CDECL __msan_unpoison(const volatile void *a, size_t size);
 
 /* Make a null-terminated string fully initialized (without changing its
    contents). */
-void __sanitizer_cdecl __msan_unpoison_string(const volatile char *a);
+void SANITIZER_CDECL __msan_unpoison_string(const volatile char *a);
 
 /* Make first n parameters of the next function call fully initialized. */
-void __sanitizer_cdecl __msan_unpoison_param(size_t n);
+void SANITIZER_CDECL __msan_unpoison_param(size_t n);
 
 /* Make memory region fully uninitialized (without changing its contents).
    This is a legacy interface that does not update origin information. Use
    __msan_allocated_memory() instead. */
-void __sanitizer_cdecl __msan_poison(const volatile void *a, size_t size);
+void SANITIZER_CDECL __msan_poison(const volatile void *a, size_t size);
 
 /* Make memory region partially uninitialized (without changing its contents).
  */
-void __sanitizer_cdecl __msan_partial_poison(const volatile void *data,
+void SANITIZER_CDECL __msan_partial_poison(const volatile void *data,
                                              void *shadow, size_t size);
 
 /* Returns the offset of the first (at least partially) poisoned byte in the
    memory range, or -1 if the whole range is good. */
-intptr_t __sanitizer_cdecl __msan_test_shadow(const volatile void *x,
+intptr_t SANITIZER_CDECL __msan_test_shadow(const volatile void *x,
                                               size_t size);
 
 /* Checks that memory range is fully initialized, and reports an error if it
  * is not. */
-void __sanitizer_cdecl __msan_check_mem_is_initialized(const volatile void *x,
+void SANITIZER_CDECL __msan_check_mem_is_initialized(const volatile void *x,
                                                        size_t size);
 
 /* For testing:
@@ -72,63 +72,63 @@ void __sanitizer_cdecl __msan_check_mem_is_initialized(const volatile void *x,
    ... some buggy code ...
    __msan_set_expect_umr(0);
    The last line will verify that a UMR happened. */
-void __sanitizer_cdecl __msan_set_expect_umr(int expect_umr);
+void SANITIZER_CDECL __msan_set_expect_umr(int expect_umr);
 
 /* Change the value of keep_going flag. Non-zero value means don't terminate
    program execution when an error is detected. This will not affect error in
    modules that were compiled without the corresponding compiler flag. */
-void __sanitizer_cdecl __msan_set_keep_going(int keep_going);
+void SANITIZER_CDECL __msan_set_keep_going(int keep_going);
 
 /* Print shadow and origin for the memory range to stderr in a human-readable
    format. */
-void __sanitizer_cdecl __msan_print_shadow(const volatile void *x, size_t size);
+void SANITIZER_CDECL __msan_print_shadow(const volatile void *x, size_t size);
 
 /* Print shadow for the memory range to stderr in a minimalistic
    human-readable format. */
-void __sanitizer_cdecl __msan_dump_shadow(const volatile void *x, size_t size);
+void SANITIZER_CDECL __msan_dump_shadow(const volatile void *x, size_t size);
 
 /* Returns true if running under a dynamic tool (DynamoRio-based). */
-int __sanitizer_cdecl __msan_has_dynamic_component(void);
+int SANITIZER_CDECL __msan_has_dynamic_component(void);
 
 /* Tell MSan about newly allocated memory (ex.: custom allocator).
    Memory will be marked uninitialized, with origin at the call site. */
-void __sanitizer_cdecl __msan_allocated_memory(const volatile void *data,
+void SANITIZER_CDECL __msan_allocated_memory(const volatile void *data,
                                                size_t size);
 
 /* Tell MSan about newly destroyed memory. Mark memory as uninitialized. */
-void __sanitizer_cdecl __sanitizer_dtor_callback(const volatile void *data,
+void SANITIZER_CDECL __sanitizer_dtor_callback(const volatile void *data,
                                                  size_t size);
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 __sanitizer_dtor_callback_fields(const volatile void *data, size_t size);
-void __sanitizer_cdecl
+void SANITIZER_CDECL
 __sanitizer_dtor_callback_vptr(const volatile void *data);
 
 /* This function may be optionally provided by user and should return
    a string containing Msan runtime options. See msan_flags.h for details. */
-const char *__sanitizer_cdecl __msan_default_options(void);
+const char *SANITIZER_CDECL __msan_default_options(void);
 
 /* Deprecated. Call __sanitizer_set_death_callback instead. */
-void __sanitizer_cdecl
-__msan_set_death_callback(void (*__sanitizer_cdecl callback)(void));
+void SANITIZER_CDECL
+__msan_set_death_callback(void (*SANITIZER_CDECL callback)(void));
 
 /* Update shadow for the application copy of size bytes from src to dst.
    Src and dst are application addresses. This function does not copy the
    actual application memory, it only updates shadow and origin for such
    copy. Source and destination regions can overlap. */
-void __sanitizer_cdecl __msan_copy_shadow(const volatile void *dst,
+void SANITIZER_CDECL __msan_copy_shadow(const volatile void *dst,
                                           const volatile void *src,
                                           size_t size);
 
 /* Disables uninitialized memory checks in interceptors. */
-void __sanitizer_cdecl __msan_scoped_disable_interceptor_checks(void);
+void SANITIZER_CDECL __msan_scoped_disable_interceptor_checks(void);
 
 /* Re-enables uninitialized memory checks in interceptors after a previous
    call to __msan_scoped_disable_interceptor_checks. */
-void __sanitizer_cdecl __msan_scoped_enable_interceptor_checks(void);
+void SANITIZER_CDECL __msan_scoped_enable_interceptor_checks(void);
 
-void __sanitizer_cdecl __msan_start_switch_fiber(const void *bottom,
+void SANITIZER_CDECL __msan_start_switch_fiber(const void *bottom,
                                                  size_t size);
-void __sanitizer_cdecl __msan_finish_switch_fiber(const void **bottom_old,
+void SANITIZER_CDECL __msan_finish_switch_fiber(const void **bottom_old,
                                                   size_t *size_old);
 
 #ifdef __cplusplus

--- a/compiler-rt/include/sanitizer/scudo_interface.h
+++ b/compiler-rt/include/sanitizer/scudo_interface.h
@@ -17,22 +17,22 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  // This function may be optionally provided by a user and should return
-  // a string containing Scudo runtime options. See scudo_flags.h for details.
-  const char* __scudo_default_options(void);
+// This function may be optionally provided by a user and should return
+// a string containing Scudo runtime options. See scudo_flags.h for details.
+const char *__sanitizer_cdecl __scudo_default_options(void);
 
-  // This function allows to set the RSS limit at runtime. This can be either
-  // the hard limit (HardLimit=1) or the soft limit (HardLimit=0). The limit
-  // can be removed by setting LimitMb to 0. This function's parameters should
-  // be fully trusted to avoid security mishaps.
-  void __scudo_set_rss_limit(size_t LimitMb, int HardLimit);
+// This function allows to set the RSS limit at runtime. This can be either
+// the hard limit (HardLimit=1) or the soft limit (HardLimit=0). The limit
+// can be removed by setting LimitMb to 0. This function's parameters should
+// be fully trusted to avoid security mishaps.
+void __sanitizer_cdecl __scudo_set_rss_limit(size_t LimitMb, int HardLimit);
 
-  // This function outputs various allocator statistics for both the Primary
-  // and Secondary allocators, including memory usage, number of allocations
-  // and deallocations.
-  void __scudo_print_stats(void);
+// This function outputs various allocator statistics for both the Primary
+// and Secondary allocators, including memory usage, number of allocations
+// and deallocations.
+void __sanitizer_cdecl __scudo_print_stats(void);
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // SANITIZER_SCUDO_INTERFACE_H_
+#endif // SANITIZER_SCUDO_INTERFACE_H_

--- a/compiler-rt/include/sanitizer/scudo_interface.h
+++ b/compiler-rt/include/sanitizer/scudo_interface.h
@@ -19,18 +19,18 @@ extern "C" {
 #endif
 // This function may be optionally provided by a user and should return
 // a string containing Scudo runtime options. See scudo_flags.h for details.
-const char *__sanitizer_cdecl __scudo_default_options(void);
+const char *SANITIZER_CDECL __scudo_default_options(void);
 
 // This function allows to set the RSS limit at runtime. This can be either
 // the hard limit (HardLimit=1) or the soft limit (HardLimit=0). The limit
 // can be removed by setting LimitMb to 0. This function's parameters should
 // be fully trusted to avoid security mishaps.
-void __sanitizer_cdecl __scudo_set_rss_limit(size_t LimitMb, int HardLimit);
+void SANITIZER_CDECL __scudo_set_rss_limit(size_t LimitMb, int HardLimit);
 
 // This function outputs various allocator statistics for both the Primary
 // and Secondary allocators, including memory usage, number of allocations
 // and deallocations.
-void __sanitizer_cdecl __scudo_print_stats(void);
+void SANITIZER_CDECL __scudo_print_stats(void);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/compiler-rt/include/sanitizer/tsan_interface.h
+++ b/compiler-rt/include/sanitizer/tsan_interface.h
@@ -98,7 +98,7 @@ void SANITIZER_CDECL __tsan_mutex_pre_lock(void *addr, unsigned flags);
 //   - __tsan_mutex_recursive_lock
 //   - all mutex creation flags
 void SANITIZER_CDECL __tsan_mutex_post_lock(void *addr, unsigned flags,
-                                              int recursion);
+                                            int recursion);
 
 // Annotate start of unlock operation.
 // Supported flags:
@@ -139,12 +139,12 @@ void SANITIZER_CDECL __tsan_mutex_post_divert(void *addr, unsigned flags);
 //   - __tsan_external_assign_tag can optionally mark a heap object with a tag
 void *SANITIZER_CDECL __tsan_external_register_tag(const char *object_type);
 void SANITIZER_CDECL __tsan_external_register_header(void *tag,
-                                                       const char *header);
+                                                     const char *header);
 void SANITIZER_CDECL __tsan_external_assign_tag(void *addr, void *tag);
 void SANITIZER_CDECL __tsan_external_read(void *addr, void *caller_pc,
-                                            void *tag);
+                                          void *tag);
 void SANITIZER_CDECL __tsan_external_write(void *addr, void *caller_pc,
-                                             void *tag);
+                                           void *tag);
 
 // Fiber switching API.
 //   - TSAN context for fiber can be created by __tsan_create_fiber
@@ -215,8 +215,8 @@ int SANITIZER_CDECL __tsan_get_report_data(
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
 int SANITIZER_CDECL __tsan_get_report_stack(void *report, unsigned long idx,
-                                              void **trace,
-                                              unsigned long trace_size);
+                                            void **trace,
+                                            unsigned long trace_size);
 
 /// Returns information about memory operations included in the report.
 ///
@@ -231,10 +231,9 @@ int SANITIZER_CDECL __tsan_get_report_stack(void *report, unsigned long idx,
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
 int SANITIZER_CDECL __tsan_get_report_mop(void *report, unsigned long idx,
-                                            int *tid, void **addr, int *size,
-                                            int *write, int *atomic,
-                                            void **trace,
-                                            unsigned long trace_size);
+                                          int *tid, void **addr, int *size,
+                                          int *write, int *atomic, void **trace,
+                                          unsigned long trace_size);
 
 /// Returns information about locations included in the report.
 ///
@@ -251,11 +250,11 @@ int SANITIZER_CDECL __tsan_get_report_mop(void *report, unsigned long idx,
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
 int SANITIZER_CDECL __tsan_get_report_loc(void *report, unsigned long idx,
-                                            const char **type, void **addr,
-                                            void **start, unsigned long *size,
-                                            int *tid, int *fd,
-                                            int *suppressable, void **trace,
-                                            unsigned long trace_size);
+                                          const char **type, void **addr,
+                                          void **start, unsigned long *size,
+                                          int *tid, int *fd, int *suppressable,
+                                          void **trace,
+                                          unsigned long trace_size);
 
 /// Returns information about mutexes included in the report.
 ///
@@ -268,9 +267,9 @@ int SANITIZER_CDECL __tsan_get_report_loc(void *report, unsigned long idx,
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
 int SANITIZER_CDECL __tsan_get_report_mutex(void *report, unsigned long idx,
-                                              uint64_t *mutex_id, void **addr,
-                                              int *destroyed, void **trace,
-                                              unsigned long trace_size);
+                                            uint64_t *mutex_id, void **addr,
+                                            int *destroyed, void **trace,
+                                            unsigned long trace_size);
 
 /// Returns information about threads included in the report.
 ///
@@ -285,10 +284,10 @@ int SANITIZER_CDECL __tsan_get_report_mutex(void *report, unsigned long idx,
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
 int SANITIZER_CDECL __tsan_get_report_thread(void *report, unsigned long idx,
-                                               int *tid, uint64_t *os_id,
-                                               int *running, const char **name,
-                                               int *parent_tid, void **trace,
-                                               unsigned long trace_size);
+                                             int *tid, uint64_t *os_id,
+                                             int *running, const char **name,
+                                             int *parent_tid, void **trace,
+                                             unsigned long trace_size);
 
 /// Returns information about unique thread IDs included in the report.
 ///
@@ -297,7 +296,7 @@ int SANITIZER_CDECL __tsan_get_report_thread(void *report, unsigned long idx,
 /// \param[out] tid Unique thread ID of the report.
 /// \returns Returns 1 if successful, 0 if not.
 int SANITIZER_CDECL __tsan_get_report_unique_tid(void *report,
-                                                   unsigned long idx, int *tid);
+                                                 unsigned long idx, int *tid);
 
 /// Returns the current report.
 ///

--- a/compiler-rt/include/sanitizer/tsan_interface.h
+++ b/compiler-rt/include/sanitizer/tsan_interface.h
@@ -21,8 +21,8 @@ extern "C" {
 
 // __tsan_release establishes a happens-before relation with a preceding
 // __tsan_acquire on the same address.
-void __tsan_acquire(void *addr);
-void __tsan_release(void *addr);
+void __sanitizer_cdecl __tsan_acquire(void *addr);
+void __sanitizer_cdecl __tsan_release(void *addr);
 
 // Annotations for custom mutexes.
 // The annotations allow to get better reports (with sets of locked mutexes),
@@ -52,16 +52,16 @@ static const unsigned __tsan_mutex_not_static       = 1 << 8;
 // Mutex operation flags:
 
 // Denotes read lock operation.
-static const unsigned __tsan_mutex_read_lock        = 1 << 3;
+static const unsigned __tsan_mutex_read_lock = 1 << 3;
 // Denotes try lock operation.
-static const unsigned __tsan_mutex_try_lock         = 1 << 4;
+static const unsigned __tsan_mutex_try_lock = 1 << 4;
 // Denotes that a try lock operation has failed to acquire the mutex.
-static const unsigned __tsan_mutex_try_lock_failed  = 1 << 5;
+static const unsigned __tsan_mutex_try_lock_failed = 1 << 5;
 // Denotes that the lock operation acquires multiple recursion levels.
 // Number of levels is passed in recursion parameter.
 // This is useful for annotation of e.g. Java builtin monitors,
 // for which wait operation releases all recursive acquisitions of the mutex.
-static const unsigned __tsan_mutex_recursive_lock   = 1 << 6;
+static const unsigned __tsan_mutex_recursive_lock = 1 << 6;
 // Denotes that the unlock operation releases all recursion levels.
 // Number of released levels is returned and later must be passed to
 // the corresponding __tsan_mutex_post_lock annotation.
@@ -75,20 +75,20 @@ static const unsigned __tsan_mutex_try_read_lock_failed =
 
 // Annotate creation of a mutex.
 // Supported flags: mutex creation flags.
-void __tsan_mutex_create(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_create(void *addr, unsigned flags);
 
 // Annotate destruction of a mutex.
 // Supported flags:
 //   - __tsan_mutex_linker_init
 //   - __tsan_mutex_not_static
-void __tsan_mutex_destroy(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_destroy(void *addr, unsigned flags);
 
 // Annotate start of lock operation.
 // Supported flags:
 //   - __tsan_mutex_read_lock
 //   - __tsan_mutex_try_lock
 //   - all mutex creation flags
-void __tsan_mutex_pre_lock(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_pre_lock(void *addr, unsigned flags);
 
 // Annotate end of lock operation.
 // Supported flags:
@@ -97,23 +97,24 @@ void __tsan_mutex_pre_lock(void *addr, unsigned flags);
 //   - __tsan_mutex_try_lock_failed
 //   - __tsan_mutex_recursive_lock
 //   - all mutex creation flags
-void __tsan_mutex_post_lock(void *addr, unsigned flags, int recursion);
+void __sanitizer_cdecl __tsan_mutex_post_lock(void *addr, unsigned flags,
+                                              int recursion);
 
 // Annotate start of unlock operation.
 // Supported flags:
 //   - __tsan_mutex_read_lock
 //   - __tsan_mutex_recursive_unlock
-int __tsan_mutex_pre_unlock(void *addr, unsigned flags);
+int __sanitizer_cdecl __tsan_mutex_pre_unlock(void *addr, unsigned flags);
 
 // Annotate end of unlock operation.
 // Supported flags:
 //   - __tsan_mutex_read_lock (must match __tsan_mutex_pre_unlock)
-void __tsan_mutex_post_unlock(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_post_unlock(void *addr, unsigned flags);
 
 // Annotate start/end of notify/signal/broadcast operation.
 // Supported flags: none.
-void __tsan_mutex_pre_signal(void *addr, unsigned flags);
-void __tsan_mutex_post_signal(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_pre_signal(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_post_signal(void *addr, unsigned flags);
 
 // Annotate start/end of a region of code where lock/unlock/signal operation
 // diverts to do something else unrelated to the mutex. This can be used to
@@ -123,8 +124,8 @@ void __tsan_mutex_post_signal(void *addr, unsigned flags);
 // __tsan_mutex_pre/post_lock, __tsan_mutex_pre/post_unlock,
 // __tsan_mutex_pre/post_signal regions.
 // Supported flags: none.
-void __tsan_mutex_pre_divert(void *addr, unsigned flags);
-void __tsan_mutex_post_divert(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_pre_divert(void *addr, unsigned flags);
+void __sanitizer_cdecl __tsan_mutex_post_divert(void *addr, unsigned flags);
 
 // External race detection API.
 // Can be used by non-instrumented libraries to detect when their objects are
@@ -136,11 +137,14 @@ void __tsan_mutex_post_divert(void *addr, unsigned flags);
 //   - __tsan_external_register_tag registers a 'tag' with the specified name,
 //       which is later used in read/write annotations to denote the object type
 //   - __tsan_external_assign_tag can optionally mark a heap object with a tag
-void *__tsan_external_register_tag(const char *object_type);
-void __tsan_external_register_header(void *tag, const char *header);
-void __tsan_external_assign_tag(void *addr, void *tag);
-void __tsan_external_read(void *addr, void *caller_pc, void *tag);
-void __tsan_external_write(void *addr, void *caller_pc, void *tag);
+void *__sanitizer_cdecl __tsan_external_register_tag(const char *object_type);
+void __sanitizer_cdecl __tsan_external_register_header(void *tag,
+                                                       const char *header);
+void __sanitizer_cdecl __tsan_external_assign_tag(void *addr, void *tag);
+void __sanitizer_cdecl __tsan_external_read(void *addr, void *caller_pc,
+                                            void *tag);
+void __sanitizer_cdecl __tsan_external_write(void *addr, void *caller_pc,
+                                             void *tag);
 
 // Fiber switching API.
 //   - TSAN context for fiber can be created by __tsan_create_fiber
@@ -150,33 +154,33 @@ void __tsan_external_write(void *addr, void *caller_pc, void *tag);
 //   - __tsan_switch_to_fiber should be called immediately before switch
 //     to fiber, such as call of swapcontext.
 //   - Fiber name can be set by __tsan_set_fiber_name.
-void *__tsan_get_current_fiber(void);
-void *__tsan_create_fiber(unsigned flags);
-void __tsan_destroy_fiber(void *fiber);
-void __tsan_switch_to_fiber(void *fiber, unsigned flags);
-void __tsan_set_fiber_name(void *fiber, const char *name);
+void *__sanitizer_cdecl __tsan_get_current_fiber(void);
+void *__sanitizer_cdecl __tsan_create_fiber(unsigned flags);
+void __sanitizer_cdecl __tsan_destroy_fiber(void *fiber);
+void __sanitizer_cdecl __tsan_switch_to_fiber(void *fiber, unsigned flags);
+void __sanitizer_cdecl __tsan_set_fiber_name(void *fiber, const char *name);
 
 // Flags for __tsan_switch_to_fiber:
 // Do not establish a happens-before relation between fibers
 static const unsigned __tsan_switch_to_fiber_no_sync = 1 << 0;
 
 // User-provided callback invoked on TSan initialization.
-void __tsan_on_initialize();
+void __sanitizer_cdecl __tsan_on_initialize();
 
 // User-provided callback invoked on TSan shutdown.
 // `failed` - Nonzero if TSan did detect issues, zero otherwise.
 // Return `0` if TSan should exit as if no issues were detected.  Return nonzero
 // if TSan should exit as if issues were detected.
-int __tsan_on_finalize(int failed);
+int __sanitizer_cdecl __tsan_on_finalize(int failed);
 
 // Release TSan internal memory in a best-effort manner.
-void __tsan_flush_memory();
+void __sanitizer_cdecl __tsan_flush_memory();
 
 // User-provided default TSAN options.
-const char* __tsan_default_options(void);
+const char *__sanitizer_cdecl __tsan_default_options(void);
 
 // User-provided default TSAN suppressions.
-const char* __tsan_default_suppressions(void);
+const char *__sanitizer_cdecl __tsan_default_suppressions(void);
 
 /// Returns a report's description.
 ///
@@ -198,11 +202,10 @@ const char* __tsan_default_suppressions(void);
 /// call.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __tsan_get_report_data(void *report, const char **description, int *count,
-                           int *stack_count, int *mop_count, int *loc_count,
-                           int *mutex_count, int *thread_count,
-                           int *unique_tid_count, void **sleep_trace,
-                           unsigned long trace_size);
+int __sanitizer_cdecl __tsan_get_report_data(
+    void *report, const char **description, int *count, int *stack_count,
+    int *mop_count, int *loc_count, int *mutex_count, int *thread_count,
+    int *unique_tid_count, void **sleep_trace, unsigned long trace_size);
 
 /// Returns information about stack traces included in the report.
 ///
@@ -211,8 +214,9 @@ int __tsan_get_report_data(void *report, const char **description, int *count,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __tsan_get_report_stack(void *report, unsigned long idx, void **trace,
-                            unsigned long trace_size);
+int __sanitizer_cdecl __tsan_get_report_stack(void *report, unsigned long idx,
+                                              void **trace,
+                                              unsigned long trace_size);
 
 /// Returns information about memory operations included in the report.
 ///
@@ -226,9 +230,11 @@ int __tsan_get_report_stack(void *report, unsigned long idx, void **trace,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __tsan_get_report_mop(void *report, unsigned long idx, int *tid,
-                          void **addr, int *size, int *write, int *atomic,
-                          void **trace, unsigned long trace_size);
+int __sanitizer_cdecl __tsan_get_report_mop(void *report, unsigned long idx,
+                                            int *tid, void **addr, int *size,
+                                            int *write, int *atomic,
+                                            void **trace,
+                                            unsigned long trace_size);
 
 /// Returns information about locations included in the report.
 ///
@@ -244,10 +250,12 @@ int __tsan_get_report_mop(void *report, unsigned long idx, int *tid,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __tsan_get_report_loc(void *report, unsigned long idx, const char **type,
-                          void **addr, void **start, unsigned long *size,
-                          int *tid, int *fd, int *suppressable, void **trace,
-                          unsigned long trace_size);
+int __sanitizer_cdecl __tsan_get_report_loc(void *report, unsigned long idx,
+                                            const char **type, void **addr,
+                                            void **start, unsigned long *size,
+                                            int *tid, int *fd,
+                                            int *suppressable, void **trace,
+                                            unsigned long trace_size);
 
 /// Returns information about mutexes included in the report.
 ///
@@ -259,9 +267,10 @@ int __tsan_get_report_loc(void *report, unsigned long idx, const char **type,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __tsan_get_report_mutex(void *report, unsigned long idx, uint64_t *mutex_id,
-                            void **addr, int *destroyed, void **trace,
-                            unsigned long trace_size);
+int __sanitizer_cdecl __tsan_get_report_mutex(void *report, unsigned long idx,
+                                              uint64_t *mutex_id, void **addr,
+                                              int *destroyed, void **trace,
+                                              unsigned long trace_size);
 
 /// Returns information about threads included in the report.
 ///
@@ -275,10 +284,11 @@ int __tsan_get_report_mutex(void *report, unsigned long idx, uint64_t *mutex_id,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __tsan_get_report_thread(void *report, unsigned long idx, int *tid,
-                             uint64_t *os_id, int *running, const char **name,
-                             int *parent_tid, void **trace,
-                             unsigned long trace_size);
+int __sanitizer_cdecl __tsan_get_report_thread(void *report, unsigned long idx,
+                                               int *tid, uint64_t *os_id,
+                                               int *running, const char **name,
+                                               int *parent_tid, void **trace,
+                                               unsigned long trace_size);
 
 /// Returns information about unique thread IDs included in the report.
 ///
@@ -286,17 +296,18 @@ int __tsan_get_report_thread(void *report, unsigned long idx, int *tid,
 /// \param idx Index to the report's unique thread IDs.
 /// \param[out] tid Unique thread ID of the report.
 /// \returns Returns 1 if successful, 0 if not.
-int __tsan_get_report_unique_tid(void *report, unsigned long idx, int *tid);
+int __sanitizer_cdecl __tsan_get_report_unique_tid(void *report,
+                                                   unsigned long idx, int *tid);
 
 /// Returns the current report.
 ///
 /// If TSan is currently reporting a detected issue on the current thread,
 /// returns an opaque pointer to the current report. Otherwise returns NULL.
 /// \returns An opaque pointer to the current report. Otherwise returns NULL.
-void *__tsan_get_current_report();
+void *__sanitizer_cdecl __tsan_get_current_report();
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // SANITIZER_TSAN_INTERFACE_H
+#endif // SANITIZER_TSAN_INTERFACE_H

--- a/compiler-rt/include/sanitizer/tsan_interface.h
+++ b/compiler-rt/include/sanitizer/tsan_interface.h
@@ -21,8 +21,8 @@ extern "C" {
 
 // __tsan_release establishes a happens-before relation with a preceding
 // __tsan_acquire on the same address.
-void __sanitizer_cdecl __tsan_acquire(void *addr);
-void __sanitizer_cdecl __tsan_release(void *addr);
+void SANITIZER_CDECL __tsan_acquire(void *addr);
+void SANITIZER_CDECL __tsan_release(void *addr);
 
 // Annotations for custom mutexes.
 // The annotations allow to get better reports (with sets of locked mutexes),
@@ -75,20 +75,20 @@ static const unsigned __tsan_mutex_try_read_lock_failed =
 
 // Annotate creation of a mutex.
 // Supported flags: mutex creation flags.
-void __sanitizer_cdecl __tsan_mutex_create(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_create(void *addr, unsigned flags);
 
 // Annotate destruction of a mutex.
 // Supported flags:
 //   - __tsan_mutex_linker_init
 //   - __tsan_mutex_not_static
-void __sanitizer_cdecl __tsan_mutex_destroy(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_destroy(void *addr, unsigned flags);
 
 // Annotate start of lock operation.
 // Supported flags:
 //   - __tsan_mutex_read_lock
 //   - __tsan_mutex_try_lock
 //   - all mutex creation flags
-void __sanitizer_cdecl __tsan_mutex_pre_lock(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_pre_lock(void *addr, unsigned flags);
 
 // Annotate end of lock operation.
 // Supported flags:
@@ -97,24 +97,24 @@ void __sanitizer_cdecl __tsan_mutex_pre_lock(void *addr, unsigned flags);
 //   - __tsan_mutex_try_lock_failed
 //   - __tsan_mutex_recursive_lock
 //   - all mutex creation flags
-void __sanitizer_cdecl __tsan_mutex_post_lock(void *addr, unsigned flags,
+void SANITIZER_CDECL __tsan_mutex_post_lock(void *addr, unsigned flags,
                                               int recursion);
 
 // Annotate start of unlock operation.
 // Supported flags:
 //   - __tsan_mutex_read_lock
 //   - __tsan_mutex_recursive_unlock
-int __sanitizer_cdecl __tsan_mutex_pre_unlock(void *addr, unsigned flags);
+int SANITIZER_CDECL __tsan_mutex_pre_unlock(void *addr, unsigned flags);
 
 // Annotate end of unlock operation.
 // Supported flags:
 //   - __tsan_mutex_read_lock (must match __tsan_mutex_pre_unlock)
-void __sanitizer_cdecl __tsan_mutex_post_unlock(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_post_unlock(void *addr, unsigned flags);
 
 // Annotate start/end of notify/signal/broadcast operation.
 // Supported flags: none.
-void __sanitizer_cdecl __tsan_mutex_pre_signal(void *addr, unsigned flags);
-void __sanitizer_cdecl __tsan_mutex_post_signal(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_pre_signal(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_post_signal(void *addr, unsigned flags);
 
 // Annotate start/end of a region of code where lock/unlock/signal operation
 // diverts to do something else unrelated to the mutex. This can be used to
@@ -124,8 +124,8 @@ void __sanitizer_cdecl __tsan_mutex_post_signal(void *addr, unsigned flags);
 // __tsan_mutex_pre/post_lock, __tsan_mutex_pre/post_unlock,
 // __tsan_mutex_pre/post_signal regions.
 // Supported flags: none.
-void __sanitizer_cdecl __tsan_mutex_pre_divert(void *addr, unsigned flags);
-void __sanitizer_cdecl __tsan_mutex_post_divert(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_pre_divert(void *addr, unsigned flags);
+void SANITIZER_CDECL __tsan_mutex_post_divert(void *addr, unsigned flags);
 
 // External race detection API.
 // Can be used by non-instrumented libraries to detect when their objects are
@@ -137,13 +137,13 @@ void __sanitizer_cdecl __tsan_mutex_post_divert(void *addr, unsigned flags);
 //   - __tsan_external_register_tag registers a 'tag' with the specified name,
 //       which is later used in read/write annotations to denote the object type
 //   - __tsan_external_assign_tag can optionally mark a heap object with a tag
-void *__sanitizer_cdecl __tsan_external_register_tag(const char *object_type);
-void __sanitizer_cdecl __tsan_external_register_header(void *tag,
+void *SANITIZER_CDECL __tsan_external_register_tag(const char *object_type);
+void SANITIZER_CDECL __tsan_external_register_header(void *tag,
                                                        const char *header);
-void __sanitizer_cdecl __tsan_external_assign_tag(void *addr, void *tag);
-void __sanitizer_cdecl __tsan_external_read(void *addr, void *caller_pc,
+void SANITIZER_CDECL __tsan_external_assign_tag(void *addr, void *tag);
+void SANITIZER_CDECL __tsan_external_read(void *addr, void *caller_pc,
                                             void *tag);
-void __sanitizer_cdecl __tsan_external_write(void *addr, void *caller_pc,
+void SANITIZER_CDECL __tsan_external_write(void *addr, void *caller_pc,
                                              void *tag);
 
 // Fiber switching API.
@@ -154,33 +154,33 @@ void __sanitizer_cdecl __tsan_external_write(void *addr, void *caller_pc,
 //   - __tsan_switch_to_fiber should be called immediately before switch
 //     to fiber, such as call of swapcontext.
 //   - Fiber name can be set by __tsan_set_fiber_name.
-void *__sanitizer_cdecl __tsan_get_current_fiber(void);
-void *__sanitizer_cdecl __tsan_create_fiber(unsigned flags);
-void __sanitizer_cdecl __tsan_destroy_fiber(void *fiber);
-void __sanitizer_cdecl __tsan_switch_to_fiber(void *fiber, unsigned flags);
-void __sanitizer_cdecl __tsan_set_fiber_name(void *fiber, const char *name);
+void *SANITIZER_CDECL __tsan_get_current_fiber(void);
+void *SANITIZER_CDECL __tsan_create_fiber(unsigned flags);
+void SANITIZER_CDECL __tsan_destroy_fiber(void *fiber);
+void SANITIZER_CDECL __tsan_switch_to_fiber(void *fiber, unsigned flags);
+void SANITIZER_CDECL __tsan_set_fiber_name(void *fiber, const char *name);
 
 // Flags for __tsan_switch_to_fiber:
 // Do not establish a happens-before relation between fibers
 static const unsigned __tsan_switch_to_fiber_no_sync = 1 << 0;
 
 // User-provided callback invoked on TSan initialization.
-void __sanitizer_cdecl __tsan_on_initialize();
+void SANITIZER_CDECL __tsan_on_initialize();
 
 // User-provided callback invoked on TSan shutdown.
 // `failed` - Nonzero if TSan did detect issues, zero otherwise.
 // Return `0` if TSan should exit as if no issues were detected.  Return nonzero
 // if TSan should exit as if issues were detected.
-int __sanitizer_cdecl __tsan_on_finalize(int failed);
+int SANITIZER_CDECL __tsan_on_finalize(int failed);
 
 // Release TSan internal memory in a best-effort manner.
-void __sanitizer_cdecl __tsan_flush_memory();
+void SANITIZER_CDECL __tsan_flush_memory();
 
 // User-provided default TSAN options.
-const char *__sanitizer_cdecl __tsan_default_options(void);
+const char *SANITIZER_CDECL __tsan_default_options(void);
 
 // User-provided default TSAN suppressions.
-const char *__sanitizer_cdecl __tsan_default_suppressions(void);
+const char *SANITIZER_CDECL __tsan_default_suppressions(void);
 
 /// Returns a report's description.
 ///
@@ -202,7 +202,7 @@ const char *__sanitizer_cdecl __tsan_default_suppressions(void);
 /// call.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __tsan_get_report_data(
+int SANITIZER_CDECL __tsan_get_report_data(
     void *report, const char **description, int *count, int *stack_count,
     int *mop_count, int *loc_count, int *mutex_count, int *thread_count,
     int *unique_tid_count, void **sleep_trace, unsigned long trace_size);
@@ -214,7 +214,7 @@ int __sanitizer_cdecl __tsan_get_report_data(
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __tsan_get_report_stack(void *report, unsigned long idx,
+int SANITIZER_CDECL __tsan_get_report_stack(void *report, unsigned long idx,
                                               void **trace,
                                               unsigned long trace_size);
 
@@ -230,7 +230,7 @@ int __sanitizer_cdecl __tsan_get_report_stack(void *report, unsigned long idx,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __tsan_get_report_mop(void *report, unsigned long idx,
+int SANITIZER_CDECL __tsan_get_report_mop(void *report, unsigned long idx,
                                             int *tid, void **addr, int *size,
                                             int *write, int *atomic,
                                             void **trace,
@@ -250,7 +250,7 @@ int __sanitizer_cdecl __tsan_get_report_mop(void *report, unsigned long idx,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __tsan_get_report_loc(void *report, unsigned long idx,
+int SANITIZER_CDECL __tsan_get_report_loc(void *report, unsigned long idx,
                                             const char **type, void **addr,
                                             void **start, unsigned long *size,
                                             int *tid, int *fd,
@@ -267,7 +267,7 @@ int __sanitizer_cdecl __tsan_get_report_loc(void *report, unsigned long idx,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __tsan_get_report_mutex(void *report, unsigned long idx,
+int SANITIZER_CDECL __tsan_get_report_mutex(void *report, unsigned long idx,
                                               uint64_t *mutex_id, void **addr,
                                               int *destroyed, void **trace,
                                               unsigned long trace_size);
@@ -284,7 +284,7 @@ int __sanitizer_cdecl __tsan_get_report_mutex(void *report, unsigned long idx,
 /// \param trace A buffer to store the stack trace.
 /// \param trace_size Size in bytes of the trace buffer.
 /// \returns Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __tsan_get_report_thread(void *report, unsigned long idx,
+int SANITIZER_CDECL __tsan_get_report_thread(void *report, unsigned long idx,
                                                int *tid, uint64_t *os_id,
                                                int *running, const char **name,
                                                int *parent_tid, void **trace,
@@ -296,7 +296,7 @@ int __sanitizer_cdecl __tsan_get_report_thread(void *report, unsigned long idx,
 /// \param idx Index to the report's unique thread IDs.
 /// \param[out] tid Unique thread ID of the report.
 /// \returns Returns 1 if successful, 0 if not.
-int __sanitizer_cdecl __tsan_get_report_unique_tid(void *report,
+int SANITIZER_CDECL __tsan_get_report_unique_tid(void *report,
                                                    unsigned long idx, int *tid);
 
 /// Returns the current report.
@@ -304,7 +304,7 @@ int __sanitizer_cdecl __tsan_get_report_unique_tid(void *report,
 /// If TSan is currently reporting a detected issue on the current thread,
 /// returns an opaque pointer to the current report. Otherwise returns NULL.
 /// \returns An opaque pointer to the current report. Otherwise returns NULL.
-void *__sanitizer_cdecl __tsan_get_current_report();
+void *SANITIZER_CDECL __tsan_get_current_report();
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/tsan_interface_atomic.h
+++ b/compiler-rt/include/sanitizer/tsan_interface_atomic.h
@@ -21,12 +21,12 @@ typedef char __tsan_atomic8;
 typedef short __tsan_atomic16;
 typedef int __tsan_atomic32;
 typedef long __tsan_atomic64;
-#if defined(__SIZEOF_INT128__) \
-    || (__clang_major__ * 100 + __clang_minor__ >= 302)
+#if defined(__SIZEOF_INT128__) ||                                              \
+    (__clang_major__ * 100 + __clang_minor__ >= 302)
 __extension__ typedef __int128 __tsan_atomic128;
-# define __TSAN_HAS_INT128 1
+#define __TSAN_HAS_INT128 1
 #else
-# define __TSAN_HAS_INT128 0
+#define __TSAN_HAS_INT128 0
 #endif
 
 // Part of ABI, do not change.
@@ -40,182 +40,187 @@ typedef enum {
   __tsan_memory_order_seq_cst
 } __tsan_memory_order;
 
-__tsan_atomic8 __tsan_atomic8_load(const volatile __tsan_atomic8 *a,
-    __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_load(const volatile __tsan_atomic16 *a,
-    __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_load(const volatile __tsan_atomic32 *a,
-    __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_load(const volatile __tsan_atomic64 *a,
-    __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl
+__tsan_atomic8_load(const volatile __tsan_atomic8 *a, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl
+__tsan_atomic16_load(const volatile __tsan_atomic16 *a, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl
+__tsan_atomic32_load(const volatile __tsan_atomic32 *a, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl
+__tsan_atomic64_load(const volatile __tsan_atomic64 *a, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_load(const volatile __tsan_atomic128 *a,
-    __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_load(
+    const volatile __tsan_atomic128 *a, __tsan_memory_order mo);
 #endif
 
-void __tsan_atomic8_store(volatile __tsan_atomic8 *a, __tsan_atomic8 v,
-    __tsan_memory_order mo);
-void __tsan_atomic16_store(volatile __tsan_atomic16 *a, __tsan_atomic16 v,
-    __tsan_memory_order mo);
-void __tsan_atomic32_store(volatile __tsan_atomic32 *a, __tsan_atomic32 v,
-    __tsan_memory_order mo);
-void __tsan_atomic64_store(volatile __tsan_atomic64 *a, __tsan_atomic64 v,
-    __tsan_memory_order mo);
+void __sanitizer_cdecl __tsan_atomic8_store(volatile __tsan_atomic8 *a,
+                                            __tsan_atomic8 v,
+                                            __tsan_memory_order mo);
+void __sanitizer_cdecl __tsan_atomic16_store(volatile __tsan_atomic16 *a,
+                                             __tsan_atomic16 v,
+                                             __tsan_memory_order mo);
+void __sanitizer_cdecl __tsan_atomic32_store(volatile __tsan_atomic32 *a,
+                                             __tsan_atomic32 v,
+                                             __tsan_memory_order mo);
+void __sanitizer_cdecl __tsan_atomic64_store(volatile __tsan_atomic64 *a,
+                                             __tsan_atomic64 v,
+                                             __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-void __tsan_atomic128_store(volatile __tsan_atomic128 *a, __tsan_atomic128 v,
-    __tsan_memory_order mo);
+void __sanitizer_cdecl __tsan_atomic128_store(volatile __tsan_atomic128 *a,
+                                              __tsan_atomic128 v,
+                                              __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_exchange(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_exchange(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_exchange(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_exchange(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 v, __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_exchange(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_exchange(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_exchange(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_exchange(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_exchange(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 v, __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_exchange(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_fetch_add(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_fetch_add(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_fetch_add(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_fetch_add(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 v, __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_add(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_add(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_add(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_add(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_fetch_add(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 v, __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_add(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_fetch_sub(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_fetch_sub(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_fetch_sub(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_fetch_sub(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 v, __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_sub(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_sub(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_sub(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_sub(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_fetch_sub(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 v, __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_sub(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_fetch_and(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_fetch_and(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_fetch_and(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_fetch_and(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 v, __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_and(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_and(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_and(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_and(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_fetch_and(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 v, __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_and(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_fetch_or(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_fetch_or(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_fetch_or(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_fetch_or(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 v, __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_or(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_or(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_or(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_or(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_fetch_or(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 v, __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_or(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_fetch_xor(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_fetch_xor(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_fetch_xor(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_fetch_xor(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 v, __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_xor(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_xor(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_xor(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_xor(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_fetch_xor(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 v, __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_xor(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_fetch_nand(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __tsan_atomic16_fetch_nand(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __tsan_atomic32_fetch_nand(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __tsan_atomic64_fetch_nand(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 v, __tsan_memory_order mo);
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_nand(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_nand(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_nand(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_nand(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_fetch_nand(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 v, __tsan_memory_order mo);
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_nand(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-int __tsan_atomic8_compare_exchange_weak(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 *c, __tsan_atomic8 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
-int __tsan_atomic16_compare_exchange_weak(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 *c, __tsan_atomic16 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
-int __tsan_atomic32_compare_exchange_weak(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 *c, __tsan_atomic32 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
-int __tsan_atomic64_compare_exchange_weak(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 *c, __tsan_atomic64 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic8_compare_exchange_weak(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic16_compare_exchange_weak(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic32_compare_exchange_weak(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic64_compare_exchange_weak(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
-int __tsan_atomic128_compare_exchange_weak(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 *c, __tsan_atomic128 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic128_compare_exchange_weak(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 *c, __tsan_atomic128 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
-int __tsan_atomic8_compare_exchange_strong(volatile __tsan_atomic8 *a,
-    __tsan_atomic8 *c, __tsan_atomic8 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
-int __tsan_atomic16_compare_exchange_strong(volatile __tsan_atomic16 *a,
-    __tsan_atomic16 *c, __tsan_atomic16 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
-int __tsan_atomic32_compare_exchange_strong(volatile __tsan_atomic32 *a,
-    __tsan_atomic32 *c, __tsan_atomic32 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
-int __tsan_atomic64_compare_exchange_strong(volatile __tsan_atomic64 *a,
-    __tsan_atomic64 *c, __tsan_atomic64 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic8_compare_exchange_strong(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic16_compare_exchange_strong(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic32_compare_exchange_strong(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic64_compare_exchange_strong(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
-int __tsan_atomic128_compare_exchange_strong(volatile __tsan_atomic128 *a,
-    __tsan_atomic128 *c, __tsan_atomic128 v, __tsan_memory_order mo,
-    __tsan_memory_order fail_mo);
+int __sanitizer_cdecl __tsan_atomic128_compare_exchange_strong(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 *c, __tsan_atomic128 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
-__tsan_atomic8 __tsan_atomic8_compare_exchange_val(
+__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_compare_exchange_val(
     volatile __tsan_atomic8 *a, __tsan_atomic8 c, __tsan_atomic8 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-__tsan_atomic16 __tsan_atomic16_compare_exchange_val(
+__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_compare_exchange_val(
     volatile __tsan_atomic16 *a, __tsan_atomic16 c, __tsan_atomic16 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-__tsan_atomic32 __tsan_atomic32_compare_exchange_val(
+__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_compare_exchange_val(
     volatile __tsan_atomic32 *a, __tsan_atomic32 c, __tsan_atomic32 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-__tsan_atomic64 __tsan_atomic64_compare_exchange_val(
+__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_compare_exchange_val(
     volatile __tsan_atomic64 *a, __tsan_atomic64 c, __tsan_atomic64 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __tsan_atomic128_compare_exchange_val(
+__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_compare_exchange_val(
     volatile __tsan_atomic128 *a, __tsan_atomic128 c, __tsan_atomic128 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
-void __tsan_atomic_thread_fence(__tsan_memory_order mo);
-void __tsan_atomic_signal_fence(__tsan_memory_order mo);
+void __sanitizer_cdecl __tsan_atomic_thread_fence(__tsan_memory_order mo);
+void __sanitizer_cdecl __tsan_atomic_signal_fence(__tsan_memory_order mo);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // TSAN_INTERFACE_ATOMIC_H
+#endif // TSAN_INTERFACE_ATOMIC_H

--- a/compiler-rt/include/sanitizer/tsan_interface_atomic.h
+++ b/compiler-rt/include/sanitizer/tsan_interface_atomic.h
@@ -56,21 +56,21 @@ __tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_load(
 #endif
 
 void SANITIZER_CDECL __tsan_atomic8_store(volatile __tsan_atomic8 *a,
-                                            __tsan_atomic8 v,
-                                            __tsan_memory_order mo);
+                                          __tsan_atomic8 v,
+                                          __tsan_memory_order mo);
 void SANITIZER_CDECL __tsan_atomic16_store(volatile __tsan_atomic16 *a,
-                                             __tsan_atomic16 v,
-                                             __tsan_memory_order mo);
+                                           __tsan_atomic16 v,
+                                           __tsan_memory_order mo);
 void SANITIZER_CDECL __tsan_atomic32_store(volatile __tsan_atomic32 *a,
-                                             __tsan_atomic32 v,
-                                             __tsan_memory_order mo);
+                                           __tsan_atomic32 v,
+                                           __tsan_memory_order mo);
 void SANITIZER_CDECL __tsan_atomic64_store(volatile __tsan_atomic64 *a,
-                                             __tsan_atomic64 v,
-                                             __tsan_memory_order mo);
+                                           __tsan_atomic64 v,
+                                           __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
 void SANITIZER_CDECL __tsan_atomic128_store(volatile __tsan_atomic128 *a,
-                                              __tsan_atomic128 v,
-                                              __tsan_memory_order mo);
+                                            __tsan_atomic128 v,
+                                            __tsan_memory_order mo);
 #endif
 
 __tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_exchange(

--- a/compiler-rt/include/sanitizer/tsan_interface_atomic.h
+++ b/compiler-rt/include/sanitizer/tsan_interface_atomic.h
@@ -13,6 +13,8 @@
 #ifndef TSAN_INTERFACE_ATOMIC_H
 #define TSAN_INTERFACE_ATOMIC_H
 
+#include <sanitizer/common_interface_defs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/compiler-rt/include/sanitizer/tsan_interface_atomic.h
+++ b/compiler-rt/include/sanitizer/tsan_interface_atomic.h
@@ -42,184 +42,184 @@ typedef enum {
   __tsan_memory_order_seq_cst
 } __tsan_memory_order;
 
-__tsan_atomic8 __sanitizer_cdecl
+__tsan_atomic8 SANITIZER_CDECL
 __tsan_atomic8_load(const volatile __tsan_atomic8 *a, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl
+__tsan_atomic16 SANITIZER_CDECL
 __tsan_atomic16_load(const volatile __tsan_atomic16 *a, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl
+__tsan_atomic32 SANITIZER_CDECL
 __tsan_atomic32_load(const volatile __tsan_atomic32 *a, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl
+__tsan_atomic64 SANITIZER_CDECL
 __tsan_atomic64_load(const volatile __tsan_atomic64 *a, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_load(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_load(
     const volatile __tsan_atomic128 *a, __tsan_memory_order mo);
 #endif
 
-void __sanitizer_cdecl __tsan_atomic8_store(volatile __tsan_atomic8 *a,
+void SANITIZER_CDECL __tsan_atomic8_store(volatile __tsan_atomic8 *a,
                                             __tsan_atomic8 v,
                                             __tsan_memory_order mo);
-void __sanitizer_cdecl __tsan_atomic16_store(volatile __tsan_atomic16 *a,
+void SANITIZER_CDECL __tsan_atomic16_store(volatile __tsan_atomic16 *a,
                                              __tsan_atomic16 v,
                                              __tsan_memory_order mo);
-void __sanitizer_cdecl __tsan_atomic32_store(volatile __tsan_atomic32 *a,
+void SANITIZER_CDECL __tsan_atomic32_store(volatile __tsan_atomic32 *a,
                                              __tsan_atomic32 v,
                                              __tsan_memory_order mo);
-void __sanitizer_cdecl __tsan_atomic64_store(volatile __tsan_atomic64 *a,
+void SANITIZER_CDECL __tsan_atomic64_store(volatile __tsan_atomic64 *a,
                                              __tsan_atomic64 v,
                                              __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-void __sanitizer_cdecl __tsan_atomic128_store(volatile __tsan_atomic128 *a,
+void SANITIZER_CDECL __tsan_atomic128_store(volatile __tsan_atomic128 *a,
                                               __tsan_atomic128 v,
                                               __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_exchange(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_exchange(
     volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_exchange(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_exchange(
     volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_exchange(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_exchange(
     volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_exchange(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_exchange(
     volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_exchange(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_exchange(
     volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_add(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_add(
     volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_add(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_add(
     volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_add(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_add(
     volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_add(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_add(
     volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_add(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_add(
     volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_sub(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_sub(
     volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_sub(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_sub(
     volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_sub(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_sub(
     volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_sub(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_sub(
     volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_sub(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_sub(
     volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_and(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_and(
     volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_and(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_and(
     volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_and(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_and(
     volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_and(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_and(
     volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_and(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_and(
     volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_or(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_or(
     volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_or(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_or(
     volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_or(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_or(
     volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_or(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_or(
     volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_or(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_or(
     volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_xor(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_xor(
     volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_xor(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_xor(
     volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_xor(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_xor(
     volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_xor(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_xor(
     volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_xor(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_xor(
     volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_fetch_nand(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_fetch_nand(
     volatile __tsan_atomic8 *a, __tsan_atomic8 v, __tsan_memory_order mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_fetch_nand(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_fetch_nand(
     volatile __tsan_atomic16 *a, __tsan_atomic16 v, __tsan_memory_order mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_fetch_nand(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_fetch_nand(
     volatile __tsan_atomic32 *a, __tsan_atomic32 v, __tsan_memory_order mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_fetch_nand(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_fetch_nand(
     volatile __tsan_atomic64 *a, __tsan_atomic64 v, __tsan_memory_order mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_fetch_nand(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_fetch_nand(
     volatile __tsan_atomic128 *a, __tsan_atomic128 v, __tsan_memory_order mo);
 #endif
 
-int __sanitizer_cdecl __tsan_atomic8_compare_exchange_weak(
+int SANITIZER_CDECL __tsan_atomic8_compare_exchange_weak(
     volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-int __sanitizer_cdecl __tsan_atomic16_compare_exchange_weak(
+int SANITIZER_CDECL __tsan_atomic16_compare_exchange_weak(
     volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-int __sanitizer_cdecl __tsan_atomic32_compare_exchange_weak(
+int SANITIZER_CDECL __tsan_atomic32_compare_exchange_weak(
     volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-int __sanitizer_cdecl __tsan_atomic64_compare_exchange_weak(
+int SANITIZER_CDECL __tsan_atomic64_compare_exchange_weak(
     volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
-int __sanitizer_cdecl __tsan_atomic128_compare_exchange_weak(
+int SANITIZER_CDECL __tsan_atomic128_compare_exchange_weak(
     volatile __tsan_atomic128 *a, __tsan_atomic128 *c, __tsan_atomic128 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
-int __sanitizer_cdecl __tsan_atomic8_compare_exchange_strong(
+int SANITIZER_CDECL __tsan_atomic8_compare_exchange_strong(
     volatile __tsan_atomic8 *a, __tsan_atomic8 *c, __tsan_atomic8 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-int __sanitizer_cdecl __tsan_atomic16_compare_exchange_strong(
+int SANITIZER_CDECL __tsan_atomic16_compare_exchange_strong(
     volatile __tsan_atomic16 *a, __tsan_atomic16 *c, __tsan_atomic16 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-int __sanitizer_cdecl __tsan_atomic32_compare_exchange_strong(
+int SANITIZER_CDECL __tsan_atomic32_compare_exchange_strong(
     volatile __tsan_atomic32 *a, __tsan_atomic32 *c, __tsan_atomic32 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-int __sanitizer_cdecl __tsan_atomic64_compare_exchange_strong(
+int SANITIZER_CDECL __tsan_atomic64_compare_exchange_strong(
     volatile __tsan_atomic64 *a, __tsan_atomic64 *c, __tsan_atomic64 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
-int __sanitizer_cdecl __tsan_atomic128_compare_exchange_strong(
+int SANITIZER_CDECL __tsan_atomic128_compare_exchange_strong(
     volatile __tsan_atomic128 *a, __tsan_atomic128 *c, __tsan_atomic128 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
-__tsan_atomic8 __sanitizer_cdecl __tsan_atomic8_compare_exchange_val(
+__tsan_atomic8 SANITIZER_CDECL __tsan_atomic8_compare_exchange_val(
     volatile __tsan_atomic8 *a, __tsan_atomic8 c, __tsan_atomic8 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-__tsan_atomic16 __sanitizer_cdecl __tsan_atomic16_compare_exchange_val(
+__tsan_atomic16 SANITIZER_CDECL __tsan_atomic16_compare_exchange_val(
     volatile __tsan_atomic16 *a, __tsan_atomic16 c, __tsan_atomic16 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-__tsan_atomic32 __sanitizer_cdecl __tsan_atomic32_compare_exchange_val(
+__tsan_atomic32 SANITIZER_CDECL __tsan_atomic32_compare_exchange_val(
     volatile __tsan_atomic32 *a, __tsan_atomic32 c, __tsan_atomic32 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
-__tsan_atomic64 __sanitizer_cdecl __tsan_atomic64_compare_exchange_val(
+__tsan_atomic64 SANITIZER_CDECL __tsan_atomic64_compare_exchange_val(
     volatile __tsan_atomic64 *a, __tsan_atomic64 c, __tsan_atomic64 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #if __TSAN_HAS_INT128
-__tsan_atomic128 __sanitizer_cdecl __tsan_atomic128_compare_exchange_val(
+__tsan_atomic128 SANITIZER_CDECL __tsan_atomic128_compare_exchange_val(
     volatile __tsan_atomic128 *a, __tsan_atomic128 c, __tsan_atomic128 v,
     __tsan_memory_order mo, __tsan_memory_order fail_mo);
 #endif
 
-void __sanitizer_cdecl __tsan_atomic_thread_fence(__tsan_memory_order mo);
-void __sanitizer_cdecl __tsan_atomic_signal_fence(__tsan_memory_order mo);
+void SANITIZER_CDECL __tsan_atomic_thread_fence(__tsan_memory_order mo);
+void SANITIZER_CDECL __tsan_atomic_signal_fence(__tsan_memory_order mo);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/compiler-rt/include/sanitizer/ubsan_interface.h
+++ b/compiler-rt/include/sanitizer/ubsan_interface.h
@@ -23,10 +23,10 @@ extern "C" {
 /// <c>verbosity=1:halt_on_error=0</c>).
 ///
 /// \returns Default options string.
-const char* __ubsan_default_options(void);
+const char *__sanitizer_cdecl __ubsan_default_options(void);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // SANITIZER_UBSAN_INTERFACE_H
+#endif // SANITIZER_UBSAN_INTERFACE_H

--- a/compiler-rt/include/sanitizer/ubsan_interface.h
+++ b/compiler-rt/include/sanitizer/ubsan_interface.h
@@ -23,7 +23,7 @@ extern "C" {
 /// <c>verbosity=1:halt_on_error=0</c>).
 ///
 /// \returns Default options string.
-const char *__sanitizer_cdecl __ubsan_default_options(void);
+const char *SANITIZER_CDECL __ubsan_default_options(void);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
This is necessary for many projects which pass `/Gz` to their compiles, which makes their default calling convention `__stdcall`.

(personal note, I _really_ wish there was a pragma for this)