### PR TITLE
[libc++][NFC] Make data members of counted_iterator private

### DIFF
--- a/libcxx/include/__iterator/counted_iterator.h
+++ b/libcxx/include/__iterator/counted_iterator.h
@@ -73,9 +73,6 @@ class counted_iterator
   , public __counted_iterator_category<_Iter>
   , public __counted_iterator_value_type<_Iter>
 {
-  _LIBCPP_NO_UNIQUE_ADDRESS _Iter __current_ = _Iter();
-  iter_difference_t<_Iter> __count_ = 0;
-
 public:
   using iterator_type = _Iter;
   using difference_type = iter_difference_t<_Iter>;
@@ -297,6 +294,12 @@ public:
                                  "Iterators must not be past end of range.");
     return ranges::iter_swap(__x.__current_, __y.__current_);
   }
+
+private:
+  _LIBCPP_NO_UNIQUE_ADDRESS _Iter __current_ = _Iter();
+  iter_difference_t<_Iter> __count_ = 0;
+  template<input_or_output_iterator _OtherIter>
+  friend class counted_iterator;
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(counted_iterator);
 

--- a/libcxx/include/__iterator/counted_iterator.h
+++ b/libcxx/include/__iterator/counted_iterator.h
@@ -73,10 +73,10 @@ class counted_iterator
   , public __counted_iterator_category<_Iter>
   , public __counted_iterator_value_type<_Iter>
 {
-public:
   _LIBCPP_NO_UNIQUE_ADDRESS _Iter __current_ = _Iter();
   iter_difference_t<_Iter> __count_ = 0;
 
+public:
   using iterator_type = _Iter;
   using difference_type = iter_difference_t<_Iter>;
 


### PR DESCRIPTION
There's no reason for them to be public AFAICT. I came across this while auditing the code bases for places where we'd be using [[no_unique_address]] incorrectly. Since one of these members is marked as [[no_unique_address]], this is an extra reason to keep this private to ensure the member isn't escaped anywhere.