### PR TITLE
[libc][bazel] Prevent LIBC_NAMESPACE leakage

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -11,7 +11,6 @@ load(
     "libc_math_function",
     "libc_support_library",
 )
-load(":libc_namespace.bzl", "LIBC_NAMESPACE")
 load(":platforms.bzl", "PLATFORM_CPU_ARM64", "PLATFORM_CPU_X86_64")
 
 package(
@@ -63,29 +62,16 @@ config_setting(
     flag_values = {":mpfr": "system"},
 )
 
-# This empty root library helps us add an include path to this directory
-# using the 'includes' attribute. The strings listed in the includes attribute
-# are relative paths wrt this library but are inherited by the dependents
-# appropriately. Hence, using this as a root dependency avoids adding include
-# paths of the kind "../../" to other libc targets.
-cc_library(
-    name = "libc_root",
-    defines = ["LIBC_NAMESPACE=" + LIBC_NAMESPACE],
-    includes = ["."],
-)
-
 ############################## Support libraries #############################
 
 libc_support_library(
     name = "__support_macros_properties_architectures",
     hdrs = ["src/__support/macros/properties/architectures.h"],
-    deps = [":libc_root"],
 )
 
 libc_support_library(
     name = "__support_macros_properties_compiler",
     hdrs = ["src/__support/macros/properties/compiler.h"],
-    deps = [":libc_root"],
 )
 
 libc_support_library(
@@ -93,14 +79,12 @@ libc_support_library(
     hdrs = ["src/__support/macros/properties/cpu_features.h"],
     deps = [
         "__support_macros_properties_architectures",
-        ":libc_root",
     ],
 )
 
 libc_support_library(
     name = "__support_macros_config",
     hdrs = ["src/__support/macros/config.h"],
-    deps = [":libc_root"],
 )
 
 libc_support_library(
@@ -108,7 +92,6 @@ libc_support_library(
     hdrs = ["src/__support/macros/attributes.h"],
     deps = [
         ":__support_macros_properties_architectures",
-        ":libc_root",
     ],
 )
 
@@ -119,7 +102,6 @@ libc_support_library(
         ":__support_macros_attributes",
         ":__support_macros_config",
         ":__support_macros_properties_compiler",
-        ":libc_root",
     ],
 )
 
@@ -128,7 +110,6 @@ libc_support_library(
     hdrs = ["src/__support/macros/sanitizer.h"],
     deps = [
         ":__support_macros_config",
-        ":libc_root",
     ],
 )
 
@@ -141,7 +122,6 @@ libc_support_library(
     deps = [
         ":__support_macros_attributes",
         ":__support_macros_properties_architectures",
-        ":libc_root",
     ],
 )
 
@@ -150,7 +130,6 @@ libc_support_library(
     hdrs = ["src/__support/CPP/algorithm.h"],
     deps = [
         ":__support_macros_attributes",
-        ":libc_root",
     ],
 )
 
@@ -159,7 +138,6 @@ libc_support_library(
     hdrs = ["src/__support/CPP/array.h"],
     deps = [
         ":__support_macros_attributes",
-        ":libc_root",
     ],
 )
 
@@ -171,7 +149,6 @@ libc_support_library(
         ":__support_macros_attributes",
         ":__support_macros_config",
         ":__support_macros_sanitizer",
-        ":libc_root",
     ],
 )
 
@@ -180,7 +157,6 @@ libc_support_library(
     hdrs = ["src/__support/CPP/bitset.h"],
     deps = [
         ":__support_macros_attributes",
-        ":libc_root",
     ],
 )
 
@@ -190,7 +166,6 @@ libc_support_library(
     deps = [
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
-        ":libc_root",
     ],
 )
 
@@ -198,7 +173,6 @@ libc_support_library(
     name = "__support_cpp_expected",
     hdrs = ["src/__support/CPP/expected.h"],
     deps = [
-        ":libc_root",
     ],
 )
 
@@ -209,14 +183,12 @@ libc_support_library(
         "__support_cpp_type_traits",
         "__support_cpp_utility",
         "__support_macros_attributes",
-        ":libc_root",
     ],
 )
 
 libc_support_library(
     name = "__support_cpp_limits",
     hdrs = ["src/__support/CPP/limits.h"],
-    deps = [":libc_root"],
 )
 
 libc_support_library(
@@ -225,7 +197,6 @@ libc_support_library(
     hdrs = ["src/__support/CPP/new.h"],
     deps = [
         ":__support_common",
-        ":libc_root",
     ],
 )
 
@@ -234,7 +205,6 @@ libc_support_library(
     hdrs = ["src/__support/CPP/optional.h"],
     deps = [
         ":__support_cpp_utility",
-        ":libc_root",
     ],
 )
 
@@ -244,7 +214,6 @@ libc_support_library(
     deps = [
         ":__support_cpp_array",
         ":__support_cpp_type_traits",
-        ":libc_root",
     ],
 )
 
@@ -253,7 +222,6 @@ libc_support_library(
     hdrs = ["src/__support/CPP/string_view.h"],
     deps = [
         ":__support_common",
-        ":libc_root",
     ],
 )
 
@@ -275,7 +243,6 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_string_view",
         ":__support_integer_to_string",
-        ":libc_root",
         ":string_memory_utils",
         ":string_utils",
     ],
