### PR TITLE
[libc++] Avoid discarding const-ness when copy-constructing vectors

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -1276,7 +1276,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20
 vector<_Tp, _Allocator>::vector(const vector& __x)
     : __end_cap_(nullptr, __alloc_traits::select_on_container_copy_construction(__x.__alloc()))
 {
-  __init_with_size(__x.__begin_, __x.__end_, __x.size());
+  __init_with_size(__x.begin(), __x.end(), __x.size());
 }
 
 template <class _Tp, class _Allocator>
@@ -1284,7 +1284,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20
 vector<_Tp, _Allocator>::vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
     : __end_cap_(nullptr, __a)
 {
-  __init_with_size(__x.__begin_, __x.__end_, __x.size());
+  __init_with_size(__x.begin(), __x.end(), __x.size());
 }
 
 template <class _Tp, class _Allocator>
@@ -1409,7 +1409,7 @@ vector<_Tp, _Allocator>::operator=(const vector& __x)
     if (this != std::addressof(__x))
     {
         __copy_assign_alloc(__x);
-        assign(__x.__begin_, __x.__end_);
+        assign(__x.begin(), __x.end());
     }
     return *this;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/copy.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/copy.pass.cpp
@@ -18,6 +18,12 @@
 #include "min_allocator.h"
 #include "asan_testing.h"
 
+struct HasNonConstCopyConstructor {
+    HasNonConstCopyConstructor() = default;
+    TEST_CONSTEXPR HasNonConstCopyConstructor(HasNonConstCopyConstructor const&) { }
+    HasNonConstCopyConstructor(HasNonConstCopyConstructor&) { assert(false); }
+};
+
 template <class C>
 TEST_CONSTEXPR_CXX20 void
 test(const C& x)
@@ -57,6 +63,12 @@ TEST_CONSTEXPR_CXX20 bool tests() {
         assert(is_contiguous_container_asan_correct(v));
         assert(is_contiguous_container_asan_correct(v2));
         assert(v2.empty());
+    }
+    {
+        // Make sure we copy elements of the vector using the right copy constructor.
+        std::vector<HasNonConstCopyConstructor> v(5);
+        std::vector<HasNonConstCopyConstructor> v2 = v;
+        assert(v2.size() == 5);
     }
 #if TEST_STD_VER >= 11
     {


### PR DESCRIPTION
Copy-constructing a std::vector<T> currently discards the const-ness of the elements of the source vector. So for example, if the elements in the vector have both `T(T&)` and `T(T const&)` constructors, the non-const constructor is going to be preferred. This patch fixes that and makes sure that constness is respected by the copy constructor and copy assignment operators.

rdar://107652763