### PR TITLE
Fixed typo in GPU libm device library warning

### DIFF
--- a/libc/src/math/gpu/vendor/CMakeLists.txt
+++ b/libc/src/math/gpu/vendor/CMakeLists.txt
@@ -20,7 +20,7 @@ if(CUDAToolkit_FOUND)
          "SHELL:-Xclang -mlink-builtin-bitcode -Xclang ${libdevice_path}")
   endif()
 else()
-  message(STATUS "Could not find the ROCm device library. Unimplemented "
+  message(STATUS "Could not find the CUDA device library. Unimplemented "
                  "functions will be an external reference to the vendor libraries.")
 endif()
 


### PR DESCRIPTION
I noticed a small typo in the error message when the CUDA device libraries are not detected.