### PR TITLE
[mlir] fix `-Wunused-but-set-parameter`

### DIFF
--- a/mlir/include/mlir/IR/Attributes.h
+++ b/mlir/include/mlir/IR/Attributes.h
@@ -405,7 +405,7 @@ struct CastInfo<To, From,
   /// returns the dynamic ID. This means that T::classof would end up comparing
   /// the static TypeID of the children to the static TypeID of its parent,
   /// making it impossible to downcast from the parent to the child.
-  static inline bool isPossible(mlir::Attribute ty) {
+  static inline bool isPossible([[maybe_unused]] mlir::Attribute ty) {
     /// Return a constant true instead of a dynamic true when casting to self or
     /// up the hierarchy.
     if constexpr (std::is_base_of_v<To, From>) {

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -1591,7 +1591,8 @@ foldTrait(Operation *, ArrayRef<Attribute>, SmallVectorImpl<OpFoldResult> &) {
 /// Given a tuple type containing a set of traits, return the result of folding
 /// the given operation.
 template <typename... Ts>
-static LogicalResult foldTraits(Operation *op, ArrayRef<Attribute> operands,
+static LogicalResult foldTraits([[maybe_unused]] Operation *op,
+                                [[maybe_unused]] ArrayRef<Attribute> operands,
                                 SmallVectorImpl<OpFoldResult> &results) {
   return success((succeeded(foldTrait<Ts>(op, operands, results)) || ...));
 }
@@ -1627,7 +1628,7 @@ verifyTrait(Operation *) {
 
 /// Given a set of traits, return the result of verifying the given operation.
 template <typename... Ts>
-LogicalResult verifyTraits(Operation *op) {
+LogicalResult verifyTraits([[maybe_unused]] Operation *op) {
   return success((succeeded(verifyTrait<Ts>(op)) && ...));
 }
 
@@ -1647,7 +1648,7 @@ verifyRegionTrait(Operation *) {
 /// Given a set of traits, return the result of verifying the regions of the
 /// given operation.
 template <typename... Ts>
-LogicalResult verifyRegionTraits(Operation *op) {
+LogicalResult verifyRegionTraits([[maybe_unused]] Operation *op) {
   return success((succeeded(verifyRegionTrait<Ts>(op)) && ...));
 }
 } // namespace op_definition_impl

--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -577,6 +577,7 @@ public:
       // dictionnary of discardable attributes for now.
       return cast<ConcreteOp>(op)->getDiscardableAttr(name);
     }
+
     void setInherentAttr(Operation *op, StringAttr name,
                          Attribute value) final {
       if constexpr (hasProperties) {
@@ -588,20 +589,24 @@ public:
       // dictionnary of discardable attributes for now.
       return cast<ConcreteOp>(op)->setDiscardableAttr(name, value);
     }
-    void populateInherentAttrs(Operation *op, NamedAttrList &attrs) final {
+
+    void populateInherentAttrs([[maybe_unused]] Operation *op,
+                               NamedAttrList &attrs) final {
       if constexpr (hasProperties) {
         auto concreteOp = cast<ConcreteOp>(op);
         ConcreteOp::populateInherentAttrs(concreteOp->getContext(),
                                           concreteOp.getProperties(), attrs);
       }
     }
-    LogicalResult
-    verifyInherentAttrs(OperationName opName, NamedAttrList &attributes,
-                        function_ref<InFlightDiagnostic()> emitError) final {
+
+    LogicalResult verifyInherentAttrs(
+        [[maybe_unused]] OperationName opName, NamedAttrList &attributes,
+        [[maybe_unused]] function_ref<InFlightDiagnostic()> emitError) final {
       if constexpr (hasProperties)
         return ConcreteOp::verifyInherentAttrs(opName, attributes, emitError);
       return success();
     }
+
     // Detect if the concrete operation defined properties.
     static constexpr bool hasProperties = !std::is_same_v<
         typename ConcreteOp::template InferredProperties<ConcreteOp>,
@@ -612,8 +617,9 @@ public:
         return sizeof(Properties);
       return 0;
     }
-    void initProperties(OperationName opName, OpaqueProperties storage,
-                        OpaqueProperties init) final {
+
+    void initProperties([[maybe_unused]] OperationName opName,
+                        OpaqueProperties storage, OpaqueProperties init) final {
       using Properties =
           typename ConcreteOp::template InferredProperties<ConcreteOp>;
       if (init)
@@ -624,11 +630,14 @@ public:
         ConcreteOp::populateDefaultProperties(opName,
                                               *storage.as<Properties *>());
     }
+
     void deleteProperties(OpaqueProperties prop) final {
       prop.as<Properties *>()->~Properties();
     }
-    void populateDefaultProperties(OperationName opName,
-                                   OpaqueProperties properties) final {
+
+    void populateDefaultProperties(
+        [[maybe_unused]] OperationName opName,
+        [[maybe_unused]] OpaqueProperties properties) final {
       if constexpr (hasProperties)
         ConcreteOp::populateDefaultProperties(opName,
                                               *properties.as<Properties *>());
@@ -645,7 +654,8 @@ public:
       emitError() << "this operation does not support properties";
       return failure();
     }
-    Attribute getPropertiesAsAttr(Operation *op) final {
+
+    Attribute getPropertiesAsAttr([[maybe_unused]] Operation *op) final {
       if constexpr (hasProperties) {
         auto concreteOp = cast<ConcreteOp>(op);
         return ConcreteOp::getPropertiesAsAttr(concreteOp->getContext(),
@@ -653,17 +663,22 @@ public:
       }
       return {};
     }
-    bool compareProperties(OpaqueProperties lhs, OpaqueProperties rhs) final {
+
+    bool compareProperties([[maybe_unused]] OpaqueProperties lhs,
+                           [[maybe_unused]] OpaqueProperties rhs) final {
       if constexpr (hasProperties) {
         return *lhs.as<Properties *>() == *rhs.as<Properties *>();
       } else {
         return true;
       }
     }
+
     void copyProperties(OpaqueProperties lhs, OpaqueProperties rhs) final {
       *lhs.as<Properties *>() = *rhs.as<Properties *>();
     }
-    llvm::hash_code hashProperties(OpaqueProperties prop) final {
+
+    llvm::hash_code
+    hashProperties([[maybe_unused]] OpaqueProperties prop) final {
       if constexpr (hasProperties)
         return ConcreteOp::computePropertiesHash(*prop.as<Properties *>());
 

--- a/mlir/include/mlir/IR/Types.h
+++ b/mlir/include/mlir/IR/Types.h
@@ -402,7 +402,7 @@ struct CastInfo<
   /// ID. This means that T::classof would end up comparing the static TypeID of
   /// the children to the static TypeID of its parent, making it impossible to
   /// downcast from the parent to the child.
-  static inline bool isPossible(mlir::Type ty) {
+  static inline bool isPossible([[maybe_unused]] mlir::Type ty) {
     /// Return a constant true instead of a dynamic true when casting to self or
     /// up the hierarchy.
     if constexpr (std::is_base_of_v<To, From>) {

--- a/mlir/include/mlir/IR/Value.h
+++ b/mlir/include/mlir/IR/Value.h
@@ -601,7 +601,7 @@ struct CastInfo<
   /// that returns the dynamic type. This means that T::classof would end up
   /// comparing the static Kind of the children to the static Kind of its
   /// parent, making it impossible to downcast from the parent to the child.
-  static inline bool isPossible(mlir::Value ty) {
+  static inline bool isPossible([[maybe_unused]] mlir::Value ty) {
     /// Return a constant true instead of a dynamic true when casting to self or
     /// up the hierarchy.
     if constexpr (std::is_base_of_v<To, From>) {

--- a/mlir/include/mlir/Query/Matcher/Marshallers.h
+++ b/mlir/include/mlir/Query/Matcher/Marshallers.h
@@ -150,11 +150,10 @@ inline bool checkArgTypeAtIndex(llvm::StringRef matcherName,
 
 // Marshaller function for fixed number of arguments
 template <typename ReturnType, typename... ArgTypes, size_t... Is>
-static VariantMatcher
-matcherMarshallFixedImpl(void (*matcherFunc)(), llvm::StringRef matcherName,
-                         SourceRange nameRange,
-                         llvm::ArrayRef<ParserValue> args, Diagnostics *error,
-                         std::index_sequence<Is...>) {
+static VariantMatcher matcherMarshallFixedImpl(
+    void (*matcherFunc)(), [[maybe_unused]] llvm::StringRef matcherName,
+    SourceRange nameRange, llvm::ArrayRef<ParserValue> args, Diagnostics *error,
+    std::index_sequence<Is...>) {
   using FuncType = ReturnType (*)(ArgTypes...);
 
   // Check if the argument count matches the expected count


### PR DESCRIPTION
Recently been seeing a lot more `-Wunused-but-set-parameter` build log noise. According to [discourse](https://discourse.llvm.org/t/maybe-unused-vs-attribute-unused-vs-void-var-for-assert-variables/64212/28) we're going with `[[maybe_unused]]` for this but let me know if this isn't the right way.

