### PR TITLE
[MLIR][FuncToLLVM] Remove typed pointers from call conversion test pass

### DIFF
--- a/mlir/test/Transforms/test-convert-call-op.mlir
+++ b/mlir/test/Transforms/test-convert-call-op.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-opt %s -test-convert-call-op | FileCheck %s
 
-// CHECK-LABEL: llvm.func @callee(!llvm.ptr<i8>) -> i32
+// CHECK-LABEL: llvm.func @callee(!llvm.ptr) -> i32
 func.func private @callee(!test.test_type) -> i32
 
 // CHECK-NEXT: llvm.func @caller() -> i32
@@ -9,6 +9,6 @@ func.func @caller() -> i32 {
   %out = call @callee(%arg) : (!test.test_type) -> i32
   return %out : i32
 }
-// CHECK-NEXT: [[ARG:%.*]] = llvm.mlir.zero : !llvm.ptr<i8>
+// CHECK-NEXT: [[ARG:%.*]] = llvm.mlir.zero : !llvm.ptr
 // CHECK-NEXT: [[OUT:%.*]] = llvm.call @callee([[ARG]])
-// CHECK-SAME:     : (!llvm.ptr<i8>) -> i32
+// CHECK-SAME:     : (!llvm.ptr) -> i32

--- a/mlir/test/lib/Conversion/FuncToLLVM/TestConvertCallOp.cpp
+++ b/mlir/test/lib/Conversion/FuncToLLVM/TestConvertCallOp.cpp
@@ -49,12 +49,11 @@ struct TestConvertCallOp
     ModuleOp m = getOperation();
 
     LowerToLLVMOptions options(m.getContext());
-    options.useOpaquePointers = false;
 
     // Populate type conversions.
     LLVMTypeConverter typeConverter(m.getContext(), options);
     typeConverter.addConversion([&](test::TestType type) {
-      return LLVM::LLVMPointerType::get(IntegerType::get(m.getContext(), 8));
+      return LLVM::LLVMPointerType::get(m.getContext());
     });
     typeConverter.addConversion([&](test::SimpleAType type) {
       return IntegerType::get(type.getContext(), 42);


### PR DESCRIPTION
This commit removes typed pointers from the Func to LLVM test pass. Typed pointers have been deprecated for a while now and it's planned to soon remove them from the LLVM dialect.

Related PSA: https://discourse.llvm.org/t/psa-removal-of-typed-pointers-from-the-llvm-dialect/74502