### PR TITLE
[GISel] Make target's PartMapping, ValueMapping, and BankIDToCopyMapIdx arrays const.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64GenRegisterBankInfo.def
+++ b/llvm/lib/Target/AArch64/AArch64GenRegisterBankInfo.def
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 namespace llvm {
-RegisterBankInfo::PartialMapping AArch64GenRegisterBankInfo::PartMappings[]{
+const RegisterBankInfo::PartialMapping AArch64GenRegisterBankInfo::PartMappings[]{
     /* StartIdx, Length, RegBank */
     // 0: FPR 16-bit value.
     {0, 16, AArch64::FPRRegBank},
@@ -34,7 +34,7 @@ RegisterBankInfo::PartialMapping AArch64GenRegisterBankInfo::PartMappings[]{
 };
 
 // ValueMappings.
-RegisterBankInfo::ValueMapping AArch64GenRegisterBankInfo::ValMappings[]{
+const RegisterBankInfo::ValueMapping AArch64GenRegisterBankInfo::ValMappings[]{
     /* BreakDown, NumBreakDowns */
     // 0: invalid
     {nullptr, 0},
@@ -212,7 +212,7 @@ AArch64GenRegisterBankInfo::getValueMapping(PartialMappingIdx RBIdx,
   return &ValMappings[ValMappingIdx];
 }
 
-AArch64GenRegisterBankInfo::PartialMappingIdx
+const AArch64GenRegisterBankInfo::PartialMappingIdx
     AArch64GenRegisterBankInfo::BankIDToCopyMapIdx[]{
         PMI_None,     // CCR
         PMI_FirstFPR, // FPR

--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
@@ -43,9 +43,9 @@ protected:
     PMI_Min = PMI_FirstFPR,
   };
 
-  static RegisterBankInfo::PartialMapping PartMappings[];
-  static RegisterBankInfo::ValueMapping ValMappings[];
-  static PartialMappingIdx BankIDToCopyMapIdx[];
+  static const RegisterBankInfo::PartialMapping PartMappings[];
+  static const RegisterBankInfo::ValueMapping ValMappings[];
+  static const PartialMappingIdx BankIDToCopyMapIdx[];
 
   enum ValueMappingIdx {
     InvalidIdx = 0,

--- a/llvm/lib/Target/ARM/ARMRegisterBankInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMRegisterBankInfo.cpp
@@ -35,7 +35,7 @@ enum PartialMappingIdx {
   PMI_Min = PMI_GPR,
 };
 
-RegisterBankInfo::PartialMapping PartMappings[]{
+const RegisterBankInfo::PartialMapping PartMappings[]{
     // GPR Partial Mapping
     {0, 32, GPRRegBank},
     // SPR Partial Mapping
@@ -72,7 +72,7 @@ enum ValueMappingIdx {
   DPR3OpsIdx = 7,
 };
 
-RegisterBankInfo::ValueMapping ValueMappings[] = {
+const RegisterBankInfo::ValueMapping ValueMappings[] = {
     // invalid
     {nullptr, 0},
     // 3 ops in GPRs
@@ -89,8 +89,9 @@ RegisterBankInfo::ValueMapping ValueMappings[] = {
     {&PartMappings[PMI_DPR - PMI_Min], 1}};
 
 #ifndef NDEBUG
-static bool checkValueMapping(const RegisterBankInfo::ValueMapping &VM,
-                              RegisterBankInfo::PartialMapping *BreakDown) {
+static bool
+checkValueMapping(const RegisterBankInfo::ValueMapping &VM,
+                  const RegisterBankInfo::PartialMapping *BreakDown) {
   return VM.NumBreakDowns == 1 && VM.BreakDown == BreakDown;
 }
 

--- a/llvm/lib/Target/M68k/GISel/M68kRegisterBankInfo.cpp
+++ b/llvm/lib/Target/M68k/GISel/M68kRegisterBankInfo.cpp
@@ -33,7 +33,7 @@ enum PartialMappingIdx {
   PMI_Min = PMI_GPR,
 };
 
-RegisterBankInfo::PartialMapping PartMappings[]{
+const RegisterBankInfo::PartialMapping PartMappings[]{
     // GPR Partial Mapping
     {0, 32, GPRRegBank},
 };
@@ -43,7 +43,7 @@ enum ValueMappingIdx {
   GPR3OpsIdx = 1,
 };
 
-RegisterBankInfo::ValueMapping ValueMappings[] = {
+const RegisterBankInfo::ValueMapping ValueMappings[] = {
     // invalid
     {nullptr, 0},
     // 3 operands in GPRs

--- a/llvm/lib/Target/Mips/MipsRegisterBankInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsRegisterBankInfo.cpp
@@ -32,7 +32,7 @@ enum PartialMappingIdx {
   PMI_Min = PMI_GPR,
 };
 
-RegisterBankInfo::PartialMapping PartMappings[]{
+const RegisterBankInfo::PartialMapping PartMappings[]{
     {0, 32, GPRBRegBank},
     {0, 32, FPRBRegBank},
     {0, 64, FPRBRegBank},
@@ -47,7 +47,7 @@ enum ValueMappingIdx {
     MSAIdx = 10
 };
 
-RegisterBankInfo::ValueMapping ValueMappings[] = {
+const RegisterBankInfo::ValueMapping ValueMappings[] = {
     // invalid
     {nullptr, 0},
     // up to 3 operands in GPRs

--- a/llvm/lib/Target/PowerPC/GISel/PPCRegisterBankInfo.h
+++ b/llvm/lib/Target/PowerPC/GISel/PPCRegisterBankInfo.h
@@ -37,9 +37,9 @@ protected:
     PMI_Min = PMI_GPR32,
   };
 
-  static RegisterBankInfo::PartialMapping PartMappings[];
-  static RegisterBankInfo::ValueMapping ValMappings[];
-  static PartialMappingIdx BankIDToCopyMapIdx[];
+  static const RegisterBankInfo::PartialMapping PartMappings[];
+  static const RegisterBankInfo::ValueMapping ValMappings[];
+  static const PartialMappingIdx BankIDToCopyMapIdx[];
 
   /// Get the pointer to the ValueMapping representing the RegisterBank
   /// at \p RBIdx.

--- a/llvm/lib/Target/PowerPC/PPCGenRegisterBankInfo.def
+++ b/llvm/lib/Target/PowerPC/PPCGenRegisterBankInfo.def
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 namespace llvm {
-RegisterBankInfo::PartialMapping PPCGenRegisterBankInfo::PartMappings[]{
+const RegisterBankInfo::PartialMapping PPCGenRegisterBankInfo::PartMappings[]{
     /* StartIdx, Length, RegBank */
     // 0: GPR 32-bit value.
     {0, 32, PPC::GPRRegBank},
@@ -39,7 +39,7 @@ RegisterBankInfo::PartialMapping PPCGenRegisterBankInfo::PartMappings[]{
 //   3-operands instructions.
 // - Last, mappings for cross-register bank moves follow. Since COPY has only
 //   2 operands, a mapping consists of 2 entries.
-RegisterBankInfo::ValueMapping PPCGenRegisterBankInfo::ValMappings[]{
+const RegisterBankInfo::ValueMapping PPCGenRegisterBankInfo::ValMappings[]{
     /* BreakDown, NumBreakDowns */
     // 0: invalid
     {nullptr, 0},
@@ -77,7 +77,7 @@ PPCGenRegisterBankInfo::getValueMapping(PartialMappingIdx RBIdx) {
   return &ValMappings[1 + 3 * ValMappingIdx];
 }
 
-PPCGenRegisterBankInfo::PartialMappingIdx
+const PPCGenRegisterBankInfo::PartialMappingIdx
   PPCGenRegisterBankInfo::BankIDToCopyMapIdx[]{
     PMI_None,
     PMI_FPR64,  // FPR

--- a/llvm/lib/Target/RISCV/GISel/RISCVRegisterBankInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVRegisterBankInfo.cpp
@@ -24,7 +24,7 @@
 namespace llvm {
 namespace RISCV {
 
-RegisterBankInfo::PartialMapping PartMappings[] = {
+const RegisterBankInfo::PartialMapping PartMappings[] = {
     {0, 32, GPRRegBank},
     {0, 64, GPRRegBank},
     {0, 32, FPRRegBank},
@@ -38,7 +38,7 @@ enum PartialMappingIdx {
   PMI_FPR64 = 3,
 };
 
-RegisterBankInfo::ValueMapping ValueMappings[] = {
+const RegisterBankInfo::ValueMapping ValueMappings[] = {
     // Invalid value mapping.
     {nullptr, 0},
     // Maximum 3 GPR operands; 32 bit.


### PR DESCRIPTION
AMDGPU arrays were already const.