### PR TITLE
[lldb] [debugserver] Shut down the exception thread when clearing

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachTask.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.mm
@@ -145,6 +145,8 @@ bool MachTask::ExceptionPortIsValid() const {
 //----------------------------------------------------------------------
 void MachTask::Clear() {
   // Do any cleanup needed for this task
+  if (m_exception_thread)
+    ShutDownExcecptionThread();
   m_task = TASK_NULL;
   m_exception_thread = 0;
   m_exception_port = MACH_PORT_NULL;


### PR DESCRIPTION
MachProcess has a MachTask as an ivar.  In the MachProcess dtor, we call MachTask::Clear() to clear its state, before running the dtor of all our ivars, including the MachTask one.

When we attach on darwin, MachProcess calls MachTask::StartExceptionThread which does the task_for_pid and then starts a thread to listen for mach messages.  Then MachProcess calls ptrace(PT_ATTACHEXC).  If that ptrace() fails, MachProcess will call MachTask::Clear.  But the exception thread is now up & running and is not stopped; its ivars will be reset by the Clear() method, and its object will be freed after the dtor runs.

Actually eliciting a crash in this scenario is very timing sensitive; I hand-modified debugserver to fail to PT_ATTACHEXC trying to simulate it on my desktop and was unable.  But looking at the source, and an occasional crash report we've received, it's clear that this is possible.

rdar://117521198