### PR TITLE
Recognize friend operator != to fix ambiguity with operator==

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -960,7 +960,7 @@ static bool shouldAddReversedEqEq(Sema &S, SourceLocation OpLoc,
       if (FunctionsCorrespond(S.Context, EqFD, Op->getAsFunction()))
         return false;
     return true;
-  } 
+  }
   // Otherwise the search scope is the namespace scope of which F is a member.
   DeclContext *EqDC = EqFD->getEnclosingNamespaceContext();
   for (NamedDecl *Op : EqDC->lookup(NotEqOp)) {

--- a/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p3-2a.cpp
+++ b/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p3-2a.cpp
@@ -325,7 +325,7 @@ bool x = X() == X(); // expected-warning {{ambiguous}}
 } // namespace P2468R2
 
 namespace friend_opNE_GH{
-namespace test1 {
+namespace opNENotFound {
 struct S {
     operator int();
     friend bool operator==(const S &, int); // expected-note {{reversed}}
@@ -333,9 +333,9 @@ struct S {
 struct A : S {};
 struct B : S {};
 bool x = A{} == B{}; // expected-warning {{ambiguous}}
-} // namespace test1
+} // namespace opNENotFound
 
-namespace test2 {
+namespace opNEFound {
 struct S {
     operator int();
     friend bool operator==(const S &, int);
@@ -343,8 +343,8 @@ struct S {
 };
 struct A : public P {};
 struct B : public P {};
-bool check(A a, B b) { return a == b; } // expected-warning {{use of overloaded operator '==' (with operand types 'A' and 'B') to be ambiguous}}
-} // namespace test2
+bool x = A{} == B{};
+} // namespace opNEFound
 } // namespace friend_opNE_GH
 
 namespace ADL_GH68901{

--- a/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p3-2a.cpp
+++ b/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p3-2a.cpp
@@ -341,8 +341,8 @@ struct S {
     friend bool operator==(const S &, int);
     friend bool operator!=(const S &, int);
 };
-struct A : public P {};
-struct B : public P {};
+struct A : S {};
+struct B : S {};
 bool x = A{} == B{};
 } // namespace opNEFound
 } // namespace friend_opNE_GH

--- a/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p3-2a.cpp
+++ b/clang/test/CXX/over/over.match/over.match.funcs/over.match.oper/p3-2a.cpp
@@ -324,6 +324,29 @@ bool x = X() == X(); // expected-warning {{ambiguous}}
 }
 } // namespace P2468R2
 
+namespace friend_opNE_GH{
+namespace test1 {
+struct S {
+    operator int();
+    friend bool operator==(const S &, int); // expected-note {{reversed}}
+};
+struct A : S {};
+struct B : S {};
+bool x = A{} == B{}; // expected-warning {{ambiguous}}
+} // namespace test1
+
+namespace test2 {
+struct S {
+    operator int();
+    friend bool operator==(const S &, int);
+    friend bool operator!=(const S &, int);
+};
+struct A : public P {};
+struct B : public P {};
+bool check(A a, B b) { return a == b; } // expected-warning {{use of overloaded operator '==' (with operand types 'A' and 'B') to be ambiguous}}
+} // namespace test2
+} // namespace friend_opNE_GH
+
 namespace ADL_GH68901{
 namespace test1 {
 namespace A {


### PR DESCRIPTION
The namespace lookup should give a matching friend operator!= as friend functions belong to the namespace scope (as opposed to the lexical class scope).

Thus to resolve ambiguity of `operator==` with itself, defining a corresponding `friend operator!=` should suffice.

Fixes: https://github.com/llvm/llvm-project/issues/70210