### PR TITLE
[TraceIntelPT]Migrate to new function template for TraceIntelPT

### DIFF
--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPT.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPT.cpp
@@ -60,14 +60,14 @@ TraceIntelPT::PluginProperties::PluginProperties() : Properties() {
 uint64_t
 TraceIntelPT::PluginProperties::GetInfiniteDecodingLoopVerificationThreshold() {
   const uint32_t idx = ePropertyInfiniteDecodingLoopVerificationThreshold;
-  return m_collection_sp->GetPropertyAtIndexAsUInt64(
-      nullptr, idx, g_traceintelpt_properties[idx].default_uint_value);
+  return GetPropertyAtIndexAs<uint64_t>(
+      idx, g_traceintelpt_properties[idx].default_uint_value);
 }
 
 uint64_t TraceIntelPT::PluginProperties::GetExtremelyLargeDecodingThreshold() {
   const uint32_t idx = ePropertyExtremelyLargeDecodingThreshold;
-  return m_collection_sp->GetPropertyAtIndexAsUInt64(
-      nullptr, idx, g_traceintelpt_properties[idx].default_uint_value);
+  return GetPropertyAtIndexAs<uint64_t>(
+      idx, g_traceintelpt_properties[idx].default_uint_value);
 }
 
 TraceIntelPT::PluginProperties &TraceIntelPT::GetGlobalProperties() {


### PR DESCRIPTION
Easy change. Migrate to new template function call.
More context: https://github.com/llvm/llvm-project/commit/6f8b33f6dfd0a0f8d2522b6c832bd6298ae2f3f3