### PR TITLE
[OpenMP][Archer] Do not check for column numbers in backtraces

### DIFF
--- a/openmp/tools/archer/tests/races/taskwait-depend.c
+++ b/openmp/tools/archer/tests/races/taskwait-depend.c
@@ -53,7 +53,7 @@ int main() {
 
 // CHECK: WARNING: ThreadSanitizer: data race
 // CHECK-NEXT:   {{(Write|Read)}} of size 4
-// CHECK-NEXT: #0 {{.*}}taskwait-depend.c:42:20
+// CHECK-NEXT: #0 {{.*}}taskwait-depend.c:42
 // CHECK:   Previous write of size 4
-// CHECK-NEXT: #0 {{.*}}taskwait-depend.c:35:6
+// CHECK-NEXT: #0 {{.*}}taskwait-depend.c:35
 // CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings


### PR DESCRIPTION
TSan can show only line numbers on some platforms, e.g., SystemZ. Skip checking the column numbers; line numbers should be enough to verify that race detection is working.