### PR TITLE
[clang][analyzer] scan-build: Ensure path prefixes exist

### DIFF
--- a/clang/tools/scan-build/bin/scan-build
+++ b/clang/tools/scan-build/bin/scan-build
@@ -282,7 +282,7 @@ sub UpdatePrefix {
     return;
   }
 
-  chop $Prefix while (!($x =~ /^\Q$Prefix/));
+  chop $Prefix while (!($x =~ /^\Q$Prefix/) || !(-e $Prefix));
 }
 
 sub GetPrefix {


### PR DESCRIPTION
scan-build's `UpdatePrefix` calculates the shared prefix of a set of files. Its use of strings and regular expressions to do so means that it can sometimes end up calculating a prefix which does not correspond to a real directory that exists on the filesystem. If such a prefix is calculated, when it is subsequently used in the calculation of the paths to files containing bugs in the toplevel html report, it can cause incorrect paths to be generated.

This patch fixes this by requiring that a calculated prefix exist in the filesystem for it to be considered valid.

I noticed this when using `scan-build` to analyse a project which contains several folders each starting with a common prefix. `UpdatePrefix` was including this prefix in its calculated prefix, which subsequently caused the paths in the report to lack it. I have created a project which can demonstrate the issue [here](https://github.com/amcn/scan-build-path-bug-example-repo).
