### PR TITLE
[Github] Add lldb docs step to Github docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,11 +16,13 @@ on:
       - 'llvm/docs/**'
       - 'clang/docs/**'
       - 'clang-tools-extra/docs/**'
+      - 'lldb/docs/**'
   pull_request:
     paths:
       - 'llvm/docs/**'
       - 'clang/docs/**'
       - 'clang-tools-extra/docs/**'
+      - 'lldb/docs/**'
 
 jobs:
   check-docs-build:
@@ -51,6 +53,8 @@ jobs:
               - 'clang/docs/**'
             clang-tools-extra:
               - 'clang-tools-extra/docs/**'
+            lldb:
+              - 'lldb/docs/**'
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:
@@ -62,7 +66,8 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build
+          # swig and graphviz are lldb specific dependencies
+          sudo apt-get install -y cmake ninja-build swig graphviz
       - name: Build LLVM docs
         if: steps.docs-changed-subprojects.outputs.llvm_any_changed == 'true'
         run: |
@@ -78,4 +83,9 @@ jobs:
         run: |
           cmake -B clang-tools-extra-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" -DLLVM_ENABLE_SPHINX=ON ./llvm
           TZ=UTC ninja -C clang-tools-extra-build docs-clang-tools-html docs-clang-tools-man
+      - name: Build LLDB docs
+        if: steps.docs-changed-subprojects.outputs.lldb_any_changed == 'true'
+        run: |
+          cmake -B lldb-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;lldb" -DLLVM_ENABLE_SPHINX=ON ./llvm
+          TZ=UTC ninja -C lldb-build docs-lldb-html docs-lldb-man
 


### PR DESCRIPTION
This patch adds a step to build the lldb docs when they change to the Github docs action, enabling easy triage of warnings/docs build failures during the PR process.