### PR TITLE
[llvm] Followup fix for "Use XMACROS for MachO platforms"

### DIFF
--- a/llvm/lib/TextAPI/Platform.cpp
+++ b/llvm/lib/TextAPI/Platform.cpp
@@ -76,7 +76,7 @@ PlatformType getPlatformFromName(StringRef Name) {
       .Case("osx", PLATFORM_MACOS)
 #define PLATFORM(platform, id, name, build_name, target, tapi_target,          \
                  marketing)                                                    \
-  .Case(#tapi_target, PLATFORM_##platform)
+  .Case(#target, PLATFORM_##platform)
 #include "llvm/BinaryFormat/MachO.def"
       .Default(PLATFORM_UNKNOWN);
 }

--- a/llvm/unittests/TextAPI/TextStubV4Tests.cpp
+++ b/llvm/unittests/TextAPI/TextStubV4Tests.cpp
@@ -542,6 +542,22 @@ TEST(TBDv4, Target_maccatalyst) {
             stripWhitespace(Buffer.c_str()));
 }
 
+TEST(TBDv4, Target_maccatalyst2) {
+  static const char TBDv4TargetMacCatalyst[] =
+      "--- !tapi-tbd\n"
+      "tbd-version: 4\n"
+      "targets: [  x86_64-maccatalyst ]\n"
+      "install-name: Test.dylib\n"
+      "...\n";
+
+  Expected<TBDFile> Result =
+      TextAPIReader::get(MemoryBufferRef(TBDv4TargetMacCatalyst, "Test.tbd"));
+  EXPECT_TRUE(!!Result);
+  TBDFile File = std::move(Result.get());
+  EXPECT_EQ(File->getPlatforms().size(), 1U);
+  EXPECT_EQ(getPlatformFromName("ios-macabi"), *File->getPlatforms().begin());
+}
+
 TEST(TBDv4, Target_x86_ios) {
   static const char TBDv4Targetx86iOS[] = "--- !tapi-tbd\n"
                                           "tbd-version: 4\n"


### PR DESCRIPTION
Fix the use of tapi_target in getPlatformFromName.
