### PR TITLE
[Github] Add support for building libc docs in Github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -115,6 +115,6 @@ jobs:
         if: steps.docs-changed-subprojects.outputs.libc_any_changed == 'true'
         run: |
           cmake -B libc-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libc" -DLLVM_ENABLE_SPHINX=ON ./runtimes
-          TZ=UTC ninja -C libc-build docs-libc-html
+          TZ=UTC ninja -C docs-libc-html
 
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -117,4 +117,3 @@ jobs:
           cmake -B libc-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libc" -DLLVM_ENABLE_SPHINX=ON ./runtimes
           TZ=UTC ninja -C docs-libc-html
 
-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ on:
       - 'lldb/docs/**'
       - 'libunwind/docs/**'
       - 'libcxx/docs/**'
+      - 'libc/docs/**'
   pull_request:
     paths:
       - 'llvm/docs/**'
@@ -27,6 +28,7 @@ on:
       - 'lldb/docs/**'
       - 'libunwind/docs/**'
       - 'libcxx/docs/**'
+      - 'libc/docs/**'
 
 jobs:
   check-docs-build:
@@ -59,6 +61,8 @@ jobs:
               - 'libunwind/docs/**'
             libcxx:
               - 'libcxx/docs/**'
+            libc:
+              - 'libc/docs/**'
       - name: Fetch LLVM sources (PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
@@ -107,4 +111,10 @@ jobs:
         run: |
           cmake -B libcxx-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libcxxabi;libcxx" -DLLVM_ENABLE_SPHINX=ON ./runtimes
           TZ=UTC ninja -C libcxx-build docs-libcxx-html
+      - name: Build libc docs
+        if: steps.docs-changed-subprojects.outputs.libc_any_changed == 'true'
+        run: |
+          cmake -B libc-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libc" -DLLVM_ENABLE_SPHINX=ON ./runtimes
+          TZ=UTC ninja -C libc-build docs-libc-html
+
 


### PR DESCRIPTION
This patch adds support for building the libc docs in Github actions. This eanbles easily diagnosing doc build failures/warnings in PRs and at the tip of tree.