### PR TITLE
[ConstantFolding] Consider `tanh*` to always be a noop

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -3440,6 +3440,9 @@ bool llvm::isMathLibCallNoop(const CallBase *Call,
       case LibFunc_atan:
       case LibFunc_atanf:
       case LibFunc_atanl:
+      case LibFunc_tanh:
+      case LibFunc_tanhf:
+      case LibFunc_tanhl:
         // Per POSIX, this MAY fail if Op is denormal. We choose not failing.
         return true;
 


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/108965

Most trigonometry functions are already considered, but tanh* was missing. According to POSIX, these functions may fail on subnormals, so we choose not to fail, allowing the calls to be eliminated. https://pubs.opengroup.org/onlinepubs/9699919799/functions/tanh.html

The existing test llvm/test/Transforms/InstSimplify/ConstProp/calls.ll already eliminated the call since it marked tanh as `nounwind`, which causes it to be eliminated as well.

I am not sure whether I should add a new test without the `nounwind` or whether it makes more sense to remove the `nounwind` from the existing tests.