### PR TITLE
[RISCV][GISel] Rename XLenVT sXLen to be consistent with other LLTs.

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -384,8 +384,8 @@ bool RISCVInstructionSelector::replacePtrWithInt(MachineOperand &Op,
   Register PtrReg = Op.getReg();
   assert(MRI.getType(PtrReg).isPointer() && "Operand is not a pointer!");
 
-  const LLT XLenLLT = LLT::scalar(STI.getXLen());
-  auto PtrToInt = MIB.buildPtrToInt(XLenLLT, PtrReg);
+  const LLT sXLen = LLT::scalar(STI.getXLen());
+  auto PtrToInt = MIB.buildPtrToInt(sXLen, PtrReg);
   MRI.setRegBank(PtrToInt.getReg(0), RBI.getRegBank(RISCV::GPRRegBankID));
   Op.setReg(PtrToInt.getReg(0));
   return select(*PtrToInt);
@@ -397,11 +397,11 @@ void RISCVInstructionSelector::preISelLower(MachineInstr &MI,
   switch (MI.getOpcode()) {
   case TargetOpcode::G_PTR_ADD: {
     Register DstReg = MI.getOperand(0).getReg();
-    const LLT XLenLLT = LLT::scalar(STI.getXLen());
+    const LLT sXLen = LLT::scalar(STI.getXLen());
 
     replacePtrWithInt(MI.getOperand(1), MIB, MRI);
     MI.setDesc(TII.get(TargetOpcode::G_ADD));
-    MRI.setType(DstReg, XLenLLT);
+    MRI.setType(DstReg, sXLen);
     break;
   }
   }

--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
@@ -23,8 +23,8 @@ using namespace LegalityPredicates;
 
 RISCVLegalizerInfo::RISCVLegalizerInfo(const RISCVSubtarget &ST) {
   const unsigned XLen = ST.getXLen();
-  const LLT XLenLLT = LLT::scalar(XLen);
-  const LLT DoubleXLenLLT = LLT::scalar(2 * XLen);
+  const LLT sXLen = LLT::scalar(XLen);
+  const LLT sDoubleXLen = LLT::scalar(2 * XLen);
   const LLT p0 = LLT::pointer(0, XLen);
   const LLT s8 = LLT::scalar(8);
   const LLT s16 = LLT::scalar(16);
@@ -34,38 +34,35 @@ RISCVLegalizerInfo::RISCVLegalizerInfo(const RISCVSubtarget &ST) {
   using namespace TargetOpcode;
 
   getActionDefinitionsBuilder({G_ADD, G_SUB, G_AND, G_OR, G_XOR})
-      .legalFor({s32, XLenLLT})
+      .legalFor({s32, sXLen})
       .widenScalarToNextPow2(0)
-      .clampScalar(0, s32, XLenLLT);
+      .clampScalar(0, s32, sXLen);
 
   getActionDefinitionsBuilder(
       {G_UADDE, G_UADDO, G_USUBE, G_USUBO}).lower();
 
-  getActionDefinitionsBuilder({G_SADDO, G_SSUBO}).minScalar(0, XLenLLT).lower();
+  getActionDefinitionsBuilder({G_SADDO, G_SSUBO}).minScalar(0, sXLen).lower();
 
   getActionDefinitionsBuilder({G_ASHR, G_LSHR, G_SHL})
-      .legalFor({{s32, s32}, {XLenLLT, XLenLLT}})
+      .legalFor({{s32, s32}, {sXLen, sXLen}})
       .widenScalarToNextPow2(0)
-      .clampScalar(1, s32, XLenLLT)
-      .clampScalar(0, s32, XLenLLT)
+      .clampScalar(1, s32, sXLen)
+      .clampScalar(0, s32, sXLen)
       .minScalarSameAs(1, 0);
 
   if (ST.is64Bit()) {
     getActionDefinitionsBuilder({G_ZEXT, G_SEXT, G_ANYEXT})
-        .legalFor({{XLenLLT, s32}})
-        .maxScalar(0, XLenLLT);
+        .legalFor({{sXLen, s32}})
+        .maxScalar(0, sXLen);
 
     getActionDefinitionsBuilder(G_SEXT_INREG)
-        .customFor({XLenLLT})
-        .maxScalar(0, XLenLLT)
+        .customFor({sXLen})
+        .maxScalar(0, sXLen)
         .lower();
   } else {
-    getActionDefinitionsBuilder({G_ZEXT, G_SEXT, G_ANYEXT})
-        .maxScalar(0, XLenLLT);
+    getActionDefinitionsBuilder({G_ZEXT, G_SEXT, G_ANYEXT}).maxScalar(0, sXLen);
 
-    getActionDefinitionsBuilder(G_SEXT_INREG)
-        .maxScalar(0, XLenLLT)
-        .lower();
+    getActionDefinitionsBuilder(G_SEXT_INREG).maxScalar(0, sXLen).lower();
   }
 
   // Merge/Unmerge
@@ -75,123 +72,112 @@ RISCVLegalizerInfo::RISCVLegalizerInfo(const RISCVSubtarget &ST) {
     getActionDefinitionsBuilder(Op)
         .widenScalarToNextPow2(LitTyIdx, XLen)
         .widenScalarToNextPow2(BigTyIdx, XLen)
-        .clampScalar(LitTyIdx, XLenLLT, XLenLLT)
-        .clampScalar(BigTyIdx, XLenLLT, XLenLLT);
+        .clampScalar(LitTyIdx, sXLen, sXLen)
+        .clampScalar(BigTyIdx, sXLen, sXLen);
   }
 
   getActionDefinitionsBuilder({G_CONSTANT, G_IMPLICIT_DEF})
-      .legalFor({s32, XLenLLT, p0})
+      .legalFor({s32, sXLen, p0})
       .widenScalarToNextPow2(0)
-      .clampScalar(0, s32, XLenLLT);
+      .clampScalar(0, s32, sXLen);
 
   getActionDefinitionsBuilder(G_ICMP)
-      .legalFor({{XLenLLT, XLenLLT}, {XLenLLT, p0}})
+      .legalFor({{sXLen, sXLen}, {sXLen, p0}})
       .widenScalarToNextPow2(1)
-      .clampScalar(1, XLenLLT, XLenLLT)
-      .clampScalar(0, XLenLLT, XLenLLT);
+      .clampScalar(1, sXLen, sXLen)
+      .clampScalar(0, sXLen, sXLen);
 
   getActionDefinitionsBuilder(G_SELECT)
-      .legalFor({{XLenLLT, XLenLLT}, {p0, XLenLLT}})
+      .legalFor({{sXLen, sXLen}, {p0, sXLen}})
       .widenScalarToNextPow2(0)
-      .clampScalar(0, XLenLLT, XLenLLT)
-      .clampScalar(1, XLenLLT, XLenLLT);
+      .clampScalar(0, sXLen, sXLen)
+      .clampScalar(1, sXLen, sXLen);
 
   getActionDefinitionsBuilder({G_LOAD, G_STORE})
       .legalForTypesWithMemDesc({{s32, p0, s8, 8},
                                  {s32, p0, s16, 16},
                                  {s32, p0, s32, 32},
-                                 {XLenLLT, p0, s8, 8},
-                                 {XLenLLT, p0, s16, 16},
-                                 {XLenLLT, p0, s32, 32},
-                                 {XLenLLT, p0, XLenLLT, XLen},
-                                 {p0, p0, XLenLLT, XLen}})
-      .clampScalar(0, s32, XLenLLT)
+                                 {sXLen, p0, s8, 8},
+                                 {sXLen, p0, s16, 16},
+                                 {sXLen, p0, s32, 32},
+                                 {sXLen, p0, sXLen, XLen},
+                                 {p0, p0, sXLen, XLen}})
+      .clampScalar(0, s32, sXLen)
       .lower();
 
-  auto &ExtLoadActions =
-      getActionDefinitionsBuilder({G_SEXTLOAD, G_ZEXTLOAD})
-          .legalForTypesWithMemDesc({{s32, p0, s8, 8},
-                                     {s32, p0, s16, 16},
-                                     {XLenLLT, p0, s8, 8},
-                                     {XLenLLT, p0, s16, 16}});
+  auto &ExtLoadActions = getActionDefinitionsBuilder({G_SEXTLOAD, G_ZEXTLOAD})
+                             .legalForTypesWithMemDesc({{s32, p0, s8, 8},
+                                                        {s32, p0, s16, 16},
+                                                        {sXLen, p0, s8, 8},
+                                                        {sXLen, p0, s16, 16}});
   if (XLen == 64)
-    ExtLoadActions.legalForTypesWithMemDesc({{XLenLLT, p0, s32, 32}});
-  ExtLoadActions
-    .widenScalarToNextPow2(0)
-    .clampScalar(0, s32, XLenLLT)
-    .lower();
+    ExtLoadActions.legalForTypesWithMemDesc({{sXLen, p0, s32, 32}});
+  ExtLoadActions.widenScalarToNextPow2(0).clampScalar(0, s32, sXLen).lower();
 
-  getActionDefinitionsBuilder(G_PTR_ADD)
-      .legalFor({{p0, XLenLLT}});
+  getActionDefinitionsBuilder(G_PTR_ADD).legalFor({{p0, sXLen}});
 
   getActionDefinitionsBuilder(G_PTRTOINT)
-      .legalFor({{XLenLLT, p0}})
-      .clampScalar(0, XLenLLT, XLenLLT);
+      .legalFor({{sXLen, p0}})
+      .clampScalar(0, sXLen, sXLen);
 
   getActionDefinitionsBuilder(G_INTTOPTR)
-      .legalFor({{p0, XLenLLT}})
-      .clampScalar(1, XLenLLT, XLenLLT);
+      .legalFor({{p0, sXLen}})
+      .clampScalar(1, sXLen, sXLen);
 
-  getActionDefinitionsBuilder(G_BRCOND)
-      .legalFor({XLenLLT})
-      .minScalar(0, XLenLLT);
+  getActionDefinitionsBuilder(G_BRCOND).legalFor({sXLen}).minScalar(0, sXLen);
 
   getActionDefinitionsBuilder(G_PHI)
-      .legalFor({p0, XLenLLT})
+      .legalFor({p0, sXLen})
       .widenScalarToNextPow2(0)
-      .clampScalar(0, XLenLLT, XLenLLT);
+      .clampScalar(0, sXLen, sXLen);
 
   getActionDefinitionsBuilder(G_GLOBAL_VALUE)
       .legalFor({p0});
 
   if (ST.hasStdExtM() || ST.hasStdExtZmmul()) {
     getActionDefinitionsBuilder(G_MUL)
-        .legalFor({s32, XLenLLT})
+        .legalFor({s32, sXLen})
         .widenScalarToNextPow2(0)
-        .clampScalar(0, s32, XLenLLT);
+        .clampScalar(0, s32, sXLen);
 
     // clang-format off
     getActionDefinitionsBuilder({G_SMULH, G_UMULH})
-        .legalFor({XLenLLT})
+        .legalFor({sXLen})
         .lower();
     // clang-format on
 
-    getActionDefinitionsBuilder({G_SMULO, G_UMULO})
-        .minScalar(0, XLenLLT)
-        .lower();
+    getActionDefinitionsBuilder({G_SMULO, G_UMULO}).minScalar(0, sXLen).lower();
   } else {
     getActionDefinitionsBuilder(G_MUL)
-        .libcallFor({XLenLLT, DoubleXLenLLT})
+        .libcallFor({sXLen, sDoubleXLen})
         .widenScalarToNextPow2(0)
-        .clampScalar(0, XLenLLT, DoubleXLenLLT);
+        .clampScalar(0, sXLen, sDoubleXLen);
 
-    getActionDefinitionsBuilder({G_SMULH, G_UMULH}).lowerFor({XLenLLT});
+    getActionDefinitionsBuilder({G_SMULH, G_UMULH}).lowerFor({sXLen});
 
     getActionDefinitionsBuilder({G_SMULO, G_UMULO})
-        .minScalar(0, XLenLLT)
-        // Widen XLenLLT to DoubleXLenLLT so we can use a single libcall to get
+        .minScalar(0, sXLen)
+        // Widen sXLen to sDoubleXLen so we can use a single libcall to get
         // the low bits for the mul result and high bits to do the overflow
         // check.
         .widenScalarIf(
+            [=](const LegalityQuery &Query) { return Query.Types[0] == sXLen; },
             [=](const LegalityQuery &Query) {
-              return Query.Types[0] == XLenLLT;
-            },
-            [=](const LegalityQuery &Query) {
-              return std::make_pair(0, DoubleXLenLLT);
+              return std::make_pair(0, sDoubleXLen);
             })
         .lower();
   }
 
   if (ST.hasStdExtM()) {
     getActionDefinitionsBuilder({G_UDIV, G_SDIV, G_UREM, G_SREM})
-        .legalFor({s32, XLenLLT})
-        .libcallFor({DoubleXLenLLT})
-        .clampScalar(0, s32, DoubleXLenLLT)
+        .legalFor({s32, sXLen})
+        .libcallFor({sDoubleXLen})
+        .clampScalar(0, s32, sDoubleXLen)
         .widenScalarToNextPow2(0);
   } else {
     getActionDefinitionsBuilder({G_UDIV, G_SDIV, G_UREM, G_SREM})
-        .libcallFor({XLenLLT, DoubleXLenLLT})
-        .clampScalar(0, XLenLLT, DoubleXLenLLT)
+        .libcallFor({sXLen, sDoubleXLen})
+        .clampScalar(0, sXLen, sDoubleXLen)
         .widenScalarToNextPow2(0);
   }
 


### PR DESCRIPTION
This also renames DoubleXLenLLT to sDoubleXLen.