### PR TITLE
[clang][Diagnostics] Provide source range to constexpr function diags

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2457,7 +2457,8 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
       !Expr::isPotentialConstantExpr(Dcl, Diags)) {
     SemaRef.Diag(Dcl->getLocation(),
                  diag::ext_constexpr_function_never_constant_expr)
-        << isa<CXXConstructorDecl>(Dcl) << Dcl->isConsteval();
+        << isa<CXXConstructorDecl>(Dcl) << Dcl->isConsteval()
+        << Dcl->getNameInfo().getSourceRange();
     for (size_t I = 0, N = Diags.size(); I != N; ++I)
       SemaRef.Diag(Diags[I].first, Diags[I].second);
     // Don't return false here: we allow this for compatibility in

--- a/clang/test/Misc/constexpr-source-ranges.cpp
+++ b/clang/test/Misc/constexpr-source-ranges.cpp
@@ -49,3 +49,7 @@ constexpr int uninit() {
   return aaa;
 }
 static_assert(uninit() == 0, "");
+
+
+constexpr void neverValid() { throw; }
+// CHECK: :{[[@LINE-1]]:16-[[@LINE-1]]:26}:


### PR DESCRIPTION
Before:
```console
./array.cpp:290:16: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
  290 | constexpr void neverValid() {
      |                ^
./array.cpp:291:3: note: subexpression not valid in a constant expression
  291 |   throw;
      |   ^~~~~
```

After:
```console
./array.cpp:290:16: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
  290 | constexpr void neverValid() {
      |                ^~~~~~~~~~
./array.cpp:291:3: note: subexpression not valid in a constant expression
  291 |   throw;
      |   ^~~~~
```