### PR TITLE
Support VFE in thinLTO

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7378,10 +7378,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (VirtualFunctionElimination) {
     // VFE requires full LTO (currently, this might be relaxed to allow ThinLTO
     // in the future).
-    if (LTOMode != LTOK_Full)
+    if (LTOMode != LTOK_Full && LTOMode != LTOK_Thin)
       D.Diag(diag::err_drv_argument_only_allowed_with)
           << "-fvirtual-function-elimination"
-          << "-flto=full";
+          << "-flto";
 
     CmdArgs.push_back("-fvirtual-function-elimination");
   }

--- a/clang/test/CodeGenCXX/vfe-thin.cpp
+++ b/clang/test/CodeGenCXX/vfe-thin.cpp
@@ -1,0 +1,123 @@
+// REQUIRES: system-darwin
+// RUN: rm -rf %t_devirt && mkdir %t_devirt
+// RUN: rm -rf %t.dir
+// RUN: split-file %s %t.dir
+
+// RUN: %clang -flto=thin -target arm64-apple-ios16 -emit-llvm -c -fwhole-program-vtables -fvirtual-function-elimination -mllvm -enable-vfe-summary -o %t.main.bc %t.dir/vfe-main.cpp
+// RUN: llvm-dis %t.main.bc -o - | FileCheck %s --check-prefix=CHECK
+// RUN: %clang -flto=thin -target arm64-apple-ios16 -emit-llvm -c -fwhole-program-vtables -fvirtual-function-elimination -mllvm -enable-vfe-summary -o %t.input.bc %t.dir/vfe-input.cpp
+// RUN: llvm-dis %t.input.bc -o - | FileCheck %s --check-prefix=INPUT
+
+// RUN: llvm-lto2 run %t.main.bc %t.input.bc -save-temps -enable-vfe-on-thinlto -o %t.out \
+// RUN:   -r=%t.main.bc,__Z6test_1P1A,pl \
+// RUN:   -r=%t.main.bc,__Z4testv,pl \
+// RUN:   -r=%t.main.bc,__Znwm, \
+// RUN:   -r=%t.main.bc,__ZN1AC1Ev,pl \
+// RUN:   -r=%t.main.bc,___gxx_personality_v0, \
+// RUN:   -r=%t.main.bc,__ZN1AC2Ev,pl \
+// RUN:   -r=%t.main.bc,__ZN1BC2Ev,pl \
+// RUN:   -r=%t.main.bc,__ZN1BC1Ev,pl \
+// RUN:   -r=%t.main.bc,__ZN1A3fooEv,pl \
+// RUN:   -r=%t.main.bc,__ZN1A3barEv,pl \
+// RUN:   -r=%t.main.bc,__Z6test_2P1B,pl \
+// RUN:   -r=%t.main.bc,_main,plx \
+// RUN:   -r=%t.main.bc,__ZdlPv \
+// RUN:   -r=%t.main.bc,__ZTV1A,pl \
+// RUN:   -r=%t.main.bc,__ZTV1B, \
+// RUN:   -r=%t.main.bc,__ZTVN10__cxxabiv117__class_type_infoE, \
+// RUN:   -r=%t.main.bc,__ZTS1A,pl \
+// RUN:   -r=%t.main.bc,__ZTI1A,pl \
+// RUN:   -r=%t.input.bc,__ZN1CC2Ev,pl \
+// RUN:   -r=%t.input.bc,__ZN1CC1Ev,pl \
+// RUN:   -r=%t.input.bc,__Z6test_3P1C,pl \
+// RUN:   -r=%t.input.bc,__Z6test_4P1C,pl \
+// RUN:   -r=%t.input.bc,__Z6test_5P1CMS_FvvE,pl \
+// RUN:   -r=%t.input.bc,__ZTV1C,
+
+// RUN: llvm-dis %t.out.1.0.preopt.bc -o - | FileCheck %s --check-prefix=ORIGINAL
+// RUN: llvm-dis %t.out.1.4.opt.bc -o - | FileCheck %s --check-prefix=AFTERVFE
+// ORIGINAL: define{{.*}}_ZN1A3barEv
+// AFTERVFE-NOT: define{{.*}}_ZN1A3barEv
+
+//--- vfe-main.cpp
+// CHECK: @_ZTV1A = {{.*}}constant {{.*}}@_ZTI1A{{.*}}@_ZN1A3fooEv{{.*}}_ZN1A3barEv{{.*}}!type [[A16:![0-9]+]]
+// CHECK-NOT: @_ZTV1B = {{.*}}!type
+struct __attribute__((visibility("hidden"))) A {
+  A();
+  virtual void foo();
+  virtual void bar();
+};
+
+__attribute__((used)) void test_1(A *p) {
+  // CHECK-LABEL: define{{.*}} void @_Z6test_1P1A
+  // CHECK: [[VTABLE:%.+]] = load
+  // CHECK: @llvm.type.checked.load(ptr {{%.+}}, i32 0, metadata !"_ZTS1A")
+  p->foo();
+}
+
+__attribute__((used)) A *test() {
+  return new (A)();
+}
+
+struct __attribute__((visibility("hidden"))) B {
+  B();
+  virtual void foo();
+};
+
+A::A() {}
+B::B() {}
+void A::foo() {}
+void A::bar() {}
+void test_2(B *p) {
+  // CHECK-LABEL: define{{.*}} void @_Z6test_2P1B
+  // CHECK: [[VTABLE:%.+]] = load
+  // CHECK: @llvm.type.checked.load(ptr {{%.+}}, i32 0, metadata !"_ZTS1B")
+  p->foo();
+}
+
+// INPUT-NOT: @_ZTV1C = {{.*}}!type
+// INPUT-LABEL: define{{.*}} void @_Z6test_3P1C
+// INPUT: [[LOAD:%.+]] = {{.*}}call { ptr, i1 } @llvm.type.checked.load(ptr {{%.+}}, i32 0, metadata !"_ZTS1C")
+// INPUT: [[FN_PTR:%.+]] = extractvalue { ptr, i1 } [[LOAD]], 0
+// INPUT: call void [[FN_PTR]](
+
+// INPUT-LABEL: define{{.*}} void @_Z6test_4P1C
+// INPUT: [[LOAD:%.+]] = {{.*}}call { ptr, i1 } @llvm.type.checked.load(ptr {{%.+}}, i32 8, metadata !"_ZTS1C")
+// INPUT: [[FN_PTR:%.+]] = extractvalue { ptr, i1 } [[LOAD]], 0
+// INPUT: call void [[FN_PTR]](
+
+int main() {
+}
+
+// CHECK: [[BAR:\^[0-9]+]] = gv: (name: "_ZN1A3barEv", {{.*}}
+// CHECK: FuncsWithNonVtableRef
+// CHECK-NOT: [[BAR]]
+//--- vfe-input.cpp
+struct __attribute__((visibility("hidden"))) C {
+  C();
+  virtual void foo();
+  virtual void bar();
+};
+
+C::C() {}
+void test_3(C *p) {
+  // C has hidden visibility, so we generate type.checked.load to allow VFE.
+  p->foo();
+}
+
+void test_4(C *p) {
+  // When using type.checked.load, we pass the vtable offset to the intrinsic,
+  // rather than adding it to the pointer with a GEP.
+  p->bar();
+}
+
+void test_5(C *p, void (C::*q)(void)) {
+  // We also use type.checked.load for the virtual side of member function
+  // pointer calls. We use a GEP to calculate the address to load from and pass
+  // 0 as the offset to the intrinsic, because we know that the load must be
+  // from exactly the point marked by one of the function-type metadatas (in
+  // this case "_ZTSM1CFvvE.virtual"). If we passed the offset from the member
+  // function pointer to the intrinsic, this information would be lost. No
+  // codegen changes on the non-virtual side.
+  (p->*q)();
+}

