### PR TITLE
[clang-tidy]fix misc-unused-using-decls false positive false for using in elaborated type

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
@@ -8,6 +8,7 @@
 
 #include "UnusedUsingDeclsCheck.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Lex/Lexer.h"
 
@@ -71,6 +72,10 @@ void UnusedUsingDeclsCheck::registerMatchers(MatchFinder *Finder) {
                          templateArgument().bind("used")))),
                      this);
   Finder->addMatcher(userDefinedLiteral().bind("used"), this);
+  Finder->addMatcher(
+      elaboratedType(unless(hasQualifier(nestedNameSpecifier())),
+                     hasUnqualifiedDesugaredType(type().bind("usedType"))),
+      this);
   // Cases where we can identify the UsingShadowDecl directly, rather than
   // just its target.
   // FIXME: cover more cases in this way, as the AST supports it.
@@ -142,6 +147,12 @@ void UnusedUsingDeclsCheck::check(const MatchFinder::MatchResult &Result) {
   // marked after a corresponding using decl has been found.
   if (const auto *Used = Result.Nodes.getNodeAs<NamedDecl>("used")) {
     RemoveNamedDecl(Used);
+    return;
+  }
+
+  if (const auto *T = Result.Nodes.getNodeAs<Type>("usedType")) {
+    if (const auto *ND = T->getAsTagDecl())
+      RemoveNamedDecl(ND);
     return;
   }
 

--- a/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
@@ -73,8 +73,8 @@ void UnusedUsingDeclsCheck::registerMatchers(MatchFinder *Finder) {
                      this);
   Finder->addMatcher(userDefinedLiteral().bind("used"), this);
   Finder->addMatcher(
-      elaboratedType(unless(hasQualifier(nestedNameSpecifier())),
-                     hasUnqualifiedDesugaredType(type().bind("usedType"))),
+      loc(elaboratedType(unless(hasQualifier(nestedNameSpecifier())),
+                         hasUnqualifiedDesugaredType(type().bind("usedType")))),
       this);
   // Cases where we can identify the UsingShadowDecl directly, rather than
   // just its target.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -290,6 +290,10 @@ Changes in existing checks
   <clang-tidy/checks/misc/redundant-expression>` check to ignore
   false-positives in unevaluated context (e.g., ``decltype``).
 
+- Improved :doc:`misc-unused-using-decls
+  <clang-tidy/checks/misc/unused-using-decls>` check to avoid false positive when
+  using in elaborated type.
+
 - Improved :doc:`modernize-avoid-bind
   <clang-tidy/checks/modernize/avoid-bind>` check to
   not emit a ``return`` for fixes when the function returns ``void``.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.cpp
@@ -213,3 +213,12 @@ template <typename T, template <typename> class U> class Bar {};
 // We used to report Q unsued, because we only checked the first template
 // argument.
 Bar<int, Q> *bar;
+
+namespace gh69714 {
+struct StructGH69714_1 {};
+struct StructGH69714_2 {};
+} // namespace gh69714
+using gh69714::StructGH69714_1;
+using gh69714::StructGH69714_2;
+struct StructGH69714_1 a;
+struct StructGH69714_2 *b;


### PR DESCRIPTION
`ElaboratedType` including tag keywords and any nested-name-specifiers.
We should ignore nested-name-specifiers case but consider tag keywords case for `misc-unused-using-decls` check
Fixes: #69714
