### PR TITLE
[TableGen] Precompute tree depths of asm operand classes

### DIFF
--- a/llvm/test/TableGen/UserOperandClassSorting.td
+++ b/llvm/test/TableGen/UserOperandClassSorting.td
@@ -1,0 +1,49 @@
+// RUN: llvm-tblgen -gen-asm-matcher -I %p/../../include %s | FileCheck %s
+
+/* We test the following poset of user-defined asm operand classes:
+ *
+ *                          Top
+ *                         /   \
+ *                        /   Right1
+ *                       /      |
+ *                     Left   Right2
+ *                       \      |
+ *                        \   Right3
+ *                         \   /
+ *                        Bottom
+ *
+ * With this poset, Bottom should be sorted before Right3, but its left-biased
+ * depth is only 2 while the left-biased depth of Right3 is 3. Thus with a
+ * careless use of left-biased depth ordering, we might end up sorting Bottom
+ * after Right3, which will fail EXPENSIVE_CHECKS.
+ */
+
+include "llvm/Target/Target.td"
+
+def ArchInstrInfo : InstrInfo;
+
+def Arch : Target {
+  let InstructionSet = ArchInstrInfo;
+}
+
+def DummyReg : Register<"dummy">;
+def DummyRC : RegisterClass<"Arch", [i16], 16, (add DummyReg)>;
+
+class AOC<string N, list<AsmOperandClass> supers = []> : AsmOperandClass {
+  let Name = N;
+  let SuperClasses = supers;
+}
+
+def Top : AOC<"Top">;
+def Left : AOC<"Left", [Top]>;
+def Right1 : AOC<"Right1", [Top]>;
+def Right2 : AOC<"Right2", [Right1]>;
+def Right3 : AOC<"Right3", [Right2]>;
+def Bottom : AOC<"Bottom", [Left, Right3]>;
+
+// The MatchClassKind enum is emitted in the topsort order, so it's a good proxy:
+// CHECK:     enum MatchClassKind {
+// CHECK-NOT: };
+// CHECK:     MCK_Bottom,
+// CHECK-NOT: };
+// CHECK:     MCK_Right3,

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -178,6 +178,11 @@ struct ClassInfo {
   /// operands include all superclasses.
   std::vector<ClassInfo*> SuperClasses;
 
+  /// TreeDepth - The maximum depth of this class in the poset of classes. This
+  /// field is only computed and set for tokens and user-defined classes to
+  /// speed up class sorting.
+  std::optional<int> TreeDepth;
+
   /// Name - The full class name, suitable for use in an enum.
   std::string Name;
 
@@ -290,13 +295,9 @@ public:
   }
 
   int getTreeDepth() const {
-    int Depth = 0;
-    const ClassInfo *Root = this;
-    while (!Root->SuperClasses.empty()) {
-      Depth++;
-      Root = Root->SuperClasses.front();
-    }
-    return Depth;
+    assert(TreeDepth.has_value() &&
+           "Attempting to get the TreeDepth of a class that doesn't have one!");
+    return *TreeDepth;
   }
 
   const ClassInfo *findRoot() const {
@@ -304,6 +305,17 @@ public:
     while (!Root->SuperClasses.empty())
       Root = Root->SuperClasses.front();
     return Root;
+  }
+
+  int computeTreeDepth() {
+    if (TreeDepth.has_value())
+      return *TreeDepth;
+
+    int Depth = 0;
+    for (ClassInfo *Parent : SuperClasses)
+      Depth = std::max(Depth, 1 + Parent->computeTreeDepth());
+    TreeDepth = Depth;
+    return Depth;
   }
 
   /// Compare two classes. This does not produce a total ordering, but does
@@ -1664,6 +1676,11 @@ void AsmMatcherInfo::buildInfo() {
                     "error: Destination value identical to source value.");
     FromClass->SuperClasses.push_back(ToClass);
   }
+
+  // Precompute tree depths for classes which use them for comparisons
+  for (ClassInfo &CI : Classes)
+    if (CI.Kind == ClassInfo::Token || CI.isUserClass())
+      CI.computeTreeDepth();
 
   // Reorder classes so that classes precede super classes.
   Classes.sort();


### PR DESCRIPTION
User-defined AsmOperandClass instances need to declare their
superclasses. This information is used to sort these classes
topologically, but it is used in an indirect fashion: the sorting
algorithm computes the left-biased depth of each class in the DAG of
user-defined classes, and it sorts the deeper classes first.

This sorting algorithm is not guaranteed to produce a correct
topological sort (see the poset in UserOperandClassSorting.td for an
example where it fails). It does work under the assumption that the
left-biased path is a longest path from the given class to a maximal
class.

This patch adds a field called TreeDepth of type std::optional<int> in
ClassInfo. This field is precomputed for all instances of ClassInfo
which are compared using ClassInfo::getTreeDepth(), namely tokens and
user-defined classes, and is guaranteed to contain the length of a
longest path to a maximal class. getTreeDepth is now merely a getter for
this value.
