### PR TITLE
Introduce DIExpressionOptimizer to DIExpression::appendOpsToArg

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -3073,6 +3073,67 @@ template <> struct DenseMapInfo<DIExpression::FragmentInfo> {
   static bool isEqual(const FragInfo &A, const FragInfo &B) { return A == B; }
 };
 
+/// Holds a DIExpression and keeps track of how many operands have been consumed
+/// so far.
+class DIExpressionCursor {
+  DIExpression::expr_op_iterator Start, End;
+
+public:
+  DIExpressionCursor(const DIExpression *Expr) {
+    if (!Expr) {
+      assert(Start == End);
+      return;
+    }
+    Start = Expr->expr_op_begin();
+    End = Expr->expr_op_end();
+  }
+
+  DIExpressionCursor(ArrayRef<uint64_t> Expr)
+      : Start(Expr.begin()), End(Expr.end()) {}
+
+  DIExpressionCursor(const DIExpressionCursor &) = default;
+
+  /// Consume one operation.
+  std::optional<DIExpression::ExprOperand> take() {
+    if (Start == End)
+      return std::nullopt;
+    return *(Start++);
+  }
+
+  /// Consume N operations.
+  void consume(unsigned N) { std::advance(Start, N); }
+
+  /// Return the current operation.
+  std::optional<DIExpression::ExprOperand> peek() const {
+    if (Start == End)
+      return std::nullopt;
+    return *(Start);
+  }
+
+  /// Return the next operation.
+  std::optional<DIExpression::ExprOperand> peekNext() const {
+    if (Start == End)
+      return std::nullopt;
+
+    auto Next = Start.getNext();
+    if (Next == End)
+      return std::nullopt;
+
+    return *Next;
+  }
+
+  /// Determine whether there are any operations left in this expression.
+  operator bool() const { return Start != End; }
+
+  DIExpression::expr_op_iterator begin() const { return Start; }
+  DIExpression::expr_op_iterator end() const { return End; }
+
+  /// Retrieve the fragment information, if any.
+  std::optional<DIExpression::FragmentInfo> getFragmentInfo() const {
+    return DIExpression::getFragmentInfo(Start, End);
+  }
+};
+
 /// Global variables.
 ///
 /// TODO: Remove DisplayName.  It's always equal to Name.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -31,67 +31,6 @@ class DIELoc;
 class TargetRegisterInfo;
 class MachineLocation;
 
-/// Holds a DIExpression and keeps track of how many operands have been consumed
-/// so far.
-class DIExpressionCursor {
-  DIExpression::expr_op_iterator Start, End;
-
-public:
-  DIExpressionCursor(const DIExpression *Expr) {
-    if (!Expr) {
-      assert(Start == End);
-      return;
-    }
-    Start = Expr->expr_op_begin();
-    End = Expr->expr_op_end();
-  }
-
-  DIExpressionCursor(ArrayRef<uint64_t> Expr)
-      : Start(Expr.begin()), End(Expr.end()) {}
-
-  DIExpressionCursor(const DIExpressionCursor &) = default;
-
-  /// Consume one operation.
-  std::optional<DIExpression::ExprOperand> take() {
-    if (Start == End)
-      return std::nullopt;
-    return *(Start++);
-  }
-
-  /// Consume N operations.
-  void consume(unsigned N) { std::advance(Start, N); }
-
-  /// Return the current operation.
-  std::optional<DIExpression::ExprOperand> peek() const {
-    if (Start == End)
-      return std::nullopt;
-    return *(Start);
-  }
-
-  /// Return the next operation.
-  std::optional<DIExpression::ExprOperand> peekNext() const {
-    if (Start == End)
-      return std::nullopt;
-
-    auto Next = Start.getNext();
-    if (Next == End)
-      return std::nullopt;
-
-    return *Next;
-  }
-
-  /// Determine whether there are any operations left in this expression.
-  operator bool() const { return Start != End; }
-
-  DIExpression::expr_op_iterator begin() const { return Start; }
-  DIExpression::expr_op_iterator end() const { return End; }
-
-  /// Retrieve the fragment information, if any.
-  std::optional<DIExpression::FragmentInfo> getFragmentInfo() const {
-    return DIExpression::getFragmentInfo(Start, End);
-  }
-};
-
 /// Base class containing the logic for constructing DWARF expressions
 /// independently of whether they are emitted into a DIE or into a .debug_loc
 /// entry.

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -1983,19 +1983,19 @@ DIExpression *DIExpression::append(const DIExpression *Expr,
 
   // Copy Expr's current op list.
   SmallVector<uint64_t, 16> NewOps;
+  DIExpressionOptimizer Optimizer;
   for (auto Op : Expr->expr_ops()) {
     // Append new opcodes before DW_OP_{stack_value, LLVM_fragment}.
     if (Op.getOp() == dwarf::DW_OP_stack_value ||
         Op.getOp() == dwarf::DW_OP_LLVM_fragment) {
-      NewOps.append(Ops.begin(), Ops.end());
+      Optimizer.optimize(NewOps, Ops);
 
       // Ensure that the new opcodes are only appended once.
       Ops = std::nullopt;
     }
     Op.appendToVector(NewOps);
   }
-
-  NewOps.append(Ops.begin(), Ops.end());
+  Optimizer.optimize(NewOps, Ops);
   auto *result = DIExpression::get(Expr->getContext(), NewOps);
   assert(result->isValid() && "concatenated expression is not valid");
   return result;

--- a/llvm/test/DebugInfo/MIR/AArch64/dbgcall-site-expr-chain.mir
+++ b/llvm/test/DebugInfo/MIR/AArch64/dbgcall-site-expr-chain.mir
@@ -105,7 +105,7 @@ body:             |
 
 # CHECK: DW_TAG_GNU_call_site_parameter
 # CHECK-NEXT: DW_AT_location (DW_OP_reg2 W2)
-# CHECK-NEXT: DW_AT_GNU_call_site_value (DW_OP_breg19 W19+700, DW_OP_plus_uconst 0x9, DW_OP_plus_uconst 0x50)
+# CHECK-NEXT: DW_AT_GNU_call_site_value (DW_OP_breg19 W19+789)
 
 # CHECK: DW_TAG_GNU_call_site_parameter
 # CHECK-NEXT: DW_AT_location (DW_OP_reg1 W1)
@@ -113,4 +113,4 @@ body:             |
 
 # CHECK: DW_TAG_GNU_call_site_parameter
 # CHECK-NEXT: DW_AT_location (DW_OP_reg0 W0)
-# CHECK-NEXT: DW_AT_GNU_call_site_value (DW_OP_breg19 W19+100, DW_OP_plus_uconst 0x17)
+# CHECK-NEXT: DW_AT_GNU_call_site_value (DW_OP_breg19 W19+123)

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -3132,12 +3132,17 @@ TEST_F(DIExpressionTest, optimize) {
                        dwarf::DW_OP_plus};
   auto *ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  auto *AppendToArgExpr =
+      DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_plus_uconst, <const>} to a DW_OP_plus
   // expression
   uint64_t PlusUConstOps[] = {dwarf::DW_OP_plus_uconst, 3};
   AppendExpr = DIExpression::append(Expr, PlusUConstOps);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_constu, 0, DW_OP_plus} to an expression
   AppendOps[1] = 0;
