### PR TITLE
Add known and demanded bits support for zext nneg

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1104,7 +1104,7 @@ static void computeKnownBitsFromOperator(const Operator *I,
     Known = Known.anyextOrTrunc(SrcBitWidth);
     computeKnownBits(I->getOperand(0), Known, Depth + 1, Q);
     if (auto *Inst = dyn_cast<PossiblyNonNegInst>(I);
-        Inst && Inst->hasNonNeg())
+        Inst && Inst->hasNonNeg() && !Known.isNegative())
       Known.makeNonNegative();
     Known = Known.zextOrTrunc(BitWidth);
     break;

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1103,6 +1103,9 @@ static void computeKnownBitsFromOperator(const Operator *I,
     assert(SrcBitWidth && "SrcBitWidth can't be zero");
     Known = Known.anyextOrTrunc(SrcBitWidth);
     computeKnownBits(I->getOperand(0), Known, Depth + 1, Q);
+    if (auto *Inst = dyn_cast<PossiblyNonNegInst>(I);
+        Inst && Inst->hasNonNeg())
+      Known.makeNonNegative();
     Known = Known.zextOrTrunc(BitWidth);
     break;
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -429,7 +429,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Value *V, APInt DemandedMask,
       return I;
     }
     assert(InputKnown.getBitWidth() == SrcBitWidth && "Src width changed?");
-    if (I->getOpcode() == Instruction::ZExt && I->hasNonNeg())
+    if (I->getOpcode() == Instruction::ZExt && I->hasNonNeg() &&
+        !InputKnown.isNegative())
       InputKnown.makeNonNegative();
     Known = InputKnown.zextOrTrunc(BitWidth);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -429,7 +429,10 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Value *V, APInt DemandedMask,
       return I;
     }
     assert(InputKnown.getBitWidth() == SrcBitWidth && "Src width changed?");
+    if (I->getOpcode() == Instruction::ZExt && I->hasNonNeg())
+      InputKnown.makeNonNegative();
     Known = InputKnown.zextOrTrunc(BitWidth);
+
     assert(!Known.hasConflict() && "Bits known to be one AND zero?");
     break;
   }

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -825,7 +825,6 @@ define i64 @zext_nneg_signbit_extract(i32 %a) nounwind {
 }
 
 define i64 @zext_nneg_demanded_constant(i8 %a) nounwind {
-;
 ; CHECK-LABEL: @zext_nneg_demanded_constant(
 ; CHECK-NEXT:    [[B:%.*]] = zext nneg i8 [[A:%.*]] to i64
 ; CHECK-NEXT:    call void @use64(i64 [[B]]) #[[ATTR0:[0-9]+]]

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -795,9 +795,8 @@ define i16 @zext_nneg_flag_drop(i8 %x, i16 %y) {
 
 define i32 @zext_nneg_redundant_and(i8 %a) {
 ; CHECK-LABEL: @zext_nneg_redundant_and(
-; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[A:%.*]], 127
-; CHECK-NEXT:    [[RES:%.*]] = zext i8 [[TMP1]] to i32
-; CHECK-NEXT:    ret i32 [[RES]]
+; CHECK-NEXT:    [[A_I32:%.*]] = zext nneg i8 [[A:%.*]] to i32
+; CHECK-NEXT:    ret i32 [[A_I32]]
 ;
   %a.i32 = zext nneg i8 %a to i32
   %res = and i32 %a.i32, 127
@@ -818,9 +817,7 @@ define i32 @zext_nneg_redundant_and_neg(i8 %a) {
 
 define i64 @zext_nneg_signbit_extract(i32 %a) nounwind {
 ; CHECK-LABEL: @zext_nneg_signbit_extract(
-; CHECK-NEXT:    [[TMP1:%.*]] = lshr i32 [[A:%.*]], 31
-; CHECK-NEXT:    [[C:%.*]] = zext i32 [[TMP1]] to i64
-; CHECK-NEXT:    ret i64 [[C]]
+; CHECK-NEXT:    ret i64 0
 ;
   %b = zext nneg i32 %a to i64
   %c = lshr i64 %b, 31
@@ -828,10 +825,11 @@ define i64 @zext_nneg_signbit_extract(i32 %a) nounwind {
 }
 
 define i64 @zext_nneg_demanded_constant(i8 %a) nounwind {
+;
 ; CHECK-LABEL: @zext_nneg_demanded_constant(
 ; CHECK-NEXT:    [[B:%.*]] = zext nneg i8 [[A:%.*]] to i64
 ; CHECK-NEXT:    call void @use64(i64 [[B]]) #[[ATTR0:[0-9]+]]
-; CHECK-NEXT:    [[C:%.*]] = and i64 [[B]], 254
+; CHECK-NEXT:    [[C:%.*]] = and i64 [[B]], 126
 ; CHECK-NEXT:    ret i64 [[C]]
 ;
   %b = zext nneg i8 %a to i64

--- a/llvm/test/Transforms/LoopVectorize/reduction.ll
+++ b/llvm/test/Transforms/LoopVectorize/reduction.ll
@@ -1204,7 +1204,7 @@ define i64 @reduction_with_phi_with_one_incoming_on_backedge(i16 %n, ptr %A) {
 ; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i16 [[SMAX]], 5
 ; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label [[SCALAR_PH:%.*]], label [[VECTOR_PH:%.*]]
 ; CHECK:       vector.ph:
-; CHECK-NEXT:    [[N_VEC:%.*]] = and i32 [[TMP1]], 65532
+; CHECK-NEXT:    [[N_VEC:%.*]] = and i32 [[TMP1]], 32764
 ; CHECK-NEXT:    [[DOTCAST:%.*]] = trunc i32 [[N_VEC]] to i16
 ; CHECK-NEXT:    [[IND_END:%.*]] = or i16 [[DOTCAST]], 1
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
@@ -1282,7 +1282,7 @@ define i64 @reduction_with_phi_with_two_incoming_on_backedge(i16 %n, ptr %A) {
 ; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i16 [[SMAX]], 5
 ; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label [[SCALAR_PH:%.*]], label [[VECTOR_PH:%.*]]
 ; CHECK:       vector.ph:
-; CHECK-NEXT:    [[N_VEC:%.*]] = and i32 [[TMP1]], 65532
+; CHECK-NEXT:    [[N_VEC:%.*]] = and i32 [[TMP1]], 32764
 ; CHECK-NEXT:    [[DOTCAST:%.*]] = trunc i32 [[N_VEC]] to i16
 ; CHECK-NEXT:    [[IND_END:%.*]] = or i16 [[DOTCAST]], 1
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]


### PR DESCRIPTION
zext nneg was recently added to the IR in #67982.   This patch teaches
demanded bits and known bits about the semantics of the instruction, and
adds a couple of test cases to illustrate basic functionality.