### PR TITLE
Also log the error output from xcrun, if it fails.

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -417,6 +417,8 @@ xcrun(const std::string &sdk, llvm::ArrayRef<llvm::StringRef> arguments,
     // xcrun didn't find a matching SDK. Not an error, we'll try
     // different spellings.
     LLDB_LOG(log, "xcrun returned exit code {0}", status);
+    if (!output_str.empty())
+      LLDB_LOG(log, "xcrun output was:\n{0}", output_str);
     return "";
   }
   if (output_str.empty()) {


### PR DESCRIPTION
In the  rare case that an  Xcode installation is damaged,  this output could contain clues to further diagnose the issue.

rdar://117698630