### PR TITLE
[NFC][DominanceFrontier] Replace std::map with DenseMap for DomSetMapType

### DIFF
--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_ANALYSIS_DOMINANCEFRONTIER_H
 #define LLVM_ANALYSIS_DOMINANCEFRONTIER_H
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Config/llvm-config.h"
@@ -24,7 +25,6 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/GenericDomTree.h"
 #include <cassert>
-#include <map>
 #include <utility>
 
 namespace llvm {
@@ -42,7 +42,7 @@ public:
   // Dom set for a bb. Use SetVector to make iterating dom frontiers of a bb
   // deterministic.
   using DomSetType = SetVector<BlockT *>;
-  using DomSetMapType = std::map<BlockT *, DomSetType>; // Dom set map
+  using DomSetMapType = DenseMap<BlockT *, DomSetType>; // Dom set map
 
 protected:
   using BlockTraits = GraphTraits<BlockT *>;


### PR DESCRIPTION
DenseMap is preferred according to llvm CodingStandards.