### PR TITLE
[clang] Do not pass -canonical-system-headers on Windows by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1180,8 +1180,19 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     if (ArgM->getOption().matches(options::OPT_M) ||
         ArgM->getOption().matches(options::OPT_MD))
       CmdArgs.push_back("-sys-header-deps");
+
+      // #70011: Canonicalization on Windows does unexpected things like change
+      // drive letters.
+      // FIXME: find and use Windows API that canonicalizes paths except for
+      // drive letter.
+#if defined(_WIN32) || defined(_WIN64)
+    bool CanonicalSystemHeadersDefault = false;
+#else
+    bool CanonicalSystemHeadersDefault = true;
+#endif
     if (Args.hasFlag(options::OPT_canonical_prefixes,
-                     options::OPT_no_canonical_prefixes, true))
+                     options::OPT_no_canonical_prefixes,
+                     CanonicalSystemHeadersDefault))
       CmdArgs.push_back("-canonical-system-headers");
     if ((isa<PrecompileJobAction>(JA) &&
          !Args.hasArg(options::OPT_fno_module_file_deps)) ||

--- a/clang/test/Driver/canonical-system-headers-win.c
+++ b/clang/test/Driver/canonical-system-headers-win.c
@@ -1,9 +1,9 @@
-// REQUIRES: !system-windows
+// REQUIRES: system-windows
 // The default on Windows is false due to #70011.
 
 // RUN: %clang -MD -no-canonical-prefixes -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO
 // RUN: %clang -MD -canonical-prefixes -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-YES
-// RUN: %clang -MD -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-YES
+// RUN: %clang -MD -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO
 
 // CHECK-YES: "-canonical-system-headers"
 // CHECK-NO-NOT: "-canonical-system-headers"


### PR DESCRIPTION
Canonicalizing paths on Windows leads to unexpected things like changing
drive letters. As a short term fix, do not canonicalize system headers
on Windows by default.

Fixes #70011
