### PR TITLE
[NFC][RISCV] Add `SiFive` prefix for XSfvfnrclipxfqf description

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -846,11 +846,11 @@ def HasVendorXSfvfwmaccqqq : Predicate<"Subtarget->hasVendorXSfvfwmaccqqq()">,
 
 def FeatureVendorXSfvfnrclipxfqf
     : SubtargetFeature<"xsfvfnrclipxfqf", "HasVendorXSfvfnrclipxfqf", "true",
-                       "'XSfvfnrclipxfqf' (FP32-to-int8 Ranged Clip Instructions)",
+                       "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)",
                        [FeatureStdExtZve32f]>;
 def HasVendorXSfvfnrclipxfqf : Predicate<"Subtarget->hasVendorXSfvfnrclipxfqf()">,
                                AssemblerPredicate<(all_of FeatureVendorXSfvfnrclipxfqf),
-                               "'XSfvfnrclipxfqf' (FP32-to-int8 Ranged Clip Instructions)">;
+                               "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)">;
 
 def FeatureVendorXCVbitmanip
     : SubtargetFeature<"xcvbitmanip", "HasVendorXCVbitmanip", "true",


### PR DESCRIPTION
`'XSfvfnrclipxfqf' (FP32-to-int8 Ranged Clip Instructions)` -> `'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)`