### PR TITLE
[lldb] Deprecate SBBreakpoint::AddName in favor of AddNameWithErrorHandling

### DIFF
--- a/lldb/include/lldb/API/SBBreakpoint.h
+++ b/lldb/include/lldb/API/SBBreakpoint.h
@@ -112,6 +112,7 @@ public:
 
   SBError SetScriptCallbackBody(const char *script_body_text);
 
+  LLDB_DEPRECATED("Use AddNameWithErrorHandling instead")
   bool AddName(const char *new_name);
 
   SBError AddNameWithErrorHandling(const char *new_name);

--- a/lldb/include/lldb/API/SBBreakpoint.h
+++ b/lldb/include/lldb/API/SBBreakpoint.h
@@ -112,7 +112,7 @@ public:
 
   SBError SetScriptCallbackBody(const char *script_body_text);
 
-  LLDB_DEPRECATED("Use AddNameWithErrorHandling instead")
+  LLDB_DEPRECATED_FIXME("Doesn't provide error handling", "AddNameWithErrorHandling")
   bool AddName(const char *new_name);
 
   SBError AddNameWithErrorHandling(const char *new_name);

--- a/lldb/include/lldb/API/SBBreakpoint.h
+++ b/lldb/include/lldb/API/SBBreakpoint.h
@@ -112,7 +112,8 @@ public:
 
   SBError SetScriptCallbackBody(const char *script_body_text);
 
-  LLDB_DEPRECATED_FIXME("Doesn't provide error handling", "AddNameWithErrorHandling")
+  LLDB_DEPRECATED_FIXME("Doesn't provide error handling",
+                        "AddNameWithErrorHandling")
   bool AddName(const char *new_name);
 
   SBError AddNameWithErrorHandling(const char *new_name);


### PR DESCRIPTION
AddName gives no feedback other than if it succeeded whereas AddNameWithErrorHandling gives you back an SBError object. I would like to mark AddName as deprecated and direct folks to use AddNameWithErorrHandling instead.