### PR TITLE
[libc++] Add missing headers to the modulemap

### DIFF
--- a/libcxx/include/__algorithm/pstl_move.h
+++ b/libcxx/include/__algorithm/pstl_move.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___ALGORITHM_PSTL_MOVE_H
 
 #include <__algorithm/copy_n.h>
+#include <__algorithm/pstl_backend.h>
 #include <__algorithm/pstl_frontend_dispatch.h>
 #include <__algorithm/pstl_transform.h>
 #include <__config>

--- a/libcxx/include/__algorithm/pstl_rotate_copy.h
+++ b/libcxx/include/__algorithm/pstl_rotate_copy.h
@@ -13,6 +13,7 @@
 #include <__algorithm/pstl_copy.h>
 #include <__algorithm/pstl_frontend_dispatch.h>
 #include <__type_traits/is_execution_policy.h>
+#include <optional>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/experimental/__simd/abi_tag.h
+++ b/libcxx/include/experimental/__simd/abi_tag.h
@@ -10,8 +10,9 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_ABI_TAG_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_ABI_TAG_H
 
-#include <experimental/__simd/scalar.h>
-#include <experimental/__simd/vec_ext.h>
+#include <cstddef>
+#include <experimental/__config>
+#include <experimental/__simd/internal_declaration.h>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
 

--- a/libcxx/include/experimental/__simd/aligned_tag.h
+++ b/libcxx/include/experimental/__simd/aligned_tag.h
@@ -12,7 +12,8 @@
 
 #include <__bit/bit_ceil.h>
 #include <__memory/assume_aligned.h>
-#include <cstdint>
+#include <cstddef>
+#include <experimental/__config>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
 

--- a/libcxx/include/experimental/__simd/declaration.h
+++ b/libcxx/include/experimental/__simd/declaration.h
@@ -10,6 +10,9 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_DECLARATION_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_DECLARATION_H
 
+#include <experimental/__config>
+#include <experimental/__simd/abi_tag.h>
+
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
 
 _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL

--- a/libcxx/include/experimental/__simd/internal_declaration.h
+++ b/libcxx/include/experimental/__simd/internal_declaration.h
@@ -10,10 +10,17 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_INTERNAL_DECLARATION_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_INTERNAL_DECLARATION_H
 
+#include <experimental/__config>
+
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
 
 _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL
 inline namespace parallelism_v2 {
+namespace simd_abi {
+template <int>
+struct __vec_ext;
+struct __scalar;
+} // namespace simd_abi
 
 template <class _Tp, class _Abi>
 struct __simd_storage;

--- a/libcxx/include/experimental/__simd/reference.h
+++ b/libcxx/include/experimental/__simd/reference.h
@@ -11,6 +11,10 @@
 #define _LIBCPP_EXPERIMENTAL___SIMD_REFERENCE_H
 
 #include <__type_traits/is_assignable.h>
+#include <__type_traits/is_same.h>
+#include <__utility/forward.h>
+#include <cstddef>
+#include <experimental/__config>
 #include <experimental/__simd/utility.h>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)

--- a/libcxx/include/experimental/__simd/scalar.h
+++ b/libcxx/include/experimental/__simd/scalar.h
@@ -11,7 +11,9 @@
 #define _LIBCPP_EXPERIMENTAL___SIMD_SCALAR_H
 
 #include <cstddef>
+#include <experimental/__config>
 #include <experimental/__simd/internal_declaration.h>
+#include <experimental/__simd/traits.h>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
 
@@ -22,6 +24,9 @@ struct __scalar {
   static constexpr size_t __simd_size = 1;
 };
 } // namespace simd_abi
+
+template <>
+inline constexpr bool is_abi_tag_v<simd_abi::__scalar> = true;
 
 template <class _Tp>
 struct __simd_storage<_Tp, simd_abi::__scalar> {

--- a/libcxx/include/experimental/__simd/simd.h
+++ b/libcxx/include/experimental/__simd/simd.h
@@ -10,13 +10,17 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_SIMD_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_SIMD_H
 
+#include <__type_traits/is_same.h>
 #include <__type_traits/remove_cvref.h>
+#include <__utility/forward.h>
+#include <cstddef>
+#include <experimental/__config>
 #include <experimental/__simd/abi_tag.h>
 #include <experimental/__simd/declaration.h>
+#include <experimental/__simd/internal_declaration.h>
 #include <experimental/__simd/reference.h>
-#include <experimental/__simd/scalar.h>
 #include <experimental/__simd/traits.h>
-#include <experimental/__simd/vec_ext.h>
+#include <experimental/__simd/utility.h>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
 
@@ -66,6 +70,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI reference operator[](size_t __i) noexcept { return reference(__s_, __i); }
   _LIBCPP_HIDE_FROM_ABI value_type operator[](size_t __i) const noexcept { return __s_.__get(__i); }
 };
