### PR TITLE
[CUDA, NVPTX] accept/ignore any -mcmodel arguments.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5743,6 +5743,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else if (Triple.getArch() == llvm::Triple::x86_64) {
       Ok = llvm::is_contained({"small", "kernel", "medium", "large", "tiny"},
                               CM);
+    } else if (Triple.isNVPTX()) {
+      // NVPTX does not care about the code model and will accept whatever works
+      // for the host.
+      Ok = true;
     }
     if (Ok) {
       CmdArgs.push_back(Args.MakeArgString("-mcmodel=" + CM));


### PR DESCRIPTION
Code model has no impact on NVPTX as we do not produce any object files, but we need to avoid erroring out on the -mcmodel argument passed to the top-level compilation and propagated to all sub-compilations.