### PR TITLE
[Clang][Driver][LTO] Fix empty stats filename when in LTO mode

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -540,7 +540,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
         Inputs, [](const InputInfo &II) -> bool { return II.isFilename(); });
     if (Input == Inputs.end())
       // For a very rare case, all of the inputs to the linker are
-      // flags. If that happens, just use the first InputInfo.
+      // InputArg. If that happens, just use the first InputInfo.
       Input = Inputs.begin();
 
     addLTOOptions(ToolChain, Args, CmdArgs, Output, *Input,

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -535,7 +535,15 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (D.isUsingLTO()) {
     assert(!Inputs.empty() && "Must have at least one input.");
-    addLTOOptions(ToolChain, Args, CmdArgs, Output, Inputs[0],
+    // Find the first filename InputInfo object.
+    auto Input = llvm::find_if(
+        Inputs, [](const InputInfo &II) -> bool { return II.isFilename(); });
+    if (Input == Inputs.end())
+      // For a very rare case, all of the inputs to the linker are
+      // flags. If that happens, just use the first InputInfo.
+      Input = Inputs.begin();
+
+    addLTOOptions(ToolChain, Args, CmdArgs, Output, *Input,
                   D.getLTOMode() == LTOK_Thin);
   }
 

--- a/clang/test/Driver/save-stats.c
+++ b/clang/test/Driver/save-stats.c
@@ -21,7 +21,7 @@
 
 // RUN: %clang -target x86_64-linux-unknown -save-stats -flto -o obj/dir/save-stats.exe %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // Previously `-plugin-opt=stats-file` would use empty filename if a linker flag (i.e. -Wl) is presented before any input filename.
-// RUN: %clang -target x86_64-linux-unknown -save-stats -flto -o obj/dir/save-stats.exe -Wl,-plugin-opt=-dummy %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
+// RUN: %clang --target=x86_64-linux-unknown -save-stats -flto -o obj/dir/save-stats.exe -Wl,-plugin-opt=-dummy %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // CHECK-LTO: "-stats-file=save-stats.stats"
 // CHECK-LTO: "-o" "obj/dir{{/|\\\\}}save-stats.exe"
 // CHECK-LTO: "-plugin-opt=stats-file=save-stats.stats"

--- a/clang/test/Driver/save-stats.c
+++ b/clang/test/Driver/save-stats.c
@@ -20,6 +20,8 @@
 // CHECK-INVALID: invalid value 'bla' in '-save-stats=bla'
 
 // RUN: %clang -target x86_64-linux-unknown -save-stats -flto -o obj/dir/save-stats.exe %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
+// Previously `-plugin-opt=stats-file` would use empty filename if a linker flag (i.e. -Wl) is presented before any input filename.
+// RUN: %clang -target x86_64-linux-unknown -save-stats -flto -o obj/dir/save-stats.exe -Wl,-plugin-opt=-dummy %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-LTO
 // CHECK-LTO: "-stats-file=save-stats.stats"
 // CHECK-LTO: "-o" "obj/dir{{/|\\\\}}save-stats.exe"
 // CHECK-LTO: "-plugin-opt=stats-file=save-stats.stats"


### PR DESCRIPTION
Previously, if a linker flag (i.e. -Wl) is presented before any input filenames, Gnu driver would use the InputInfo object of that flag to generate stats filename for LTO backend, causing an empty filename. This patch fixes such issue.