### PR TITLE
[CSKY] Don't emit `__multi3`  on 32-bit CSKY

### DIFF
--- a/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
+++ b/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
@@ -109,6 +109,14 @@ CSKYTargetLowering::CSKYTargetLowering(const TargetMachine &TM,
 
   setOperationAction(ISD::ATOMIC_FENCE, MVT::Other, Expand);
 
+  // These libcalls are not available in 32-bit.
+  setLibcallName(RTLIB::SHL_I128, nullptr);
+  setLibcallName(RTLIB::SRL_I128, nullptr);
+  setLibcallName(RTLIB::SRA_I128, nullptr);
+  setLibcallName(RTLIB::MUL_I128, nullptr);
+  setLibcallName(RTLIB::MULO_I64, nullptr);
+  setLibcallName(RTLIB::MULO_I128, nullptr);
+      
   // Float
 
   ISD::CondCode FPCCToExtend[] = {


### PR DESCRIPTION
close #68971
according to  #21245 , disable `__multi3` and other buitin functions which are not available in 32-bit target.
