### PR TITLE
[libunwind][AIX] static_cast the value from getLR() to avoid the warning from -Wconversion

### DIFF
--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -2404,7 +2404,7 @@ int UnwindCursor<A, R>::stepWithTBTable(pint_t pc, tbtable *TBTable,
     if (!TBTable->tb.saves_lr && registers.getLR()) {
       // This case should only occur if we were called from a signal handler
       // and the signal occurred in a function that doesn't save the LR.
-      returnAddress = registers.getLR();
+      returnAddress = static_cast<pint_t>(registers.getLR());
       _LIBUNWIND_TRACE_UNWINDING("Use saved LR=%p",
                                  reinterpret_cast<void *>(returnAddress));
     } else {


### PR DESCRIPTION
This PR adds `static_cast` to the value returned from `getLR()` in the AIX unwinder to avoid warning in case `-Wconversion` is specified to build in 32-bit mode.