### PR TITLE
[RISCV] Macro-fusion support for veyron-v1 CPU.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -973,12 +973,12 @@ def TuneLUIADDIFusion
 def TuneAUIPCADDIFusion
     : SubtargetFeature<"auipc-addi-fusion", "HasAUIPCADDIFusion",
                        "true", "Enable AUIPC+ADDI macrofusion">;
-def TuneSLLISRLIFusion
-    : SubtargetFeature<"slli-srli-fusion", "HasSLLISRLIFusion",
-                       "true", "Enable SLLI+SRLI macrofusion">;
+def TuneShiftedZExtFusion
+    : SubtargetFeature<"shifted-zext-fusion", "HasShiftedZExtFusion",
+                       "true", "Enable SLLI+SRLI to be fused when computing (shifted) zero extension">;
 def TuneLDADDFusion
     : SubtargetFeature<"ld-add-fusion", "HasLDADDFusion",
-                       "true", "Enable fusion of load with the last instruction of the address calculation">;
+                       "true", "Enable LD+ADD macrofusion.">;
 
 def TuneNoDefaultUnroll
     : SubtargetFeature<"no-default-unroll", "EnableDefaultUnroll", "false",
@@ -1001,7 +1001,7 @@ def TuneVeyronFusions : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "V
                                          "Ventana Veyron-Series processors",
                                          [TuneLUIADDIFusion,
                                           TuneAUIPCADDIFusion,
-                                          TuneSLLISRLIFusion,
+                                          TuneShiftedZExtFusion,
                                           TuneLDADDFusion]>;
 
 // Assume that lock-free native-width atomics are available, even if the target

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -997,19 +997,12 @@ def TuneSiFive7 : SubtargetFeature<"sifive7", "RISCVProcFamily", "SiFive7",
                                    [TuneNoDefaultUnroll,
                                     TuneShortForwardBranchOpt]>;
 
-<<<<<<< HEAD
-def TuneVentanaVeyron : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "VentanaVeyron",
-                                         "Ventana-Veyron Series processors",
-                                         [TuneLUIADDIFusion]>;
-=======
 def TuneVeyronFusions : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "VentanaVeyron",
                                          "Ventana Veyron-Series processors",
                                          [TuneLUIADDIFusion,
                                           TuneAUIPCADDIFusion,
                                           TuneSLLISRLIFusion,
                                           TuneLDADDFusion]>;
-
->>>>>>> bbf0196a7d42 ([RISCV] Macro-fusion support for veyron-v1 CPU.)
 
 // Assume that lock-free native-width atomics are available, even if the target
 // and operating system combination would not usually provide them. The user

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -970,6 +970,16 @@ def TuneLUIADDIFusion
     : SubtargetFeature<"lui-addi-fusion", "HasLUIADDIFusion",
                        "true", "Enable LUI+ADDI macrofusion">;
 
+def TuneAUIPCADDIFusion
+    : SubtargetFeature<"auipc-addi-fusion", "HasAUIPCADDIFusion",
+                       "true", "Enable AUIPC+ADDI macrofusion">;
+def TuneSLLISRLIFusion
+    : SubtargetFeature<"slli-srli-fusion", "HasSLLISRLIFusion",
+                       "true", "Enable SLLI+SRLI macrofusion">;
+def TuneLDADDFusion
+    : SubtargetFeature<"ld-add-fusion", "HasLDADDFusion",
+                       "true", "Enable fusion of load with the last instruction of the address calculation">;
+
 def TuneNoDefaultUnroll
     : SubtargetFeature<"no-default-unroll", "EnableDefaultUnroll", "false",
                        "Disable default unroll preference.">;
@@ -987,9 +997,19 @@ def TuneSiFive7 : SubtargetFeature<"sifive7", "RISCVProcFamily", "SiFive7",
                                    [TuneNoDefaultUnroll,
                                     TuneShortForwardBranchOpt]>;
 
+<<<<<<< HEAD
 def TuneVentanaVeyron : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "VentanaVeyron",
                                          "Ventana-Veyron Series processors",
                                          [TuneLUIADDIFusion]>;
