### PR TITLE
[compiler-rt] [test] Apply the MSVC scalbn test exceptions to MinGW too

### DIFF
--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbn_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbn_test.c
@@ -61,13 +61,13 @@ int main() {
   // should have the same rounding behavior as double-precision multiplication.
 #if (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) || \
     defined(__i386__) || defined(__x86_64__)
-// Skip these tests for MSVC because its scalbn function always behaves as if
-// the default rounding mode is set (FE_TONEAREST).
+// Skip these tests on Windows because the UCRT scalbn function always behaves
+// as if the default rounding mode is set (FE_TONEAREST).
 // Also skip for newlib because although its scalbn function does respect the
 // rounding mode, where the tests trigger an underflow or overflow using a
 // large exponent the result is rounded in the opposite direction to that which
 // would be expected in the (FE_UPWARD) and (FE_DOWNWARD) modes.
-#  if !defined(_MSC_VER) && !defined(_NEWLIB_VERSION)
+#  if !defined(_WIN32) && !defined(_NEWLIB_VERSION)
   fesetround(FE_UPWARD);
   if (iterate_cases("FE_UPWARD")) return 1;
 

--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbnf_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbnf_test.c
@@ -60,13 +60,13 @@ int main() {
   // should have the same rounding behavior as single-precision multiplication.
 #if (defined(__arm__) || defined(__aarch64__)) && defined(__ARM_FP) || \
     defined(__i386__) || defined(__x86_64__)
-// Skip these tests for MSVC because its scalbnf function always behaves as if
-// the default rounding mode is set (FE_TONEAREST).
+// Skip these tests on Windows because the UCRT scalbnf function always behaves
+// as if the default rounding mode is set (FE_TONEAREST).
 // Also skip for newlib because although its scalbnf function does respect the
 // rounding mode, where the tests trigger an underflow or overflow using a
 // large exponent the result is rounded in the opposite direction to that which
 // would be expected in the (FE_UPWARD) and (FE_DOWNWARD) modes.
-#  if !defined(_MSC_VER) && !defined(_NEWLIB_VERSION)
+#  if !defined(_WIN32) && !defined(_NEWLIB_VERSION)
   fesetround(FE_UPWARD);
   if (iterate_cases("FE_UPWARD")) return 1;
 


### PR DESCRIPTION
MinGW mode can also use the MSVC/UCRT math functions. On ARM/ARM64, mingw-w64 has always used the UCRT scalbn function. On x86, mingw-w64 recently changed to prefer the UCRT version for a large number of math functions (even if scalbn/scalbnf might be reverted to the internal version on x86 due to this noncompliance).