### PR TITLE
Strip authentication bits from vtable load address

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -235,14 +235,17 @@ llvm::Expected<LanguageRuntime::VTableInfo>
                                    "failed to get the address of the value");
 
   Status error;
-  const lldb::addr_t vtable_load_addr =
+  lldb::addr_t vtable_load_addr =
       process->ReadPointerFromMemory(original_ptr, error);
 
   if (!error.Success() || vtable_load_addr == LLDB_INVALID_ADDRESS)
     return llvm::createStringError(std::errc::invalid_argument,
         "failed to read vtable pointer from memory at 0x%" PRIx64,
         original_ptr);
-;
+
+  // The vtable load address can have authentication bits with
+  // AArch64 targets on Darwin.
+  vtable_load_addr = process->FixDataAddress(vtable_load_addr);
 
   // Find the symbol that contains the "vtable_load_addr" address
   Address vtable_addr;


### PR DESCRIPTION
The current Darwin arm64e ABI on AArch64 systems using ARMv8.3 & newer cores, adds authentication bits to the vtable pointer address. The vtable address must be in addressable memory, so running it through Process::FixDataAddress will be a no-op on other targets.

This was originally a downstream change that I hadn't upstreamed yet, and it was surfaced by Greg's changes in
https://github.com/llvm/llvm-project/pull/67599
so I needed to update the local patch, and was reminded that I should upstream this.