### PR TITLE
[clang] Bounds checking on unclosed parentheses, brackets or braces in Expanded Tokens

### DIFF
--- a/clang/unittests/Tooling/Syntax/TokensTest.cpp
+++ b/clang/unittests/Tooling/Syntax/TokensTest.cpp
@@ -585,6 +585,17 @@ TEST_F(TokenCollectorTest, DelayedParsing) {
   EXPECT_THAT(collectAndDump(Code), StartsWith(ExpectedTokens));
 }
 
+TEST_F(TokenCollectorTest, UnclosedToken) {
+  llvm::StringLiteral Code = R"cpp(
+    int main() {
+    // this should not result in a segfault or UB.
+  )cpp";
+  std::string ExpectedTokens =
+      "expanded tokens:\n  int main ( ) {\nfile './input.cpp'\n  spelled "
+      "tokens:\n    int main ( ) {\n  no mappings.\n";
+  EXPECT_THAT(collectAndDump(Code), StartsWith(ExpectedTokens));
+}
+
 TEST_F(TokenCollectorTest, MultiFile) {
   addFile("./foo.h", R"cpp(
     #define ADD(X, Y) X+Y


### PR DESCRIPTION
When getting the AST from clangd, if there is an unclosed token, a segfault or an UB can happen when accessing `File.SpelledTokens` because the supposed closing token is not present, so its index is greater than the vec's size.

This fixes the issue by returning a `nullptr` on the function that caused the UB and then checking if the spelled token is null, returning `nullopt` for the whole expanded token.

Fixes https://github.com/clangd/clangd/issues/1559.