### PR TITLE
[OpenMP][libomptarget] Fixes possible no-return warning

### DIFF
--- a/openmp/libomptarget/DeviceRTL/include/Debug.h
+++ b/openmp/libomptarget/DeviceRTL/include/Debug.h
@@ -36,7 +36,8 @@ void __assert_fail_internal(const char *expr, const char *msg, const char *file,
   }
 #define UNREACHABLE(msg)                                                       \
   PRINT(msg);                                                                  \
-  __builtin_trap();
+  __builtin_trap();                                                            \
+  __builtin_unreachable();
 
 ///}
 


### PR DESCRIPTION
The UNREACHABLE macro resolves to message + trap, which may still give you no-return warnings. This silences these warnings.