### PR TITLE
Increase git fetch depth

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -10,14 +10,14 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 2000 # Fetches only the last 2000 commits
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:
           separator: ","
-          fetch_depth: 100 # Fetches only the last 10 commits
+          fetch_depth: 2000 # Fetches only the last 2000 commits
 
       - name: "Listed files"
         run: |

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2000 # Fetches only the last 2000 commits
+          fetch-depth: 2 # Fetches only the last 2 commits
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
We've gotten ~750 commits in the last 7 days. Upping the fetch depth to 2000 will make it more likely that PRs up to 2 weeks old will have enough fetch history to find a common parent. This _might_ address some of the failures we're seeing in the clang-format action where it cannot find a common base commit.