### PR TITLE
[LLD] [MinGW] Hook up --icf=safe to -opt:safeicf

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -375,7 +375,9 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     StringRef s = a->getValue();
     if (s == "all")
       add("-opt:icf");
-    else if (s == "safe" || s == "none")
+    else if (s == "safe")
+      add("-opt:safeicf");
+    else if (s == "none")
       add("-opt:noicf");
     else
       error("unknown parameter: --icf=" + s);

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -205,9 +205,11 @@ GC-SECTIONS: -opt:ref
 RUN: ld.lld -### -m i386pep foo.o 2>&1 | FileCheck -check-prefix ICF-NONE %s
 RUN: ld.lld -### -m i386pep foo.o --icf=none 2>&1 | FileCheck -check-prefix ICF-NONE %s
 RUN: ld.lld -### -m i386pep foo.o -icf=none 2>&1 | FileCheck -check-prefix ICF-NONE %s
-RUN: ld.lld -### -m i386pep foo.o --icf=safe 2>&1 | FileCheck -check-prefix ICF-NONE %s
-RUN: ld.lld -### -m i386pep foo.o -icf=safe 2>&1 | FileCheck -check-prefix ICF-NONE %s
 ICF-NONE: -opt:noicf
+
+RUN: ld.lld -### -m i386pep foo.o --icf=safe 2>&1 | FileCheck -check-prefix ICF-SAFE %s
+RUN: ld.lld -### -m i386pep foo.o -icf=safe 2>&1 | FileCheck -check-prefix ICF-SAFE %s
+ICF-SAFE: -opt:safeicf
 
 RUN: ld.lld -### -m i386pep foo.o --icf=all 2>&1 | FileCheck -check-prefix ICF %s
 RUN: ld.lld -### -m i386pep foo.o -icf=all 2>&1 | FileCheck -check-prefix ICF %s


### PR DESCRIPTION
Back when the --icf= option was hooked up in the MinGW frontend in LLD, in 2017, lld-link didn't support safe ICF, and mapping it to noicf was suggested in review: https://reviews.llvm.org/D40019

Later in 2021, lld-link did get support for safe ICF in 5bdc5e7efda4100c4d11085c2da8f1fb932ccce4 / https://reviews.llvm.org/D97436.

Hook this up for the MinGW frontend as well.