### PR TITLE
[libc++] Fixed uniform_real_distribution.h where it was allowing initialization with non floating point types

### DIFF
--- a/libcxx/include/__random/uniform_real_distribution.h
+++ b/libcxx/include/__random/uniform_real_distribution.h
@@ -27,6 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template<class _RealType = double>
 class _LIBCPP_TEMPLATE_VIS uniform_real_distribution
 {
+     static_assert(std::is_floating_point<_RealType>::value, "result_type must be a floating point type");
 public:
     // types
     typedef _RealType result_type;


### PR DESCRIPTION
Included a static_assert to deal with cases where result_types are initialized with non floating point type values which can cause undefined behaviour as mentioned [here](https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution)