### PR TITLE
[lldb][lldb-server] Enable sending RegisterFlags as XML

### DIFF
--- a/lldb/include/lldb/Target/RegisterFlags.h
+++ b/lldb/include/lldb/Target/RegisterFlags.h
@@ -9,8 +9,6 @@
 #ifndef LLDB_TARGET_REGISTERFLAGS_H
 #define LLDB_TARGET_REGISTERFLAGS_H
 
-#include <cassert>
-#include <stdint.h>
 #include <string>
 #include <vector>
 
@@ -25,10 +23,7 @@ public:
   public:
     /// Where start is the least significant bit and end is the most
     /// significant bit. The start bit must be <= the end bit.
-    Field(std::string name, unsigned start, unsigned end)
-        : m_name(std::move(name)), m_start(start), m_end(end) {
-      assert(m_start <= m_end && "Start bit must be <= end bit.");
-    }
+    Field(std::string name, unsigned start, unsigned end);
 
     /// Construct a field that occupies a single bit.
     Field(std::string name, unsigned bit_position)

--- a/lldb/include/lldb/Target/RegisterFlags.h
+++ b/lldb/include/lldb/Target/RegisterFlags.h
@@ -58,7 +58,7 @@ public:
     unsigned PaddingDistance(const Field &other) const;
 
     /// Output XML that describes this field, to be inserted into a target XML
-    /// file. Reserved characters in field names like "<"" are replaced with
+    /// file. Reserved characters in field names like "<" are replaced with
     /// their XML safe equivalents like "&gt;".
     void ToXML(StreamString &strm) const;
 

