### PR TITLE
[Driver] Add `--` to some test clang-cl command lines.

### DIFF
--- a/clang/test/Driver/cl-offload.cu
+++ b/clang/test/Driver/cl-offload.cu
@@ -1,15 +1,14 @@
-// REQUIRES: !system-darwin
 // REQUIRES: !system-solaris
 
 // The test cannot be run on Darwin because /Users will be treated as a MSVC option.
 
 // RUN: %clang_cl -### -target x86_64-pc-windows-msvc --offload-arch=sm_35 -fgpu-rdc \
 // RUN:   --cuda-path=%S/Inputs/CUDA/usr/local/cuda \
-// RUN:   /Wall -x cuda %s 2>&1 \
+// RUN:   /Wall -x cuda -- %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=CUDA
 
 // RUN: %clang_cl -### -target x86_64-pc-windows-msvc --offload-arch=gfx1010 -fgpu-rdc --hip-link \
-// RUN:   --rocm-path=%S/Inputs/rocm /Wall -x hip %s 2>&1 \
+// RUN:   --rocm-path=%S/Inputs/rocm /Wall -x hip -- %s 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=HIP
 
 // CUDA: "-cc1" "-triple" "nvptx64-nvidia-cuda" "-aux-triple" "x86_64-pc-windows-msvc"


### PR DESCRIPTION
If clang/test/Driver/cl-offload.cu is run on Unix in a directory whose absolute pathname starts with `/w`, such as the `/workspace` used by at least some Jenkins CI setups, then the file name on the clang command line is misinterpreted as some kind of MSVC warning-control option, and ignored by the catch-all `_SLASH_w` option in Options.td.

Other clang-cl tests take care to put a `--` before the input file name, to force clang to treat it as a filename even if it starts with a / and accidentally looks like a cl option. Do the same here.