### PR TITLE
[DominanceFrontier] make iterating dereferenced DominanceFrontierBase::find deterministic

### DIFF
--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -18,13 +18,13 @@
 #define LLVM_ANALYSIS_DOMINANCEFRONTIER_H
 
 #include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/GenericDomTree.h"
 #include <cassert>
 #include <map>
-#include <set>
 #include <utility>
 
 namespace llvm {
@@ -39,7 +39,7 @@ class raw_ostream;
 template <class BlockT, bool IsPostDom>
 class DominanceFrontierBase {
 public:
-  using DomSetType = std::set<BlockT *>;                // Dom set for a bb
+  using DomSetType = SetVector<BlockT *>;               // Dom set for a bb
   using DomSetMapType = std::map<BlockT *, DomSetType>; // Dom set map
 
 protected:

--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -39,7 +39,9 @@ class raw_ostream;
 template <class BlockT, bool IsPostDom>
 class DominanceFrontierBase {
 public:
-  using DomSetType = SetVector<BlockT *>;               // Dom set for a bb
+  // Dom set for a bb. Use SetVector to make iterating dom frontiers of a bb
+  // deterministic.
+  using DomSetType = SetVector<BlockT *>;
   using DomSetMapType = std::map<BlockT *, DomSetType>; // Dom set map
 
 protected:

--- a/llvm/include/llvm/Analysis/DominanceFrontierImpl.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontierImpl.h
@@ -49,7 +49,7 @@ template <class BlockT, bool IsPostDom>
 void DominanceFrontierBase<BlockT, IsPostDom>::removeBlock(BlockT *BB) {
   assert(find(BB) != end() && "Block is not in DominanceFrontier!");
   for (iterator I = begin(), E = end(); I != E; ++I)
-    I->second.erase(BB);
+    I->second.remove(BB);
   Frontiers.erase(BB);
 }
 
@@ -65,7 +65,7 @@ void DominanceFrontierBase<BlockT, IsPostDom>::removeFromFrontier(
     iterator I, BlockT *Node) {
   assert(I != end() && "BB is not in DominanceFrontier!");
   assert(I->second.count(Node) && "Node is not in DominanceFrontier of BB");
-  I->second.erase(Node);
+  I->second.remove(Node);
 }
 
 template <class BlockT, bool IsPostDom>
@@ -133,7 +133,7 @@ void DominanceFrontierBase<BlockT, IsPostDom>::print(raw_ostream &OS) const {
       OS << " <<exit node>>";
     OS << " is:\t";
 
-    const std::set<BlockT *> &BBs = I->second;
+    const SetVector<BlockT *> &BBs = I->second;
 
     for (const BlockT *BB : BBs) {
       OS << ' ';

--- a/llvm/include/llvm/Analysis/RegionInfoImpl.h
+++ b/llvm/include/llvm/Analysis/RegionInfoImpl.h
@@ -587,7 +587,7 @@ bool RegionInfoBase<Tr>::isRegion(BlockT *entry, BlockT *exit) const {
   for (BlockT *Succ : *entrySuccs) {
     if (Succ == exit || Succ == entry)
       continue;
-    if (exitSuccs->find(Succ) == exitSuccs->end())
+    if (!exitSuccs->contains(Succ))
       return false;
     if (!isCommonDomFrontier(Succ, entry, exit))
       return false;

--- a/llvm/test/Analysis/DominanceFrontier/new_pm_test.ll
+++ b/llvm/test/Analysis/DominanceFrontier/new_pm_test.ll
@@ -9,42 +9,42 @@ define void @a_linear_impl_fig_1() nounwind {
 2:
   br label %3
 3:
-  br i1 1, label %12, label %4
+  br i1 1, label %a12, label %4
 4:
   br i1 1, label %5, label %1
 5:
-  br i1 1, label %8, label %6
+  br i1 1, label %a8, label %6
 6:
-  br i1 1, label %7, label %4
-7:
+  br i1 1, label %a7, label %4
+a7:
   ret void
-8:
-  br i1 1, label %9, label %1
-9:
-  br label %10
-10:
-  br i1 1, label %13, label %11
-11:
-  br i1 1, label %9, label %8
-12:
+a8:
+  br i1 1, label %a9, label %1
+a9:
+  br label %a10
+a10:
+  br i1 1, label %a13, label %a11
+a11:
+  br i1 1, label %a9, label %a8
+a12:
   br i1 1, label %2, label %1
-13:
-   switch i32 0, label %1 [ i32 0, label %9
-                              i32 1, label %8]
+a13:
+   switch i32 0, label %1 [ i32 0, label %a9
+                              i32 1, label %a8]
 }
 
 ; CHECK: DominanceFrontier for function: a_linear_impl_fig_1
 ; CHECK-DAG:  DomFrontier for BB %0 is:
-; CHECK-DAG:  DomFrontier for BB %11 is:   %{{[8|9]}} %{{[8|9]}}
+; CHECK-DAG:  DomFrontier for BB %a11 is:   %a9 %a8
 ; CHECK-DAG:  DomFrontier for BB %1 is:    %1
-; CHECK-DAG:  DomFrontier for BB %2 is:    %{{[1|2]}} %{{[1|2]}}
-; CHECK-DAG:  DomFrontier for BB %3 is:    %{{[1|2]}} %{{[1|2]}}
-; CHECK-DAG:  DomFrontier for BB %12 is:   %{{[1|2]}} %{{[1|2]}}
-; CHECK-DAG:  DomFrontier for BB %4 is:    %{{[1|4]}} %{{[1|4]}}
-; CHECK-DAG:  DomFrontier for BB %5 is:    %{{[1|4]}} %{{[1|4]}}
-; CHECK-DAG:  DomFrontier for BB %8 is:    %{{[1|8]}} %{{[1|8]}}
+; CHECK-DAG:  DomFrontier for BB %2 is:    %1 %2
+; CHECK-DAG:  DomFrontier for BB %3 is:    %1 %2
+; CHECK-DAG:  DomFrontier for BB %a12 is:   %2 %1
+; CHECK-DAG:  DomFrontier for BB %4 is:    %1 %4
+; CHECK-DAG:  DomFrontier for BB %5 is:    %4 %1
+; CHECK-DAG:  DomFrontier for BB %a8 is:    %1 %a8
 ; CHECK-DAG:  DomFrontier for BB %6 is:    %4
-; CHECK-DAG:  DomFrontier for BB %7 is:
-; CHECK-DAG:  DomFrontier for BB %9 is:    %{{[1|8|9]}} %{{[1|8|9]}} %{{[1|8|9]}}
-; CHECK-DAG:  DomFrontier for BB %10 is:   %{{[1|8|9]}} %{{[1|8|9]}} %{{[1|8|9]}}
-; CHECK-DAG:  DomFrontier for BB %13 is:   %{{[1|8|9]}} %{{[1|8|9]}} %{{[1|8|9]}}
+; CHECK-DAG:  DomFrontier for BB %a7 is:
+; CHECK-DAG:  DomFrontier for BB %a9 is:    %a9 %a8 %1
+; CHECK-DAG:  DomFrontier for BB %a10 is:   %a9 %a8 %1
+; CHECK-DAG:  DomFrontier for BB %a13 is:   %1 %a9 %a8


### PR DESCRIPTION
DominanceFrontierBase::find returns an iterator to a set of dominance
frontiers. When we dereference the iterator and then iterate over the
set, the order of the dominance frontiers is indeterministic.
This results in indeterministic IR output in our downstream use case
that depends on the order.