### PR TITLE
[mlir][arith] Add ArithOpsInterfaces to mlir-generic-headers

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Arith/IR/CMakeLists.txt
@@ -7,8 +7,4 @@ mlir_tablegen(ArithOpsAttributes.cpp.inc -gen-attrdef-defs
               -attrdefs-dialect=arith)
 add_mlir_dialect(ArithOps arith)
 add_mlir_doc(ArithOps ArithOps Dialects/ -gen-dialect-doc)
-
-set(LLVM_TARGET_DEFINITIONS ArithOpsInterfaces.td)
-mlir_tablegen(ArithOpsInterfaces.h.inc -gen-op-interface-decls)
-mlir_tablegen(ArithOpsInterfaces.cpp.inc -gen-op-interface-defs)
-add_public_tablegen_target(MLIRArithOpsInterfacesIncGen)
+add_mlir_interface(ArithOpsInterfaces)


### PR DESCRIPTION
This is achieved by calling add_mlir_interface.

The issue manifests as ArithOpsInterfaces.h.inc not being available when a pass includes something like MemRef.h which includes Arith.h.

Tested with check-mlir.