### PR TITLE
[LIT] Print discovered tests and percentages (#66057)

### DIFF
--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -311,6 +311,7 @@ def print_histogram(tests):
 
 def print_results(tests, elapsed, opts):
     tests_by_code = {code: [] for code in lit.Test.ResultCode.all_codes()}
+    total_tests = len(tests)
     for test in tests:
         tests_by_code[test.result.code].append(test)
 
@@ -321,7 +322,7 @@ def print_results(tests, elapsed, opts):
             opts.shown_codes,
         )
 
-    print_summary(tests_by_code, opts.quiet, elapsed)
+    print_summary(total_tests, tests_by_code, opts.quiet, elapsed)
 
 
 def print_group(tests, code, shown_codes):
@@ -336,10 +337,11 @@ def print_group(tests, code, shown_codes):
     sys.stdout.write("\n")
 
 
-def print_summary(tests_by_code, quiet, elapsed):
+def print_summary(total_tests, tests_by_code, quiet, elapsed):
     if not quiet:
         print("\nTesting Time: %.2fs" % elapsed)
 
+    print("\nTotal Discovered Tests: %s" % (total_tests))
     codes = [c for c in lit.Test.ResultCode.all_codes() if not quiet or c.isFailure]
     groups = [(c.label, len(tests_by_code[c])) for c in codes]
     groups = [(label, count) for label, count in groups if count]
@@ -352,4 +354,4 @@ def print_summary(tests_by_code, quiet, elapsed):
     for (label, count) in groups:
         label = label.ljust(max_label_len)
         count = str(count).rjust(max_count_len)
-        print("  %s: %s" % (label, count))
+        print("  %s: %s (%.2f%%)" % (label, count, float(count) / total_tests * 100))

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/before-name.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/before-name.txt
@@ -4,4 +4,4 @@
 #      CHECK: Substitution name 'foo %{name}' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/between-name-equals.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/between-name-equals.txt
@@ -6,4 +6,4 @@
 #      CHECK: Substitution name '%{name}:' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-empty.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-empty.txt
@@ -4,4 +4,4 @@
 #      CHECK: Substitution name '%{}' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-dot.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-dot.txt
@@ -9,4 +9,4 @@
 #      CHECK: Substitution name '%{foo.bar}' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-equals.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-equals.txt
@@ -6,4 +6,4 @@
 #      CHECK: Substitution name '%{foo' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-newline.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-newline.txt
@@ -5,4 +5,4 @@
 #      CHECK: Substitution name '%{foo bar}' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-number.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-number.txt
@@ -9,4 +9,4 @@
 #      CHECK: Substitution name '%{3}' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-ws.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/braces-with-ws.txt
@@ -4,4 +4,4 @@
 #      CHECK: Substitution name '%{foo bar}' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/empty.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/empty.txt
@@ -4,4 +4,4 @@
 #      CHECK: Substitution's definition does not contain '='
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/no-equals.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/no-equals.txt
@@ -4,4 +4,4 @@
 #      CHECK: Substitution's definition does not contain '='
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/no-name.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/no-name.txt
@@ -4,4 +4,4 @@
 #      CHECK: Substitution name '' is malformed {{.*}}
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/ws-only.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/assignment/ws-only.txt
@@ -5,4 +5,4 @@
 #      CHECK: Substitution's definition does not contain '='
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/empty.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/empty.txt
@@ -7,4 +7,4 @@
 #      CHECK: Substitution's continuation is empty
 # CHECK-NEXT: in DEFINE: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/end-in-double-backslash.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/end-in-double-backslash.txt
@@ -8,4 +8,4 @@
 #      CHECK: Substitution's continuation is empty
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-bad-redefine.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-bad-redefine.txt
@@ -10,4 +10,4 @@
 #      CHECK: Substitution's definition does not contain '='
 # CHECK-NEXT: in {{REDEFINE}}: directive on test line [[#@LINE-5]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-continuation.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-continuation.txt
@@ -6,4 +6,4 @@
 
 # CHECK: Test has unterminated '{{DEFINE}}:' directive (with '\') from line [[#@LINE-3]] to [[#@LINE-2]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-redefine.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-redefine.txt
@@ -10,4 +10,4 @@
 
 # CHECK: Test has unterminated '{{DEFINE}}:' directive (with '\') at line [[#@LINE-5]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-run.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define-run.txt
@@ -6,4 +6,4 @@
 
 # CHECK: Test has unterminated '{{DEFINE}}:' directive (with '\') at line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-define.txt
@@ -5,4 +5,4 @@
 
 # CHECK: Test has unterminated '{{DEFINE}}:' directive (with '\') at line [[#@LINE-2]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-bad-define.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-bad-define.txt
@@ -10,4 +10,4 @@
 #      CHECK: Substitution's definition does not contain '='
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-5]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-continuation.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-continuation.txt
@@ -6,4 +6,4 @@
 
 # CHECK: Test has unterminated '{{REDEFINE}}:' directive (with '\') from line [[#@LINE-3]] to [[#@LINE-2]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-define.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-define.txt
