### PR TITLE
[lldb][Test] TestDataFormatterLibcxxChrono.py: skip test on older clang versions

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/TestDataFormatterLibcxxChrono.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/TestDataFormatterLibcxxChrono.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 class LibcxxChronoDataFormatterTestCase(TestBase):
     @add_test_categories(["libc++"])
+    @skipIf(compiler="clang", compiler_version=["<", "11.0"])
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()


### PR DESCRIPTION
These tests were failing on the LLDB public matrix build-bots for older clang versions:
```
clang-7: warning: argument unused during compilation: '-nostdlib++' [-Wunused-command-line-argument]
error: invalid value 'c++20' in '-std=c++20'
note: use 'c++98' or 'c++03' for 'ISO C++ 1998 with amendments' standard
note: use 'gnu++98' or 'gnu++03' for 'ISO C++ 1998 with amendments and GNU extensions' standard
note: use 'c++11' for 'ISO C++ 2011 with amendments' standard
note: use 'gnu++11' for 'ISO C++ 2011 with amendments and GNU extensions' standard
note: use 'c++14' for 'ISO C++ 2014 with amendments' standard
note: use 'gnu++14' for 'ISO C++ 2014 with amendments and GNU extensions' standard
note: use 'c++17' for 'ISO C++ 2017 with amendments' standard
note: use 'gnu++17' for 'ISO C++ 2017 with amendments and GNU extensions' standard
note: use 'c++2a' for 'Working draft for ISO C++ 2020' standard
note: use 'gnu++2a' for 'Working draft for ISO C++ 2020 with GNU extensions' standard
make: *** [main.o] Error 1
```

The test fails because we try to compile it with `-std=c++20` (which is required for std::chrono::{days,weeks,months,years}) on clang versions that don't support the `-std=c++20` flag.

We could change the test to conditionally compile the C++20 parts of the test based on the `-std=` flag and have two versions of the python tests, one for the C++11 chrono features and one for the C++20 features.

This patch instead just disables the test on older clang versions (because it's simpler and we don't really lose important coverage).