### PR TITLE
[CMake] Fix __builtin_thread_pointer check with LTO

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -65,7 +65,12 @@ check_include_file(fenv.h HAVE_FENV_H)
 check_symbol_exists(FE_ALL_EXCEPT "fenv.h" HAVE_DECL_FE_ALL_EXCEPT)
 check_symbol_exists(FE_INEXACT "fenv.h" HAVE_DECL_FE_INEXACT)
 check_c_source_compiles("
-        void *foo() {
+        #if __has_attribute(used)
+        #define LLVM_ATTRIBUTE_USED __attribute__((__used__))
+        #else
+        #define LLVM_ATTRIBUTE_USED
+        #endif
+        LLVM_ATTRIBUTE_USED void *foo() {
           return __builtin_thread_pointer();
         }
         int main(void) { return 0; }"


### PR DESCRIPTION
With LTO, gcc's IPA passes might drop the foo() function and then the test will pass even on platforms where __builtin_thread_pointer is unavailable.

On PPC64, we get this as a result:
```
llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp:361:61: error: ‘__builtin_thread_pointer’ is not supported on this targ
```

Just mark the function in the CMake configure test with the 'used' attribute to avoid it being optimised out. The test then behaves correctly with -flto.

Reported-by: matoro