### PR TITLE
[Github] Add flang docs to Github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ on:
       - 'lld/docs/**'
       - 'openmp/docs/**'
       - 'polly/docs/**'
+      - 'flang/docs/**'
   pull_request:
     paths:
       - 'llvm/docs/**'
@@ -35,6 +36,7 @@ on:
       - 'lld/docs/**'
       - 'openmp/docs/**'
       - 'polly/docs/**'
+      - 'flang/docs/**'
 
 jobs:
   check-docs-build:
@@ -75,6 +77,8 @@ jobs:
               - 'openmp/docs/**'
             polly:
               - 'polly/docs/**'
+            flang:
+              - 'flang/docs/**'
       - name: Fetch LLVM sources (PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
@@ -143,4 +147,11 @@ jobs:
         run: |
           cmake -B polly-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="polly" -DLLVM_ENABLE_SPHINX=ON ./llvm
           TZ=UTC ninja -C polly-build docs-polly-html docs-polly-man
+      - name: Build Flang docs
+        if: steps.docs-changed-subprojects.outputs.flang_any_changed == 'true'
+        # TODO(boomanaiden154): Remove the SPHINX_WARNINGS_AS_ERRORS from the
+        # CMake invocation once the warnings in the flang docs build are fixed.
+        run: |
+          cmake -B flang-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;mlir;flang" -DLLVM_ENABLE_SPHINX=ON -DSPHINX_WARNINGS_AS_ERRORS=OFF ./llvm
+          TZ=UTC ninja -C flang-build docs-flang-html docs-flang-man
 


### PR DESCRIPTION
This patch enables building the flang docs in Github actions to enable rapid iteration in PRs and to catch docs build failures more easily before merge/after merge. This patch currently doesn't fail for Sphinx warnings, but the intention is to enable this functionality once the flang docs are fixed to build without warnings after the transition to Myst.