### PR TITLE
[DAG] Canonicalize zero_extend to sign_extend based on target preference

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -2419,7 +2419,7 @@ bool TargetLowering::SimplifyDemandedBits(
     Known = Known.sext(BitWidth);
 
     // If the sign bit is known zero, convert this to a zero extend.
-    if (Known.isNonNegative()) {
+    if (Known.isNonNegative() && !isSExtCheaperThanZExt(SrcVT, VT)) {
       unsigned Opc =
           IsVecInReg ? ISD::ZERO_EXTEND_VECTOR_INREG : ISD::ZERO_EXTEND;
       if (!TLO.LegalOperations() || isOperationLegal(Opc, VT))


### PR DESCRIPTION
We already had code to stop the canonicalization in the other direction, let's add the inverse combine.  It turned out we'd missed a least one case which unconditionally created zero_extend, so fix that too to avoid a combine loop.

Note that this will most likely be entirely reworked in the near future based on the new nneg flag.  This change was triggered by me investigating what that would look like, and asking why the current structure was incomplete.