### PR TITLE
[lldb][Symtab][NFCI] Replace vector::swap with shrink_to_fit

### DIFF
--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -1010,10 +1010,7 @@ void Symtab::Finalize() {
   // Calculate the size of symbols inside InitAddressIndexes.
   InitAddressIndexes();
   // Shrink to fit the symbols so we don't waste memory
-  if (m_symbols.capacity() > m_symbols.size()) {
-    collection new_symbols(m_symbols.begin(), m_symbols.end());
-    m_symbols.swap(new_symbols);
-  }
+  m_symbols.shrink_to_fit();
   SaveToCache();
 }
 


### PR DESCRIPTION
Replaces the old idiom (of swapping the container to shrink it) with the newer STL alternative.

Similar transition in LLDB was done in: https://reviews.llvm.org/D47492