+
+template <class _Tp, class _Abi>
+inline constexpr bool is_simd_v<simd<_Tp, _Abi>> = true;
 
 template <class _Tp>
 using native_simd = simd<_Tp, simd_abi::native<_Tp>>;

--- a/libcxx/include/experimental/__simd/simd_mask.h
+++ b/libcxx/include/experimental/__simd/simd_mask.h
@@ -10,11 +10,14 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_SIMD_MASK_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_SIMD_MASK_H
 
+#include <__type_traits/is_same.h>
+#include <cstddef>
+#include <experimental/__config>
 #include <experimental/__simd/abi_tag.h>
 #include <experimental/__simd/declaration.h>
+#include <experimental/__simd/internal_declaration.h>
 #include <experimental/__simd/reference.h>
-#include <experimental/__simd/scalar.h>
-#include <experimental/__simd/vec_ext.h>
+#include <experimental/__simd/traits.h>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
 
@@ -55,6 +58,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI reference operator[](size_t __i) noexcept { return reference(__s_, __i); }
   _LIBCPP_HIDE_FROM_ABI value_type operator[](size_t __i) const noexcept { return __s_.__get(__i); }
 };
+
+template <class _Tp, class _Abi>
+inline constexpr bool is_simd_mask_v<simd_mask<_Tp, _Abi>> = true;
 
 template <class _Tp>
 using native_simd_mask = simd_mask<_Tp, simd_abi::native<_Tp>>;

--- a/libcxx/include/experimental/__simd/traits.h
+++ b/libcxx/include/experimental/__simd/traits.h
@@ -10,9 +10,14 @@
 #ifndef _LIBCPP_EXPERIMENTAL___SIMD_TRAITS_H
 #define _LIBCPP_EXPERIMENTAL___SIMD_TRAITS_H
 
+#include <__type_traits/integral_constant.h>
+#include <__type_traits/is_same.h>
+#include <cstddef>
+#include <experimental/__config>
 #include <experimental/__simd/abi_tag.h>
 #include <experimental/__simd/aligned_tag.h>
 #include <experimental/__simd/declaration.h>
+#include <experimental/__simd/internal_declaration.h>
 #include <experimental/__simd/utility.h>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
@@ -24,29 +29,17 @@ inline namespace parallelism_v2 {
 template <class _Tp>
 inline constexpr bool is_abi_tag_v = false;
 
-template <>
-inline constexpr bool is_abi_tag_v<simd_abi::__scalar> = true;
-
-template <int _Np>
-inline constexpr bool is_abi_tag_v<simd_abi::__vec_ext<_Np>> = _Np > 0 && _Np <= 32;
-
 template <class _Tp>
 struct is_abi_tag : bool_constant<is_abi_tag_v<_Tp>> {};
 
 template <class _Tp>
 inline constexpr bool is_simd_v = false;
 
-template <class _Tp, class _Abi>
-inline constexpr bool is_simd_v<simd<_Tp, _Abi>> = true;
-
 template <class _Tp>
 struct is_simd : bool_constant<is_simd_v<_Tp>> {};
 
 template <class _Tp>
 inline constexpr bool is_simd_mask_v = false;
-
-template <class _Tp, class _Abi>
-inline constexpr bool is_simd_mask_v<simd_mask<_Tp, _Abi>> = true;
 
 template <class _Tp>
 struct is_simd_mask : bool_constant<is_simd_mask_v<_Tp>> {};

--- a/libcxx/include/experimental/__simd/utility.h
+++ b/libcxx/include/experimental/__simd/utility.h
@@ -20,7 +20,9 @@
 #include <__type_traits/void_t.h>
 #include <__utility/declval.h>
 #include <__utility/integer_sequence.h>
+#include <cstddef>
 #include <cstdint>
+#include <experimental/__config>
 #include <limits>
 
 _LIBCPP_PUSH_MACROS

--- a/libcxx/include/experimental/__simd/vec_ext.h
+++ b/libcxx/include/experimental/__simd/vec_ext.h
@@ -12,8 +12,11 @@
 
 #include <__bit/bit_ceil.h>
 #include <__utility/forward.h>
+#include <__utility/integer_sequence.h>
 #include <cstddef>
+#include <experimental/__config>
 #include <experimental/__simd/internal_declaration.h>
+#include <experimental/__simd/traits.h>
 #include <experimental/__simd/utility.h>
 
 #if _LIBCPP_STD_VER >= 17 && defined(_LIBCPP_ENABLE_EXPERIMENTAL)
@@ -26,6 +29,9 @@ struct __vec_ext {
   static constexpr size_t __simd_size = _Np;
 };
 } // namespace simd_abi
