### PR TITLE
[clang][Module] Mark test unsupported since objc doesn't have xcoff/g…

### DIFF
--- a/clang/test/Modules/relative-resource-dir.m
+++ b/clang/test/Modules/relative-resource-dir.m
@@ -1,3 +1,4 @@
+// UNSUPPORTED: -zos, -aix
 // REQUIRES: shell
 
 // RUN: EXPECTED_RESOURCE_DIR=`%clang -print-resource-dir` && \


### PR DESCRIPTION
…off support

Same as D135848. The newly added test fails with `fatal error: error in backend: Objective-C support is unimplemented for object file format`. 