### PR TITLE
[libcxx][test] std::array::iterator are not pointers by C++ standard

### DIFF
--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.pass.cpp
@@ -128,8 +128,8 @@ constexpr bool test() {
   { // check that an iterator is returned with a borrowing range
     std::array in{1, 2, 3, 4};
     std::array<int, 4> out;
-    std::same_as<std::ranges::in_out_result<int*, int*>> auto ret = std::ranges::copy(std::views::all(in), out.data());
-    assert(ret.in == in.data() + 4);
+    std::same_as<std::ranges::in_out_result<std::array<int, 4>::iterator, int*>> auto ret = std::ranges::copy(std::views::all(in), out.data());
+    assert(ret.in == in.end());
     assert(ret.out == out.data() + 4);
     assert(in == out);
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.pass.cpp
@@ -128,7 +128,8 @@ constexpr bool test() {
   { // check that an iterator is returned with a borrowing range
     std::array in{1, 2, 3, 4};
     std::array<int, 4> out;
-    std::same_as<std::ranges::in_out_result<std::array<int, 4>::iterator, int*>> auto ret = std::ranges::copy(std::views::all(in), out.data());
+    std::same_as<std::ranges::in_out_result<std::array<int, 4>::iterator, int*>> auto ret =
+        std::ranges::copy(std::views::all(in), out.data());
     assert(ret.in == in.end());
     assert(ret.out == out.data() + 4);
     assert(in == out);

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp
@@ -247,9 +247,9 @@ constexpr bool test() {
   { // check that an iterator is returned with a borrowing range
     std::array in {1, 2, 3, 4};
     std::array<int, 4> out;
-    std::same_as<std::ranges::in_out_result<int*, int*>> auto ret =
+    std::same_as<std::ranges::in_out_result<std::array<int, 4>::iterator, int*>> auto ret =
         std::ranges::copy_backward(std::views::all(in), out.data() + out.size());
-    assert(ret.in == in.data() + in.size());
+    assert(ret.in == in.end());
     assert(ret.out == out.data());
     assert(in == out);
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.pass.cpp
@@ -53,7 +53,7 @@ constexpr void test_iterators() {
   { // check that an empty range works
     std::array<int, 0> in;
     std::array<int, 0> out;
-    auto ret = std::ranges::copy_n(In(in.data()), in.size(), Out(out.begin()));
+    auto ret = std::ranges::copy_n(In(in.data()), in.size(), Out(out.data()));
     assert(base(ret.in) == in.data());
     assert(base(ret.out) == out.data());
   }
@@ -103,7 +103,7 @@ constexpr bool test() {
     };
     std::array<CopyOnce, 4> in {};
     std::array<CopyOnce, 4> out {};
-    auto ret = std::ranges::copy_n(in.data(), in.size(), out.begin());
+    auto ret = std::ranges::copy_n(in.begin(), in.size(), out.begin());
     assert(ret.in == in.end());
     assert(ret.out == out.end());
     assert(std::all_of(out.begin(), out.end(), [](const auto& e) { return e.copied; }));

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.fill/ranges.fill.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.fill/ranges.fill.pass.cpp
@@ -120,13 +120,13 @@ constexpr bool test() {
     {
       std::array<std::string, 10> a;
       auto ret = std::ranges::fill(a.begin(), a.end(), "long long string so no SSO");
-      assert(ret == a.begin() + a.size());
+      assert(ret == a.end());
       assert(std::all_of(a.begin(), a.end(), [](auto& s) { return s == "long long string so no SSO"; }));
     }
     {
       std::array<std::string, 10> a;
       auto ret = std::ranges::fill(a, "long long string so no SSO");
-      assert(ret == a.begin() + a.size());
+      assert(ret == a.end());
       assert(std::all_of(a.begin(), a.end(), [](auto& s) { return s == "long long string so no SSO"; }));
     }
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.fill/ranges.fill.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.fill/ranges.fill.pass.cpp
@@ -120,13 +120,13 @@ constexpr bool test() {
     {
       std::array<std::string, 10> a;
       auto ret = std::ranges::fill(a.begin(), a.end(), "long long string so no SSO");
-      assert(ret == a.data() + a.size());
+      assert(ret == a.begin() + a.size());
       assert(std::all_of(a.begin(), a.end(), [](auto& s) { return s == "long long string so no SSO"; }));
     }
     {
       std::array<std::string, 10> a;
       auto ret = std::ranges::fill(a, "long long string so no SSO");
-      assert(ret == a.data() + a.size());
+      assert(ret == a.begin() + a.size());
       assert(std::all_of(a.begin(), a.end(), [](auto& s) { return s == "long long string so no SSO"; }));
     }
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
@@ -275,9 +275,9 @@ constexpr bool test() {
   { // check that an iterator is returned with a borrowing range
     std::array in {1, 2, 3, 4};
     std::array<int, 4> out;
-    std::same_as<std::ranges::in_out_result<int*, int*>> decltype(auto) ret =
+    std::same_as<std::ranges::in_out_result<std::array<int, 4>::iterator, int*>> decltype(auto) ret =
         std::ranges::move(std::views::all(in), out.data());
-    assert(ret.in == in.data() + 4);
+    assert(ret.in == in.end());
     assert(ret.out == out.data() + 4);
     assert(in == out);
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.pass.cpp
@@ -261,9 +261,9 @@ constexpr bool test() {
   { // check that an iterator is returned with a borrowing range
     std::array in {1, 2, 3, 4};
     std::array<int, 4> out;
-    std::same_as<std::ranges::in_out_result<int*, int*>> auto ret =
+    std::same_as<std::ranges::in_out_result<std::array<int, 4>::iterator, int*>> auto ret =
         std::ranges::move_backward(std::views::all(in), out.data() + out.size());
-    assert(ret.in == in.data() + in.size());
+    assert(ret.in == in.end());
     assert(ret.out == out.data());
     assert(in == out);
   }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.partitions/ranges_partition_copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.partitions/ranges_partition_copy.pass.cpp
@@ -132,7 +132,7 @@ constexpr void test_one(std::array<int, N1> input, Pred pred, std::array<int, N2
     std::array<int, N3> out2;
 
     std::same_as<ResultT> decltype(auto) result = std::ranges::partition_copy(
-        Iter(begin), Sent(Iter(end)), OutIter1(out1.begin()), OutIter2(out2.begin()), pred);
+        Iter(begin), Sent(Iter(end)), OutIter1(out1.data()), OutIter2(out2.data()), pred);
 
     assert(base(result.in) == input.data() + input.size());
     assert(base(result.out1) == out1.data() + expected_true.size());
@@ -148,7 +148,7 @@ constexpr void test_one(std::array<int, N1> input, Pred pred, std::array<int, N2
     std::array<int, N3> out2;
 
     std::same_as<ResultT> decltype(auto) result = std::ranges::partition_copy(
-        range, OutIter1(out1.begin()), OutIter2(out2.begin()), pred);
+        range, OutIter1(out1.data()), OutIter2(out2.data()), pred);
 
     assert(base(result.in) == input.data() + input.size());
     assert(base(result.out1) == out1.data() + expected_true.size());

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.sample/ranges_sample.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.sample/ranges_sample.pass.cpp
@@ -164,7 +164,7 @@ void test_one(std::array<int, N> in, std::size_t n, Gen gen) {
     auto begin = Iter(in.data());
     auto end = Sent(Iter(in.data() + in.size()));
     std::array<int, N> output;
-    auto out = Out(output.begin());
+    auto out = Out(output.data());
 
     std::same_as<Out> decltype(auto) result = std::ranges::sample(
         std::move(begin), std::move(end), std::move(out), n, gen);
@@ -177,7 +177,7 @@ void test_one(std::array<int, N> in, std::size_t n, Gen gen) {
     auto begin = Iter(in.data());
     auto end = Sent(Iter(in.data() + in.size()));
     std::array<int, N> output;
-    auto out = Out(output.begin());
+    auto out = Out(output.data());
 
     std::same_as<Out> decltype(auto) result = std::ranges::sample(std::ranges::subrange(
         std::move(begin), std::move(end)), std::move(out), n, gen);

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges.remove.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges.remove.pass.cpp
@@ -65,7 +65,7 @@ constexpr void test(Data<N, M> d) {
 
     assert(base(ret.begin()) == input.data() + M);
     assert(base(ret.end()) == input.data() + N);
-    assert(std::ranges::equal(input.begin(), base(ret.begin()), d.expected.begin(), d.expected.end()));
+    assert(std::ranges::equal(input.data(), base(ret.begin()), d.expected.begin(), d.expected.end()));
   }
 
   { // range overload
@@ -76,7 +76,7 @@ constexpr void test(Data<N, M> d) {
 
     assert(base(ret.begin()) == input.data() + M);
     assert(base(ret.end()) == input.data() + N);
-    assert(std::ranges::equal(base(input.begin()), base(ret.begin()), d.expected.begin(), d.expected.end()));
+    assert(std::ranges::equal(input.data(), base(ret.begin()), d.expected.begin(), d.expected.end()));
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges.remove_if.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges.remove_if.pass.cpp
@@ -85,7 +85,7 @@ constexpr void test(Data<N, M> d) {
 
     assert(base(ret.begin()) == input.data() + M);
     assert(base(ret.end()) == input.data() + N);
-    assert(std::ranges::equal(base(input.begin()), base(ret.begin()), d.expected.begin(), d.expected.end()));
+    assert(std::ranges::equal(input.data(), base(ret.begin()), d.expected.begin(), d.expected.end()));
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.swap/ranges.swap_ranges.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.swap/ranges.swap_ranges.pass.cpp
@@ -65,7 +65,7 @@ constexpr void test_range() {
   std::array r2 = {4, 5, 6};
 
 
-  std::same_as<std::ranges::in_in_result<int*, int*>> auto r = std::ranges::swap_ranges(r1, r2);
+  std::same_as<std::ranges::in_in_result<std::array<int, 3>::iterator, std::array<int, 3>::iterator>> auto r = std::ranges::swap_ranges(r1, r2);
   assert(r.in1 == r1.end());
   assert(r.in2 == r2.end());
 
@@ -146,7 +146,7 @@ constexpr void test_iterators() {
 
 constexpr void test_rval_range() {
   {
-    using Expected = std::ranges::swap_ranges_result<int*, std::ranges::dangling>;
+    using Expected = std::ranges::swap_ranges_result<std::array<int, 3>::iterator, std::ranges::dangling>;
     std::array<int, 3> r = {1, 2, 3};
     std::same_as<Expected> auto a = std::ranges::swap_ranges(r, std::array{4, 5, 6});
     assert((r == std::array{4, 5, 6}));
@@ -154,7 +154,7 @@ constexpr void test_rval_range() {
   }
   {
     std::array<int, 3> r = {1, 2, 3};
-    using Expected = std::ranges::swap_ranges_result<std::ranges::dangling, int*>;
+    using Expected = std::ranges::swap_ranges_result<std::ranges::dangling, std::array<int, 3>::iterator>;
     std::same_as<Expected> auto b = std::ranges::swap_ranges(std::array{4, 5, 6}, r);
     assert((r == std::array{4, 5, 6}));
     assert(b.in2 == r.begin() + 3);

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.unique/ranges_unique_copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.unique/ranges_unique_copy.pass.cpp
@@ -186,7 +186,7 @@ constexpr void testUniqueCopyImpl(std::array<int, N1> in, std::array<int, N2> ex
   {
     std::array<int, N2> out;
     std::same_as<std::ranges::unique_copy_result<InIter, OutIter>> decltype(auto) result =
-        std::ranges::unique_copy(InIter{in.data()}, Sent{InIter{in.data() + in.size()}}, OutIter{out.begin()});
+        std::ranges::unique_copy(InIter{in.data()}, Sent{InIter{in.data() + in.size()}}, OutIter{out.data()});
     assert(std::ranges::equal(out, expected));
     assert(base(result.in) == in.data() + in.size());
     assert(base(result.out) == out.data() + out.size());
@@ -197,7 +197,7 @@ constexpr void testUniqueCopyImpl(std::array<int, N1> in, std::array<int, N2> ex
     std::array<int, N2> out;
     std::ranges::subrange r{InIter{in.data()}, Sent{InIter{in.data() + in.size()}}};
     std::same_as<std::ranges::unique_copy_result<InIter, OutIter>> decltype(auto) result =
-        std::ranges::unique_copy(r, OutIter{out.begin()});
+        std::ranges::unique_copy(r, OutIter{out.data()});
     assert(std::ranges::equal(out, expected));
     assert(base(result.in) == in.data() + in.size());
     assert(base(result.out) == out.data() + out.size());

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.all_of/ranges.all_of.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.all_of/ranges.all_of.pass.cpp
@@ -93,7 +93,7 @@ constexpr void test_iterators() {
       auto pred = [&](int) { ++predicateCount; return true; };
       auto proj = [&](int i) { ++projectionCount; return i; };
       std::array a = {9, 7, 5, 3};
-      assert(std::ranges::all_of(It(a.begin()), Sent(It(a.end())), pred, proj));
+      assert(std::ranges::all_of(It(a.data()), Sent(It(a.data() + a.size())), pred, proj));
       assert(predicateCount == 4);
       assert(projectionCount == 4);
     }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.any_of/ranges.any_of.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.any_of/ranges.any_of.pass.cpp
@@ -93,7 +93,7 @@ constexpr void test_iterators() {
       auto pred = [&](int) { ++predicateCount; return false; };
       auto proj = [&](int i) { ++projectionCount; return i; };
       std::array a = {9, 7, 5, 3};
-      assert(!std::ranges::any_of(It(a.begin()), Sent(It(a.end())), pred, proj));
+      assert(!std::ranges::any_of(It(a.data()), Sent(It(a.data() + a.size())), pred, proj));
       assert(predicateCount == 4);
       assert(projectionCount == 4);
     }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.none_of/ranges.none_of.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.none_of/ranges.none_of.pass.cpp
@@ -93,7 +93,7 @@ constexpr void test_iterators() {
       auto pred = [&](int) { ++predicateCount; return false; };
       auto proj = [&](int i) { ++projectionCount; return i; };
       std::array a = {9, 7, 5, 3};
-      assert(std::ranges::none_of(It(a.begin()), Sent(It(a.end())), pred, proj));
+      assert(std::ranges::none_of(It(a.data()), Sent(It(a.data() + a.size())), pred, proj));
       assert(predicateCount == 4);
       assert(projectionCount == 4);
     }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/mismatch/ranges_mismatch.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/mismatch/ranges_mismatch.pass.cpp
@@ -105,7 +105,7 @@ constexpr bool test() {
   { // test with a range
     std::array<int, 5> a = {1, 2, 3, 4, 5};
     std::array<int, 5> b = {1, 2, 3, 5, 4};
-    using Expected = std::ranges::mismatch_result<int*, int*>;
+    using Expected = std::ranges::mismatch_result<std::array<int, 5>::iterator, std::array<int, 5>::iterator>;
     std::same_as<Expected> auto ret = std::ranges::mismatch(a, b);
     assert(ret.in1 == a.begin() + 3);
     assert(ret.in2 == b.begin() + 3);

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/make.heap/ranges_make_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/make.heap/ranges_make_heap.pass.cpp
@@ -61,6 +61,13 @@ static_assert(!HasMakeHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `so
 template <std::size_t N, class T, class Iter>
 constexpr void verify_heap(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
   assert(heapified == expected);
+  assert(last == heapified.end());
+  assert(std::is_heap(heapified.begin(), heapified.end()));
+}
+
+template <std::size_t N, class T, class Iter>
+constexpr void verify_heap_iterator(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
+  assert(heapified == expected);
   assert(base(last) == heapified.data() + heapified.size());
   assert(std::is_heap(heapified.begin(), heapified.end()));
 }
@@ -73,7 +80,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(heapified.data() + heapified.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::make_heap(b, e);
-    verify_heap(heapified, last, expected);
+    verify_heap_iterator(heapified, last, expected);
   }
 
   { // (range) overload.
@@ -83,7 +90,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::make_heap(range);
-    verify_heap(heapified, last, expected);
+    verify_heap_iterator(heapified, last, expected);
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/make.heap/ranges_make_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/make.heap/ranges_make_heap.pass.cpp
@@ -61,14 +61,7 @@ static_assert(!HasMakeHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `so
 template <std::size_t N, class T, class Iter>
 constexpr void verify_heap(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
   assert(heapified == expected);
-  assert(last == heapified.end());
-  assert(std::is_heap(heapified.begin(), heapified.end()));
-}
-
-template <std::size_t N, class T, class Iter>
-constexpr void verify_heap_iterator(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
-  assert(heapified == expected);
-  assert(base(last) == heapified.data() + heapified.size());
+  assert(std::to_address(base(last)) == heapified.data() + heapified.size());
   assert(std::is_heap(heapified.begin(), heapified.end()));
 }
 
@@ -80,7 +73,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(heapified.data() + heapified.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::make_heap(b, e);
-    verify_heap_iterator(heapified, last, expected);
+    verify_heap(heapified, last, expected);
   }
 
   { // (range) overload.
@@ -90,7 +83,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::make_heap(range);
-    verify_heap_iterator(heapified, last, expected);
+    verify_heap(heapified, last, expected);
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/ranges_pop_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/ranges_pop_heap.pass.cpp
@@ -61,6 +61,14 @@ static_assert(!HasPopHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `sor
 template <std::size_t N, class T, class Iter>
 constexpr void verify_heap(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
   assert(heapified == expected);
+  assert(last == heapified.end());
+  assert(std::is_heap(heapified.begin(), heapified.end() - 1));
+  assert(*std::max_element(heapified.begin(), heapified.end()) == heapified.back());
+}
+
+template <std::size_t N, class T, class Iter>
+constexpr void verify_heap_iterator(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
+  assert(heapified == expected);
   assert(base(last) == heapified.data() + heapified.size());
   assert(std::is_heap(heapified.begin(), heapified.end() - 1));
   assert(*std::max_element(heapified.begin(), heapified.end()) == heapified.back());
@@ -77,7 +85,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(heapified.data() + heapified.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::pop_heap(b, e);
-    verify_heap(heapified, last, expected);
+    verify_heap_iterator(heapified, last, expected);
   }
 
   { // (range) overload.
@@ -87,7 +95,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::pop_heap(range);
-    verify_heap(heapified, last, expected);
+    verify_heap_iterator(heapified, last, expected);
   }
 }
 
@@ -130,7 +138,7 @@ constexpr bool test() {
       auto in = input;
       auto last = std::ranges::pop_heap(in.begin(), in.end(), comp);
       assert(in == expected);
-      assert(last == in.data() + in.size());
+      assert(last == in.end());
       assert(std::is_heap(in.begin(), in.end() - 1, comp));
     }
 
@@ -138,7 +146,7 @@ constexpr bool test() {
       auto in = input;
       auto last = std::ranges::pop_heap(in, comp);
       assert(in == expected);
-      assert(last == in.data() + in.size());
+      assert(last == in.end());
       assert(std::is_heap(in.begin(), in.end() - 1, comp));
     }
   }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/ranges_pop_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/pop.heap/ranges_pop_heap.pass.cpp
@@ -61,15 +61,7 @@ static_assert(!HasPopHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `sor
 template <std::size_t N, class T, class Iter>
 constexpr void verify_heap(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
   assert(heapified == expected);
-  assert(last == heapified.end());
-  assert(std::is_heap(heapified.begin(), heapified.end() - 1));
-  assert(*std::max_element(heapified.begin(), heapified.end()) == heapified.back());
-}
-
-template <std::size_t N, class T, class Iter>
-constexpr void verify_heap_iterator(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
-  assert(heapified == expected);
-  assert(base(last) == heapified.data() + heapified.size());
+  assert(std::to_address(base(last)) == heapified.data() + heapified.size());
   assert(std::is_heap(heapified.begin(), heapified.end() - 1));
   assert(*std::max_element(heapified.begin(), heapified.end()) == heapified.back());
 }
@@ -85,7 +77,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(heapified.data() + heapified.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::pop_heap(b, e);
-    verify_heap_iterator(heapified, last, expected);
+    verify_heap(heapified, last, expected);
   }
 
   { // (range) overload.
@@ -95,7 +87,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::pop_heap(range);
-    verify_heap_iterator(heapified, last, expected);
+    verify_heap(heapified, last, expected);
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/push.heap/ranges_push_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/push.heap/ranges_push_heap.pass.cpp
@@ -61,6 +61,13 @@ static_assert(!HasPushHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `so
 template <std::size_t N, class T, class Iter>
 constexpr void verify_heap(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
   assert(heapified == expected);
+  assert(last == heapified.end());
+  assert(std::is_heap(heapified.begin(), heapified.end()));
+}
+
+template <std::size_t N, class T, class Iter>
+constexpr void verify_heap_iterator(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
+  assert(heapified == expected);
   assert(base(last) == heapified.data() + heapified.size());
   assert(std::is_heap(heapified.begin(), heapified.end()));
 }
@@ -77,7 +84,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(heapified.data() + heapified.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::push_heap(b, e);
-    verify_heap(heapified, last, expected);
+    verify_heap_iterator(heapified, last, expected);
   }
 
   { // (range) overload.
@@ -87,7 +94,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::push_heap(range);
-    verify_heap(heapified, last, expected);
+    verify_heap_iterator(heapified, last, expected);
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/push.heap/ranges_push_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/push.heap/ranges_push_heap.pass.cpp
@@ -61,14 +61,7 @@ static_assert(!HasPushHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `so
 template <std::size_t N, class T, class Iter>
 constexpr void verify_heap(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
   assert(heapified == expected);
-  assert(last == heapified.end());
-  assert(std::is_heap(heapified.begin(), heapified.end()));
-}
-
-template <std::size_t N, class T, class Iter>
-constexpr void verify_heap_iterator(const std::array<T, N>& heapified, Iter last, std::array<T, N> expected) {
-  assert(heapified == expected);
-  assert(base(last) == heapified.data() + heapified.size());
+  assert(std::to_address(base(last)) == heapified.data() + heapified.size());
   assert(std::is_heap(heapified.begin(), heapified.end()));
 }
 
@@ -84,7 +77,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(heapified.data() + heapified.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::push_heap(b, e);
-    verify_heap_iterator(heapified, last, expected);
+    verify_heap(heapified, last, expected);
   }
 
   { // (range) overload.
@@ -94,7 +87,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::push_heap(range);
-    verify_heap_iterator(heapified, last, expected);
+    verify_heap(heapified, last, expected);
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp
@@ -62,6 +62,13 @@ static_assert(!HasSortHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `so
 template <std::size_t N, class T, class Iter>
 constexpr void verify_sorted(const std::array<T, N>& sorted, Iter last, std::array<T, N> expected) {
   assert(sorted == expected);
+  assert(last == sorted.end());
+  assert(std::is_sorted(sorted.begin(), sorted.end()));
+}
+
+template <std::size_t N, class T, class Iter>
+constexpr void verify_sorted_iterator(const std::array<T, N>& sorted, Iter last, std::array<T, N> expected) {
+  assert(sorted == expected);
   assert(base(last) == sorted.data() + sorted.size());
   assert(std::is_sorted(sorted.begin(), sorted.end()));
 }
@@ -76,7 +83,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(sorted.data() + sorted.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::sort_heap(b, e);
-    verify_sorted(sorted, last, expected);
+    verify_sorted_iterator(sorted, last, expected);
   }
 
   { // (range) overload.
@@ -86,7 +93,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::sort_heap(range);
-    verify_sorted(sorted, last, expected);
+    verify_sorted_iterator(sorted, last, expected);
   }
 }
 
@@ -131,14 +138,14 @@ constexpr bool test() {
       auto in = input;
       auto last = std::ranges::sort_heap(in.begin(), in.end(), comp);
       assert(in == expected);
-      assert(last == in.data() + in.size());
+      assert(last == in.end());
     }
 
     {
       auto in = input;
       auto last = std::ranges::sort_heap(in, comp);
       assert(in == expected);
-      assert(last == in.data() + in.size());
+      assert(last == in.end());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp
@@ -62,14 +62,7 @@ static_assert(!HasSortHeapR<UncheckedRange<const int*>>); // Doesn't satisfy `so
 template <std::size_t N, class T, class Iter>
 constexpr void verify_sorted(const std::array<T, N>& sorted, Iter last, std::array<T, N> expected) {
   assert(sorted == expected);
-  assert(last == sorted.end());
-  assert(std::is_sorted(sorted.begin(), sorted.end()));
-}
-
-template <std::size_t N, class T, class Iter>
-constexpr void verify_sorted_iterator(const std::array<T, N>& sorted, Iter last, std::array<T, N> expected) {
-  assert(sorted == expected);
-  assert(base(last) == sorted.data() + sorted.size());
+  assert(std::to_address(base(last)) == sorted.data() + sorted.size());
   assert(std::is_sorted(sorted.begin(), sorted.end()));
 }
 
@@ -83,7 +76,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto e = Sent(Iter(sorted.data() + sorted.size()));
 
     std::same_as<Iter> decltype(auto) last = std::ranges::sort_heap(b, e);
-    verify_sorted_iterator(sorted, last, expected);
+    verify_sorted(sorted, last, expected);
   }
 
   { // (range) overload.
@@ -93,7 +86,7 @@ constexpr void test_one(const std::array<int, N> input, std::array<int, N> expec
     auto range = std::ranges::subrange(b, e);
 
     std::same_as<Iter> decltype(auto) last = std::ranges::sort_heap(range);
-    verify_sorted_iterator(sorted, last, expected);
+    verify_sorted(sorted, last, expected);
   }
 }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.merge/ranges_merge.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.merge/ranges_merge.pass.cpp
@@ -264,7 +264,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 6>{1, 3, 3, 5, 8, 8}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -277,7 +277,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 6>{1, 3, 3, 5, 8, 8}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -369,7 +369,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -382,7 +382,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Comparator iterator overload
@@ -395,7 +395,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Comparator range overload
@@ -408,7 +408,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 
@@ -431,7 +431,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -444,7 +444,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Projection iterator overload
@@ -457,7 +457,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Projection range overload
@@ -470,7 +470,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.nth.element/ranges_nth_element.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.nth.element/ranges_nth_element.pass.cpp
@@ -68,7 +68,7 @@ template <std::size_t N, class T, class Iter>
 constexpr void verify_nth(const std::array<T, N>& partially_sorted, std::size_t nth_index, Iter last, T expected_nth) {
   // Note that the exact output of `nth_element` is unspecified and may vary between implementations.
 
-  assert(base(last) == partially_sorted.end());
+  assert(base(last) == partially_sorted.data() + partially_sorted.size());
 
   auto b = partially_sorted.begin();
   auto nth = b + nth_index;

--- a/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.difference/ranges_set_difference.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.difference/ranges_set_difference.pass.cpp
@@ -271,7 +271,7 @@ constexpr bool test() {
       auto result = std::ranges::set_difference(r1.begin(), r1.end(), r2.begin(), r2.end(), out.data());
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 3>{5, 15, 16}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -283,7 +283,7 @@ constexpr bool test() {
       auto result = std::ranges::set_difference(r1, r2, out.data());
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 3>{5, 15, 16}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -347,7 +347,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{4, 12}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -359,7 +359,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{4, 12}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Comparator iterator overload
@@ -371,7 +371,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{4, 12}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Comparator range overload
@@ -383,7 +383,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{4, 12}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 
@@ -404,7 +404,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{1, 5}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -416,7 +416,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{1, 5}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Projection iterator overload
@@ -428,7 +428,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{1, 5}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Projection range overload
@@ -440,7 +440,7 @@ constexpr bool test() {
       assert(std::ranges::equal(out, std::array{1, 5}, {}, &Data::data));
 
       assert(result.in == r1.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.intersection/ranges_set_intersection.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.intersection/ranges_set_intersection.pass.cpp
@@ -285,7 +285,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 2>{3, 8}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -298,7 +298,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 2>{3, 8}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -362,7 +362,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -376,7 +376,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Comparator iterator overload
@@ -389,7 +389,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Comparator range overload
@@ -401,7 +401,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 
@@ -422,7 +422,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -434,7 +434,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Projection iterator overload
@@ -447,7 +447,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // member pointer Projection range overload
@@ -459,7 +459,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/ranges_set_symmetric_difference.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.symmetric.difference/ranges_set_symmetric_difference.pass.cpp
@@ -291,7 +291,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 4>{1, 5, 15, 16}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -304,7 +304,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 4>{1, 5, 15, 16}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -368,7 +368,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -382,7 +382,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 
@@ -403,7 +403,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -415,7 +415,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.union/ranges_set_union.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.set.operations/set.union/ranges_set_union.pass.cpp
@@ -291,7 +291,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 6>{1, 3, 5, 8, 15, 16}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -304,7 +304,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
       assert(std::ranges::equal(out, std::array<TracedCopy, 6>{1, 3, 5, 8, 15, 16}));
 
       assert(std::ranges::all_of(out, &TracedCopy::copiedOnce));
@@ -368,7 +368,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -382,7 +382,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 
@@ -403,7 +403,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
 
     // range overload
@@ -415,7 +415,7 @@ constexpr bool test() {
 
       assert(result.in1 == r1.end());
       assert(result.in2 == r2.end());
-      assert(result.out == out.end());
+      assert(result.out == out.data() + out.size());
     }
   }
 

--- a/libcxx/test/std/algorithms/ranges_robust_against_dangling.pass.cpp
+++ b/libcxx/test/std/algorithms/ranges_robust_against_dangling.pass.cpp
@@ -94,6 +94,8 @@ constexpr bool test_all() {
   using std::ranges::swap_ranges_result;
   using std::ranges::unary_transform_result;
   using std::ranges::unique_copy_result;
+  using InIter = std::array<int, 3>::iterator;
+  using OutIter = std::array<int, 6>::iterator;
 
   auto unary_pred = [](int i) { return i > 0; };
   auto binary_pred = [](int i, int j) { return i < j; };
@@ -102,7 +104,7 @@ constexpr bool test_all() {
   std::array in = {1, 2, 3};
   std::array in2 = {4, 5, 6};
 
-  auto mid = in.begin() + 1;
+  auto mid = in.data() + 1;
 
   std::array output = {7, 8, 9, 10, 11, 12};
   auto out = output.begin();
@@ -116,8 +118,8 @@ constexpr bool test_all() {
   dangling_1st(std::ranges::find_if_not, in, unary_pred);
   dangling_1st(std::ranges::find_first_of, in, in2);
   dangling_1st(std::ranges::adjacent_find, in);
-  dangling_1st<mismatch_result<dangling, int*>>(std::ranges::mismatch, in, in2);
-  dangling_2nd<mismatch_result<int*, dangling>>(std::ranges::mismatch, in, in2);
+  dangling_1st<mismatch_result<dangling, InIter>>(std::ranges::mismatch, in, in2);
+  dangling_2nd<mismatch_result<InIter, dangling>>(std::ranges::mismatch, in, in2);
   dangling_both<mismatch_result<dangling, dangling>>(std::ranges::mismatch, in, in2);
   dangling_1st(std::ranges::partition_point, in, unary_pred);
   dangling_1st(std::ranges::lower_bound, in, x);
@@ -132,55 +134,56 @@ constexpr bool test_all() {
   dangling_1st(std::ranges::is_sorted_until, in);
   dangling_1st(std::ranges::is_heap_until, in);
   dangling_1st<for_each_result<dangling, decltype(unary_pred)>>(std::ranges::for_each, in, unary_pred);
-  dangling_1st<copy_result<dangling, int*>>(std::ranges::copy, in, out);
-  dangling_1st<copy_backward_result<dangling, int*>>(std::ranges::copy_backward, in, output.end());
-  dangling_1st<copy_if_result<dangling, int*>>(std::ranges::copy_if, in, out, unary_pred);
-  dangling_1st<move_result<dangling, int*>>(std::ranges::move, in, out);
-  dangling_1st<move_backward_result<dangling, int*>>(std::ranges::move_backward, in, output.end());
+  dangling_1st<copy_result<dangling, OutIter>>(std::ranges::copy, in, out);
+  dangling_1st<copy_backward_result<dangling, OutIter>>(std::ranges::copy_backward, in, output.end());
+  dangling_1st<copy_if_result<dangling, OutIter>>(std::ranges::copy_if, in, out, unary_pred);
+  dangling_1st<move_result<dangling, OutIter>>(std::ranges::move, in, out);
+  dangling_1st<move_backward_result<dangling, OutIter>>(std::ranges::move_backward, in, output.end());
   dangling_1st(std::ranges::fill, in, x);
   { // transform
+    using OutTransformIter = std::array<bool, 3>::iterator;
     std::array out_transform = {false, true, true};
-    dangling_1st<unary_transform_result<dangling, bool*>>(std::ranges::transform, in, out_transform.begin(), unary_pred);
-    dangling_1st<binary_transform_result<dangling, int*, bool*>>(
+    dangling_1st<unary_transform_result<dangling, OutTransformIter>>(std::ranges::transform, in, out_transform.begin(), unary_pred);
+    dangling_1st<binary_transform_result<dangling, InIter, OutTransformIter>>(
         std::ranges::transform, in, in2, out_transform.begin(), binary_pred);
-    dangling_2nd<binary_transform_result<int*, dangling, bool*>>(
+    dangling_2nd<binary_transform_result<InIter, dangling, OutTransformIter>>(
         std::ranges::transform, in, in2, out_transform.begin(), binary_pred);
-    dangling_both<binary_transform_result<dangling, dangling, bool*>>(
+    dangling_both<binary_transform_result<dangling, dangling, OutTransformIter>>(
         std::ranges::transform, in, in2, out_transform.begin(), binary_pred);
   }
   dangling_1st(std::ranges::generate, in, gen);
-  dangling_1st<remove_copy_result<dangling, int*>>(std::ranges::remove_copy, in, out, x);
-  dangling_1st<remove_copy_if_result<dangling, int*>>(std::ranges::remove_copy_if, in, out, unary_pred);
+  dangling_1st<remove_copy_result<dangling, OutIter>>(std::ranges::remove_copy, in, out, x);
+  dangling_1st<remove_copy_if_result<dangling, OutIter>>(std::ranges::remove_copy_if, in, out, unary_pred);
   dangling_1st(std::ranges::replace, in, x, x);
   dangling_1st(std::ranges::replace_if, in, std::identity{}, x);
-  dangling_1st<replace_copy_result<dangling, int*>>(std::ranges::replace_copy, in, out, x, x);
-  dangling_1st<replace_copy_if_result<dangling, int*>>(std::ranges::replace_copy_if, in, out, unary_pred, x);
-  dangling_1st<swap_ranges_result<dangling, int*>>(std::ranges::swap_ranges, in, in2);
-  dangling_2nd<swap_ranges_result<int*, dangling>>(std::ranges::swap_ranges, in, in2);
+  dangling_1st<replace_copy_result<dangling, OutIter>>(std::ranges::replace_copy, in, out, x, x);
+  dangling_1st<replace_copy_if_result<dangling, OutIter>>(std::ranges::replace_copy_if, in, out, unary_pred, x);
+  dangling_1st<swap_ranges_result<dangling, InIter>>(std::ranges::swap_ranges, in, in2);
+  dangling_2nd<swap_ranges_result<InIter, dangling>>(std::ranges::swap_ranges, in, in2);
   dangling_both<swap_ranges_result<dangling, dangling>>(std::ranges::swap_ranges, in, in2);
-  dangling_1st<reverse_copy_result<dangling, int*>>(std::ranges::reverse_copy, in, out);
-  dangling_1st<rotate_copy_result<dangling, int*>>(std::ranges::rotate_copy, in, mid, out);
-  dangling_1st<unique_copy_result<dangling, int*>>(std::ranges::unique_copy, in, out);
-  dangling_1st<partition_copy_result<dangling, int*, int*>>(std::ranges::partition_copy, in, out, out2, unary_pred);
-  dangling_1st<partial_sort_copy_result<dangling, int*>>(std::ranges::partial_sort_copy, in, in2);
-  dangling_2nd<partial_sort_copy_result<int*, dangling>>(std::ranges::partial_sort_copy, in, in2);
+  dangling_1st<reverse_copy_result<dangling, OutIter>>(std::ranges::reverse_copy, in, out);
+  dangling_1st<rotate_copy_result<dangling, OutIter>>(std::ranges::rotate_copy, in, mid, out);
+  dangling_1st<unique_copy_result<dangling, OutIter>>(std::ranges::unique_copy, in, out);
+  dangling_1st<partition_copy_result<dangling, OutIter, OutIter>>(std::ranges::partition_copy, in, out, out2, unary_pred);
+  dangling_1st<partial_sort_copy_result<dangling, InIter>>(std::ranges::partial_sort_copy, in, in2);
+  dangling_2nd<partial_sort_copy_result<InIter, dangling>>(std::ranges::partial_sort_copy, in, in2);
   dangling_both<partial_sort_copy_result<dangling, dangling>>(std::ranges::partial_sort_copy, in, in2);
-  dangling_1st<merge_result<dangling, int*, int*>>(std::ranges::merge, in, in2, out);
-  dangling_2nd<merge_result<int*, dangling, int*>>(std::ranges::merge, in, in2, out);
-  dangling_both<merge_result<dangling, dangling, int*>>(std::ranges::merge, in, in2, out);
-  dangling_1st<set_difference_result<dangling, int*>>(std::ranges::set_difference, in, in2, out);
-  dangling_1st<set_intersection_result<dangling, int*, int*>>(std::ranges::set_intersection, in, in2, out);
-  dangling_2nd<set_intersection_result<int*, dangling, int*>>(std::ranges::set_intersection, in, in2, out);
-  dangling_both<set_intersection_result<dangling, dangling, int*>>(std::ranges::set_intersection, in, in2, out);
-  dangling_1st<set_symmetric_difference_result<dangling, int*, int*>>(
+  dangling_1st<merge_result<dangling, InIter, OutIter>>(std::ranges::merge, in, in2, out);
+  dangling_2nd<merge_result<InIter, dangling, OutIter>>(std::ranges::merge, in, in2, out);
+  dangling_both<merge_result<dangling, dangling, OutIter>>(std::ranges::merge, in, in2, out);
+  dangling_1st<set_difference_result<dangling, OutIter>>(std::ranges::set_difference, in, in2, out);
+  dangling_1st<set_intersection_result<dangling, InIter, OutIter>>(std::ranges::set_intersection, in, in2, out);
+  dangling_2nd<set_intersection_result<InIter, dangling, OutIter>>(std::ranges::set_intersection, in, in2, out);
+  dangling_both<set_intersection_result<dangling, dangling, OutIter>>(std::ranges::set_intersection, in, in2, out);
+  dangling_1st<set_symmetric_difference_result<dangling, InIter, OutIter>>(
       std::ranges::set_symmetric_difference, in, in2, out);
-  dangling_2nd<set_symmetric_difference_result<int*, dangling, int*>>(
+  dangling_2nd<set_symmetric_difference_result<InIter, dangling, OutIter>>(
       std::ranges::set_symmetric_difference, in, in2, out);
-  dangling_both<set_symmetric_difference_result<dangling, dangling, int*>>(
+  dangling_both<set_symmetric_difference_result<dangling, dangling, OutIter>>(
       std::ranges::set_symmetric_difference, in, in2, out);
-  dangling_1st<set_union_result<dangling, int*, int*>>(std::ranges::set_union, in, in2, out);
-  dangling_2nd<set_union_result<int*, dangling, int*>>(std::ranges::set_union, in, in2, out);
-  dangling_both<set_union_result<dangling, dangling, int*>>(std::ranges::set_union, in, in2, out);
+  dangling_1st<set_union_result<dangling, InIter, OutIter>>(std::ranges::set_union, in, in2, out);
+  dangling_2nd<set_union_result<InIter, dangling, OutIter>>(std::ranges::set_union, in, in2, out);
+  dangling_both<set_union_result<dangling, dangling, OutIter>>(std::ranges::set_union, in, in2, out);
   dangling_1st(std::ranges::remove, in, x);
   dangling_1st(std::ranges::remove_if, in, unary_pred);
   dangling_1st(std::ranges::reverse, in);

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp
@@ -86,10 +86,10 @@ constexpr void test() {
   };
 
   for (std::ptrdiff_t n = 0; n != 5; ++n) {
-    FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
-    FilterIterator const iter(view, Iterator(array.begin() + n));
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
+    FilterIterator const iter(view, Iterator(array.data() + n));
     std::same_as<Iterator> decltype(auto) result = iter.operator->();
-    assert(base(result) == array.begin() + n);
+    assert(base(result) == array.data() + n);
     assert(iter->x == n);
     assert(iter->y == n);
   }

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/base.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/base.pass.cpp
@@ -33,23 +33,23 @@ constexpr void test() {
   };
 
   std::array<int, 5> array{0, 1, 2, 3, 4};
-  FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
+  FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
 
   // Test the const& version
   {
-    FilterIterator const iter(view, Iterator(array.begin()));
+    FilterIterator const iter(view, Iterator(array.data()));
     Iterator const& result = iter.base();
     ASSERT_SAME_TYPE(Iterator const&, decltype(iter.base()));
     ASSERT_NOEXCEPT(iter.base());
-    assert(base(result) == array.begin());
+    assert(base(result) == array.data());
   }
 
   // Test the && version
   {
-    FilterIterator iter(view, Iterator(array.begin()));
+    FilterIterator iter(view, Iterator(array.data()));
     Iterator result = std::move(iter).base();
     ASSERT_SAME_TYPE(Iterator, decltype(std::move(iter).base()));
-    assert(base(result) == array.begin());
+    assert(base(result) == array.data());
   }
 }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp
@@ -38,7 +38,7 @@ constexpr void test() {
 
   {
     std::array<int, 5> array{0, 1, 2, 3, 4};
-    FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
     FilterIterator it1 = view.begin();
     FilterIterator it2 = view.begin();
     std::same_as<bool> decltype(auto) result = (it1 == it2);
@@ -50,7 +50,7 @@ constexpr void test() {
 
   {
     std::array<int, 5> array{0, 1, 2, 3, 4};
-    FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
     assert(!(view.begin() == view.end()));
   }
 }

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/ctor.parent_iter.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/ctor.parent_iter.pass.cpp
@@ -25,12 +25,12 @@ constexpr void test() {
   using FilterIterator = std::ranges::iterator_t<FilterView>;
 
   std::array<int, 10> array{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  View view(Iterator(array.begin()), Sentinel(Iterator(array.end())));
+  View view(Iterator(array.data()), Sentinel(Iterator(array.data() + array.size())));
   Iterator iter = view.begin();
 
   FilterView filter_view(std::move(view), AlwaysTrue{});
   FilterIterator filter_iter(filter_view, std::move(iter));
-  assert(base(filter_iter.base()) == array.begin());
+  assert(base(filter_iter.base()) == array.data());
 }
 
 constexpr bool tests() {

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/decrement.pass.cpp
@@ -52,61 +52,61 @@ constexpr void test() {
   // Test with a single satisfied value
   {
     std::array<int, 5> array{0, 1, 2, 3, 4};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
     FilterIterator it = std::ranges::next(view.begin(), view.end());
-    assert(base(it.base()) == array.end()); // test the test
+    assert(base(it.base()) == array.data() + array.size()); // test the test
 
     FilterIterator& result = --it;
     ASSERT_SAME_TYPE(FilterIterator&, decltype(--it));
     assert(&result == &it);
-    assert(base(result.base()) == array.begin() + 1);
+    assert(base(result.base()) == array.data() + 1);
   }
 
   // Test with more than one satisfied value
   {
     std::array<int, 6> array{0, 1, 2, 3, 1, 4};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
     FilterIterator it = std::ranges::next(view.begin(), view.end());
-    assert(base(it.base()) == array.end()); // test the test
+    assert(base(it.base()) == array.data() + array.size()); // test the test
 
     FilterIterator& result = --it;
     assert(&result == &it);
-    assert(base(result.base()) == array.begin() + 4);
+    assert(base(result.base()) == array.data() + 4);
 
     --it;
-    assert(base(it.base()) == array.begin() + 1);
+    assert(base(it.base()) == array.data() + 1);
   }
 
   // Test going forward and then backward on the same iterator
   {
     std::array<int, 10> array{0, 1, 2, 3, 1, 1, 4, 5, 1, 6};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
     FilterIterator it = view.begin();
     ++it;
-    --it; assert(base(it.base()) == array.begin() + 1);
+    --it; assert(base(it.base()) == array.data() + 1);
     ++it; ++it;
-    --it; assert(base(it.base()) == array.begin() + 4);
+    --it; assert(base(it.base()) == array.data() + 4);
     ++it; ++it;
-    --it; assert(base(it.base()) == array.begin() + 5);
+    --it; assert(base(it.base()) == array.data() + 5);
     ++it; ++it;
-    --it; assert(base(it.base()) == array.begin() + 8);
+    --it; assert(base(it.base()) == array.data() + 8);
   }
 
   // Test post-decrement
   {
     std::array<int, 6> array{0, 1, 2, 3, 1, 4};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
     FilterIterator it = std::ranges::next(view.begin(), view.end());
-    assert(base(it.base()) == array.end()); // test the test
+    assert(base(it.base()) == array.data() + array.size()); // test the test
 
     FilterIterator result = it--;
     ASSERT_SAME_TYPE(FilterIterator, decltype(it--));
-    assert(base(result.base()) == array.end());
-    assert(base(it.base()) == array.begin() + 4);
+    assert(base(result.base()) == array.data() + array.size());
+    assert(base(it.base()) == array.data() + 4);
 
     result = it--;
-    assert(base(result.base()) == array.begin() + 4);
-    assert(base(it.base()) == array.begin() + 1);
+    assert(base(result.base()) == array.data() + 4);
+    assert(base(it.base()) == array.data() + 1);
   }
 }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/deref.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/deref.pass.cpp
@@ -33,13 +33,13 @@ constexpr void test() {
   };
 
   std::array array{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
+  FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
 
   for (std::size_t n = 0; n != array.size(); ++n) {
-    FilterIterator const iter(view, Iterator(array.begin() + n));
+    FilterIterator const iter(view, Iterator(array.data() + n));
     ValueType& result = *iter;
     ASSERT_SAME_TYPE(ValueType&, decltype(*iter));
-    assert(&result == array.begin() + n);
+    assert(&result == array.data() + n);
   }
 }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/increment.pass.cpp
@@ -48,58 +48,58 @@ constexpr void test() {
   // Increment an iterator when it won't find another satisfied value after begin()
   {
     std::array<int, 5> array{0, 1, 2, 3, 4};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
 
     FilterIterator it = view.begin();
     FilterIterator& result = ++it;
     ASSERT_SAME_TYPE(FilterIterator&, decltype(++it));
     assert(&result == &it);
-    assert(base(result.base()) == array.end());
+    assert(base(result.base()) == array.data() + array.size());
   }
 
   // Increment the iterator and it finds another value after begin()
   {
     std::array<int, 5> array{99, 1, 99, 1, 99};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
 
     FilterIterator it = view.begin();
     ++it;
-    assert(base(it.base()) == array.begin() + 3);
+    assert(base(it.base()) == array.data() + 3);
   }
 
   // Increment advances all the way to the end of the range
   {
     std::array<int, 5> array{99, 1, 99, 99, 1};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
 
     FilterIterator it = view.begin();
     ++it;
-    assert(base(it.base()) == array.begin() + 4);
+    assert(base(it.base()) == array.data() + 4);
   }
 
   // Increment an iterator multiple times
   {
     std::array<int, 10> array{0, 1, 2, 3, 1, 1, 4, 5, 1, 6};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
 
     FilterIterator it = view.begin();
-          assert(base(it.base()) == array.begin() + 1);
-    ++it; assert(base(it.base()) == array.begin() + 4);
-    ++it; assert(base(it.base()) == array.begin() + 5);
-    ++it; assert(base(it.base()) == array.begin() + 8);
-    ++it; assert(base(it.base()) == array.end());
+          assert(base(it.base()) == array.data() + 1);
+    ++it; assert(base(it.base()) == array.data() + 4);
+    ++it; assert(base(it.base()) == array.data() + 5);
+    ++it; assert(base(it.base()) == array.data() + 8);
+    ++it; assert(base(it.base()) == array.data() + array.size());
   }
 
   // Test with a predicate that takes by non-const reference
   if constexpr (!IsConst) {
     std::array<int, 4> array{99, 1, 99, 1};
-    View v{Iterator(array.begin()), Sentinel(Iterator(array.end()))};
+    View v{Iterator(array.data()), Sentinel(Iterator(array.data() + array.size()))};
     auto pred = [](int& x) { return x == 1; };
     auto view = std::ranges::filter_view(std::move(v), pred);
     auto it = view.begin();
-    assert(base(it.base()) == array.begin() + 1);
+    assert(base(it.base()) == array.data() + 1);
     ++it;
-    assert(base(it.base()) == array.begin() + 3);
+    assert(base(it.base()) == array.data() + 3);
   }
 
   // Make sure we do not make a copy of the predicate when we increment
@@ -107,7 +107,7 @@ constexpr void test() {
   {
     bool moved = false, copied = false;
     std::array<int, 3> array{1, 1, 1};
-    View v{Iterator(array.begin()), Sentinel(Iterator(array.end()))};
+    View v{Iterator(array.data()), Sentinel(Iterator(array.data() + array.size()))};
     auto view = std::ranges::filter_view(std::move(v), TrackingPred(&moved, &copied));
     moved = false;
     copied = false;
@@ -121,39 +121,39 @@ constexpr void test() {
   // Check post-increment for input ranges
   if constexpr (!IsForwardRange) {
     std::array<int, 10> array{0, 1, 2, 3, 1, 1, 4, 5, 1, 6};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
 
     FilterIterator it = view.begin();
-          assert(base(it.base()) == array.begin() + 1);
-    it++; assert(base(it.base()) == array.begin() + 4);
-    it++; assert(base(it.base()) == array.begin() + 5);
-    it++; assert(base(it.base()) == array.begin() + 8);
-    it++; assert(base(it.base()) == array.end());
+          assert(base(it.base()) == array.data() + 1);
+    it++; assert(base(it.base()) == array.data() + 4);
+    it++; assert(base(it.base()) == array.data() + 5);
+    it++; assert(base(it.base()) == array.data() + 8);
+    it++; assert(base(it.base()) == array.data() + array.size());
     static_assert(std::is_same_v<decltype(it++), void>);
   }
 
   // Check post-increment for forward ranges
   if constexpr (IsForwardRange) {
     std::array<int, 10> array{0, 1, 2, 3, 1, 1, 4, 5, 1, 6};
-    FilterView view = make_filter_view(array.begin(), array.end(), EqualTo{1});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), EqualTo{1});
 
     FilterIterator it = view.begin();
     FilterIterator result = it++;
     ASSERT_SAME_TYPE(FilterIterator, decltype(it++));
-    assert(base(result.base()) == array.begin() + 1);
-    assert(base(it.base()) == array.begin() + 4);
+    assert(base(result.base()) == array.data() + 1);
+    assert(base(it.base()) == array.data() + 4);
 
     result = it++;
-    assert(base(result.base()) == array.begin() + 4);
-    assert(base(it.base()) == array.begin() + 5);
+    assert(base(result.base()) == array.data() + 4);
+    assert(base(it.base()) == array.data() + 5);
 
     result = it++;
-    assert(base(result.base()) == array.begin() + 5);
-    assert(base(it.base()) == array.begin() + 8);
+    assert(base(result.base()) == array.data() + 5);
+    assert(base(it.base()) == array.data() + 8);
 
     result = it++;
-    assert(base(result.base()) == array.begin() + 8);
-    assert(base(it.base()) == array.end());
+    assert(base(result.base()) == array.data() + 8);
+    assert(base(it.base()) == array.data() + array.size());
   }
 }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/iter_move.pass.cpp
@@ -34,12 +34,12 @@ constexpr void test() {
 
   {
     std::array<int, 5> array{0, 1, 2, 3, 4};
-    FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
     FilterIterator const it = view.begin();
 
     int&& result = iter_move(it);
     static_assert(noexcept(iter_move(it)) == HasNoexceptIterMove);
-    assert(&result == array.begin());
+    assert(&result == array.data());
   }
 }
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/iterator/iter_swap.pass.cpp
@@ -45,7 +45,7 @@ constexpr void test() {
 
   {
     std::array<int, 5> array{1, 2, 1, 4, 1};
-    FilterView view = make_filter_view(array.begin(), array.end(), IsEven{});
+    FilterView view = make_filter_view(array.data(), array.data() + array.size(), IsEven{});
     FilterIterator const it1 = view.begin();
     FilterIterator const it2 = std::ranges::next(view.begin());
 

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/base.pass.cpp
@@ -31,11 +31,11 @@ constexpr void test() {
   };
 
   std::array<int, 5> array{0, 1, 2, 3, 4};
-  FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
+  FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
 
   FilterSentinel const sent = view.end();
   std::same_as<Sentinel> decltype(auto) result = sent.base();
-  assert(base(base(result)) == array.end());
+  assert(base(base(result)) == array.data() + array.size());
 }
 
 constexpr bool tests() {

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/compare.pass.cpp
@@ -26,7 +26,7 @@ constexpr void test() {
   std::array<int, 5> array{0, 1, 2, 3, 4};
 
   {
-    View v(Iterator(array.begin()), Sentinel(Iterator(array.end())));
+    View v(Iterator(array.data()), Sentinel(Iterator(array.data() + array.size())));
     std::ranges::filter_view view(std::move(v), AlwaysTrue{});
     auto const it = view.begin();
     auto const sent = view.end();
@@ -34,7 +34,7 @@ constexpr void test() {
     assert(!result);
   }
   {
-    View v(Iterator(array.begin()), Sentinel(Iterator(array.end())));
+    View v(Iterator(array.data()), Sentinel(Iterator(array.data() + array.size())));
     std::ranges::filter_view view(std::move(v), [](auto) { return false; });
     auto const it = view.begin();
     auto const sent = view.end();

--- a/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.filter/sentinel/ctor.parent.pass.cpp
@@ -31,7 +31,7 @@ constexpr void test() {
   };
 
   std::array<int, 5> array{0, 1, 2, 3, 4};
-  FilterView view = make_filter_view(array.begin(), array.end(), AlwaysTrue{});
+  FilterView view = make_filter_view(array.data(), array.data() + array.size(), AlwaysTrue{});
 
   FilterSentinel sent(view);
   assert(base(base(sent.base())) == base(base(view.end().base())));

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/types.h
@@ -67,10 +67,10 @@ struct ForwardDiffView : std::ranges::view_base {
   constexpr ForwardDiffView& operator=(ForwardDiffView&&) = default;
   constexpr ForwardDiffView(const ForwardDiffView&) = default;
   constexpr ForwardDiffView& operator=(const ForwardDiffView&) = default;
-  constexpr forward_iterator<char*> begin() { return forward_iterator<char*>(buffer_.begin().base()); }
-  constexpr forward_iterator<char*> end()  { return forward_iterator<char*>(buffer_.end().base()); }
-  constexpr forward_iterator<const char*> begin() const { return forward_iterator<const char*>(buffer_.begin().base()); }
-  constexpr forward_iterator<const char*> end() const { return forward_iterator<const char*>(buffer_.end().base()); }
+  constexpr forward_iterator<char*> begin() { return forward_iterator<char*>(buffer_.data()); }
+  constexpr forward_iterator<char*> end()  { return forward_iterator<char*>(buffer_.data() + buffer_.size()); }
+  constexpr forward_iterator<const char*> begin() const { return forward_iterator<const char*>(buffer_.data()); }
+  constexpr forward_iterator<const char*> end() const { return forward_iterator<const char*>(buffer_.data() + buffer_.size()); }
 };
 static_assert( std::ranges::forward_range<ForwardView>);
 static_assert( std::ranges::forward_range<const ForwardView>);
@@ -148,15 +148,15 @@ struct InputView : std::ranges::view_base {
     buffer_ = v;
   }
 
-  constexpr cpp20_input_iterator<char*> begin() { return cpp20_input_iterator<char*>(buffer_.begin().base()); }
+  constexpr cpp20_input_iterator<char*> begin() { return cpp20_input_iterator<char*>(buffer_.data()); }
   constexpr sentinel_wrapper<cpp20_input_iterator<char*>> end() {
-    return sentinel_wrapper(cpp20_input_iterator<char*>(buffer_.end().base()));
+    return sentinel_wrapper(cpp20_input_iterator<char*>(buffer_.data() + buffer_.size()));
   }
   constexpr cpp20_input_iterator<const char*> begin() const {
-    return cpp20_input_iterator<const char*>(buffer_.begin().base());
+    return cpp20_input_iterator<const char*>(buffer_.data());
   }
   constexpr sentinel_wrapper<cpp20_input_iterator<const char*>> end() const {
-    return sentinel_wrapper(cpp20_input_iterator<const char*>(buffer_.end().base()));
+    return sentinel_wrapper(cpp20_input_iterator<const char*>(buffer_.data() + buffer_.size()));
   }
   friend constexpr bool operator==(const InputView& lhs, const InputView& rhs) {
     return lhs.buffer_ == rhs.buffer_;


### PR DESCRIPTION
This is to modify a list of libcxx tests written under the assumption that iterators for std::array, std::string_view, and std::string are pointers. The motivation for this PR is to make the tests more universal and potentially being used to test other C++ standard library implementations, for example [microsoft/STL](https://github.com/microsoft/STL).

I can confirm that this patch makes a number of tests compatible with microsoft STL:
`Failed :  204 (2.12%)`  ->  `Failed :  136 (1.42%)`
, and does not break any tests on `libcxx`.

This is not a complete list of such incompatibilities, but I am hoping this will start a discussion about whether we are open to accepting such changes.
