### PR TITLE
[Github] Add Polly docs to Github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ on:
       - 'libc/docs/**'
       - 'lld/docs/**'
       - 'openmp/docs/**'
+      - 'polly/docs/**'
   pull_request:
     paths:
       - 'llvm/docs/**'
@@ -33,6 +34,7 @@ on:
       - 'libc/docs/**'
       - 'lld/docs/**'
       - 'openmp/docs/**'
+      - 'polly/docs/**'
 
 jobs:
   check-docs-build:
@@ -71,6 +73,8 @@ jobs:
               - 'lld/docs/**'
             openmp:
               - 'openmp/docs/**'
+            polly:
+              - 'polly/docs/**'
       - name: Fetch LLVM sources (PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
@@ -134,4 +138,9 @@ jobs:
         run: |
           cmake -B openmp-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;openmp" -DLLVM_ENABLE_SPHINX=ON ./llvm
           TZ=UTC ninja -C openmp-build docs-openmp-html
+      - name: Build Polly docs
+        if: steps.docs-changed-subprojects.outputs.polly_any_changed == 'true'
+        run: |
+          cmake -B polly-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="polly" -DLLVM_ENABLE_SPHINX=ON ./llvm
+          TZ=UTC ninja -C polly-build docs-polly-html docs-polly-man
 


### PR DESCRIPTION
This patch enables building the polly docs in CI to catch warnings/build regressions in the documentation.