### PR TITLE
[flang] Fold IS_IOSTAT_END() & IS_IOSTAT_EOR()

### DIFF
--- a/flang/test/Evaluate/fold-iostat.f90
+++ b/flang/test/Evaluate/fold-iostat.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/test_folding.py %s %flang_fc1
+module m
+  use iso_fortran_env
+  logical, parameter :: test_end1 = is_iostat_end(iostat_end)
+  logical, parameter :: test_end2 = .not. is_iostat_end(iostat_eor)
+  logical, parameter :: test_eor1 = is_iostat_eor(iostat_eor)
+  logical, parameter :: test_eor2 = .not. is_iostat_eor(iostat_end)
+  logical, parameter :: test_arr1 = &
+    all(is_iostat_end([iostat_end, iostat_eor]) .eqv. [.true., .false.])
+  logical, parameter :: test_arr2 = &
+    all(is_iostat_eor([iostat_end, iostat_eor]) .eqv. [.false., .true.])
+end


### PR DESCRIPTION
These intrinsic functions are not particularly valuable -- one can just compare a value to IOSTAT_END or IOSTAT_EOR directly -- but they are in the standard and are allowed to appear in constant expressions, so here's code to fold them.