### PR TITLE
[llvm-c] Improve TargetMachine bindings

### DIFF
--- a/llvm/bindings/ocaml/target/llvm_target.ml
+++ b/llvm/bindings/ocaml/target/llvm_target.ml
@@ -44,6 +44,13 @@ module CodeGenFileType = struct
   | ObjectFile
 end
 
+module GlobalISelAbortMode = struct
+  type t =
+  | Enable
+  | Disable
+  | DisableWithDiag
+end
+
 exception Error of string
 
 let () = Callback.register_exception "Llvm_target.Error" (Error "")
@@ -124,6 +131,14 @@ module TargetMachine = struct
                        = "llvm_targetmachine_data_layout"
   external set_verbose_asm : bool -> t -> unit
                            = "llvm_targetmachine_set_verbose_asm"
+  external set_fast_isel : bool -> t -> unit
+                           = "llvm_targetmachine_set_fast_isel"
+  external set_global_isel : bool -> t -> unit
+                           = "llvm_targetmachine_set_global_isel"
+  external set_global_isel_abort : ?mode:GlobalISelAbortMode.t -> t -> unit
+                                 = "llvm_targetmachine_set_global_isel_abort"
+  external set_machine_outliner : bool -> t -> unit
+                                = "llvm_targetmachine_set_machine_outliner"
   external emit_to_file : Llvm.llmodule -> CodeGenFileType.t -> string ->
                           t -> unit
                         = "llvm_targetmachine_emit_to_file"

--- a/llvm/bindings/ocaml/target/llvm_target.mli
+++ b/llvm/bindings/ocaml/target/llvm_target.mli
@@ -49,6 +49,13 @@ module CodeGenFileType : sig
   | ObjectFile
 end
 
+module GlobalISelAbortMode : sig
+  type t =
+  | Enable
+  | Disable
+  | DisableWithDiag
+end
+
 (** {6 Exceptions} *)
 
 exception Error of string
@@ -203,6 +210,22 @@ module TargetMachine : sig
   (** Sets the assembly verbosity of this target machine.
       See [llvm::TargetMachine::setAsmVerbosity]. *)
   val set_verbose_asm : bool -> t -> unit
+
+  (** Enable fast-path instruction selection.
+      See [llvm::TargetMachine::setFastISel]. *)
+  val set_fast_isel : bool -> t -> unit
+
+  (** Enable global instruction selection.
+      See [llvm::TargetMachine::setGlobalISel]. *)
+  val set_global_isel : bool -> t -> unit
+
+  (** Set abort behaviour when global instruction selection fails to lower/select an instruction.
+      See [llvm::TargetMachine::setGlobalISelAbort]. *)
+  val set_global_isel_abort : ?mode:GlobalISelAbortMode.t -> t -> unit
+
+  (** Enable the MachineOutliner pass.
+      See [llvm::TargetMachine::setMachineOutliner]. *)
+  val set_machine_outliner : bool -> t -> unit
 
   (** Emits assembly or object data for the given module to the given
       file or raise [Error]. *)

--- a/llvm/bindings/ocaml/target/target_ocaml.c
+++ b/llvm/bindings/ocaml/target/target_ocaml.c
@@ -301,6 +301,35 @@ value llvm_targetmachine_set_verbose_asm(value Verb, value Machine) {
   return Val_unit;
 }
 
