### PR TITLE
Update mlir-spirv-cpu-runner.cpp

### DIFF
--- a/mlir/tools/mlir-spirv-cpu-runner/mlir-spirv-cpu-runner.cpp
+++ b/mlir/tools/mlir-spirv-cpu-runner/mlir-spirv-cpu-runner.cpp
@@ -94,8 +94,8 @@ static LogicalResult runMLIRPasses(Operation *module,
   nestedPM.addPass(spirv::createSPIRVUpdateVCEPass());
   passManager.addPass(createLowerHostCodeToLLVMPass(
       enableOpaquePointers(LowerHostCodeToLLVMPassOptions{})));
-  passManager.addPass(createConvertSPIRVToLLVMPass(
-      enableOpaquePointers(ConvertSPIRVToLLVMPassOptions{})));
+  passManager.addPass(
+      createConvertSPIRVToLLVMPass(ConvertSPIRVToLLVMPassOptions{}));
   return passManager.run(module);
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/70568 removed the support for lowering SPIRV to LLVM dialect. We now need to stop using enableOpaquePointers with ConvertSPIRVToLLVMPassOptions.