### PR TITLE
[lldb][AArch64] Read mte_ctrl register from core files

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.cpp
@@ -55,6 +55,10 @@ bool RegisterContextPOSIX_arm64::IsTLS(unsigned reg) const {
   return m_register_info_up->IsTLSReg(reg);
 }
 
+bool RegisterContextPOSIX_arm64::IsMTE(unsigned reg) const {
+  return m_register_info_up->IsMTEReg(reg);
+}
+
 RegisterContextPOSIX_arm64::RegisterContextPOSIX_arm64(
     lldb_private::Thread &thread,
     std::unique_ptr<RegisterInfoPOSIX_arm64> register_info)

--- a/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.h
@@ -57,6 +57,7 @@ protected:
   bool IsPAuth(unsigned reg) const;
   bool IsTLS(unsigned reg) const;
   bool IsSME(unsigned reg) const;
+  bool IsMTE(unsigned reg) const;
 
   bool IsSVEZ(unsigned reg) const { return m_register_info_up->IsSVEZReg(reg); }
   bool IsSVEP(unsigned reg) const { return m_register_info_up->IsSVEPReg(reg); }

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.h
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.h
@@ -59,6 +59,7 @@ private:
   lldb_private::DataExtractor m_pac_data;
   lldb_private::DataExtractor m_tls_data;
   lldb_private::DataExtractor m_za_data;
+  lldb_private::DataExtractor m_mte_data;
 
   SVEState m_sve_state = SVEState::Unknown;
   uint16_t m_sve_vector_length = 0;

--- a/lldb/source/Plugins/Process/elf-core/RegisterUtilities.h
+++ b/lldb/source/Plugins/Process/elf-core/RegisterUtilities.h
@@ -135,6 +135,11 @@ constexpr RegsetDesc AARCH64_TLS_Desc[] = {
     {llvm::Triple::Linux, llvm::Triple::aarch64, llvm::ELF::NT_ARM_TLS},
 };
 
+constexpr RegsetDesc AARCH64_MTE_Desc[] = {
+    {llvm::Triple::Linux, llvm::Triple::aarch64,
+     llvm::ELF::NT_ARM_TAGGED_ADDR_CTRL},
+};
+
 constexpr RegsetDesc PPC_VMX_Desc[] = {
     {llvm::Triple::FreeBSD, llvm::Triple::UnknownArch, llvm::ELF::NT_PPC_VMX},
     {llvm::Triple::Linux, llvm::Triple::UnknownArch, llvm::ELF::NT_PPC_VMX},

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -208,6 +208,7 @@ Changes to LLDB
 * ``lldb-vscode`` was renamed to ``lldb-dap`` and and its installation
   instructions have been updated to reflect this. The underlying functionality
   remains unchanged.
+* The ``mte_ctrl`` register can now be read from AArch64 Linux core files.
 
 Changes to Sanitizers
 ---------------------


### PR DESCRIPTION
This register reports the configuration of the AArch64 Linux tagged address ABI, part of which is the memory tagging (MTE) settings.

It will always be present in core files because even without MTE, there are parts of the tagged address ABI that can be configured (these parts use the Top Byte Ignore feature).

I missed adding this when I previously worked on MTE support. Until now you could read memory tags from a core file but not this register.