### PR TITLE
LoopIdiomRecognize: update comment about ctpop (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -24,12 +24,6 @@
 //   memcmp, strlen, etc.
 // Future floating point idioms to recognize in -ffast-math mode:
 //   fpowi
-// Future integer operation idioms to recognize:
-//   ctpop
-//
-// Beware that isel's default lowering for ctpop is highly inefficient for
-// i64 and larger types when i64 is legal and the value has few bits set.  It
-// would be good to enhance isel to emit a loop for ctpop in this case.
 //
 // This could recognize common matrix multiplies and dot product idioms and
 // replace them with calls to BLAS (if linked in??).


### PR DESCRIPTION
Ever since 95de7c3, LoopIdiomRecognize has been able to recognize the ctpop idiom, with target-specific lowering information. However, the comment in the header about ctpop not being recognized is outdated. Remove it.