### PR TITLE
[LLDB][easy] Fix a bug in DummySyntheticFrontEnd

### DIFF
--- a/lldb/source/Core/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/Core/ValueObjectSyntheticFilter.cpp
@@ -41,7 +41,7 @@ public:
     return m_backend.GetIndexOfChildWithName(name);
   }
 
-  bool MightHaveChildren() override { return true; }
+  bool MightHaveChildren() override { return m_backend.MightHaveChildren(); }
 
   bool Update() override { return false; }
 };


### PR DESCRIPTION
DummySyntheticFrontEnd is implementing correctly CalculateNumChildren but not MightHaveChildren, where instead of delegating its action, it was returning true.
This fixes that simple bug.
