### PR TITLE
-fstack-usage: fix filename for functions in an included file

### DIFF
--- a/clang/test/CodeGen/stack-usage.c
+++ b/clang/test/CodeGen/stack-usage.c
@@ -1,17 +1,20 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: rm -rf %t && mkdir %t && cd %t
-// RUN: %clang_cc1 -triple aarch64-unknown -stack-usage-file b.su -emit-obj %s -o b.o
-// RUN: FileCheck %s < b.su
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: %clang_cc1 -triple aarch64-unknown -I . -stack-usage-file a.su -emit-obj a.c -o a.o
+// RUN: FileCheck %s < a.su
 
-// CHECK: stack-usage.c:[[#@LINE+1]]:foo	{{[0-9]+}}	static
+// CHECK: {{.*}}x.inc:1:bar	[[#]]	dynamic
+// CHECK: a.c:2:foo	[[#]]	static
+//--- a.c
+#include "x.inc"
 int foo() {
   char a[8];
 
   return 0;
 }
 
-// CHECK: stack-usage.c:[[#@LINE+1]]:bar	{{[0-9]+}}	dynamic
+//--- x.inc
 int bar(int len) {
   char a[len];
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1469,9 +1469,10 @@ void AsmPrinter::emitStackUsage(const MachineFunction &MF) {
     }
   }
 
-  *StackUsageStream << MF.getFunction().getParent()->getName();
   if (const DISubprogram *DSP = MF.getFunction().getSubprogram())
-    *StackUsageStream << ':' << DSP->getLine();
+    *StackUsageStream << DSP->getFilename() << ':' << DSP->getLine();
+  else
+    *StackUsageStream << MF.getFunction().getParent()->getName();
 
   *StackUsageStream << ':' << MF.getName() << '\t' << StackSize << '\t';
   if (FrameInfo.hasVarSizedObjects())


### PR DESCRIPTION
Fix #69889
