### PR TITLE
[analyzer] Improve diagnostics from ArrayBoundCheckerV2

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -279,7 +279,7 @@ static std::string getTaintMsg(std::string RegName) {
   SmallString<128> Buf;
   llvm::raw_svector_ostream Out(Buf);
   Out << "Access of " << RegName
-      << " with a tainted offset that may be out of bounds";
+      << " with a tainted offset that may be too large";
   return std::string(Buf);
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -279,7 +279,7 @@ static std::string getTaintMsg(std::string RegName) {
   SmallString<128> Buf;
   llvm::raw_svector_ostream Out(Buf);
   Out << "Access of " << RegName
-      << " with a tainted offset that may be too large";
+      << " with a tainted offset that may be out of bounds";
   return std::string(Buf);
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -177,15 +177,13 @@ compareValueToThreshold(ProgramStateRef State, NonLoc Value, NonLoc Threshold,
 }
 
 static std::string getRegionName(const SubRegion *Region) {
-  std::string RegName = Region->getDescriptiveName();
-  if (!RegName.empty())
+  if (std::string RegName = Region->getDescriptiveName(); !RegName.empty())
     return RegName;
 
   // Field regions only have descriptive names when their parent has a
   // descriptive name; so we provide a fallback representation for them:
   if (const auto *FR = Region->getAs<FieldRegion>()) {
-    StringRef Name = FR->getDecl()->getName();
-    if (!Name.empty())
+    if (StringRef Name = FR->getDecl()->getName(); !Name.empty())
       return formatv("the field '{0}'", Name);
     return "the unnamed field";
   }
@@ -205,18 +203,17 @@ static std::string getRegionName(const SubRegion *Region) {
 
 static std::optional<int64_t> getConcreteValue(NonLoc SV) {
   if (auto ConcreteVal = SV.getAs<nonloc::ConcreteInt>()) {
-    const llvm::APSInt &IntVal = ConcreteVal->getValue();
-    return IntVal.tryExtValue();
+    return ConcreteVal->getValue().tryExtValue();
   }
   return std::nullopt;
 }
 
-static const char *ShortMsgTemplates[] = {
-    "Out of bound access to memory preceding {0}",
-    "Out of bound access to memory after the end of {0}",
-    "Potential out of bound access to {0} with tainted offset"};
-
 static std::string getShortMsg(OOB_Kind Kind, std::string RegName) {
+  static const char *ShortMsgTemplates[] = {
+      "Out of bound access to memory preceding {0}",
+      "Out of bound access to memory after the end of {0}",
+      "Potential out of bound access to {0} with tainted offset"};
+
   return formatv(ShortMsgTemplates[Kind], RegName);
 }
 

--- a/clang/test/Analysis/out-of-bounds-diagnostics.c
+++ b/clang/test/Analysis/out-of-bounds-diagnostics.c
@@ -1,0 +1,149 @@
+// RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-output=text        \
+// RUN:     -analyzer-checker=core,alpha.security.ArrayBoundV2,unix.Malloc,alpha.security.taint -verify %s
+
+int array[10];
+
+void arrayUnderflow(void) {
+  array[-3] = 5;
+  // expected-warning@-1 {{Out of bound access to memory preceding 'array'}}
+  // expected-note@-2 {{Access of 'array' at negative byte offset -12}}
+}
+
+int scanf(const char *restrict fmt, ...);
+
+void taintedIndex(void) {
+  int index;
+  scanf("%d", &index);
+  // expected-note@-1 {{Taint originated here}}
+  // expected-note@-2 {{Taint propagated to the 2nd argument}}
+  array[index] = 5;
+  // expected-warning@-1 {{Potential out of bound access to 'array' with tainted offset}}
+  // expected-note@-2 {{Access of 'array' with a tainted offset that may be too large}}
+}
+
+void arrayOverflow(void) {
+  array[12] = 5;
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'array'}}
+  // expected-note@-2 {{Access of 'array' at index 12, while it holds only 10 'int' elements}}
+}
+
+int scalar;
+int scalarOverflow(void) {
+  return (&scalar)[1];
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'scalar'}}
+  // expected-note@-2 {{Access of 'scalar' at index 1, while it holds only a single 'int' element}}
+}
+
+int oneElementArray[1];
+int oneElementArrayOverflow(void) {
+  return oneElementArray[1];
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'oneElementArray'}}
+  // expected-note@-2 {{Access of 'oneElementArray' at index 1, while it holds only a single 'int' element}}
+}
+
+short convertedArray(void) {
+  return ((short*)array)[47];
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'array'}}
+  // expected-note@-2 {{Access of 'array' at index 47, while it holds only 20 'short' elements}}
+}
+
+struct vec {
+  int len;
+  double elems[64];
+} v;
+
+double arrayInStruct(void) {
+  return v.elems[64];
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'v.elems'}}
+  // expected-note@-2 {{Access of 'v.elems' at index 64, while it holds only 64 'double' elements}}
+}
+
+double arrayInStructPtr(struct vec *pv) {
+  return pv->elems[64];
+  // expected-warning@-1 {{Out of bound access to memory after the end of the field 'elems'}}
+  // expected-note@-2 {{Access of the field 'elems' at index 64, while it holds only 64 'double' elements}}
+}
+
+struct two_bytes {
+  char lo, hi;
+};
+
+struct two_bytes convertedArray2(void) {
+  // We report this with byte offsets because the offset is not divisible by the element size.
+  struct two_bytes a = {0, 0};
+  char *p = (char*)&a;
+  return *((struct two_bytes*)(p + 7));
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'a'}}
+  // expected-note@-2 {{Access of 'a' at byte offset 7, while it holds only 2 bytes}}
+}
+
+int intFromString(void) {
+  // We report this with byte offsets because the extent is not divisible by the element size.
+  return ((const int*)"this is a string of 33 characters")[20];
+  // expected-warning@-1 {{Out of bound access to memory after the end of the string literal}}
+  // expected-note@-2 {{Access of the string literal at byte offset 80, while it holds only 34 bytes}}
+}
+
+int intFromStringDivisible(void) {
+  // However, this is reported with indices/elements, because the extent happens to be a multiple of 4.
+  return ((const int*)"abc")[20];
+  // expected-warning@-1 {{Out of bound access to memory after the end of the string literal}}
+  // expected-note@-2 {{Access of the string literal at index 20, while it holds only a single 'int' element}}
+}
+
+typedef __typeof(sizeof(int)) size_t;
+void *malloc(size_t size);
+
+int *mallocRegion(void) {
+  int *mem = (int*)malloc(2*sizeof(int));
+  mem[3] = -2;
+  // expected-warning@-1 {{Out of bound access to memory after the end of the heap area}}
+  // expected-note@-2 {{Access of the heap area at index 3, while it holds only 2 'int' elements}}
+  return mem;
+}
+
+void *alloca(size_t size);
+
+int allocaRegion(void) {
+  int *mem = (int*)alloca(2*sizeof(int));
+  mem[3] = -2;
+  // expected-warning@-1 {{Out of bound access to memory after the end of the heap area}}
+  // expected-note@-2 {{Access of the heap area at index 3, while it holds only 2 'int' elements}}
+  // FIXME: this should be
+  //   {{Out of bound access to memory after the end of the memory returned by 'alloca'}}
+  //   {{Access of the memory returned by 'alloca' at index 3, while it holds only 2 'int' elements}}
+  // but apparently something models 'alloca' as if it was allocating on the heap
+  return *mem;
+}
+
+int *unknownExtent(int arg) {
+  if (arg >= 2)
+    return 0;
+  int *mem = (int*)malloc(arg);
+  mem[8] = -2;
+  // FIXME: this should produce
+  //   {{Out of bound access to memory after the end of the heap area}}
+  //   {{Access of 'int' element in the heap area at index 8}}
+  return mem;
+}
+
+void unknownIndex(int arg) {
+  // expected-note@+2 {{Assuming 'arg' is >= 12}}
+  // expected-note@+1 {{Taking true branch}}
+  if (arg >= 12)
+    array[arg] = -2;
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'array'}}
+  // expected-note@-2 {{Access of 'array' at an overflowing index, while it holds only 10 'int' elements}}
+}
+
+int *nothingIsCertain(int x, int y) {
+  if (x >= 2)
+    return 0;
+  int *mem = (int*)malloc(x);
+  if (y >= 8)
+    mem[y] = -2;
+  // FIXME: this should produce
+  //   {{Out of bound access to memory after the end of the heap area}}
+  //   {{Access of 'int' element in the heap area at an overflowing index}}
+  return mem;
+}

