### PR TITLE
[llvm][NewGVN] Fixing the replacement of incorrect instructions [wip]

### DIFF
--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -3066,9 +3066,14 @@ void NewGVN::valueNumberMemoryPhi(MemoryPhi *MP) {
   // Sadly, we can't use std::equals since these are random access iterators.
   const auto *AllSameValue = *MappedBegin;
   ++MappedBegin;
-  bool AllEqual = std::all_of(
-      MappedBegin, MappedEnd,
-      [&AllSameValue](const MemoryAccess *V) { return V == AllSameValue; });
+  bool AllEqual;
+  if (MappedBegin == MappedEnd) {
+    AllEqual = false;
+  } else {
+    AllEqual = std::all_of(
+        MappedBegin, MappedEnd,
+        [&AllSameValue](const MemoryAccess *V) { return V == AllSameValue; });
+  }
 
   if (AllEqual)
     LLVM_DEBUG(dbgs() << "Memory Phi value numbered to " << *AllSameValue


### PR DESCRIPTION
I notice if first-iter equals to end-iter of std::all_of, it will do nothing for judgement. So I add an additional judgement to handle this.

issue: https://github.com/llvm/llvm-project/issues/70421