### PR TITLE
[Clang][Driver] Add new flags to control machine instruction verification

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -206,6 +206,13 @@ New Compiler Flags
   Since enabling the verifier adds a non-trivial cost of a few percent impact on
   build times, it's disabled by default, unless your LLVM distribution itself is
   compiled with runtime checks enabled.
+* ``-fverify-machine-code`` and its complement ``-fno-verify-machine-code``.
+  Enable or disable the verification of the generated machine code.
+  Users can pass this to turn on extra verification to catch certain types of
+  compiler bugs at the cost of extra compile time.
+  This verifier adds a huge overhead to compile time, it's expected that build times
+  can double, so this is disabled by default.
+  This flag is currently limited to non-LTO builds.
 * ``-fkeep-system-includes`` modifies the behavior of the ``-E`` option,
   preserving ``#include`` directives for "system" headers instead of copying
   the preprocessed text to the output. This can greatly reduce the size of the

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1925,6 +1925,12 @@ def fverify_intermediate_code : Flag<["-"], "fverify-intermediate-code">,
 def fno_verify_intermediate_code : Flag<["-"], "fno-verify-intermediate-code">,
   Group<f_clang_Group>, Visibility<[ClangOption, CLOption, DXCOption]>,
   HelpText<"Disable verification of LLVM IR">;
+def fverify_machine_code : Flag<["-"], "fverify-machine-code">,
+  Group<f_clang_Group>, Visibility<[ClangOption, CLOption, DXCOption]>,
+  HelpText<"Enable verification of generated machine code">;
+def fno_verify_machine_code : Flag<["-"], "fno-verify-machine-code">,
+  Group<f_clang_Group>, Visibility<[ClangOption, CLOption, DXCOption]>,
+  HelpText<"Disable verification of generated machine code">;
 def fdiscard_value_names : Flag<["-"], "fdiscard-value-names">,
   Group<f_clang_Group>, Visibility<[ClangOption, DXCOption]>,
   HelpText<"Discard value names in LLVM IR">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5175,6 +5175,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-disable-llvm-verifier");
   }
 
+  // Enable the machine code verification pass. Note that this is force enabled
+  // elsewhere with LLVM_ENABLE_EXPENSIVE_CHECKS.
+  if (Args.hasFlag(options::OPT_fverify_machine_code,
+                   options::OPT_fno_verify_machine_code, false)) {
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back("-verify-machineinstrs");
+  }
+
   // Discard value names in assert builds unless otherwise specified.
   if (Args.hasFlag(options::OPT_fdiscard_value_names,
                    options::OPT_fno_discard_value_names, !IsAssertBuild)) {

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -525,6 +525,11 @@
 // CHECK-VERIFY-INTERMEDIATE-CODE-NOT: "-disable-llvm-verifier"
 // CHECK-NO-VERIFY-INTERMEDIATE-CODE: "-disable-llvm-verifier"
 
+// RUN: %clang -### -S -fverify-machine-code %s 2>&1 | FileCheck -check-prefix=CHECK-VERIFY-MACHINE-CODE %s
+// RUN: %clang -### -S -fno-verify-machine-code %s 2>&1 | FileCheck -check-prefix=CHECK-NO-VERIFY-MACHINE-CODE %s
+// CHECK-VERIFY-MACHINE-CODE: "-mllvm" "-verify-machineinstrs"
+// CHECK-NO-VERIFY-MACHINE-CODE-NOT: "-mllvm" "-verify-machineinstrs"
+
 // RUN: %clang -### -S -fdiscard-value-names %s 2>&1 | FileCheck -check-prefix=CHECK-DISCARD-NAMES %s
 // RUN: %clang -### -S -fno-discard-value-names %s 2>&1 | FileCheck -check-prefix=CHECK-NO-DISCARD-NAMES %s
 // CHECK-DISCARD-NAMES: "-discard-value-names"


### PR DESCRIPTION
Present shortcomings are that this only works for non-LTO builds, and that this new pass doesn't work quite the same as the IR verification flag, as it runs between every machine pass and is thus much more expensive.

Though I recently discussed this with @aeubanks during the US devmtg and we think this is worthwhile as a first step.