### PR TITLE
[libc++] Externally instantiate std::vformat_to

### DIFF
--- a/libcxx/include/__availability
+++ b/libcxx/include/__availability
@@ -150,6 +150,10 @@
 #  define _LIBCPP_AVAILABILITY_HAS_NO_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
 #endif
 
+// Enable extern instantiations for <format> functions. This significantly reduces the amount of code generated in every
+// TU that uses most of the <format> and <print> utilities.
+// #  define _LIBCPP_AVAILABILITY_HAS_NO_FORMAT_EXPLICIT_INSTANTIATIONS
+
 #elif defined(__APPLE__)
 
 #  if (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 50000)
@@ -247,6 +251,12 @@
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 80000)
 #    define _LIBCPP_AVAILABILITY_HAS_NO_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
 #  endif
+
+// TODO: Replace this with the correct conditions once Apple ships a dylib with the <format> functions
+#  if 1
+#    define _LIBCPP_AVAILABILITY_HAS_NO_FORMAT_EXPLICIT_INSTANTIATIONS
+#  endif
+
 #else
 
 // ...New vendors can add availability markup here...

--- a/libcxx/include/__format/format_error.h
+++ b/libcxx/include/__format/format_error.h
@@ -32,8 +32,12 @@ public:
       : runtime_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI format_error(const format_error&) = default;
   _LIBCPP_HIDE_FROM_ABI format_error& operator=(const format_error&) = default;
+#ifdef _LIBCPP_AVAILABILITY_HAS_NO_FORMAT_EXPLICIT_INSTANTIATIONS
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL
   ~format_error() noexcept override = default;
+#else
+  ~format_error() noexcept override;
+#endif
 };
 _LIBCPP_DIAGNOSTIC_POP
 

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -397,18 +397,30 @@ requires(output_iterator<_OutIt, const _CharT&>) _LIBCPP_HIDE_FROM_ABI _OutIt
 // https://reviews.llvm.org/D110499#inline-1180704
 // TODO FMT Evaluate whether we want to file a Clang bug report regarding this.
 template <output_iterator<const char&> _OutIt>
-_LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
+_LIBCPP_ALWAYS_INLINE _OutIt
 vformat_to(_OutIt __out_it, string_view __fmt, format_args __args) {
   return _VSTD::__vformat_to(_VSTD::move(__out_it), __fmt, __args);
 }
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <output_iterator<const wchar_t&> _OutIt>
-_LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt
+_LIBCPP_ALWAYS_INLINE _OutIt
 vformat_to(_OutIt __out_it, wstring_view __fmt, wformat_args __args) {
   return _VSTD::__vformat_to(_VSTD::move(__out_it), __fmt, __args);
 }
 #endif
+
+#ifndef _LIBCPP_AVAILABILITY_HAS_NO_FORMAT_EXPLICIT_INSTANTIATIONS
+
+extern template _LIBCPP_EXPORTED_FROM_ABI back_insert_iterator<string>
+    vformat_to<back_insert_iterator<string>>(back_insert_iterator<string>, string_view, format_args);
+
+#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+extern template _LIBCPP_EXPORTED_FROM_ABI back_insert_iterator<wstring>
+    vformat_to<back_insert_iterator<wstring>>(back_insert_iterator<wstring>, wstring_view, wformat_args);
+#endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
+
+#endif // _LIBCPP_AVAILABILITY_HAS_NO_FORMAT_EXPLICIT_INSTANTIATIONS
 
 template <output_iterator<const char&> _OutIt, class... _Args>
 _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _OutIt

--- a/libcxx/src/CMakeLists.txt
+++ b/libcxx/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBCXX_SOURCES
   filesystem/filesystem_error.cpp
   filesystem/path_parser.h
   filesystem/path.cpp
+  format.cpp
   functional.cpp
   future.cpp
   hash.cpp

--- a/libcxx/src/format.cpp
+++ b/libcxx/src/format.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <format>
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template back_insert_iterator<string>
+    vformat_to<back_insert_iterator<string>>(back_insert_iterator<string>, string_view, format_args);
+
+#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+template back_insert_iterator<wstring>
+    vformat_to<back_insert_iterator<wstring>>(back_insert_iterator<wstring>, wstring_view, wformat_args);
+#endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
+
+format_error::~format_error() noexcept = default;
+
+_LIBCPP_END_NAMESPACE_STD


### PR DESCRIPTION
This significantly decreases the amount of code generated per TU that is using format utilities and improves compile times (https://godbolt.org/z/8G9zM56cb). The dylib size increases from 1249472 to 1383680, or by 134208. This increase is quite significant, but I think it's worth it given the amount of code it saves. 