### PR TITLE
Metadata: Optimize metadata queries

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -303,8 +303,14 @@ public:
   /// Get the metadata of given kind attached to this Instruction.
   /// If the metadata is not found then return null.
   MDNode *getMetadata(unsigned KindID) const {
-    if (!hasMetadata()) return nullptr;
-    return getMetadataImpl(KindID);
+    // Handle 'dbg' as a special case since it is not stored in the hash table.
+    if (KindID == LLVMContext::MD_dbg) {
+      return DbgLoc.getAsMDNode();
+    }
+    if (hasMetadataOtherThanDebugLoc()) {
+      return getMetadataImpl(KindID);
+    }
+    return nullptr;
   }
 
   /// Get the metadata of given kind attached to this Instruction.

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -306,9 +306,7 @@ public:
     // Handle 'dbg' as a special case since it is not stored in the hash table.
     if (KindID == LLVMContext::MD_dbg)
       return DbgLoc.getAsMDNode();
-    if (hasMetadataOtherThanDebugLoc())
-      return getMetadataImpl(KindID);
-    return nullptr;
+    return Value::getMetadata(KindID);
   }
 
   /// Get the metadata of given kind attached to this Instruction.
@@ -598,7 +596,6 @@ public:
 
 private:
   // These are all implemented in Metadata.cpp.
-  MDNode *getMetadataImpl(unsigned KindID) const;
   MDNode *getMetadataImpl(StringRef Kind) const;
   void
   getAllMetadataImpl(SmallVectorImpl<std::pair<unsigned, MDNode *>> &) const;

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -304,12 +304,10 @@ public:
   /// If the metadata is not found then return null.
   MDNode *getMetadata(unsigned KindID) const {
     // Handle 'dbg' as a special case since it is not stored in the hash table.
-    if (KindID == LLVMContext::MD_dbg) {
+    if (KindID == LLVMContext::MD_dbg)
       return DbgLoc.getAsMDNode();
-    }
-    if (hasMetadataOtherThanDebugLoc()) {
+    if (hasMetadataOtherThanDebugLoc())
       return getMetadataImpl(KindID);
-    }
     return nullptr;
   }
 

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -562,7 +562,11 @@ protected:
   /// These functions require that the value have at most a single attachment
   /// of the given kind, and return \c nullptr if such an attachment is missing.
   /// @{
-  MDNode *getMetadata(unsigned KindID) const;
+  MDNode *getMetadata(unsigned KindID) const {
+    if (!HasMetadata)
+      return nullptr;
+    return getMetadataImpl(KindID);
+  }
   MDNode *getMetadata(StringRef Kind) const;
   /// @}
 
@@ -616,6 +620,11 @@ protected:
 
   /// Erase all metadata attached to this Value.
   void clearMetadata();
+
+  /// Get metadata for the given kind, if any.
+  /// This is an internal function that must only be called after
+  /// checking that `hasMetadata()` returns true.
+  MDNode *getMetadataImpl(unsigned KindID) const;
 
 public:
   /// Return true if this value is a swifterror value.

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1466,12 +1466,10 @@ void Instruction::setMetadata(StringRef Kind, MDNode *Node) {
 MDNode *Instruction::getMetadataImpl(StringRef Kind) const {
   const LLVMContext &Ctx = getContext();
   unsigned KindID = Ctx.getMDKindID(Kind);
-  if (KindID == LLVMContext::MD_dbg) {
+  if (KindID == LLVMContext::MD_dbg)
     return DbgLoc.getAsMDNode();
-  }
-  if (hasMetadataOtherThanDebugLoc()) {
+  if (hasMetadataOtherThanDebugLoc())
     return getValueMetadata(*this, KindID, Ctx);
-  }
   return nullptr;
 }
 


### PR DESCRIPTION
 Optimize metadata query code:
- Avoid `DenseMap::operator[]` in situations where it is known that the key exists in the map. Instead use `DenseMap::at()`/ `DenseMap::find()->second`. This avoids code-bloat and bad inlining decisions for the unused insertion/growing code in `operator[]`.
- Directly query the map in `Instruction::getMetadataImpl` instead of using `Value::getMetadata` to avoid a redundant `hasMetadata()` check.
- Move the `KindID == LLVMContext::MD_dbg` case to `Instruction::getMetadata` and check it first assuming that it can be constant folded after inlining in many situations.

The motivation for this change is a regression triggered by e3cf80c5c1fe55efd8216575ccadea0ab087e79c which could attributed to the compiler inlining the insertion part of `DenseMap::operator[]` in more cases while unbeknownst to a  compiler (without PGO) that code is never used in this context. This change improves performance and eliminates difference before and after that change in my measurements.