### PR TITLE
[BOLT][RISCV] Set minimum function alignment to 2 for RVC

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1721,14 +1721,7 @@ public:
     // Align data in code BFs minimum to CI alignment
     if (!size() && hasIslandsInfo())
       return getConstantIslandAlignment();
-
-    // Minimal code alignment on AArch64 and RISCV is 4
-    if (BC.isAArch64() || BC.isRISCV())
-      return 4;
-
-    // We have to use at least 2-byte alignment for functions because
-    // of C++ ABI.
-    return 2;
+    return BC.MIB->getMinFunctionAlignment();
   }
 
   Align getMinAlign() const { return Align(getMinAlignment()); }

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -2077,6 +2077,12 @@ public:
     return BlocksVectorTy();
   }
 
+  virtual uint16_t getMinFunctionAlignment() const {
+    // We have to use at least 2-byte alignment for functions because of C++
+    // ABI.
+    return 2;
+  }
+
   // AliasMap caches a mapping of registers to the set of registers that
   // alias (are sub or superregs of itself, including itself).
   std::vector<BitVector> AliasMap;

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -1643,6 +1643,8 @@ public:
 
     return Relocation({RelOffset, RelSymbol, RelType, RelAddend, 0});
   }
+
+  uint16_t getMinFunctionAlignment() const override { return 4; }
 };
 
 } // end anonymous namespace

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -493,7 +493,10 @@ public:
   }
 
   uint16_t getMinFunctionAlignment() const override {
-    return STI->getFeatureBits()[RISCV::FeatureStdExtC] ? 2 : 4;
+    if (STI->hasFeature(RISCV::FeatureStdExtC) ||
+        STI->hasFeature(RISCV::FeatureStdExtZca))
+      return 2;
+    return 4;
   }
 };
 

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -15,6 +15,7 @@
 #include "bolt/Core/MCPlusBuilder.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
@@ -489,6 +490,10 @@ public:
 
     assert(Second.getOpcode() == RISCV::JALR);
     return true;
+  }
+
+  uint16_t getMinFunctionAlignment() const override {
+    return STI->getFeatureBits()[RISCV::FeatureStdExtC] ? 2 : 4;
   }
 };
 

--- a/bolt/test/RISCV/function-alignment.s
+++ b/bolt/test/RISCV/function-alignment.s
@@ -1,0 +1,38 @@
+## Test that BOLT uses a minimum function alignment of 4 (or 2 for RVC) bytes.
+
+# RUN: llvm-mc -triple=riscv64 -filetype=obj -o %t.o %s
+# RUN: ld.lld -q -o %t %t.o
+# RUN: llvm-bolt --align-functions=1 --use-old-text=0 -o %t.bolt %t
+# RUN: llvm-nm -n %t.bolt | FileCheck %s
+
+# RUN: llvm-mc -triple=riscv64 -mattr=+c -filetype=obj -o %t-c.o %s
+# RUN: ld.lld -q -o %t-c %t-c.o
+# RUN: llvm-bolt --align-functions=1 --use-old-text=0 -o %t-c.bolt %t-c
+# RUN: llvm-nm -n %t-c.bolt | FileCheck --check-prefix=CHECK-C %s
+
+# CHECK:      {{[048c]}} T _start
+# CHECK-NEXT: {{[048c]}} T dummy
+
+# CHECK-C:      {{[02468ace]}} T _start
+# CHECK-C-NEXT: {{[02468ace]}} T dummy
+
+    .text
+
+    # Make sure input binary is only 1 byte aligned. BOLT should increase the
+    # alignment to 2 or 4 bytes.
+    .byte 0
+    .balign 1
+
+    .globl _start
+    .type _start, @function
+_start:
+    # Dummy reloc to force relocation mode.
+    .reloc 0, R_RISCV_NONE
+    ret
+    .size _start, .-_start
+
+    .globl dummy
+    .type dummy, @function
+dummy:
+    ret
+    .size dummy, .-dummy


### PR DESCRIPTION
In #67707, the minimum function alignment on RISC-V was set to 4. When
RVC (compressed instructions) is enabled, the minimum alignment can be
reduced to 2.

This patch implements this by delegating the choice of minimum alignment
to a new `MCPlusBuilder::getMinFunctionAlignment` function. This way,
the target-dependent code in `BinaryFunction` is minimized.