### PR TITLE
[clangd] Fix RawStringLiteral being available to C and C++ versions prior to C++11

### DIFF
--- a/clang-tools-extra/clangd/refactor/tweaks/RawStringLiteral.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/RawStringLiteral.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include "ParsedAST.h"
 #include "refactor/Tweak.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Stmt.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"
@@ -43,6 +44,12 @@ private:
 
 REGISTER_TWEAK(RawStringLiteral)
 
+static bool isFeatureAvailable(const ASTContext &Context) {
+  // Raw strings are available only for C++11 or later versions, and they are
+  // not available for C.
+  return Context.getLangOpts().CPlusPlus11;
+}
+
 static bool isNormalString(const StringLiteral &Str, SourceLocation Cursor,
                           SourceManager &SM) {
   // All chunks must be normal ASCII strings, not u8"..." etc.
@@ -72,6 +79,9 @@ static bool canBeRaw(llvm::StringRef Content) {
 }
 
 bool RawStringLiteral::prepare(const Selection &Inputs) {
+  if (!isFeatureAvailable(Inputs.AST->getASTContext())) {
+    return false;
+  }
   const SelectionTree::Node *N = Inputs.ASTSelection.commonAncestor();
   if (!N)
     return false;

--- a/clang-tools-extra/clangd/unittests/tweaks/RawStringLiteralTests.cpp
+++ b/clang-tools-extra/clangd/unittests/tweaks/RawStringLiteralTests.cpp
@@ -36,6 +36,20 @@ literal)")cpp";
   EXPECT_EQ(apply(Input), Output);
 }
 
+TEST_F(RawStringLiteralTest, TestC) {
+  Context = File;
+  FileName = "TestTU.c";
+  ExtraArgs = {"-xc"}; // raw strings are unavailable in C
+  EXPECT_UNAVAILABLE(R"c(const char *a = ^"^f^o^o^\^n^";)c");
+}
+
+TEST_F(RawStringLiteralTest, TestCpp98) {
+  Context = File;
+  ExtraArgs = {"-std=c++98"}; // raw strings are unavailable
+                              // in versions prior to C++11
+  EXPECT_UNAVAILABLE(R"cpp(const char *a = ^"^f^o^o^\^n^";)cpp");
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang


### PR DESCRIPTION
The `RawStringLiteral` code action runs both on C and C++ versions prior to C++11, where this feature is unavailable.

This patch adds a condition to check if the context is running a version equal or greater than C++11 and adds tests for failing in the wrong versions.

Fixes https://github.com/clangd/clangd/issues/1795.