### PR TITLE
[lld][COFF]Expose UnifiedLTO and PassPipeline Options

### DIFF
--- a/lld/tools/lld/CMakeLists.txt
+++ b/lld/tools/lld/CMakeLists.txt
@@ -9,6 +9,9 @@ add_lld_tool(lld
   SUPPORT_PLUGINS
   GENERATE_DRIVER
   )
+if(LLVM_BUILD_INSTRUMENTED)
+  target_compile_definitions(lld PRIVATE LLVM_BUILD_INSTRUMENTED)
+endif()
 export_executable_symbols_for_plugins(lld)
 
 function(lld_target_link_libraries target type)

--- a/lld/tools/lld/lld.cpp
+++ b/lld/tools/lld/lld.cpp
@@ -88,7 +88,13 @@ int lld_main(int argc, char **argv, const llvm::ToolContext &) {
   if (!inTestVerbosity()) {
     int r =
         lld::unsafeLldMain(args, llvm::outs(), llvm::errs(), LLD_ALL_DRIVERS,
-                           /*exitEarly=*/true);
+    /*exitEarly=*/
+#ifdef LLVM_BUILD_INSTRUMENTED
+                           false
+#else
+                           true
+#endif
+        );
     return r;
   }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/ab9b3c84a588f86e7f66eeb577bea7155817ff06 added UnifiedLTO support and  related arguments to lld-ELF.
This patch attempts to do the same with lld-COFF.

I'm not familiar with LLVM's TableGen based OptParser so a second pair of eyes might be required