### PR TITLE
[AMDGPU] Correct assert that incorrectly chained multiple == operators.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -1121,8 +1121,8 @@ void MFMASmallGemmSingleWaveOpt::applyIGLPStrategy(
   unsigned MFMACount = 0;
   unsigned DSRCount = 0;
 
-  assert((IsPostRA ||
-          DSWCount == DSWWithPermCount == DSWWithSharedVMEMCount == 0) &&
+  assert((IsPostRA || (DSWCount == 0 && DSWWithPermCount == 0 &&
+                       DSWWithSharedVMEMCount == 0)) &&
          "DSWCounters should be zero in pre-RA scheduling!");
   SmallVector<SUnit *, 6> DSWithPerms;
   for (auto &SU : DAG->SUnits) {


### PR DESCRIPTION
I believe this assert was trying to check that 3 variables were equal to 0.

I think it instead got interpreted as ((DSWCount == DSWWithPermCount) == DSWWithSharedVMEMCount) == 0 I guess (DSWCount == DSWWithPermCount) was true because both counts were 0. Then true got compared to DSWWithSharedVMEMCount, and since DSWWithSharedVMEMCount is 0, that compare was false. And then that false compared equal to the final 0.