### PR TITLE
[openmp] Clarify error message if TSan is missing

### DIFF
--- a/openmp/tools/archer/ompt-tsan.cpp
+++ b/openmp/tools/archer/ompt-tsan.cpp
@@ -1248,7 +1248,7 @@ ompt_start_tool(unsigned int omp_version, const char *runtime_version) {
                           // tool the chance to be loaded
   {
     if (archer_flags->verbose)
-      std::cout << "Archer detected OpenMP application without TSan "
+      std::cout << "Archer detected OpenMP application without TSan; "
                    "stopping operation"
                 << std::endl;
     delete archer_flags;


### PR DESCRIPTION
For an uninformed user, the error message might refer to a missing "TSan stopping operation", rather than indicating that TSan is missing **and therefore** operation is stopped.