### PR TITLE
[clang-tidy] Fix crash in modernize-use-trailing-return-type

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -103,7 +103,7 @@ public:
 
   bool VisitDeclRefExpr(DeclRefExpr *S) {
     DeclarationName Name = S->getNameInfo().getName();
-    return S->getQualifierLoc() || !Name.isIdentifier() ||
+    return S->getQualifierLoc() || Name.isEmpty() || !Name.isIdentifier() ||
            !visitUnqualName(Name.getAsIdentifierInfo()->getName());
   }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type-cxx20.cpp
@@ -98,3 +98,21 @@ struct TestDefaultOperatorB {
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
   // CHECK-FIXES: {{^}}  friend auto operator<(const TestDefaultOperatorB &, const TestDefaultOperatorB &) noexcept -> bool = default;{{$}}
 };
+
+namespace PR69863 {
+
+template <unsigned Len>
+struct CustomCompileTimeString {
+  constexpr CustomCompileTimeString(const char (&)[Len]) noexcept {}
+};
+
+template <CustomCompileTimeString Str>
+constexpr decltype(Str) operator""__csz() noexcept {
+// CHECK-MESSAGES: :[[@LINE-1]]:25: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
+// CHECK-FIXES: {{^}}constexpr auto operator""__csz() noexcept -> decltype(Str) {
+  return Str;
+}
+
+inline constexpr CustomCompileTimeString SomeString = "This line will cause a crash"__csz;
+
+}


### PR DESCRIPTION
Resolved the crash that occurred during the use of a user-defined C-style string literal. The fix entails checking whether the identifier is non-empty before attempting to read its name.