### PR TITLE
[Driver] Fix -r handling on Solaris

### DIFF
--- a/clang/lib/Driver/ToolChains/Solaris.cpp
+++ b/clang/lib/Driver/ToolChains/Solaris.cpp
@@ -96,7 +96,8 @@ void solaris::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!LinkerIsGnuLd)
     CmdArgs.push_back("-C");
 
-  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_shared)) {
+  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_shared,
+                   options::OPT_r)) {
     CmdArgs.push_back("-e");
     CmdArgs.push_back("_start");
   }
@@ -114,10 +115,8 @@ void solaris::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-Bstatic");
     CmdArgs.push_back("-dn");
   } else {
-    CmdArgs.push_back("-Bdynamic");
-    if (Args.hasArg(options::OPT_shared)) {
+    if (!Args.hasArg(options::OPT_r) && Args.hasArg(options::OPT_shared))
       CmdArgs.push_back("-shared");
-    }
 
     // libpthread has been folded into libc since Solaris 10, no need to do
     // anything for pthreads. Claim argument to avoid warning.

--- a/clang/test/Driver/solaris-ld.c
+++ b/clang/test/Driver/solaris-ld.c
@@ -177,6 +177,7 @@
 // RUN:   | FileCheck %s --check-prefix=CHECK-RELOCATABLE
 // CHECK-RELOCATABLE:     "-L
 // CHECK-RELOCATABLE:     "-r"
+// CHECK-RELOCATABLE-NOT: "-e"
 // CHECK-RELOCATABLE-NOT: "-l
 // CHECK-RELOCATABLE-NOT: /crt{{[^.]+}}.o
 // CHECK-RELOCATABLE-NOT: /values-{{[^.]+}}.o


### PR DESCRIPTION
As discussed in [[Driver] Link Flang runtime on Solaris](https://github.com/llvm/llvm-project/pull/65644), `clang -r` incorrectly passes both `-Bdynamic` and `-e _start` to `ld` which lets the linker choke.

This patch fixes this, omitting `-Bdynamic` completely which is the linker default.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`.