### PR TITLE
[lldb][windows] Allow exporting plugin symbols in LLDB_EXPORT_ALL_SYMBOLS

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -128,6 +128,11 @@ set(LLDB_EXPORT_ALL_SYMBOLS 0 CACHE BOOL
 set(LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE "" CACHE PATH
   "When `LLDB_EXPORT_ALL_SYMBOLS` is enabled, this specifies the exports file to use when building liblldb.")
 
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  set(LLDB_EXPORT_ALL_SYMBOLS_PLUGINS "" CACHE STRING
+    "When `LLDB_EXPORT_ALL_SYMBOLS` is enabled, this specifies the plugins whose symbols should be exported.")
+endif()
+
 if ((NOT MSVC) OR MSVC12)
   add_definitions( -DHAVE_ROUND )
 endif()

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -196,13 +196,15 @@ elseif (LLDB_EXPORT_ALL_SYMBOLS)
   MESSAGE("-- Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
 
   # Pull out the various lldb libraries linked into liblldb, these will be used
-  # when looking for symbols to extract. We ignore plugin libraries here,
-  # because these symbols aren't publicly exposed.
+  # when looking for symbols to extract. We ignore most plugin libraries here,
+  # because we may expose more symbols than the DLL limit and these symbols
+  # aren't useful to expose.
   get_target_property(all_liblldb_libs liblldb LINK_LIBRARIES)
   set(lldb_libs "")
   foreach(lib ${all_liblldb_libs})
     if(TARGET ${lib} AND ${lib} MATCHES "^lldb" AND
-       NOT ${lib} MATCHES "^lldbPlugin")
+       (${lib} IN_LIST LLDB_EXPORT_ALL_SYMBOLS_PLUGINS OR
+        NOT ${lib} MATCHES "^lldbPlugin"))
       get_target_property(lib_type ${lib} TYPE)
       if("${lib_type}" STREQUAL "STATIC_LIBRARY")
         list(APPEND lldb_libs ${lib})


### PR DESCRIPTION
Plugins aren't exported by default in the msvc path because we explicitly
limit the symbols exported to prevent hitting the symbol export limit.
Some plugins, however, can still be useful for downstream projects to
build on, e.g. the Mojo language uses parts of the dwarf plugin to implement
dwarf handling within its debugger plugin.

This PR adds a cmake variable in the MSVC path,
LLDB_EXPORT_ALL_SYMBOLS_PLUGINS, that allows for providing the set
of plugins to export symbols from.