### PR TITLE
[libc++] Remove alignment_of uses

### DIFF
--- a/libcxx/include/__memory/temporary_buffer.h
+++ b/libcxx/include/__memory/temporary_buffer.h
@@ -38,8 +38,7 @@ get_temporary_buffer(ptrdiff_t __n) _NOEXCEPT
 #if !defined(_LIBCPP_HAS_NO_ALIGNED_ALLOCATION)
     if (__is_overaligned_for_new(_LIBCPP_ALIGNOF(_Tp)))
         {
-            align_val_t __al =
-                align_val_t(alignment_of<_Tp>::value);
+            align_val_t __al = align_val_t(_LIBCPP_ALIGNOF(_Tp));
             __r.first = static_cast<_Tp*>(::operator new(
                 __n * sizeof(_Tp), __al, nothrow));
         } else {

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -90,7 +90,6 @@ namespace std {
 #include <__type_traits/add_const.h>
 #include <__type_traits/add_pointer.h>
 #include <__type_traits/aligned_storage.h>
-#include <__type_traits/alignment_of.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/decay.h>
 #include <__type_traits/is_constructible.h>
@@ -156,14 +155,13 @@ add_pointer_t<_ValueType> any_cast(any *) _NOEXCEPT;
 namespace __any_imp
 {
   _LIBCPP_SUPPRESS_DEPRECATED_PUSH
-  using _Buffer = aligned_storage_t<3*sizeof(void*), alignment_of<void*>::value>;
+  using _Buffer = aligned_storage_t<3*sizeof(void*), alignof(void*)>;
   _LIBCPP_SUPPRESS_DEPRECATED_POP
 
   template <class _Tp>
   using _IsSmallObject = integral_constant<bool
         , sizeof(_Tp) <= sizeof(_Buffer)
-          && alignment_of<_Buffer>::value
-             % alignment_of<_Tp>::value == 0
+          && alignof(_Buffer) % alignof(_Tp) == 0
           && is_nothrow_move_constructible<_Tp>::value
         >;
 

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -382,7 +382,6 @@ template <class R, class Alloc> struct uses_allocator<packaged_task<R>, Alloc>;
 #include <__system_error/error_code.h>
 #include <__system_error/error_condition.h>
 #include <__type_traits/aligned_storage.h>
-#include <__type_traits/alignment_of.h>
 #include <__type_traits/strip_signature.h>
 #include <__utility/auto_cast.h>
 #include <__utility/forward.h>
@@ -648,7 +647,7 @@ class _LIBCPP_AVAILABILITY_FUTURE _LIBCPP_HIDDEN __assoc_state
 {
     typedef __assoc_sub_state base;
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
-    typedef typename aligned_storage<sizeof(_Rp), alignment_of<_Rp>::value>::type _Up;
+    typedef typename aligned_storage<sizeof(_Rp), _LIBCPP_ALIGNOF(_Rp)>::type _Up;
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 protected:
     _Up __value_;

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -90,7 +90,6 @@ void  operator delete[](void* ptr, void*) noexcept;
 #include <__availability>
 #include <__config>
 #include <__exception/exception.h>
-#include <__type_traits/alignment_of.h>
 #include <__type_traits/is_function.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/remove_cv.h>
@@ -261,7 +260,7 @@ _LIBCPP_CONSTEXPR inline _LIBCPP_INLINE_VISIBILITY bool __is_overaligned_for_new
 #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
   return __align > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 #else
-  return __align > alignment_of<max_align_t>::value;
+  return __align > _LIBCPP_ALIGNOF(max_align_t);
 #endif
 }
 


### PR DESCRIPTION
There is no reason to use `alignment_of<T>` instead of `alignof(T)` or `_LIBCPP_ALIGNOF(T)`. It only makes the code more verbose and results in slightly worse compile times.