### PR TITLE
[lldb][AArch64][Linux] Rename Is<ext>Enabled to Is<ext>Present

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h
@@ -120,12 +120,12 @@ public:
     return false;
   }
 
-  bool IsSVEEnabled() const { return m_opt_regsets.AnySet(eRegsetMaskSVE); }
-  bool IsSSVEEnabled() const { return m_opt_regsets.AnySet(eRegsetMaskSSVE); }
-  bool IsZAEnabled() const { return m_opt_regsets.AnySet(eRegsetMaskZA); }
-  bool IsPAuthEnabled() const { return m_opt_regsets.AnySet(eRegsetMaskPAuth); }
-  bool IsMTEEnabled() const { return m_opt_regsets.AnySet(eRegsetMaskMTE); }
-  bool IsTLSEnabled() const { return m_opt_regsets.AnySet(eRegsetMaskTLS); }
+  bool IsSVEPresent() const { return m_opt_regsets.AnySet(eRegsetMaskSVE); }
+  bool IsSSVEPresent() const { return m_opt_regsets.AnySet(eRegsetMaskSSVE); }
+  bool IsZAPresent() const { return m_opt_regsets.AnySet(eRegsetMaskZA); }
+  bool IsPAuthPresent() const { return m_opt_regsets.AnySet(eRegsetMaskPAuth); }
+  bool IsMTEPresent() const { return m_opt_regsets.AnySet(eRegsetMaskMTE); }
+  bool IsTLSPresent() const { return m_opt_regsets.AnySet(eRegsetMaskTLS); }
 
   bool IsSVEReg(unsigned reg) const;
   bool IsSVEZReg(unsigned reg) const;

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
@@ -75,7 +75,7 @@ RegisterContextCorePOSIX_arm64::RegisterContextCorePOSIX_arm64(
       m_register_info_up->GetTargetArchitecture().GetTriple();
   m_fpr_data = getRegset(notes, target_triple, FPR_Desc);
 
-  if (m_register_info_up->IsSSVEEnabled()) {
+  if (m_register_info_up->IsSSVEPresent()) {
     m_sve_data = getRegset(notes, target_triple, AARCH64_SSVE_Desc);
     lldb::offset_t flags_offset = 12;
     uint16_t flags = m_sve_data.GetU32(&flags_offset);
@@ -83,19 +83,19 @@ RegisterContextCorePOSIX_arm64::RegisterContextCorePOSIX_arm64(
       m_sve_state = SVEState::Streaming;
   }
 
-  if (m_sve_state != SVEState::Streaming && m_register_info_up->IsSVEEnabled())
+  if (m_sve_state != SVEState::Streaming && m_register_info_up->IsSVEPresent())
     m_sve_data = getRegset(notes, target_triple, AARCH64_SVE_Desc);
 
-  if (m_register_info_up->IsPAuthEnabled())
+  if (m_register_info_up->IsPAuthPresent())
     m_pac_data = getRegset(notes, target_triple, AARCH64_PAC_Desc);
 
-  if (m_register_info_up->IsTLSEnabled())
+  if (m_register_info_up->IsTLSPresent())
     m_tls_data = getRegset(notes, target_triple, AARCH64_TLS_Desc);
 
-  if (m_register_info_up->IsZAEnabled())
+  if (m_register_info_up->IsZAPresent())
     m_za_data = getRegset(notes, target_triple, AARCH64_ZA_Desc);
 
-  if (m_register_info_up->IsMTEEnabled())
+  if (m_register_info_up->IsMTEPresent())
     m_mte_data = getRegset(notes, target_triple, AARCH64_MTE_Desc);
 
   ConfigureRegisterContext();


### PR DESCRIPTION
For most register sets, if it was enabled this meant you could use it, it was present in the process. There was no present but turned off state. So "enabled" made sense.

Then ZA came along (and soon to be ZT0) where ZA can be present in the hardware when you have SME, but ZA itself can be made inactive. This means that "IsZAEnabled()" doesn't mean is it active, it means do you have SME. Which is very confusing when we actually want to know if ZA is active.

So instead say "IsZAPresent", to make these checks more specific. For things that can't be made inactive, present will imply "active" as they're never inactive.