### PR TITLE
[X86] Place data in large sections for large code model

### DIFF
--- a/llvm/lib/Target/TargetMachine.cpp
+++ b/llvm/lib/Target/TargetMachine.cpp
@@ -42,9 +42,8 @@ TargetMachine::~TargetMachine() = default;
 bool TargetMachine::isLargeData(const GlobalVariable *GV) const {
   if (getTargetTriple().getArch() != Triple::x86_64 || GV->isThreadLocal())
     return false;
-  // Large data under the large code model still needs to be thought about, so
-  // restrict this to medium.
-  if (getCodeModel() != CodeModel::Medium)
+
+  if (getCodeModel() != CodeModel::Medium && getCodeModel() != CodeModel::Large)
     return false;
 
   // Allowing large metadata sections in the presence of an explicit section is

--- a/llvm/test/CodeGen/X86/code-model-elf-sections.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf-sections.ll
@@ -6,7 +6,9 @@
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=LARGE
 ; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=medium -large-data-threshold=80 -o %t
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=SMALL
-; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -o %t
+; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -large-data-threshold=79 -o %t
+; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=LARGE
+; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -large-data-threshold=80 -o %t
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=SMALL
 
 ; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=small -data-sections -o %t
@@ -14,7 +16,7 @@
 ; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=medium -data-sections -o %t
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=LARGE-DS
 ; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -data-sections -o %t
-; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=SMALL-DS
+; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=LARGE-DS
 
 ; SMALL: .data {{.*}} WA {{.*}}
 ; SMALL: .data.x {{.*}} WA {{.*}}


### PR DESCRIPTION
This allows better interoperability mixing small/medium/large code model
code since large code model data can be put into separate large sections.

And respect large data threshold under large code model.
gcc also does this: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html.

See https://groups.google.com/g/x86-64-abi/c/jnQdJeabxiU.