### PR TITLE
[flang] Fix regression in submodule symbol checking

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -2395,6 +2395,10 @@ void CheckHelper::Check(const Scope &scope) {
     for (const auto &pair : scope) {
       Check(*pair.second);
     }
+    if (scope.IsSubmodule() && scope.symbol()) {
+      // Submodule names are not in their parent's scopes
+      Check(*scope.symbol());
+    }
     for (const auto &pair : scope.commonBlocks()) {
       CheckCommonBlock(*pair.second);
     }


### PR DESCRIPTION
The change https://github.com/llvm/llvm-project/pull/67361 removed submodule name symbols from the name dictionaries of their parent (sub)modules to prevent needless errors about name clashes, but these symbols still need to be checked for things like excessive length.