### PR TITLE
[flang] Place MIN/MAX A1/A2 first in semantic analysis

### DIFF
--- a/flang/include/flang/Evaluate/intrinsics.h
+++ b/flang/include/flang/Evaluate/intrinsics.h
@@ -99,6 +99,9 @@ public:
   // On success, the actual arguments are transferred to the result
   // in dummy argument order; on failure, the actual arguments remain
   // untouched.
+  // For MIN and MAX, only a1 and a2 actual arguments are transferred in dummy
+  // order on success and the other arguments are transferred afterwards
+  // without being sorted.
   std::optional<SpecificCall> Probe(
       const CallCharacteristics &, ActualArguments &, FoldingContext &) const;
 

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1462,8 +1462,7 @@ static bool CheckMaxMinArgument(parser::CharBlock keyword,
         keyword, intrinsicName);
     return false;
   }
-  auto [_, wasInserted]{set.insert(keyword)};
-  if (!wasInserted) {
+  if (!set.insert(keyword).second) {
     messages.Say(keyword,
         "argument keyword '%s=' was repeated in call to '%s'"_err_en_US,
         keyword, intrinsicName);

--- a/flang/test/Lower/Intrinsics/min.f90
+++ b/flang/test/Lower/Intrinsics/min.f90
@@ -1,0 +1,34 @@
+! RUN: bbc -emit-hlfir -o - %s 2>&1 | FileCheck %s
+! Test that min/max A(X>2) optional arguments are handled regardless
+! of the order in which they appear. Only A1 and A2 are mandatory.
+
+real function test(a, b, c)
+  real, optional :: a, b, c
+  test = min(a1=a, a3=c, a2=c)
+end function
+! CHECK-LABEL:   func.func @_QPtest(
+! CHECK-SAME:                       %[[VAL_0:.*]]: !fir.ref<f32> {fir.bindc_name = "a", fir.optional},
+! CHECK-SAME:                       %[[VAL_1:.*]]: !fir.ref<f32> {fir.bindc_name = "b", fir.optional},
+! CHECK-SAME:                       %[[VAL_2:.*]]: !fir.ref<f32> {fir.bindc_name = "c", fir.optional}) -> f32 {
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_0]] {{.*}}uniq_name = "_QFtestEa"}
+! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_1]] {{.*}}uniq_name = "_QFtestEb"}
+! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_2]] {{.*}}uniq_name = "_QFtestEc"}
+! CHECK:           %[[VAL_6:.*]] = fir.alloca f32 {bindc_name = "test", uniq_name = "_QFtestEtest"}
+! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_6]] {uniq_name = "_QFtestEtest"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
+! CHECK:           %[[VAL_8:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<f32>
+! CHECK:           %[[VAL_9:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<f32>
+! CHECK:           %[[VAL_10:.*]] = fir.is_present %[[VAL_5]]#0 : (!fir.ref<f32>) -> i1
+! CHECK:           %[[VAL_11:.*]] = arith.cmpf olt, %[[VAL_8]], %[[VAL_9]] : f32
+! CHECK:           %[[VAL_12:.*]] = arith.select %[[VAL_11]], %[[VAL_8]], %[[VAL_9]] : f32
+! CHECK:           %[[VAL_13:.*]] = fir.if %[[VAL_10]] -> (f32) {
+! CHECK:             %[[VAL_14:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<f32>
+! CHECK:             %[[VAL_15:.*]] = arith.cmpf olt, %[[VAL_12]], %[[VAL_14]] : f32
+! CHECK:             %[[VAL_16:.*]] = arith.select %[[VAL_15]], %[[VAL_12]], %[[VAL_14]] : f32
+! CHECK:             fir.result %[[VAL_16]] : f32
+! CHECK:           } else {
+! CHECK:             fir.result %[[VAL_12]] : f32
+! CHECK:           }
+! CHECK:           hlfir.assign %[[VAL_13]] to %[[VAL_7]]#0 : f32, !fir.ref<f32>
+! CHECK:           %[[VAL_17:.*]] = fir.load %[[VAL_7]]#1 : !fir.ref<f32>
+! CHECK:           return %[[VAL_17]] : f32
+! CHECK:         }

--- a/flang/test/Semantics/call23.f90
+++ b/flang/test/Semantics/call23.f90
@@ -1,15 +1,15 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 ! Check errors on MAX/MIN with keywords, a weird case in Fortran
 real :: x = 0.0, y = 0.0 , y1 = 0.0 ! prevent folding
-!ERROR: Argument keyword 'a1=' was repeated in call to 'max'
+!ERROR: argument keyword 'a1=' was repeated in call to 'max'
 print *, max(a1=x,a1=1)
-!ERROR: Keyword argument 'a1=' has already been specified positionally (#1) in this procedure reference
+!ERROR: keyword argument 'a1=' to intrinsic 'max' was supplied positionally by an earlier actual argument
 print *, max(x,a1=1)
-!ERROR: Keyword argument 'a1=' has already been specified positionally (#1) in this procedure reference
+!ERROR: keyword argument 'a1=' to intrinsic 'min1' was supplied positionally by an earlier actual argument
 print *, min1(1.,a1=2.,a2=3.)
 print *, max(a1=x,a2=0,a4=0) ! ok
 print *, max(x,0,a99=0) ! ok
-!ERROR: Argument keyword 'a06=' is not known in call to 'max'
+!ERROR: argument keyword 'a06=' is not known in call to 'max'
 print *, max(a1=x,a2=0,a06=0)
 !ERROR: missing mandatory 'a2=' argument
 print *, max(a3=y, a1=x)
@@ -29,10 +29,18 @@ print *, max(a1=x)
 print *, max(a2=y)
 !ERROR: missing mandatory 'a1=' and 'a2=' arguments
 print *, max(a3=x)
-!ERROR: Argument keyword 'a0=' is not known in call to 'max'
+!ERROR: argument keyword 'a0=' is not known in call to 'max'
 print *, max(a0=x)
-!ERROR: Argument keyword 'a03=' is not known in call to 'max'
+!ERROR: argument keyword 'a03=' is not known in call to 'max'
 print *, max(a03=x)
-!ERROR: Argument keyword 'abad=' is not known in call to 'max'
+!ERROR: argument keyword 'abad=' is not known in call to 'max'
 print *, max(abad=x)
+!ERROR: actual argument #2 without a keyword may not follow an actual argument with a keyword
+print *, max(a1=x, y)
+!ERROR: Keyword argument 'a3=' has already been specified positionally (#3) in this procedure reference
+print *, max(x, y, y1, a3=x)
+print *, max(a3=x, a4=x, a2=x, a1=x) ! ok
+print *, max(a3=x, a2=y, a4=x, a1=x) ! ok
+print *, max(x, a2=y, a5=x, a4=x) ! ok
+print *, max(x, y, a4=x, a6=x) ! ok
 end


### PR DESCRIPTION
Intrinsic analysis in semantics reorder the actual arguments so that they match the dummy order. This was not done for MIN/MAX because they are special: these are the only intrinsics with a variadic number of arguments.

This caused bugs in lowering that only check the optionality of actual arguments from the third position (since A1 and A2 are mandatory).

Update semantics to place A1/A2 first. This also allow removing some checks that were specific to MIN/MAX. There is no point in sorting/placing the rest of the arguments which would be tedious and tricky because of the variadic aspect.