### PR TITLE
[DebugInfo] Use human-friendly printing for DWARF column attributes

### DIFF
--- a/bolt/test/AArch64/go_dwarf.test
+++ b/bolt/test/AArch64/go_dwarf.test
@@ -23,7 +23,7 @@ CHECKORIG-NEXT:        DW_AT_external  (true)
 CHECKORIG-NEXT:        DW_AT_name      ("main")
 CHECKORIG-NEXT:        DW_AT_decl_file
 CHECKORIG-NEXT:        DW_AT_decl_line (1)
-CHECKORIG-NEXT:        DW_AT_decl_column       (0x05)
+CHECKORIG-NEXT:        DW_AT_decl_column       (5)
 CHECKORIG-NEXT:        DW_AT_type
 CHECKORIG-NEXT:        DW_AT_low_pc    (0x0000000000000660)
 CHECKORIG-NEXT:        DW_AT_high_pc   (0x0000000000000684)
@@ -47,7 +47,7 @@ CHECK-NEXT:        DW_AT_external  (true)
 CHECK-NEXT:        DW_AT_name      ("main")
 CHECK-NEXT:        DW_AT_decl_file
 CHECK-NEXT:        DW_AT_decl_line (1)
-CHECK-NEXT:        DW_AT_decl_column       (0x05)
+CHECK-NEXT:        DW_AT_decl_column       (5)
 CHECK-NEXT:        DW_AT_type
 CHECK-NEXT:        DW_AT_low_pc    (0x0000000000000660)
 CHECK-NEXT:        DW_AT_high_pc (0x0000000000000024)

--- a/bolt/test/X86/dwarf5-df-inlined-subroutine-range-0.test
+++ b/bolt/test/X86/dwarf5-df-inlined-subroutine-range-0.test
@@ -27,6 +27,6 @@
 ; BOLT-MAIN: DW_AT_abstract_origin [DW_FORM_ref4]  (cu + 0x005a => {0x0000005a} "_Z11doStuffSamei")
 ; BOLT-MAIN: DW_AT_call_file [DW_FORM_data1] (0x00)
 ; BOLT-MAIN: DW_AT_call_line [DW_FORM_data1] (16)
