### PR TITLE
[BOLT][RISCV] Use target features from object file

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -118,7 +118,7 @@ Expected<std::unique_ptr<BinaryContext>>
 BinaryContext::createBinaryContext(const ObjectFile *File, bool IsPIC,
                                    std::unique_ptr<DWARFContext> DwCtx) {
   StringRef ArchName = "";
-  StringRef FeaturesStr = "";
+  std::string FeaturesStr = "";
   switch (File->getArch()) {
   case llvm::Triple::x86_64:
     ArchName = "x86-64";
@@ -128,11 +128,20 @@ BinaryContext::createBinaryContext(const ObjectFile *File, bool IsPIC,
     ArchName = "aarch64";
     FeaturesStr = "+all";
     break;
-  case llvm::Triple::riscv64:
+  case llvm::Triple::riscv64: {
     ArchName = "riscv64";
-    // RV64GC
-    FeaturesStr = "+m,+a,+f,+d,+zicsr,+zifencei,+c,+relax";
+    Expected<SubtargetFeatures> Features = File->getFeatures();
+
+    if (auto E = Features.takeError())
+      return E;
+
+    // We rely on relaxation for some transformations (e.g., promoting all calls
+    // to PseudoCALL and then making JITLink relax them). Since the relax
+    // feature is not stored in the object file, we manually enable it.
+    Features->AddFeature("relax");
+    FeaturesStr = Features->getString();
     break;
+  }
   default:
     return createStringError(std::errc::not_supported,
                              "BOLT-ERROR: Unrecognized machine in ELF file");

--- a/bolt/test/RISCV/call-annotations.s
+++ b/bolt/test/RISCV/call-annotations.s
@@ -1,12 +1,13 @@
 /// Test that annotations are properly carried over to fixed calls.
 /// Note that --enable-bat is used to force offsets to be kept.
 
-// RUN: llvm-mc -triple riscv64 -filetype obj -o %t.o %s
+// RUN: llvm-mc -triple riscv64 -mattr=+c -filetype obj -o %t.o %s
 // RUN: ld.lld --emit-relocs -o %t %t.o
 // RUN: llvm-bolt --enable-bat --print-cfg --print-fix-riscv-calls \
 // RUN:     -o /dev/null %t | FileCheck %s
 
   .text
+  .option norvc
   .global f
   .p2align 1
 f:

--- a/bolt/test/RISCV/internal-func-reloc.s
+++ b/bolt/test/RISCV/internal-func-reloc.s
@@ -2,18 +2,14 @@
 /// get transformed by BOLT. The tests rely on the "remove-nops" optimization:
 /// if nops got removed from the function, it got transformed by BOLT.
 
-// RUN: %clang %cflags -o %t %s
+// RUN: llvm-mc -triple riscv64 -filetype=obj -o %t.o %s
+// RUN: ld.lld --emit-relocs -o %t %t.o
 // RUN: llvm-bolt -o %t.bolt %t
 // RUN: llvm-objdump -d %t.bolt | FileCheck %s
 
   .text
-
-  /// These options are only used to make the assembler output easier to predict
-  .option norelax
-  .option norvc
-
   .globl _start
-  .p2align 1
+  .p2align 2
 // CHECK: <_start>:
 // CHECK-NEXT: j 0x{{.*}} <_start>
 _start:
@@ -23,10 +19,10 @@ _start:
   .size _start, .-_start
 
   .globl f
-  .p2align 1
+  .p2align 2
 // CHECK: <f>:
-// CHECK-NEXT: auipc a0, 0
-// CHECK-NEXT: addi a0, a0, 64
+// CHECK-NEXT: auipc a0, [[#]]
+// CHECK-NEXT: addi a0, a0, [[#]]
 f:
   nop
 1:
@@ -37,7 +33,7 @@ f:
   .size f, .-f
 
   .globl g
-  .p2align 1
+  .p2align 2
 g:
   ret
   .size g, .-g


### PR DESCRIPTION
We used to hard-code target features for RISC-V. However, most features (with the exception of relax) are stored in the object file. This patch extracts those features to ensure BOLT's output doesn't use any features not present in the input file.