### PR TITLE
[DebugInfo][Verifier] Verify that array types have base types present

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1289,8 +1289,7 @@ void Verifier::visitDICompositeType(const DICompositeType &N) {
   }
 
   if (N.getTag() == dwarf::DW_TAG_array_type) {
-    CheckDI(N.getRawBaseType(),
-            "array types must have a base type", &N);
+    CheckDI(N.getRawBaseType(), "array types must have a base type", &N);
   }
 }
 

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1287,6 +1287,11 @@ void Verifier::visitDICompositeType(const DICompositeType &N) {
     CheckDI(N.getTag() == dwarf::DW_TAG_array_type,
             "rank can only appear in array type");
   }
+
+  if (N.getTag() == dwarf::DW_TAG_array_type) {
+    CheckDI(N.getRawBaseType(),
+            "array types must have a base type", &N);
+  }
 }
 
 void Verifier::visitDISubroutineType(const DISubroutineType &N) {

--- a/llvm/test/DebugInfo/Generic/arrays-need-types.ll
+++ b/llvm/test/DebugInfo/Generic/arrays-need-types.ll
@@ -1,0 +1,27 @@
+; RUN: opt %s -o - -S --passes=verify 2>&1 | FileCheck %s
+
+; CHECK:      array types must have a base type
+; CHECK-NEXT: !DICompositeType(tag: DW_TAG_array_type,
+; CHECK-NEXT: warning: ignoring invalid debug info
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+define i32 @func(ptr %0) !dbg !3 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !6, metadata !DIExpression()), !dbg !10
+  ret i32 0
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C11, file: !2, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+!2 = !DIFile(filename: "file.c", directory: "/")
+!3 = distinct !DISubprogram(name: "func", scope: !2, file: !2, line: 46, type: !4, scopeLine: 48, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !1)
+!4 = distinct !DISubroutineType(types: !5)
+!5 = !{}
+!6 = !DILocalVariable(name: "op", arg: 5, scope: !3, file: !2, line: 47, type: !7)
+!7 = !DICompositeType(tag: DW_TAG_array_type, size: 2624, elements: !8)
+!8 = !{!9}
+!9 = !DISubrange(count: 41)
+!10 = !DILocation(line: 0, scope: !3)


### PR DESCRIPTION
The base-type field of a DICompositeType is optional in the IR syntax, however it makes no sense to have an array of an unspecified type. Such debug-info would be meaningless, and the added test crashes otherwise (see #70787). Thus, add a verifier check to reject such ill-formed debug info metadata.  Test produced by Christian Ulmann.

fixes #70787