### PR TITLE
[CodeGen][MIR] Support parsing of scalable vectors in MIR

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1963,8 +1963,7 @@ bool MIParser::parseLowLevelType(StringRef::iterator Loc, LLT &Ty) {
     if (HasVScale)
       return error(
           Loc, "expected <vscale x M x sN> or <vscale M x pA> for vector type");
-    else
-      return error(Loc, "expected <M x sN> or <M x pA> for vector type");
+    return error(Loc, "expected <M x sN> or <M x pA> for vector type");
   };
 
   if (Token.isNot(MIToken::IntegerLiteral))

--- a/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid1.mir
+++ b/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid1.mir
@@ -5,6 +5,6 @@ name: test_low_level_type_does_not_start_with_s_p_lt
 body: |
   bb.0:
     liveins: $x0
-    ; CHECK: [[@LINE+1]]:10: expected sN, pA, <M x sN>, or <M x pA> for GlobalISel type
+    ; CHECK: [[@LINE+1]]:10: expected sN, pA, <M x sN>, <M x pA>, <vscale x M x sN>, or <vscale x M x pA> for GlobalISel type
     %0:_(i64) = COPY $x0
 ...

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err0.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err0.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscale0
+body: |
+  bb.0:
+    %0:_(<vscale) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale x M x pA>
+

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err1.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err1.mir
@@ -1,0 +1,9 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscale1
+body: |
+  bb.0:
+    %0:_(<vscale notanx) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale x M x pA>

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err10.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err10.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscalexMxp
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x p) = IMPLICIT_DEF
+...
+
+# CHECK: expected integers after 's'/'p' type character

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err11.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err11.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscalexMxs32
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x s32) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err12.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err12.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscalexMxp0
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x p0) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err13.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err13.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscalexMxs32X
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x s32 X) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err14.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err14.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscalexMxp0
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x p0 X) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err15.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err15.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscale0
+body: |
+  bb.0:
+    %0:_(notatype) = IMPLICIT_DEF
+...
+
+# CHECK: expected sN, pA, <M x sN>, <M x pA>, <vscale x M x sN>, or <vscale x M x pA> for GlobalISel type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err2.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err2.mir
@@ -1,0 +1,9 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscalex0
+body: |
+  bb.0:
+    %0:_(<vscale x) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err3.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err3.mir
@@ -1,0 +1,9 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscalex0
+body: |
+  bb.0:
+    %0:_(<vscale x) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err4.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err4.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscalex1
+body: |
+  bb.0:
+    %0:_(<vscale x notanint) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type
+

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err5.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err5.mir
@@ -1,0 +1,9 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscalexM
+body: |
+  bb.0:
+    %0:_(<vscale x 4) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err6.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err6.mir
@@ -1,0 +1,11 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscalexMx0
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type
+

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err7.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err7.mir
@@ -1,0 +1,9 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscalexMx1
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x notansorp) = IMPLICIT_DEF
+...
+
+# CHECK: expected <vscale x M x sN> or <vscale M x pA> for vector type

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err8.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err8.mir
@@ -1,0 +1,10 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+
+---
+name: err_after_vscalexMxs
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x s) = IMPLICIT_DEF
+...
+
+# CHECK: expected integers after 's'/'p' type character

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err9.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err9.mir
@@ -1,0 +1,11 @@
+# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
+---
+name: err_after_vscalexMxpX
+body: |
+  bb.0:
+    %0:_(<vscale x 4 x pX) = IMPLICIT_DEF
+...
+
+# CHECK: expected integers after 's'/'p' type character
+
+

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type.mir
@@ -1,0 +1,23 @@
+# RUN: llc -run-pass=none -o - %s | FileCheck %s
+
+---
+name:            scalable_vector_type_s
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: scalable_vector_type_s
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x s8>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x s8>) = COPY [[DEF]](<vscale x 1 x s8>)
+    %0:_(<vscale x 1 x s8>) = IMPLICIT_DEF
+    %1:_(<vscale x 1 x s8>) = COPY %0
+...
+
+---
+name:            scalable_vector_type_p
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: scalable_vector_type_p
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x p0>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x p0>) = COPY [[DEF]](<vscale x 1 x p0>)
+    %0:_(<vscale x 1 x p0>) = IMPLICIT_DEF
+    %1:_(<vscale x 1 x p0>) = COPY %0
+...

--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type.mir
@@ -1,10 +1,10 @@
 # RUN: llc -run-pass=none -o - %s | FileCheck %s
 
 ---
