### PR TITLE
[ModuleInliner] Remove an extraneous pair of std::push_heap and std::pop_heap (NFC)

### DIFF
--- a/llvm/lib/Analysis/InlineOrder.cpp
+++ b/llvm/lib/Analysis/InlineOrder.cpp
@@ -222,13 +222,12 @@ class PriorityInlineOrder : public InlineOrder<std::pair<CallBase *, int>> {
   // desirability of the front call site decreases, an updated one would be
   // pushed right back into the heap. For simplicity, those cases where the
   // desirability of a call site increases are ignored here.
-  void adjust() {
+  void pop_heap_adjust() {
     std::pop_heap(Heap.begin(), Heap.end(), isLess);
     while (updateAndCheckDecreased(Heap.back())) {
       std::push_heap(Heap.begin(), Heap.end(), isLess);
       std::pop_heap(Heap.begin(), Heap.end(), isLess);
     }
-    std::push_heap(Heap.begin(), Heap.end(), isLess);
   }
 
 public:
@@ -253,9 +252,8 @@ public:
 
   T pop() override {
     assert(size() > 0);
-    adjust();
+    pop_heap_adjust();
 
-    std::pop_heap(Heap.begin(), Heap.end(), isLess);
     CallBase *CB = Heap.pop_back_val();
     T Result = std::make_pair(CB, InlineHistoryMap[CB]);
     InlineHistoryMap.erase(CB);


### PR DESCRIPTION
Immediately after the "while" loop in adjust, Heap.back() is
guaranteed to be the highest priority item for the current values of
Priorities.  std::push_back() at the end of adjust moves the highest
priority item to Heap.front(), but std::pop_heap() in pop moves it
right back to Heap.back().

This roundtrip is wasteful.  This patch removes the extraneous pair of
std::push_heap and std::pop_heap.  This patch cuts down about 45% of
calls to std::push_heap and std::pop_heap in InlineOrder.cpp while
building clang with FDO+ThinLTO.

Strictly speaking, removing the pair of calls may change the order in
which call sites with identical priorities are removed from the
priority queue, but we do not need to worry about that.

Since the functionality of adjust becomes more like a smart version of
pop_heap, this patch renames adjust to pop_heap_adjust.
