### PR TITLE
[libc++] Speed up classic locale

### DIFF
--- a/libcxx/benchmarks/stringstream.bench.cpp
+++ b/libcxx/benchmarks/stringstream.bench.cpp
@@ -25,6 +25,15 @@ static void BM_Istream_numbers(benchmark::State& state) {
   while (state.KeepRunning())
     benchmark::DoNotOptimize(i += istream_numbers());
 }
+BENCHMARK(BM_Istream_numbers)->RangeMultiplier(2)->Range(1024, 4096)->UseRealTime()->Threads(1)->ThreadPerCpu();
 
-BENCHMARK(BM_Istream_numbers)->RangeMultiplier(2)->Range(1024, 4096);
+static void BM_Ostream_number(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    std::ostringstream ss;
+    ss << 0;
+    benchmark::DoNotOptimize(ss.str().c_str());
+  }
+}
+BENCHMARK(BM_Ostream_number)->UseRealTime()->Threads(1)->ThreadPerCpu();
+
 BENCHMARK_MAIN();

--- a/libcxx/benchmarks/stringstream.bench.cpp
+++ b/libcxx/benchmarks/stringstream.bench.cpp
@@ -1,11 +1,12 @@
 #include "benchmark/benchmark.h"
 #include "test_macros.h"
 
+#include <mutex>
 #include <sstream>
 
 TEST_NOINLINE double istream_numbers();
 
