### PR TITLE
[Clangd] Sanitize path before recording into IncludeStructure during buildPreamble

### DIFF
--- a/clang-tools-extra/clangd/URI.cpp
+++ b/clang-tools-extra/clangd/URI.cpp
@@ -191,7 +191,7 @@ llvm::Expected<URI> URI::parse(llvm::StringRef OrigUri) {
     Uri = Uri.substr(Pos);
   }
   U.Body = percentDecode(Uri);
-  if (clang::clangd::isWindowsPath(U.Body)) {
+  if (U.scheme() == "file" && clang::clangd::isWindowsPath(U.Body)) {
     Pos = U.Body.find(":");
     U.Body.at(Pos - 1) = std::toupper(U.Body.at(Pos - 1));
   }

--- a/clang-tools-extra/clangd/URI.cpp
+++ b/clang-tools-extra/clangd/URI.cpp
@@ -165,8 +165,7 @@ std::string URI::toString() const {
     return Result;
   // If authority if empty, we only print body if it starts with "/"; otherwise,
   // the URI is invalid.
-  if (!Authority.empty() || llvm::StringRef(Body).startswith("/"))
-  {
+  if (!Authority.empty() || llvm::StringRef(Body).startswith("/")) {
     Result.append("//");
     percentEncode(Authority, Result);
   }
@@ -192,6 +191,10 @@ llvm::Expected<URI> URI::parse(llvm::StringRef OrigUri) {
     Uri = Uri.substr(Pos);
   }
   U.Body = percentDecode(Uri);
+  if (clang::clangd::isWindowsPath(U.Body)) {
+    Pos = U.Body.find(":");
+    U.Body.at(Pos - 1) = std::toupper(U.Body.at(Pos - 1));
+  }
   return U;
 }
 

--- a/clang-tools-extra/clangd/URI.cpp
+++ b/clang-tools-extra/clangd/URI.cpp
@@ -191,7 +191,9 @@ llvm::Expected<URI> URI::parse(llvm::StringRef OrigUri) {
     Uri = Uri.substr(Pos);
   }
   U.Body = percentDecode(Uri);
-  if (U.scheme() == "file" && clang::clangd::isWindowsPath(U.Body)) {
+  if (U.scheme() == "file" &&
+      (clang::clangd::isWindowsPath(U.Body.substr(Pos + 1)) ||
+       (clang::clangd::isWindowsPath(U.Body.substr(Pos))))) {
     Pos = U.Body.find(":");
     U.Body.at(Pos - 1) = std::toupper(U.Body.at(Pos - 1));
   }


### PR DESCRIPTION
Addresses https://github.com/clangd/clangd/issues/1800, where mismatching drive letter case can cause command inference for header files to fail on windows.

@sam-mccall any comments would be appreciated.