### PR TITLE
[flang] Fix flang tests on MacOS

### DIFF
--- a/flang/test/Driver/ctofortran.f90
+++ b/flang/test/Driver/ctofortran.f90
@@ -1,4 +1,5 @@
-! UNSUPPORTED: system-windows
+! MacOS needs -isysroot <osx_sysroot> with clang and flang to build binaries.
+! UNSUPPORTED: system-windows, system-darwin
 ! RUN: split-file %s %t
 ! RUN: chmod +x %t/runtest.sh
 ! RUN: %t/runtest.sh %t %flang $t/ffile.f90 $t/cfile.c

--- a/flang/test/Driver/lto-flags.f90
+++ b/flang/test/Driver/lto-flags.f90
@@ -10,7 +10,9 @@
 ! RUN: %flang -### -S -flto=jobserver %s 2>&1 | FileCheck %s --check-prefix=FULL-LTO
 
 ! Also check linker plugin opt for Thin LTO
-! RUN: %flang -### -flto=thin %s 2>&1 | FileCheck %s --check-prefix=THIN-LTO
+! RUN: %flang -### -flto=thin %s 2>&1 | FileCheck %s \
+! RUN:        --check-prefixes=%if system-darwin %{THIN-LTO-ALL%} \
+! RUN:        %else %{THIN-LTO-ALL,THIN-LTO-LINKER-PLUGIN%}
 
 ! RUN: not %flang -### -S -flto=somelto %s 2>&1 | FileCheck %s --check-prefix=ERROR
 
@@ -25,9 +27,9 @@
 ! FULL-LTO: "-fc1"
 ! FULL-LTO-SAME: "-flto=full"
 
-! THIN-LTO: flang-new: warning: the option '-flto=thin' is a work in progress
-! THIN-LTO: "-fc1"
-! THIN-LTO-SAME: "-flto=thin"
-! THIN-LTO: "-plugin-opt=thinlto"
+! THIN-LTO-ALL: flang-new: warning: the option '-flto=thin' is a work in progress
+! THIN-LTO-ALL: "-fc1"
+! THIN-LTO-ALL-SAME: "-flto=thin"
+! THIN-LTO-LINKER-PLUGIN: "-plugin-opt=thinlto"
 
 ! ERROR: error: unsupported argument 'somelto' to option '-flto=

--- a/flang/test/Driver/save-mlir-temps.f90
+++ b/flang/test/Driver/save-mlir-temps.f90
@@ -6,8 +6,9 @@
 
 ! As `flang` does not implement `-fc1as` (i.e. a driver for the integrated
 ! assembler), we need to use `-fno-integrated-as` here.
-
-! UNSUPPORTED: system-windows
+! However, calling an external assembler on arm64 Macs fails, because it's
+! currently being invoked with the `-Q` flag, that is not supported on arm64.
+! UNSUPPORTED: system-windows, system-darwin
 
 !--------------------------
 ! Invalid output directory

--- a/flang/test/Evaluate/fold-out_of_range.f90
+++ b/flang/test/Evaluate/fold-out_of_range.f90
@@ -1,5 +1,5 @@
 ! RUN: %python %S/test_folding.py %s %flang_fc1
-! UNSUPPORTED: target=powerpc{{.*}}, target=aarch{{.*}}, system-windows, system-solaris
+! UNSUPPORTED: target=powerpc{{.*}}, target=aarch{{.*}}, target=arm{{.*}}, system-windows, system-solaris
 ! Tests folding of OUT_OF_RANGE().
 module m
   integer(1),  parameter :: i1v(*)  = [ -huge(1_1)  - 1_1,  huge(1_1) ]

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -163,7 +163,10 @@ if config.cc:
         and os.path.isdir(include)
     ):
         config.available_features.add("c-compiler")
-        tools.append(ToolSubst("%cc", command=config.cc, unresolved="fatal"))
+        cc_cmd = config.cc
+        if config.osx_sysroot:
+            cc_cmd += " -isysroot " + config.osx_sysroot
+        tools.append(ToolSubst("%cc", command=cc_cmd, unresolved="fatal"))
         tools.append(ToolSubst("%libruntime", command=libruntime, unresolved="fatal"))
         tools.append(ToolSubst("%libdecimal", command=libdecimal, unresolved="fatal"))
         tools.append(ToolSubst("%include", command=include, unresolved="fatal"))

--- a/flang/test/lit.site.cfg.py.in
+++ b/flang/test/lit.site.cfg.py.in
@@ -22,6 +22,7 @@ config.flang_standalone_build = @FLANG_STANDALONE_BUILD@
 config.has_plugins = @LLVM_ENABLE_PLUGINS@
 config.linked_bye_extension = @LLVM_BYE_LINK_INTO_TOOLS@
 config.cc = "@CMAKE_C_COMPILER@"
+config.osx_sysroot = path(r"@CMAKE_OSX_SYSROOT@")
 config.targets_to_build = "@TARGETS_TO_BUILD@"
 
 import lit.llvm


### PR DESCRIPTION
Adjust some of the tests run by check-flang to make them pass on MacOS,
either by skipping unsupported tests or by adapting the test for correct
execution on MacOS.

For now ctofortran.f90 test is marked as unsupported, but it can be
adapted to run on MacOS once support for -isysroot flag is added to
flang.

Issues #70805 and #70807 are tracking the failing tests that remain, as
these reveal real problems with flang.