### PR TITLE
[ARM] Add a method to clear registers

### DIFF
--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6747,7 +6747,9 @@ void ARMBaseInstrInfo::buildClearRegister(Register DstReg,
   const TargetRegisterInfo &TRI = *STI.getRegisterInfo();
 
   if (TRI.isGeneralPurposeRegister(MF, DstReg)) {
-    unsigned Opc = Subtarget.isThumb() ? ARM::t2MOVi32imm : ARM::MOVi32imm;
+    unsigned Opc = STI.isThumb1Only()
+      ? ARM::tMOVi32imm
+      : (STI.isThumb2() ? ARM::t2MOVi32imm : ARM::MOVi32imm);
     BuildMI(MBB, Iter, DL, get(Opc), DstReg).addImm(0);
   } else if (ARM::DPRRegClass.contains(DstReg)) {
     // f64, v8i8, v4i16, v2i32, v1i64, v2f32, v4f16, and v4bf16 registers.

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6741,8 +6741,7 @@ void ARMBaseInstrInfo::buildClearRegister(Register DstReg,
                                           DebugLoc &DL,
                                           bool AllowSideEffects) const {
   unsigned Opc = Subtarget.isThumb2() ? ARM::t2MOVi32imm : ARM::MOVi32imm;
-  BuildMI(MBB, Iter, DL, get(Opc), DstReg)
-      .addImm(0);
+  BuildMI(MBB, Iter, DL, get(Opc), DstReg).addImm(0);
 }
 
 bool ARMBaseInstrInfo::shouldOutlineFromFunctionByDefault(

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6760,9 +6760,9 @@ void ARMBaseInstrInfo::buildClearRegister(Register DstReg,
   } else if (ARM::HPRRegClass.contains(DstReg)) {
     // f16 and bf16 registers.
     BuildMI(MBB, Iter, DL, get(ARM::FCONSTH), DstReg).addImm(0);
+  } else {
+    llvm_unreachable("Unsupported register class");
   }
-
-  llvm_unreachable("Unsupported register class");
 }
 
 bool ARMBaseInstrInfo::shouldOutlineFromFunctionByDefault(

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6735,6 +6735,16 @@ MachineBasicBlock::iterator ARMBaseInstrInfo::insertOutlinedCall(
   return CallPt;
 }
 
+void ARMBaseInstrInfo::buildClearRegister(Register DstReg,
+                                          MachineBasicBlock &MBB,
+                                          MachineBasicBlock::iterator Iter,
+                                          DebugLoc &DL,
+                                          bool AllowSideEffects) const {
+  unsigned Opc = Subtarget.isThumb2() ? ARM::t2MOVi32imm : ARM::MOVi32imm;
+  BuildMI(MBB, Iter, DL, get(Opc), DstReg)
+      .addImm(0);
+}
+
 bool ARMBaseInstrInfo::shouldOutlineFromFunctionByDefault(
     MachineFunction &MF) const {
   return Subtarget.isMClass() && MF.getFunction().hasMinSize();

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6740,16 +6740,16 @@ void ARMBaseInstrInfo::buildClearRegister(Register DstReg,
                                           MachineBasicBlock::iterator Iter,
                                           DebugLoc &DL,
                                           bool AllowSideEffects) const {
-  assert(Register::isPhysicalRegister(DstReg) &&
-         "Can only clear physical registers");
+  assert(Register::isPhysicalRegister(DstReg) && "Not a physical register");
+
   const MachineFunction &MF = *MBB.getParent();
   const ARMSubtarget &STI = MF.getSubtarget<ARMSubtarget>();
   const TargetRegisterInfo &TRI = *STI.getRegisterInfo();
 
   if (TRI.isGeneralPurposeRegister(MF, DstReg)) {
     unsigned Opc = STI.isThumb1Only()
-      ? ARM::tMOVi32imm
-      : (STI.isThumb2() ? ARM::t2MOVi32imm : ARM::MOVi32imm);
+                       ? ARM::tMOVi32imm
+                       : (STI.isThumb2() ? ARM::t2MOVi32imm : ARM::MOVi32imm);
     BuildMI(MBB, Iter, DL, get(Opc), DstReg).addImm(0);
   } else if (ARM::DPRRegClass.contains(DstReg)) {
     // f64, v8i8, v4i16, v2i32, v1i64, v2f32, v4f16, and v4bf16 registers.

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
@@ -363,6 +363,11 @@ public:
                      MachineBasicBlock::iterator &It, MachineFunction &MF,
                      outliner::Candidate &C) const override;
 
+  void buildClearRegister(Register Reg, MachineBasicBlock &MBB,
+                          MachineBasicBlock::iterator Iter,
+                          DebugLoc &DL,
+                          bool AllowSideEffects = true) const override;
+
   /// Enable outlining by default at -Oz.
   bool shouldOutlineFromFunctionByDefault(MachineFunction &MF) const override;
 

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.h
@@ -364,8 +364,7 @@ public:
                      outliner::Candidate &C) const override;
 
   void buildClearRegister(Register Reg, MachineBasicBlock &MBB,
-                          MachineBasicBlock::iterator Iter,
-                          DebugLoc &DL,
+                          MachineBasicBlock::iterator Iter, DebugLoc &DL,
                           bool AllowSideEffects = true) const override;
 
   /// Enable outlining by default at -Oz.

--- a/llvm/lib/Target/ARM/ARMRegisterInfo.td
+++ b/llvm/lib/Target/ARM/ARMRegisterInfo.td
@@ -633,4 +633,4 @@ def FPCXTRegs : RegisterClass<"ARM", [i32], 32, (add FPCXTNS)>;
 // Register categories.
 //
 
-def GeneralPurposeRegisters : RegisterCategory<[GPR]>;
+def GeneralPurposeRegisters : RegisterCategory<[GPR, tGPR]>;

--- a/llvm/lib/Target/ARM/ARMRegisterInfo.td
+++ b/llvm/lib/Target/ARM/ARMRegisterInfo.td
@@ -628,3 +628,9 @@ def DQuadSpc : RegisterClass<"ARM", [v4i64], 64, (add Tuples3DSpc)>;
 
 // FP context payload
 def FPCXTRegs : RegisterClass<"ARM", [i32], 32, (add FPCXTNS)>;
+
+//===----------------------------------------------------------------------===//
+// Register categories.
+//
+
+def GeneralPurposeRegisters : RegisterCategory<[GPR]>;


### PR DESCRIPTION
This allows us to clear registers in target-independent code. The first
use will be for clearing the stack protector from registers before
returning.