### PR TITLE
[llvm][AArch64][Assembly]: Add FP8 instructions assembly and disassembly.

### DIFF
--- a/llvm/include/llvm/TargetParser/AArch64TargetParser.h
+++ b/llvm/include/llvm/TargetParser/AArch64TargetParser.h
@@ -160,6 +160,7 @@ enum ArchExtKind : unsigned {
   AEK_ITE =           56, // FEAT_ITE
   AEK_GCS =           57, // FEAT_GCS
   AEK_FPMR =          58, // FEAT_FPMR
+  AEK_FP8 =           59, // FEAT_FP8
   AEK_NUM_EXTENSIONS
 };
 using ExtensionBitset = Bitset<AEK_NUM_EXTENSIONS>;
@@ -269,6 +270,7 @@ inline constexpr ExtensionInfo Extensions[] = {
     {"wfxt", AArch64::AEK_NONE, {}, {}, FEAT_WFXT, "+wfxt", 550},
     {"gcs", AArch64::AEK_GCS, "+gcs", "-gcs", FEAT_INIT, "", 0},
     {"fpmr", AArch64::AEK_FPMR, "+fpmr", "-fpmr", FEAT_INIT, "", 0},
+    {"fp8", AArch64::AEK_FP8, "+fp8", "-fp8", FEAT_INIT, "+fpmr", 0},
     // Special cases
     {"none", AArch64::AEK_NONE, {}, {}, FEAT_INIT, "", ExtensionInfo::MaxFMVPriority},
 };

--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -130,6 +130,9 @@ def FeatureSVE : SubtargetFeature<"sve", "HasSVE", "true",
 def FeatureFPMR : SubtargetFeature<"fpmr", "HasFPMR", "true",
   "Enable FPMR Register (FEAT_FPMR)">;
 
+def FeatureFP8 : SubtargetFeature<"fp8", "HasFP8", "true",
+  "Enable FP8 instructions (FEAT_FP8)">;
+
 // This flag is currently still labeled as Experimental, but when fully
 // implemented this should tell the compiler to use the zeroing pseudos to
 // benefit from the reverse instructions (e.g. SUB vs SUBR) if the inactive

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -6056,6 +6056,49 @@ multiclass SIMDThreeSameVectorFML<bit U, bit b13, bits<3> size, string asm,
 }
 
 
+// FP8 assembly/disassembly classes
+
+//----------------------------------------------------------------------------
+// FP8 Advanced SIMD three-register extension
+//----------------------------------------------------------------------------
+class BaseSIMDThreeVectors<bit Q, bit U, bits<2> size, bits<4> op,
+                           RegisterOperand regtype1,
+                           RegisterOperand regtype2, string asm,
+                           string kind1, string kind2>
+  : I<(outs regtype1:$Rd), (ins regtype2:$Rn, regtype2:$Rm), asm,
+      "\t$Rd" # kind1 # ", $Rn" # kind2 # ", $Rm" # kind2, "", []>, Sched<[]> {
+  bits<5> Rd;
+  bits<5> Rn;
+  bits<5> Rm;
+  let Inst{31}    = 0;
+  let Inst{30}    = Q;
+  let Inst{29}    = U;
+  let Inst{28-24} = 0b01110;
+  let Inst{23-22} = size;
+  let Inst{21}    = 0b0;
+  let Inst{20-16} = Rm;
+  let Inst{15}    = 0b1;
+  let Inst{14-11} = op;
+  let Inst{10}    = 0b1;
+  let Inst{9-5}   = Rn;
+  let Inst{4-0}   = Rd;
+}
+
+
+// FCVTN (FP16 to FP8)
+multiclass SIMDThreeSameSizeVectorCvt<string asm> {
+   def v8f8 : BaseSIMDThreeVectors<0b0, 0b0, 0b01, 0b1110, V64, V64, asm, ".8b",".4h">;
+   def v16f8 : BaseSIMDThreeVectors<0b1, 0b0, 0b01, 0b1110,  V128, V128, asm, ".16b", ".8h">;
+}
+
+// TODO : Create v16f8 value type
+// FCVTN, FCVTN2 (FP32 to FP8)
+multiclass SIMDThreeVectorCvt<string asm> {
+   def v8f8 : BaseSIMDThreeVectors<0b0, 0b0, 0b00, 0b1110, V64, V128, asm, ".8b", ".4s">;
+   def 2v16f8 : BaseSIMDThreeSameVectorDot<0b1, 0b0, 0b00, 0b1110, asm#2, ".16b", ".4s",
+                                           V128, v16i8, v4f32, null_frag>;
+}
+
 //----------------------------------------------------------------------------
 // AdvSIMD two register vector instructions.
 //----------------------------------------------------------------------------
@@ -6477,6 +6520,16 @@ multiclass SIMDMixedTwoVector<bit U, bits<5> opc, string asm,
   def : Pat<(concat_vectors (v2i32 V64:$Rd), (OpNode (v2i64 V128:$Rn))),
             (!cast<Instruction>(NAME # "v4i32")
                 (INSERT_SUBREG (IMPLICIT_DEF), V64:$Rd, dsub), V128:$Rn)>;
+}
+
+//----------------------------------------------------------------------------
+// FP8 Advanced SIMD two-register miscellaneous
+//----------------------------------------------------------------------------
+multiclass SIMDMixedTwoVectorFP8<bits<2>sz, string asm> {
+  def v8f16 : BaseSIMDMixedTwoVector<0b0, 0b1, sz, 0b10111, V64, V128,
+                                     asm, ".8h", ".8b", []>;
+  def 2v8f16 : BaseSIMDMixedTwoVector<0b1, 0b1, sz, 0b10111, V128, V128,
+                                     asm#2, ".8h", ".16b", []>;
 }
 
 class BaseSIMDCmpTwoVector<bit Q, bit U, bits<2> size, bits<2> size2,

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -162,6 +162,8 @@ def HasSME2p1        : Predicate<"Subtarget->hasSME2p1()">,
                                  AssemblerPredicateWithAll<(all_of FeatureSME2p1), "sme2p1">;
 def HasFPMR          : Predicate<"Subtarget->hasFPMR()">,
                                  AssemblerPredicateWithAll<(all_of FeatureFPMR), "fpmr">;
+def HasFP8           : Predicate<"Subtarget->hasFP8()">,
+                                 AssemblerPredicateWithAll<(all_of FeatureFP8), "fp8">;
 
 // A subset of SVE(2) instructions are legal in Streaming SVE execution mode,
 // they should be enabled if either has been specified.
@@ -173,6 +175,10 @@ def HasSVE2orSME
     : Predicate<"Subtarget->hasSVE2() || Subtarget->hasSME()">,
                 AssemblerPredicateWithAll<(any_of FeatureSVE2, FeatureSME),
                 "sve2 or sme">;
+def HasSVE2orSME2
+    : Predicate<"Subtarget->hasSVE2() || Subtarget->hasSME2()">,
+                AssemblerPredicateWithAll<(any_of FeatureSVE2, FeatureSME2),
+                "sve2 or sme2">;
 def HasSVE2p1_or_HasSME
     : Predicate<"Subtarget->hasSVE2p1() || Subtarget->hasSME()">,
                  AssemblerPredicateWithAll<(any_of FeatureSME, FeatureSVE2p1), "sme or sve2p1">;
@@ -9249,6 +9255,15 @@ let Predicates = [HasD128] in {
   }
 }
 
+let Predicates = [HasFP8] in {
+  defm F1CVTL  : SIMDMixedTwoVectorFP8<0b00, "f1cvtl">;
+  defm F2CVTL  : SIMDMixedTwoVectorFP8<0b01, "f2cvtl">;
+  defm BF1CVTL : SIMDMixedTwoVectorFP8<0b10, "bf1cvtl">;
+  defm BF2CVTL : SIMDMixedTwoVectorFP8<0b11, "bf2cvtl">;
+  defm FCVTN_F16_F8 : SIMDThreeSameSizeVectorCvt<"fcvtn">;
+  defm FCVTN_F32_F8 : SIMDThreeVectorCvt<"fcvtn">;
+  defm FSCALE : SIMDThreeSameVectorFP<0b1, 0b1, 0b111, "fscale", null_frag>;
+} // End let Predicates = [HasFP8]
 
 include "AArch64InstrAtomics.td"
 include "AArch64SVEInstrInfo.td"

--- a/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
@@ -330,14 +330,14 @@ defm UMLSL_VG4_M4ZZ  : sme2_int_mla_long_array_vg4_single<"umlsl", 0b11, int_aar
 defm UMLSL_VG2_M2Z2Z : sme2_int_mla_long_array_vg2_multi<"umlsl",  0b11, int_aarch64_sme_umlsl_vg2x2>;
 defm UMLSL_VG4_M4Z4Z : sme2_int_mla_long_array_vg4_multi<"umlsl",  0b11, int_aarch64_sme_umlsl_vg2x4>;
 
-defm FCVT_Z2Z_StoH   : sme2_cvt_vg2_single<"fcvt",   0b0000, nxv8f16, nxv4f32, int_aarch64_sve_fcvt_x2>;
-defm FCVTN_Z2Z_StoH  : sme2_cvt_vg2_single<"fcvtn",  0b0001, nxv8f16, nxv4f32, int_aarch64_sve_fcvtn_x2>;
-defm BFCVT_Z2Z_StoH  : sme2_cvt_vg2_single<"bfcvt",  0b1000, nxv8bf16, nxv4f32, int_aarch64_sve_bfcvt_x2>;
-defm BFCVTN_Z2Z_StoH : sme2_cvt_vg2_single<"bfcvtn", 0b1001, nxv8bf16, nxv4f32, int_aarch64_sve_bfcvtn_x2>;
+defm FCVT_Z2Z_StoH   : sme2_cvt_vg2_single<"fcvt",   0b00000, nxv8f16, nxv4f32, int_aarch64_sve_fcvt_x2>;
+defm FCVTN_Z2Z_StoH  : sme2_cvt_vg2_single<"fcvtn",  0b00001, nxv8f16, nxv4f32, int_aarch64_sve_fcvtn_x2>;
+defm BFCVT_Z2Z_StoH  : sme2_cvt_vg2_single<"bfcvt",  0b10000, nxv8bf16, nxv4f32, int_aarch64_sve_bfcvt_x2>;
+defm BFCVTN_Z2Z_StoH : sme2_cvt_vg2_single<"bfcvtn", 0b10001, nxv8bf16, nxv4f32, int_aarch64_sve_bfcvtn_x2>;
 
