### PR TITLE
[Release] Build compiler-rt during Phase 1 on AIX 

### DIFF
--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -1,4 +1,4 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
 #===-- test-release.sh - Test the LLVM release candidates ------------------===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -1,4 +1,4 @@
-u!/usr/bin/env bash
+!/usr/bin/env bash
 #===-- test-release.sh - Test the LLVM release candidates ------------------===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -417,7 +417,7 @@ function configure_llvmCore() {
     # building itself and any selected runtimes in the second phase.
     if [ "$Phase" -lt "2" ]; then
       runtime_list=""
-      # compiler-rt built-ins needed on AIX to have a functional Phase 1 clang.
+      # compiler-rt builtins is needed on AIX to have a functional Phase 1 clang.
       if [ "$System" = "AIX" ]; then
         runtime_list="compiler-rt"
       fi  

--- a/llvm/utils/release/test-release.sh
+++ b/llvm/utils/release/test-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+u!/usr/bin/env bash
 #===-- test-release.sh - Test the LLVM release candidates ------------------===#
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -417,6 +417,10 @@ function configure_llvmCore() {
     # building itself and any selected runtimes in the second phase.
     if [ "$Phase" -lt "2" ]; then
       runtime_list=""
+      # compiler-rt built-ins needed on AIX to have a functional Phase 1 clang.
+      if [ "$System" = "AIX" ]; then
+        runtime_list="compiler-rt"
+      fi  
     else
       runtime_list="$runtimes"
     fi


### PR DESCRIPTION
Compiler-rt built-ins are needed to have a functional Phase 1 clang compiler on AIX: 
```
CMake Error at /gsa/rtpgsa-p2/00/xlcmpbldenv/aix/cmake-3.22.0/share/cmake-3.22/Modules/CMakeTestCCompiler.cmake:69 (message):
  The C compiler

    "/scratch/alisonz/llvm/clang17.0.3-final/final/Phase1/Release/llvmCore-17.0.3-final.install/usr/local/bin/clang"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /scratch/alisonz/llvm/clang17.0.3-final/final/Phase2/Release/llvmCore-17.0.3-final.obj/CMakeFiles/CMakeTmp
    
    Run Build Command(s):/xl_le/gsa/rtpgsa/projects/w/wyvern-environment/compilers/AIX/ninja cmTC_6ad06 && [1/2] Building C object CMakeFiles/cmTC_6ad06.dir/testCCompiler.c.o
    [2/2] Linking C executable cmTC_6ad06
    FAILED: cmTC_6ad06 
    : && /scratch/alisonz/llvm/clang17.0.3-final/final/Phase1/Release/llvmCore-17.0.3-final.install/usr/local/bin/clang  -Wl,-bnoipath  CMakeFiles/cmTC_6ad06.dir/testCCompiler.c.o -o cmTC_6ad06  -Wl,-blibpath:/usr/lib:/lib && :
    ld: 0706-005 Cannot find or open file: /scratch/alisonz/llvm/clang17.0.3-final/final/Phase1/Release/llvmCore-17.0.3-final.install/usr/local/lib/clang/17/lib/aix/libclang_rt.builtins-powerpc64.a
        ld:open(): A file or directory in the path name does not exist.
    clang: error: linker command failed with exit code 255 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
    

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:47 (project)


-- Configuring incomplete, errors occurred!
```
This PR adds compiler-rt to the runtime_list during Phase 1 to avoid this problem. 