### PR TITLE
[BOLT] Add itrace aggregation for AUX data

### DIFF
--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -160,8 +160,6 @@ void DataAggregator::findPerfExecutable() {
 }
 
 void DataAggregator::start() {
-  std::string ItracePerfScriptArgs;
-
   outs() << "PERF2BOLT: Starting data aggregation job for " << Filename << "\n";
 
   // Don't launch perf for pre-aggregated files
@@ -176,7 +174,7 @@ void DataAggregator::start() {
                       "script -F pid,event,ip",
                       /*Wait = */false);
   } else if (!opts::ITraceAggregation.empty()) {
-    ItracePerfScriptArgs = llvm::formatv(
+    std::string ItracePerfScriptArgs = llvm::formatv(
         "script -F pid,ip,brstack --itrace={0}", opts::ITraceAggregation);
     launchPerfProcess("branch events with itrace", MainEventsPPI,
                       ItracePerfScriptArgs.c_str(),

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -46,6 +46,11 @@ static cl::opt<bool>
                      cl::desc("aggregate basic samples (without LBR info)"),
                      cl::cat(AggregatorCategory));
 
+static cl::opt<std::string>
+    ITraceAggregation("itrace",
+                      cl::desc("Generate LBR info with perf itrace argument"),
+                      cl::cat(AggregatorCategory));
+
 static cl::opt<bool>
 FilterMemProfile("filter-mem-profile",
   cl::desc("if processing a memory profile, filter out stack or heap accesses "
@@ -155,6 +160,8 @@ void DataAggregator::findPerfExecutable() {
 }
 
 void DataAggregator::start() {
+  std::string ItracePerfScriptArgs;
+
   outs() << "PERF2BOLT: Starting data aggregation job for " << Filename << "\n";
 
   // Don't launch perf for pre-aggregated files
@@ -163,16 +170,23 @@ void DataAggregator::start() {
 
   findPerfExecutable();
 
-  if (opts::BasicAggregation)
+  if (opts::BasicAggregation) {
     launchPerfProcess("events without LBR",
                       MainEventsPPI,
                       "script -F pid,event,ip",
                       /*Wait = */false);
-  else
+  } else if (!opts::ITraceAggregation.empty()) {
+    ItracePerfScriptArgs = llvm::formatv(
+        "script -F pid,ip,brstack --itrace={0}", opts::ITraceAggregation);
+    launchPerfProcess("branch events with itrace", MainEventsPPI,
+                      ItracePerfScriptArgs.c_str(),
+                      /*Wait = */ false);
+  } else {
     launchPerfProcess("branch events",
                       MainEventsPPI,
                       "script -F pid,ip,brstack",
                       /*Wait = */false);
+  }
 
   // Note: we launch script for mem events regardless of the option, as the
   //       command fails fairly fast if mem events were not collected.


### PR DESCRIPTION
If you have a perf.data with Arm ETM data the only way to use perf2bolt with Branch Aggregation is to first run `perf inject --itrace=l64i1us -o perf-brstack.data` and then pass the new perf-brstack.data into perf2bolt. perf2bolt then runs `perf script -F pid,ip,brstack` to produce the brstacks.

This PR adds `--itrace` arg to perf2bolt to enable Itrace Aggregation. It takes a string which is what is passed to the `perf script -F pid,ip,brstack --itrace={0}`. This command produces the brstacks without having to run perf inject and creating a new perf.data file.