### PR TITLE
[BOLT] Reduce the number of emitted symbols. NFCI.

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -1181,7 +1181,7 @@ public:
   bool clearOffset(MCInst &Inst);
 
   /// Return the label of \p Inst, if available.
-  std::optional<MCSymbol *> getLabel(const MCInst &Inst) const;
+  MCSymbol *getLabel(const MCInst &Inst) const;
 
   /// Set the label of \p Inst. This label will be emitted right before \p Inst
   /// is emitted to MCStreamer.

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1901,8 +1901,8 @@ void BinaryContext::printInstruction(raw_ostream &OS, const MCInst &Instruction,
   }
   if (std::optional<uint32_t> Offset = MIB->getOffset(Instruction))
     OS << " # Offset: " << *Offset;
-  if (auto Label = MIB->getLabel(Instruction))
-    OS << " # Label: " << **Label;
+  if (MCSymbol *Label = MIB->getLabel(Instruction))
+    OS << " # Label: " << *Label;
 
   MIB->printAnnotations(Instruction, OS);
 

--- a/bolt/lib/Core/MCPlusBuilder.cpp
+++ b/bolt/lib/Core/MCPlusBuilder.cpp
@@ -268,10 +268,10 @@ bool MCPlusBuilder::clearOffset(MCInst &Inst) {
   return true;
 }
 
-std::optional<MCSymbol *> MCPlusBuilder::getLabel(const MCInst &Inst) const {
+MCSymbol *MCPlusBuilder::getLabel(const MCInst &Inst) const {
   if (auto Label = tryGetAnnotationAs<MCSymbol *>(Inst, MCAnnotation::kLabel))
     return *Label;
-  return std::nullopt;
+  return nullptr;
 }
 
 bool MCPlusBuilder::setLabel(MCInst &Inst, MCSymbol *Label,

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -610,8 +610,8 @@ void LowerAnnotations::runOnFunctions(BinaryContext &BC) {
           if (BF.requiresAddressTranslation() && BC.MIB->getOffset(*II))
             PreservedOffsetAnnotations.emplace_back(&(*II),
                                                     *BC.MIB->getOffset(*II));
-          if (auto Label = BC.MIB->getLabel(*II))
-            PreservedLabelAnnotations.emplace_back(&*II, *Label);
+          if (MCSymbol *Label = BC.MIB->getLabel(*II))
+            PreservedLabelAnnotations.emplace_back(&*II, Label);
           BC.MIB->stripAnnotations(*II);
         }
       }
@@ -620,8 +620,8 @@ void LowerAnnotations::runOnFunctions(BinaryContext &BC) {
   for (BinaryFunction *BF : BC.getInjectedBinaryFunctions())
     for (BinaryBasicBlock &BB : *BF)
       for (MCInst &Instruction : BB) {
-        if (auto Label = BC.MIB->getLabel(Instruction))
-          PreservedLabelAnnotations.emplace_back(&Instruction, *Label);
+        if (MCSymbol *Label = BC.MIB->getLabel(Instruction))
+          PreservedLabelAnnotations.emplace_back(&Instruction, Label);
         BC.MIB->stripAnnotations(Instruction);
       }
 


### PR DESCRIPTION
We emit a symbol before an instruction for a number of reasons, e.g. for tracking LocSyms, debug line, or if the instruction has a label annotation. Currently, we may emit multiple symbols per instruction.

Reuse the same label instead of creating and emitting new ones when possible. I'm planning to refactor EH labels as well in a separate diff.

Change getLabel() to return a pointer instead of std::optional<> since an empty label should be treated identically to no label.