### PR TITLE
[BOLT] Use Label annotation instead of EHLabel pseudo. NFCI.

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -560,10 +560,6 @@ public:
     return false;
   }
 
-  virtual bool isEHLabel(const MCInst &Inst) const {
-    return Inst.getOpcode() == TargetOpcode::EH_LABEL;
-  }
-
   virtual bool isPop(const MCInst &Inst) const { return false; }
 
   /// Return true if the instruction is used to terminate an indirect branch.
@@ -1738,15 +1734,6 @@ public:
                                    MCContext *Ctx) const {
     llvm_unreachable("not implemented");
     return false;
-  }
-
-  virtual bool createEHLabel(MCInst &Inst, const MCSymbol *Label,
-                             MCContext *Ctx) const {
-    Inst.setOpcode(TargetOpcode::EH_LABEL);
-    Inst.clear();
-    Inst.addOperand(MCOperand::createExpr(
-        MCSymbolRefExpr::create(Label, MCSymbolRefExpr::VK_None, *Ctx)));
-    return true;
   }
 
   /// Extract a symbol and an addend out of the fixup value expression.

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1862,10 +1862,6 @@ void BinaryContext::printInstruction(raw_ostream &OS, const MCInst &Instruction,
                                      bool PrintMCInst, bool PrintMemData,
                                      bool PrintRelocations,
                                      StringRef Endl) const {
-  if (MIB->isEHLabel(Instruction)) {
-    OS << "  EH_LABEL: " << *MIB->getTargetSymbol(Instruction) << Endl;
-    return;
-  }
   OS << format("    %08" PRIx64 ": ", Offset);
   if (MIB->isCFI(Instruction)) {
     uint32_t Offset = Instruction.getOperand(0).getImm();

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -461,13 +461,6 @@ void BinaryEmitter::emitFunctionBody(BinaryFunction &BF, FunctionFragment &FF,
         continue;
 
       // Handle pseudo instructions.
-      if (BC.MIB->isEHLabel(Instr)) {
-        const MCSymbol *Label = BC.MIB->getTargetSymbol(Instr);
-        assert(Instr.getNumOperands() >= 1 && Label &&
-               "bad EH_LABEL instruction");
-        Streamer.emitLabel(const_cast<MCSymbol *>(Label));
-        continue;
-      }
       if (BC.MIB->isCFI(Instr)) {
         emitCFIInstruction(*BF.getCFIFor(Instr));
         continue;

--- a/bolt/lib/Core/Exceptions.cpp
+++ b/bolt/lib/Core/Exceptions.cpp
@@ -373,12 +373,12 @@ void BinaryFunction::updateEHRanges() {
     const MCSymbol *StartRange = nullptr;
 
     for (BinaryBasicBlock *const BB : FF) {
-      for (auto II = BB->begin(); II != BB->end(); ++II) {
-        if (!BC.MIB->isCall(*II))
+      for (MCInst &Instr : *BB) {
+        if (!BC.MIB->isCall(Instr))
           continue;
 
         // Instruction can throw an exception that should be handled.
-        const bool Throws = BC.MIB->isInvoke(*II);
+        const bool Throws = BC.MIB->isInvoke(Instr);
 
         // Ignore the call if it's a continuation of a no-throw gap.
         if (!Throws && !StartRange)
@@ -388,7 +388,7 @@ void BinaryFunction::updateEHRanges() {
         const MCSymbol *LP = nullptr;
         uint64_t Action = 0;
         if (const std::optional<MCPlus::MCLandingPad> EHInfo =
-                BC.MIB->getEHInfo(*II))
+                BC.MIB->getEHInfo(Instr))
           std::tie(LP, Action) = *EHInfo;
 
         // No action if the exception handler has not changed.
@@ -397,15 +397,14 @@ void BinaryFunction::updateEHRanges() {
           continue;
 
         // Same symbol is used for the beginning and the end of the range.
-        const MCSymbol *EHSymbol;
-        MCInst EHLabel;
-        {
+        MCSymbol *EHSymbol;
+        if (auto InstrLabel = BC.MIB->getLabel(Instr)) {
+          EHSymbol = *InstrLabel;
+        } else {
           std::unique_lock<llvm::sys::RWMutex> Lock(BC.CtxMutex);
           EHSymbol = BC.Ctx->createNamedTempSymbol("EH");
-          BC.MIB->createEHLabel(EHLabel, EHSymbol, BC.Ctx.get());
+          BC.MIB->setLabel(Instr, EHSymbol);
         }
-
-        II = std::next(BB->insertPseudoInstr(II, EHLabel));
 
         // At this point we could be in one of the following states:
         //

--- a/bolt/lib/Passes/StokeInfo.cpp
+++ b/bolt/lib/Passes/StokeInfo.cpp
@@ -50,11 +50,17 @@ void StokeInfo::checkInstr(const BinaryFunction &BF, StokeFuncInfo &FuncInfo) {
     if (BB->empty())
       continue;
 
+    // Skip function with exception handling.
+    if (BB->throw_size() || BB->lp_size()) {
+      FuncInfo.Omitted = true;
+      return;
+    }
+
     for (const MCInst &It : *BB) {
       if (MIB->isPseudo(It))
         continue;
       // skip function with exception handling yet
-      if (MIB->isEHLabel(It) || MIB->isInvoke(It)) {
+      if (MIB->isInvoke(It)) {
         FuncInfo.Omitted = true;
         return;
       }

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -320,7 +320,6 @@ public:
     default:
       return false;
     case RISCV::C_J:
-    case TargetOpcode::EH_LABEL:
       OpNum = 0;
       return true;
     case RISCV::AUIPC:


### PR DESCRIPTION
When we need to attach EH label to an instruction, we can now use Label annotation instead of EHLabel pseudo instruction.