### PR TITLE
[clang-format] Change LLVM style to BreakAfterAttributes == ABS_Leave

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -794,6 +794,7 @@ clang-format
 ------------
 - Add ``AllowBreakBeforeNoexceptSpecifier`` option.
 - Add ``AllowShortCompoundRequirementOnASingleLine`` option.
+- Change ``BreakAfterAttributes`` from ``Never`` to ``Leave`` in LLVM style
 
 libclang
 --------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -794,7 +794,7 @@ clang-format
 ------------
 - Add ``AllowBreakBeforeNoexceptSpecifier`` option.
 - Add ``AllowShortCompoundRequirementOnASingleLine`` option.
-- Change ``BreakAfterAttributes`` from ``Never`` to ``Leave`` in LLVM style
+- Change ``BreakAfterAttributes`` from ``Never`` to ``Leave`` in LLVM style.
 
 libclang
 --------

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1476,7 +1476,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
                              /*SplitEmptyFunction=*/true,
                              /*SplitEmptyRecord=*/true,
                              /*SplitEmptyNamespace=*/true};
-  LLVMStyle.BreakAfterAttributes = FormatStyle::ABS_Never;
+  LLVMStyle.BreakAfterAttributes = FormatStyle::ABS_Leave;
   LLVMStyle.BreakAfterJavaFieldAnnotations = false;
   LLVMStyle.BreakArrays = true;
   LLVMStyle.BreakBeforeBinaryOperators = FormatStyle::BOS_None;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26179,7 +26179,7 @@ TEST_F(FormatTest, RemoveSemicolon) {
 
 TEST_F(FormatTest, BreakAfterAttributes) {
   FormatStyle Style = getLLVMStyle();
-  EXPECT_EQ(Style.BreakAfterAttributes, FormatStyle::ABS_Never);
+  EXPECT_EQ(Style.BreakAfterAttributes, FormatStyle::ABS_Leave);
 
   constexpr StringRef Code("[[nodiscard]] inline int f(int &i);\n"
                            "[[foo([[]])]] [[nodiscard]]\n"
@@ -26193,7 +26193,9 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                            "  i = 0;\n"
                            "  return 1;\n"
                            "}");
+  verifyNoChange(Code, Style);
 
+  Style.BreakAfterAttributes = FormatStyle::ABS_Never;
   verifyFormat("[[nodiscard]] inline int f(int &i);\n"
                "[[foo([[]])]] [[nodiscard]] int g(int &i);\n"
                "[[nodiscard]] inline int f(int &i) {\n"
@@ -26205,9 +26207,6 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                "  return 1;\n"
                "}",
                Code, Style);
-
-  Style.BreakAfterAttributes = FormatStyle::ABS_Leave;
-  verifyNoChange(Code, Style);
 
   Style.BreakAfterAttributes = FormatStyle::ABS_Always;
   verifyFormat("[[nodiscard]]\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26179,7 +26179,6 @@ TEST_F(FormatTest, RemoveSemicolon) {
 
 TEST_F(FormatTest, BreakAfterAttributes) {
   FormatStyle Style = getLLVMStyle();
-  EXPECT_EQ(Style.BreakAfterAttributes, FormatStyle::ABS_Leave);
 
   constexpr StringRef Code("[[nodiscard]] inline int f(int &i);\n"
                            "[[foo([[]])]] [[nodiscard]]\n"
@@ -26193,6 +26192,8 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                            "  i = 0;\n"
                            "  return 1;\n"
                            "}");
+
+  EXPECT_EQ(Style.BreakAfterAttributes, FormatStyle::ABS_Leave);
   verifyNoChange(Code, Style);
 
   Style.BreakAfterAttributes = FormatStyle::ABS_Never;


### PR DESCRIPTION
This patch addresses some examples of bad formatting in Clang. The following commit contains only changes suggested by clang-format: https://github.com/llvm/llvm-project/pull/70349/commits/21689b56d1fc1db0b2263e8049ff656d3757ad36. I believe it's a net negative on readability, with a couple of particularly bad cases. Highlights:
```diff
-    [[clang::preferred_type(bool)]]
-    mutable unsigned CachedLocalOrUnnamed : 1;
+    [[clang::preferred_type(bool)]] mutable unsigned CachedLocalOrUnnamed : 1;
```
```diff
-    [[clang::preferred_type(TypeDependence)]]
-    unsigned Dependence : llvm::BitWidth<TypeDependence>;
+    [[clang::preferred_type(TypeDependence)]] unsigned Dependence
+        : llvm::BitWidth<TypeDependence>;
```
```diff
-    [[clang::preferred_type(ExceptionSpecificationType)]]
-    unsigned ExceptionSpecType : 4;
+    [[clang::preferred_type(
+        ExceptionSpecificationType)]] unsigned ExceptionSpecType : 4;
```