### PR TITLE
[PowerPC] redesign the target flags

### DIFF
--- a/llvm/lib/Target/PowerPC/PPC.h
+++ b/llvm/lib/Target/PowerPC/PPC.h
@@ -102,79 +102,99 @@ class ModulePass;
     // PPC Specific MachineOperand flags.
     MO_NO_FLAG,
 
+    /// On PPC, the 12 bits are not enough for all target operand flags.
+    /// Treat all PPC target flags as direct flags. This also means we can not
+    /// use a bitmask flag, so if one operand has two or more flags, a fake
+    /// combination flag must be created. See example MO_GOT_TPREL_PCREL_FLAG.
+
     /// On a symbol operand "FOO", this indicates that the reference is actually
     /// to "FOO@plt".  This is used for calls and jumps to external functions
     /// and for PIC calls on 32-bit ELF systems.
-    MO_PLT = 1,
+    MO_PLT,
 
     /// MO_PIC_FLAG - If this bit is set, the symbol reference is relative to
     /// the function's picbase, e.g. lo16(symbol-picbase).
-    MO_PIC_FLAG = 2,
+    MO_PIC_FLAG,
 
     /// MO_PCREL_FLAG - If this bit is set, the symbol reference is relative to
     /// the current instruction address(pc), e.g., var@pcrel. Fixup is VK_PCREL.
-    MO_PCREL_FLAG = 4,
+    MO_PCREL_FLAG,
 
     /// MO_GOT_FLAG - If this bit is set the symbol reference is to be computed
     /// via the GOT. For example when combined with the MO_PCREL_FLAG it should
     /// produce the relocation @got@pcrel. Fixup is VK_PPC_GOT_PCREL.
-    MO_GOT_FLAG = 8,
+    MO_GOT_FLAG,
 
-    // MO_PCREL_OPT_FLAG - If this bit is set the operand is part of a
-    // PC Relative linker optimization.
-    MO_PCREL_OPT_FLAG = 16,
+    /// MO_PCREL_OPT_FLAG - If this bit is set the operand is part of a
+    /// PC Relative linker optimization.
+    MO_PCREL_OPT_FLAG,
 
     /// MO_TLSGD_FLAG - If this bit is set the symbol reference is relative to
     /// TLS General Dynamic model for Linux and the variable offset of TLS
     /// General Dynamic model for AIX.
-    MO_TLSGD_FLAG = 32,
+    MO_TLSGD_FLAG,
 
     /// MO_TPREL_FLAG - If this bit is set, the symbol reference is relative to
     /// the thread pointer and the symbol can be used for the TLS Initial Exec
     /// and Local Exec models.
-    MO_TPREL_FLAG = 64,
+    MO_TPREL_FLAG,
 
     /// MO_TLSLD_FLAG - If this bit is set the symbol reference is relative to
     /// TLS Local Dynamic model.
-    MO_TLSLD_FLAG = 128,
+    MO_TLSLD_FLAG,
 
     /// MO_TLSGDM_FLAG - If this bit is set the symbol reference is relative
     /// to the region handle of TLS General Dynamic model for AIX.
-    MO_TLSGDM_FLAG = 256,
+    MO_TLSGDM_FLAG,
 
     /// MO_GOT_TLSGD_PCREL_FLAG - A combintaion of flags, if these bits are set
     /// they should produce the relocation @got@tlsgd@pcrel.
     /// Fix up is VK_PPC_GOT_TLSGD_PCREL
-    MO_GOT_TLSGD_PCREL_FLAG = MO_PCREL_FLAG | MO_GOT_FLAG | MO_TLSGD_FLAG,
+    /// MO_GOT_TLSGD_PCREL_FLAG = MO_PCREL_FLAG | MO_GOT_FLAG | MO_TLSGD_FLAG,
+    MO_GOT_TLSGD_PCREL_FLAG,
 
     /// MO_GOT_TLSLD_PCREL_FLAG - A combintaion of flags, if these bits are set
     /// they should produce the relocation @got@tlsld@pcrel.
     /// Fix up is VK_PPC_GOT_TLSLD_PCREL
-    MO_GOT_TLSLD_PCREL_FLAG = MO_PCREL_FLAG | MO_GOT_FLAG | MO_TLSLD_FLAG,
+    /// MO_GOT_TLSLD_PCREL_FLAG = MO_PCREL_FLAG | MO_GOT_FLAG | MO_TLSLD_FLAG,
+    MO_GOT_TLSLD_PCREL_FLAG,
 
     /// MO_GOT_TPREL_PCREL_FLAG - A combintaion of flags, if these bits are set
     /// they should produce the relocation @got@tprel@pcrel.
     /// Fix up is VK_PPC_GOT_TPREL_PCREL
