### PR TITLE
[mlir][python] add type wrappers

### DIFF
--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2538,8 +2538,8 @@ void mlir::python::populateIRCore(py::module &m) {
           [](py::object & /*class*/) {
             auto *context = PyThreadContextEntry::getDefaultContext();
             if (!context)
-              throw py::value_error("No current Context");
-            return context;
+              return py::none().cast<py::object>();
+            return py::cast(context);
           },
           "Gets the Context bound to the current thread or raises ValueError")
       .def_property_readonly(

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -21,6 +21,7 @@ declare_mlir_python_sources(MLIRPythonSources.Core.Python
     _mlir_libs/__init__.py
     ir.py
     passmanager.py
+    types.py
     dialects/_ods_common.py
 
     # The main _mlir module has submodules: include stubs from each.

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -21,7 +21,7 @@ declare_mlir_python_sources(MLIRPythonSources.Core.Python
     _mlir_libs/__init__.py
     ir.py
     passmanager.py
-    types.py
+    extras/types.py
     dialects/_ods_common.py
 
     # The main _mlir module has submodules: include stubs from each.

--- a/mlir/python/mlir/extras/types.py
+++ b/mlir/python/mlir/extras/types.py
@@ -5,11 +5,10 @@
 from functools import partial
 from typing import Optional, List
 
-from .ir import (
+from ..ir import (
     Attribute,
     BF16Type,
     ComplexType,
-    Context,
     F16Type,
     F32Type,
     F64Type,
@@ -32,55 +31,54 @@ from .ir import (
     VectorType,
 )
 
-__all__ = []
-
-_index = lambda: IndexType.get()
-_bool = lambda: IntegerType.get_signless(1)
-
-_i8 = lambda: IntegerType.get_signless(8)
-_i16 = lambda: IntegerType.get_signless(16)
-_i32 = lambda: IntegerType.get_signless(32)
-_i64 = lambda: IntegerType.get_signless(64)
-
-_si8 = lambda: IntegerType.get_signed(8)
-_si16 = lambda: IntegerType.get_signed(16)
-_si32 = lambda: IntegerType.get_signed(32)
-_si64 = lambda: IntegerType.get_signed(64)
-
-_ui8 = lambda: IntegerType.get_unsigned(8)
-_ui16 = lambda: IntegerType.get_unsigned(16)
-_ui32 = lambda: IntegerType.get_unsigned(32)
-_ui64 = lambda: IntegerType.get_unsigned(64)
-
-_f16 = lambda: F16Type.get()
-_f32 = lambda: F32Type.get()
-_f64 = lambda: F64Type.get()
-_bf16 = lambda: BF16Type.get()
-
-_f8e5m2 = lambda: Float8E5M2Type.get()
-_f8e4m3 = lambda: Float8E4M3FNType.get()
-_f8e4m3b11fnuz = lambda: Float8E4M3B11FNUZType.get()
-
-_none = lambda: NoneType.get()
+index = lambda: IndexType.get()
 
 
-def _i(width):
+def i(width):
     return IntegerType.get_signless(width)
 
 
-def _si(width):
+def si(width):
     return IntegerType.get_signed(width)
 
 
-def _ui(width):
+def ui(width):
     return IntegerType.get_unsigned(width)
 
 
-def _complex(type):
+bool = lambda: i(1)
+i8 = lambda: i(8)
+i16 = lambda: i(16)
+i32 = lambda: i(32)
+i64 = lambda: i(64)
+
+si8 = lambda: si(8)
+si16 = lambda: si(16)
+si32 = lambda: si(32)
+si64 = lambda: si(64)
+
+ui8 = lambda: ui(8)
+ui16 = lambda: ui(16)
+ui32 = lambda: ui(32)
+ui64 = lambda: ui(64)
+
+f16 = lambda: F16Type.get()
+f32 = lambda: F32Type.get()
+f64 = lambda: F64Type.get()
+bf16 = lambda: BF16Type.get()
+
+f8E5M2 = lambda: Float8E5M2Type.get()
+f8E4M3 = lambda: Float8E4M3FNType.get()
+f8E4M3B11FNUZ = lambda: Float8E4M3B11FNUZType.get()
+
+none = lambda: NoneType.get()
+
+
+def complex(type):
     return ComplexType.get(type)
 
 
-def _opaque(dialect_namespace, type_data):
+def opaque(dialect_namespace, type_data):
     return OpaqueType.get(dialect_namespace, type_data)
 
 
@@ -105,7 +103,7 @@ def _shaped(*shape, element_type: Type = None, type_constructor=None):
         return type_constructor(type)
 
 
-def _vector(
+def vector(
     *shape,
     element_type: Type = None,
     scalable: Optional[List[bool]] = None,
@@ -120,7 +118,7 @@ def _vector(
     )
 
 
-def _tensor(*shape, element_type: Type = None, encoding: Optional[str] = None):
+def tensor(*shape, element_type: Type = None, encoding: Optional[str] = None):
     if encoding is not None:
         encoding = StringAttr.get(encoding)
     if not shape or (len(shape) == 1 and isinstance(shape[-1], Type)):
@@ -136,7 +134,7 @@ def _tensor(*shape, element_type: Type = None, encoding: Optional[str] = None):
     )
 
 
-def _memref(
+def memref(
     *shape,
     element_type: Type = None,
     memory_space: Optional[int] = None,
@@ -159,31 +157,9 @@ def _memref(
     )
 
 
-def _tuple(*elements):
+def tuple(*elements):
     return TupleType.get_tuple(elements)
 
 
-def _function(*, inputs, results):
+def function(*, inputs, results):
     return FunctionType.get(inputs, results)
-
-
-def __getattr__(name):
-    if name == "__path__":
-        # https://docs.python.org/3/reference/import.html#path__
-        # If a module is a package (either regular or namespace), the module object’s __path__ attribute must be set.
-        # This module is NOT a package and so this must be None (rather than throw the RuntimeError below).
-        return None
-    try:
-        Context.current
-    except ValueError:
-        raise RuntimeError("Types can only be instantiated under an active context.")
-
-    if f"_{name}" in globals():
-        builder = globals()[f"_{name}"]
-        if (
-            isinstance(builder, type(lambda: None))
-            and builder.__name__ == (lambda: None).__name__
-        ):
-            return builder()
-        return builder
-    raise RuntimeError(f"{name} is not a legal type.")

--- a/mlir/python/mlir/types.py
+++ b/mlir/python/mlir/types.py
@@ -1,0 +1,189 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from functools import partial
+from typing import Optional, List
+
+from .ir import (
+    Attribute,
+    BF16Type,
+    ComplexType,
+    Context,
+    F16Type,
+    F32Type,
+    F64Type,
+    Float8E4M3B11FNUZType,
+    Float8E4M3FNType,
+    Float8E5M2Type,
+    FunctionType,
+    IndexType,
+    IntegerType,
+    MemRefType,
+    NoneType,
+    OpaqueType,
+    RankedTensorType,
+    StridedLayoutAttr,
+    StringAttr,
+    TupleType,
+    Type,
+    UnrankedMemRefType,
+    UnrankedTensorType,
+    VectorType,
+)
+
+__all__ = []
+
+_index = lambda: IndexType.get()
+_bool = lambda: IntegerType.get_signless(1)
+
+_i8 = lambda: IntegerType.get_signless(8)
+_i16 = lambda: IntegerType.get_signless(16)
+_i32 = lambda: IntegerType.get_signless(32)
+_i64 = lambda: IntegerType.get_signless(64)
+
+_si8 = lambda: IntegerType.get_signed(8)
+_si16 = lambda: IntegerType.get_signed(16)
+_si32 = lambda: IntegerType.get_signed(32)
+_si64 = lambda: IntegerType.get_signed(64)
+
+_ui8 = lambda: IntegerType.get_unsigned(8)
+_ui16 = lambda: IntegerType.get_unsigned(16)
+_ui32 = lambda: IntegerType.get_unsigned(32)
+_ui64 = lambda: IntegerType.get_unsigned(64)
+
+_f16 = lambda: F16Type.get()
+_f32 = lambda: F32Type.get()
+_f64 = lambda: F64Type.get()
+_bf16 = lambda: BF16Type.get()
+
+_f8e5m2 = lambda: Float8E5M2Type.get()
+_f8e4m3 = lambda: Float8E4M3FNType.get()
+_f8e4m3b11fnuz = lambda: Float8E4M3B11FNUZType.get()
+
+_none = lambda: NoneType.get()
+
+
+def _i(width):
+    return IntegerType.get_signless(width)
+
+
+def _si(width):
+    return IntegerType.get_signed(width)
+
+
+def _ui(width):
+    return IntegerType.get_unsigned(width)
+
+
+def _complex(type):
+    return ComplexType.get(type)
+
+
+def _opaque(dialect_namespace, type_data):
+    return OpaqueType.get(dialect_namespace, type_data)
+
+
+def _shaped(*shape, element_type: Type = None, type_constructor=None):
+    if type_constructor is None:
+        raise ValueError("shaped is an abstract base class - cannot be constructed.")
+    if (element_type is None and shape and not isinstance(shape[-1], Type)) or (
+        shape and isinstance(shape[-1], Type) and element_type is not None
+    ):
+        raise ValueError(
+            f"Either element_type must be provided explicitly XOR last arg to tensor type constructor must be the element type."
+        )
+    if element_type is not None:
+        type = element_type
+        sizes = shape
+    else:
+        type = shape[-1]
+        sizes = shape[:-1]
+    if sizes:
+        return type_constructor(sizes, type)
+    else:
+        return type_constructor(type)
+
+
+def _vector(
+    *shape,
+    element_type: Type = None,
+    scalable: Optional[List[bool]] = None,
+    scalable_dims: Optional[List[int]] = None,
+):
+    return _shaped(
+        *shape,
+        element_type=element_type,
+        type_constructor=partial(
+            VectorType.get, scalable=scalable, scalable_dims=scalable_dims
+        ),
+    )
+
+
+def _tensor(*shape, element_type: Type = None, encoding: Optional[str] = None):
+    if encoding is not None:
+        encoding = StringAttr.get(encoding)
+    if not shape or (len(shape) == 1 and isinstance(shape[-1], Type)):
+        if encoding is not None:
+            raise ValueError("UnrankedTensorType does not support encoding.")
+        return _shaped(
+            *shape, element_type=element_type, type_constructor=UnrankedTensorType.get
+        )
+    return _shaped(
+        *shape,
+        element_type=element_type,
+        type_constructor=partial(RankedTensorType.get, encoding=encoding),
+    )
+
+
+def _memref(
+    *shape,
+    element_type: Type = None,
+    memory_space: Optional[int] = None,
+    layout: Optional[StridedLayoutAttr] = None,
+):
+    if memory_space is not None:
+        memory_space = Attribute.parse(str(memory_space))
+    if not shape or (len(shape) == 1 and isinstance(shape[-1], Type)):
+        return _shaped(
+            *shape,
+            element_type=element_type,
+            type_constructor=partial(UnrankedMemRefType.get, memory_space=memory_space),
+        )
+    return _shaped(
+        *shape,
+        element_type=element_type,
+        type_constructor=partial(
+            MemRefType.get, memory_space=memory_space, layout=layout
+        ),
+    )
+
+
+def _tuple(*elements):
+    return TupleType.get_tuple(elements)
+
+
+def _function(*, inputs, results):
+    return FunctionType.get(inputs, results)
+
+
+def __getattr__(name):
+    if name == "__path__":
+        # https://docs.python.org/3/reference/import.html#path__
+        # If a module is a package (either regular or namespace), the module object’s __path__ attribute must be set.
+        # This module is NOT a package and so this must be None (rather than throw the RuntimeError below).
+        return None
+    try:
+        Context.current
+    except ValueError:
+        raise RuntimeError("Types can only be instantiated under an active context.")
+
+    if f"_{name}" in globals():
+        builder = globals()[f"_{name}"]
+        if (
+            isinstance(builder, type(lambda: None))
+            and builder.__name__ == (lambda: None).__name__
+        ):
+            return builder()
+        return builder
+    raise RuntimeError(f"{name} is not a legal type.")

--- a/mlir/test/python/ir/builtin_types.py
+++ b/mlir/test/python/ir/builtin_types.py
@@ -3,6 +3,7 @@
 import gc
 from mlir.ir import *
 from mlir.dialects import arith, tensor, func, memref
+import mlir.types as T
 
 
 def run(f):
@@ -772,3 +773,114 @@ def testCustomTypeTypeCaster():
         print(t)
         # CHECK: OperationType(!transform.op<"foo.bar">)
         print(repr(t))
+
+
+# CHECK-LABEL: TEST: testTypeWrappers
+@run
+def testTypeWrappers():
+    try:
+        from mlir.types import i32
+    except RuntimeError as e:
+        assert e.args[0] == "Types can only be instantiated under an active context."
+
+    try:
+        from mlir.types import tensor
+    except RuntimeError as e:
+        assert e.args[0] == "Types can only be instantiated under an active context."
+
+    def stride(strides, offset=0):
+        return StridedLayoutAttr.get(offset, strides)
+
+    with Context(), Location.unknown():
+        try:
+            from mlir.types import non_existent_type
+        except RuntimeError as e:
+            assert e.args[0] == "non_existent_type is not a legal type."
+
+        ia = T.i(5)
+        sia = T.si(6)
+        uia = T.ui(7)
+        assert repr(ia) == "IntegerType(i5)"
+        assert repr(sia) == "IntegerType(si6)"
+        assert repr(uia) == "IntegerType(ui7)"
+
+        assert T.i(16) == T.i16
+        assert T.si(16) == T.si16
+        assert T.ui(16) == T.ui16
+
+        c1 = T.complex(T.f16)
+        c2 = T.complex(T.i32)
+        assert repr(c1) == "ComplexType(complex<f16>)"
+        assert repr(c2) == "ComplexType(complex<i32>)"
+
+        vec_1 = T.vector(2, 3, T.f32)
+        vec_2 = T.vector(2, 3, 4, T.f32)
+        assert repr(vec_1) == "VectorType(vector<2x3xf32>)"
+        assert repr(vec_2) == "VectorType(vector<2x3x4xf32>)"
+
+        m1 = T.memref(2, 3, 4, T.f64)
+        assert repr(m1) == "MemRefType(memref<2x3x4xf64>)"
+
+        m2 = T.memref(2, 3, 4, T.f64, memory_space=1)
+        assert repr(m2) == "MemRefType(memref<2x3x4xf64, 1>)"
+
+        m3 = T.memref(2, 3, 4, T.f64, memory_space=1, layout=stride([5, 7, 13]))
+        assert repr(m3) == "MemRefType(memref<2x3x4xf64, strided<[5, 7, 13]>, 1>)"
+
+        m4 = T.memref(2, 3, 4, T.f64, memory_space=1, layout=stride([5, 7, 13], 42))
+        assert (
+            repr(m4)
+            == "MemRefType(memref<2x3x4xf64, strided<[5, 7, 13], offset: 42>, 1>)"
+        )
+
+        S = ShapedType.get_dynamic_size()
+
+        t1 = T.tensor(S, 3, S, T.f64)
+        assert repr(t1) == "RankedTensorType(tensor<?x3x?xf64>)"
+        ut1 = T.tensor(T.f64)
+        assert repr(ut1) == "UnrankedTensorType(tensor<*xf64>)"
+        t2 = T.tensor(S, 3, S, element_type=T.f64)
+        assert repr(t2) == "RankedTensorType(tensor<?x3x?xf64>)"
+        ut2 = T.tensor(element_type=T.f64)
+        assert repr(ut2) == "UnrankedTensorType(tensor<*xf64>)"
+
+        t3 = T.tensor(S, 3, S, T.f64, encoding="encoding")
+        assert repr(t3) == 'RankedTensorType(tensor<?x3x?xf64, "encoding">)'
+
+        v = T.vector(3, 3, 3, T.f64)
+        assert repr(v) == "VectorType(vector<3x3x3xf64>)"
+
+        m5 = T.memref(S, 3, S, T.f64)
+        assert repr(m5) == "MemRefType(memref<?x3x?xf64>)"
+        um1 = T.memref(T.f64)
+        assert repr(um1) == "UnrankedMemRefType(memref<*xf64>)"
+        m6 = T.memref(S, 3, S, element_type=T.f64)
+        assert repr(m6) == "MemRefType(memref<?x3x?xf64>)"
+        um2 = T.memref(element_type=T.f64)
+        assert repr(um2) == "UnrankedMemRefType(memref<*xf64>)"
+
+        m7 = T.memref(S, 3, S, T.f64)
+        assert repr(m7) == "MemRefType(memref<?x3x?xf64>)"
+        um3 = T.memref(T.f64)
+        assert repr(um3) == "UnrankedMemRefType(memref<*xf64>)"
+
+        scalable_1 = T.vector(2, 3, T.f32, scalable=[False, True])
+        scalable_2 = T.vector(2, 3, 4, T.f32, scalable=[True, False, True])
+        assert repr(scalable_1) == "VectorType(vector<2x[3]xf32>)"
+        assert repr(scalable_2) == "VectorType(vector<[2]x3x[4]xf32>)"
+
+        scalable_3 = T.vector(2, 3, T.f32, scalable_dims=[1])
+        scalable_4 = T.vector(2, 3, 4, T.f32, scalable_dims=[0, 2])
+        assert scalable_3 == scalable_1
+        assert scalable_4 == scalable_2
+
+        opaq = T.opaque("scf", "placeholder")
+        assert repr(opaq) == "OpaqueType(!scf.placeholder)"
+
+        tup1 = T.tuple(T.i16, T.i32, T.i64)
+        tup2 = T.tuple(T.f16, T.f32, T.f64)
+        assert repr(tup1) == "TupleType(tuple<i16, i32, i64>)"
+        assert repr(tup2) == "TupleType(tuple<f16, f32, f64>)"
+
+        func = T.function(inputs=(T.i16, T.i32, T.i64), results=(T.f16, T.f32, T.f64))
+        assert repr(func) == "FunctionType((i16, i32, i64) -> (f16, f32, f64))"

--- a/mlir/test/python/ir/builtin_types.py
+++ b/mlir/test/python/ir/builtin_types.py
@@ -3,7 +3,7 @@
 import gc
 from mlir.ir import *
 from mlir.dialects import arith, tensor, func, memref
-import mlir.types as T
+import mlir.extras.types as T
 
 
 def run(f):
@@ -778,25 +778,10 @@ def testCustomTypeTypeCaster():
 # CHECK-LABEL: TEST: testTypeWrappers
 @run
 def testTypeWrappers():
-    try:
-        from mlir.types import i32
-    except RuntimeError as e:
-        assert e.args[0] == "Types can only be instantiated under an active context."
-
-    try:
-        from mlir.types import tensor
-    except RuntimeError as e:
-        assert e.args[0] == "Types can only be instantiated under an active context."
-
     def stride(strides, offset=0):
         return StridedLayoutAttr.get(offset, strides)
 
     with Context(), Location.unknown():
-        try:
-            from mlir.types import non_existent_type
-        except RuntimeError as e:
-            assert e.args[0] == "non_existent_type is not a legal type."
-
         ia = T.i(5)
         sia = T.si(6)
         uia = T.ui(7)
@@ -804,30 +789,30 @@ def testTypeWrappers():
         assert repr(sia) == "IntegerType(si6)"
         assert repr(uia) == "IntegerType(ui7)"
 
-        assert T.i(16) == T.i16
-        assert T.si(16) == T.si16
-        assert T.ui(16) == T.ui16
+        assert T.i(16) == T.i16()
+        assert T.si(16) == T.si16()
+        assert T.ui(16) == T.ui16()
 
-        c1 = T.complex(T.f16)
-        c2 = T.complex(T.i32)
+        c1 = T.complex(T.f16())
+        c2 = T.complex(T.i32())
         assert repr(c1) == "ComplexType(complex<f16>)"
         assert repr(c2) == "ComplexType(complex<i32>)"
 
-        vec_1 = T.vector(2, 3, T.f32)
-        vec_2 = T.vector(2, 3, 4, T.f32)
+        vec_1 = T.vector(2, 3, T.f32())
+        vec_2 = T.vector(2, 3, 4, T.f32())
         assert repr(vec_1) == "VectorType(vector<2x3xf32>)"
         assert repr(vec_2) == "VectorType(vector<2x3x4xf32>)"
 
-        m1 = T.memref(2, 3, 4, T.f64)
+        m1 = T.memref(2, 3, 4, T.f64())
         assert repr(m1) == "MemRefType(memref<2x3x4xf64>)"
 
-        m2 = T.memref(2, 3, 4, T.f64, memory_space=1)
+        m2 = T.memref(2, 3, 4, T.f64(), memory_space=1)
         assert repr(m2) == "MemRefType(memref<2x3x4xf64, 1>)"
 
-        m3 = T.memref(2, 3, 4, T.f64, memory_space=1, layout=stride([5, 7, 13]))
+        m3 = T.memref(2, 3, 4, T.f64(), memory_space=1, layout=stride([5, 7, 13]))
         assert repr(m3) == "MemRefType(memref<2x3x4xf64, strided<[5, 7, 13]>, 1>)"
 
-        m4 = T.memref(2, 3, 4, T.f64, memory_space=1, layout=stride([5, 7, 13], 42))
+        m4 = T.memref(2, 3, 4, T.f64(), memory_space=1, layout=stride([5, 7, 13], 42))
         assert (
             repr(m4)
             == "MemRefType(memref<2x3x4xf64, strided<[5, 7, 13], offset: 42>, 1>)"
@@ -835,52 +820,54 @@ def testTypeWrappers():
 
         S = ShapedType.get_dynamic_size()
 
-        t1 = T.tensor(S, 3, S, T.f64)
+        t1 = T.tensor(S, 3, S, T.f64())
         assert repr(t1) == "RankedTensorType(tensor<?x3x?xf64>)"
-        ut1 = T.tensor(T.f64)
+        ut1 = T.tensor(T.f64())
         assert repr(ut1) == "UnrankedTensorType(tensor<*xf64>)"
-        t2 = T.tensor(S, 3, S, element_type=T.f64)
+        t2 = T.tensor(S, 3, S, element_type=T.f64())
         assert repr(t2) == "RankedTensorType(tensor<?x3x?xf64>)"
-        ut2 = T.tensor(element_type=T.f64)
+        ut2 = T.tensor(element_type=T.f64())
         assert repr(ut2) == "UnrankedTensorType(tensor<*xf64>)"
 
-        t3 = T.tensor(S, 3, S, T.f64, encoding="encoding")
+        t3 = T.tensor(S, 3, S, T.f64(), encoding="encoding")
         assert repr(t3) == 'RankedTensorType(tensor<?x3x?xf64, "encoding">)'
 
-        v = T.vector(3, 3, 3, T.f64)
+        v = T.vector(3, 3, 3, T.f64())
         assert repr(v) == "VectorType(vector<3x3x3xf64>)"
 
-        m5 = T.memref(S, 3, S, T.f64)
+        m5 = T.memref(S, 3, S, T.f64())
         assert repr(m5) == "MemRefType(memref<?x3x?xf64>)"
-        um1 = T.memref(T.f64)
+        um1 = T.memref(T.f64())
         assert repr(um1) == "UnrankedMemRefType(memref<*xf64>)"
-        m6 = T.memref(S, 3, S, element_type=T.f64)
+        m6 = T.memref(S, 3, S, element_type=T.f64())
         assert repr(m6) == "MemRefType(memref<?x3x?xf64>)"
-        um2 = T.memref(element_type=T.f64)
+        um2 = T.memref(element_type=T.f64())
         assert repr(um2) == "UnrankedMemRefType(memref<*xf64>)"
 
-        m7 = T.memref(S, 3, S, T.f64)
+        m7 = T.memref(S, 3, S, T.f64())
         assert repr(m7) == "MemRefType(memref<?x3x?xf64>)"
-        um3 = T.memref(T.f64)
+        um3 = T.memref(T.f64())
         assert repr(um3) == "UnrankedMemRefType(memref<*xf64>)"
 
-        scalable_1 = T.vector(2, 3, T.f32, scalable=[False, True])
-        scalable_2 = T.vector(2, 3, 4, T.f32, scalable=[True, False, True])
+        scalable_1 = T.vector(2, 3, T.f32(), scalable=[False, True])
+        scalable_2 = T.vector(2, 3, 4, T.f32(), scalable=[True, False, True])
         assert repr(scalable_1) == "VectorType(vector<2x[3]xf32>)"
         assert repr(scalable_2) == "VectorType(vector<[2]x3x[4]xf32>)"
 
-        scalable_3 = T.vector(2, 3, T.f32, scalable_dims=[1])
-        scalable_4 = T.vector(2, 3, 4, T.f32, scalable_dims=[0, 2])
+        scalable_3 = T.vector(2, 3, T.f32(), scalable_dims=[1])
+        scalable_4 = T.vector(2, 3, 4, T.f32(), scalable_dims=[0, 2])
         assert scalable_3 == scalable_1
         assert scalable_4 == scalable_2
 
         opaq = T.opaque("scf", "placeholder")
         assert repr(opaq) == "OpaqueType(!scf.placeholder)"
 
-        tup1 = T.tuple(T.i16, T.i32, T.i64)
-        tup2 = T.tuple(T.f16, T.f32, T.f64)
+        tup1 = T.tuple(T.i16(), T.i32(), T.i64())
+        tup2 = T.tuple(T.f16(), T.f32(), T.f64())
         assert repr(tup1) == "TupleType(tuple<i16, i32, i64>)"
         assert repr(tup2) == "TupleType(tuple<f16, f32, f64>)"
 
-        func = T.function(inputs=(T.i16, T.i32, T.i64), results=(T.f16, T.f32, T.f64))
+        func = T.function(
+            inputs=(T.i16(), T.i32(), T.i64()), results=(T.f16(), T.f32(), T.f64())
+        )
         assert repr(func) == "FunctionType((i16, i32, i64) -> (f16, f32, f64))"

--- a/mlir/test/python/ir/context_managers.py
+++ b/mlir/test/python/ir/context_managers.py
@@ -15,13 +15,7 @@ def run(f):
 def testContextEnterExit():
     with Context() as ctx:
         assert Context.current is ctx
-    try:
-        _ = Context.current
-    except ValueError as e:
-        # CHECK: No current Context
-        print(e)
-    else:
-        assert False, "Expected exception"
+    assert Context.current is None
 
 
 run(testContextEnterExit)


### PR DESCRIPTION
Inspired by this comment https://github.com/llvm/llvm-project/pull/71050#discussion_r1380372340, let's give people a nicer way to instantiate types.

The goal of the design here is to provide a module of Pythonic type builders but have simple types (such as `i32`, `f16`, etc.) appear is if they've already been built (so that users don't need to call a seemingly superfluous `.get()`). The problem of course is that types can't be "pre-instantiated" in an arbitrary module since they need a context (and requiring that the module itself only be imported under a `with Context()...` is weird IMHO). 

The solution uses a little-known python feature of attribute resolution on modules, namely that you can "override" [`__getattr__` for a module](https://peps.python.org/pep-0562/). And so `types.i32`, `types.f64`, etc. appear if they're using already instantiated types but in actuality are just calling `IntegerType.get_signless(32)`, `F64Type.get()`, etc., at point-of-use.

There's some room for bikeshedding/discussion here, e.g., whether these type builders such be spelled with a `_t` suffix to distinguish e.g., `vector` dialect from `types.vector` type. I didn't do this because like I describe above, these are meant to most often be accessed through the `types` module. Also, with the goal of matching as closely the appearance of MLIR IR source as possible, all the complex types builder (`vector`, `memref`, `tensor`) take their shape args as a `*shape`. That means no keyword-only args are possible (because you can't have two `*`s in the params list of a Python function). Keyword args still work (I just had to add a little boilerplate checking in the `*shape` tuple) but keyword-**only** args can't be supported. The alternative is to require the shape to be a list/tuple.