### PR TITLE
[compiler-rt][builtins] Fix FLOAT16 feature detection

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -5,7 +5,6 @@
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   cmake_minimum_required(VERSION 3.20.0)
 
-  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
   project(CompilerRTBuiltins C ASM)
   set(COMPILER_RT_STANDALONE_BUILD TRUE)
   set(COMPILER_RT_BUILTINS_STANDALONE_BUILD TRUE)
@@ -49,6 +48,8 @@ if (COMPILER_RT_STANDALONE_BUILD)
     "Turns on or off -fPIC for the builtin library source"
     ON)
 endif()
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 include(builtin-config-ix)
 include(CMakeDependentOption)


### PR DESCRIPTION
I'm submitting this patch authored by @tstellar:

CMAKE_TRY_COMPILE_TARGET_TYPE defaults to EXECUTABLE, which causes any feature detection code snippet without a main function to fail, so we need to make sure it gets explicitly set to STATIC_LIBRARY.

I think maybe it should be up-streamed, since it causes some issues [1,2] in some distros. Please have a review to see whether this patch should be applied in upstream, or just in distro.

[1] https://github.com/ROCmSoftwarePlatform/rocFFT/issues/439
[2] https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1350