### PR TITLE
[lldb] Part 2 of 2 - Refactor `CommandObject::DoExecute(...)` return `void` (not `bool`)

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandObject.h
+++ b/lldb/include/lldb/Interpreter/CommandObject.h
@@ -401,7 +401,7 @@ public:
   void Execute(const char *args_string, CommandReturnObject &result) override;
 
 protected:
-  virtual bool DoExecute(Args &command, CommandReturnObject &result) = 0;
+  virtual void DoExecute(Args &command, CommandReturnObject &result) = 0;
 
   bool WantsRawCommandString() override { return false; }
 };
@@ -418,7 +418,7 @@ public:
   void Execute(const char *args_string, CommandReturnObject &result) override;
 
 protected:
-  virtual bool DoExecute(llvm::StringRef command,
+  virtual void DoExecute(llvm::StringRef command,
                          CommandReturnObject &result) = 0;
 
   bool WantsRawCommandString() override { return true; }

--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -70,13 +70,11 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     SBCommandReturnObject sb_return(result);
     SBCommandInterpreter sb_interpreter(&m_interpreter);
     SBDebugger debugger_sb(m_interpreter.GetDebugger().shared_from_this());
-    bool ret = m_backend->DoExecute(debugger_sb, command.GetArgumentVector(),
-                                    sb_return);
-    return ret;
+    m_backend->DoExecute(debugger_sb, command.GetArgumentVector(), sb_return);
   }
   std::shared_ptr<lldb::SBCommandPluginInterface> m_backend;
   std::optional<std::string> m_auto_repeat_command;

--- a/lldb/source/Commands/CommandObjectApropos.cpp
+++ b/lldb/source/Commands/CommandObjectApropos.cpp
@@ -38,7 +38,7 @@ CommandObjectApropos::CommandObjectApropos(CommandInterpreter &interpreter)
 
 CommandObjectApropos::~CommandObjectApropos() = default;
 
-bool CommandObjectApropos::DoExecute(Args &args, CommandReturnObject &result) {
+void CommandObjectApropos::DoExecute(Args &args, CommandReturnObject &result) {
   const size_t argc = args.GetArgumentCount();
 
   if (argc == 1) {
@@ -90,6 +90,4 @@ bool CommandObjectApropos::DoExecute(Args &args, CommandReturnObject &result) {
   } else {
     result.AppendError("'apropos' must be called with exactly one argument.\n");
   }
-
-  return result.Succeeded();
 }

--- a/lldb/source/Commands/CommandObjectApropos.h
+++ b/lldb/source/Commands/CommandObjectApropos.h
@@ -23,7 +23,7 @@ public:
   ~CommandObjectApropos() override;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -528,7 +528,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget(m_dummy_options.m_use_dummy);
 
     // The following are the various types of breakpoints that could be set:
@@ -577,12 +577,12 @@ protected:
       if (num_files == 0) {
         if (!GetDefaultFile(target, file, result)) {
           result.AppendError("No file supplied and no default file available.");
-          return false;
+          return;
         }
       } else if (num_files > 1) {
         result.AppendError("Only one file at a time is allowed for file and "
                            "line breakpoints.");
-        return false;
+        return;
       } else
         file = m_options.m_filenames.GetFileSpecAtIndex(0);
 
@@ -613,7 +613,7 @@ protected:
       } else {
         result.AppendError("Only one shared library can be specified for "
                            "address breakpoints.");
-        return false;
+        return;
       }
       break;
     }
@@ -647,7 +647,7 @@ protected:
             result.AppendWarning(
                 "Function name regex does not accept glob patterns.");
         }
-        return false;
+        return;
       }
 
       bp_sp = target.CreateFuncRegexBreakpoint(
@@ -664,7 +664,7 @@ protected:
         if (!GetDefaultFile(target, file, result)) {
           result.AppendError(
               "No files provided and could not find default file.");
-          return false;
+          return;
         } else {
           m_options.m_filenames.Append(file);
         }
@@ -675,7 +675,7 @@ protected:
         result.AppendErrorWithFormat(
             "Source text regular expression could not be compiled: \"%s\"",
             llvm::toString(std::move(err)).c_str());
-        return false;
+        return;
       }
       bp_sp = target.CreateSourceRegexBreakpoint(
           &(m_options.m_modules), &(m_options.m_filenames),
@@ -693,7 +693,7 @@ protected:
             "Error setting extra exception arguments: %s",
             precond_error.AsCString());
         target.RemoveBreakpointByID(bp_sp->GetID());
-        return false;
+        return;
       }
     } break;
     case eSetTypeScripted: {
@@ -707,7 +707,7 @@ protected:
         result.AppendErrorWithFormat(
             "Error setting extra exception arguments: %s", error.AsCString());
         target.RemoveBreakpointByID(bp_sp->GetID());
-        return false;
+        return;
       }
     } break;
     default:
@@ -726,7 +726,7 @@ protected:
             result.AppendErrorWithFormat("Invalid breakpoint name: %s",
                                          name.c_str());
             target.RemoveBreakpointByID(bp_sp->GetID());
-            return false;
+            return;
           }
         }
       }
@@ -753,8 +753,6 @@ protected:
     } else if (!bp_sp) {
       result.AppendError("Breakpoint creation failed: No breakpoint created.");
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -835,7 +833,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget(m_dummy_opts.m_use_dummy);
 
     std::unique_lock<std::recursive_mutex> lock;
@@ -868,8 +866,6 @@ protected:
         }
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -906,7 +902,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
 
     std::unique_lock<std::recursive_mutex> lock;
@@ -918,7 +914,7 @@ protected:
 
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints exist to be enabled.");
-      return false;
+      return;
     }
 
     if (command.empty()) {
@@ -963,8 +959,6 @@ protected:
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       }
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -1020,7 +1014,7 @@ the second re-enables the first location.");
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
     std::unique_lock<std::recursive_mutex> lock;
     target.GetBreakpointList().GetListMutex(lock);
@@ -1030,7 +1024,7 @@ protected:
 
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints exist to be disabled.");
-      return false;
+      return;
     }
 
     if (command.empty()) {
@@ -1076,8 +1070,6 @@ protected:
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       }
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -1168,7 +1160,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget(m_options.m_use_dummy);
 
     const BreakpointList &breakpoints =
@@ -1181,7 +1173,7 @@ protected:
     if (num_breakpoints == 0) {
       result.AppendMessage("No breakpoints currently set.");
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     Stream &output_stream = result.GetOutputStream();
@@ -1216,8 +1208,6 @@ protected:
         result.AppendError("Invalid breakpoint ID.");
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -1289,7 +1279,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
 
     // The following are the various types of breakpoints that could be
@@ -1310,7 +1300,7 @@ protected:
     // Early return if there's no breakpoint at all.
     if (num_breakpoints == 0) {
       result.AppendError("Breakpoint clear: No breakpoint cleared.");
-      return result.Succeeded();
+      return;
     }
 
     // Find matching breakpoints and delete them.
@@ -1357,8 +1347,6 @@ protected:
     } else {
       result.AppendError("Breakpoint clear: No breakpoint cleared.");
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -1445,7 +1433,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget(m_options.m_use_dummy);
     result.Clear();
     
@@ -1458,7 +1446,7 @@ protected:
 
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints exist to be deleted.");
-      return false;
+      return;
     }
 
     // Handle the delete all breakpoints case:
@@ -1475,7 +1463,7 @@ protected:
             (uint64_t)num_breakpoints, num_breakpoints > 1 ? "s" : "");
       }
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return result.Succeeded();
+      return;
     }
  
     // Either we have some kind of breakpoint specification(s),
@@ -1491,7 +1479,7 @@ protected:
             command, &target, result, &excluded_bp_ids,
             BreakpointName::Permissions::PermissionKinds::deletePerm);
         if (!result.Succeeded())
-          return false;
+          return;
       }
 
       for (auto breakpoint_sp : breakpoints.Breakpoints()) {
@@ -1504,14 +1492,14 @@ protected:
       }
       if (valid_bp_ids.GetSize() == 0) {
         result.AppendError("No disabled breakpoints.");
-        return false;
+        return;
       }
     } else {
       CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
           command, &target, result, &valid_bp_ids,
           BreakpointName::Permissions::PermissionKinds::deletePerm);
       if (!result.Succeeded())
-        return false;
+        return;
     }
     
     int delete_count = 0;
@@ -1542,7 +1530,6 @@ protected:
         "%d breakpoints deleted; %d breakpoint locations disabled.\n",
         delete_count, disable_count);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 
 private:
@@ -1709,12 +1696,12 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
 
     const size_t argc = command.GetArgumentCount();
     if (argc == 0) {
       result.AppendError("No names provided.");
-      return false;
+      return;
     }
 
     Target &target = GetSelectedOrDummyTarget(false);
@@ -1728,7 +1715,7 @@ protected:
       if (!BreakpointID::StringIsBreakpointName(entry.ref(), error)) {
         result.AppendErrorWithFormat("Invalid breakpoint name: %s - %s",
                                      entry.c_str(), error.AsCString());
-        return false;
+        return;
       }
     }
     // Now configure them, we already pre-checked the names so we don't need to
@@ -1741,7 +1728,7 @@ protected:
       if (!bp_sp) {
         result.AppendErrorWithFormatv("Could not find specified breakpoint {0}",
                                       bp_id);
-        return false;
+        return;
       }
     }
 
@@ -1765,7 +1752,6 @@ protected:
                                        m_bp_opts.GetBreakpointOptions(),
                                        m_access_options.GetPermissions());
     }
-    return true;
   }
 
 private:
@@ -1806,10 +1792,10 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (!m_name_options.m_name.OptionWasSet()) {
       result.AppendError("No name option provided.");
-      return false;
+      return;
     }
 
     Target &target =
@@ -1823,7 +1809,7 @@ protected:
     size_t num_breakpoints = breakpoints.GetSize();
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints, cannot add names.");
-      return false;
+      return;
     }
 
     // Particular breakpoint selected; disable that breakpoint.
@@ -1835,7 +1821,7 @@ protected:
     if (result.Succeeded()) {
       if (valid_bp_ids.GetSize() == 0) {
         result.AppendError("No breakpoints specified, cannot add names.");
-        return false;
+        return;
       }
       size_t num_valid_ids = valid_bp_ids.GetSize();
       const char *bp_name = m_name_options.m_name.GetCurrentValue();
@@ -1848,8 +1834,6 @@ protected:
         target.AddNameToBreakpoint(bp_sp, bp_name, error);
       }
     }
-
-    return true;
   }
 
 private:
@@ -1889,10 +1873,10 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (!m_name_options.m_name.OptionWasSet()) {
       result.AppendError("No name option provided.");
-      return false;
+      return;
     }
 
     Target &target =
@@ -1906,7 +1890,7 @@ protected:
     size_t num_breakpoints = breakpoints.GetSize();
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints, cannot delete names.");
-      return false;
+      return;
     }
 
     // Particular breakpoint selected; disable that breakpoint.
@@ -1918,7 +1902,7 @@ protected:
     if (result.Succeeded()) {
       if (valid_bp_ids.GetSize() == 0) {
         result.AppendError("No breakpoints specified, cannot delete names.");
-        return false;
+        return;
       }
       ConstString bp_name(m_name_options.m_name.GetCurrentValue());
       size_t num_valid_ids = valid_bp_ids.GetSize();
@@ -1929,8 +1913,6 @@ protected:
         target.RemoveNameFromBreakpoint(bp_sp, bp_name);
       }
     }
-
-    return true;
   }
 
 private:
@@ -1955,7 +1937,7 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target =
         GetSelectedOrDummyTarget(m_name_options.m_use_dummy.GetCurrentValue());
 
@@ -2005,7 +1987,6 @@ protected:
         }
       }
     }
-    return true;
   }
 
 private:
@@ -2267,7 +2248,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
 
     std::unique_lock<std::recursive_mutex> lock;
@@ -2281,7 +2262,7 @@ protected:
 
     if (!error.Success()) {
       result.AppendError(error.AsCString());
-      return false;
+      return;
     }
 
     Stream &output_stream = result.GetOutputStream();
@@ -2302,7 +2283,6 @@ protected:
                              false);
       }
     }
-    return result.Succeeded();
   }
 
 private:
@@ -2383,7 +2363,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
 
     std::unique_lock<std::recursive_mutex> lock;
@@ -2397,7 +2377,7 @@ protected:
 
       if (!result.Succeeded()) {
         result.SetStatus(eReturnStatusFailed);
-        return false;
+        return;
       }
     }
     FileSpec file_spec(m_options.m_filename);
@@ -2408,7 +2388,6 @@ protected:
       result.AppendErrorWithFormat("error serializing breakpoints: %s.",
                                    error.AsCString());
     }
-    return result.Succeeded();
   }
 
 private:

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -334,7 +334,7 @@ are no syntax errors may indicate that a function was declared but never called.
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget(m_options.m_use_dummy);
 
     const BreakpointList &breakpoints = target.GetBreakpointList();
@@ -342,7 +342,7 @@ protected:
 
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints exist to have commands added");
-      return false;
+      return;
     }
 
     if (!m_func_options.GetName().empty()) {
@@ -412,8 +412,6 @@ protected:
           CollectDataForBreakpointCommandCallback(m_bp_options_vec, result);
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -506,7 +504,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget(m_options.m_use_dummy);
 
     const BreakpointList &breakpoints = target.GetBreakpointList();
@@ -514,13 +512,13 @@ protected:
 
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints exist to have commands deleted");
-      return false;
+      return;
     }
 
     if (command.empty()) {
       result.AppendError(
           "No breakpoint specified from which to delete the commands");
-      return false;
+      return;
     }
 
     BreakpointIDList valid_bp_ids;
@@ -544,7 +542,7 @@ protected:
               result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.\n",
                                            cur_bp_id.GetBreakpointID(),
                                            cur_bp_id.GetLocationID());
-              return false;
+              return;
             }
           } else {
             bp->ClearCallback();
@@ -552,7 +550,6 @@ protected:
         }
       }
     }
-    return result.Succeeded();
   }
 
 private:
@@ -586,7 +583,7 @@ public:
   ~CommandObjectBreakpointCommandList() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     const BreakpointList &breakpoints = target->GetBreakpointList();
@@ -594,13 +591,13 @@ protected:
 
     if (num_breakpoints == 0) {
       result.AppendError("No breakpoints exist for which to list commands");
-      return false;
+      return;
     }
 
     if (command.empty()) {
       result.AppendError(
           "No breakpoint specified for which to list the commands");
-      return false;
+      return;
     }
 
     BreakpointIDList valid_bp_ids;
@@ -624,7 +621,7 @@ protected:
                 result.AppendErrorWithFormat("Invalid breakpoint ID: %u.%u.\n",
                                              cur_bp_id.GetBreakpointID(),
                                              cur_bp_id.GetLocationID());
-                return false;
+                return;
               }
             }
 
@@ -661,8 +658,6 @@ protected:
         }
       }
     }
-
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -129,12 +129,12 @@ protected:
     OptionValueBoolean m_cmd_relative_to_command_file;
   };
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
           "'%s' takes exactly one executable filename argument.\n",
           GetCommandName().str().c_str());
-      return false;
+      return;
     }
 
     FileSpec source_dir = {};
@@ -144,7 +144,7 @@ protected:
         result.AppendError("command source -C can only be specified "
                            "from a command file");
         result.SetStatus(eReturnStatusFailed);
-        return false;
+        return;
       }
     }
 
@@ -155,7 +155,7 @@ protected:
         result.AppendError("command source -C can only be used "
                            "with a relative path.");
         result.SetStatus(eReturnStatusFailed);
-        return false;
+        return;
       }
       cmd_file.MakeAbsolute(source_dir);
     }
@@ -186,7 +186,6 @@ protected:
     }
 
     m_interpreter.HandleCommandsFromFile(cmd_file, options, result);
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -384,11 +383,11 @@ rather than using a positional placeholder:"
   ~CommandObjectCommandsAlias() override = default;
 
 protected:
-  bool DoExecute(llvm::StringRef raw_command_line,
+  void DoExecute(llvm::StringRef raw_command_line,
                  CommandReturnObject &result) override {
     if (raw_command_line.empty()) {
       result.AppendError("'command alias' requires at least two arguments");
-      return false;
+      return;
     }
 
     ExecutionContext exe_ctx = GetCommandInterpreter().GetExecutionContext();
@@ -399,14 +398,14 @@ protected:
     if (args_with_suffix.HasArgs())
       if (!ParseOptionsAndNotify(args_with_suffix.GetArgs(), result,
                                  m_option_group, exe_ctx))
-        return false;
+        return;
 
     llvm::StringRef raw_command_string = args_with_suffix.GetRawPart();
     Args args(raw_command_string);
 
     if (args.GetArgumentCount() < 2) {
       result.AppendError("'command alias' requires at least two arguments");
-      return false;
+      return;
     }
 
     // Get the alias command.
@@ -418,7 +417,7 @@ protected:
         result.AppendWarning("if trying to pass options to 'command alias' add "
                              "a -- at the end of the options");
       }
-      return false;
+      return;
     }
 
     // Strip the new alias name off 'raw_command_string'  (leave it on args,
@@ -431,7 +430,7 @@ protected:
         raw_command_string = raw_command_string.substr(pos);
     } else {
       result.AppendError("Error parsing command string.  No alias created.");
-      return false;
+      return;
     }
 
     // Verify that the command is alias-able.
@@ -439,7 +438,7 @@ protected:
       result.AppendErrorWithFormat(
           "'%s' is a permanent debugger command and cannot be redefined.\n",
           args[0].c_str());
-      return false;
+      return;
     }
 
     if (m_interpreter.UserMultiwordCommandExists(alias_command)) {
@@ -447,7 +446,7 @@ protected:
           "'%s' is a user container command and cannot be overwritten.\n"
           "Delete it first with 'command container delete'\n",
           args[0].c_str());
-      return false;
+      return;
     }
 
     // Get CommandObject that is being aliased. The command name is read from
@@ -462,17 +461,15 @@ protected:
                                    "'%s' does not begin with a valid command."
                                    "  No alias created.",
                                    original_raw_command_string.str().c_str());
-      return false;
     } else if (!cmd_obj->WantsRawCommandString()) {
       // Note that args was initialized with the original command, and has not
       // been updated to this point. Therefore can we pass it to the version of
       // Execute that does not need/expect raw input in the alias.
-      return HandleAliasingNormalCommand(args, result);
+      HandleAliasingNormalCommand(args, result);
     } else {
-      return HandleAliasingRawCommand(alias_command, raw_command_string,
-                                      *cmd_obj, result);
+      HandleAliasingRawCommand(alias_command, raw_command_string, *cmd_obj,
+                               result);
     }
-    return result.Succeeded();
   }
 
   bool HandleAliasingRawCommand(llvm::StringRef alias_command,
@@ -653,13 +650,13 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     CommandObject::CommandMap::iterator pos;
     CommandObject *cmd_obj;
 
     if (args.empty()) {
       result.AppendError("must call 'unalias' with a valid alias");
-      return false;
+      return;
     }
 
     auto command_name = args[0].ref();
@@ -669,7 +666,7 @@ protected:
           "'%s' is not a known command.\nTry 'help' to see a "
           "current list of commands.\n",
           args[0].c_str());
-      return false;
+      return;
     }
 
     if (m_interpreter.CommandExists(command_name)) {
@@ -683,7 +680,7 @@ protected:
             "'%s' is a permanent debugger command and cannot be removed.\n",
             args[0].c_str());
       }
-      return false;
+      return;
     }
 
     if (!m_interpreter.RemoveAlias(command_name)) {
@@ -694,11 +691,10 @@ protected:
       else
         result.AppendErrorWithFormat("'%s' is not an existing alias.\n",
                                      args[0].c_str());
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 };
 
@@ -742,14 +738,14 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     CommandObject::CommandMap::iterator pos;
 
     if (args.empty()) {
       result.AppendErrorWithFormat("must call '%s' with one or more valid user "
                                    "defined regular expression command names",
                                    GetCommandName().str().c_str());
-      return false;
+      return;
     }
 
     auto command_name = args[0].ref();
@@ -761,18 +757,17 @@ protected:
           &error_msg_stream, command_name, llvm::StringRef(), llvm::StringRef(),
           generate_upropos, generate_type_lookup);
       result.AppendError(error_msg_stream.GetString());
-      return false;
+      return;
     }
 
     if (!m_interpreter.RemoveCommand(command_name)) {
       result.AppendErrorWithFormat(
           "'%s' is a permanent debugger command and cannot be removed.\n",
           args[0].c_str());
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return true;
   }
 };
 
@@ -868,12 +863,12 @@ protected:
     }
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
     if (argc == 0) {
       result.AppendError("usage: 'command regex <command-name> "
                          "[s/<regex1>/<subst1>/ s/<regex2>/<subst2>/ ...]'\n");
-      return false;
+      return;
     }
 
     Status error;
@@ -914,8 +909,6 @@ protected:
     if (error.Fail()) {
       result.AppendError(error.AsCString());
     }
-
-    return result.Succeeded();
   }
 
   Status AppendRegexSubstitution(const llvm::StringRef &regex_sed,
@@ -1126,7 +1119,7 @@ public:
   bool WantsCompletion() override { return true; }
 
 protected:
-  bool DoExecute(llvm::StringRef raw_command_line,
+  void DoExecute(llvm::StringRef raw_command_line,
                  CommandReturnObject &result) override {
     ScriptInterpreter *scripter = GetDebugger().GetScriptInterpreter();
 
@@ -1147,8 +1140,6 @@ protected:
           result.SetStatus(eReturnStatusSuccessFinishResult);
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -1222,7 +1213,7 @@ public:
   }
 
 protected:
-  bool DoExecute(llvm::StringRef raw_command_line,
+  void DoExecute(llvm::StringRef raw_command_line,
                  CommandReturnObject &result) override {
     ScriptInterpreter *scripter = GetDebugger().GetScriptInterpreter();
 
@@ -1243,8 +1234,6 @@ protected:
           result.SetStatus(eReturnStatusSuccessFinishResult);
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -1330,10 +1319,10 @@ protected:
     bool silent = false;
   };
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.empty()) {
       result.AppendError("command script import needs one or more arguments");
-      return false;
+      return;
     }
 
     FileSpec source_dir = {};
@@ -1342,7 +1331,7 @@ protected:
       if (!source_dir) {
         result.AppendError("command script import -c can only be specified "
                            "from a command file");
-        return false;
+        return;
       }
     }
 
@@ -1371,8 +1360,6 @@ protected:
                                      error.AsCString());
       }
     }
-
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -1567,16 +1554,16 @@ protected:
     io_handler.SetIsDone(true);
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (GetDebugger().GetScriptLanguage() != lldb::eScriptLanguagePython) {
       result.AppendError("only scripting language supported for scripted "
                          "commands is currently Python");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
       result.AppendError("'command script add' requires at least one argument");
-      return false;
+      return;
     }
     // Store the options in case we get multi-line input, also figure out the
     // default if not user supplied:
@@ -1598,7 +1585,7 @@ protected:
     if (path_error.Fail()) {
       result.AppendErrorWithFormat("error in command path: %s",
                                    path_error.AsCString());
-      return false;
+      return;
     }
 
     if (!m_container) {
@@ -1617,7 +1604,7 @@ protected:
     if (m_options.m_class_name.empty() && m_options.m_funct_name.empty()) {
       m_interpreter.GetPythonCommandsFromIOHandler("     ", // Prompt
                                                    *this);  // IOHandlerDelegate
-      return result.Succeeded();
+      return;
     }
 
     CommandObjectSP new_cmd_sp;
@@ -1629,7 +1616,7 @@ protected:
       ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
       if (!interpreter) {
         result.AppendError("cannot find ScriptInterpreter");
-        return false;
+        return;
       }
 
       auto cmd_obj_sp = interpreter->CreateScriptCommandObject(
@@ -1637,7 +1624,7 @@ protected:
       if (!cmd_obj_sp) {
         result.AppendErrorWithFormatv("cannot create helper object for: "
                                       "'{0}'", m_options.m_class_name);
-        return false;
+        return;
       }
 
       new_cmd_sp.reset(new CommandObjectScriptingObject(
@@ -1660,7 +1647,6 @@ protected:
         result.AppendErrorWithFormat("cannot add command: %s", 
                                      llvm::toString(std::move(llvm_error)).c_str());
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -1684,12 +1670,10 @@ public:
 
   ~CommandObjectCommandsScriptList() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     m_interpreter.GetHelp(result, CommandInterpreter::eCommandTypesUserDef);
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-
-    return true;
   }
 };
 
@@ -1704,12 +1688,10 @@ public:
   ~CommandObjectCommandsScriptClear() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     m_interpreter.RemoveAllUser();
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-
-    return true;
   }
 };
 
@@ -1748,44 +1730,44 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
 
     llvm::StringRef root_cmd = command[0].ref();
     size_t num_args = command.GetArgumentCount();
 
     if (root_cmd.empty()) {
       result.AppendErrorWithFormat("empty root command name");
-      return false;
+      return;
     }
     if (!m_interpreter.HasUserCommands() &&
         !m_interpreter.HasUserMultiwordCommands()) {
       result.AppendErrorWithFormat("can only delete user defined commands, "
                                    "but no user defined commands found");
-      return false;
+      return;
     }
 
     CommandObjectSP cmd_sp = m_interpreter.GetCommandSPExact(root_cmd);
     if (!cmd_sp) {
       result.AppendErrorWithFormat("command '%s' not found.",
                                    command[0].c_str());
-      return false;
+      return;
     }
     if (!cmd_sp->IsUserCommand()) {
       result.AppendErrorWithFormat("command '%s' is not a user command.",
                                    command[0].c_str());
-      return false;
+      return;
     }
     if (cmd_sp->GetAsMultiwordCommand() && num_args == 1) {
       result.AppendErrorWithFormat("command '%s' is a multi-word command.\n "
                                    "Delete with \"command container delete\"",
                                    command[0].c_str());
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 1) {
       m_interpreter.RemoveUser(root_cmd);
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
     // We're deleting a command from a multiword command.  Verify the command
     // path:
@@ -1796,14 +1778,14 @@ protected:
     if (error.Fail()) {
       result.AppendErrorWithFormat("could not resolve command path: %s",
                                    error.AsCString());
-      return false;
+      return;
     }
     if (!container) {
       // This means that command only had a leaf command, so the container is
       // the root.  That should have been handled above.
       result.AppendErrorWithFormat("could not find a container for '%s'",
                                    command[0].c_str());
-      return false;
+      return;
     }
     const char *leaf_cmd = command[num_args - 1].c_str();
     llvm::Error llvm_error = container->RemoveUserSubcommand(leaf_cmd,
@@ -1812,7 +1794,7 @@ protected:
       result.AppendErrorWithFormat("could not delete command '%s': %s",
                                    leaf_cmd, 
                                    llvm::toString(std::move(llvm_error)).c_str());
-      return false;
+      return;
     }
 
     Stream &out_stream = result.GetOutputStream();
@@ -1824,7 +1806,6 @@ protected:
     }
     out_stream << '\n';
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 };
 
@@ -1945,12 +1926,12 @@ protected:
     std::string m_long_help;
     bool m_overwrite = false;
   };
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     size_t num_args = command.GetArgumentCount();
 
     if (num_args == 0) {
       result.AppendError("no command was specified");
-      return false;
+      return;
     }
 
     if (num_args == 1) {
@@ -1965,10 +1946,10 @@ protected:
       if (add_error.Fail()) {
         result.AppendErrorWithFormat("error adding command: %s",
                                      add_error.AsCString());
-        return false;
+        return;
       }
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     // We're adding this to a subcommand, first find the subcommand:
@@ -1980,7 +1961,7 @@ protected:
     if (!add_to_me) {
       result.AppendErrorWithFormat("error adding command: %s",
                                    path_error.AsCString());
-      return false;
+      return;
     }
 
     const char *cmd_name = command.GetArgumentAtIndex(num_args - 1);
@@ -1992,11 +1973,10 @@ protected:
     if (llvm_error) {
       result.AppendErrorWithFormat("error adding subcommand: %s",
                                    llvm::toString(std::move(llvm_error)).c_str());
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return true;
   }
 
 private:
@@ -2039,12 +2019,12 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     size_t num_args = command.GetArgumentCount();
 
     if (num_args == 0) {
       result.AppendError("No command was specified.");
-      return false;
+      return;
     }
 
     if (num_args == 1) {
@@ -2057,27 +2037,27 @@ protected:
       if (!cmd_sp) {
         result.AppendErrorWithFormat("container command %s doesn't exist.",
                                      cmd_name);
-        return false;
+        return;
       }
       if (!cmd_sp->IsUserCommand()) {
         result.AppendErrorWithFormat(
             "container command %s is not a user command", cmd_name);
-        return false;
+        return;
       }
       if (!cmd_sp->GetAsMultiwordCommand()) {
         result.AppendErrorWithFormat("command %s is not a container command",
                                      cmd_name);
-        return false;
+        return;
       }
 
       bool did_remove = GetCommandInterpreter().RemoveUserMultiword(cmd_name);
       if (!did_remove) {
         result.AppendErrorWithFormat("error removing command %s.", cmd_name);
-        return false;
+        return;
       }
 
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     // We're removing a subcommand, first find the subcommand's owner:
@@ -2089,7 +2069,7 @@ protected:
     if (!container) {
       result.AppendErrorWithFormat("error removing container command: %s",
                                    path_error.AsCString());
-      return false;
+      return;
     }
     const char *leaf = command.GetArgumentAtIndex(num_args - 1);
     llvm::Error llvm_error =
@@ -2097,10 +2077,9 @@ protected:
     if (llvm_error) {
       result.AppendErrorWithFormat("error removing container command: %s",
                                    llvm::toString(std::move(llvm_error)).c_str());
-      return false;
+      return;
     }
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return true;
   }
 };
 

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -58,7 +58,7 @@ void CommandObjectDWIMPrint::HandleArgumentCompletion(
       GetCommandInterpreter(), lldb::eVariablePathCompletion, request, nullptr);
 }
 
-bool CommandObjectDWIMPrint::DoExecute(StringRef command,
+void CommandObjectDWIMPrint::DoExecute(StringRef command,
                                        CommandReturnObject &result) {
   m_option_group.NotifyOptionParsingStarting(&m_exe_ctx);
   OptionsWithRaw args{command};
@@ -67,13 +67,13 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
   if (expr.empty()) {
     result.AppendErrorWithFormatv("'{0}' takes a variable or expression",
                                   m_cmd_name);
-    return false;
+    return;
   }
 
   if (args.HasArgs()) {
     if (!ParseOptionsAndNotify(args.GetArgs(), result, m_option_group,
                                m_exe_ctx))
-      return false;
+      return;
   }
 
   // If the user has not specified, default to disabling persistent results.
@@ -164,7 +164,7 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
         valobj_sp->Dump(result.GetOutputStream(), dump_options);
       }
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
   }
 
@@ -216,14 +216,12 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
         }
 
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
     } else {
       if (valobj_sp)
         result.SetError(valobj_sp->GetError());
       else
         result.AppendErrorWithFormatv(
             "unknown error evaluating expression `{0}`", expr);
-      return false;
     }
   }
 }

--- a/lldb/source/Commands/CommandObjectDWIMPrint.h
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.h
@@ -44,7 +44,7 @@ public:
                            OptionElementVector &opt_element_vector) override;
 
 private:
-  bool DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
+  void DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
 
   OptionGroupOptions m_option_group;
   OptionGroupFormat m_format_options = lldb::eFormatDefault;

--- a/lldb/source/Commands/CommandObjectDiagnostics.cpp
+++ b/lldb/source/Commands/CommandObjectDiagnostics.cpp
@@ -77,12 +77,12 @@ protected:
     return Diagnostics::CreateUniqueDirectory();
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     llvm::Expected<FileSpec> directory = GetDirectory();
 
     if (!directory) {
       result.AppendError(llvm::toString(directory.takeError()));
-      return result.Succeeded();
+      return;
     }
 
     llvm::Error error = Diagnostics::Instance().Create(*directory);
@@ -90,13 +90,13 @@ protected:
       result.AppendErrorWithFormat("failed to write diagnostics to %s",
                                    directory->GetPath().c_str());
       result.AppendError(llvm::toString(std::move(error)));
-      return result.Succeeded();
+      return;
     }
 
     result.GetOutputStream() << "diagnostics written to " << *directory << '\n';
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
+    return;
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -437,7 +437,7 @@ CommandObjectDisassemble::GetRangesForSelectedMode(
   return CommandObjectDisassemble::GetPCRanges();
 }
 
-bool CommandObjectDisassemble::DoExecute(Args &command,
+void CommandObjectDisassemble::DoExecute(Args &command,
                                          CommandReturnObject &result) {
   Target *target = &GetSelectedTarget();
 
@@ -447,7 +447,7 @@ bool CommandObjectDisassemble::DoExecute(Args &command,
   if (!m_options.arch.IsValid()) {
     result.AppendError(
         "use the --arch option or set the target architecture to disassemble");
-    return false;
+    return;
   }
 
   const char *plugin_name = m_options.GetPluginName();
@@ -466,7 +466,7 @@ bool CommandObjectDisassemble::DoExecute(Args &command,
       result.AppendErrorWithFormat(
           "Unable to find Disassembler plug-in for the '%s' architecture.\n",
           m_options.arch.GetArchitectureName());
-    return false;
+    return;
   } else if (flavor_string != nullptr && !disassembler->FlavorValidForArchSpec(
                                              m_options.arch, flavor_string))
     result.AppendWarningWithFormat(
@@ -481,7 +481,7 @@ bool CommandObjectDisassemble::DoExecute(Args &command,
         GetCommandInterpreter().GetDebugger().GetTerminalWidth();
     GetOptions()->GenerateOptionUsage(result.GetErrorStream(), *this,
                                       terminal_width);
-    return false;
+    return;
   }
 
   if (m_options.show_mixed && m_options.num_lines_context == 0)
@@ -508,7 +508,7 @@ bool CommandObjectDisassemble::DoExecute(Args &command,
       GetRangesForSelectedMode(result);
   if (!ranges) {
     result.AppendError(toString(ranges.takeError()));
-    return result.Succeeded();
+    return;
   }
 
   bool print_sc_header = ranges->size() > 1;
@@ -541,6 +541,4 @@ bool CommandObjectDisassemble::DoExecute(Args &command,
     if (print_sc_header)
       result.GetOutputStream() << "\n";
   }
-
-  return result.Succeeded();
 }

--- a/lldb/source/Commands/CommandObjectDisassemble.h
+++ b/lldb/source/Commands/CommandObjectDisassemble.h
@@ -73,7 +73,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 
   llvm::Expected<std::vector<AddressRange>>
   GetRangesForSelectedMode(CommandReturnObject &result);

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -594,7 +594,7 @@ GetExprOptions(ExecutionContext &ctx,
   return expr_options;
 }
 
-bool CommandObjectExpression::DoExecute(llvm::StringRef command,
+void CommandObjectExpression::DoExecute(llvm::StringRef command,
                                         CommandReturnObject &result) {
   m_fixed_expression.clear();
   auto exe_ctx = GetCommandInterpreter().GetExecutionContext();
@@ -602,7 +602,7 @@ bool CommandObjectExpression::DoExecute(llvm::StringRef command,
 
   if (command.empty()) {
     GetMultilineExpression();
-    return result.Succeeded();
+    return;
   }
 
   OptionsWithRaw args(command);
@@ -610,7 +610,7 @@ bool CommandObjectExpression::DoExecute(llvm::StringRef command,
 
   if (args.HasArgs()) {
     if (!ParseOptionsAndNotify(args.GetArgs(), result, m_option_group, exe_ctx))
-      return false;
+      return;
 
     if (m_repl_option.GetOptionValue().GetCurrentValue()) {
       Target &target = GetSelectedOrDummyTarget();
@@ -642,7 +642,7 @@ bool CommandObjectExpression::DoExecute(llvm::StringRef command,
                                     nullptr, true);
           if (!repl_error.Success()) {
             result.SetError(repl_error);
-            return result.Succeeded();
+            return;
           }
         }
 
@@ -662,14 +662,14 @@ bool CommandObjectExpression::DoExecute(llvm::StringRef command,
               "Couldn't create a REPL for %s",
               Language::GetNameForLanguageType(m_command_options.language));
           result.SetError(repl_error);
-          return result.Succeeded();
+          return;
         }
       }
     }
     // No expression following options
     else if (expr.empty()) {
       GetMultilineExpression();
-      return result.Succeeded();
+      return;
     }
   }
 
@@ -691,8 +691,7 @@ bool CommandObjectExpression::DoExecute(llvm::StringRef command,
         fixed_command.append(m_fixed_expression);
       history.AppendString(fixed_command);
     }
-    return true;
+    return;
   }
   result.SetStatus(eReturnStatusFailed);
-  return false;
 }

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -75,7 +75,7 @@ protected:
   bool IOHandlerIsInputComplete(IOHandler &io_handler,
                                 StringList &lines) override;
 
-  bool DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
+  void DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
 
   /// Evaluates the given expression.
   /// \param output_stream The stream to which the evaluation result will be

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -133,7 +133,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Thread *thread = m_exe_ctx.GetThreadPtr();
     StackFrameSP frame_sp = thread->GetSelectedFrame(SelectMostRelevantFrame);
 
@@ -143,7 +143,7 @@ protected:
       if (m_options.reg || m_options.offset) {
         result.AppendError(
             "`frame diagnose --address` is incompatible with other arguments.");
-        return false;
+        return;
       }
       valobj_sp = frame_sp->GuessValueForAddress(*m_options.address);
     } else if (m_options.reg) {
@@ -153,7 +153,7 @@ protected:
       StopInfoSP stop_info_sp = thread->GetStopInfo();
       if (!stop_info_sp) {
         result.AppendError("No arguments provided, and no stop info.");
-        return false;
+        return;
       }
 
       valobj_sp = StopInfo::GetCrashingDereference(stop_info_sp);
@@ -161,7 +161,7 @@ protected:
 
     if (!valobj_sp) {
       result.AppendError("No diagnosis available.");
-      return false;
+      return;
     }
 
     DumpValueObjectOptions::DeclPrintingHelper helper =
@@ -180,8 +180,6 @@ protected:
     ValueObjectPrinter printer(valobj_sp.get(), &result.GetOutputStream(),
                                options);
     printer.PrintValueObject();
-
-    return true;
   }
 
   CommandOptions m_options;
@@ -205,10 +203,9 @@ public:
   ~CommandObjectFrameInfo() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     m_exe_ctx.GetFrameRef().DumpUsingSettingsFormat(&result.GetOutputStream());
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -299,7 +296,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // No need to check "thread" for validity as eCommandRequiresThread ensures
     // it is valid
     Thread *thread = m_exe_ctx.GetThreadPtr();
@@ -320,7 +317,7 @@ protected:
             // If you are already at the bottom of the stack, then just warn
             // and don't reset the frame.
             result.AppendError("Already at the bottom of the stack.");
-            return false;
+            return;
           } else
             frame_idx = 0;
         }
@@ -345,7 +342,7 @@ protected:
               // If we are already at the top of the stack, just warn and don't
               // reset the frame.
               result.AppendError("Already at the top of the stack.");
-              return false;
+              return;
             } else
               frame_idx = num_frames - 1;
           }
@@ -359,14 +356,14 @@ protected:
         m_options.GenerateOptionUsage(
             result.GetErrorStream(), *this,
             GetCommandInterpreter().GetDebugger().GetTerminalWidth());
-        return false;
+        return;
       }
 
       if (command.GetArgumentCount() == 1) {
         if (command[0].ref().getAsInteger(0, frame_idx)) {
           result.AppendErrorWithFormat("invalid frame index argument '%s'.",
                                        command[0].c_str());
-          return false;
+          return;
         }
       } else if (command.GetArgumentCount() == 0) {
         frame_idx = thread->GetSelectedFrameIndex(SelectMostRelevantFrame);
@@ -385,8 +382,6 @@ protected:
       result.AppendErrorWithFormat("Frame index (%u) out of range.\n",
                                    frame_idx);
     }
-
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -524,7 +519,7 @@ protected:
     return std::nullopt;
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // No need to check "frame" for validity as eCommandRequiresFrame ensures
     // it is valid
     StackFrame *frame = m_exe_ctx.GetFramePtr();
@@ -733,13 +728,11 @@ protected:
                                            m_cmd_name);
 
     // Increment statistics.
-    bool res = result.Succeeded();
     TargetStats &target_stats = GetSelectedOrDummyTarget().GetStatistics();
-    if (res)
+    if (result.Succeeded())
       target_stats.GetFrameVariableStats().NotifySuccess();
     else
       target_stats.GetFrameVariableStats().NotifyFailure();
-    return res;
   }
 
   OptionGroupOptions m_option_group;
@@ -821,7 +814,7 @@ private:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 
 public:
   CommandObjectFrameRecognizerAdd(CommandInterpreter &interpreter)
@@ -877,33 +870,33 @@ Process 1234 stopped
   ~CommandObjectFrameRecognizerAdd() override = default;
 };
 
-bool CommandObjectFrameRecognizerAdd::DoExecute(Args &command,
+void CommandObjectFrameRecognizerAdd::DoExecute(Args &command,
                                                 CommandReturnObject &result) {
 #if LLDB_ENABLE_PYTHON
   if (m_options.m_class_name.empty()) {
     result.AppendErrorWithFormat(
         "%s needs a Python class name (-l argument).\n", m_cmd_name.c_str());
-    return false;
+    return;
   }
 
   if (m_options.m_module.empty()) {
     result.AppendErrorWithFormat("%s needs a module name (-s argument).\n",
                                  m_cmd_name.c_str());
-    return false;
+    return;
   }
 
   if (m_options.m_symbols.empty()) {
     result.AppendErrorWithFormat(
         "%s needs at least one symbol name (-n argument).\n",
         m_cmd_name.c_str());
-    return false;
+    return;
   }
 
   if (m_options.m_regex && m_options.m_symbols.size() > 1) {
     result.AppendErrorWithFormat(
         "%s needs only one symbol regular expression (-n argument).\n",
         m_cmd_name.c_str());
-    return false;
+    return;
   }
 
   ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
@@ -934,7 +927,6 @@ bool CommandObjectFrameRecognizerAdd::DoExecute(Args &command,
 #endif
 
   result.SetStatus(eReturnStatusSuccessFinishNoResult);
-  return result.Succeeded();
 }
 
 class CommandObjectFrameRecognizerClear : public CommandObjectParsed {
@@ -946,12 +938,11 @@ public:
   ~CommandObjectFrameRecognizerClear() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     GetSelectedOrDummyTarget()
         .GetFrameRecognizerManager()
         .RemoveAllRecognizers();
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -995,33 +986,33 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() == 0) {
       if (!m_interpreter.Confirm(
               "About to delete all frame recognizers, do you want to do that?",
               true)) {
         result.AppendMessage("Operation cancelled...");
-        return false;
+        return;
       }
 
       GetSelectedOrDummyTarget()
           .GetFrameRecognizerManager()
           .RemoveAllRecognizers();
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return result.Succeeded();
+      return;
     }
 
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat("'%s' takes zero or one arguments.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     uint32_t recognizer_id;
     if (!llvm::to_integer(command.GetArgumentAtIndex(0), recognizer_id)) {
       result.AppendErrorWithFormat("'%s' is not a valid recognizer id.\n",
                                    command.GetArgumentAtIndex(0));
-      return false;
+      return;
     }
 
     if (!GetSelectedOrDummyTarget()
@@ -1029,10 +1020,9 @@ protected:
              .RemoveRecognizerWithID(recognizer_id)) {
       result.AppendErrorWithFormat("'%s' is not a valid recognizer id.\n",
                                    command.GetArgumentAtIndex(0));
-      return false;
+      return;
     }
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -1046,7 +1036,7 @@ public:
   ~CommandObjectFrameRecognizerList() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     bool any_printed = false;
     GetSelectedOrDummyTarget().GetFrameRecognizerManager().ForEach(
         [&result, &any_printed](
@@ -1078,7 +1068,6 @@ protected:
       result.GetOutputStream().PutCString("no matching results found.\n");
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
-    return result.Succeeded();
   }
 };
 
@@ -1107,35 +1096,35 @@ public:
   ~CommandObjectFrameRecognizerInfo() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const char *frame_index_str = command.GetArgumentAtIndex(0);
     uint32_t frame_index;
     if (!llvm::to_integer(frame_index_str, frame_index)) {
       result.AppendErrorWithFormat("'%s' is not a valid frame index.",
                                    frame_index_str);
-      return false;
+      return;
     }
 
     Process *process = m_exe_ctx.GetProcessPtr();
     if (process == nullptr) {
       result.AppendError("no process");
-      return false;
+      return;
     }
     Thread *thread = m_exe_ctx.GetThreadPtr();
     if (thread == nullptr) {
       result.AppendError("no thread");
-      return false;
+      return;
     }
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
           "'%s' takes exactly one frame index argument.\n", m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     StackFrameSP frame_sp = thread->GetStackFrameAtIndex(frame_index);
     if (!frame_sp) {
       result.AppendErrorWithFormat("no frame with index %u", frame_index);
-      return false;
+      return;
     }
 
     auto recognizer = GetSelectedOrDummyTarget()
@@ -1152,7 +1141,6 @@ protected:
     }
     output_stream.EOL();
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectGUI.cpp
+++ b/lldb/source/Commands/CommandObjectGUI.cpp
@@ -24,7 +24,7 @@ CommandObjectGUI::CommandObjectGUI(CommandInterpreter &interpreter)
 
 CommandObjectGUI::~CommandObjectGUI() = default;
 
-bool CommandObjectGUI::DoExecute(Args &args, CommandReturnObject &result) {
+void CommandObjectGUI::DoExecute(Args &args, CommandReturnObject &result) {
 #if LLDB_ENABLE_CURSES
   Debugger &debugger = GetDebugger();
 
@@ -39,9 +39,7 @@ bool CommandObjectGUI::DoExecute(Args &args, CommandReturnObject &result) {
   } else {
     result.AppendError("the gui command requires an interactive terminal.");
   }
-  return true;
 #else
   result.AppendError("lldb was not built with gui support");
-  return false;
 #endif
 }

--- a/lldb/source/Commands/CommandObjectGUI.h
+++ b/lldb/source/Commands/CommandObjectGUI.h
@@ -22,7 +22,7 @@ public:
   ~CommandObjectGUI() override;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override;
+  void DoExecute(Args &args, CommandReturnObject &result) override;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Commands/CommandObjectHelp.cpp
+++ b/lldb/source/Commands/CommandObjectHelp.cpp
@@ -74,7 +74,7 @@ CommandObjectHelp::CommandOptions::GetDefinitions() {
   return llvm::ArrayRef(g_help_options);
 }
 
-bool CommandObjectHelp::DoExecute(Args &command, CommandReturnObject &result) {
+void CommandObjectHelp::DoExecute(Args &command, CommandReturnObject &result) {
   CommandObject::CommandMap::iterator pos;
   CommandObject *cmd_obj;
   const size_t argc = command.GetArgumentCount();
@@ -142,14 +142,14 @@ bool CommandObjectHelp::DoExecute(Args &command, CommandReturnObject &result) {
           }
           s.Printf("\n");
           result.AppendError(s.GetString());
-          return false;
+          return;
         } else if (!sub_cmd_obj) {
           StreamString error_msg_stream;
           GenerateAdditionalHelpAvenuesMessage(
               &error_msg_stream, cmd_string.c_str(),
               m_interpreter.GetCommandPrefix(), sub_command.c_str());
           result.AppendError(error_msg_stream.GetString());
-          return false;
+          return;
         } else {
           GenerateAdditionalHelpAvenuesMessage(
               &result.GetOutputStream(), cmd_string.c_str(),
@@ -197,8 +197,6 @@ bool CommandObjectHelp::DoExecute(Args &command, CommandReturnObject &result) {
       }
     }
   }
-
-  return result.Succeeded();
 }
 
 void CommandObjectHelp::HandleCompletion(CompletionRequest &request) {

--- a/lldb/source/Commands/CommandObjectHelp.h
+++ b/lldb/source/Commands/CommandObjectHelp.h
@@ -76,7 +76,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 
 private:
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectLanguage.h
+++ b/lldb/source/Commands/CommandObjectLanguage.h
@@ -19,7 +19,7 @@ public:
   ~CommandObjectLanguage() override;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result);
+  void DoExecute(Args &command, CommandReturnObject &result);
 };
 } // namespace lldb_private
 

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -162,19 +162,19 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.GetArgumentCount() < 2) {
       result.AppendErrorWithFormat(
           "%s takes a log channel and one or more log types.\n",
           m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     if (m_options.handler == eLogHandlerCircular &&
         m_options.buffer_size.GetCurrentValue() == 0) {
       result.AppendError(
           "the circular buffer handler requires a non-zero buffer size.\n");
-      return false;
+      return;
     }
 
     if ((m_options.handler != eLogHandlerCircular &&
@@ -182,13 +182,13 @@ protected:
         m_options.buffer_size.GetCurrentValue() != 0) {
       result.AppendError("a buffer size can only be specified for the circular "
                          "and stream buffer handler.\n");
-      return false;
+      return;
     }
 
     if (m_options.handler != eLogHandlerStream && m_options.log_file) {
       result.AppendError(
           "a file name can only be specified for the stream handler.\n");
-      return false;
+      return;
     }
 
     // Store into a std::string since we're about to shift the channel off.
@@ -212,7 +212,6 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     else
       result.SetStatus(eReturnStatusFailed);
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -257,12 +256,12 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.empty()) {
       result.AppendErrorWithFormat(
           "%s takes a log channel and one or more log types.\n",
           m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     const std::string channel = std::string(args[0].ref());
@@ -278,7 +277,6 @@ protected:
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       result.GetErrorStream() << error_stream.str();
     }
-    return result.Succeeded();
   }
 };
 
@@ -315,7 +313,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     std::string output;
     llvm::raw_string_ostream output_stream(output);
     if (args.empty()) {
@@ -330,7 +328,6 @@ protected:
         result.SetStatus(eReturnStatusSuccessFinishResult);
     }
     result.GetOutputStream() << output_stream.str();
-    return result.Succeeded();
   }
 };
 class CommandObjectLogDump : public CommandObjectParsed {
@@ -398,12 +395,12 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.empty()) {
       result.AppendErrorWithFormat(
           "%s takes a log channel and one or more log types.\n",
           m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     std::unique_ptr<llvm::raw_ostream> stream_up;
@@ -417,7 +414,7 @@ protected:
         result.AppendErrorWithFormat("Unable to open log file '%s': %s",
                                      m_options.log_file.GetPath().c_str(),
                                      llvm::toString(file.takeError()).c_str());
-        return false;
+        return;
       }
       stream_up = std::make_unique<llvm::raw_fd_ostream>(
           (*file)->GetDescriptor(), /*shouldClose=*/true);
@@ -435,8 +432,6 @@ protected:
       result.SetStatus(eReturnStatusFailed);
       result.GetErrorStream() << error_stream.str();
     }