--- a/lldb/include/lldb/Target/RegisterFlags.h
+++ b/lldb/include/lldb/Target/RegisterFlags.h
@@ -10,6 +10,7 @@
 #define LLDB_TARGET_REGISTERFLAGS_H
 
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/StreamString.h"
 
 namespace lldb_private {
 
@@ -50,6 +51,10 @@ public:
     /// Return the number of bits between this field and the other, that are not
     /// covered by either field.
     unsigned PaddingDistance(const Field &other) const;
+
+    /// Output XML that describes this field, to be inserted into a target XML
+    /// file.
+    void ToXML(StreamString &strm) const;
 
     bool operator<(const Field &rhs) const {
       return GetStart() < rhs.GetStart();
@@ -105,6 +110,9 @@ public:
   /// going to print the table to. If the table would exceed this width, it will
   /// be split into many tables as needed.
   std::string AsTable(uint32_t max_width) const;
+
+  // Output XML that describes this set of flags.
+  void ToXML(StreamString &strm) const;
 
 private:
   const std::string m_id;

--- a/lldb/include/lldb/Target/RegisterFlags.h
+++ b/lldb/include/lldb/Target/RegisterFlags.h
@@ -9,10 +9,15 @@
 #ifndef LLDB_TARGET_REGISTERFLAGS_H
 #define LLDB_TARGET_REGISTERFLAGS_H
 
-#include "lldb/Utility/Log.h"
-#include "lldb/Utility/StreamString.h"
+#include <cassert>
+#include <stdint.h>
+#include <string>
+#include <vector>
 
 namespace lldb_private {
+
+class StreamString;
+class Log;
 
 class RegisterFlags {
 public:

--- a/lldb/include/lldb/Target/RegisterFlags.h
+++ b/lldb/include/lldb/Target/RegisterFlags.h
@@ -58,7 +58,8 @@ public:
     unsigned PaddingDistance(const Field &other) const;
 
     /// Output XML that describes this field, to be inserted into a target XML
-    /// file.
+    /// file. Reserved characters in field names like "<"" are replaced with
+    /// their XML safe equivalents like "&gt;".
     void ToXML(StreamString &strm) const;
 
     bool operator<(const Field &rhs) const {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -3094,6 +3094,12 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
       continue;
     }
 
+    if (reg_info->flags_type) {
+      response.IndentMore();
+      reg_info->flags_type->ToXML(response);
+      response.IndentLess();
+    }
+
     response.Indent();
     response.Printf("<reg name=\"%s\" bitsize=\"%" PRIu32
                     "\" regnum=\"%d\" ",
@@ -3112,6 +3118,10 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
     llvm::StringRef format = GetFormatNameOrEmpty(*reg_info);
     if (!format.empty())
       response << "format=\"" << format << "\" ";
+
+    if (reg_info->flags_type) {
+      response << "type=\"" << reg_info->flags_type->GetID() << "\" ";
+    }
 
     const char *const register_set_name =
         reg_context.GetRegisterSetNameForRegisterAtIndex(reg_index);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -3119,9 +3119,8 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
     if (!format.empty())
       response << "format=\"" << format << "\" ";
 
-    if (reg_info->flags_type) {
+    if (reg_info->flags_type)
       response << "type=\"" << reg_info->flags_type->GetID() << "\" ";
-    }
 
     const char *const register_set_name =
         reg_context.GetRegisterSetNameForRegisterAtIndex(reg_index);

--- a/lldb/source/Target/RegisterFlags.cpp
+++ b/lldb/source/Target/RegisterFlags.cpp
@@ -175,3 +175,35 @@ std::string RegisterFlags::AsTable(uint32_t max_width) const {
 
   return table;
 }
+
+void RegisterFlags::ToXML(StreamString &strm) const {
+  // Example XML:
+  // <flags id="cpsr_flags" size="4">
+  //   <field name="incorrect" start="0" end="0"/>
+  // </flags>
+  strm.Indent();
+  strm << "<flags id=\"" << GetID() << "\" ";
+  strm.Printf("size=\"%d\"", GetSize());
+  strm << ">";
+  for (const Field &field : m_fields) {
+    // Skip padding fields.
+    if (field.GetName().empty())
+      continue;
+
+    strm << "\n";
+    strm.IndentMore();
+    field.ToXML(strm);
+    strm.IndentLess();
+  }
+  strm.PutChar('\n');
+  strm.Indent("</flags>\n");
+}
+
+void RegisterFlags::Field::ToXML(StreamString &strm) const {
+  // Example XML:
+  // <field name="correct" start="0" end="0"/>
+  strm.Indent();
+  strm << "<field name=\"" << GetName() << "\" ";
+  strm.Printf("start=\"%d\" end=\"%d\"", GetStart(), GetEnd());
+  strm << "/>";
+}

--- a/lldb/source/Target/RegisterFlags.cpp
+++ b/lldb/source/Target/RegisterFlags.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Target/RegisterFlags.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 
 #include <numeric>

--- a/lldb/source/Target/RegisterFlags.cpp
+++ b/lldb/source/Target/RegisterFlags.cpp
@@ -10,6 +10,8 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 
+#include "llvm/ADT/StringExtras.h"
+
 #include <numeric>
 #include <optional>
 
@@ -204,7 +206,13 @@ void RegisterFlags::Field::ToXML(StreamString &strm) const {
   // Example XML:
   // <field name="correct" start="0" end="0"/>
   strm.Indent();
-  strm << "<field name=\"" << GetName() << "\" ";
+  strm << "<field name=\"";
+
+  std::string escaped_name;
+  llvm::raw_string_ostream escape_strm(escaped_name);
+  llvm::printHTMLEscaped(GetName(), escape_strm);
+  strm << escaped_name << "\" ";
+
   strm.Printf("start=\"%d\" end=\"%d\"", GetStart(), GetEnd());
   strm << "/>";
 }

--- a/lldb/source/Target/RegisterFlags.cpp
+++ b/lldb/source/Target/RegisterFlags.cpp
@@ -17,6 +17,11 @@
 
 using namespace lldb_private;
 
+RegisterFlags::Field::Field(std::string name, unsigned start, unsigned end)
+    : m_name(std::move(name)), m_start(start), m_end(end) {
+  assert(m_start <= m_end && "Start bit must be <= end bit.");
+}
+
 void RegisterFlags::Field::log(Log *log) const {
   LLDB_LOG(log, "  Name: \"{0}\" Start: {1} End: {2}", m_name.c_str(), m_start,
            m_end);

--- a/lldb/unittests/Target/RegisterFlagsTest.cpp
+++ b/lldb/unittests/Target/RegisterFlagsTest.cpp
@@ -258,3 +258,35 @@ TEST(RegisterFlagsTest, AsTable) {
             "| really long name |",
             max_many_columns.AsTable(23));
 }
+
+TEST(RegisterFieldsTest, ToXML) {
+  StreamString strm;
+
+  // RegisterFlags requires that some fields be given, so no testing of empty
+  // input.
+
+  // Unnamed fields are padding that are ignored. This applies to fields passed
+  // in, and those generated to fill the other bits (31-1 here).
+  RegisterFlags("Foo", 4, {RegisterFlags::Field("", 0, 0)}).ToXML(strm);
+  ASSERT_EQ(strm.GetString(), "<flags id=\"Foo\" size=\"4\">\n"
+                              "</flags>\n");
+
+  strm.Clear();
+  RegisterFlags("Foo", 4, {RegisterFlags::Field("abc", 0, 0)}).ToXML(strm);
+  ASSERT_EQ(strm.GetString(), "<flags id=\"Foo\" size=\"4\">\n"
+                              "  <field name=\"abc\" start=\"0\" end=\"0\"/>\n"
+                              "</flags>\n");
+
+  strm.Clear();
+  // Should use the current indentation level as a starting point.
+  strm.IndentMore();
+  RegisterFlags(
+      "Bar", 5,
+      {RegisterFlags::Field("f1", 25, 32), RegisterFlags::Field("f2", 10, 24)})
+      .ToXML(strm);
+  ASSERT_EQ(strm.GetString(),
+            "  <flags id=\"Bar\" size=\"5\">\n"
+            "    <field name=\"f1\" start=\"25\" end=\"32\"/>\n"
+            "    <field name=\"f2\" start=\"10\" end=\"24\"/>\n"
+            "  </flags>\n");
+}

--- a/lldb/unittests/Target/RegisterFlagsTest.cpp
+++ b/lldb/unittests/Target/RegisterFlagsTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Target/RegisterFlags.h"
+#include "lldb/Utility/StreamString.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -289,4 +290,21 @@ TEST(RegisterFieldsTest, ToXML) {
             "    <field name=\"f1\" start=\"25\" end=\"32\"/>\n"
             "    <field name=\"f2\" start=\"10\" end=\"24\"/>\n"
             "  </flags>\n");
+
+  strm.Clear();
+  strm.IndentLess();
+  // Should replace any XML unsafe characters in field names.
+  RegisterFlags("Safe", 8,
+                {RegisterFlags::Field("A<", 4), RegisterFlags::Field("B>", 3),
+                 RegisterFlags::Field("C'", 2), RegisterFlags::Field("D\"", 1),
+                 RegisterFlags::Field("E&", 0)})
+      .ToXML(strm);
+  ASSERT_EQ(strm.GetString(),
+            "<flags id=\"Safe\" size=\"8\">\n"
+            "  <field name=\"A&lt;\" start=\"4\" end=\"4\"/>\n"
+            "  <field name=\"B&gt;\" start=\"3\" end=\"3\"/>\n"
+            "  <field name=\"C&apos;\" start=\"2\" end=\"2\"/>\n"
+            "  <field name=\"D&quot;\" start=\"1\" end=\"1\"/>\n"
+            "  <field name=\"E&amp;\" start=\"0\" end=\"0\"/>\n"
+            "</flags>\n");
 }


### PR DESCRIPTION
This adds ToXML methods to encode RegisterFlags and its fields into XML according to GDB's target XML format:
https://sourceware.org/gdb/onlinedocs/gdb/Target-Description-Format.html#Target-Description-Format

lldb-server does not use libXML to build XML, so this follows the existing code that uses strings. Indentation is used so the result is still human readable.

```
<flags id=\"Foo\" size=\"4\">
  <field name=\"abc\" start=\"0\" end=\"0\"/>
</flags>
```

This is used by lldb-server when building target XML, though no one sets any fields yet. That'll come in a later commit.