### PR TITLE
[AMDGPU] Cleanup hasUnwantedEffectsWhenEXECEmpty function

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3906,8 +3906,7 @@ bool SIInstrInfo::hasUnwantedEffectsWhenEXECEmpty(const MachineInstr &MI) const 
   //
   // However, executing them with EXEC = 0 causes them to operate on undefined
   // data, which we avoid by returning true here.
-  if (Opcode == AMDGPU::V_READFIRSTLANE_B32 ||
-      Opcode == AMDGPU::V_READLANE_B32 || Opcode == AMDGPU::V_WRITELANE_B32)
+  if (Opcode == AMDGPU::V_READFIRSTLANE_B32)
     return true;
 
   return false;

--- a/llvm/test/CodeGen/AMDGPU/remove-short-exec-branches-special-instructions.mir
+++ b/llvm/test/CodeGen/AMDGPU/remove-short-exec-branches-special-instructions.mir
@@ -130,13 +130,12 @@ body: |
 
 ---
 
-name: need_skip_writelane_b32
+name: dont_skip_writelane_b32
 body: |
-  ; CHECK-LABEL: name: need_skip_writelane_b32
+  ; CHECK-LABEL: name: dont_skip_writelane_b32
   ; CHECK: bb.0:
-  ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; CHECK-NEXT:   successors: %bb.1(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_CBRANCH_EXECZ %bb.2, implicit $exec
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
@@ -160,13 +159,12 @@ body: |
 ...
 
 ---
-name: need_skip_readlane_b32
+name: dont_skip_readlane_b32
 body: |
-  ; CHECK-LABEL: name: need_skip_readlane_b32
+  ; CHECK-LABEL: name: dont_skip_readlane_b32
   ; CHECK: bb.0:
-  ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; CHECK-NEXT:   successors: %bb.1(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_CBRANCH_EXECZ %bb.2, implicit $exec
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)


### PR DESCRIPTION
The readlane & writelane instructions don't really depend on the the EXEC mask and they should return false from here.