### PR TITLE
[SCCP] Infer nneg on zext when forming from non-negative sext.

### DIFF
--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -171,6 +171,7 @@ static bool replaceSignedInst(SCCPSolver &Solver,
     if (InsertedValues.count(Op0) || !isNonNegative(Op0))
       return false;
     NewInst = new ZExtInst(Op0, Inst.getType(), "", &Inst);
+    NewInst->setNonNeg();
     break;
   }
   case Instruction::AShr: {

--- a/llvm/test/Transforms/SCCP/add-nuw-nsw-flags.ll
+++ b/llvm/test/Transforms/SCCP/add-nuw-nsw-flags.ll
@@ -124,7 +124,7 @@ define i16 @sge_with_sext_to_zext_conversion(i8 %a)  {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[A:%.*]], 0
 ; CHECK-NEXT:    br i1 [[CMP]], label [[THEN:%.*]], label [[ELSE:%.*]]
 ; CHECK:       then:
-; CHECK-NEXT:    [[SEXT:%.*]] = zext i8 [[A]] to i16
+; CHECK-NEXT:    [[SEXT:%.*]] = zext nneg i8 [[A]] to i16
 ; CHECK-NEXT:    [[ADD_1:%.*]] = add i16 [[SEXT]], 1
 ; CHECK-NEXT:    [[ADD_2:%.*]] = add i16 [[SEXT]], -128
 ; CHECK-NEXT:    [[ADD_3:%.*]] = add i16 [[SEXT]], -127
@@ -219,7 +219,7 @@ define i16 @test_add_in_different_block(i1 %c, i8 %a) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i8 [[A:%.*]], 0
 ; CHECK-NEXT:    [[COND4:%.*]] = select i1 [[CMP]], i8 1, i8 0
-; CHECK-NEXT:    [[CONV:%.*]] = zext i8 [[COND4]] to i16
+; CHECK-NEXT:    [[CONV:%.*]] = zext nneg i8 [[COND4]] to i16
 ; CHECK-NEXT:    br i1 [[C:%.*]], label [[THEN:%.*]], label [[ELSE:%.*]]
 ; CHECK:       then:
 ; CHECK-NEXT:    [[ADD:%.*]] = add i16 1, [[CONV]]

--- a/llvm/test/Transforms/SCCP/ip-ranges-casts.ll
+++ b/llvm/test/Transforms/SCCP/ip-ranges-casts.ll
@@ -112,7 +112,7 @@ define i1 @caller.zext() {
 ; x = [100, 301)
 define internal i1 @f.sext(i32 %x, i32 %y) {
 ; CHECK-LABEL: @f.sext(
-; CHECK-NEXT:    [[T_1:%.*]] = zext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[T_1:%.*]] = zext nneg i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C_2:%.*]] = icmp sgt i64 [[T_1]], 299
 ; CHECK-NEXT:    [[C_4:%.*]] = icmp slt i64 [[T_1]], 101
 ; CHECK-NEXT:    [[RES_1:%.*]] = add nuw nsw i1 false, [[C_2]]
@@ -318,7 +318,7 @@ entry:
 
 define internal i64 @f.sext_to_zext(i32 %t) {
 ; CHECK-LABEL: @f.sext_to_zext(
-; CHECK-NEXT:    [[A:%.*]] = zext i32 [[T:%.*]] to i64
+; CHECK-NEXT:    [[A:%.*]] = zext nneg i32 [[T:%.*]] to i64
 ; CHECK-NEXT:    ret i64 [[A]]
 ;
   %a = sext i32 %t to i64

--- a/llvm/test/Transforms/SCCP/ip-ranges-sext.ll
+++ b/llvm/test/Transforms/SCCP/ip-ranges-sext.ll
@@ -6,7 +6,7 @@ define i64 @test1(i32 %x) {
 ; CHECK-NEXT:    [[C:%.*]] = icmp sgt i32 [[X:%.*]], 0
 ; CHECK-NEXT:    br i1 [[C]], label [[TRUE:%.*]], label [[FALSE:%.*]]
 ; CHECK:       true:
-; CHECK-NEXT:    [[EXT_1:%.*]] = zext i32 [[X]] to i64
+; CHECK-NEXT:    [[EXT_1:%.*]] = zext nneg i32 [[X]] to i64
 ; CHECK-NEXT:    ret i64 [[EXT_1]]
 ; CHECK:       false:
 ; CHECK-NEXT:    [[EXT_2:%.*]] = sext i32 [[X]] to i64
@@ -29,7 +29,7 @@ define i64 @test2(i32 %x) {
 ; CHECK-NEXT:    [[C:%.*]] = icmp sge i32 [[X:%.*]], 0
 ; CHECK-NEXT:    br i1 [[C]], label [[TRUE:%.*]], label [[FALSE:%.*]]
 ; CHECK:       true:
-; CHECK-NEXT:    [[EXT_1:%.*]] = zext i32 [[X]] to i64
+; CHECK-NEXT:    [[EXT_1:%.*]] = zext nneg i32 [[X]] to i64
 ; CHECK-NEXT:    ret i64 [[EXT_1]]
 ; CHECK:       false:
 ; CHECK-NEXT:    [[EXT_2:%.*]] = sext i32 [[X]] to i64
@@ -105,7 +105,7 @@ exit:
 define i64 @test5(i32 %x) {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:    [[P:%.*]] = and i32 [[X:%.*]], 15
-; CHECK-NEXT:    [[EXT:%.*]] = zext i32 [[P]] to i64
+; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i32 [[P]] to i64
 ; CHECK-NEXT:    ret i64 [[EXT]]
 ;
   %p = and i32 %x, 15
@@ -126,7 +126,7 @@ define i64 @test6(i32 %x) {
 define i64 @test7(i16 %x) {
 ; CHECK-LABEL: @test7(
 ; CHECK-NEXT:    [[P:%.*]] = and i16 [[X:%.*]], 15
-; CHECK-NEXT:    [[EXT_1:%.*]] = zext i16 [[P]] to i32
+; CHECK-NEXT:    [[EXT_1:%.*]] = zext nneg i16 [[P]] to i32
 ; CHECK-NEXT:    [[EXT_2:%.*]] = sext i32 [[EXT_1]] to i64
 ; CHECK-NEXT:    ret i64 [[EXT_2]]
 ;

--- a/llvm/test/Transforms/SCCP/ranges-sext.ll
+++ b/llvm/test/Transforms/SCCP/ranges-sext.ll
@@ -68,8 +68,8 @@ exit:
 define i64 @test2(i32 %x) {
 ; CHECK-LABEL: @test2(
 ; CHECK-NEXT:    [[P:%.*]] = and i32 [[X:%.*]], 15
-; CHECK-NEXT:    [[TMP1:%.*]] = zext i32 [[P]] to i64
-; CHECK-NEXT:    ret i64 [[TMP1]]
+; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i32 [[P]] to i64
+; CHECK-NEXT:    ret i64 [[EXT]]
 ;
   %p = and i32 %x, 15
   %ext = sext i32 %p to i64
@@ -87,8 +87,8 @@ define i64 @test3(i1 %c.1, i1 %c.2) {
 ; CHECK-NEXT:    br label [[EXIT]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    [[P:%.*]] = phi i32 [ 0, [[TRUE_1]] ], [ 1, [[TRUE_2]] ], [ 3, [[FALSE]] ]
-; CHECK-NEXT:    [[TMP1:%.*]] = zext i32 [[P]] to i64
-; CHECK-NEXT:    ret i64 [[TMP1]]
+; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i32 [[P]] to i64
+; CHECK-NEXT:    ret i64 [[EXT]]
 ;
   br i1 %c.1, label %true.1, label %false
 

--- a/llvm/test/Transforms/SCCP/widening.ll
+++ b/llvm/test/Transforms/SCCP/widening.ll
@@ -450,7 +450,7 @@ define void @foo(ptr %arg) {
 ; SCCP-NEXT:    [[TMP7:%.*]] = sub nuw nsw i64 3, [[TMP6]]
 ; SCCP-NEXT:    [[TMP8:%.*]] = shl nuw nsw i64 [[TMP7]], 1
 ; SCCP-NEXT:    [[TMP9:%.*]] = trunc i64 [[TMP8]] to i32
-; SCCP-NEXT:    [[TMP10:%.*]] = zext i32 [[TMP9]] to i64
+; SCCP-NEXT:    [[TMP10:%.*]] = zext nneg i32 [[TMP9]] to i64
 ; SCCP-NEXT:    br label [[BB11:%.*]]
 ; SCCP:       bb11:
 ; SCCP-NEXT:    [[TMP12:%.*]] = phi i64 [ [[TMP10]], [[BB4]] ], [ [[TMP17:%.*]], [[BB18:%.*]] ]
@@ -487,7 +487,7 @@ define void @foo(ptr %arg) {
 ; IPSCCP-NEXT:    [[TMP7:%.*]] = sub nuw nsw i64 3, [[TMP6]]
 ; IPSCCP-NEXT:    [[TMP8:%.*]] = shl nuw nsw i64 [[TMP7]], 1
 ; IPSCCP-NEXT:    [[TMP9:%.*]] = trunc i64 [[TMP8]] to i32
-; IPSCCP-NEXT:    [[TMP10:%.*]] = zext i32 [[TMP9]] to i64
+; IPSCCP-NEXT:    [[TMP10:%.*]] = zext nneg i32 [[TMP9]] to i64
 ; IPSCCP-NEXT:    br label [[BB11:%.*]]
 ; IPSCCP:       bb11:
 ; IPSCCP-NEXT:    [[TMP12:%.*]] = phi i64 [ [[TMP10]], [[BB4]] ], [ [[TMP17:%.*]], [[BB18:%.*]] ]


### PR DESCRIPTION
Builds on #67982 which recently introduced the nneg flag on a zext
instruction.