### PR TITLE
[Pass] Support MachineFunction in getIRName

### DIFF
--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Analysis/CallGraphSCCPass.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
@@ -221,6 +222,9 @@ std::string getIRName(Any IR) {
 
   if (const auto **L = llvm::any_cast<const Loop *>(&IR))
     return (*L)->getName().str();
+
+  if (const auto **MF = llvm::any_cast<const MachineFunction *>(&IR))
+    return (*MF)->getName().str();
 
   llvm_unreachable("Unknown wrapped IR type");
 }


### PR DESCRIPTION
It is necessary in MachinePassManager. `llc` can show function names when using `debug-pass-manager`.
Part of #69879.
@arsenm 