-
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -467,7 +462,7 @@ public:
   ~CommandObjectLogTimerEnable() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusFailed);
 
     if (args.GetArgumentCount() == 0) {
@@ -488,7 +483,6 @@ protected:
       result.AppendError("Missing subcommand");
       result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
     }
-    return result.Succeeded();
   }
 };
 
@@ -503,7 +497,7 @@ public:
   ~CommandObjectLogTimerDisable() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Timer::DumpCategoryTimes(result.GetOutputStream());
     Timer::SetDisplayDepth(0);
     result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -512,7 +506,6 @@ protected:
       result.AppendError("Missing subcommand");
       result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
     }
-    return result.Succeeded();
   }
 };
 
@@ -526,7 +519,7 @@ public:
   ~CommandObjectLogTimerDump() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Timer::DumpCategoryTimes(result.GetOutputStream());
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
@@ -534,7 +527,6 @@ protected:
       result.AppendError("Missing subcommand");
       result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
     }
-    return result.Succeeded();
   }
 };
 
@@ -549,7 +541,7 @@ public:
   ~CommandObjectLogTimerReset() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Timer::ResetCategoryTimes();
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
@@ -557,7 +549,6 @@ protected:
       result.AppendError("Missing subcommand");
       result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
     }
-    return result.Succeeded();
   }
 };
 
@@ -593,7 +584,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusFailed);
 
     if (args.GetArgumentCount() == 1) {
@@ -612,7 +603,6 @@ protected:
       result.AppendError("Missing subcommand");
       result.AppendErrorWithFormat("Usage: %s\n", m_cmd_syntax.c_str());
     }
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -348,7 +348,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // No need to check "target" for validity as eCommandRequiresTarget ensures
     // it is valid
     Target *target = m_exe_ctx.GetTargetPtr();
@@ -361,7 +361,7 @@ protected:
                                    m_cmd_name.c_str());
       result.AppendWarning("Expressions should be quoted if they contain "
                            "spaces or other special characters.");
-      return false;
+      return;
     }
 
     CompilerType compiler_type;
@@ -441,7 +441,7 @@ protected:
             } else {
               result.AppendErrorWithFormat("invalid type string: '%s'\n",
                                            view_as_type_cstr);
-              return false;
+              return;
             }
             break;
 
@@ -490,7 +490,7 @@ protected:
               "Mutiple types found matching raw type '%s', please disambiguate "
               "by specifying the language with -x",
               lookup_type_name.GetCString());
-          return false;
+          return;
         }
 
         if (user_defined_types.size() == 1) {
@@ -504,7 +504,7 @@ protected:
                                        "the raw type '%s' for full type '%s'\n",
                                        lookup_type_name.GetCString(),
                                        view_as_type_cstr);
-          return false;
+          return;
         } else {
           TypeSP type_sp(type_list.GetTypeAtIndex(0));
           compiler_type = type_sp->GetFullCompilerType();
@@ -517,7 +517,7 @@ protected:
           compiler_type = pointer_type;
         else {
           result.AppendError("unable make a pointer type\n");
-          return false;
+          return;
         }
         --pointer_count;
       }
@@ -527,7 +527,7 @@ protected:
         result.AppendErrorWithFormat(
             "unable to get the byte size of the type '%s'\n",
             view_as_type_cstr);
-        return false;
+        return;
       }
       m_format_options.GetByteSizeValue() = *size;
 
@@ -540,7 +540,7 @@ protected:
     // Look for invalid combinations of settings
     if (error.Fail()) {
       result.AppendError(error.AsCString());
-      return false;
+      return;
     }
 
     lldb::addr_t addr;
@@ -591,7 +591,7 @@ protected:
     if (addr == LLDB_INVALID_ADDRESS) {
       result.AppendError("invalid start address expression.");
       result.AppendError(error.AsCString());
-      return false;
+      return;
     }
 
     if (argc == 2) {
@@ -601,19 +601,19 @@ protected:
       if (end_addr == LLDB_INVALID_ADDRESS) {
         result.AppendError("invalid end address expression.");
         result.AppendError(error.AsCString());
-        return false;
+        return;
       } else if (end_addr <= addr) {
         result.AppendErrorWithFormat(
             "end address (0x%" PRIx64
             ") must be greater than the start address (0x%" PRIx64 ").\n",
             end_addr, addr);
-        return false;
+        return;
       } else if (m_format_options.GetCountValue().OptionWasSet()) {
         result.AppendErrorWithFormat(
             "specify either the end address (0x%" PRIx64
             ") or the count (--count %" PRIu64 "), not both.\n",
             end_addr, (uint64_t)item_count);
-        return false;
+        return;
       }
 
       total_byte_size = end_addr - addr;
@@ -631,7 +631,7 @@ protected:
           "Please use --force to override this restriction just once.\n");
       result.AppendErrorWithFormat("or set target.max-memory-read-size if you "
                                    "will often need a larger limit.\n");
-      return false;
+      return;
     }
 
     WritableDataBufferSP data_sp;
@@ -645,7 +645,7 @@ protected:
       std::optional<uint64_t> size = compiler_type.GetByteSize(nullptr);
       if (!size) {
         result.AppendError("can't get size of type");
-        return false;
+        return;
       }
       bytes_read = *size * m_format_options.GetCountValue().GetCurrentValue();
 
@@ -659,7 +659,7 @@ protected:
             "can't allocate 0x%" PRIx32
             " bytes for the memory read buffer, specify a smaller size to read",
             (uint32_t)total_byte_size);
-        return false;
+        return;
       }
 
       Address address(addr, nullptr);
@@ -673,7 +673,7 @@ protected:
           result.AppendErrorWithFormat(
               "failed to read memory from 0x%" PRIx64 ".\n", addr);
         }
-        return false;
+        return;
       }
 
       if (bytes_read < total_byte_size)
@@ -699,7 +699,7 @@ protected:
             "can't allocate 0x%" PRIx64
             " bytes for the memory read buffer, specify a smaller size to read",
             (uint64_t)((item_byte_size + 1) * item_count));
-        return false;
+        return;
       }
       uint8_t *data_ptr = data_sp->GetBytes();
       auto data_addr = addr;
@@ -715,7 +715,7 @@ protected:
         if (error.Fail()) {
           result.AppendErrorWithFormat(
               "failed to read memory from 0x%" PRIx64 ".\n", addr);
-          return false;
+          return;
         }
 
         if (item_byte_size == read) {
@@ -777,12 +777,12 @@ protected:
             result.GetOutputStream().Printf(
                 "%zi bytes %s to '%s'\n", bytes_written,
                 append ? "appended" : "written", path.c_str());
-            return true;
+            return;
           } else {
             result.AppendErrorWithFormat("Failed to write %" PRIu64
                                          " bytes to '%s'.\n",
                                          (uint64_t)bytes_read, path.c_str());
-            return false;
+            return;
           }
         } else {
           // We are going to write ASCII to the file just point the
@@ -795,7 +795,7 @@ protected:
                                      path.c_str(), append ? "append" : "write");
 
         result.AppendError(llvm::toString(outfile.takeError()));
-        return false;
+        return;
       }
     } else {
       output_stream_p = &result.GetOutputStream();
@@ -823,10 +823,10 @@ protected:
           result.AppendErrorWithFormat(
               "failed to create a value object for: (%s) %s\n",
               view_as_type_cstr, name_strm.GetData());
-          return false;
+          return;
         }
       }
-      return true;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -852,7 +852,7 @@ protected:
         result.AppendErrorWithFormat(
             "reading memory as characters of size %" PRIu64 " is not supported",
             (uint64_t)item_byte_size);
-        return false;
+        return;
       }
     }
 
@@ -863,7 +863,6 @@ protected:
         exe_scope, m_memory_tag_options.GetShowTags().GetCurrentValue());
     m_next_addr = addr + bytes_dumped;
     output_stream_p->EOL();
-    return true;
   }
 
   OptionGroupOptions m_option_group;
@@ -1010,7 +1009,7 @@ protected:
     lldb::addr_t m_base_addr;
     bool m_is_valid = true;
   };
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // No need to check "process" for validity as eCommandRequiresProcess
     // ensures it is valid
     Process *process = m_exe_ctx.GetProcessPtr();
@@ -1019,7 +1018,7 @@ protected:
 
     if (argc != 2) {
       result.AppendError("two addresses needed for memory find");
-      return false;
+      return;
     }
 
     Status error;
@@ -1027,19 +1026,19 @@ protected:
         &m_exe_ctx, command[0].ref(), LLDB_INVALID_ADDRESS, &error);
     if (low_addr == LLDB_INVALID_ADDRESS || error.Fail()) {
       result.AppendError("invalid low address");
-      return false;
+      return;
     }
     lldb::addr_t high_addr = OptionArgParser::ToAddress(
         &m_exe_ctx, command[1].ref(), LLDB_INVALID_ADDRESS, &error);
     if (high_addr == LLDB_INVALID_ADDRESS || error.Fail()) {
       result.AppendError("invalid high address");
-      return false;
+      return;
     }
 
     if (high_addr <= low_addr) {
       result.AppendError(
           "starting address must be smaller than ending address");
-      return false;
+      return;
     }
 
     lldb::addr_t found_location = LLDB_INVALID_ADDRESS;
@@ -1051,7 +1050,7 @@ protected:
           m_memory_options.m_string.GetValueAs<llvm::StringRef>().value_or("");
       if (str.empty()) {
         result.AppendError("search string must have non-zero length.");
-        return false;
+        return;
       }
       buffer.CopyData(str);
     } else if (m_memory_options.m_expr.OptionWasSet()) {
@@ -1067,7 +1066,7 @@ protected:
         std::optional<uint64_t> size =
             result_sp->GetCompilerType().GetByteSize(nullptr);
         if (!size)
-          return false;
+          return;
         switch (*size) {
         case 1: {
           uint8_t byte = (uint8_t)value;
@@ -1089,21 +1088,21 @@ protected:
         case 6:
         case 7:
           result.AppendError("unknown type. pass a string instead");
-          return false;
+          return;
         default:
           result.AppendError(
               "result size larger than 8 bytes. pass a string instead");
-          return false;
+          return;
         }
       } else {
         result.AppendError(
             "expression evaluation failed. pass a string instead");
-        return false;
+        return;
       }
     } else {
       result.AppendError(
           "please pass either a block of text, or an expression to evaluate.");
-      return false;
+      return;
     }
 
     size_t count = m_memory_options.m_count.GetCurrentValue();
@@ -1146,7 +1145,6 @@ protected:
     }
 
     result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
-    return true;
   }
 
   lldb::addr_t FastSearch(lldb::addr_t low, lldb::addr_t high, uint8_t *buffer,
@@ -1291,7 +1289,7 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // No need to check "process" for validity as eCommandRequiresProcess
     // ensures it is valid
     Process *process = m_exe_ctx.GetProcessPtr();
@@ -1303,19 +1301,19 @@ protected:
         result.AppendErrorWithFormat(
             "%s takes a destination address when writing file contents.\n",
             m_cmd_name.c_str());
-        return false;
+        return;
       }
       if (argc > 1) {
         result.AppendErrorWithFormat(
             "%s takes only a destination address when writing file contents.\n",
             m_cmd_name.c_str());
-        return false;
+        return;
       }
     } else if (argc < 2) {
       result.AppendErrorWithFormat(
           "%s takes a destination address and at least one value.\n",
           m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     StreamString buffer(
@@ -1333,7 +1331,7 @@ protected:
     if (addr == LLDB_INVALID_ADDRESS) {
       result.AppendError("invalid address expression\n");
       result.AppendError(error.AsCString());
-      return false;
+      return;
     }
 
     if (m_memory_options.m_infile) {
@@ -1372,7 +1370,7 @@ protected:
       } else {
         result.AppendErrorWithFormat("Unable to read contents of file.\n");
       }
-      return result.Succeeded();
+      return;
     } else if (item_byte_size == 0) {
       if (m_format_options.GetFormat() == eFormatPointer)
         item_byte_size = buffer.GetAddressByteSize();
@@ -1415,7 +1413,7 @@ protected:
       case eFormatInstruction:
       case eFormatVoid:
         result.AppendError("unsupported format for writing memory");
-        return false;
+        return;
 
       case eFormatDefault:
       case eFormatBytes:
@@ -1433,13 +1431,13 @@ protected:
         if (!success) {
           result.AppendErrorWithFormat(
               "'%s' is not a valid hex string value.\n", entry.c_str());
-          return false;
+          return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value 0x%" PRIx64
                                        " is too large to fit in a %" PRIu64
                                        " byte unsigned integer value.\n",
                                        uval64, (uint64_t)item_byte_size);
-          return false;
+          return;
         }
         buffer.PutMaxHex64(uval64, item_byte_size);
         break;
@@ -1449,7 +1447,7 @@ protected:
         if (!success) {
           result.AppendErrorWithFormat(
               "'%s' is not a valid boolean string value.\n", entry.c_str());
-          return false;
+          return;
         }
         buffer.PutMaxHex64(uval64, item_byte_size);
         break;
@@ -1458,13 +1456,13 @@ protected:
         if (entry.ref().getAsInteger(2, uval64)) {
           result.AppendErrorWithFormat(
               "'%s' is not a valid binary string value.\n", entry.c_str());
-          return false;
+          return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value 0x%" PRIx64
                                        " is too large to fit in a %" PRIu64
                                        " byte unsigned integer value.\n",
                                        uval64, (uint64_t)item_byte_size);
-          return false;
+          return;
         }
         buffer.PutMaxHex64(uval64, item_byte_size);
         break;
@@ -1486,7 +1484,7 @@ protected:
           result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
                                        " failed: %s.\n",
                                        addr, error.AsCString());
-          return false;
+          return;
         }
         break;
       }
@@ -1494,13 +1492,13 @@ protected:
         if (entry.ref().getAsInteger(0, sval64)) {
           result.AppendErrorWithFormat(
               "'%s' is not a valid signed decimal value.\n", entry.c_str());
-          return false;
+          return;
         } else if (!llvm::isIntN(item_byte_size * 8, sval64)) {
           result.AppendErrorWithFormat(
               "Value %" PRIi64 " is too large or small to fit in a %" PRIu64
               " byte signed integer value.\n",
               sval64, (uint64_t)item_byte_size);
-          return false;
+          return;
         }
         buffer.PutMaxHex64(sval64, item_byte_size);
         break;
@@ -1511,13 +1509,13 @@ protected:
           result.AppendErrorWithFormat(
               "'%s' is not a valid unsigned decimal string value.\n",
               entry.c_str());
-          return false;
+          return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value %" PRIu64
                                        " is too large to fit in a %" PRIu64
                                        " byte unsigned integer value.\n",
                                        uval64, (uint64_t)item_byte_size);
-          return false;
+          return;
         }
         buffer.PutMaxHex64(uval64, item_byte_size);
         break;
@@ -1526,13 +1524,13 @@ protected:
         if (entry.ref().getAsInteger(8, uval64)) {
           result.AppendErrorWithFormat(
               "'%s' is not a valid octal string value.\n", entry.c_str());
-          return false;
+          return;
         } else if (!llvm::isUIntN(item_byte_size * 8, uval64)) {
           result.AppendErrorWithFormat("Value %" PRIo64
                                        " is too large to fit in a %" PRIu64
                                        " byte unsigned integer value.\n",
                                        uval64, (uint64_t)item_byte_size);
-          return false;
+          return;
         }
         buffer.PutMaxHex64(uval64, item_byte_size);
         break;
@@ -1541,18 +1539,18 @@ protected:
 
     if (!buffer.GetString().empty()) {
       Status error;
-      if (process->WriteMemory(addr, buffer.GetString().data(),
-                               buffer.GetString().size(),
-                               error) == buffer.GetString().size())
-        return true;
-      else {
+      const char *buffer_data = buffer.GetString().data();
+      const size_t buffer_size = buffer.GetString().size();
+      const size_t write_size =
+          process->WriteMemory(addr, buffer_data, buffer_size, error);
+
+      if (write_size != buffer_size) {
         result.AppendErrorWithFormat("Memory write to 0x%" PRIx64
                                      " failed: %s.\n",
                                      addr, error.AsCString());
-        return false;
+        return;
       }
     }
-    return true;
   }
 
   OptionGroupOptions m_option_group;
@@ -1595,13 +1593,13 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc == 0 || argc > 1) {
       result.AppendErrorWithFormat("%s takes an address expression",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     Status error;
@@ -1611,7 +1609,7 @@ protected:
     if (addr == LLDB_INVALID_ADDRESS) {
       result.AppendError("invalid address expression");
       result.AppendError(error.AsCString());
-      return false;
+      return;
     }
 
     Stream *output_stream = &result.GetOutputStream();
@@ -1622,7 +1620,7 @@ protected:
 
     if (!memory_history) {
       result.AppendError("no available memory history provider");
-      return false;
+      return;
     }
 
     HistoryThreads thread_list = memory_history->GetHistoryThreads(addr);
@@ -1633,8 +1631,6 @@ protected:
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-
-    return true;
   }
 };
 
@@ -1747,12 +1743,12 @@ protected:
     }
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     ProcessSP process_sp = m_exe_ctx.GetProcessSP();
     if (!process_sp) {
       m_prev_end_addr = LLDB_INVALID_ADDRESS;
       result.AppendError("invalid process");
-      return false;
+      return;
     }
 
     Status error;
@@ -1767,7 +1763,7 @@ protected:
         result.AppendError(
             "The \"--all\" option cannot be used when an address "
             "argument is given");
-        return false;
+        return;
       }
 
       auto load_addr_str = command[0].ref();
@@ -1776,7 +1772,7 @@ protected:
       if (error.Fail() || load_addr == LLDB_INVALID_ADDRESS) {
         result.AppendErrorWithFormat("invalid address argument \"%s\": %s\n",
                                      command[0].c_str(), error.AsCString());
-        return false;
+        return;
       }
     } else if (argc > 1 ||
                // When we're repeating the command, the previous end address is
@@ -1792,7 +1788,7 @@ protected:
       result.AppendErrorWithFormat(
           "'%s' takes one argument or \"--all\" option:\nUsage: %s\n",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());
-      return false;
+      return;
     }
 
     // It is important that we track the address used to request the region as
@@ -1832,11 +1828,10 @@ protected:
       }
 
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
 
     result.AppendErrorWithFormat("%s\n", error.AsCString());
-    return false;
   }
 
   std::optional<std::string> GetRepeatCommand(Args &current_command_args,

--- a/lldb/source/Commands/CommandObjectMemoryTag.cpp
+++ b/lldb/source/Commands/CommandObjectMemoryTag.cpp
@@ -42,12 +42,12 @@ public:
   ~CommandObjectMemoryTagRead() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if ((command.GetArgumentCount() < 1) || (command.GetArgumentCount() > 2)) {
       result.AppendError(
           "wrong number of arguments; expected at least <address-expression>, "
           "at most <address-expression> <end-address-expression>");
-      return false;
+      return;
     }
 
     Status error;
@@ -56,7 +56,7 @@ protected:
     if (start_addr == LLDB_INVALID_ADDRESS) {
       result.AppendErrorWithFormatv("Invalid address expression, {0}",
                                     error.AsCString());
-      return false;
+      return;
     }
 
     // Default 1 byte beyond start, rounds up to at most 1 granule later
@@ -68,7 +68,7 @@ protected:
       if (end_addr == LLDB_INVALID_ADDRESS) {
         result.AppendErrorWithFormatv("Invalid end address expression, {0}",
                                       error.AsCString());
-        return false;
+        return;
       }
     }
 