+=======
+def TuneVeyronFusions : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "VentanaVeyron",
+                                         "Ventana Veyron-Series processors",
+                                         [TuneLUIADDIFusion,
+                                          TuneAUIPCADDIFusion,
+                                          TuneSLLISRLIFusion,
+                                          TuneLDADDFusion]>;
+
+>>>>>>> bbf0196a7d42 ([RISCV] Macro-fusion support for veyron-v1 CPU.)
 
 // Assume that lock-free native-width atomics are available, even if the target
 // and operating system combination would not usually provide them. The user

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.cpp
@@ -88,7 +88,7 @@ static bool isSLLISRLI(const MachineInstr *FirstMI,
     return false;
 
   unsigned SLLIImm = FirstMI->getOperand(2).getImm();
-  if (IsShiftBy48 ? (SLLIImm != 48) : (SLLIImm > 32))
+  if (IsShiftBy48 ? (SLLIImm != 48) : (SLLIImm != 32))
     return false;
 
   return checkRegisters(FirstMI->getOperand(0).getReg(), SecondMI);

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.cpp
@@ -18,26 +18,7 @@
 
 using namespace llvm;
 
-// Fuse LUI followed by ADDI or ADDIW.
-// rd = imm[31:0] which decomposes to
-// lui rd, imm[31:12]
-// addi(w) rd, rd, imm[11:0]
-static bool isLUIADDI(const MachineInstr *FirstMI,
-                      const MachineInstr &SecondMI) {
-  if (SecondMI.getOpcode() != RISCV::ADDI &&
-      SecondMI.getOpcode() != RISCV::ADDIW)
-    return false;
-
-  // Assume the 1st instr to be a wildcard if it is unspecified.
-  if (!FirstMI)
-    return true;
-
-  if (FirstMI->getOpcode() != RISCV::LUI)
-    return false;
-
-  Register FirstDest = FirstMI->getOperand(0).getReg();
-
-  // Destination of LUI should be the ADDI(W) source register.
+static bool checkRegisters(Register FirstDest, const MachineInstr &SecondMI) {
   if (SecondMI.getOperand(1).getReg() != FirstDest)
     return false;
 
@@ -47,9 +28,101 @@ static bool isLUIADDI(const MachineInstr *FirstMI,
     return MRI.hasOneNonDBGUse(FirstDest);
   }
 
-  // If the FirstMI destination is non-virtual, it should match the SecondMI
-  // destination.
   return SecondMI.getOperand(0).getReg() == FirstDest;
+}
+
+// Fuse Load
+static bool isLDADD(const MachineInstr *FirstMI, const MachineInstr &SecondMI) {
+  if (SecondMI.getOpcode() != RISCV::LD)
+    return false;
+
+  if (!SecondMI.getOperand(2).isImm())
+    return false;
+
+  if (SecondMI.getOperand(2).getImm() != 0)
+    return false;
+
+  // Given SecondMI, when FirstMI is unspecified, we must return
+  // if SecondMI may be part of a fused pair at all.
+  if (!FirstMI)
+    return true;
+
+  if (FirstMI->getOpcode() != RISCV::ADD)
+    return true;
+
+  return checkRegisters(FirstMI->getOperand(0).getReg(), SecondMI);
+}
+
+// Fuse SLLI by 32 feeding into SRLI by 32 or less or
+// SLLI by exactly 48 feeding into SRLI by exactly 48.
+static bool isSLLISRLI(const MachineInstr *FirstMI,
+                       const MachineInstr &SecondMI) {
+  if (SecondMI.getOpcode() != RISCV::SRLI)
+    return false;
+
+  if (!SecondMI.getOperand(2).isImm())
+    return false;
+
+  unsigned SRLIImm = SecondMI.getOperand(2).getImm();
+  bool IsShiftBy48 = SRLIImm == 48;
+  if (SRLIImm > 32 && !IsShiftBy48)
+    return false;
+
+  // Given SecondMI, when FirstMI is unspecified, we must return
+  // if SecondMI may be part of a fused pair at all.
+  if (!FirstMI)
+    return true;
+
+  if (FirstMI->getOpcode() != RISCV::SLLI)
+    return false;
+
+  unsigned SLLIImm = FirstMI->getOperand(2).getImm();
+  if (IsShiftBy48 ? (SLLIImm != 48) : (SLLIImm > 32))
+    return false;
+
+  return checkRegisters(FirstMI->getOperand(0).getReg(), SecondMI);
+}
+
+// Fuse AUIPC followed by ADDI
+static bool isAUIPCADDI(const MachineInstr *FirstMI,
+                        const MachineInstr &SecondMI) {
+  if (SecondMI.getOpcode() != RISCV::ADDI)
+    return false;
+  // Assume the 1st instr to be a wildcard if it is unspecified.
+  if (!FirstMI)
+    return true;
+
+  if (FirstMI->getOpcode() != RISCV::AUIPC)
+    return false;
+
+  // The first operand of ADDI might be a frame index.
+  if (!SecondMI.getOperand(1).isReg())
+    return false;
+
+  return checkRegisters(FirstMI->getOperand(0).getReg(), SecondMI);
+}
+
+// Fuse LUI followed by ADDI or ADDIW.
+// rd = imm[31:0] which decomposes to
+// lui rd, imm[31:12]
+// addi(w) rd, rd, imm[11:0]
+static bool isLUIADDI(const MachineInstr *FirstMI,
+                      const MachineInstr &SecondMI) {
+  if (SecondMI.getOpcode() != RISCV::ADDI &&
+      SecondMI.getOpcode() != RISCV::ADDIW)
+    return false;
+  // Assume the 1st instr to be a wildcard if it is unspecified.
+  if (!FirstMI)
+    return true;
+
+  if (FirstMI->getOpcode() != RISCV::LUI)
+    return false;
+
+  // The first operand of ADDI might be a frame index.
+  if (!SecondMI.getOperand(1).isReg())
+    return false;
+
+  return checkRegisters(FirstMI->getOperand(0).getReg(), SecondMI);
 }
 
 static bool shouldScheduleAdjacent(const TargetInstrInfo &TII,
@@ -59,6 +132,15 @@ static bool shouldScheduleAdjacent(const TargetInstrInfo &TII,
   const RISCVSubtarget &ST = static_cast<const RISCVSubtarget &>(TSI);
 
   if (ST.hasLUIADDIFusion() && isLUIADDI(FirstMI, SecondMI))
+    return true;
+
+  if (ST.hasAUIPCADDIFusion() && isAUIPCADDI(FirstMI, SecondMI))
+    return true;
+
+  if (ST.hasSLLISRLIFusion() && isSLLISRLI(FirstMI, SecondMI))
+    return true;
+
+  if (ST.hasLDADDFusion() && isLDADD(FirstMI, SecondMI))
     return true;
 
   return false;

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -254,7 +254,7 @@ def VENTANA_VEYRON_V1 : RISCVProcessorModel<"veyron-v1",
                                              FeatureStdExtZicbop,
                                              FeatureStdExtZicboz,
                                              FeatureVendorXVentanaCondOps],
-                                             [TuneVentanaVeyron]>;
+                                             [TuneVeyronFusions]>;
 
 def XIANGSHAN_NANHU : RISCVProcessorModel<"xiangshan-nanhu",
                                           NoSchedModel,

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -192,7 +192,10 @@ public:
     return UserReservedRegister[i];
   }
 
-  bool hasMacroFusion() const { return hasLUIADDIFusion(); }
+  bool hasMacroFusion() const {
+    return hasLUIADDIFusion() || hasAUIPCADDIFusion() || hasSLLISRLIFusion() ||
+           hasLDADDFusion();
+  }
 
   // Vector codegen related methods.
   bool hasVInstructions() const { return HasStdExtZve32x; }

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -193,8 +193,8 @@ public:
   }
 
   bool hasMacroFusion() const {
-    return hasLUIADDIFusion() || hasAUIPCADDIFusion() || hasSLLISRLIFusion() ||
-           hasLDADDFusion();
+    return hasLUIADDIFusion() || hasAUIPCADDIFusion() ||
+           hasShiftedZExtFusion() || hasLDADDFusion();
   }
 
   // Vector codegen related methods.

--- a/llvm/test/CodeGen/RISCV/macro-fusions-veyron-v1.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-veyron-v1.mir
@@ -1,0 +1,159 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv64-linux-gnu  -mcpu=veyron-v1 -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+lui-addi-fusion,+auipc-addi-fusion,+slli-srli-fusion,+ld-add-fusion \
+# RUN:   | FileCheck %s
+
+# CHECK: lui_addi:%bb.0
+# CHECK: Macro fuse: {{.*}}LUI - ADDI
+---
+name: lui_addi
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = LUI 1
+    %3:gpr = ADDI %1, 2
+    %4:gpr = ADDI %2, 3
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: auipc_addi
+# CHECK: Macro fuse: {{.*}}AUIPC - ADDI
+---
+name: auipc_addi
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = AUIPC 1
+    %3:gpr = ADDI %1, 2
+    %4:gpr = ADDI %2, 3
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slli_srli
+# CHECK: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 32
+    %3:gpr = ADDI %1, 3
+    %4:gpr = SRLI %2, 4
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slli_srli_48
+# CHECK: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli_48
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 48
+    %3:gpr = ADDI %1, 3
+    %4:gpr = SRLI %2, 48
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slli_srli_no_fusion_0
+# CHECK-NOT: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli_no_fusion_0
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 32
+    %3:gpr = ADDI %1, 3
+    %4:gpr = SRLI %2, 33
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slli_srli_no_fusion_1
+# CHECK-NOT: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli_no_fusion_1
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 48
+    %3:gpr = ADDI %1, 3
+    %4:gpr = SRLI %2, 4
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slli_srli_no_fusion_2
+# CHECK-NOT: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli_no_fusion_2
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 31
+    %3:gpr = ADDI %1, 3
+    %4:gpr = SRLI %2, 4
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slli_srli_no_fusion_3
+# CHECK-NOT: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli_no_fusion_3
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 31
+    %3:gpr = ADDI %1, 3
+    %4:gpr = SRLI %2, 48
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: ld_add
+# CHECK: Macro fuse: {{.*}}ADD - LD
+---
+name: ld_add
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = ADD %1, %2
+    %4:gpr = ADDI %2, 3
+    %5:gpr = LD %3, 0
+    $x10 = COPY %4
+    $x11 = COPY %5
+    PseudoRET
+...

--- a/llvm/test/CodeGen/RISCV/macro-fusions-veyron-v1.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-veyron-v1.mir
@@ -1,7 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu  -mcpu=veyron-v1 -x=mir < %s \
 # RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
-# RUN:   -mattr=+lui-addi-fusion,+auipc-addi-fusion,+slli-srli-fusion,+ld-add-fusion \
+# RUN:   -mattr=+lui-addi-fusion,+auipc-addi-fusion,+shifted-zext-fusion,+ld-add-fusion \
 # RUN:   | FileCheck %s
 
 # CHECK: lui_addi:%bb.0
@@ -14,7 +14,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = LUI 1
-    %3:gpr = ADDI %1, 2
+    %3:gpr = XORI %1, 2
     %4:gpr = ADDI %2, 3
     $x10 = COPY %3
     $x11 = COPY %4
@@ -31,7 +31,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = AUIPC 1
-    %3:gpr = ADDI %1, 2
+    %3:gpr = XORI %1, 2
     %4:gpr = ADDI %2, 3
     $x10 = COPY %3
     $x11 = COPY %4
@@ -48,7 +48,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = SLLI %1, 32
-    %3:gpr = ADDI %1, 3
+    %3:gpr = XORI %1, 3
     %4:gpr = SRLI %2, 4
     $x10 = COPY %3
     $x11 = COPY %4
@@ -65,7 +65,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = SLLI %1, 48
-    %3:gpr = ADDI %1, 3
+    %3:gpr = XORI %1, 3
     %4:gpr = SRLI %2, 48
     $x10 = COPY %3
     $x11 = COPY %4
@@ -82,7 +82,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = SLLI %1, 32
-    %3:gpr = ADDI %1, 3
+    %3:gpr = XORI %1, 3
     %4:gpr = SRLI %2, 33
     $x10 = COPY %3
     $x11 = COPY %4
@@ -99,7 +99,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = SLLI %1, 48
-    %3:gpr = ADDI %1, 3
+    %3:gpr = XORI %1, 3
     %4:gpr = SRLI %2, 4
     $x10 = COPY %3
     $x11 = COPY %4
@@ -116,7 +116,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = SLLI %1, 31
-    %3:gpr = ADDI %1, 3
+    %3:gpr = XORI %1, 3
     %4:gpr = SRLI %2, 4
     $x10 = COPY %3
     $x11 = COPY %4
@@ -133,7 +133,7 @@ body:             |
     liveins: $x10
     %1:gpr = COPY $x10
     %2:gpr = SLLI %1, 31
-    %3:gpr = ADDI %1, 3
+    %3:gpr = XORI %1, 3
     %4:gpr = SRLI %2, 48
     $x10 = COPY %3
     $x11 = COPY %4
@@ -151,7 +151,7 @@ body:             |
     %1:gpr = COPY $x10
     %2:gpr = COPY $x11
     %3:gpr = ADD %1, %2
-    %4:gpr = ADDI %2, 3
+    %4:gpr = XORI %2, 3
     %5:gpr = LD %3, 0
     $x10 = COPY %4
     $x11 = COPY %5


### PR DESCRIPTION
Support was added for the following fusions:
  auipc-addi, slli-srli, ld-add
Some parts of the code became repetative, so small refactoring of existing lui-addi fusion was done.