### PR TITLE
libcxx: remove redundant <cstdint> include from <string>

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -614,7 +614,6 @@ basic_string<char32_t> operator""s( const char32_t *str, size_t len );          
 #include <__utility/swap.h>
 #include <__utility/unreachable.h>
 #include <climits>
-#include <cstdint>
 #include <cstdio>  // EOF
 #include <cstring>
 #include <limits>


### PR DESCRIPTION
It looks like this has been there for so long that my git-blaming ran into the end of history when libc++ was imported from svn in 2010. This change will undoubtedly break some downstream code with broken includes, but libstdc++ does not do the same here, so such code was already broken on libstdc++; as such this change improves compatibility between the two implementations.