@@ -78,7 +78,7 @@ protected:
 
     if (!tag_manager_or_err) {
       result.SetError(Status(tag_manager_or_err.takeError()));
-      return false;
+      return;
     }
 
     const MemoryTagManager *tag_manager = *tag_manager_or_err;
@@ -103,7 +103,7 @@ protected:
 
     if (!tagged_range) {
       result.SetError(Status(tagged_range.takeError()));
-      return false;
+      return;
     }
 
     llvm::Expected<std::vector<lldb::addr_t>> tags = process->ReadMemoryTags(
@@ -111,7 +111,7 @@ protected:
 
     if (!tags) {
       result.SetError(Status(tags.takeError()));
-      return false;
+      return;
     }
 
     result.AppendMessageWithFormatv("Logical tag: {0:x}", logical_tag);
@@ -128,7 +128,6 @@ protected:
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 };
 
@@ -195,11 +194,11 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() < 2) {
       result.AppendError("wrong number of arguments; expected "
                          "<address-expression> <tag> [<tag> [...]]");
-      return false;
+      return;
     }
 
     Status error;
@@ -208,7 +207,7 @@ protected:
     if (start_addr == LLDB_INVALID_ADDRESS) {
       result.AppendErrorWithFormatv("Invalid address expression, {0}",
                                     error.AsCString());
-      return false;
+      return;
     }
 
     command.Shift(); // shift off start address
@@ -221,7 +220,7 @@ protected:
         result.AppendErrorWithFormat(
             "'%s' is not a valid unsigned decimal string value.\n",
             entry.c_str());
-        return false;
+        return;
       }
       tags.push_back(tag_value);
     }
@@ -232,7 +231,7 @@ protected:
 
     if (!tag_manager_or_err) {
       result.SetError(Status(tag_manager_or_err.takeError()));
-      return false;
+      return;
     }
 
     const MemoryTagManager *tag_manager = *tag_manager_or_err;
@@ -284,7 +283,7 @@ protected:
 
     if (!tagged_range) {
       result.SetError(Status(tagged_range.takeError()));
-      return false;
+      return;
     }
 
     Status status = process->WriteMemoryTags(tagged_range->GetRangeBase(),
@@ -292,11 +291,10 @@ protected:
 
     if (status.Fail()) {
       result.SetError(status);
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 
   OptionGroupOptions m_option_group;

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -169,7 +169,7 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.GetArgumentCount() == 1) {
       const char *platform_name = args.GetArgumentAtIndex(0);
       if (platform_name && platform_name[0]) {
@@ -194,7 +194,6 @@ protected:
       result.AppendError(
           "platform create takes a platform name as an argument\n");
     }
-    return result.Succeeded();
   }
 
   OptionGroupOptions m_option_group;
@@ -212,7 +211,7 @@ public:
   ~CommandObjectPlatformList() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &ostrm = result.GetOutputStream();
     ostrm.Printf("Available platforms:\n");
 
@@ -235,7 +234,6 @@ protected:
       result.AppendError("no platforms are available\n");
     } else
       result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -250,7 +248,7 @@ public:
   ~CommandObjectPlatformStatus() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &ostrm = result.GetOutputStream();
 
     Target *target = GetDebugger().GetSelectedTarget().get();
@@ -267,7 +265,6 @@ protected:
     } else {
       result.AppendError("no platform is currently selected\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -286,7 +283,7 @@ public:
   ~CommandObjectPlatformConnect() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &ostrm = result.GetOutputStream();
 
     PlatformSP platform_sp(
@@ -307,7 +304,6 @@ protected:
     } else {
       result.AppendError("no platform is currently selected\n");
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override {
@@ -334,7 +330,7 @@ public:
   ~CommandObjectPlatformDisconnect() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -374,7 +370,6 @@ protected:
     } else {
       result.AppendError("no platform is currently selected");
     }
-    return result.Succeeded();
   }
 };
 
@@ -394,7 +389,7 @@ public:
   ~CommandObjectPlatformSettings() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -404,7 +399,6 @@ protected:
     } else {
       result.AppendError("no platform is currently selected");
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override {
@@ -430,7 +424,7 @@ public:
 
   ~CommandObjectPlatformMkDir() override = default;
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -453,7 +447,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override {
@@ -489,7 +482,7 @@ public:
           nullptr);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -517,7 +510,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override {
@@ -544,7 +536,7 @@ public:
 
   ~CommandObjectPlatformFClose() override = default;
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -554,7 +546,7 @@ public:
       if (!llvm::to_integer(cmd_line, fd)) {
         result.AppendErrorWithFormatv("'{0}' is not a valid file descriptor.\n",
                                       cmd_line);
-        return result.Succeeded();
+        return;
       }
       Status error;
       bool success = platform_sp->CloseFile(fd, error);
@@ -567,7 +559,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -588,7 +579,7 @@ public:
 
   ~CommandObjectPlatformFRead() override = default;
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -598,7 +589,7 @@ public:
       if (!llvm::to_integer(cmd_line, fd)) {
         result.AppendErrorWithFormatv("'{0}' is not a valid file descriptor.\n",
                                       cmd_line);
-        return result.Succeeded();
+        return;
       }
       std::string buffer(m_options.m_count, 0);
       Status error;
@@ -614,7 +605,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override { return &m_options; }
@@ -684,7 +674,7 @@ public:
 
   ~CommandObjectPlatformFWrite() override = default;
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -695,7 +685,7 @@ public:
       if (!llvm::to_integer(cmd_line, fd)) {
         result.AppendErrorWithFormatv("'{0}' is not a valid file descriptor.",
                                       cmd_line);
-        return result.Succeeded();
+        return;
       }
       uint64_t retcode =
           platform_sp->WriteFile(fd, m_options.m_offset, &m_options.m_data[0],
@@ -709,7 +699,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override { return &m_options; }
@@ -839,12 +828,12 @@ public:
           GetCommandInterpreter(), lldb::eDiskFileCompletion, request, nullptr);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     // If the number of arguments is incorrect, issue an error message.
     if (args.GetArgumentCount() != 2) {
       result.AppendError("required arguments missing; specify both the "
                          "source and destination file paths");
-      return false;
+      return;
     }
 
     PlatformSP platform_sp(
@@ -866,7 +855,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -911,12 +899,12 @@ public:
         nullptr);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     // If the number of arguments is incorrect, issue an error message.
     if (args.GetArgumentCount() != 1) {
       result.AppendError("required argument missing; specify the source file "
                          "path as the only argument");
-      return false;
+      return;
     }
 
     PlatformSP platform_sp(
@@ -937,7 +925,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -982,12 +969,12 @@ public:
         nullptr);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     // If the number of arguments is incorrect, issue an error message.
     if (args.GetArgumentCount() != 1) {
       result.AppendError("required argument missing; specify the source file "
                          "path as the only argument");
-      return false;
+      return;
     }
 
     PlatformSP platform_sp(
@@ -1007,7 +994,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -1052,12 +1038,12 @@ public:
         nullptr);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     // If the number of arguments is incorrect, issue an error message.
     if (args.GetArgumentCount() != 1) {
       result.AppendError("required argument missing; specify the source file "
                          "path as the only argument");
-      return false;
+      return;
     }
 
     PlatformSP platform_sp(
@@ -1072,7 +1058,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -1114,7 +1099,7 @@ public:
           nullptr);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     const char *src = args.GetArgumentAtIndex(0);
     const char *dst = args.GetArgumentAtIndex(1);
 
@@ -1134,7 +1119,6 @@ public:
     } else {
       result.AppendError("no platform currently selected\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -1160,7 +1144,7 @@ public:
   Options *GetOptions() override { return &m_all_options; }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = GetDebugger().GetSelectedTarget().get();
     PlatformSP platform_sp;
     if (target) {
@@ -1220,10 +1204,10 @@ protected:
 
         if (!process_sp && error.Success()) {
           result.AppendError("failed to launch or debug process");
-          return false;
+          return;
         } else if (!error.Success()) {
           result.AppendError(error.AsCString());
-          return false;
+          return;
         }
 
         const bool synchronous_execution =
@@ -1242,7 +1226,7 @@ protected:
         if (rebroadcast_first_stop) {
           assert(first_stop_event_sp);
           process_sp->BroadcastEvent(first_stop_event_sp);
-          return true;
+          return;
         }
 
         switch (state) {
@@ -1272,18 +1256,17 @@ protected:
 
         if (process_sp && process_sp->IsAlive()) {
           result.SetStatus(eReturnStatusSuccessFinishNoResult);
-          return true;
+          return;
         }
       } else {
         result.AppendError("'platform process launch' uses the current target "
                            "file and arguments, or the executable and its "
                            "arguments can be specified in this command");
-        return false;
+        return;
       }
     } else {
       result.AppendError("no platform is selected\n");
     }
-    return result.Succeeded();
   }
 
   CommandOptionsProcessLaunch m_options;
@@ -1310,7 +1293,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = GetDebugger().GetSelectedTarget().get();
     PlatformSP platform_sp;
     if (target) {
@@ -1398,7 +1381,6 @@ protected:
     } else {
       result.AppendError("no platform is selected\n");
     }
-    return result.Succeeded();
   }
 
   class CommandOptions : public Options {
@@ -1578,7 +1560,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = GetDebugger().GetSelectedTarget().get();
     PlatformSP platform_sp;
     if (target) {
@@ -1627,7 +1609,6 @@ protected:
     } else {
       result.AppendError("no platform is currently selected");
     }
-    return result.Succeeded();
   }
 };
 
@@ -1649,7 +1630,7 @@ public:
 
   ~CommandObjectPlatformProcessAttach() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (platform_sp) {
@@ -1673,7 +1654,6 @@ public:
     } else {
       result.AppendError("no platform is currently selected");
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override { return &m_all_options; }
@@ -1788,7 +1768,7 @@ public:
 
   Options *GetOptions() override { return &m_options; }
 
-  bool DoExecute(llvm::StringRef raw_command_line,
+  void DoExecute(llvm::StringRef raw_command_line,
                  CommandReturnObject &result) override {
     ExecutionContext exe_ctx = GetCommandInterpreter().GetExecutionContext();
     m_options.NotifyOptionParsingStarting(&exe_ctx);
@@ -1796,7 +1776,7 @@ public:
     // Print out an usage syntax on an empty command line.
     if (raw_command_line.empty()) {
       result.GetOutputStream().Printf("%s\n", this->GetSyntax().str().c_str());
-      return true;
+      return;
     }
 
     const bool is_alias = !raw_command_line.contains("platform");
@@ -1804,12 +1784,12 @@ public:
 
     if (args.HasArgs())
       if (!ParseOptions(args.GetArgs(), result))
-        return false;
+        return;
 
     if (args.GetRawPart().empty()) {
       result.GetOutputStream().Printf("%s <shell-command>\n",
                                       is_alias ? "shell" : "platform shell");
-      return false;
+      return;
     }
 
     llvm::StringRef cmd = args.GetRawPart();
@@ -1856,7 +1836,6 @@ public:
     } else {
       result.SetStatus(eReturnStatusSuccessFinishResult);
     }
-    return true;
   }
 
   CommandOptions m_options;
@@ -1887,10 +1866,10 @@ public:
         GetCommandInterpreter(), lldb::eDiskFileCompletion, request, nullptr);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.GetArgumentCount() != 2) {
       result.AppendError("platform target-install takes two arguments");
-      return false;
+      return;
     }
     // TODO: move the bulk of this code over to the platform itself
     FileSpec src(args.GetArgumentAtIndex(0));
@@ -1898,13 +1877,13 @@ public:
     FileSpec dst(args.GetArgumentAtIndex(1));
     if (!FileSystem::Instance().Exists(src)) {
       result.AppendError("source location does not exist or is not accessible");
-      return false;
+      return;
     }
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
     if (!platform_sp) {
       result.AppendError("no platform currently selected");
-      return false;
+      return;
     }
 
     Status error = platform_sp->Install(src, dst);
@@ -1913,7 +1892,6 @@ public:
     } else {
       result.AppendErrorWithFormat("install failed: %s", error.AsCString());
     }
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -44,12 +44,12 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     size_t argc = command.GetArgumentCount();
 
     if (argc != 1) {
       result.AppendError("'plugin load' requires one argument");
-      return false;
+      return;
     }
 
     Status error;
@@ -62,8 +62,6 @@ protected:
     else {
       result.AppendError(error.AsCString());
     }
-
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -160,7 +160,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &launch_args, CommandReturnObject &result) override {
+  void DoExecute(Args &launch_args, CommandReturnObject &result) override {
     Debugger &debugger = GetDebugger();
     Target *target = debugger.GetSelectedTarget().get();
     // If our listener is nullptr, users aren't allows to launch
@@ -174,13 +174,13 @@ protected:
     if (exe_module_sp == nullptr && !target->GetProcessLaunchInfo().GetExecutableFile()) {
       result.AppendError("no file in target, create a debug target using the "
                          "'target create' command");
-      return false;
+      return;
     }
 
     StateType state = eStateInvalid;
 
     if (!StopProcessIfNecessary(m_exe_ctx.GetProcessPtr(), state, result))
-      return false;
+      return;
 
     // Determine whether we will disable ASLR or leave it in the default state
     // (i.e. enabled if the platform supports it). First check if the process
@@ -290,7 +290,6 @@ protected:
     } else {
       result.AppendError(error.AsCString());
     }
-    return result.Succeeded();
   }
 
   CommandOptionsProcessLaunch m_options;
@@ -320,7 +319,7 @@ public:
   Options *GetOptions() override { return &m_all_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
 
@@ -334,7 +333,7 @@ protected:
     Process *process = m_exe_ctx.GetProcessPtr();
 
     if (!StopProcessIfNecessary(process, state, result))
-      return false;
+      return;
 
     if (target == nullptr) {
       // If there isn't a current target create one.
@@ -348,7 +347,7 @@ protected:
       target = new_target_sp.get();
       if (target == nullptr || error.Fail()) {
         result.AppendError(error.AsCString("Error creating target"));
-        return false;
+        return;
       }
     }
 
@@ -384,7 +383,7 @@ protected:
     }
 
     if (!result.Succeeded())
-      return false;
+      return;
 
     // Okay, we're done.  Last step is to warn if the executable module has
     // changed:
@@ -429,8 +428,6 @@ protected:
       ExecutionContext exe_ctx(process_sp);
       m_interpreter.HandleCommand("process continue", eLazyBoolNo, exe_ctx, result);
     }
-
-    return result.Succeeded();
   }
 
   CommandOptionsProcessAttach m_options;
@@ -504,8 +501,7 @@ protected:
     bool m_any_bkpts_specified = false;
   };
 
-
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
     bool synchronous_execution = m_interpreter.GetSynchronous();
     StateType state = process->GetState();
@@ -543,13 +539,13 @@ protected:
             m_options.m_run_to_bkpt_args, target, result, &run_to_bkpt_ids,
             BreakpointName::Permissions::disablePerm);
       if (!result.Succeeded()) {
-        return false;
+        return;
       }
       result.Clear();
       if (m_options.m_any_bkpts_specified && run_to_bkpt_ids.GetSize() == 0) {
         result.AppendError("continue-to breakpoints did not specify any actual "
                            "breakpoints or locations");
-        return false;
+        return;
       }
 
       // First figure out which breakpoints & locations were specified by the
@@ -612,7 +608,7 @@ protected:
         if (!any_enabled) {
           result.AppendError("at least one of the continue-to breakpoints must "
                              "be enabled.");
-          return false;
+          return;
         }
 
         // Also, if you specify BOTH a breakpoint and one of it's locations,
@@ -737,7 +733,6 @@ protected:
           "Process cannot be continued from its current state (%s).\n",
           StateAsCString(state));
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override { return &m_options; }
@@ -809,7 +804,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
     // FIXME: This will be a Command Option:
     bool keep_stopped;
@@ -826,9 +821,7 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
       result.AppendErrorWithFormat("Detach failed: %s\n", error.AsCString());
-      return false;
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -894,12 +887,12 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
           "'%s' takes exactly one argument:\nUsage: %s\n", m_cmd_name.c_str(),
           m_cmd_syntax.c_str());
-      return false;
+      return;
     }
 
     Process *process = m_exe_ctx.GetProcessPtr();
@@ -908,7 +901,7 @@ protected:
           "Process %" PRIu64
           " is currently being debugged, kill the process before connecting.\n",
           process->GetID());
-      return false;
+      return;
     }
 
     const char *plugin_name = nullptr;
@@ -929,9 +922,7 @@ protected:
                   error);
     if (error.Fail() || process_sp == nullptr) {
       result.AppendError(error.AsCString("Error connecting to the process"));
-      return false;
     }
-    return true;
   }
 
   CommandOptions m_options;
@@ -1032,7 +1023,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
 
     for (auto &entry : command.entries()) {
@@ -1071,7 +1062,6 @@ protected:
                                      error.AsCString());
       }
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -1115,7 +1105,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
 
     for (auto &entry : command.entries()) {
@@ -1138,7 +1128,6 @@ protected:
         }
       }
     }
-    return result.Succeeded();
   }
 };
 
@@ -1184,7 +1173,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
 
     if (command.GetArgumentCount() == 1) {
@@ -1214,7 +1203,6 @@ protected:
           "'%s' takes exactly one signal number argument:\nUsage: %s\n",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());
     }
-    return result.Succeeded();
   }
 };
 
@@ -1233,11 +1221,11 @@ public:
   ~CommandObjectProcessInterrupt() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
     if (process == nullptr) {
       result.AppendError("no process to halt");
-      return false;
+      return;
     }
 
     bool clear_thread_plans = true;
@@ -1248,7 +1236,6 @@ protected:
       result.AppendErrorWithFormat("Failed to halt process: %s\n",
                                    error.AsCString());
     }
-    return result.Succeeded();
   }
 };
 
@@ -1267,11 +1254,11 @@ public:
   ~CommandObjectProcessKill() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
     if (process == nullptr) {
       result.AppendError("no process to kill");
-      return false;
+      return;
     }
 
     Status error(process->Destroy(true));
@@ -1281,7 +1268,6 @@ protected:
       result.AppendErrorWithFormat("Failed to kill process: %s\n",
                                    error.AsCString());
     }
-    return result.Succeeded();
   }
 };
 
@@ -1356,7 +1342,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     ProcessSP process_sp = m_exe_ctx.GetProcessSP();
     if (process_sp) {
       if (command.GetArgumentCount() == 1) {
@@ -1390,10 +1376,7 @@ protected:
       }
     } else {
       result.AppendError("invalid process");
-      return false;
     }
-
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -1451,7 +1434,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Stream &strm = result.GetOutputStream();
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
 
@@ -1483,7 +1466,7 @@ protected:
       PlatformSP platform_sp = process->GetTarget().GetPlatform();
       if (!platform_sp) {
         result.AppendError("Couldn'retrieve the target's platform");
-        return result.Succeeded();
+        return;
       }
 
       auto expected_crash_info =
@@ -1491,7 +1474,7 @@ protected:
 
       if (!expected_crash_info) {
         result.AppendError(llvm::toString(expected_crash_info.takeError()));
-        return result.Succeeded();
+        return;
       }
 
       StructuredData::DictionarySP crash_info_sp = *expected_crash_info;
@@ -1502,8 +1485,6 @@ protected:
         crash_info_sp->GetDescription(strm);
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -1676,7 +1657,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &signal_args, CommandReturnObject &result) override {
+  void DoExecute(Args &signal_args, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
 
     // Any signals that are being set should be added to the Target's
@@ -1693,28 +1674,28 @@ protected:
         !VerifyCommandOptionValue(m_options.stop, stop_action)) {
       result.AppendError("Invalid argument for command option --stop; must be "
                          "true or false.\n");
-      return false;
+      return;
     }
 
     if (!m_options.notify.empty() &&
         !VerifyCommandOptionValue(m_options.notify, notify_action)) {
       result.AppendError("Invalid argument for command option --notify; must "
                          "be true or false.\n");
-      return false;
+      return;
     }
 
     if (!m_options.pass.empty() &&
         !VerifyCommandOptionValue(m_options.pass, pass_action)) {
       result.AppendError("Invalid argument for command option --pass; must be "
                          "true or false.\n");
-      return false;
+      return;
     }
 
     bool no_actions = (stop_action == -1 && pass_action == -1
         && notify_action == -1);
     if (m_options.only_target_values && !no_actions) {
       result.AppendError("-t is for reporting, not setting, target values.");
-      return false;
+      return;
     }
 
     size_t num_args = signal_args.GetArgumentCount();
@@ -1729,7 +1710,7 @@ protected:
     if (m_options.only_target_values) {
       target.PrintDummySignals(result.GetOutputStream(), signal_args);
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
 
     // This handles clearing values:
@@ -1738,7 +1719,7 @@ protected:
       if (m_options.dummy)
         GetDummyTarget().ClearDummySignals(signal_args);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     // This rest handles setting values:
@@ -1774,7 +1755,7 @@ protected:
           if (llvm::to_integer(arg.c_str(), signo)) {
             result.AppendErrorWithFormat("Can't set signal handling by signal "
                                          "number with no process");
-            return false;
+            return;
           }
          num_signals_set = num_args;
         }
@@ -1831,8 +1812,6 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishResult);
     else
       result.SetStatus(eReturnStatusFailed);
-
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -1873,7 +1852,7 @@ public:
 
   ~CommandObjectProcessTraceStop() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     ProcessSP process_sp = m_exe_ctx.GetProcessSP();
 
     TraceSP trace_sp = process_sp->GetTarget().GetTrace();
@@ -1882,8 +1861,6 @@ public:
       result.AppendError(toString(std::move(err)));
     else
       result.SetStatus(eReturnStatusSuccessFinishResult);
-
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectQuit.cpp
+++ b/lldb/source/Commands/CommandObjectQuit.cpp
@@ -62,7 +62,7 @@ bool CommandObjectQuit::ShouldAskForConfirmation(bool &is_a_detach) {
   return should_prompt;
 }
 
-bool CommandObjectQuit::DoExecute(Args &command, CommandReturnObject &result) {
+void CommandObjectQuit::DoExecute(Args &command, CommandReturnObject &result) {
   bool is_a_detach = true;
   if (ShouldAskForConfirmation(is_a_detach)) {
     StreamString message;
@@ -71,14 +71,14 @@ bool CommandObjectQuit::DoExecute(Args &command, CommandReturnObject &result) {
                    (is_a_detach ? "detach from" : "kill"));
     if (!m_interpreter.Confirm(message.GetString(), true)) {
       result.SetStatus(eReturnStatusFailed);
-      return false;
+      return;
     }
   }
 
   if (command.GetArgumentCount() > 1) {
     result.AppendError("Too many arguments for 'quit'. Only an optional exit "
                        "code is allowed");
-    return false;
+    return;
   }
 
   // We parse the exit code argument if there is one.
@@ -90,12 +90,12 @@ bool CommandObjectQuit::DoExecute(Args &command, CommandReturnObject &result) {
       std::string arg_str = arg.str();
       s.Printf("Couldn't parse '%s' as integer for exit code.", arg_str.data());
       result.AppendError(s.GetString());
-      return false;
+      return;
     }
     if (!m_interpreter.SetQuitExitCode(exit_code)) {
       result.AppendError("The current driver doesn't allow custom exit codes"
                          " for the quit command.");
-      return false;
+      return;
     }
   }
 
@@ -103,6 +103,4 @@ bool CommandObjectQuit::DoExecute(Args &command, CommandReturnObject &result) {
       CommandInterpreter::eBroadcastBitQuitCommandReceived;
   m_interpreter.BroadcastEvent(event_type);
   result.SetStatus(eReturnStatusQuit);
-
-  return true;
 }

--- a/lldb/source/Commands/CommandObjectQuit.h
+++ b/lldb/source/Commands/CommandObjectQuit.h
@@ -22,7 +22,7 @@ public:
   ~CommandObjectQuit() override;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override;
+  void DoExecute(Args &args, CommandReturnObject &result) override;
 
   bool ShouldAskForConfirmation(bool &is_a_detach);
 };

