### PR TITLE
[SystemZ][NFC] Fix a couple of style issues

### DIFF
--- a/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
+++ b/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
@@ -154,8 +154,8 @@ private:
   }
 
 public:
-  SystemZOperand(OperandKind kind, SMLoc startLoc, SMLoc endLoc)
-      : Kind(kind), StartLoc(startLoc), EndLoc(endLoc) {}
+  SystemZOperand(OperandKind Kind, SMLoc StartLoc, SMLoc EndLoc)
+      : Kind(Kind), StartLoc(StartLoc), EndLoc(EndLoc) {}
 
   // Create particular kinds of operand.
   static std::unique_ptr<SystemZOperand> createInvalid(SMLoc StartLoc,
@@ -1084,7 +1084,8 @@ SystemZAsmParser::parseAddressRegister(Register &Reg) {
   if (Reg.Group == RegV) {
     Error(Reg.StartLoc, "invalid use of vector addressing");
     return true;
-  } else if (Reg.Group != RegGR) {
+  }
+  if (Reg.Group != RegGR) {
     Error(Reg.StartLoc, "invalid address register");
     return true;
   }
@@ -1236,8 +1237,8 @@ bool SystemZAsmParser::ParseDirectiveInsn(SMLoc L) {
   assert(Entry->Format == Format);
 
   // Parse the following operands using the table's information.
-  for (int i = 0; i < Entry->NumOperands; i++) {
-    MatchClassKind Kind = Entry->OperandKinds[i];
+  for (int I = 0; I < Entry->NumOperands; I++) {
+    MatchClassKind Kind = Entry->OperandKinds[I];
 
     SMLoc StartLoc = Parser.getTok().getLoc();
 
@@ -1285,9 +1286,9 @@ bool SystemZAsmParser::ParseDirectiveInsn(SMLoc L) {
   // Build the instruction with the parsed operands.
   MCInst Inst = MCInstBuilder(Entry->Opcode);
 
-  for (size_t i = 0; i < Operands.size(); i++) {
-    MCParsedAsmOperand &Operand = *Operands[i];
-    MatchClassKind Kind = Entry->OperandKinds[i];
+  for (size_t I = 0; I < Operands.size(); I++) {
+    MCParsedAsmOperand &Operand = *Operands[I];
+    MatchClassKind Kind = Entry->OperandKinds[I];
 
     // Verify operand.
     unsigned Res = validateOperandClass(Operand, Kind);
@@ -1583,7 +1584,7 @@ ParseStatus SystemZAsmParser::parsePCRel(OperandVector &Operands,
   if (getParser().parseExpression(Expr))
     return ParseStatus::NoMatch;
 
-  auto isOutOfRangeConstant = [&](const MCExpr *E, bool Negate) -> bool {
+  auto IsOutOfRangeConstant = [&](const MCExpr *E, bool Negate) -> bool {
     if (auto *CE = dyn_cast<MCConstantExpr>(E)) {
       int64_t Value = CE->getValue();
       if (Negate)
@@ -1599,7 +1600,7 @@ ParseStatus SystemZAsmParser::parsePCRel(OperandVector &Operands,
   if (auto *CE = dyn_cast<MCConstantExpr>(Expr)) {
     if (isParsingHLASM())
       return Error(StartLoc, "Expected PC-relative expression");
-    if (isOutOfRangeConstant(CE, false))
+    if (IsOutOfRangeConstant(CE, false))
       return Error(StartLoc, "offset out of range");
     int64_t Value = CE->getValue();
     MCSymbol *Sym = Ctx.createTempSymbol();
@@ -1612,8 +1613,8 @@ ParseStatus SystemZAsmParser::parsePCRel(OperandVector &Operands,
   // For consistency with the GNU assembler, conservatively assume that a
   // constant offset must by itself be within the given size range.
   if (const auto *BE = dyn_cast<MCBinaryExpr>(Expr))
-    if (isOutOfRangeConstant(BE->getLHS(), false) ||
-        isOutOfRangeConstant(BE->getRHS(),
+    if (IsOutOfRangeConstant(BE->getLHS(), false) ||
+        IsOutOfRangeConstant(BE->getRHS(),
                              BE->getOpcode() == MCBinaryExpr::Sub))
       return Error(StartLoc, "offset out of range");
 
@@ -1702,6 +1703,7 @@ bool SystemZAsmParser::isLabel(AsmToken &Token) {
 }
 
 // Force static initialization.
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZAsmParser() {
   RegisterMCAsmParser<SystemZAsmParser> X(getTheSystemZTarget());
 }

--- a/llvm/lib/Target/SystemZ/Disassembler/SystemZDisassembler.cpp
+++ b/llvm/lib/Target/SystemZ/Disassembler/SystemZDisassembler.cpp
@@ -32,7 +32,7 @@ public:
     : MCDisassembler(STI, Ctx) {}
   ~SystemZDisassembler() override = default;
 
-  DecodeStatus getInstruction(MCInst &instr, uint64_t &Size,
+  DecodeStatus getInstruction(MCInst &Instr, uint64_t &Size,
                               ArrayRef<uint8_t> Bytes, uint64_t Address,
                               raw_ostream &CStream) const override;
 };
@@ -45,6 +45,7 @@ static MCDisassembler *createSystemZDisassembler(const Target &T,
   return new SystemZDisassembler(STI, Ctx);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZDisassembler() {
   // Register the disassembler.
   TargetRegistry::RegisterMCDisassembler(getTheSystemZTarget(),
@@ -70,11 +71,11 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZDisassembler() {
 /// is done and if a symbol is found an MCExpr is created with that, else
 /// an MCExpr with the immediate Value is created.  This function returns true
 /// if it adds an operand to the MCInst and false otherwise.
-static bool tryAddingSymbolicOperand(int64_t Value, bool isBranch,
+static bool tryAddingSymbolicOperand(int64_t Value, bool IsBranch,
                                      uint64_t Address, uint64_t Offset,
                                      uint64_t Width, MCInst &MI,
                                      const MCDisassembler *Decoder) {
-  return Decoder->tryAddingSymbolicOperand(MI, Value, Address, isBranch, Offset,
+  return Decoder->tryAddingSymbolicOperand(MI, Value, Address, IsBranch, Offset,
                                            Width, /*InstSize=*/0);
 }
 

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZELFObjectWriter.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZELFObjectWriter.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstdint>
+#include <memory>
 
 using namespace llvm;
 

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZGOFFObjectWriter.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZGOFFObjectWriter.cpp
@@ -8,6 +8,7 @@
 
 #include "MCTargetDesc/SystemZMCTargetDesc.h"
 #include "llvm/MC/MCGOFFObjectWriter.h"
+#include <memory>
 
 using namespace llvm;
 

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCCodeEmitter.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCCodeEmitter.cpp
@@ -22,7 +22,6 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cstdint>
 
@@ -37,9 +36,8 @@ class SystemZMCCodeEmitter : public MCCodeEmitter {
   MCContext &Ctx;
 
 public:
-  SystemZMCCodeEmitter(const MCInstrInfo &mcii, MCContext &ctx)
-    : MCII(mcii), Ctx(ctx) {
-  }
+  SystemZMCCodeEmitter(const MCInstrInfo &MCII, MCContext &Ctx)
+      : MCII(MCII), Ctx(Ctx) {}
 
   ~SystemZMCCodeEmitter() override = default;
 

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCExpr.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCExpr.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TARGET_SystemZ_MCTARGETDESC_SystemZMCEXPR_H
-#define LLVM_LIB_TARGET_SystemZ_MCTARGETDESC_SystemZMCEXPR_H
+#ifndef LLVM_LIB_TARGET_SYSTEMZ_MCTARGETDESC_SYSTEMZMCEXPR_H
+#define LLVM_LIB_TARGET_SYSTEMZ_MCTARGETDESC_SYSTEMZMCEXPR_H
 
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCStreamer.h"

--- a/llvm/lib/Target/SystemZ/SystemZSubtarget.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZSubtarget.cpp
@@ -59,10 +59,8 @@ SystemZSubtarget::initializeSpecialRegisters() {
     return new SystemZXPLINK64Registers;
   else if (isTargetELF())
     return new SystemZELFRegisters;
-  else {
-    llvm_unreachable("Invalid Calling Convention. Cannot initialize Special "
-                     "Call Registers!");
-  }
+  llvm_unreachable("Invalid Calling Convention. Cannot initialize Special "
+                   "Call Registers!");
 }
 
 SystemZSubtarget::SystemZSubtarget(const Triple &TT, const std::string &CPU,

--- a/llvm/lib/Target/SystemZ/SystemZTargetMachine.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZTargetMachine.cpp
@@ -13,8 +13,6 @@
 #include "SystemZMachineScheduler.h"
 #include "SystemZTargetTransformInfo.h"
 #include "TargetInfo/SystemZTargetInfo.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/CodeGen/Passes.h"
@@ -25,11 +23,13 @@
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Transforms/Scalar.h"
+#include <memory>
 #include <optional>
 #include <string>
 
 using namespace llvm;
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZTarget() {
   // Register the target.
   RegisterTargetMachine<SystemZTargetMachine> X(getTheSystemZTarget());
@@ -171,9 +171,9 @@ SystemZTargetMachine::getSubtargetImpl(const Function &F) const {
   // FIXME: This is related to the code below to reset the target options,
   // we need to know whether or not the soft float flag is set on the
   // function, so we can enable it as a subtarget feature.
-  bool softFloat = F.getFnAttribute("use-soft-float").getValueAsBool();
+  bool SoftFloat = F.getFnAttribute("use-soft-float").getValueAsBool();
 
-  if (softFloat)
+  if (SoftFloat)
     FS += FS.empty() ? "+soft-float" : ",+soft-float";
 
   auto &I = SubtargetMap[CPU + TuneCPU + FS];

--- a/llvm/lib/Target/SystemZ/TargetInfo/SystemZTargetInfo.cpp
+++ b/llvm/lib/Target/SystemZ/TargetInfo/SystemZTargetInfo.cpp
@@ -16,6 +16,7 @@ Target &llvm::getTheSystemZTarget() {
   return TheSystemZTarget;
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZTargetInfo() {
   RegisterTarget<Triple::systemz, /*HasJIT=*/true> X(
       getTheSystemZTarget(), "systemz", "SystemZ", "SystemZ");


### PR DESCRIPTION
Some fixes for style issues pointed out by clang-tidy:

- Upper case/lower case fixes
- No else after return
- Removed unused #include's
- Added NOLINTNEXTLINE() for the LLVM* functions

All changes are NFC.