### PR TITLE
[llvm-objcopy] Check for missing argument values

### DIFF
--- a/llvm/test/tools/llvm-objcopy/tool-options.test
+++ b/llvm/test/tools/llvm-objcopy/tool-options.test
@@ -1,6 +1,6 @@
 ## An error must be reported if a required argument value is missing.
 # RUN: not llvm-objcopy --only-section 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE-ONLY-SECTION %s
-# CHECK-NO-VALUE-ONLY-SECTION: error: argument to '--only-section' is missing
+# CHECK-NO-VALUE-ONLY-SECTION: error: argument to '--only-section' is missing (expected 1 value(s))
 
 # RUN: not llvm-objcopy -O 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE-O %s
-# CHECK-NO-VALUE-O: error: argument to '-O' is missing
+# CHECK-NO-VALUE-O: error: argument to '-O' is missing (expected 1 value(s))

--- a/llvm/test/tools/llvm-objcopy/tool-options.test
+++ b/llvm/test/tools/llvm-objcopy/tool-options.test
@@ -1,0 +1,4 @@
+## An error must be reported if a required argument value is missing.
+# RUN: not llvm-objcopy --only-section 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE %s
+# RUN: not llvm-objcopy -O 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE %s
+# CHECK-NO-VALUE: error: argument to '{{.*}}' is missing

--- a/llvm/test/tools/llvm-objcopy/tool-options.test
+++ b/llvm/test/tools/llvm-objcopy/tool-options.test
@@ -1,4 +1,6 @@
 ## An error must be reported if a required argument value is missing.
-# RUN: not llvm-objcopy --only-section 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE %s
-# RUN: not llvm-objcopy -O 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE %s
-# CHECK-NO-VALUE: error: argument to '{{.*}}' is missing
+# RUN: not llvm-objcopy --only-section 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE-ONLY-SECTION %s
+# CHECK-NO-VALUE-ONLY-SECTION: error: argument to '--only-section' is missing
+
+# RUN: not llvm-objcopy -O 2>&1 | FileCheck --check-prefix=CHECK-NO-VALUE-O %s
+# CHECK-NO-VALUE-O: error: argument to '-O' is missing

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -571,6 +571,12 @@ objcopy::parseObjcopyOptions(ArrayRef<const char *> RawArgsArr,
   llvm::opt::InputArgList InputArgs =
       T.ParseArgs(ArgsArr, MissingArgumentIndex, MissingArgumentCount);
 
+  if (MissingArgumentCount)
+    return createStringError(
+        errc::invalid_argument,
+        "argument to '%s' is missing (expected %d value(s))",
+        InputArgs.getArgString(MissingArgumentIndex), MissingArgumentCount);
+
   if (InputArgs.size() == 0 && DashDash == RawArgsArr.end()) {
     printHelp(T, errs(), ToolType::Objcopy);
     exit(1);


### PR DESCRIPTION
Report an error if a required value for a command line argument is missing.