--- a/clang/test/Driver/virtual-function-elimination.cpp
+++ b/clang/test/Driver/virtual-function-elimination.cpp
@@ -1,6 +1,5 @@
 // RUN: not %clang -target x86_64-unknown-linux -fvirtual-function-elimination -### %s 2>&1 | FileCheck --check-prefix=BAD-LTO %s
-// RUN: not %clang -target x86_64-unknown-linux -fvirtual-function-elimination -flto=thin -### %s 2>&1 | FileCheck --check-prefix=BAD-LTO %s
-// BAD-LTO: invalid argument '-fvirtual-function-elimination' only allowed with '-flto=full'
+// BAD-LTO: invalid argument '-fvirtual-function-elimination' only allowed with '-flto'
 
 // RUN: %clang -target x86_64-unknown-linux -fvirtual-function-elimination -flto -### %s 2>&1 | FileCheck --check-prefix=GOOD %s
 // RUN: %clang -target x86_64-unknown-linux -fvirtual-function-elimination -flto=full -### %s 2>&1 | FileCheck --check-prefix=GOOD %s

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -362,6 +362,7 @@ namespace llvm {
     bool parseGVReference(ValueInfo &VI, unsigned &GVId);
     bool parseSummaryIndexFlags();
     bool parseBlockCount();
+    bool parseFuncsWithNonVtableRefEntry(unsigned ID);
     bool parseGVEntry(unsigned ID);
     bool parseFunctionSummary(std::string Name, GlobalValue::GUID, unsigned ID);
     bool parseVariableSummary(std::string Name, GlobalValue::GUID, unsigned ID);

--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -399,6 +399,7 @@ enum Kind {
   kw_args,
   kw_typeid,
   kw_typeidCompatibleVTable,
+  kw_FuncsWithNonVtableRef,
   kw_summary,
   kw_typeTestRes,
   kw_kind,

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -319,6 +319,7 @@ enum GlobalValueSummarySymtabCodes {
   //  numver x version]
   FS_COMBINED_ALLOC_INFO = 29,
   FS_STACK_IDS = 30,
+  OBJC_FUNC_NON_VTABLE_REF = 31,
 };
 
 enum MetadataCodes {

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -1362,6 +1362,8 @@ private:
   // Temporary map while building StackIds list. Clear when index is completely
   // built via releaseTemporaryMemory.
   std::map<uint64_t, unsigned> StackIdToIndex;
+  std::set<GlobalValue::GUID> FuncsWithNonVtableRef;
+  std::set<GlobalValue::GUID> VFuncsToBeRemoved; // no need to serialize
 
   // YAML I/O support.
   friend yaml::MappingTraits<ModuleSummaryIndex>;
@@ -1809,6 +1811,26 @@ public:
         ModuleToDefinedGVSummaries[Summary->modulePath()][GUID] = Summary.get();
       }
     }
+  }
+
+  bool isFuncWithNonVtableRef(GlobalValue::GUID fId) const {
+    return FuncsWithNonVtableRef.count(fId);
+  }
+  void addFuncWithNonVtableRef(GlobalValue::GUID fId) {
+    FuncsWithNonVtableRef.insert(fId);
+  }
+  const std::set<GlobalValue::GUID> &funcsWithNonVtableRef() const {
+    return FuncsWithNonVtableRef;
+  }
+
+  bool isFuncToBeRemoved(GlobalValue::GUID fId) const {
+    return VFuncsToBeRemoved.count(fId);
+  }
+  void addFuncToBeRemoved(GlobalValue::GUID fId) {
+    VFuncsToBeRemoved.insert(fId);
+  }
+  const std::set<GlobalValue::GUID> &funcsToBeRemoved() const {
+    return VFuncsToBeRemoved;
   }
 
   /// Print to an output stream.

