### PR TITLE
Change 'grow_by' to use precise size for the first SSO --> long allocation

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -2315,10 +2315,13 @@ basic_string<_CharT, _Traits, _Allocator>::__grow_by_and_replace
     size_type __ms = max_size();
     if (__delta_cap > __ms - __old_cap - 1)
         __throw_length_error();
-    pointer __old_p = __get_pointer();
-    size_type __cap = __old_cap < __ms / 2 - __alignment ?
-                          __recommend(std::max(__old_cap + __delta_cap, 2 * __old_cap)) :
-                          __ms - 1;
+    const bool __was_short = !__is_long();
+    pointer __old_p        = __was_short ? __get_short_pointer() : __get_long_pointer();
+    size_type __cap =
+        __was_short
+            ? __recommend(__old_cap + __delta_cap)
+            : (__old_cap < __ms / 2 - __alignment ? __recommend(std::max(__old_cap + __delta_cap, 2 * __old_cap))
+                                                  : __ms - 1);
     auto __allocation = std::__allocate_at_least(__alloc(), __cap + 1);
     pointer __p = __allocation.ptr;
     __begin_lifetime(__p, __allocation.count);
@@ -2356,10 +2359,13 @@ basic_string<_CharT, _Traits, _Allocator>::__grow_by(size_type __old_cap, size_t
     size_type __ms = max_size();
     if (__delta_cap > __ms - __old_cap)
         __throw_length_error();
-    pointer __old_p = __get_pointer();
-    size_type __cap = __old_cap < __ms / 2 - __alignment ?
-                          __recommend(std::max(__old_cap + __delta_cap, 2 * __old_cap)) :
-                          __ms - 1;
+    const bool __was_short = !__is_long();
+    pointer __old_p        = __was_short ? __get_short_pointer() : __get_long_pointer();
+    size_type __cap =
+        __was_short
+            ? __recommend(__old_cap + __delta_cap)
+            : (__old_cap < __ms / 2 - __alignment ? __recommend(std::max(__old_cap + __delta_cap, 2 * __old_cap))
+                                                  : __ms - 1);
     auto __allocation = std::__allocate_at_least(__alloc(), __cap + 1);
     pointer __p = __allocation.ptr;
     __begin_lifetime(__p, __allocation.count);

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/allocation_size.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/allocation_size.pass.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <cstddef>
 #include <string>
+#include <iostream>
 
 #include "test_macros.h"
 
@@ -26,7 +27,7 @@ const std::size_t alignment =
     16;
 #endif
 
-int main(int, char**) {
+void test_size_wrt_alignment() {
   std::string input_string;
   input_string.resize(64, 'a');
 
@@ -40,6 +41,25 @@ int main(int, char**) {
   } else {
     assert(test_string.capacity() == expected_align8_size + 8);
   }
+}
+
+void test_resize_from_small_size() {
+  // Test that we don't waste additional bytes when growing from the SSO
+  // to a specific size. The size of the SSO is an implementation detail
+  // and shouldn't be taken into account when deciding on the next size.
+  {
+    const std::size_t sso_capacity = std::string().capacity();
+    const std::string input(sso_capacity, 'a');
+    std::string s;
+    s = input.c_str();
+    std::cout << "Have capacity = " << s.capacity() << " and size = " << s.size() << std::endl;
+    assert(s.capacity() == input.size());
+  }
+}
+
+int main(int, char**) {
+  test_size_wrt_alignment();
+  test_resize_from_small_size();
 
   return 0;
 }

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/allocation_size.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/allocation_size.pass.cpp
@@ -14,7 +14,7 @@
 #include <cassert>
 #include <cstddef>
 #include <string>
-#include <iostream>
+#include <cstdio>
 
 #include "test_macros.h"
 
@@ -52,7 +52,7 @@ void test_resize_from_small_size() {
     const std::string input(sso_capacity, 'a');
     std::string s;
     s = input.c_str();
-    std::cout << "Have capacity = " << s.capacity() << " and size = " << s.size() << std::endl;
+    std::printf("Have Capacity = %zu and size = %zu\n", s.capacity(), s.size());
     assert(s.capacity() == input.size());
   }
 }


### PR DESCRIPTION
The logic currently always at least doubles the capacity on growth. However, the SSO size is an implementation detail, and represents nothing about the usage pattern of the string (unlike long capacities).

Further this causes any short or empty initialized string exceeding 22 bytes to be allocated to at least 48 bytes. (22 * 2 rounded up to 48). This is wasteful as there are likely plenty of strings that could be allocated into 40 (glibc) or 32 (tcmalloc) sized allocs.

This patch was originally from mvels.