-defm SQCVT_Z2Z_StoH  : sme2_cvt_vg2_single<"sqcvt",  0b0110, nxv8i16, nxv4i32, int_aarch64_sve_sqcvt_x2>;
-defm UQCVT_Z2Z_StoH  : sme2_cvt_vg2_single<"uqcvt",  0b0111, nxv8i16, nxv4i32, int_aarch64_sve_uqcvt_x2>;
-defm SQCVTU_Z2Z_StoH : sme2_cvt_vg2_single<"sqcvtu", 0b1110, nxv8i16, nxv4i32, int_aarch64_sve_sqcvtu_x2>;
+defm SQCVT_Z2Z_StoH  : sme2_cvt_vg2_single<"sqcvt",  0b00110, nxv8i16, nxv4i32, int_aarch64_sve_sqcvt_x2>;
+defm UQCVT_Z2Z_StoH  : sme2_cvt_vg2_single<"uqcvt",  0b00111, nxv8i16, nxv4i32, int_aarch64_sve_uqcvt_x2>;
+defm SQCVTU_Z2Z_StoH : sme2_cvt_vg2_single<"sqcvtu", 0b10110, nxv8i16, nxv4i32, int_aarch64_sve_sqcvtu_x2>;
 defm SQCVT_Z4Z      : sme2_int_cvt_vg4_single<"sqcvt", 0b000, int_aarch64_sve_sqcvt_x4>;
 defm UQCVT_Z4Z      : sme2_int_cvt_vg4_single<"uqcvt", 0b001, int_aarch64_sve_uqcvt_x4>;
 defm SQCVTU_Z4Z     : sme2_int_cvt_vg4_single<"sqcvtu", 0b100, int_aarch64_sve_sqcvtu_x4>;
@@ -855,3 +855,26 @@ defm BFCLAMP_VG4_4ZZZ: sme2p1_bfclamp_vector_vg4_multi<"bfclamp">;
 defm BFMOPA_MPPZZ_H : sme2p1_fmop_tile_fp16<"bfmopa", 0b1, 0b0, 0b11, ZPR16>;
 defm BFMOPS_MPPZZ_H : sme2p1_fmop_tile_fp16<"bfmops", 0b1, 0b1, 0b11, ZPR16>;
 }
+
+let Predicates = [HasSME2, HasFP8] in {
+defm F1CVT_2ZZ_BtoH    : sme2p1_fp8_cvt_vector_vg2_single<"f1cvt",   0b00, 0b0>;
+defm F1CVTL_2ZZ_BtoH   : sme2p1_fp8_cvt_vector_vg2_single<"f1cvtl",  0b00, 0b1>;
+defm BF1CVT_2ZZ_BtoH   : sme2p1_fp8_cvt_vector_vg2_single<"bf1cvt",  0b01, 0b0>;
+defm BF1CVTL_2ZZ_BtoH  : sme2p1_fp8_cvt_vector_vg2_single<"bf1cvtl", 0b01, 0b1>;
+defm F2CVT_2ZZ_BtoH    : sme2p1_fp8_cvt_vector_vg2_single<"f2cvt",   0b10, 0b0>;
+defm F2CVTL_2ZZ_BtoH   : sme2p1_fp8_cvt_vector_vg2_single<"f2cvtl",  0b10, 0b1>;
+defm BF2CVT_2ZZ_BtoH   : sme2p1_fp8_cvt_vector_vg2_single<"bf2cvt",  0b11, 0b0>;
+defm BF2CVTL_2ZZ_BtoH  : sme2p1_fp8_cvt_vector_vg2_single<"bf2cvtl", 0b11, 0b1>;
+
+defm FCVT_Z2Z_HtoB  : sme2_fp8_cvt_vg2_single<"fcvt",   0b0>;
+defm BFCVT_Z2Z_HtoB : sme2_fp8_cvt_vg2_single<"bfcvt",  0b1>;
+defm FCVT_Z4Z_StoB  : sme2_fp8_cvt_vg4_single<"fcvt",   0b0>;
+defm FCVTN_Z4Z_StoB : sme2_fp8_cvt_vg4_single<"fcvtn",  0b1>;
+
+defm FSCALE_2ZZ   : sme2_fp_sve_destructive_vector_vg2_single<"fscale", 0b0011000>;
+defm FSCALE_4ZZ   : sme2_fp_sve_destructive_vector_vg4_single<"fscale", 0b0011000>;
+defm FSCALE_2Z2Z  : sme2_fp_sve_destructive_vector_vg2_multi<"fscale",  0b0011000>;
+defm FSCALE_4Z4Z  : sme2_fp_sve_destructive_vector_vg4_multi<"fscale",  0b0011000>;
+
+} // [HasSME2, HasFP8]
+

--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4002,3 +4002,24 @@ defm UZPQ1_ZZZ : sve2p1_permute_vec_elems_q<0b010, "uzpq1">;
 defm UZPQ2_ZZZ : sve2p1_permute_vec_elems_q<0b011, "uzpq2">;
 defm TBLQ_ZZZ  : sve2p1_tblq<"tblq">;
 } // End HasSVE2p1_or_HasSME2p1
