### PR TITLE
[libc] Add a few missing casts

### DIFF
--- a/libc/src/__support/integer_to_string.h
+++ b/libc/src/__support/integer_to_string.h
@@ -213,15 +213,15 @@ template <typename T, typename Fmt = radix::Dec> class IntegerToString {
 
     LIBC_INLINE static char digit_char(uint8_t digit) {
       if (digit < 10)
-        return '0' + digit;
-      return (Fmt::IS_UPPERCASE ? 'A' : 'a') + (digit - 10);
+        return '0' + static_cast<char>(digit);
+      return (Fmt::IS_UPPERCASE ? 'A' : 'a') + static_cast<char>(digit - 10);
     }
 
     LIBC_INLINE static void
     write_unsigned_number(UNSIGNED_T value,
                           details::BackwardStringBufferWriter &sink) {
       for (; sink.ok() && value != 0; value /= Fmt::BASE) {
-        const uint8_t digit(value % Fmt::BASE);
+        const uint8_t digit(static_cast<uint8_t>(value % Fmt::BASE));
         sink.push(digit_char(digit));
       }
     }

--- a/libc/src/stdio/printf_core/writer.h
+++ b/libc/src/stdio/printf_core/writer.h
@@ -93,7 +93,7 @@ public:
   // Takes a string, copies it into the buffer if there is space, else passes it
   // to the overflow mechanism to be handled separately.
   LIBC_INLINE int write(cpp::string_view new_string) {
-    chars_written += new_string.size();
+    chars_written += static_cast<int>(new_string.size());
     if (LIBC_LIKELY(wb->buff_cur + new_string.size() <= wb->buff_len)) {
       inline_memcpy(wb->buff + wb->buff_cur, new_string.data(),
                     new_string.size());
@@ -107,7 +107,7 @@ public:
   // if there is space, else calls pad which will loop and call the overflow
   // mechanism on a secondary buffer.
   LIBC_INLINE int write(char new_char, size_t length) {
-    chars_written += length;
+    chars_written += static_cast<int>(length);
 
     if (LIBC_LIKELY(wb->buff_cur + length <= wb->buff_len)) {
       inline_memset(wb->buff + wb->buff_cur, new_char, length);


### PR DESCRIPTION
Stricter GCC warnings about implicit widening and narrowing cases necessitate additional explicit casts around some integer operations.