+/* bool -> TargetMachine.t -> unit */
+value llvm_targetmachine_set_fast_isel(value Enable, value Machine) {
+  LLVMSetTargetMachineFastISel(TargetMachine_val(Machine), Bool_val(Enable));
+  return Val_unit;
+}
+
+/* bool -> TargetMachine.t -> unit */
+value llvm_targetmachine_set_global_isel(value Enable, value Machine) {
+  LLVMSetTargetMachineGlobalISel(TargetMachine_val(Machine), Bool_val(Enable));
+  return Val_unit;
+}
+
+/* ?mode:GlobalISelAbortMode.t -> TargetMachine.t -> unit */
+value llvm_targetmachine_set_global_isel_abort(value Mode, value Machine) {
+  LLVMGlobalISelAbortMode AbortModeEnum = LLVMGlobalISelAbortEnable;
+  if (Mode != Val_int(0))
+    AbortModeEnum = Int_val(Field(Mode, 0));
+  LLVMSetTargetMachineGlobalISelAbort(TargetMachine_val(Machine),
+                                      AbortModeEnum);
+  return Val_unit;
+}
+
+/* bool -> TargetMachine.t -> unit */
+value llvm_targetmachine_set_machine_outliner(value Enable, value Machine) {
+  LLVMSetTargetMachineMachineOutliner(TargetMachine_val(Machine),
+                                      Bool_val(Enable));
+  return Val_unit;
+}
+
 /* Llvm.llmodule -> CodeGenFileType.t -> string -> TargetMachine.t -> unit */
 value llvm_targetmachine_emit_to_file(value Module, value FileType,
                                       value FileName, value Machine) {

--- a/llvm/include/llvm-c/TargetMachine.h
+++ b/llvm/include/llvm-c/TargetMachine.h
@@ -66,6 +66,12 @@ typedef enum {
     LLVMObjectFile
 } LLVMCodeGenFileType;
 
+typedef enum {
+  LLVMGlobalISelAbortEnable,
+  LLVMGlobalISelAbortDisable,
+  LLVMGlobalISelAbortDisableWithDiag,
+} LLVMGlobalISelAbortMode;
+
 /** Returns the first llvm::Target in the registered targets list. */
 LLVMTargetRef LLVMGetFirstTarget(void);
 /** Returns the next llvm::Target given a previous one (or null if there's none) */
@@ -131,6 +137,21 @@ LLVMTargetDataRef LLVMCreateTargetDataLayout(LLVMTargetMachineRef T);
 /** Set the target machine's ASM verbosity. */
 void LLVMSetTargetMachineAsmVerbosity(LLVMTargetMachineRef T,
                                       LLVMBool VerboseAsm);
+
+/** Enable fast-path instruction selection. */
+void LLVMSetTargetMachineFastISel(LLVMTargetMachineRef T, LLVMBool Enable);
+
+/** Enable global instruction selection. */
+void LLVMSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable);
+
+/** Set abort behaviour when global instruction selection fails to lower/select
+ * an instruction. */
+void LLVMSetTargetMachineGlobalISelAbort(LLVMTargetMachineRef T,
+                                         LLVMGlobalISelAbortMode Mode);
+
+/** Enable the MachineOutliner pass. */
+void LLVMSetTargetMachineMachineOutliner(LLVMTargetMachineRef T,
+                                         LLVMBool Enable);
 
 /** Emits an asm or object file for the given module to the filename. This
   wraps several c++ only classes (among them a file stream). Returns any

--- a/llvm/lib/Target/TargetMachineC.cpp
+++ b/llvm/lib/Target/TargetMachineC.cpp
@@ -175,6 +175,40 @@ void LLVMSetTargetMachineAsmVerbosity(LLVMTargetMachineRef T,
   unwrap(T)->Options.MCOptions.AsmVerbose = VerboseAsm;
 }
 
+void LLVMSetTargetMachineFastISel(LLVMTargetMachineRef T, LLVMBool Enable) {
+  unwrap(T)->setFastISel(Enable);
+}
+
+void LLVMSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable) {
+  unwrap(T)->setGlobalISel(Enable);
+}
+
+void LLVMSetTargetMachineGlobalISelAbort(LLVMTargetMachineRef T,
+                                         LLVMGlobalISelAbortMode Mode) {
+  GlobalISelAbortMode AM;
+  switch (Mode) {
+  case LLVMGlobalISelAbortDisable:
+    AM = GlobalISelAbortMode::Disable;
+    break;
+  case LLVMGlobalISelAbortEnable:
+    AM = GlobalISelAbortMode::Enable;
+    break;
+  case LLVMGlobalISelAbortDisableWithDiag:
+    AM = GlobalISelAbortMode::DisableWithDiag;
+    break;
+  default:
+    AM = GlobalISelAbortMode::Enable;
+    break;
+  }
+
+  unwrap(T)->setGlobalISelAbort(AM);
+}
+
+void LLVMSetTargetMachineMachineOutliner(LLVMTargetMachineRef T,
+                                         LLVMBool Enable) {
+  unwrap(T)->setMachineOutliner(Enable);
+}
+
 LLVMTargetDataRef LLVMCreateTargetDataLayout(LLVMTargetMachineRef T) {
   return wrap(new DataLayout(unwrap(T)->createDataLayout()));
 }


### PR DESCRIPTION
This PR exposes four APIs for `TargetMachine`:
```
/** Enable fast-path instruction selection. */
void LLVMSetTargetMachineFastISel(LLVMTargetMachineRef T, LLVMBool Enable);

/** Enable global instruction selection. */
void LLVMSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable);

/** Set abort behaviour when global instruction selection fails to lower/select
 * an instruction. */
void LLVMSetTargetMachineGlobalISelAbort(LLVMTargetMachineRef T,
                                         LLVMGlobalISelAbortMode Mode);

/** Enable the MachineOutliner pass. */
void LLVMSetTargetMachineMachineOutliner(LLVMTargetMachineRef T,
                                         LLVMBool Enable);
```

Fixes #70666.
