### PR TITLE
[flang][openmp] Fix `not yet implemented intrinsic` message for omp_lib

### DIFF
--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -2534,7 +2534,8 @@ public:
             procRef.proc().GetSpecificIntrinsic())
       return genIntrinsicRef(procRef, resultType, *intrinsic);
 
-    if (Fortran::lower::isIntrinsicModuleProcRef(procRef))
+    if (Fortran::lower::isIntrinsicModuleProcRef(procRef) &&
+        !Fortran::semantics::IsBindCProcedure(*procRef.proc().GetSymbol()))
       return genIntrinsicRef(procRef, resultType);
 
     if (isStatementFunctionCall(procRef))

--- a/flang/test/Lower/OpenMP/omp-lib-num-threads.f90
+++ b/flang/test/Lower/OpenMP/omp-lib-num-threads.f90
@@ -1,5 +1,7 @@
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - 2>&1 | FileCheck %s
 ! RUN: bbc -fopenmp -emit-hlfir -o - %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-fir -fopenmp %s -o - 2>&1 | FileCheck %s
+! RUN: bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
 !
 ! Test that the calls to omp_lib's omp_get_num_threads and omp_set_num_threads
 ! get lowered even though their implementation is not in the omp_lib module


### PR DESCRIPTION
PR#70386 removed hardcoded omp_lib name when checking if it is intrinsic module procedure reference - but instead relied on bind(c) to avoid generating error when the implementation is external to module.

However, this change only worked for HLFIR. Make it work for FIR flow and update the test to exercise that as well.