### PR TITLE
[LLD] [COFF] Recognize Itanium vtables for ICF

### DIFF
--- a/lld/COFF/ICF.cpp
+++ b/lld/COFF/ICF.cpp
@@ -94,7 +94,10 @@ bool ICF::isEligible(SectionChunk *c) {
     return true;
 
   // So are vtables.
-  if (c->sym && c->sym->getName().starts_with("??_7"))
+  const char *itaniumVtablePrefix =
+      ctx.config.machine == I386 ? "__ZTV" : "_ZTV";
+  if (c->sym && (c->sym->getName().starts_with("??_7") ||
+                 c->sym->getName().starts_with(itaniumVtablePrefix)))
     return true;
 
   // Anything else not in an address-significance table is eligible.

--- a/lld/test/COFF/icf-vtables-itanium-i386.s
+++ b/lld/test/COFF/icf-vtables-itanium-i386.s
@@ -1,0 +1,27 @@
+# REQUIRES: x86
+# RUN: llvm-mc -triple=i386-windows-gnu -filetype=obj -o %t.obj %s
+# RUN: lld-link %t.obj /out:%t.exe /entry:main /subsystem:console /safeseh:no
+# RUN: llvm-objdump -s %t.exe | FileCheck %s
+
+# CHECK: Contents of section .text:
+.globl _main
+_main:
+# CHECK-NEXT: 401000 00204000 01204000 01204000
+.long __ZTS
+.long __ZTV
+.long __ZTVa
+
+.section .rdata,"dr",discard,__ZTS
+.globl __ZTS
+__ZTS:
+.byte 42
+
+.section .rdata,"dr",discard,__ZTV
+.globl __ZTV
+__ZTV:
+.byte 42
+
+.section .rdata,"dr",discard,__ZTVa
+.globl __ZTVa
+__ZTVa:
+.byte 42

--- a/lld/test/COFF/icf-vtables-itanium.s
+++ b/lld/test/COFF/icf-vtables-itanium.s
@@ -1,0 +1,28 @@
+# REQUIRES: x86
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj -o %t.obj %s
+# RUN: lld-link %t.obj /out:%t.exe /entry:main /subsystem:console
+# RUN: llvm-objdump -s %t.exe | FileCheck %s
+
+# CHECK: Contents of section .text:
+.globl main
+main:
+# CHECK-NEXT: 140001000 00200040 01000000 01200040 01000000
+.8byte _ZTS
+.8byte _ZTV
+# CHECK-NEXT: 140001010 01200040 01000000
+.8byte _ZTVa
+
+.section .rdata,"dr",discard,_ZTS
+.globl _ZTS
+_ZTS:
+.byte 42
+
+.section .rdata,"dr",discard,_ZTV
+.globl _ZTV
+_ZTV:
+.byte 42
+
+.section .rdata,"dr",discard,_ZTVa
+.globl _ZTVa
+_ZTVa:
+.byte 42


### PR DESCRIPTION
The testcases are plain copies of the existing ICF vtable testcase, with symbol names renamed to match the Itanium vtable name pattern.