### PR TITLE
ISel/RISCV: restrict custom lowering of ISD::LRINT, ISD::LLRINT

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -731,7 +731,12 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
                          VT, Custom);
       setOperationAction({ISD::FP_TO_SINT_SAT, ISD::FP_TO_UINT_SAT}, VT,
                          Custom);
-      setOperationAction({ISD::LRINT, ISD::LLRINT}, VT, Custom);
+      if (VT.getVectorElementType() == MVT::i32 ||
+          (VT.getVectorElementType() == MVT::i64 && Subtarget.is64Bit()))
+        setOperationAction({ISD::LRINT}, VT, Custom);
+      if (VT.getVectorElementType() == MVT::i64 ||
+          VT.getVectorElementType() == MVT::i32)
+        setOperationAction({ISD::LLRINT}, VT, Custom);
       setOperationAction(
           {ISD::SADDSAT, ISD::UADDSAT, ISD::SSUBSAT, ISD::USUBSAT}, VT, Legal);
 


### PR DESCRIPTION
To follow up on 7a76038 (CodeGen/RISCV: increase test coverage of lrint, llrint), it is clear that the custom lowering of ISD::LRINT always works for i32, and only works for i64 if the subtarget is 64-bit. ISD::LLRINT custom-lowering works for i32 and i64. Hence, guard the appropriate setOperationAction() calls with these checks.