### PR TITLE
varconst/fix flaky atomic wait

### DIFF
--- a/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_notify_all.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_notify_all.pass.cpp
@@ -56,15 +56,21 @@ struct TestFn {
     {
       volatile A a(T(2));
       static_assert(noexcept(std::atomic_notify_all(&a)), "");
-      auto f = [&]() {
+
+      std::atomic<bool> is_ready[2] = {false, false};
+      auto f = [&](int index) {
         assert(std::atomic_load(&a) == T(2));
+        is_ready[index].store(true);
+
         std::atomic_wait(&a, T(2));
         assert(std::atomic_load(&a) == T(4));
       };
-      std::thread t1 = support::make_test_thread(f);
-      std::thread t2 = support::make_test_thread(f);
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::thread t1 = support::make_test_thread(f, /*index=*/0);
+      std::thread t2 = support::make_test_thread(f, /*index=*/1);
 
+      while (!is_ready[0] || !is_ready[1]) {
+        // Spin
+      }
       std::atomic_store(&a, T(4));
       std::atomic_notify_all(&a);
       t1.join();

--- a/libcxx/test/std/thread/thread.jthread/cons.func.token.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/cons.func.token.pass.cpp
@@ -56,7 +56,7 @@ int main(int, char**) {
   // invoke(auto(std::forward<F>(f)), get_stop_token(), auto(std::forward<Args>(args))...)
   // if that expression is well-formed,
   {
-    int result = 0;
+    int result      = 0;
     std::jthread jt = support::make_test_jthread(
         [&result](std::stop_token st, int i) {
           assert(st.stop_possible());
@@ -71,7 +71,7 @@ int main(int, char**) {
   // otherwise
   // invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)
   {
-    int result = 0;
+    int result      = 0;
     std::jthread jt = support::make_test_jthread([&result](int i) { result += i; }, 5);
     jt.join();
     assert(result == 5);


### PR DESCRIPTION
- [libc++] Make sure all `jthread` tests use `support::make_test_jthread`.
- clang-format
- [libc++] Fix flakiness in `atomic_notify_all.pass.cpp`
