### PR TITLE
[mlir][sparse] cleanup of enums header

### DIFF
--- a/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
@@ -349,35 +349,35 @@ static_assert(
     (buildLevelType(LevelFormat::Dense, false, true) == std::nullopt &&
      buildLevelType(LevelFormat::Dense, true, false) == std::nullopt &&
      buildLevelType(LevelFormat::Dense, false, false) == std::nullopt &&
-     buildLevelType(LevelFormat::Dense, true, true) == DimLevelType::Dense &&
-     buildLevelType(LevelFormat::Compressed, true, true) ==
+     *buildLevelType(LevelFormat::Dense, true, true) == DimLevelType::Dense &&
+     *buildLevelType(LevelFormat::Compressed, true, true) ==
          DimLevelType::Compressed &&
-     buildLevelType(LevelFormat::Compressed, true, false) ==
+     *buildLevelType(LevelFormat::Compressed, true, false) ==
          DimLevelType::CompressedNu &&
-     buildLevelType(LevelFormat::Compressed, false, true) ==
+     *buildLevelType(LevelFormat::Compressed, false, true) ==
          DimLevelType::CompressedNo &&
-     buildLevelType(LevelFormat::Compressed, false, false) ==
+     *buildLevelType(LevelFormat::Compressed, false, false) ==
          DimLevelType::CompressedNuNo &&
-     buildLevelType(LevelFormat::Singleton, true, true) ==
+     *buildLevelType(LevelFormat::Singleton, true, true) ==
          DimLevelType::Singleton &&
-     buildLevelType(LevelFormat::Singleton, true, false) ==
+     *buildLevelType(LevelFormat::Singleton, true, false) ==
          DimLevelType::SingletonNu &&
-     buildLevelType(LevelFormat::Singleton, false, true) ==
+     *buildLevelType(LevelFormat::Singleton, false, true) ==
          DimLevelType::SingletonNo &&
-     buildLevelType(LevelFormat::Singleton, false, false) ==
+     *buildLevelType(LevelFormat::Singleton, false, false) ==
          DimLevelType::SingletonNuNo &&
-     buildLevelType(LevelFormat::LooseCompressed, true, true) ==
+     *buildLevelType(LevelFormat::LooseCompressed, true, true) ==
          DimLevelType::LooseCompressed &&
-     buildLevelType(LevelFormat::LooseCompressed, true, false) ==
+     *buildLevelType(LevelFormat::LooseCompressed, true, false) ==
          DimLevelType::LooseCompressedNu &&
-     buildLevelType(LevelFormat::LooseCompressed, false, true) ==
+     *buildLevelType(LevelFormat::LooseCompressed, false, true) ==
          DimLevelType::LooseCompressedNo &&
-     buildLevelType(LevelFormat::LooseCompressed, false, false) ==
+     *buildLevelType(LevelFormat::LooseCompressed, false, false) ==
          DimLevelType::LooseCompressedNuNo &&
      buildLevelType(LevelFormat::TwoOutOfFour, false, true) == std::nullopt &&
      buildLevelType(LevelFormat::TwoOutOfFour, true, false) == std::nullopt &&
      buildLevelType(LevelFormat::TwoOutOfFour, false, false) == std::nullopt &&
-     buildLevelType(LevelFormat::TwoOutOfFour, true, true) ==
+     *buildLevelType(LevelFormat::TwoOutOfFour, true, true) ==
          DimLevelType::TwoOutOfFour),
     "buildLevelType conversion is broken");
 

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
@@ -263,16 +263,16 @@ constexpr bool isCompressedDLT(DimLevelType dlt) {
          static_cast<uint8_t>(DimLevelType::Compressed);
 }
 
-/// Check if the `DimLevelType` is loose compressed (regardless of properties).
-constexpr bool isLooseCompressedDLT(DimLevelType dlt) {
-  return (static_cast<uint8_t>(dlt) & ~3) ==
-         static_cast<uint8_t>(DimLevelType::LooseCompressed);
-}
-
 /// Check if the `DimLevelType` is singleton (regardless of properties).
 constexpr bool isSingletonDLT(DimLevelType dlt) {
   return (static_cast<uint8_t>(dlt) & ~3) ==
          static_cast<uint8_t>(DimLevelType::Singleton);
+}
+
+/// Check if the `DimLevelType` is loose compressed (regardless of properties).
+constexpr bool isLooseCompressedDLT(DimLevelType dlt) {
+  return (static_cast<uint8_t>(dlt) & ~3) ==
+         static_cast<uint8_t>(DimLevelType::LooseCompressed);
 }
 
 /// Check if the `DimLevelType` is 2OutOf4 (regardless of properties).
