### PR TITLE
[clang][wasm] Resolve assertion errors caused by converting ComplexTy…

### DIFF
--- a/clang/lib/CodeGen/Targets/WebAssembly.cpp
+++ b/clang/lib/CodeGen/Targets/WebAssembly.cpp
@@ -114,6 +114,9 @@ ABIArgInfo WebAssemblyABIInfo::classifyArgumentType(QualType Ty) const {
       return ABIArgInfo::getDirect(CGT.ConvertType(QualType(SeltTy, 0)));
     // For the experimental multivalue ABI, fully expand all other aggregates
     if (Kind == WebAssemblyABIKind::ExperimentalMV) {
+      if (Ty->getAs<ComplexType>()) {
+        return ABIArgInfo::getDirect();
+      }
       const RecordType *RT = Ty->getAs<RecordType>();
       assert(RT);
       bool HasBitField = false;

--- a/clang/test/CodeGen/pr70496.c
+++ b/clang/test/CodeGen/pr70496.c
@@ -1,0 +1,3 @@
+// RUN: %clang --target=wasm32 -mmultivalue -Xclang -target-abi -Xclang experimental-mv %s -S -Xclang -verify
+
+float crealf() { return 0;} // expected-no-diagnostics


### PR DESCRIPTION
When a function parameter is of the built-in Complex type in Clang, the conversion from ComplexType to RecordType is not possible, resulting in a crash in Clang. RecordType is a helper class for structs, unions, and classes.

https://github.com/llvm/llvm-project/issues/70402