### PR TITLE
[flang] Fix build warning on now-unused variable

### DIFF
--- a/flang/lib/Evaluate/type.cpp
+++ b/flang/lib/Evaluate/type.cpp
@@ -37,9 +37,7 @@ static bool IsDescriptor(const ObjectEntityDetails &details) {
   if (IsDescriptor(details.type()) || details.IsAssumedRank()) {
     return true;
   }
-  std::size_t j{0};
   for (const ShapeSpec &shapeSpec : details.shape()) {
-    ++j;
     if (const auto &ub{shapeSpec.ubound().GetExplicit()}) {
       if (!IsConstantExpr(*ub)) {
         return true;


### PR DESCRIPTION
A recent change of mine caused a local variable to become obsolete in its function, leading to a warning with some build compilers that is fatal under -Werror, breaking a build bot.  Remove the variable.