### PR TITLE
[lldb] Remove more references to lldb-vscode

### DIFF
--- a/lldb/CodeOwners.rst
+++ b/lldb/CodeOwners.rst
@@ -234,8 +234,8 @@ lldb-server
 | Pavel Labath
 | pavel\@labath.sk (email), labath (Phabricator), labath (GitHub), labath (Discourse)
 
-lldb-vscode
-~~~~~~~~~~~
+lldb-dap
+~~~~~~~~
 | Greg Clayton
 | gclayton\@fb.com (email), clayborg (Phabricator), clayborg (GitHub), clayborg (Discourse)
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -80,7 +80,7 @@ def read_packet(f, verbose=False, trace_file=None):
         # Decode the JSON bytes into a python dictionary
         return json.loads(json_str)
 
-    raise Exception("unexpected malformed message from lldb-vscode: " + line)
+    raise Exception("unexpected malformed message from lldb-dap: " + line)
 
 
 def packet_type_is(packet, packet_type):
@@ -104,7 +104,7 @@ def read_packet_thread(vs_comm, log_file):
             packet = read_packet(vs_comm.recv, trace_file=vs_comm.trace_file)
             # `packet` will be `None` on EOF. We want to pass it down to
             # handle_recv_packet anyway so the main thread can handle unexpected
-            # termination of lldb-vscode and stop waiting for new packets.
+            # termination of lldb-dap and stop waiting for new packets.
             done = not vs_comm.handle_recv_packet(packet)
     finally:
         dump_dap_log(log_file)
@@ -1172,7 +1172,7 @@ def main():
         dest="debuggerRoot",
         default=None,
         help=(
-            "Set the working directory for lldb-vscode for any object files "
+            "Set the working directory for lldb-dap for any object files "
             "with relative paths in the Mach-o debug map."
         ),
     )
@@ -1203,7 +1203,7 @@ def main():
         action="store_true",
         dest="sourceInitFile",
         default=False,
-        help="Whether lldb-vscode should source .lldbinit file or not",
+        help="Whether lldb-dap should source .lldbinit file or not",
     )
 
     parser.add_option(
@@ -1360,7 +1360,7 @@ def main():
         print(
             "error: must either specify a path to a Visual Studio Code "
             "Debug Adaptor vscode executable path using the --vscode "
-            "option, or a port to attach to for an existing lldb-vscode "
+            "option, or a port to attach to for an existing lldb-dap "
             "using the --port option"
         )
         return

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -248,7 +248,7 @@ if (
     "lldb-repro-capture" in config.available_features
     or "lldb-repro-replay" in config.available_features
 ):
-    dotest_cmd += ["--skip-category=lldb-vscode", "--skip-category=std-module"]
+    dotest_cmd += ["--skip-category=lldb-dap", "--skip-category=std-module"]
 
 if "lldb-simulator-ios" in config.available_features:
     dotest_cmd += ["--apple-sdk", "iphonesimulator", "--platform-name", "ios-simulator"]

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -114,8 +114,8 @@ if(TARGET lldb-server)
   add_lldb_test_dependency(lldb-server)
 endif()
 
-if(TARGET lldb-vscode)
-  add_lldb_test_dependency(lldb-vscode)
+if(TARGET lldb-dap)
+  add_lldb_test_dependency(lldb-dap)
 endif()
 
 if(TARGET liblldb)

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -97,9 +97,9 @@ static constexpr llvm::opt::OptTable::Info InfoTable[] = {
 #include "Options.inc"
 #undef OPTION
 };
-class LLDBVSCodeOptTable : public llvm::opt::GenericOptTable {
+class LLDBDAPOptTable : public llvm::opt::GenericOptTable {
 public:
-  LLDBVSCodeOptTable() : llvm::opt::GenericOptTable(InfoTable, true) {}
+  LLDBDAPOptTable() : llvm::opt::GenericOptTable(InfoTable, true) {}
 };
 
 typedef void (*RequestCallback)(const llvm::json::Object &command);
@@ -3569,9 +3569,9 @@ void RegisterRequestCallbacks() {
 
 } // anonymous namespace
 
-static void printHelp(LLDBVSCodeOptTable &table, llvm::StringRef tool_name) {
+static void printHelp(LLDBDAPOptTable &table, llvm::StringRef tool_name) {
   std::string usage_str = tool_name.str() + " options";
-  table.printHelp(llvm::outs(), usage_str.c_str(), "LLDB VSCode", false);
+  table.printHelp(llvm::outs(), usage_str.c_str(), "LLDB DAP", false);
 
   std::string examples = R"___(
 EXAMPLES:
@@ -3706,7 +3706,7 @@ int main(int argc, char *argv[]) {
   llvm::sys::fs::make_absolute(program_path);
   g_dap.debug_adaptor_path = program_path.str().str();
 
-  LLDBVSCodeOptTable T;
+  LLDBDAPOptTable T;
   unsigned MAI, MAC;
   llvm::ArrayRef<const char *> ArgsArr = llvm::ArrayRef(argv + 1, argc);
   llvm::opt::InputArgList input_args = T.ParseArgs(ArgsArr, MAI, MAC);


### PR DESCRIPTION
There are some uses of "vscode" in
`lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py` where I'm not sure if it's referring to the adapter or VS Code itself, so those remain.