### PR TITLE
[BOLT][AArch64] Handle IFUNCS properly

### DIFF
--- a/bolt/include/bolt/Core/Relocation.h
+++ b/bolt/include/bolt/Core/Relocation.h
@@ -124,6 +124,10 @@ struct Relocation {
   /// otherwise.
   bool isRelative() const { return isRelative(Type); }
 
+  /// Return true if this relocation is R_*_IRELATIVE type. Return false
+  /// otherwise.
+  bool isIRelative() const { return isIRelative(Type); }
+
   /// Emit relocation at a current \p Streamer' position. The caller is
   /// responsible for setting the position correctly.
   size_t emit(MCStreamer *Streamer) const;

--- a/bolt/test/AArch64/Inputs/iplt.ld
+++ b/bolt/test/AArch64/Inputs/iplt.ld
@@ -1,0 +1,3 @@
+SECTIONS {
+  .plt : ALIGN(16) { *(.plt) *(.iplt) }
+}

--- a/bolt/test/AArch64/ifunc.c
+++ b/bolt/test/AArch64/ifunc.c
@@ -1,0 +1,40 @@
+// This test checks that IFUNC trampoline is properly recognised by BOLT
+
+// With -O0 indirect call is performed on IPLT trampoline. IPLT trampoline
+// has IFUNC symbol.
+// RUN: %clang %cflags -nostdlib -O0 -no-pie %s -fuse-ld=lld \
+// RUN:    -o %t.O0.exe -Wl,-q
+// RUN: llvm-bolt %t.O0.exe -o %t.O0.bolt.exe \
+// RUN:   --print-disasm --print-only=_start | \
+// RUN:   FileCheck --check-prefix=O0_CHECK %s
+
+// With -O3 direct call is performed on IPLT trampoline. IPLT trampoline
+// doesn't have associated symbol. The ifunc symbol has the same address as
+// IFUNC resolver function.
+// RUN: %clang %cflags -nostdlib -O3 %s -fuse-ld=lld -fPIC -pie \
+// RUN:   -o %t.O3_pie.exe -Wl,-q
+// RUN: llvm-bolt %t.O3_pie.exe -o %t.O3_pie.bolt.exe  \
+// RUN:   --print-disasm --print-only=_start | \
+// RUN:   FileCheck --check-prefix=O3_CHECK %s
+
+// Check that IPLT trampoline located in .plt section are normally handled by
+// BOLT. The gnu-ld linker doesn't use separate .iplt section.
+// RUN: %clang %cflags -nostdlib -O3 %s -fuse-ld=lld -fPIC -pie \
+// RUN:   -T %p/Inputs/iplt.ld -o %t.iplt_O3_pie.exe -Wl,-q
+// RUN: llvm-bolt %t.iplt_O3_pie.exe -o %t.iplt_O3_pie.bolt.exe  \
+// RUN:   --print-disasm --print-only=_start  | \
+// RUN:   FileCheck --check-prefix=O3_CHECK %s
+
+// O0_CHECK: adr x{{[0-9]+}}, ifoo
+// O3_CHECK: b "{{resolver_foo|ifoo}}{{.*}}@PLT"
+
+#include <stdio.h>
+#include <string.h>
+
+static void foo() {}
+
+static void *resolver_foo(void) { return foo; }
+
+__attribute__((ifunc("resolver_foo"))) void ifoo();
+
+void _start() { ifoo(); }

--- a/bolt/test/runtime/iplt.c
+++ b/bolt/test/runtime/iplt.c
@@ -1,9 +1,15 @@
 // This test checks that the ifuncs works after bolt.
+// Compiling with 00 results in IFUNC indirect calling.
 
-// RUN: %clang %cflags -no-pie %s -fuse-ld=lld \
+// RUN: %clang %cflags -O0 -no-pie %s -fuse-ld=lld \
 // RUN:    -o %t.exe -Wl,-q
 // RUN: llvm-bolt %t.exe -o %t.bolt.exe --use-old-text=0 --lite=0
 // RUN: %t.bolt.exe  | FileCheck %s
+
+// RUN: %clang %cflags -O3 -no-pie %s -fuse-ld=lld \
+// RUN:    -o %t.O3.exe -Wl,-q
+// RUN: llvm-bolt %t.O3.exe -o %t.O3.bolt.exe --use-old-text=0 --lite=0
+// RUN: %t.O3.bolt.exe  | FileCheck %s
 
 // CHECK: foo
 


### PR DESCRIPTION
Currently we were testing only the binaries compiled with O0, which
results in indirect call to the IFUNC trampoline and the trampoline has
associated IFUNC symbol with it. Compile with O3 results in direct
calling the IFUNC trampoline and no symbols are associated with it, the
IFUNC symbol address becomes the same as IFUNC resolver address. Since
no symbol was associated the BF was not created before PLT analyze and
be the algorithm we're going to analyze target relocation. As we're
expecting the JUMP relocation we're also expecting the associated symbol
with it to be presented. But for IFUNC relocation the IRELATIVE
relocation is used and no symbol is associated with it, the addend value
is pointing on the target symbol, so we need to find BF using it and use
it's symbol in this situation. Currently this is checked only for
AArch64 platform, so I've limited it in code to use this logic only for
this platform, although I wouldn't be surprised if other platforms needs
to activate this logic too.
