### PR TITLE
[mlir][nvgpu] Remove strict verifiers on `warpgroup.generate.descriptor`

### DIFF
--- a/mlir/lib/Dialect/NVGPU/IR/NVGPUDialect.cpp
+++ b/mlir/lib/Dialect/NVGPU/IR/NVGPUDialect.cpp
@@ -375,14 +375,8 @@ LogicalResult WarpgroupGenerateDescriptorOp::verify() {
   MemRefType memrefType = getTensor().getType();
   MemRefType tensorMapType = getTensorMap().getType().getTensor();
 
-  if (memrefType != tensorMapType)
-    return emitError() << "memref and tensor map type mismatch";
-
   if (!memrefType.hasStaticShape() || !tensorMapType.hasStaticShape())
     return emitError() << "supports only static shapes";
-
-  if (memrefType.getRank() != 2)
-    return emitError() << "supports only 2d memref is supported for now";
 
   if (getTensorMap().getType().getSwizzle() !=
       TensorMapSwizzleKind::SWIZZLE_128B) {


### PR DESCRIPTION
This PR relaxes some rules in the verifier. I found this to be overly restrictive. It's certainly possible to work around these rules, for example one way is to generate additional subview and etc., but this just bloats the IR.

The test #69913 needs this PR. 