### PR TITLE
[BasicAA] Make isNotCapturedBeforeOrAt() check for calls more precise

### DIFF
--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -152,8 +152,11 @@ raw_ostream &operator<<(raw_ostream &OS, AliasResult AR);
 /// Virtual base class for providers of capture information.
 struct CaptureInfo {
   virtual ~CaptureInfo() = 0;
-  virtual bool isNotCapturedBeforeOrAt(const Value *Object,
-                                       const Instruction *I) = 0;
+
+  /// Check whether Object is not captured before instruction I. If OrAt is
+  /// true, captures by instruction I itself are also considered.
+  virtual bool isNotCapturedBefore(const Value *Object, const Instruction *I,
+                                   bool OrAt) = 0;
 };
 
 /// Context-free CaptureInfo provider, which computes and caches whether an
@@ -163,8 +166,8 @@ class SimpleCaptureInfo final : public CaptureInfo {
   SmallDenseMap<const Value *, bool, 8> IsCapturedCache;
 
 public:
-  bool isNotCapturedBeforeOrAt(const Value *Object,
-                               const Instruction *I) override;
+  bool isNotCapturedBefore(const Value *Object, const Instruction *I,
+                           bool OrAt) override;
 };
 
 /// Context-sensitive CaptureInfo provider, which computes and caches the
@@ -188,8 +191,8 @@ public:
   EarliestEscapeInfo(DominatorTree &DT, const LoopInfo *LI = nullptr)
       : DT(DT), LI(LI) {}
 
-  bool isNotCapturedBeforeOrAt(const Value *Object,
-                               const Instruction *I) override;
+  bool isNotCapturedBefore(const Value *Object, const Instruction *I,
+                           bool OrAt) override;
 
   void removeInstruction(Instruction *I);
 };

--- a/llvm/test/Transforms/GVN/captured-before.ll
+++ b/llvm/test/Transforms/GVN/captured-before.ll
@@ -83,8 +83,7 @@ define i32 @test_capture_readonly() {
 ; CHECK-NEXT:    [[A:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    store i32 123, ptr [[A]], align 4
 ; CHECK-NEXT:    call void @capture(ptr readonly [[A]])
-; CHECK-NEXT:    [[V:%.*]] = load i32, ptr [[A]], align 4
-; CHECK-NEXT:    ret i32 [[V]]
+; CHECK-NEXT:    ret i32 123
 ;
   %a = alloca i32
   store i32 123, ptr %a


### PR DESCRIPTION
For calls, we are only interested in captures before the call, not captures by the call itself -- arguments that get passed to the call are checked explicitly.

In particular, the current implementation is not optimal if the pointer is captured via a readonly argument -- in that case, we know that even if the argument is captured, the call will not modify the argument (at least not via that argument).

Make this more precise by renaming to isCapturedBefore() and adding an OrAt argument that allows us to toggle whether to consider captures in the instruction itself or not.