### PR TITLE
[InstCombine] Remove scalable vector extracts to and from the same type

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3002,6 +3002,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
 
     if (DstTy && VecTy) {
       auto DstEltCnt = DstTy->getElementCount();
+      auto VecEltCnt = VecTy->getElementCount();
       unsigned IdxN = cast<ConstantInt>(Idx)->getZExtValue();
 
       // Extracting the entirety of Vec is a nop.
@@ -3012,7 +3013,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
 
       // Only canonicalize to shufflevector if the destination vector and
       // Vec are fixed vectors.
-      if (dyn_cast<ScalableVectorType>(VecTy) || DstEltCnt.isScalable())
+      if (VecEltCnt.isScalable() || DstEltCnt.isScalable())
         break;
 
       SmallVector<int, 8> Mask;

--- a/llvm/test/Transforms/InstCombine/canonicalize-vector-extract.ll
+++ b/llvm/test/Transforms/InstCombine/canonicalize-vector-extract.ll
@@ -10,6 +10,7 @@ declare <3 x i32> @llvm.vector.extract.v3i32.v8i32(<8 x i32> %vec, i64 %idx)
 declare <4 x i32> @llvm.vector.extract.v4i32.nxv4i32(<vscale x 4 x i32> %vec, i64 %idx)
 declare <4 x i32> @llvm.vector.extract.v4i32.v8i32(<8 x i32> %vec, i64 %idx)
 declare <8 x i32> @llvm.vector.extract.v8i32.v8i32(<8 x i32> %vec, i64 %idx)
+declare <vscale x 8 x i32> @llvm.vector.extract.nxv8i32.nxv8i32(<vscale x 8 x i32> %vec, i64 %idx)
 
 ; ============================================================================ ;
 ; Trivial cases
@@ -22,6 +23,15 @@ define <8 x i32> @trivial_nop(<8 x i32> %vec) {
 ;
   %1 = call <8 x i32> @llvm.vector.extract.v8i32.v8i32(<8 x i32> %vec, i64 0)
   ret <8 x i32> %1
+}
+
+define <vscale x 8 x i32> @trivial_nop_scalable(<vscale x 8 x i32> %vec) {
+; CHECK-LABEL: define <vscale x 8 x i32> @trivial_nop_scalable(
+; CHECK-SAME: <vscale x 8 x i32> [[VEC:%.*]]) {
+; CHECK-NEXT:    ret <vscale x 8 x i32> [[VEC]]
+;
+  %ext = call <vscale x 8 x i32> @llvm.vector.extract.nxv8i32.nxv8i32(<vscale x 8 x i32> %vec, i64 0)
+  ret <vscale x 8 x i32> %ext
 }
 
 ; ============================================================================ ;


### PR DESCRIPTION
visitCallInst already looks for fixed width vector extracts where number of elements in
the source and destination types are equal. This patch modifies the function to also
identify scalable extracts which can be removed.