### PR TITLE
[Github] Add lld to docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ on:
       - 'libunwind/docs/**'
       - 'libcxx/docs/**'
       - 'libc/docs/**'
+      - 'lld/docs/**'
   pull_request:
     paths:
       - 'llvm/docs/**'
@@ -29,6 +30,7 @@ on:
       - 'libunwind/docs/**'
       - 'libcxx/docs/**'
       - 'libc/docs/**'
+      - 'lld/docs/**'
 
 jobs:
   check-docs-build:
@@ -63,6 +65,8 @@ jobs:
               - 'libcxx/docs/**'
             libc:
               - 'libc/docs/**'
+            lld:
+              - 'lld/docs/**'
       - name: Fetch LLVM sources (PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
@@ -116,4 +120,9 @@ jobs:
         run: |
           cmake -B libc-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libc" -DLLVM_ENABLE_SPHINX=ON ./runtimes
           TZ=UTC ninja -C docs-libc-html
+      - name: Build LLD docs
+        if: steps.docs-changed-subprojects.outputs.lld_any_changed == 'true'
+        run: |
+          cmake -B lld-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="lld" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON ./llvm
+          TZ=UTC ninja -C lld-build docs-lld-html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -123,6 +123,6 @@ jobs:
       - name: Build LLD docs
         if: steps.docs-changed-subprojects.outputs.lld_any_changed == 'true'
         run: |
-          cmake -B lld-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="lld" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_OUTPUT_HTML=ON ./llvm
+          cmake -B lld-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="lld" -DLLVM_ENABLE_SPHINX=ON ./llvm
           TZ=UTC ninja -C lld-build docs-lld-html
 


### PR DESCRIPTION
This patch adds the lld documentation to the documentation github actions CI to automatically validate in PRs/at tip of tree that the docs build and there aren't any Sphinx warnings. There is existing buildbot coverage for the lld docs, but this much more convienient to use in cases like PRs.