### PR TITLE
[instcombine] Drop zext nneg flag when simplify operand

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -422,8 +422,12 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Value *V, APInt DemandedMask,
 
     APInt InputDemandedMask = DemandedMask.zextOrTrunc(SrcBitWidth);
     KnownBits InputKnown(SrcBitWidth);
-    if (SimplifyDemandedBits(I, 0, InputDemandedMask, InputKnown, Depth + 1))
+    if (SimplifyDemandedBits(I, 0, InputDemandedMask, InputKnown, Depth + 1)) {
+      // For zext nneg, we may have dropped the instruction which made the
+      // input non-negative.
+      I->dropPoisonGeneratingFlags();
       return I;
+    }
     assert(InputKnown.getBitWidth() == SrcBitWidth && "Src width changed?");
     Known = InputKnown.zextOrTrunc(BitWidth);
     assert(!Known.hasConflict() && "Bits known to be one AND zero?");

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -779,8 +779,6 @@ define i64 @evaluate_zexted_const_expr(i1 %c) {
   ret i64 %ext
 }
 
-; FIXME: This is currently miscompiling as the and gets dropped,
-; but the flag on the zext doesn't.
 define i16 @zext_nneg_flag_drop(i8 %x, i16 %y) {
 ; CHECK-LABEL: @zext_nneg_flag_drop(
 ; CHECK-NEXT:    [[EXT:%.*]] = zext i8 [[X:%.*]] to i16

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -783,7 +783,7 @@ define i64 @evaluate_zexted_const_expr(i1 %c) {
 ; but the flag on the zext doesn't.
 define i16 @zext_nneg_flag_drop(i8 %x, i16 %y) {
 ; CHECK-LABEL: @zext_nneg_flag_drop(
-; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i8 [[X:%.*]] to i16
+; CHECK-NEXT:    [[EXT:%.*]] = zext i8 [[X:%.*]] to i16
 ; CHECK-NEXT:    [[OR1:%.*]] = or i16 [[EXT]], [[Y:%.*]]
 ; CHECK-NEXT:    [[OR2:%.*]] = or i16 [[OR1]], 128
 ; CHECK-NEXT:    ret i16 [[OR2]]


### PR DESCRIPTION
This fixes a miscompile introduced in the recent #67982, and likely exposed in changes since to infer and leverage the same.  No active bug reports as of yet.

This was noticed in https://github.com/llvm/llvm-project/pull/70858#discussion_r1378203532.