### PR TITLE
[Driver] Clean up unused architecture related bits for *BSD's

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -247,12 +247,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     switch (os) {
     case llvm::Triple::Linux:
       return std::make_unique<LinuxTargetInfo<ARMbeTargetInfo>>(Triple, Opts);
-    case llvm::Triple::FreeBSD:
-      return std::make_unique<FreeBSDTargetInfo<ARMbeTargetInfo>>(Triple, Opts);
     case llvm::Triple::NetBSD:
       return std::make_unique<NetBSDTargetInfo<ARMbeTargetInfo>>(Triple, Opts);
-    case llvm::Triple::OpenBSD:
-      return std::make_unique<OpenBSDTargetInfo<ARMbeTargetInfo>>(Triple, Opts);
     case llvm::Triple::RTEMS:
       return std::make_unique<RTEMSTargetInfo<ARMbeTargetInfo>>(Triple, Opts);
     case llvm::Triple::NaCl:
@@ -487,15 +483,11 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       return std::make_unique<SparcV8TargetInfo>(Triple, Opts);
     }
 
-  // The 'sparcel' architecture copies all the above cases except for Solaris.
   case llvm::Triple::sparcel:
     switch (os) {
     case llvm::Triple::Linux:
       return std::make_unique<LinuxTargetInfo<SparcV8elTargetInfo>>(Triple,
                                                                     Opts);
-    case llvm::Triple::NetBSD:
-      return std::make_unique<NetBSDTargetInfo<SparcV8elTargetInfo>>(Triple,
-                                                                     Opts);
     case llvm::Triple::RTEMS:
       return std::make_unique<RTEMSTargetInfo<SparcV8elTargetInfo>>(Triple,
                                                                     Opts);

--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -88,8 +88,6 @@ void freebsd::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-meabi=5");
     break;
   }
-  case llvm::Triple::sparc:
-  case llvm::Triple::sparcel:
   case llvm::Triple::sparcv9: {
     std::string CPU = getCPUName(D, Args, getToolChain().getTriple());
     CmdArgs.push_back(
@@ -167,7 +165,7 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("/libexec/ld-elf.so.1");
     }
     const llvm::Triple &T = ToolChain.getTriple();
-    if (Arch == llvm::Triple::arm || Arch == llvm::Triple::sparc || T.isX86())
+    if (Arch == llvm::Triple::arm || T.isX86())
       CmdArgs.push_back("--hash-style=both");
     CmdArgs.push_back("--enable-new-dtags");
   }

--- a/clang/lib/Driver/ToolChains/NetBSD.cpp
+++ b/clang/lib/Driver/ToolChains/NetBSD.cpp
@@ -78,8 +78,7 @@ void netbsd::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
     break;
   }
 
-  case llvm::Triple::sparc:
-  case llvm::Triple::sparcel: {
+  case llvm::Triple::sparc: {
     CmdArgs.push_back("-32");
     std::string CPU = getCPUName(D, Args, Triple);
     CmdArgs.push_back(sparc::getSparcAsmModeForCPU(CPU, Triple));

--- a/clang/lib/Driver/ToolChains/OpenBSD.cpp
+++ b/clang/lib/Driver/ToolChains/OpenBSD.cpp
@@ -45,8 +45,7 @@ void openbsd::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("--32");
     break;
 
-  case llvm::Triple::arm:
-  case llvm::Triple::armeb: {
+  case llvm::Triple::arm: {
     StringRef MArch, MCPU;
     arm::getARMArchCPUFromArgs(Args, MArch, MCPU, /*FromAs*/ true);
     std::string Arch = arm::getARMTargetCPU(MCPU, MArch, Triple);

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -163,9 +163,9 @@
 // CHECK-ARM-EABIHF-NOT: as{{.*}}" "-mfpu=softvfp"
 // CHECK-ARM-EABIHF-NOT: as{{.*}}" "-matpcs"
 
-// RUN: %clang --target=sparc-unknown-freebsd -### %s -fpic -no-integrated-as 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-SPARC-PIE %s
-// CHECK-SPARC-PIE: as{{.*}}" "-KPIC
+// RUN: %clang --target=sparc64-unknown-freebsd -### %s -fpic -no-integrated-as 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-SPARC-PIC %s
+// CHECK-SPARC-PIC: as{{.*}}" "-KPIC
 
 // RUN: %clang -mcpu=ultrasparc --target=sparc64-unknown-freebsd -### %s -no-integrated-as 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-SPARC-CPU %s
@@ -190,11 +190,6 @@
 // RUN: %clang --target=mips64el-unknown-freebsd -### -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-MIPS64-CPU %s
 // CHECK-MIPS64-CPU: "-target-cpu" "mips3"
-
-// Check that the integrated assembler is enabled for SPARC64
-// RUN: %clang --target=sparc64-unknown-freebsd -### -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHECK-IAS %s
-// CHECK-IAS-NOT: "-no-integrated-as"
 
 // RUN: %clang --target=ppc64-unknown-freebsd13.0 -### -S %s 2>&1 | \
 // RUN: FileCheck -check-prefix=PPC64-MUNWIND %s


### PR DESCRIPTION
- FreeBSD removed big-endian arm with 12.0.
- OpenBSD never had big-endian arm support. I added it just in case, but it has never been used.
- Remove sparcel bits. It was sprinkled in a few places but it will never be a thing.
- Remove 32-bit sparc bits for FreeBSD. FreeBSD has never had 32-bit sparc support.
- Remove sparc64 IAS test as support was enabled across the board awhile ago.