### PR TITLE
Fix to attribute plugins reaching an unreachable

### DIFF
--- a/clang/lib/Sema/ParsedAttr.cpp
+++ b/clang/lib/Sema/ParsedAttr.cpp
@@ -200,12 +200,12 @@ bool ParsedAttr::existsInTarget(const TargetInfo &Target) const {
   // function just returns true.
   bool HasSpelling = K != IgnoredAttribute && K != UnknownAttribute &&
                      K != NoSemaHandlerAttribute;
-  bool TargetSpecificSpellingExists = !HasSpelling ||
-    getInfo().spellingExistsInTarget(Target, getAttributeSpellingListIndex());
+  bool TargetSpecificSpellingExists =
+      !HasSpelling ||
+      getInfo().spellingExistsInTarget(Target, getAttributeSpellingListIndex());
 
   return getInfo().existsInTarget(Target) && TargetSpecificSpellingExists;
 }
-
 
 bool ParsedAttr::isKnownToGCC() const { return getInfo().IsKnownToGCC; }
 

--- a/clang/lib/Sema/ParsedAttr.cpp
+++ b/clang/lib/Sema/ParsedAttr.cpp
@@ -193,10 +193,19 @@ bool ParsedAttr::isTypeAttr() const { return getInfo().IsType; }
 bool ParsedAttr::isStmtAttr() const { return getInfo().IsStmt; }
 
 bool ParsedAttr::existsInTarget(const TargetInfo &Target) const {
-  return getInfo().existsInTarget(Target) &&
-         getInfo().spellingExistsInTarget(Target,
-                                          getAttributeSpellingListIndex());
+  Kind K = getParsedKind();
+
+  // If the attribute has a target-specific spelling, check that it exists.
+  // Only call this if the attr is not ignored/unknown. For most targets, this
+  // function just returns true.
+  bool HasSpelling = K != IgnoredAttribute && K != UnknownAttribute &&
+                     K != NoSemaHandlerAttribute;
+  bool TargetSpecificSpellingExists = !HasSpelling ||
+    getInfo().spellingExistsInTarget(Target, getAttributeSpellingListIndex());
+
+  return getInfo().existsInTarget(Target) && TargetSpecificSpellingExists;
 }
+
 
 bool ParsedAttr::isKnownToGCC() const { return getInfo().IsKnownToGCC; }
 


### PR DESCRIPTION
[0faee97](https://github.com/llvm/llvm-project/commit/0faee97a924adec76d5c7cd680c289ced51e6b5a) broke attribute plugins. Specifically, it added a call to `getAttributeSpellingListIndex()` in situations that reached an unreachable statement. This patch adds a check before calling that to avoid hitting the unreachable.

`clang/test/Frontend/plugin-attribute.cpp` has been broken since [0faee97](https://github.com/llvm/llvm-project/commit/0faee97a924adec76d5c7cd680c289ced51e6b5a), and this patch fixes it. 

Bug: [70702](https://github.com/llvm/llvm-project/issues/70702)