### PR TITLE
[OpenMP][Flang] Fix some of the Fortan OpenMP Offloading tests

### DIFF
--- a/openmp/libomptarget/test/offloading/fortran/basic-target-region-3D-array.f90
+++ b/openmp/libomptarget/test/offloading/fortran/basic-target-region-3D-array.f90
@@ -23,7 +23,7 @@ program main
     end do
 
 i = 1
-j = 1 
+j = 1
 k = 1
 
 !$omp target map(tofrom:x, counter) map(to: i, j, k, i2, j2, k2)
@@ -50,5 +50,12 @@ k = 1
         end do
     end do
 end program main
-  
-! CHECK: 1 2 3 4 5 6 7 8
+
+! CHECK: 1
+! CHECK: 2
+! CHECK: 3
+! CHECK: 4
+! CHECK: 5
+! CHECK: 6
+! CHECK: 7
+! CHECK: 8

--- a/openmp/libomptarget/test/offloading/fortran/target_map_common_block2.f90
+++ b/openmp/libomptarget/test/offloading/fortran/target_map_common_block2.f90
@@ -7,7 +7,6 @@
 ! UNSUPPORTED: x86_64-pc-linux-gnu-LTO
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
-! XFAIL: *
 
 program main
   use omp_lib
@@ -15,11 +14,11 @@ program main
   common var4
   var4 = 24
   tmp = 12
-  print *, "var4 before target = ", var4
+  print *, "var4 before target =", var4
   !$omp target map(tofrom:var4)
     var4 = tmp
   !$omp end target
-  print *, "var4 after target = ", var4
+  print *, "var4 after target =", var4
 end program
 
 ! CHECK: var4 before target = 24


### PR DESCRIPTION
target_map_common_block2.f90
	- Fix the extra space in the print message.
	- #67164 fixes this. So moving it outside of failing and also removing XFAIL marker.

basic-target-region-3D-array.f90
	- Corrected the check to account for the new lines printed.

Depends on #67319