-    MO_GOT_TPREL_PCREL_FLAG = MO_GOT_FLAG | MO_TPREL_FLAG | MO_PCREL_FLAG,
-
-    /// The next are not flags but distinct values.
-    MO_ACCESS_MASK = 0xf00,
+    /// MO_GOT_TPREL_PCREL_FLAG = MO_GOT_FLAG | MO_TPREL_FLAG | MO_PCREL_FLAG,
+    MO_GOT_TPREL_PCREL_FLAG,
 
     /// MO_LO, MO_HA - lo16(symbol) and ha16(symbol)
-    MO_LO = 1 << 8,
-    MO_HA = 2 << 8,
+    MO_LO,
+    MO_HA,
 
-    MO_TPREL_LO = 4 << 8,
-    MO_TPREL_HA = 3 << 8,
+    MO_TPREL_LO,
+    MO_TPREL_HA,
 
     /// These values identify relocations on immediates folded
     /// into memory operations.
-    MO_DTPREL_LO = 5 << 8,
-    MO_TLSLD_LO = 6 << 8,
-    MO_TOC_LO = 7 << 8,
+    MO_DTPREL_LO,
+    MO_TLSLD_LO,
+    MO_TOC_LO,
 
-    // Symbol for VK_PPC_TLS fixup attached to an ADD instruction
-    MO_TLS = 8 << 8
+    /// Symbol for VK_PPC_TLS fixup attached to an ADD instruction
+    MO_TLS,
+
+    /// MO_PIC_HA_FLAG = MO_PIC_FLAG | MO_HA
+    MO_PIC_HA_FLAG,
+
+    /// MO_PIC_LO_FLAG = MO_PIC_FLAG | MO_LO
+    MO_PIC_LO_FLAG,
+
+    /// MO_TPREL_PCREL_FLAG = MO_PCREL_FLAG | MO_TPREL_FLAG
+    MO_TPREL_PCREL_FLAG,
+
+    /// MO_TPREL_PCREL_FLAG = MO_PCREL_FLAG | MO_TLS
+    MO_TLS_PCREL_FLAG,
+
+    /// MO_GOT_PCREL_FLAG = MO_PCREL_FLAG | MO_GOT_FLAG
+    MO_GOT_PCREL_FLAG,
   };
   } // end namespace PPCII
 

--- a/llvm/lib/Target/PowerPC/PPC.h
+++ b/llvm/lib/Target/PowerPC/PPC.h
@@ -103,9 +103,9 @@ class ModulePass;
     MO_NO_FLAG,
 
     /// On PPC, the 12 bits are not enough for all target operand flags.
-    /// Treat all PPC target flags as direct flags. This also means we can not
-    /// use a bitmask flag, so if one operand has two or more flags, a fake
-    /// combination flag must be created. See example MO_GOT_TPREL_PCREL_FLAG.
+    /// Treat all PPC target flags as direct flags. To define new flag, add new
+    /// enum entry instead of combining existing flags. See example
+    /// MO_GOT_TPREL_PCREL_FLAG.
 
     /// On a symbol operand "FOO", this indicates that the reference is actually
     /// to "FOO@plt".  This is used for calls and jumps to external functions

--- a/llvm/lib/Target/PowerPC/PPC.h
+++ b/llvm/lib/Target/PowerPC/PPC.h
@@ -103,9 +103,9 @@ class ModulePass;
     MO_NO_FLAG,
 
     /// On PPC, the 12 bits are not enough for all target operand flags.
-    /// Treat all PPC target flags as direct flags. To define new flag, add new
-    /// enum entry instead of combining existing flags. See example
-    /// MO_GOT_TPREL_PCREL_FLAG.
+    /// Treat all PPC target flags as direct flags. To define new flag that is
+    /// combination of other flags, add new enum entry instead of combining
+    /// existing flags. See example MO_GOT_TPREL_PCREL_FLAG.
 
     /// On a symbol operand "FOO", this indicates that the reference is actually
     /// to "FOO@plt".  This is used for calls and jumps to external functions

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -715,25 +715,11 @@ static MCSymbol *getMCSymbolForTOCPseudoMO(const MachineOperand &MO,
   }
 }
 
