### PR TITLE
Added removal of file extension when guessing the toolchain

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -345,10 +345,11 @@ static const DriverSuffix *parseDriverSuffix(StringRef ProgName, size_t &Pos) {
   // added via -target as implicit first argument.
   const DriverSuffix *DS = FindDriverSuffix(ProgName, Pos);
 
-  if (!DS && ProgName.endswith(".exe")) {
-    // Try again after stripping the executable suffix:
+  if (!DS) {
+    // Try again after stripping the file extension suffix:
     // clang++.exe -> clang++
-    ProgName = ProgName.drop_back(StringRef(".exe").size());
+    // cl.bat -> cl
+    ProgName = ProgName.slice(0, ProgName.find('.'));
     DS = FindDriverSuffix(ProgName, Pos);
   }
 

--- a/clang/unittests/Driver/ToolChainTest.cpp
+++ b/clang/unittests/Driver/ToolChainTest.cpp
@@ -509,6 +509,18 @@ TEST(ToolChainTest, GetTargetAndMode) {
   EXPECT_TRUE(Res.ModeSuffix == "clang-dxc");
   EXPECT_STREQ(Res.DriverMode, "--driver-mode=dxc");
   EXPECT_FALSE(Res.TargetIsValid);
+
+  Res = ToolChain::getTargetAndModeFromProgramName("cl.exe");
+  EXPECT_TRUE(Res.TargetPrefix.empty());
+  EXPECT_TRUE(Res.ModeSuffix == "cl");
+  EXPECT_STREQ(Res.DriverMode, "--driver-mode=cl");
+  EXPECT_FALSE(Res.TargetIsValid);
+
+  Res = ToolChain::getTargetAndModeFromProgramName("cl.bat");
+  EXPECT_TRUE(Res.TargetPrefix.empty());
+  EXPECT_TRUE(Res.ModeSuffix == "cl");
+  EXPECT_STREQ(Res.DriverMode, "--driver-mode=cl");
+  EXPECT_FALSE(Res.TargetIsValid);
 }
 
 TEST(ToolChainTest, CommandOutput) {


### PR DESCRIPTION
I'm using Buck2 to create the compile_commands.json and since it uses a cl.bat wrapper around cl.exe, that's what shows up in the compile_commands.json. Of course Buck2 could be changed to create a compile_commands.json with the cl.exe path but I think this change to clang is better.

Please let me know what you think.