### PR TITLE
[JITLink][AArch32] Add support for ELF::R_ARM_THM_MOV{W_PREL_NC,T_PREL}

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
@@ -89,7 +89,15 @@ enum EdgeKind_aarch32 : Edge::Kind {
   /// Write immediate value to the top halfword of the destination register
   Thumb_MovtAbs,
 
-  LastThumbRelocation = Thumb_MovtAbs,
+  /// Write PC-relative immediate value to the lower halfword of the destination
+  /// register
+  Thumb_MovwPrelNC,
+
+  /// Write PC-relative immediate value to the top halfword of the destination
+  /// register
+  Thumb_MovtPrel,
+
+  LastThumbRelocation = Thumb_MovtPrel,
 };
 
 /// Flags enum for AArch32-specific symbol properties

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
@@ -53,6 +53,10 @@ Expected<aarch32::EdgeKind_aarch32> getJITLinkEdgeKind(uint32_t ELFType) {
     return aarch32::Thumb_MovwAbsNC;
   case ELF::R_ARM_THM_MOVT_ABS:
     return aarch32::Thumb_MovtAbs;
+  case ELF::R_ARM_THM_MOVW_PREL_NC:
+    return aarch32::Thumb_MovwPrelNC;
+  case ELF::R_ARM_THM_MOVT_PREL:
+    return aarch32::Thumb_MovtPrel;
   }
 
   return make_error<JITLinkError>(
@@ -83,6 +87,10 @@ Expected<uint32_t> getELFRelocationType(Edge::Kind Kind) {
     return ELF::R_ARM_THM_MOVW_ABS_NC;
   case aarch32::Thumb_MovtAbs:
     return ELF::R_ARM_THM_MOVT_ABS;
+  case aarch32::Thumb_MovwPrelNC:
+    return ELF::R_ARM_THM_MOVW_PREL_NC;
+  case aarch32::Thumb_MovtPrel:
+    return ELF::R_ARM_THM_MOVT_PREL;
   }
 
   return make_error<JITLinkError>(formatv("Invalid aarch32 edge {0:d}: ",

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_static_thumb_reloc.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_static_thumb_reloc.s
@@ -100,7 +100,7 @@ data_symbol:
 # CHECK-INSTR: 	00000014 <movw_prel>:
 # CHECK-INSTR: 	      14: f240 0000     movw    r0, #0x0
 # jitlink-check: decode_operand(movw_prel, 1) = \
-# jitlink-check:              ((external_func - next_pc(movw_prel) + 4)&0x0000ffff)
+# jitlink-check:              ((external_func - movw_prel)&0x0000ffff)
 .globl	movw_prel
 .type	movw_prel,%function
 .p2align	1
@@ -114,7 +114,7 @@ movw_prel:
 # CHECK-INSTR: 	00000018 <movt_prel>:
 # CHECK-INSTR: 	      18: f2c0 0000    movt    r0, #0x0
 # jitlink-check: decode_operand(movt_prel, 2) = \
-# jitlink-check:               ((external_func - next_pc(movt_prel) + 4)&0xffff0000>>16)
+# jitlink-check:               ((external_func - movt_prel)&0xffff0000>>16)
 .globl	movt_prel
 .type	movt_prel,%function
 .p2align	1

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_static_thumb_reloc.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_static_thumb_reloc.s
@@ -2,7 +2,8 @@
 # RUN: llvm-objdump -r %t.o | FileCheck --check-prefix=CHECK-TYPE %s
 # RUN: llvm-objdump --disassemble %t.o | FileCheck --check-prefix=CHECK-INSTR %s
 # RUN: llvm-jitlink -noexec -slab-address 0x76ff0000 -slab-allocate 10Kb \
-# RUN:              -slab-page-size 4096 -show-entry-es -check %s %t.o
+# RUN:              -slab-page-size 4096 -abs external_func=0x76bbe880 \
+# RUN:              -check %s %t.o
 
 
 	.text
@@ -94,6 +95,34 @@ data_symbol:
 	.long 1073741822
 
 	.text
+
+# CHECK-TYPE: {{[0-9a-f]+}} R_ARM_THM_MOVW_PREL_NC external_func
+# CHECK-INSTR: 	00000014 <movw_prel>:
+# CHECK-INSTR: 	      14: f240 0000     movw    r0, #0x0
+# jitlink-check: decode_operand(movw_prel, 1) = \
+# jitlink-check:              ((external_func - next_pc(movw_prel) + 4)&0x0000ffff)
+.globl	movw_prel
+.type	movw_prel,%function
+.p2align	1
+.code	16
+.thumb_func
+movw_prel:
+	movw r0, :lower16:external_func - .
+	.size	movw_prel,	.-movw_prel
+
+# CHECK-TYPE: {{[0-9a-f]+}} R_ARM_THM_MOVT_PREL external_func 
+# CHECK-INSTR: 	00000018 <movt_prel>:
+# CHECK-INSTR: 	      18: f2c0 0000    movt    r0, #0x0
+# jitlink-check: decode_operand(movt_prel, 2) = \
+# jitlink-check:               ((external_func - next_pc(movt_prel) + 4)&0xffff0000>>16)
+.globl	movt_prel
+.type	movt_prel,%function
+.p2align	1
+.code	16
+.thumb_func
+movt_prel:
+	movt r0, :upper16:external_func - .
+	.size	movt_prel,	.-movt_prel
 
 # Empty main function for jitlink to be happy
 	.globl	main


### PR DESCRIPTION
Support for ELF::R_ARM_THM_MOVW_PREL_NC and ELF::R_ARM_THM_MOVT_PREL
is added. Move instructions with PC-relative immediates can be handled in Thumb mode with this addition.
