### PR TITLE
[clang][deps] Skip writing `DIAG_PRAGMA_MAPPINGS` record

### DIFF
--- a/clang/include/clang/Lex/HeaderSearchOptions.h
+++ b/clang/include/clang/Lex/HeaderSearchOptions.h
@@ -247,6 +247,11 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned ModulesSkipHeaderSearchPaths : 1;
 
+  /// Whether to entirely skip writing pragma diagnostic mappings.
+  /// Primarily used to speed up deserialization during dependency scanning.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned ModulesSkipPragmaDiagnosticMappings : 1;
+
   LLVM_PREFERRED_TYPE(bool)
   unsigned ModulesHashContent : 1;
 
@@ -270,7 +275,8 @@ public:
         ForceCheckCXX20ModulesInputFiles(false), UseDebugInfo(false),
         ModulesValidateDiagnosticOptions(true),
         ModulesSkipDiagnosticOptions(false),
-        ModulesSkipHeaderSearchPaths(false), ModulesHashContent(false),
+        ModulesSkipHeaderSearchPaths(false),
+        ModulesSkipPragmaDiagnosticMappings(false), ModulesHashContent(false),
         ModulesStrictContextHash(false) {}
 
   /// AddPath - Add the \p Path path to the specified \p Group list.

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1261,8 +1261,8 @@ void ASTWriter::writeUnhashedControlBlock(Preprocessor &PP,
     Stream.EmitRecord(HEADER_SEARCH_PATHS, Record);
   }
 
-  // Write out the diagnostic/pragma mappings.
-  WritePragmaDiagnosticMappings(Diags, /* isModule = */ WritingModule);
+  if (!HSOpts.ModulesSkipPragmaDiagnosticMappings)
+    WritePragmaDiagnosticMappings(Diags, /* isModule = */ WritingModule);
 
   // Header search entry usage.
   auto HSEntryUsage = PP.getHeaderSearchInfo().computeUserEntryUsage();

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -255,6 +255,8 @@ public:
     ScanInstance.getHeaderSearchOpts().ModulesStrictContextHash = true;
     ScanInstance.getHeaderSearchOpts().ModulesSkipDiagnosticOptions = true;
     ScanInstance.getHeaderSearchOpts().ModulesSkipHeaderSearchPaths = true;
+    ScanInstance.getHeaderSearchOpts().ModulesSkipPragmaDiagnosticMappings =
+        true;
 
     // Avoid some checks and module map parsing when loading PCM files.
     ScanInstance.getPreprocessorOpts().ModulesCheckRelocated = false;


### PR DESCRIPTION
Following up on #69975, this patch skips writing `DIAG_PRAGMA_MAPPINGS` as well. Deserialization of this PCM record is still showing up in profiles, since it needs to be VBR-decoded for every transitively loaded PCM file.

The scanner doesn't make any guarantees about diagnostic accuracy (and it even disables all warnings), so skipping this record should be safe.