### PR TITLE
[mlir][python] C++ API demo

### DIFF
--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -607,11 +607,13 @@ if(MLIR_INCLUDE_TESTS)
     ROOT_DIR "${MLIR_SOURCE_DIR}/test/python/lib"
     SOURCES
       PythonTestModule.cpp
+      PythonTestPass.cpp
     PRIVATE_LINK_LIBS
       LLVMSupport
     EMBED_CAPI_LINK_LIBS
       MLIRCAPIPythonTestDialect
   )
+  set_source_files_properties(${MLIR_SOURCE_DIR}/test/python/lib/PythonTestPass.cpp PROPERTIES COMPILE_FLAGS -fno-rtti)
 endif()
 
 ################################################################################

--- a/mlir/python/mlir/dialects/python_test.py
+++ b/mlir/python/mlir/dialects/python_test.py
@@ -15,3 +15,9 @@ def register_python_test_dialect(context, load=True):
     from .._mlir_libs import _mlirPythonTest
 
     _mlirPythonTest.register_python_test_dialect(context, load)
+
+
+def register_python_test_pass_demo_pass(func):
+    from .._mlir_libs import _mlirPythonTest
+
+    _mlirPythonTest.register_python_test_pass_demo_pass(func)

--- a/mlir/test/python/lib/CMakeLists.txt
+++ b/mlir/test/python/lib/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_OPTIONAL_SOURCES
   PythonTestCAPI.cpp
   PythonTestDialect.cpp
   PythonTestModule.cpp
+  PythonTestPass.cpp
 )
 
 add_mlir_library(MLIRPythonTestDialect
@@ -29,4 +30,3 @@ add_mlir_public_c_api_library(MLIRCAPIPythonTestDialect
   MLIRCAPIIR
   MLIRPythonTestDialect
 )
-

--- a/mlir/test/python/lib/PythonTestModule.cpp
+++ b/mlir/test/python/lib/PythonTestModule.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "PythonTestCAPI.h"
+#include "PythonTestPass.h"
+
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/IR.h"
@@ -33,6 +35,10 @@ PYBIND11_MODULE(_mlirPythonTest, m) {
         }
       },
       py::arg("context"), py::arg("load") = true);
+
+  m.def("register_python_test_pass_demo_pass", [](py::function func) {
+    registerPythonTestPassDemoPassWithFunc(func.ptr());
+  });
 
   mlir_attribute_subclass(m, "TestAttr",
                           mlirAttributeIsAPythonTestTestAttribute)

--- a/mlir/test/python/lib/PythonTestPass.cpp
+++ b/mlir/test/python/lib/PythonTestPass.cpp
@@ -1,0 +1,53 @@
+//===- PythonTestPassDemo.cpp -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PythonTestPass.h"
+
+#include "mlir-c/Bindings/Python/Interop.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+namespace {
+
+struct PythonTestPassDemo
+    : public PassWrapper<PythonTestPassDemo, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PythonTestPassDemo)
+
+  PythonTestPassDemo(PyObject *func) : func(func) {}
+  StringRef getArgument() const final { return "python-pass-demo"; }
+
+  void runOnOperation() override {
+    this->getOperation()->walk([this](Operation *op) {
+      PyObject *mlirModule =
+          PyImport_ImportModule(MAKE_MLIR_PYTHON_QUALNAME("ir"));
+      PyObject *cAPIFactory = PyObject_GetAttrString(
+          PyObject_GetAttrString(mlirModule, "Operation"),
+          MLIR_PYTHON_CAPI_FACTORY_ATTR);
+      PyObject *opApiObject = PyObject_CallFunction(
+          cAPIFactory, "(O)", mlirPythonOperationToCapsule(wrap(op)));
+      (void)PyObject_CallFunction(func, "(O)", opApiObject);
+      Py_DECREF(opApiObject);
+    });
+  }
+
+  PyObject *func;
+};
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createPythonTestPassDemoPassWithFunc(PyObject *func) {
+  return std::make_unique<PythonTestPassDemo>(func);
+}
+
+} // namespace
+
+void registerPythonTestPassDemoPassWithFunc(PyObject *func) {
+  registerPass([func]() { return createPythonTestPassDemoPassWithFunc(func); });
+}

--- a/mlir/test/python/lib/PythonTestPass.h
+++ b/mlir/test/python/lib/PythonTestPass.h
@@ -1,0 +1,16 @@
+//===- PythonTestPassDemo.h ---------------------------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_TEST_PYTHON_PASS_PYTHONTESTCAPI_H
+#define MLIR_TEST_PYTHON_PASS_PYTHONTESTCAPI_H
+
+#include <Python.h>
+
+void registerPythonTestPassDemoPassWithFunc(PyObject *func);
+
+#endif


### PR DESCRIPTION
This PR demonstrates how to call C++ APIs directly without going through the C API and without RTTI.

In fact it demonstrates something more exciting: tunneling python callbacks all the way into MLIR passes:

```python
def print_ops(op):
    print(op.name)

test.register_python_test_pass_demo_pass(print_ops)

module = """
module {
  func.func @main() {
    %memref = memref.alloca() : memref<1xi64>
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : i64
    memref.store %c1, %memref[%c0] : memref<1xi64>
    %u_memref = memref.cast %memref : memref<1xi64> to memref<*xi64>
    return
  }
}
"""

mlir_module = Module.parse(module)
PassManager.parse("builtin.module(python-pass-demo)").run(mlir_module.operation)
```

This will print

```
memref.alloca
arith.constant
arith.constant
memref.store
memref.cast
func.return
func.func
builtin.module
```

by calling `print_ops` _from inside the pass_ (where there's a `this->getOperation()->walk([this](Operation *op) { ... });`).

Note, there's some boilerplate Python C API munging for going between MLIR-C API types (like `MlirOperation`) and Python API objects (like `ir.Operation`) that can be polished up for public consumption (maybe to live in `mlir-c/Bindings/Python/Interop.h`) but before typing all those words I wanted to gauge interest.

Also, I probably need some more `Py_DECREF`s but I'll need to run this through ASAN to be sure.