### PR TITLE
[Libomptarget] Bump up PTX version from +ptx61 to +ptx63

### DIFF
--- a/openmp/libomptarget/DeviceRTL/CMakeLists.txt
+++ b/openmp/libomptarget/DeviceRTL/CMakeLists.txt
@@ -232,7 +232,7 @@ function(compileDeviceRTLLibrary target_cpu target_name target_triple)
 
   set(target_feature "")
   if("${target_triple}" STREQUAL "nvptx64-nvidia-cuda")
-    set(target_feature "feature=+ptx61")
+    set(target_feature "feature=+ptx63")
   endif()
 
   # Package the bitcode in the bitcode and embed it in an ELF for the static library


### PR DESCRIPTION
Summary:
This version is required to support the 'activemask' feature which is
used for certain features, such as reductions. This ties the
implementation of the DeviceRTL roughly to the features provided by the
CUDA 9.0 release, which should be sufficienly old as to not cause
problems since this is a minor version jump that corresponds to the
release of `sm_53`.
