### PR TITLE
[scudo] Pass the max number of blocks to popBlocks

### DIFF
--- a/compiler-rt/lib/scudo/standalone/primary32.h
+++ b/compiler-rt/lib/scudo/standalone/primary32.h
@@ -191,13 +191,15 @@ public:
     return BlockSize > PageSize;
   }
 
-  u16 popBlocks(CacheT *C, uptr ClassId, CompactPtrT *ToArray) {
+  u16 popBlocks(CacheT *C, uptr ClassId, CompactPtrT *ToArray,
+                const u16 MaxBlockCount) {
     TransferBatchT *B = popBatch(C, ClassId);
     if (!B)
       return 0;
 
     const u16 Count = B->getCount();
     DCHECK_GT(Count, 0U);
+    DCHECK_LE(Count, MaxBlockCount);
     B->moveToArray(ToArray);
 
     if (ClassId != SizeClassMap::BatchClassId)

--- a/compiler-rt/lib/scudo/standalone/primary32.h
+++ b/compiler-rt/lib/scudo/standalone/primary32.h
@@ -191,15 +191,17 @@ public:
     return BlockSize > PageSize;
   }
 
+  // Note that the `MaxBlockCount` will be used when we support arbitrary blocks
+  // count. Now it's the same as the number of blocks stored in the
+  // `TransferBatch`.
   u16 popBlocks(CacheT *C, uptr ClassId, CompactPtrT *ToArray,
-                const u16 MaxBlockCount) {
+                UNUSED const u16 MaxBlockCount) {
     TransferBatchT *B = popBatch(C, ClassId);
     if (!B)
       return 0;
 
     const u16 Count = B->getCount();
     DCHECK_GT(Count, 0U);
-    DCHECK_LE(Count, MaxBlockCount);
     B->moveToArray(ToArray);
 
     if (ClassId != SizeClassMap::BatchClassId)

--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -221,15 +221,17 @@ public:
     DCHECK_EQ(BlocksInUse, BatchClassUsedInFreeLists);
   }
 
+  // Note that the `MaxBlockCount` will be used when we support arbitrary blocks
+  // count. Now it's the same as the number of blocks stored in the
+  // `TransferBatch`.
   u16 popBlocks(CacheT *C, uptr ClassId, CompactPtrT *ToArray,
-                const u16 MaxBlockCount) {
+                UNUSED const u16 MaxBlockCount) {
     TransferBatchT *B = popBatch(C, ClassId);
     if (!B)
       return 0;
 
     const u16 Count = B->getCount();
     DCHECK_GT(Count, 0U);
-    DCHECK_LE(Count, MaxBlockCount);
     B->moveToArray(ToArray);
 
     if (ClassId != SizeClassMap::BatchClassId)

--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -221,13 +221,15 @@ public:
     DCHECK_EQ(BlocksInUse, BatchClassUsedInFreeLists);
   }
 
-  u16 popBlocks(CacheT *C, uptr ClassId, CompactPtrT *ToArray) {
+  u16 popBlocks(CacheT *C, uptr ClassId, CompactPtrT *ToArray,
+                const u16 MaxBlockCount) {
     TransferBatchT *B = popBatch(C, ClassId);
     if (!B)
       return 0;
 
     const u16 Count = B->getCount();
     DCHECK_GT(Count, 0U);
+    DCHECK_LE(Count, MaxBlockCount);
     B->moveToArray(ToArray);
 
     if (ClassId != SizeClassMap::BatchClassId)


### PR DESCRIPTION
Make the cache have the fully control on how many blocks to be popped (At before, it depended the number of blocks stored in the TransferBatch)