### PR TITLE
[clang-tidy] fix match for binaryOperator in ExprMutationAnalyzer for misc-const-correctness

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -307,11 +307,9 @@ Changes in existing checks
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check to avoid false positive when
   using pointer to member function.
-
-- Improved :doc:`misc-const-correctness
-  <clang-tidy/checks/misc/const-correctness>` check to not warn on uses in
-  type-dependent binary operators, when the variable that is being
-  looked at, is not the dependent operand.
+  Additionally, the check no longer emits a diagnostic when
+  a variable that is not type-dependent is an operand of a
+  type-dependent binary operator.
 
 - Improved :doc:`misc-include-cleaner
   <clang-tidy/checks/misc/include-cleaner>` check by adding option

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -306,9 +306,8 @@ Changes in existing checks
 
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check to avoid false positive when
-  using pointer to member function.
-  Additionally, the check no longer emits a diagnostic when
-  a variable that is not type-dependent is an operand of a
+  using pointer to member function. Additionally, the check no longer emits
+  a diagnostic when a variable that is not type-dependent is an operand of a
   type-dependent binary operator.
 
 - Improved :doc:`misc-include-cleaner

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -308,6 +308,11 @@ Changes in existing checks
   <clang-tidy/checks/misc/const-correctness>` check to avoid false positive when
   using pointer to member function.
 
+- Improved :doc:`misc-const-correctness
+  <clang-tidy/checks/misc/const-correctness>` check to not warn on uses in
+  type-dependent binary operators, when the variable that is being
+  looked at, is not the dependent operand.
+
 - Improved :doc:`misc-include-cleaner
   <clang-tidy/checks/misc/include-cleaner>` check by adding option
   `DeduplicateFindings` to output one finding per symbol occurrence, avoid

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
@@ -22,12 +22,15 @@ void instantiate_template_cases() {
 }
 
 namespace gh57297{
-struct Stream {};
-// Explicitly not declaring a (templated) stream operator
-// so the `<<` is a `binaryOperator` with a dependent type.
-template <typename T> void f() {
-  T t;
-  Stream stream;
-  stream << t;
-}
+// The expression to check may not be the dependent operand in a dependent
+// operator.
+
+// Explicitly adding the conversion operator to int for `Stream` to make the
+// explicit instantiation (required due to windows' delayed template parsing
+// pre C++20) of `f` work without compile errors. Writing an `operator<<` for
+// `Stream` would make the `x << t` expression a CXXOperatorCallExpr, not a
+// BinaryOperator.
+struct Stream { operator int(); };
+template <typename T> void f() { T t; Stream x; x << t; }
+void foo() { f<int>(); }
 } // namespace gh57297

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
@@ -25,12 +25,8 @@ namespace gh57297{
 // The expression to check may not be the dependent operand in a dependent
 // operator.
 
-// Explicitly adding the conversion operator to int for `Stream` to make the
-// explicit instantiation (required due to windows' delayed template parsing
-// pre C++20) of `f` work without compile errors. Writing an `operator<<` for
-// `Stream` would make the `x << t` expression a CXXOperatorCallExpr, not a
-// BinaryOperator.
-struct Stream { operator int(); };
+// Explicitly not declaring a (templated) stream operator
+// so the `<<` is a `binaryOperator` with a dependent type.
+struct Stream { };
 template <typename T> void f() { T t; Stream x; x << t; }
-void foo() { f<int>(); }
 } // namespace gh57297

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
@@ -20,3 +20,14 @@ void instantiate_template_cases() {
   type_dependent_variables<int>();
   type_dependent_variables<float>();
 }
+
+namespace gh57297{
+struct Stream {};
+// Explicitly not declaring a (templated) stream operator
+// so the `<<` is a `binaryOperator` with a dependent type.
+template <typename T> void f() {
+  T t;
+  Stream stream;
+  stream << t;
+}
+} // namespace gh57297

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -683,9 +683,6 @@ Bug Fixes to AST Handling
 - Fixed a bug where RecursiveASTVisitor fails to visit the
   initializer of a bitfield.
   `Issue 64916 <https://github.com/llvm/llvm-project/issues/64916>`_
