### PR TITLE
[OpenMP][Tests] Sync struct DEP with the runtime

### DIFF
--- a/openmp/runtime/test/tasking/kmp_detach_tasks_t3.c
+++ b/openmp/runtime/test/tasking/kmp_detach_tasks_t3.c
@@ -56,7 +56,7 @@ typedef struct task {
 typedef struct DEP {
   size_t addr;
   size_t len;
-  int flags;
+  unsigned char flags;
 } dep;
 
 typedef int(* task_entry_t)( int, ptask );

--- a/openmp/runtime/test/tasking/kmp_taskwait_nowait.c
+++ b/openmp/runtime/test/tasking/kmp_taskwait_nowait.c
@@ -11,7 +11,7 @@
 typedef struct DEP {
   size_t addr;
   size_t len;
-  int flags;
+  unsigned char flags;
 } _dep;
 typedef struct ID {
   int reserved_1;

--- a/openmp/runtime/test/tasking/omp50_task_depend_mtx.c
+++ b/openmp/runtime/test/tasking/omp50_task_depend_mtx.c
@@ -37,7 +37,7 @@ typedef int(*entry_t)(int, int**);
 typedef struct DEP {
   size_t addr;
   size_t len;
-  int flags;
+  unsigned char flags;
 } dep;
 typedef struct ID {
   int reserved_1;

--- a/openmp/runtime/test/tasking/omp50_task_depend_mtx2.c
+++ b/openmp/runtime/test/tasking/omp50_task_depend_mtx2.c
@@ -37,7 +37,7 @@ typedef int(*entry_t)(int, int**);
 typedef struct DEP {
   size_t addr;
   size_t len;
-  int flags;
+  unsigned char flags;
 } dep;
 typedef struct ID {
   int reserved_1;


### PR DESCRIPTION
struct DEP defined in multiple testcases must correspond to runtime's struct kmp_depend_info. The former defines flags as int, and the latter as kmp_uint8_t. This discrepancy goes unnoticed on little-endian systems, but breaks big-endian ones.

Make flags in struct DEP unsigned char.