### PR TITLE
[BOLT] Fix build issues after #69836

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -133,7 +133,7 @@ BinaryContext::createBinaryContext(const ObjectFile *File, bool IsPIC,
     Expected<SubtargetFeatures> Features = File->getFeatures();
 
     if (auto E = Features.takeError())
-      return E;
+      return std::move(E);
 
     // We rely on relaxation for some transformations (e.g., promoting all calls
     // to PseudoCALL and then making JITLink relax them). Since the relax


### PR DESCRIPTION
Fix clang build (`return Error => return std::move(Error)`)