### PR TITLE
[RISCV] Fix using undefined variable %pt2 in mask-reg-alloc.mir testcase

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv/mask-reg-alloc.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/mask-reg-alloc.mir
@@ -28,7 +28,7 @@ body:             |
     %3:vr = COPY $v3
     %4:vmv0 = COPY %0
     %pt1:vrnov0 = IMPLICIT_DEF
-    %5:vrnov0 = PseudoVMERGE_VIM_M1 %pt2, killed %2, 1, %4, 1, 3
+    %5:vrnov0 = PseudoVMERGE_VIM_M1 %pt1, killed %2, 1, %4, 1, 3
     %6:vmv0 = COPY %1
     %pt2:vrnov0 = IMPLICIT_DEF
     %7:vrnov0 = PseudoVMERGE_VIM_M1 %pt2, killed %3, 1, %6, 1, 3


### PR DESCRIPTION
First PseudoVMERGE_VIM_M1 should use %pt1 as its operand instead of %pt2.

I found this error when I add LiveIntervals analysis pass in my downstream. And it crashes with the message:

```
Use of %7 does not have a corresponding definition on every path:
112r %6:vrnov0 = PseudoVMERGE_VIM_M1 %pt2:vrnov0(tied-def 0), %2:vr, 1, %4:vmv0, 1, 3
LLVM ERROR: Use not jointly dominated by defs.
```