### PR TITLE
[WIP][libc++] Fixes basic_streambuf instantiation.

### DIFF
--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -448,7 +448,7 @@ protected:
     int_type overflow (int_type __c = traits_type::eof()) override;
     pos_type seekoff(off_type __off, ios_base::seekdir __way,
                      ios_base::openmode __wch = ios_base::in | ios_base::out) override;
-    _LIBCPP_HIDE_FROM_ABI_VIRTUAL
+//    _LIBCPP_HIDE_FROM_ABI_VIRTUAL
     pos_type seekpos(pos_type __sp,
                      ios_base::openmode __wch = ios_base::in | ios_base::out) override {
         return seekoff(__sp, ios_base::beg, __wch);

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -320,6 +320,7 @@ generic-gcc)
                    -DLIBCXXABI_ENABLE_WERROR=NO \
                    -DLIBUNWIND_ENABLE_WERROR=NO
     check-runtimes
+    check-abi-list
 ;;
 generic-gcc-cxx11)
     clean


### PR DESCRIPTION
The patch https://reviews.llvm.org/D156609 fails in the CI [1] due to linker issues of

std::__1::basic_stringbuf<char, std::__1::char_traits<char>, std::__1::allocator<char> >::seekpos(std::__1::fpos<__mbstate_t>, unsigned int)

This is the only virtual function in this class marked _LIBCPP_HIDE_FROM_ABI_VIRTUAL causing the function not to be instantiated in the dylib.

[1] https://buildkite.com/llvm-project/libcxx-ci/builds/31253#018b8227-8bdb-4f77-b578-f6ef9f14d7de