### PR TITLE
[CodeGenPrepare] Replace deleted ext instr with the promoted value.

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -3078,12 +3078,8 @@ struct ExtAddrMode : public TargetLowering::AddrMode {
   // E.g., SExt insts may be promoted and deleted. We should replace them with
   // the promoted values.
   void replaceWith(Value *From, Value *To) {
-    if (BaseReg == From)
-      BaseReg = To;
     if (ScaledReg == From)
       ScaledReg = To;
-    if (OriginalValue == From)
-      OriginalValue = To;
   }
 
   FieldName compare(const ExtAddrMode &other) {

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -3074,6 +3074,9 @@ struct ExtAddrMode : public TargetLowering::AddrMode {
   void print(raw_ostream &OS) const;
   void dump() const;
 
+  // Replace From in ExtAddrMode with To.
+  // E.g., SExt insts may be promoted and deleted. We should replace them with
+  // the promoted values.
   void replaceWith(Value *From, Value *To) {
     if (BaseReg == From)
       BaseReg = To;

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -3074,6 +3074,15 @@ struct ExtAddrMode : public TargetLowering::AddrMode {
   void print(raw_ostream &OS) const;
   void dump() const;
 
+  void replaceWith(Value *From, Value *To) {
+    if (BaseReg == From)
+      BaseReg = To;
+    if (ScaledReg == From)
+      ScaledReg = To;
+    if (OriginalValue == From)
+      OriginalValue = To;
+  }
+
   FieldName compare(const ExtAddrMode &other) {
     // First check that the types are the same on each field, as differing types
     // is something we can't cope with later on.
@@ -5365,6 +5374,9 @@ bool AddressingModeMatcher::matchOperationAddr(User *AddrInst, unsigned Opcode,
       TPT.rollback(LastKnownGood);
       return false;
     }
+
+    // SExt has been deleted. Make sure it is not referenced by the AddrMode.
+    AddrMode.replaceWith(Ext, PromotedOperand);
     return true;
   }
   case Instruction::Call:

--- a/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
+++ b/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
@@ -644,3 +644,27 @@ if.end:                                           ; preds = %entry
   store i8 0, ptr %arrayidx8, align 1
   ret void
 }
+
+define void @pr119429() {
+; CHECK-LABEL: define void @pr119429() {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[AND:%.*]] = and i64 0, 0
+; CHECK-NEXT:    [[SUNKADDR:%.*]] = inttoptr i64 [[AND]] to ptr
+; CHECK-NEXT:    [[SUNKADDR1:%.*]] = mul i64 [[AND]], 2
+; CHECK-NEXT:    [[SUNKADDR2:%.*]] = getelementptr i8, ptr [[SUNKADDR]], i64 [[SUNKADDR1]]
+; CHECK-NEXT:    store i64 0, ptr [[SUNKADDR2]], align 8
+; CHECK-NEXT:    ret void
+;
+entry:
+  %and = and i32 0, 0
+  %conv1 = zext i32 %and to i64
+  %sub = add i64 %conv1, 0
+  br label %if.end
+
+if.end:
+  %mul = shl i64 %sub, 1
+  %add = add i64 %mul, %conv1
+  %ptr = inttoptr i64 %add to ptr
+  store i64 0, ptr %ptr, align 8
+  ret void
+}

--- a/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
+++ b/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
@@ -622,16 +622,17 @@ define i8 @oneArgPromotionBlockSExtZExt(i1 %arg1, ptr %base) {
 }
 
 ; Check that we replace the deleted sext with the promoted value.
+define void @pr70938(ptr %f) {
 ; CHECK-LABEL: define void @pr70938(
 ; CHECK-SAME: ptr [[F:%.*]]) {
-; CHECK-NEXT:  entry:
+; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[ADD:%.*]] = add nsw i64 0, 1
 ; CHECK-NEXT:    [[SUNKADDR:%.*]] = mul i64 [[ADD]], 2
 ; CHECK-NEXT:    [[SUNKADDR1:%.*]] = getelementptr i8, ptr [[F]], i64 [[SUNKADDR]]
 ; CHECK-NEXT:    [[SUNKADDR2:%.*]] = getelementptr i8, ptr [[SUNKADDR1]], i64 1
 ; CHECK-NEXT:    store i8 0, ptr [[SUNKADDR2]], align 1
 ; CHECK-NEXT:    ret void
-define void @pr70938(ptr %f) {
+;
 entry:
   %add = add nsw i32 0, 1
   %idxprom3 = sext i32 %add to i64

--- a/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
+++ b/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
@@ -620,3 +620,25 @@ define i8 @oneArgPromotionBlockSExtZExt(i1 %arg1, ptr %base) {
   %res = load i8, ptr %arrayidx
   ret i8 %res
 }
+
+; Check that we replace the deleted sext with the promoted value.
+; CHECK-LABEL: define void @pr70938(
+; CHECK-SAME: ptr [[F:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i64 0, 0
+; CHECK-NEXT:    [[SUNKADDR:%.*]] = mul i64 [[ADD]], 2
+; CHECK-NEXT:    [[SUNKADDR1:%.*]] = getelementptr i8, ptr [[F]], i64 [[SUNKADDR]]
+; CHECK-NEXT:    store i8 0, ptr [[SUNKADDR1]], align 1
+; CHECK-NEXT:    ret void
+define void @pr70938(ptr %f) {
+entry:
+  %add = add nsw i32 0, 0
+  %idxprom3 = sext i32 %add to i64
+  %arrayidx4 = getelementptr [2 x [1 x [2 x i8]]], ptr %f, i64 0, i64 %idxprom3
+  %arrayidx8 = getelementptr [2 x i8], ptr %arrayidx4, i64 0, i64 %idxprom3
+  br label %if.end
+
+if.end:                                           ; preds = %entry
+  store i8 0, ptr %arrayidx8, align 1
+  ret void
+}

--- a/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
+++ b/llvm/test/CodeGen/X86/codegen-prepare-addrmode-sext.ll
@@ -625,14 +625,15 @@ define i8 @oneArgPromotionBlockSExtZExt(i1 %arg1, ptr %base) {
 ; CHECK-LABEL: define void @pr70938(
 ; CHECK-SAME: ptr [[F:%.*]]) {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i64 0, 0
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i64 0, 1
 ; CHECK-NEXT:    [[SUNKADDR:%.*]] = mul i64 [[ADD]], 2
 ; CHECK-NEXT:    [[SUNKADDR1:%.*]] = getelementptr i8, ptr [[F]], i64 [[SUNKADDR]]
-; CHECK-NEXT:    store i8 0, ptr [[SUNKADDR1]], align 1
+; CHECK-NEXT:    [[SUNKADDR2:%.*]] = getelementptr i8, ptr [[SUNKADDR1]], i64 1
+; CHECK-NEXT:    store i8 0, ptr [[SUNKADDR2]], align 1
 ; CHECK-NEXT:    ret void
 define void @pr70938(ptr %f) {
 entry:
-  %add = add nsw i32 0, 0
+  %add = add nsw i32 0, 1
   %idxprom3 = sext i32 %add to i64
   %arrayidx4 = getelementptr [2 x [1 x [2 x i8]]], ptr %f, i64 0, i64 %idxprom3
   %arrayidx8 = getelementptr [2 x i8], ptr %arrayidx4, i64 0, i64 %idxprom3


### PR DESCRIPTION
This PR replaces the deleted ext with the promoted value in `AddrMode`.
Fixes #70938.