### PR TITLE
[mlir][linalg] Enable CollapseLinalgDimensions to collapse ops with C…

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.td
@@ -668,6 +668,35 @@ def LinalgStructuredInterface
         return;
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the indexing map which matches the OpOperand
+        is considered as a canonicalized identity.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isCanonicalizedIdentityMap",
+      /*args=*/(ins "OpOperand*": $opOperand),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+          auto indexingMap = $_op.getMatchingIndexingMap(opOperand);
+          return indexingMap.isCanonicalizedIdentity(getShape(opOperand));
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if all of the indexing maps of the specefic linalg operation
+        are considered as canonicalized identity.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"hasOnlyCanonicalizedIdentityMaps",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+          return llvm::all_of(this->getOperation()->getOpOperands(),[&](OpOperand &opOperand){
+            return $_op.isCanonicalizedIdentityMap(&opOperand);
+          });
+      }]
+    >,
     //===------------------------------------------------------------------===//
     // Linalg generalization hooks.
     //===------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1043,8 +1043,9 @@ splitReductionByScaling(RewriterBase &b, LinalgOp op,
 /// range of the specified indexing map.
 bool isDimSequencePreserved(AffineMap map, ReassociationIndicesRef dimSequence);
 /// Return `true` if all sequences of dimensions specified in `dimSequences` are
-/// contiguous in all the ranges of the `maps`.
-bool areDimSequencesPreserved(ArrayRef<AffineMap> maps,
+/// contiguous in all the ranges of the indexing maps of the `op`.
+template <typename LinalgType>
+bool areDimSequencesPreserved(LinalgType op,
                               ArrayRef<ReassociationIndices> dimSequences);
 
 /// Collapses dimensions of linalg.generic/linalg.copy operation. A precondition

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -131,6 +131,17 @@ public:
   /// affine map (d0, ..., dn) -> (dp, ..., dn) on the most minor dimensions.
   bool isMinorIdentity() const;
 
+  /// Returns true if this affine map is a canonicalized identity.
+  /// Otherwise return false.
+  /// A canonicalized identity affine map corresponds to an identity
+  /// affine function on the dimensional identifiers. which may
+  /// include zero constant expressions in the affine map results.
+  /// These zero constants should be corresponded to dimesnions with
+  /// value 1.
+  /// Example: affine_map<(d0, d1, d2, d3, d4) -> (0, d1, d2, d3, d4)>
+  /// is considered a canonicalized identity if `shape[0] == 1`.
+  bool isCanonicalizedIdentity(ArrayRef<int64_t> shape) const;
+
   /// Returns true if this affine map is a minor identity up to broadcasted
   /// dimensions which are indicated by value 0 in the result. If
   /// `broadcastedDims` is not null, it will be populated with the indices of


### PR DESCRIPTION
…anonicalized Identity maps

Supporting collapsion of linalg ops which have
canonicalized identity maps matched for their
OpOperands.

Canonnicalized Identity is an identity affine map
which include zero constants corresponded to the
values of `1` of the Operand's shape.

a common use case for this support would be the
usage of CollapseLinalgDimensions after Tosa-To-Linalg ,
since the later generates linalg.generic ops with canonicalized
identity maps (and the rewrite pattern would fail matching, 
since it supports only projected permutes indexing maps).