### PR TITLE
[TableGen][NFC] Add record kind to `Record` class

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1650,6 +1650,8 @@ public:
     DumpInfo(SMLoc Loc, Init *Message) : Loc(Loc), Message(Message) {}
   };
 
+  enum RecordKind { RK_Normal, RK_Anonymous, RK_Class, RK_MultiClass };
+
 private:
   Init *Name;
   // Location where record was instantiated, followed by the location of
@@ -1676,24 +1678,22 @@ private:
   // Unique record ID.
   unsigned ID;
 
-  bool IsAnonymous;
-  bool IsClass;
+  RecordKind Kind;
 
   void checkName();
 
 public:
   // Constructs a record.
   explicit Record(Init *N, ArrayRef<SMLoc> locs, RecordKeeper &records,
-                  bool Anonymous = false, bool Class = false)
+                  RecordKind Kind = RK_Normal)
       : Name(N), Locs(locs.begin(), locs.end()), TrackedRecords(records),
-        ID(getNewUID(N->getRecordKeeper())), IsAnonymous(Anonymous),
-        IsClass(Class) {
+        ID(getNewUID(N->getRecordKeeper())), Kind(Kind) {
     checkName();
   }
 
   explicit Record(StringRef N, ArrayRef<SMLoc> locs, RecordKeeper &records,
-                  bool Class = false)
-      : Record(StringInit::get(records, N), locs, records, false, Class) {}
+                  RecordKind Kind = RK_Normal)
+      : Record(StringInit::get(records, N), locs, records, Kind) {}
 
   // When copy-constructing a Record, we must still guarantee a globally unique
   // ID number. Don't copy CorrespondingDefInit either, since it's owned by the
@@ -1702,8 +1702,7 @@ public:
       : Name(O.Name), Locs(O.Locs), TemplateArgs(O.TemplateArgs),
         Values(O.Values), Assertions(O.Assertions),
         SuperClasses(O.SuperClasses), TrackedRecords(O.TrackedRecords),
-        ID(getNewUID(O.getRecords())), IsAnonymous(O.IsAnonymous),
-        IsClass(O.IsClass) {}
+        ID(getNewUID(O.getRecords())), Kind(O.Kind) {}
 
   static unsigned getNewUID(RecordKeeper &RK);
 
@@ -1743,7 +1742,11 @@ public:
   /// get the corresponding DefInit.
   DefInit *getDefInit();
 
-  bool isClass() const { return IsClass; }
+  bool isClass() const { return Kind == RK_Class; }
+
+  bool isMultiClass() const { return Kind == RK_MultiClass; }
+
+  bool isAnonymous() const { return Kind == RK_Anonymous; }
 
   ArrayRef<Init *> getTemplateArgs() const {
     return TemplateArgs;
@@ -1869,10 +1872,6 @@ public:
 
   RecordKeeper &getRecords() const {
     return TrackedRecords;
-  }
-
-  bool isAnonymous() const {
-    return IsAnonymous;
   }
 
   void dump() const;

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1650,7 +1650,7 @@ public:
     DumpInfo(SMLoc Loc, Init *Message) : Loc(Loc), Message(Message) {}
   };
 
-  enum RecordKind { RK_Normal, RK_Anonymous, RK_Class, RK_MultiClass };
+  enum RecordKind { RK_Def, RK_AnonymousDef, RK_Class, RK_MultiClass };
 
 private:
   Init *Name;
@@ -1685,14 +1685,14 @@ private:
 public:
   // Constructs a record.
   explicit Record(Init *N, ArrayRef<SMLoc> locs, RecordKeeper &records,
-                  RecordKind Kind = RK_Normal)
+                  RecordKind Kind = RK_Def)
       : Name(N), Locs(locs.begin(), locs.end()), TrackedRecords(records),
         ID(getNewUID(N->getRecordKeeper())), Kind(Kind) {
     checkName();
   }
 
   explicit Record(StringRef N, ArrayRef<SMLoc> locs, RecordKeeper &records,
-                  RecordKind Kind = RK_Normal)
+                  RecordKind Kind = RK_Def)
       : Record(StringInit::get(records, N), locs, records, Kind) {}
 
   // When copy-constructing a Record, we must still guarantee a globally unique