-double istream_numbers() {
+double istream_numbers(std::locale* l) {
   const char* a[] = {"-6  69 -71  2.4882e-02 -100 101 -2.00005 5000000 -50000000",
                      "-25 71   7 -9.3262e+01 -100 101 -2.00005 5000000 -50000000",
                      "-14 53  46 -6.7026e-02 -100 101 -2.00005 5000000 -50000000"};
@@ -14,26 +15,72 @@ double istream_numbers() {
   double f1 = 0.0, f2 = 0.0, q = 0.0;
   for (int i = 0; i < 3; i++) {
     std::istringstream s(a[i]);
+    if (l)
+      s.imbue(*l);
     s >> a1 >> a2 >> a3 >> f1 >> a4 >> a5 >> f2 >> a6 >> a7;
     q += (a1 + a2 + a3 + a4 + a5 + a6 + a7 + f1 + f2) / 1000000;
   }
   return q;
 }
 
+struct LocaleSelector {
+  std::locale* imbue;
+  std::locale old;
+
+  LocaleSelector(benchmark::State& state) {
+    static std::mutex mu;
+    std::lock_guard l(mu);
+    switch (state.range(0)) {
+    case 0: {
+      old   = std::locale::global(std::locale::classic());
+      imbue = nullptr;
+      break;
+    }
+    case 1: {
+      old = std::locale::global(std::locale::classic());
+      thread_local std::locale l("en_US.UTF-8");
+      imbue = &l;
+      break;
+    }
+    case 2: {
+      old = std::locale::global(std::locale::classic());
+      static std::locale l("en_US.UTF-8");
+      imbue = &l;
+      break;
+    }
+    case 3: {
+      old   = std::locale::global(std::locale("en_US.UTF-8"));
+      imbue = nullptr;
+      break;
+    }
+    }
+  }
+
+  ~LocaleSelector() {
+    static std::mutex mu;
+    std::lock_guard l(mu);
+    std::locale::global(old);
+  }
+};
+
 static void BM_Istream_numbers(benchmark::State& state) {
+  LocaleSelector sel(state);
   double i = 0;
   while (state.KeepRunning())
-    benchmark::DoNotOptimize(i += istream_numbers());
+    benchmark::DoNotOptimize(i += istream_numbers(sel.imbue));
 }
-BENCHMARK(BM_Istream_numbers)->RangeMultiplier(2)->Range(1024, 4096)->UseRealTime()->Threads(1)->ThreadPerCpu();
+BENCHMARK(BM_Istream_numbers)->DenseRange(0, 3)->UseRealTime()->Threads(1)->ThreadPerCpu();
 
 static void BM_Ostream_number(benchmark::State& state) {
+  LocaleSelector sel(state);
   while (state.KeepRunning()) {
     std::ostringstream ss;
+    if (sel.imbue)
+      ss.imbue(*sel.imbue);
     ss << 0;
     benchmark::DoNotOptimize(ss.str().c_str());
   }
 }
-BENCHMARK(BM_Ostream_number)->UseRealTime()->Threads(1)->ThreadPerCpu();
+BENCHMARK(BM_Ostream_number)->DenseRange(0, 3)->UseRealTime()->Threads(1)->ThreadPerCpu();
 
 BENCHMARK_MAIN();

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -90,8 +90,8 @@ public:
         all = collate | ctype | monetary | numeric | time | messages;
 
     // construct/copy/destroy:
-    locale()  _NOEXCEPT;
-    locale(const locale&)  _NOEXCEPT;
+    _LIBCPP_HIDE_FROM_ABI locale()  _NOEXCEPT;
+    _LIBCPP_HIDE_FROM_ABI locale(const locale&)  _NOEXCEPT;
     explicit locale(const char*);
     explicit locale(const string&);
     locale(const locale&, const char*, category);
@@ -100,7 +100,7 @@ public:
         _LIBCPP_INLINE_VISIBILITY locale(const locale&, _Facet*);
     locale(const locale&, const locale&, category);
 
-    ~locale();
+    _LIBCPP_HIDE_FROM_ABI ~locale();
 
     const locale& operator=(const locale&)  _NOEXCEPT;
 
@@ -129,11 +129,11 @@ private:
     static __imp* __classic_;
 
     void __install_ctor(const locale&, facet*, long);
-    static __imp*& __global();
+    static _LIBCPP_HIDE_FROM_ABI __imp*& __global();
     static __imp* __make_global();
-    static __imp* __maybe_acquire(__imp* __i);
+    static _LIBCPP_HIDE_FROM_ABI __imp* __maybe_acquire(__imp* __i);
     static __imp* __do_acquire(__imp* __i);
-    static void __maybe_release(__imp* __i);
+    static _LIBCPP_HIDE_FROM_ABI void __maybe_release(__imp* __i);
     static void __do_release(__imp* __i);
     bool has_facet(id&) const;
     const facet* use_facet(id&) const;

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -126,15 +126,55 @@ public:
 private:
     class __imp;
     __imp* __locale_;
+    static __imp* __classic_;
 
     void __install_ctor(const locale&, facet*, long);
-    static locale& __global();
+    static __imp*& __global();
+    static __imp* __make_global();
+    static __imp* __maybe_acquire(__imp* __i);
+    static __imp* __do_acquire(__imp* __i);
+    static void __maybe_release(__imp* __i);
+    static void __do_release(__imp* __i);
     bool has_facet(id&) const;
     const facet* use_facet(id&) const;
 
     template <class _Facet> friend bool has_facet(const locale&)  _NOEXCEPT;
     template <class _Facet> friend const _Facet& use_facet(const locale&);
 };
+
+inline locale::locale() _NOEXCEPT
+    : __locale_(__maybe_acquire(__global()))
+{
+}
+
+inline locale::locale(const locale& l) _NOEXCEPT
+    : __locale_(__maybe_acquire(l.__locale_))
+{
+}
+
+inline locale::~locale()
+{
+    __maybe_release(__locale_);
+}
+
+inline locale::__imp*& locale::__global()
+{
+    static __imp* __g = __make_global();
+    return __g;
+}
+
+inline locale::__imp* locale::__maybe_acquire(__imp* __i)
+{
+    if (__i != __classic_)
+        __do_acquire(__i);
+    return __i;
+}
+
+inline void locale::__maybe_release(__imp* __i)
+{
+    if (__i != __classic_)
+        __do_release(__i);
+}
 
 class _LIBCPP_EXPORTED_FROM_ABI locale::facet
     : public __shared_count


### PR DESCRIPTION
Locale objects use atomic reference counting, which may be very expensive in parallel applications. The classic locale is used by default by all streams and can be very contended. But it's never destroyed, so the reference counting is also completely pointless on the classic locale. Currently ~70% of time in the parallel stringstream benchmarks is spent in locale ctor/dtor. And the execution radically slows down with more threads.

Avoid reference counting on the classic locale and inline common ctors/dtor. With this change locale ctor/dtor time become negligible and the benchmark starts to scale with threads.

```
                                       │ bench/stream.baseline.res │     bench/stream.optimized.res      │
                                       │          sec/op           │   sec/op     vs base                │
Istream_numbers/0/real_time/threads:1                  4.686µ ± 0%   4.213µ ± 0%  -10.09% (p=0.000 n=24)
Istream_numbers/0/real_time/threads:72               339.712µ ± 4%   8.939µ ± 2%  -97.37% (p=0.000 n=24)
Istream_numbers/1/real_time/threads:1                  4.900µ ± 0%   4.773µ ± 0%   -2.60% (p=0.000 n=24)
Istream_numbers/1/real_time/threads:72                49.308µ ± 3%   9.694µ ± 1%  -80.34% (p=0.000 n=24)
Istream_numbers/2/real_time/threads:1                  4.902µ ± 0%   4.769µ ± 0%   -2.72% (p=0.000 n=24)
Istream_numbers/2/real_time/threads:72                 416.6µ ± 9%   410.5µ ± 6%        ~ (p=0.111 n=24)
Istream_numbers/3/real_time/threads:1                  4.716µ ± 0%   4.737µ ± 0%   +0.45% (p=0.000 n=24)
Istream_numbers/3/real_time/threads:72                 419.7µ ± 6%   458.3µ ± 4%   +9.19% (p=0.003 n=24)
Ostream_number/0/real_time/threads:1                   184.0n ± 1%   135.0n ± 1%  -26.63% (p=0.000 n=24)
Ostream_number/0/real_time/threads:72                17279.0n ± 4%   308.0n ± 1%  -98.22% (p=0.000 n=24)
Ostream_number/1/real_time/threads:1                   253.5n ± 1%   199.0n ± 1%  -21.50% (p=0.000 n=24)
Ostream_number/1/real_time/threads:72                13957.5n ± 2%   382.0n ± 0%  -97.26% (p=0.000 n=24)
Ostream_number/2/real_time/threads:1                   253.0n ± 1%   202.0n ± 1%  -20.16% (p=0.000 n=24)
Ostream_number/2/real_time/threads:72                  28.04µ ± 4%   18.80µ ± 7%  -32.96% (p=0.000 n=24)
Ostream_number/3/real_time/threads:1                   187.0n ± 1%   190.5n ± 0%   +1.87% (p=0.000 n=24)
Ostream_number/3/real_time/threads:72                  20.25µ ± 7%   20.37µ ± 5%        ~ (p=0.736 n=24)

```