@@ -340,7 +307,6 @@ libc_support_library(
     deps = [
         ":__support_macros_attributes",
         ":__support_macros_config",
-        ":libc_root",
     ],
 )
 
@@ -357,7 +323,6 @@ libc_support_library(
     deps = [
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
-        ":libc_root",
     ],
 )
 
@@ -368,7 +333,6 @@ libc_support_library(
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
         ":__support_macros_properties_architectures",
-        ":libc_root",
     ],
 )
 
@@ -377,7 +341,6 @@ libc_support_library(
     hdrs = ["src/__support/arg_list.h"],
     deps = [
         ":__support_common",
-        ":libc_root",
     ],
 )
 
@@ -386,7 +349,6 @@ libc_support_library(
     hdrs = ["src/__support/c_string.h"],
     deps = [
         ":__support_cpp_string",
-        ":libc_root",
     ],
 )
 
@@ -396,7 +358,6 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_expected",
-        ":libc_root",
     ],
 )
 
@@ -415,7 +376,6 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_libc_assert",
         ":__support_uint",
-        ":libc_root",
     ],
 )
 
@@ -425,7 +385,6 @@ libc_support_library(
     deps = [
         ":__support_cpp_type_traits",
         ":__support_named_pair",
-        ":libc_root",
     ],
 )
 
@@ -437,7 +396,6 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_type_traits",
         ":__support_number_pair",
-        ":libc_root",
     ],
 )
 
@@ -454,7 +412,6 @@ libc_support_library(
         ":__support_macros_attributes",
         ":__support_macros_optimization",
         ":__support_number_pair",
-        ":libc_root",
     ],
 )
 
@@ -463,7 +420,6 @@ libc_support_library(
     hdrs = ["src/__support/UInt128.h"],
     deps = [
         ":__support_uint",
-        ":libc_root",
     ],
 )
 
@@ -471,7 +427,6 @@ libc_support_library(
     name = "__support_str_to_num_result",
     hdrs = ["src/__support/str_to_num_result.h"],
     deps = [
-        ":libc_root",
     ],
 )
 
@@ -493,7 +448,6 @@ libc_support_library(
         ":__support_cpp_span",
         ":__support_cpp_string_view",
         ":__support_cpp_type_traits",
-        ":libc_root",
     ],
 )
 
@@ -505,7 +459,6 @@ libc_support_library(
         ":__support_macros_attributes",
         ":__support_osutil_io",
         ":__support_osutil_quick_exit",
-        ":libc_root",
     ],
 )
 
@@ -559,7 +512,6 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_type_traits",
         ":__support_fputil_fp_bits",
-        ":libc_root",
     ],
 )
 
@@ -573,7 +525,6 @@ libc_support_library(
         ":__support_error_or",
         ":__support_threads_mutex",
         ":errno",
-        ":libc_root",
     ],
 )
 
@@ -591,7 +542,6 @@ libc_support_library(
 libc_support_library(
     name = "__support_named_pair",
     hdrs = ["src/__support/named_pair.h"],
-    deps = [":libc_root"],
 )
 
 libc_support_library(
@@ -602,7 +552,6 @@ libc_support_library(
         ":__support_macros_attributes",
         ":__support_macros_config",
         ":__support_named_pair",
-        ":libc_root",
     ],
 )
 
@@ -616,7 +565,6 @@ libc_support_library(
         ":__support_cpp_type_traits",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
-        ":libc_root",
         ":math_utils",
     ],
 )