-- Fixed a bug where ``ExprMutationAnalyzer`` did not find a potential mutation
-  for uses in type-dependent binary operators, when the variable that is being
-  looked at, is not the dependent operand.
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -683,6 +683,9 @@ Bug Fixes to AST Handling
 - Fixed a bug where RecursiveASTVisitor fails to visit the
   initializer of a bitfield.
   `Issue 64916 <https://github.com/llvm/llvm-project/issues/64916>`_
+- Fixed a bug where ``ExprMutationAnalyzer`` did not find a potential mutation
+  for uses in type-dependent binary operators, when the variable that is being
+  looked at, is not the dependent operand.
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Analysis/ExprMutationAnalyzer.cpp
+++ b/clang/lib/Analysis/ExprMutationAnalyzer.cpp
@@ -296,9 +296,9 @@ const Stmt *ExprMutationAnalyzer::findDirectMutation(const Expr *Exp) {
       // resolved and modelled as `binaryOperator` on a dependent type.
       // Such instances are considered a modification, because they can modify
       // in different instantiations of the template.
-      binaryOperator(hasEitherOperand(
-          allOf(ignoringImpCasts(canResolveToExpr(equalsNode(Exp))),
-                isTypeDependent()))),
+      binaryOperator(
+          hasEitherOperand(ignoringImpCasts(canResolveToExpr(equalsNode(Exp)))),
+          isTypeDependent()),
       // Within class templates and member functions the member expression might
       // not be resolved. In that case, the `callExpr` is considered to be a
       // modification.

--- a/clang/unittests/Analysis/ExprMutationAnalyzerTest.cpp
+++ b/clang/unittests/Analysis/ExprMutationAnalyzerTest.cpp
@@ -345,10 +345,18 @@ TEST(ExprMutationAnalyzerTest, UnresolvedOperator) {
 
 TEST(ExprMutationAnalyzerTest, DependentOperatorWithNonDependentOperand) {
   // gh57297
-  // Explicitly not declaring a (templated) stream operator
-  // so the `<<` is a `binaryOperator` with a dependent type.
-  const auto AST = buildASTFromCode("struct Stream {}; template <typename T> "
-                                    "void f() { T t; Stream x; x << t;}");
+  // The expression to check may not be the dependent operand in a dependent
+  // operator.
+
+  // Explicitly adding the conversion operator to int for `Stream` to make the
+  // explicit instantiation (required due to windows' delayed template parsing
+  // pre C++20) of `f` work without compile errors. Writing an `operator<<` for
+  // `Stream` would make the `x << t` expression a CXXOperatorCallExpr, not a
+  // BinaryOperator.
+  const auto AST = buildASTFromCode(
+      "struct Stream { operator int(); };"
+      "template <typename T> void f() { T t; Stream x; x << t; }"
+      "void foo() { f<int>(); }");
   const auto Results =
       match(withEnclosingCompound(declRefTo("x")), AST->getASTContext());
   EXPECT_THAT(mutatedBy(Results, AST.get()), ElementsAre("x << t"));

--- a/clang/unittests/Analysis/ExprMutationAnalyzerTest.cpp
+++ b/clang/unittests/Analysis/ExprMutationAnalyzerTest.cpp
@@ -343,6 +343,17 @@ TEST(ExprMutationAnalyzerTest, UnresolvedOperator) {
   EXPECT_TRUE(isMutated(Results, AST.get()));
 }
 
+TEST(ExprMutationAnalyzerTest, DependentOperatorWithNonDependentOperand) {
+  // gh57297
+  // Explicitly not declaring a (templated) stream operator
+  // so the `<<` is a `binaryOperator` with a dependent type.
+  const auto AST = buildASTFromCode("struct Stream {}; template <typename T> "
+                                    "void f() { T t; Stream x; x << t;}");
+  const auto Results =
+      match(withEnclosingCompound(declRefTo("x")), AST->getASTContext());
+  EXPECT_THAT(mutatedBy(Results, AST.get()), ElementsAre("x << t"));
+}
+
 // Section: expression as call argument
 
 TEST(ExprMutationAnalyzerTest, ByValueArgument) {


### PR DESCRIPTION
The `ExprMutationAnalyzer`s matcher of `binaryOperator`s
that contained the variable expr, were previously narrowing the
variable to be type dependent, when the `binaryOperator` should
have been narrowed as dependent.
The variable we are trying to find mutations for does
not need to be the dependent type, the other operand of
the `binaryOperator` could be dependent.

Fixes #57297
