### PR TITLE
[OpenMP] Make use of getloadavg() on *BSD OS's

### DIFF
--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -2206,7 +2206,8 @@ int __kmp_is_address_mapped(void *addr) {
 
 #ifdef USE_LOAD_BALANCE
 
-#if KMP_OS_DARWIN || KMP_OS_NETBSD
+#if KMP_OS_DARWIN || KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD ||    \
+    KMP_OS_OPENBSD
 
 // The function returns the rounded value of the system load average
 // during given time interval which depends on the value of


### PR DESCRIPTION
OpenBSD does not have /proc filesystem, neither does FreeBSD (by default).