### PR TITLE
[mlir] Change default NVVM compilation  to `fatbin` from `bin`

### DIFF
--- a/mlir/test/lib/Dialect/GPU/TestLowerToNVVM.cpp
+++ b/mlir/test/lib/Dialect/GPU/TestLowerToNVVM.cpp
@@ -60,7 +60,7 @@ struct TestLowerToNVVMOptions
   PassOptions::Option<std::string> cubinFormat{
       *this, "cubin-format",
       llvm::cl::desc("Compilation format to use to serialize to cubin."),
-      llvm::cl::init("bin")};
+      llvm::cl::init("fatbin")};
   PassOptions::Option<int> optLevel{
       *this, "opt-level",
       llvm::cl::desc("Optimization level for NVVM compilation"),


### PR DESCRIPTION
Change the NVVM assembly to `fatbin` as it is executable for multiple architectures. Using `bin` caused test errors at runtime in the test systems.