### PR TITLE
Reapply #2 [clang-repl] [test] Make an XFAIL more precise

### DIFF
--- a/clang/test/Interpreter/const.cpp
+++ b/clang/test/Interpreter/const.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-aix
 // see https://github.com/llvm/llvm-project/issues/68092
-// XFAIL: system-windows
+// XFAIL: host={{.*}}-windows-msvc
 
 // RUN: cat %s | clang-repl | FileCheck %s
 // RUN: cat %s | clang-repl -Xcc -O2 | FileCheck %s

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -477,10 +477,6 @@ if config.target_triple:
     if not config.target_triple.startswith(("nvptx", "xcore")):
         config.available_features.add("object-emission")
 
-# Allow checking for specific details in the host triple
-if config.host_triple:
-    config.available_features.add('host=%s' % config.host_triple)
-
 if config.have_llvm_driver:
     config.available_features.add("llvm-driver")
 

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -97,6 +97,7 @@ class LLVMConfig(object):
         # part of the standard header.  But currently they aren't)
         host_triple = getattr(config, "host_triple", None)
         target_triple = getattr(config, "target_triple", None)
+        features.add("host=%s" % host_triple)
         features.add("target=%s" % target_triple)
         if host_triple and host_triple == target_triple:
             features.add("native")


### PR DESCRIPTION
The const.cpp testcase fails when running in MSVC mode, while it does succeed in MinGW mode.

In MSVC mode, there are more constructor invocations than expected, as the printout looks like this:

    A(1), this = 0000025597930000
    A(1), this = 0000025597930000
    f: this = 0000025597930000, val = 1
    A(1), this = 0000025597930000
    f: this = 0000025597930000, val = 1
    ~A, this = 0000025597930000, val = 1
    ~A, this = 0000025597930000, val = 1
    ~A, this = 0000025597930000, val = 1

While the expected printout looks like this:

    A(1), this = 000002C903E10000
    f: this = 000002C903E10000, val = 1
    f: this = 000002C903E10000, val = 1
    ~A, this = 000002C903E10000, val = 1

Reapplying #70991 with the XFAIL changed to check the host triple, not the target triple. On an MSVC based build of Clang, but with the default target triple set to PS4/PS5, we will still see the failure. And a Linux based build of Clang that targets PS4/PS5 won't see the issue.