### PR TITLE
[objcopy] Implement --weaken, --weaken-symbol(s) flags for MachO Object Files

### DIFF
--- a/llvm/lib/ObjCopy/ConfigManager.cpp
+++ b/llvm/lib/ObjCopy/ConfigManager.cpp
@@ -34,13 +34,13 @@ Expected<const MachOConfig &> ConfigManager::getMachOConfig() const {
   if (!Common.SplitDWO.empty() || !Common.SymbolsPrefix.empty() ||
       !Common.AllocSectionsPrefix.empty() || !Common.KeepSection.empty() ||
       !Common.SymbolsToGlobalize.empty() || !Common.SymbolsToKeep.empty() ||
-      !Common.SymbolsToLocalize.empty() || !Common.SymbolsToWeaken.empty() ||
+      !Common.SymbolsToLocalize.empty() ||
       !Common.SymbolsToKeepGlobal.empty() || !Common.SectionsToRename.empty() ||
       !Common.UnneededSymbolsToRemove.empty() ||
       !Common.SetSectionAlignment.empty() || !Common.SetSectionFlags.empty() ||
       !Common.SetSectionType.empty() || Common.ExtractDWO ||
       Common.PreserveDates || Common.StripAllGNU || Common.StripDWO ||
-      Common.StripNonAlloc || Common.StripSections || Common.Weaken ||
+      Common.StripNonAlloc || Common.StripSections ||
       Common.DecompressDebugSections || Common.StripUnneeded ||
       Common.DiscardMode == DiscardType::Locals || !Common.SymbolsToAdd.empty())
     return createStringError(llvm::errc::invalid_argument,

--- a/llvm/test/tools/llvm-objcopy/MachO/weaken-all.s
+++ b/llvm/test/tools/llvm-objcopy/MachO/weaken-all.s
@@ -1,0 +1,100 @@
+# REQUIRES: x86-registered-target
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t
+
+# RUN: llvm-objcopy --weaken %t %t2
+# RUN: llvm-readobj --symbols %t2 --sort-symbols=name | FileCheck %s
+
+# CHECK:      Symbols [
+# CHECK-NEXT: Symbol {
+# CHECK-NEXT:   Name: _global ({{[0-9]+}})
+# CHECK-NEXT:   Extern
+# CHECK-NEXT:   Type: Section (0xE)
+# CHECK-NEXT:   Section: __text (0x1)
+# CHECK-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-NEXT:   Flags [ (0x80)
+# CHECK-NEXT:     WeakDef (0x80)
+# CHECK-NEXT:   ]
+# CHECK-NEXT:   Value: 0x0
+# CHECK-NEXT: }
+# CHECK-NEXT: Symbol {
+# CHECK-NEXT:   Name: _global_data ({{[0-9]+}})
+# CHECK-NEXT:   Extern
+# CHECK-NEXT:   Type: Section (0xE)
+# CHECK-NEXT:   Section: __const (0x2)
+# CHECK-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-NEXT:   Flags [ (0x80)
+# CHECK-NEXT:     WeakDef (0x80)
+# CHECK-NEXT:   ]
+# CHECK-NEXT:   Value: 0x0
+# CHECK-NEXT: }
+# CHECK-NEXT: Symbol {
+# CHECK-NEXT:   Name: _local ({{[0-9]+}})
+# CHECK-NEXT:   Type: Section (0xE)
+# CHECK-NEXT:   Section: __text (0x1)
+# CHECK-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-NEXT:   Flags [ (0x0)
+# CHECK-NEXT:   ]
+# CHECK-NEXT:   Value: 0x0
+# CHECK-NEXT: }
+# CHECK-NEXT: Symbol {
+# CHECK-NEXT:   Name: _local_data ({{[0-9]+}})
+# CHECK-NEXT:   Type: Section (0xE)
+# CHECK-NEXT:   Section: __const (0x2)
+# CHECK-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-NEXT:   Flags [ (0x0)
+# CHECK-NEXT:   ]
+# CHECK-NEXT:   Value: 0x0
+# CHECK-NEXT: }
+# CHECK-NEXT: Symbol {
+# CHECK-NEXT:   Name: _weak ({{[0-9]+}})
+# CHECK-NEXT:   Type: Section (0xE)
+# CHECK-NEXT:   Section: __text (0x1)
+# CHECK-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-NEXT:   Flags [ (0x80)
+# CHECK-NEXT:     WeakDef (0x80)
+# CHECK-NEXT:   ]
+# CHECK-NEXT:   Value: 0x0
+# CHECK-NEXT: }
+# CHECK-NEXT: Symbol {
+# CHECK-NEXT:   Name: _weak_data ({{[0-9]+}})
+# CHECK-NEXT:   Type: Section (0xE)
+# CHECK-NEXT:   Section: __const (0x2)
+# CHECK-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-NEXT:   Flags [ (0x80)
+# CHECK-NEXT:     WeakDef (0x80)
+# CHECK-NEXT:   ]
+# CHECK-NEXT:   Value: 0x0
+# CHECK-NEXT: }
+# CHECK-NEXT: Symbol {
+# CHECK-NEXT:   Name: _weak_global ({{[0-9]+}})
+# CHECK-NEXT:   Extern
+# CHECK-NEXT:   Type: Section (0xE)
+# CHECK-NEXT:   Section: __text (0x1)
+# CHECK-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-NEXT:   Flags [ (0x80)
+# CHECK-NEXT:     WeakDef (0x80)
+# CHECK-NEXT:   ]
+# CHECK-NEXT:   Value: 0x0
+# CHECK-NEXT: }
+# CHECK-NEXT: ]
+
+.globl _global
+_global:
+
+_local:
+
+.weak_definition _weak
+_weak:
+
+.weak_definition _weak_global
+.globl _weak_global
+_weak_global:
+
+.section __TEXT,__const
+.globl _global_data
+_global_data:
+_local_data:
+
+.weak_definition _weak_data
+_weak_data:

--- a/llvm/test/tools/llvm-objcopy/MachO/weaken.s
+++ b/llvm/test/tools/llvm-objcopy/MachO/weaken.s
@@ -1,0 +1,89 @@
+# REQUIRES: x86-registered-target
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64-apple-macos %s -o %t
+
+# RUN: llvm-objcopy -W _func %t %t2
+# RUN: llvm-readobj --symbols %t2 | FileCheck %s -check-prefix=CHECK-1
+
+# CHECK-1:      Symbol {
+# CHECK-1-NEXT:   Name: _foo (1)
+# CHECK-1-NEXT:   Extern
+# CHECK-1-NEXT:   Type: Section (0xE)
+# CHECK-1-NEXT:   Section: __const (0x2)
+# CHECK-1-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-1-NEXT:   Flags [ (0x0)
+# CHECK-1-NEXT:   ]
+# CHECK-1-NEXT:   Value: 0x0
+# CHECK-1-NEXT: }
+# CHECK-1-NEXT: Symbol {
+# CHECK-1-NEXT:   Name: _func (6)
+# CHECK-1-NEXT:   Extern
+# CHECK-1-NEXT:   Type: Section (0xE)
+# CHECK-1-NEXT:   Section: __text (0x1)
+# CHECK-1-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-1-NEXT:   Flags [ (0x80)
+# CHECK-1-NEXT:     WeakDef (0x80)
+# CHECK-1-NEXT:   ]
+# CHECK-1-NEXT:   Value: 0x0
+# CHECK-1-NEXT: }
+
+# RUN: echo _foo > %t.weaken.txt
+# RUN: echo _func >> %t.weaken.txt
+# RUN: llvm-objcopy --weaken-symbols %t.weaken.txt %t %t3
+# RUN: llvm-readobj --symbols %t3 | FileCheck %s -check-prefix=CHECK-2
+
+# CHECK-2:      Symbol {
+# CHECK-2-NEXT:   Name: _foo (1)
+# CHECK-2-NEXT:   Extern
+# CHECK-2-NEXT:   Type: Section (0xE)
+# CHECK-2-NEXT:   Section: __const (0x2)
+# CHECK-2-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-2-NEXT:   Flags [ (0x80)
+# CHECK-2-NEXT:     WeakDef (0x80)
+# CHECK-2-NEXT:   ]
+# CHECK-2-NEXT:   Value: 0x0
+# CHECK-2-NEXT: }
+# CHECK-2-NEXT: Symbol {
+# CHECK-2-NEXT:   Name: _func (6)
+# CHECK-2-NEXT:   Extern
+# CHECK-2-NEXT:   Type: Section (0xE)
+# CHECK-2-NEXT:   Section: __text (0x1)
+# CHECK-2-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-2-NEXT:   Flags [ (0x80)
+# CHECK-2-NEXT:     WeakDef (0x80)
+# CHECK-2-NEXT:   ]
+# CHECK-2-NEXT:   Value: 0x0
+# CHECK-2-NEXT: }
+
+## Verify --weaken-symbol plays nice with --redefine-sym.
+# RUN: llvm-objcopy -W _foo --redefine-sym _foo=_bar %t %t4
+# RUN: llvm-readobj --symbols %t4 | FileCheck %s -check-prefix=CHECK-3
+
+# CHECK-3:      Symbol {
+# CHECK-3-NEXT:   Name: _bar (1)
+# CHECK-3-NEXT:   Extern
+# CHECK-3-NEXT:   Type: Section (0xE)
+# CHECK-3-NEXT:   Section: __const (0x2)
+# CHECK-3-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-3-NEXT:   Flags [ (0x80)
+# CHECK-3-NEXT:     WeakDef (0x80)
+# CHECK-3-NEXT:   ]
+# CHECK-3-NEXT:   Value: 0x0
+# CHECK-3-NEXT: }
+# CHECK-3-NEXT: Symbol {
+# CHECK-3-NEXT:   Name: _func (6)
+# CHECK-3-NEXT:   Extern
+# CHECK-3-NEXT:   Type: Section (0xE)
+# CHECK-3-NEXT:   Section: __text (0x1)
+# CHECK-3-NEXT:   RefType: UndefinedNonLazy (0x0)
+# CHECK-3-NEXT:   Flags [ (0x0)
+# CHECK-3-NEXT:   ]
+# CHECK-3-NEXT:   Value: 0x0
+# CHECK-3-NEXT: }
+
+.globl _func
+_func:
+
+.section __TEXT,__const
+.globl _foo
+_foo:


### PR DESCRIPTION
In a recent legacy codebase I found an invocation of GNU `objconv` used to weaken symbols of MachO object files. I tried to replace `objconv` with the corresponding invocation of `llvm-objcopy` and found `--weaken` (and friends) weren't implemented for MachO.

This PR implements those weakening flags for MachO file types.
