### PR TITLE
[lldb][gardening] Remove full name of "DWARFDIE" type in GetTypeForDIE

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParser.h
@@ -64,8 +64,7 @@ public:
   ParseChildArrayInfo(const DWARFDIE &parent_die,
                       const ExecutionContext *exe_ctx = nullptr);
 
-  lldb_private::Type *
-  GetTypeForDIE(const lldb_private::plugin::dwarf::DWARFDIE &die);
+  lldb_private::Type *GetTypeForDIE(const DWARFDIE &die);
 
   static lldb::AccessType GetAccessTypeFromDWARF(uint32_t dwarf_accessibility);
 


### PR DESCRIPTION
When moving the GetTypeForDIE function from DWARFASTParserClang to DWARFASTParser, I kept the signature as-is. To match the rest of the function signatures in DWARFASTParser, remove the full name (lldb_private::plugin::dwarf::DWARFDIE -> DWARFDIE) in the signature of DWARFASTParser::GetTypeForDIE.