### PR TITLE
[AMDGPU] Remove unnecessary conditionality on atomic CSUB pseudo-ops

### DIFF
--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -1047,14 +1047,9 @@ defm BUFFER_ATOMIC_DEC_X2 : MUBUF_Pseudo_Atomics <
 >;
 
 let SubtargetPredicate = HasGFX10_BEncoding in {
-  defm BUFFER_ATOMIC_CSUB : MUBUF_Pseudo_Atomics_RTN <
+  defm BUFFER_ATOMIC_CSUB : MUBUF_Pseudo_Atomics <
     "buffer_atomic_csub", VGPR_32, i32, int_amdgcn_global_atomic_csub
   >;
-
-  let OtherPredicates = [HasAtomicCSubNoRtnInsts] in
-    defm BUFFER_ATOMIC_CSUB : MUBUF_Pseudo_Atomics_NO_RTN <
-      "buffer_atomic_csub", VGPR_32, i32
-    >;
 }
 
 let SubtargetPredicate = isGFX8GFX9 in {

--- a/llvm/lib/Target/AMDGPU/FLATInstructions.td
+++ b/llvm/lib/Target/AMDGPU/FLATInstructions.td
@@ -871,12 +871,8 @@ defm GLOBAL_ATOMIC_DEC_X2 : FLAT_Global_Atomic_Pseudo <"global_atomic_dec_x2",
                               VReg_64, i64>;
 
 let SubtargetPredicate = HasGFX10_BEncoding in {
-  defm GLOBAL_ATOMIC_CSUB : FLAT_Global_Atomic_Pseudo_RTN <"global_atomic_csub",
+  defm GLOBAL_ATOMIC_CSUB : FLAT_Global_Atomic_Pseudo <"global_atomic_csub",
                                 VGPR_32, i32>;
-
-  let OtherPredicates = [HasAtomicCSubNoRtnInsts] in
-    defm GLOBAL_ATOMIC_CSUB : FLAT_Global_Atomic_Pseudo_NO_RTN <"global_atomic_csub",
-                                  VGPR_32, i32>;
 }
 
 defm GLOBAL_LOAD_LDS_UBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ubyte">;


### PR DESCRIPTION
The pseudo-ops for BUFFER_ATOMIC_CSUB and GLOBAL_ATOMIC_CSUB should not
be conditional on FeatureAtomicCSubNoRtnInsts, as that feature rightly
should only control whether or not the non-returning forms are available
for instruction selection, not whether they exist or not.

Change-Id: Icb2fcdcf6c7bc55e48b522d0eec8dd35637c768e