@@ -1746,7 +1746,7 @@ public:
 
   bool isMultiClass() const { return Kind == RK_MultiClass; }
 
-  bool isAnonymous() const { return Kind == RK_Anonymous; }
+  bool isAnonymous() const { return Kind == RK_AnonymousDef; }
 
   ArrayRef<Init *> getTemplateArgs() const {
     return TemplateArgs;

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -2263,9 +2263,9 @@ void VarDefInit::Profile(FoldingSetNodeID &ID) const {
 DefInit *VarDefInit::instantiate() {
   if (!Def) {
     RecordKeeper &Records = Class->getRecords();
-    auto NewRecOwner = std::make_unique<Record>(Records.getNewAnonymousName(),
-                                                Class->getLoc(), Records,
-                                                /*Kind=*/Record::RK_Anonymous);
+    auto NewRecOwner =
+        std::make_unique<Record>(Records.getNewAnonymousName(), Class->getLoc(),
+                                 Records, Record::RK_AnonymousDef);
     Record *NewRec = NewRecOwner.get();
 
     // Copy values from class to instance

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -2264,8 +2264,8 @@ DefInit *VarDefInit::instantiate() {
   if (!Def) {
     RecordKeeper &Records = Class->getRecords();
     auto NewRecOwner = std::make_unique<Record>(Records.getNewAnonymousName(),
-                                           Class->getLoc(), Records,
-                                           /*IsAnonymous=*/true);
+                                                Class->getLoc(), Records,
+                                                /*Kind=*/Record::RK_Anonymous);
     Record *NewRec = NewRecOwner.get();
 
     // Copy values from class to instance

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -111,10 +111,11 @@ static void checkConcrete(Record &R) {
 
 /// Return an Init with a qualifier prefix referring
 /// to CurRec's name.
-static Init *QualifyName(Record &CurRec, Init *Name, bool IsMC = false) {
+static Init *QualifyName(Record &CurRec, Init *Name) {
   RecordKeeper &RK = CurRec.getRecords();
   Init *NewName = BinOpInit::getStrConcat(
-      CurRec.getNameInit(), StringInit::get(RK, IsMC ? "::" : ":"));
+      CurRec.getNameInit(),
+      StringInit::get(RK, CurRec.isMultiClass() ? "::" : ":"));
   NewName = BinOpInit::getStrConcat(NewName, Name);
 
   if (BinOpInit *BinOp = dyn_cast<BinOpInit>(NewName))
@@ -123,16 +124,16 @@ static Init *QualifyName(Record &CurRec, Init *Name, bool IsMC = false) {
 }
 
 static Init *QualifyName(MultiClass *MC, Init *Name) {
-  return QualifyName(MC->Rec, Name, /*IsMC=*/true);
+  return QualifyName(MC->Rec, Name);
 }
 
 /// Return the qualified version of the implicit 'NAME' template argument.
-static Init *QualifiedNameOfImplicitName(Record &Rec, bool IsMC = false) {
-  return QualifyName(Rec, StringInit::get(Rec.getRecords(), "NAME"), IsMC);
+static Init *QualifiedNameOfImplicitName(Record &Rec) {
+  return QualifyName(Rec, StringInit::get(Rec.getRecords(), "NAME"));
 }
 
 static Init *QualifiedNameOfImplicitName(MultiClass *MC) {
-  return QualifiedNameOfImplicitName(MC->Rec, /*IsMC=*/true);
+  return QualifiedNameOfImplicitName(MC->Rec);
 }
 
 Init *TGVarScope::getVar(RecordKeeper &Records, MultiClass *ParsingMultiClass,
@@ -143,11 +144,10 @@ Init *TGVarScope::getVar(RecordKeeper &Records, MultiClass *ParsingMultiClass,
   if (It != Vars.end())
     return It->second;
 
-  auto FindValueInArgs = [&](Record *Rec, StringInit *Name,
-                             bool IsMC) -> Init * {
+  auto FindValueInArgs = [&](Record *Rec, StringInit *Name) -> Init * {
     if (!Rec)
       return nullptr;
-    Init *ArgName = QualifyName(*Rec, Name, IsMC);
+    Init *ArgName = QualifyName(*Rec, Name);
     if (Rec->isTemplateArg(ArgName)) {
       RecordVal *RV = Rec->getValue(ArgName);
       assert(RV && "Template arg doesn't exist??");
@@ -177,7 +177,7 @@ Init *TGVarScope::getVar(RecordKeeper &Records, MultiClass *ParsingMultiClass,
 
       // The variable is a class template argument?
       if (CurRec->isClass())
-        if (auto *V = FindValueInArgs(CurRec, Name, /*IsMC=*/false))
+        if (auto *V = FindValueInArgs(CurRec, Name))
           return V;
     }
     break;
@@ -194,7 +194,7 @@ Init *TGVarScope::getVar(RecordKeeper &Records, MultiClass *ParsingMultiClass,
   case SK_MultiClass: {
     // The variable is a multiclass template argument?
     if (CurMultiClass)
-      if (auto *V = FindValueInArgs(&CurMultiClass->Rec, Name, /*IsMC=*/true))
+      if (auto *V = FindValueInArgs(&CurMultiClass->Rec, Name))
         return V;
     break;
   }
@@ -772,8 +772,7 @@ ParseSubClassReference(Record *CurRec, bool isDefm) {
     return Result;
   }
 
-  if (ParseTemplateArgValueList(Result.TemplateArgs, CurRec, Result.Rec,
-                                isDefm)) {
+  if (ParseTemplateArgValueList(Result.TemplateArgs, CurRec, Result.Rec)) {
     Result.Rec = nullptr; // Error parsing value list.
     return Result;
   }
@@ -810,7 +809,7 @@ ParseSubMultiClassReference(MultiClass *CurMC) {
   }
 
   if (ParseTemplateArgValueList(Result.TemplateArgs, &CurMC->Rec,
-                                &Result.MC->Rec, true)) {
+                                &Result.MC->Rec)) {
     Result.MC = nullptr; // Error parsing value list.
     return Result;
   }
@@ -3160,8 +3159,7 @@ void TGParser::ParseValueList(SmallVectorImpl<Init *> &Result, Record *CurRec,
 //   PostionalArgValueList ::= [Value {',' Value}*]
 //   NamedArgValueList ::= [NameValue '=' Value {',' NameValue '=' Value}*]
 bool TGParser::ParseTemplateArgValueList(
-    SmallVectorImpl<ArgumentInit *> &Result, Record *CurRec, Record *ArgsRec,
-    bool IsDefm) {
+    SmallVectorImpl<ArgumentInit *> &Result, Record *CurRec, Record *ArgsRec) {
   assert(Result.empty() && "Result vector is not empty");
   ArrayRef<Init *> TArgs = ArgsRec->getTemplateArgs();
 
@@ -3192,7 +3190,7 @@ bool TGParser::ParseTemplateArgValueList(
                      "The name of named argument should be a valid identifier");
 
       auto *Name = cast<StringInit>(Value);
-      Init *QualifiedName = QualifyName(*ArgsRec, Name, /*IsMC=*/IsDefm);
+      Init *QualifiedName = QualifyName(*ArgsRec, Name);
       auto *NamedArg = ArgsRec->getValue(QualifiedName);
       if (!NamedArg)
         return Error(ValueLoc,
@@ -3612,7 +3610,7 @@ bool TGParser::ParseDef(MultiClass *CurMultiClass) {
   if (isa<UnsetInit>(Name)) {
     CurRec =
         std::make_unique<Record>(Records.getNewAnonymousName(), DefLoc, Records,
-                                 /*Anonymous=*/true);
+                                 /*Kind=*/Record::RK_Anonymous);
   } else {
     CurRec = std::make_unique<Record>(Name, NameLoc, Records);
   }
@@ -3932,7 +3930,7 @@ bool TGParser::ParseClass() {
     // If this is the first reference to this class, create and add it.
     auto NewRec =
         std::make_unique<Record>(Lex.getCurStrVal(), Lex.getLoc(), Records,
-                                  /*Class=*/true);
+                                 /*Kind=*/Record::RK_Class);
     CurRec = NewRec.get();
     Records.addClass(std::move(NewRec));
   }

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3608,9 +3608,8 @@ bool TGParser::ParseDef(MultiClass *CurMultiClass) {
     return true;
 
   if (isa<UnsetInit>(Name)) {
-    CurRec =
-        std::make_unique<Record>(Records.getNewAnonymousName(), DefLoc, Records,
-                                 /*Kind=*/Record::RK_Anonymous);
+    CurRec = std::make_unique<Record>(Records.getNewAnonymousName(), DefLoc,
+                                      Records, Record::RK_AnonymousDef);
   } else {
     CurRec = std::make_unique<Record>(Name, NameLoc, Records);
   }
@@ -3928,9 +3927,8 @@ bool TGParser::ParseClass() {
     CurRec->updateClassLoc(Lex.getLoc());
   } else {
     // If this is the first reference to this class, create and add it.
-    auto NewRec =
-        std::make_unique<Record>(Lex.getCurStrVal(), Lex.getLoc(), Records,
-                                 /*Kind=*/Record::RK_Class);
+    auto NewRec = std::make_unique<Record>(Lex.getCurStrVal(), Lex.getLoc(),
+                                           Records, Record::RK_Class);
     CurRec = NewRec.get();
     Records.addClass(std::move(NewRec));
   }

--- a/llvm/lib/TableGen/TGParser.h
+++ b/llvm/lib/TableGen/TGParser.h
@@ -85,7 +85,7 @@ struct MultiClass {
   void dump() const;
 
   MultiClass(StringRef Name, SMLoc Loc, RecordKeeper &Records)
-      : Rec(Name, Loc, Records, /*Kind=*/Record::RK_MultiClass) {}
+      : Rec(Name, Loc, Records, Record::RK_MultiClass) {}
 };
 
 class TGVarScope {

--- a/llvm/lib/TableGen/TGParser.h
+++ b/llvm/lib/TableGen/TGParser.h
@@ -85,7 +85,7 @@ struct MultiClass {
   void dump() const;
 
   MultiClass(StringRef Name, SMLoc Loc, RecordKeeper &Records)
-      : Rec(Name, Loc, Records) {}
+      : Rec(Name, Loc, Records, /*Kind=*/Record::RK_MultiClass) {}
 };
 
 class TGVarScope {
@@ -293,8 +293,7 @@ private:  // Parser methods.
   void ParseValueList(SmallVectorImpl<llvm::Init*> &Result,
                       Record *CurRec, RecTy *ItemType = nullptr);
   bool ParseTemplateArgValueList(SmallVectorImpl<llvm::ArgumentInit *> &Result,
-                                 Record *CurRec, Record *ArgsRec,
-                                 bool IsDefm = false);
+                                 Record *CurRec, Record *ArgsRec);
   void ParseDagArgList(
       SmallVectorImpl<std::pair<llvm::Init*, StringInit*>> &Result,
       Record *CurRec);


### PR DESCRIPTION
enum `RecordKind` is added to indicate the kind of Record (which
can be a normal record definition, anonymous record definition,
class or multiclass).

Some arguments like `IsMC` and `IsDefm` are removed since we can
get the information from `RecordKind`.
