### PR TITLE
[compiler-rt] Switch LLD specific tests to a more precise option

### DIFF
--- a/compiler-rt/test/profile/Windows/coverage-weak-lld.cpp
+++ b/compiler-rt/test/profile/Windows/coverage-weak-lld.cpp
@@ -14,7 +14,7 @@
 // RUN: llvm-profdata show %t.profraw --all-functions | FileCheck %s --check-prefix=PROFILE1
 
 /// link.exe does not support weak overridding weak.
-// RUN: %clang_profgen -fcoverage-mapping -fuse-ld=lld -Wl,-lldmingw,-opt:ref %t0.o %t2.o -o %t2
+// RUN: %clang_profgen -fcoverage-mapping -fuse-ld=lld -Wl,-lld-allow-duplicate-weak,-opt:ref %t0.o %t2.o -o %t2
 // RUN: env LLVM_PROFILE_FILE=%t.profraw %run %t2 | FileCheck %s --check-prefix=CHECK2
 // RUN: llvm-profdata show %t.profraw --all-functions | FileCheck %s --check-prefix=PROFILE2
 
@@ -30,7 +30,7 @@
 // RUN: env LLVM_PROFILE_FILE=%t.profraw %run %t1 | FileCheck %s --check-prefix=CHECK1
 // RUN: llvm-profdata show %t.profraw --all-functions | FileCheck %s --check-prefix=PROFILE1
 
-// RUN: %clang_profgen -fcoverage-mapping -fuse-ld=lld -Wl,-lldmingw,-opt:ref %t0.o %t2.o -o %t2
+// RUN: %clang_profgen -fcoverage-mapping -fuse-ld=lld -Wl,-lld-allow-duplicate-weak,-opt:ref %t0.o %t2.o -o %t2
 // RUN: env LLVM_PROFILE_FILE=%t.profraw %run %t2 | FileCheck %s --check-prefix=CHECK2
 // RUN: llvm-profdata show %t.profraw --all-functions | FileCheck %s --check-prefix=PROFILE2
 


### PR DESCRIPTION
Prefer the new flag -lld-allow-duplicate-weak (which was added recently in a67ae8c0fd301a11e2a058e8035304cfc70a3e91), over the old -lldmingw.

The -lldmingw option enables a number of different behaviours, while this test only is interested in one aspect of them.

This should allow making -lldmingw more strict with not enabling MSVC specific behaviours like inferring lib directories automatically from the environment, as being pursued in https://reviews.llvm.org/D144084.