### PR TITLE
[Github] Add libcxx docs to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ on:
       - 'clang-tools-extra/docs/**'
       - 'lldb/docs/**'
       - 'libunwind/docs/**'
+      - 'libcxx/docs/**'
   pull_request:
     paths:
       - 'llvm/docs/**'
@@ -25,6 +26,7 @@ on:
       - 'clang-tools-extra/docs/**'
       - 'lldb/docs/**'
       - 'libunwind/docs/**'
+      - 'libcxx/docs/**'
 
 jobs:
   check-docs-build:
@@ -62,6 +64,8 @@ jobs:
               - 'lldb/docs/**'
             libunwind:
               - 'libunwind/docs/**'
+            libcxx:
+              - 'libcxx/docs/**'
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:
@@ -100,4 +104,9 @@ jobs:
         run: |
           cmake -B libunwind-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libunwind" -DLLVM_ENABLE_SPHINX=ON ./runtimes
           TZ=UTC ninja -C libunwind-build docs-libunwind-html
+      - name: Build libcxx docs
+        if: steps.docs-changed-subprojects.outputs.libcxx_any_changed == 'true'
+        run: |
+          cmake -B libcxx-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libcxxabi;libcxx" -DLLVM_ENABLE_SPHINX=ON ./runtimes
+          TZ=UTC ninja -C libcxx-build docs-libcxx-html
 


### PR DESCRIPTION
This patch adds a step to the documentation Github action to build the libc++ docs if they have changed. This enables easily diagnosing build failures/warnings in PRs.