@@ -10,4 +10,4 @@
 
 # CHECK: Test has unterminated '{{REDEFINE}}:' directive (with '\') at line [[#@LINE-5]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-run.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine-run.txt
@@ -6,4 +6,4 @@
 
 # CHECK: Test has unterminated '{{REDEFINE}}:' directive (with '\') at line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-redefine.txt
@@ -5,4 +5,4 @@
 
 # CHECK: Test has unterminated '{{REDEFINE}}:' directive (with '\') at line [[#@LINE-2]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-run-define.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-run-define.txt
@@ -6,4 +6,4 @@
 
 # CHECK: Test has unterminated '{{RUN}}:' directive (with '\') at line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-run-redefine.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/unterminated-run-redefine.txt
@@ -6,4 +6,4 @@
 
 # CHECK: Test has unterminated '{{RUN}}:' directive (with '\') at line [[#@LINE-4]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/ws-only.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/continuation/ws-only.txt
@@ -8,4 +8,4 @@
 #      CHECK: Substitution's continuation is empty
 # CHECK-NEXT: in {{DEFINE}}: directive on test line [[#@LINE-5]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-already-by-config.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-already-by-config.txt
@@ -5,4 +5,4 @@
 # CHECK-NEXT: Existing pattern: %{global:greeting}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-already-by-test.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-already-by-test.txt
@@ -7,4 +7,4 @@
 # CHECK-NEXT: Existing pattern: %{foo}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-inside-pattern.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-inside-pattern.txt
@@ -5,4 +5,4 @@
 # CHECK-NEXT: Existing pattern: <%{global:inside}>
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-multiple-exact.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-multiple-exact.txt
@@ -6,4 +6,4 @@
 # CHECK-NEXT: Existing pattern: %{global:multiple-exact}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-multiple-once-exact.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-multiple-once-exact.txt
@@ -6,4 +6,4 @@
 # CHECK-NEXT: Existing pattern: %{global:multiple-once-exact}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-prefixes-pattern.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-prefixes-pattern.txt
@@ -5,4 +5,4 @@
 # CHECK-NEXT: Existing pattern: %{global:prefix}\((.*)\)
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-suffixes-pattern.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/define-suffixes-pattern.txt
@@ -5,4 +5,4 @@
 # CHECK-NEXT: Existing pattern: @%{global:suffix}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-inside-pattern.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-inside-pattern.txt
@@ -6,4 +6,4 @@
 # CHECK-NEXT: Existing pattern: <%{global:inside}>
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-multiple-exact.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-multiple-exact.txt
@@ -10,4 +10,4 @@
 # CHECK-NEXT: Existing pattern: %{global:multiple-exact}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-multiple-once-exact.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-multiple-once-exact.txt
@@ -9,4 +9,4 @@
 # CHECK-NEXT: Existing pattern: %{global:multiple-once-exact}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-none.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-none.txt
@@ -4,4 +4,4 @@
 #     CHECK: ValueError: No substitution for '%{local}' is defined before '{{REDEFINE}}:' directive at line [[#@LINE-3]]
 # CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-prefixes-pattern.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-prefixes-pattern.txt
@@ -6,4 +6,4 @@
 # CHECK-NEXT: Existing pattern: %{global:prefix}\((.*)\)
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-suffixes-pattern.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/defined-check/redefine-suffixes-pattern.txt
@@ -6,4 +6,4 @@
 # CHECK-NEXT: Existing pattern: @%{global:suffix}
 #  CHECK-NOT: Existing pattern:
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/location-range.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/location-range.txt
@@ -5,4 +5,4 @@
 
 # CHECK: ValueError: Substitution whose pattern contains '%{foo}' is already defined before '{{DEFINE}}:' directive from line [[#@LINE-4]] to [[#@LINE-3]]
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/errors/no-run.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/errors/no-run.txt
@@ -5,4 +5,4 @@
 
 # CHECK: Test has no '{{RUN}}:' line
 
-# CHECK: Unresolved: 1
+# CHECK: Unresolved: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/examples/param-subst.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/examples/param-subst.txt
@@ -31,4 +31,4 @@
 ; RUN: %{check}
 ; CHECK:# | %clang_cc1 -verify -fopenmp -fopenmp-version=51 -triple x86_64-unknown-linux-gnu -emit-llvm -o - {{.*}} | FileCheck -check-prefix=NO-SIMD {{.*}}
 
