### PR TITLE
Update SimplifyIndVar.cpp

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
@@ -664,7 +664,7 @@ bool SimplifyIndvar::replaceFloatIVWithIntegerIV(Instruction *UseInst) {
     MaskBits = SE->getSignedRange(IV).getMinSignedBits();
   else
     MaskBits = SE->getUnsignedRange(IV).getActiveBits();
-  unsigned DestNumSigBits = UseInst->getType()->getFPMantissaWidth();
+  int DestNumSigBits = UseInst->getType()->getFPMantissaWidth();
   if (MaskBits <= DestNumSigBits) {
     for (User *U : UseInst->users()) {
       // Match for fptosi/fptoui of sitofp and with same type.


### PR DESCRIPTION
In SimplifyIndvar::replaceFloatIVWithIntegerIV() the return value of getFPMantissaWidth() was being cast as an unsigned integer and then compared with the number of bits needed to represent an integer that was cast to and from a floating-point type. This is a problem because getFPMantissaWidth() returns -1 if the type does not have a stable mantissa.

Currently the only type that returns -1 is ppc_fp128, so you'd need a pretty big induction variable to cause a problem. However, this problem will be more likely to be exposed when we implement support for decimal floating-point types.

Strictly speaking, what we want to know here is the size of the biggest integer that can be represented exactly. We could get that information even with an unstable mantissa width, but getFPMantissaWidth() won't do it.