### PR TITLE
[lldb] Add value to enumerator dump

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -8550,7 +8550,8 @@ static bool DumpEnumValue(const clang::QualType &qual_type, Stream &s,
     ++num_enumerators;
     if (val == enum_svalue) {
       // Found an exact match, that's all we need to do.
-      s.Printf("%s(%" PRIi64 ")", enumerator->getNameAsString().c_str(), enum_svalue);
+      s.Printf("%s(%" PRIi64 ")", enumerator->getNameAsString().c_str(),
+               enum_svalue);
       return true;
     }
   }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -8550,7 +8550,7 @@ static bool DumpEnumValue(const clang::QualType &qual_type, Stream &s,
     ++num_enumerators;
     if (val == enum_svalue) {
       // Found an exact match, that's all we need to do.
-      s.PutCString(enumerator->getNameAsString());
+      s.Printf("%s(%" PRIi64 ")", enumerator->getNameAsString().c_str(), enum_svalue);
       return true;
     }
   }

--- a/lldb/test/API/commands/expression/cast_int_to_anonymous_enum/TestCastIntToAnonymousEnum.py
+++ b/lldb/test/API/commands/expression/cast_int_to_anonymous_enum/TestCastIntToAnonymousEnum.py
@@ -18,4 +18,4 @@ class TestCastIntToAnonymousEnum(TestBase):
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )
 
-        self.expect_expr("(flow_e)0", result_type="flow_e", result_value="A")
+        self.expect_expr("(flow_e)0", result_type="flow_e", result_value="A(0)")

--- a/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
@@ -22,12 +22,12 @@ class EnumTypesTestCase(TestBase):
             self, "// Breakpoint for bitfield", lldb.SBFileSpec("main.c")
         )
 
