### PR TITLE
[openmp][flang] Add tests for map clause

### DIFF
--- a/openmp/libomptarget/test/offloading/fortran/failing/target_map_common_block1.f90
+++ b/openmp/libomptarget/test/offloading/fortran/failing/target_map_common_block1.f90
@@ -1,0 +1,29 @@
+! REQUIRES: flang, amdgcn-amd-amdhsa
+! UNSUPPORTED: nvptx64-nvidia-cuda
+! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+! UNSUPPORTED: aarch64-unknown-linux-gnu
+! UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+! UNSUPPORTED: x86_64-pc-linux-gnu
+! UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: *
+
+program main
+  use omp_lib
+  integer :: devices(2), var1
+  common var1
+  var1 = 10
+  print *, "var1 before target = ", var1
+  devices(1) = omp_get_device_num()
+  !$omp target map(tofrom:devices) map(tofrom:var1)
+    var1 = 20
+    devices(2) = omp_get_device_num()
+  !$omp end target
+  print *, "var1 after target = ", var1
+  print *, "devices: ", devices
+end program
+
+! CHECK: var1 before target =  10
+! CHECK: var1 after target =  20
+! CHECK: devices:  1 0

--- a/openmp/libomptarget/test/offloading/fortran/failing/target_map_common_block2.f90
+++ b/openmp/libomptarget/test/offloading/fortran/failing/target_map_common_block2.f90
@@ -1,0 +1,27 @@
+! REQUIRES: flang, amdgcn-amd-amdhsa
+! UNSUPPORTED: nvptx64-nvidia-cuda
+! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+! UNSUPPORTED: aarch64-unknown-linux-gnu
+! UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+! UNSUPPORTED: x86_64-pc-linux-gnu
+! UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: *
+
+program main
+  use omp_lib
+  integer :: tmp, var4
+  common var4
+  var4 = 24
+  tmp = 12
+  print *, "var4 before target = ", var4
+  !$omp target map(tofrom:var4)
+    var4 = tmp
+  !$omp end target
+  print *, "var4 after target = ", var4
+end program
+
+! CHECK: var4 before target = 24
+! CHECK: var4 after target = 12
+

--- a/openmp/libomptarget/test/offloading/fortran/target_map_common_block.f90
+++ b/openmp/libomptarget/test/offloading/fortran/target_map_common_block.f90
@@ -1,0 +1,82 @@
+! Basic offloading test with a target region
+! REQUIRES: flang, amdgcn-amd-amdhsa
+! UNSUPPORTED: nvptx64-nvidia-cuda
+! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+! UNSUPPORTED: aarch64-unknown-linux-gnu
+! UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+! UNSUPPORTED: x86_64-pc-linux-gnu
+! UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+
+! Testing simple variables in common block.
+program main
+  call check_device
+  call commonblock_simple_with_implicit_type
+  call commonblock_simple_with_integer
+  call commonblock_simple_with_real
+end program main
+
+!-----
+
+subroutine check_device
+  use omp_lib
+  integer :: devices(2)
+  devices(1) = omp_get_device_num()
+  !$omp target map(tofrom:devices)
+    devices(2) = omp_get_device_num()
+  !$omp end target
+  print *, "devices: ", devices
+end subroutine check_device
+
+!CHECK: devices: 1 0
+
+!-----
+
+subroutine commonblock_simple_with_implicit_type
+  use omp_lib
+  common var1
+  var1 = 10
+  print *, "var1 before target = ", var1
+  !$omp target map(tofrom:var1)
+    var1 = 20
+  !$omp end target
+  print *, "var1 after target = ", var1
+end subroutine
+
+! CHECK: var1 before target = 10
+! CHECK: var1 after target = 20
+
+! -----
+
+subroutine commonblock_simple_with_integer
+  use omp_lib
+  integer :: var2
+  common var2
+  var2 = 10
+  print *, "var2 before target = ", var2
+  !$omp target map(tofrom:var2)
+    var2 = 20
+  !$omp end target
+  print *, "var2 after target = ", var2
+end subroutine
+
+! CHECK: var2 before target = 10
+! CHECK: var2 after target = 20
+
+! -----
+
+subroutine commonblock_simple_with_real
+  use omp_lib
+  real :: var3
+  common var3
+  var3 = 12.5
+  print *, "var3 before target = ", var3
+  !$omp target map(tofrom:var3)
+    var3 = 14.5
+  !$omp end target
+  print *, "var3 after target = ", var3
+end subroutine
+
+! CHECK: var3 before target = 12.5
+! CHECK: var3 after target = 14.5


### PR DESCRIPTION
This patch adds basic tests for map clause on target construct for commonblocks. There will be more tests to add, which will be added in future patches. Currently failing tests are added in a separate folder with XFAIL. They should be moved as they are fixed.