### PR TITLE
[flang][openacc] Warn only when the same variable is in the same declare

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -401,14 +401,23 @@ void AccStructureChecker::CheckMultipleOccurrenceInDeclare(
             [&](const Fortran::parser::Designator &designator) {
               if (const auto *name = getDesignatorNameIfDataRef(designator)) {
                 if (declareSymbols.contains(&name->symbol->GetUltimate())) {
-                  context_.Say(GetContext().clauseSource,
-                      "'%s' in the %s clause is already present in another "
-                      "clause in this module"_err_en_US,
-                      name->symbol->name(),
-                      parser::ToUpperCaseLetters(
-                          llvm::acc::getOpenACCClauseName(clause).str()));
+                  if (declareSymbols[&name->symbol->GetUltimate()] == clause) {
+                    context_.Say(GetContext().clauseSource,
+                        "'%s' in the %s clause is already present in the same "
+                        "clause in this module"_warn_en_US,
+                        name->symbol->name(),
+                        parser::ToUpperCaseLetters(
+                            llvm::acc::getOpenACCClauseName(clause).str()));
+                  } else {
+                    context_.Say(GetContext().clauseSource,
+                        "'%s' in the %s clause is already present in another "
+                        "clause in this module"_err_en_US,
+                        name->symbol->name(),
+                        parser::ToUpperCaseLetters(
+                            llvm::acc::getOpenACCClauseName(clause).str()));
+                  }
                 }
-                declareSymbols.insert(&name->symbol->GetUltimate());
+                declareSymbols.insert({&name->symbol->GetUltimate(), clause});
               }
             },
             [&](const Fortran::parser::Name &name) {

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -411,10 +411,14 @@ void AccStructureChecker::CheckMultipleOccurrenceInDeclare(
                   } else {
                     context_.Say(GetContext().clauseSource,
                         "'%s' in the %s clause is already present in another "
-                        "clause in this module"_err_en_US,
+                        "%s clause in this module"_err_en_US,
                         name->symbol->name(),
                         parser::ToUpperCaseLetters(
-                            llvm::acc::getOpenACCClauseName(clause).str()));
+                            llvm::acc::getOpenACCClauseName(clause).str()),
+                        parser::ToUpperCaseLetters(
+                            llvm::acc::getOpenACCClauseName(
+                                declareSymbols[&name->symbol->GetUltimate()])
+                                .str()));
                   }
                 }
                 declareSymbols.insert({&name->symbol->GetUltimate(), clause});

--- a/flang/lib/Semantics/check-acc-structure.h
+++ b/flang/lib/Semantics/check-acc-structure.h
@@ -18,7 +18,7 @@
 #include "flang/Common/enum-set.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/semantics.h"
-#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/Frontend/OpenACC/ACC.h.inc"
 
 using AccDirectiveSet = Fortran::common::EnumSet<llvm::acc::Directive,
@@ -91,7 +91,7 @@ private:
   llvm::StringRef getClauseName(llvm::acc::Clause clause) override;
   llvm::StringRef getDirectiveName(llvm::acc::Directive directive) override;
 
-  llvm::SmallDenseSet<Symbol *> declareSymbols;
+  llvm::SmallDenseMap<Symbol *, llvm::acc::Clause> declareSymbols;
   unsigned loopNestLevel = 0;
 };
 

--- a/flang/test/Semantics/OpenACC/acc-declare-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-declare-validity.f90
@@ -14,7 +14,7 @@ module openacc_declare_validity
 
   !$acc declare create(aa, bb)
 
-  !ERROR: 'aa' in the CREATE clause is already present in another clause in this module
+  !WARNING: 'aa' in the CREATE clause is already present in the same clause in this module
   !$acc declare create(aa)
 
   !$acc declare link(ab)

--- a/flang/test/Semantics/OpenACC/acc-declare-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-declare-validity.f90
@@ -36,13 +36,16 @@ module openacc_declare_validity
   !ERROR: The ZERO modifier is not allowed for the CREATE clause on the DECLARE directive
   !$acc declare create(zero: dd)
 
+  !ERROR: 'bb' in the COPYIN clause is already present in another CREATE clause in this module
+  !$acc declare copyin(bb)
+
 contains
 
   subroutine sub1(cc, dd)
     real(8) :: cc(:)
     real(8) :: dd(:)
     !$acc declare present(cc, dd)
-    !ERROR: 'cc' in the CREATE clause is already present in another clause in this module
+    !ERROR: 'cc' in the CREATE clause is already present in another PRESENT clause in this module
     !$acc declare create(cc)
   end subroutine sub1
 


### PR DESCRIPTION
A var may appear at most once in all the clauses of declare directives for a function, subroutine, program, or module.
We raise an error when a var appears in two different clauses. If it is in the same clauses, we just issue a warning. 