-        self.expect("fr var a", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = A$"])
-        self.expect("fr var b", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = B$"])
-        self.expect("fr var c", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = C$"])
-        self.expect("fr var ab", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = AB$"])
+        self.expect("fr var a", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = A\\(1\\)$"])
+        self.expect("fr var b", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = B\\(2\\)$"])
+        self.expect("fr var c", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = C\\(4\\)$"])
+        self.expect("fr var ab", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = AB\\(3\\)$"])
         self.expect("fr var ac", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = A | C$"])
-        self.expect("fr var all", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = ALL$"])
+        self.expect("fr var all", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = ALL\\(7\\)$"])
         # Test that an enum that doesn't match the heuristic we use in
         # TypeSystemClang::DumpEnumValue, gets printed as a raw integer.
         self.expect("fr var omega", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = 7$"])

--- a/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
@@ -22,12 +22,22 @@ class EnumTypesTestCase(TestBase):
             self, "// Breakpoint for bitfield", lldb.SBFileSpec("main.c")
         )
 
-        self.expect("fr var a", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = A\\(1\\)$"])
-        self.expect("fr var b", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = B\\(2\\)$"])
-        self.expect("fr var c", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = C\\(4\\)$"])
-        self.expect("fr var ab", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = AB\\(3\\)$"])
+        self.expect(
+            "fr var a", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = A\\(1\\)$"]
+        )
+        self.expect(
+            "fr var b", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = B\\(2\\)$"]
+        )
+        self.expect(
+            "fr var c", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = C\\(4\\)$"]
+        )
+        self.expect(
+            "fr var ab", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = AB\\(3\\)$"]
+        )
         self.expect("fr var ac", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = A | C$"])
-        self.expect("fr var all", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = ALL\\(7\\)$"])
+        self.expect(
+            "fr var all", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = ALL\\(7\\)$"]
+        )
         # Test that an enum that doesn't match the heuristic we use in
         # TypeSystemClang::DumpEnumValue, gets printed as a raw integer.
         self.expect("fr var omega", DATA_TYPES_DISPLAYED_CORRECTLY, patterns=[" = 7$"])

--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -57,12 +57,12 @@ class TestCase(TestBase):
         self.expect_expr("A::wchar_min == wchar_min", result_value="true")
 
         # Test an unscoped enum.
-        self.expect_expr("A::enum_val", result_value="enum_case2")
+        self.expect_expr("A::enum_val", result_value="enum_case2(2)")
         # Test an unscoped enum with bool as the underlying type.
-        self.expect_expr("A::enum_bool_val", result_value="enum_bool_case1")
+        self.expect_expr("A::enum_bool_val", result_value="enum_bool_case1(0)")
 
         # Test a scoped enum.
-        self.expect_expr("A::scoped_enum_val", result_value="scoped_enum_case2")
+        self.expect_expr("A::scoped_enum_val", result_value="scoped_enum_case2(2)")
         # Test an scoped enum with a value that isn't an enumerator.
         self.expect_expr(
             "A::not_enumerator_scoped_enum_val", result_value="scoped_enum_case1 | 0x4"
@@ -74,9 +74,9 @@ class TestCase(TestBase):
         )
 
         # Test an enum with fixed underlying type.
-        self.expect_expr("A::scoped_char_enum_val", result_value="case2")
-        self.expect_expr("A::scoped_ll_enum_val_neg", result_value="case0")
-        self.expect_expr("A::scoped_ll_enum_val", result_value="case2")
+        self.expect_expr("A::scoped_char_enum_val", result_value="case2(2)")
+        self.expect_expr("A::scoped_ll_enum_val_neg", result_value="case0(-9223372036854775808)")
+        self.expect_expr("A::scoped_ll_enum_val", result_value="case2(9223372036854775807)")
 
         # Test taking address.
         if lldbplatformutil.getPlatform() == "windows":
@@ -126,15 +126,15 @@ class TestCase(TestBase):
 
         # Test `constexpr static`.
         self.expect_expr("ClassWithConstexprs::member", result_value="2")
-        self.expect_expr("ClassWithConstexprs::enum_val", result_value="enum_case2")
+        self.expect_expr("ClassWithConstexprs::enum_val", result_value="enum_case2(2)")
         self.expect_expr(
-            "ClassWithConstexprs::scoped_enum_val", result_value="scoped_enum_case2"
+            "ClassWithConstexprs::scoped_enum_val", result_value="scoped_enum_case2(2)"
         )
 
         # Test an aliased enum with fixed underlying type.
         self.expect_expr(
-            "ClassWithEnumAlias::enum_alias", result_value="scoped_enum_case2"
+            "ClassWithEnumAlias::enum_alias", result_value="scoped_enum_case2(2)"
         )
         self.expect_expr(
-            "ClassWithEnumAlias::enum_alias_alias", result_value="scoped_enum_case1"
+            "ClassWithEnumAlias::enum_alias_alias", result_value="scoped_enum_case1(1)"
         )

--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -75,8 +75,12 @@ class TestCase(TestBase):
 
         # Test an enum with fixed underlying type.
         self.expect_expr("A::scoped_char_enum_val", result_value="case2(2)")
-        self.expect_expr("A::scoped_ll_enum_val_neg", result_value="case0(-9223372036854775808)")
-        self.expect_expr("A::scoped_ll_enum_val", result_value="case2(9223372036854775807)")
+        self.expect_expr(
+            "A::scoped_ll_enum_val_neg", result_value="case0(-9223372036854775808)"
+        )
+        self.expect_expr(
+            "A::scoped_ll_enum_val", result_value="case2(9223372036854775807)"
+        )
 
         # Test taking address.
         if lldbplatformutil.getPlatform() == "windows":

--- a/lldb/test/API/lang/cpp/enum_types/TestCPP11EnumTypes.py
+++ b/lldb/test/API/lang/cpp/enum_types/TestCPP11EnumTypes.py
@@ -23,9 +23,18 @@ class CPP11EnumTypesTestCase(TestBase):
             substrs=["Case1", "Case2", "Case3"],
         )
         # Test each case in the enum.
-        self.expect("expr var1_" + suffix, patterns=[f"\\({enum_name}\\) \\$\\d+ = Case1\\(-?\\d+\\)"])
-        self.expect("expr var2_" + suffix, patterns=[f"\\({enum_name}\\) \\$\\d+ = Case2\\(-?\\d+\\)"])
-        self.expect("expr var3_" + suffix, patterns=[f"\\({enum_name}\\) \\$\\d+ = Case3\\(-?\\d+\\)"])
+        self.expect(
+            "expr var1_" + suffix,
+            patterns=[f"\\({enum_name}\\) \\$\\d+ = Case1\\(-?\\d+\\)"],
+        )
+        self.expect(
+            "expr var2_" + suffix,
+            patterns=[f"\\({enum_name}\\) \\$\\d+ = Case2\\(-?\\d+\\)"],
+        )
+        self.expect(
+            "expr var3_" + suffix,
+            patterns=[f"\\({enum_name}\\) \\$\\d+ = Case3\\(-?\\d+\\)"],
+        )
 
         if unsigned:
             self.expect_expr(

--- a/lldb/test/API/lang/cpp/enum_types/TestCPP11EnumTypes.py
+++ b/lldb/test/API/lang/cpp/enum_types/TestCPP11EnumTypes.py
@@ -23,9 +23,9 @@ class CPP11EnumTypesTestCase(TestBase):
             substrs=["Case1", "Case2", "Case3"],
         )
         # Test each case in the enum.
-        self.expect_expr("var1_" + suffix, result_type=enum_name, result_value="Case1")
-        self.expect_expr("var2_" + suffix, result_type=enum_name, result_value="Case2")
-        self.expect_expr("var3_" + suffix, result_type=enum_name, result_value="Case3")
+        self.expect("expr var1_" + suffix, patterns=[f"\\({enum_name}\\) \\$\\d+ = Case1\\(-?\\d+\\)"])
+        self.expect("expr var2_" + suffix, patterns=[f"\\({enum_name}\\) \\$\\d+ = Case2\\(-?\\d+\\)"])
+        self.expect("expr var3_" + suffix, patterns=[f"\\({enum_name}\\) \\$\\d+ = Case3\\(-?\\d+\\)"])
 
         if unsigned:
             self.expect_expr(

--- a/lldb/test/API/lang/rust/enum-structs/TestRustEnumStructs.py
+++ b/lldb/test/API/lang/rust/enum-structs/TestRustEnumStructs.py
@@ -32,7 +32,7 @@ class TestRustEnumStructs(TestBase):
             self.target().FindFirstGlobalVariable("CLIKE_U32_B").GetValue(),
         ]
         self.assertEqual(
-            all_values, ["A", "B", "VariantA", "VariantC", "VariantA", "VariantB"]
+            all_values, ["A(2)", "B(10)", "VariantA(0)", "VariantC(2)", "VariantA(1)", "VariantB(2)"]
         )
 
     def test_enum_with_tuples_has_all_variants(self):

--- a/lldb/test/API/lang/rust/enum-structs/TestRustEnumStructs.py
+++ b/lldb/test/API/lang/rust/enum-structs/TestRustEnumStructs.py
@@ -32,7 +32,15 @@ class TestRustEnumStructs(TestBase):
             self.target().FindFirstGlobalVariable("CLIKE_U32_B").GetValue(),
         ]
         self.assertEqual(
-            all_values, ["A(2)", "B(10)", "VariantA(0)", "VariantC(2)", "VariantA(1)", "VariantB(2)"]
+            all_values,
+            [
+                "A(2)",
+                "B(10)",
+                "VariantA(0)",
+                "VariantC(2)",
+                "VariantA(1)",
+                "VariantB(2)",
+            ],
         )
 
     def test_enum_with_tuples_has_all_variants(self):


### PR DESCRIPTION
This patch adds the value to enumerator dump, e.g. `Enumerator` now dumped as `Enumerator(0)`. There are not-so-uncommon cases when value of enumerator is no less important than its name. One example can be found in https://github.com/llvm/llvm-project/blob/4aae5387a874a55ee491f5dc23ce0506c5cdc678/clang/include/clang/AST/DeclarationName.h#L183 Another one, number of bits to shift, can be found in https://github.com/llvm/llvm-project/blob/4aae5387a874a55ee491f5dc23ce0506c5cdc678/llvm/include/llvm/ADT/PointerIntPair.h#L181