@@ -630,7 +578,6 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_manipulation_functions",
         ":__support_fputil_normal_float",
-        ":libc_root",
     ],
 )
 
@@ -642,7 +589,6 @@ libc_support_library(
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
-        ":libc_root",
     ],
 )
 
@@ -660,7 +606,6 @@ libc_support_library(
         ":__support_macros_properties_architectures",
         ":__support_macros_sanitizer",
         ":errno",
-        ":libc_root",
     ],
 )
 
@@ -669,7 +614,6 @@ libc_support_library(
     hdrs = ["src/__support/FPUtil/rounding_mode.h"],
     deps = [
         ":__support_macros_attributes",
-        ":libc_root",
     ],
 )
 
@@ -679,7 +623,6 @@ libc_support_library(
     deps = [
         ":__support_fputil_platform_defs",
         ":__support_uint128",
-        ":libc_root",
     ],
 )
 
@@ -695,7 +638,6 @@ libc_support_library(
         ":__support_fputil_float_properties",
         ":__support_fputil_platform_defs",
         ":__support_uint128",
-        ":libc_root",
     ],
 )
 
@@ -711,7 +653,6 @@ libc_support_library(
         ":__support_fputil_platform_defs",
         ":__support_integer_to_string",
         ":__support_uint128",
-        ":libc_root",
     ],
 )
 
@@ -728,7 +669,6 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
         ":__support_uint128",
-        ":libc_root",
     ],
 )
 
@@ -746,7 +686,6 @@ libc_support_library(
         ":__support_fputil_platform_defs",
         ":__support_macros_optimization",
         ":__support_uint128",
-        ":libc_root",
     ],
 )
 
@@ -759,7 +698,6 @@ libc_support_library(
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
-        ":libc_root",
     ],
 )
 
@@ -770,7 +708,6 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_type_traits",
         ":__support_fputil_fp_bits",
-        ":libc_root",
     ],
 )
 
@@ -779,7 +716,6 @@ libc_support_library(
     hdrs = ["src/__support/FPUtil/PlatformDefs.h"],
     deps = [
         ":__support_common",
-        ":libc_root",
     ],
 )
 
@@ -812,7 +748,6 @@ libc_support_library(
         ":__support_fputil_platform_defs",
         ":__support_fputil_rounding_mode",
         ":__support_uint128",
-        ":libc_root",
     ],
 )
 
@@ -844,7 +779,6 @@ libc_support_library(
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_uint128",
-        ":libc_root",
     ],
 )
 
@@ -891,7 +825,6 @@ libc_support_library(
         ":__support_macros_optimization",
         ":__support_macros_properties_architectures",
         ":__support_macros_properties_cpu_features",
-        ":libc_root",
     ],
 )
 
@@ -902,7 +835,6 @@ libc_support_library(
         ":__support_common",
         ":__support_fputil_multiply_add",
         ":__support_number_pair",
-        ":libc_root",
     ],
 )
 
@@ -911,7 +843,6 @@ libc_support_library(
     hdrs = ["src/__support/FPUtil/triple_double.h"],
     deps = [
         ":__support_common",
-        ":libc_root",
     ],
 )
 
@@ -925,7 +856,6 @@ libc_support_library(
         ":__support_fputil_multiply_add",
         ":__support_macros_optimization",
         ":__support_uint",
-        ":libc_root",
     ],
 )
 
@@ -940,7 +870,6 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_bit",
-        ":libc_root",
     ],
 )
 
@@ -954,7 +883,6 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_string_view",
         ":__support_osutil_syscall",
-        ":libc_root",
         ":string_utils",
     ],
 )
@@ -968,7 +896,6 @@ libc_support_library(
     ],
     deps = [
         ":__support_osutil_syscall",
-        ":libc_root",
     ],
 )
 
@@ -993,7 +920,6 @@ libc_support_library(
         ":__support_integer_to_string",
         ":__support_macros_attributes",
         ":errno",
-        ":libc_root",
     ],
 )
 
