### PR TITLE
[RISCV][GISel] Add helper to convert a LLT size to a RegisterBankInfo::ValueMapping* for FP.

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVRegisterBankInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVRegisterBankInfo.cpp
@@ -69,8 +69,8 @@ enum ValueMappingsIdx {
 
 const RegisterBankInfo::ValueMapping *getFPValueMapping(unsigned Size) {
   assert(Size == 32 || Size == 64);
-  unsigned Idx = Size == 64 ? PMI_FPR64 : PMI_FPR32;
-  return &ValueMappings[1 + Idx * 3];
+  unsigned Idx = Size == 64 ? FPR64Idx : FPR32Idx;
+  return &ValueMappings[Idx];
 }
 } // namespace RISCV
 } // namespace llvm


### PR DESCRIPTION
Use this to simplify code.