+
+template <int _Np>
+inline constexpr bool is_abi_tag_v<simd_abi::__vec_ext<_Np>> = _Np > 0 && _Np <= 32;
 
 template <class _Tp, int _Np>
 struct __simd_storage<_Tp, simd_abi::__vec_ext<_Np>> {

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -265,6 +265,10 @@ module std_strstream [system] {
   header "strstream"
   export *
 }
+module std_syncstream [system] {
+  header "syncstream"
+  export *
+}
 module std_system_error [system] {
   header "system_error"
   export *
@@ -551,6 +555,18 @@ module std_experimental [system] {
     export *
   }
   module simd {
+    module abi_tag              { private header "experimental/__simd/abi_tag.h" }
+    module aligned_tag          { private header "experimental/__simd/aligned_tag.h" }
+    module declaration          { private header "experimental/__simd/declaration.h" }
+    module internal_declaration { private header "experimental/__simd/internal_declaration.h" }
+    module reference            { private header "experimental/__simd/reference.h" }
+    module scalar               { private header "experimental/__simd/scalar.h" }
+    module simd                 { private header "experimental/__simd/simd.h" }
+    module simd_mask            { private header "experimental/__simd/simd_mask.h" }
+    module traits               { private header "experimental/__simd/traits.h" }
+    module utility              { private header "experimental/__simd/utility.h" }
+    module vec_ext              { private header "experimental/__simd/vec_ext.h" }
+
     header "experimental/simd"
     export *
   }
@@ -613,6 +629,9 @@ module std_private_availability      [system] {
 module std_private_bit_reference     [system] {
   header "__bit_reference"
   export *
+}
+module std_private_fwd_bit_reference [system] {
+  header "__fwd/bit_reference.h"
 }
 module std_private_config            [system] {
   textual header "__config"
@@ -790,7 +809,9 @@ module std_private_algorithm_pstl_frontend_dispatch                      [system
 module std_private_algorithm_pstl_generate                               [system] { header "__algorithm/pstl_generate.h" }
 module std_private_algorithm_pstl_is_partitioned                         [system] { header "__algorithm/pstl_is_partitioned.h" }
 module std_private_algorithm_pstl_merge                                  [system] { header "__algorithm/pstl_merge.h" }
+module std_private_algorithm_pstl_move                                   [system] { header "__algorithm/pstl_move.h" }
 module std_private_algorithm_pstl_replace                                [system] { header "__algorithm/pstl_replace.h" }
+module std_private_algorithm_pstl_rotate_copy                            [system] { header "__algorithm/pstl_rotate_copy.h" }
 module std_private_algorithm_pstl_sort                                   [system] { header "__algorithm/pstl_sort.h" }
 module std_private_algorithm_pstl_stable_sort                            [system] {
   header "__algorithm/pstl_stable_sort.h"
@@ -827,6 +848,7 @@ module std_private_algorithm_ranges_copy_n                               [system
 }
 module std_private_algorithm_ranges_count                                [system] { header "__algorithm/ranges_count.h" }
 module std_private_algorithm_ranges_count_if                             [system] { header "__algorithm/ranges_count_if.h" }
+module std_private_algorithm_ranges_ends_with                            [system] { header "__algorithm/ranges_ends_with.h" }
 module std_private_algorithm_ranges_equal                                [system] { header "__algorithm/ranges_equal.h" }
 module std_private_algorithm_ranges_equal_range                          [system] {
   header "__algorithm/ranges_equal_range.h"
@@ -1136,6 +1158,7 @@ module std_private_bit_countl         [system] { header "__bit/countl.h" }
 module std_private_bit_countr         [system] { header "__bit/countr.h" }
 module std_private_bit_endian         [system] { header "__bit/endian.h" }
 module std_private_bit_has_single_bit [system] { header "__bit/has_single_bit.h" }
+module std_private_bit_invert_if      [system] { header "__bit/invert_if.h" }
 module std_private_bit_popcount       [system] { header "__bit/popcount.h" }
 module std_private_bit_rotate         [system] { header "__bit/rotate.h" }
 
@@ -1665,7 +1688,7 @@ module std_private_ranges_all                        [system] {
   export std_private_ranges_owning_view
 }
 module std_private_ranges_as_rvalue_view             [system] { header "__ranges/as_rvalue_view.h" }
-module std_private_ranges_chunk_by_view              [system] { header "__ranages/chunk_by_view.h" }
+module std_private_ranges_chunk_by_view              [system] { header "__ranges/chunk_by_view.h" }
 module std_private_ranges_common_view                [system] { header "__ranges/common_view.h" }
 module std_private_ranges_concepts                   [system] {
   header "__ranges/concepts.h"

--- a/libcxx/test/libcxx/headers_in_modulemap.sh.py
+++ b/libcxx/test/libcxx/headers_in_modulemap.sh.py
@@ -1,0 +1,30 @@
+# RUN: %{python} %s %{libcxx}/utils %{include}
+
+import sys
+
+sys.path.append(sys.argv[1])
+
+import pathlib
+import sys
+from libcxx.header_information import is_modulemap_header, is_header
+
+headers = list(pathlib.Path(sys.argv[2]).rglob("*"))
+modulemap = open(f"{sys.argv[2]}/module.modulemap").read()
+
+isHeaderMissing = False
+
+for header in headers:
+    if not is_header(header):
+        continue
+
+    header = header.relative_to(pathlib.Path(sys.argv[2])).as_posix()
+
+    if not is_modulemap_header(header):
+        continue
+
+    if not str(header) in modulemap:
+        print(f"Header {header} seems to be missing from the modulemap!")
+        isHeaderMissing = True
+
+if isHeaderMissing:
+    exit(1)

--- a/libcxx/utils/libcxx/header_information.py
+++ b/libcxx/utils/libcxx/header_information.py
@@ -166,12 +166,35 @@ headers_not_available = [
 
 def is_header(file):
     """Returns whether the given file is a header (i.e. not a directory or the modulemap file)."""
-    return (
-        not file.is_dir()
-        and not file.name == "module.modulemap.in"
-        and not file.name == "CMakeLists.txt"
-        and file.name != "libcxx.imp"
-    )
+    return not file.is_dir() and not file.name in [
+        "module.modulemap.in",
+        "module.modulemap",
+        "CMakeLists.txt",
+        "libcxx.imp",
+    ]
+
+
+def is_modulemap_header(header):
+    """Returns whether a header should be listed in the modulemap"""
+    # TODO: Should `__config_site` be in the modulemap?
+    if header == "__config_site":
+        return False
+
+    # exclude libc++abi files
+    if header in ["cxxabi.h", "__cxxabi_config.h"]:
+        return False
+
+    # exclude headers in __support/ - these aren't supposed to work everywhere,
+    # so they shouldn't be included in general
+    if header.startswith("__support/"):
+        return False
+
+    # exclude ext/ headers - these are non-standard extensions and are barely
+    # maintained. People should migrate away from these and we don't need to
+    # burden ourself with maintaining them in any way.
+    if header.startswith("ext/"):
+        return False
+    return True
 
 libcxx_root = pathlib.Path(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 include = pathlib.Path(os.path.join(libcxx_root, "include"))


### PR DESCRIPTION
I don't know when, but at some point we lost test coverage to ensue that all the headers are in the modulemap. This adds a test to make sure all the headers (excluding a few which shouldn't be part of the modulemap) are at least mentioned. This also fixes a few headers which bit-rotted while we were missing the coverage.
