### PR TITLE
[LLDB] Update docs on building documentation

### DIFF
--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -403,13 +403,21 @@ dependencies are required:
 * Sphinx (for the website and the Python API reference)
 * Graphviz (for the 'dot' tool)
 * doxygen (if you wish to build the C++ API reference)
+* Swig (for generating Python bindings)
 
-To install the prerequisites for building the documentation (on Debian/Ubuntu)
+To install the system prerequisites for building the documentation (on Debian/Ubuntu)
 do:
 
 ::
 
-  $ sudo apt-get install doxygen graphviz python3-sphinx
+  $ sudo apt-get install doxygen graphviz swig
+
+To install Sphinx and its dependencies, use the ``requirements.txt`` available within LLVM
+to ensure you get a working configuration:
+
+::
+
+  $ pip3 install -r /path/to/llvm-project/llvm/docs/requirements.txt
 
 To build the documentation, configure with ``LLVM_ENABLE_SPHINX=ON`` and build the desired target(s).
 

--- a/lldb/docs/resources/build.rst
+++ b/lldb/docs/resources/build.rst
@@ -403,7 +403,7 @@ dependencies are required:
 * Sphinx (for the website and the Python API reference)
 * Graphviz (for the 'dot' tool)
 * doxygen (if you wish to build the C++ API reference)
-* Swig (for generating Python bindings)
+* SWIG (for generating Python bindings)
 
 To install the system prerequisites for building the documentation (on Debian/Ubuntu)
 do:


### PR DESCRIPTION
This patch updates the documentation to match recent changes and make it more clear. More specifically, the process for installing sphinx has changed with the transition to myst with the requirements.txt in llvm/docs being the preferred method for installation now. In addition, the docs-lldb-html target is never generated if swig isn't installed, so having something expliti in the documentation section (even if it is mentioned as a dependency of lldb itself above) probably doesn't hurt.