### PR TITLE
[lldb] Move FindSymbolFileInBundle to SymbolLocator plugin

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -346,10 +346,12 @@ public:
   GetSymbolVendorCreateCallbackAtIndex(uint32_t idx);
 
   // SymbolLocator
-  static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
-                             SymbolLocatorCreateInstance create_callback,
-                             SymbolLocatorLocateExecutableObjectFile
-                                 locate_executable_object_file = nullptr);
+  static bool RegisterPlugin(
+      llvm::StringRef name, llvm::StringRef description,
+      SymbolLocatorCreateInstance create_callback,
+      SymbolLocatorLocateExecutableObjectFile locate_executable_object_file =
+          nullptr,
+      SymbolLocatorFindSymbolFileInBundle find_symbol_file_in_bundle = nullptr);
 
   static bool UnregisterPlugin(SymbolLocatorCreateInstance create_callback);
 
@@ -357,6 +359,10 @@ public:
   GetSymbolLocatorCreateCallbackAtIndex(uint32_t idx);
 
   static ModuleSpec LocateExecutableObjectFile(const ModuleSpec &module_spec);
+
+  static FileSpec FindSymbolFileInBundle(const FileSpec &dsym_bundle_fspec,
+                                         const UUID *uuid,
+                                         const ArchSpec *arch);
 
   // Trace
   static bool RegisterPlugin(

--- a/lldb/include/lldb/Symbol/LocateSymbolFile.h
+++ b/lldb/include/lldb/Symbol/LocateSymbolFile.h
@@ -32,10 +32,6 @@ public:
   LocateExecutableSymbolFile(const ModuleSpec &module_spec,
                              const FileSpecList &default_search_paths);
 
-  static FileSpec FindSymbolFileInBundle(const FileSpec &dsym_bundle_fspec,
-                                         const lldb_private::UUID *uuid,
-                                         const ArchSpec *arch);
-
   // Locate the object and symbol file given a module specification.
   //
   // Locating the file can try to download the file from a corporate build

--- a/lldb/include/lldb/lldb-private-interfaces.h
+++ b/lldb/include/lldb/lldb-private-interfaces.h
@@ -92,6 +92,8 @@ typedef SymbolVendor *(*SymbolVendorCreateInstance)(
 typedef SymbolLocator *(*SymbolLocatorCreateInstance)();
 typedef std::optional<ModuleSpec> (*SymbolLocatorLocateExecutableObjectFile)(
     const ModuleSpec &module_spec);
+typedef std::optional<FileSpec> (*SymbolLocatorFindSymbolFileInBundle)(
+    const FileSpec &dsym_bundle_fspec, const UUID *uuid, const ArchSpec *arch);
 typedef bool (*BreakpointHitCallback)(void *baton,
                                       StoppointCallbackContext *context,
                                       lldb::user_id_t break_id,

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -321,8 +321,8 @@ Status PlatformDarwin::ResolveSymbolFile(Target &target,
                                          FileSpec &sym_file) {
   sym_file = sym_spec.GetSymbolFileSpec();
   if (FileSystem::Instance().IsDirectory(sym_file)) {
-    sym_file = Symbols::FindSymbolFileInBundle(sym_file, sym_spec.GetUUIDPtr(),
-                                               sym_spec.GetArchitecturePtr());
+    sym_file = PluginManager::FindSymbolFileInBundle(
+        sym_file, sym_spec.GetUUIDPtr(), sym_spec.GetArchitecturePtr());
   }
   return {};
 }

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.h
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.h
@@ -37,6 +37,10 @@ public:
   // current computers global settings.
   static std::optional<ModuleSpec>
   LocateExecutableObjectFile(const ModuleSpec &module_spec);
+
+  static std::optional<FileSpec>
+  FindSymbolFileInBundle(const FileSpec &dsym_bundle_fspec, const UUID *uuid,
+                         const ArchSpec *arch);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Symbol/LocateSymbolFile.cpp
+++ b/lldb/source/Symbol/LocateSymbolFile.cpp
@@ -408,13 +408,6 @@ void Symbols::DownloadSymbolFileAsync(const UUID &uuid) {
 
 #if !defined(__APPLE__)
 
-FileSpec Symbols::FindSymbolFileInBundle(const FileSpec &symfile_bundle,
-                                         const lldb_private::UUID *uuid,
-                                         const ArchSpec *arch) {
-  // FIXME
-  return FileSpec();
-}
-
 bool Symbols::DownloadObjectAndSymbolFile(ModuleSpec &module_spec,
                                           Status &error, bool force_lookup,
                                           bool copy_executable) {

--- a/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
+++ b/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleList.h"
 #include "lldb/Core/ModuleSpec.h"
+#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Symbol/ObjectFile.h"
@@ -119,8 +120,8 @@ int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
               FileSystem::Instance().Resolve(dsym_filespec);
 
             if (FileSystem::Instance().IsDirectory(dsym_filespec)) {
-              dsym_filespec =
-                  Symbols::FindSymbolFileInBundle(dsym_filespec, uuid, arch);
+              dsym_filespec = PluginManager::FindSymbolFileInBundle(
+                  dsym_filespec, uuid, arch);
               ++items_found;
             } else {
               ++items_found;
@@ -287,45 +288,6 @@ int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
   }
 
   return items_found;
-}
-
-FileSpec Symbols::FindSymbolFileInBundle(const FileSpec &dsym_bundle_fspec,
-                                         const lldb_private::UUID *uuid,
-                                         const ArchSpec *arch) {
-  std::string dsym_bundle_path = dsym_bundle_fspec.GetPath();
-  llvm::SmallString<128> buffer(dsym_bundle_path);
-  llvm::sys::path::append(buffer, "Contents", "Resources", "DWARF");
-
-  std::error_code EC;
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs =
-      FileSystem::Instance().GetVirtualFileSystem();
-  llvm::vfs::recursive_directory_iterator Iter(*vfs, buffer.str(), EC);
-  llvm::vfs::recursive_directory_iterator End;
-  for (; Iter != End && !EC; Iter.increment(EC)) {
-    llvm::ErrorOr<llvm::vfs::Status> Status = vfs->status(Iter->path());
-    if (Status->isDirectory())
-      continue;
-
-    FileSpec dsym_fspec(Iter->path());
-    ModuleSpecList module_specs;
-    if (ObjectFile::GetModuleSpecifications(dsym_fspec, 0, 0, module_specs)) {
-      ModuleSpec spec;
-      for (size_t i = 0; i < module_specs.GetSize(); ++i) {
-        bool got_spec = module_specs.GetModuleSpecAtIndex(i, spec);
-        assert(got_spec); // The call has side-effects so can't be inlined.
-        UNUSED_IF_ASSERT_DISABLED(got_spec);
-        if ((uuid == nullptr ||
-             (spec.GetUUIDPtr() && spec.GetUUID() == *uuid)) &&
-            (arch == nullptr ||
-             (spec.GetArchitecturePtr() &&
-              spec.GetArchitecture().IsCompatibleMatch(*arch)))) {
-          return dsym_fspec;
-        }
-      }
-    }
-  }
-
-  return {};
 }
 
 static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,


### PR DESCRIPTION
This builds on top of the work started in c3a302d to convert LocateSymbolFile to a SymbolLocator plugin. This commit moves FindSymbolFileInBundle.