### PR TITLE
[lldb][AArch64] Correct type of 32 bit GPR RegisterValues when using core files

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
@@ -184,11 +184,9 @@ bool RegisterContextCorePOSIX_arm64::ReadRegister(const RegisterInfo *reg_info,
 
   offset = reg_info->byte_offset;
   if (offset + reg_info->byte_size <= GetGPRSize()) {
-    uint64_t v = m_gpr_data.GetMaxU64(&offset, reg_info->byte_size);
-    if (offset == reg_info->byte_offset + reg_info->byte_size) {
-      value = v;
-      return true;
-    }
+    value.SetFromMemoryData(*reg_info, m_gpr_data.GetDataStart() + offset,
+                            reg_info->byte_size, lldb::eByteOrderLittle, error);
+    return error.Success();
   }
 
   const uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];


### PR DESCRIPTION
As ReadRegister always read into a uint64_t, when it called operator= with uint64_t it was setting the RegisterValue's type to eTypeUInt64 regardless of its size.

This mostly works because most registers are 64 bit, and very few bits of code rely on the type being correct. However, cpsr, fpsr and fpcr are in fact 32 bit, and my upcoming register fields code relies on this type being correct.

Which is how I found this bug and unfortunately is the only way to test it. As RegisterValue::Type never makes it out via the API anywhere. So this change will be tested once I start adding register field information.