### PR TITLE
[mlir][docs] Add link to Visual Studio Code extension

### DIFF
--- a/mlir/docs/Tools/MLIRLSP.md
+++ b/mlir/docs/Tools/MLIRLSP.md
@@ -392,7 +392,8 @@ to work:
 
 ### Visual Studio Code
 
-Provides language IDE features for [MLIR](https://mlir.llvm.org/) related
+The [MLIR extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-mlir)
+provides language IDE features for [MLIR](https://mlir.llvm.org/) related
 languages: [MLIR](#mlir---mlir-textual-assembly-format),
 [PDLL](#pdll---mlir-pdll-pattern-files), and [TableGen](#td---tablegen-files)
 


### PR DESCRIPTION
The document talks a lot about it but never says explicitly that it comes from the marketplace. At first I thought I had to install it locally.