### PR TITLE
[MLIR][MemRefToLLVM] Remove last typed pointer remnants

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/FunctionCallUtils.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/FunctionCallUtils.h
@@ -50,16 +50,16 @@ LLVM::LLVMFuncOp lookupOrCreatePrintCloseFn(ModuleOp moduleOp);
 LLVM::LLVMFuncOp lookupOrCreatePrintCommaFn(ModuleOp moduleOp);
 LLVM::LLVMFuncOp lookupOrCreatePrintNewlineFn(ModuleOp moduleOp);
 LLVM::LLVMFuncOp lookupOrCreateMallocFn(ModuleOp moduleOp, Type indexType,
-                                        bool opaquePointers);
+                                        bool opaquePointers = true);
 LLVM::LLVMFuncOp lookupOrCreateAlignedAllocFn(ModuleOp moduleOp, Type indexType,
                                               bool opaquePointers = true);
 LLVM::LLVMFuncOp lookupOrCreateFreeFn(ModuleOp moduleOp,
                                       bool opaquePointers = true);
 LLVM::LLVMFuncOp lookupOrCreateGenericAllocFn(ModuleOp moduleOp, Type indexType,
-                                              bool opaquePointers);
-LLVM::LLVMFuncOp lookupOrCreateGenericAlignedAllocFn(ModuleOp moduleOp,
-                                                     Type indexType,
-                                                     bool opaquePointers);
+                                              bool opaquePointers = true);
+LLVM::LLVMFuncOp
+lookupOrCreateGenericAlignedAllocFn(ModuleOp moduleOp, Type indexType,
+                                    bool opaquePointers = true);
 LLVM::LLVMFuncOp lookupOrCreateGenericFreeFn(ModuleOp moduleOp,
                                              bool opaquePointers = true);
 LLVM::LLVMFuncOp lookupOrCreateMemRefCopyFn(ModuleOp moduleOp, Type indexType,

--- a/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.td
@@ -30,8 +30,6 @@ def MemrefToLLVMTypeConverterOp : Op<Transform_Dialect,
       machine word.
     - `use_generic_functions`: Use generic allocation and deallocation functions
       instead of the classic "malloc", "aligned_alloc" and "free" functions.
-    - `use_opaque_pointers`: Generate LLVM IR using opaque pointers instead of
-      typed pointers.
     // TODO: the following two options don't really make sense for 
     // memref_to_llvm_type_converter specifically.
     // We should have a single to_llvm_type_converter.
@@ -45,7 +43,6 @@ def MemrefToLLVMTypeConverterOp : Op<Transform_Dialect,
       DefaultValuedOptionalAttr<BoolAttr, "false">:$use_aligned_alloc,
       DefaultValuedOptionalAttr<I64Attr, "64">:$index_bitwidth,
       DefaultValuedOptionalAttr<BoolAttr, "false">:$use_generic_functions,
-      DefaultValuedOptionalAttr<BoolAttr, "false">:$use_opaque_pointers,
       DefaultValuedOptionalAttr<BoolAttr, "false">:$use_bare_ptr_call_conv,
       OptionalAttr<StrAttr>:$data_layout);
   let assemblyFormat = "attr-dict";

--- a/mlir/lib/Conversion/MemRefToLLVM/AllocLikeConversion.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/AllocLikeConversion.cpp
@@ -23,11 +23,9 @@ LLVM::LLVMFuncOp getNotalignedAllocFn(const LLVMTypeConverter *typeConverter,
   bool useGenericFn = typeConverter->getOptions().useGenericFunctions;
 
   if (useGenericFn)
-    return LLVM::lookupOrCreateGenericAllocFn(
-        module, indexType, typeConverter->useOpaquePointers());
+    return LLVM::lookupOrCreateGenericAllocFn(module, indexType);
 
-  return LLVM::lookupOrCreateMallocFn(module, indexType,
-                                      typeConverter->useOpaquePointers());
+  return LLVM::lookupOrCreateMallocFn(module, indexType);
 }
 
 LLVM::LLVMFuncOp getAlignedAllocFn(const LLVMTypeConverter *typeConverter,
@@ -35,11 +33,9 @@ LLVM::LLVMFuncOp getAlignedAllocFn(const LLVMTypeConverter *typeConverter,
   bool useGenericFn = typeConverter->getOptions().useGenericFunctions;
 
   if (useGenericFn)
-    return LLVM::lookupOrCreateGenericAlignedAllocFn(
-        module, indexType, typeConverter->useOpaquePointers());
+    return LLVM::lookupOrCreateGenericAlignedAllocFn(module, indexType);
 
-  return LLVM::lookupOrCreateAlignedAllocFn(module, indexType,
-                                            typeConverter->useOpaquePointers());
+  return LLVM::lookupOrCreateAlignedAllocFn(module, indexType);
 }
 
 } // end namespace
@@ -70,10 +66,6 @@ static Value castAllocFuncResult(ConversionPatternRewriter &rewriter,
         typeConverter.getPointerType(allocatedPtrTy.getElementType(),
                                      memrefAddrSpace),
         allocatedPtr);
-
-  if (!typeConverter.useOpaquePointers())
-    allocatedPtr =
-        rewriter.create<LLVM::BitcastOp>(loc, elementPtrType, allocatedPtr);
   return allocatedPtr;
 }
 

--- a/mlir/lib/Dialect/MemRef/TransformOps/MemRefTransformOps.cpp
+++ b/mlir/lib/Dialect/MemRef/TransformOps/MemRefTransformOps.cpp
@@ -42,7 +42,6 @@ transform::MemrefToLLVMTypeConverterOp::getTypeConverter() {
       (getUseAlignedAlloc() ? LowerToLLVMOptions::AllocLowering::AlignedAlloc
                             : LowerToLLVMOptions::AllocLowering::Malloc);
   options.useGenericFunctions = getUseGenericFunctions();
-  options.useOpaquePointers = getUseOpaquePointers();
 
   if (getIndexBitwidth() != kDeriveIndexBitwidthFromDataLayout)
     options.overrideIndexBitwidth(getIndexBitwidth());


### PR DESCRIPTION
This commit removes the last typed pointer remnants from the MemRef to LLVM conversions, including the transform dialect operation. Typed pointers have been deprecated for a while now and it's planned to soon remove them from the LLVM dialect.

Related PSA: https://discourse.llvm.org/t/psa-removal-of-typed-pointers-from-the-llvm-dialect/74502