### PR TITLE
[lld][NCF] Add missing llvm-mc invocation to arm64ec-codemap.test.

### DIFF
--- a/lld/test/COFF/arm64ec-codemap.test
+++ b/lld/test/COFF/arm64ec-codemap.test
@@ -3,6 +3,7 @@ RUN: split-file %s %t.dir && cd %t.dir
 
 RUN: llvm-mc -filetype=obj -triple=arm64-windows arm64-func-sym.s -o arm64-func-sym.obj
 RUN: llvm-mc -filetype=obj -triple=arm64ec-windows arm64ec-func-sym.s -o arm64ec-func-sym.obj
+RUN: llvm-mc -filetype=obj -triple=arm64ec-windows data-sec.s -o data-sec.obj
 RUN: llvm-mc -filetype=obj -triple=x86_64-windows x86_64-func-sym.s -o x86_64-func-sym.obj
 RUN: llvm-mc -filetype=obj -triple=arm64ec-windows codemap.s -o codemap.obj
 RUN: llvm-mc -filetype=obj -triple=arm64ec-windows codemap2.s -o codemap2.obj


### PR DESCRIPTION
Fixup for #70722.