@@ -283,13 +283,13 @@ constexpr bool is2OutOf4DLT(DimLevelType dlt) {
 
 /// Check if the `DimLevelType` needs positions array.
 constexpr bool isDLTWithPos(DimLevelType dlt) {
-  return isLooseCompressedDLT(dlt) || isCompressedDLT(dlt);
+  return isCompressedDLT(dlt) || isLooseCompressedDLT(dlt);
 }
 
 /// Check if the `DimLevelType` needs coordinates array.
 constexpr bool isDLTWithCrd(DimLevelType dlt) {
-  return isSingletonDLT(dlt) || isLooseCompressedDLT(dlt) ||
-         isCompressedDLT(dlt) || is2OutOf4DLT(dlt);
+  return isCompressedDLT(dlt) || isSingletonDLT(dlt) ||
+         isLooseCompressedDLT(dlt) || is2OutOf4DLT(dlt);
 }
 
 /// Check if the `DimLevelType` is ordered (regardless of storage format).
@@ -322,7 +322,10 @@ buildLevelType(LevelFormat lf, bool ordered, bool unique) {
   return isValidDLT(dlt) ? std::optional(dlt) : std::nullopt;
 }
 
-/// Ensure the above conversion works as intended.
+//
+// Ensure the above methods work as indended.
+//
+
 static_assert(
     (getLevelFormat(DimLevelType::Undef) == std::nullopt &&
      *getLevelFormat(DimLevelType::Dense) == LevelFormat::Dense &&
@@ -381,7 +384,6 @@ static_assert(
          DimLevelType::TwoOutOfFour),
     "buildLevelType conversion is broken");
 
-// Ensure the above predicates work as intended.
 static_assert((isValidDLT(DimLevelType::Undef) &&
                isValidDLT(DimLevelType::Dense) &&
                isValidDLT(DimLevelType::Compressed) &&
@@ -399,6 +401,22 @@ static_assert((isValidDLT(DimLevelType::Undef) &&
                isValidDLT(DimLevelType::TwoOutOfFour)),
               "isValidDLT definition is broken");
 
+static_assert((isDenseDLT(DimLevelType::Dense) &&
+               !isDenseDLT(DimLevelType::Compressed) &&
+               !isDenseDLT(DimLevelType::CompressedNu) &&
+               !isDenseDLT(DimLevelType::CompressedNo) &&
+               !isDenseDLT(DimLevelType::CompressedNuNo) &&
+               !isDenseDLT(DimLevelType::Singleton) &&
+               !isDenseDLT(DimLevelType::SingletonNu) &&
+               !isDenseDLT(DimLevelType::SingletonNo) &&
+               !isDenseDLT(DimLevelType::SingletonNuNo) &&
+               !isDenseDLT(DimLevelType::LooseCompressed) &&
+               !isDenseDLT(DimLevelType::LooseCompressedNu) &&
+               !isDenseDLT(DimLevelType::LooseCompressedNo) &&
+               !isDenseDLT(DimLevelType::LooseCompressedNuNo) &&
+               !isDenseDLT(DimLevelType::TwoOutOfFour)),
+              "isDenseDLT definition is broken");
+
 static_assert((!isCompressedDLT(DimLevelType::Dense) &&
                isCompressedDLT(DimLevelType::Compressed) &&
                isCompressedDLT(DimLevelType::CompressedNu) &&
@@ -414,6 +432,22 @@ static_assert((!isCompressedDLT(DimLevelType::Dense) &&
                !isCompressedDLT(DimLevelType::LooseCompressedNuNo) &&
                !isCompressedDLT(DimLevelType::TwoOutOfFour)),
               "isCompressedDLT definition is broken");
+
+static_assert((!isSingletonDLT(DimLevelType::Dense) &&
+               !isSingletonDLT(DimLevelType::Compressed) &&
+               !isSingletonDLT(DimLevelType::CompressedNu) &&
+               !isSingletonDLT(DimLevelType::CompressedNo) &&
+               !isSingletonDLT(DimLevelType::CompressedNuNo) &&
+               isSingletonDLT(DimLevelType::Singleton) &&
+               isSingletonDLT(DimLevelType::SingletonNu) &&
+               isSingletonDLT(DimLevelType::SingletonNo) &&
+               isSingletonDLT(DimLevelType::SingletonNuNo) &&
+               !isSingletonDLT(DimLevelType::LooseCompressed) &&
+               !isSingletonDLT(DimLevelType::LooseCompressedNu) &&
+               !isSingletonDLT(DimLevelType::LooseCompressedNo) &&
+               !isSingletonDLT(DimLevelType::LooseCompressedNuNo) &&
+               !isSingletonDLT(DimLevelType::TwoOutOfFour)),
+              "isSingletonDLT definition is broken");
 
 static_assert((!isLooseCompressedDLT(DimLevelType::Dense) &&
                !isLooseCompressedDLT(DimLevelType::Compressed) &&
@@ -431,21 +465,21 @@ static_assert((!isLooseCompressedDLT(DimLevelType::Dense) &&
                !isLooseCompressedDLT(DimLevelType::TwoOutOfFour)),
               "isLooseCompressedDLT definition is broken");
 
-static_assert((!isSingletonDLT(DimLevelType::Dense) &&
-               !isSingletonDLT(DimLevelType::Compressed) &&
-               !isSingletonDLT(DimLevelType::CompressedNu) &&
-               !isSingletonDLT(DimLevelType::CompressedNo) &&
-               !isSingletonDLT(DimLevelType::CompressedNuNo) &&
-               isSingletonDLT(DimLevelType::Singleton) &&
-               isSingletonDLT(DimLevelType::SingletonNu) &&
-               isSingletonDLT(DimLevelType::SingletonNo) &&
-               isSingletonDLT(DimLevelType::SingletonNuNo) &&
-               !isSingletonDLT(DimLevelType::LooseCompressed) &&
-               !isSingletonDLT(DimLevelType::LooseCompressedNu) &&
-               !isSingletonDLT(DimLevelType::LooseCompressedNo) &&
-               !isSingletonDLT(DimLevelType::LooseCompressedNuNo) &&
-               !isSingletonDLT(DimLevelType::TwoOutOfFour)),
-              "isSingletonDLT definition is broken");
+static_assert((!is2OutOf4DLT(DimLevelType::Dense) &&
+               !is2OutOf4DLT(DimLevelType::Compressed) &&
+               !is2OutOf4DLT(DimLevelType::CompressedNu) &&
+               !is2OutOf4DLT(DimLevelType::CompressedNo) &&
+               !is2OutOf4DLT(DimLevelType::CompressedNuNo) &&
+               !is2OutOf4DLT(DimLevelType::Singleton) &&
+               !is2OutOf4DLT(DimLevelType::SingletonNu) &&
+               !is2OutOf4DLT(DimLevelType::SingletonNo) &&
+               !is2OutOf4DLT(DimLevelType::SingletonNuNo) &&
+               !is2OutOf4DLT(DimLevelType::LooseCompressed) &&
+               !is2OutOf4DLT(DimLevelType::LooseCompressedNu) &&
+               !is2OutOf4DLT(DimLevelType::LooseCompressedNo) &&
+               !is2OutOf4DLT(DimLevelType::LooseCompressedNuNo) &&
+               is2OutOf4DLT(DimLevelType::TwoOutOfFour)),
+              "is2OutOf4DLT definition is broken");
 
 static_assert((isOrderedDLT(DimLevelType::Dense) &&
                isOrderedDLT(DimLevelType::Compressed) &&

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
@@ -289,7 +289,7 @@ constexpr bool isDLTWithPos(DimLevelType dlt) {
 /// Check if the `DimLevelType` needs coordinates array.
 constexpr bool isDLTWithCrd(DimLevelType dlt) {
   return isSingletonDLT(dlt) || isLooseCompressedDLT(dlt) ||
-         isCompressedDLT(dlt);
+         isCompressedDLT(dlt) || is2OutOf4DLT(dlt);
 }
 
 /// Check if the `DimLevelType` is ordered (regardless of storage format).

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
@@ -89,16 +89,6 @@ inline MemRefType getMemRefType(T &&t) {
 /// Returns null-attribute for any type without an encoding.
 SparseTensorEncodingAttr getSparseTensorEncoding(Type type);
 
-/// Convenience method to query whether a given DLT needs both position and
-/// coordinates array or only coordinates array.
-constexpr inline bool isDLTWithPos(DimLevelType dlt) {
-  return isLooseCompressedDLT(dlt) || isCompressedDLT(dlt);
-}
-constexpr inline bool isDLTWithCrd(DimLevelType dlt) {
-  return isSingletonDLT(dlt) || isLooseCompressedDLT(dlt) ||
-         isCompressedDLT(dlt);
-}
-
 /// Returns true iff the given sparse tensor encoding attribute has a trailing
 /// COO region starting at the given level.
 bool isCOOType(SparseTensorEncodingAttr enc, Level startLvl, bool isUnique);

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.td
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.td
@@ -371,10 +371,10 @@ def SparseTensorEncodingAttr : SparseTensor_Attr<"SparseTensorEncoding",
     ::mlir::sparse_tensor::DimLevelType getLvlType(::mlir::sparse_tensor::Level l) const;
 
     bool isDenseLvl(::mlir::sparse_tensor::Level l) const { return isDenseDLT(getLvlType(l)); }
-    bool isTwoOutOfFourLvl(::mlir::sparse_tensor::Level l) const { return is2OutOf4DLT(getLvlType(l)); }
     bool isCompressedLvl(::mlir::sparse_tensor::Level l) const { return isCompressedDLT(getLvlType(l)); }
-    bool isLooseCompressedLvl(::mlir::sparse_tensor::Level l) const { return isLooseCompressedDLT(getLvlType(l)); }
     bool isSingletonLvl(::mlir::sparse_tensor::Level l) const { return isSingletonDLT(getLvlType(l)); }
+    bool isLooseCompressedLvl(::mlir::sparse_tensor::Level l) const { return isLooseCompressedDLT(getLvlType(l)); }
+    bool isTwoOutOfFourLvl(::mlir::sparse_tensor::Level l) const { return is2OutOf4DLT(getLvlType(l)); }
     bool isOrderedLvl(::mlir::sparse_tensor::Level l) const { return isOrderedDLT(getLvlType(l)); }
     bool isUniqueLvl(::mlir::sparse_tensor::Level l) const { return isUniqueDLT(getLvlType(l)); }
 

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.td
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.td
@@ -371,7 +371,7 @@ def SparseTensorEncodingAttr : SparseTensor_Attr<"SparseTensorEncoding",
     ::mlir::sparse_tensor::DimLevelType getLvlType(::mlir::sparse_tensor::Level l) const;
 
     bool isDenseLvl(::mlir::sparse_tensor::Level l) const { return isDenseDLT(getLvlType(l)); }
-    bool isTwoOutOfFourLvl(::mlir::sparse_tensor::Level l) const { return isTwoOutOfFourDLT(getLvlType(l)); }
+    bool isTwoOutOfFourLvl(::mlir::sparse_tensor::Level l) const { return is2OutOf4DLT(getLvlType(l)); }
     bool isCompressedLvl(::mlir::sparse_tensor::Level l) const { return isCompressedDLT(getLvlType(l)); }
     bool isLooseCompressedLvl(::mlir::sparse_tensor::Level l) const { return isLooseCompressedDLT(getLvlType(l)); }
     bool isSingletonLvl(::mlir::sparse_tensor::Level l) const { return isSingletonDLT(getLvlType(l)); }

--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -10,6 +10,7 @@
 
 #include "Detail/DimLvlMapParser.h"
 
+#include "mlir/Dialect/SparseTensor/IR/Enums.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensorStorageLayout.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensorType.h"


### PR DESCRIPTION
Some DLT related methods leaked into sparse_tensor.h, and this moves it back to the right header. Also, the asserts were incomplete and some DLT methods duplicated.