### PR TITLE
[LLD][ELF] Change default flags for NOBITS sections with no inputs

### DIFF
--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -577,6 +577,17 @@ static void finalizeShtGroup(OutputSection *os, InputSection *section) {
 void OutputSection::finalize() {
   InputSection *first = getFirstInputSection(this);
 
+  // Mark as WA output sections without input sections and with
+  // type == SHT_NOBITS. Without this, every SHT_NOBITS section can be
+  // accounted as program text by size/llvm-size. This is also related to GNU
+  // ld's compatibility.
+  if (!first && type == SHT_NOBITS) {
+    // SHT_NOBITS section can inheiret SHF_EXECINSTR from the previous
+    // section, clear it in this case.
+    flags &= ~SHF_EXECINSTR;
+    flags |= SHF_WRITE;
+  }
+
   if (flags & SHF_LINK_ORDER) {
     // We must preserve the link order dependency of sections with the
     // SHF_LINK_ORDER flag. The dependency is indicated by the sh_link field. We

--- a/lld/test/ELF/linkerscript/custom-section-type.s
+++ b/lld/test/ELF/linkerscript/custom-section-type.s
@@ -14,7 +14,7 @@
 # CHECK-NEXT:  [ 0]                   NULL            [[#%x,]]         [[#%x,]] 000000 00      0   0  0
 # CHECK-NEXT:  [ 1] progbits          PROGBITS        [[#%x,]]         [[#%x,]] 000001 00   A  0   0  1
 # CHECK-NEXT:  [ 2] note              NOTE            [[#%x,]]         [[#%x,]] 000002 00   A  0   0  1
-# CHECK-NEXT:  [ 3] nobits            NOBITS          [[#%x,]]         [[#%x,]] 000001 00   A  0   0  1
+# CHECK-NEXT:  [ 3] nobits            NOBITS          [[#%x,]]         [[#%x,]] 000001 00  WA  0   0  1
 # CHECK-NEXT:  [ 4] init_array        INIT_ARRAY      [[#%x,]]         [[#%x,]] 000008 00   A  0   0  1
 # CHECK-NEXT:  [ 5] fini_array        FINI_ARRAY      [[#%x,]]         [[#%x,]] 000008 00   A  0   0  1
 # CHECK-NEXT:  [ 6] preinit_array     PREINIT_ARRAY   [[#%x,]]         [[#%x,]] 000008 00   A  0   0  1

--- a/lld/test/ELF/linkerscript/locationcountererr-arm-exidx.test
+++ b/lld/test/ELF/linkerscript/locationcountererr-arm-exidx.test
@@ -21,11 +21,11 @@
 
 # CHECK:       [Nr] Name              Type            Address  Off    Size   ES Flg Lk Inf Al
 # CHECK-NEXT:  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
-# CHECK-NEXT:  [ 1] dummy1            NOBITS          00001000 001000 00000c 00   A  0   0  1
-# CHECK-NEXT:  [ 2] dummy2            NOBITS          00002000 001000 00000c 00   A  0   0  1
+# CHECK-NEXT:  [ 1] dummy1            NOBITS          00001000 001000 00000c 00  WA  0   0  1
+# CHECK-NEXT:  [ 2] dummy2            NOBITS          00002000 001000 00000c 00  WA  0   0  1
 # CHECK-NEXT:  [ 3] .text             PROGBITS        00004000 001000 000054 00  AX  0   0  4
 # CHECK-NEXT:  [ 4] .ARM.exidx        ARM_EXIDX       00004054 001054 000010 00  AL  3   0  4
-# CHECK-NEXT:  [ 5] code.unused_space NOBITS          00004064 001064 00000c 00   A  0   0  1
+# CHECK-NEXT:  [ 5] code.unused_space NOBITS          00004064 001064 00000c 00  WA  0   0  1
 
 #--- a.s
 .globl _start


### PR DESCRIPTION
Mark as WA output sections without input sections and with type == SHT_NOBITS. Without this, every SHT_NOBITS section can be accounted as program text by size/llvm-size which is particularly not desirable in the embedded development domain. This is also related to GNU ld's compatibility.