### PR TITLE
[CodeGen] Add a helper class to reuse `expandMBB`. NFC.

### DIFF
--- a/llvm/include/llvm/CodeGen/ExpandPseudoInstsPass.h
+++ b/llvm/include/llvm/CodeGen/ExpandPseudoInstsPass.h
@@ -1,0 +1,40 @@
+//===-- ExpandPseudoInstsPass.h - Pass for expanding pseudo insts-*-C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ExpandPseudoInstsPass class. It provides a default
+// implementation for expandMBB to simplify target-specific pseudo instruction
+// expansion passes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CODEGEN_EXPANDPSEUDOINSTSPASS_H
+#define LLVM_CODEGEN_EXPANDPSEUDOINSTSPASS_H
+
+#include "llvm/CodeGen/MachineFunctionPass.h"
+
+namespace llvm {
+
+/// ExpandPseudoInstsPass - Helper class for expanding pseudo instructions.
+class ExpandPseudoInstsPass : public MachineFunctionPass {
+protected:
+  explicit ExpandPseudoInstsPass(char &ID) : MachineFunctionPass(ID) {}
+
+  /// If MBBI references a pseudo instruction that should be expanded here,
+  /// do the expansion and return true.  Otherwise return false.
+  virtual bool expandMI(MachineBasicBlock &MBB,
+                        MachineBasicBlock::iterator MBBI,
+                        MachineBasicBlock::iterator &NextMBBI) = 0;
+
+  /// Iterate over the instructions in basic block MBB and expand any
+  /// pseudo instructions.  Return true if anything was modified.
+  bool expandMBB(MachineBasicBlock &MBB);
+};
+
+} // namespace llvm
+
+#endif

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -72,6 +72,7 @@ add_llvm_component_library(LLVMCodeGen
   ExpandLargeFpConvert.cpp
   ExpandMemCmp.cpp
   ExpandPostRAPseudos.cpp
+  ExpandPseudoInstsPass.cpp
   ExpandReductions.cpp
   ExpandVectorPredication.cpp
   FaultMaps.cpp

--- a/llvm/lib/CodeGen/ExpandPseudoInstsPass.cpp
+++ b/llvm/lib/CodeGen/ExpandPseudoInstsPass.cpp
@@ -1,0 +1,34 @@
+//===- ExpandPseudoInstsPass.cpp - Pass for expanding pseudo insts*-C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the ExpandPseudoInstsPass class. It provides a default
+// implementation for expandMBB to simplify target-specific pseudo instruction
+// expansion passes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/ExpandPseudoInstsPass.h"
+
+namespace llvm {
+
+/// Iterate over the instructions in basic block MBB and expand any
+/// pseudo instructions.  Return true if anything was modified.
+bool ExpandPseudoInstsPass::expandMBB(MachineBasicBlock &MBB) {
+  bool Modified = false;
+
+  MachineBasicBlock::iterator MBBI = MBB.begin(), E = MBB.end();
+  while (MBBI != E) {
+    MachineBasicBlock::iterator NMBBI = std::next(MBBI);
+    Modified |= expandMI(MBB, MBBI, NMBBI);
+    MBBI = NMBBI;
+  }
+
+  return Modified;
+}
+
+} // namespace llvm

--- a/llvm/lib/Target/Mips/MipsExpandPseudo.cpp
+++ b/llvm/lib/Target/Mips/MipsExpandPseudo.cpp
@@ -21,8 +21,8 @@
 #include "Mips.h"
 #include "MipsInstrInfo.h"
 #include "MipsSubtarget.h"
+#include "llvm/CodeGen/ExpandPseudoInstsPass.h"
 #include "llvm/CodeGen/LivePhysRegs.h"
-#include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 
 using namespace llvm;
@@ -30,10 +30,10 @@ using namespace llvm;
 #define DEBUG_TYPE "mips-pseudo"
 
 namespace {
-  class MipsExpandPseudo : public MachineFunctionPass {
+  class MipsExpandPseudo : public ExpandPseudoInstsPass {
   public:
     static char ID;
-    MipsExpandPseudo() : MachineFunctionPass(ID) {}
+    MipsExpandPseudo() : ExpandPseudoInstsPass(ID) {}
 
     const MipsInstrInfo *TII;
     const MipsSubtarget *STI;
@@ -65,8 +65,7 @@ namespace {
                                   MachineBasicBlock::iterator &NMBBI);
 
     bool expandMI(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
-                  MachineBasicBlock::iterator &NMBB);
-    bool expandMBB(MachineBasicBlock &MBB);
+                  MachineBasicBlock::iterator &NMBB) override;
    };
   char MipsExpandPseudo::ID = 0;
 }
@@ -876,19 +875,6 @@ bool MipsExpandPseudo::expandMI(MachineBasicBlock &MBB,
   default:
     return Modified;
   }
-}
-
-bool MipsExpandPseudo::expandMBB(MachineBasicBlock &MBB) {
-  bool Modified = false;
-
-  MachineBasicBlock::iterator MBBI = MBB.begin(), E = MBB.end();
-  while (MBBI != E) {
-    MachineBasicBlock::iterator NMBBI = std::next(MBBI);
-    Modified |= expandMI(MBB, MBBI, NMBBI);
-    MBBI = NMBBI;
-  }
-
-  return Modified;
 }
 
 bool MipsExpandPseudo::runOnMachineFunction(MachineFunction &MF) {


### PR DESCRIPTION
This PR adds a helper class `ExpandPseudoInstsPass` to avoid copying and pasting `expandMBB` implementations.
IMHO, I am not sure this change is profitable. I just posted this patch for your opinion.
