### PR TITLE
[ELF] Define NOMINMAX to fix zlib.h caused build failure on Windows

### DIFF
--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -22,6 +22,8 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TimeProfiler.h"
 #if LLVM_ENABLE_ZLIB
+// Avoid introducing max as a macro from Windows headers.
+#define NOMINMAX
 #include <zlib.h>
 #endif
 #if LLVM_ENABLE_ZSTD


### PR DESCRIPTION
On Windows when zlib is enabled, zlib header introduced some Windows headers which defines max as a macro. Since OutputSections.cpp uses std::max with template argument, this causes compilation error.

Define macro NOMINMAX to avoid this.