### PR TITLE
[clang-format] unexpected break after binOp '<<'

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5119,7 +5119,9 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
   if (Left.IsUnterminatedLiteral)
     return true;
   if (Right.is(tok::lessless) && Right.Next && Left.is(tok::string_literal) &&
-      Right.Next->is(tok::string_literal)) {
+      Right.Next->is(tok::string_literal) &&
+      (Style.BreakBeforeBinaryOperators == FormatStyle::BOS_All ||
+       Style.BreakBeforeBinaryOperators == FormatStyle::BOS_NonAssignment)) {
     return true;
   }
   if (Right.is(TT_RequiresClause)) {


### PR DESCRIPTION
the problem occurred while checking for the correctness of the break after binary operators. The output statement 'tok::lessless' is then break line every possible time, which is not expected with the BreakBeforeBinaryOperators: None

Fixes https://github.com/llvm/llvm-project/issues/59797
Fixes https://github.com/llvm/llvm-project/issues/44363