### PR TITLE
[lit] Use raw strings for backslash escapes to fix SyntaxWarnings

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -271,7 +271,7 @@ def ptxas_version(ptxas):
     ptxas_cmd = subprocess.Popen([ptxas, "--version"], stdout=subprocess.PIPE)
     ptxas_out = ptxas_cmd.stdout.read().decode("ascii")
     ptxas_cmd.wait()
-    match = re.search("release (\d+)\.(\d+)", ptxas_out)
+    match = re.search(r"release (\d+)\.(\d+)", ptxas_out)
     if match:
         return (int(match.group(1)), int(match.group(2)))
     print("couldn't determine ptxas version")


### PR DESCRIPTION
Unless specified as a "raw" string, Python will try to interpret backslashes, which means they don't get passed on correctly to the underlying regex-engine, unless escaped manually (`\\`).

Use raw strings in `llvm/test/lit.cfg.py` to avoid a `SyntaxWarning`:
```
llvm/test/lit.cfg.py:275: SyntaxWarning: invalid escape sequence '\d'
  match = re.search("release (\d+)\.(\d+)", ptxas_out)
```

Other such warning present in 17.0.x were already fixed in 7ed0f5b6de74989c739389770a2d45dc7d58166a.