### PR TITLE
[MLIR][CFGToSCF] Fix exit latch location preservation

### DIFF
--- a/mlir/lib/Transforms/Utils/CFGToSCF.cpp
+++ b/mlir/lib/Transforms/Utils/CFGToSCF.cpp
@@ -601,7 +601,7 @@ static FailureOr<StructuredLoopProperties> createSingleExitingLatch(
   {
     auto builder = OpBuilder::atBlockBegin(latchBlock);
     interface.createConditionalBranch(
-        builder.getUnknownLoc(), builder, shouldRepeat, loopHeader,
+        loc, builder, shouldRepeat, loopHeader,
         latchBlock->getArguments().take_front(loopHeader->getNumArguments()),
         /*falseDest=*/exitBlock,
         /*falseArgs=*/{});


### PR DESCRIPTION
This commit ensures that the CFG to SCF lifting does not accidentally drop locations of loop latches during the lifting.

Note that I didn't add a test as we do not seem to have any tests for location tracking in any of the similar passes.