### PR TITLE
[mlir] Remove old comment in AsmPrinter

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2430,9 +2430,6 @@ void AsmPrinter::Impl::printDenseIntOrFPElementsAttr(
 
   if (ComplexType complexTy = llvm::dyn_cast<ComplexType>(elementType)) {
     Type complexElementType = complexTy.getElementType();
-    // Note: The if and else below had a common lambda function which invoked
-    // printDenseElementsAttrImpl. This lambda was hitting a bug in gcc 9.1,9.2
-    // and hence was replaced.
     if (llvm::isa<IntegerType>(complexElementType)) {
       auto valueIt = attr.value_begin<std::complex<APInt>>();
       printDenseElementsAttrImpl(attr.isSplat(), type, os, [&](unsigned index) {


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/68407.

As pointed out by @Chandlerooo, the comment about a bug in gcc 9.1 does not seem relevant anymore. More specifically, this comment was added in https://github.com/llvm/llvm-project/commit/6cd232056c3cdaf5e9eb85ede8e42d0db97f0f71 (2020) to ensure that people would avoid a bug in gcc 9.1. A bug that was fixed in 2019 for gcc 9.3/10.

I've looked into putting a lambda function back, but it doesn't look like it's worth it. The code has not so much duplication and already contains a lambda which is passed to `printDenseElementsAttrImpl`. We could create a lambda to generate a lambda but that would make this needlessly complex.

I suggest to just remove the comment and close the issue.