--- a/llvm/include/llvm/Transforms/IPO/GlobalDCE.h
+++ b/llvm/include/llvm/Transforms/IPO/GlobalDCE.h
@@ -35,7 +35,16 @@ class Value;
 /// Pass to remove unused function declarations.
 class GlobalDCEPass : public PassInfoMixin<GlobalDCEPass> {
 public:
-  GlobalDCEPass(bool InLTOPostLink = false) : InLTOPostLink(InLTOPostLink) {}
+  GlobalDCEPass(bool InLTOPostLink = false)
+      : InLTOPostLink(InLTOPostLink), ExportSummary(nullptr),
+        ImportSummary(nullptr) {}
+  GlobalDCEPass(ModuleSummaryIndex *ExportSummary,
+                const ModuleSummaryIndex *ImportSummary,
+                bool InLTOPostLink = false)
+      : InLTOPostLink(InLTOPostLink), ExportSummary(ExportSummary),
+        ImportSummary(ImportSummary) {
+    assert(!(ExportSummary && ImportSummary));
+  }
 
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 
@@ -44,6 +53,8 @@ public:
 
 private:
   bool InLTOPostLink = false;
+  ModuleSummaryIndex *ExportSummary;
+  const ModuleSummaryIndex *ImportSummary;
 
   SmallPtrSet<GlobalValue*, 32> AliveGlobals;
 
@@ -78,6 +89,8 @@ private:
   void ComputeDependencies(Value *V, SmallPtrSetImpl<GlobalValue *> &U);
 };
 
