### PR TITLE
[clang][driver] Add \<executable\>/../include/c++/v1 to include path on Darwin

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2471,8 +2471,8 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
   switch (GetCXXStdlibType(DriverArgs)) {
   case ToolChain::CST_Libcxx: {
     // On Darwin, libc++ can be installed in one of the following places:
-    // 1. Alongside the compiler in         <install>/include/c++/v1
-    // 2. Alongside the compiler in         <clang-executable-location>/../include/c++/v1
+    // 1. Alongside the compiler in <install>/include/c++/v1
+    // 2. Alongside the compiler in <clang-executable-folder>/../include/c++/v1
     // 3. In a SDK (or a custom sysroot) in <sysroot>/usr/include/c++/v1
     //
     // The precedence of paths is as listed above, i.e. we take the first path
@@ -2512,7 +2512,7 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
       }
     }
 
-    // Otherwise, check for (2)
+    // Otherwise, check for (3)
     llvm::SmallString<128> SysrootUsr = Sysroot;
     llvm::sys::path::append(SysrootUsr, "usr", "include", "c++", "v1");
     if (getVFS().exists(SysrootUsr)) {

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2470,14 +2470,19 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
 
   switch (GetCXXStdlibType(DriverArgs)) {
   case ToolChain::CST_Libcxx: {
-    // On Darwin, libc++ can be installed in one of the following two places:
+    // On Darwin, libc++ can be installed in one of the following places:
     // 1. Alongside the compiler in         <install>/include/c++/v1
-    // 2. In a SDK (or a custom sysroot) in <sysroot>/usr/include/c++/v1
+    // 2. Alongside the compiler in         <clang-executable-location>/../include/c++/v1
+    // 3. In a SDK (or a custom sysroot) in <sysroot>/usr/include/c++/v1
     //
-    // The precendence of paths is as listed above, i.e. we take the first path
-    // that exists. Also note that we never include libc++ twice -- we take the
-    // first path that exists and don't send the other paths to CC1 (otherwise
+    // The precedence of paths is as listed above, i.e. we take the first path
+    // that exists. Note that we never include libc++ twice -- we take the first
+    // path that exists and don't send the other paths to CC1 (otherwise
     // include_next could break).
+    //
+    // Also note that in most cases, (1) and (2) are exactly the same path.
+    // Those two paths will differ only when the `clang` program being run
+    // is actually a symlink to the real executable.
 
     // Check for (1)
     // Get from '<install>/bin' to '<install>/include/c++/v1'.
@@ -2494,7 +2499,7 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
                    << "\"\n";
     }
 
-    // Check for the folder where the executable is located, if different.
+    // (2) Check for the folder where the executable is located, if different.
     if (getDriver().getInstalledDir() != getDriver().Dir) {
       InstallBin = llvm::StringRef(getDriver().Dir.c_str());
       llvm::sys::path::append(InstallBin, "..", "include", "c++", "v1");

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2501,7 +2501,7 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
 
     // (2) Check for the folder where the executable is located, if different.
     if (getDriver().getInstalledDir() != getDriver().Dir) {
-      InstallBin = llvm::StringRef(getDriver().Dir.c_str());
+      InstallBin = llvm::StringRef(getDriver().Dir);
       llvm::sys::path::append(InstallBin, "..", "include", "c++", "v1");
       if (getVFS().exists(InstallBin)) {
         addSystemInclude(DriverArgs, CC1Args, InstallBin);

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2499,7 +2499,8 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
                    << "\"\n";
     }
 
-    llvm::outs() << "DEBUG: getInstalledDir() " << getDriver().getInstalledDir() << "\"\n";
+    llvm::outs() << "DEBUG: getInstalledDir() "
+       << getDriver().getInstalledDir() << "\"\n";
     llvm::outs() << "DEBUG: Dir " << getDriver().Dir << "\"\n";
     // (2) Check for the folder where the executable is located, if different.
     if (getDriver().getInstalledDir() != getDriver().Dir) {

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2494,6 +2494,19 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
                    << "\"\n";
     }
 
+    // Check for the folder where the executable is located, if different.
+    if (getDriver().getInstalledDir() != getDriver().Dir) {
+      InstallBin = llvm::StringRef(getDriver().Dir.c_str());
+      llvm::sys::path::append(InstallBin, "..", "include", "c++", "v1");
+      if (getVFS().exists(InstallBin)) {
+        addSystemInclude(DriverArgs, CC1Args, InstallBin);
+        return;
+      } else if (DriverArgs.hasArg(options::OPT_v)) {
+        llvm::errs() << "ignoring nonexistent directory \"" << InstallBin
+                     << "\"\n";
+      }
+    }
+
     // Otherwise, check for (2)
     llvm::SmallString<128> SysrootUsr = Sysroot;
     llvm::sys::path::append(SysrootUsr, "usr", "include", "c++", "v1");

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2499,6 +2499,8 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
                    << "\"\n";
     }
 
+    llvm::outs() << "DEBUG: getInstalledDir() " << getDriver().getInstalledDir() << "\"\n";
+    llvm::outs() << "DEBUG: Dir " << getDriver().Dir << "\"\n";
     // (2) Check for the folder where the executable is located, if different.
     if (getDriver().getInstalledDir() != getDriver().Dir) {
       InstallBin = llvm::StringRef(getDriver().Dir);

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2499,9 +2499,6 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
                    << "\"\n";
     }
 
-    llvm::outs() << "DEBUG: getInstalledDir() "
-       << getDriver().getInstalledDir() << "\"\n";
-    llvm::outs() << "DEBUG: Dir " << getDriver().Dir << "\"\n";
     // (2) Check for the folder where the executable is located, if different.
     if (getDriver().getInstalledDir() != getDriver().Dir) {
       InstallBin = llvm::StringRef(getDriver().Dir);

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -180,6 +180,8 @@
 
 // RUN: %t/xpacks/.bin/clang++ -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
-// RUN:   | FileCheck --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s
+// RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
+// RUN:   | FileCheck -DSYSROOT=%S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
+// RUN:               --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s
 // CHECK-TOOLCHAIN-INCLUDE-CXX-V1: "-internal-isystem" "{{.*}}/bin/../include/c++/v1"
-// CHECK-TOOLCHAIN-INCLUDE-CXX-V1-NOT: "-internal-isystem" "{{.*}}/SDKs/MacOSX.sdk/usr/include/c++/v1"
+// CHECK-TOOLCHAIN-INCLUDE-CXX-V1-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -180,6 +180,14 @@
 
 // RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
+// RUN:     -v
+
+// RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
+// RUN:     --target=x86_64-apple-darwin \
+// RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 -v
+
+// RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
+// RUN:     --target=x86_64-apple-darwin \
 // RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
 // RUN:   | FileCheck -DSYSROOT=%S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
 // RUN:               --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -180,7 +180,6 @@
 
 // RUN: %t/xpacks/.bin/clang++ -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
-// RUN:   | FileCheck -DRESOURCE=%S/Inputs/resource_dir \
-// RUN:               --check-prefix=CHECK-LIBCXX-TOOLCHAIN-3 %s
-// CHECK-LIBCXX-TOOLCHAIN-3: "-internal-isystem" "{{.+}}/bin/../include/c++/v1"
-// CHECK-LIBCXX-TOOLCHAIN-3-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
+// RUN:   | FileCheck --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s
+// CHECK-TOOLCHAIN-INCLUDE-CXX-V1: "-internal-isystem" "{{.*}}/bin/../include/c++/v1"
+// CHECK-TOOLCHAIN-INCLUDE-CXX-V1-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -176,10 +176,11 @@
 // Make sure the target folder has no toolchain structure.
 // RUN: rm -rf %t/xpacks
 // RUN: mkdir -pv %t/xpacks/.bin
-// RUN: ln -s %clang++ %t/xpacks/.bin/clang++
+// RUN: ln -s %clang_cpp %t/xpacks/.bin/clang++
 
 // RUN: %t/xpacks/.bin/clang++ -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:   | FileCheck -DRESOURCE=%S/Inputs/resource_dir \
-// RUN:               --check-prefix=CHECK-SAME %s
-// CHECK-SAME: "-internal-isystem" "[[RESOURCE]]/bin/../include/c++/v1"
+// RUN:               --check-prefix=CHECK-LIBCXX-TOOLCHAIN-3 %s
+// CHECK-LIBCXX-TOOLCHAIN-3: "-internal-isystem" "{{.+}}/bin/../include/c++/v1"
+// CHECK-LIBCXX-TOOLCHAIN-3-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -176,9 +176,9 @@
 // Make sure the target folder has no toolchain structure.
 // RUN: rm -rf %t/xpacks
 // RUN: mkdir -pv %t/xpacks/.bin
-// RUN: ln -s %clang_cpp %t/xpacks/.bin/clang++
+// RUN: ln -s %clang %t/xpacks/.bin/clang
 
-// RUN: %t/xpacks/.bin/clang++ -### %s -fsyntax-only 2>&1 \
+// RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
 // RUN:   | FileCheck -DSYSROOT=%S/Inputs/basic_darwin_sdk_usr_cxx_v1 \

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -172,3 +172,14 @@
 // RUN:               --check-prefix=CHECK-LIBCXX-STDLIB-UNSPECIFIED %s
 // CHECK-LIBCXX-STDLIB-UNSPECIFIED: "-cc1"
 // CHECK-LIBCXX-STDLIB-UNSPECIFIED: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
+
+// Make sure the target folder has no toolchain structure.
+// RUN: rm -rf %t/xpacks
+// RUN: mkdir -pv %t/xpacks/.bin
+// RUN: ln -s %clang++ %t/xpacks/.bin/clang++
+
+// RUN: %t/xpacks/.bin/clang++ -### %s -fsyntax-only 2>&1 \
+// RUN:     --target=x86_64-apple-darwin \
+// RUN:   | FileCheck -DRESOURCE=%S/Inputs/resource_dir \
+// RUN:               --check-prefix=CHECK-SAME %s
+// CHECK-SAME: "-internal-isystem" "[[RESOURCE]]/bin/../include/c++/v1"

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -182,4 +182,4 @@
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:   | FileCheck --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s
 // CHECK-TOOLCHAIN-INCLUDE-CXX-V1: "-internal-isystem" "{{.*}}/bin/../include/c++/v1"
-// CHECK-TOOLCHAIN-INCLUDE-CXX-V1-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
+// CHECK-TOOLCHAIN-INCLUDE-CXX-V1-NOT: "-internal-isystem" "{{.*}}/SDKs/MacOSX.sdk/usr/include/c++/v1"

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -178,20 +178,14 @@
 // RUN: mkdir -pv %t/xpacks/.bin
 // RUN: ln -s %clang %t/xpacks/.bin/clang
 
-// RUN: %clang -### %s -fsyntax-only 2>&1 \
-// RUN:     --target=x86_64-apple-darwin \
-// RUN:     -v
-
 // RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
-// RUN:     -v
-
-// RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
-// RUN:     --target=x86_64-apple-darwin \
+// RUN:     -stdlib=libc++ \
 // RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 -v
 
 // RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
+// RUN:     -stdlib=libc++ \
 // RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
 // RUN:   | FileCheck -DSYSROOT=%S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
 // RUN:               --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -173,16 +173,13 @@
 // CHECK-LIBCXX-STDLIB-UNSPECIFIED: "-cc1"
 // CHECK-LIBCXX-STDLIB-UNSPECIFIED: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
 
-// Make sure the target folder has no toolchain structure.
+// Reproduce the xPack use case; there must be no include here,
+// to select the executable folder.
 // RUN: rm -rf %t/xpacks
 // RUN: mkdir -pv %t/xpacks/.bin
-// RUN: ln -s %clang %t/xpacks/.bin/clang
+// RUN: ln -svf %clang %t/xpacks/.bin/clang
+// The build folders do not include this include; create it.
 // RUN: mkdir -pv $(dirname $(which %clang))/../include/c++/v1
-
-// RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
-// RUN:     --target=x86_64-apple-darwin \
-// RUN:     -stdlib=libc++ \
-// RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 -v
 
 // RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -177,6 +177,7 @@
 // RUN: rm -rf %t/xpacks
 // RUN: mkdir -pv %t/xpacks/.bin
 // RUN: ln -s %clang %t/xpacks/.bin/clang
+// RUN: mkdir -pv $(dirname $(which %clang))/../include/c++/v1
 
 // RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -178,6 +178,10 @@
 // RUN: mkdir -pv %t/xpacks/.bin
 // RUN: ln -s %clang %t/xpacks/.bin/clang
 
+// RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     --target=x86_64-apple-darwin \
+// RUN:     -v
+
 // RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -v

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -174,8 +174,10 @@
 // CHECK-LIBCXX-STDLIB-UNSPECIFIED: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
 
 // ----------------------------------------------------------------------------
-// This is the use case with single symlinks to binaries, specific
-// to the xpm/npm ecosystem.
+// On Darwin, libc++ can be installed in one of the following places:
+// 1. Alongside the compiler in <install>/include/c++/v1
+// 2. Alongside the compiler in <clang-executable-folder>/../include/c++/v1
+// 3. In a SDK (or a custom sysroot) in <sysroot>/usr/include/c++/v1
 
 // The build folders do not have an `include/c++/v1`; create a new
 // local folder hierarchy that meets this requirement.
@@ -185,14 +187,30 @@
 // RUN: cp %clang %t/install/bin/clang
 // RUN: mkdir -pv %t/install/include/c++/v1
 
-// Reproduce the xPack use case; there must be no `include/c++/v1` here,
-// to force the inclusion from the executable folder.
-// RUN: rm -rf %t/xpacks
-// RUN: mkdir -pv %t/xpacks/.bin
-// RUN: ln -svf %t/install/bin/clang %t/xpacks/.bin/clang
+// Headers in (1) and in (2) -> (1) is preferred over (2)
+// RUN: rm -rf %t/symlinked1
+// RUN: mkdir -pv %t/symlinked1/bin
+// RUN: ln -svf %t/install/bin/clang %t/symlinked1/bin/clang
+// RUN: mkdir -pv %t/symlinked1/include/c++/v1
 
-// Invoke clang via a symlink.
-// RUN: %t/xpacks/.bin/clang -### %s -fsyntax-only 2>&1 \
+// RUN: %t/symlinked1/bin/clang -### %s -fsyntax-only 2>&1 \
+// RUN:     --target=x86_64-apple-darwin \
+// RUN:     -stdlib=libc++ \
+// RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
+// RUN:   | FileCheck -DSYMLINKED=%t/symlinked1 \
+// RUN:               -DTOOLCHAIN=%t/install \
+// RUN:               -DSYSROOT=%S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
+// RUN:               --check-prefix=CHECK-SYMLINKED-INCLUDE-CXX-V1 %s
+// CHECK-SYMLINKED-INCLUDE-CXX-V1: "-internal-isystem" "[[SYMLINKED]]/bin/../include/c++/v1"
+// CHECK-SYMLINKED-INCLUDE-CXX-V1-NOT: "-internal-isystem" "[[TOOLCHAIN]]/bin/../include/c++/v1"
+// CHECK-SYMLINKED-INCLUDE-CXX-V1-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
+
+// Headers in (2) and in (3) -> (2) is preferred over (3)
+// RUN: rm -rf %t/symlinked2
+// RUN: mkdir -pv %t/symlinked2/bin
+// RUN: ln -svf %t/install/bin/clang %t/symlinked2/bin/clang
+
+// RUN: %t/symlinked2/bin/clang -### %s -fsyntax-only 2>&1 \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -stdlib=libc++ \
 // RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
@@ -201,3 +219,13 @@
 // RUN:               --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s
 // CHECK-TOOLCHAIN-INCLUDE-CXX-V1: "-internal-isystem" "[[TOOLCHAIN]]/bin/../include/c++/v1"
 // CHECK-TOOLCHAIN-INCLUDE-CXX-V1-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
+
+// Headers in (2) and nowhere else -> (2) is used
+// RUN: %t/symlinked2/bin/clang -### %s -fsyntax-only 2>&1 \
+// RUN:     --target=x86_64-apple-darwin \
+// RUN:     -stdlib=libc++ \
+// RUN:     -isysroot %S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
+// RUN:   | FileCheck -DTOOLCHAIN=%t/install \
+// RUN:               -DSYSROOT=%S/Inputs/basic_darwin_sdk_no_libcxx \
+// RUN:               --check-prefix=CHECK-TOOLCHAIN-NO-SYSROOT %s
+// CHECK-TOOLCHAIN-NO-SYSROOT: "-internal-isystem" "[[TOOLCHAIN]]/bin/../include/c++/v1"


### PR DESCRIPTION
On macOS, when clang is invoked via a symlink, since the InstalledDir is where the link is located, the C++ headers are not identified and the default system headers are used.

```console
% ln -s /Users/ilg/Library/xPacks/@xpack-dev-tools/clang/15.0.7-3.1/.content/bin/clang++ ~/tmp/clang++
%  ~/tmp/clang++ -v hello.cpp -stdlib=libc++
xPack x86_64 clang version 15.0.7 (https://github.com/xpack-dev-tools/clang-xpack 9b1ff65945b1aaddfe7c0c4d99001ebca5d67b03)
Target: x86_64-apple-darwin21.6.0
Thread model: posix

InstalledDir: /Users/ilg/tmp/. <--- !!!
ignoring nonexistent directory "/Users/ilg/tmp/./../include/c++/v1" <--- !!!

 "/Users/ilg/Library/xPacks/@xpack-dev-tools/clang/15.0.7-3.1/.content/bin/clang-15" -cc1 -triple x86_64-apple-macosx12.0.0 -Wundef-prefix=TARGET_OS_ -Werror=undef-prefix -Wdeprecated-objc-isa-usage -Werror=deprecated-objc-isa-usage -emit-obj -mrelax-all --mrelax-relocations -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name hello.cpp -mrelocation-model pic -pic-level 2 -mframe-pointer=all -ffp-contract=on -fno-rounding-math -funwind-tables=2 -fcompatibility-qualified-id-block-type-checking -fvisibility-inlines-hidden-static-local-var -target-cpu penryn -tune-cpu generic -mllvm -treat-scalable-fixed-error-as-warning -debugger-tuning=lldb -target-linker-version 409.12 -v -fcoverage-compilation-dir=/Users/ilg/tmp -resource-dir /Users/ilg/Library/xPacks/@xpack-dev-tools/clang/15.0.7-3.1/.content/lib/clang/15.0.7 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -stdlib=libc++ -internal-isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -internal-isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/local/include -internal-isystem /Users/ilg/Library/xPacks/@xpack-dev-tools/clang/15.0.7-3.1/.content/lib/clang/15.0.7/include -internal-externc-isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -fdeprecated-macro -fdebug-compilation-dir=/Users/ilg/tmp -ferror-limit 19 -stack-protector 1 -fblocks -fencode-extended-block-signature -fregister-global-dtors-with-atexit -fgnuc-version=4.2.1 -fcxx-exceptions -fexceptions -fmax-type-align=16 -fcolor-diagnostics -D__GCC_HAVE_DWARF2_CFI_ASM=1 -o /var/folders/gr/13tt3vcd7m1gnbhwtkmf5cnw0000gn/T/hello-a87934.o -x c++ hello.cpp
clang -cc1 version 15.0.7 based upon LLVM 15.0.7 default target x86_64-apple-darwin21.6.0
ignoring nonexistent directory "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/local/include"
ignoring nonexistent directory "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/Library/Frameworks"
#include "..." search starts here:
#include <...> search starts here:

 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 <--- Wrong!

 /Users/ilg/Library/xPacks/@xpack-dev-tools/clang/15.0.7-3.1/.content/lib/clang/15.0.7/include
 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
 /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks (framework directory)
End of search list.
 "/usr/bin/ld" -demangle -lto_library /Users/ilg/Library/xPacks/@xpack-dev-tools/clang/15.0.7-3.1/.content/lib/libLTO.dylib -no_deduplicate -dynamic -arch x86_64 -macosx_version_min 12.0.0 -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -o a.out /var/folders/gr/13tt3vcd7m1gnbhwtkmf5cnw0000gn/T/hello-a87934.o -lc++ -lSystem /Users/ilg/Library/xPacks/@xpack-dev-tools/clang/15.0.7-3.1/.content/lib/clang/15.0.7/lib/darwin/libclang_rt.osx.a
```

Using the system headers instead of the toolchain headers may have very subtle consequences, sometimes leading to compile errors which are hard to diagnose.

This fix adds a second check using the folder where the executable is located.