### PR TITLE
[Symbolizer] Compute Nearest Line Info for Address.

### DIFF
--- a/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -76,13 +76,13 @@ public:
   // Overloads accepting ObjectFile does not support COFF currently
   Expected<DILineInfo> symbolizeCode(const ObjectFile &Obj,
                                      object::SectionedAddress ModuleOffset,
-                                     bool nearest = false);
+                                     bool Nearest = false);
   Expected<DILineInfo> symbolizeCode(const std::string &ModuleName,
                                      object::SectionedAddress ModuleOffset,
-                                     bool nearest = false);
+                                     bool Nearest = false);
   Expected<DILineInfo> symbolizeCode(ArrayRef<uint8_t> BuildID,
                                      object::SectionedAddress ModuleOffset,
-                                     bool nearest = false);
+                                     bool Nearest = false);
   Expected<DIInliningInfo>
   symbolizeInlinedCode(const ObjectFile &Obj,
                        object::SectionedAddress ModuleOffset);
@@ -146,7 +146,7 @@ private:
   Expected<DILineInfo>
   symbolizeCodeCommon(const T &ModuleSpecifier,
                       object::SectionedAddress ModuleOffset,
-                      bool nearest = false);
+                      bool Nearest = false);
   template <typename T>
   Expected<DIInliningInfo>
   symbolizeInlinedCodeCommon(const T &ModuleSpecifier,

--- a/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -75,11 +75,14 @@ public:
 
   // Overloads accepting ObjectFile does not support COFF currently
   Expected<DILineInfo> symbolizeCode(const ObjectFile &Obj,
-                                     object::SectionedAddress ModuleOffset);
+                                     object::SectionedAddress ModuleOffset,
+                                     bool nearest = false);
   Expected<DILineInfo> symbolizeCode(const std::string &ModuleName,
-                                     object::SectionedAddress ModuleOffset);
+                                     object::SectionedAddress ModuleOffset,
+                                     bool nearest = false);
   Expected<DILineInfo> symbolizeCode(ArrayRef<uint8_t> BuildID,
-                                     object::SectionedAddress ModuleOffset);
+                                     object::SectionedAddress ModuleOffset,
+                                     bool nearest = false);
   Expected<DIInliningInfo>
   symbolizeInlinedCode(const ObjectFile &Obj,
                        object::SectionedAddress ModuleOffset);
