### PR TITLE
[lldb] Change Breakpoint::AddName return value

### DIFF
--- a/lldb/include/lldb/Breakpoint/Breakpoint.h
+++ b/lldb/include/lldb/Breakpoint/Breakpoint.h
@@ -523,8 +523,7 @@ public:
 
   lldb::SearchFilterSP GetSearchFilter() { return m_filter_sp; }
 
-private: // The target needs to manage adding & removing names.  It will do the
-         // checking for name validity as well.
+private:
   void AddName(llvm::StringRef new_name);
 
   void RemoveName(const char *name_to_remove) {

--- a/lldb/include/lldb/Breakpoint/Breakpoint.h
+++ b/lldb/include/lldb/Breakpoint/Breakpoint.h
@@ -525,7 +525,7 @@ public:
 
 private: // The target needs to manage adding & removing names.  It will do the
          // checking for name validity as well.
-  bool AddName(llvm::StringRef new_name);
+  void AddName(llvm::StringRef new_name);
 
   void RemoveName(const char *name_to_remove) {
     if (name_to_remove)

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -841,9 +841,8 @@ bool Breakpoint::HasResolvedLocations() const {
 
 size_t Breakpoint::GetNumLocations() const { return m_locations.GetSize(); }
 
-bool Breakpoint::AddName(llvm::StringRef new_name) {
+void Breakpoint::AddName(llvm::StringRef new_name) {
   m_name_list.insert(new_name.str());
-  return true;
 }
 
 void Breakpoint::GetDescription(Stream *s, lldb::DescriptionLevel level,


### PR DESCRIPTION
The return value is completely unused. Let's just return nothing.