-static bool hasTLSFlag(const MachineOperand &MO) {
-  unsigned Flags = MO.getTargetFlags();
-  if (Flags & PPCII::MO_TLSGD_FLAG || Flags & PPCII::MO_TPREL_FLAG ||
-      Flags & PPCII::MO_TLSLD_FLAG || Flags & PPCII::MO_TLSGDM_FLAG)
-    return true;
-
-  if (Flags == PPCII::MO_TPREL_LO || Flags == PPCII::MO_TPREL_HA ||
-      Flags == PPCII::MO_DTPREL_LO || Flags == PPCII::MO_TLSLD_LO ||
-      Flags == PPCII::MO_TLS)
-    return true;
-
-  return false;
-}
-
 static PPCAsmPrinter::TOCEntryType
 getTOCEntryTypeForMO(const MachineOperand &MO) {
   // Use the target flags to determine if this MO is Thread Local.
   // If we don't do this it comes out as Global.
-  if (hasTLSFlag(MO))
+  if (PPCInstrInfo::hasTLSFlag(MO.getTargetFlags()))
     return PPCAsmPrinter::TOCType_ThreadLocal;
 
   switch (MO.getType()) {
@@ -830,7 +816,9 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
     // For TLS initial-exec and local-exec accesses on AIX, we have one TOC
     // entry for the symbol (with the variable offset), which is differentiated
     // by MO_TPREL_FLAG.
-    if (MO.getTargetFlags() & PPCII::MO_TPREL_FLAG) {
+    if (MO.getTargetFlags() == PPCII::MO_TPREL_FLAG ||
+        MO.getTargetFlags() == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
+        MO.getTargetFlags() == PPCII::MO_TPREL_PCREL_FLAG) {
       assert(MO.isGlobal() && "Only expecting a global MachineOperand here!\n");
       TLSModel::Model Model = TM.getTLSModel(MO.getGlobal());
       if (Model == TLSModel::LocalExec)
@@ -842,9 +830,10 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
     // For GD TLS access on AIX, we have two TOC entries for the symbol (one for
     // the variable offset and the other for the region handle). They are
     // differentiated by MO_TLSGD_FLAG and MO_TLSGDM_FLAG.
-    if (MO.getTargetFlags() & PPCII::MO_TLSGDM_FLAG)
+    if (MO.getTargetFlags() == PPCII::MO_TLSGDM_FLAG)
       return MCSymbolRefExpr::VariantKind::VK_PPC_AIX_TLSGDM;
-    if (MO.getTargetFlags() & PPCII::MO_TLSGD_FLAG)
+    if (MO.getTargetFlags() == PPCII::MO_TLSGD_FLAG ||
+        MO.getTargetFlags() == PPCII::MO_GOT_TLSGD_PCREL_FLAG)
       return MCSymbolRefExpr::VariantKind::VK_PPC_AIX_TLSGD;
     return MCSymbolRefExpr::VariantKind::VK_None;
   };
@@ -1539,7 +1528,9 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
     // with an immediate operand having the MO_TPREL_FLAG. Such an instruction
     // does not otherwise arise.
     const MachineOperand &MO = MI->getOperand(2);
-    if ((MO.getTargetFlags() & PPCII::MO_TPREL_FLAG) != 0) {
+    if (MO.getTargetFlags() == PPCII::MO_TPREL_FLAG ||
+        MO.getTargetFlags() == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
+        MO.getTargetFlags() == PPCII::MO_TPREL_PCREL_FLAG) {
       assert(
           Subtarget->hasAIXSmallLocalExecTLS() &&
           "addi with thread-pointer only expected with local-exec small TLS");

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -816,9 +816,10 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
     // For TLS initial-exec and local-exec accesses on AIX, we have one TOC
     // entry for the symbol (with the variable offset), which is differentiated
     // by MO_TPREL_FLAG.
-    if (MO.getTargetFlags() == PPCII::MO_TPREL_FLAG ||
-        MO.getTargetFlags() == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
-        MO.getTargetFlags() == PPCII::MO_TPREL_PCREL_FLAG) {
+    unsigned Flag = MO.getTargetFlags();
+    if (Flag == PPCII::MO_TPREL_FLAG ||
+        Flag == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
+        Flag == PPCII::MO_TPREL_PCREL_FLAG) {
       assert(MO.isGlobal() && "Only expecting a global MachineOperand here!\n");
       TLSModel::Model Model = TM.getTLSModel(MO.getGlobal());
       if (Model == TLSModel::LocalExec)
@@ -830,10 +831,9 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
     // For GD TLS access on AIX, we have two TOC entries for the symbol (one for
     // the variable offset and the other for the region handle). They are
     // differentiated by MO_TLSGD_FLAG and MO_TLSGDM_FLAG.
-    if (MO.getTargetFlags() == PPCII::MO_TLSGDM_FLAG)
+    if (Flag == PPCII::MO_TLSGDM_FLAG)
       return MCSymbolRefExpr::VariantKind::VK_PPC_AIX_TLSGDM;
-    if (MO.getTargetFlags() == PPCII::MO_TLSGD_FLAG ||
-        MO.getTargetFlags() == PPCII::MO_GOT_TLSGD_PCREL_FLAG)
+    if (Flag == PPCII::MO_TLSGD_FLAG || Flag == PPCII::MO_GOT_TLSGD_PCREL_FLAG)
       return MCSymbolRefExpr::VariantKind::VK_PPC_AIX_TLSGD;
     return MCSymbolRefExpr::VariantKind::VK_None;
   };
@@ -1527,10 +1527,10 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
     // The faster non-TOC-based local-exec sequence is represented by `addi`
     // with an immediate operand having the MO_TPREL_FLAG. Such an instruction
     // does not otherwise arise.
-    const MachineOperand &MO = MI->getOperand(2);
-    if (MO.getTargetFlags() == PPCII::MO_TPREL_FLAG ||
-        MO.getTargetFlags() == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
-        MO.getTargetFlags() == PPCII::MO_TPREL_PCREL_FLAG) {
+    unsigned Flag = MI->getOperand(2).getTargetFlags();
+    if (Flag == PPCII::MO_TPREL_FLAG ||
+        Flag == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
+        Flag == PPCII::MO_TPREL_PCREL_FLAG) {
       assert(
           Subtarget->hasAIXSmallLocalExecTLS() &&
           "addi with thread-pointer only expected with local-exec small TLS");

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -2973,27 +2973,12 @@ unsigned PPCInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
 
 std::pair<unsigned, unsigned>
 PPCInstrInfo::decomposeMachineOperandsTargetFlags(unsigned TF) const {
-  const unsigned Mask = PPCII::MO_ACCESS_MASK;
-  return std::make_pair(TF & Mask, TF & ~Mask);
+  // PPC always uses a direct mask.
+  return std::make_pair(TF, 0u);
 }
 
 ArrayRef<std::pair<unsigned, const char *>>
 PPCInstrInfo::getSerializableDirectMachineOperandTargetFlags() const {
-  using namespace PPCII;
-  static const std::pair<unsigned, const char *> TargetFlags[] = {
-      {MO_LO, "ppc-lo"},
-      {MO_HA, "ppc-ha"},
-      {MO_TPREL_LO, "ppc-tprel-lo"},
-      {MO_TPREL_HA, "ppc-tprel-ha"},
-      {MO_DTPREL_LO, "ppc-dtprel-lo"},
-      {MO_TLSLD_LO, "ppc-tlsld-lo"},
-      {MO_TOC_LO, "ppc-toc-lo"},
-      {MO_TLS, "ppc-tls"}};
-  return ArrayRef(TargetFlags);
-}
-
-ArrayRef<std::pair<unsigned, const char *>>
-PPCInstrInfo::getSerializableBitmaskMachineOperandTargetFlags() const {
   using namespace PPCII;
   static const std::pair<unsigned, const char *> TargetFlags[] = {
       {MO_PLT, "ppc-plt"},
@@ -3002,12 +2987,26 @@ PPCInstrInfo::getSerializableBitmaskMachineOperandTargetFlags() const {
       {MO_GOT_FLAG, "ppc-got"},
       {MO_PCREL_OPT_FLAG, "ppc-opt-pcrel"},
       {MO_TLSGD_FLAG, "ppc-tlsgd"},
-      {MO_TLSLD_FLAG, "ppc-tlsld"},
       {MO_TPREL_FLAG, "ppc-tprel"},
+      {MO_TLSLD_FLAG, "ppc-tlsld"},
       {MO_TLSGDM_FLAG, "ppc-tlsgdm"},
       {MO_GOT_TLSGD_PCREL_FLAG, "ppc-got-tlsgd-pcrel"},
       {MO_GOT_TLSLD_PCREL_FLAG, "ppc-got-tlsld-pcrel"},
-      {MO_GOT_TPREL_PCREL_FLAG, "ppc-got-tprel-pcrel"}};
+      {MO_GOT_TPREL_PCREL_FLAG, "ppc-got-tprel-pcrel"},
+      {MO_LO, "ppc-lo"},
+      {MO_HA, "ppc-ha"},
+      {MO_TPREL_LO, "ppc-tprel-lo"},
+      {MO_TPREL_HA, "ppc-tprel-ha"},
+      {MO_DTPREL_LO, "ppc-dtprel-lo"},
+      {MO_TLSLD_LO, "ppc-tlsld-lo"},
+      {MO_TOC_LO, "ppc-toc-lo"},
+      {MO_TLS, "ppc-tls"},
+      {MO_PIC_HA_FLAG, "ppc-ha-pic"},
+      {MO_PIC_LO_FLAG, "ppc-lo-pic"},
+      {MO_TPREL_PCREL_FLAG, "ppc-tprel-pcrel"},
+      {MO_TLS_PCREL_FLAG, "ppc-tls-pcrel"},
+      {MO_GOT_PCREL_FLAG, "ppc-got-pcrel"},
+  };
   return ArrayRef(TargetFlags);
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -14,6 +14,7 @@
 #define LLVM_LIB_TARGET_POWERPC_PPCINSTRINFO_H
 
 #include "MCTargetDesc/PPCMCTargetDesc.h"
+#include "PPC.h"
 #include "PPCRegisterInfo.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
@@ -281,6 +282,32 @@ public:
       if (Opcode == CopyOpcodes[i])
         return true;
     return false;
+  }
+
+  static bool hasPCRelFlag(unsigned TF) {
+    return TF == PPCII::MO_PCREL_FLAG || TF == PPCII::MO_GOT_TLSGD_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_TLSLD_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
+           TF == PPCII::MO_TPREL_PCREL_FLAG || TF == PPCII::MO_TLS_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_PCREL_FLAG;
+  }
+
+  static bool hasGOTFlag(unsigned TF) {
+    return TF == PPCII::MO_GOT_FLAG || TF == PPCII::MO_GOT_TLSGD_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_TLSLD_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_TPREL_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_PCREL_FLAG;
+  }
+
+  static bool hasTLSFlag(unsigned TF) {
+    return TF == PPCII::MO_TLSGD_FLAG || TF == PPCII::MO_TPREL_FLAG ||
+           TF == PPCII::MO_TLSLD_FLAG || TF == PPCII::MO_TLSGDM_FLAG ||
+           TF == PPCII::MO_GOT_TLSGD_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_TLSLD_PCREL_FLAG ||
+           TF == PPCII::MO_GOT_TPREL_PCREL_FLAG || TF == PPCII::MO_TPREL_LO ||
+           TF == PPCII::MO_TPREL_HA || TF == PPCII::MO_DTPREL_LO ||
+           TF == PPCII::MO_TLSLD_LO || TF == PPCII::MO_TLS ||
+           TF == PPCII::MO_TPREL_PCREL_FLAG || TF == PPCII::MO_TLS_PCREL_FLAG;
   }
 
   ScheduleHazardRecognizer *
@@ -554,9 +581,6 @@ public:
 
   ArrayRef<std::pair<unsigned, const char *>>
   getSerializableDirectMachineOperandTargetFlags() const override;
-
-  ArrayRef<std::pair<unsigned, const char *>>
-  getSerializableBitmaskMachineOperandTargetFlags() const override;
 
   // Expand VSX Memory Pseudo instruction to either a VSX or a FP instruction.
   bool expandVSXMemPseudo(MachineInstr &MI) const;

--- a/llvm/lib/Target/PowerPC/PPCMCInstLower.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMCInstLower.cpp
@@ -54,7 +54,7 @@ static MCOperand GetSymbolRef(const MachineOperand &MO, const MCSymbol *Symbol,
   MCContext &Ctx = Printer.OutContext;
   MCSymbolRefExpr::VariantKind RefKind = MCSymbolRefExpr::VK_None;
 
-  unsigned access = MO.getTargetFlags() & PPCII::MO_ACCESS_MASK;
+  unsigned access = MO.getTargetFlags();
 
   switch (access) {
     case PPCII::MO_TPREL_LO:
@@ -73,9 +73,10 @@ static MCOperand GetSymbolRef(const MachineOperand &MO, const MCSymbol *Symbol,
       RefKind = MCSymbolRefExpr::VK_PPC_TOC_LO;
       break;
     case PPCII::MO_TLS:
-      bool IsPCRel = (MO.getTargetFlags() & ~access) == PPCII::MO_PCREL_FLAG;
-      RefKind = IsPCRel ? MCSymbolRefExpr::VK_PPC_TLS_PCREL
-                        : MCSymbolRefExpr::VK_PPC_TLS;
+      RefKind = MCSymbolRefExpr::VK_PPC_TLS;
+      break;
+    case PPCII::MO_TLS_PCREL_FLAG:
+      RefKind = MCSymbolRefExpr::VK_PPC_TLS_PCREL;
       break;
   }
 
@@ -85,9 +86,9 @@ static MCOperand GetSymbolRef(const MachineOperand &MO, const MCSymbol *Symbol,
     RefKind = MCSymbolRefExpr::VK_PLT;
   else if (MO.getTargetFlags() == PPCII::MO_PCREL_FLAG)
     RefKind = MCSymbolRefExpr::VK_PCREL;
-  else if (MO.getTargetFlags() == (PPCII::MO_PCREL_FLAG | PPCII::MO_GOT_FLAG))
+  else if (MO.getTargetFlags() == PPCII::MO_GOT_PCREL_FLAG)
     RefKind = MCSymbolRefExpr::VK_PPC_GOT_PCREL;
-  else if (MO.getTargetFlags() == (PPCII::MO_PCREL_FLAG | PPCII::MO_TPREL_FLAG))
+  else if (MO.getTargetFlags() == PPCII::MO_TPREL_PCREL_FLAG)
     RefKind = MCSymbolRefExpr::VK_TPREL;
   else if (MO.getTargetFlags() == PPCII::MO_GOT_TLSGD_PCREL_FLAG)
     RefKind = MCSymbolRefExpr::VK_PPC_GOT_TLSGD_PCREL;
@@ -138,7 +139,9 @@ static MCOperand GetSymbolRef(const MachineOperand &MO, const MCSymbol *Symbol,
                                    Ctx);
 
   // Subtract off the PIC base if required.
-  if (MO.getTargetFlags() & PPCII::MO_PIC_FLAG) {
+  if (MO.getTargetFlags() == PPCII::MO_PIC_FLAG ||
+      MO.getTargetFlags() == PPCII::MO_PIC_HA_FLAG ||
+      MO.getTargetFlags() == PPCII::MO_PIC_LO_FLAG) {
     const MachineFunction *MF = MO.getParent()->getParent()->getParent();
 
     const MCExpr *PB = MCSymbolRefExpr::create(MF->getPICBaseSymbol(), Ctx);
@@ -148,9 +151,11 @@ static MCOperand GetSymbolRef(const MachineOperand &MO, const MCSymbol *Symbol,
   // Add ha16() / lo16() markers if required.
   switch (access) {
     case PPCII::MO_LO:
+    case PPCII::MO_PIC_LO_FLAG:
       Expr = PPCMCExpr::createLo(Expr, Ctx);
       break;
     case PPCII::MO_HA:
+    case PPCII::MO_PIC_HA_FLAG:
       Expr = PPCMCExpr::createHa(Expr, Ctx);
       break;
   }

--- a/llvm/lib/Target/PowerPC/PPCPreEmitPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPreEmitPeephole.cpp
@@ -240,7 +240,7 @@ static bool hasPCRelativeForm(MachineInstr &Use) {
         return false;
 
       // Finally return true only if the GOT flag is present.
-      return (SymbolOp.getTargetFlags() & PPCII::MO_GOT_FLAG);
+      return PPCInstrInfo::hasGOTFlag(SymbolOp.getTargetFlags());
     }
 
     bool addLinkerOpt(MachineBasicBlock &MBB, const TargetRegisterInfo *TRI) {

--- a/llvm/lib/Target/PowerPC/PPCTOCRegDeps.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTOCRegDeps.cpp
@@ -100,7 +100,7 @@ protected:
         return true;
 
       for (const MachineOperand &MO : MI.operands()) {
-        if ((MO.getTargetFlags() & PPCII::MO_ACCESS_MASK) == PPCII::MO_TOC_LO)
+        if (MO.getTargetFlags() == PPCII::MO_TOC_LO)
           return true;
       }
 

--- a/llvm/test/CodeGen/PowerPC/aix-tls-gd-double.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-tls-gd-double.ll
@@ -24,7 +24,7 @@ define void @storesTGUninit(double %Val) #0 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C0(2) # target-flags(ppc-lo) @TGUninit
+; SMALL32-NEXT:    lwz 3, L..C0(2) # target-flags(ppc-tlsgdm) @TGUninit
 ; SMALL32-NEXT:    lwz 4, L..C1(2) # target-flags(ppc-tlsgd) @TGUninit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -54,7 +54,7 @@ define void @storesTGUninit(double %Val) #0 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C0(2) # target-flags(ppc-lo) @TGUninit
+; SMALL64-NEXT:    ld 3, L..C0(2) # target-flags(ppc-tlsgdm) @TGUninit
 ; SMALL64-NEXT:    ld 4, L..C1(2) # target-flags(ppc-tlsgd) @TGUninit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]
@@ -90,7 +90,7 @@ define void @storesTGInit(double %Val) #0 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C2(2) # target-flags(ppc-lo) @TGInit
+; SMALL32-NEXT:    lwz 3, L..C2(2) # target-flags(ppc-tlsgdm) @TGInit
 ; SMALL32-NEXT:    lwz 4, L..C3(2) # target-flags(ppc-tlsgd) @TGInit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -120,7 +120,7 @@ define void @storesTGInit(double %Val) #0 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C2(2) # target-flags(ppc-lo) @TGInit
+; SMALL64-NEXT:    ld 3, L..C2(2) # target-flags(ppc-tlsgdm) @TGInit
 ; SMALL64-NEXT:    ld 4, L..C3(2) # target-flags(ppc-tlsgd) @TGInit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]
@@ -156,7 +156,7 @@ define void @storesTIInit(double %Val) #0 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C4(2) # target-flags(ppc-lo) @TIInit
+; SMALL32-NEXT:    lwz 3, L..C4(2) # target-flags(ppc-tlsgdm) @TIInit
 ; SMALL32-NEXT:    lwz 4, L..C5(2) # target-flags(ppc-tlsgd) @TIInit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -186,7 +186,7 @@ define void @storesTIInit(double %Val) #0 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C4(2) # target-flags(ppc-lo) @TIInit
+; SMALL64-NEXT:    ld 3, L..C4(2) # target-flags(ppc-tlsgdm) @TIInit
 ; SMALL64-NEXT:    ld 4, L..C5(2) # target-flags(ppc-tlsgd) @TIInit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]
@@ -222,7 +222,7 @@ define void @storesTWInit(double %Val) #0 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C6(2) # target-flags(ppc-lo) @TWInit
+; SMALL32-NEXT:    lwz 3, L..C6(2) # target-flags(ppc-tlsgdm) @TWInit
 ; SMALL32-NEXT:    lwz 4, L..C7(2) # target-flags(ppc-tlsgd) @TWInit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -252,7 +252,7 @@ define void @storesTWInit(double %Val) #0 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C6(2) # target-flags(ppc-lo) @TWInit
+; SMALL64-NEXT:    ld 3, L..C6(2) # target-flags(ppc-tlsgdm) @TWInit
 ; SMALL64-NEXT:    ld 4, L..C7(2) # target-flags(ppc-tlsgd) @TWInit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]
@@ -288,7 +288,7 @@ define double @loadsTGUninit() #1 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C0(2) # target-flags(ppc-lo) @TGUninit
+; SMALL32-NEXT:    lwz 3, L..C0(2) # target-flags(ppc-tlsgdm) @TGUninit
 ; SMALL32-NEXT:    lwz 4, L..C1(2) # target-flags(ppc-tlsgd) @TGUninit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -325,7 +325,7 @@ define double @loadsTGUninit() #1 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C0(2) # target-flags(ppc-lo) @TGUninit
+; SMALL64-NEXT:    ld 3, L..C0(2) # target-flags(ppc-tlsgdm) @TGUninit
 ; SMALL64-NEXT:    ld 4, L..C1(2) # target-flags(ppc-tlsgd) @TGUninit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]
@@ -370,7 +370,7 @@ define double @loadsTGInit() #1 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C2(2) # target-flags(ppc-lo) @TGInit
+; SMALL32-NEXT:    lwz 3, L..C2(2) # target-flags(ppc-tlsgdm) @TGInit
 ; SMALL32-NEXT:    lwz 4, L..C3(2) # target-flags(ppc-tlsgd) @TGInit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -407,7 +407,7 @@ define double @loadsTGInit() #1 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C2(2) # target-flags(ppc-lo) @TGInit
+; SMALL64-NEXT:    ld 3, L..C2(2) # target-flags(ppc-tlsgdm) @TGInit
 ; SMALL64-NEXT:    ld 4, L..C3(2) # target-flags(ppc-tlsgd) @TGInit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]
@@ -452,7 +452,7 @@ define double @loadsTIInit() #1 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C4(2) # target-flags(ppc-lo) @TIInit
+; SMALL32-NEXT:    lwz 3, L..C4(2) # target-flags(ppc-tlsgdm) @TIInit
 ; SMALL32-NEXT:    lwz 4, L..C5(2) # target-flags(ppc-tlsgd) @TIInit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -489,7 +489,7 @@ define double @loadsTIInit() #1 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C4(2) # target-flags(ppc-lo) @TIInit
+; SMALL64-NEXT:    ld 3, L..C4(2) # target-flags(ppc-tlsgdm) @TIInit
 ; SMALL64-NEXT:    ld 4, L..C5(2) # target-flags(ppc-tlsgd) @TIInit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]
@@ -534,7 +534,7 @@ define double @loadsTWInit() #1 {
 ; SMALL32:       # %bb.0: # %entry
 ; SMALL32-NEXT:    mflr 0
 ; SMALL32-NEXT:    stwu 1, -32(1)
-; SMALL32-NEXT:    lwz 3, L..C6(2) # target-flags(ppc-lo) @TWInit
+; SMALL32-NEXT:    lwz 3, L..C6(2) # target-flags(ppc-tlsgdm) @TWInit
 ; SMALL32-NEXT:    lwz 4, L..C7(2) # target-flags(ppc-tlsgd) @TWInit
 ; SMALL32-NEXT:    stw 0, 40(1)
 ; SMALL32-NEXT:    bla .__tls_get_addr[PR]
@@ -571,7 +571,7 @@ define double @loadsTWInit() #1 {
 ; SMALL64:       # %bb.0: # %entry
 ; SMALL64-NEXT:    mflr 0
 ; SMALL64-NEXT:    stdu 1, -48(1)
-; SMALL64-NEXT:    ld 3, L..C6(2) # target-flags(ppc-lo) @TWInit
+; SMALL64-NEXT:    ld 3, L..C6(2) # target-flags(ppc-tlsgdm) @TWInit
 ; SMALL64-NEXT:    ld 4, L..C7(2) # target-flags(ppc-tlsgd) @TWInit
 ; SMALL64-NEXT:    std 0, 64(1)
 ; SMALL64-NEXT:    bla .__tls_get_addr[PR]

--- a/llvm/test/CodeGen/PowerPC/aix-tls-gd-target-flags.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-tls-gd-target-flags.ll
@@ -8,11 +8,11 @@
 define signext i32 @foo() {
   ; CHECK-LABEL: name: foo
   ; CHECK: bb.0.entry:
-  ; CHECK-NEXT:   [[LDtoc:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-lo) @a, $x2 :: (load (s64) from got)
+  ; CHECK-NEXT:   [[LDtoc:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-tlsgdm) @a, $x2 :: (load (s64) from got)
   ; CHECK-NEXT:   [[LDtoc1:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-tlsgd) @a, $x2 :: (load (s64) from got)
   ; CHECK-NEXT:   [[TLSGDAIX8_:%[0-9]+]]:g8rc_and_g8rc_nox0 = TLSGDAIX8 killed [[LDtoc1]], killed [[LDtoc]]
   ; CHECK-NEXT:   [[LWZ:%[0-9]+]]:gprc = LWZ 0, killed [[TLSGDAIX8_]] :: (dereferenceable load (s32) from @a)
-  ; CHECK-NEXT:   [[LDtoc2:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-lo) @b, $x2 :: (load (s64) from got)
+  ; CHECK-NEXT:   [[LDtoc2:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-tlsgdm) @b, $x2 :: (load (s64) from got)
   ; CHECK-NEXT:   [[LDtoc3:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-tlsgd) @b, $x2 :: (load (s64) from got)
   ; CHECK-NEXT:   [[TLSGDAIX8_1:%[0-9]+]]:g8rc_and_g8rc_nox0 = TLSGDAIX8 killed [[LDtoc3]], killed [[LDtoc2]]
   ; CHECK-NEXT:   [[LWZ1:%[0-9]+]]:gprc = LWZ 0, killed [[TLSGDAIX8_1]] :: (dereferenceable load (s32) from @b)

--- a/llvm/test/CodeGen/PowerPC/ctrloops-pseudo.ll
+++ b/llvm/test/CodeGen/PowerPC/ctrloops-pseudo.ll
@@ -375,7 +375,7 @@ define i32 @test4(i32 %inp) {
   ; AIX64-NEXT:   B %bb.2
   ; AIX64-NEXT: {{  $}}
   ; AIX64-NEXT: bb.2.return:
-  ; AIX64-NEXT:   [[LDtoc:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-lo) @tls_var, $x2 :: (load (s64) from got)
+  ; AIX64-NEXT:   [[LDtoc:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-tlsgdm) @tls_var, $x2 :: (load (s64) from got)
   ; AIX64-NEXT:   [[LDtoc1:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-tlsgd) @tls_var, $x2 :: (load (s64) from got)
   ; AIX64-NEXT:   [[TLSGDAIX8_:%[0-9]+]]:g8rc = TLSGDAIX8 killed [[LDtoc1]], killed [[LDtoc]]
   ; AIX64-NEXT:   [[COPY2:%[0-9]+]]:gprc = COPY [[TLSGDAIX8_]].sub_32
@@ -405,7 +405,7 @@ define i32 @test4(i32 %inp) {
   ; AIX32-NEXT:   B %bb.2
   ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT: bb.2.return:
-  ; AIX32-NEXT:   [[LWZtoc:%[0-9]+]]:gprc = LWZtoc target-flags(ppc-lo) @tls_var, $r2 :: (load (s32) from got)
+  ; AIX32-NEXT:   [[LWZtoc:%[0-9]+]]:gprc = LWZtoc target-flags(ppc-tlsgdm) @tls_var, $r2 :: (load (s32) from got)
   ; AIX32-NEXT:   [[LWZtoc1:%[0-9]+]]:gprc = LWZtoc target-flags(ppc-tlsgd) @tls_var, $r2 :: (load (s32) from got)
   ; AIX32-NEXT:   [[TLSGDAIX:%[0-9]+]]:gprc = TLSGDAIX killed [[LWZtoc1]], killed [[LWZtoc]]
   ; AIX32-NEXT:   [[ADD4_:%[0-9]+]]:gprc = ADD4 killed [[TLSGDAIX]], [[ISEL]]

--- a/llvm/test/CodeGen/PowerPC/tls-crash.mir
+++ b/llvm/test/CodeGen/PowerPC/tls-crash.mir
@@ -18,8 +18,8 @@ body: |
     liveins: $x3
 
     %0:g8rc = COPY killed $x3
-    %1:g8rc_and_g8rc_nox0 = PADDI8pc 0, target-flags(ppc-pcrel, ppc-got, ppc-tlsld) @x
-    %2:g8rc_and_g8rc_nox0 = PADDIdtprel killed %1, target-flags(ppc-pcrel, ppc-got, ppc-tlsld) @x
+    %1:g8rc_and_g8rc_nox0 = PADDI8pc 0, target-flags(ppc-got-tlsld-pcrel) @x
+    %2:g8rc_and_g8rc_nox0 = PADDIdtprel killed %1, target-flags(ppc-got-tlsld-pcrel) @x
     STD killed %0, 0, killed %2 :: (store (s64) into `i8** bitcast (%0** @x to i8**)`)
     BLR8 implicit $lr8, implicit $rm
 ...


### PR DESCRIPTION
Redesign how PPC target set the target specific flags. With this patch, all ppc target flags are direct flags. No bitmask flag in PPC anymore. 12 bit is not enough for PPC's target specific flags. If 8 bit for the bitmask flags, 4 bit for the direct mask, PPC can total have 16 direct mask and 8 bitmask. Not enough for PPC, see this issue in https://github.com/llvm/llvm-project/pull/66316

Reducing the bitmask's 8 bit to a smaller value would be also workable, but that is not robust if we continue to add more target specific flags.

Increasing the size of `SubReg_TargetFlags` in `MachineOperand` is also workable, but that will increase memory usage for all targets. I think this should be avoided.

This patch aligns with some targets like X86 which also has many target specific flags.

The patch also fixes a bug related to flag `MO_TLSGDM_FLAG` and `MO_LO`. They are the same value and the test case changes in this PR shows the bug.