### PR TITLE
[CSKY] Don't emit `__multi3` on 32-bit CSKY

### DIFF
--- a/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
+++ b/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
@@ -109,6 +109,14 @@ CSKYTargetLowering::CSKYTargetLowering(const TargetMachine &TM,
 
   setOperationAction(ISD::ATOMIC_FENCE, MVT::Other, Expand);
 
+  // These libcalls are not available in 32-bit.
+  setLibcallName(RTLIB::SHL_I128, nullptr);
+  setLibcallName(RTLIB::SRL_I128, nullptr);
+  setLibcallName(RTLIB::SRA_I128, nullptr);
+  setLibcallName(RTLIB::MUL_I128, nullptr);
+  setLibcallName(RTLIB::MULO_I64, nullptr);
+  setLibcallName(RTLIB::MULO_I128, nullptr);
+      
   // Float
 
   ISD::CondCode FPCCToExtend[] = {

--- a/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
+++ b/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
@@ -116,7 +116,7 @@ CSKYTargetLowering::CSKYTargetLowering(const TargetMachine &TM,
   setLibcallName(RTLIB::MUL_I128, nullptr);
   setLibcallName(RTLIB::MULO_I64, nullptr);
   setLibcallName(RTLIB::MULO_I128, nullptr);
-      
+
   // Float
 
   ISD::CondCode FPCCToExtend[] = {

--- a/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
+++ b/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
@@ -116,6 +116,18 @@ CSKYTargetLowering::CSKYTargetLowering(const TargetMachine &TM,
   setLibcallName(RTLIB::MUL_I128, nullptr);
   setLibcallName(RTLIB::MULO_I64, nullptr);
   setLibcallName(RTLIB::MULO_I128, nullptr);
+  setLibcallName(SINTTOFP_I128_F16, nullptr);
+  setLibcallName(SINTTOFP_I128_F32, nullptr);
+  setLibcallName(SINTTOFP_I128_F64, nullptr);
+  setLibcallName(SINTTOFP_I128_F80, nullptr);
+  setLibcallName(SINTTOFP_I128_F128, nullptr);
+  setLibcallName(SINTTOFP_I128_PPCF128, nullptr);
+  setLibcallName(UINTTOFP_I128_F16, nullptr);
+  setLibcallName(UINTTOFP_I128_F32, nullptr);
+  setLibcallName(UINTTOFP_I128_F64, nullptr);
+  setLibcallName(UINTTOFP_I128_F80, nullptr);
+  setLibcallName(UINTTOFP_I128_F128, nullptr);
+  setLibcallName(UINTTOFP_I128_PPCF128, nullptr);
 
   // Float
 


### PR DESCRIPTION
Fix #68971
According to #21245 , disable `__multi3` and other buitin functions which are not available in 32-bit target.