### PR TITLE
[lldb] Replace the usage of module imp with module importlib

### DIFF
--- a/lldb/scripts/use_lldb_suite.py
+++ b/lldb/scripts/use_lldb_suite.py
@@ -18,24 +18,11 @@ def find_lldb_root():
 
 lldb_root = find_lldb_root()
 
-# Module imp got removed in Python 3.12.
-if (
-    sys.version_info.major == 3 and sys.version_info.minor >= 12
-) or sys.version_info.major > 3:
-    import importlib.machinery
-    import importlib.util
+import importlib.machinery
+import importlib.util
 
-    path = os.path.join(lldb_root, "use_lldb_suite_root.py")
-    loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
-    spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-else:
-    import imp
-
-    fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
-    try:
-        imp.load_module("use_lldb_suite_root", fp, pathname, desc)
-    finally:
-        if fp:
-            fp.close()
+path = os.path.join(lldb_root, "use_lldb_suite_root.py")
+loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
+spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)

--- a/lldb/scripts/use_lldb_suite.py
+++ b/lldb/scripts/use_lldb_suite.py
@@ -17,11 +17,25 @@ def find_lldb_root():
 
 
 lldb_root = find_lldb_root()
-import imp
 
-fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
-try:
-    imp.load_module("use_lldb_suite_root", fp, pathname, desc)
-finally:
-    if fp:
-        fp.close()
+# Module imp got removed in Python 3.12.
+if (
+    sys.version_info.major == 3 and sys.version_info.minor >= 12
+) or sys.version_info.major > 3:
+    import importlib.machinery
+    import importlib.util
+
+    path = os.path.join(lldb_root, "use_lldb_suite_root.py")
+    loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
+    spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+else:
+    import imp
+
+    fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
+    try:
+        imp.load_module("use_lldb_suite_root", fp, pathname, desc)
+    finally:
+        if fp:
+            fp.close()

--- a/lldb/test/API/use_lldb_suite.py
+++ b/lldb/test/API/use_lldb_suite.py
@@ -20,24 +20,11 @@ def find_lldb_root():
 
 lldb_root = find_lldb_root()
 
-# Module imp got removed in Python 3.12.
-if (
-    sys.version_info.major == 3 and sys.version_info.minor >= 12
-) or sys.version_info.major > 3:
-    import importlib.machinery
-    import importlib.util
+import importlib.machinery
+import importlib.util
 
-    path = os.path.join(lldb_root, "use_lldb_suite_root.py")
-    loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
-    spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-else:
-    import imp
-
-    fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
-    try:
-        imp.load_module("use_lldb_suite_root", fp, pathname, desc)
-    finally:
-        if fp:
-            fp.close()
+path = os.path.join(lldb_root, "use_lldb_suite_root.py")
+loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
+spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)

--- a/lldb/test/API/use_lldb_suite.py
+++ b/lldb/test/API/use_lldb_suite.py
@@ -20,11 +20,24 @@ def find_lldb_root():
 
 lldb_root = find_lldb_root()
 
-import imp
+# Module imp got removed in Python 3.12.
+if (
+    sys.version_info.major == 3 and sys.version_info.minor >= 12
+) or sys.version_info.major > 3:
+    import importlib.machinery
+    import importlib.util
 
-fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
-try:
-    imp.load_module("use_lldb_suite_root", fp, pathname, desc)
-finally:
-    if fp:
-        fp.close()
+    path = os.path.join(lldb_root, "use_lldb_suite_root.py")
+    loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
+    spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+else:
+    import imp
+
+    fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
+    try:
+        imp.load_module("use_lldb_suite_root", fp, pathname, desc)
+    finally:
+        if fp:
+            fp.close()


### PR DESCRIPTION
imp got removed in Python 3.12 [1] and the community recommends using importlib in newer Python versions.

[1] https://docs.python.org/3.12/whatsnew/3.12.html#imp