### PR TITLE
Improve llvm-config.h to record which target is configured or not

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -955,6 +955,8 @@ foreach(t ${LLVM_TARGETS_TO_BUILD})
     endif()
   else()
     set(LLVM_ENUM_TARGETS "${LLVM_ENUM_TARGETS}LLVM_TARGET(${t})\n")
+    string(TOUPPER ${t} T_UPPER)
+    set(LLVM_HAS_${T_UPPER}_TARGET 1)
   endif()
 
   file(GLOB asmp_file "${td}/*AsmPrinter.cpp")

--- a/llvm/include/llvm/Config/llvm-config.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config.h.cmake
@@ -54,6 +54,81 @@
 /* LLVM name for the native target MCA init function, if available */
 #cmakedefine LLVM_NATIVE_TARGETMCA LLVMInitialize${LLVM_NATIVE_ARCH}TargetMCA
 
+/* Define if the AArch64 target is built in */
+#cmakedefine01 LLVM_HAS_AARCH64_TARGET
+
+/* Define if the AMDGPU target is built in */
+#cmakedefine01 LLVM_HAS_AMDGPU_TARGET
+
+/* Define if the ARC target is built in */
+#cmakedefine01 LLVM_HAS_ARC_TARGET
+
+/* Define if the ARM target is built in */
+#cmakedefine01 LLVM_HAS_ARM_TARGET
+
+/* Define if the AVR target is built in */
+#cmakedefine01 LLVM_HAS_AVR_TARGET
+
+/* Define if the BPF target is built in */
+#cmakedefine01 LLVM_HAS_BPF_TARGET
+
+/* Define if the CSKY target is built in */
+#cmakedefine01 LLVM_HAS_CSKY_TARGET
+
+/* Define if the DirectX target is built in */
+#cmakedefine01 LLVM_HAS_DIRECTX_TARGET
+
+/* Define if the Hexagon target is built in */
+#cmakedefine01 LLVM_HAS_HEXAGON_TARGET
+
+/* Define if the Lanai target is built in */
+#cmakedefine01 LLVM_HAS_LANAI_TARGET
+
+/* Define if the LoongArch target is built in */
+#cmakedefine01 LLVM_HAS_LOONGARCH_TARGET
+
+/* Define if the M68k target is built in */
+#cmakedefine01 LLVM_HAS_M68K_TARGET
+
+/* Define if the Mips target is built in */
+#cmakedefine01 LLVM_HAS_MIPS_TARGET
+
+/* Define if the MSP430 target is built in */
+#cmakedefine01 LLVM_HAS_MSP430_TARGET
+
+/* Define if the NVPTX target is built in */
+#cmakedefine01 LLVM_HAS_NVPTX_TARGET
+
+/* Define if the PowerPC target is built in */
+#cmakedefine01 LLVM_HAS_POWERPC_TARGET
+
+/* Define if the RISCV target is built in */
+#cmakedefine01 LLVM_HAS_RISCV_TARGET
+
+/* Define if the Sparc target is built in */
+#cmakedefine01 LLVM_HAS_SPARC_TARGET
+
+/* Define if the SPIRV target is built in */
+#cmakedefine01 LLVM_HAS_SPIRV_TARGET
+
+/* Define if the SystemZ target is built in */
+#cmakedefine01 LLVM_HAS_SYSTEMZ_TARGET
+
+/* Define if the VE target is built in */
+#cmakedefine01 LLVM_HAS_VE_TARGET
+
+/* Define if the WebAssembly target is built in */
+#cmakedefine01 LLVM_HAS_WEBASSEMBLY_TARGET
+
+/* Define if the X86 target is built in */
+#cmakedefine01 LLVM_HAS_X86_TARGET
+
+/* Define if the XCore target is built in */
+#cmakedefine01 LLVM_HAS_XCORE_TARGET
+
+/* Define if the Xtensa target is built in */
+#cmakedefine01 LLVM_HAS_XTENSA_TARGET
+
 /* Define if this is Unixish platform */
 #cmakedefine LLVM_ON_UNIX ${LLVM_ON_UNIX}
 


### PR DESCRIPTION
These macro can help guarding some tests and other section of code
which rely on detecting if a particular target is available. This
is common the MLIR codegeneration for GPU targets for example.
