### PR TITLE
[GISel] Remove BitVector from RegBank. Use tablegen CoverageData tables directly. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/RegisterBank.h
+++ b/llvm/include/llvm/CodeGen/RegisterBank.h
@@ -13,7 +13,7 @@
 #ifndef LLVM_CODEGEN_REGISTERBANK_H
 #define LLVM_CODEGEN_REGISTERBANK_H
 
-#include "llvm/ADT/BitVector.h"
+#include <cstdint>
 
 namespace llvm {
 // Forward declarations.
@@ -28,15 +28,18 @@ class TargetRegisterInfo;
 class RegisterBank {
 private:
   unsigned ID;
+  unsigned NumRegClasses;
   const char *Name;
-  BitVector ContainedRegClasses;
+  const uint32_t *CoveredClasses;
 
   /// Only the RegisterBankInfo can initialize RegisterBank properly.
   friend RegisterBankInfo;
 
 public:
   RegisterBank(unsigned ID, const char *Name, const uint32_t *CoveredClasses,
-               unsigned NumRegClasses);
+               unsigned NumRegClasses)
+      : ID(ID), NumRegClasses(NumRegClasses), Name(Name),
+        CoveredClasses(CoveredClasses) {}
 
   /// Get the identifier of this register bank.
   unsigned getID() const { return ID; }

--- a/llvm/lib/CodeGen/RegisterBank.cpp
+++ b/llvm/lib/CodeGen/RegisterBank.cpp
@@ -20,14 +20,6 @@
 
 using namespace llvm;
 
-RegisterBank::RegisterBank(unsigned ID, const char *Name,
-                           const uint32_t *CoveredClasses,
-                           unsigned NumRegClasses)
-    : ID(ID), Name(Name) {
-  ContainedRegClasses.resize(NumRegClasses);
-  ContainedRegClasses.setBitsInMask(CoveredClasses);
-}
-
 bool RegisterBank::verify(const RegisterBankInfo &RBI,
                           const TargetRegisterInfo &TRI) const {
   for (unsigned RCId = 0, End = TRI.getNumRegClasses(); RCId != End; ++RCId) {
@@ -58,7 +50,7 @@ bool RegisterBank::verify(const RegisterBankInfo &RBI,
 }
 
 bool RegisterBank::covers(const TargetRegisterClass &RC) const {
-  return ContainedRegClasses.test(RC.getID());
+  return (CoveredClasses[RC.getID() / 32] & (1U << RC.getID() % 32)) != 0;
 }
 
 bool RegisterBank::operator==(const RegisterBank &OtherRB) const {
@@ -81,14 +73,18 @@ void RegisterBank::print(raw_ostream &OS, bool IsForDebug,
   OS << getName();
   if (!IsForDebug)
     return;
+
+  unsigned Count = 0;
+  for (int i = 0, e = ((NumRegClasses + 31) / 32); i != e; ++i)
+    Count += llvm::popcount(CoveredClasses[i]);
+
   OS << "(ID:" << getID() << ")\n"
-     << "Number of Covered register classes: " << ContainedRegClasses.count()
-     << '\n';
+     << "Number of Covered register classes: " << Count << '\n';
   // Print all the subclasses if we can.
   // This register classes may not be properly initialized yet.
-  if (!TRI || ContainedRegClasses.empty())
+  if (!TRI || NumRegClasses == 0)
     return;
-  assert(ContainedRegClasses.size() == TRI->getNumRegClasses() &&
+  assert(NumRegClasses == TRI->getNumRegClasses() &&
          "TRI does not match the initialization process?");
   OS << "Covered register classes:\n";
   ListSeparator LS;


### PR DESCRIPTION
RegBanks are allocated as global variables. The use of BitVector causes a static global constructor to be used. The BitVector is initialized from a table of bits that is created by tablegen. We can keep a pointer to that data and use it as the bit vector instead.

This does require a little bit of manual indexing and reimplementation of BitVector::count.