--- a/lldb/source/Commands/CommandObjectRegexCommand.cpp
+++ b/lldb/source/Commands/CommandObjectRegexCommand.cpp
@@ -54,7 +54,7 @@ llvm::Expected<std::string> CommandObjectRegexCommand::SubstituteVariables(
   return output.str();
 }
 
-bool CommandObjectRegexCommand::DoExecute(llvm::StringRef command,
+void CommandObjectRegexCommand::DoExecute(llvm::StringRef command,
                                           CommandReturnObject &result) {
   EntryCollection::const_iterator pos, end = m_entries.end();
   for (pos = m_entries.begin(); pos != end; ++pos) {
@@ -64,7 +64,7 @@ bool CommandObjectRegexCommand::DoExecute(llvm::StringRef command,
           SubstituteVariables(pos->command, matches);
       if (!new_command) {
         result.SetError(new_command.takeError());
-        return false;
+        return;
       }
 
       // Interpret the new command and return this as the result!
@@ -73,8 +73,9 @@ bool CommandObjectRegexCommand::DoExecute(llvm::StringRef command,
       // We don't have to pass an override_context here, as the command that 
       // called us should have set up the context appropriately.
       bool force_repeat_command = true;
-      return m_interpreter.HandleCommand(new_command->c_str(), eLazyBoolNo,
-                                         result, force_repeat_command);
+      m_interpreter.HandleCommand(new_command->c_str(), eLazyBoolNo, result,
+                                  force_repeat_command);
+      return;
     }
   }
   result.SetStatus(eReturnStatusFailed);
@@ -85,7 +86,6 @@ bool CommandObjectRegexCommand::DoExecute(llvm::StringRef command,
                             << "' failed to match any "
                                "regular expression in the '"
                             << m_cmd_name << "' regex ";
-  return false;
 }
 
 bool CommandObjectRegexCommand::AddRegexCommand(llvm::StringRef re_cstr,

--- a/lldb/source/Commands/CommandObjectRegexCommand.h
+++ b/lldb/source/Commands/CommandObjectRegexCommand.h
@@ -37,7 +37,7 @@ public:
   void HandleCompletion(CompletionRequest &request) override;
 
 protected:
-  bool DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
+  void DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
 
   /// Substitute variables of the format %\d+ in the input string.
   static llvm::Expected<std::string> SubstituteVariables(

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -161,7 +161,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Stream &strm = result.GetOutputStream();
     RegisterContext *reg_ctx = m_exe_ctx.GetRegisterContext();
 
@@ -234,7 +234,6 @@ protected:
         }
       }
     }
-    return result.Succeeded();
   }
 
   class CommandOptions : public OptionGroup {
@@ -348,7 +347,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     DataExtractor reg_data;
     RegisterContext *reg_ctx = m_exe_ctx.GetRegisterContext();
 
@@ -378,7 +377,7 @@ protected:
             // has been written.
             m_exe_ctx.GetThreadRef().Flush();
             result.SetStatus(eReturnStatusSuccessFinishNoResult);
-            return true;
+            return;
           }
         }
         if (error.AsCString()) {
@@ -396,7 +395,6 @@ protected:
                                      reg_name.str().c_str());
       }
     }
-    return result.Succeeded();
   }
 };
 
@@ -447,10 +445,10 @@ different for the same register when connected to different debug servers.)");
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
       result.AppendError("register info takes exactly 1 argument: <reg-name>");
-      return result.Succeeded();
+      return;
     }
 
     llvm::StringRef reg_name = command[0].ref();
@@ -464,8 +462,6 @@ protected:
     } else
       result.AppendErrorWithFormat("No register found with name '%s'.\n",
                                    reg_name.str().c_str());
-
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectScript.cpp
+++ b/lldb/source/Commands/CommandObjectScript.cpp
@@ -65,14 +65,14 @@ CommandObjectScript::CommandObjectScript(CommandInterpreter &interpreter)
 
 CommandObjectScript::~CommandObjectScript() = default;
 
-bool CommandObjectScript::DoExecute(llvm::StringRef command,
+void CommandObjectScript::DoExecute(llvm::StringRef command,
                                     CommandReturnObject &result) {
   // Try parsing the language option but when the command contains a raw part
   // separated by the -- delimiter.
   OptionsWithRaw raw_args(command);
   if (raw_args.HasArgs()) {
     if (!ParseOptions(raw_args.GetArgs(), result))
-      return false;
+      return;
     command = raw_args.GetRawPart();
   }
 
@@ -84,7 +84,7 @@ bool CommandObjectScript::DoExecute(llvm::StringRef command,
   if (language == lldb::eScriptLanguageNone) {
     result.AppendError(
         "the script-lang setting is set to none - scripting not available");
-    return false;
+    return;
   }
 
   ScriptInterpreter *script_interpreter =
@@ -92,7 +92,7 @@ bool CommandObjectScript::DoExecute(llvm::StringRef command,
 
   if (script_interpreter == nullptr) {
     result.AppendError("no script interpreter");
-    return false;
+    return;
   }
 
   // Script might change Python code we use for formatting. Make sure we keep
@@ -102,7 +102,7 @@ bool CommandObjectScript::DoExecute(llvm::StringRef command,
   if (command.empty()) {
     script_interpreter->ExecuteInterpreterLoop();
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
+    return;
   }
 
   // We can do better when reporting the status of one-liner script execution.
@@ -110,6 +110,4 @@ bool CommandObjectScript::DoExecute(llvm::StringRef command,
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
   else
     result.SetStatus(eReturnStatusFailed);
-
-  return result.Succeeded();
 }

--- a/lldb/source/Commands/CommandObjectScript.h
+++ b/lldb/source/Commands/CommandObjectScript.h
@@ -31,7 +31,7 @@ public:
   };
 
 protected:
-  bool DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
+  void DoExecute(llvm::StringRef command, CommandReturnObject &result) override;
 
 private:
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectSession.cpp
+++ b/lldb/source/Commands/CommandObjectSession.cpp
@@ -36,7 +36,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     llvm::StringRef file_path;
 
     if (!args.empty())
@@ -46,7 +46,6 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     else
       result.SetStatus(eReturnStatusFailed);
-    return result.Succeeded();
   }
 };
 
@@ -127,7 +126,7 @@ protected:
     OptionValueBoolean m_clear;
   };
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (m_options.m_clear.GetCurrentValue() &&
         m_options.m_clear.OptionWasSet()) {
       m_interpreter.GetCommandHistory().Clear();
@@ -189,7 +188,6 @@ protected:
                      stop_idx.second);
       }
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -169,27 +169,27 @@ insert-before or insert-after.");
   }
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     Args cmd_args(command);
 
     // Process possible options.
     if (!ParseOptions(cmd_args, result))
-      return false;
+      return;
 
     const size_t min_argc = m_options.m_force ? 1 : 2;
     const size_t argc = cmd_args.GetArgumentCount();
 
     if ((argc < min_argc) && (!m_options.m_global)) {
       result.AppendError("'settings set' takes more arguments");
-      return false;
+      return;
     }
 
     const char *var_name = cmd_args.GetArgumentAtIndex(0);
     if ((var_name == nullptr) || (var_name[0] == '\0')) {
       result.AppendError(
           "'settings set' command requires a valid variable name");
-      return false;
+      return;
     }
 
     // A missing value corresponds to clearing the setting when "force" is
@@ -199,9 +199,8 @@ protected:
           &m_exe_ctx, eVarSetOperationClear, var_name, llvm::StringRef()));
       if (error.Fail()) {
         result.AppendError(error.AsCString());
-        return false;
       }
-      return result.Succeeded();
+      return;
     }
 
     // Split the raw command into var_name and value pair.
@@ -227,11 +226,10 @@ protected:
 
     if (error.Fail() && !m_options.m_exists) {
       result.AppendError(error.AsCString());
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 
 private:
@@ -273,7 +271,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
     if (!args.empty()) {
@@ -291,8 +289,6 @@ protected:
       GetDebugger().DumpAllPropertyValues(&m_exe_ctx, result.GetOutputStream(),
                                           OptionValue::eDumpGroupValue);
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -368,7 +364,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     FileSpec file_spec(m_options.m_filename);
     FileSystem::Instance().Resolve(file_spec);
     std::string path(file_spec.GetPath());
@@ -383,7 +379,7 @@ protected:
 
     if (!out_file.GetFile().IsValid()) {
       result.AppendErrorWithFormat("%s: unable to write to file", path.c_str());
-      return false;
+      return;
     }
 
     // Exporting should not be context sensitive.
@@ -392,7 +388,7 @@ protected:
     if (args.empty()) {
       GetDebugger().DumpAllPropertyValues(&clean_ctx, out_file,
                                           OptionValue::eDumpGroupExport);
-      return result.Succeeded();
+      return;
     }
 
     for (const auto &arg : args) {
@@ -402,8 +398,6 @@ protected:
         result.AppendError(error.AsCString());
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -461,7 +455,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     FileSpec file(m_options.m_filename);
     FileSystem::Instance().Resolve(file);
     CommandInterpreterRunOptions options;
@@ -471,7 +465,6 @@ protected:
     options.SetPrintErrors(true);
     options.SetStopOnError(false);
     m_interpreter.HandleCommandsFromFile(file, options, result);
-    return result.Succeeded();
   }
 
 private:
@@ -517,7 +510,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
     const size_t argc = args.GetArgumentCount();
@@ -543,8 +536,6 @@ protected:
       GetDebugger().DumpAllDescriptions(m_interpreter,
                                         result.GetOutputStream());
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -601,7 +592,7 @@ public:
   }
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
 
@@ -609,7 +600,7 @@ protected:
 
     // Process possible options.
     if (!ParseOptions(cmd_args, result))
-      return false;
+      return;
 
     const size_t argc = cmd_args.GetArgumentCount();
     if (argc == 0) {
@@ -617,14 +608,14 @@ protected:
                          "or an array followed by one or more indexes, or a "
                          "dictionary followed by one or more key names to "
                          "remove");
-      return false;
+      return;
     }
 
     const char *var_name = cmd_args.GetArgumentAtIndex(0);
     if ((var_name == nullptr) || (var_name[0] == '\0')) {
       result.AppendError(
           "'settings remove' command requires a valid variable name");
-      return false;
+      return;
     }
 
     // Split the raw command into var_name and value pair.
@@ -635,10 +626,7 @@ protected:
         &m_exe_ctx, eVarSetOperationRemove, var_name, var_value));
     if (error.Fail()) {
       result.AppendError(error.AsCString());
-      return false;
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -709,7 +697,7 @@ public:
   }
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
 
@@ -718,7 +706,7 @@ protected:
     if ((var_name == nullptr) || (var_name[0] == '\0')) {
       result.AppendError("'settings replace' command requires a valid variable "
                          "name; No value supplied");
-      return false;
+      return;
     }
 
     // Split the raw command into var_name, index_value, and value triple.
@@ -729,12 +717,9 @@ protected:
         &m_exe_ctx, eVarSetOperationReplace, var_name, var_value));
     if (error.Fail()) {
       result.AppendError(error.AsCString());
-      return false;
     } else {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -801,7 +786,7 @@ public:
   }
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
 
@@ -810,14 +795,14 @@ protected:
 
     if (argc < 3) {
       result.AppendError("'settings insert-before' takes more arguments");
-      return false;
+      return;
     }
 
     const char *var_name = cmd_args.GetArgumentAtIndex(0);
     if ((var_name == nullptr) || (var_name[0] == '\0')) {
       result.AppendError("'settings insert-before' command requires a valid "
                          "variable name; No value supplied");
-      return false;
+      return;
     }
 
     // Split the raw command into var_name, index_value, and value triple.
@@ -828,10 +813,7 @@ protected:
         &m_exe_ctx, eVarSetOperationInsertBefore, var_name, var_value));
     if (error.Fail()) {
       result.AppendError(error.AsCString());
-      return false;
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -897,7 +879,7 @@ public:
   }
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
 
@@ -906,14 +888,14 @@ protected:
 
     if (argc < 3) {
       result.AppendError("'settings insert-after' takes more arguments");
-      return false;
+      return;
     }
 
     const char *var_name = cmd_args.GetArgumentAtIndex(0);
     if ((var_name == nullptr) || (var_name[0] == '\0')) {
       result.AppendError("'settings insert-after' command requires a valid "
                          "variable name; No value supplied");
-      return false;
+      return;
     }
 
     // Split the raw command into var_name, index_value, and value triple.
@@ -924,10 +906,7 @@ protected:
         &m_exe_ctx, eVarSetOperationInsertAfter, var_name, var_value));
     if (error.Fail()) {
       result.AppendError(error.AsCString());
-      return false;
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -982,7 +961,7 @@ public:
   }
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
     Args cmd_args(command);
@@ -990,14 +969,14 @@ protected:
 
     if (argc < 2) {
       result.AppendError("'settings append' takes more arguments");
-      return false;
+      return;
     }
 
     const char *var_name = cmd_args.GetArgumentAtIndex(0);
     if ((var_name == nullptr) || (var_name[0] == '\0')) {
       result.AppendError("'settings append' command requires a valid variable "
                          "name; No value supplied");
-      return false;
+      return;
     }
 
     // Do not perform cmd_args.Shift() since StringRef is manipulating the raw
@@ -1011,10 +990,7 @@ protected:
         &m_exe_ctx, eVarSetOperationAppend, var_name, var_value));
     if (error.Fail()) {
       result.AppendError(error.AsCString());
-      return false;
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -1089,39 +1065,36 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
     const size_t argc = command.GetArgumentCount();
 
     if (m_options.m_clear_all) {
       if (argc != 0) {
         result.AppendError("'settings clear --all' doesn't take any arguments");
-        return false;
+        return;
       }
       GetDebugger().GetValueProperties()->Clear();
-      return result.Succeeded();
+      return;
     }
 
     if (argc != 1) {
       result.AppendError("'settings clear' takes exactly one argument");
-      return false;
+      return;
     }
 
     const char *var_name = command.GetArgumentAtIndex(0);
     if ((var_name == nullptr) || (var_name[0] == '\0')) {
       result.AppendError("'settings clear' command requires a valid variable "
                          "name; No value supplied");
-      return false;
+      return;
     }
 
     Status error(GetDebugger().SetPropertyValue(
         &m_exe_ctx, eVarSetOperationClear, var_name, llvm::StringRef()));
     if (error.Fail()) {
       result.AppendError(error.AsCString());
-      return false;
     }
-
-    return result.Succeeded();
   }
 
   private:

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -532,14 +532,14 @@ protected:
     return true;
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
     if (target == nullptr) {
       target = GetDebugger().GetSelectedTarget().get();
       if (target == nullptr) {
         result.AppendError("invalid target, create a debug target using the "
                            "'target create' command.");
-        return false;
+        return;
       }
     }
 
@@ -562,11 +562,11 @@ protected:
       }
       if (!m_module_list.GetSize()) {
         result.AppendError("No modules match the input.");
-        return false;
+        return;
       }
     } else if (target->GetImages().GetSize() == 0) {
       result.AppendError("The target has no associated executable images.");
-      return false;
+      return;
     }
 
     // Check the arguments to see what lines we should dump.
@@ -595,7 +595,6 @@ protected:
       else
         result.SetStatus(eReturnStatusFailed);
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -910,7 +909,7 @@ protected:
     }
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
 
     if (!m_options.symbol_name.empty()) {
@@ -939,7 +938,7 @@ protected:
       if (sc_list.GetSize() == 0) {
         result.AppendErrorWithFormat("Could not find function named: \"%s\".\n",
                                      m_options.symbol_name.c_str());
-        return false;
+        return;
       }
 
       std::set<SourceInfo> source_match_set;
@@ -958,7 +957,7 @@ protected:
         result.SetStatus(eReturnStatusSuccessFinishResult);
       else
         result.SetStatus(eReturnStatusFailed);
-      return result.Succeeded();
+      return;
     } else if (m_options.address != LLDB_INVALID_ADDRESS) {
       Address so_addr;
       StreamString error_strm;
@@ -987,7 +986,7 @@ protected:
               "no modules have source information for file address 0x%" PRIx64
               ".\n",
               m_options.address);
-          return false;
+          return;
         }
       } else {
         // The target has some things loaded, resolve this address to a compile
@@ -1009,7 +1008,7 @@ protected:
                                            "is no line table information "
                                            "available for this address.\n",
                                            error_strm.GetData());
-              return false;
+              return;
             }
           }
         }
@@ -1018,7 +1017,7 @@ protected:
           result.AppendErrorWithFormat(
               "no modules contain load address 0x%" PRIx64 ".\n",
               m_options.address);
-          return false;
+          return;
         }
       }
       for (const SymbolContext &sc : sc_list) {
@@ -1134,7 +1133,7 @@ protected:
       if (num_matches == 0) {
         result.AppendErrorWithFormat("Could not find source file \"%s\".\n",
                                      m_options.file_name.c_str());
-        return false;
+        return;
       }
 
       if (num_matches > 1) {
@@ -1155,7 +1154,7 @@ protected:
           result.AppendErrorWithFormat(
               "Multiple source files found matching: \"%s.\"\n",
               m_options.file_name.c_str());
-          return false;
+          return;
         }
       }
 
@@ -1184,11 +1183,9 @@ protected:
         } else {
           result.AppendErrorWithFormat("No comp unit found for: \"%s.\"\n",
                                        m_options.file_name.c_str());
-          return false;
         }
       }
     }
-    return result.Succeeded();
   }
 
   const SymbolContextList *GetBreakpointLocations() {
@@ -1213,7 +1210,7 @@ public:
   ~CommandObjectSourceCacheDump() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // Dump the debugger source cache.
     result.GetOutputStream() << "Debugger Source File Cache\n";
     SourceManager::SourceFileCache &cache = GetDebugger().GetSourceFileCache();
@@ -1227,7 +1224,6 @@ protected:
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -1240,7 +1236,7 @@ public:
   ~CommandObjectSourceCacheClear() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // Clear the debugger cache.
     SourceManager::SourceFileCache &cache = GetDebugger().GetSourceFileCache();
     cache.Clear();
@@ -1250,7 +1246,6 @@ protected:
       process_sp->GetSourceFileCache().Clear();
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectStats.cpp
+++ b/lldb/source/Commands/CommandObjectStats.cpp
@@ -26,15 +26,14 @@ public:
   ~CommandObjectStatsEnable() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (DebuggerStats::GetCollectingStats()) {
       result.AppendError("statistics already enabled");
-      return false;
+      return;
     }
 
     DebuggerStats::SetCollectingStats(true);
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 };
 
@@ -48,15 +47,14 @@ public:
   ~CommandObjectStatsDisable() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (!DebuggerStats::GetCollectingStats()) {
       result.AppendError("need to enable statistics before disabling them");
-      return false;
+      return;
     }
 
     DebuggerStats::SetCollectingStats(false);
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 };
 
@@ -105,7 +103,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = nullptr;
     if (!m_options.m_all_targets)
       target = m_exe_ctx.GetTargetPtr();
@@ -113,7 +111,6 @@ protected:
     result.AppendMessageWithFormatv(
         "{0:2}", DebuggerStats::ReportStatistics(GetDebugger(), target));
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -263,7 +263,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
     FileSpec core_file(m_core_file.GetOptionValue().GetCurrentValue());
     FileSpec remote_file(m_remote_file.GetOptionValue().GetCurrentValue());
@@ -276,7 +276,7 @@ protected:
         result.AppendErrorWithFormatv("Cannot open '{0}': {1}.",
                                       core_file.GetPath(),
                                       llvm::toString(file.takeError()));
-        return false;
+        return;
       }
     }
 
@@ -290,7 +290,7 @@ protected:
           result.AppendErrorWithFormatv("Cannot open '{0}': {1}.",
                                         symfile.GetPath(),
                                         llvm::toString(file.takeError()));
-          return false;
+          return;
         }
       }
 
@@ -310,7 +310,7 @@ protected:
 
       if (!target_sp) {
         result.AppendError(error.AsCString());
-        return false;
+        return;
       }
 
       const llvm::StringRef label =
@@ -318,7 +318,7 @@ protected:
       if (!label.empty()) {
         if (auto E = target_sp->SetLabel(label))
           result.SetError(std::move(E));
-        return false;
+        return;
       }
 
       auto on_error = llvm::make_scope_exit(
@@ -353,7 +353,7 @@ protected:
               Status err = platform_sp->PutFile(file_spec, remote_file);
               if (err.Fail()) {
                 result.AppendError(err.AsCString());
-                return false;
+                return;
               }
             }
           } else {
@@ -367,7 +367,7 @@ protected:
               Status err = platform_sp->GetFile(remote_file, file_spec);
               if (err.Fail()) {
                 result.AppendError(err.AsCString());
-                return false;
+                return;
               }
             } else {
               // If the remote file exists, we can debug reading that out of
@@ -381,12 +381,12 @@ protected:
               if (platform_sp->IsHost()) {
                 result.AppendError("Supply a local file, not a remote file, "
                                    "when debugging on the host.");
-                return false;
+                return;
               }
               if (platform_sp->IsConnected() && !platform_sp->GetFileExists(remote_file)) {
                 result.AppendError("remote --> local transfer without local "
                                  "path is not implemented yet");
-                return false;
+                return;
               }
               // Since there's only a remote file, we need to set the executable
               // file spec to the remote one.
@@ -397,7 +397,7 @@ protected:
           }
         } else {
           result.AppendError("no platform found for target");
-          return false;
+          return;
         }
       }
 
@@ -438,7 +438,7 @@ protected:
           if (error.Fail()) {
             result.AppendError(
                 error.AsCString("can't find plug-in for core file"));
-            return false;
+            return;
           } else {
             result.AppendMessageWithFormatv(
                 "Core file '{0}' ({1}) was loaded.\n", core_file.GetPath(),
@@ -464,8 +464,6 @@ protected:
                                    "argument, or use the --core option.\n",
                                    m_cmd_name.c_str());
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -492,7 +490,7 @@ public:
   ~CommandObjectTargetList() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &strm = result.GetOutputStream();
 
     bool show_stopped_process_status = false;
@@ -501,7 +499,6 @@ protected:
       strm.PutCString("No targets.\n");
     }
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -520,7 +517,7 @@ public:
   ~CommandObjectTargetSelect() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     if (args.GetArgumentCount() == 1) {
       const char *target_identifier = args.GetArgumentAtIndex(0);
       uint32_t target_idx = LLDB_INVALID_INDEX32;
@@ -570,7 +567,6 @@ protected:
       result.AppendError(
           "'target select' takes a single argument: a target index\n");
     }
-    return result.Succeeded();
   }
 };
 
@@ -606,7 +602,7 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     const size_t argc = args.GetArgumentCount();
     std::vector<TargetSP> delete_target_list;
     TargetList &target_list = GetDebugger().GetTargetList();
