### PR TITLE
[mlir][sparse] remove (some) deprecated dim/lvl methods

### DIFF
--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensor.h
@@ -162,12 +162,10 @@ bool isBlockSparsity(AffineMap dimToLvl);
 /// [deprecated] Convenience method to translate the given level to the
 /// corresponding dimension. Requires: `0 <= l < lvlRank`.
 Dimension toOrigDim(SparseTensorEncodingAttr enc, Level l);
-Dimension toOrigDim(RankedTensorType type, Level l);
 
 /// [deprecated] Convenience method to translate the given dimension to
 /// the corresponding level. Requires: `0 <= d < dimRank`.
 Level toStoredDim(SparseTensorEncodingAttr enc, Dimension d);
-Level toStoredDim(RankedTensorType type, Dimension d);
 
 } // namespace sparse_tensor
 } // namespace mlir

--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -409,6 +409,7 @@ SparseTensorEncodingAttr::tranlateShape(ArrayRef<int64_t> srcShape,
 
   if (isPermutation()) {
     for (unsigned r = 0; r < rank; r++) {
+      // FIXME: `toOrigDim` and `toStoredDim` are deprecated.
       unsigned trans = dir == CrdTransDirectionKind::dim2lvl
                            ? toOrigDim(*this, r)
                            : toStoredDim(*this, r);
@@ -951,21 +952,6 @@ Level mlir::sparse_tensor::toStoredDim(SparseTensorEncodingAttr enc,
     }
   }
   return d;
-}
-
-// TODO: Remove this definition once all use-sites have been fixed to
-// properly handle non-permutations.
-Dimension mlir::sparse_tensor::toOrigDim(RankedTensorType type, Level l) {
-  const auto enc = getSparseTensorEncoding(type);
-  assert(!enc || l < enc.getLvlRank());
-  return toOrigDim(enc, l);
-}
-
-// TODO: Remove this definition once all use-sites have been fixed to
-// properly handle non-permutations.
-Level mlir::sparse_tensor::toStoredDim(RankedTensorType type, Dimension d) {
-  assert(d < static_cast<Dimension>(type.getRank()));
-  return toStoredDim(getSparseTensorEncoding(type), d);
 }
 
 /// We normalized sparse tensor encoding attribute by always using

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
@@ -248,7 +248,7 @@ static void createAllocFields(OpBuilder &builder, Location loc,
   for (Level lvlRank = stt.getLvlRank(), l = 0; l < lvlRank; l++) {
     // Fills dim sizes array.
     // FIXME: `toOrigDim` is deprecated.
-    desc.setLvlSize(builder, loc, l, dimSizes[toOrigDim(stt, l)]);
+    desc.setLvlSize(builder, loc, l, dimSizes[toOrigDim(stt.getEncoding(), l)]);
     // Pushes a leading zero to positions memref.
     if (stt.isCompressedLvl(l))
       createPushback(builder, loc, desc, SparseTensorFieldKind::PosMemRef, l,

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorRewriting.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorRewriting.cpp
@@ -872,8 +872,9 @@ struct SparseTensorDimOpRewriter : public OpRewritePattern<tensor::DimOp> {
       return failure();
 
     if (stt.isPermutation()) {
+      // FIXME: `toStoredDim` is deprecated
       rewriter.replaceOpWithNewOp<LvlOp>(op, op.getSource(),
-                                         toStoredDim(stt, *dim));
+                                         toStoredDim(stt.getEncoding(), *dim));
       return success();
     }
 


### PR DESCRIPTION
This removes the most obvious ones. The others are still TBD.