### PR TITLE
[ASAN] For Asan instrumented global, emit two symbols, one with actual size and other with instrumented size.

### DIFF
--- a/clang/test/CodeGen/asan_globals_symbols.cpp
+++ b/clang/test/CodeGen/asan_globals_symbols.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -S -x c++ -std=c++11 -triple x86_64-linux \
+// RUN:   -fsanitize=address -o %t.out %s
+// RUN: FileCheck %s --input-file=%t.out --check-prefix=CHECK-A
+
+// CHECK-A: myGlobal:
+// CHECK-A: .size   myGlobal, 4
+// CHECK-A: myGlobal__sanitized_padded_global:
+// CHECK-A  .size   myGlobal__sanitized_padded_global, 32
+
+int myGlobal;
+
+int main() {
+    myGlobal = 0;
+    return 0;
+}

--- a/clang/test/CodeGen/asan_globals_symbols_ir_attribute.cpp
+++ b/clang/test/CodeGen/asan_globals_symbols_ir_attribute.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 %s -triple x86_64-unknown-linux-gnu -fsanitize=address -emit-llvm -o - | FileCheck -check-prefix=CHECK-ASAN %s
+
+// CHECK-ASAN: @myGlobal1 = global { i32, [28 x i8] } zeroinitializer, align 32 #[[ATTR0:[0-9]+]]
+// CHECK-ASAN: @myGlobal2 = global i32 0, no_sanitize_address, align 4
+// CHECK-NOT: #[[ATTR1:[0-9]+]]
+// CHECK-ASAN: attributes #[[ATTR0]] = { sanitized_padded_global }
+
+int myGlobal1;
+int __attribute__((no_sanitize("address"))) myGlobal2;
+
+int main() {
+    myGlobal1 = 0;
+    myGlobal2 = 0;
+    return 0;
+}

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -801,6 +801,19 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   // sections and expected to be contiguous (e.g. ObjC metadata).
   const Align Alignment = getGVAlignment(GV, DL);
 
+  // Identify globals with "SanitizedPaddedGlobal" attribute and extract
+  // the actual global variable size.
+  uint64_t ActualSize = 0;
+  if (GV->hasAttribute(Attribute::SanitizedPaddedGlobal)) {
+    StructType *ST = dyn_cast<StructType>(GV->getValueType());
+    if (ST && ST->getNumElements() == 2) {
+      auto *ET0 = ST->getElementType(0);
+      if (ET0 && isa<ArrayType>(ST->getElementType(1))) {
+        ActualSize = DL.getTypeAllocSize(ET0);
+      }
+    }
+  }
+
   for (const HandlerInfo &HI : Handlers) {
     NamedRegionTimer T(HI.TimerName, HI.TimerDescription,
                        HI.TimerGroupName, HI.TimerGroupDescription,
@@ -911,6 +924,18 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
 
   MCSymbol *EmittedInitSym = GVSym;
 
+  if (GV->hasAttribute(Attribute::SanitizedPaddedGlobal)) {
+    OutStreamer->switchSection(TheSection);
+    emitLinkage(GV, EmittedInitSym);
+    OutStreamer->emitLabel(EmittedInitSym);
+    if (MAI->hasDotTypeDotSizeDirective())
+      OutStreamer->emitELFSize(EmittedInitSym,
+                               MCConstantExpr::create(ActualSize, OutContext));
+    EmittedInitSym = OutContext.getOrCreateSymbol(
+        GVSym->getName() + Twine("__sanitized_padded_global"));
+    emitVisibility(EmittedInitSym, GV->getVisibility(), !GV->isDeclaration());
+  }
+
   OutStreamer->switchSection(TheSection);
 
   emitLinkage(GV, EmittedInitSym);
@@ -918,7 +943,8 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
 
   OutStreamer->emitLabel(EmittedInitSym);
   MCSymbol *LocalAlias = getSymbolPreferLocal(*GV);
-  if (LocalAlias != EmittedInitSym)
+  if ((LocalAlias != EmittedInitSym) &&
+      !GV->hasAttribute(Attribute::SanitizedPaddedGlobal))
     OutStreamer->emitLabel(LocalAlias);
 
   emitGlobalConstant(GV->getParent()->getDataLayout(), GV->getInitializer());

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2496,6 +2496,9 @@ void ModuleAddressSanitizer::instrumentGlobals(IRBuilder<> &IRB, Module &M,
     // zero so we can copy the metadata over as is.
     NewGlobal->copyMetadata(G, 0);
 
+    // Attach "SanitizedPaddedGlobal" attribute to the new global.
+    NewGlobal->addAttribute(Attribute::SanitizedPaddedGlobal);
+
     Value *Indices2[2];
     Indices2[0] = IRB.getInt32(0);
     Indices2[1] = IRB.getInt32(0);

--- a/llvm/test/Instrumentation/AddressSanitizer/debug-info-global-var.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/debug-info-global-var.ll
@@ -2,7 +2,7 @@
 source_filename = "version.c"
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.12.0"
-; CHECK: @version = constant { [5 x i8], [27 x i8] } {{.*}}, !dbg ![[GV:.*]]
+; CHECK: @version = constant { [5 x i8], [27 x i8] } {{.*}}, !dbg ![[GV:.*]] {{.*}}
 
 @version = constant [5 x i8] c"4.00\00", align 1, !dbg !0
 


### PR DESCRIPTION
This PR has dependency on #68865

Asan instrumented global variable size includes actual size plus redzone size. Symbol table entry for the instrumented global would report the padded size (actual size+ redzone size) but has the name of actual global variable. 

AMD language runtimes provide queries for the size of device global symbols and functions to copy data to and from device global variables. Runtime gets the needed information form the ELF symbol table. So, when it querires the size of device global variable, it gets the padded size rather than actual size.

To fix this, #66666 was created, where actual size of global was emitted for the symbol. But @hctim pointed out that the approach would have issue with relinkers.

As a solution, we are proposing the below approach.

- Identify instrumented global variable by attaching "asan_instrumented" attribute to the global. (#68865 under review).
- For the instrumented global, emit two symbols at the same offset but with different sizes. One with actual global variable name and actual size. Other symbol will have different name and size of instrumented variable.
