### PR TITLE
[libc] Fix incorrect printing for alt mode ints

### DIFF
--- a/libc/src/stdio/printf_core/int_converter.h
+++ b/libc/src/stdio/printf_core/int_converter.h
@@ -113,7 +113,7 @@ LIBC_INLINE int convert_int(Writer *writer, const FormatSection &to_conv) {
   size_t prefix_len;
   char prefix[2];
   if ((to_lower(to_conv.conv_name) == 'x') &&
-      ((flags & FormatFlags::ALTERNATE_FORM) != 0)) {
+      ((flags & FormatFlags::ALTERNATE_FORM) != 0) && num != 0) {
     prefix_len = 2;
     prefix[0] = '0';
     prefix[1] = a + ('x' - 'a');
@@ -158,8 +158,20 @@ LIBC_INLINE int convert_int(Writer *writer, const FormatSection &to_conv) {
                               prefix_len);
   }
 
+  // The standard says that alternate form for the o conversion "increases
+  // the precision, if and only if necessary, to force the first digit of the
+  // result to be a zero (if the value and precision are both 0, a single 0 is
+  // printed)"
+  // This if checks the following conditions:
+  // 1) is this an o conversion in alternate form?
+  // 2) does this number has a leading zero?
+  //    2a) ... because there are additional leading zeroes?
+  //    2b) ... because it is just "0", unless it will not write any digits.
+  const bool has_leading_zero =
+      (zeroes > 0) || ((num == 0) && (digits_written != 0));
   if ((to_conv.conv_name == 'o') &&
-      ((to_conv.flags & FormatFlags::ALTERNATE_FORM) != 0) && zeroes < 1) {
+      ((to_conv.flags & FormatFlags::ALTERNATE_FORM) != 0) &&
+      !has_leading_zero) {
     zeroes = 1;
     --spaces;
   }

--- a/libc/test/src/stdio/sprintf_test.cpp
+++ b/libc/test/src/stdio/sprintf_test.cpp
@@ -329,6 +329,10 @@ TEST(LlvmLibcSPrintfTest, HexConv) {
   EXPECT_EQ(written, 5);
   ASSERT_STREQ(buff, "0xd3f");
 
+  written = LIBC_NAMESPACE::sprintf(buff, "%#x", 0);
+  EXPECT_EQ(written, 1);
+  ASSERT_STREQ(buff, "0");
+
   written = LIBC_NAMESPACE::sprintf(buff, "%#X", 0xE40);
   EXPECT_EQ(written, 5);
   ASSERT_STREQ(buff, "0XE40");
@@ -358,6 +362,10 @@ TEST(LlvmLibcSPrintfTest, HexConv) {
   written = LIBC_NAMESPACE::sprintf(buff, "%#9.5X", 0x9d4);
   EXPECT_EQ(written, 9);
   ASSERT_STREQ(buff, "  0X009D4");
+
+  written = LIBC_NAMESPACE::sprintf(buff, "%#.x", 0);
+  EXPECT_EQ(written, 0);
+  ASSERT_STREQ(buff, "");
 
   written = LIBC_NAMESPACE::sprintf(buff, "%-7.5x", 0x260);
   EXPECT_EQ(written, 7);
@@ -516,6 +524,10 @@ TEST(LlvmLibcSPrintfTest, OctConv) {
   EXPECT_EQ(written, 4);
   ASSERT_STREQ(buff, "0234");
 
+  written = LIBC_NAMESPACE::sprintf(buff, "%#o", 0);
+  EXPECT_EQ(written, 1);
+  ASSERT_STREQ(buff, "0");
+
   written = LIBC_NAMESPACE::sprintf(buff, "%05o", 0470);
   EXPECT_EQ(written, 5);
   ASSERT_STREQ(buff, "00470");
@@ -533,6 +545,10 @@ TEST(LlvmLibcSPrintfTest, OctConv) {
   written = LIBC_NAMESPACE::sprintf(buff, "%#-07o", 0703);
   EXPECT_EQ(written, 7);
   ASSERT_STREQ(buff, "0703   ");
+
+  written = LIBC_NAMESPACE::sprintf(buff, "%#.o", 0);
+  EXPECT_EQ(written, 1);
+  ASSERT_STREQ(buff, "0");
 
   written = LIBC_NAMESPACE::sprintf(buff, "%7.5o", 0314);
   EXPECT_EQ(written, 7);


### PR DESCRIPTION
Previously, our printf would incorrectly handle conversions like
("%#x",0) and ("%#o",0). This patch corrects the behavior to match what
is described in the standard.
