### PR TITLE
[clang-tidy][libc] Ignore implicit function inline

### DIFF
--- a/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.cpp
@@ -45,7 +45,9 @@ InlineFunctionDeclCheck::InlineFunctionDeclCheck(StringRef Name,
       HeaderFileExtensions(Context->getHeaderFileExtensions()) {}
 
 void InlineFunctionDeclCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(decl(functionDecl()).bind("func_decl"), this);
+  // Ignore functions that have been deleted.
+  Finder->addMatcher(decl(functionDecl(unless(isDeleted()))).bind("func_decl"),
+                     this);
 }
 
 void InlineFunctionDeclCheck::check(const MatchFinder::MatchResult &Result) {
@@ -78,10 +80,6 @@ void InlineFunctionDeclCheck::check(const MatchFinder::MatchResult &Result) {
   if (const auto *MethodDecl = dyn_cast<CXXMethodDecl>(FuncDecl))
     if (MethodDecl->getParent()->isLambda())
       return;
-
-  // Ignore functions that have been deleted.
-  if (FuncDecl->isDeleted())
-    return;
 
   // Check if decl starts with LIBC_INLINE
   auto Loc = FullSourceLoc(Result.SourceManager->getFileLoc(SrcBegin),

--- a/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.cpp
@@ -79,6 +79,10 @@ void InlineFunctionDeclCheck::check(const MatchFinder::MatchResult &Result) {
     if (MethodDecl->getParent()->isLambda())
       return;
 
+  // Ignore implicit functions (e.g. implicit constructors or destructors)
+  if (FuncDecl->isImplicit())
+    return;
+
   // Check if decl starts with LIBC_INLINE
   auto Loc = FullSourceLoc(Result.SourceManager->getFileLoc(SrcBegin),
                            *Result.SourceManager);

--- a/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.cpp
@@ -79,8 +79,8 @@ void InlineFunctionDeclCheck::check(const MatchFinder::MatchResult &Result) {
     if (MethodDecl->getParent()->isLambda())
       return;
 
-  // Ignore implicit functions (e.g. implicit constructors or destructors)
-  if (FuncDecl->isImplicit())
+  // Ignore functions that have been deleted.
+  if (FuncDecl->isDeleted())
     return;
 
   // Check if decl starts with LIBC_INLINE

--- a/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.h
+++ b/clang-tools-extra/clang-tidy/llvmlibc/InlineFunctionDeclCheck.h
@@ -33,6 +33,11 @@ public:
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
+  // Ignore implicit functions (e.g. implicit constructors or destructors)
+  std::optional<TraversalKind> getCheckTraversalKind() const override {
+    return TK_IgnoreUnlessSpelledInSource;
+  }
+
 private:
   FileExtensionsSet HeaderFileExtensions;
 };

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -304,6 +304,10 @@ Changes in existing checks
   customizable namespace. This further allows for testing the libc when the
   system-libc is also LLVM's libc.
 
+- Improved :doc:`llvmlibc-inline-function-decl
+  <clang-tidy/checks/llvmlibc/inline-function-decl>` to properly ignore implicit
+  functions, such as struct constructors.
+
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check to avoid false positive when
   using pointer to member function.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -306,7 +306,7 @@ Changes in existing checks
 
 - Improved :doc:`llvmlibc-inline-function-decl
   <clang-tidy/checks/llvmlibc/inline-function-decl>` to properly ignore implicit
-  functions, such as struct constructors.
+  functions, such as struct constructors, and explicitly deleted functions.
 
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check to avoid false positive when

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.rst
@@ -3,6 +3,7 @@
 llvmlibc-inline-function-decl
 =============================
 
-Checks that all implicit and explicit inline functions in header files are
-tagged with the ``LIBC_INLINE`` macro. See the `libc style guide
-<https://libc.llvm.org/dev/code_style.html>`_ for more information about this macro.
+Checks that all implicitly and explicitly inline functions in header files are
+tagged with the ``LIBC_INLINE`` macro, except for functions implicit to classes.
+See the `libc style guide<https://libc.llvm.org/dev/code_style.html>`_ for more
+information about this macro.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.rst
@@ -4,6 +4,7 @@ llvmlibc-inline-function-decl
 =============================
 
 Checks that all implicitly and explicitly inline functions in header files are
-tagged with the ``LIBC_INLINE`` macro, except for functions implicit to classes.
+tagged with the ``LIBC_INLINE`` macro, except for functions implicit to classes
+or deleted functions.
 See the `libc style guide <https://libc.llvm.org/dev/code_style.html>`_ for more
 information about this macro.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvmlibc/inline-function-decl.rst
@@ -5,5 +5,5 @@ llvmlibc-inline-function-decl
 
 Checks that all implicitly and explicitly inline functions in header files are
 tagged with the ``LIBC_INLINE`` macro, except for functions implicit to classes.
-See the `libc style guide<https://libc.llvm.org/dev/code_style.html>`_ for more
+See the `libc style guide <https://libc.llvm.org/dev/code_style.html>`_ for more
 information about this macro.

--- a/clang-tools-extra/test/clang-tidy/checkers/llvmlibc/inline-function-decl.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvmlibc/inline-function-decl.hpp
@@ -278,6 +278,17 @@ template <typename T>LIBC_INLINE void goodWeirdFormatting() {}
 template <typename T>void LIBC_INLINE badWeirdFormatting() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: 'badWeirdFormatting' must be tagged with the LIBC_INLINE macro; the macro should be placed at the beginning of the declaration [llvmlibc-inline-function-decl]
 
+
+template <unsigned int NumberOfBits> struct HasMemberAndTemplate {
+  char Data[NumberOfBits];
+
+  void explicitFunction() {}
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'explicitFunction' must be tagged with the LIBC_INLINE macro; the macro should be placed at the beginning of the declaration [llvmlibc-inline-function-decl]
+// CHECK-FIXES: LIBC_INLINE void explicitFunction() {}
+};
+
+static auto instanceOfStruct = HasMemberAndTemplate<16>(); 
+
 } // namespace issue_62746
 
 } // namespace __llvm_libc

--- a/clang-tools-extra/test/clang-tidy/checkers/llvmlibc/inline-function-decl.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvmlibc/inline-function-decl.hpp
@@ -289,6 +289,17 @@ template <unsigned int NumberOfBits> struct HasMemberAndTemplate {
 
 static auto instanceOfStruct = HasMemberAndTemplate<16>(); 
 
+struct HasMemberAndExplicitDefault {
+  int TrivialMember;
+
+  HasMemberAndExplicitDefault() = default;
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'HasMemberAndExplicitDefault' must be tagged with the LIBC_INLINE macro; the macro should be placed at the beginning of the declaration [llvmlibc-inline-function-decl]
+// CHECK-FIXES: LIBC_INLINE HasMemberAndExplicitDefault() = default;
+
+  ~HasMemberAndExplicitDefault() = delete;
+};
+
+
 } // namespace issue_62746
 
 } // namespace __llvm_libc


### PR DESCRIPTION
This patch adjusts the inline function decl check for LLVM libc to
ignore implicit functions. For the moment the plan is to ignore these
and mark the class with a macro so that it can be given the appropriate
properties without explicitly defining all its ctors/dtors.
