### PR TITLE
[libc++] Remove the Buildkite job that builds documentation

### DIFF
--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -38,9 +38,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y bash curl
 
 # Install various tools used by the build or the test suite
-#RUN apt-get update && apt-get install -y ninja-build python3 python3-sphinx python3-distutils python3-psutil git gdb ccache
+#RUN apt-get update && apt-get install -y ninja-build python3 python3-distutils python3-psutil git gdb ccache
 # TODO add ninja-build once 1.11 is available in Ubuntu, also remove the manual installation.
-RUN apt-get update && apt-get install -y python3 python3-sphinx python3-distutils python3-psutil git gdb ccache
+RUN apt-get update && apt-get install -y python3 python3-distutils python3-psutil git gdb ccache
 RUN apt-get update && apt-get install -y wget && \
   wget -qO /usr/local/bin/ninja.gz https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip && \
   gunzip /usr/local/bin/ninja.gz && \

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -30,31 +30,10 @@ env:
     GCC_STABLE_VERSION: "13"
 steps:
   #
-  # Light pre-commit tests for things like forgetting to update generated files.
-  #
-  - label: "Documentation"
-    command: "libcxx/utils/ci/run-buildbot documentation"
-    artifact_paths:
-      - "**/test-results.xml"
-    env:
-        CC: "clang-${LLVM_HEAD_VERSION}"
-        CXX: "clang++-${LLVM_HEAD_VERSION}"
-    agents:
-      queue: "libcxx-builders"
-      os: "linux"
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-    timeout_in_minutes: 120
-
-  #
   # General testing with the default configuration, under all the supported
   # Standard modes, with Clang and GCC. This catches most issues upfront.
   # The goal of this step is to catch most issues while being very fast.
   #
-  - wait
-
   - label: "GCC ${GCC_STABLE_VERSION} / C++latest"
     command: "libcxx/utils/ci/run-buildbot generic-gcc"
     artifact_paths:

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -587,13 +587,6 @@ benchmarks)
     generate-cmake
     check-cxx-benchmarks
 ;;
-documentation)
-    clean
-    generate-cmake -DLLVM_ENABLE_SPHINX=ON
-
-    echo "+++ Generating documentation"
-    ${NINJA} -vC "${BUILD_DIR}" docs-libcxx-html
-;;
 aarch64)
     clean
     generate-cmake -C "${MONOREPO_ROOT}/libcxx/cmake/caches/AArch64.cmake"


### PR DESCRIPTION
Since #69828, we have a Github Action that builds the documentation for libc++, so we don't need to do it as part of our Buildkite pipeline anymore.