### PR TITLE
[libc++] add commonly used aliases in <__config> and remove <cstddef> includes

### DIFF
--- a/libcxx/include/__algorithm/copy_move_common.h
+++ b/libcxx/include/__algorithm/copy_move_common.h
@@ -25,7 +25,6 @@
 #include <__type_traits/is_volatile.h>
 #include <__utility/move.h>
 #include <__utility/pair.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__algorithm/pstl_backends/cpu_backends/backend.h
+++ b/libcxx/include/__algorithm/pstl_backends/cpu_backends/backend.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___ALGORITHM_PSTL_BACKENDS_CPU_BACKEND_BACKEND_H
 
 #include <__config>
-#include <cstddef>
 
 #if defined(_LIBCPP_PSTL_CPU_BACKEND_SERIAL)
 #  include <__algorithm/pstl_backends/cpu_backends/serial.h>

--- a/libcxx/include/__algorithm/pstl_backends/cpu_backends/find_if.h
+++ b/libcxx/include/__algorithm/pstl_backends/cpu_backends/find_if.h
@@ -19,7 +19,6 @@
 #include <__type_traits/is_execution_policy.h>
 #include <__utility/move.h>
 #include <__utility/pair.h>
-#include <cstddef>
 #include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__algorithm/pstl_backends/cpu_backends/libdispatch.h
+++ b/libcxx/include/__algorithm/pstl_backends/cpu_backends/libdispatch.h
@@ -27,7 +27,6 @@
 #include <__utility/exception_guard.h>
 #include <__utility/move.h>
 #include <__utility/pair.h>
-#include <cstddef>
 #include <new>
 #include <optional>
 

--- a/libcxx/include/__algorithm/pstl_backends/cpu_backends/serial.h
+++ b/libcxx/include/__algorithm/pstl_backends/cpu_backends/serial.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__utility/empty.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__algorithm/pstl_backends/cpu_backends/thread.h
+++ b/libcxx/include/__algorithm/pstl_backends/cpu_backends/thread.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__utility/empty.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__algorithm/shuffle.h
+++ b/libcxx/include/__algorithm/shuffle.h
@@ -16,7 +16,6 @@
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/swap.h>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__atomic/aliases.h
+++ b/libcxx/include/__atomic/aliases.h
@@ -15,7 +15,6 @@
 #include <__atomic/is_always_lock_free.h>
 #include <__config>
 #include <__type_traits/conditional.h>
-#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 

--- a/libcxx/include/__atomic/atomic.h
+++ b/libcxx/include/__atomic/atomic.h
@@ -18,7 +18,6 @@
 #include <__type_traits/is_function.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/remove_pointer.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__atomic/cxx_atomic_impl.h
+++ b/libcxx/include/__atomic/cxx_atomic_impl.h
@@ -17,7 +17,6 @@
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_trivially_copyable.h>
 #include <__type_traits/remove_const.h>
-#include <cstddef>
 #include <cstring>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__charconv/to_chars_integral.h
+++ b/libcxx/include/__charconv/to_chars_integral.h
@@ -20,11 +20,11 @@
 #include <__system_error/errc.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/integral_constant.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/make_32_64_or_128_bit.h>
 #include <__type_traits/make_unsigned.h>
 #include <__utility/unreachable.h>
-#include <cstddef>
 #include <cstdint>
 #include <limits>
 

--- a/libcxx/include/__compare/common_comparison_category.h
+++ b/libcxx/include/__compare/common_comparison_category.h
@@ -12,7 +12,6 @@
 #include <__compare/ordering.h>
 #include <__config>
 #include <__type_traits/is_same.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__concepts/swappable.h
+++ b/libcxx/include/__concepts/swappable.h
@@ -22,7 +22,6 @@
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/swap.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -827,8 +827,6 @@ typedef __char32_t char32_t;
 #  define _LIBCPP_END_NAMESPACE_STD }}
 #  define _VSTD std
 
