### PR TITLE
Escape LLVM_TARGETS_TO_BUILD while checking against LLVM_ALL_TARGETS and LLVM_EXPERIMENTAL_TARGETS_TO_BUILD

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -943,7 +943,7 @@ foreach(t ${LLVM_TARGETS_TO_BUILD})
   # We allow experimental targets that are not in LLVM_ALL_EXPERIMENTAL_TARGETS,
   # as long as they are passed via LLVM_EXPERIMENTAL_TARGETS_TO_BUILD.
   if ( NOT "${t}" IN_LIST LLVM_ALL_TARGETS AND NOT "${t}" IN_LIST LLVM_EXPERIMENTAL_TARGETS_TO_BUILD )
-    if( ${t} IN_LIST LLVM_ALL_EXPERIMENTAL_TARGETS )
+    if( "${t}" IN_LIST LLVM_ALL_EXPERIMENTAL_TARGETS )
       message(FATAL_ERROR "The target `${t}' is experimental and must be passed "
         "via LLVM_EXPERIMENTAL_TARGETS_TO_BUILD.")
     else()

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -942,7 +942,7 @@ foreach(t ${LLVM_TARGETS_TO_BUILD})
   # LLVM_EXPERIMENTAL_TARGETS_TO_BUILD, not LLVM_TARGETS_TO_BUILD.
   # We allow experimental targets that are not in LLVM_ALL_EXPERIMENTAL_TARGETS,
   # as long as they are passed via LLVM_EXPERIMENTAL_TARGETS_TO_BUILD.
-  if ( NOT ${t} IN_LIST LLVM_ALL_TARGETS AND NOT ${t} IN_LIST LLVM_EXPERIMENTAL_TARGETS_TO_BUILD )
+  if ( NOT "${t}" IN_LIST LLVM_ALL_TARGETS AND NOT "${t}" IN_LIST LLVM_EXPERIMENTAL_TARGETS_TO_BUILD )
     if( ${t} IN_LIST LLVM_ALL_EXPERIMENTAL_TARGETS )
       message(FATAL_ERROR "The target `${t}' is experimental and must be passed "
         "via LLVM_EXPERIMENTAL_TARGETS_TO_BUILD.")


### PR DESCRIPTION
Targeting X86 while building LLVM with the Android NDK, currently fails with "The target `X86' is not a core tier target. It may be experimental, if so it must be passed via LLVM_EXPERIMENTAL_TARGETS_TO_BUILD."

This is happening because the Android NDK defines a variable named X86, which will lead to a "fun" CMake feature. For further details reference [this post](https://discourse.llvm.org/t/the-target-x86-is-not-a-core-tier-target/73784).

To fix this, the LLVM_TARGETS_TO_BUILD need to be escaped while checking agains LLVM_ALL_TARGETS and LLVM_EXPERIMENTAL_TARGETS_TO_BUILD.
