### PR TITLE
[flang] Catch READ(... SIZE=) with NML= or FMT=*

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -305,6 +305,10 @@ end
   compilers.
 * A `NULL()` pointer is treated as an unallocated allocatable
   when associated with an `INTENT(IN)` allocatable dummy argument.
+* `READ(..., SIZE=n)` is accepted with `NML=` and `FMT=*` with
+  a portability warning.
+  The Fortran standard doesn't allow `SIZE=` with formatted input
+  modes that might require look-ahead, perhaps to ease implementations.
 
 ### Extensions supported when enabled by options
 

--- a/flang/lib/Semantics/check-io.cpp
+++ b/flang/lib/Semantics/check-io.cpp
@@ -793,6 +793,14 @@ void IoChecker::Leave(const parser::ReadStmt &readStmt) {
   CheckForProhibitedSpecifier(IoSpecKind::Delim); // C1212
   CheckForProhibitedSpecifier(IoSpecKind::Sign); // C1212
   CheckForProhibitedSpecifier(IoSpecKind::Rec, IoSpecKind::End); // C1220
+  if (specifierSet_.test(IoSpecKind::Size)) {
+    // F'2023 C1214 - allow with a warning
+    if (specifierSet_.test(IoSpecKind::Nml)) {
+      context_.Say("If NML appears, SIZE should not appear"_port_en_US);
+    } else if (flags_.test(Flag::StarFmt)) {
+      context_.Say("If FMT=* appears, SIZE should not appear"_port_en_US);
+    }
+  }
   CheckForRequiredSpecifier(IoSpecKind::Eor,
       specifierSet_.test(IoSpecKind::Advance) && !flags_.test(Flag::AdvanceYes),
       "ADVANCE with value 'NO'"); // C1222 + 12.6.2.1p2

--- a/flang/test/Semantics/io03.f90
+++ b/flang/test/Semantics/io03.f90
@@ -155,6 +155,11 @@
   !ERROR: If PAD appears, FMT or NML must also appear
   read(10, pad='no', round='nearest') jj
 
+  !PORTABILITY: If NML appears, SIZE should not appear
+  read(10, nml=nnn, size=kk)
+  !PORTABILITY: If FMT=* appears, SIZE should not appear
+  read(10, *, size=kk) jj
+
   !ERROR: ID kind (2) is smaller than default INTEGER kind (4)
   read(10, id=id2, asynchronous='yes') jj
 


### PR DESCRIPTION
The SIZE= specifier may not appear on a list-directed or namelist READ statement.