-_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
-
 #  if _LIBCPP_STD_VER >= 17
 #    define _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM                                                                         \
        _LIBCPP_BEGIN_NAMESPACE_STD inline namespace __fs { namespace filesystem {
@@ -1499,6 +1497,13 @@ __sanitizer_verify_double_ended_contiguous_container(const void*, const void*, c
 #  endif // (defined(_OPENMP) && _OPENMP >= 201307)
 
 #  define _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
+
+// define a few very widely used type aliases
+_LIBCPP_BEGIN_NAMESPACE_STD
+using size_t    = __SIZE_TYPE__;
+using ptrdiff_t = __PTRDIFF_TYPE__;
+using nullptr_t = decltype(nullptr);
+_LIBCPP_END_NAMESPACE_STD
 
 #endif // __cplusplus
 

--- a/libcxx/include/__coroutine/coroutine_handle.h
+++ b/libcxx/include/__coroutine/coroutine_handle.h
@@ -15,7 +15,6 @@
 #include <__memory/addressof.h>
 #include <__type_traits/remove_cv.h>
 #include <compare>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__exception/exception_ptr.h
+++ b/libcxx/include/__exception/exception_ptr.h
@@ -12,7 +12,6 @@
 #include <__config>
 #include <__exception/operations.h>
 #include <__memory/addressof.h>
-#include <cstddef>
 #include <cstdlib>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__exception/nested_exception.h
+++ b/libcxx/include/__exception/nested_exception.h
@@ -13,6 +13,7 @@
 #include <__exception/exception_ptr.h>
 #include <__memory/addressof.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_base_of.h>
 #include <__type_traits/is_class.h>
 #include <__type_traits/is_convertible.h>
@@ -20,7 +21,6 @@
 #include <__type_traits/is_final.h>
 #include <__type_traits/is_polymorphic.h>
 #include <__utility/forward.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__exception/operations.h
+++ b/libcxx/include/__exception/operations.h
@@ -11,7 +11,6 @@
 
 #include <__availability>
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__filesystem/directory_iterator.h
+++ b/libcxx/include/__filesystem/directory_iterator.h
@@ -23,7 +23,6 @@
 #include <__ranges/enable_view.h>
 #include <__system_error/error_code.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -23,7 +23,6 @@
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/remove_const.h>
 #include <__type_traits/remove_pointer.h>
-#include <cstddef>
 #include <string>
 #include <string_view>
 

--- a/libcxx/include/__filesystem/path_iterator.h
+++ b/libcxx/include/__filesystem/path_iterator.h
@@ -15,7 +15,6 @@
 #include <__config>
 #include <__filesystem/path.h>
 #include <__iterator/iterator_traits.h>
-#include <cstddef>
 #include <string>
 #include <string_view>
 

--- a/libcxx/include/__filesystem/recursive_directory_iterator.h
+++ b/libcxx/include/__filesystem/recursive_directory_iterator.h
@@ -22,7 +22,6 @@
 #include <__ranges/enable_view.h>
 #include <__system_error/error_code.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__format/buffer.h
+++ b/libcxx/include/__format/buffer.h
@@ -37,7 +37,6 @@
 #include <__type_traits/conditional.h>
 #include <__utility/exception_guard.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <string_view>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__format/escaped_output_table.h
+++ b/libcxx/include/__format/escaped_output_table.h
@@ -63,7 +63,6 @@
 
 #include <__algorithm/ranges_upper_bound.h>
 #include <__config>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__format/extended_grapheme_cluster_table.h
+++ b/libcxx/include/__format/extended_grapheme_cluster_table.h
@@ -64,7 +64,6 @@
 #include <__algorithm/ranges_upper_bound.h>
 #include <__config>
 #include <__iterator/access.h>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__format/format_args.h
+++ b/libcxx/include/__format/format_args.h
@@ -15,7 +15,6 @@
 #include <__format/format_arg.h>
 #include <__format/format_arg_store.h>
 #include <__format/format_fwd.h>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__format/format_context.h
+++ b/libcxx/include/__format/format_context.h
@@ -24,7 +24,6 @@
 #include <__memory/addressof.h>
 #include <__utility/move.h>
 #include <__variant/monostate.h>
-#include <cstddef>
 
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
 #include <locale>

--- a/libcxx/include/__format/format_string.h
+++ b/libcxx/include/__format/format_string.h
@@ -15,7 +15,6 @@
 #include <__format/format_error.h>
 #include <__iterator/concepts.h>
 #include <__iterator/iterator_traits.h> // iter_value_t
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__format/formatter_floating_point.h
+++ b/libcxx/include/__format/formatter_floating_point.h
@@ -35,7 +35,6 @@
 #include <__utility/move.h>
 #include <__utility/unreachable.h>
 #include <cmath>
-#include <cstddef>
 
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
 #  include <locale>

--- a/libcxx/include/__format/formatter_output.h
+++ b/libcxx/include/__format/formatter_output.h
@@ -27,7 +27,6 @@
 #include <__memory/addressof.h>
 #include <__utility/move.h>
 #include <__utility/unreachable.h>
-#include <cstddef>
 #include <string_view>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__format/formatter_pointer.h
+++ b/libcxx/include/__format/formatter_pointer.h
@@ -18,7 +18,6 @@
 #include <__format/formatter_integral.h>
 #include <__format/formatter_output.h>
 #include <__format/parser_std_format_spec.h>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__format/width_estimation_table.h
+++ b/libcxx/include/__format/width_estimation_table.h
@@ -63,7 +63,6 @@
 
 #include <__algorithm/ranges_upper_bound.h>
 #include <__config>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__functional/bind.h
+++ b/libcxx/include/__functional/bind.h
@@ -16,7 +16,6 @@
 #include <__type_traits/decay.h>
 #include <__type_traits/is_reference_wrapper.h>
 #include <__type_traits/is_void.h>
-#include <cstddef>
 #include <tuple>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -23,7 +23,6 @@
 #include <__utility/move.h>
 #include <__utility/pair.h>
 #include <__utility/swap.h>
-#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>

--- a/libcxx/include/__fwd/array.h
+++ b/libcxx/include/__fwd/array.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___FWD_ARRAY_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__fwd/get.h
+++ b/libcxx/include/__fwd/get.h
@@ -16,7 +16,6 @@
 #include <__fwd/subrange.h>
 #include <__fwd/tuple.h>
 #include <__tuple/tuple_element.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__fwd/span.h
+++ b/libcxx/include/__fwd/span.h
@@ -11,7 +11,6 @@
 #define _LIBCPP___FWD_SPAN_H
 
 #include <__config>
-#include <cstddef>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__iterator/access.h
+++ b/libcxx/include/__iterator/access.h
@@ -11,7 +11,6 @@
 #define _LIBCPP___ITERATOR_ACCESS_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/back_insert_iterator.h
+++ b/libcxx/include/__iterator/back_insert_iterator.h
@@ -15,7 +15,6 @@
 #include <__iterator/iterator_traits.h>
 #include <__memory/addressof.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/data.h
+++ b/libcxx/include/__iterator/data.h
@@ -11,7 +11,6 @@
 #define _LIBCPP___ITERATOR_DATA_H
 
 #include <__config>
-#include <cstddef>
 #include <initializer_list>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__iterator/empty.h
+++ b/libcxx/include/__iterator/empty.h
@@ -11,7 +11,6 @@
 #define _LIBCPP___ITERATOR_EMPTY_H
 
 #include <__config>
-#include <cstddef>
 #include <initializer_list>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__iterator/front_insert_iterator.h
+++ b/libcxx/include/__iterator/front_insert_iterator.h
@@ -15,7 +15,6 @@
 #include <__iterator/iterator_traits.h>
 #include <__memory/addressof.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/incrementable_traits.h
+++ b/libcxx/include/__iterator/incrementable_traits.h
@@ -18,7 +18,6 @@
 #include <__type_traits/make_signed.h>
 #include <__type_traits/remove_cvref.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/insert_iterator.h
+++ b/libcxx/include/__iterator/insert_iterator.h
@@ -16,7 +16,6 @@
 #include <__memory/addressof.h>
 #include <__ranges/access.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/istream_iterator.h
+++ b/libcxx/include/__iterator/istream_iterator.h
@@ -17,7 +17,6 @@
 #include <__iterator/iterator.h>
 #include <__iterator/iterator_traits.h>
 #include <__memory/addressof.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/iterator.h
+++ b/libcxx/include/__iterator/iterator.h
@@ -11,7 +11,6 @@
 #define _LIBCPP___ITERATOR_ITERATOR_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -25,6 +25,7 @@
 #include <__type_traits/common_reference.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/disjunction.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_object.h>
 #include <__type_traits/is_primary_template.h>
@@ -35,7 +36,6 @@
 #include <__type_traits/remove_cvref.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/ostream_iterator.h
+++ b/libcxx/include/__iterator/ostream_iterator.h
@@ -16,7 +16,6 @@
 #include <__iterator/iterator.h>
 #include <__iterator/iterator_traits.h>
 #include <__memory/addressof.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/ostreambuf_iterator.h
+++ b/libcxx/include/__iterator/ostreambuf_iterator.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__iterator/iterator.h>
 #include <__iterator/iterator_traits.h>
-#include <cstddef>
 #include <iosfwd> // for forward declaration of basic_streambuf
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__iterator/reverse_access.h
+++ b/libcxx/include/__iterator/reverse_access.h
@@ -12,7 +12,6 @@
 
 #include <__config>
 #include <__iterator/reverse_iterator.h>
-#include <cstddef>
 #include <initializer_list>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__iterator/segmented_iterator.h
+++ b/libcxx/include/__iterator/segmented_iterator.h
@@ -42,7 +42,6 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/size.h
+++ b/libcxx/include/__iterator/size.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__type_traits/common_type.h>
 #include <__type_traits/make_signed.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -16,7 +16,6 @@
 #include <__memory/pointer_traits.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_convertible.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -22,7 +22,6 @@
 #include <string>
 
 // Some platforms require more includes than others. Keep the includes on all plaforms for now.
-#include <cstddef>
 #include <cstring>
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS

--- a/libcxx/include/__mdspan/default_accessor.h
+++ b/libcxx/include/__mdspan/default_accessor.h
@@ -23,7 +23,6 @@
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/remove_const.h>
 #include <cinttypes>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__mdspan/extents.h
+++ b/libcxx/include/__mdspan/extents.h
@@ -21,6 +21,7 @@
 #include <__config>
 #include <__type_traits/common_type.h>
 #include <__type_traits/is_convertible.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/make_unsigned.h>
@@ -29,7 +30,6 @@
 #include <array>
 #include <cinttypes>
 #include <concepts>
-#include <cstddef>
 #include <limits>
 #include <span>
 

--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -27,7 +27,6 @@
 #include <__utility/integer_sequence.h>
 #include <array>
 #include <cinttypes>
-#include <cstddef>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__mdspan/layout_right.h
+++ b/libcxx/include/__mdspan/layout_right.h
@@ -26,7 +26,6 @@
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__utility/integer_sequence.h>
 #include <cinttypes>
-#include <cstddef>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -29,7 +29,6 @@
 #include <__utility/swap.h>
 #include <array>
 #include <cinttypes>
-#include <cstddef>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__mdspan/mdspan.h
+++ b/libcxx/include/__mdspan/mdspan.h
@@ -39,7 +39,6 @@
 #include <__utility/integer_sequence.h>
 #include <array>
 #include <cinttypes>
-#include <cstddef>
 #include <limits>
 #include <span>
 

--- a/libcxx/include/__memory/align.h
+++ b/libcxx/include/__memory/align.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___MEMORY_ALIGN_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory/aligned_alloc.h
+++ b/libcxx/include/__memory/aligned_alloc.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___MEMORY_ALIGNED_ALLOC_H
 
 #include <__config>
-#include <cstddef>
 #include <cstdlib>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory/allocate_at_least.h
+++ b/libcxx/include/__memory/allocate_at_least.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__memory/allocator_traits.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory/allocation_guard.h
+++ b/libcxx/include/__memory/allocation_guard.h
@@ -14,7 +14,6 @@
 #include <__memory/addressof.h>
 #include <__memory/allocator_traits.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory/allocator.h
+++ b/libcxx/include/__memory/allocator.h
@@ -19,7 +19,6 @@
 #include <__type_traits/is_void.h>
 #include <__type_traits/is_volatile.h>
 #include <__utility/forward.h>
-#include <cstddef>
 #include <new>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory/assume_aligned.h
+++ b/libcxx/include/__memory/assume_aligned.h
@@ -13,7 +13,6 @@
 #include <__assert>
 #include <__config>
 #include <__type_traits/is_constant_evaluated.h>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory/builtin_new_allocator.h
+++ b/libcxx/include/__memory/builtin_new_allocator.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__memory/unique_ptr.h>
-#include <cstddef>
 #include <new>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory/compressed_pair.h
+++ b/libcxx/include/__memory/compressed_pair.h
@@ -25,7 +25,6 @@
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/piecewise_construct.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory/destruct_n.h
+++ b/libcxx/include/__memory/destruct_n.h
@@ -12,7 +12,6 @@
 #include <__config>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_trivially_destructible.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -15,12 +15,12 @@
 #include <__type_traits/conditional.h>
 #include <__type_traits/conjunction.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_class.h>
 #include <__type_traits/is_function.h>
 #include <__type_traits/is_void.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory/raw_storage_iterator.h
+++ b/libcxx/include/__memory/raw_storage_iterator.h
@@ -15,7 +15,6 @@
 #include <__iterator/iterator_traits.h>
 #include <__memory/addressof.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <new>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -35,6 +35,7 @@
 #include <__type_traits/conditional.h>
 #include <__type_traits/conjunction.h>
 #include <__type_traits/disjunction.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_array.h>
 #include <__type_traits/is_bounded_array.h>
 #include <__type_traits/is_convertible.h>
@@ -50,7 +51,6 @@
 #include <__utility/move.h>
 #include <__utility/swap.h>
 #include <__verbose_abort>
-#include <cstddef>
 #include <new>
 #include <typeinfo>
 #if !defined(_LIBCPP_HAS_NO_ATOMIC_HEADER)

--- a/libcxx/include/__memory/temporary_buffer.h
+++ b/libcxx/include/__memory/temporary_buffer.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__type_traits/alignment_of.h>
 #include <__utility/pair.h>
-#include <cstddef>
 #include <new>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -22,6 +22,7 @@
 #include <__type_traits/add_lvalue_reference.h>
 #include <__type_traits/common_type.h>
 #include <__type_traits/dependent_type.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_array.h>
 #include <__type_traits/is_assignable.h>
@@ -38,7 +39,6 @@
 #include <__type_traits/type_identity.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory/uses_allocator.h
+++ b/libcxx/include/__memory/uses_allocator.h
@@ -12,7 +12,6 @@
 
 #include <__config>
 #include <__type_traits/is_convertible.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory_resource/pool_options.h
+++ b/libcxx/include/__memory_resource/pool_options.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___MEMORY_RESOURCE_POOL_OPTIONS_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__memory_resource/synchronized_pool_resource.h
+++ b/libcxx/include/__memory_resource/synchronized_pool_resource.h
@@ -14,7 +14,6 @@
 #include <__memory_resource/memory_resource.h>
 #include <__memory_resource/pool_options.h>
 #include <__memory_resource/unsynchronized_pool_resource.h>
-#include <cstddef>
 #include <mutex>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory_resource/unsynchronized_pool_resource.h
+++ b/libcxx/include/__memory_resource/unsynchronized_pool_resource.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__memory_resource/memory_resource.h>
 #include <__memory_resource/pool_options.h>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__numeric/midpoint.h
+++ b/libcxx/include/__numeric/midpoint.h
@@ -21,7 +21,6 @@
 #include <__type_traits/is_void.h>
 #include <__type_traits/make_unsigned.h>
 #include <__type_traits/remove_pointer.h>
-#include <cstddef>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__random/discard_block_engine.h
+++ b/libcxx/include/__random/discard_block_engine.h
@@ -14,7 +14,6 @@
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_convertible.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <iosfwd>
 #include <limits>
 

--- a/libcxx/include/__random/discrete_distribution.h
+++ b/libcxx/include/__random/discrete_distribution.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__random/is_valid.h>
 #include <__random/uniform_real_distribution.h>
-#include <cstddef>
 #include <iosfwd>
 #include <numeric>
 #include <vector>

--- a/libcxx/include/__random/independent_bits_engine.h
+++ b/libcxx/include/__random/independent_bits_engine.h
@@ -18,7 +18,6 @@
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_convertible.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__random/log2.h
+++ b/libcxx/include/__random/log2.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/conditional.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__random/mersenne_twister_engine.h
+++ b/libcxx/include/__random/mersenne_twister_engine.h
@@ -13,7 +13,7 @@
 #include <__algorithm/min.h>
 #include <__config>
 #include <__random/is_seed_sequence.h>
-#include <cstddef>
+#include <__type_traits/enable_if.h>
 #include <cstdint>
 #include <iosfwd>
 #include <limits>

--- a/libcxx/include/__random/seed_seq.h
+++ b/libcxx/include/__random/seed_seq.h
@@ -14,6 +14,8 @@
 #include <__algorithm/max.h>
 #include <__config>
 #include <__iterator/iterator_traits.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/is_integral.h>
 #include <cstdint>
 #include <initializer_list>
 #include <vector>

--- a/libcxx/include/__random/shuffle_order_engine.h
+++ b/libcxx/include/__random/shuffle_order_engine.h
@@ -16,7 +16,6 @@
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_convertible.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <cstdint>
 #include <iosfwd>
 

--- a/libcxx/include/__random/subtract_with_carry_engine.h
+++ b/libcxx/include/__random/subtract_with_carry_engine.h
@@ -14,7 +14,7 @@
 #include <__config>
 #include <__random/is_seed_sequence.h>
 #include <__random/linear_congruential_engine.h>
-#include <cstddef>
+#include <__type_traits/enable_if.h>
 #include <cstdint>
 #include <iosfwd>
 #include <limits>

--- a/libcxx/include/__random/uniform_int_distribution.h
+++ b/libcxx/include/__random/uniform_int_distribution.h
@@ -15,7 +15,6 @@
 #include <__random/log2.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/make_unsigned.h>
-#include <cstddef>
 #include <cstdint>
 #include <iosfwd>
 #include <limits>

--- a/libcxx/include/__ranges/access.h
+++ b/libcxx/include/__ranges/access.h
@@ -21,7 +21,6 @@
 #include <__type_traits/remove_reference.h>
 #include <__utility/auto_cast.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/counted.h
+++ b/libcxx/include/__ranges/counted.h
@@ -22,7 +22,6 @@
 #include <__type_traits/decay.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <span>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__ranges/drop_view.h
+++ b/libcxx/include/__ranges/drop_view.h
@@ -42,7 +42,6 @@
 #include <__utility/auto_cast.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/elements_view.h
+++ b/libcxx/include/__ranges/elements_view.h
@@ -37,7 +37,6 @@
 #include <__utility/declval.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/empty_view.h
+++ b/libcxx/include/__ranges/empty_view.h
@@ -14,7 +14,6 @@
 #include <__ranges/enable_borrowed_range.h>
 #include <__ranges/view_interface.h>
 #include <__type_traits/is_object.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/istream_view.h
+++ b/libcxx/include/__ranges/istream_view.h
@@ -22,7 +22,6 @@
 #include <__ranges/view_interface.h>
 #include <__type_traits/remove_cvref.h>
 #include <__utility/forward.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/single_view.h
+++ b/libcxx/include/__ranges/single_view.h
@@ -20,7 +20,6 @@
 #include <__utility/forward.h>
 #include <__utility/in_place.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/size.h
+++ b/libcxx/include/__ranges/size.h
@@ -22,7 +22,6 @@
 #include <__type_traits/remove_cvref.h>
 #include <__utility/auto_cast.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -34,13 +34,13 @@
 #include <__tuple/tuple_size.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/is_reference.h>
 #include <__type_traits/make_unsigned.h>
 #include <__type_traits/remove_const.h>
 #include <__type_traits/remove_pointer.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/take_view.h
+++ b/libcxx/include/__ranges/take_view.h
@@ -42,7 +42,6 @@
 #include <__utility/auto_cast.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__ranges/to.h
+++ b/libcxx/include/__ranges/to.h
@@ -32,7 +32,6 @@
 #include <__type_traits/type_identity.h>
 #include <__utility/declval.h>
 #include <__utility/forward.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -34,7 +34,6 @@
 #include <__type_traits/remove_reference.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__stop_token/intrusive_shared_ptr.h
+++ b/libcxx/include/__stop_token/intrusive_shared_ptr.h
@@ -16,7 +16,6 @@
 #include <__type_traits/is_reference.h>
 #include <__utility/move.h>
 #include <__utility/swap.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -20,7 +20,6 @@
 #include <__iterator/iterator_traits.h>
 #include <__string/constexpr_c_functions.h>
 #include <__type_traits/is_constant_evaluated.h>
-#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <iosfwd>

--- a/libcxx/include/__string/constexpr_c_functions.h
+++ b/libcxx/include/__string/constexpr_c_functions.h
@@ -13,17 +13,18 @@
 #include <__memory/addressof.h>
 #include <__memory/construct_at.h>
 #include <__type_traits/datasizeof.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_always_bitcastable.h>
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_equality_comparable.h>
+#include <__type_traits/is_integral.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_trivially_copyable.h>
 #include <__type_traits/is_trivially_lexicographically_comparable.h>
 #include <__type_traits/remove_cv.h>
 #include <__utility/is_pointer_in_range.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__support/win32/locale_win32.h
+++ b/libcxx/include/__support/win32/locale_win32.h
@@ -11,7 +11,6 @@
 #define _LIBCPP___SUPPORT_WIN32_LOCALE_WIN32_H
 
 #include <__config>
-#include <cstddef>
 #include <locale.h> // _locale_t
 #include <stdio.h>
 #include <string>

--- a/libcxx/include/__system_error/error_code.h
+++ b/libcxx/include/__system_error/error_code.h
@@ -17,7 +17,6 @@
 #include <__system_error/errc.h>
 #include <__system_error/error_category.h>
 #include <__system_error/error_condition.h>
-#include <cstddef>
 #include <string>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__system_error/error_condition.h
+++ b/libcxx/include/__system_error/error_condition.h
@@ -16,7 +16,6 @@
 #include <__functional/unary_function.h>
 #include <__system_error/errc.h>
 #include <__system_error/error_category.h>
-#include <cstddef>
 #include <string>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__tuple/make_tuple_types.h
+++ b/libcxx/include/__tuple/make_tuple_types.h
@@ -19,7 +19,6 @@
 #include <__type_traits/apply_cv.h>
 #include <__type_traits/remove_cv.h>
 #include <__type_traits/remove_reference.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__tuple/sfinae_helpers.h
@@ -24,7 +24,6 @@
 #include <__type_traits/is_same.h>
 #include <__type_traits/remove_cvref.h>
 #include <__type_traits/remove_reference.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__tuple/tuple_element.h
+++ b/libcxx/include/__tuple/tuple_element.h
@@ -15,7 +15,6 @@
 #include <__type_traits/add_const.h>
 #include <__type_traits/add_cv.h>
 #include <__type_traits/add_volatile.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__tuple/tuple_indices.h
+++ b/libcxx/include/__tuple/tuple_indices.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__utility/integer_sequence.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__tuple/tuple_like.h
+++ b/libcxx/include/__tuple/tuple_like.h
@@ -16,7 +16,6 @@
 #include <__fwd/tuple.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/remove_cvref.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__tuple/tuple_like_ext.h
+++ b/libcxx/include/__tuple/tuple_like_ext.h
@@ -15,7 +15,6 @@
 #include <__fwd/tuple.h>
 #include <__tuple/tuple_types.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__tuple/tuple_size.h
+++ b/libcxx/include/__tuple/tuple_size.h
@@ -12,9 +12,10 @@
 #include <__config>
 #include <__fwd/tuple.h>
 #include <__tuple/tuple_types.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_const.h>
 #include <__type_traits/is_volatile.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/aligned_storage.h
+++ b/libcxx/include/__type_traits/aligned_storage.h
@@ -14,7 +14,6 @@
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/nat.h>
 #include <__type_traits/type_list.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/aligned_union.h
+++ b/libcxx/include/__type_traits/aligned_union.h
@@ -12,7 +12,6 @@
 #include <__config>
 #include <__type_traits/aligned_storage.h>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/alignment_of.h
+++ b/libcxx/include/__type_traits/alignment_of.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/datasizeof.h
+++ b/libcxx/include/__type_traits/datasizeof.h
@@ -12,7 +12,6 @@
 #include <__config>
 #include <__type_traits/is_class.h>
 #include <__type_traits/is_final.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -51,7 +50,7 @@ struct __libcpp_datasizeof {
   // the use as an extension.
   _LIBCPP_DIAGNOSTIC_PUSH
   _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-offsetof")
-  static const size_t value = offsetof(_FirstPaddingByte<>, __first_padding_byte_);
+  static const size_t value = __builtin_offsetof(_FirstPaddingByte<>, __first_padding_byte_);
   _LIBCPP_DIAGNOSTIC_POP
 };
 

--- a/libcxx/include/__type_traits/extent.h
+++ b/libcxx/include/__type_traits/extent.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_allocator.h
+++ b/libcxx/include/__type_traits/is_allocator.h
@@ -13,7 +13,6 @@
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_array.h
+++ b/libcxx/include/__type_traits/is_array.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_bounded_array.h
+++ b/libcxx/include/__type_traits/is_bounded_array.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_convertible.h
+++ b/libcxx/include/__type_traits/is_convertible.h
@@ -16,7 +16,6 @@
 #include <__type_traits/is_void.h>
 #include <__type_traits/remove_reference.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_member_function_pointer.h
+++ b/libcxx/include/__type_traits/is_member_function_pointer.h
@@ -13,7 +13,6 @@
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_function.h>
 #include <__type_traits/remove_cv.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_nothrow_constructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_constructible.h
@@ -14,7 +14,6 @@
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_reference.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_nothrow_destructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_destructible.h
@@ -16,7 +16,6 @@
 #include <__type_traits/is_scalar.h>
 #include <__type_traits/remove_all_extents.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_null_pointer.h
+++ b/libcxx/include/__type_traits/is_null_pointer.h
@@ -12,7 +12,6 @@
 #include <__config>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/remove_cv.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/is_swappable.h
+++ b/libcxx/include/__type_traits/is_swappable.h
@@ -22,7 +22,6 @@
 #include <__type_traits/is_void.h>
 #include <__type_traits/nat.h>
 #include <__utility/declval.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/rank.h
+++ b/libcxx/include/__type_traits/rank.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/remove_all_extents.h
+++ b/libcxx/include/__type_traits/remove_all_extents.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_REMOVE_ALL_EXTENTS_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/remove_extent.h
+++ b/libcxx/include/__type_traits/remove_extent.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_REMOVE_EXTENT_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/remove_reference.h
+++ b/libcxx/include/__type_traits/remove_reference.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_REMOVE_REFERENCE_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__type_traits/type_list.h
+++ b/libcxx/include/__type_traits/type_list.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_TYPE_LIST_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__utility/in_place.h
+++ b/libcxx/include/__utility/in_place.h
@@ -10,8 +10,8 @@
 #define _LIBCPP___UTILITY_IN_PLACE_H
 
 #include <__config>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/remove_cvref.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__utility/integer_sequence.h
+++ b/libcxx/include/__utility/integer_sequence.h
@@ -11,7 +11,6 @@
 
 #include <__config>
 #include <__type_traits/is_integral.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -27,6 +27,7 @@
 #include <__type_traits/common_type.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_constructible.h>
@@ -50,7 +51,6 @@
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/piecewise_construct.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__utility/priority_tag.h
+++ b/libcxx/include/__utility/priority_tag.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___UTILITY_PRIORITY_TAG_H
 
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__utility/swap.h
+++ b/libcxx/include/__utility/swap.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___UTILITY_SWAP_H
 
 #include <__config>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_move_assignable.h>
 #include <__type_traits/is_move_constructible.h>
 #include <__type_traits/is_nothrow_move_assignable.h>
@@ -17,7 +18,6 @@
 #include <__type_traits/is_swappable.h>
 #include <__utility/declval.h>
 #include <__utility/move.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__variant/monostate.h
+++ b/libcxx/include/__variant/monostate.h
@@ -13,7 +13,6 @@
 #include <__compare/ordering.h>
 #include <__config>
 #include <__functional/hash.h>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/algorithm
+++ b/libcxx/include/algorithm
@@ -1973,6 +1973,7 @@ template <class BidirectionalIterator, class Compare>
 #  include <atomic>
 #  include <bit>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <cstring>
 #  include <iterator>

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -93,6 +93,7 @@ namespace std {
 #include <__type_traits/alignment_of.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/decay.h>
+#include <__type_traits/enable_if.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_copy_constructible.h>
 #include <__type_traits/is_function.h>
@@ -722,6 +723,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iosfwd>
 #  include <iterator>

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -546,6 +546,7 @@ _LIBCPP_END_NAMESPACE_STD
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <algorithm>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iterator>
 #  include <type_traits>

--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -551,6 +551,7 @@ template <class T>
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <cmath>
 #  include <compare>
+#  include <cstddef>
 #  include <cstring>
 #  include <type_traits>
 #endif

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -54,7 +54,6 @@ namespace std
 #include <__thread/poll_with_backoff.h>
 #include <__thread/timed_backoff_policy.h>
 #include <__utility/move.h>
-#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <version>
@@ -355,6 +354,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <iterator>
 #  include <memory>
 #  include <stdexcept>

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -132,7 +132,6 @@ template <size_t N> struct hash<std::bitset<N>>;
 #include <__functional/unary_function.h>
 #include <__type_traits/is_char_like_type.h>
 #include <climits>
-#include <cstddef>
 #include <stdexcept>
 #include <string_view>
 #include <version>
@@ -1172,6 +1171,7 @@ _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <type_traits>
 #endif

--- a/libcxx/include/charconv
+++ b/libcxx/include/charconv
@@ -95,6 +95,7 @@ _LIBCPP_END_NAMESPACE_STD
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <cmath>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdint>
 #  include <cstdlib>
 #  include <cstring>

--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -845,6 +845,7 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <bit>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstring>
 #  include <forward_list>
 #  include <string>

--- a/libcxx/include/compare
+++ b/libcxx/include/compare
@@ -162,6 +162,7 @@ namespace std {
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <type_traits>
 #endif
 

--- a/libcxx/include/concepts
+++ b/libcxx/include/concepts
@@ -156,6 +156,7 @@ namespace std {
 #include <version>
 
 #if _LIBCPP_STD_VER <= 20 && !defined(_LIPCPP_REMOVE_TRANSITIVE_INCLUDES)
+#  include <cstddef>
 #  include <type_traits>
 #endif
 

--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -339,6 +339,7 @@ _LIBCPP_END_NAMESPACE_STD
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdint>
 #  include <cstdlib>
 #  include <cstring>

--- a/libcxx/include/coroutine
+++ b/libcxx/include/coroutine
@@ -56,6 +56,7 @@ struct suspend_always;
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <iosfwd>
 #  include <type_traits>
 #endif

--- a/libcxx/include/cstddef
+++ b/libcxx/include/cstddef
@@ -56,9 +56,7 @@ Types:
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::nullptr_t;
-using ::ptrdiff_t _LIBCPP_USING_IF_EXISTS;
-using ::size_t _LIBCPP_USING_IF_EXISTS;
+// nullptr_t, ptrdiff_t and size_t are always provided by <__config>
 
 #if !defined(_LIBCPP_CXX03_LANG)
 using ::max_align_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/include/cwchar
+++ b/libcxx/include/cwchar
@@ -255,4 +255,8 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp
 
 _LIBCPP_END_NAMESPACE_STD
 
+#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
+#endif
+
 #endif // _LIBCPP_CWCHAR

--- a/libcxx/include/exception
+++ b/libcxx/include/exception
@@ -90,6 +90,7 @@ template <class E> void rethrow_if_nested(const E& e);
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <cstdlib>
 #  include <type_traits>
 #endif

--- a/libcxx/include/expected
+++ b/libcxx/include/expected
@@ -51,4 +51,3 @@ namespace std {
 #endif
 
 #endif // _LIBCPP_EXPECTED
-

--- a/libcxx/include/experimental/iterator
+++ b/libcxx/include/experimental/iterator
@@ -119,6 +119,7 @@ _LIBCPP_END_NAMESPACE_LFTS
 #endif // _LIBCPP_STD_VER >= 14
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <iosfwd>
 #  include <type_traits>
 #endif

--- a/libcxx/include/experimental/propagate_const
+++ b/libcxx/include/experimental/propagate_const
@@ -128,7 +128,6 @@
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/swap.h>
-#include <cstddef>
 #include <experimental/__config>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -600,6 +599,7 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <type_traits>
 #endif
 

--- a/libcxx/include/filesystem
+++ b/libcxx/include/filesystem
@@ -564,6 +564,7 @@ inline constexpr bool std::ranges::enable_view<std::filesystem::recursive_direct
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iosfwd>
 #  include <new>

--- a/libcxx/include/format
+++ b/libcxx/include/format
@@ -203,4 +203,8 @@ namespace std {
 #  pragma GCC system_header
 #endif
 
+#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
+#endif
+
 #endif // _LIBCPP_FORMAT

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -1749,6 +1749,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iosfwd>
 #  include <limits>

--- a/libcxx/include/functional
+++ b/libcxx/include/functional
@@ -551,6 +551,7 @@ POLICY:  For non-variadic implementations, the number of arguments is limited
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <exception>
 #  include <iosfwd>

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -2474,6 +2474,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <exception>
 #  include <iosfwd>

--- a/libcxx/include/initializer_list
+++ b/libcxx/include/initializer_list
@@ -44,7 +44,6 @@ template<class E> const E* end(initializer_list<E> il) noexcept; // constexpr in
 
 #include <__assert> // all public C++ headers provide the assertion handler
 #include <__config>
-#include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -114,5 +113,9 @@ end(initializer_list<_Ep> __il) _NOEXCEPT
 #endif // !defined(_LIBCPP_CXX03_LANG)
 
 } // namespace std
+
+#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
+#endif
 
 #endif // _LIBCPP_INITIALIZER_LIST

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -1647,6 +1647,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstddef>
 #  include <iosfwd>
 #  include <type_traits>
 #endif

--- a/libcxx/include/iterator
+++ b/libcxx/include/iterator
@@ -716,6 +716,7 @@ template <class E> constexpr const E* data(initializer_list<E> il) noexcept;    
 #include <__iterator/wrap_iter.h>
 #include <__memory/addressof.h>
 #include <__memory/pointer_traits.h>
+#include <initializer_list>
 #include <version>
 
 // standard-mandated includes
@@ -729,6 +730,7 @@ template <class E> constexpr const E* data(initializer_list<E> il) noexcept;    
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <cstdlib>
 #  include <exception>
 #  include <new>

--- a/libcxx/include/latch
+++ b/libcxx/include/latch
@@ -46,7 +46,6 @@ namespace std
 #include <__atomic/memory_order.h>
 #include <__availability>
 #include <__config>
-#include <cstddef>
 #include <limits>
 #include <version>
 
@@ -133,6 +132,7 @@ _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
+#  include <cstddef>
 #endif
 
 #endif //_LIBCPP_LATCH

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -4346,6 +4346,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdarg>
 #  include <iterator>
 #  include <mutex>

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -563,6 +563,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <cstring>
 #  include <ctime>

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -94,7 +94,7 @@ void  operator delete[](void* ptr, void*) noexcept;
 #include <__type_traits/is_function.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/remove_cv.h>
-#include <cstddef>
+#include <__verbose_abort>
 #include <version>
 
 #if defined(_LIBCPP_ABI_VCRUNTIME)
@@ -368,7 +368,11 @@ inline constexpr size_t hardware_constructive_interference_size = __GCC_CONSTRUC
 _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+<<<<<<< HEAD
 #  include <cstdlib>
+=======
+#  include <cstddef>
+>>>>>>> 5c5665e90594 ([libc++] add commonly used aliases in <__config> and remove <cstddef> includes)
 #  include <exception>
 #  include <type_traits>
 #endif

--- a/libcxx/include/numeric
+++ b/libcxx/include/numeric
@@ -171,6 +171,7 @@ template<class T>
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <cmath>
 #  include <concepts>
+#  include <cstddef>
 #  include <functional>
 #  include <iterator>
 #  include <type_traits>

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -1682,6 +1682,7 @@ _LIBCPP_POP_MACROS
 #  include <atomic>
 #  include <climits>
 #  include <concepts>
+#  include <cstddef>
 #  include <ctime>
 #  include <iterator>
 #  include <memory>

--- a/libcxx/include/ostream
+++ b/libcxx/include/ostream
@@ -1200,6 +1200,7 @@ _LIBCPP_END_NAMESPACE_STD
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iosfwd>
 #  include <iterator>

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -1129,6 +1129,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <functional>
 #  include <type_traits>

--- a/libcxx/include/ranges
+++ b/libcxx/include/ranges
@@ -436,6 +436,7 @@ namespace std {
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iosfwd>
 #  include <type_traits>

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -6949,6 +6949,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iosfwd>
 #  include <iterator>

--- a/libcxx/include/scoped_allocator
+++ b/libcxx/include/scoped_allocator
@@ -707,6 +707,7 @@ _LIBCPP_POP_MACROS
 #  include <atomic>
 #  include <climits>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstring>
 #  include <ctime>
 #  include <iterator>

--- a/libcxx/include/semaphore
+++ b/libcxx/include/semaphore
@@ -55,7 +55,6 @@ using binary_semaphore = counting_semaphore<1>;
 #include <__thread/poll_with_backoff.h>
 #include <__thread/timed_backoff_policy.h>
 #include <__threading_support>
-#include <cstddef>
 #include <limits>
 #include <version>
 
@@ -212,6 +211,7 @@ _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
+#  include <cstddef>
 #endif
 
 #endif //_LIBCPP_SEMAPHORE

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -460,6 +460,7 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <system_error>
 #endif
 

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -1205,6 +1205,7 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #if _LIBCPP_STD_VER <= 20 && !defined(_LIPCPP_REMOVE_TRANSITIVE_INCLUDES)
+#  include <cstddef>
 #  include <type_traits>
 #endif
 

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -433,6 +433,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstddef>
 #  include <functional>
 #  include <type_traits>
 #endif

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -227,7 +227,6 @@ namespace std {
 #include <__type_traits/remove_cvref.h>
 #include <__type_traits/remove_reference.h>
 #include <__type_traits/type_identity.h>
-#include <cstddef>
 #include <iosfwd>
 #include <limits>
 #include <stdexcept>
@@ -1049,6 +1048,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <algorithm>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iterator>
 #  include <type_traits>

--- a/libcxx/include/system_error
+++ b/libcxx/include/system_error
@@ -163,6 +163,7 @@ template <> struct hash<std::error_condition>;
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <cstdint>
 #  include <cstring>
 #  include <limits>

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -259,7 +259,6 @@ template <class... Types>
 #include <__utility/pair.h>
 #include <__utility/piecewise_construct.h>
 #include <__utility/swap.h>
-#include <cstddef>
 #include <version>
 
 // standard-mandated includes
@@ -1674,6 +1673,7 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <exception>
 #  include <iosfwd>
 #  include <new>

--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -535,9 +535,11 @@ namespace std
 #include <__type_traits/unwrap_ref.h>
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
-#include <cstddef>
-#include <cstdint>
 #include <version>
+
+#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
+#endif
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -60,9 +60,9 @@ public:
 #include <__availability>
 #include <__config>
 #include <__exception/exception.h>
+#include <__type_traits/integral_constant.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__verbose_abort>
-#include <cstddef>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -417,6 +417,7 @@ void __throw_bad_cast()
 _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <cstdlib>
 #  include <exception>
 #  include <type_traits>

--- a/libcxx/include/utility
+++ b/libcxx/include/utility
@@ -283,6 +283,7 @@ template <class T>
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <cstdlib>
 #  include <iosfwd>
 #  include <type_traits>

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -361,7 +361,6 @@ template <class T> unspecified2 end(const valarray<T>& v);
 #include <__utility/move.h>
 #include <__utility/swap.h>
 #include <cmath>
-#include <cstddef>
 #include <new>
 #include <version>
 
@@ -4206,6 +4205,7 @@ _LIBCPP_POP_MACROS
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <algorithm>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <cstring>
 #  include <functional>

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1834,6 +1834,7 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstddef>
 #  include <exception>
 #  include <type_traits>
 #  include <typeinfo>

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -3434,6 +3434,7 @@ _LIBCPP_POP_MACROS
 #  include <algorithm>
 #  include <atomic>
 #  include <concepts>
+#  include <cstddef>
 #  include <cstdlib>
 #  include <type_traits>
 #  include <typeinfo>

--- a/libcxx/test/libcxx/transitive_includes/cxx20.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx20.csv
@@ -230,9 +230,7 @@ exception cstddef
 exception cstdlib
 exception type_traits
 exception version
-execution cstddef
 execution version
-expected cstddef
 expected initializer_list
 expected new
 expected version
@@ -535,7 +533,6 @@ map version
 mdspan array
 mdspan cinttypes
 mdspan concepts
-mdspan cstddef
 mdspan limits
 mdspan span
 mdspan version
@@ -813,7 +810,6 @@ stdexcept cstdlib
 stdexcept exception
 stdexcept iosfwd
 stop_token atomic
-stop_token cstddef
 stop_token cstdint
 stop_token cstring
 stop_token ctime

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -1,5 +1,4 @@
 algorithm climits
-algorithm cstddef
 algorithm cstdint
 algorithm cstring
 algorithm ctime
@@ -12,7 +11,6 @@ algorithm new
 algorithm optional
 algorithm ratio
 algorithm version
-any cstddef
 any cstdint
 any cstring
 any initializer_list
@@ -21,14 +19,12 @@ any new
 any typeinfo
 any version
 array compare
-array cstddef
 array cstdint
 array initializer_list
 array limits
 array new
 array stdexcept
 array version
-atomic cstddef
 atomic cstdint
 atomic cstdlib
 atomic cstring
@@ -36,7 +32,6 @@ atomic ctime
 atomic limits
 atomic ratio
 atomic version
-barrier cstddef
 barrier cstdint
 barrier cstring
 barrier ctime
@@ -48,7 +43,6 @@ bit cstdint
 bit limits
 bit version
 bitset climits
-bitset cstddef
 bitset cstdint
 bitset cstring
 bitset cwchar
@@ -62,7 +56,6 @@ bitset string_view
 bitset version
 ccomplex complex
 charconv cerrno
-charconv cstddef
 charconv cstdint
 charconv initializer_list
 charconv limits
@@ -71,7 +64,6 @@ charconv version
 chrono array
 chrono cmath
 chrono compare
-chrono cstddef
 chrono cstdint
 chrono ctime
 chrono forward_list
@@ -93,7 +85,6 @@ cmath limits
 cmath version
 codecvt cctype
 codecvt clocale
-codecvt cstddef
 codecvt cstdint
 codecvt cstdlib
 codecvt cstring
@@ -106,18 +97,15 @@ codecvt tuple
 codecvt typeinfo
 codecvt version
 compare cmath
-compare cstddef
 compare cstdint
 compare limits
 compare version
 complex cmath
 complex sstream
 complex version
-concepts cstddef
 concepts version
 condition_variable atomic
 condition_variable cerrno
-condition_variable cstddef
 condition_variable cstdint
 condition_variable cstring
 condition_variable ctime
@@ -129,7 +117,6 @@ condition_variable string
 condition_variable typeinfo
 condition_variable version
 coroutine compare
-coroutine cstddef
 coroutine cstdint
 coroutine cstring
 coroutine limits
@@ -137,7 +124,6 @@ coroutine version
 cstddef version
 ctgmath ccomplex
 ctgmath cmath
-cwchar cstddef
 cwchar cwctype
 cwctype cctype
 deque compare
@@ -151,12 +137,9 @@ deque new
 deque stdexcept
 deque tuple
 deque version
-exception cstddef
 exception cstdlib
 exception version
-execution cstddef
 execution version
-expected cstddef
 expected initializer_list
 expected new
 expected version
@@ -164,7 +147,6 @@ experimental/deque deque
 experimental/deque experimental/memory_resource
 experimental/forward_list experimental/memory_resource
 experimental/forward_list forward_list
-experimental/iterator cstddef
 experimental/iterator iterator
 experimental/list experimental/memory_resource
 experimental/list list
@@ -176,7 +158,6 @@ experimental/memory_resource limits
 experimental/memory_resource new
 experimental/memory_resource stdexcept
 experimental/memory_resource tuple
-experimental/propagate_const cstddef
 experimental/regex experimental/memory_resource
 experimental/regex experimental/string
 experimental/regex regex
@@ -197,7 +178,6 @@ experimental/utility utility
 experimental/vector experimental/memory_resource
 experimental/vector vector
 filesystem compare
-filesystem cstddef
 filesystem cstdint
 filesystem cstring
 filesystem ctime
@@ -210,7 +190,6 @@ filesystem string_view
 filesystem version
 format array
 format cmath
-format cstddef
 format cstdint
 format initializer_list
 format limits
@@ -233,7 +212,6 @@ forward_list tuple
 forward_list version
 fstream cctype
 fstream clocale
-fstream cstddef
 fstream cstdint
 fstream cstdio
 fstream cstdlib
@@ -250,7 +228,6 @@ fstream tuple
 fstream typeinfo
 fstream version
 functional array
-functional cstddef
 functional cstdint
 functional cstring
 functional initializer_list
@@ -262,7 +239,6 @@ functional unordered_map
 functional vector
 functional version
 future cerrno
-future cstddef
 future cstdint
 future cstdlib
 future cstring
@@ -276,13 +252,11 @@ future string
 future thread
 future typeinfo
 future version
-initializer_list cstddef
 iomanip istream
 iomanip version
 ios cctype
 ios cerrno
 ios clocale
-ios cstddef
 ios cstdint
 ios cstdlib
 ios cstring
@@ -304,18 +278,15 @@ iostream istream
 iostream ostream
 iostream streambuf
 iostream version
-istream cstddef
 istream ostream
 istream version
 iterator compare
 iterator concepts
-iterator cstddef
 iterator initializer_list
 iterator iosfwd
 iterator limits
 iterator variant
 iterator version
-latch cstddef
 latch cstdint
 latch cstring
 latch ctime
@@ -335,7 +306,6 @@ list version
 locale cctype
 locale cerrno
 locale clocale
-locale cstddef
 locale cstdint
 locale cstdio
 locale cstdlib
@@ -365,12 +335,10 @@ map version
 mdspan array
 mdspan cinttypes
 mdspan concepts
-mdspan cstddef
 mdspan limits
 mdspan span
 mdspan version
 memory compare
-memory cstddef
 memory cstdint
 memory cstring
 memory initializer_list
@@ -387,7 +355,6 @@ memory_resource new
 memory_resource tuple
 memory_resource version
 mutex cerrno
-mutex cstddef
 mutex cstdint
 mutex ctime
 mutex limits
@@ -398,7 +365,6 @@ mutex string
 mutex tuple
 mutex typeinfo
 mutex version
-new cstddef
 new version
 numbers version
 numeric climits
@@ -414,7 +380,6 @@ numeric optional
 numeric ratio
 numeric version
 optional compare
-optional cstddef
 optional cstdint
 optional cstring
 optional initializer_list
@@ -423,7 +388,6 @@ optional new
 optional version
 ostream bitset
 ostream cerrno
-ostream cstddef
 ostream cstdint
 ostream cstring
 ostream initializer_list
@@ -438,7 +402,6 @@ ostream version
 print array
 print cerrno
 print cmath
-print cstddef
 print cstdint
 print cstdio
 print initializer_list
@@ -452,7 +415,6 @@ print string_view
 print tuple
 print version
 queue compare
-queue cstddef
 queue cstdint
 queue deque
 queue initializer_list
@@ -461,7 +423,6 @@ queue new
 queue vector
 queue version
 random cmath
-random cstddef
 random cstdint
 random initializer_list
 random iosfwd
@@ -471,7 +432,6 @@ random string
 random vector
 random version
 ranges compare
-ranges cstddef
 ranges cwchar
 ranges initializer_list
 ranges iterator
@@ -488,7 +448,6 @@ ratio version
 regex cctype
 regex clocale
 regex compare
-regex cstddef
 regex cstdint
 regex cstdlib
 regex cstring
@@ -503,12 +462,10 @@ regex tuple
 regex typeinfo
 regex vector
 regex version
-scoped_allocator cstddef
 scoped_allocator limits
 scoped_allocator new
 scoped_allocator tuple
 scoped_allocator version
-semaphore cstddef
 semaphore cstdint
 semaphore cstring
 semaphore ctime
@@ -525,7 +482,6 @@ set optional
 set tuple
 set version
 shared_mutex cerrno
-shared_mutex cstddef
 shared_mutex ctime
 shared_mutex limits
 shared_mutex ratio
@@ -539,13 +495,11 @@ span cstddef
 span initializer_list
 span limits
 span version
-sstream cstddef
 sstream istream
 sstream ostream
 sstream string
 sstream version
 stack compare
-stack cstddef
 stack cstdint
 stack deque
 stack initializer_list
@@ -553,7 +507,6 @@ stack limits
 stack new
 stack version
 stop_token atomic
-stop_token cstddef
 stop_token cstdint
 stop_token cstring
 stop_token ctime
@@ -579,7 +532,6 @@ string string_view
 string tuple
 string version
 string_view compare
-string_view cstddef
 string_view cstdint
 string_view cstdio
 string_view cstring
@@ -595,7 +547,6 @@ strstream ostream
 strstream version
 system_error cerrno
 system_error compare
-system_error cstddef
 system_error stdexcept
 system_error string
 system_error version
@@ -619,15 +570,12 @@ thread string_view
 thread tuple
 thread version
 tuple compare
-tuple cstddef
 tuple version
-type_traits cstddef
 type_traits cstdint
 type_traits version
 typeindex compare
 typeindex typeinfo
 typeindex version
-typeinfo cstddef
 typeinfo cstdint
 unordered_map cmath
 unordered_map compare
@@ -653,19 +601,16 @@ unordered_set optional
 unordered_set tuple
 unordered_set version
 utility compare
-utility cstddef
 utility initializer_list
 utility limits
 utility version
 valarray cmath
-valarray cstddef
 valarray cstdint
 valarray initializer_list
 valarray limits
 valarray new
 valarray version
 variant compare
-variant cstddef
 variant cstdint
 variant cstring
 variant initializer_list
@@ -677,7 +622,6 @@ vector array
 vector cerrno
 vector climits
 vector compare
-vector cstddef
 vector cstdint
 vector cstring
 vector cwchar

--- a/libcxx/test/std/numerics/bit/byteswap.pass.cpp
+++ b/libcxx/test/std/numerics/bit/byteswap.pass.cpp
@@ -10,6 +10,7 @@
 
 #include <bit>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <utility>
 


### PR DESCRIPTION
We include `<cstddef>` in almost every public header, but almost always just use `size_t`, `ptrdiff_t` or `nullptr_t`. Since these aliases are trivial to define, we can just add them to <__config> and avoid including `<cstddef>` everywhere.