+void runVFEOnIndex(ModuleSummaryIndex &Summary,
+                   function_ref<bool(GlobalValue::GUID)> isRetained);
 }
 
 #endif // LLVM_TRANSFORMS_IPO_GLOBALDCE_H

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -950,6 +950,9 @@ bool LLParser::parseSummaryEntry() {
   case lltok::kw_blockcount:
     result = parseBlockCount();
     break;
+  case lltok::kw_FuncsWithNonVtableRef:
+    result = parseFuncsWithNonVtableRefEntry(SummaryID);
+    break;
   default:
     result = error(Lex.getLoc(), "unexpected summary kind");
     break;
@@ -8202,6 +8205,19 @@ bool LLParser::parseTypeIdSummary(TypeIdSummary &TIS) {
 
 static ValueInfo EmptyVI =
     ValueInfo(false, (GlobalValueSummaryMapTy::value_type *)-8);
+
+/// FuncsWithNonVtableRefEntry
+///   ::= 'FuncsWithNonVtableRef' ':' '('
+///   ')'
+bool LLParser::parseFuncsWithNonVtableRefEntry(unsigned ID) {
+  assert(Lex.getKind() == lltok::kw_FuncsWithNonVtableRef);
+  Lex.Lex();
+  std::string Name;
+  if (parseToken(lltok::colon, "expected ':' here") ||
+      parseToken(lltok::lparen, "expected '(' here"))
+    return true;
+  return false;
+}
 
 /// TypeIdCompatibleVtableEntry
 ///   ::= 'typeidCompatibleVTable' ':' '(' 'name' ':' STRINGCONSTANT ','

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -7497,6 +7497,11 @@ Error ModuleSummaryIndexBitcodeReader::parseEntireSummary(unsigned ID) {
       LastSeenGUID = 0;
       break;
     }
+    case bitc::OBJC_FUNC_NON_VTABLE_REF: {
+      for (unsigned I = 0; I != Record.size(); I++)
+        TheIndex.addFuncWithNonVtableRef(Record[I]);
+      break;
+    }
     case bitc::FS_TYPE_TESTS:
       assert(PendingTypeTests.empty());
       llvm::append_range(PendingTypeTests, Record);

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2941,6 +2941,19 @@ void AssemblyWriter::printModuleSummaryIndex() {
     Out << ") ; guid = " << GUID << "\n";
   }
 
+  // Print FuncsWithNonVtableRef.
+  // Need to find a case where this is set.
+  if (!TheIndex->funcsWithNonVtableRef().empty()) {
+    Out << "^" << NumSlots << " = FuncsWithNonVtableRef: (";
+    FieldSeparator FS;
+    for (auto FID : TheIndex->funcsWithNonVtableRef()) {
+      Out << FS;
+      Out << "^" << Machine.getGUIDSlot(FID);
+    }
+    Out << ")\n";
+    ++NumSlots;
+  }
+
   // Don't emit flags when it's not really needed (value is zero by default).
   if (TheIndex->getFlags()) {
     Out << "^" << NumSlots << " = flags: " << TheIndex->getFlags() << "\n";

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -281,6 +281,9 @@ cl::opt<bool> EnableMemProfContextDisambiguation(
     cl::ZeroOrMore, cl::desc("Enable MemProf context disambiguation"));
 
 extern cl::opt<bool> EnableInferAlignmentPass;
+cl::opt<bool> EnableVFEOnThinLTO("enable-vfe-on-thinlto", cl::init(false),
+                                 cl::Hidden, cl::ZeroOrMore,
+                                 cl::desc("enable VFE with ThinLTO"));
 
 PipelineTuningOptions::PipelineTuningOptions() {
   LoopInterleaving = true;
@@ -1582,6 +1585,9 @@ PassBuilder::buildThinLTOPreLinkDefaultPipeline(OptimizationLevel Level) {
 ModulePassManager PassBuilder::buildThinLTODefaultPipeline(
     OptimizationLevel Level, const ModuleSummaryIndex *ImportSummary) {
   ModulePassManager MPM;
+
+  if (EnableVFEOnThinLTO && ImportSummary)
+    MPM.addPass(GlobalDCEPass(nullptr, ImportSummary));
 
   if (ImportSummary) {
     // For ThinLTO we must apply the context disambiguation decisions early, to


### PR DESCRIPTION
We add a run of GlobalDCEPass with ImportSummary. When ImportSummary is true, we remove virtual functions in vtables with VCallVisibility not Public. In this run, the regular GlobalDCEPass::AddVirtualFunctionDependencies will be bypassed, we will use ImportSummary to decide which virtual functions to remove.

Discussion points:
1> FuncsWithNonVtableRef: this is currently in ModuleSummaryIndex, does it
   make sense to be part of FunctionSummary?
   std::set<GlobalValue::GUID> FuncsWithNonVtableRef;
2> ComputeDependencies is copied from GlobalDCE to ModuleSummaryAnalysis, for the former,
   ConstantDependenciesCache is a member variable
3> match from summary to Function in IR
   Resolution is saved in std::set<GlobalValue::GUID> VFuncsToBeRemoved
   Use F->getGUID() or GlobalValue::getGUID(F->getName()) when searching in VFuncsToBeRemoved

TODO:
1> support hybrid Regular/ThinLTO
2> support legacy thinLTO backend (ThinLTOCodeGenerator)