### PR TITLE
[clang] Non-object types are non-trivially relocatable

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -637,6 +637,9 @@ Bug Fixes in This Version
 - Fix crash during code generation of C++ coroutine initial suspend when the return
   type of await_resume is not trivially destructible.
   Fixes (`#63803 <https://github.com/llvm/llvm-project/issues/63803>`_)
+- ``__is_trivially_relocatable`` no longer returns true for non-object types
+  such as references and functions.
+  Fixes (`#67498 <https://github.com/llvm/llvm-project/issues/67498>`_)
 - Fix crash when the object used as a ``static_assert`` message has ``size`` or ``data`` members
   which are not member functions.
 - Support UDLs in ``static_assert`` message.

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2649,6 +2649,8 @@ bool QualType::isTriviallyRelocatableType(const ASTContext &Context) const {
 
   if (BaseElementType->isIncompleteType()) {
     return false;
+  } else if (!BaseElementType->isObjectType()) {
+    return false;
   } else if (const auto *RD = BaseElementType->getAsRecordDecl()) {
     return RD->canPassInRegisters();
   } else {

--- a/clang/test/SemaCXX/type-traits-incomplete.cpp
+++ b/clang/test/SemaCXX/type-traits-incomplete.cpp
@@ -1,8 +1,14 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s 
 
-struct S; // expected-note 2 {{forward declaration of 'S'}}
+struct S; // expected-note 6 {{forward declaration of 'S'}}
 
 void f() {
   __is_pod(S); // expected-error{{incomplete type 'S' used in type trait expression}}
   __is_pod(S[]); // expected-error{{incomplete type 'S' used in type trait expression}}
+
+  __is_trivially_copyable(S); // expected-error{{incomplete type 'S' used in type trait expression}}
+  __is_trivially_copyable(S[]); // expected-error{{incomplete type 'S' used in type trait expression}}
+
+  __is_trivially_relocatable(S); // expected-error{{incomplete type 'S' used in type trait expression}}
+  __is_trivially_relocatable(S[]); // expected-error{{incomplete type 'S' used in type trait expression}}
 }

--- a/clang/test/SemaCXX/type-traits-nonobject.cpp
+++ b/clang/test/SemaCXX/type-traits-nonobject.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
+
+// expected-no-diagnostics
+
+static_assert(!__is_pod(void), "");
+static_assert(!__is_pod(int&), "");
+static_assert(!__is_pod(int()), "");
+
+static_assert(!__is_trivially_copyable(void), "");
+static_assert(!__is_trivially_copyable(int&), "");
+static_assert(!__is_trivially_copyable(int()), "");
+
+static_assert(!__is_trivially_relocatable(void), "");
+static_assert(!__is_trivially_relocatable(int&), "");
+static_assert(!__is_trivially_relocatable(int()), "");


### PR DESCRIPTION
Both active C++ proposals (P1144 and P2786) agree that `is_trivially_relocatable_v<int&>` and `is_trivially_relocatable_v<int()>` should be false, not true. Only complete object types can be trivially relocatable.

Fixes #67498