--- a/clang/test/Analysis/out-of-bounds-diagnostics.c
+++ b/clang/test/Analysis/out-of-bounds-diagnostics.c
@@ -18,7 +18,7 @@ void taintedIndex(void) {
   // expected-note@-2 {{Taint propagated to the 2nd argument}}
   array[index] = 5;
   // expected-warning@-1 {{Potential out of bound access to 'array' with tainted offset}}
-  // expected-note@-2 {{Access of 'array' with a tainted offset that may be too large}}
+  // expected-note@-2 {{Access of 'array' with a tainted offset that may be out of bounds}}
 }
 
 void arrayOverflow(void) {

--- a/clang/test/Analysis/out-of-bounds-diagnostics.c
+++ b/clang/test/Analysis/out-of-bounds-diagnostics.c
@@ -18,7 +18,7 @@ void taintedIndex(void) {
   // expected-note@-2 {{Taint propagated to the 2nd argument}}
   array[index] = 5;
   // expected-warning@-1 {{Potential out of bound access to 'array' with tainted offset}}
-  // expected-note@-2 {{Access of 'array' with a tainted offset that may be out of bounds}}
+  // expected-note@-2 {{Access of 'array' with a tainted offset that may be too large}}
 }
 
 void arrayOverflow(void) {

--- a/clang/test/Analysis/out-of-bounds-new.cpp
+++ b/clang/test/Analysis/out-of-bounds-new.cpp
@@ -5,7 +5,7 @@
 // - constant integer size for buffer
 void test1(int x) {
   int *buf = new int[100];
-  buf[100] = 1; // expected-warning{{Out of bound memory access}}
+  buf[100] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ok(int x) {
@@ -20,7 +20,7 @@ void test1_ok(int x) {
 void test1_ptr(int x) {
   int *buf = new int[100];
   int *p = buf;
-  p[101] = 1; // expected-warning{{Out of bound memory access}}
+  p[101] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ptr_ok(int x) {
@@ -37,7 +37,7 @@ void test1_ptr_arith(int x) {
   int *buf = new int[100];
   int *p = buf;
   p = p + 100;
-  p[0] = 1; // expected-warning{{Out of bound memory access}}
+  p[0] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ptr_arith_ok(int x) {
@@ -51,7 +51,7 @@ void test1_ptr_arith_bad(int x) {
   int *buf = new int[100];
   int *p = buf;
   p = p + 99;
-  p[1] = 1; // expected-warning{{Out of bound memory access}}
+  p[1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ptr_arith_ok2(int x) {
@@ -66,7 +66,7 @@ void test1_ptr_arith_ok2(int x) {
 // - constant integer size for buffer
 void test2(int x) {
   int *buf = new int[100];
-  buf[-1] = 1; // expected-warning{{Out of bound memory access}}
+  buf[-1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests doing an out-of-bounds access before the start of an array using:
@@ -76,7 +76,7 @@ void test2(int x) {
 void test2_ptr(int x) {
   int *buf = new int[100];
   int *p = buf;
-  p[-1] = 1; // expected-warning{{Out of bound memory access}}
+  p[-1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests doing an out-of-bounds access before the start of an array using:
@@ -87,35 +87,35 @@ void test2_ptr_arith(int x) {
   int *buf = new int[100];
   int *p = buf;
   --p;
-  p[0] = 1; // expected-warning {{Out of bound memory access (accessed memory precedes memory block)}}
+  p[0] = 1; // expected-warning {{Out of bound access to memory preceding}}
 }
 
 // Tests under-indexing
 // of a multi-dimensional array
 void test2_multi(int x) {
   auto buf = new int[100][100];
-  buf[0][-1] = 1; // expected-warning{{Out of bound memory access}}
+  buf[0][-1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests under-indexing
 // of a multi-dimensional array
 void test2_multi_b(int x) {
   auto buf = new int[100][100];
-  buf[-1][0] = 1; // expected-warning{{Out of bound memory access}}
+  buf[-1][0] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests over-indexing
 // of a multi-dimensional array
 void test2_multi_c(int x) {
   auto buf = new int[100][100];
-  buf[100][0] = 1; // expected-warning{{Out of bound memory access}}
+  buf[100][0] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests over-indexing
 // of a multi-dimensional array
 void test2_multi_2(int x) {
   auto buf = new int[100][100];
-  buf[99][100] = 1; // expected-warning{{Out of bound memory access}}
+  buf[99][100] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests normal access of
@@ -131,7 +131,7 @@ void test_diff_types(int x) {
   int *buf = new int[10]; //10*sizeof(int) Bytes allocated
   char *cptr = (char *)buf;
   cptr[sizeof(int) * 9] = 1;  // no-warning
-  cptr[sizeof(int) * 10] = 1; // expected-warning{{Out of bound memory access}}
+  cptr[sizeof(int) * 10] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests over-indexing
@@ -139,7 +139,7 @@ void test_diff_types(int x) {
 void test_non_array(int x) {
   int *ip = new int;
   ip[0] = 1; // no-warning
-  ip[1] = 2; // expected-warning{{Out of bound memory access}}
+  ip[1] = 2; // expected-warning{{Out of bound access to memory}}
 }
 
 //Tests over-indexing

--- a/clang/test/Analysis/out-of-bounds.c
+++ b/clang/test/Analysis/out-of-bounds.c
@@ -7,7 +7,7 @@ void clang_analyzer_eval(int);
 // - constant integer size for buffer
 void test1(int x) {
   int buf[100];
-  buf[100] = 1; // expected-warning{{Out of bound memory access}}
+  buf[100] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ok(int x) {
@@ -17,12 +17,12 @@ void test1_ok(int x) {
 
 const char test1_strings_underrun(int x) {
   const char *mystr = "mary had a little lamb";
-  return mystr[-1]; // expected-warning{{Out of bound memory access}}
+  return mystr[-1]; // expected-warning{{Out of bound access to memory}}
 }
 
 const char test1_strings_overrun(int x) {
   const char *mystr = "mary had a little lamb";
-  return mystr[1000];  // expected-warning{{Out of bound memory access}}
+  return mystr[1000];  // expected-warning{{Out of bound access to memory}}
 }
 
 const char test1_strings_ok(int x) {
@@ -37,7 +37,7 @@ const char test1_strings_ok(int x) {
 void test1_ptr(int x) {
   int buf[100];
   int *p = buf;
-  p[101] = 1; // expected-warning{{Out of bound memory access}}
+  p[101] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ptr_ok(int x) {
@@ -54,7 +54,7 @@ void test1_ptr_arith(int x) {
   int buf[100];
   int *p = buf;
   p = p + 100;
-  p[0] = 1; // expected-warning{{Out of bound memory access}}
+  p[0] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ptr_arith_ok(int x) {
@@ -68,7 +68,7 @@ void test1_ptr_arith_bad(int x) {
   int buf[100];
   int *p = buf;
   p = p + 99;
-  p[1] = 1; // expected-warning{{Out of bound memory access}}
+  p[1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test1_ptr_arith_ok2(int x) {
@@ -83,7 +83,7 @@ void test1_ptr_arith_ok2(int x) {
 // - constant integer size for buffer
 void test2(int x) {
   int buf[100];
-  buf[-1] = 1; // expected-warning{{Out of bound memory access}}
+  buf[-1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests doing an out-of-bounds access before the start of an array using:
@@ -93,7 +93,7 @@ void test2(int x) {
 void test2_ptr(int x) {
   int buf[100];
   int *p = buf;
-  p[-1] = 1; // expected-warning{{Out of bound memory access}}
+  p[-1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests doing an out-of-bounds access before the start of an array using:
@@ -104,7 +104,7 @@ void test2_ptr_arith(int x) {
   int buf[100];
   int *p = buf;
   --p;
-  p[0] = 1; // expected-warning {{Out of bound memory access (accessed memory precedes memory block)}}
+  p[0] = 1; // expected-warning {{Out of bound access to memory preceding}}
 }
 
 // Tests doing an out-of-bounds access before the start of a multi-dimensional
@@ -113,7 +113,7 @@ void test2_ptr_arith(int x) {
 // - constant integer sizes for the array
 void test2_multi(int x) {
   int buf[100][100];
-  buf[0][-1] = 1; // expected-warning{{Out of bound memory access}}
+  buf[0][-1] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 // Tests doing an out-of-bounds access before the start of a multi-dimensional
@@ -122,7 +122,7 @@ void test2_multi(int x) {
 // - constant integer sizes for the array
 void test2_multi_b(int x) {
   int buf[100][100];
-  buf[-1][0] = 1; // expected-warning{{Out of bound memory access}}
+  buf[-1][0] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test2_multi_ok(int x) {
@@ -133,13 +133,13 @@ void test2_multi_ok(int x) {
 void test3(int x) {
   int buf[100];
   if (x < 0)
-    buf[x] = 1; // expected-warning{{Out of bound memory access}}
+    buf[x] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test4(int x) {
   int buf[100];
   if (x > 99)
-    buf[x] = 1; // expected-warning{{Out of bound memory access}}
+    buf[x] = 1; // expected-warning{{Out of bound access to memory}}
 }
 
 void test_assume_after_access(unsigned long x) {
@@ -165,7 +165,7 @@ typedef struct {
 user_t *get_symbolic_user(void);
 char test_underflow_symbolic_2() {
   user_t *user = get_symbolic_user();
-  return user->name[-1]; // expected-warning{{Out of bound memory access}}
+  return user->name[-1]; // expected-warning{{Out of bound access to memory}}
 }
 
 void test_incomplete_struct(void) {

--- a/clang/test/Analysis/taint-diagnostic-visitor.c
+++ b/clang/test/Analysis/taint-diagnostic-visitor.c
@@ -29,8 +29,8 @@ int taintDiagnosticOutOfBound(void) {
   int Array[] = {1, 2, 3, 4, 5};
   scanf("%d", &index); // expected-note {{Taint originated here}}
                        // expected-note@-1 {{Taint propagated to the 2nd argument}}
-  return Array[index]; // expected-warning {{Out of bound memory access (index is tainted)}}
-                       // expected-note@-1 {{Out of bound memory access (index is tainted)}}
+  return Array[index]; // expected-warning {{Potential out of bound access to 'Array' with tainted offset}}
+                       // expected-note@-1 {{Access of 'Array' with a tainted offset that may be too large}}
 }
 
 int taintDiagnosticDivZero(int operand) {

--- a/clang/test/Analysis/taint-diagnostic-visitor.c
+++ b/clang/test/Analysis/taint-diagnostic-visitor.c
@@ -30,7 +30,7 @@ int taintDiagnosticOutOfBound(void) {
   scanf("%d", &index); // expected-note {{Taint originated here}}
                        // expected-note@-1 {{Taint propagated to the 2nd argument}}
   return Array[index]; // expected-warning {{Potential out of bound access to 'Array' with tainted offset}}
-                       // expected-note@-1 {{Access of 'Array' with a tainted offset that may be too large}}
+                       // expected-note@-1 {{Access of 'Array' with a tainted offset that may be out of bounds}}
 }
 
 int taintDiagnosticDivZero(int operand) {

--- a/clang/test/Analysis/taint-diagnostic-visitor.c
+++ b/clang/test/Analysis/taint-diagnostic-visitor.c
@@ -30,7 +30,7 @@ int taintDiagnosticOutOfBound(void) {
   scanf("%d", &index); // expected-note {{Taint originated here}}
                        // expected-note@-1 {{Taint propagated to the 2nd argument}}
   return Array[index]; // expected-warning {{Potential out of bound access to 'Array' with tainted offset}}
-                       // expected-note@-1 {{Access of 'Array' with a tainted offset that may be out of bounds}}
+                       // expected-note@-1 {{Access of 'Array' with a tainted offset that may be too large}}
 }
 
 int taintDiagnosticDivZero(int operand) {

--- a/clang/test/Analysis/taint-generic.c
+++ b/clang/test/Analysis/taint-generic.c
@@ -169,21 +169,21 @@ void bufferScanfDirect(void)
 {
   int n;
   scanf("%d", &n);
-  Buffer[n] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[n] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void bufferScanfArithmetic1(int x) {
   int n;
   scanf("%d", &n);
   int m = (n - 3);
-  Buffer[m] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[m] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void bufferScanfArithmetic2(int x) {
   int n;
   scanf("%d", &n);
   int m = 100 - (n + 3) * x;
-  Buffer[m] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[m] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void bufferScanfAssignment(int x) {
@@ -192,7 +192,7 @@ void bufferScanfAssignment(int x) {
   int m;
   if (x > 0) {
     m = n;
-    Buffer[m] = 1; // expected-warning {{Out of bound memory access }}
+    Buffer[m] = 1; // expected-warning {{Potential out of bound access }}
   }
 }
 
@@ -203,7 +203,7 @@ void scanfArg(void) {
 
 void bufferGetchar(int x) {
   int m = getchar();
-  Buffer[m] = 1;  //expected-warning {{Out of bound memory access (index is tainted)}}
+  Buffer[m] = 1;  //expected-warning {{Potential out of bound access}}
 }
 
 extern const unsigned short int **__ctype_b_loc (void);
@@ -216,7 +216,7 @@ int isdigitImplFalsePositive(void) {
   // macros in ctypes.h.
   int c = getchar();
   return ((*__ctype_b_loc ())[(int) (c)] & (unsigned short int) _ISdigit);
-  //expected-warning@-1 {{Out of bound memory access (index is tainted)}}
+  //expected-warning@-1 {{Potential out of bound access}}
 }
 
 int isdigitSuppressed(void) {
@@ -1113,26 +1113,26 @@ void mySink(int, int, int);
 
 void testConfigurationSources1(void) {
   int x = mySource1();
-  Buffer[x] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[x] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationSources2(void) {
   int x;
   mySource2(&x);
-  Buffer[x] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[x] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationSources3(void) {
   int x, y;
   myScanf("%d %d", &x, &y);
-  Buffer[y] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[y] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationPropagation(void) {
   int x = mySource1();
   int y;
   myPropagator(x, &y);
-  Buffer[y] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[y] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationFilter(void) {

--- a/clang/test/Analysis/taint-generic.cpp
+++ b/clang/test/Analysis/taint-generic.cpp
@@ -46,7 +46,7 @@ void testConfigurationNamespacePropagation1() {
   Buffer[x] = 1; // no-warning
 
   scanf("%d", &x);
-  Buffer[x] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[x] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationNamespacePropagation2() {
@@ -54,19 +54,19 @@ void testConfigurationNamespacePropagation2() {
   Buffer[x] = 1; // no-warning
 
   int y = myNamespace::mySource3();
-  Buffer[y] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[y] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationNamespacePropagation3() {
   int x = myAnotherNamespace::mySource3();
-  Buffer[x] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[x] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationNamespacePropagation4() {
   int x;
   // Configured functions without scope should match for all function.
   myNamespace::myScanf("%d", &x);
-  Buffer[x] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[x] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationNamespaceFilter1() {
@@ -78,7 +78,7 @@ void testConfigurationNamespaceFilter1() {
   int y = mySource1();
   if (isOutOfRange2(&y))
     return;
-  Buffer[y] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[y] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testConfigurationNamespaceFilter2() {
@@ -128,11 +128,11 @@ void testConfigurationMemberFunc() {
   Buffer[x] = 1; // no-warning
 
   foo.myMemberScanf("%d", &x);
-  Buffer[x] = 1; // expected-warning {{Out of bound memory access }}
+  Buffer[x] = 1; // expected-warning {{Potential out of bound access }}
 }
 
 void testReadingFromStdin(char **p) {
   int n;
   fscanf(stdin, "%d", &n);
-  Buffer[n] = 1; // expected-warning {{Out of bound memory access (index is tainted)}}
+  Buffer[n] = 1; // expected-warning {{Potential out of bound access }}
 }


### PR DESCRIPTION
Previously alpha.security.ArrayBoundV2 produced very spartan bug reports; this commit ensures that the relevant (and known) details are reported to the user.

The logic for detecting bugs is not changed, after this commit the checker will report the same set of issues, but with better messages.

To test the details of the message generation this commit adds a new test file 'out-of-bounds-diagnostics.c'. Three of the testcases are added with FIXME notes because they reveal shortcomings of the existing modeling and bounds checking code. I will try to fix them in separate follow-up commits.