### PR TITLE
Formatting Ranges: Range "m" specifier do not pass through to underlying element

### DIFF
--- a/libcxx/include/__format/range_formatter.h
+++ b/libcxx/include/__format/range_formatter.h
@@ -89,10 +89,10 @@ struct _LIBCPP_TEMPLATE_VIS range_formatter {
 
     // Add "m" specifier semantics if there are no underlying specifier
     if (!__has_range_underlying_spec && __has_m_specifier) {
-        if constexpr (__fmt_pair_like<_Tp>) { // should always be true
-            __underlying_.set_brackets({}, {});
-            __underlying_.set_separator(_LIBCPP_STATICALLY_WIDEN(_CharT, ": "));
-        }
+      if constexpr (__fmt_pair_like<_Tp>) { // should always be true
+        __underlying_.set_brackets({}, {});
+        __underlying_.set_separator(_LIBCPP_STATICALLY_WIDEN(_CharT, ": "));
+      }
     }
 
     // This test should not be required if __has_range_underlying_spec is false.

--- a/libcxx/include/__format/range_formatter.h
+++ b/libcxx/include/__format/range_formatter.h
@@ -216,6 +216,8 @@ private:
       if constexpr (__fmt_pair_like<_Tp>) {
         set_brackets(_LIBCPP_STATICALLY_WIDEN(_CharT, "{"), _LIBCPP_STATICALLY_WIDEN(_CharT, "}"));
         set_separator(_LIBCPP_STATICALLY_WIDEN(_CharT, ", "));
+        __underlying_.set_brackets({}, {});
+        __underlying_.set_separator(_LIBCPP_STATICALLY_WIDEN(_CharT, ": "));
         ++__begin;
       } else
         std::__throw_format_error("Type m requires a pair or a tuple with two elements");

--- a/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.tests.h
+++ b/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.tests.h
@@ -983,10 +983,10 @@ void test_pair_tuple(TestFunction check, ExceptionTest check_exception, auto&& i
 
   // *** n
   check(SV("__(1, 'a'), (42, '*')___"), SV("{:_^24n}"), input);
-  check(SV("__(1, 'a'), (42, '*')___"), SV("{:_^24nm}"), input); // m should have no effect
+  check(SV("____1: 'a', 42: '*'_____"), SV("{:_^24nm}"), input);
 
   // *** type ***
-  check(SV("__{(1, 'a'), (42, '*')}___"), SV("{:_^26m}"), input);
+  check(SV("____{1: 'a', 42: '*'}_____"), SV("{:_^26m}"), input);
   check_exception("Type s requires character type as formatting argument", SV("{:s}"), input);
   check_exception("Type ?s requires character type as formatting argument", SV("{:?s}"), input);
   for (std::basic_string_view<CharT> fmt : fmt_invalid_types<CharT>("s"))


### PR DESCRIPTION
In libc++ implementation of C++23 ranges formatting facility, the following code (MVP):
```cpp
#include <format>
#include <vector>
#include <iostream>

int main()
{
    std::vector<std::pair<int, int>> vs{{1, 1}, {2, 2}};
    std::cout << std::format("vs = {0}\nmap = {0:m}\nmapmap = {0:m:m}\n", vs);
    return 0;
}
```
outputs ([Compiler Explorer @ x86-64 clang trunk with libc++](https://godbolt.org/z/GPboxKKoY))
```
vs = [(1, 1), (2, 2)]
map = {(1, 1), (2, 2)}
mapmap = {1: 1, 2: 2}
```

However, the m specifier for ranges should also imply m formatting (i.e. "key: value" for pair and 2-tuple) on the elements of the ranges, as per [\[tab:formatter.range.type\]/1](https://eel.is/c++draft/tab:formatter.range.type):
```
Indicates that the opening bracket should be "{", the closing bracket should be "}", the separator should be ", ",
and each range element should be formatted as if m were specified for its tuple-type.
```
In other words, `{:m}` should be equivalent to `{:m:m}`, yet in the above output it clearly isn't.