### PR TITLE
[Github] Only run github actions on main monorepo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,7 @@ jobs:
   check-docs-build:
     name: "Test documentation build"
     runs-on: ubuntu-latest
+    if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -6,6 +6,7 @@ permissions:
 jobs:
   code_formatter:
     runs-on: ubuntu-latest
+    if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4


### PR DESCRIPTION
There are currently a couple jobs that run on all forks of LLVM too (if there is a PR opened, or in the case of the documentation builds, upon pushing to main). This isn't desired behavior. This commit disables that behavior, forcing the jobs to not run if they aren't running against llvm/llvm-project or a PR against that repo.