@@ -620,7 +616,7 @@ protected:
       // Bail out if don't have any targets.
       if (num_targets == 0) {
         result.AppendError("no targets to delete");
-        return false;
+        return;
       }
 
       for (auto &entry : args.entries()) {
@@ -628,7 +624,7 @@ protected:
         if (entry.ref().getAsInteger(0, target_idx)) {
           result.AppendErrorWithFormat("invalid target index '%s'\n",
                                        entry.c_str());
-          return false;
+          return;
         }
         if (target_idx < num_targets) {
           target_sp = target_list.GetTargetAtIndex(target_idx);
@@ -646,13 +642,13 @@ protected:
               "target index %u is out of range, the only valid index is 0\n",
               target_idx);
 
-        return false;
+        return;
       }
     } else {
       target_sp = target_list.GetSelectedTarget();
       if (!target_sp) {
         result.AppendErrorWithFormat("no target is currently selected\n");
-        return false;
+        return;
       }
       delete_target_list.push_back(target_sp);
     }
@@ -673,7 +669,7 @@ protected:
                                     (uint32_t)num_targets_to_delete);
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
-    return true;
+    return;
   }
 
   OptionGroupOptions m_option_group;
@@ -694,7 +690,7 @@ public:
   ~CommandObjectTargetShowLaunchEnvironment() override = default;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
     Environment env = target->GetEnvironment();
 
@@ -712,7 +708,6 @@ protected:
       strm.Format("{0}={1}\n", KV->first(), KV->second);
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -865,7 +860,7 @@ protected:
     }
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
     const size_t argc = args.GetArgumentCount();
     Stream &s = result.GetOutputStream();
@@ -882,7 +877,7 @@ protected:
           if (!regex.IsValid()) {
             result.GetErrorStream().Printf(
                 "error: invalid regular expression: '%s'\n", arg.c_str());
-            return false;
+            return;
           }
           use_var_name = true;
           target->GetImages().FindGlobalVariables(regex, UINT32_MAX,
@@ -898,7 +893,7 @@ protected:
         if (matches == 0) {
           result.AppendErrorWithFormat("can't find global variable '%s'",
                                        arg.c_str());
-          return false;
+          return;
         } else {
           for (uint32_t global_idx = 0; global_idx < matches; ++global_idx) {
             VariableSP var_sp(variable_list.GetVariableAtIndex(global_idx));
@@ -1016,8 +1011,6 @@ protected:
 
     m_interpreter.PrintWarningsIfNecessary(result.GetOutputStream(),
                                            m_cmd_name);
-
-    return result.Succeeded();
   }
 
   OptionGroupOptions m_option_group;
@@ -1064,7 +1057,7 @@ public:
   ~CommandObjectTargetModulesSearchPathsAdd() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     const size_t argc = command.GetArgumentCount();
     if (argc & 1) {
@@ -1094,7 +1087,6 @@ protected:
         }
       }
     }
-    return result.Succeeded();
   }
 };
 
@@ -1112,12 +1104,11 @@ public:
   ~CommandObjectTargetModulesSearchPathsClear() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     bool notify = true;
     target->GetImageSearchPathList().Clear(notify);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 };
 
@@ -1187,7 +1178,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     size_t argc = command.GetArgumentCount();
     // check for at least 3 arguments and an odd number of parameters
@@ -1198,7 +1189,7 @@ protected:
         result.AppendErrorWithFormat(
             "<index> parameter is not an integer: '%s'.\n",
             command.GetArgumentAtIndex(0));
-        return result.Succeeded();
+        return;
       }
 
       // shift off the index
@@ -1219,14 +1210,12 @@ protected:
             result.AppendError("<path-prefix> can't be empty\n");
           else
             result.AppendError("<new-path-prefix> can't be empty\n");
-          return false;
+          return;
         }
       }
     } else {
       result.AppendError("insert requires at least three arguments\n");
-      return result.Succeeded();
     }
-    return result.Succeeded();
   }
 };
 
@@ -1244,12 +1233,11 @@ public:
   ~CommandObjectTargetModulesSearchPathsList() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     target->GetImageSearchPathList().Dump(&result.GetOutputStream());
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -1280,11 +1268,11 @@ public:
   ~CommandObjectTargetModulesSearchPathsQuery() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     if (command.GetArgumentCount() != 1) {
       result.AppendError("query requires one argument\n");
-      return result.Succeeded();
+      return;
     }
 
     ConstString orig(command.GetArgumentAtIndex(0));
@@ -1295,7 +1283,6 @@ protected:
       result.GetOutputStream().Printf("%s\n", orig.GetCString());
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -1962,7 +1949,7 @@ public:
   ~CommandObjectTargetModulesDumpObjfile() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     uint32_t addr_byte_size = target->GetArchitecture().GetAddressByteSize();
@@ -2001,7 +1988,6 @@ protected:
     } else {
       result.AppendError("no matching executable images found");
     }
-    return result.Succeeded();
   }
 };
 
@@ -2064,7 +2050,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     uint32_t num_dumped = 0;
     Mangled::NamePreference name_preference =
@@ -2100,7 +2086,7 @@ protected:
         }
       } else {
         result.AppendError("the target has no associated executable images");
-        return false;
+        return;
       }
     } else {
       // Dump specified images (by basename or fullpath)
@@ -2140,7 +2126,6 @@ protected:
     else {
       result.AppendError("no matching executable images found");
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -2163,7 +2148,7 @@ public:
   ~CommandObjectTargetModulesDumpSections() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     uint32_t num_dumped = 0;
 
@@ -2176,7 +2161,7 @@ protected:
       const size_t num_modules = target->GetImages().GetSize();
       if (num_modules == 0) {
         result.AppendError("the target has no associated executable images");
-        return false;
+        return;
       }
 
       result.GetOutputStream().Format("Dumping sections for {0} modules.\n",
@@ -2231,7 +2216,6 @@ protected:
     else {
       result.AppendError("no matching executable images found");
     }
-    return result.Succeeded();
   }
 };
 
@@ -2249,11 +2233,11 @@ public:
   ~CommandObjectTargetModulesDumpClangPCMInfo() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat("'%s' takes exactly one pcm path argument.",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     const char *pcm_path = command.GetArgumentAtIndex(0);
@@ -2261,12 +2245,12 @@ protected:
 
     if (pcm_file.GetFileNameExtension() != ".pcm") {
       result.AppendError("file must have a .pcm extension");
-      return false;
+      return;
     }
 
     if (!FileSystem::Instance().Exists(pcm_file)) {
       result.AppendError("pcm file does not exist");
-      return false;
+      return;
     }
 
     clang::CompilerInstance compiler;
@@ -2286,8 +2270,6 @@ protected:
 
     if (compiler.ExecuteAction(dump_module_info))
       result.SetStatus(eReturnStatusSuccessFinishResult);
-
-    return result.Succeeded();
   }
 };
 
@@ -2308,14 +2290,14 @@ public:
   ~CommandObjectTargetModulesDumpClangAST() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     const ModuleList &module_list = target->GetImages();
     const size_t num_modules = module_list.GetSize();
     if (num_modules == 0) {
       result.AppendError("the target has no associated executable images");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
@@ -2329,7 +2311,7 @@ protected:
           sf->DumpClangAST(result.GetOutputStream());
       }
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
 
     // Dump specified ASTs (by basename or fullpath)
@@ -2359,7 +2341,6 @@ protected:
       }
     }
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 };
 
@@ -2380,7 +2361,7 @@ public:
   ~CommandObjectTargetModulesDumpSymfile() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     uint32_t num_dumped = 0;
 
@@ -2395,7 +2376,7 @@ protected:
       const size_t num_modules = target_modules.GetSize();
       if (num_modules == 0) {
         result.AppendError("the target has no associated executable images");
-        return false;
+        return;
       }
       result.GetOutputStream().Format(
           "Dumping debug symbols for {0} modules.\n", num_modules);
@@ -2440,7 +2421,6 @@ protected:
     else {
       result.AppendError("no matching executable images found");
     }
-    return result.Succeeded();
   }
 };
 
@@ -2464,7 +2444,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
     uint32_t total_num_dumped = 0;
 
@@ -2474,7 +2454,7 @@ protected:
 
     if (command.GetArgumentCount() == 0) {
       result.AppendError("file option must be specified.");
-      return result.Succeeded();
+      return;
     } else {
       // Dump specified images (by basename or fullpath)
       const char *arg_cstr;
@@ -2516,7 +2496,6 @@ protected:
     else {
       result.AppendError("no source filenames matched any command arguments");
     }
-    return result.Succeeded();
   }
 
   class CommandOptions : public Options {
@@ -2601,7 +2580,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedTarget();
     uint32_t num_dumped = 0;
 
@@ -2617,7 +2596,7 @@ protected:
       const size_t num_modules = target_modules.GetSize();
       if (num_modules == 0) {
         result.AppendError("the target has no associated executable images");
-        return false;
+        return;
       }
       for (ModuleSP module_sp : target_modules.ModulesNoLocking()) {
         if (INTERRUPT_REQUESTED(
@@ -2711,7 +2690,6 @@ protected:
     } else {
       result.AppendError("no matching executable images found");
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -2800,7 +2778,7 @@ protected:
   OptionGroupUUID m_uuid_option_group;
   OptionGroupFile m_symbol_file;
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     bool flush = false;
 
@@ -2820,7 +2798,7 @@ protected:
               target->GetOrCreateModule(module_spec, true /* notify */));
           if (module_sp) {
             result.SetStatus(eReturnStatusSuccessFinishResult);
-            return true;
+            return;
           } else {
             StreamString strm;
             module_spec.GetUUID().Dump(strm);
@@ -2843,7 +2821,7 @@ protected:
                                            "or symbol file with UUID %s",
                                            strm.GetData());
             }
-            return false;
+            return;
           }
         } else {
           StreamString strm;
@@ -2852,12 +2830,12 @@ protected:
               "Unable to locate the executable or symbol file with UUID %s",
               strm.GetData());
           result.SetError(error);
-          return false;
+          return;
         }
       } else {
         result.AppendError(
             "one or more executable image paths must be specified");
-        return false;
+        return;
       }
     } else {
       for (auto &entry : args.entries()) {
@@ -2885,7 +2863,7 @@ protected:
             else
               result.AppendErrorWithFormat("unsupported module: %s",
                                            entry.c_str());
-            return false;
+            return;
           } else {
             flush = true;
           }
@@ -2910,8 +2888,6 @@ protected:
       if (process)
         process->Flush();
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -2952,7 +2928,7 @@ public:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     const bool load = m_load_option.GetOptionValue().GetCurrentValue();
     const bool set_pc = m_pc_option.GetOptionValue().GetCurrentValue();
@@ -3025,14 +3001,14 @@ protected:
                 } else {
                   result.AppendError("one or more section name + load "
                                      "address pair must be specified");
-                  return false;
+                  return;
                 }
               } else {
                 if (m_slide_option.GetOptionValue().OptionWasSet()) {
                   result.AppendError("The \"--slide <offset>\" option can't "
                                      "be used in conjunction with setting "
                                      "section load addresses.\n");
-                  return false;
+                  return;
                 }
 
                 for (size_t i = 0; i < argc; i += 2) {
@@ -3094,22 +3070,22 @@ protected:
                 Address file_entry = objfile->GetEntryPointAddress();
                 if (!process) {
                   result.AppendError("No process");
-                  return false;
+                  return;
                 }
                 if (set_pc && !file_entry.IsValid()) {
                   result.AppendError("No entry address in object file");
-                  return false;
+                  return;
                 }
                 std::vector<ObjectFile::LoadableData> loadables(
                     objfile->GetLoadableData(*target));
                 if (loadables.size() == 0) {
                   result.AppendError("No loadable sections");
-                  return false;
+                  return;
                 }
                 Status error = process->WriteObjectFile(std::move(loadables));
                 if (error.Fail()) {
                   result.AppendError(error.AsCString());
-                  return false;
+                  return;
                 }
                 if (set_pc) {
                   ThreadList &thread_list = process->GetThreadList();
@@ -3171,9 +3147,7 @@ protected:
     } else {
       result.AppendError("either the \"--file <module>\" or the \"--uuid "
                          "<uuid>\" option must be specified.\n");
-      return false;
     }
-    return result.Succeeded();
   }
 
   OptionGroupOptions m_option_group;
@@ -3245,7 +3219,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = GetDebugger().GetSelectedTarget().get();
     const bool use_global_module_list = m_options.m_use_global_module_list;
     // Define a local module list here to ensure it lives longer than any
@@ -3255,7 +3229,7 @@ protected:
     if (target == nullptr && !use_global_module_list) {
       result.AppendError("invalid target, create a debug target using the "
                          "'target create' command");
-      return false;
+      return;
     } else {
       if (target) {
         uint32_t addr_byte_size =
@@ -3288,7 +3262,7 @@ protected:
           result.AppendError(
               "Can only look up modules by address with a valid target.");
         }
-        return result.Succeeded();
+        return;
       }
 
       size_t num_modules = 0;
@@ -3318,7 +3292,7 @@ protected:
             if (argc == 1) {
               result.AppendErrorWithFormat("no modules found that match '%s'",
                                            arg.c_str());
-              return false;
+              return;
             }
           }
         }
@@ -3364,10 +3338,9 @@ protected:
             result.AppendError(
                 "the target has no associated executable images");
         }
-        return false;
+        return;
       }
     }
-    return result.Succeeded();
   }
 
   void PrintModule(Target *target, Module *module, int indent, Stream &strm) {
@@ -3601,7 +3574,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
     Process *process = m_exe_ctx.GetProcessPtr();
     ABI *abi = nullptr;
@@ -3611,19 +3584,19 @@ protected:
     if (process == nullptr) {
       result.AppendError(
           "You must have a process running to use this command.");
-      return false;
+      return;
     }
 
     ThreadList threads(process->GetThreadList());
     if (threads.GetSize() == 0) {
       result.AppendError("The process must be paused to use this command.");
-      return false;
+      return;
     }
 
     ThreadSP thread(threads.GetThreadAtIndex(0));
     if (!thread) {
       result.AppendError("The process must be paused to use this command.");
-      return false;
+      return;
     }
 
     SymbolContextList sc_list;
@@ -3650,13 +3623,13 @@ protected:
     } else {
       result.AppendError(
           "address-expression or function name option must be specified.");
-      return false;
+      return;
     }
 
     if (sc_list.GetSize() == 0) {
       result.AppendErrorWithFormat("no unwind data found that matches '%s'.",
                                    m_options.m_str.c_str());
-      return false;
+      return;
     }
 
     for (const SymbolContext &sc : sc_list) {
@@ -3855,7 +3828,6 @@ protected:
 
       result.GetOutputStream().Printf("\n");
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -4159,7 +4131,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     bool syntax_error = false;
     uint32_t i;
@@ -4180,7 +4152,7 @@ protected:
         num_successful_lookups++;
         if (!m_options.m_print_all) {
           result.SetStatus(eReturnStatusSuccessFinishResult);
-          return result.Succeeded();
+          return;
         }
       }
 
@@ -4190,7 +4162,7 @@ protected:
       std::lock_guard<std::recursive_mutex> guard(target_modules.GetMutex());
       if (target_modules.GetSize() == 0) {
         result.AppendError("the target has no associated executable images");
-        return false;
+        return;
       }
 
       for (ModuleSP module_sp : target_modules.ModulesNoLocking()) {
@@ -4230,7 +4202,6 @@ protected:
       result.SetStatus(eReturnStatusSuccessFinishResult);
     else
       result.SetStatus(eReturnStatusFailed);
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -4679,7 +4650,7 @@ protected:
     return true;
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Target *target = m_exe_ctx.GetTargetPtr();
     result.SetStatus(eReturnStatusFailed);
     bool flush = false;
@@ -4764,7 +4735,6 @@ protected:
       if (process)
         process->Flush();
     }
-    return result.Succeeded();
   }
 
   OptionGroupOptions m_option_group;
@@ -5066,7 +5036,7 @@ protected:
     io_handler.SetIsDone(true);
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     m_stop_hook_sp.reset();
 
     Target &target = GetSelectedOrDummyTarget();
@@ -5163,7 +5133,7 @@ protected:
         result.AppendErrorWithFormat("Couldn't add stop hook: %s",
                                      error.AsCString());
         target.UndoCreateStopHook(new_hook_sp->GetID());
-        return false;
+        return;
       }
     } else {
       m_stop_hook_sp = new_hook_sp;
@@ -5171,8 +5141,6 @@ protected:
                                                  *this); // IOHandlerDelegate
     }
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-
-    return result.Succeeded();
   }
 
 private:
@@ -5209,14 +5177,14 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
     // FIXME: see if we can use the breakpoint id style parser?
     size_t num_args = command.GetArgumentCount();
     if (num_args == 0) {
       if (!m_interpreter.Confirm("Delete all stop hooks?", true)) {
         result.SetStatus(eReturnStatusFailed);
-        return false;
+        return;
       } else {
         target.RemoveAllStopHooks();
       }
@@ -5226,17 +5194,16 @@ protected:
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
           result.AppendErrorWithFormat("invalid stop hook id: \"%s\".\n",
                                        command.GetArgumentAtIndex(i));
-          return false;
+          return;
         }
         if (!target.RemoveStopHookByID(user_id)) {
           result.AppendErrorWithFormat("unknown stop hook id: \"%s\".\n",
                                        command.GetArgumentAtIndex(i));
-          return false;
+          return;
         }
       }
     }
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 };
 
@@ -5266,7 +5233,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
     // FIXME: see if we can use the breakpoint id style parser?
     size_t num_args = command.GetArgumentCount();
@@ -5280,18 +5247,17 @@ protected:
         if (!llvm::to_integer(command.GetArgumentAtIndex(i), user_id)) {
           result.AppendErrorWithFormat("invalid stop hook id: \"%s\".\n",
                                        command.GetArgumentAtIndex(i));
-          return false;
+          return;
         }
         success = target.SetStopHookActiveStateByID(user_id, m_enable);
         if (!success) {
           result.AppendErrorWithFormat("unknown stop hook id: \"%s\".\n",
                                        command.GetArgumentAtIndex(i));
-          return false;
+          return;
         }
       }
     }
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 
 private:
@@ -5311,7 +5277,7 @@ public:
   ~CommandObjectTargetStopHookList() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedOrDummyTarget();
 
     size_t num_hooks = target.GetNumStopHooks();
@@ -5327,7 +5293,6 @@ protected:
       }
     }
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -5377,14 +5342,13 @@ public:
   ~CommandObjectTargetDumpTypesystem() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // Go over every scratch TypeSystem and dump to the command output.
     for (lldb::TypeSystemSP ts : GetSelectedTarget().GetScratchTypeSystems())
       if (ts)
         ts->Dump(result.GetOutputStream().AsRawOstream());
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -5403,11 +5367,10 @@ public:
   ~CommandObjectTargetDumpSectionLoadList() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target = GetSelectedTarget();
     target.GetSectionLoadList().Dump(result.GetOutputStream(), &target);
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -412,7 +412,7 @@ public:
   Options *GetOptions() override { return &m_all_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
     bool synchronous_execution = m_interpreter.GetSynchronous();
 
@@ -424,7 +424,7 @@ protected:
 
       if (thread == nullptr) {
         result.AppendError("no selected thread in process");
-        return false;
+        return;
       }
     } else {
       const char *thread_idx_cstr = command.GetArgumentAtIndex(0);
@@ -433,7 +433,7 @@ protected:
       if (!llvm::to_integer(thread_idx_cstr, step_thread_idx)) {
         result.AppendErrorWithFormat("invalid thread index '%s'.\n",
                                      thread_idx_cstr);
-        return false;
+        return;
       }
       thread =
           process->GetThreadList().FindThreadByIndexID(step_thread_idx).get();
@@ -441,20 +441,20 @@ protected:
         result.AppendErrorWithFormat(
             "Thread index %u is out of range (valid values are 0 - %u).\n",
             step_thread_idx, num_threads);
-        return false;
+        return;
       }
     }
 
     if (m_step_type == eStepTypeScripted) {
       if (m_class_options.GetName().empty()) {
         result.AppendErrorWithFormat("empty class name for scripted step.");
-        return false;
+        return;
       } else if (!GetDebugger().GetScriptInterpreter()->CheckObjectExists(
                      m_class_options.GetName().c_str())) {
         result.AppendErrorWithFormat(
             "class for scripted step: \"%s\" does not exist.",
             m_class_options.GetName().c_str());
-        return false;
+        return;
       }
     }
 
@@ -462,7 +462,7 @@ protected:
         m_step_type != eStepTypeInto) {
       result.AppendErrorWithFormat(
           "end line option is only valid for step into");
-      return false;
+      return;
     }
 
     const bool abort_other_plans = false;
@@ -494,14 +494,14 @@ protected:
                                                    error)) {
             result.AppendErrorWithFormat("invalid end-line option: %s.",
                                          error.AsCString());
-            return false;
+            return;
           }
         } else if (m_options.m_end_line_is_block_end) {
           Status error;
           Block *block = frame->GetSymbolContext(eSymbolContextBlock).block;
           if (!block) {
             result.AppendErrorWithFormat("Could not find the current block.");
-            return false;
+            return;
           }
 
           AddressRange block_range;
@@ -510,7 +510,7 @@ protected:
           if (!block_range.GetBaseAddress().IsValid()) {
             result.AppendErrorWithFormat(
                 "Could not find the current block address.");
-            return false;
+            return;
           }
           lldb::addr_t pc_offset_in_block =
               pc_address.GetFileAddress() -
@@ -569,7 +569,7 @@ protected:
           new_plan_status);
     } else {
       result.AppendError("step type is not supported");
-      return false;
+      return;
     }
 
     // If we got a new plan, then set it to be a controlling plan (User level
@@ -600,7 +600,7 @@ protected:
 
       if (!error.Success()) {
         result.AppendMessage(error.AsCString());
-        return false;
+        return;
       }
 
       // There is a race condition where this thread will return up the call
@@ -624,7 +624,6 @@ protected:
     } else {
       result.SetError(new_plan_status);
     }
-    return result.Succeeded();
   }
 
   StepType m_step_type;
@@ -672,13 +671,13 @@ public:
         nullptr);
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     bool synchronous_execution = m_interpreter.GetSynchronous();
 
     Process *process = m_exe_ctx.GetProcessPtr();
     if (process == nullptr) {
       result.AppendError("no process exists. Cannot continue");
-      return false;
+      return;
     }
 
     StateType state = process->GetState();
@@ -698,7 +697,7 @@ public:
           if (entry.ref().getAsInteger(0, thread_idx)) {
             result.AppendErrorWithFormat(
                 "invalid thread index argument: \"%s\".\n", entry.c_str());
-            return false;
+            return;
           }
           Thread *thread =
               process->GetThreadList().FindThreadByIndexID(thread_idx).get();
@@ -708,13 +707,13 @@ public:
           } else {
             result.AppendErrorWithFormat("invalid thread index %u.\n",
                                          thread_idx);
-            return false;
+            return;
           }
         }
 
         if (resume_threads.empty()) {
           result.AppendError("no valid thread indexes were specified");
-          return false;
+          return;
         } else {
           if (resume_threads.size() == 1)
             result.AppendMessageWithFormat("Resuming thread: ");
@@ -753,7 +752,7 @@ public:
         Thread *current_thread = GetDefaultThread();
         if (current_thread == nullptr) {
           result.AppendError("the process doesn't have a current thread");
-          return false;
+          return;
         }
         // Set the actions that the threads should each take when resuming
         for (uint32_t idx = 0; idx < num_threads; ++idx) {
@@ -801,8 +800,6 @@ public:
           "Process cannot be continued from its current state (%s).\n",
           StateAsCString(state));
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -920,7 +917,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     bool synchronous_execution = m_interpreter.GetSynchronous();
 
     Target *target = &GetSelectedTarget();
@@ -939,14 +936,14 @@ protected:
           if (!llvm::to_integer(command.GetArgumentAtIndex(i), line_number)) {
             result.AppendErrorWithFormat("invalid line number: '%s'.\n",
                                          command.GetArgumentAtIndex(i));
-            return false;
+            return;
           } else
             line_numbers.push_back(line_number);
         }
       } else if (m_options.m_until_addrs.empty()) {
         result.AppendErrorWithFormat("No line number or address provided:\n%s",
                                      GetSyntax().str().c_str());
-        return false;
+        return;
       }
 
       if (m_options.m_thread_idx == LLDB_INVALID_THREAD_ID) {
@@ -962,7 +959,7 @@ protected:
         result.AppendErrorWithFormat(
             "Thread index %u is out of range (valid values are 0 - %u).\n",
             m_options.m_thread_idx, num_threads);
-        return false;
+        return;
       }
 
       const bool abort_other_plans = false;
