### PR TITLE
[flang] Match argument types for std::min

### DIFF
--- a/flang/lib/Evaluate/fold-implementation.h
+++ b/flang/lib/Evaluate/fold-implementation.h
@@ -910,8 +910,7 @@ template <typename T> Expr<T> Folder<T>::RESHAPE(FunctionRef<T> &&funcRef) {
                 : pad->Reshape(std::move(shape.value()))};
         ConstantSubscripts subscripts{result.lbounds()};
         auto copied{result.CopyFrom(*source,
-            std::min(static_cast<decltype(resultElements)>(source->size()),
-                resultElements),
+            std::min(static_cast<uint64_t>(source->size()), resultElements),
             subscripts, dimOrderPtr)};
         if (copied < resultElements) {
           CHECK(pad);

--- a/flang/lib/Evaluate/fold-implementation.h
+++ b/flang/lib/Evaluate/fold-implementation.h
@@ -910,7 +910,9 @@ template <typename T> Expr<T> Folder<T>::RESHAPE(FunctionRef<T> &&funcRef) {
                 : pad->Reshape(std::move(shape.value()))};
         ConstantSubscripts subscripts{result.lbounds()};
         auto copied{result.CopyFrom(*source,
-            std::min(source->size(), resultElements), subscripts, dimOrderPtr)};
+            std::min(static_cast<decltype(resultElements)>(source->size()),
+                resultElements),
+            subscripts, dimOrderPtr)};
         if (copied < resultElements) {
           CHECK(pad);
           copied += result.CopyFrom(


### PR DESCRIPTION
PR #68342 causes build breakage on MacOS due to uint64_t being defined as unsigned long long instead of unsigned long. It leads to type mismatch in the arguments for std::min.