### PR TITLE
[NFC][Clang] Fix potential deref of end iterator

### DIFF
--- a/clang/include/clang/Sema/CXXFieldCollector.h
+++ b/clang/include/clang/Sema/CXXFieldCollector.h
@@ -65,7 +65,7 @@ public:
 
   /// getCurFields - Pointer to array of fields added to the currently parsed
   /// class.
-  FieldDecl **getCurFields() { return &*(Fields.end() - getCurNumFields()); }
+  FieldDecl **getCurFields() { return Fields.end() - getCurNumFields(); }
 
   /// FinishClass - Called by Sema::ActOnFinishCXXClassDef.
   void FinishClass() {


### PR DESCRIPTION
This was found by doing bound-checking on SmallVector iterator usage. When the count is 0, the end iterator is dereferenced to get its address. This doesn't seem to be an issue in practice as most of the time we should be allowed to deref this address, but I don't think this is correct.