### PR TITLE
[lldb] Replace some register handling asserts with lldbassert

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
@@ -143,7 +143,8 @@ NativeRegisterContextLinux_arm::ReadRegister(const RegisterInfo *reg_info,
 
   // Get pointer to m_fpr variable and set the data from it.
   uint32_t fpr_offset = CalculateFprOffset(reg_info);
-  assert(fpr_offset < sizeof m_fpr);
+  lldbassert(fpr_offset < sizeof m_fpr &&
+             "Invalid fpr offset for register read");
   uint8_t *src = (uint8_t *)&m_fpr + fpr_offset;
   switch (reg_info->byte_size) {
   case 2:
@@ -186,7 +187,8 @@ NativeRegisterContextLinux_arm::WriteRegister(const RegisterInfo *reg_info,
   if (IsFPR(reg_index)) {
     // Get pointer to m_fpr variable and set the data to it.
     uint32_t fpr_offset = CalculateFprOffset(reg_info);
-    assert(fpr_offset < sizeof m_fpr);
+    lldbassert(fpr_offset < sizeof m_fpr &&
+               "Invalid fpr offset for register read");
     uint8_t *dst = (uint8_t *)&m_fpr + fpr_offset;
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
@@ -794,7 +796,8 @@ Status NativeRegisterContextLinux_arm::DoReadRegisterValue(
   // read out the full GPR register set instead. This approach is about 4 times
   // slower but the performance overhead is negligible in comparison to
   // processing time in lldb-server.
-  assert(offset % 4 == 0 && "Try to write a register with unaligned offset");
+  lldbassert(offset % 4 == 0 &&
+             "Trying to read a register with unaligned offset");
   if (offset + sizeof(uint32_t) > sizeof(m_gpr_arm))
     return Status("Register isn't fit into the size of the GPR area");
 
@@ -813,7 +816,8 @@ Status NativeRegisterContextLinux_arm::DoWriteRegisterValue(
   // read out the full GPR register set, modify the requested register and
   // write it back. This approach is about 4 times slower but the performance
   // overhead is negligible in comparison to processing time in lldb-server.
-  assert(offset % 4 == 0 && "Try to write a register with unaligned offset");
+  lldbassert(offset % 4 == 0 &&
+             "Try to write a register with unaligned offset");
   if (offset + sizeof(uint32_t) > sizeof(m_gpr_arm))
     return Status("Register isn't fit into the size of the GPR area");
 

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
@@ -113,7 +113,7 @@ Status NativeRegisterContextLinux_loongarch64::ReadRegister(
       return error;
 
     offset = reg_info->byte_offset;
-    assert(offset < GetGPRSize());
+    lldbassert(offset < GetGPRSize() && "Invalid GPR register read offset");
     src = (uint8_t *)GetGPRBuffer() + offset;
 
   } else if (IsFPR(reg)) {
@@ -122,7 +122,7 @@ Status NativeRegisterContextLinux_loongarch64::ReadRegister(
       return error;
 
     offset = CalculateFprOffset(reg_info);
-    assert(offset < GetFPRSize());
+    lldbassert(offset < GetFPRSize() && "Invalid FPR register read offset");
     src = (uint8_t *)GetFPRBuffer() + offset;
   } else
     return Status("failed - register wasn't recognized to be a GPR or an FPR, "
@@ -156,7 +156,8 @@ Status NativeRegisterContextLinux_loongarch64::WriteRegister(
     if (error.Fail())
       return error;
 
-    assert(reg_info->byte_offset < GetGPRSize());
+    lldbassert(reg_info->byte_offset < GetGPRSize() &&
+               "Invalid GPR register write offset");
     dst = (uint8_t *)GetGPRBuffer() + reg_info->byte_offset;
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
@@ -167,7 +168,7 @@ Status NativeRegisterContextLinux_loongarch64::WriteRegister(
       return error;
 
     offset = CalculateFprOffset(reg_info);
-    assert(offset < GetFPRSize());
+    lldbassert(offset < GetFPRSize() && "Invalid FPR register write offset");
     dst = (uint8_t *)GetFPRBuffer() + offset;
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_riscv64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_riscv64.cpp
@@ -113,6 +113,7 @@ NativeRegisterContextLinux_riscv64::ReadRegister(const RegisterInfo *reg_info,
 
   uint8_t *src = nullptr;
   uint32_t offset = LLDB_INVALID_INDEX32;
+  Status offset_error("Invalid register read offset");
 
   if (IsGPR(reg)) {
     error = ReadGPR();
@@ -120,7 +121,7 @@ NativeRegisterContextLinux_riscv64::ReadRegister(const RegisterInfo *reg_info,
       return error;
 
     offset = reg_info->byte_offset;
-    assert(offset < GetGPRSize());
+    lldbassert(offset < GetGPRSize() && "Invalid GPR register read offset");
     src = (uint8_t *)GetGPRBuffer() + offset;
 
   } else if (IsFPR(reg)) {
@@ -129,7 +130,7 @@ NativeRegisterContextLinux_riscv64::ReadRegister(const RegisterInfo *reg_info,
       return error;
 
     offset = CalculateFprOffset(reg_info);
-    assert(offset < GetFPRSize());
+    lldbassert(offset < GetFPRSize() && "Invalid FPR register read offset");
     src = (uint8_t *)GetFPRBuffer() + offset;
   } else
     return Status("failed - register wasn't recognized to be a GPR or an FPR, "
@@ -168,7 +169,8 @@ Status NativeRegisterContextLinux_riscv64::WriteRegister(
     if (error.Fail())
       return error;
 
-    assert(reg_info->byte_offset < GetGPRSize());
+    lldbassert(reg_info->byte_offset < GetGPRSize() &&
+               "Invalid GPR register write offset");
     dst = (uint8_t *)GetGPRBuffer() + reg_info->byte_offset;
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
@@ -179,7 +181,7 @@ Status NativeRegisterContextLinux_riscv64::WriteRegister(
       return error;
 
     offset = CalculateFprOffset(reg_info);
-    assert(offset < GetFPRSize());
+    lldbassert(offset < GetFPRSize() && "Invalid FPR register write offset");
     dst = (uint8_t *)GetFPRBuffer() + offset;
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_arm64.cpp
@@ -246,8 +246,8 @@ bool RegisterContextCorePOSIX_arm64::ReadRegister(const RegisterInfo *reg_info,
         offset = CalculateSVEOffset(GetRegisterInfoAtIndex(sve_reg_num));
       }
 
-      assert(sve_reg_num != LLDB_INVALID_REGNUM);
-      assert(offset < m_sve_data.GetByteSize());
+      lldbassert(sve_reg_num != LLDB_INVALID_REGNUM);
+      lldbassert(offset < m_sve_data.GetByteSize());
       value.SetFromMemoryData(*reg_info, GetSVEBuffer(offset),
                               reg_info->byte_size, lldb::eByteOrderLittle,
                               error);
@@ -269,7 +269,7 @@ bool RegisterContextCorePOSIX_arm64::ReadRegister(const RegisterInfo *reg_info,
       if (IsSVEZ(reg)) {
         byte_size = 16;
         offset = CalculateSVEOffset(reg_info);
-        assert(offset < m_sve_data.GetByteSize());
+        lldbassert(offset < m_sve_data.GetByteSize());
         src = GetSVEBuffer(offset);
       }
       value.SetFromMemoryData(*reg_info, src, byte_size, lldb::eByteOrderLittle,
@@ -278,7 +278,7 @@ bool RegisterContextCorePOSIX_arm64::ReadRegister(const RegisterInfo *reg_info,
     case SVEState::Full:
     case SVEState::Streaming:
       offset = CalculateSVEOffset(reg_info);
-      assert(offset < m_sve_data.GetByteSize());
+      lldbassert(offset < m_sve_data.GetByteSize());
       value.SetFromMemoryData(*reg_info, GetSVEBuffer(offset),
                               reg_info->byte_size, lldb::eByteOrderLittle,
                               error);
@@ -289,17 +289,17 @@ bool RegisterContextCorePOSIX_arm64::ReadRegister(const RegisterInfo *reg_info,
     }
   } else if (IsPAuth(reg)) {
     offset = reg_info->byte_offset - m_register_info_up->GetPAuthOffset();
-    assert(offset < m_pac_data.GetByteSize());
+    lldbassert(offset < m_pac_data.GetByteSize());
     value.SetFromMemoryData(*reg_info, m_pac_data.GetDataStart() + offset,
                             reg_info->byte_size, lldb::eByteOrderLittle, error);
   } else if (IsTLS(reg)) {
     offset = reg_info->byte_offset - m_register_info_up->GetTLSOffset();
-    assert(offset < m_tls_data.GetByteSize());
+    lldbassert(offset < m_tls_data.GetByteSize());
     value.SetFromMemoryData(*reg_info, m_tls_data.GetDataStart() + offset,
                             reg_info->byte_size, lldb::eByteOrderLittle, error);
   } else if (IsMTE(reg)) {
     offset = reg_info->byte_offset - m_register_info_up->GetMTEOffset();
-    assert(offset < m_mte_data.GetByteSize());
+    lldbassert(offset < m_mte_data.GetByteSize());
     value.SetFromMemoryData(*reg_info, m_mte_data.GetDataStart() + offset,
                             reg_info->byte_size, lldb::eByteOrderLittle, error);
   } else if (IsSME(reg)) {
@@ -343,7 +343,7 @@ bool RegisterContextCorePOSIX_arm64::ReadRegister(const RegisterInfo *reg_info,
                               error);
     } else {
       offset = reg_info->byte_offset - m_register_info_up->GetSMEOffset();
-      assert(offset < sizeof(m_sme_pseudo_regs));
+      lldbassert(offset < sizeof(m_sme_pseudo_regs));
       // Host endian since these values are derived instead of being read from a
       // core file note.
       value.SetFromMemoryData(


### PR DESCRIPTION
These asserts are important if they fail, but using assert meant
there was no checking in a release build.

lldbassert does the check and reports any failure but doesn't
crash the debugger.

I know we're not supposed to be adding new lldbasserts, but it's
exactly what's needed here.