### PR TITLE
[GISel] Make RegBank constructor constexpr. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/RegisterBank.h
+++ b/llvm/include/llvm/CodeGen/RegisterBank.h
@@ -36,8 +36,8 @@ private:
   friend RegisterBankInfo;
 
 public:
-  RegisterBank(unsigned ID, const char *Name, const uint32_t *CoveredClasses,
-               unsigned NumRegClasses)
+  constexpr RegisterBank(unsigned ID, const char *Name,
+                         const uint32_t *CoveredClasses, unsigned NumRegClasses)
       : ID(ID), NumRegClasses(NumRegClasses), Name(Name),
         CoveredClasses(CoveredClasses) {}
 

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -244,7 +244,7 @@ void RegisterBankEmitter::emitBaseClassImplementation(
   for (const auto &Bank : Banks) {
     std::string QualifiedBankID =
         (TargetName + "::" + Bank.getEnumeratorName()).str();
-    OS << "const RegisterBank " << Bank.getInstanceVarName() << "(/* ID */ "
+    OS << "constexpr RegisterBank " << Bank.getInstanceVarName() << "(/* ID */ "
        << QualifiedBankID << ", /* Name */ \"" << Bank.getName() << "\", "
        << "/* CoveredRegClasses */ " << Bank.getCoverageArrayName()
        << ", /* NumRegClasses */ "


### PR DESCRIPTION
RegBanks are constructed as global objects. Making the constructor
constexpr helps the compiler constructor it without a global constructor.
    
clang's optimizer seems to figure this out on its own, but at
least gcc 8 does not.

This is stacked on #71105