### PR TITLE
[clang] Do not clear FP pragma stack when instantiating functions

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -714,7 +714,7 @@ public:
   class FpPragmaStackSaveRAII {
   public:
     FpPragmaStackSaveRAII(Sema &S)
-      : S(S), SavedStack(std::move(S.FpPragmaStack)) {
+        : S(S), SavedStack(std::move(S.FpPragmaStack)) {
       S.FpPragmaStack.Stack.clear();
     }
     ~FpPragmaStackSaveRAII() { S.FpPragmaStack = std::move(SavedStack); }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -714,7 +714,9 @@ public:
   class FpPragmaStackSaveRAII {
   public:
     FpPragmaStackSaveRAII(Sema &S)
-        : S(S), SavedStack(std::move(S.FpPragmaStack)) {}
+      : S(S), SavedStack(std::move(S.FpPragmaStack)) {
+      S.FpPragmaStack.Stack.clear();
+    }
     ~FpPragmaStackSaveRAII() { S.FpPragmaStack = std::move(SavedStack); }
 
   private:

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -710,9 +710,11 @@ public:
     return result;
   }
 
+  // Saves the current floating-point pragma stack and clear it in this Sema.
   class FpPragmaStackSaveRAII {
   public:
-    FpPragmaStackSaveRAII(Sema &S) : S(S), SavedStack(S.FpPragmaStack) {}
+    FpPragmaStackSaveRAII(Sema &S)
+        : S(S), SavedStack(std::move(S.FpPragmaStack)) {}
     ~FpPragmaStackSaveRAII() { S.FpPragmaStack = std::move(SavedStack); }
 
   private:
@@ -722,7 +724,6 @@ public:
 
   void resetFPOptions(FPOptions FPO) {
     CurFPFeatures = FPO;
-    FpPragmaStack.Stack.clear();
     FpPragmaStack.CurrentValue = FPO.getChangesFrom(FPOptions(LangOpts));
   }
 

--- a/clang/test/Sema/PR69717.cpp
+++ b/clang/test/Sema/PR69717.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+// expected-no-diagnostics
+
+// Testcase for https://github.com/llvm/llvm-project/issues/69717
+
+#pragma float_control(precise, on, push)
+
+template<typename T>
+constexpr T multi(T x, T y) {
+  return x * y;
+}
+
+int multi_i(int x, int y) {
+  return multi<int>(x, y);
+}
+
+#pragma float_control(pop)


### PR DESCRIPTION
When instantiation function, a call to Sema::resetFPOption was used to set the FP options associated with AST node. However this function also cleared FP pragma stack, and it is incorrect. Template instantiation takes place on AST representation and semantic information like the FP pragma stack should not affect it. This was a reason for miscompilation in some cases.

To make the Sema interface more consistent, now `resetFPOptions` does not clear FP pragma stack anymore. It is cleared in `FpPragmaStackSaveRAII`, which is used in parsing only.

This change must fix https://github.com/llvm/llvm-project/issues/69717 (Problems with float_control pragma stack in Clang 17.x).