### PR TITLE
[docs] Remove Visual Studio 2017 references and bump VS 2019 to VS 2022

### DIFF
--- a/clang/www/get_started.html
+++ b/clang/www/get_started.html
@@ -125,7 +125,7 @@ Visual Studio:</p>
         project files.  Get it from:
         <a href="https://cmake.org/download/">
         https://cmake.org/download/</a></li>
-    <li><b>Visual Studio 2019 16.7 or later</b></li>
+    <li><b>Visual Studio 2019 16.7 or later</b>. This tutorial assumes Visual Studio 2022.</li>
     <li><b>Python</b>.  It is used to run the clang test suite. Get it from:
         <a href="https://www.python.org/download/">
         https://www.python.org/download/</a></li>
@@ -156,8 +156,8 @@ Visual Studio:</p>
     <li><tt>mkdir build</tt> (for building without polluting the source dir)</li>
     <li><tt>cd build</tt></li>
     <li>
-      If you are using Visual Studio 2019:
-      <tt>cmake -DLLVM_ENABLE_PROJECTS=clang -G "Visual Studio 16 2019" -A x64 -Thost=x64 ..\llvm</tt><br/>
+      If you are using Visual Studio 2022:
+      <tt>cmake -DLLVM_ENABLE_PROJECTS=clang -G "Visual Studio 17 2022" -A x64 -Thost=x64 ..\llvm</tt><br/>
       <tt>-Thost=x64</tt> is required, since the 32-bit linker will run out of memory.
     </li>
     <li>To generate x86 binaries instead of x64, pass <tt>-A Win32</tt>.</li>
@@ -195,12 +195,12 @@ second build directory next to it for running the tests with these steps:</p>
       <li>If you open the start menu and search for "Command Prompt", you should
         see shortcuts created by Visual Studio to do this. To use native x64
         tools, choose the one titled "x64 Native Tools Command Prompt for VS
-        2017".</li>
+        2022".</li>
       <li> Alternatively, launch a regular <tt>cmd</tt> prompt and run the
-        appropriate vcvarsall.bat incantation. To get the 2017 x64 tools, this
+        appropriate vcvarsall.bat incantation. To get the 2022 x64 tools, this
         would be:<br/>
-        <tt>"C:\Program Files (x86)\Microsoft Visual
-          Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64</tt>
+        <tt>"C:\Program Files\Microsoft Visual
+          Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64</tt>
       </li>
     </ul>
   </li>


### PR DESCRIPTION
The docs say that Visual Studio 2019 16.7 or later is required to build clang but reference VS 2017.

* Remove references to VS 2017
* Update instructions to use VS 2022, since that's the current version available for download from MS' website
  * The path to VS 2022 executables is `Program Files` instead of `Program Files (x86)`, as VS 2022 is 64-bit