### PR TITLE
[libcxx] Amend XFAIL for failing tests on Windows

### DIFF
--- a/libcxx/test/libcxx/atomics/diagnose_invalid_memory_order.verify.cpp
+++ b/libcxx/test/libcxx/atomics/diagnose_invalid_memory_order.verify.cpp
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This test fails because diagnose_if doesn't emit all of the diagnostics
-// when -fdelayed-template-parsing is enabled, like it is in MSVC mode.
-// XFAIL: msvc
+// This test fails with Clang <18 because diagnose_if doesn't emit all of the
+// diagnostics when -fdelayed-template-parsing is enabled, like it is in MSVC
+// mode.
+// XFAIL: msvc && (clang-16 || clang-17)
 
 // REQUIRES: diagnose-if-support
 

--- a/libcxx/test/libcxx/fuzzing/random.pass.cpp
+++ b/libcxx/test/libcxx/fuzzing/random.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// This test fails because Clang no longer enables -fdelayed-template-parsing
+// by default on Windows with C++20 (#69431).
+// XFAIL: msvc && clang-18
+
 // UNSUPPORTED: c++03, c++11
 
 #include <cassert>

--- a/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// This test fails because Clang no longer enables -fdelayed-template-parsing
+// by default on Windows with C++20 (#69431).
+// XFAIL: msvc && clang-18
+
 // <math.h>
 
 #include <math.h>

--- a/libcxx/test/std/numerics/c.math/cmath.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/cmath.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// This test fails because Clang no longer enables -fdelayed-template-parsing
+// by default on Windows with C++20 (#69431).
+// XFAIL: msvc && clang-18
+
 // <cmath>
 
 #include <cmath>


### PR DESCRIPTION
Some tests starting passing/failing after #69431 because Clang no longer enables -fdelayed-template-parsing by default on Windows with C++20.