### PR TITLE
[GISel] Remove remainder of the concept of an invalid RegisterBank.

### DIFF
--- a/llvm/include/llvm/CodeGen/RegisterBank.h
+++ b/llvm/include/llvm/CodeGen/RegisterBank.h
@@ -31,10 +31,6 @@ private:
   const char *Name;
   BitVector ContainedRegClasses;
 
-  /// Sentinel value used to recognize register bank not properly
-  /// initialized yet.
-  static const unsigned InvalidID;
-
   /// Only the RegisterBankInfo can initialize RegisterBank properly.
   friend RegisterBankInfo;
 
@@ -49,9 +45,6 @@ public:
   /// Should be used only for debugging purposes.
   const char *getName() const { return Name; }
 
-  /// Check whether this instance is ready to be used.
-  bool isValid() const;
-
   /// Check if this register bank is valid. In other words,
   /// if it has been properly constructed.
   ///
@@ -63,7 +56,6 @@ public:
   /// Check whether this register bank covers \p RC.
   /// In other words, check if this register bank fully covers
   /// the registers that \p RC contains.
-  /// \pre isValid()
   bool covers(const TargetRegisterClass &RC) const;
 
   /// Check whether \p OtherRB is the same as this.

--- a/llvm/lib/CodeGen/RegisterBank.cpp
+++ b/llvm/lib/CodeGen/RegisterBank.cpp
@@ -20,8 +20,6 @@
 
 using namespace llvm;
 
-const unsigned RegisterBank::InvalidID = UINT_MAX;
-
 RegisterBank::RegisterBank(unsigned ID, const char *Name,
                            const uint32_t *CoveredClasses,
                            unsigned NumRegClasses)
@@ -32,7 +30,6 @@ RegisterBank::RegisterBank(unsigned ID, const char *Name,
 
 bool RegisterBank::verify(const RegisterBankInfo &RBI,
                           const TargetRegisterInfo &TRI) const {
-  assert(isValid() && "Invalid register bank");
   for (unsigned RCId = 0, End = TRI.getNumRegClasses(); RCId != End; ++RCId) {
     const TargetRegisterClass &RC = *TRI.getRegClass(RCId);
 
@@ -61,14 +58,7 @@ bool RegisterBank::verify(const RegisterBankInfo &RBI,
 }
 
 bool RegisterBank::covers(const TargetRegisterClass &RC) const {
-  assert(isValid() && "RB hasn't been initialized yet");
   return ContainedRegClasses.test(RC.getID());
-}
-
-bool RegisterBank::isValid() const {
-  return ID != InvalidID && Name != nullptr &&
-         // A register bank that does not cover anything is useless.
-         !ContainedRegClasses.empty();
 }
 
 bool RegisterBank::operator==(const RegisterBank &OtherRB) const {
@@ -92,7 +82,6 @@ void RegisterBank::print(raw_ostream &OS, bool IsForDebug,
   if (!IsForDebug)
     return;
   OS << "(ID:" << getID() << ")\n"
-     << "isValid:" << isValid() << '\n'
      << "Number of Covered register classes: " << ContainedRegClasses.count()
      << '\n';
   // Print all the subclasses if we can.

--- a/llvm/lib/CodeGen/RegisterBankInfo.cpp
+++ b/llvm/lib/CodeGen/RegisterBankInfo.cpp
@@ -61,7 +61,8 @@ RegisterBankInfo::RegisterBankInfo(const RegisterBank **RegBanks,
 #ifndef NDEBUG
   for (unsigned Idx = 0, End = getNumRegBanks(); Idx != End; ++Idx) {
     assert(RegBanks[Idx] != nullptr && "Invalid RegisterBank");
-    assert(RegBanks[Idx]->isValid() && "RegisterBank should be valid");
+    assert(RegBanks[Idx]->getID() == Idx &&
+           "RegisterBank ID should match index");
   }
 #endif // NDEBUG
 }


### PR DESCRIPTION
RegisterBank no longer has a default constructor so there's no way to create an invalid register bank.

Remove InvalidID and the isValid method.

Replace the one use of isValid outside of RegBank with a check that the ID matches so there's still some check of sanity.