### PR TITLE
[flang][cuda] Remove check for obsolete constraint

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -1394,12 +1394,6 @@ void CheckHelper::CheckSubprogram(
     if (ClassifyProcedure(symbol) == ProcedureDefinitionClass::Internal) {
       messages_.Say(symbol.name(),
           "A device subprogram may not be an internal subprogram"_err_en_US);
-    } else if ((*cudaAttrs == common::CUDASubprogramAttrs::Device ||
-                   *cudaAttrs == common::CUDASubprogramAttrs::HostDevice) &&
-        (symbol.owner().kind() != Scope::Kind::Module ||
-            details.isInterface())) {
-      messages_.Say(symbol.name(),
-          "An ATTRIBUTES(DEVICE) subprogram must be a top-level module procedure"_err_en_US);
     }
   }
   if ((!details.cudaLaunchBounds().empty() ||

--- a/flang/test/Semantics/cuf02.cuf
+++ b/flang/test/Semantics/cuf02.cuf
@@ -1,7 +1,6 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 module m
   interface
-    !ERROR: An ATTRIBUTES(DEVICE) subprogram must be a top-level module procedure
     attributes(device) subroutine exts1
     end
   end interface
@@ -44,6 +43,5 @@ module m
   end
 end
 
-!ERROR: An ATTRIBUTES(DEVICE) subprogram must be a top-level module procedure
 attributes(device) subroutine exts1
 end


### PR DESCRIPTION
The online CUDA Fortran documentation states that a device subprogram must be a top-level module subprogram, but this has turned out to be an obsolete constraint.  Stop enforcing it.