### PR TITLE
[flang] Fix IsDescriptor() to fix SMP compatibility checking

### DIFF
--- a/flang/lib/Evaluate/type.cpp
+++ b/flang/lib/Evaluate/type.cpp
@@ -40,18 +40,12 @@ static bool IsDescriptor(const ObjectEntityDetails &details) {
   std::size_t j{0};
   for (const ShapeSpec &shapeSpec : details.shape()) {
     ++j;
-    if (const auto &lb{shapeSpec.lbound().GetExplicit()};
-        !lb || !IsConstantExpr(*lb)) {
-      return true;
-    }
     if (const auto &ub{shapeSpec.ubound().GetExplicit()}) {
       if (!IsConstantExpr(*ub)) {
         return true;
       }
-    } else if (j == details.shape().size() && details.isDummy()) {
-      // assumed size array
     } else {
-      return true;
+      return shapeSpec.ubound().isColon();
     }
   }
   return false;

--- a/flang/test/Semantics/separate-mp02.f90
+++ b/flang/test/Semantics/separate-mp02.f90
@@ -35,6 +35,9 @@ module m1
       character(len=*) :: z
       character(len=*) :: w
     end
+    module subroutine s10(x, y, z, w)
+      real x(0:), y(:), z(0:*), w(*)
+    end
   end interface
 end
 
@@ -77,6 +80,9 @@ contains
     character(len=*) :: z
     !ERROR: Dummy argument 'w' has type CHARACTER(KIND=1,LEN=4_8); the corresponding argument in the interface body has type CHARACTER(KIND=1,LEN=*)
     character(len=4) :: w
+  end
+  module subroutine s10(x, y, z, w)
+    real x(:), y(0:), z(*), w(0:*) ! all ok, lower bounds don't matter
   end
 end
 


### PR DESCRIPTION
Fix IsDescriptor() so that it doesn't return a false negative result that messes up compatibility checking between a separate module procedure's interface and its redundant definition (without MODULE PROCEDURE).  Specifically, lower bounds just don't matter, and any upper bound that's not explicit is dispositive.