### PR TITLE
[OpenMP 5.2] Deprecate old syntax of linear clause

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1350,6 +1350,8 @@ def warn_omp_extra_tokens_at_eol : Warning<
   InGroup<ExtraTokens>;
 def err_omp_multiple_step_or_linear_modifier : Error<
   "multiple %select{'step size'|'linear modifier'}0 found in linear clause">;
+def err_omp_deprecate_old_syntax: Error<
+  "old syntax '%0' on '%1' clause was deprecated, use new syntax '%2'">;
 def warn_pragma_expected_colon_r_paren : Warning<
   "missing ':' or ')' after %0 - ignoring">, InGroup<IgnoredPragmas>;
 def err_omp_unknown_directive : Error<

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -4573,6 +4573,10 @@ bool Parser::ParseOpenMPVarList(OpenMPDirectiveKind DKind,
       Data.ExtraModifierLoc = ConsumeToken();
       LinearT.consumeOpen();
       NeedRParenForLinear = true;
+      if (getLangOpts().OpenMP >= 52)
+        Diag(Data.ExtraModifierLoc, diag::err_omp_deprecate_old_syntax)
+            << "linear-modifier(list)" << getOpenMPClauseName(Kind)
+            << "linear(list: [linear-modifier,] step(step-size))";
     }
   } else if (Kind == OMPC_lastprivate) {
     // Try to parse modifier if any.

--- a/clang/test/OpenMP/for_ast_print.cpp
+++ b/clang/test/OpenMP/for_ast_print.cpp
@@ -48,7 +48,11 @@ public:
 #pragma omp for lastprivate(a) lastprivate(this->a) lastprivate(T::a)
     for (int k = 0; k < a.a; ++k)
       ++this->a.a;
+#if defined(OMP52)
+#pragma omp for linear(c: val)
+#else
 #pragma omp for linear(val(c))
+#endif
     for (int k = 0; k < a.a; ++k)
       ++this->a.a;
   }
@@ -59,7 +63,11 @@ public:
 #pragma omp for lastprivate(a) lastprivate(this->a)
     for (int k = 0; k < s.a.a; ++k)
       ++s.a.a;
+#if defined(OMP52)
+#pragma omp for linear(this->b: uval)
+#else
 #pragma omp for linear(uval(this->b))
+#endif
     for (int k = 0; k < s.a.a; ++k)
       ++s.a.a;
     return *this;
@@ -87,7 +95,11 @@ public:
 #pragma omp for lastprivate(a) lastprivate(this->a) lastprivate(S7<S>::a)
     for (int k = 0; k < a.a; ++k)
       ++this->a.a;
+#if defined(OMP52)
+#pragma omp for linear(S7<S>::d: ref)
+#else
 #pragma omp for linear(ref(S7<S>::d))
+#endif
     for (int k = 0; k < a.a; ++k)
       ++this->a.a;
   }

