### PR TITLE
[clang][analyzer] Do not analyze opaque types in CXXDeleteChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CXXDeleteChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CXXDeleteChecker.cpp
@@ -114,6 +114,9 @@ void DeleteWithNonVirtualDtorChecker::checkTypedDeleteExpr(
   if (!BaseClass || !DerivedClass)
     return;
 
+  if (!BaseClass->hasDefinition() || !DerivedClass->hasDefinition())
+    return;
+
   if (BaseClass->getDestructor()->isVirtual())
     return;
 
@@ -146,6 +149,9 @@ void CXXArrayDeleteChecker::checkTypedDeleteExpr(
   const auto *DerivedClass =
       DerivedClassRegion->getSymbol()->getType()->getPointeeCXXRecordDecl();
   if (!BaseClass || !DerivedClass)
+    return;
+
+  if (!BaseClass->hasDefinition() || !DerivedClass->hasDefinition())
     return;
 
   if (DE->getOperatorDelete()->getOverloadedOperator() != OO_Array_Delete)


### PR DESCRIPTION
While inheritance can only be expressed if the class has a definition, in this case one of the types might be opaque to the analyzer.

Fixes a crash encountered while analyzing LLVM.