### PR TITLE
[clang][Interp] Handle CXXTryStmts

### DIFF
--- a/clang/lib/AST/Interp/ByteCodeStmtGen.cpp
+++ b/clang/lib/AST/Interp/ByteCodeStmtGen.cpp
@@ -255,6 +255,8 @@ bool ByteCodeStmtGen<Emitter>::visitStmt(const Stmt *S) {
     return visitAsmStmt(cast<AsmStmt>(S));
   case Stmt::AttributedStmtClass:
     return visitAttributedStmt(cast<AttributedStmt>(S));
+  case Stmt::CXXTryStmtClass:
+    return visitCXXTryStmt(cast<CXXTryStmt>(S));
   case Stmt::NullStmtClass:
     return true;
   default: {
@@ -641,6 +643,12 @@ template <class Emitter>
 bool ByteCodeStmtGen<Emitter>::visitAttributedStmt(const AttributedStmt *S) {
   // Ignore all attributes.
   return this->visitStmt(S->getSubStmt());
+}
+
+template <class Emitter>
+bool ByteCodeStmtGen<Emitter>::visitCXXTryStmt(const CXXTryStmt *S) {
+  // Ignore all handlers.
+  return this->visitStmt(S->getTryBlock());
 }
 
 namespace clang {

--- a/clang/lib/AST/Interp/ByteCodeStmtGen.h
+++ b/clang/lib/AST/Interp/ByteCodeStmtGen.h
@@ -65,6 +65,7 @@ private:
   bool visitDefaultStmt(const DefaultStmt *S);
   bool visitAsmStmt(const AsmStmt *S);
   bool visitAttributedStmt(const AttributedStmt *S);
+  bool visitCXXTryStmt(const CXXTryStmt *S);
 
   bool emitLambdaStaticInvokerBody(const CXXMethodDecl *MD);
 

--- a/clang/test/AST/Interp/cxx20.cpp
+++ b/clang/test/AST/Interp/cxx20.cpp
@@ -739,3 +739,16 @@ namespace NonPrimitiveOpaqueValue
 
   static_assert(!ternary(), "");
 }
+
+namespace TryCatch {
+  constexpr int foo() {
+    int a = 10;
+    try {
+      ++a;
+    } catch(int m) {
+      --a;
+    }
+    return a;
+  }
+  static_assert(foo() == 11);
+}


### PR DESCRIPTION
Just do the same thing the current interpreter does: Ignore all handlers and visit the try block like normal.