### PR TITLE
[lldb] Fix missing comsumeError() with LLDB_LOG in ObjectFileCOFF/PECOFF

### DIFF
--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -271,9 +271,9 @@ void ObjectFileCOFF::ParseSymtab(lldb_private::Symtab &symtab) {
     const auto COFFSymRef = m_object->getCOFFSymbol(SymRef);
 
     Expected<StringRef> NameOrErr = SymRef.getName();
-    if (auto error = NameOrErr.takeError()) {
-      LLDB_LOG(log, "ObjectFileCOFF: failed to get symbol name: {0}",
-               llvm::fmt_consume(std::move(error)));
+    if (!NameOrErr) {
+      LLDB_LOG_ERROR(log, NameOrErr.takeError(),
+                     "ObjectFileCOFF: failed to get symbol name: {0}");
       continue;
     }
 

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -791,11 +791,10 @@ void ObjectFilePECOFF::AppendFromCOFFSymbolTable(
   for (const auto &sym_ref : m_binary->symbols()) {
     const auto coff_sym_ref = m_binary->getCOFFSymbol(sym_ref);
     auto name_or_error = sym_ref.getName();
-    if (auto err = name_or_error.takeError()) {
-      LLDB_LOG(log,
-               "ObjectFilePECOFF::AppendFromCOFFSymbolTable - failed to get "
-               "symbol table entry name: {0}",
-               llvm::fmt_consume(std::move(err)));
+    if (!name_or_error) {
+      LLDB_LOG_ERROR(log, name_or_error.takeError(),
+                     "ObjectFilePECOFF::AppendFromCOFFSymbolTable - failed to "
+                     "get symbol table entry name: {0}");
       continue;
     }
     const llvm::StringRef sym_name = *name_or_error;


### PR DESCRIPTION
I actually ran into it with a downstream fork:
```
llvm::Error::fatalUncheckedError(), llvm-project\llvm\lib\Support\Error.cpp, line 117
ObjectFilePECOFF::AppendFromCOFFSymbolTable(), llvm-project\lldb\source\Plugins\ObjectFile\PECOFF\ObjectFilePECOFF.cpp, line 806
ObjectFilePECOFF::ParseSymtab(), llvm-project\lldb\source\Plugins\ObjectFile\PECOFF\ObjectFilePECOFF.cpp, line 777
```

If logging is disabled `LLDB_LOG_ERROR` calls `llvm::consumeError()`, which marks the error as checked. All `llvm::Error`s must be checked before destruction. This patch fixes one more such case in `ObjectFileCOFF::ParseSymtab()`.