-name:            scalable_vector_type_s
+name:            test_nxv1s8
 body: |
   bb.0:
-    ; CHECK-LABEL: name: scalable_vector_type_s
+    ; CHECK-LABEL: name: test_nxv1s8
     ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x s8>) = IMPLICIT_DEF
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x s8>) = COPY [[DEF]](<vscale x 1 x s8>)
     %0:_(<vscale x 1 x s8>) = IMPLICIT_DEF
@@ -12,12 +12,122 @@ body: |
 ...
 
 ---
-name:            scalable_vector_type_p
+name:            test_nxv1s16
 body: |
   bb.0:
-    ; CHECK-LABEL: name: scalable_vector_type_p
+    ; CHECK-LABEL: name: test_nxv1s16
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x s16>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x s16>) = COPY [[DEF]](<vscale x 1 x s16>)
+    %0:_(<vscale x 1 x s16>) = IMPLICIT_DEF
+    %1:_(<vscale x 1 x s16>) = COPY %0
+...
+
+---
+name:            test_nxv1s32
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv1s32
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x s32>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x s32>) = COPY [[DEF]](<vscale x 1 x s32>)
+    %0:_(<vscale x 1 x s32>) = IMPLICIT_DEF
+    %1:_(<vscale x 1 x s32>) = COPY %0
+...
+
+---
+name:            test_nxv1s64
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv1s64
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x s64>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x s64>) = COPY [[DEF]](<vscale x 1 x s64>)
+    %0:_(<vscale x 1 x s64>) = IMPLICIT_DEF
+    %1:_(<vscale x 1 x s64>) = COPY %0
+...
+
+---
+name:            test_nxv4s8
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv4s8
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 4 x s8>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 4 x s8>) = COPY [[DEF]](<vscale x 4 x s8>)
+    %0:_(<vscale x 4 x s8>) = IMPLICIT_DEF
+    %1:_(<vscale x 4 x s8>) = COPY %0
+...
+
+---
+name:            test_nxv4s16
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv4s16
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 4 x s16>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 4 x s16>) = COPY [[DEF]](<vscale x 4 x s16>)
+    %0:_(<vscale x 4 x s16>) = IMPLICIT_DEF
+    %1:_(<vscale x 4 x s16>) = COPY %0
+...
+
+---
+name:            test_nxv4s32
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv4s32
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 4 x s32>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 4 x s32>) = COPY [[DEF]](<vscale x 4 x s32>)
+    %0:_(<vscale x 4 x s32>) = IMPLICIT_DEF
+    %1:_(<vscale x 4 x s32>) = COPY %0
+...
+
+---
+name:            test_nxv4s64
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv4s64
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 4 x s64>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 4 x s64>) = COPY [[DEF]](<vscale x 4 x s64>)
+    %0:_(<vscale x 4 x s64>) = IMPLICIT_DEF
+    %1:_(<vscale x 4 x s64>) = COPY %0
+...
+
+---
+name:            test_nxv1p0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv1p0
     ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x p0>) = IMPLICIT_DEF
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x p0>) = COPY [[DEF]](<vscale x 1 x p0>)
     %0:_(<vscale x 1 x p0>) = IMPLICIT_DEF
     %1:_(<vscale x 1 x p0>) = COPY %0
+...
+
+---
+name:            test_nxv1sp1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv1sp1
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 1 x p0>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 1 x p0>) = COPY [[DEF]](<vscale x 1 x p0>)
+    %0:_(<vscale x 1 x p0>) = IMPLICIT_DEF
+    %1:_(<vscale x 1 x p0>) = COPY %0
+...
+
+---
+name:            test_nxv4p0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv4p0
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 4 x p0>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 4 x p0>) = COPY [[DEF]](<vscale x 4 x p0>)
+    %0:_(<vscale x 4 x p0>) = IMPLICIT_DEF
+    %1:_(<vscale x 4 x p0>) = COPY %0
+...
+
+---
+name:            test_nxv4p1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_nxv4p1
+    ; CHECK: [[DEF:%[0-9]+]]:_(<vscale x 4 x p1>) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<vscale x 4 x p1>) = COPY [[DEF]](<vscale x 4 x p1>)
+    %0:_(<vscale x 4 x p1>) = IMPLICIT_DEF
+    %1:_(<vscale x 4 x p1>) = COPY %0
 ...


### PR DESCRIPTION
This patch builds on the support for vectors by adding ability to parse scalable vectors in MIR.