### PR TITLE
[flang] Make NULL() initializers explicit for allocatables in DATA co…

### DIFF
--- a/flang/lib/Evaluate/initial-image.cpp
+++ b/flang/lib/Evaluate/initial-image.cpp
@@ -119,9 +119,16 @@ public:
             for (std::size_t j{0}; j < elements; ++j, at += stride) {
               if (Result value{image_.AsConstantPointer(at)}) {
                 typedValue[j].emplace(component, std::move(*value));
+              } else {
+                typedValue[j].emplace(component, Expr<SomeType>{NullPointer{}});
               }
             }
-          } else if (!IsAllocatable(component)) {
+          } else if (IsAllocatable(component)) {
+            // Lowering needs an explicit NULL() for allocatables
+            for (std::size_t j{0}; j < elements; ++j, at += stride) {
+              typedValue[j].emplace(component, Expr<SomeType>{NullPointer{}});
+            }
+          } else {
             auto componentType{DynamicType::From(component)};
             CHECK(componentType.has_value());
             auto componentExtents{GetConstantExtents(context_, component)};

--- a/flang/test/Semantics/data19.f90
+++ b/flang/test/Semantics/data19.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang_fc1 -fdebug-dump-symbols %s 2>&1 | FileCheck %s
 ! Test truncation/padding in DATA statement.
-
+program main
   character(len=3) :: c1, c2, c3(2), c4(2)
   data c1(1:2), c1(3:3) /'123', '4'/
   data c2(1:2), c2(3:3) /'1', '2'/

--- a/flang/test/Semantics/data20.f90
+++ b/flang/test/Semantics/data20.f90
@@ -1,0 +1,18 @@
+! RUN: %flang_fc1 -fdebug-dump-symbols %s 2>&1 | FileCheck %s
+! Verify that allocatable components have explicit NULL() initializers
+! when converted from DATA statements
+!CHECK: x1 (InDataStmt) size=32 offset=0: ObjectEntity type: TYPE(t) init:t(a=NULL(),n=1_4)
+!CHECK: x2 (InDataStmt) size=64 offset=32: ObjectEntity type: TYPE(t) shape: 1_8:2_8 init:[t::t(a=NULL(),n=2_4),t(a=NULL(),n=3_4)]
+!CHECK: x3 (InDataStmt) size=64 offset=96: ObjectEntity type: TYPE(t2) init:t2(b=[t::t(a=NULL(),n=4_4),t(a=NULL(),n=5_4)])
+program main
+  type t
+    real, allocatable :: a
+    integer n
+  end type
+  type t2
+    type(t) b(2)
+  end type
+  type(t) x1, x2(2)
+  type(t2) x3
+  data x1%n/1/, x2(:)%n/2, 3/, x3%b(:)%n/4, 5/
+end


### PR DESCRIPTION
…nversion

As requested by people working on lowering: when semantics converts the contents of DATA statements into explicit object initializers, ensure that structure constructors for derived types contain explicit NULL() values for their allocatable components.