### PR TITLE
[libc++] Add a %{verify} substitution

### DIFF
--- a/libcxx/test/libcxx/selftest/convenience_substitutions/verify.sh.cpp
+++ b/libcxx/test/libcxx/selftest/convenience_substitutions/verify.sh.cpp
@@ -12,4 +12,5 @@
 
 // RUN: %{verify}
 
-static_assert(false, ""); // expected-error {{static assertion failed}}
+struct Foo { };
+typedef Foo::x x; // expected-error {{no type named 'x' in 'Foo'}}

--- a/libcxx/test/libcxx/selftest/convenience_substitutions/verify.sh.cpp
+++ b/libcxx/test/libcxx/selftest/convenience_substitutions/verify.sh.cpp
@@ -12,5 +12,5 @@
 
 // RUN: %{verify}
 
-struct Foo { };
+struct Foo {};
 typedef Foo::x x; // expected-error {{no type named 'x' in 'Foo'}}

--- a/libcxx/test/libcxx/selftest/convenience_substitutions/verify.sh.cpp
+++ b/libcxx/test/libcxx/selftest/convenience_substitutions/verify.sh.cpp
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: verify-support
+
+// Make sure that we provide the %{verify} convenience substitution.
+
+// RUN: %{verify}
+
+static_assert(false, ""); // expected-error {{static assertion failed}}

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -81,8 +81,15 @@ def parseScript(test, preamble):
     #       errors, which doesn't make sense for clang-verify tests because we may want to check
     #       for specific warning diagnostics.
     _checkBaseSubstitutions(substitutions)
-    substitutions.append(("%{build}", "%{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe"))
-    substitutions.append(("%{verify}", "%{cxx} %s %{flags} %{compile_flags} -fsyntax-only -Wno-error -Xclang -verify -Xclang -verify-ignore-unexpected=note -ferror-limit=0"))
+    substitutions.append(
+        ("%{build}", "%{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe")
+    )
+    substitutions.append(
+        (
+            "%{verify}",
+            "%{cxx} %s %{flags} %{compile_flags} -fsyntax-only -Wno-error -Xclang -verify -Xclang -verify-ignore-unexpected=note -ferror-limit=0",
+        )
+    )
     substitutions.append(("%{run}", "%{exec} %t.exe"))
 
     # Parse the test file, including custom directives
@@ -312,9 +319,7 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
                         test.getFullName()
                     ),
                 )
-            steps = [
-                "%dbg(COMPILED WITH) %{verify}"
-            ]
+            steps = ["%dbg(COMPILED WITH) %{verify}"]
             return self._executeShTest(test, litConfig, steps)
         # Make sure to check these ones last, since they will match other
         # suffixes above too.

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -75,11 +75,14 @@ def parseScript(test, preamble):
     tmpDir, tmpBase = _getTempPaths(test)
     substitutions = lit.TestRunner.getDefaultSubstitutions(test, tmpDir, tmpBase)
 
-    # Check base substitutions and add the %{build} and %{run} convenience substitutions
+    # Check base substitutions and add the %{build}, %{verify} and %{run} convenience substitutions
+    #
+    # Note: We use -Wno-error with %{verify} to make sure that we don't treat all diagnostics as
+    #       errors, which doesn't make sense for clang-verify tests because we may want to check
+    #       for specific warning diagnostics.
     _checkBaseSubstitutions(substitutions)
-    substitutions.append(
-        ("%{build}", "%{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe")
-    )
+    substitutions.append(("%{build}", "%{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe"))
+    substitutions.append(("%{verify}", "%{cxx} %s %{flags} %{compile_flags} -fsyntax-only -Wno-error -Xclang -verify -Xclang -verify-ignore-unexpected=note -ferror-limit=0"))
     substitutions.append(("%{run}", "%{exec} %t.exe"))
 
     # Parse the test file, including custom directives
@@ -227,6 +230,13 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
             file with the %{flags}, %{compile_flags} and %{link_flags}
             substitutions, and that produces an executable named %t.exe.
 
+        %{verify}
+            Expands to a command-line that builds the current source
+            file with the %{flags} and %{compile_flags} substitutions
+            and enables clang-verify. This can be used to write .sh.cpp
+            tests that use clang-verify. Note that this substitution can
+            only be used when the 'verify-support' feature is available.
+
         %{run}
             Equivalent to `%{exec} %t.exe`. This is intended to be used
             in conjunction with the %{build} substitution.
@@ -265,9 +275,6 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
             yield lit.Test.Test(testSuite, pathInSuite, localConfig)
 
     def execute(self, test, litConfig):
-        VERIFY_FLAGS = (
-            "-Xclang -verify -Xclang -verify-ignore-unexpected=note -ferror-limit=0"
-        )
         supportsVerify = "verify-support" in test.config.available_features
         filename = test.path_in_suite[-1]
 
@@ -306,11 +313,7 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
                     ),
                 )
             steps = [
-                # Note: Use -Wno-error to make sure all diagnostics are not treated as errors,
-                #       which doesn't make sense for clang-verify tests.
-                "%dbg(COMPILED WITH) %{{cxx}} %s %{{flags}} %{{compile_flags}} -fsyntax-only -Wno-error {}".format(
-                    VERIFY_FLAGS
-                )
+                "%dbg(COMPILED WITH) %{verify}"
             ]
             return self._executeShTest(test, litConfig, steps)
         # Make sure to check these ones last, since they will match other


### PR DESCRIPTION
This makes it easier to write .sh.cpp tests that perform multiple clang-verify checks in the same test.