@@ -3145,6 +3150,8 @@ TEST_F(DIExpressionTest, optimize) {
   OpsRes[3] = Ops[3];
   ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_constu, 0, DW_OP_minus} to an expression
   AppendOps[2] = dwarf::DW_OP_minus;
@@ -3152,6 +3159,8 @@ TEST_F(DIExpressionTest, optimize) {
   OpsRes[3] = Ops[3];
   ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_constu, 0, DW_OP_shl} to an expression
   AppendOps[2] = dwarf::DW_OP_shl;
@@ -3159,6 +3168,8 @@ TEST_F(DIExpressionTest, optimize) {
   OpsRes[3] = Ops[3];
   ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_constu, 0, DW_OP_shr} to an expression
   AppendOps[2] = dwarf::DW_OP_shr;
@@ -3166,6 +3177,8 @@ TEST_F(DIExpressionTest, optimize) {
   OpsRes[3] = Ops[3];
   ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_constu, <const>, DW_OP_mul} to a DW_OP_mul
   // expression
@@ -3178,6 +3191,8 @@ TEST_F(DIExpressionTest, optimize) {
   OpsRes[4] = dwarf::DW_OP_mul;
   ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_constu, 1, DW_OP_mul} to an expression
   AppendOps[1] = 1;
@@ -3185,6 +3200,8 @@ TEST_F(DIExpressionTest, optimize) {
   OpsRes[3] = Ops[3];
   ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 
   // Test appending a {dwarf::DW_OP_constu, 1, DW_OP_div} to an expression
   AppendOps[1] = 1;
@@ -3193,6 +3210,8 @@ TEST_F(DIExpressionTest, optimize) {
   OpsRes[3] = Ops[3];
   ResExpr = DIExpression::get(Context, OpsRes);
   EXPECT_EQ(ResExpr, AppendExpr);
+  AppendToArgExpr = DIExpression::appendOpsToArg(Expr, AppendOps, 0, false);
+  EXPECT_EQ(ResExpr, AppendToArgExpr);
 }
 
 TEST_F(DIExpressionTest, isValid) {


### PR DESCRIPTION
This commit is used to use the new DIExpressionOptimizer class to optimize DIExpression::appendOpsToArg calls.

The results of this work reduced the debug_loc section in clang.dSYM build with Cmake option RelWithDebInfo from 204.337 MB to 204.022 MB

This patch is part of a stacked diff, I was not sure how to do this any better because github squashes multiple commits in one PR, but the PRs this depends on are:

https://github.com/llvm/llvm-project/pull/69768
https://github.com/llvm/llvm-project/pull/69769
https://github.com/llvm/llvm-project/pull/69770