### PR TITLE
[builtins] Fix floattitf.c etc. compilation on Solaris/SPARC

### DIFF
--- a/compiler-rt/lib/builtins/floattitf.c
+++ b/compiler-rt/lib/builtins/floattitf.c
@@ -16,6 +16,7 @@
 #include "fp_lib.h"
 #include "int_lib.h"
 
+#if defined(CRT_HAS_TF_MODE)
 #define SRC_I128
 #define DST_QUAD
 #include "int_to_fp_impl.inc"
@@ -29,7 +30,6 @@
 // mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
 // mmmm mmmm mmmm
 
-#if defined(CRT_HAS_TF_MODE)
 COMPILER_RT_ABI fp_t __floattitf(ti_int a) { return __floatXiYf__(a); }
 
 #endif

--- a/compiler-rt/lib/builtins/floatuntitf.c
+++ b/compiler-rt/lib/builtins/floatuntitf.c
@@ -16,6 +16,7 @@
 #include "fp_lib.h"
 #include "int_lib.h"
 
+#if defined(CRT_HAS_TF_MODE)
 #define SRC_U128
 #define DST_QUAD
 #include "int_to_fp_impl.inc"
@@ -29,7 +30,6 @@
 // mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
 // mmmm mmmm mmmm
 
-#if defined(CRT_HAS_TF_MODE)
 COMPILER_RT_ABI fp_t __floatuntitf(tu_int a) { return __floatXiYf__(a); }
 
 #endif


### PR DESCRIPTION
69660ccf2ae402b02799efed072afd8ecf5a6eb0 broke the [Solaris/sparcv9 buildbot](https://lab.llvm.org/staging/#/builders/12/builds/264): `compiler-rt/lib/builtins/int_to_fp.h` unconditionally uses `*int128_t` which don't exist on 32-bit SPARC.

As suggested in https://github.com/llvm/llvm-project/pull/67540, this patch fixes this by moving the `CRT_HAS_TF_MODE` guard up which does the necessary checks.

Tested on `sparcv9-sun-solaris2.11`.