@@ -1010,7 +936,6 @@ libc_support_library(
     deps = [
         ":__support_cpp_atomic",
         ":__support_osutil_syscall",
-        ":libc_root",
     ],
 )
 
@@ -1180,7 +1105,6 @@ libc_support_library(
         "__support_cpp_type_traits",
         ":__support_common",
         ":errno",
-        ":libc_root",
     ],
 )
 
@@ -1191,7 +1115,6 @@ libc_support_library(
     deps = [
         ":__support_fputil_triple_double",
         ":__support_number_pair",
-        ":libc_root",
     ],
 )
 
@@ -1207,7 +1130,6 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
-        ":libc_root",
     ],
 )
 
@@ -1217,7 +1139,6 @@ libc_support_library(
     deps = [
         ":__support_fputil_fp_bits",
         ":__support_fputil_polyeval",
-        ":libc_root",
         ":range_reduction",
     ],
 )
@@ -1235,7 +1156,6 @@ libc_support_library(
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":common_constants",
-        ":libc_root",
         ":math_utils",
     ],
 )
@@ -1252,7 +1172,6 @@ libc_support_library(
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
-        ":libc_root",
         ":math_utils",
     ],
 )
@@ -2221,7 +2140,6 @@ libc_support_library(
         ":__support_macros_optimization",
         ":__support_macros_properties_architectures",
         ":__support_macros_properties_cpu_features",
-        ":libc_root",
     ],
 )
 
@@ -2232,7 +2150,6 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_bitset",
         ":__support_macros_optimization",
-        ":libc_root",
         ":string_memory_utils",
     ],
 )
@@ -2692,7 +2609,6 @@ libc_support_library(
     deps = [
         ":__support_cpp_string_view",
         ":__support_fputil_fp_bits",
-        ":libc_root",
     ],
 )
 
@@ -2701,7 +2617,6 @@ libc_support_library(
     hdrs = ["src/stdio/printf_core/printf_config.h"],
     defines = PRINTF_COPTS,
     deps = [
-        ":libc_root",
     ],
 )
 
@@ -2719,7 +2634,6 @@ libc_support_library(
         ":__support_ctype_utils",
         ":__support_fputil_fp_bits",
         ":__support_str_to_integer",
-        ":libc_root",
         ":printf_config",
         ":printf_core_structs",
     ],
@@ -2740,7 +2654,6 @@ libc_support_library(
         ":__support_ctype_utils",
         ":__support_fputil_fp_bits",
         ":__support_str_to_integer",
-        ":libc_root",
         ":printf_config",
         ":printf_core_structs",
     ],
