### PR TITLE
Always use pthread_rwlock on Apple platforms

### DIFF
--- a/llvm/include/llvm/Support/RWMutex.h
+++ b/llvm/include/llvm/Support/RWMutex.h
@@ -19,11 +19,8 @@
 #include <mutex>
 #include <shared_mutex>
 
-// std::shared_timed_mutex is only available on macOS 10.12 and later.
-#if defined(__APPLE__) && defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__)
-#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101200
+#if defined(__APPLE__)
 #define LLVM_USE_RW_MUTEX_IMPL
-#endif
 #endif
 
 namespace llvm {


### PR DESCRIPTION
pthread_rwlock is faster than std::shared_mutex, especially in heavily threaded code such as the Swift compiler.

rdar://117445844