@@ -973,7 +970,7 @@ protected:
         result.AppendErrorWithFormat(
             "Frame index %u is out of range for thread id %" PRIu64 ".\n",
             m_options.m_frame_idx, thread->GetID());
-        return false;
+        return;
       }
 
       ThreadPlanSP new_plan_sp;
@@ -991,7 +988,7 @@ protected:
           result.AppendErrorWithFormat("Failed to resolve the line table for "
                                        "frame %u of thread id %" PRIu64 ".\n",
                                        m_options.m_frame_idx, thread->GetID());
-          return false;
+          return;
         }
 
         LineEntry function_start;
@@ -1003,7 +1000,7 @@ protected:
         if (!sc.function) {
           result.AppendErrorWithFormat("Have debug information but no "
                                        "function info - can't get until range.");
-          return false;
+          return;
         }
 
         AddressRange fun_addr_range = sc.function->GetAddressRange();
@@ -1067,7 +1064,7 @@ protected:
             result.AppendErrorWithFormat(
                 "Until target outside of the current function.\n");
 
-          return false;
+          return;
         }
 
         new_plan_sp = thread->QueueThreadPlanForStepUntil(
@@ -1083,20 +1080,20 @@ protected:
           new_plan_sp->SetOkayToDiscard(false);
         } else {
           result.SetError(new_plan_status);
-          return false;
+          return;
         }
       } else {
         result.AppendErrorWithFormat("Frame index %u of thread id %" PRIu64
                                      " has no debug information.\n",
                                      m_options.m_frame_idx, thread->GetID());
-        return false;
+        return;
       }
 
       if (!process->GetThreadList().SetSelectedThreadByID(thread->GetID())) {
         result.AppendErrorWithFormat(
             "Failed to set the selected thread to thread id %" PRIu64 ".\n",
             thread->GetID());
-        return false;
+        return;
       }
 
       StreamString stream;
@@ -1125,7 +1122,6 @@ protected:
                                      error.AsCString());
       }
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -1170,23 +1166,23 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
     if (process == nullptr) {
       result.AppendError("no process");
-      return false;
+      return;
     } else if (command.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat(
           "'%s' takes exactly one thread index argument:\nUsage: %s\n",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());
-      return false;
+      return;
     }
 
     uint32_t index_id;
     if (!llvm::to_integer(command.GetArgumentAtIndex(0), index_id)) {
       result.AppendErrorWithFormat("Invalid thread index '%s'",
                                    command.GetArgumentAtIndex(0));
-      return false;
+      return;
     }
 
     Thread *new_thread =
@@ -1194,13 +1190,11 @@ protected:
     if (new_thread == nullptr) {
       result.AppendErrorWithFormat("invalid thread #%s.\n",
                                    command.GetArgumentAtIndex(0));
-      return false;
+      return;
     }
 
     process->GetThreadList().SetSelectedThreadByID(new_thread->GetID(), true);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-
-    return result.Succeeded();
   }
 };
 
@@ -1221,7 +1215,7 @@ public:
   ~CommandObjectThreadList() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Stream &strm = result.GetOutputStream();
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
     Process *process = m_exe_ctx.GetProcessPtr();
@@ -1232,7 +1226,6 @@ protected:
     process->GetStatus(strm);
     process->GetThreadStatus(strm, only_threads_with_stop_reason, start_frame,
                              num_frames, num_frames_with_source, false);
-    return result.Succeeded();
   }
 };
 
@@ -1511,7 +1504,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     // I am going to handle this by hand, because I don't want you to have to
     // say:
@@ -1539,7 +1532,7 @@ protected:
               "Could not select 0th frame after unwinding expression.");
         }
       }
-      return result.Succeeded();
+      return;
     }
 
     ValueObjectSP return_valobj_sp;
@@ -1549,7 +1542,7 @@ protected:
 
     if (frame_sp->IsInlined()) {
       result.AppendError("Don't know how to return from inlined frames.");
-      return false;
+      return;
     }
 
     if (!command.empty()) {
@@ -1570,7 +1563,7 @@ protected:
         else
           result.AppendErrorWithFormat(
               "Unknown error evaluating result expression.");
-        return false;
+        return;
       }
     }
 
@@ -1582,11 +1575,10 @@ protected:
       result.AppendErrorWithFormat(
           "Error returning from frame %d of thread %d: %s.", frame_idx,
           thread_sp->GetIndexID(), error.AsCString());
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 
   CommandOptions m_options;
@@ -1667,7 +1659,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     RegisterContext *reg_ctx = m_exe_ctx.GetRegisterContext();
     StackFrame *frame = m_exe_ctx.GetFramePtr();
     Thread *thread = m_exe_ctx.GetThreadPtr();
@@ -1682,13 +1674,13 @@ protected:
       lldb::addr_t callAddr = dest.GetCallableLoadAddress(target);
       if (callAddr == LLDB_INVALID_ADDRESS) {
         result.AppendErrorWithFormat("Invalid destination address.");
-        return false;
+        return;
       }
 
       if (!reg_ctx->SetPC(callAddr)) {
         result.AppendErrorWithFormat("Error changing PC value for thread %d.",
                                      thread->GetIndexID());
-        return false;
+        return;
       }
     } else {
       // Pick either the absolute line, or work out a relative one.
@@ -1704,7 +1696,7 @@ protected:
       if (!file) {
         result.AppendErrorWithFormat(
             "No source file available for the current location.");
-        return false;
+        return;
       }
 
       std::string warnings;
@@ -1712,7 +1704,7 @@ protected:
 
       if (err.Fail()) {
         result.SetError(err);
-        return false;
+        return;
       }
 
       if (!warnings.empty())
@@ -1720,7 +1712,6 @@ protected:
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 
   CommandOptions m_options;
@@ -1804,7 +1795,7 @@ public:
 
   Options *GetOptions() override { return &m_options; }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // If we are reporting all threads, dispatch to the Process to do that:
     if (command.GetArgumentCount() == 0 && m_options.m_tids.empty()) {
       Stream &strm = result.GetOutputStream();
@@ -1814,7 +1805,7 @@ public:
       m_exe_ctx.GetProcessPtr()->DumpThreadPlans(
           strm, desc_level, m_options.m_internal, true, m_options.m_unreported);
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     } else {
       // Do any TID's that the user may have specified as TID, then do any
       // Thread Indexes...
@@ -1829,7 +1820,7 @@ public:
           if (!success) {
             result.AppendError("Error dumping plans:");
             result.AppendError(tmp_strm.GetString());
-            return false;
+            return;
           }
           // Otherwise, add our data to the output:
           result.GetOutputStream() << tmp_strm.GetString();
@@ -1899,13 +1890,13 @@ public:
     m_exe_ctx.GetThreadPtr()->AutoCompleteThreadPlans(request);
   }
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Thread *thread = m_exe_ctx.GetThreadPtr();
     if (args.GetArgumentCount() != 1) {
       result.AppendErrorWithFormat("Too many arguments, expected one - the "
                                    "thread plan index - but got %zu.",
                                    args.GetArgumentCount());
-      return false;
+      return;
     }
 
     uint32_t thread_plan_idx;
@@ -1913,23 +1904,21 @@ public:
       result.AppendErrorWithFormat(
           "Invalid thread index: \"%s\" - should be unsigned int.",
           args.GetArgumentAtIndex(0));
-      return false;
+      return;
     }
 
     if (thread_plan_idx == 0) {
       result.AppendErrorWithFormat(
           "You wouldn't really want me to discard the base thread plan.");
-      return false;
+      return;
     }
 
     if (thread->DiscardUserThreadPlansUpToIndex(thread_plan_idx)) {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
     } else {
       result.AppendErrorWithFormat(
           "Could not find User thread plan with index %s.",
           args.GetArgumentAtIndex(0));
-      return false;
     }
   }
 };
@@ -1965,13 +1954,13 @@ public:
 
   ~CommandObjectThreadPlanPrune() override = default;
 
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     Process *process = m_exe_ctx.GetProcessPtr();
 
     if (args.GetArgumentCount() == 0) {
       process->PruneThreadPlans();
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     const size_t num_args = args.GetArgumentCount();
@@ -1984,16 +1973,15 @@ public:
       if (!llvm::to_integer(args.GetArgumentAtIndex(i), tid)) {
         result.AppendErrorWithFormat("invalid thread specification: \"%s\"\n",
                                      args.GetArgumentAtIndex(i));
-        return false;
+        return;
       }
       if (!process->PruneThreadPlansForTID(tid)) {
         result.AppendErrorWithFormat("Could not find unreported tid: \"%s\"\n",
                                      args.GetArgumentAtIndex(i));
-        return false;
+        return;
       }
     }
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return true;
   }
 };
 
@@ -2187,11 +2175,11 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     ThreadSP thread_sp = GetSingleThreadFromArgs(m_exe_ctx, args, result);
     if (!thread_sp) {
       result.AppendError("invalid thread\n");
-      return false;
+      return;
     }
 
     llvm::Expected<TraceCursorSP> cursor_or_error =
@@ -2199,7 +2187,7 @@ protected:
 
     if (!cursor_or_error) {
       result.AppendError(llvm::toString(cursor_or_error.takeError()));
-      return false;
+      return;
     }
     TraceCursorSP &cursor_sp = *cursor_or_error;
 
@@ -2217,7 +2205,6 @@ protected:
                        m_options.m_dumper_options);
 
     dumper.DumpFunctionCalls();
-    return true;
   }
 
   CommandOptions m_options;
@@ -2371,11 +2358,11 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override {
+  void DoExecute(Args &args, CommandReturnObject &result) override {
     ThreadSP thread_sp = GetSingleThreadFromArgs(m_exe_ctx, args, result);
     if (!thread_sp) {
       result.AppendError("invalid thread\n");
-      return false;
+      return;
     }
 
     if (m_options.m_continue && m_last_id) {
@@ -2390,14 +2377,14 @@ protected:
 
     if (!cursor_or_error) {
       result.AppendError(llvm::toString(cursor_or_error.takeError()));
-      return false;
+      return;
     }
     TraceCursorSP &cursor_sp = *cursor_or_error;
 
     if (m_options.m_dumper_options.id &&
         !cursor_sp->HasId(*m_options.m_dumper_options.id)) {
       result.AppendError("invalid instruction id\n");
-      return false;
+      return;
     }
 
     std::optional<StreamFile> out_file;
@@ -2419,7 +2406,6 @@ protected:
                        m_options.m_dumper_options);
 
     m_last_id = dumper.DumpInstructions(m_options.m_count);
-    return true;
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectThreadUtil.h
+++ b/lldb/source/Commands/CommandObjectThreadUtil.h
@@ -54,7 +54,7 @@ public:
 
   ~CommandObjectIterateOverThreads() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 
 protected:
   // Override this to do whatever you need to do for one thread.
@@ -84,7 +84,7 @@ public:
                                const char *name, const char *help,
                                const char *syntax, uint32_t flags);
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 
 protected:
   /// Method that handles the command after the main arguments have been parsed.

--- a/lldb/source/Commands/CommandObjectTrace.cpp
+++ b/lldb/source/Commands/CommandObjectTrace.cpp
@@ -103,11 +103,11 @@ public:
   ~CommandObjectTraceSave() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.size() != 1) {
       result.AppendError("a single path to a directory where the trace bundle "
                          "will be created is required");
-      return false;
+      return;
     }
 
     FileSpec bundle_dir(command[0].ref());
@@ -125,8 +125,6 @@ protected:
     } else {
       result.AppendError(toString(desc_file.takeError()));
     }
-
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -194,11 +192,11 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.size() != 1) {
       result.AppendError("a single path to a JSON file containing a the "
                          "description of the trace bundle is required");
-      return false;
+      return;
     }
 
     const FileSpec trace_description_file(command[0].ref());
@@ -210,7 +208,7 @@ protected:
     if (!trace_or_err) {
       result.AppendErrorWithFormat(
           "%s\n", llvm::toString(trace_or_err.takeError()).c_str());
-      return false;
+      return;
     }
 
     if (m_options.m_verbose) {
@@ -219,7 +217,6 @@ protected:
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 
   CommandOptions m_options;
@@ -276,7 +273,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Status error;
     // TODO: fill in the dumping code here!
     if (error.Success()) {
@@ -284,7 +281,6 @@ protected:
     } else {
       result.AppendErrorWithFormat("%s\n", error.AsCString());
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;
@@ -345,12 +341,12 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Status error;
     if (command.empty()) {
       result.AppendError(
           "trace schema cannot be invoked without a plug-in as argument");
-      return false;
+      return;
     }
 
     StringRef plugin_name(command[0].c_str());
@@ -376,7 +372,6 @@ protected:
     } else {
       result.AppendErrorWithFormat("%s\n", error.AsCString());
     }
-    return result.Succeeded();
   }
 
   CommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -276,7 +276,7 @@ public:
                        Status *error = nullptr);
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 };
 
 static const char *g_synth_addreader_instructions =
@@ -389,18 +389,17 @@ private:
   bool Execute_PythonClass(Args &command, CommandReturnObject &result);
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     WarnOnPotentialUnquotedUnsignedType(command, result);
 
     if (m_options.handwrite_python)
-      return Execute_HandwritePython(command, result);
+      Execute_HandwritePython(command, result);
     else if (m_options.is_class_based)
-      return Execute_PythonClass(command, result);
+      Execute_PythonClass(command, result);
     else {
       result.AppendError("must either provide a children list, a Python class "
                          "name, or use -P and type a Python class "
                          "line-by-line");
-      return false;
     }
   }
 
@@ -649,13 +648,13 @@ pointers to floats.  Nor will it change the default display for Afloat and Bfloa
   ~CommandObjectTypeFormatAdd() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
       result.AppendErrorWithFormat("%s takes one or more args.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     const Format format = m_format_options.GetFormat();
@@ -663,7 +662,7 @@ protected:
         m_command_options.m_custom_type_name.empty()) {
       result.AppendErrorWithFormat("%s needs a valid format.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     TypeFormatImplSP entry;
@@ -688,14 +687,14 @@ protected:
     DataVisualization::Categories::GetCategory(
         ConstString(m_command_options.m_category), category_sp);
     if (!category_sp)
-      return false;
+      return;
 
     WarnOnPotentialUnquotedUnsignedType(command, result);
 
     for (auto &arg_entry : command.entries()) {
       if (arg_entry.ref().empty()) {
         result.AppendError("empty typenames not allowed");
-        return false;
+        return;
       }
 
       FormatterMatchType match_type = eFormatterMatchExact;
@@ -705,14 +704,13 @@ protected:
         if (!typeRX.IsValid()) {
           result.AppendError(
               "regex format error (maybe this is not really a regex?)");
-          return false;
+          return;
         }
       }
       category_sp->AddTypeFormat(arg_entry.ref(), match_type, entry);
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 };
 
@@ -828,12 +826,12 @@ public:
 protected:
   virtual bool FormatterSpecificDeletion(ConstString typeCS) { return false; }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc != 1) {
       result.AppendErrorWithFormat("%s takes 1 arg.\n", m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     const char *typeA = command.GetArgumentAtIndex(0);
@@ -841,7 +839,7 @@ protected:
 
     if (!typeCS) {
       result.AppendError("empty typenames not allowed");
-      return false;
+      return;
     }
 
     if (m_options.m_delete_all) {
@@ -851,7 +849,7 @@ protected:
             return true;
           });
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return result.Succeeded();
+      return;
     }
 
     bool delete_category = false;
@@ -875,10 +873,8 @@ protected:
 
     if (delete_category || extra_deletion) {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return result.Succeeded();
     } else {
       result.AppendErrorWithFormat("no custom formatter for %s.\n", typeA);
-      return false;
     }
   }
 };
@@ -942,7 +938,7 @@ public:
 protected:
   virtual void FormatterSpecificDeletion() {}
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (m_options.m_delete_all) {
       DataVisualization::Categories::ForEach(
           [this](const TypeCategoryImplSP &category_sp) -> bool {
@@ -965,7 +961,6 @@ protected:
     FormatterSpecificDeletion();
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -1077,7 +1072,7 @@ protected:
     return regex == nullptr || s == regex->GetText() || regex->Execute(s);
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     std::unique_ptr<RegularExpression> category_regex;
@@ -1090,7 +1085,7 @@ protected:
         result.AppendErrorWithFormat(
             "syntax error in category regular expression '%s'",
             m_options.m_category_regex.GetCurrentValueAsRef().str().c_str());
-        return false;
+        return;
       }
     }
 
@@ -1100,7 +1095,7 @@ protected:
       if (!formatter_regex->IsValid()) {
         result.AppendErrorWithFormat("syntax error in regular expression '%s'",
                                      arg);
-        return false;
+        return;
       }
     }
 
@@ -1154,7 +1149,6 @@ protected:
       result.GetOutputStream().PutCString("no matching results found.\n");
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
-    return result.Succeeded();
   }
 };
 
@@ -1557,20 +1551,20 @@ Alternatively, the -o option can be used when providing a simple one-line Python
 (lldb) type summary add JustADemo -o "value = valobj.GetChildMemberWithName('value'); return 'My value is ' + value.GetValue();")");
 }
 
-bool CommandObjectTypeSummaryAdd::DoExecute(Args &command,
+void CommandObjectTypeSummaryAdd::DoExecute(Args &command,
                                             CommandReturnObject &result) {
   WarnOnPotentialUnquotedUnsignedType(command, result);
 
   if (m_options.m_is_add_script) {
 #if LLDB_ENABLE_PYTHON
-    return Execute_ScriptSummary(command, result);
+    Execute_ScriptSummary(command, result);
 #else
     result.AppendError("python is disabled");
-    return false;
 #endif
+    return;
   }
 
-  return Execute_StringSummary(command, result);
+  Execute_StringSummary(command, result);
 }
 
 static bool FixArrayTypeNameWithRegex(ConstString &type_name) {
@@ -1773,13 +1767,13 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
       result.AppendErrorWithFormat("%s takes 1 or more args.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     for (auto &entry : command.entries()) {
@@ -1795,7 +1789,6 @@ protected:
     }
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -1875,13 +1868,13 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1 && m_options.m_language == lldb::eLanguageTypeUnknown) {
       result.AppendErrorWithFormat("%s takes arguments and/or a language",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     if (argc == 1 && strcmp(command.GetArgumentAtIndex(0), "*") == 0) {
@@ -1893,7 +1886,7 @@ protected:
 
         if (!typeCS) {
           result.AppendError("empty category name not allowed");
-          return false;
+          return;
         }
         DataVisualization::Categories::Enable(typeCS);
         lldb::TypeCategoryImplSP cate;
@@ -1909,7 +1902,6 @@ protected:
       DataVisualization::Categories::Enable(m_options.m_language);
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -1943,13 +1935,13 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
       result.AppendErrorWithFormat("%s takes 1 or more arg.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     bool success = true;
@@ -1961,17 +1953,15 @@ protected:
 
       if (!typeCS) {
         result.AppendError("empty category name not allowed");
-        return false;
+        return;
       }
       if (!DataVisualization::Categories::Delete(typeCS))
         success = false; // keep deleting even if we hit an error
     }
     if (success) {
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return result.Succeeded();
     } else {
       result.AppendError("cannot delete one or more categories\n");
-      return false;
     }
   }
 };
@@ -2052,13 +2042,13 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1 && m_options.m_language == lldb::eLanguageTypeUnknown) {
       result.AppendErrorWithFormat("%s takes arguments and/or a language",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     if (argc == 1 && strcmp(command.GetArgumentAtIndex(0), "*") == 0) {
@@ -2071,7 +2061,7 @@ protected:
 
         if (!typeCS) {
           result.AppendError("empty category name not allowed");
-          return false;
+          return;
         }
         DataVisualization::Categories::Disable(typeCS);
       }
@@ -2081,7 +2071,6 @@ protected:
       DataVisualization::Categories::Disable(m_options.m_language);
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -2117,7 +2106,7 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     std::unique_ptr<RegularExpression> regex;
@@ -2128,12 +2117,12 @@ protected:
       if (!regex->IsValid()) {
         result.AppendErrorWithFormat(
             "syntax error in category regular expression '%s'", arg);
-        return false;
+        return;
       }
     } else if (argc != 0) {
       result.AppendErrorWithFormat("%s takes 0 or one arg.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     DataVisualization::Categories::ForEach(
@@ -2157,7 +2146,6 @@ protected:
         });
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return result.Succeeded();
   }
 };
 
@@ -2570,19 +2558,19 @@ all children of my_foo as if no filter was defined:"
   ~CommandObjectTypeFilterAdd() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
 
     if (argc < 1) {
       result.AppendErrorWithFormat("%s takes one or more args.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     if (m_options.m_expr_paths.empty()) {
       result.AppendErrorWithFormat("%s needs one or more children.\n",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     TypeFilterImplSP entry(new TypeFilterImpl(
@@ -2611,7 +2599,7 @@ protected:
     for (auto &arg_entry : command.entries()) {
       if (arg_entry.ref().empty()) {
         result.AppendError("empty typenames not allowed");
-        return false;
+        return;
       }
 
       ConstString typeCS(arg_entry.ref());
@@ -2619,12 +2607,11 @@ protected:
                      m_options.m_regex ? eRegexFilter : eRegularFilter,
                      m_options.m_category, &error)) {
         result.AppendError(error.AsCString());
-        return false;
+        return;
       }
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    return result.Succeeded();
   }
 };
 
@@ -2730,12 +2717,12 @@ public:
     return m_cmd_help_long;
   }
 
-  bool DoExecute(llvm::StringRef raw_command_line,
+  void DoExecute(llvm::StringRef raw_command_line,
                  CommandReturnObject &result) override {
     if (raw_command_line.empty()) {
       result.AppendError(
           "type lookup cannot be invoked without a type name as argument");
-      return false;
+      return;
     }
 
     auto exe_ctx = GetCommandInterpreter().GetExecutionContext();
@@ -2747,7 +2734,7 @@ public:
     if (args.HasArgs())
       if (!ParseOptionsAndNotify(args.GetArgs(), result, m_option_group,
                                  exe_ctx))
-        return false;
+        return;
 
     ExecutionContextScope *best_scope = exe_ctx.GetBestExecutionContextScope();
 
@@ -2827,7 +2814,6 @@ public:
 
     result.SetStatus(any_found ? lldb::eReturnStatusSuccessFinishResult
                                : lldb::eReturnStatusSuccessFinishNoResult);
-    return true;
   }
 };
 
@@ -2858,13 +2844,13 @@ public:
   ~CommandObjectFormatterInfo() override = default;
 
 protected:
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     TargetSP target_sp = GetDebugger().GetSelectedTarget();
     Thread *thread = GetDefaultThread();
     if (!thread) {
       result.AppendError("no default thread");
-      return false;
+      return;
     }
 
     StackFrameSP frame_sp =
@@ -2894,10 +2880,8 @@ protected:
             << ") " << command << "\n";
         result.SetStatus(lldb::eReturnStatusSuccessFinishNoResult);
       }
