### PR TITLE
Extra assertions in RS4GC

### DIFF
--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1249,10 +1249,11 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
 
 #ifndef NDEBUG
   VerifyStates();
-  // get the data layout to compare the sizes of base/derived pointer values
-  auto &DL = cast<llvm::Instruction>(Def)->getModule()->getDataLayout();
 #endif
 
+  // get the data layout to compare the sizes of base/derived pointer values
+  [[maybe_unused]]
+  auto &DL = cast<llvm::Instruction>(Def)->getModule()->getDataLayout();
   // Cache all of our results so we can cheaply reuse them
   // NOTE: This is actually two caches: one of the base defining value
   // relation and one of the base pointer relation!  FIXME

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1252,8 +1252,8 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
 #endif
 
   // get the data layout to compare the sizes of base/derived pointer values
-  [[maybe_unused]]
-  auto &DL = cast<llvm::Instruction>(Def)->getModule()->getDataLayout();
+  [[maybe_unused]] auto &DL =
+      cast<llvm::Instruction>(Def)->getModule()->getDataLayout();
   // Cache all of our results so we can cheaply reuse them
   // NOTE: This is actually two caches: one of the base defining value
   // relation and one of the base pointer relation!  FIXME

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1249,6 +1249,8 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
 
 #ifndef NDEBUG
   VerifyStates();
+  // get the data layout to compare the sizes of base/derived pointer values 
+  auto &DL = cast<llvm::Instruction>(Def)->getModule()->getDataLayout();
 #endif
 
   // Cache all of our results so we can cheaply reuse them
@@ -1258,6 +1260,8 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
     auto *BDV = Pair.first;
     Value *Base = Pair.second.getBaseValue();
     assert(BDV && Base);
+    // the assumption is that whenever we have a derived ptr(s), their base ptr(s) must be of the same size, not necessarily the same type
+    assert(DL.getTypeAllocSize(BDV->getType()) == DL.getTypeAllocSize(Base->getType()) && "Derived and base values should have same size");
     // Only values that do not have known bases or those that have differing
     // type (scalar versus vector) from a possible known base should be in the
     // lattice.

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1249,7 +1249,7 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
 
 #ifndef NDEBUG
   VerifyStates();
-  // get the data layout to compare the sizes of base/derived pointer values 
+  // get the data layout to compare the sizes of base/derived pointer values
   auto &DL = cast<llvm::Instruction>(Def)->getModule()->getDataLayout();
 #endif
 
@@ -1260,8 +1260,11 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
     auto *BDV = Pair.first;
     Value *Base = Pair.second.getBaseValue();
     assert(BDV && Base);
-    // the assumption is that whenever we have a derived ptr(s), their base ptr(s) must be of the same size, not necessarily the same type
-    assert(DL.getTypeAllocSize(BDV->getType()) == DL.getTypeAllocSize(Base->getType()) && "Derived and base values should have same size");
+    // the assumption is that whenever we have a derived ptr(s), their base
+    // ptr(s) must be of the same size, not necessarily the same type
+    assert(DL.getTypeAllocSize(BDV->getType()) ==
+               DL.getTypeAllocSize(Base->getType()) &&
+           "Derived and base values should have same size");
     // Only values that do not have known bases or those that have differing
     // type (scalar versus vector) from a possible known base should be in the
     // lattice.

--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -1261,7 +1261,7 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &Cache,
     auto *BDV = Pair.first;
     Value *Base = Pair.second.getBaseValue();
     assert(BDV && Base);
-    // the assumption is that whenever we have a derived ptr(s), their base
+    // Whenever we have a derived ptr(s), their base
     // ptr(s) must be of the same size, not necessarily the same type
     assert(DL.getTypeAllocSize(BDV->getType()) ==
                DL.getTypeAllocSize(Base->getType()) &&


### PR DESCRIPTION
Adds assertion that the base/derived pointers are of the same size. 

