### PR TITLE
Improve debug names index fetching global variables performance

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -129,19 +129,19 @@ void DebugNamesDWARFIndex::GetGlobalVariables(
     DWARFUnit &cu, llvm::function_ref<bool(DWARFDIE die)> callback) {
   uint64_t cu_offset = cu.GetOffset();
   bool found_entry_for_cu = false;
-  for (const DebugNames::NameIndex &ni: *m_debug_names_up) {
+  for (const DebugNames::NameIndex &ni : *m_debug_names_up) {
     // Check if this name index contains an entry for the given CU.
-    bool has_match_cu = false;
-    for (uint32_t i = 0;i < ni.getCUCount();++i) {
+    bool cu_matches = false;
+    for (uint32_t i = 0; i < ni.getCUCount(); ++i) {
       if (ni.getCUOffset(i) == cu_offset) {
-        has_match_cu = true;
+        cu_matches = true;
         break;
       }
     }
-    if (!has_match_cu)
+    if (!cu_matches)
       continue;
 
-    for (DebugNames::NameTableEntry nte: ni) {
+    for (DebugNames::NameTableEntry nte : ni) {
       uint64_t entry_offset = nte.getEntryOffset();
       llvm::Expected<DebugNames::Entry> entry_or = ni.getEntry(&entry_offset);
       for (; entry_or; entry_or = ni.getEntry(&entry_offset)) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -130,6 +130,17 @@ void DebugNamesDWARFIndex::GetGlobalVariables(
   uint64_t cu_offset = cu.GetOffset();
   bool found_entry_for_cu = false;
   for (const DebugNames::NameIndex &ni: *m_debug_names_up) {
+    // Check if this name index contains an entry for the given CU.
+    bool has_match_cu = false;
+    for (uint32_t i = 0;i < ni.getCUCount();++i) {
+      if (ni.getCUOffset(i) == cu_offset) {
+        has_match_cu = true;
+        break;
+      }
+    }
+    if (!has_match_cu)
+      continue;
+
     for (DebugNames::NameTableEntry nte: ni) {
       uint64_t entry_offset = nte.getEntryOffset();
       llvm::Expected<DebugNames::Entry> entry_or = ni.getEntry(&entry_offset);


### PR DESCRIPTION
While using dwarf5 `.debug_names` in internal large targets, we noticed a performance issue (around 10 seconds delay) while `lldb-vscode` tries to show `scopes` for a compile unit. Profiling shows the bottleneck is inside `DebugNamesDWARFIndex::GetGlobalVariables` which linearly search all index entries belongs to a compile unit. 

This patch improves the performance by using the compile units list to filter first before checking index entries. This significantly improves the performance (drops from 10 seconds => under 1 second) in the split dwarf situation because each compile unit has its own named index. 


