### PR TITLE
[lldb] Use get-task-allow entitlement on macOS too

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -88,17 +88,18 @@ class BuilderDarwin(Builder):
                 args["FRAMEWORK_INCLUDES"] = "-F{}".format(private_frameworks)
 
         operating_system, env = get_os_and_env()
-        if operating_system and operating_system != "macosx":
-            builder_dir = os.path.dirname(os.path.abspath(__file__))
-            test_dir = os.path.dirname(builder_dir)
+
+        builder_dir = os.path.dirname(os.path.abspath(__file__))
+        test_dir = os.path.dirname(builder_dir)
+        if not operating_system:
+            entitlements_file = "entitlements-macos.plist"
+        else:
             if env == "simulator":
                 entitlements_file = "entitlements-simulator.plist"
             else:
                 entitlements_file = "entitlements.plist"
-            entitlements = os.path.join(test_dir, "make", entitlements_file)
-            args["CODESIGN"] = "codesign --entitlements {}".format(entitlements)
-        else:
-            args["CODESIGN"] = "codesign"
+        entitlements = os.path.join(test_dir, "make", entitlements_file)
+        args["CODESIGN"] = "codesign --entitlements {}".format(entitlements)
 
         # Return extra args as a formatted string.
         return ["{}={}".format(key, value) for key, value in args.items()]

--- a/lldb/packages/Python/lldbsuite/test/make/entitlements-macos.plist
+++ b/lldb/packages/Python/lldbsuite/test/make/entitlements-macos.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Running the LLDB test suite in a GUI-less macOS environment (say, ssh) requires that the debugged tasks be signed with the get-task-allow entitlement.

NOTE: I'm not entirely sure why the LLDB macOS builders don't run into this; it could be something that occurs on newer macOS, or it could be that they have some global setting that prevents the debugger attachment check from firing.