### PR TITLE
LoopVectorize/test: add missing CHECK lines, cleanup intrinsic.ll

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/intrinsic.ll
+++ b/llvm/test/Transforms/LoopVectorize/intrinsic.ll
@@ -517,7 +517,7 @@ declare float @llvm.copysign.f32(float, float)
 
 define void @copysign_f64(i32 %n, ptr %y, ptr %x, ptr %z) {
 ; CHECK-LABEL: @copysign_f64(
-; CHECK-NOT: llvm.copysign
+; CHECK: llvm.copysign.v4f64
 ; CHECK: ret void
 ;
 entry:
@@ -529,7 +529,7 @@ for.body:                                         ; preds = %entry, %for.body
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
   %arrayidx1 = getelementptr inbounds double, ptr %z, i64 %indvars.iv
-  %1 = load double, ptr %arrayidx, align 8
+  %1 = load double, ptr %arrayidx1, align 8
   %call = tail call double @llvm.copysign(double %0, double %1)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
@@ -598,10 +598,11 @@ for.end:                                          ; preds = %for.body, %entry
 
 declare double @llvm.floor.f64(double)
 
-;CHECK-LABEL: @ceil_f32(
-;CHECK: llvm.ceil.v4f32
-;CHECK: ret void
 define void @ceil_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @ceil_f32(
+; CHECK: llvm.ceil.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end

--- a/llvm/test/Transforms/LoopVectorize/intrinsic.ll
+++ b/llvm/test/Transforms/LoopVectorize/intrinsic.ll
@@ -1,11 +1,10 @@
 ; RUN: opt < %s -passes=loop-vectorize,dce,instcombine -force-vector-interleave=1 -force-vector-width=4 -S | FileCheck %s
 
-target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
-
-;CHECK-LABEL: @sqrt_f32(
-;CHECK: llvm.sqrt.v4f32
-;CHECK: ret void
-define void @sqrt_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sqrt_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @sqrt_f32(
+; CHECK: llvm.sqrt.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -14,7 +13,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.sqrt.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.sqrt.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -26,12 +25,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.sqrt.f32(float) nounwind readnone
+declare float @llvm.sqrt.f32(float)
 
-;CHECK-LABEL: @sqrt_f64(
-;CHECK: llvm.sqrt.v4f64
-;CHECK: ret void
-define void @sqrt_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sqrt_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @sqrt_f64(
+; CHECK: llvm.sqrt.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -40,7 +40,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.sqrt.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.sqrt.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -52,12 +52,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.sqrt.f64(double) nounwind readnone
+declare double @llvm.sqrt.f64(double)
 
-;CHECK-LABEL: @sin_f32(
-;CHECK: llvm.sin.v4f32
-;CHECK: ret void
-define void @sin_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sin_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @sin_f32(
+; CHECK: llvm.sin.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -66,7 +67,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.sin.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.sin.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -78,12 +79,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.sin.f32(float) nounwind readnone
+declare float @llvm.sin.f32(float)
 
-;CHECK-LABEL: @sin_f64(
-;CHECK: llvm.sin.v4f64
-;CHECK: ret void
-define void @sin_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @sin_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @sin_f64(
+; CHECK: llvm.sin.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -92,7 +94,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.sin.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.sin.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -104,12 +106,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.sin.f64(double) nounwind readnone
+declare double @llvm.sin.f64(double)
 
-;CHECK-LABEL: @cos_f32(
-;CHECK: llvm.cos.v4f32
-;CHECK: ret void
-define void @cos_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @cos_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @cos_f32(
+; CHECK: llvm.cos.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -118,7 +121,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.cos.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.cos.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -130,12 +133,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.cos.f32(float) nounwind readnone
+declare float @llvm.cos.f32(float)
 
-;CHECK-LABEL: @cos_f64(
-;CHECK: llvm.cos.v4f64
-;CHECK: ret void
-define void @cos_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @cos_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @cos_f64(
+; CHECK: llvm.cos.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -144,7 +148,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.cos.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.cos.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -156,12 +160,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.cos.f64(double) nounwind readnone
+declare double @llvm.cos.f64(double)
 
-;CHECK-LABEL: @exp_f32(
-;CHECK: llvm.exp.v4f32
-;CHECK: ret void
-define void @exp_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @exp_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @exp_f32(
+; CHECK: llvm.exp.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -170,7 +175,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.exp.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.exp.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -182,12 +187,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.exp.f32(float) nounwind readnone
+declare float @llvm.exp.f32(float)
 
-;CHECK-LABEL: @exp_f64(
-;CHECK: llvm.exp.v4f64
-;CHECK: ret void
-define void @exp_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @exp_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @exp_f64(
+; CHECK: llvm.exp.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -196,7 +202,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.exp.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.exp.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -208,12 +214,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.exp.f64(double) nounwind readnone
+declare double @llvm.exp.f64(double)
 
-;CHECK-LABEL: @exp2_f32(
-;CHECK: llvm.exp2.v4f32
-;CHECK: ret void
-define void @exp2_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @exp2_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @exp2_f32(
+; CHECK: llvm.exp2.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -222,7 +229,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.exp2.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.exp2.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -234,12 +241,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.exp2.f32(float) nounwind readnone
+declare float @llvm.exp2.f32(float)
 
-;CHECK-LABEL: @exp2_f64(
-;CHECK: llvm.exp2.v4f64
-;CHECK: ret void
-define void @exp2_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @exp2_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @exp2_f64(
+; CHECK: llvm.exp2.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -248,7 +256,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.exp2.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.exp2.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -260,12 +268,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.exp2.f64(double) nounwind readnone
+declare double @llvm.exp2.f64(double)
 
-;CHECK-LABEL: @log_f32(
-;CHECK: llvm.log.v4f32
-;CHECK: ret void
-define void @log_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @log_f32(
+; CHECK: llvm.log.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -274,7 +283,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.log.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.log.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -286,12 +295,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.log.f32(float) nounwind readnone
+declare float @llvm.log.f32(float)
 
-;CHECK-LABEL: @log_f64(
-;CHECK: llvm.log.v4f64
-;CHECK: ret void
-define void @log_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @log_f64(
+; CHECK: llvm.log.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -300,7 +310,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.log.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.log.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -312,12 +322,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.log.f64(double) nounwind readnone
+declare double @llvm.log.f64(double)
 
-;CHECK-LABEL: @log10_f32(
-;CHECK: llvm.log10.v4f32
-;CHECK: ret void
-define void @log10_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log10_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @log10_f32(
+; CHECK: llvm.log10.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -326,7 +337,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.log10.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.log10.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -338,12 +349,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.log10.f32(float) nounwind readnone
+declare float @llvm.log10.f32(float)
 
-;CHECK-LABEL: @log10_f64(
-;CHECK: llvm.log10.v4f64
-;CHECK: ret void
-define void @log10_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log10_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @log10_f64(
+; CHECK: llvm.log10.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -352,7 +364,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.log10.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.log10.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -364,12 +376,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.log10.f64(double) nounwind readnone
+declare double @llvm.log10.f64(double)
 
-;CHECK-LABEL: @log2_f32(
-;CHECK: llvm.log2.v4f32
-;CHECK: ret void
-define void @log2_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log2_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @log2_f32(
+; CHECK: llvm.log2.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -378,7 +391,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.log2.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.log2.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -390,12 +403,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.log2.f32(float) nounwind readnone
+declare float @llvm.log2.f32(float)
 
-;CHECK-LABEL: @log2_f64(
-;CHECK: llvm.log2.v4f64
-;CHECK: ret void
-define void @log2_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @log2_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @log2_f64(
+; CHECK: llvm.log2.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -404,7 +418,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.log2.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.log2.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -416,12 +430,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.log2.f64(double) nounwind readnone
+declare double @llvm.log2.f64(double)
 
-;CHECK-LABEL: @fabs_f32(
-;CHECK: llvm.fabs.v4f32
-;CHECK: ret void
-define void @fabs_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @fabs_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @fabs_f32(
+; CHECK: llvm.fabs.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -430,7 +445,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.fabs.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.fabs.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -442,9 +457,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.fabs.f32(float) nounwind readnone
+declare float @llvm.fabs.f32(float)
 
-define void @fabs_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @fabs_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @fabs_f64(
+; CHECK: llvm.fabs.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -453,7 +472,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.fabs(double %0) nounwind readnone
+  %call = tail call double @llvm.fabs(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -465,12 +484,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.fabs(double) nounwind readnone
+declare double @llvm.fabs(double)
 
-;CHECK-LABEL: @copysign_f32(
-;CHECK: llvm.copysign.v4f32
-;CHECK: ret void
-define void @copysign_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @copysign_f32(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @copysign_f32(
+; CHECK: llvm.copysign.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -481,7 +501,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load float, ptr %arrayidx, align 4
   %arrayidx1 = getelementptr inbounds float, ptr %z, i64 %indvars.iv
   %1 = load float, ptr %arrayidx1, align 4
-  %call = tail call float @llvm.copysign.f32(float %0, float %1) nounwind readnone
+  %call = tail call float @llvm.copysign.f32(float %0, float %1)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -493,9 +513,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.copysign.f32(float, float) nounwind readnone
+declare float @llvm.copysign.f32(float, float)
 
-define void @copysign_f64(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @copysign_f64(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @copysign_f64(
+; CHECK-NOT: llvm.copysign
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -506,7 +530,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load double, ptr %arrayidx, align 8
   %arrayidx1 = getelementptr inbounds double, ptr %z, i64 %indvars.iv
   %1 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.copysign(double %0, double %1) nounwind readnone
+  %call = tail call double @llvm.copysign(double %0, double %1)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -518,12 +542,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.copysign(double, double) nounwind readnone
+declare double @llvm.copysign(double, double)
 
-;CHECK-LABEL: @floor_f32(
-;CHECK: llvm.floor.v4f32
-;CHECK: ret void
-define void @floor_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @floor_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @floor_f32(
+; CHECK: llvm.floor.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -532,7 +557,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.floor.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.floor.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -544,12 +569,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.floor.f32(float) nounwind readnone
+declare float @llvm.floor.f32(float)
 
-;CHECK-LABEL: @floor_f64(
-;CHECK: llvm.floor.v4f64
-;CHECK: ret void
-define void @floor_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @floor_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @floor_f64(
+; CHECK: llvm.floor.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -558,7 +584,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.floor.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.floor.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -570,12 +596,12 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.floor.f64(double) nounwind readnone
+declare double @llvm.floor.f64(double)
 
 ;CHECK-LABEL: @ceil_f32(
 ;CHECK: llvm.ceil.v4f32
 ;CHECK: ret void
-define void @ceil_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @ceil_f32(i32 %n, ptr %y, ptr %x) {
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -584,7 +610,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.ceil.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.ceil.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -596,12 +622,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.ceil.f32(float) nounwind readnone
+declare float @llvm.ceil.f32(float)
 
-;CHECK-LABEL: @ceil_f64(
-;CHECK: llvm.ceil.v4f64
-;CHECK: ret void
-define void @ceil_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @ceil_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @ceil_f64(
+; CHECK: llvm.ceil.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -610,7 +637,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.ceil.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.ceil.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -622,12 +649,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.ceil.f64(double) nounwind readnone
+declare double @llvm.ceil.f64(double)
 
-;CHECK-LABEL: @trunc_f32(
-;CHECK: llvm.trunc.v4f32
-;CHECK: ret void
-define void @trunc_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @trunc_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @trunc_f32(
+; CHECK: llvm.trunc.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -636,7 +664,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.trunc.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.trunc.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -648,12 +676,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.trunc.f32(float) nounwind readnone
+declare float @llvm.trunc.f32(float)
 
-;CHECK-LABEL: @trunc_f64(
-;CHECK: llvm.trunc.v4f64
-;CHECK: ret void
-define void @trunc_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @trunc_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @trunc_f64(
+; CHECK: llvm.trunc.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -662,7 +691,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.trunc.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.trunc.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -674,12 +703,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.trunc.f64(double) nounwind readnone
+declare double @llvm.trunc.f64(double)
 
-;CHECK-LABEL: @rint_f32(
-;CHECK: llvm.rint.v4f32
-;CHECK: ret void
-define void @rint_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @rint_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @rint_f32(
+; CHECK: llvm.rint.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -688,7 +718,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.rint.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.rint.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -700,12 +730,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.rint.f32(float) nounwind readnone
+declare float @llvm.rint.f32(float)
 
-;CHECK-LABEL: @rint_f64(
-;CHECK: llvm.rint.v4f64
-;CHECK: ret void
-define void @rint_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @rint_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @rint_f64(
+; CHECK: llvm.rint.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -714,7 +745,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.rint.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.rint.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -726,12 +757,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.rint.f64(double) nounwind readnone
+declare double @llvm.rint.f64(double)
 
-;CHECK-LABEL: @nearbyint_f32(
-;CHECK: llvm.nearbyint.v4f32
-;CHECK: ret void
-define void @nearbyint_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @nearbyint_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @nearbyint_f32(
+; CHECK: llvm.nearbyint.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -740,7 +772,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.nearbyint.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.nearbyint.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -752,12 +784,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.nearbyint.f32(float) nounwind readnone
+declare float @llvm.nearbyint.f32(float)
 
-;CHECK-LABEL: @nearbyint_f64(
-;CHECK: llvm.nearbyint.v4f64
-;CHECK: ret void
-define void @nearbyint_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @nearbyint_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @nearbyint_f64(
+; CHECK: llvm.nearbyint.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -766,7 +799,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.nearbyint.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.nearbyint.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -778,12 +811,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.nearbyint.f64(double) nounwind readnone
+declare double @llvm.nearbyint.f64(double)
 
-;CHECK-LABEL: @round_f32(
-;CHECK: llvm.round.v4f32
-;CHECK: ret void
-define void @round_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @round_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @round_f32(
+; CHECK: llvm.round.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -792,7 +826,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.round.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.round.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -804,12 +838,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.round.f32(float) nounwind readnone
+declare float @llvm.round.f32(float)
 
-;CHECK-LABEL: @round_f64(
-;CHECK: llvm.round.v4f64
-;CHECK: ret void
-define void @round_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @round_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @round_f64(
+; CHECK: llvm.round.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -818,7 +853,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.round.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.round.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -830,12 +865,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.round.f64(double) nounwind readnone
+declare double @llvm.round.f64(double)
 
-;CHECK-LABEL: @roundeven_f32(
-;CHECK: llvm.roundeven.v4f32
-;CHECK: ret void
-define void @roundeven_f32(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @roundeven_f32(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @roundeven_f32(
+; CHECK: llvm.roundeven.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -844,7 +880,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds float, ptr %y, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @llvm.roundeven.f32(float %0) nounwind readnone
+  %call = tail call float @llvm.roundeven.f32(float %0)
   %arrayidx2 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx2, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -856,12 +892,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.roundeven.f32(float) nounwind readnone
+declare float @llvm.roundeven.f32(float)
 
-;CHECK-LABEL: @roundeven_f64(
-;CHECK: llvm.roundeven.v4f64
-;CHECK: ret void
-define void @roundeven_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @roundeven_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @roundeven_f64(
+; CHECK: llvm.roundeven.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.end
@@ -870,7 +907,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.roundeven.f64(double %0) nounwind readnone
+  %call = tail call double @llvm.roundeven.f64(double %0)
   %arrayidx2 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx2, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -882,12 +919,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.roundeven.f64(double) nounwind readnone
+declare double @llvm.roundeven.f64(double)
 
-;CHECK-LABEL: @fma_f32(
-;CHECK: llvm.fma.v4f32
-;CHECK: ret void
-define void @fma_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z, ptr noalias %w) nounwind uwtable {
+define void @fma_f32(i32 %n, ptr %y, ptr %x, ptr %z, ptr %w) {
+; CHECK-LABEL: @fma_f32(
+; CHECK: llvm.fma.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp12 = icmp sgt i32 %n, 0
   br i1 %cmp12, label %for.body, label %for.end
@@ -912,12 +950,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.fma.f32(float, float, float) nounwind readnone
+declare float @llvm.fma.f32(float, float, float)
 
-;CHECK-LABEL: @fma_f64(
-;CHECK: llvm.fma.v4f64
-;CHECK: ret void
-define void @fma_f64(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z, ptr noalias %w) nounwind uwtable {
+define void @fma_f64(i32 %n, ptr %y, ptr %x, ptr %z, ptr %w) {
+; CHECK-LABEL: @fma_f64(
+; CHECK: llvm.fma.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp12 = icmp sgt i32 %n, 0
   br i1 %cmp12, label %for.body, label %for.end
@@ -942,12 +981,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.fma.f64(double, double, double) nounwind readnone
+declare double @llvm.fma.f64(double, double, double)
 
-;CHECK-LABEL: @fmuladd_f32(
-;CHECK: llvm.fmuladd.v4f32
-;CHECK: ret void
-define void @fmuladd_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z, ptr noalias %w) nounwind uwtable {
+define void @fmuladd_f32(i32 %n, ptr %y, ptr %x, ptr %z, ptr %w) {
+; CHECK-LABEL: @fmuladd_f32(
+; CHECK: llvm.fmuladd.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp12 = icmp sgt i32 %n, 0
   br i1 %cmp12, label %for.body, label %for.end
@@ -972,12 +1012,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.fmuladd.f32(float, float, float) nounwind readnone
+declare float @llvm.fmuladd.f32(float, float, float)
 
-;CHECK-LABEL: @fmuladd_f64(
-;CHECK: llvm.fmuladd.v4f64
-;CHECK: ret void
-define void @fmuladd_f64(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z, ptr noalias %w) nounwind uwtable {
+define void @fmuladd_f64(i32 %n, ptr %y, ptr %x, ptr %z, ptr %w) {
+; CHECK-LABEL: @fmuladd_f64(
+; CHECK: llvm.fmuladd.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp12 = icmp sgt i32 %n, 0
   br i1 %cmp12, label %for.body, label %for.end
@@ -1002,12 +1043,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare double @llvm.fmuladd.f64(double, double, double) nounwind readnone
+declare double @llvm.fmuladd.f64(double, double, double)
 
-;CHECK-LABEL: @pow_f32(
-;CHECK: llvm.pow.v4f32
-;CHECK: ret void
-define void @pow_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @pow_f32(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @pow_f32(
+; CHECK: llvm.pow.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1018,7 +1060,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load float, ptr %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, ptr %z, i64 %indvars.iv
   %1 = load float, ptr %arrayidx2, align 4
-  %call = tail call float @llvm.pow.f32(float %0, float %1) nounwind readnone
+  %call = tail call float @llvm.pow.f32(float %0, float %1)
   %arrayidx4 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx4, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1030,12 +1072,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.pow.f32(float, float) nounwind readnone
+declare float @llvm.pow.f32(float, float)
 
-;CHECK-LABEL: @pow_f64(
-;CHECK: llvm.pow.v4f64
-;CHECK: ret void
-define void @pow_f64(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @pow_f64(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @pow_f64(
+; CHECK: llvm.pow.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1046,7 +1089,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load double, ptr %arrayidx, align 8
   %arrayidx2 = getelementptr inbounds double, ptr %z, i64 %indvars.iv
   %1 = load double, ptr %arrayidx2, align 8
-  %call = tail call double @llvm.pow.f64(double %0, double %1) nounwind readnone
+  %call = tail call double @llvm.pow.f64(double %0, double %1)
   %arrayidx4 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx4, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1058,10 +1101,11 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
+define void @fabs_libm(ptr %x) {
 ; CHECK: fabs_libm
-; CHECK:  call <4 x float> @llvm.fabs.v4f32
+; CHECK: call <4 x float> @llvm.fabs.v4f32
 ; CHECK: ret void
-define void @fabs_libm(ptr nocapture %x) nounwind {
+;
 entry:
   br label %for.body
 
@@ -1082,20 +1126,19 @@ for.end:                                          ; preds = %for.body
 
 declare float @fabsf(float) nounwind readnone
 
-declare double @llvm.pow.f64(double, double) nounwind readnone
-
-
+declare double @llvm.pow.f64(double, double)
 
 ; Make sure we don't replace calls to functions with standard library function
 ; signatures but defined with internal linkage.
 
-define internal float @roundf(float %x) nounwind readnone {
+define internal float @roundf(float %x) {
   ret float 0.00000000
 }
+define void @internal_round(ptr %x) {
 ; CHECK-LABEL: internal_round
 ; CHECK-NOT:  load <4 x float>
-
-define void @internal_round(ptr nocapture %x) nounwind {
+; CHECK: ret void
+;
 entry:
   br label %for.body
 
@@ -1103,7 +1146,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
   %arrayidx = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   %0 = load float, ptr %arrayidx, align 4
-  %call = tail call float @roundf(float %0) nounwind readnone
+  %call = tail call float @roundf(float %0)
   store float %call, ptr %arrayidx, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32
@@ -1119,10 +1162,11 @@ for.end:                                          ; preds = %for.body
 
 declare void @round(double %f)
 
+define void @wrong_signature(ptr %x) {
 ; CHECK-LABEL: wrong_signature
 ; CHECK-NOT:  load <4 x double>
-
-define void @wrong_signature(ptr nocapture %x) nounwind {
+; CHECK: ret void
+;
 entry:
   br label %for.body
 
@@ -1131,7 +1175,7 @@ for.body:                                         ; preds = %entry, %for.body
   %arrayidx = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 4
   store double %0, ptr %arrayidx, align 4
-  tail call void @round(double %0) nounwind readnone
+  tail call void @round(double %0)
   %indvars.iv.next = add i64 %indvars.iv, 1
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32
   %exitcond = icmp eq i32 %lftr.wideiv, 1024
@@ -1141,12 +1185,13 @@ for.end:                                          ; preds = %for.body
   ret void
 }
 
-declare double @llvm.powi.f64.i32(double %Val, i32 %power) nounwind readnone
+declare double @llvm.powi.f64.i32(double %Val, i32 %power)
 
-;CHECK-LABEL: @powi_f64(
-;CHECK: llvm.powi.v4f64
-;CHECK: ret void
-define void @powi_f64(i32 %n, ptr noalias %y, ptr noalias %x, i32 %P) nounwind uwtable {
+define void @powi_f64(i32 %n, ptr %y, ptr %x, i32 %P) {
+; CHECK-LABEL: @powi_f64(
+; CHECK: llvm.powi.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1155,7 +1200,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
-  %call = tail call double @llvm.powi.f64.i32(double %0, i32  %P) nounwind readnone
+  %call = tail call double @llvm.powi.f64.i32(double %0, i32  %P)
   %arrayidx4 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx4, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1167,10 +1212,11 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-;CHECK-LABEL: @powi_f64_neg(
-;CHECK-NOT: llvm.powi.v4f64
-;CHECK: ret void
-define void @powi_f64_neg(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @powi_f64_neg(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @powi_f64_neg(
+; CHECK-NOT: llvm.powi.v4f64
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1180,7 +1226,7 @@ for.body:                                         ; preds = %entry, %for.body
   %arrayidx = getelementptr inbounds double, ptr %y, i64 %indvars.iv
   %0 = load double, ptr %arrayidx, align 8
   %1 = trunc i64 %indvars.iv to i32
-  %call = tail call double @llvm.powi.f64.i32(double %0, i32  %1) nounwind readnone
+  %call = tail call double @llvm.powi.f64.i32(double %0, i32  %1)
   %arrayidx4 = getelementptr inbounds double, ptr %x, i64 %indvars.iv
   store double %call, ptr %arrayidx4, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1192,12 +1238,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare i64  @llvm.cttz.i64 (i64, i1) nounwind readnone
+declare i64  @llvm.cttz.i64 (i64, i1)
 
-;CHECK-LABEL: @cttz_f64(
-;CHECK: llvm.cttz.v4i64
-;CHECK: ret void
-define void @cttz_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @cttz_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @cttz_f64(
+; CHECK: llvm.cttz.v4i64
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1206,7 +1253,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds i64, ptr %y, i64 %indvars.iv
   %0 = load i64, ptr %arrayidx, align 8
-  %call = tail call i64 @llvm.cttz.i64(i64 %0, i1 true) nounwind readnone
+  %call = tail call i64 @llvm.cttz.i64(i64 %0, i1 true)
   %arrayidx4 = getelementptr inbounds i64, ptr %x, i64 %indvars.iv
   store i64 %call, ptr %arrayidx4, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1218,12 +1265,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare i64  @llvm.ctlz.i64 (i64, i1) nounwind readnone
+declare i64  @llvm.ctlz.i64 (i64, i1)
 
-;CHECK-LABEL: @ctlz_f64(
-;CHECK: llvm.ctlz.v4i64
-;CHECK: ret void
-define void @ctlz_f64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
+define void @ctlz_f64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @ctlz_f64(
+; CHECK: llvm.ctlz.v4i64
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1232,7 +1280,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds i64, ptr %y, i64 %indvars.iv
   %0 = load i64, ptr %arrayidx, align 8
-  %call = tail call i64 @llvm.ctlz.i64(i64 %0, i1 true) nounwind readnone
+  %call = tail call i64 @llvm.ctlz.i64(i64 %0, i1 true)
   %arrayidx4 = getelementptr inbounds i64, ptr %x, i64 %indvars.iv
   store i64 %call, ptr %arrayidx4, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1244,12 +1292,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare i64 @llvm.abs.i64 (i64, i1) nounwind readnone
+declare i64 @llvm.abs.i64 (i64, i1)
 
-define void @abs_i64(i32 %n, ptr noalias %y, ptr noalias %x) nounwind uwtable {
-;CHECK-LABEL: @abs_i64(
-;CHECK: llvm.abs.v4i64(<4 x i64> [[WIDE_LOADX:%.*]], i1 true)
-;CHECK: ret void
+define void @abs_i64(i32 %n, ptr %y, ptr %x) {
+; CHECK-LABEL: @abs_i64(
+; CHECK: llvm.abs.v4i64(<4 x i64> [[WIDE_LOADX:%.*]], i1 true)
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1258,7 +1307,7 @@ for.body:                                         ; preds = %entry, %for.body
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %entry ]
   %arrayidx = getelementptr inbounds i64, ptr %y, i64 %indvars.iv
   %0 = load i64, ptr %arrayidx, align 8
-  %call = tail call i64 @llvm.abs.i64(i64 %0, i1 true) nounwind readnone
+  %call = tail call i64 @llvm.abs.i64(i64 %0, i1 true)
   %arrayidx4 = getelementptr inbounds i64, ptr %x, i64 %indvars.iv
   store i64 %call, ptr %arrayidx4, align 8
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1272,10 +1321,11 @@ for.end:                                          ; preds = %for.body, %entry
 
 declare i32 @llvm.smin.i32 (i32, i32)
 
-define void @smin_i32(i32 %n, ptr noalias %x, ptr noalias %y) {
+define void @smin_i32(i32 %n, ptr %x, ptr %y) {
 ; CHECK-LABEL: @smin_i32(
 ; CHECK:         call <4 x i32> @llvm.smin.v4i32(<4 x i32> [[WIDE_LOADX:%.*]], <4 x i32> [[WIDE_LOADY:%.*]])
 ; CHECK:         ret void
+;
 entry:
   %cmp = icmp sgt i32 %n, 0
   br i1 %cmp, label %loop, label %end
@@ -1298,10 +1348,11 @@ end:
 
 declare i32 @llvm.smax.i32 (i32, i32)
 
-define void @smax_i32(i32 %n, ptr noalias %x, ptr noalias %y) {
+define void @smax_i32(i32 %n, ptr %x, ptr %y) {
 ; CHECK-LABEL: @smax_i32(
 ; CHECK:         call <4 x i32> @llvm.smax.v4i32(<4 x i32> [[WIDE_LOADX:%.*]], <4 x i32> [[WIDE_LOADY:%.*]])
 ; CHECK:         ret void
+;
 entry:
   %cmp = icmp sgt i32 %n, 0
   br i1 %cmp, label %loop, label %end
@@ -1324,10 +1375,11 @@ end:
 
 declare i32 @llvm.umin.i32 (i32, i32)
 
-define void @umin_i32(i32 %n, ptr noalias %x, ptr noalias %y) {
+define void @umin_i32(i32 %n, ptr %x, ptr %y) {
 ; CHECK-LABEL: @umin_i32(
 ; CHECK:         call <4 x i32> @llvm.umin.v4i32(<4 x i32> [[WIDE_LOADX:%.*]], <4 x i32> [[WIDE_LOADY:%.*]])
 ; CHECK:         ret void
+;
 entry:
   %cmp = icmp sgt i32 %n, 0
   br i1 %cmp, label %loop, label %end
@@ -1350,10 +1402,11 @@ end:
 
 declare i32 @llvm.umax.i32 (i32, i32)
 
-define void @umax_i32(i32 %n, ptr noalias %x, ptr noalias %y) {
+define void @umax_i32(i32 %n, ptr %x, ptr %y) {
 ; CHECK-LABEL: @umax_i32(
 ; CHECK:         call <4 x i32> @llvm.umax.v4i32(<4 x i32> [[WIDE_LOADX:%.*]], <4 x i32> [[WIDE_LOADY:%.*]])
 ; CHECK:         ret void
+;
 entry:
   %cmp = icmp sgt i32 %n, 0
   br i1 %cmp, label %loop, label %end
@@ -1376,10 +1429,11 @@ end:
 
 declare i32 @llvm.fshl.i32 (i32, i32, i32)
 
-define void @fshl_i32(i32 %n, ptr noalias %x, ptr noalias %y, i32 %shAmt) {
+define void @fshl_i32(i32 %n, ptr %x, ptr %y, i32 %shAmt) {
 ; CHECK-LABEL: @fshl_i32(
 ; CHECK:         call <4 x i32> @llvm.fshl.v4i32(<4 x i32> [[WIDE_LOADX:%.*]], <4 x i32> [[WIDE_LOADY:%.*]], <4 x i32> [[SPLAT:%.*]])
 ; CHECK:         ret void
+;
 entry:
   %cmp = icmp sgt i32 %n, 0
   br i1 %cmp, label %loop, label %end
@@ -1402,10 +1456,11 @@ end:
 
 declare i32 @llvm.fshr.i32 (i32, i32, i32)
 
-define void @fshr_i32(i32 %n, ptr noalias %x, ptr noalias %y, i32 %shAmt) {
+define void @fshr_i32(i32 %n, ptr %x, ptr %y, i32 %shAmt) {
 ; CHECK-LABEL: @fshr_i32(
 ; CHECK:         call <4 x i32> @llvm.fshr.v4i32(<4 x i32> [[WIDE_LOADX:%.*]], <4 x i32> [[WIDE_LOADY:%.*]], <4 x i32> [[SPLAT:%.*]])
 ; CHECK:         ret void
+;
 entry:
   %cmp = icmp sgt i32 %n, 0
   br i1 %cmp, label %loop, label %end
@@ -1426,12 +1481,13 @@ end:
   ret void
 }
 
-declare float @llvm.minnum.f32(float, float) nounwind readnone
+declare float @llvm.minnum.f32(float, float)
 
-;CHECK-LABEL: @minnum_f32(
-;CHECK: llvm.minnum.v4f32
-;CHECK: ret void
-define void @minnum_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @minnum_f32(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @minnum_f32(
+; CHECK: llvm.minnum.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1442,7 +1498,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load float, ptr %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, ptr %z, i64 %indvars.iv
   %1 = load float, ptr %arrayidx2, align 4
-  %call = tail call float @llvm.minnum.f32(float %0, float %1) nounwind readnone
+  %call = tail call float @llvm.minnum.f32(float %0, float %1)
   %arrayidx4 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx4, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1454,12 +1510,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.maxnum.f32(float, float) nounwind readnone
+declare float @llvm.maxnum.f32(float, float)
 
-;CHECK-LABEL: @maxnum_f32(
-;CHECK: llvm.maxnum.v4f32
-;CHECK: ret void
-define void @maxnum_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @maxnum_f32(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @maxnum_f32(
+; CHECK: llvm.maxnum.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1470,7 +1527,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load float, ptr %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, ptr %z, i64 %indvars.iv
   %1 = load float, ptr %arrayidx2, align 4
-  %call = tail call float @llvm.maxnum.f32(float %0, float %1) nounwind readnone
+  %call = tail call float @llvm.maxnum.f32(float %0, float %1)
   %arrayidx4 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx4, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1482,12 +1539,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.minimum.f32(float, float) nounwind readnone
+declare float @llvm.minimum.f32(float, float)
 
-;CHECK-LABEL: @minimum_f32(
-;CHECK: llvm.minimum.v4f32
-;CHECK: ret void
-define void @minimum_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @minimum_f32(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @minimum_f32(
+; CHECK: llvm.minimum.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1498,7 +1556,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load float, ptr %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, ptr %z, i64 %indvars.iv
   %1 = load float, ptr %arrayidx2, align 4
-  %call = tail call float @llvm.minimum.f32(float %0, float %1) nounwind readnone
+  %call = tail call float @llvm.minimum.f32(float %0, float %1)
   %arrayidx4 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx4, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1
@@ -1510,12 +1568,13 @@ for.end:                                          ; preds = %for.body, %entry
   ret void
 }
 
-declare float @llvm.maximum.f32(float, float) nounwind readnone
+declare float @llvm.maximum.f32(float, float)
 
-;CHECK-LABEL: @maximum_f32(
-;CHECK: llvm.maximum.v4f32
-;CHECK: ret void
-define void @maximum_f32(i32 %n, ptr noalias %y, ptr noalias %x, ptr noalias %z) nounwind uwtable {
+define void @maximum_f32(i32 %n, ptr %y, ptr %x, ptr %z) {
+; CHECK-LABEL: @maximum_f32(
+; CHECK: llvm.maximum.v4f32
+; CHECK: ret void
+;
 entry:
   %cmp9 = icmp sgt i32 %n, 0
   br i1 %cmp9, label %for.body, label %for.end
@@ -1526,7 +1585,7 @@ for.body:                                         ; preds = %entry, %for.body
   %0 = load float, ptr %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds float, ptr %z, i64 %indvars.iv
   %1 = load float, ptr %arrayidx2, align 4
-  %call = tail call float @llvm.maximum.f32(float %0, float %1) nounwind readnone
+  %call = tail call float @llvm.maximum.f32(float %0, float %1)
   %arrayidx4 = getelementptr inbounds float, ptr %x, i64 %indvars.iv
   store float %call, ptr %arrayidx4, align 4
   %indvars.iv.next = add i64 %indvars.iv, 1


### PR DESCRIPTION
Clean up intrinsic.ll by removing extraneous attributes and target datalayout, fix a bug in the copysign_f64 test, and add missing CHECK lines.