### PR TITLE
[LLDB] Update breakpoint-command.test to use string instead of number.

### DIFF
--- a/lldb/test/Shell/Breakpoint/breakpoint-command.test
+++ b/lldb/test/Shell/Breakpoint/breakpoint-command.test
@@ -1,7 +1,7 @@
 # REQUIRES: lua || python
 
 # RUN: %build %p/Inputs/dummy-target.c -o %t.out
-# RUN: %lldb %t.out -o 'b main' -o 'break command add 1 -o "script print(95000 + 126)"' -o 'r' | FileCheck %s
+# RUN: %lldb %t.out -o 'b main' -o 'break command add 1 -o "script print(\"A R4Nd0m\" + \" Str1ng\")"' -o 'r' | FileCheck %s
 
-# CHECK: 95126
-# CHECK-NOT: 95126
+# CHECK: A R4Nd0m Str1ng
+# CHECK-NOT: A R4Nd0m Str1ng


### PR DESCRIPTION
lldb/test/Shell/Breakpoint/breakpoint-command.test adds a python command, to be executed when a breakpoint hits, that writes out a number. It then runs, hits the breakpoint and checks that the number is present exactly once.

The problem is that on some systems the test can be run in a filepath that happens to contain the number (e.g. auto-generated directory names). The number is then detected multiple times and the test fails.

This patch fixes the issue by using a string instead, particularly a string with spaces, which is very unlikely to be auto-generated by any system.