-; CHECK: Passed: 1
+; CHECK: Passed: 1 {{\([0-9]*\.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/expansion-order.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/expansion-order.txt
@@ -38,4 +38,4 @@
 # RUN: %{local:echo}
 # CHECK:# | LOCAL: So Long World World
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/line-number-substitutions.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/line-number-substitutions.txt
@@ -29,4 +29,4 @@
 # RUN: echo '%{lines-rel}'
 # CHECK:# | [[#@LINE+1]], [[#@LINE-3]], [[#@LINE-12]]
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/name-chars.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/name-chars.txt
@@ -22,4 +22,4 @@
 # RUN: echo '%{_foo_bar_}'
 # CHECK:# | ok at [[#@LINE - 2]]
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/recursiveExpansionLimit.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/recursiveExpansionLimit.txt
@@ -9,4 +9,4 @@
 # CHECK-NON-RECUR:# | %{inner}
 # CHECK-RECUR:# | expanded
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/shared-substs-0.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/shared-substs-0.txt
@@ -19,4 +19,4 @@
 # DEFINE: %{local:echo}=echo LOCAL0: subst
 # RUN: %{local:echo}
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/shared-substs-1.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/shared-substs-1.txt
@@ -19,4 +19,4 @@
 # DEFINE: %{local:echo}=echo LOCAL1: subst
 # RUN: %{local:echo}
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/value-equals.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/value-equals.txt
@@ -19,4 +19,4 @@
 # RUN: echo '%{continue-equals}'
 # CHECK:# | FileCheck -input-file=test.txt -implicit-check-not=foobar -check-prefixes=FOO,BAR
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/value-escaped.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/value-escaped.txt
@@ -13,4 +13,4 @@
 # RUN: echo '%{escape}'
 # CHECK:# | {{\\?}}\n {{\\?}}\g<param>
 
-# CHECK: Passed: 1
+# CHECK: Passed: 1 {{\([0-9]*.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/Inputs/shtest-define/ws-and-continuations.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-define/ws-and-continuations.txt
@@ -132,4 +132,4 @@
 # RUN: %{deceptive-continue}
 # CHECK:# | x=3
 
-# CHECK:{{ *}}Passed: 1
+# CHECK:{{ *}}Passed: 1 {{\([0-9]*\.[0-9]*%\)}}

--- a/llvm/utils/lit/tests/discovery.py
+++ b/llvm/utils/lit/tests/discovery.py
@@ -28,6 +28,13 @@
 # CHECK-BASIC-OUT: top-level-suite :: test-one
 # CHECK-BASIC-OUT: top-level-suite :: test-two
 
+# RUN: %{lit} %{inputs}/discovery \
+# RUN:   -v > %t.out 2> %t.err
+# RUN: FileCheck --check-prefix=CHECK-PERCENTAGES-OUT < %/t.out %s
+#
+# CHECK-PERCENTAGES-OUT:  Total Discovered Tests: {{[0-9]*}}
+# CHECK-PERCENTAGES-OUT:  Passed: {{[0-9]*}} {{\([0-9]*\.[0-9]*%\)}}
+
 # Check discovery when providing the special builtin 'config_map'
 # RUN: %{python} %{inputs}/config-map-discovery/driver.py \
 # RUN:           %{inputs}/config-map-discovery/main-config/lit.cfg \

--- a/llvm/utils/lit/tests/ignore-fail.py
+++ b/llvm/utils/lit/tests/ignore-fail.py
@@ -12,8 +12,9 @@
 # CHECK-DAG: XPASS: ignore-fail :: xpass.txt
 
 #      CHECK: Testing Time:
-# CHECK-NEXT:   Expectedly Failed : 1
-# CHECK-NEXT:   Unresolved : 1
-# CHECK-NEXT:   Failed : 1
-# CHECK-NEXT:   Unexpectedly Passed: 1
+# CHECK: Total Discovered Tests:
+# CHECK-NEXT:   Expectedly Failed : 1 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK-NEXT:   Unresolved : 1 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK-NEXT:   Failed : 1 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK-NEXT:   Unexpectedly Passed: 1 {{\([0-9]*\.[0-9]*%\)}}
 #  CHECK-NOT: {{.}}

--- a/llvm/utils/lit/tests/shtest-env.py
+++ b/llvm/utils/lit/tests/shtest-env.py
@@ -120,6 +120,7 @@
 # CHECK-NOT: {{^[^#]}}
 # CHECK: --
 
-# CHECK: Passed:  4
-# CHECK: Failed: 12
+# CHECK: Total Discovered Tests: 16
+# CHECK: Passed:  4 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Failed: 12 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}

--- a/llvm/utils/lit/tests/shtest-not.py
+++ b/llvm/utils/lit/tests/shtest-not.py
@@ -184,6 +184,7 @@
 # CHECK: # | Error: 'not --crash' cannot call 'rm'
 # CHECK: # error: command failed with exit status: {{.*}}
 
-# CHECK: Passed:  1
-# CHECK: Failed: 16
+# CHECK: Total Discovered Tests: 17
+# CHECK: Passed:  1 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Failed: 16 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}

--- a/llvm/utils/lit/tests/shtest-pushd-popd.py
+++ b/llvm/utils/lit/tests/shtest-pushd-popd.py
@@ -19,6 +19,7 @@
 # CHECK: pushd a b
 # CHECK: # | 'pushd' supports only one argument
 
-# CHECK: Passed:  1
-# CHECK: Failed:  3
+# CHECK: Total Discovered Tests: 4
+# CHECK: Passed:  1 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Failed:  3 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}


### PR DESCRIPTION
This patch adds "nice-to-have" feature in lit.
it prints the total number of discovered tests at the beginning. It is covenient to see the total number of tests and avoid scrolling up to the beginning of log.

Further, this patch also prints %ge of tests.

This patch fixes tests pointed by previous attempt of landing this patch.

Reviewed By: RoboTux, jdenny-ornl