-; BOLT-MAIN: DW_AT_call_column [DW_FORM_data1] (0x1d)
+; BOLT-MAIN: DW_AT_call_column [DW_FORM_data1] (29)
 ; BOLT-MAIN: DW_AT_low_pc [DW_FORM_addrx]  (indexed (00000002) address = <unresolved>)
 ; BOLT-MAIN: DW_AT_high_pc [DW_FORM_data4] (0x00000042)

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -147,7 +147,8 @@ static void dumpAttribute(raw_ostream &OS, const DWARFDie &Die,
 
   if (!Name.empty())
     WithColor(OS, Color) << Name;
-  else if (Attr == DW_AT_decl_line || Attr == DW_AT_call_line) {
+  else if (Attr == DW_AT_decl_line || Attr == DW_AT_decl_column ||
+           Attr == DW_AT_call_line || Attr == DW_AT_call_column) {
     if (std::optional<uint64_t> Val = FormValue.getAsUnsignedConstant())
       OS << *Val;
     else

--- a/llvm/test/DebugInfo/X86/fission-inline.ll
+++ b/llvm/test/DebugInfo/X86/fission-inline.ll
@@ -70,7 +70,7 @@
 ; CHECK-NOT: {{DW_AT|DW_TAG|NULL}}
 ; CHECK:     DW_AT_call_file
 ; CHECK-NEXT:     DW_AT_call_line {{.*}} (18)
-; CHECK-NEXT:     DW_AT_call_column {{.*}} (0x05)
+; CHECK-NEXT:     DW_AT_call_column {{.*}} (5)
 ; CHECK:     DW_AT_call_file
 ; CHECK-NEXT:     DW_AT_call_line {{.*}} (21)
 ; CHECK-NOT: DW_

--- a/llvm/test/tools/llvm-dwarfdump/X86/locstats-for-absctract-origin-vars.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/locstats-for-absctract-origin-vars.yaml
@@ -32,7 +32,7 @@
 ##       DW_AT_high_pc (0x0000000000000007)
 ##       DW_AT_call_file       (0x01)
 ##       DW_AT_call_line       (1)
-##       DW_AT_call_column     (0x01)
+##       DW_AT_call_column     (1)
 ##       DW_TAG_formal_parameter
 ##         DW_AT_abstract_origin       (0x00000018)
 ##       DW_TAG_variable
@@ -44,7 +44,7 @@
 ##       DW_AT_high_pc       (0x0000000000000007)
 ##       DW_AT_call_file     (0x01)
 ##       DW_AT_call_line     (1)
-##       DW_AT_call_column   (0x01)
+##       DW_AT_call_column   (1)
 ##       DW_TAG_formal_parameter
 ##         DW_AT_abstract_origin     (0x00000018)
 ##         DW_AT_location    ()
@@ -57,28 +57,28 @@
 ##       DW_AT_high_pc       (0x0000000000000007)
 ##       DW_AT_call_file     (0x01)
 ##       DW_AT_call_line     (1)
-##       DW_AT_call_column   (0x01)
+##       DW_AT_call_column   (1)
 ##     DW_TAG_inlined_subroutine
 ##       DW_AT_abstract_origin (0x00000014)
 ##       DW_AT_low_pc  (0x0000000000000002)
 ##       DW_AT_high_pc (0x000000000000000a)
 ##       DW_AT_call_file       (0x01)
 ##       DW_AT_call_line       (3)
-##       DW_AT_call_column     (0x03)
+##       DW_AT_call_column     (3)
 ##     DW_TAG_inlined_subroutine
 ##       DW_AT_abstract_origin (0x000000e5)
 ##       DW_AT_low_pc  (0x0000000000000006)
 ##       DW_AT_high_pc (0x0000000000000010)
 ##       DW_AT_call_file       (0x01)
 ##       DW_AT_call_line       (3)
-##       DW_AT_call_column     (0x03)
+##       DW_AT_call_column     (3)
 ##     DW_TAG_inlined_subroutine
 ##       DW_AT_abstract_origin (0x000000e5)
 ##       DW_AT_low_pc  (0x0000000000000006)
 ##       DW_AT_high_pc (0x0000000000000010)
 ##       DW_AT_call_file       (0x01)
 ##       DW_AT_call_line       (3)
-##       DW_AT_call_column     (0x03)
+##       DW_AT_call_column     (3)
 ##       DW_TAG_formal_parameter
 ##         DW_AT_abstract_origin       (0x000000e9)
 ##         DW_AT_location      ()
@@ -88,7 +88,7 @@
 ##       DW_AT_high_pc (0x000000000000001a)
 ##       DW_AT_call_file       (0x01)
 ##       DW_AT_call_line       (3)
-##       DW_AT_call_column     (0x03)
+##       DW_AT_call_column     (3)
 ##       DW_TAG_formal_parameter
 ##         DW_AT_abstract_origin       (0x000000f4)
 ##       DW_TAG_lexical_block

--- a/llvm/test/tools/llvm-dwarfdump/X86/source-coordinates.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/X86/source-coordinates.yaml
@@ -1,0 +1,100 @@
+# RUN: yaml2obj %s | llvm-dwarfdump - | FileCheck %s
+
+# CHECK:      0x0000001e:   DW_TAG_subprogram
+# CHECK-NEXT:                 DW_AT_name	("main")
+# CHECK-NEXT:                 DW_AT_low_pc	(0x0000000000001000)
+# CHECK-NEXT:                 DW_AT_high_pc	(0x0000000000002000)
+# CHECK-NEXT:                 DW_AT_decl_line	(5)
+# CHECK-NEXT:                 DW_AT_decl_column	(2)
+# CHECK:      0x00000035:     DW_TAG_inlined_subroutine
+# CHECK-NEXT:                   DW_AT_name	("inline1")
+# CHECK-NEXT:                   DW_AT_low_pc	(0x0000000000001100)
+# CHECK-NEXT:                   DW_AT_high_pc	(0x0000000000001200)
+# CHECK-NEXT:                   DW_AT_call_line	(10)
+# CHECK-NEXT:                   DW_AT_call_column	(6)
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+DWARF:
+  debug_str:
+    - ''
+    - '/tmp/main.c'
+    - main
+    - inline1
+  debug_abbrev:
+    - Table:
+        - Code:            0x0000000000000001
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_data2
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_stmt_list
+              Form:            DW_FORM_sec_offset
+        - Code:            0x0000000000000002
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_decl_line
+              Form:            DW_FORM_data1
+            - Attribute:       DW_AT_decl_column
+              Form:            DW_FORM_data1
+        - Code:            0x0000000000000003
+          Tag:             DW_TAG_inlined_subroutine
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+            - Attribute:       DW_AT_call_line
+              Form:            DW_FORM_data1
+            - Attribute:       DW_AT_call_column
+              Form:            DW_FORM_data1
+  debug_info:
+    - Length:          0x0000000000000046
+      Version:         4
+      AbbrOffset:      0x0000000000000000
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x00000001
+          Values:
+            - Value:           0x0000000000000001
+            - Value:           0x0000000000000002
+            - Value:           0x0000000000000000
+            - Value:           0x0000000000000000
+        - AbbrCode:        0x00000002
+          Values:
+            - Value:           0x000000000000000D
+            - Value:           0x0000000000001000
+            - Value:           0x0000000000002000
+            - Value:           0x0000000000000005
+            - Value:           0x0000000000000002
+        - AbbrCode:        0x00000003
+          Values:
+            - Value:           0x0000000000000012
+            - Value:           0x0000000000001100
+            - Value:           0x0000000000000100
+            - Value:           0x000000000000000A
+            - Value:           0x0000000000000006
+        - AbbrCode:        0x00000000
+          Values:          []
+        - AbbrCode:        0x00000000
+          Values:          []
+...


### PR DESCRIPTION
This prints DWARF attributes that describes source columns as base 10 integers for easier comprehension (via `llvm-dwarfdump` and similar tools) and matches the behaviour for source line attributes.