### PR TITLE
[flang][openacc] Do not error when bind symbol is defined later or external

### DIFF
--- a/flang/test/Lower/OpenACC/acc-routine.f90
+++ b/flang/test/Lower/OpenACC/acc-routine.f90
@@ -96,3 +96,14 @@ subroutine acc_routine12()
   end interface
 
 end subroutine
+
+subroutine acc_routine13()
+  !$acc routine bind(acc_routine14)
+end subroutine
+
+subroutine acc_routine14()
+end subroutine
+
+subroutine acc_routine15()
+  !$acc routine bind(acc_routine16)
+end subroutine

--- a/flang/test/Semantics/OpenACC/acc-routine-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-routine-validity.f90
@@ -15,7 +15,6 @@ module openacc_routine_validity
   !ERROR: ROUTINE directive without name must appear within the specification part of a subroutine or function definition, or within an interface body for a subroutine or function in an interface block
   !$acc routine seq
 
-  !ERROR: No function or subroutine declared for 'dummy'
   !$acc routine(dummy) seq
 
 contains
@@ -70,7 +69,6 @@ contains
 
   subroutine sub6(a)
     real :: a(:)
-    !ERROR: No function or subroutine declared for 'dummy_sub'
     !$acc routine seq bind(dummy_sub)
   end subroutine sub6
 


### PR DESCRIPTION
The symbol in bind clause on acc routine refers to a function or a subroutine. This patch avoids to raise error when the function or subroutine is declared later in the code or is external. This is in line with normal procedure name resolution in Fortran code. 