### PR TITLE
[clang-format] Add ability for clang-format-diff to exit with non-0 status

### DIFF
--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -325,7 +325,6 @@ output of a unified diff and reformats all contained lines with
                           The name of the predefined style used as a fallback in case clang-format is invoked with-style=file, but can not
                           find the .clang-formatfile to use.
     -binary BINARY        location of binary to use for clang-format
-    -non-zero-exit-code   exit with a non-zero status if formatting changes are necessary
 
 To reformat all the lines in the latest Mercurial/:program:`hg` commit, do:
 

--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -325,6 +325,7 @@ output of a unified diff and reformats all contained lines with
                           The name of the predefined style used as a fallback in case clang-format is invoked with-style=file, but can not
                           find the .clang-formatfile to use.
     -binary BINARY        location of binary to use for clang-format
+    -non-zero-exit-code   exit with a non-zero status if formatting changes are necessary
 
 To reformat all the lines in the latest Mercurial/:program:`hg` commit, do:
 

--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -95,12 +95,6 @@ def main():
         default="clang-format",
         help="location of binary to use for clang-format",
     )
-    parser.add_argument(
-        "-non-zero-exit-code",
-        action="store_true",
-        default=False,
-        help="exit with a non-zero status if formatting changes are necessary",
-    )
     args = parser.parse_args()
 
     # Extract changed lines for each file.

--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -191,8 +191,7 @@ def main():
             diff_string = "".join(diff)
             if len(diff_string) > 0:
                 sys.stdout.write(diff_string)
-                if args.non_zero_exit_code:
-                    sys.exit(1)
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -95,6 +95,12 @@ def main():
         default="clang-format",
         help="location of binary to use for clang-format",
     )
+    parser.add_argument(
+        "-non-zero-exit-code",
+        action="store_true",
+        default=False,
+        help="exit with a non-zero status if formatting changes are necessary"
+    )
     args = parser.parse_args()
 
     # Extract changed lines for each file.
@@ -185,6 +191,8 @@ def main():
             diff_string = "".join(diff)
             if len(diff_string) > 0:
                 sys.stdout.write(diff_string)
+                if args.non_zero_exit_code:
+                    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -99,7 +99,7 @@ def main():
         "-non-zero-exit-code",
         action="store_true",
         default=False,
-        help="exit with a non-zero status if formatting changes are necessary"
+        help="exit with a non-zero status if formatting changes are necessary",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
This patch adds the ability for the clang-format-diff script to exit with a non-zero status if it detects that formatting changes are necessary. This makes it easier to use clang-format-diff as part of a DevOps pipeline, since you could add a stage to run clang-format-diff and fail if the formatting needs to be fixed.