### PR TITLE
[Coverage] Fix implicit conversion from int64_t to uint64_t

### DIFF
--- a/compiler-rt/include/profile/InstrProfData.inc
+++ b/compiler-rt/include/profile/InstrProfData.inc
@@ -214,7 +214,7 @@ COVMAP_FUNC_RECORD(const uint32_t, llvm::Type::getInt32Ty(Ctx), NameSize, \
                    NameValue.size()))
 #endif
 #ifdef COVMAP_V2_OR_V3
-COVMAP_FUNC_RECORD(const int64_t, llvm::Type::getInt64Ty(Ctx), NameRef, \
+COVMAP_FUNC_RECORD(const uint64_t, llvm::Type::getInt64Ty(Ctx), NameRef, \
                    llvm::ConstantInt::get( \
                      llvm::Type::getInt64Ty(Ctx), NameHash))
 #endif

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -344,7 +344,7 @@ public:
 
   /// Return the number of times that a region of code associated with this
   /// counter was executed.
-  Expected<int64_t> evaluate(const Counter &C) const;
+  Expected<uint64_t> evaluate(const Counter &C) const;
 
   unsigned getMaxCounterID(const Counter &C) const;
 };

--- a/llvm/include/llvm/ProfileData/InstrProfData.inc
+++ b/llvm/include/llvm/ProfileData/InstrProfData.inc
@@ -214,7 +214,7 @@ COVMAP_FUNC_RECORD(const uint32_t, llvm::Type::getInt32Ty(Ctx), NameSize, \
                    NameValue.size()))
 #endif
 #ifdef COVMAP_V2_OR_V3
-COVMAP_FUNC_RECORD(const int64_t, llvm::Type::getInt64Ty(Ctx), NameRef, \
+COVMAP_FUNC_RECORD(const uint64_t, llvm::Type::getInt64Ty(Ctx), NameRef, \
                    llvm::ConstantInt::get( \
                      llvm::Type::getInt64Ty(Ctx), NameHash))
 #endif


### PR DESCRIPTION
Detected by `-fsanitize=implicit-conversion` .