+
+//===----------------------------------------------------------------------===//
+// SVE2 FP8 instructions
+//===----------------------------------------------------------------------===//
+let Predicates = [HasSVE2orSME2, HasFP8] in {
+// FP8 upconvert
+defm F1CVT_ZZ     : sve2_fp8_cvt_single<0b0, 0b00, "f1cvt">;
+defm F2CVT_ZZ     : sve2_fp8_cvt_single<0b0, 0b01, "f2cvt">;
+defm BF1CVT_ZZ    : sve2_fp8_cvt_single<0b0, 0b10, "bf1cvt">;
+defm BF2CVT_ZZ    : sve2_fp8_cvt_single<0b0, 0b11, "bf2cvt">;
+defm F1CVTLT_ZZ   : sve2_fp8_cvt_single<0b1, 0b00, "f1cvtlt">;
+defm F2CVTLT_ZZ   : sve2_fp8_cvt_single<0b1, 0b01, "f2cvtlt">;
+defm BF1CVTLT_ZZ  : sve2_fp8_cvt_single<0b1, 0b10, "bf1cvtlt">;
+defm BF2CVTLT_ZZ  : sve2_fp8_cvt_single<0b1, 0b11, "bf2cvtlt">;
+
+// FP8 downconvert
+defm FCVTN_Z2Z_HtoB  : sve2_fp8_down_cvt_single<0b00, "fcvtn", ZZ_h_mul_r>;
+defm FCVTNB_Z2Z_StoB : sve2_fp8_down_cvt_single<0b01, "fcvtnb", ZZ_s_mul_r>;
+defm BFCVTN_Z2Z_HtoB : sve2_fp8_down_cvt_single<0b10, "bfcvtn", ZZ_h_mul_r>;
+defm FCVTNT_Z2Z_StoB : sve2_fp8_down_cvt_single<0b11, "fcvtnt", ZZ_s_mul_r>;
+} // End HasSVE2orSME2, HasFP8

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -3639,6 +3639,7 @@ static const struct Extension {
     {"ssbs", {AArch64::FeatureSSBS}},
     {"tme", {AArch64::FeatureTME}},
     {"fpmr", {AArch64::FeatureFPMR}},
+    {"fp8", {AArch64::FeatureFP8}},
 };
 
 static void setRequiredFeatureString(FeatureBitset FBS, std::string &Str) {

--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -2161,15 +2161,16 @@ multiclass sme2_frint_vector_vg4_multi<string mnemonic, bits<7> op> {
                                          mnemonic>;
 }
 
-class sme2_cvt_vg2_single<string mnemonic, bits<4> op>
-    : I<(outs ZPR16:$Zd), (ins ZZ_s_mul_r:$Zn),
+class sme2_cvt_vg2_single<string mnemonic, bits<5> op,
+                           RegisterOperand first_ty, RegisterOperand second_ty>
+    : I<(outs first_ty:$Zd), (ins second_ty:$Zn),
         mnemonic, "\t$Zd, $Zn", "", []>, Sched<[]> {
   bits<4> Zn;
   bits<5> Zd;
   let Inst{31-23} = 0b110000010;
-  let Inst{22}    = op{3};
-  let Inst{21-18} = 0b1000;
-  let Inst{17-16} = op{2-1};
+  let Inst{22}    = op{4};
+  let Inst{21-19} = 0b100;
+  let Inst{18-16} = op{3-1};
   let Inst{15-10} = 0b111000;
   let Inst{9-6}   = Zn;
   let Inst{5}     = op{0};
@@ -2178,10 +2179,15 @@ class sme2_cvt_vg2_single<string mnemonic, bits<4> op>
 
 // SME2 multi-vec FP down convert two registers
 // SME2 multi-vec int down convert two registers
-multiclass sme2_cvt_vg2_single<string mnemonic, bits<4> op, ValueType out_vt,
+multiclass sme2_cvt_vg2_single<string mnemonic, bits<5> op, ValueType out_vt,
                                ValueType in_vt, SDPatternOperator intrinsic> {
-  def NAME :  sme2_cvt_vg2_single<mnemonic, op>;
+  def NAME :  sme2_cvt_vg2_single<mnemonic, op, ZPR16, ZZ_s_mul_r>;
   def : SVE2p1_Cvt_VG2_Pat<NAME, intrinsic, out_vt, in_vt>;
+}
+
+// SME2 multi-vec FP8 down convert two registers
+multiclass sme2_fp8_cvt_vg2_single<string mnemonic, bit op> {
+  def NAME :  sme2_cvt_vg2_single<mnemonic, {op, 0b1000}, ZPR8, ZZ_h_mul_r>;
 }
 
 class sme2_cvt_unpk_vector_vg2<bits<2>sz, bits<3> op, bit u, RegisterOperand first_ty,
@@ -2212,7 +2218,13 @@ multiclass sme2p1_fp_cvt_vector_vg2_single<string mnemonic, bit l> {
   def _S : sme2_cvt_unpk_vector_vg2<0b10, 0b000, l, ZZ_s_mul_r, ZPR16, mnemonic>;
 }
 
-class sme2_cvt_vg4_single<bit sz, bits<3> op, RegisterOperand first_ty,
+// SME2 multi-vec FP8 up convert two registers
+multiclass sme2p1_fp8_cvt_vector_vg2_single<string mnemonic, bits<2> opc, bit L> {
+  def _NAME : sme2_cvt_unpk_vector_vg2<opc, 0b110, L, ZZ_h_mul_r, ZPR8, mnemonic>;
+}
+
+
+class sme2_cvt_vg4_single<bit sz, bits<3> op, bits<4>op2,  RegisterOperand first_ty,
                           RegisterOperand second_ty, string mnemonic>
     : I<(outs first_ty:$Zd), (ins second_ty:$Zn),
         mnemonic, "\t$Zd, $Zn", "", []>, Sched<[]> {
@@ -2221,7 +2233,9 @@ class sme2_cvt_vg4_single<bit sz, bits<3> op, RegisterOperand first_ty,
   let Inst{31-24} = 0b11000001;
   let Inst{23}    = sz;
   let Inst{22}    = op{2};
-  let Inst{21-10} = 0b110011111000;
+  let Inst{21-20} = 0b11;
+  let Inst{19-16} = op2;
+  let Inst{15-10} = 0b111000;
   let Inst{9-7}   = Zn;
   let Inst{6-5}   = op{1-0};
   let Inst{4-0}   = Zd;
@@ -2229,11 +2243,16 @@ class sme2_cvt_vg4_single<bit sz, bits<3> op, RegisterOperand first_ty,
 
 // SME2 multi-vec int down convert four registers
 multiclass sme2_int_cvt_vg4_single<string mnemonic, bits<3> op, SDPatternOperator intrinsic> {
-  def _StoB : sme2_cvt_vg4_single<0, op, ZPR8, ZZZZ_s_mul_r, mnemonic>;
-  def _DtoH : sme2_cvt_vg4_single<1, op, ZPR16, ZZZZ_d_mul_r, mnemonic>;
+  def _StoB : sme2_cvt_vg4_single<0, op, 0b0011, ZPR8, ZZZZ_s_mul_r, mnemonic>;
+  def _DtoH : sme2_cvt_vg4_single<1, op, 0b0011, ZPR16, ZZZZ_d_mul_r, mnemonic>;
 
   def : SME2_Cvt_VG4_Pat<NAME # _StoB, intrinsic, nxv16i8, nxv4i32>;
   def : SME2_Cvt_VG4_Pat<NAME # _DtoH, intrinsic, nxv8i16, nxv2i64>;
+}
+
+//SME2 multi-vec FP8 down convert four registers
+multiclass sme2_fp8_cvt_vg4_single<string mnemonic, bit N> {
+ def _NAME : sme2_cvt_vg4_single<0b0, {0b00, N}, 0b0100, ZPR8, ZZZZ_s_mul_r, mnemonic>;
 }
 
 class sme2_unpk_vector_vg4<bits<2>sz, bit u, RegisterOperand first_ty,

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -10078,3 +10078,46 @@ multiclass sve2p1_tblq<string mnemonic> {
   def _S : sve2p1_permute_vec_elems_q<0b10, 0b110, mnemonic, ZPR32, Z_s>;
   def _D : sve2p1_permute_vec_elems_q<0b11, 0b110, mnemonic, ZPR64, Z_d>;
 }
+
+//===----------------------------------------------------------------------===//
+// SVE2 FP8 Instructions
+//===----------------------------------------------------------------------===//
+
+// FP8 upconvert
+class sve2_fp8_cvt_single<bit L, bits<2> opc, string mnemonic,
+                          ZPRRegOp dst_ty, ZPRRegOp src_ty>
+    : I<(outs dst_ty:$Zd), (ins src_ty:$Zn),
+      mnemonic, "\t$Zd, $Zn",
+      "", []>, Sched<[]>{
+  bits<5> Zd;
+  bits<5> Zn;
+  let Inst{31-17} = 0b011001010000100;
+  let Inst{16}    = L;
+  let Inst{15-12} = 0b0011;
+  let Inst{11-10} = opc;
+  let Inst{9-5}   = Zn;
+  let Inst{4-0}   = Zd;
+}
+
+multiclass sve2_fp8_cvt_single<bit L, bits<2> opc, string mnemonic> {
+  def _BtoH : sve2_fp8_cvt_single<L, opc, mnemonic, ZPR16, ZPR8>;
+}
+
+// FP8 downconvert
+class sve2_fp8_down_cvt_single<bits<2> opc, string mnemonic,
+                              ZPRRegOp dst_ty, RegisterOperand src_ty>
+    : I<(outs dst_ty:$Zd), (ins src_ty:$Zn),
+      mnemonic, "\t$Zd, $Zn",
+      "", []>, Sched<[]>{
+  bits<5> Zd;
+  bits<4> Zn;
+  let Inst{31-12} = 0b01100101000010100011;
+  let Inst{11-10} = opc;
+  let Inst{9-6} = Zn;
+  let Inst{5} = 0b0;
+  let Inst{4-0} = Zd;
+}
+
+multiclass sve2_fp8_down_cvt_single<bits<2> opc, string mnemonic, RegisterOperand src> {
+  def NAME : sve2_fp8_down_cvt_single<opc, mnemonic, ZPR8, src>;
+}

--- a/llvm/test/MC/AArch64/FP8/directive-arch-negative.s
+++ b/llvm/test/MC/AArch64/FP8/directive-arch-negative.s
@@ -1,0 +1,7 @@
+// RUN: not llvm-mc -triple aarch64 -filetype asm -o - %s 2>&1 | FileCheck %s
+
+.arch armv9-a+fp8
+.arch armv9-a+nofp8
+bf1cvtl v0.8h, v0.8b
+// CHECK: error: instruction requires: fp8
+// CHECK: bf1cvtl v0.8h, v0.8b

--- a/llvm/test/MC/AArch64/FP8/directive-arch.s
+++ b/llvm/test/MC/AArch64/FP8/directive-arch.s
@@ -1,0 +1,7 @@
+// RUN: llvm-mc -triple aarch64 -o - %s 2>&1 | FileCheck %s
+
+.arch armv9-a+fp8
+bf1cvtl v0.8h, v0.8b
+// CHECK: bf1cvtl v0.8h, v0.8b
+
+.arch armv9-a+nofp8

--- a/llvm/test/MC/AArch64/FP8/miscellaneous-fp8-diagnostics.s
+++ b/llvm/test/MC/AArch64/FP8/miscellaneous-fp8-diagnostics.s
@@ -1,0 +1,84 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+fp8 2>&1 < %s| FileCheck %s
+
+// --------------------------------------------------------------------------//
+// Element size extension incorrect
+
+bf1cvtl v0.8h, v0.8h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf1cvtl v0.8h, v0.8h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf1cvtl2 v0.8h, v0.16h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid vector kind qualifier
+// CHECK-NEXT: bf1cvtl2 v0.8h, v0.16h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvtl v0.8h, v0.8h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf2cvtl v0.8h, v0.8h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvtl2 v0.8h, v0.16h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid vector kind qualifier
+// CHECK-NEXT: bf2cvtl2 v0.8h, v0.16h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvtl v0.8h, v0.8h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f1cvtl v0.8h, v0.8h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvtl2 v0.8h, v0.16h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid vector kind qualifier
+// CHECK-NEXT: f1cvtl2 v0.8h, v0.16h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvtl v0.8h, v0.8h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f2cvtl v0.8h, v0.8h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvtl2 v0.8h, v0.16h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid vector kind qualifier
+// CHECK-NEXT: f2cvtl2 v0.8h, v0.16h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn  v31.8h, v31.4h, v31.4h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fcvtn  v31.8h, v31.4h, v31.4h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn  v0.8s, v0.4s, v0.4s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid vector kind qualifier
+// CHECK-NEXT: fcvtn  v0.8s, v0.4s, v0.4s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn2  v0.16s, v0.4s, v0.4s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid vector kind qualifier
+// CHECK-NEXT: fcvtn2  v0.16s, v0.4s, v0.4s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  v0.4h, v0.4s, v0.4s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  v0.4h, v0.4s, v0.4s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  v0.8h, v0.8s, v0.8s
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid vector kind qualifier
+// CHECK-NEXT: fscale  v0.8h, v0.8s, v0.8s
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  v0.2s, v0.2h, v0.2h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  v0.2s, v0.2h, v0.2h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  v0.4s, v31.4h, v0.4h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  v0.4s, v31.4h, v0.4h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  v0.2d, v31.2h, v0.2h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  v0.2d, v31.2h, v0.2h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/FP8/miscellaneous-fp8.s
+++ b/llvm/test/MC/AArch64/FP8/miscellaneous-fp8.s
@@ -1,0 +1,355 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+fp8 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=+fp8 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+fp8 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+fp8 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+///
+/// BF1CVTL instructions.
+///
+bf1cvtl v0.8h, v0.8b
+// CHECK-INST: bf1cvtl v0.8h, v0.8b
+// CHECK-ENCODING: [0x00,0x78,0xa1,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ea17800 <unknown>
+
+bf1cvtl v0.8h, v31.8b
+// CHECK-INST: bf1cvtl v0.8h, v31.8b
+// CHECK-ENCODING: [0xe0,0x7b,0xa1,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ea17be0 <unknown>
+
+bf1cvtl v31.8h, v31.8b
+// CHECK-INST: bf1cvtl v31.8h, v31.8b
+// CHECK-ENCODING: [0xff,0x7b,0xa1,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ea17bff <unknown>
+
+///
+/// BF1CVTL2 instructions.
+///
+bf1cvtl2 v0.8h, v0.16b
+// CHECK-INST: bf1cvtl2 v0.8h, v0.16b
+// CHECK-ENCODING: [0x00,0x78,0xa1,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ea17800 <unknown>
+
+bf1cvtl2 v0.8h, v31.16b
+// CHECK-INST: bf1cvtl2 v0.8h, v31.16b
+// CHECK-ENCODING: [0xe0,0x7b,0xa1,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ea17be0 <unknown>
+
+bf1cvtl2 v31.8h, v31.16b
+// CHECK-INST: bf1cvtl2 v31.8h, v31.16b
+// CHECK-ENCODING: [0xff,0x7b,0xa1,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ea17bff <unknown>
+
+///
+/// BF2CVTL instructions.
+///
+bf2cvtl v0.8h, v0.8b
+// CHECK-INST: bf2cvtl v0.8h, v0.8b
+// CHECK-ENCODING: [0x00,0x78,0xe1,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ee17800 <unknown>
+
+bf2cvtl v0.8h, v31.8b
+// CHECK-INST: bf2cvtl v0.8h, v31.8b
+// CHECK-ENCODING: [0xe0,0x7b,0xe1,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ee17be0 <unknown>
+
+bf2cvtl v31.8h, v31.8b
+// CHECK-INST: bf2cvtl v31.8h, v31.8b
+// CHECK-ENCODING: [0xff,0x7b,0xe1,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ee17bff <unknown>
+
+///
+/// BF2CVTL2 instructions.
+///
+bf2cvtl2 v0.8h, v0.16b
+// CHECK-INST: bf2cvtl2 v0.8h, v0.16b
+// CHECK-ENCODING: [0x00,0x78,0xe1,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ee17800 <unknown>
+
+bf2cvtl2 v0.8h, v31.16b
+// CHECK-INST: bf2cvtl2 v0.8h, v31.16b
+// CHECK-ENCODING: [0xe0,0x7b,0xe1,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ee17be0 <unknown>
+
+bf2cvtl2 v31.8h, v31.16b
+// CHECK-INST: bf2cvtl2 v31.8h, v31.16b
+// CHECK-ENCODING: [0xff,0x7b,0xe1,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ee17bff <unknown>
+
+///
+/// F1CVTL instructions.
+///
+f1cvtl v0.8h, v0.8b
+// CHECK-INST: f1cvtl v0.8h, v0.8b
+// CHECK-ENCODING: [0x00,0x78,0x21,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2e217800 <unknown>
+
+f1cvtl v0.8h, v31.8b
+// CHECK-INST: f1cvtl v0.8h, v31.8b
+// CHECK-ENCODING: [0xe0,0x7b,0x21,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2e217be0 <unknown>
+
+f1cvtl v31.8h, v31.8b
+// CHECK-INST: f1cvtl v31.8h, v31.8b
+// CHECK-ENCODING: [0xff,0x7b,0x21,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2e217bff <unknown>
+
+///
+/// F1CVTL2 instructions.
+///
+f1cvtl2 v0.8h, v0.16b
+// CHECK-INST: f1cvtl2 v0.8h, v0.16b
+// CHECK-ENCODING: [0x00,0x78,0x21,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6e217800 <unknown>
+
+f1cvtl2 v0.8h, v31.16b
+// CHECK-INST: f1cvtl2 v0.8h, v31.16b
+// CHECK-ENCODING: [0xe0,0x7b,0x21,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6e217be0 <unknown>
+
+f1cvtl2 v31.8h, v31.16b
+// CHECK-INST: f1cvtl2 v31.8h, v31.16b
+// CHECK-ENCODING: [0xff,0x7b,0x21,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6e217bff <unknown>
+
+///
+/// F2CVTL instructions.
+///
+f2cvtl v0.8h, v0.8b
+// CHECK-INST: f2cvtl v0.8h, v0.8b
+// CHECK-ENCODING: [0x00,0x78,0x61,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2e617800 <unknown>
+
+f2cvtl v0.8h, v31.8b
+// CHECK-INST: f2cvtl v0.8h, v31.8b
+// CHECK-ENCODING: [0xe0,0x7b,0x61,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2e617be0 <unknown>
+
+f2cvtl v31.8h, v31.8b
+// CHECK-INST: f2cvtl v31.8h, v31.8b
+// CHECK-ENCODING: [0xff,0x7b,0x61,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2e617bff <unknown>
+
+///
+/// F2CVTL2 instructions.
+///
+f2cvtl2 v0.8h, v0.16b
+// CHECK-INST: f2cvtl2 v0.8h, v0.16b
+// CHECK-ENCODING: [0x00,0x78,0x61,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6e617800 <unknown>
+
+f2cvtl2 v0.8h, v31.16b
+// CHECK-INST: f2cvtl2 v0.8h, v31.16b
+// CHECK-ENCODING: [0xe0,0x7b,0x61,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6e617be0 <unknown>
+
+f2cvtl2 v31.8h, v31.16b
+// CHECK-INST: f2cvtl2 v31.8h, v31.16b
+// CHECK-ENCODING: [0xff,0x7b,0x61,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6e617bff <unknown>
+
+///
+/// FCVTN instructions.
+///
+// FP16 TO FP8
+fcvtn  v31.8b, v31.4h, v31.4h
+// CHECK-INST: fcvtn  v31.8b, v31.4h, v31.4h
+// CHECK-ENCODING: [0xff,0xf7,0x5f,0x0e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 0e5ff7ff <unknown>
+
+fcvtn  v31.8b, v0.4h, v0.4h
+// CHECK-INST: fcvtn  v31.8b, v0.4h, v0.4h
+// CHECK-ENCODING: [0x1f,0xf4,0x40,0x0e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 0e40f41f <unknown>
+
+fcvtn  v0.8b, v0.4h, v0.4h
+// CHECK-INST: fcvtn  v0.8b, v0.4h, v0.4h
+// CHECK-ENCODING: [0x00,0xf4,0x40,0x0e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 0e40f400 <unknown>
+
+fcvtn  v0.16b, v0.8h, v0.8h
+// CHECK-INST: fcvtn  v0.16b, v0.8h, v0.8h
+// CHECK-ENCODING: [0x00,0xf4,0x40,0x4e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 4e40f400 <unknown>
+
+fcvtn  v31.16b, v0.8h, v0.8h
+// CHECK-INST: fcvtn  v31.16b, v0.8h, v0.8h
+// CHECK-ENCODING: [0x1f,0xf4,0x40,0x4e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 4e40f41f <unknown>
+
+fcvtn  v31.16b, v31.8h, v31.8h
+// CHECK-INST: fcvtn  v31.16b, v31.8h, v31.8h
+// CHECK-ENCODING: [0xff,0xf7,0x5f,0x4e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 4e5ff7ff <unknown>
+
+// FP32 TO FP8
+fcvtn  v0.8b, v0.4s, v0.4s
+// CHECK-INST: fcvtn  v0.8b, v0.4s, v0.4s
+// CHECK-ENCODING: [0x00,0xf4,0x00,0x0e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 0e00f400 <unknown>
+
+fcvtn  v0.8b, v31.4s, v31.4s
+// CHECK-INST: fcvtn  v0.8b, v31.4s, v31.4s
+// CHECK-ENCODING: [0xe0,0xf7,0x1f,0x0e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 0e1ff7e0 <unknown>
+
+fcvtn  v31.8b, v31.4s, v31.4s
+// CHECK-INST: fcvtn  v31.8b, v31.4s, v31.4s
+// CHECK-ENCODING: [0xff,0xf7,0x1f,0x0e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 0e1ff7ff <unknown>
+
+///
+/// FCVTN2 instructions.
+///
+
+fcvtn2  v0.16b, v0.4s, v0.4s
+// CHECK-INST: fcvtn2  v0.16b, v0.4s, v0.4s
+// CHECK-ENCODING: [0x00,0xf4,0x00,0x4e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 4e00f400 <unknown>
+
+fcvtn2  v0.16b, v0.4s, v31.4s
+// CHECK-INST: fcvtn2  v0.16b, v0.4s, v31.4s
+// CHECK-ENCODING: [0x00,0xf4,0x1f,0x4e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 4e1ff400 <unknown>
+
+fcvtn2  v31.16b, v31.4s, v31.4s
+// CHECK-INST: fcvtn2  v31.16b, v31.4s, v31.4s
+// CHECK-ENCODING: [0xff,0xf7,0x1f,0x4e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 4e1ff7ff <unknown>
+
+///
+/// FSCALE instructions.
+///
+fscale  v0.4h, v0.4h, v0.4h
+// CHECK-INST: fscale  v0.4h, v0.4h, v0.4h
+// CHECK-ENCODING: [0x00,0x3c,0xc0,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ec03c00 <unknown>
+
+fscale  v0.4h, v31.4h, v31.4h
+// CHECK-INST: fscale  v0.4h, v31.4h, v31.4h
+// CHECK-ENCODING: [0xe0,0x3f,0xdf,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2edf3fe0 <unknown>
+
+fscale  v31.4h, v31.4h, v31.4h
+// CHECK-INST: fscale  v31.4h, v31.4h, v31.4h
+// CHECK-ENCODING: [0xff,0x3f,0xdf,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2edf3fff <unknown>
+
+fscale  v0.8h, v0.8h, v0.8h
+// CHECK-INST: fscale  v0.8h, v0.8h, v0.8h
+// CHECK-ENCODING: [0x00,0x3c,0xc0,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ec03c00 <unknown>
+
+fscale  v31.8h, v0.8h, v0.8h
+// CHECK-INST: fscale  v31.8h, v0.8h, v0.8h
+// CHECK-ENCODING: [0x1f,0x3c,0xc0,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ec03c1f <unknown>
+
+fscale  v31.8h, v31.8h, v31.8h
+// CHECK-INST: fscale  v31.8h, v31.8h, v31.8h
+// CHECK-ENCODING: [0xff,0x3f,0xdf,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6edf3fff <unknown>
+
+fscale  v0.2s, v0.2s, v0.2s
+// CHECK-INST: fscale  v0.2s, v0.2s, v0.2s
+// CHECK-ENCODING: [0x00,0xfc,0xa0,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ea0fc00 <unknown>
+
+fscale  v0.2s, v0.2s, v31.2s
+// CHECK-INST: fscale  v0.2s, v0.2s, v31.2s
+// CHECK-ENCODING: [0x00,0xfc,0xbf,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ebffc00 <unknown>
+
+fscale  v31.2s, v31.2s, v31.2s
+// CHECK-INST: fscale  v31.2s, v31.2s, v31.2s
+// CHECK-ENCODING: [0xff,0xff,0xbf,0x2e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 2ebfffff <unknown>
+
+fscale  v0.4s, v0.4s, v0.4s
+// CHECK-INST: fscale  v0.4s, v0.4s, v0.4s
+// CHECK-ENCODING: [0x00,0xfc,0xa0,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ea0fc00 <unknown>
+
+fscale  v0.4s, v31.4s, v0.4s
+// CHECK-INST: fscale  v0.4s, v31.4s, v0.4s
+// CHECK-ENCODING: [0xe0,0xff,0xa0,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ea0ffe0 <unknown>
+
+fscale  v31.4s, v31.4s, v31.4s
+// CHECK-INST: fscale  v31.4s, v31.4s, v31.4s
+// CHECK-ENCODING: [0xff,0xff,0xbf,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ebfffff <unknown>
+
+fscale  v0.2d, v0.2d, v0.2d
+// CHECK-INST: fscale  v0.2d, v0.2d, v0.2d
+// CHECK-ENCODING: [0x00,0xfc,0xe0,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ee0fc00 <unknown>
+
+fscale  v0.2d, v31.2d, v0.2d
+// CHECK-INST: fscale  v0.2d, v31.2d, v0.2d
+// CHECK-ENCODING: [0xe0,0xff,0xe0,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6ee0ffe0 <unknown>
+
+fscale  v31.2d, v31.2d, v31.2d
+// CHECK-INST: fscale  v31.2d, v31.2d, v31.2d
+// CHECK-ENCODING: [0xff,0xff,0xff,0x6e]
+// CHECK-ERROR: instruction requires: fp8
+// CHECK-UNKNOWN: 6effffff

--- a/llvm/test/MC/AArch64/FP8_SME2/cvt-diagnostics.s
+++ b/llvm/test/MC/AArch64/FP8_SME2/cvt-diagnostics.s
@@ -1,0 +1,87 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 2>&1 < %s| FileCheck %s
+
+// --------------------------------------------------------------------------//
+// Incorrect operand
+
+f1cvt  { z0.h, z1.h }, z0
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: unknown token in expression
+// CHECK-NEXT: f1cvt  { z0.h, z1.h }, z0
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf1cvt  { z0, z1 }, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf1cvt  { z0, z1 }, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf1cvtl { z0.b, z1.b }, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf1cvtl { z0.b, z1.b }, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvt  { z0.h, z1.h }, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf2cvt  { z0.h, z1.h }, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvtl { z30.h}, z31.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf2cvtl { z30.h}, z31.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvt   { z0, z1.h }, {z0.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: mismatched register size suffix
+// CHECK-NEXT: f2cvt   { z0, z1.h }, {z0.b}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvtl  z0.h, z1.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f2cvtl  z0.h, z1.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvt    z31.b, { z30.h }
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fcvt    z31.b, { z30.h }
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bfcvt   z0.b, { z0.b, z1.b }
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bfcvt   z0.b, { z0.b, z1.b }
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// --------------------------------------------------------------------------//
+// Incorrect range of vectors
+
+bf1cvt { z1.h, z2.h }, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT: bf1cvt { z1.h, z2.h }, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvt  { z1.h, z0.h }, z31.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f1cvt  { z1.h, z0.h }, z31.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvtl { z31.h, z0.h }, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT: f1cvtl { z31.h, z0.h }, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvt   z31.b, { z29.s - z0.s }
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
+// CHECK-NEXT: fcvt   z31.b, { z29.s - z0.s }
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn  z31.b, { z30.s - z1.s }
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
+// CHECK-NEXT: fcvtn  z31.b, { z30.s - z1.s }
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn  z0.b, { z31.s - z2.s }
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
+// CHECK-NEXT: fcvtn  z0.b, { z31.s - z2.s }
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn  z0.b, { z1.s - z4.s }
+// CHECK: [[@LINE-1]]:{{[0-9]+}}:
+// CHECK-NEXT: fcvtn  z0.b, { z1.s - z4.s }
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/FP8_SME2/cvt.s
+++ b/llvm/test/MC/AArch64/FP8_SME2/cvt.s
@@ -1,0 +1,157 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme2,+fp8 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2,+fp8 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+f1cvt   {z0.h-z1.h}, z0.b  // 11000001-00100110-11100000-00000000
+// CHECK-INST: f1cvt   { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x00,0xe0,0x26,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c126e000 <unknown>
+
+f1cvt   {z30.h-z31.h}, z31.b  // 11000001-00100110-11100011-11111110
+// CHECK-INST: f1cvt   { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xfe,0xe3,0x26,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c126e3fe <unknown>
+
+f1cvtl  {z0.h-z1.h}, z0.b  // 11000001-00100110-11100000-00000001
+// CHECK-INST: f1cvtl  { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x01,0xe0,0x26,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c126e001 <unknown>
+
+f1cvtl  {z30.h-z31.h}, z31.b  // 11000001-00100110-11100011-11111111
+// CHECK-INST: f1cvtl  { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xff,0xe3,0x26,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c126e3ff <unknown>
+
+bf1cvt  {z0.h-z1.h}, z0.b  // 11000001-01100110-11100000-00000000
+// CHECK-INST: bf1cvt  { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x00,0xe0,0x66,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c166e000 <unknown>
+
+bf1cvt  {z30.h-z31.h}, z31.b  // 11000001-01100110-11100011-11111110
+// CHECK-INST: bf1cvt  { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xfe,0xe3,0x66,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c166e3fe <unknown>
+
+bf1cvtl {z0.h-z1.h}, z0.b  // 11000001-01100110-11100000-00000001
+// CHECK-INST: bf1cvtl { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x01,0xe0,0x66,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c166e001 <unknown>
+
+bf1cvtl {z30.h-z31.h}, z31.b  // 11000001-01100110-11100011-11111111
+// CHECK-INST: bf1cvtl { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xff,0xe3,0x66,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c166e3ff <unknown>
+
+bf2cvt  {z0.h-z1.h}, z0.b  // 11000001-11100110-11100000-00000000
+// CHECK-INST: bf2cvt  { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x00,0xe0,0xe6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e6e000 <unknown>
+
+bf2cvt  {z30.h-z31.h}, z31.b  // 11000001-11100110-11100011-11111110
+// CHECK-INST: bf2cvt  { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xfe,0xe3,0xe6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e6e3fe <unknown>
+
+bf2cvtl {z0.h-z1.h}, z0.b  // 11000001-11100110-11100000-00000001
+// CHECK-INST: bf2cvtl { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x01,0xe0,0xe6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e6e001 <unknown>
+
+bf2cvtl {z30.h-z31.h}, z31.b  // 11000001-11100110-11100011-11111111
+// CHECK-INST: bf2cvtl { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xff,0xe3,0xe6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e6e3ff <unknown>
+
+f2cvt   {z0.h-z1.h}, z0.b  // 11000001-10100110-11100000-00000000
+// CHECK-INST: f2cvt   { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x00,0xe0,0xa6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a6e000 <unknown>
+
+f2cvt   {z30.h-z31.h}, z31.b  // 11000001-10100110-11100011-11111110
+// CHECK-INST: f2cvt   { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xfe,0xe3,0xa6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a6e3fe <unknown>
+
+f2cvtl  {z0.h-z1.h}, z0.b  // 11000001-10100110-11100000-00000001
+// CHECK-INST: f2cvtl  { z0.h, z1.h }, z0.b
+// CHECK-ENCODING: [0x01,0xe0,0xa6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a6e001 <unknown>
+
+f2cvtl  {z30.h-z31.h}, z31.b  // 11000001-10100110-11100011-11111111
+// CHECK-INST: f2cvtl  { z30.h, z31.h }, z31.b
+// CHECK-ENCODING: [0xff,0xe3,0xa6,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a6e3ff <unknown>
+
+fcvt    z0.b, {z0.h-z1.h}  // 11000001-00100100-11100000-00000000
+// CHECK-INST: fcvt    z0.b, { z0.h, z1.h }
+// CHECK-ENCODING: [0x00,0xe0,0x24,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c124e000 <unknown>
+
+fcvt    z31.b, {z30.h-z31.h}  // 11000001-00100100-11100011-11011111
+// CHECK-INST: fcvt    z31.b, { z30.h, z31.h }
+// CHECK-ENCODING: [0xdf,0xe3,0x24,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c124e3df <unknown>
+
+fcvt    z0.b, {z0.s-z3.s}  // 11000001-00110100-11100000-00000000
+// CHECK-INST: fcvt    z0.b, { z0.s - z3.s }
+// CHECK-ENCODING: [0x00,0xe0,0x34,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c134e000 <unknown>
+
+fcvt    z31.b, {z28.s-z31.s}  // 11000001-00110100-11100011-10011111
+// CHECK-INST: fcvt    z31.b, { z28.s - z31.s }
+// CHECK-ENCODING: [0x9f,0xe3,0x34,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c134e39f <unknown>
+
+fcvtn   z0.b, {z0.s-z3.s}  // 11000001-00110100-11100000-00100000
+// CHECK-INST: fcvtn   z0.b, { z0.s - z3.s }
+// CHECK-ENCODING: [0x20,0xe0,0x34,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c134e020 <unknown>
+
+fcvtn   z31.b, {z28.s-z31.s}  // 11000001-00110100-11100011-10111111
+// CHECK-INST: fcvtn   z31.b, { z28.s - z31.s }
+// CHECK-ENCODING: [0xbf,0xe3,0x34,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c134e3bf <unknown>
+
+bfcvt   z0.b, {z0.h-z1.h}  // 11000001-01100100-11100000-00000000
+// CHECK-INST: bfcvt   z0.b, { z0.h, z1.h }
+// CHECK-ENCODING: [0x00,0xe0,0x64,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c164e000 <unknown>
+
+bfcvt   z31.b, {z30.h-z31.h}  // 11000001-01100100-11100011-11011111
+// CHECK-INST: bfcvt   z31.b, { z30.h, z31.h }
+// CHECK-ENCODING: [0xdf,0xe3,0x64,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c164e3df <unknown>

--- a/llvm/test/MC/AArch64/FP8_SME2/fscale-diagnostics.c
+++ b/llvm/test/MC/AArch64/FP8_SME2/fscale-diagnostics.c
@@ -1,0 +1,62 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 2>&1 < %s| FileCheck %s
+
+// --------------------------------------------------------------------------//
+// Incorrect operand
+
+fscale  {z0.h-z1.h}, {z0.h-z1.h}, z0
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand
+// CHECK-NEXT: fscale  {z0.h-z1.h}, {z0.h-z1.h}, z0
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z0.d-z1.d}, {z0.h-z1.h}, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  {z0.d-z1.d}, {z0.h-z1.h}, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z30.s-z31.s}, {z30.s-z31.s}, {z30 - z31}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  {z30.s-z31.s}, {z30.s-z31.s}, {z30 - z31}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z0.s-z3.s}, {z0.d-z3.d}, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  {z0.s-z3.s}, {z0.d-z3.d}, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z28.h-z31.h}, {z28-z31}, {z28.h-z31.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  {z28.h-z31.h}, {z28-z31}, {z28.h-z31.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z28.d-z31.d}, z28.d, {z28.d-z31.d}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  {z28.d-z31.d}, z28.d, {z28.d-z31.d}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z0.h-z1.h}, {z1.h-z4.h}, {z0.h-z1.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fscale  {z0.h-z1.h}, {z1.h-z4.h}, {z0.h-z1.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+// --------------------------------------------------------------------------//
+// Incorrect range of vectors
+
+fscale  {z0.h-z1.h}, {z1.h-z2.h}, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT: fscale  {z0.h-z1.h}, {z1.h-z2.h}, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z0.h-z1.h}, {z31.h-z0.h}, {z0.h-z1.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT: fscale  {z0.h-z1.h}, {z31.h-z0.h}, {z0.h-z1.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z2.h-z5.h}, {z0.h-z3.h}, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
+// CHECK-NEXT: fscale  {z2.h-z5.h}, {z0.h-z3.h}, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fscale  {z0.h-z3.h}, {z0.h-z3.h}, {z3.h-z6.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
+// CHECK-NEXT: fscale  {z0.h-z3.h}, {z0.h-z3.h}, {z3.h-z6.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/FP8_SME2/fscale.s
+++ b/llvm/test/MC/AArch64/FP8_SME2/fscale.s
@@ -1,0 +1,160 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme2,+fp8 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2,+fp8 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+//2X
+fscale  {z0.h-z1.h}, {z0.h-z1.h}, z0.h  // 11000001-01100000-10100001-10000000
+// CHECK-INST: fscale  { z0.h, z1.h }, { z0.h, z1.h }, z0.h
+// CHECK-ENCODING: [0x80,0xa1,0x60,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c160a180 <unknown>
+
+fscale  {z30.h-z31.h}, {z30.h-z31.h}, z15.h  // 11000001-01101111-10100001-10011110
+// CHECK-INST: fscale  { z30.h, z31.h }, { z30.h, z31.h }, z15.h
+// CHECK-ENCODING: [0x9e,0xa1,0x6f,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c16fa19e <unknown>
+
+fscale  {z0.s-z1.s}, {z0.s-z1.s}, z0.s  // 11000001-10100000-10100001-10000000
+// CHECK-INST: fscale  { z0.s, z1.s }, { z0.s, z1.s }, z0.s
+// CHECK-ENCODING: [0x80,0xa1,0xa0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a0a180 <unknown>
+
+fscale  {z30.s-z31.s}, {z30.s-z31.s}, z15.s  // 11000001-10101111-10100001-10011110
+// CHECK-INST: fscale  { z30.s, z31.s }, { z30.s, z31.s }, z15.s
+// CHECK-ENCODING: [0x9e,0xa1,0xaf,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1afa19e <unknown>
+
+fscale  {z0.d-z1.d}, {z0.d-z1.d}, z0.d  // 11000001-11100000-10100001-10000000
+// CHECK-INST: fscale  { z0.d, z1.d }, { z0.d, z1.d }, z0.d
+// CHECK-ENCODING: [0x80,0xa1,0xe0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e0a180 <unknown>
+
+fscale  {z30.d-z31.d}, {z30.d-z31.d}, z15.d  // 11000001-11101111-10100001-10011110
+// CHECK-INST: fscale  { z30.d, z31.d }, { z30.d, z31.d }, z15.d
+// CHECK-ENCODING: [0x9e,0xa1,0xef,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1efa19e <unknown>
+
+fscale  {z0.h-z1.h}, {z0.h-z1.h}, {z0.h-z1.h}  // 11000001-01100000-10110001-10000000
+// CHECK-INST: fscale  { z0.h, z1.h }, { z0.h, z1.h }, { z0.h, z1.h }
+// CHECK-ENCODING: [0x80,0xb1,0x60,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c160b180 <unknown>
+
+fscale  {z30.h-z31.h}, {z30.h-z31.h}, {z30.h-z31.h}  // 11000001-01111110-10110001-10011110
+// CHECK-INST: fscale  { z30.h, z31.h }, { z30.h, z31.h }, { z30.h, z31.h }
+// CHECK-ENCODING: [0x9e,0xb1,0x7e,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c17eb19e <unknown>
+
+fscale  {z0.s-z1.s}, {z0.s-z1.s}, {z0.s-z1.s}  // 11000001-10100000-10110001-10000000
+// CHECK-INST: fscale  { z0.s, z1.s }, { z0.s, z1.s }, { z0.s, z1.s }
+// CHECK-ENCODING: [0x80,0xb1,0xa0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a0b180 <unknown>
+
+fscale  {z30.s-z31.s}, {z30.s-z31.s}, {z30.s-z31.s}  // 11000001-10111110-10110001-10011110
+// CHECK-INST: fscale  { z30.s, z31.s }, { z30.s, z31.s }, { z30.s, z31.s }
+// CHECK-ENCODING: [0x9e,0xb1,0xbe,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1beb19e <unknown>
+
+fscale  {z0.d-z1.d}, {z0.d-z1.d}, {z0.d-z1.d}  // 11000001-11100000-10110001-10000000
+// CHECK-INST: fscale  { z0.d, z1.d }, { z0.d, z1.d }, { z0.d, z1.d }
+// CHECK-ENCODING: [0x80,0xb1,0xe0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e0b180 <unknown>
+
+fscale  {z30.d-z31.d}, {z30.d-z31.d}, {z30.d-z31.d}  // 11000001-11111110-10110001-10011110
+// CHECK-INST: fscale  { z30.d, z31.d }, { z30.d, z31.d }, { z30.d, z31.d }
+// CHECK-ENCODING: [0x9e,0xb1,0xfe,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1feb19e <unknown>
+
+
+//4X
+
+fscale  {z0.h-z3.h}, {z0.h-z3.h}, z0.h  // 11000001-01100000-10101001-10000000
+// CHECK-INST: fscale  { z0.h - z3.h }, { z0.h - z3.h }, z0.h
+// CHECK-ENCODING: [0x80,0xa9,0x60,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c160a980 <unknown>
+
+fscale  {z28.h-z31.h}, {z28.h-z31.h}, z15.h  // 11000001-01101111-10101001-10011100
+// CHECK-INST: fscale  { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+// CHECK-ENCODING: [0x9c,0xa9,0x6f,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c16fa99c <unknown>
+
+fscale  {z0.s-z3.s}, {z0.s-z3.s}, z0.s  // 11000001-10100000-10101001-10000000
+// CHECK-INST: fscale  { z0.s - z3.s }, { z0.s - z3.s }, z0.s
+// CHECK-ENCODING: [0x80,0xa9,0xa0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a0a980 <unknown>
+
+fscale  {z28.s-z31.s}, {z28.s-z31.s}, z15.s  // 11000001-10101111-10101001-10011100
+// CHECK-INST: fscale  { z28.s - z31.s }, { z28.s - z31.s }, z15.s
+// CHECK-ENCODING: [0x9c,0xa9,0xaf,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1afa99c <unknown>
+
+fscale  {z0.d-z3.d}, {z0.d-z3.d}, z0.d  // 11000001-11100000-10101001-10000000
+// CHECK-INST: fscale  { z0.d - z3.d }, { z0.d - z3.d }, z0.d
+// CHECK-ENCODING: [0x80,0xa9,0xe0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e0a980 <unknown>
+
+fscale  {z28.d-z31.d}, {z28.d-z31.d}, z15.d  // 11000001-11101111-10101001-10011100
+// CHECK-INST: fscale  { z28.d - z31.d }, { z28.d - z31.d }, z15.d
+// CHECK-ENCODING: [0x9c,0xa9,0xef,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1efa99c <unknown>
+
+fscale  {z0.h-z3.h}, {z0.h-z3.h}, {z0.h-z3.h}  // 11000001-01100000-10111001-10000000
+// CHECK-INST: fscale  { z0.h - z3.h }, { z0.h - z3.h }, { z0.h - z3.h }
+// CHECK-ENCODING: [0x80,0xb9,0x60,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c160b980 <unknown>
+
+fscale  {z28.h-z31.h}, {z28.h-z31.h}, {z28.h-z31.h}  // 11000001-01111100-10111001-10011100
+// CHECK-INST: fscale  { z28.h - z31.h }, { z28.h - z31.h }, { z28.h - z31.h }
+// CHECK-ENCODING: [0x9c,0xb9,0x7c,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c17cb99c <unknown>
+
+fscale  {z0.s-z3.s}, {z0.s-z3.s}, {z0.s-z3.s}  // 11000001-10100000-10111001-10000000
+// CHECK-INST: fscale  { z0.s - z3.s }, { z0.s - z3.s }, { z0.s - z3.s }
+// CHECK-ENCODING: [0x80,0xb9,0xa0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1a0b980 <unknown>
+
+fscale  {z28.s-z31.s}, {z28.s-z31.s}, {z28.s-z31.s}  // 11000001-10111100-10111001-10011100
+// CHECK-INST: fscale  { z28.s - z31.s }, { z28.s - z31.s }, { z28.s - z31.s }
+// CHECK-ENCODING: [0x9c,0xb9,0xbc,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1bcb99c <unknown>
+
+fscale  {z0.d-z3.d}, {z0.d-z3.d}, {z0.d-z3.d}  // 11000001-11100000-10111001-10000000
+// CHECK-INST: fscale  { z0.d - z3.d }, { z0.d - z3.d }, { z0.d - z3.d }
+// CHECK-ENCODING: [0x80,0xb9,0xe0,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1e0b980 <unknown>
+
+fscale  {z28.d-z31.d}, {z28.d-z31.d}, {z28.d-z31.d}  // 11000001-11111100-10111001-10011100
+// CHECK-INST: fscale  { z28.d - z31.d }, { z28.d - z31.d }, { z28.d - z31.d }
+// CHECK-ENCODING: [0x9c,0xb9,0xfc,0xc1]
+// CHECK-ERROR: instruction requires: fp8 sme2
+// CHECK-UNKNOWN: c1fcb99c <unknown>

--- a/llvm/test/MC/AArch64/FP8_SVE2/fcvt-diagnostics.s
+++ b/llvm/test/MC/AArch64/FP8_SVE2/fcvt-diagnostics.s
@@ -1,0 +1,131 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2,+fp8 2>&1 < %s | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 2>&1 < %s | FileCheck %s
+
+// --------------------------------------------------------------------------//
+
+f1cvt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f1cvt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f1cvt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f1cvt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+f2cvt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f2cvt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f2cvt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f2cvt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+bf1cvt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf1cvt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf1cvt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf1cvt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf1cvt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf1cvt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+bf2cvt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf2cvt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf2cvt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf2cvt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+f1cvtlt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f1cvtlt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvtlt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f1cvtlt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f1cvtlt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f1cvtlt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+f2cvtlt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f2cvtlt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvtlt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: f2cvtlt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+f2cvtlt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: f2cvtlt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+bf1cvtlt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf1cvtlt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf1cvtlt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf1cvtlt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf1cvtlt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf1cvtlt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+bf2cvtlt z0.h, z0.h
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf2cvtlt z0.h, z0.h
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvtlt z0.b, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: bf2cvtlt z0.b, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bf2cvtlt z32.h, z0.b
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bf2cvtlt z32.h, z0.b
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/FP8_SVE2/fcvt.s
+++ b/llvm/test/MC/AArch64/FP8_SVE2/fcvt.s
@@ -1,0 +1,237 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2,+fp8 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sve2,+fp8 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2,+fp8 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sve2,+fp8 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+//
+// F1CVT instructions
+//
+f1cvt   z0.h, z0.b  // 01100101-00001000-00110000-00000000
+// CHECK-INST: f1cvt   z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x30,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083000 <unknown>
+
+f1cvt   z0.h, z31.b  // 01100101-00001000-00110011-11100000
+// CHECK-INST: f1cvt   z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x33,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650833e0 <unknown>
+
+f1cvt   z31.h, z0.b  // 01100101-00001000-00110000-00011111
+// CHECK-INST: f1cvt   z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x30,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 6508301f <unknown>
+
+f1cvt   z31.h, z31.b  // 01100101-00001000-00110011-11111111
+// CHECK-INST: f1cvt   z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x33,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650833ff <unknown>
+
+//
+// F2CVT instructions
+//
+f2cvt   z0.h, z0.b  // 01100101-00001000-00110100-00000000
+// CHECK-INST: f2cvt   z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x34,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083400 <unknown>
+
+f2cvt   z0.h, z31.b  // 01100101-00001000-00110111-11100000
+// CHECK-INST: f2cvt   z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x37,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650837e0 <unknown>
+
+f2cvt   z31.h, z0.b  // 01100101-00001000-00110100-00011111
+// CHECK-INST: f2cvt   z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x34,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 6508341f <unknown>
+
+f2cvt   z31.h, z31.b  // 01100101-00001000-00110111-11111111
+// CHECK-INST: f2cvt   z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x37,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650837ff <unknown>
+
+
+//
+// BF1CVT instructions
+//
+bf1cvt  z0.h, z0.b  // 01100101-00001000-00111000-00000000
+// CHECK-INST: bf1cvt  z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x38,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083800 <unknown>
+
+bf1cvt  z0.h, z31.b  // 01100101-00001000-00111011-11100000
+// CHECK-INST: bf1cvt  z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x3b,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083be0 <unknown>
+
+bf1cvt  z31.h, z0.b  // 01100101-00001000-00111000-00011111
+// CHECK-INST: bf1cvt  z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x38,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 6508381f <unknown>
+
+bf1cvt  z31.h, z31.b  // 01100101-00001000-00111011-11111111
+// CHECK-INST: bf1cvt  z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x3b,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083bff <unknown>
+
+
+//
+// BF2CVT instructions
+//
+bf2cvt  z0.h, z0.b  // 01100101-00001000-00111100-00000000
+// CHECK-INST: bf2cvt  z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x3c,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083c00 <unknown>
+
+bf2cvt  z0.h, z31.b  // 01100101-00001000-00111111-11100000
+// CHECK-INST: bf2cvt  z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x3f,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083fe0 <unknown>
+
+bf2cvt  z31.h, z0.b  // 01100101-00001000-00111100-00011111
+// CHECK-INST: bf2cvt  z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x3c,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083c1f <unknown>
+
+bf2cvt  z31.h, z31.b  // 01100101-00001000-00111111-11111111
+// CHECK-INST: bf2cvt  z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x3f,0x08,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65083fff <unknown>
+
+
+//
+// F1CVTLT instructions
+//
+f1cvtlt z0.h, z0.b  // 01100101-00001001-00110000-00000000
+// CHECK-INST: f1cvtlt z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x30,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093000 <unknown>
+
+f1cvtlt z0.h, z31.b  // 01100101-00001001-00110011-11100000
+// CHECK-INST: f1cvtlt z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x33,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650933e0 <unknown>
+
+f1cvtlt z31.h, z0.b  // 01100101-00001001-00110000-00011111
+// CHECK-INST: f1cvtlt z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x30,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 6509301f <unknown>
+
+f1cvtlt z31.h, z31.b  // 01100101-00001001-00110011-11111111
+// CHECK-INST: f1cvtlt z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x33,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650933ff <unknown>
+
+
+//
+// F2CVTLT instructions
+//
+f2cvtlt z0.h, z0.b  // 01100101-00001001-00110100-00000000
+// CHECK-INST: f2cvtlt z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x34,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093400 <unknown>
+
+f2cvtlt z0.h, z31.b  // 01100101-00001001-00110111-11100000
+// CHECK-INST: f2cvtlt z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x37,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650937e0 <unknown>
+
+f2cvtlt z31.h, z0.b  // 01100101-00001001-00110100-00011111
+// CHECK-INST: f2cvtlt z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x34,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 6509341f <unknown>
+
+f2cvtlt z31.h, z31.b  // 01100101-00001001-00110111-11111111
+// CHECK-INST: f2cvtlt z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x37,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650937ff <unknown>
+
+
+//
+// BF1CVTLT instructions
+//
+bf1cvtlt z0.h, z0.b  // 01100101-00001001-00111000-00000000
+// CHECK-INST: bf1cvtlt z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x38,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093800 <unknown>
+
+bf1cvtlt z0.h, z31.b  // 01100101-00001001-00111011-11100000
+// CHECK-INST: bf1cvtlt z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x3b,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093be0 <unknown>
+
+bf1cvtlt z31.h, z0.b  // 01100101-00001001-00111000-00011111
+// CHECK-INST: bf1cvtlt z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x38,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 6509381f <unknown>
+
+bf1cvtlt z31.h, z31.b  // 01100101-00001001-00111011-11111111
+// CHECK-INST: bf1cvtlt z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x3b,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093bff <unknown>
+
+
+//
+// BF2CVTLT instructions
+//
+bf2cvtlt z0.h, z0.b  // 01100101-00001001-00111100-00000000
+// CHECK-INST: bf2cvtlt z0.h, z0.b
+// CHECK-ENCODING: [0x00,0x3c,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093c00 <unknown>
+
+bf2cvtlt z0.h, z31.b  // 01100101-00001001-00111111-11100000
+// CHECK-INST: bf2cvtlt z0.h, z31.b
+// CHECK-ENCODING: [0xe0,0x3f,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093fe0 <unknown>
+
+bf2cvtlt z31.h, z0.b  // 01100101-00001001-00111100-00011111
+// CHECK-INST: bf2cvtlt z31.h, z0.b
+// CHECK-ENCODING: [0x1f,0x3c,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093c1f <unknown>
+
+bf2cvtlt z31.h, z31.b  // 01100101-00001001-00111111-11111111
+// CHECK-INST: bf2cvtlt z31.h, z31.b
+// CHECK-ENCODING: [0xff,0x3f,0x09,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 65093fff <unknown>

--- a/llvm/test/MC/AArch64/FP8_SVE2/fcvtn-diagnostics.s
+++ b/llvm/test/MC/AArch64/FP8_SVE2/fcvtn-diagnostics.s
@@ -1,0 +1,70 @@
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2,+fp8 2>&1 < %s | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 2>&1 < %s | FileCheck %s
+
+// --------------------------------------------------------------------------//
+
+fcvtn z0.b, {z1.h, z2.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error:  Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT:  fcvtn z0.b, {z1.h, z2.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn z0.h, {z0.h, z1.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fcvtn z0.h, {z0.h, z1.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtn z0.b, {z0.b, z1.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fcvtn z0.b, {z0.b, z1.b}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+
+fcvtnb  z0.b, {z1.s, z2.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element type
+// CHECK-NEXT:  fcvtnb z0.b, {z1.s, z2.s}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtnb z0.h, {z0.s, z1.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK-NEXT: fcvtnb z0.h, {z0.s, z1.s}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtnb z0.b, {z0.h, z1.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fcvtnb z0.b, {z0.h, z1.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+
+bfcvtn z0.b, {z1.h, z2.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error:  Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT:  bfcvtn z0.b, {z1.h, z2.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bfcvtn z0.h, {z0.h, z1.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bfcvtn z0.h, {z0.h, z1.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+bfcvtn z0.b, {z0.b, z1.b}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: bfcvtn z0.b, {z0.b, z1.b}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+
+
+fcvtnt  z0.b, {z1.s, z2.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element type
+// CHECK-NEXT:  fcvtnt z0.b, {z1.s, z2.s}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtnt z0.h, {z0.s, z1.s}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fcvtnt z0.h, {z0.s, z1.s}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+fcvtnt z0.b, {z0.h, z1.h}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
+// CHECK-NEXT: fcvtnt z0.b, {z0.h, z1.h}
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/FP8_SVE2/fcvtn.s
+++ b/llvm/test/MC/AArch64/FP8_SVE2/fcvtn.s
@@ -1,0 +1,125 @@
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2,+fp8 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2,+fp8 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sve2,+fp8 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve2,+fp8 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// Disassemble encoding and check the re-encoding (-show-encoding) matches.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve2,+fp8 < %s \
+// RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sve2,+fp8 -disassemble -show-encoding \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+
+//
+// FCVTN instructions
+//
+fcvtn   z0.b, {z0.h, z1.h}  // 01100101-00001010-00110000-00000000
+// CHECK-INST: fcvtn   z0.b, { z0.h, z1.h }
+// CHECK-ENCODING: [0x00,0x30,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3000 <unknown>
+
+fcvtn   z0.b, {z30.h, z31.h}  // 01100101-00001010-00110011-11000000
+// CHECK-INST: fcvtn   z0.b, { z30.h, z31.h }
+// CHECK-ENCODING: [0xc0,0x33,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a33c0 <unknown>
+
+fcvtn   z31.b, {z0.h, z1.h}  // 01100101-00001010-00110000-00011111
+// CHECK-INST: fcvtn   z31.b, { z0.h, z1.h }
+// CHECK-ENCODING: [0x1f,0x30,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a301f <unknown>
+
+fcvtn   z31.b, {z30.h, z31.h}  // 01100101-00001010-00110011-11011111
+// CHECK-INST: fcvtn   z31.b, { z30.h, z31.h }
+// CHECK-ENCODING: [0xdf,0x33,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a33df <unknown>
+
+//
+// FCVTNB instructions
+//
+fcvtnb  z0.b, {z0.s, z1.s}  // 01100101-00001010-00110100-00000000
+// CHECK-INST: fcvtnb  z0.b, { z0.s, z1.s }
+// CHECK-ENCODING: [0x00,0x34,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3400 <unknown>
+
+fcvtnb  z0.b, {z30.s, z31.s}  // 01100101-00001010-00110111-11000000
+// CHECK-INST: fcvtnb  z0.b, { z30.s, z31.s }
+// CHECK-ENCODING: [0xc0,0x37,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a37c0 <unknown>
+
+fcvtnb  z31.b, {z0.s, z1.s}  // 01100101-00001010-00110100-00011111
+// CHECK-INST: fcvtnb  z31.b, { z0.s, z1.s }
+// CHECK-ENCODING: [0x1f,0x34,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a341f <unknown>
+
+fcvtnb  z31.b, {z30.s, z31.s}  // 01100101-00001010-00110111-11011111
+// CHECK-INST: fcvtnb  z31.b, { z30.s, z31.s }
+// CHECK-ENCODING: [0xdf,0x37,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a37df <unknown>
+
+
+//
+// BFCVTN instructions
+//
+bfcvtn  z0.b, {z0.h, z1.h}  // 01100101-00001010-00111000-00000000
+// CHECK-INST: bfcvtn  z0.b, { z0.h, z1.h }
+// CHECK-ENCODING: [0x00,0x38,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3800 <unknown>
+
+bfcvtn  z0.b, {z30.h, z31.h}  // 01100101-00001010-00111011-11000000
+// CHECK-INST: bfcvtn  z0.b, { z30.h, z31.h }
+// CHECK-ENCODING: [0xc0,0x3b,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3bc0 <unknown>
+
+bfcvtn  z31.b, {z0.h, z1.h}  // 01100101-00001010-00111000-00011111
+// CHECK-INST: bfcvtn  z31.b, { z0.h, z1.h }
+// CHECK-ENCODING: [0x1f,0x38,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a381f <unknown>
+
+bfcvtn  z31.b, {z30.h, z31.h}  // 01100101-00001010-00111011-11011111
+// CHECK-INST: bfcvtn  z31.b, { z30.h, z31.h }
+// CHECK-ENCODING: [0xdf,0x3b,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3bdf <unknown>
+
+
+//
+// FCVTNT instructions
+//
+fcvtnt  z0.b, {z0.s, z1.s}  // 01100101-00001010-00111100-00000000
+// CHECK-INST: fcvtnt  z0.b, { z0.s, z1.s }
+// CHECK-ENCODING: [0x00,0x3c,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3c00 <unknown>
+
+fcvtnt  z0.b, {z30.s, z31.s}  // 01100101-00001010-00111111-11000000
+// CHECK-INST: fcvtnt  z0.b, { z30.s, z31.s }
+// CHECK-ENCODING: [0xc0,0x3f,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3fc0 <unknown>
+
+fcvtnt  z31.b, {z0.s, z1.s}  // 01100101-00001010-00111100-00011111
+// CHECK-INST: fcvtnt  z31.b, { z0.s, z1.s }
+// CHECK-ENCODING: [0x1f,0x3c,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3c1f <unknown>
+
+fcvtnt  z31.b, {z30.s, z31.s}  // 01100101-00001010-00111111-11011111
+// CHECK-INST: fcvtnt  z31.b, { z30.s, z31.s }
+// CHECK-ENCODING: [0xdf,0x3f,0x0a,0x65]
+// CHECK-ERROR: instruction requires: fp8 sve2
+// CHECK-UNKNOWN: 650a3fdf <unknown>

--- a/llvm/test/MC/AArch64/SVE2/fcvtnt-diagnostics.s
+++ b/llvm/test/MC/AArch64/SVE2/fcvtnt-diagnostics.s
@@ -5,7 +5,7 @@
 // Invalid element width
 
 fcvtnt z0.b, p0/m, z0.b
-// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 // CHECK-NEXT: fcvtnt z0.b, p0/m, z0.b
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
 
@@ -25,7 +25,7 @@ fcvtnt z0.d, p0/m, z0.d
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
 
 fcvtnt z0.b, p0/m, z0.h
-// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid element width
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 // CHECK-NEXT: fcvtnt z0.b, p0/m, z0.h
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
 

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1732,7 +1732,7 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
       AArch64::AEK_RCPC3,   AArch64::AEK_THE,       AArch64::AEK_D128,
       AArch64::AEK_LSE128,  AArch64::AEK_SPECRES2,  AArch64::AEK_RASv2,
       AArch64::AEK_ITE,     AArch64::AEK_GCS,       AArch64::AEK_FPMR,
-  };
+      AArch64::AEK_FP8};
 
   std::vector<StringRef> Features;
 
@@ -1805,6 +1805,7 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
   EXPECT_TRUE(llvm::is_contained(Features, "+ite"));
   EXPECT_TRUE(llvm::is_contained(Features, "+gcs"));
   EXPECT_TRUE(llvm::is_contained(Features, "+fpmr"));
+  EXPECT_TRUE(llvm::is_contained(Features, "+fp8"));
 
   // Assuming we listed every extension above, this should produce the same
   // result. (note that AEK_NONE doesn't have a name so it won't be in the
@@ -1929,6 +1930,7 @@ TEST(TargetParserTest, AArch64ArchExtFeature) {
       {"rasv2", "norasv2", "+rasv2", "-rasv2"},
       {"gcs", "nogcs", "+gcs", "-gcs"},
       {"fpmr", "nofpmr", "+fpmr", "-fpmr"},
+      {"fp8", "nofp8", "+fp8", "-fp8"},
   };
 
   for (unsigned i = 0; i < std::size(ArchExt); i++) {


### PR DESCRIPTION
This patch adds the feature flag FP8 and the assembly/disassembly
for the following instructions of NEON, SVE2 and SME2:
  * NEON Instructions:
    + Advanced SIMD two-register miscellaneous:
      - F1CVTL, F1CVTL2, F2CVTL, F2CVTL2 
      - BF1CVTL, BF1CVTL2, BF2CVTL, BF2CVTL2
    + Advanced SIMD three-register extension:
       - FCVTN, FCVTN2 (FP32 to FP8) 
       - FCVTN (FP16 to FP8)
    + Advanced SIMD three same:
      - FSCALE
  * SVE2 Instructions:
    + Downconvert instructions:
       - FCVTN_Z2Z_HtoB
       - FCVTNB_Z2Z_StoB 
       - BFCVTN_Z2Z_HtoB 
       - FCVTNT_Z2Z_StoB
     + Upconvert instructions:
          - F1CVT_ZZ, F2CVT_ZZ
          - BF1CVT_ZZ, BF2CVT_ZZ
          - F1CVTLT_ZZ, F2CVTLT_ZZ 
          - BF1CVTLT_ZZ, BF2CVTLT_ZZ

  * SME2 Instructions:
    - F1CVT_2ZZ, F2CVT_2ZZ
    - BF1CVT_2ZZ, BF2CVT_2ZZ
    - F1CVTL_2ZZ, F2CVTL_2ZZ
    - BF1CVTL_2ZZ, BF2CVTL_2ZZ
    - FCVT_Z2Z_HtoB, BFCVT_Z2Z_HtoB
    - FCVT_Z4Z - FCVTN_Z4Z
    - FSCALE_2ZZ, FSCALE_4ZZ
    - FSCALE_2Z2Z, FSCALE_4Z4Z

That is according to this documentation:
https://developer.arm.com/documentation/ddi0602/2023-09