### PR TITLE
[clang-apply-replacements] Apply format only if --format is specified

### DIFF
--- a/clang-tools-extra/clang-apply-replacements/tool/ClangApplyReplacementsMain.cpp
+++ b/clang-tools-extra/clang-apply-replacements/tool/ClangApplyReplacementsMain.cpp
@@ -141,9 +141,9 @@ int main(int argc, char **argv) {
 
   tooling::ApplyChangesSpec Spec;
   Spec.Cleanup = true;
-  Spec.Style = FormatStyle;
   Spec.Format = DoFormat ? tooling::ApplyChangesSpec::kAll
                          : tooling::ApplyChangesSpec::kNone;
+  Spec.Style = DoFormat ? FormatStyle : format::getNoStyle();
 
   for (const auto &FileChange : Changes) {
     FileEntryRef Entry = FileChange.first;

--- a/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/no.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/no.cpp
@@ -1,0 +1,10 @@
+#include <string>
+// CHECK: #include <string>
+// CHECK-NEXT: #include <memory>
+// CHECK-NEXT: #include "bar.h"
+#include <memory>
+#include "foo.h"
+#include "bar.h"
+
+void foo() {
+}

--- a/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/no.yaml
+++ b/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/no.yaml
@@ -1,0 +1,14 @@
+---
+MainSourceFile:  no.cpp
+Diagnostics:
+  - DiagnosticName:  test-header-format
+    DiagnosticMessage:
+      Message: Fix
+      FilePath: $(path)/no.cpp
+      FileOffset: 36
+      Replacements:
+        - FilePath:        $(path)/no.cpp
+          Offset:          36
+          Length:          17
+          ReplacementText: ""
+...

--- a/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/yes.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/yes.cpp
@@ -1,0 +1,10 @@
+#include <string>
+// CHECK: #include "bar.h"
+// CHECK-NEXT: #include <memory>
+// CHECK-NEXT: #include <string>
+#include <memory>
+#include "foo.h"
+#include "bar.h"
+
+void foo() {
+}

--- a/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/yes.yaml
+++ b/clang-tools-extra/test/clang-apply-replacements/Inputs/format_header/yes.yaml
@@ -1,0 +1,14 @@
+---
+MainSourceFile:  yes.cpp
+Diagnostics:
+  - DiagnosticName:  test-header-format
+    DiagnosticMessage:
+      Message: Fix
+      FilePath: $(path)/yes.cpp
+      FileOffset: 36
+      Replacements:
+        - FilePath:        $(path)/yes.cpp
+          Offset:          36
+          Length:          17
+          ReplacementText: ""
+...

--- a/clang-tools-extra/test/clang-apply-replacements/format-header.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/format-header.cpp
@@ -1,0 +1,13 @@
+// RUN: mkdir -p %T/Inputs/format_header_yes
+// RUN: mkdir -p %T/Inputs/format_header_no
+//
+//
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format_header/yes.cpp > %T/Inputs/format_header_yes/yes.cpp
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format_header/no.cpp > %T/Inputs/format_header_no/no.cpp
+// RUN: sed "s#\$(path)#%/T/Inputs/format_header_yes#" %S/Inputs/format_header/yes.yaml > %T/Inputs/format_header_yes/yes.yaml
+// RUN: sed "s#\$(path)#%/T/Inputs/format_header_no#" %S/Inputs/format_header/no.yaml > %T/Inputs/format_header_no/no.yaml
+// RUN: clang-apply-replacements -format -style="{BasedOnStyle: llvm, SortIncludes: CaseSensitive}" %T/Inputs/format_header_yes
+// RUN: clang-apply-replacements %T/Inputs/format_header_no
+// RUN: FileCheck --strict-whitespace -input-file=%T/Inputs/format_header_yes/yes.cpp %S/Inputs/format_header/yes.cpp
+// RUN: FileCheck --strict-whitespace -input-file=%T/Inputs/format_header_no/no.cpp %S/Inputs/format_header/no.cpp
+//


### PR DESCRIPTION
clang-apply-replacements is now applying format even when --format is not specified.  Methods like createReplacementsForHeaders only takes the Spec.Style and would re-order the headers even when it was not requested. The fix is to set up Spec.Style only if --format is provided.