### PR TITLE
[flang] Enforce C839

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -564,6 +564,10 @@ void CheckHelper::CheckValue(
           "VALUE attribute may not apply to a type with a coarray ultimate component"_err_en_US);
     }
   }
+  if (evaluate::IsAssumedRank(symbol)) {
+    messages_.Say(
+        "VALUE attribute may not apply to an assumed-rank array"_err_en_US);
+  }
 }
 
 void CheckHelper::CheckAssumedTypeEntity( // C709
@@ -655,6 +659,10 @@ void CheckHelper::CheckObjectEntity(
     if (IsBadCoarrayType(derived)) { // C747 & C824
       messages_.Say(
           "Coarray '%s' may not have type TEAM_TYPE, C_PTR, or C_FUNPTR"_err_en_US,
+          symbol.name());
+    }
+    if (evaluate::IsAssumedRank(symbol)) {
+      messages_.Say("Coarray '%s' may not be an assumed-rank array"_err_en_US,
           symbol.name());
     }
   }

--- a/flang/test/Semantics/call14.f90
+++ b/flang/test/Semantics/call14.f90
@@ -7,7 +7,7 @@ module m
   end type
  contains
   !ERROR: VALUE attribute may apply only to a dummy data object
-  subroutine C863(notData,assumedSize,coarray,coarrayComponent)
+  subroutine C863(notData,assumedSize,coarray,coarrayComponent,assumedRank)
     external :: notData
     !ERROR: VALUE attribute may apply only to a dummy argument
     real, value :: notADummy
@@ -18,6 +18,8 @@ module m
     real, value :: coarray[*]
     !ERROR: VALUE attribute may not apply to a type with a coarray ultimate component
     type(hasCoarray), value :: coarrayComponent
+    !ERROR: VALUE attribute may not apply to an assumed-rank array
+    real, value :: assumedRank(..)
   end subroutine
   subroutine C864(allocatable, inout, out, pointer, volatile)
     !ERROR: VALUE attribute may not apply to an ALLOCATABLE

--- a/flang/test/Semantics/misc-declarations.f90
+++ b/flang/test/Semantics/misc-declarations.f90
@@ -38,4 +38,8 @@ module m
       volatile :: coarrayComponent
     end block
   end subroutine
+  subroutine C839(x)
+    !ERROR: Coarray 'x' may not be an assumed-rank array
+    real, intent(in) :: x(..)[*]
+  end
 end module


### PR DESCRIPTION
An assumed-rank array may not be a coarray and may not have the VALUE attribute.