### PR TITLE
Reintroduce accidentally deleted "protected" keyword in SymbolFileDWARF

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -82,6 +82,7 @@ public:
   friend class DebugMapModule;
   friend class DWARFCompileUnit;
   friend class DWARFDIE;
+  friend class DWARFASTParser;
   friend class ::DWARFASTParserClang;
 
   // Static Functions
@@ -321,6 +322,7 @@ public:
     m_file_index = file_index;
   }
 
+protected:
   typedef llvm::DenseMap<const DWARFDebugInfoEntry *, Type *> DIEToTypePtr;
   typedef llvm::DenseMap<const DWARFDebugInfoEntry *, lldb::VariableSP>
       DIEToVariableSP;


### PR DESCRIPTION
The "protected" was accidentally removed during refactoring of SymbolFileDWARF. Reintroduce it and also make DWARFASTParser a friend class since 040c4f4d98f3306e068521e3c218bdbc170f81f3 was merged and won't build without it, as it dependeds on a method which was made public by accident.