### PR TITLE
[clang] Robustify openmp test

### DIFF
--- a/clang/test/OpenMP/declare_variant_device_kind_codegen.cpp
+++ b/clang/test/OpenMP/declare_variant_device_kind_codegen.cpp
@@ -80,7 +80,7 @@
 
 // expected-no-diagnostics
 
-// CHECK-NOT: alias
+// CHECK-NOT: {{ (no)?alias }}
 
 // CHECK-NOT: ret i32 {{1|4|81|84}}
 // CHECK-DAG: declare {{.*}}i32 @_Z5bazzzv()

--- a/clang/test/OpenMP/declare_variant_device_kind_codegen.cpp
+++ b/clang/test/OpenMP/declare_variant_device_kind_codegen.cpp
@@ -80,7 +80,8 @@
 
 // expected-no-diagnostics
 
-// CHECK-NOT: {{ (no)?alias }}
+// Verify no unexpected global symbol aliasing
+// CHECK-NOT: @{{[^ ]+}} = {{.*}}alias
 
 // CHECK-NOT: ret i32 {{1|4|81|84}}
 // CHECK-DAG: declare {{.*}}i32 @_Z5bazzzv()


### PR DESCRIPTION
If the source path contains 'alias' this would spuriously fail.  Be more specific about not wanting [no]alias annotations.