### PR TITLE
[compiler-rt] Do not assume pthread_key_t to be a scalar type.

### DIFF
--- a/compiler-rt/lib/orc/elfnix_platform.cpp
+++ b/compiler-rt/lib/orc/elfnix_platform.cpp
@@ -72,7 +72,7 @@ Error runInitArray(const std::vector<ExecutorAddrRange> &InitArraySections,
 }
 
 struct TLSInfoEntry {
-  unsigned long Key = 0;
+  pthread_key_t Key;
   unsigned long DataAddress = 0;
 };
 

--- a/compiler-rt/lib/orc/macho_platform.cpp
+++ b/compiler-rt/lib/orc/macho_platform.cpp
@@ -143,7 +143,7 @@ public:
 namespace {
 struct TLVDescriptor {
   void *(*Thunk)(TLVDescriptor *) = nullptr;
-  unsigned long Key = 0;
+  pthread_key_t Key;
   unsigned long DataAddress = 0;
 };
 


### PR DESCRIPTION
`pthread_key_t` must be assumed to be an opaque object.
Some platforms have declare this type as an alias of a scalar type, like `int` or `long`, but others do not.
When compiling compiler-rt for those systems, an error is returned because a structure and a scalar type are not the same thing. CYGWIN is an example of platform showing this error.

See also issue #62717 for more details.

The patch does not produce any difference in compiled code when `pthread_key_t` is a scalar type, as I verified with Debian 11.
On the systems with different declaration of this type, the patch fixes two of the four errors signaled into issue #62717.
