### PR TITLE
[flang][openacc] Support single array element in data clause

### DIFF
--- a/flang/lib/Lower/DirectivesCommon.h
+++ b/flang/lib/Lower/DirectivesCommon.h
@@ -898,9 +898,17 @@ mlir::Value gatherDataOperandAddrAndBounds(
                       builder, operandLocation, converter, compExv, baseAddr);
                 }
               } else {
-                // Scalar or full array.
-                if (const auto *dataRef{
-                        std::get_if<Fortran::parser::DataRef>(&designator.u)}) {
+                if (Fortran::parser::Unwrap<Fortran::parser::ArrayElement>(
+                        designator)) {
+                  // Single array element.
+                  fir::ExtendedValue compExv =
+                      converter.genExprAddr(operandLocation, *expr, stmtCtx);
+                  baseAddr = fir::getBase(compExv);
+                  asFortran << (*expr).AsFortran();
+                } else if (const auto *dataRef{
+                               std::get_if<Fortran::parser::DataRef>(
+                                   &designator.u)}) {
+                  // Scalar or full array.
                   const Fortran::parser::Name &name =
                       Fortran::parser::GetLastName(*dataRef);
                   fir::ExtendedValue dataExv =

--- a/flang/test/Lower/OpenACC/acc-enter-data.f90
+++ b/flang/test/Lower/OpenACC/acc-enter-data.f90
@@ -803,3 +803,17 @@ subroutine acc_enter_data_derived_type()
 !CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<!fir.array<10xf32>>)
 
 end subroutine
+
+subroutine acc_enter_data_single_array_element()
+  type t1
+    real, allocatable :: a(:, :)
+  end type t1
+  type(t1), allocatable :: e(:)
+  allocate(e(10)%a(5,5))
+
+  !$acc enter data create(e(2)%a(1,2))
+
+!CHECK: %[[CREATE:.*]] = acc.create varPtr(%{{.*}} : !fir.ref<f32>) -> !fir.ref<f32> {name = "e(2_8)%a(1_8,2_8)", structured = false}
+!CHECK: acc.enter_data dataOperands(%[[CREATE]] : !fir.ref<f32>)
+
+end subroutine


### PR DESCRIPTION
`gatherDataOperandAddrAndBounds` was crashing when a single array element  was passed in a data clause. This patch fixes the issue. 