### PR TITLE
[run-clang-tidy] Accept export directory if PyYAML is not installed

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
@@ -187,6 +187,15 @@ def main():
             "parameter is a directory, the fixes of each compilation unit are "
             "stored in individual yaml files in the directory.",
         )
+    else:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="DIRECTORY",
+            dest="export_fixes",
+            help="A directory to store suggested fixes in, which can be applied "
+            "with clang-apply-replacements. The fixes of each compilation unit are "
+            "stored in individual yaml files in the directory.",
+        )
     parser.add_argument(
         "-extra-arg",
         dest="extra_arg",
@@ -270,7 +279,12 @@ def main():
         ):
             os.makedirs(args.export_fixes)
 
-        if not os.path.isdir(args.export_fixes) and yaml:
+        if not os.path.isdir(args.export_fixes):
+            if not yaml:
+                raise RuntimeError(
+                    "Cannot combine fixes in one yaml file. Either install PyYAML or specify an output directory."
+                )
+
             combine_fixes = True
 
         if os.path.isdir(args.export_fixes):

--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -315,6 +315,15 @@ def main():
             "parameter is a directory, the fixes of each compilation unit are "
             "stored in individual yaml files in the directory.",
         )
+    else:
+        parser.add_argument(
+            "-export-fixes",
+            metavar="directory",
+            dest="export_fixes",
+            help="A directory to store suggested fixes in, which can be applied "
+            "with clang-apply-replacements. The fixes of each compilation unit are "
+            "stored in individual yaml files in the directory.",
+        )
     parser.add_argument(
         "-j",
         type=int,
@@ -401,7 +410,12 @@ def main():
         ):
             os.makedirs(args.export_fixes)
 
-        if not os.path.isdir(args.export_fixes) and yaml:
+        if not os.path.isdir(args.export_fixes):
+            if not yaml:
+                raise RuntimeError(
+                    "Cannot combine fixes in one yaml file. Either install PyYAML or specify an output directory."
+                )
+
             combine_fixes = True
 
         if os.path.isdir(args.export_fixes):


### PR DESCRIPTION
If PyYAML is not installed, the `-export-fixes` can be used to specify a directory (not a file).

Mentioning @PiotrZSL @dyung 

Follows #69453