### PR TITLE
[Github] Fetch number of commits in PR for docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,19 @@ jobs:
     name: "Test documentation build"
     runs-on: ubuntu-latest
     steps:
-      # Get changed files before we do a checkout to force the action to use
-      # the GH API to look for changed files and avoid an expensive partial
-      # fetch operation.
+      # Fetch all the commits in a pull request so that the
+      # docs-changed-subprojects step won't pull them in itself in an extremely
+      # slow manner.
+      - name: Fetch LLVM sources (PR)
+        if: ${{ github.event_name == 'pull_request' }} 
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event.pull_request.commits }}
+      - name: Fetch LLVM sources (push)
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Get subprojects that have doc changes
         id: docs-changed-subprojects
         uses: tj-actions/changed-files@v39
@@ -37,10 +47,6 @@ jobs:
               - 'llvm/docs/**'
             clang:
               - 'clang/docs/**'
-      - name: Fetch LLVM sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,9 @@ jobs:
     name: "Test documentation build"
     runs-on: ubuntu-latest
     steps:
+      # Get changed files before we do a checkout to force the action to use
+      # the GH API to look for changed files and avoid an expensive partial
+      # fetch operation.
       - name: Get subprojects that have doc changes
         id: docs-changed-subprojects
         uses: tj-actions/changed-files@v39

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,15 @@ jobs:
     name: "Test documentation build"
     runs-on: ubuntu-latest
     steps:
+      - name: Get subprojects that have doc changes
+        id: docs-changed-subprojects
+        uses: tj-actions/changed-files@v39
+        with:
+          files_yaml: |
+            llvm:
+              - 'llvm/docs/**'
+            clang:
+              - 'clang/docs/**'
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
@@ -41,15 +50,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build
-      - name: Get subprojects that have doc changes
-        id: docs-changed-subprojects
-        uses: tj-actions/changed-files@v39
-        with:
-          files_yaml: |
-            llvm:
-              - 'llvm/docs/**'
-            clang:
-              - 'clang/docs/**'
       - name: Build LLVM docs
         if: steps.docs-changed-subprojects.outputs.llvm_any_changed == 'true'
         run: |


### PR DESCRIPTION
This patches changes the docs action to run a fetch with a depth of the number of commits in the PR (1 if we're just running against a push event) which significantly increases the speed of the changed files event. The changed files event goes from taking ~30m to ~3s without any noticeable increase in fetch time.