### PR TITLE
llvm: [NFC] Robustify testcase

### DIFF
--- a/llvm/test/Verifier/alias.ll
+++ b/llvm/test/Verifier/alias.ll
@@ -1,6 +1,6 @@
 ; RUN:  not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
 
-; CHECK: llvm-as: assembly parsed, but does not verify as correct!
+; CHECK: : assembly parsed, but does not verify as correct!
 ; CHECK-NOT: {{(^A| a)lias(es)? }}
 
 declare void @f()

--- a/llvm/test/Verifier/alias.ll
+++ b/llvm/test/Verifier/alias.ll
@@ -1,5 +1,7 @@
-; RUN:  not llvm-as %s -o /dev/null 2>&1 | FileCheck %s --implicit-check-not=alias --implicit-check-not=Alias
+; RUN:  not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
 
+; CHECK: llvm-as: assembly parsed, but does not verify as correct!
+; CHECK-NOT: {{(^A| a)lias(es)? }}
 
 declare void @f()
 @fa = alias void (), ptr @f


### PR DESCRIPTION
This is llvm's instance of unfortunate testfailure with a pathname containing 'alias'. Clang's case was addressed with https://github.com/llvm/llvm-project/pull/69739.  CHECK-NOT regexes can be tricky.

Expect llvm-as diagnostic and robustify 'alias' check-not, to avoid problems with pathnames.