--- a/clang/test/OpenMP/for_linear_messages.cpp
+++ b/clang/test/OpenMP/for_linear_messages.cpp
@@ -215,6 +215,8 @@ int main(int argc, char **argv) {
     int i;
     #pragma omp for linear(i)
     for (int k = 0; k < argc; ++k) ++k;
+    #pragma omp for linear(val(i)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
+    for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
     #pragma omp for linear(i : step(4))
 #else

--- a/clang/test/OpenMP/masked_taskloop_simd_linear_messages.cpp
+++ b/clang/test/OpenMP/masked_taskloop_simd_linear_messages.cpp
@@ -131,11 +131,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp masked taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp masked taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp masked taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear () // expected-error {{expected expression}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -143,7 +143,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear (val argc // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp masked taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear (argc > 0 ? argv[1] : argv[2]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -164,11 +164,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}}
+  #pragma omp masked taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear(h, z) // expected-error {{threadprivate or thread local variable cannot be linear}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+  #pragma omp masked taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel
   {
@@ -177,9 +177,9 @@ template<class I, class C> int foomain(I argc, C **argv) {
     #pragma omp masked taskloop simd allocate(omp_thread_mem_alloc: v) linear(v:i) // expected-warning {{allocator with the 'thread' trait access has unspecified behavior on 'masked taskloop simd' directive}}
     for (int k = 0; k < argc; ++k) { i = k; v += i; }
   }
-  #pragma omp masked taskloop simd linear(ref(j))
+  #pragma omp masked taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear(uval(j))
+  #pragma omp masked taskloop simd linear(uval(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   int v = 0;
   #pragma omp masked taskloop simd linear(v:j)
@@ -201,13 +201,13 @@ void linear_modifiers(int argc) {
   int &f = argc;
   #pragma omp masked taskloop simd linear(f)
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear(val(f))
+  #pragma omp masked taskloop simd linear(val(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear(uval(f))
+  #pragma omp masked taskloop simd linear(uval(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear(ref(f))
+  #pragma omp masked taskloop simd linear(ref(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}}
+  #pragma omp masked taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
 }
 
@@ -233,9 +233,9 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear (ref()) // expected-error {{expected expression}}
+  #pragma omp masked taskloop simd linear (ref()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp masked taskloop simd linear (foo()) // expected-error {{expected expression}}
+  #pragma omp masked taskloop simd linear (foo()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear (argc // expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -253,6 +253,7 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp masked taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{argument of a linear clause should be of integral or pointer type, not 'S4'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S5'}}
   #pragma omp masked taskloop simd linear(val(e, g))
@@ -262,12 +263,12 @@ int main(int argc, char **argv) {
   #pragma omp parallel
   {
     int i;
-    #pragma omp masked taskloop simd linear(val(i))
+    #pragma omp masked taskloop simd linear(val(i)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
     for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
     #pragma omp masked taskloop simd linear(i : uval, step(4)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
 #else
-    #pragma omp masked taskloop simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+    #pragma omp masked taskloop simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
     for (int k = 0; k < argc; ++k) { ++k; i += 4; }
   }

--- a/clang/test/OpenMP/master_taskloop_simd_linear_messages.cpp
+++ b/clang/test/OpenMP/master_taskloop_simd_linear_messages.cpp
@@ -131,11 +131,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp master taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp master taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp master taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear () // expected-error {{expected expression}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -143,7 +143,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear (val argc // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp master taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear (argc > 0 ? argv[1] : argv[2]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -157,6 +157,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp master taskloop simd linear (a, b: val, B::ib)
 #else
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{linear variable with incomplete type 'S1'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp master taskloop simd linear (val(a, b):B::ib)
@@ -164,11 +165,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}}
+  #pragma omp master taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear(h, z) // expected-error {{threadprivate or thread local variable cannot be linear}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+  #pragma omp master taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel
   {
@@ -177,9 +178,9 @@ template<class I, class C> int foomain(I argc, C **argv) {
     #pragma omp master taskloop simd allocate(omp_thread_mem_alloc: v) linear(v:i) // expected-warning {{allocator with the 'thread' trait access has unspecified behavior on 'master taskloop simd' directive}}
     for (int k = 0; k < argc; ++k) { i = k; v += i; }
   }
-  #pragma omp master taskloop simd linear(ref(j))
+  #pragma omp master taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear(uval(j))
+  #pragma omp master taskloop simd linear(uval(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   int v = 0;
   #pragma omp master taskloop simd linear(v:j)
@@ -201,13 +202,13 @@ void linear_modifiers(int argc) {
   int &f = argc;
   #pragma omp master taskloop simd linear(f)
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear(val(f))
+  #pragma omp master taskloop simd linear(val(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear(uval(f))
+  #pragma omp master taskloop simd linear(uval(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear(ref(f))
+  #pragma omp master taskloop simd linear(ref(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}}
+  #pragma omp master taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
 }
 
@@ -233,9 +234,9 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear (ref()) // expected-error {{expected expression}}
+  #pragma omp master taskloop simd linear (ref()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp master taskloop simd linear (foo()) // expected-error {{expected expression}}
+  #pragma omp master taskloop simd linear (foo()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear (argc // expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -253,6 +254,7 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp master taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{argument of a linear clause should be of integral or pointer type, not 'S4'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S5'}}
   #pragma omp master taskloop simd linear(val(e, g))
@@ -262,19 +264,19 @@ int main(int argc, char **argv) {
   #pragma omp parallel
   {
     int i;
-    #pragma omp master taskloop simd linear(val(i))
+    #pragma omp master taskloop simd linear(val(i)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
     for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
     #pragma omp master taskloop simd linear(i : uval, step(4)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
 #else
-    #pragma omp master taskloop simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+    #pragma omp master taskloop simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
     for (int k = 0; k < argc; ++k) { ++k; i += 4; }
   }
 #ifdef OMP52
   #pragma omp master taskloop simd linear(j: ref)
 #else  
-  #pragma omp master taskloop simd linear(ref(j))
+  #pragma omp master taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
   for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52

--- a/clang/test/OpenMP/parallel_masked_taskloop_simd_linear_messages.cpp
+++ b/clang/test/OpenMP/parallel_masked_taskloop_simd_linear_messages.cpp
@@ -131,11 +131,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp parallel masked taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp parallel masked taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp parallel masked taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear () // expected-error {{expected expression}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -143,7 +143,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear (val argc // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp parallel masked taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear (argc > 0 ? argv[1] : argv[2]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -157,6 +157,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp parallel masked taskloop simd linear (a, b: val, B::ib)
 #else
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{linear variable with incomplete type 'S1'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp parallel masked taskloop simd linear (val(a, b):B::ib)
@@ -164,11 +165,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}}
+  #pragma omp parallel masked taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear(h, z) // expected-error {{threadprivate or thread local variable cannot be linear}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+  #pragma omp parallel masked taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel
   {
@@ -177,9 +178,9 @@ template<class I, class C> int foomain(I argc, C **argv) {
     #pragma omp parallel masked taskloop simd allocate(omp_thread_mem_alloc: v) linear(v:i) // expected-warning {{allocator with the 'thread' trait access has unspecified behavior on 'parallel masked taskloop simd' directive}}
     for (int k = 0; k < argc; ++k) { i = k; v += i; }
   }
-  #pragma omp parallel masked taskloop simd linear(ref(j))
+  #pragma omp parallel masked taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear(uval(j))
+  #pragma omp parallel masked taskloop simd linear(uval(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   int v = 0;
   #pragma omp parallel masked taskloop simd linear(v:j)
@@ -201,13 +202,13 @@ void linear_modifiers(int argc) {
   int &f = argc;
   #pragma omp parallel masked taskloop simd linear(f)
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear(val(f))
+  #pragma omp parallel masked taskloop simd linear(val(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear(uval(f))
+  #pragma omp parallel masked taskloop simd linear(uval(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear(ref(f))
+  #pragma omp parallel masked taskloop simd linear(ref(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}}
+  #pragma omp parallel masked taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
 }
 
@@ -233,9 +234,9 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear (ref()) // expected-error {{expected expression}}
+  #pragma omp parallel masked taskloop simd linear (ref()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel masked taskloop simd linear (foo()) // expected-error {{expected expression}}
+  #pragma omp parallel masked taskloop simd linear (foo()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear (argc // expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -253,6 +254,7 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel masked taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{argument of a linear clause should be of integral or pointer type, not 'S4'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S5'}}
   #pragma omp parallel masked taskloop simd linear(val(e, g))
@@ -262,19 +264,19 @@ int main(int argc, char **argv) {
   #pragma omp parallel
   {
     int i;
-    #pragma omp parallel masked taskloop simd linear(val(i))
+    #pragma omp parallel masked taskloop simd linear(val(i)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
     for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
     #pragma omp parallel masked taskloop simd linear(i : uval, step(4)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
 #else
-    #pragma omp parallel masked taskloop simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+    #pragma omp parallel masked taskloop simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
     for (int k = 0; k < argc; ++k) { ++k; i += 4; }
   }
 #ifdef OMP52
   #pragma omp parallel masked taskloop simd linear(j: ref)
 #else  
-  #pragma omp parallel masked taskloop simd linear(ref(j))
+  #pragma omp parallel masked taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
   for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
@@ -295,4 +297,3 @@ int main(int argc, char **argv) {
   foomain<int,char>(argc,argv); // expected-note {{in instantiation of function template specialization 'foomain<int, char>' requested here}}
   return 0;
 }
-

--- a/clang/test/OpenMP/parallel_master_taskloop_simd_linear_messages.cpp
+++ b/clang/test/OpenMP/parallel_master_taskloop_simd_linear_messages.cpp
@@ -131,11 +131,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp parallel master taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp parallel master taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp parallel master taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear () // expected-error {{expected expression}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -143,7 +143,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear (val argc // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp parallel master taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear (argc > 0 ? argv[1] : argv[2]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -157,6 +157,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp parallel master taskloop simd linear (a, b: val, B::ib)
 #else
+  // omp52-error @+3{{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{linear variable with incomplete type 'S1'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp parallel master taskloop simd linear (val(a, b):B::ib)
@@ -164,11 +165,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}}
+  #pragma omp parallel master taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear(h, z) // expected-error {{threadprivate or thread local variable cannot be linear}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+  #pragma omp parallel master taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel
   {
@@ -177,9 +178,9 @@ template<class I, class C> int foomain(I argc, C **argv) {
     #pragma omp parallel master taskloop simd allocate(omp_thread_mem_alloc: v) linear(v:i) // expected-warning {{allocator with the 'thread' trait access has unspecified behavior on 'parallel master taskloop simd' directive}}
     for (int k = 0; k < argc; ++k) { i = k; v += i; }
   }
-  #pragma omp parallel master taskloop simd linear(ref(j))
+  #pragma omp parallel master taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear(uval(j))
+  #pragma omp parallel master taskloop simd linear(uval(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   int v = 0;
   #pragma omp parallel master taskloop simd linear(v:j)
@@ -201,13 +202,13 @@ void linear_modifiers(int argc) {
   int &f = argc;
   #pragma omp parallel master taskloop simd linear(f)
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear(val(f))
+  #pragma omp parallel master taskloop simd linear(val(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear(uval(f))
+  #pragma omp parallel master taskloop simd linear(uval(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear(ref(f))
+  #pragma omp parallel master taskloop simd linear(ref(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}}
+  #pragma omp parallel master taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
 }
 
@@ -233,9 +234,9 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear (ref()) // expected-error {{expected expression}}
+  #pragma omp parallel master taskloop simd linear (ref()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp parallel master taskloop simd linear (foo()) // expected-error {{expected expression}}
+  #pragma omp parallel master taskloop simd linear (foo()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear (argc // expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -253,6 +254,7 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel master taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{argument of a linear clause should be of integral or pointer type, not 'S4'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S5'}}
   #pragma omp parallel master taskloop simd linear(val(e, g))
@@ -262,7 +264,7 @@ int main(int argc, char **argv) {
   #pragma omp parallel
   {
     int i;
-    #pragma omp parallel master taskloop simd linear(val(i))
+    #pragma omp parallel master taskloop simd linear(val(i)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
     for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
     #pragma omp parallel master taskloop simd linear(i : uval, step(4)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
@@ -274,7 +276,7 @@ int main(int argc, char **argv) {
 #ifdef OMP52
   #pragma omp parallel master taskloop simd linear(j: ref)
 #else  
-  #pragma omp parallel master taskloop simd linear(ref(j))
+  #pragma omp parallel master taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
   for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52

--- a/clang/test/OpenMP/simd_linear_messages.cpp
+++ b/clang/test/OpenMP/simd_linear_messages.cpp
@@ -121,11 +121,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear () // expected-error {{expected expression}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -133,7 +133,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear (val argc // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear (argc > 0 ? argv[1] : argv[2]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -147,6 +147,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp simd linear (a, b: val, B::ib)
 #else
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{linear variable with incomplete type 'S1'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp simd linear (val(a, b):B::ib)
@@ -154,11 +155,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}}
+  #pragma omp simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear(h, z) // expected-error {{threadprivate or thread local variable cannot be linear}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+  #pragma omp simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel
   {
@@ -167,9 +168,9 @@ template<class I, class C> int foomain(I argc, C **argv) {
     #pragma omp simd linear(v:i)
     for (int k = 0; k < argc; ++k) { i = k; v += i; }
   }
-  #pragma omp simd linear(ref(j))
+  #pragma omp simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear(uval(j))
+  #pragma omp simd linear(uval(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   int v = 0;
   #pragma omp simd linear(v:j)
@@ -191,13 +192,13 @@ void linear_modifiers(int argc) {
   int &f = argc;
   #pragma omp simd linear(f)
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear(val(f))
+  #pragma omp simd linear(val(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear(uval(f))
+  #pragma omp simd linear(uval(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear(ref(f))
+  #pragma omp simd linear(ref(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}}
+  #pragma omp simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
 }
 
@@ -223,9 +224,9 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear (ref()) // expected-error {{expected expression}}
+  #pragma omp simd linear (ref()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp simd linear (foo()) // expected-error {{expected expression}}
+  #pragma omp simd linear (foo()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear (argc // expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -243,6 +244,7 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{argument of a linear clause should be of integral or pointer type, not 'S4'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S5'}}
   #pragma omp simd linear(val(e, g))
@@ -252,19 +254,19 @@ int main(int argc, char **argv) {
   #pragma omp parallel
   {
     int i;
-    #pragma omp simd linear(val(i))
+    #pragma omp simd linear(val(i)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
     for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
     #pragma omp simd linear(i : uval, step(4)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
 #else
-    #pragma omp simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+    #pragma omp simd linear(uval(i) : 4) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
     for (int k = 0; k < argc; ++k) { ++k; i += 4; }
   }
 #ifdef OMP52
   #pragma omp simd linear(j: ref)
 #else  
-  #pragma omp simd linear(ref(j))
+  #pragma omp simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
   for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
@@ -287,4 +289,3 @@ int main(int argc, char **argv) {
   foomain<int,char>(argc,argv); // expected-note {{in instantiation of function template specialization 'foomain<int, char>' requested here}}
   return 0;
 }
-

--- a/clang/test/OpenMP/taskloop_simd_linear_messages.cpp
+++ b/clang/test/OpenMP/taskloop_simd_linear_messages.cpp
@@ -131,11 +131,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp taskloop simd linear (uval( // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp taskloop simd linear (ref() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp taskloop simd linear (foo() // expected-error {{expected expression}} expected-error {{expected ')'}} expected-note {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear () // expected-error {{expected expression}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -143,7 +143,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear (val argc // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}}
+  #pragma omp taskloop simd linear (val(argc, // expected-error {{expected expression}} expected-error 2 {{expected ')'}} expected-note 2 {{to match this '('}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear (argc > 0 ? argv[1] : argv[2]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -157,6 +157,7 @@ template<class I, class C> int foomain(I argc, C **argv) {
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp taskloop simd linear (a, b: val, B::ib)
 #else
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{linear variable with incomplete type 'S1'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S2'}}
   #pragma omp taskloop simd linear (val(a, b):B::ib)
@@ -164,11 +165,11 @@ template<class I, class C> int foomain(I argc, C **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}}
+  #pragma omp taskloop simd linear(ref(e, g)) // expected-error 2 {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'ref'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear(h, z) // expected-error {{threadprivate or thread local variable cannot be linear}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
+  #pragma omp taskloop simd linear(uval(i)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp parallel
   {
@@ -177,9 +178,9 @@ template<class I, class C> int foomain(I argc, C **argv) {
     #pragma omp taskloop simd allocate(omp_thread_mem_alloc: v) linear(v:i) // expected-warning {{allocator with the 'thread' trait access has unspecified behavior on 'taskloop simd' directive}}
     for (int k = 0; k < argc; ++k) { i = k; v += i; }
   }
-  #pragma omp taskloop simd linear(ref(j))
+  #pragma omp taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear(uval(j))
+  #pragma omp taskloop simd linear(uval(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   int v = 0;
   #pragma omp taskloop simd linear(v:j)
@@ -201,13 +202,13 @@ void linear_modifiers(int argc) {
   int &f = argc;
   #pragma omp taskloop simd linear(f)
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear(val(f))
+  #pragma omp taskloop simd linear(val(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear(uval(f))
+  #pragma omp taskloop simd linear(uval(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear(ref(f))
+  #pragma omp taskloop simd linear(ref(f)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}}
+  #pragma omp taskloop simd linear(foo(f)) // expected-error {{expected one of 'ref', val' or 'uval' modifiers}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
 }
 
@@ -233,9 +234,9 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear (val // expected-error {{use of undeclared identifier 'val'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear (ref()) // expected-error {{expected expression}}
+  #pragma omp taskloop simd linear (ref()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
-  #pragma omp taskloop simd linear (foo()) // expected-error {{expected expression}}
+  #pragma omp taskloop simd linear (foo()) // expected-error {{expected expression}} omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear (argc // expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int k = 0; k < argc; ++k) ++k;
@@ -253,6 +254,7 @@ int main(int argc, char **argv) {
   for (int k = 0; k < argc; ++k) ++k;
   #pragma omp taskloop simd linear (argv[1]) // expected-error {{expected variable name}}
   for (int k = 0; k < argc; ++k) ++k;
+  // omp52-error@+3 {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
   // expected-error@+2 {{argument of a linear clause should be of integral or pointer type, not 'S4'}}
   // expected-error@+1 {{argument of a linear clause should be of integral or pointer type, not 'S5'}}
   #pragma omp taskloop simd linear(val(e, g))
@@ -262,7 +264,7 @@ int main(int argc, char **argv) {
   #pragma omp parallel
   {
     int i;
-    #pragma omp taskloop simd linear(val(i))
+    #pragma omp taskloop simd linear(val(i)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
     for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52
     #pragma omp taskloop simd linear(i : uval, step(4)) // expected-error {{variable of non-reference type 'int' can be used only with 'val' modifier, but used with 'uval'}}
@@ -274,7 +276,7 @@ int main(int argc, char **argv) {
 #ifdef OMP52
   #pragma omp taskloop simd linear(j: ref)
 #else  
-  #pragma omp taskloop simd linear(ref(j))
+  #pragma omp taskloop simd linear(ref(j)) // omp52-error {{old syntax 'linear-modifier(list)' on 'linear' clause was deprecated, use new syntax 'linear(list: [linear-modifier,] step(step-size))'}}
 #endif
   for (int k = 0; k < argc; ++k) ++k;
 #ifdef OMP52


### PR DESCRIPTION
The syntax of the linear clause that specifies its argument and linear-modifier as linear-modifier(list) was deprecated since OpenMP 5.2 and the step modifier was added for specifying the linear step.

Reference: OpenMP 5.2 Spec, Page 627, Line 15