### PR TITLE
Fix python escapes

### DIFF
--- a/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
+++ b/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
@@ -25,7 +25,7 @@ class Generator(object):
 
     def GeneratePrologue(self):
 
-        self.implementationContent += """
+        self.implementationContent += R"""
 /*===- Generated file -------------------------------------------*- C++ -*-===*\
 |*                                                                            *|
 |* Introspection of available AST node SourceLocations                        *|
@@ -58,7 +58,7 @@ struct RecursionPopper
 private:
 std::vector<clang::TypeLoc> &TLRG;
 };
-"""
+"""[1:]
 
     def GenerateBaseGetLocationsDeclaration(self, CladeName):
         InstanceDecoration = "*"

--- a/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
+++ b/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
@@ -25,7 +25,7 @@ class Generator(object):
 
     def GeneratePrologue(self):
 
-        self.implementationContent += R"""
+        self.implementationContent += r"""
 /*===- Generated file -------------------------------------------*- C++ -*-===*\
 |*                                                                            *|
 |* Introspection of available AST node SourceLocations                        *|

--- a/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
+++ b/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
@@ -58,7 +58,7 @@ struct RecursionPopper
 private:
 std::vector<clang::TypeLoc> &TLRG;
 };
-"""[1:]
+"""
 
     def GenerateBaseGetLocationsDeclaration(self, CladeName):
         InstanceDecoration = "*"

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -271,7 +271,7 @@ def ptxas_version(ptxas):
     ptxas_cmd = subprocess.Popen([ptxas, "--version"], stdout=subprocess.PIPE)
     ptxas_out = ptxas_cmd.stdout.read().decode("ascii")
     ptxas_cmd.wait()
-    match = re.search("release (\d+)\.(\d+)", ptxas_out)
+    match = re.search(R"release (\d+)\.(\d+)", ptxas_out)
     if match:
         return (int(match.group(1)), int(match.group(2)))
     print("couldn't determine ptxas version")

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -271,7 +271,7 @@ def ptxas_version(ptxas):
     ptxas_cmd = subprocess.Popen([ptxas, "--version"], stdout=subprocess.PIPE)
     ptxas_out = ptxas_cmd.stdout.read().decode("ascii")
     ptxas_cmd.wait()
-    match = re.search(R"release (\d+)\.(\d+)", ptxas_out)
+    match = re.search(r"release (\d+)\.(\d+)", ptxas_out)
     if match:
         return (int(match.group(1)), int(match.group(2)))
     print("couldn't determine ptxas version")


### PR DESCRIPTION
With Fedora 39, I encountered 2 new python warnings:

/home/nathan/gh/llvm/push/strict-aliasing/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py:28: SyntaxWarning: invalid escape sequence '\*'
  self.implementationContent += """

/home/nathan/gh/llvm/push/strict-aliasing/llvm/test/lit.cfg.py:274: SyntaxWarning: invalid escape sequence '\d'
  match = re.search("release (\d+)\.(\d+)", ptxas_out)

Use raw strings here. I guess python got pickier or something?
