### PR TITLE
[DevPolicy] Add guidance to not submit code or reviews on someone else's

### DIFF
--- a/llvm/docs/CodeOfConduct.rst
+++ b/llvm/docs/CodeOfConduct.rst
@@ -2,6 +2,8 @@
    This work is licensed under a Creative Commons Attribution 3.0 Unported License.
    SPDX-License-Identifier: CC-BY-3.0
 
+.. _LLVM Community Code of Conduct:
+
 ==============================
 LLVM Community Code of Conduct
 ==============================

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -104,6 +104,12 @@ When submitting patches, please do not add confidentiality or non-disclosure
 notices to the patches themselves.  These notices conflict with the LLVM
 licensing terms and may result in your contribution being excluded.
 
+When being asked by someone to add code (e.g. create a PR), or write review
+comments on their behalf, do suggest that they do it directly themselves. Or
+ask the reasons why they're not doing it themselves. There should be few
+legitimate reasons for them not doing so themselves.
+
+
 .. _code review:
 
 Code Reviews

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -104,11 +104,6 @@ When submitting patches, please do not add confidentiality or non-disclosure
 notices to the patches themselves.  These notices conflict with the LLVM
 licensing terms and may result in your contribution being excluded.
 
-When being asked by someone to add code (e.g. create a PR), or write review
-comments on their behalf, do suggest that they do it directly themselves. Or
-ask the reasons why they're not doing it themselves. There should be few
-legitimate reasons for them not doing so themselves.
-
 
 .. _code review:
 
@@ -639,6 +634,24 @@ author and the committer like git does. As such, older commits used a different
 attribution mechanism. The previous method was to include "Patch by John Doe."
 in a separate line of the commit message and there are automated processes that
 rely on this format.
+
+Bans
+----
+
+The goal of a ban is to protect people in the community from having to interact
+with people who are consistently not respecting the
+:ref:`LLVM Community Code of Conduct` in LLVM project spaces. Contributions of
+any variety (pull requests, issue reports, forum posts, etc.) require
+interacting with the community. Therefore, we do not accept any form of direct
+contribution from a banned individual.
+
+Indirect contributions are permissible only by someone taking full ownership of
+such a contribution and they are responsible for all related interactions with
+the community regarding that contribution.
+
+When in doubt how to act in a specific instance, please reach out to
+conduct@llvm.org for advice.
+
 
 .. _IR backwards compatibility:
 


### PR DESCRIPTION
... behalf.

There should be few legitimate reasons for people not submitting code or review comments themselves. Furthermore, it helps avoid situations where banned individuals circumvent their ban by asking others to submit code or review comments on their behalf.

More details, see
https://discourse.llvm.org/t/submitting-code-or-review-comments-on-someone-elses-behalf/74269