### PR TITLE
[MSVC] fix the build

### DIFF
--- a/compiler-rt/lib/builtins/int_to_fp.h
+++ b/compiler-rt/lib/builtins/int_to_fp.h
@@ -44,7 +44,10 @@ static __inline int clzSrcT(usrc_t x) { return __clzti2(x); }
 typedef float dst_t;
 typedef uint32_t dst_rep_t;
 #define DST_REP_C UINT32_C
-static const int dstSigBits = 23;
+
+enum {
+  dstSigBits = 23,
+};
 
 #elif defined DST_DOUBLE
 typedef double dst_t;

--- a/compiler-rt/lib/builtins/int_to_fp_impl.inc
+++ b/compiler-rt/lib/builtins/int_to_fp_impl.inc
@@ -17,10 +17,15 @@
 static __inline dst_t __floatXiYf__(src_t a) {
   if (a == 0)
     return 0.0;
-  const int dstMantDig = dstSigBits + 1;
-  const int srcBits = sizeof(src_t) * CHAR_BIT;
-  const int srcIsSigned = ((src_t)-1) < 0;
+
+  enum {
+    dstMantDig = dstSigBits + 1,
+    srcBits = sizeof(src_t) * CHAR_BIT,
+    srcIsSigned = ((src_t)-1) < 0,
+  };
+
   const src_t s = srcIsSigned ? a >> (srcBits - 1) : 0;
+
   a = (usrc_t)(a ^ s) - s;
   int sd = srcBits - clzSrcT(a);         // number of significant digits
   int e = sd - 1;                        // exponent


### PR DESCRIPTION
MSVC in C mode apparently doesn't consider `const int` to be sufficiently constant expression

This was broken in #66903.