@@ -142,7 +145,8 @@ private:
   template <typename T>
   Expected<DILineInfo>
   symbolizeCodeCommon(const T &ModuleSpecifier,
-                      object::SectionedAddress ModuleOffset);
+                      object::SectionedAddress ModuleOffset,
+                      bool nearest = false);
   template <typename T>
   Expected<DIInliningInfo>
   symbolizeInlinedCodeCommon(const T &ModuleSpecifier,

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -55,7 +55,7 @@ template <typename T>
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCodeCommon(const T &ModuleSpecifier,
                                     object::SectionedAddress ModuleOffset,
-                                    bool nearest) {
+                                    bool Nearest) {
 
   auto InfoOrErr = getOrCreateModuleInfo(ModuleSpecifier);
   if (!InfoOrErr)
@@ -103,22 +103,22 @@ LLVMSymbolizer::symbolizeCodeCommon(const T &ModuleSpecifier,
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCode(const ObjectFile &Obj,
                               object::SectionedAddress ModuleOffset,
-                              bool nearest) {
-  return symbolizeCodeCommon(Obj, ModuleOffset, nearest);
+                              bool Nearest) {
+  return symbolizeCodeCommon(Obj, ModuleOffset, Nearest);
 }
 
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCode(const std::string &ModuleName,
                               object::SectionedAddress ModuleOffset,
-                              bool nearest) {
-  return symbolizeCodeCommon(ModuleName, ModuleOffset, nearest);
+                              bool Nearest) {
+  return symbolizeCodeCommon(ModuleName, ModuleOffset, Nearest);
 }
 
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCode(ArrayRef<uint8_t> BuildID,
                               object::SectionedAddress ModuleOffset,
-                              bool nearest) {
-  return symbolizeCodeCommon(BuildID, ModuleOffset, nearest);
+                              bool Nearest) {
+  return symbolizeCodeCommon(BuildID, ModuleOffset, Nearest);
 }
 
 template <typename T>

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -74,7 +74,7 @@ LLVMSymbolizer::symbolizeCodeCommon(const T &ModuleSpecifier,
     ModuleOffset.Address += Info->getModulePreferredBase();
 
   DILineInfo LineInfo;
-  if (!nearest)
+  if (!Nearest)
     LineInfo = Info->symbolizeCode(
         ModuleOffset, DILineInfoSpecifier(Opts.PathStyle, Opts.PrintFunctions),
         Opts.UseSymbolTable);

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -14,6 +14,7 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/DebugInfo/BTF/BTFContext.h"
+#include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/PDB/PDB.h"
 #include "llvm/DebugInfo/PDB/PDBContext.h"
@@ -24,6 +25,7 @@
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/MachO.h"
 #include "llvm/Object/MachOUniversal.h"
+#include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/CRC.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/DataExtractor.h"
@@ -52,7 +54,8 @@ LLVMSymbolizer::~LLVMSymbolizer() = default;
 template <typename T>
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCodeCommon(const T &ModuleSpecifier,
-                                    object::SectionedAddress ModuleOffset) {
+                                    object::SectionedAddress ModuleOffset,
+                                    bool nearest) {
 
   auto InfoOrErr = getOrCreateModuleInfo(ModuleSpecifier);
   if (!InfoOrErr)
@@ -70,9 +73,28 @@ LLVMSymbolizer::symbolizeCodeCommon(const T &ModuleSpecifier,
   if (Opts.RelativeAddresses)
     ModuleOffset.Address += Info->getModulePreferredBase();
 
-  DILineInfo LineInfo = Info->symbolizeCode(
-      ModuleOffset, DILineInfoSpecifier(Opts.PathStyle, Opts.PrintFunctions),
-      Opts.UseSymbolTable);
+  DILineInfo LineInfo;
+  if (!nearest)
+    LineInfo = Info->symbolizeCode(
+        ModuleOffset, DILineInfoSpecifier(Opts.PathStyle, Opts.PrintFunctions),
+        Opts.UseSymbolTable);
+  else {
+    object::SectionedAddress PrevModuleOffset = ModuleOffset;
+    while (LineInfo.Line = 0) {
+      LineInfo = Info->symbolizeCode(
+          ModuleOffset,
+          DILineInfoSpecifier(Opts.PathStyle, Opts.PrintFunctions),
+          Opts.UseSymbolTable);
+      if (LineInfo.Line != 0)
+        break;
+      ModuleOffset.Address++;
+      --PrevModuleOffset.Address;
+      LineInfo = Info->symbolizeCode(
+          PrevModuleOffset,
+          DILineInfoSpecifier(Opts.PathStyle, Opts.PrintFunctions),
+          Opts.UseSymbolTable);
+    }
+  }
   if (Opts.Demangle)
     LineInfo.FunctionName = DemangleName(LineInfo.FunctionName, Info);
   return LineInfo;
@@ -80,20 +102,23 @@ LLVMSymbolizer::symbolizeCodeCommon(const T &ModuleSpecifier,
 
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCode(const ObjectFile &Obj,
-                              object::SectionedAddress ModuleOffset) {
-  return symbolizeCodeCommon(Obj, ModuleOffset);
+                              object::SectionedAddress ModuleOffset,
+                              bool nearest) {
+  return symbolizeCodeCommon(Obj, ModuleOffset, nearest);
 }
 
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCode(const std::string &ModuleName,
-                              object::SectionedAddress ModuleOffset) {
-  return symbolizeCodeCommon(ModuleName, ModuleOffset);
+                              object::SectionedAddress ModuleOffset,
+                              bool nearest) {
+  return symbolizeCodeCommon(ModuleName, ModuleOffset, nearest);
 }
 
 Expected<DILineInfo>
 LLVMSymbolizer::symbolizeCode(ArrayRef<uint8_t> BuildID,
-                              object::SectionedAddress ModuleOffset) {
-  return symbolizeCodeCommon(BuildID, ModuleOffset);
+                              object::SectionedAddress ModuleOffset,
+                              bool nearest) {
+  return symbolizeCodeCommon(BuildID, ModuleOffset, nearest);
 }
 
 template <typename T>


### PR DESCRIPTION
Addresses which has line number info zero for O1,O2,O3 with debug info optimized binaries will try to find the nearest non-zero line in a bidirectional fashion starting from input address.