### PR TITLE
[libc] Cleanup ErrnoSetterMatcher target

### DIFF
--- a/libc/test/src/fcntl/CMakeLists.txt
+++ b/libc/test/src/fcntl/CMakeLists.txt
@@ -14,7 +14,7 @@ add_libc_unittest(
     libc.src.fcntl.creat
     libc.src.fcntl.open
     libc.src.unistd.close
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -30,5 +30,5 @@ add_libc_unittest(
     libc.src.fcntl.openat
     libc.src.unistd.close
     libc.src.unistd.read
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -13,7 +13,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sched.sched_getaffinity
     libc.src.sched.sched_setaffinity
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -87,5 +87,5 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sched.sched_getaffinity
     libc.src.sched.__sched_getcpucount
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/signal/CMakeLists.txt
+++ b/libc/test/src/signal/CMakeLists.txt
@@ -22,7 +22,7 @@ add_libc_unittest(
     libc.src.signal.kill
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -36,7 +36,7 @@ add_libc_unittest(
     libc.include.signal
     libc.src.signal.raise
     libc.src.signal.sigaction
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -51,7 +51,7 @@ add_libc_unittest(
     libc.src.signal.sigaddset
     libc.src.signal.sigemptyset
     libc.src.signal.sigprocmask
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -64,7 +64,7 @@ add_libc_unittest(
     libc.include.errno
     libc.include.signal
     libc.src.signal.sigaddset
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -78,7 +78,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.signal.raise
     libc.src.signal.signal
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -93,7 +93,7 @@ add_libc_unittest(
     libc.src.signal.raise
     libc.src.signal.sigfillset
     libc.src.signal.sigprocmask
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -109,7 +109,7 @@ add_libc_unittest(
     libc.src.signal.sigdelset
     libc.src.signal.sigfillset
     libc.src.signal.sigprocmask
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -124,5 +124,5 @@ add_libc_unittest(
     libc.src.signal.raise
     libc.src.signal.sigaltstack
     libc.src.signal.sigaction
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -11,7 +11,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 if (NOT LLVM_USE_SANITIZER)
@@ -28,7 +28,7 @@ if (NOT LLVM_USE_SANITIZER)
       libc.src.sys.mman.mmap
       libc.src.sys.mman.munmap
       libc.src.sys.mman.mprotect
-      libc.test.errno_setter_matcher
+      libc.test.UnitTest.ErrnoSetterMatcher
   )
 endif()
 
@@ -44,7 +44,7 @@ add_libc_unittest(
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap
     libc.src.sys.mman.madvise
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 
@@ -60,5 +60,5 @@ add_libc_unittest(
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap
     libc.src.sys.mman.posix_madvise
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/random/linux/CMakeLists.txt
+++ b/libc/test/src/sys/random/linux/CMakeLists.txt
@@ -12,5 +12,5 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.math.fabs
     libc.src.sys.random.getrandom
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/select/CMakeLists.txt
+++ b/libc/test/src/sys/select/CMakeLists.txt
@@ -25,7 +25,7 @@ add_libc_unittest(
     libc.include.unistd
     libc.src.sys.select.select
     libc.src.unistd.read
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_subdirectory(testdata)

--- a/libc/test/src/sys/utsname/CMakeLists.txt
+++ b/libc/test/src/sys/utsname/CMakeLists.txt
@@ -11,5 +11,5 @@ add_libc_unittest(
     libc.include.sys_utsname
     libc.src.__support.common
     libc.src.sys.utsname.uname
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/termios/CMakeLists.txt
+++ b/libc/test/src/termios/CMakeLists.txt
@@ -18,5 +18,5 @@ add_libc_unittest(
     libc.src.termios.tcgetsid
     libc.src.termios.tcsetattr
     libc.src.unistd.close
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -29,7 +29,7 @@ add_libc_unittest(
     libc.src.fcntl.open
     libc.src.unistd.chdir
     libc.src.unistd.close
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -48,7 +48,7 @@ add_libc_unittest(
     libc.src.unistd.read
     libc.src.unistd.unlink
     libc.src.unistd.write
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -67,7 +67,7 @@ add_libc_unittest(
     libc.src.unistd.read
     libc.src.unistd.unlink
     libc.src.unistd.write
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -86,7 +86,7 @@ add_libc_unittest(
     libc.src.unistd.read
     libc.src.unistd.unlink
     libc.src.unistd.write
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -102,7 +102,7 @@ add_libc_unittest(
     libc.src.fcntl.open
     libc.src.unistd.fchdir
     libc.src.unistd.close
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -141,7 +141,7 @@ add_libc_unittest(
     libc.src.unistd.pwrite
     libc.src.unistd.unlink
     libc.src.unistd.write
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -159,7 +159,7 @@ add_libc_unittest(
     libc.src.unistd.fsync
     libc.src.unistd.read
     libc.src.unistd.write
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -208,7 +208,7 @@ add_libc_unittest(
     libc.src.unistd.close
     libc.src.unistd.lseek
     libc.src.unistd.read
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -415,7 +415,7 @@ add_libc_unittest(
     libc.include.fcntl
     libc.include.sys_syscall
     libc.src.unistd.__llvm_libc_syscall
-    libc.test.errno_setter_matcher
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 


### PR DESCRIPTION
The ErrnoSetterMatcher target was renamed in a previous patch, but not
all uses were caught. This patch fixes those that remain.
