### PR TITLE
[WebAssembly] Mark externref as not being valid vector elements

### DIFF
--- a/clang/test/CodeGen/WebAssembly/wasm-externref-novec.c
+++ b/clang/test/CodeGen/WebAssembly/wasm-externref-novec.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -O2 -triple wasm32-unknown-unknown-wasm -emit-llvm -o - %s | FileCheck %s
+
+// From issue 69894. Reftypes need to be marked as not valid as vector elements.
+__externref_t foo(void);
+void bar(__externref_t);
+
+void
+test(int flag, __externref_t ref1, __externref_t ref2)
+{
+  if (flag) {
+    ref1 = foo();
+    ref2 = foo();
+  }
+  bar(ref1);
+  bar(ref2);
+}

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -682,8 +682,11 @@ VectorType *VectorType::get(Type *ElementType, ElementCount EC) {
 }
 
 bool VectorType::isValidElementType(Type *ElemTy) {
+  if(PointerType *PTy = dyn_cast<PointerType>(ElemTy))
+    return PTy->getAddressSpace() != 10 && PTy->getAddressSpace() != 20;
+
   return ElemTy->isIntegerTy() || ElemTy->isFloatingPointTy() ||
-         ElemTy->isPointerTy() || ElemTy->getTypeID() == TypedPointerTyID;
+         ElemTy->getTypeID() == TypedPointerTyID;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Fixes #69894 .