### PR TITLE
[mlir][attrtypedef] Sort by def order in file.

### DIFF
--- a/mlir/test/mlir-tblgen/attrdefs.td
+++ b/mlir/test/mlir-tblgen/attrdefs.td
@@ -14,9 +14,9 @@ include "mlir/IR/OpBase.td"
 
 // DEF: #ifdef GET_ATTRDEF_LIST
 // DEF: #undef GET_ATTRDEF_LIST
+// DEF: ::test::IndexAttr,
 // DEF: ::test::SimpleAAttr,
 // DEF: ::test::CompoundAAttr,
-// DEF: ::test::IndexAttr,
 // DEF: ::test::SingleParameterAttr
 
 // DEF-LABEL: ::mlir::OptionalParseResult generatedAttributeParser(
@@ -24,13 +24,13 @@ include "mlir/IR/OpBase.td"
 // DEF-SAME: ::llvm::StringRef *mnemonic, ::mlir::Type type,
 // DEF-SAME: ::mlir::Attribute &value) {
 // DEF: return ::mlir::AsmParser::KeywordSwitch<::mlir::OptionalParseResult>(parser)
+// DEF: .Case(::test::IndexAttr::getMnemonic()
+// DEF-NEXT:   value = ::test::IndexAttr::parse(parser, type);
+// DEF-NEXT:   return ::mlir::success(!!value);
 // DEF: .Case(::test::CompoundAAttr::getMnemonic()
 // DEF-NEXT: value = ::test::CompoundAAttr::parse(parser, type);
 // DEF-NEXT: return ::mlir::success(!!value);
 // DEF-NEXT: })
-// DEF-NEXT: .Case(::test::IndexAttr::getMnemonic()
-// DEF-NEXT:   value = ::test::IndexAttr::parse(parser, type);
-// DEF-NEXT:   return ::mlir::success(!!value);
 // DEF: .Default([&](llvm::StringRef keyword,
 // DEF-NEXT:   *mnemonic = keyword;
 // DEF-NEXT:   return std::nullopt;
@@ -43,6 +43,24 @@ def Test_Dialect: Dialect {
 }
 
 class TestAttr<string name> : AttrDef<Test_Dialect, name> { }
+
+def C_IndexAttr : TestAttr<"Index"> {
+    let mnemonic = "index";
+
+    let parameters = (
+      ins
+      StringRefParameter<"Label for index">:$label
+    );
+  let hasCustomAssemblyFormat = 1;
+
+// DECL-LABEL: class IndexAttr : public ::mlir::Attribute
+// DECL: static constexpr ::llvm::StringLiteral getMnemonic() {
+// DECL:   return {"index"};
+// DECL: }
+// DECL: static ::mlir::Attribute parse(
+// DECL-SAME: ::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+// DECL: void print(::mlir::AsmPrinter &odsPrinter) const;
+}
 
 def A_SimpleAttrA : TestAttr<"SimpleA"> {
 // DECL: class SimpleAAttr : public ::mlir::Attribute
@@ -98,24 +116,6 @@ def B_CompoundAttrA : TestAttr<"CompoundA"> {
 
 // DEF: ::mlir::Type CompoundAAttr::getInner() const {
 // DEF-NEXT: return getImpl()->inner;
-}
-
-def C_IndexAttr : TestAttr<"Index"> {
-    let mnemonic = "index";
-
-    let parameters = (
-      ins
-      StringRefParameter<"Label for index">:$label
-    );
-  let hasCustomAssemblyFormat = 1;
-
-// DECL-LABEL: class IndexAttr : public ::mlir::Attribute
-// DECL: static constexpr ::llvm::StringLiteral getMnemonic() {
-// DECL:   return {"index"};
-// DECL: }
-// DECL: static ::mlir::Attribute parse(
-// DECL-SAME: ::mlir::AsmParser &odsParser, ::mlir::Type odsType);
-// DECL: void print(::mlir::AsmPrinter &odsPrinter) const;
 }
 
 def D_SingleParameterAttr : TestAttr<"SingleParameter"> {

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -587,7 +587,12 @@ protected:
   DefGenerator(std::vector<llvm::Record *> &&defs, raw_ostream &os,
                StringRef defType, StringRef valueType, bool isAttrGenerator)
       : defRecords(std::move(defs)), os(os), defType(defType),
-        valueType(valueType), isAttrGenerator(isAttrGenerator) {}
+        valueType(valueType), isAttrGenerator(isAttrGenerator) {
+    // Sort by occurrence in file.
+    llvm::sort(defRecords, [](llvm::Record *lhs, llvm::Record *rhs) {
+      return lhs->getID() < rhs->getID();
+    });
+  }
 
   /// Emit the list of def type names.
   void emitTypeDefList(ArrayRef<AttrOrTypeDef> defs);


### PR DESCRIPTION
Enables having attribute that has another from same file as member.