### PR TITLE
Scalarizer: add negative test for lrint, llrint

### DIFF
--- a/llvm/test/Transforms/Scalarizer/intrinsics.ll
+++ b/llvm/test/Transforms/Scalarizer/intrinsics.ll
@@ -25,8 +25,13 @@ declare <2 x float> @llvm.powi.v2f32.i32(<2 x float>, i32)
 declare <2 x i32> @llvm.smul.fix.sat.v2i32(<2 x i32>, <2 x i32>, i32)
 declare <2 x i32> @llvm.umul.fix.sat.v2i32(<2 x i32>, <2 x i32>, i32)
 
+; Unary fp operand, int return type
 declare <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float>)
 declare <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float>)
+
+; Unary fp operand, int return type
+declare <2 x i32> @llvm.lrint.v2i32.v2f32(<2 x float>)
+declare <2 x i32> @llvm.llrint.v2i32.v2f32(<2 x float>)
 
 ; Bool return type, overloaded on fp operand type
 declare <2 x i1> @llvm.is.fpclass(<2 x float>, i32)
@@ -208,6 +213,24 @@ define <2 x i32> @scalarize_fptoui_sat(<2 x float> %x) #0 {
 ;
   %sat = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %x)
   ret <2 x i32> %sat
+}
+
+define <2 x i32> @scalarize_lrint(<2 x float> %x) #0 {
+; CHECK-LABEL: @scalarize_lrint(
+; CHECK-NEXT:    [[RND:%.*]] = call <2 x i32> @llvm.lrint.v2i32.v2f32(<2 x float> [[X:%.*]])
+; CHECK-NEXT:    ret <2 x i32> [[RND]]
+;
+  %rnd = call <2 x i32> @llvm.lrint.v2i32.v2f32(<2 x float> %x)
+  ret <2 x i32> %rnd
+}
+
+define <2 x i32> @scalarize_llrint(<2 x float> %x) #0 {
+; CHECK-LABEL: @scalarize_llrint(
+; CHECK-NEXT:    [[RND:%.*]] = call <2 x i32> @llvm.llrint.v2i32.v2f32(<2 x float> [[X:%.*]])
+; CHECK-NEXT:    ret <2 x i32> [[RND]]
+;
+  %rnd = call <2 x i32> @llvm.llrint.v2i32.v2f32(<2 x float> %x)
+  ret <2 x i32> %rnd
 }
 
 define <2 x i1> @scalarize_is_fpclass(<2 x float> %x) #0 {


### PR DESCRIPTION
With the recent change 98c90a13 (ISel: introduce vector ISD::LRINT, ISD::LLRINT; custom RISCV lowering), it is now possible to scalarize llvm.lrint and llvm.llrint with a trivial change to VectorUtils. In preparation for this change, and the corresponding test update, add a negative test for lrint and llrint.