### PR TITLE
[clang][Interp] Cleaning up `FIXME`s added during `ArrayInitLoopExpr` implementation.

### DIFF
--- a/clang/lib/AST/Interp/ByteCodeExprGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.cpp
@@ -816,21 +816,17 @@ bool ByteCodeExprGen<Emitter>::VisitArrayInitLoopExpr(
     const ArrayInitLoopExpr *E) {
   assert(Initializing);
   assert(!DiscardResult);
+
+  // We visit the common opaque expression here once so we have its value
+  // cached.
+  if (!this->discard(E->getCommonExpr()))
+    return false;
+
   // TODO: This compiles to quite a lot of bytecode if the array is larger.
   //   Investigate compiling this to a loop.
-
   const Expr *SubExpr = E->getSubExpr();
-  const Expr *CommonExpr = E->getCommonExpr();
   size_t Size = E->getArraySize().getZExtValue();
   std::optional<PrimType> ElemT = classify(SubExpr->getType());
-
-  // If the common expression is an opaque expression, we visit it
-  // here once so we have its value cached.
-  // FIXME: This might be necessary (or useful) for all expressions.
-  if (isa<OpaqueValueExpr>(CommonExpr)) {
-    if (!this->discard(CommonExpr))
-      return false;
-  }
 
   // So, every iteration, we execute an assignment here
   // where the LHS is on the stack (the target array)
@@ -882,13 +878,13 @@ bool ByteCodeExprGen<Emitter>::VisitOpaqueValueExpr(const OpaqueValueExpr *E) {
     return false;
 
   // Here the local variable is created but the value is removed from the stack,
-  // so we put it back, because the caller might need it.
+  // so we put it back if the caller needs it.
   if (!DiscardResult) {
     if (!this->emitGetLocal(SubExprT, *LocalIndex, E))
       return false;
   }
 
-  // FIXME: Ideally the cached value should be cleaned up later.
+  // This is cleaned up when the local variable is destroyed.
   OpaqueExprs.insert({E, *LocalIndex});
 
   return true;

--- a/clang/lib/AST/Interp/ByteCodeExprGen.h
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.h
@@ -405,11 +405,11 @@ public:
   }
 
   void removeIfStoredOpaqueValue(const Scope::Local &Local) {
-    if (auto *OVE =
+    if (const auto *OVE =
             llvm::dyn_cast_if_present<OpaqueValueExpr>(Local.Desc->asExpr())) {
-      if (auto it = this->Ctx->OpaqueExprs.find(OVE);
-          it != this->Ctx->OpaqueExprs.end())
-        this->Ctx->OpaqueExprs.erase(it);
+      if (auto It = this->Ctx->OpaqueExprs.find(OVE);
+          It != this->Ctx->OpaqueExprs.end())
+        this->Ctx->OpaqueExprs.erase(It);
     };
   }
 

--- a/clang/lib/AST/Interp/ByteCodeExprGen.h
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.h
@@ -54,7 +54,7 @@ protected:
 public:
   /// Initializes the compiler and the backend emitter.
   template <typename... Tys>
-  ByteCodeExprGen(Context &Ctx, Program &P, Tys &&... Args)
+  ByteCodeExprGen(Context &Ctx, Program &P, Tys &&...Args)
       : Emitter(Ctx, P, Args...), Ctx(Ctx), P(P) {}
 
   // Expression visitors - result returned on interp stack.
@@ -241,8 +241,7 @@ private:
                    llvm::function_ref<bool(PrimType)> Direct,
                    llvm::function_ref<bool(PrimType)> Indirect);
   bool dereferenceParam(const Expr *LV, PrimType T, const ParmVarDecl *PD,
-                        DerefKind AK,
-                        llvm::function_ref<bool(PrimType)> Direct,
+                        DerefKind AK, llvm::function_ref<bool(PrimType)> Direct,
                         llvm::function_ref<bool(PrimType)> Indirect);
   bool dereferenceVar(const Expr *LV, PrimType T, const VarDecl *PD,
                       DerefKind AK, llvm::function_ref<bool(PrimType)> Direct,
@@ -400,16 +399,17 @@ public:
     if (!Idx)
       return;
 
-    for (Scope::Local &Local : this->Ctx->Descriptors[*Idx]) {
+    for (const Scope::Local &Local : this->Ctx->Descriptors[*Idx]) {
       removeIfStoredOpaqueValue(Local);
     }
   }
 
   void removeIfStoredOpaqueValue(const Scope::Local &Local) {
     if (auto *OVE =
-            llvm::dyn_cast_or_null<OpaqueValueExpr>(Local.Desc->asExpr());
-        OVE && this->Ctx->OpaqueExprs.contains(OVE)) {
-      this->Ctx->OpaqueExprs.erase(OVE);
+            llvm::dyn_cast_if_present<OpaqueValueExpr>(Local.Desc->asExpr())) {
+      if (auto it = this->Ctx->OpaqueExprs.find(OVE);
+          it != this->Ctx->OpaqueExprs.end())
+        this->Ctx->OpaqueExprs.erase(it);
     };
   }
 

--- a/clang/lib/AST/Interp/ByteCodeExprGen.h
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.h
@@ -54,7 +54,7 @@ protected:
 public:
   /// Initializes the compiler and the backend emitter.
   template <typename... Tys>
-  ByteCodeExprGen(Context &Ctx, Program &P, Tys &&...Args)
+  ByteCodeExprGen(Context &Ctx, Program &P, Tys &&... Args)
       : Emitter(Ctx, P, Args...), Ctx(Ctx), P(P) {}
 
   // Expression visitors - result returned on interp stack.
@@ -241,7 +241,8 @@ private:
                    llvm::function_ref<bool(PrimType)> Direct,
                    llvm::function_ref<bool(PrimType)> Indirect);
   bool dereferenceParam(const Expr *LV, PrimType T, const ParmVarDecl *PD,
-                        DerefKind AK, llvm::function_ref<bool(PrimType)> Direct,
+                        DerefKind AK,
+                        llvm::function_ref<bool(PrimType)> Direct,
                         llvm::function_ref<bool(PrimType)> Indirect);
   bool dereferenceVar(const Expr *LV, PrimType T, const VarDecl *PD,
                       DerefKind AK, llvm::function_ref<bool(PrimType)> Direct,


### PR DESCRIPTION
This patch removes the two `FIXME`s that were added with patches related to the expression mentioned in the title.