### PR TITLE
[clang][dataflow][NFC] Move `parseAll()` to TestingSupport and rename `parseFormulas()`

### DIFF
--- a/clang/unittests/Analysis/FlowSensitive/SolverTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/SolverTest.cpp
@@ -25,6 +25,7 @@ using namespace clang;
 using namespace dataflow;
 
 using test::ConstraintContext;
+using test::parseFormulas;
 using testing::_;
 using testing::AnyOf;
 using testing::Pair;
@@ -32,21 +33,6 @@ using testing::UnorderedElementsAre;
 
 constexpr auto AssignedTrue = Solver::Result::Assignment::AssignedTrue;
 constexpr auto AssignedFalse = Solver::Result::Assignment::AssignedFalse;
-
-std::vector<const Formula *> parseAll(Arena &A, StringRef Lines) {
-  std::vector<const Formula *> Result;
-  while (!Lines.empty()) {
-    auto [First, Rest] = Lines.split('\n');
-    Lines = Rest;
-    if (First.trim().empty())
-      continue;
-    if (auto F = A.parseFormula(First))
-      Result.push_back(&*F);
-    else
-      ADD_FAILURE() << llvm::toString(F.takeError());
-  }
-  return Result;
-}
 
 // Checks if the conjunction of `Vals` is satisfiable and returns the
 // corresponding result.
@@ -277,7 +263,7 @@ TEST(SolverTest, IffWithUnits) {
 
 TEST(SolverTest, IffWithUnitsConflict) {
   Arena A;
-  auto Constraints = parseAll(A, R"(
+  auto Constraints = parseFormulas(A, R"(
      (V0 = V1)
      V0
      !V1
@@ -287,7 +273,7 @@ TEST(SolverTest, IffWithUnitsConflict) {
 
 TEST(SolverTest, IffTransitiveConflict) {
   Arena A;
-  auto Constraints = parseAll(A, R"(
+  auto Constraints = parseFormulas(A, R"(
      (V0 = V1)
      (V1 = V2)
      V2
@@ -298,7 +284,7 @@ TEST(SolverTest, IffTransitiveConflict) {
 
 TEST(SolverTest, DeMorgan) {
   Arena A;
-  auto Constraints = parseAll(A, R"(
+  auto Constraints = parseFormulas(A, R"(
      (!(V0 | V1) = (!V0 & !V1))
      (!(V2 & V3) = (!V2 | !V3))
   )");
@@ -307,7 +293,7 @@ TEST(SolverTest, DeMorgan) {
 
 TEST(SolverTest, RespectsAdditionalConstraints) {
   Arena A;
-  auto Constraints = parseAll(A, R"(
+  auto Constraints = parseFormulas(A, R"(
      (V0 = V1)
      V0
      !V1
@@ -317,7 +303,7 @@ TEST(SolverTest, RespectsAdditionalConstraints) {
 
 TEST(SolverTest, ImplicationIsEquivalentToDNF) {
   Arena A;
-  auto Constraints = parseAll(A, R"(
+  auto Constraints = parseFormulas(A, R"(
      !((V0 => V1) = (!V0 | V1))
   )");
   EXPECT_THAT(solve(Constraints), unsat());
@@ -325,7 +311,7 @@ TEST(SolverTest, ImplicationIsEquivalentToDNF) {
 
 TEST(SolverTest, ImplicationConflict) {
   Arena A;
-  auto Constraints = parseAll(A, R"(
+  auto Constraints = parseFormulas(A, R"(
      (V0 => V1)
      (V0 & !V1)
   )");
@@ -334,7 +320,7 @@ TEST(SolverTest, ImplicationConflict) {
 
 TEST(SolverTest, ReachedLimitsReflectsTimeouts) {
   Arena A;
-  auto Constraints = parseAll(A, R"(
+  auto Constraints = parseFormulas(A, R"(
      (!(V0 | V1) = (!V0 & !V1))
      (!(V2 & V3) = (!V2 & !V3))
   )");

--- a/clang/unittests/Analysis/FlowSensitive/TestingSupport.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TestingSupport.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Testing/Annotations/Annotations.h"
+#include "gtest/gtest.h"
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -216,5 +217,20 @@ const IndirectFieldDecl *test::findIndirectFieldDecl(ASTContext &ASTCtx,
   assert(TargetNodes.size() == 1 && "Name must be unique");
   const auto *Result = selectFirst<IndirectFieldDecl>("i", TargetNodes);
   assert(Result != nullptr);
+  return Result;
+}
+
+std::vector<const Formula *> test::parseFormulas(Arena &A, StringRef Lines) {
+  std::vector<const Formula *> Result;
+  while (!Lines.empty()) {
+    auto [First, Rest] = Lines.split('\n');
+    Lines = Rest;
+    if (First.trim().empty())
+      continue;
+    if (auto F = A.parseFormula(First))
+      Result.push_back(&*F);
+    else
+      ADD_FAILURE() << llvm::toString(F.takeError());
+  }
   return Result;
 }

--- a/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
+++ b/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
@@ -525,6 +525,10 @@ public:
   }
 };
 
+/// Parses a list of formulas, separated by newlines, and returns them.
+/// On parse errors, calls `ADD_FAILURE()` to fail the current test.
+std::vector<const Formula *> parseFormulas(Arena &A, StringRef Lines);
+
 } // namespace test
 } // namespace dataflow
 } // namespace clang


### PR DESCRIPTION
I'm working on a patch that will use this function from a different test.