@@ -2754,7 +2667,6 @@ libc_support_library(
     deps = [
         ":__support_cpp_string_view",
         ":__support_macros_optimization",
-        ":libc_root",
         ":printf_core_structs",
         ":string_memory_utils",
     ],
@@ -2791,7 +2703,6 @@ libc_support_library(
         ":__support_libc_assert",
         ":__support_uint",
         ":__support_uint128",
-        ":libc_root",
         ":printf_core_structs",
         ":printf_writer",
     ],
@@ -2804,7 +2715,6 @@ libc_support_library(
     defines = PRINTF_COPTS,
     deps = [
         ":__support_arg_list",
-        ":libc_root",
         ":printf_converter",
         ":printf_core_structs",
         ":printf_parser",

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -86,9 +86,8 @@ def libc_function(
     # We compile the code twice, the first target is suffixed with ".__internal__" and contains the
     # C++ functions in the "LIBC_NAMESPACE" namespace. This allows us to test the function in the
     # presence of another libc.
-    _libc_library(
+    libc_support_library(
         name = libc_internal_target(name),
-        hidden = False,
         srcs = srcs,
         copts = copts,
         **kwargs

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -13,7 +13,7 @@ def libc_internal_target(name):
     return name + ".__internal__"
 
 def libc_common_copts():
-    root_label = Label("//libc")
+    root_label = Label(":libc")
     libc_include_path = paths.join(root_label.workspace_root, root_label.package)
     return [
         "-I" + libc_include_path,

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -12,19 +12,11 @@ load(":platforms.bzl", "PLATFORM_CPU_ARM64", "PLATFORM_CPU_X86_64")
 def libc_internal_target(name):
     return name + ".__internal__"
 
-def _package_path(label):
-    """Returns the path to the package of 'label'.
-
-    Args:
-      label: label. The label to return the package path of.
-
-    For example, package_path("@foo//bar:BUILD") returns 'external/foo/bar'.
-    """
-    return paths.join(Label(label).workspace_root, Label(label).package)
-
 def libc_common_copts():
+    root_label = Label("//libc")
+    libc_include_path = paths.join(root_label.workspace_root, root_label.package)
     return [
-        "-I" + _package_path("@llvm-project//libc"),
+        "-I" + libc_include_path,
         "-DLIBC_NAMESPACE=" + LIBC_NAMESPACE,
     ]
 

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -7,7 +7,6 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load(":platforms.bzl", "PLATFORM_CPU_ARM64", "PLATFORM_CPU_X86_64")
 
-LIBC_ROOT_TARGET = ":libc_root"
 INTERNAL_SUFFIX = ".__internal__"
 
 def _libc_library(name, copts = None, **kwargs):
@@ -40,7 +39,6 @@ def libc_function(
         name,
         srcs,
         weak = False,
-        deps = None,
         copts = None,
         local_defines = None,
         **kwargs):
@@ -64,11 +62,9 @@ def libc_function(
                      its deps.
       **kwargs: Other attributes relevant for a cc_library. For example, deps.
     """
-    deps = deps or []
 
     # We use the explicit equals pattern here because append and += mutate the
     # original list, where this creates a new list and stores it in deps.
-    deps = deps + [LIBC_ROOT_TARGET]
     copts = copts or []
     copts = copts + ["-O3", "-fno-builtin", "-fno-lax-vector-conversions"]
 
@@ -78,7 +74,6 @@ def libc_function(
     native.cc_library(
         name = name + INTERNAL_SUFFIX,
         srcs = srcs,
-        deps = deps,
         copts = copts,
         linkstatic = 1,
         **kwargs
@@ -94,7 +89,6 @@ def libc_function(
     _libc_library(
         name = name,
         srcs = srcs,
-        deps = deps,
         copts = copts,
         local_defines = local_defines,
         **kwargs

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -48,7 +48,7 @@ def _libc_library(name, hidden, copts = [], deps = [], **kwargs):
 # Any library which does not define a public function should be listed with
 # libc_support_library.
 def libc_support_library(name, **kwargs):
-    _libc_library(name = name, hidden = True, **kwargs)
+    _libc_library(name = name, hidden = False, **kwargs)
 
 def libc_function(
         name,

--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -4,11 +4,13 @@
 
 # LLVM libc unittest library.
 
+load("//libc:libc_build_rules.bzl", "libc_support_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-cc_library(
+libc_support_library(
     name = "test_logger",
     srcs = ["TestLogger.cpp"],
     hdrs = ["TestLogger.h"],
@@ -17,11 +19,10 @@ cc_library(
         "//libc:__support_cpp_string_view",
         "//libc:__support_osutil_io",
         "//libc:__support_uint128",
-        "//libc:libc_root",
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "LibcUnitTest",
     srcs = [
         "BazelFilePath.cpp",
@@ -52,12 +53,11 @@ cc_library(
         "//libc:__support_stringutil",
         "//libc:__support_uint128",
         "//libc:errno",
-        "//libc:libc_root",
         "//llvm:Support",
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "fp_test_helpers",
     srcs = [
         "FPExceptMatcher.cpp",
@@ -79,11 +79,10 @@ cc_library(
         "//libc:__support_fputil_fp_bits",
         "//libc:__support_fputil_fpbits_str",
         "//libc:__support_fputil_rounding_mode",
-        "//libc:libc_root",
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "memory_matcher",
     srcs = [
         "MemoryMatcher.cpp",
@@ -100,7 +99,7 @@ cc_library(
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "printf_matcher",
     srcs = [
         "PrintfMatcher.cpp",
@@ -116,7 +115,7 @@ cc_library(
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "string_utils",
     hdrs = [
         "StringUtils.h",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/__support/CPP/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/__support/CPP/BUILD.bazel
@@ -4,119 +4,83 @@
 
 # Tests for LLVM libc CPP functions.
 
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-cc_test(
+libc_test(
     name = "atomic_test",
     srcs = ["atomic_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_atomic",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_atomic"],
 )
 
-cc_test(
+libc_test(
     name = "bitset_test",
     srcs = ["bitset_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_bitset",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_bitset"],
 )
 
-cc_test(
+libc_test(
     name = "cstddef_test",
     srcs = ["cstddef_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_cstddef",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_cstddef"],
 )
 
-cc_test(
+libc_test(
     name = "integer_sequence_test",
     srcs = ["integer_sequence_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_utility",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_utility"],
 )
 
-cc_test(
+libc_test(
     name = "limits_test",
     srcs = ["limits_test.cpp"],
     deps = [
         "//libc:__support_cpp_limits",
         "//libc:__support_uint",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
     ],
 )
 
-cc_test(
+libc_test(
     name = "optional_test",
     srcs = ["optional_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_optional",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_optional"],
 )
 
-cc_test(
+libc_test(
     name = "span_test",
     srcs = ["span_test.cpp"],
     deps = [
         "//libc:__support_cpp_array",
         "//libc:__support_cpp_span",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
     ],
 )
 
-cc_test(
+libc_test(
     name = "stringstream_test",
     srcs = ["stringstream_test.cpp"],
     deps = [
         "//libc:__support_cpp_span",
         "//libc:__support_cpp_stringstream",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
     ],
 )
 
-cc_test(
+libc_test(
     name = "string_test",
     srcs = ["string_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_string",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_string"],
 )
 
-cc_test(
+libc_test(
     name = "stringview_test",
     srcs = ["stringview_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_string_view",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_string_view"],
 )
 
-cc_test(
+libc_test(
     name = "type_traits_test",
     srcs = ["type_traits_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_type_traits",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc:__support_cpp_type_traits"],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
@@ -4,6 +4,7 @@
 
 # Tests for LLVM libc math.h functions.
 
+load("//libc:libc_build_rules.bzl", "libc_support_library")
 load("//libc/test/src/math:libc_math_test_rules.bzl", "math_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -171,7 +172,7 @@ math_test(
     deps = ["//libc/utils/MPFRWrapper:mpfr_wrapper"],
 )
 
-cc_library(
+libc_support_library(
     name = "remquo_test_template",
     hdrs = ["RemQuoTest.h"],
     deps = [
@@ -288,7 +289,7 @@ math_test(
     deps = ["//libc/utils/MPFRWrapper:mpfr_wrapper"],
 )
 
-cc_library(
+libc_support_library(
     name = "ilogb_test_template",
     hdrs = ["ILogbTest.h"],
     deps = [
@@ -313,7 +314,7 @@ math_test(
     deps = [":ilogb_test_template"],
 )
 
-cc_library(
+libc_support_library(
     name = "fdim_test_template",
     hdrs = ["FDimTest.h"],
     deps = [
@@ -340,7 +341,7 @@ math_test(
     deps = [":fdim_test_template"],
 )
 
-cc_library(
+libc_support_library(
     name = "ldexp_test_template",
     hdrs = ["LdExpTest.h"],
     deps = [
@@ -366,7 +367,7 @@ math_test(
     deps = [":ldexp_test_template"],
 )
 
-cc_library(
+libc_support_library(
     name = "rint_test_template",
     hdrs = ["RIntTest.h"],
     deps = [
@@ -402,7 +403,7 @@ math_test(
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "round_to_integer_test_template",
     hdrs = ["RoundToIntegerTest.h"],
     deps = [
@@ -510,7 +511,7 @@ math_test(
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "nextafter_test_template",
     hdrs = ["NextAfterTest.h"],
     deps = [
@@ -539,13 +540,10 @@ math_test(
     deps = [":nextafter_test_template"],
 )
 
-cc_library(
+libc_support_library(
     name = "sdcomp26094",
     hdrs = ["sdcomp26094.h"],
-    deps = [
-        "//libc:__support_cpp_array",
-        "//libc:libc_root",
-    ],
+    deps = ["//libc:__support_cpp_array"],
 )
 
 math_test(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -4,6 +4,7 @@
 
 # Tests for LLVM libc stdlib.h functions.
 
+load("//libc:libc_build_rules.bzl", "libc_support_library")
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -13,69 +14,49 @@ licenses(["notice"])
 libc_test(
     name = "abs_test",
     srcs = ["abs_test.cpp"],
-    libc_function_deps = [
-        "//libc:abs",
-    ],
+    libc_function_deps = ["//libc:abs"],
 )
 
 libc_test(
     name = "labs_test",
     srcs = ["labs_test.cpp"],
-    libc_function_deps = [
-        "//libc:labs",
-    ],
+    libc_function_deps = ["//libc:labs"],
 )
 
 libc_test(
     name = "llabs_test",
     srcs = ["llabs_test.cpp"],
-    libc_function_deps = [
-        "//libc:llabs",
-    ],
+    libc_function_deps = ["//libc:llabs"],
 )
 
-cc_library(
+libc_support_library(
     name = "div_test_helper",
     hdrs = ["DivTest.h"],
-    deps = [
-        "//libc/test/UnitTest:LibcUnitTest",
-    ],
+    deps = ["//libc/test/UnitTest:LibcUnitTest"],
 )
 
 libc_test(
     name = "div_test",
     srcs = ["div_test.cpp"],
-    libc_function_deps = [
-        "//libc:div",
-    ],
-    deps = [
-        ":div_test_helper",
-    ],
+    libc_function_deps = ["//libc:div"],
+    deps = [":div_test_helper"],
 )
 
 libc_test(
     name = "ldiv_test",
     srcs = ["ldiv_test.cpp"],
-    libc_function_deps = [
-        "//libc:ldiv",
-    ],
-    deps = [
-        ":div_test_helper",
-    ],
+    libc_function_deps = ["//libc:ldiv"],
+    deps = [":div_test_helper"],
 )
 
 libc_test(
     name = "lldiv_test",
     srcs = ["lldiv_test.cpp"],
-    libc_function_deps = [
-        "//libc:lldiv",
-    ],
-    deps = [
-        ":div_test_helper",
-    ],
+    libc_function_deps = ["//libc:lldiv"],
+    deps = [":div_test_helper"],
 )
 
-cc_library(
+libc_support_library(
     name = "atoi_test_helper",
     hdrs = ["AtoiTest.h"],
     deps = [
@@ -87,66 +68,50 @@ cc_library(
 libc_test(
     name = "atoi_test",
     srcs = ["atoi_test.cpp"],
-    libc_function_deps = [
-        "//libc:atoi",
-    ],
+    libc_function_deps = ["//libc:atoi"],
     deps = [":atoi_test_helper"],
 )
 
 libc_test(
     name = "atol_test",
     srcs = ["atol_test.cpp"],
-    libc_function_deps = [
-        "//libc:atol",
-    ],
+    libc_function_deps = ["//libc:atol"],
     deps = [":atoi_test_helper"],
 )
 
 libc_test(
     name = "atoll_test",
     srcs = ["atoll_test.cpp"],
-    libc_function_deps = [
-        "//libc:atoll",
-    ],
+    libc_function_deps = ["//libc:atoll"],
     deps = [":atoi_test_helper"],
 )
 
 libc_test(
     name = "atof_test",
     srcs = ["atof_test.cpp"],
-    libc_function_deps = [
-        "//libc:atof",
-    ],
-    deps = [
-        "//libc:__support_fputil_fp_bits",
-    ],
+    libc_function_deps = ["//libc:atof"],
+    deps = ["//libc:__support_fputil_fp_bits"],
 )
 
 libc_test(
     name = "bsearch_test",
     srcs = ["bsearch_test.cpp"],
-    libc_function_deps = [
-        "//libc:bsearch",
-    ],
+    libc_function_deps = ["//libc:bsearch"],
 )
 
 libc_test(
     name = "qsort_test",
     srcs = ["qsort_test.cpp"],
-    libc_function_deps = [
-        "//libc:qsort",
-    ],
+    libc_function_deps = ["//libc:qsort"],
 )
 
 libc_test(
     name = "qsort_r_test",
     srcs = ["qsort_r_test.cpp"],
-    libc_function_deps = [
-        "//libc:qsort_r",
-    ],
+    libc_function_deps = ["//libc:qsort_r"],
 )
 
-cc_library(
+libc_support_library(
     name = "strtol_test_helper",
     hdrs = ["StrtolTest.h"],
     deps = [
@@ -161,45 +126,35 @@ cc_library(
 libc_test(
     name = "strtol_test",
     srcs = ["strtol_test.cpp"],
-    libc_function_deps = [
-        "//libc:strtol",
-    ],
+    libc_function_deps = ["//libc:strtol"],
     deps = [":strtol_test_helper"],
 )
 
 libc_test(
     name = "strtoll_test",
     srcs = ["strtoll_test.cpp"],
-    libc_function_deps = [
-        "//libc:strtoll",
-    ],
+    libc_function_deps = ["//libc:strtoll"],
     deps = [":strtol_test_helper"],
 )
 
 libc_test(
     name = "strtoul_test",
     srcs = ["strtoul_test.cpp"],
-    libc_function_deps = [
-        "//libc:strtoul",
-    ],
+    libc_function_deps = ["//libc:strtoul"],
     deps = [":strtol_test_helper"],
 )
 
 libc_test(
     name = "strtoull_test",
     srcs = ["strtoull_test.cpp"],
-    libc_function_deps = [
-        "//libc:strtoull",
-    ],
+    libc_function_deps = ["//libc:strtoull"],
     deps = [":strtol_test_helper"],
 )
 
 libc_test(
     name = "strtof_test",
     srcs = ["strtof_test.cpp"],
-    libc_function_deps = [
-        "//libc:strtof",
-    ],
+    libc_function_deps = ["//libc:strtof"],
     deps = [
         "//libc:__support_fputil_fp_bits",
         "//libc/test/UnitTest:fp_test_helpers",
@@ -209,9 +164,7 @@ libc_test(
 libc_test(
     name = "strtod_test",
     srcs = ["strtod_test.cpp"],
-    libc_function_deps = [
-        "//libc:strtod",
-    ],
+    libc_function_deps = ["//libc:strtod"],
     deps = [
         "//libc:__support_fputil_fp_bits",
         "//libc/test/UnitTest:fp_test_helpers",
@@ -221,9 +174,7 @@ libc_test(
 libc_test(
     name = "strtold_test",
     srcs = ["strtold_test.cpp"],
-    libc_function_deps = [
-        "//libc:strtold",
-    ],
+    libc_function_deps = ["//libc:strtold"],
     deps = [
         "//libc:__support_fputil_fp_bits",
         "//libc:__support_uint128",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
@@ -4,6 +4,7 @@
 
 # Tests for LLVM libc string.h functions.
 
+load("//libc:libc_build_rules.bzl", "libc_support_library")
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -42,7 +43,7 @@ libc_test(
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "strchr_test_helper",
     hdrs = ["StrchrTest.h"],
     deps = ["//libc/test/UnitTest:LibcUnitTest"],
@@ -114,7 +115,7 @@ libc_test(
     ],
 )
 
-cc_library(
+libc_support_library(
     name = "memory_check_utils",
     hdrs = ["memory_utils/memory_check_utils.h"],
     deps = [

--- a/utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel
@@ -4,6 +4,8 @@
 
 # A wrapper library over MPFR for use with LLVM libc math unittests.
 
+load("//libc:libc_build_rules.bzl", "libc_support_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
@@ -24,7 +26,7 @@ cc_library(
     ),
 )
 
-cc_library(
+libc_support_library(
     name = "mpfr_wrapper",
     srcs = ["MPFRUtils.cpp"],
     hdrs = ["MPFRUtils.h"],
@@ -46,8 +48,6 @@ cc_library(
         "//libc:__support_fputil_fp_bits",
         "//libc:__support_fputil_fpbits_str",
         "//libc:__support_fputil_platform_defs",
-        "//libc:libc_root",
-        "//libc/test/UnitTest:LibcUnitTest",
         "//libc/test/UnitTest:fp_test_helpers",
         "//libc/utils/MPFRWrapper:mpfr_impl",
     ],


### PR DESCRIPTION
Right now `LIBC_NAMESPACE` definition is added to all rules that depend upon
any libc function. This have far-reaching effects which prevents llvm-libc
development when the installed libc is itself llvm-libc.

This PR removes the `:libc_root` target entirely and consistently use the
provided libc BUILD actions for compilation and testing. This makes sure that we
don't leak `LIBC_NAMESPACE` to our client.
