### PR TITLE
[DAGCombiner] Fix misuse of getZeroExtendInReg in SimplifySelectCC.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -27274,10 +27274,7 @@ SDValue DAGCombiner::SimplifySelectCC(const SDLoc &DL, SDValue N0, SDValue N1,
     // zext (setcc n0, n1)
     if (LegalTypes) {
       SCC = DAG.getSetCC(DL, CmpResVT, N0, N1, CC);
-      if (VT.bitsLT(SCC.getValueType()))
-        Temp = DAG.getZeroExtendInReg(SCC, SDLoc(N2), VT);
-      else
-        Temp = DAG.getNode(ISD::ZERO_EXTEND, SDLoc(N2), VT, SCC);
+      Temp = DAG.getZExtOrTrunc(SCC, SDLoc(N2), VT);
     } else {
       SCC = DAG.getSetCC(SDLoc(N0), MVT::i1, N0, N1, CC);
       Temp = DAG.getNode(ISD::ZERO_EXTEND, SDLoc(N2), VT, SCC);


### PR DESCRIPTION
If VT has less bits than SCC, using a ZeroExtendInReg isn't going to fix it. That's an AND instruction. We need to truncate the value instead.

This should be ok because we already checked that the boolean contents is ZeroOrOne so the setcc can only produce 0 or 1.

No test because I found this while trying to make i32 legal for RISC-V 64 which I'm not ready to upload yet. You can see in the coverage report that this line isn't tested today.

https://lab.llvm.org/coverage/coverage-reports/coverage/Users/buildslave/jenkins/workspace/coverage/llvm-project/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp.html#L27270