### PR TITLE
[lldb] improve dwo path in missing dwo error when relative

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1855,10 +1855,16 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
   }
 
   if (!found) {
+    FileSpec error_dwo_path(dwo_name);
+    FileSystem::Instance().Resolve(error_dwo_path);
+    if (error_dwo_path.IsRelative() && comp_dir != nullptr) {
+      error_dwo_path.PrependPathComponent(comp_dir);
+      FileSystem::Instance().Resolve(error_dwo_path);
+    }
     unit.SetDwoError(Status::createWithFormat(
         "unable to locate .dwo debug file \"{0}\" for skeleton DIE "
         "{1:x16}",
-        dwo_file.GetPath().c_str(), cu_die.GetOffset()));
+        error_dwo_path.GetPath().c_str(), cu_die.GetOffset()));
 
     if (m_dwo_warning_issued.test_and_set(std::memory_order_relaxed) == false) {
       GetObjectFile()->GetModule()->ReportWarning(

--- a/lldb/test/Shell/SymbolFile/DWARF/Inputs/dwo-missing-error.c
+++ b/lldb/test/Shell/SymbolFile/DWARF/Inputs/dwo-missing-error.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/lldb/test/Shell/SymbolFile/DWARF/dwo-missing-error.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/dwo-missing-error.test
@@ -1,0 +1,34 @@
+# Check that LLDB prints an error message containing the DWO_AT_comp_dir and
+# DW_AT_dwo_name when it can't find a DWO and the DW_AT_comp_dir and
+# DW_AT_dwo_name are relative.
+
+# -gsplit-dwarf is supported only on Linux.
+# REQUIRES: system-linux
+
+# Test the error message with a relative DW_AT_comp_dir and DW_AT_dwo_name.
+# Creating and compiling to %t.compdir makes it easy to remove the dwo files.
+# DW_AT_comp_dir should be "./a/b/", and DW_AT_dwo_name should be
+# "a.out-dwo-missing-error.dwo".
+# since %T is deprecated.
+# RUN: rm -rf %t.compdir/
+# RUN: mkdir -p %t.compdir/a/b/
+# RUN: cd %t.compdir/a/b/
+# RUN: %clang_host %S/Inputs/dwo-missing-error.c -glldb -gdwarf-5 \
+# RUN:     -gsplit-dwarf -fdebug-prefix-map=%t.compdir=. -o a.out
+# RUN: rm *.dwo
+# RUN: %lldb a.out -s %s -o exit 2>&1 | FileCheck %s 
+# RUN: cd -
+
+# Test the error message with an absolute DW_AT_comp_dir and DW_AT_dwo_name.
+# RUN: rm -rf %t.compdir/
+# RUN: mkdir -p %t.compdir/a/b/
+# RUN: %clang_host %S/Inputs/dwo-missing-error.c -glldb -gdwarf-5 \
+# RUN:     -gsplit-dwarf -o %t.compdir/a/b/a.out
+# RUN: rm %t.compdir/a/b/*.dwo
+# RUN: %lldb %t.compdir/a/b/a.out -s %s -o exit 2>&1 | FileCheck %s 
+
+b main
+run
+
+fr v
+# CHECK: error: unable to locate .dwo debug file "{{.*}}a/b/a.out-dwo-missing-error.dwo" for skeleton DIE {{.*}}


### PR DESCRIPTION
When the debug info refers to a dwo with relative `DW_AT_comp_dir` and `DW_AT_dwo_name`, we only print the `DW_AT_comp_dir` in our error message if we can't find it. This often isn't very helpful, especially when the `DW_AT_comp_dir` is ".":
```
(lldb) fr v
error: unable to locate .dwo debug file "." for skeleton DIE 0x000000000000003c
```

I'm updating the error message to include both `DW_AT_comp_dir` (if it exists) and `DW_AT_dwo_name` when the `DW_AT_dwo_name` is relative. The behavior when `DW_AT_dwo_name` is absolute should be the same.