### PR TITLE
[X86] Print 'l' section flag for SHF_X86_64_LARGE

### DIFF
--- a/llvm/lib/MC/MCSectionELF.cpp
+++ b/llvm/lib/MC/MCSectionELF.cpp
@@ -123,6 +123,9 @@ void MCSectionELF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
   } else if (Arch == Triple::hexagon) {
     if (Flags & ELF::SHF_HEX_GPREL)
       OS << 's';
+  } else if (Arch == Triple::x86_64) {
+    if (Flags & ELF::SHF_X86_64_LARGE)
+      OS << 'l';
   }
 
   OS << '"';

--- a/llvm/test/CodeGen/X86/code-model-elf-sections.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf-sections.ll
@@ -16,6 +16,8 @@
 ; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -data-sections -o %t
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=SMALL-DS
 
+; RUN: llc < %s -relocation-model=pic -filetype=asm -code-model=medium -large-data-threshold=79 -o - | FileCheck %s --check-prefix=LARGE-ASM
+
 ; SMALL: .data {{.*}} WA {{.*}}
 ; SMALL: foo {{.*}} WA {{.*}}
 ; SMALL: .bss {{.*}} WA {{.*}}
@@ -47,6 +49,8 @@
 ; LARGE-DS: .ldata.rel.ro.relro {{.*}} WAl {{.*}}
 ; LARGE-DS: .tbss.tbss {{.*}} WAT {{.*}}
 ; LARGE-DS: .tdata.tdata {{.*}} WAT {{.*}}
+
+; LARGE-ASM: .lrodata,"al"
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"

--- a/llvm/test/CodeGen/X86/code-model-elf-sections.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf-sections.ll
@@ -16,8 +16,6 @@
 ; RUN: llc < %s -relocation-model=pic -filetype=obj -code-model=large -data-sections -o %t
 ; RUN: llvm-readelf -S %t | FileCheck %s --check-prefix=SMALL-DS
 
-; RUN: llc < %s -relocation-model=pic -filetype=asm -code-model=medium -large-data-threshold=79 -o - | FileCheck %s --check-prefix=LARGE-ASM
-
 ; SMALL: .data {{.*}} WA {{.*}}
 ; SMALL: foo {{.*}} WA {{.*}}
 ; SMALL: .bss {{.*}} WA {{.*}}
@@ -49,8 +47,6 @@
 ; LARGE-DS: .ldata.rel.ro.relro {{.*}} WAl {{.*}}
 ; LARGE-DS: .tbss.tbss {{.*}} WAT {{.*}}
 ; LARGE-DS: .tdata.tdata {{.*}} WAT {{.*}}
-
-; LARGE-ASM: .lrodata,"al"
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"

--- a/llvm/test/MC/ELF/section.s
+++ b/llvm/test/MC/ELF/section.s
@@ -269,6 +269,8 @@ bar:
 // CHECK-NEXT:     ]
 
 .section .large,"l"
+// ASM: .section .large,"l"
+
 // CHECK:        Section {
 // CHECK:          Name: .large
 // CHECK-NEXT:     Type: SHT_PROGBITS


### PR DESCRIPTION
When directly compiling to an object file we properly set the section flag, but not when emitting assembly.
