### PR TITLE
[Github] Fix libc docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,7 +119,7 @@ jobs:
         if: steps.docs-changed-subprojects.outputs.libc_any_changed == 'true'
         run: |
           cmake -B libc-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libc" -DLLVM_ENABLE_SPHINX=ON ./runtimes
-          TZ=UTC ninja -C docs-libc-html
+          TZ=UTC ninja -C libc-build docs-libc-html
       - name: Build LLD docs
         if: steps.docs-changed-subprojects.outputs.lld_any_changed == 'true'
         run: |


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/69824 added libc build, but missed the folder in ninja command
, is causing failures.

ninja: fatal: chdir to 'docs-libc-html' - No such file or directory
ninja: Entering directory `docs-libc-html'
