### PR TITLE
[clang] Fix crash when inheriting from a cv-qualified type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -486,6 +486,9 @@ Bug Fixes to C++ Support
 - Fixed a bug that prevented member function templates of class templates declared with a deduced return type
   from being explicitly specialized for a given implicit instantiation of the class template.
 
+- Fix crash when inheriting from a cv-qualified type. Fixes:
+  (`#35603 <https://github.com/llvm/llvm-project/issues/35603>`_)
+
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Clang now properly preserves ``FoundDecls`` within a ``ConceptReference``. (#GH82628)

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -6456,7 +6456,7 @@ static bool HandleConstructorCall(const Expr *E, const LValue &This,
       // Non-virtual base classes are initialized in the order in the class
       // definition. We have already checked for virtual base classes.
       assert(!BaseIt->isVirtual() && "virtual base for literal type");
-      assert(Info.Ctx.hasSameType(BaseIt->getType(), BaseType) &&
+      assert(Info.Ctx.hasSameUnqualifiedType(BaseIt->getType(), BaseType) &&
              "base class initializers not in expected order");
       ++BaseIt;
 #endif

--- a/clang/test/Sema/GH70594.cpp
+++ b/clang/test/Sema/GH70594.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++11 %s -verify
+// RUN: %clang_cc1 -fsyntax-only -std=c++23 %s -verify
+
+// expected-no-diagnostics
+
+struct A {};
+using CA = const A;
+
+struct S1 : CA {
+  constexpr S1() : CA() {}
+};
+
+struct S2 : A {
+  constexpr S2() : CA() {}
+};
+
+struct S3 : CA {
+  constexpr S3() : A() {}
+};
+
+struct Int {};
+
+template <class _Hp>
+struct __tuple_leaf : _Hp {
+  constexpr __tuple_leaf() : _Hp() {}
+};
+
+constexpr __tuple_leaf<const Int> t;


### PR DESCRIPTION
Resolves Issue #35603

This change makes the `assertion` less strict in `debug` builds by stripping qualifiers from the base class and ignoring them. I hope `weakened` assertions don't affect other cases where such `errors` are intended to be `caught` by the compiler. 