-      return true;
     } else {
       result.AppendError("failed to evaluate expression");
-      return false;
     }
   }
 

--- a/lldb/source/Commands/CommandObjectVersion.cpp
+++ b/lldb/source/Commands/CommandObjectVersion.cpp
@@ -22,8 +22,7 @@ CommandObjectVersion::CommandObjectVersion(CommandInterpreter &interpreter)
 
 CommandObjectVersion::~CommandObjectVersion() = default;
 
-bool CommandObjectVersion::DoExecute(Args &args, CommandReturnObject &result) {
+void CommandObjectVersion::DoExecute(Args &args, CommandReturnObject &result) {
   result.AppendMessageWithFormat("%s\n", lldb_private::GetVersion());
   result.SetStatus(eReturnStatusSuccessFinishResult);
-  return true;
 }

--- a/lldb/source/Commands/CommandObjectVersion.h
+++ b/lldb/source/Commands/CommandObjectVersion.h
@@ -22,7 +22,7 @@ public:
   ~CommandObjectVersion() override;
 
 protected:
-  bool DoExecute(Args &args, CommandReturnObject &result) override;
+  void DoExecute(Args &args, CommandReturnObject &result) override;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -207,7 +207,7 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     if (target->GetProcessSP() && target->GetProcessSP()->IsAlive()) {
@@ -230,7 +230,7 @@ protected:
     if (num_watchpoints == 0) {
       result.AppendMessage("No watchpoints currently set.");
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     Stream &output_stream = result.GetOutputStream();
@@ -249,7 +249,7 @@ protected:
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
         result.AppendError("Invalid watchpoints specification.");
-        return false;
+        return;
       }
 
       const size_t size = wp_ids.size();
@@ -260,8 +260,6 @@ protected:
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -297,10 +295,10 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     if (!CheckTargetForWatchpointOperations(target, result))
-      return false;
+      return;
 
     std::unique_lock<std::recursive_mutex> lock;
     target->GetWatchpointList().GetListMutex(lock);
@@ -311,7 +309,7 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist to be enabled.");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
@@ -327,7 +325,7 @@ protected:
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
         result.AppendError("Invalid watchpoints specification.");
-        return false;
+        return;
       }
 
       int count = 0;
@@ -338,8 +336,6 @@ protected:
       result.AppendMessageWithFormat("%d watchpoints enabled.\n", count);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -373,10 +369,10 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     if (!CheckTargetForWatchpointOperations(target, result))
-      return false;
+      return;
 
     std::unique_lock<std::recursive_mutex> lock;
     target->GetWatchpointList().GetListMutex(lock);
@@ -386,7 +382,7 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist to be disabled.");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
@@ -405,7 +401,7 @@ protected:
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
         result.AppendError("Invalid watchpoints specification.");
-        return false;
+        return;
       }
 
       int count = 0;
@@ -416,8 +412,6 @@ protected:
       result.AppendMessageWithFormat("%d watchpoints disabled.\n", count);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
-
-    return result.Succeeded();
   }
 };
 
@@ -489,10 +483,10 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     if (!CheckTargetForWatchpointOperations(target, result))
-      return false;
+      return;
 
     std::unique_lock<std::recursive_mutex> lock;
     target->GetWatchpointList().GetListMutex(lock);
@@ -503,7 +497,7 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist to be deleted.");
-      return false;
+      return;
     }
 
     if (command.empty()) {
@@ -519,7 +513,7 @@ protected:
                                        (uint64_t)num_watchpoints);
       }
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return result.Succeeded();
+      return;
     }
 
     // Particular watchpoints selected; delete them.
@@ -527,7 +521,7 @@ protected:
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                wp_ids)) {
       result.AppendError("Invalid watchpoints specification.");
-      return false;
+      return;
     }
 
     int count = 0;
@@ -537,8 +531,6 @@ protected:
         ++count;
     result.AppendMessageWithFormat("%d watchpoints deleted.\n", count);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
-
-    return result.Succeeded();
   }
 
 private:
@@ -616,10 +608,10 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     if (!CheckTargetForWatchpointOperations(target, result))
-      return false;
+      return;
 
     std::unique_lock<std::recursive_mutex> lock;
     target->GetWatchpointList().GetListMutex(lock);
@@ -630,7 +622,7 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist to be ignored.");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
@@ -645,7 +637,7 @@ protected:
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
         result.AppendError("Invalid watchpoints specification.");
-        return false;
+        return;
       }
 
       int count = 0;
@@ -656,8 +648,6 @@ protected:
       result.AppendMessageWithFormat("%d watchpoints ignored.\n", count);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -742,10 +732,10 @@ public:
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
     if (!CheckTargetForWatchpointOperations(target, result))
-      return false;
+      return;
 
     std::unique_lock<std::recursive_mutex> lock;
     target->GetWatchpointList().GetListMutex(lock);
@@ -756,7 +746,7 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist to be modified.");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
@@ -769,7 +759,7 @@ protected:
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
         result.AppendError("Invalid watchpoints specification.");
-        return false;
+        return;
       }
 
       int count = 0;
@@ -784,8 +774,6 @@ protected:
       result.AppendMessageWithFormat("%d watchpoints modified.\n", count);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -866,7 +854,7 @@ protected:
     return variable_list.GetSize() - old_size;
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = GetDebugger().GetSelectedTarget().get();
     StackFrame *frame = m_exe_ctx.GetFramePtr();
 
@@ -875,7 +863,7 @@ protected:
     if (command.GetArgumentCount() <= 0) {
       result.AppendError("required argument missing; "
                          "specify your program variable to watch for");
-      return false;
+      return;
     }
 
     // If no '-w' is specified, default to '-w modify'.
@@ -895,7 +883,7 @@ protected:
     // A simple watch variable gesture allows only one argument.
     if (command.GetArgumentCount() != 1) {
       result.AppendError("specify exactly one variable to watch for");
-      return false;
+      return;
     }
 
     // Things have checked out ok...
@@ -943,7 +931,7 @@ protected:
         result.AppendErrorWithFormat("unable to find any variable "
                                      "expression path that matches '%s'",
                                      command.GetArgumentAtIndex(0));
-      return false;
+      return;
     }
 
     // Now it's time to create the watchpoint.
@@ -975,7 +963,7 @@ protected:
           addr, static_cast<uint64_t>(size), command.GetArgumentAtIndex(0));
       if (const char *error_message = error.AsCString(nullptr))
         result.AppendError(error_message);
-      return result.Succeeded();
+      return;
     }
 
     watch_sp->SetWatchSpec(command.GetArgumentAtIndex(0));
@@ -994,8 +982,6 @@ protected:
     watch_sp->GetDescription(&output_stream, lldb::eDescriptionLevelFull);
     output_stream.EOL();
     result.SetStatus(eReturnStatusSuccessFinishResult);
-
-    return result.Succeeded();
   }
 
 private:
@@ -1061,7 +1047,7 @@ Examples:
   Options *GetOptions() override { return &m_option_group; }
 
 protected:
-  bool DoExecute(llvm::StringRef raw_command,
+  void DoExecute(llvm::StringRef raw_command,
                  CommandReturnObject &result) override {
     auto exe_ctx = GetCommandInterpreter().GetExecutionContext();
     m_option_group.NotifyOptionParsingStarting(
@@ -1077,14 +1063,14 @@ protected:
     if (args.HasArgs())
       if (!ParseOptionsAndNotify(args.GetArgs(), result, m_option_group,
                                  exe_ctx))
-        return false;
+        return;
 
     // If no argument is present, issue an error message.  There's no way to
     // set a watchpoint.
     if (raw_command.trim().empty()) {
       result.AppendError("required argument missing; specify an expression "
                          "to evaluate into the address to watch for");
-      return false;
+      return;
     }
 
     // If no '-w' is specified, default to '-w write'.
@@ -1116,7 +1102,7 @@ protected:
       result.AppendErrorWithFormat("expression evaluated: \n%s", expr.data());
       if (valobj_sp && !valobj_sp->GetError().Success())
         result.AppendError(valobj_sp->GetError().AsCString());
-      return false;
+      return;
     }
 
     // Get the address to watch.
@@ -1124,7 +1110,7 @@ protected:
     addr = valobj_sp->GetValueAsUnsigned(0, &success);
     if (!success) {
       result.AppendError("expression did not evaluate to an address");
-      return false;
+      return;
     }
 
     if (m_option_watchpoint.watch_size != 0)
@@ -1173,8 +1159,6 @@ protected:
       if (error.AsCString(nullptr))
         result.AppendError(error.AsCString());
     }
-
-    return result.Succeeded();
   }
 
 private:

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -366,7 +366,7 @@ are no syntax errors may indicate that a function was declared but never called.
   };
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     const WatchpointList &watchpoints = target->GetWatchpointList();
@@ -374,7 +374,7 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist to have commands added");
-      return false;
+      return;
     }
 
     if (!m_options.m_function_name.empty()) {
@@ -388,7 +388,7 @@ protected:
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                valid_wp_ids)) {
       result.AppendError("Invalid watchpoints specification.");
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -441,8 +441,6 @@ protected:
         }
       }
     }
-
-    return result.Succeeded();
   }
 
 private:
@@ -475,7 +473,7 @@ public:
   ~CommandObjectWatchpointCommandDelete() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     const WatchpointList &watchpoints = target->GetWatchpointList();
@@ -483,20 +481,20 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist to have commands deleted");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
       result.AppendError(
           "No watchpoint specified from which to delete the commands");
-      return false;
+      return;
     }
 
     std::vector<uint32_t> valid_wp_ids;
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                valid_wp_ids)) {
       result.AppendError("Invalid watchpoints specification.");
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -509,10 +507,9 @@ protected:
           wp->ClearCallback();
       } else {
         result.AppendErrorWithFormat("Invalid watchpoint ID: %u.\n", cur_wp_id);
-        return false;
+        return;
       }
     }
-    return result.Succeeded();
   }
 };
 
@@ -543,7 +540,7 @@ public:
   ~CommandObjectWatchpointCommandList() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     Target *target = &GetSelectedTarget();
 
     const WatchpointList &watchpoints = target->GetWatchpointList();
@@ -551,20 +548,20 @@ protected:
 
     if (num_watchpoints == 0) {
       result.AppendError("No watchpoints exist for which to list commands");
-      return false;
+      return;
     }
 
     if (command.GetArgumentCount() == 0) {
       result.AppendError(
           "No watchpoint specified for which to list the commands");
-      return false;
+      return;
     }
 
     std::vector<uint32_t> valid_wp_ids;
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                valid_wp_ids)) {
       result.AppendError("Invalid watchpoints specification.");
-      return false;
+      return;
     }
 
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -598,8 +595,6 @@ protected:
         }
       }
     }
-
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -339,7 +339,7 @@ public:
   ~CommandObjectMultiwordItaniumABI_Demangle() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     bool demangled_any = false;
     bool error_any = false;
     for (auto &entry : command.entries()) {
@@ -372,7 +372,6 @@ protected:
         error_any ? lldb::eReturnStatusFailed
                   : (demangled_any ? lldb::eReturnStatusSuccessFinishResult
                                    : lldb::eReturnStatusSuccessFinishNoResult));
-    return result.Succeeded();
   }
 };
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -917,7 +917,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     std::unique_ptr<RegularExpression> regex_up;
     switch (command.GetArgumentCount()) {
     case 0:
@@ -929,14 +929,14 @@ protected:
         result.AppendError(
             "invalid argument - please provide a valid regular expression");
         result.SetStatus(lldb::eReturnStatusFailed);
-        return false;
+        return;
       }
       break;
     }
     default: {
       result.AppendError("please provide 0 or 1 arguments");
       result.SetStatus(lldb::eReturnStatusFailed);
-      return false;
+      return;
     }
     }
 
@@ -997,11 +997,10 @@ protected:
         }
       }
       result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
     result.AppendError("current process has no Objective-C runtime loaded");
     result.SetStatus(lldb::eReturnStatusFailed);
-    return false;
   }
 
   CommandOptions m_options;
@@ -1034,11 +1033,11 @@ public:
   ~CommandObjectMultiwordObjC_TaggedPointer_Info() override = default;
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (command.GetArgumentCount() == 0) {
       result.AppendError("this command requires arguments");
       result.SetStatus(lldb::eReturnStatusFailed);
-      return false;
+      return;
     }
 
     Process *process = m_exe_ctx.GetProcessPtr();
@@ -1048,7 +1047,7 @@ protected:
     if (!objc_runtime) {
       result.AppendError("current process has no Objective-C runtime loaded");
       result.SetStatus(lldb::eReturnStatusFailed);
-      return false;
+      return;
     }
 
     ObjCLanguageRuntime::TaggedPointerVendor *tagged_ptr_vendor =
@@ -1056,7 +1055,7 @@ protected:
     if (!tagged_ptr_vendor) {
       result.AppendError("current process has no tagged pointer support");
       result.SetStatus(lldb::eReturnStatusFailed);
-      return false;
+      return;
     }
 
     for (size_t i = 0; i < command.GetArgumentCount(); i++) {
@@ -1071,7 +1070,7 @@ protected:
         result.AppendErrorWithFormatv(
             "could not convert '{0}' to a valid address\n", arg_str);
         result.SetStatus(lldb::eReturnStatusFailed);
-        return false;
+        return;
       }
 
       if (!tagged_ptr_vendor->IsPossibleTaggedPointer(arg_addr)) {
@@ -1084,7 +1083,7 @@ protected:
         result.AppendErrorWithFormatv(
             "could not get class descriptor for {0:x16}\n", arg_addr);
         result.SetStatus(lldb::eReturnStatusFailed);
-        return false;
+        return;
       }
 
       uint64_t info_bits = 0;
@@ -1106,7 +1105,6 @@ protected:
     }
 
     result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
-    return true;
   }
 };
 

--- a/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
+++ b/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
@@ -881,7 +881,7 @@ public:
 
   ~CommandObjectProcessKDPPacketSend() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     if (!m_command_byte.GetOptionValue().OptionWasSet()) {
       result.AppendError(
           "the --command option must be set to a valid command byte");
@@ -907,7 +907,7 @@ public:
                                              "even number of ASCII hex "
                                              "characters: '%s'",
                                              ascii_hex_bytes_cstr);
-                return false;
+                return;
               }
               payload_bytes.resize(ascii_hex_bytes_cstr_len / 2);
               if (extractor.GetHexBytes(payload_bytes, '\xdd') !=
@@ -916,7 +916,7 @@ public:
                                              "ASCII hex characters (no "
                                              "spaces or hex prefixes): '%s'",
                                              ascii_hex_bytes_cstr);
-                return false;
+                return;
               }
             }
             Status error;
@@ -934,7 +934,7 @@ public:
                   endian::InlHostByteOrder(), endian::InlHostByteOrder());
               result.AppendMessage(packet.GetString());
               result.SetStatus(eReturnStatusSuccessFinishResult);
-              return true;
+              return;
             } else {
               const char *error_cstr = error.AsCString();
               if (error_cstr && error_cstr[0])
@@ -942,7 +942,7 @@ public:
               else
                 result.AppendErrorWithFormat("unknown error 0x%8.8x",
                                              error.GetError());
-              return false;
+              return;
             }
           } else {
             result.AppendErrorWithFormat("process must be stopped in order "
@@ -958,7 +958,6 @@ public:
                                      command_byte);
       }
     }
-    return false;
   }
 };
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -5179,7 +5179,7 @@ public:
 
   Options *GetOptions() override { return &m_option_group; }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
     if (argc == 0) {
       ProcessGDBRemote *process =
@@ -5201,14 +5201,13 @@ public:
             num_packets, max_send, max_recv, k_recv_amount, json,
             output_stream_sp ? *output_stream_sp : result.GetOutputStream());
         result.SetStatus(eReturnStatusSuccessFinishResult);
-        return true;
+        return;
       }
     } else {
       result.AppendErrorWithFormat("'%s' takes no arguments",
                                    m_cmd_name.c_str());
     }
     result.SetStatus(eReturnStatusFailed);
-    return false;
   }
 
 protected:
@@ -5228,16 +5227,15 @@ public:
 
   ~CommandObjectProcessGDBRemotePacketHistory() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     ProcessGDBRemote *process =
         (ProcessGDBRemote *)m_interpreter.GetExecutionContext().GetProcessPtr();
     if (process) {
       process->DumpPluginHistory(result.GetOutputStream());
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
     result.SetStatus(eReturnStatusFailed);
-    return false;
   }
 };
 
@@ -5255,14 +5253,14 @@ public:
 
   ~CommandObjectProcessGDBRemotePacketXferSize() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
     if (argc == 0) {
       result.AppendErrorWithFormat("'%s' takes an argument to specify the max "
                                    "amount to be transferred when "
                                    "reading/writing",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     ProcessGDBRemote *process =
@@ -5274,11 +5272,10 @@ public:
       if (errno == 0 && user_specified_max != 0) {
         process->SetUserSpecifiedMaxMemoryTransferSize(user_specified_max);
         result.SetStatus(eReturnStatusSuccessFinishResult);
-        return true;
+        return;
       }
     }
     result.SetStatus(eReturnStatusFailed);
-    return false;
   }
 };
 
@@ -5299,13 +5296,13 @@ public:
 
   ~CommandObjectProcessGDBRemotePacketSend() override = default;
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
     if (argc == 0) {
       result.AppendErrorWithFormat(
           "'%s' takes a one or more packet content arguments",
           m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     ProcessGDBRemote *process =
@@ -5331,7 +5328,6 @@ public:
           output_strm.Printf("response: %s\n", response.GetStringRef().data());
       }
     }
-    return true;
   }
 };
 
@@ -5348,12 +5344,12 @@ public:
 
   ~CommandObjectProcessGDBRemotePacketMonitor() override = default;
 
-  bool DoExecute(llvm::StringRef command,
+  void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
     if (command.empty()) {
       result.AppendErrorWithFormat("'%s' takes a command string argument",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
 
     ProcessGDBRemote *process =
@@ -5377,7 +5373,6 @@ public:
       else
         output_strm.Printf("response: %s\n", response.GetStringRef().data());
     }
-    return true;
   }
 };
 

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -795,12 +795,12 @@ public:
 
   Options *GetOptions() override { return &m_option_group; }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     const size_t argc = command.GetArgumentCount();
     if (argc > 0) {
       result.AppendErrorWithFormat("'%s' take no arguments, only options",
                                    m_cmd_name.c_str());
-      return false;
+      return;
     }
     SetDefaultOptionsIfNoneAreSet();
 
@@ -904,9 +904,7 @@ public:
       DumpTextStream(StreamType::FacebookThreadName,
                      "Facebook Thread Name");
     if (DumpFacebookLogcat())
-      DumpTextStream(StreamType::FacebookLogcat,
-                     "Facebook Logcat");
-    return true;
+      DumpTextStream(StreamType::FacebookLogcat, "Facebook Logcat");
   }
 };
 

--- a/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
+++ b/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
@@ -766,7 +766,7 @@ protected:
     result.AppendWarning(stream.GetString());
   }
 
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     // First off, set the global sticky state of enable/disable based on this
     // command execution.
     s_is_explicitly_enabled = m_enable;
@@ -790,14 +790,14 @@ protected:
     if (!process_sp) {
       // No active process, so there is nothing more to do right now.
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     // If the process is no longer alive, we can't do this now. We'll catch it
     // the next time the process is started up.
     if (!process_sp->IsAlive()) {
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-      return true;
+      return;
     }
 
     // Get the plugin for the process.
@@ -838,7 +838,6 @@ protected:
       // one this command is setup to do.
       plugin.SetEnabled(m_enable);
     }
-    return result.Succeeded();
   }
 
   Options *GetOptions() override {
@@ -861,7 +860,7 @@ public:
                             "plugin structured-data darwin-log status") {}
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     auto &stream = result.GetOutputStream();
 
     // Figure out if we've got a process.  If so, we can tell if DarwinLog is
@@ -891,7 +890,7 @@ protected:
     if (!options_sp) {
       // Nothing more to do.
       result.SetStatus(eReturnStatusSuccessFinishResult);
-      return true;
+      return;
     }
 
     // Print filter rules
@@ -924,7 +923,6 @@ protected:
                   options_sp->GetFallthroughAccepts() ? "accept" : "reject");
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return true;
   }
 };
 

--- a/lldb/source/Plugins/Trace/intel-pt/CommandObjectTraceStartIntelPT.h
+++ b/lldb/source/Plugins/Trace/intel-pt/CommandObjectTraceStartIntelPT.h
@@ -105,7 +105,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 
   TraceIntelPT &m_trace;
   CommandOptions m_options;

--- a/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.cpp
+++ b/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.cpp
@@ -62,7 +62,7 @@ CommandObjectThreadTraceExportCTF::CommandOptions::GetDefinitions() {
   return llvm::ArrayRef(g_thread_trace_export_ctf_options);
 }
 
-bool CommandObjectThreadTraceExportCTF::DoExecute(Args &command,
+void CommandObjectThreadTraceExportCTF::DoExecute(Args &command,
                                                   CommandReturnObject &result) {
   const TraceSP &trace_sp = m_exe_ctx.GetTargetSP()->GetTrace();
   Process *process = m_exe_ctx.GetProcessPtr();
@@ -78,7 +78,6 @@ bool CommandObjectThreadTraceExportCTF::DoExecute(Args &command,
     result.AppendErrorWithFormatv(
         "Thread index {0} is out of range (valid values are 1 - {1}).\n", tid,
         num_threads);
-    return false;
   } else {
     auto do_work = [&]() -> Error {
       Expected<TraceCursorSP> cursor = trace_sp->CreateNewCursor(*thread);
@@ -91,9 +90,6 @@ bool CommandObjectThreadTraceExportCTF::DoExecute(Args &command,
 
     if (llvm::Error err = do_work()) {
       result.AppendErrorWithFormat("%s\n", toString(std::move(err)).c_str());
-      return false;
-    } else {
-      return true;
     }
   }
 }

--- a/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.h
+++ b/lldb/source/Plugins/TraceExporter/ctf/CommandObjectThreadTraceExportCTF.h
@@ -48,7 +48,7 @@ public:
   Options *GetOptions() override { return &m_options; }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override;
+  void DoExecute(Args &command, CommandReturnObject &result) override;
 
   CommandOptions m_options;
 };

--- a/lldb/unittests/Interpreter/TestCommandPaths.cpp
+++ b/lldb/unittests/Interpreter/TestCommandPaths.cpp
@@ -48,10 +48,9 @@ public:
   }
 
 protected:
-  bool DoExecute(Args &command, CommandReturnObject &result) override {
+  void DoExecute(Args &command, CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishResult);
     result.AppendMessage("I did nothing");
-    return true;
   }
 };
 


### PR DESCRIPTION
[lldb] Part 2 of 2 - Refactor `CommandObject::DoExecute(...)` to return `void` instead of ~~`bool`~~

Justifications:
- The code doesn't ultimately apply the `true`/`false` return values.
- The methods already pass around a `CommandReturnObject`, typically with a `result` parameter.
- Each command return object already contains:
	- A more precise status
	- The error code(s) that apply to that status

Part 1 refactors the `CommandObject::Execute(...)` method.
- See [https://github.com/llvm/llvm-project/pull/69989](https://github.com/llvm/llvm-project/pull/69989)

rdar://117378957