### PR TITLE
[clang] Add Obj-C bridging-related attributes to C-Index API

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -2199,7 +2199,10 @@ enum CXCursorKind {
   CXCursor_WarnUnusedAttr = 439,
   CXCursor_WarnUnusedResultAttr = 440,
   CXCursor_AlignedAttr = 441,
-  CXCursor_LastAttr = CXCursor_AlignedAttr,
+  CXCursor_ObjCBridgeAttr = 442,
+  CXCursor_ObjCBridgeMutableAttr = 443,
+  CXCursor_ObjCBridgeRelatedAttr = 444,
+  CXCursor_LastAttr = CXCursor_ObjCBridgeRelatedAttr,
 
   /* Preprocessing */
   CXCursor_PreprocessingDirective = 500,

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -6097,6 +6097,12 @@ CXString clang_getCursorKindSpelling(enum CXCursorKind Kind) {
     return cxstring::createRef("attribute(aligned)");
   case CXCursor_ConceptDecl:
     return cxstring::createRef("ConceptDecl");
+  case CXCursor_ObjCBridgeAttr:
+    return cxstring::createRef("ObjCBridgeAttr");
+  case CXCursor_ObjCBridgeMutableAttr:
+    return cxstring::createRef("ObjCBridgeMutableAttr");
+  case CXCursor_ObjCBridgeRelatedAttr:
+    return cxstring::createRef("ObjCBridgeRelatedAttr");
   }
 
   llvm_unreachable("Unhandled CXCursorKind");

--- a/clang/tools/libclang/CXCursor.cpp
+++ b/clang/tools/libclang/CXCursor.cpp
@@ -124,6 +124,12 @@ static CXCursorKind GetCursorKind(const Attr *A) {
     return CXCursor_WarnUnusedResultAttr;
   case attr::Aligned:
     return CXCursor_AlignedAttr;
+  case attr::ObjCBridge:
+    return CXCursor_ObjCBridgeAttr;
+  case attr::ObjCBridgeMutable:
+    return CXCursor_ObjCBridgeMutableAttr;
+  case attr::ObjCBridgeRelated:
+    return CXCursor_ObjCBridgeRelatedAttr;
   }
 
   return CXCursor_UnexposedAttr;


### PR DESCRIPTION
Yowza, I haven't tried to upstream anything to LLVM in a long time. It was so long ago I just had my coworker submit it for me with their SVN access...

Anyways, this adds `ObjCBridgeAttr`, `ObjCBridgeMutableAttr`, and `ObjCBridgeRelatedAttr` attributes to C-Index (c-index? C-index?). Truth be told, I just wanted a way to figure out that a `SecKeyRef` parameter in a header was usable as an Obj-C object.

Now `c-index-test -test-print-type -Xclang -triple -Xclang arm64-apple-ios17.0.0 -x objective-c ./objc-bridge-attr-test.h` prints:

```
<pre-defined macro definition spam>
...
ObjCClassRef=Protocol:0:0 [type=Protocol] [typekind=ObjCInterface] [isPOD=0] [isAnonRecDecl=0]
StructDecl=__SecKey:3:60 [type=struct __SecKey] [typekind=Record] [isPOD=0] [isAnonRecDecl=0]
attribute(packed)=packed [type=] [typekind=Invalid] [isPOD=0] [isAnonRecDecl=0]
ObjCBridgeAttr= [type=] [typekind=Invalid] [isPOD=0] [isAnonRecDecl=0]
TypedefDecl=SecKeyRef:3:70 (Definition) [type=SecKeyRef] [typekind=Typedef] [canonicaltype=struct __SecKey *] [canonicaltypekind=Pointer] [isPOD=1] [isAnonRecDecl=0]
TypeRef=struct __SecKey:3:60 [type=struct __SecKey] [typekind=Record] [isPOD=0] [isAnonRecDecl=0]
FunctionDecl=i_take_a_key:5:12 [type=int (SecKeyRef)] [typekind=FunctionProto] [canonicaltype=int (struct __SecKey *)] [canonicaltypekind=FunctionProto] [resulttype=int] [resulttypekind=Int] [args= [SecKeyRef] [Elaborated]] [isPOD=0] [isAnonRecDecl=0]
ParmDecl=my_key:5:35 (Definition) [type=SecKeyRef] [typekind=Elaborated] [canonicaltype=struct __SecKey *] [canonicaltypekind=Pointer] [isPOD=1] [isAnonRecDecl=0]
TypeRef=SecKeyRef:3:70 [type=SecKeyRef] [typekind=Typedef] [canonicaltype=struct __SecKey *] [canonicaltypekind=Pointer] [isPOD=1] [isAnonRecDecl=0]
```
with `objc-bridge-attr-test.h`:
```
#define CF_BRIDGED_TYPE(T) __attribute__((objc_bridge(T)))

typedef struct __attribute__((packed)) CF_BRIDGED_TYPE(id) __SecKey *SecKeyRef;

extern int i_take_a_key(SecKeyRef my_key);
```

(That is not the true typedef of `SecKeyRef`, I just threw another, already supported, `__attribute__((packed))` in there for testing.)

Speaking of testing, do all new `CXCursorKind` enums need unit tests written for them?

Thanks and long live the Dragon.