### PR TITLE
[OpenMP][DeviceRTL] implemented nteams-var ICV, omp_get_max_teams(), and omp_set_num_teams()

### DIFF
--- a/openmp/docs/design/Runtimes.rst
+++ b/openmp/docs/design/Runtimes.rst
@@ -115,6 +115,19 @@ threads for that level is inherited from the previous level.
 | **Syntax:** ``OMP_NUM_THREADS=value[,value]*``
 | **Example:** ``OMP_NUM_THREADS=4,3``
 
+OMP_NUM_TEAMS_DEV_<device>
+""""""""""""""""""""""""""
+
+Sets the maximum number of teams for a device with ``deviceId`` being ``<device>``. This also sets
+the ICV ``NTeams`` of the device to such value. The value must be nonnegative. If using 
+``void omp_set_num_teams(uint32_t V)`` to update ``NTeams`` ICV, ``V`` has a lower bound of 0 and upper 
+bound of the environment variable's value; if ``V`` is negative, it will be set to 0; if ``V`` is larger
+than the value of ``OMP_NUM_TEAMS_DEV_<device>``, it will be set to that value.
+
+| **Default:** ``0``
+| **Syntax:** ``OMP_NUM_TEAMS_DEV_<device>=value``
+| **Example:** ``OMP_NUM_TEAMS_DEV_4=8`` sets maximum number of teams of device whose ``deviceId`` is 4 to 8.
+
 OMP_PLACES
 """"""""""
 

--- a/openmp/libomptarget/DeviceRTL/include/Configuration.h
+++ b/openmp/libomptarget/DeviceRTL/include/Configuration.h
@@ -56,7 +56,7 @@ bool mayUseThreadStates();
 bool mayUseNestedParallelism();
 
 /// Return max number of teams in the device it's called on.
-uint32_t getMaxTeams(); 
+uint32_t getMaxTeams();
 
 } // namespace config
 } // namespace ompx

--- a/openmp/libomptarget/DeviceRTL/include/Configuration.h
+++ b/openmp/libomptarget/DeviceRTL/include/Configuration.h
@@ -55,6 +55,9 @@ bool mayUseThreadStates();
 /// parallelism, or if it was explicitly disabled by the user.
 bool mayUseNestedParallelism();
 
+/// Return max number of teams in the device it's called on.
+uint32_t getMaxTeams(); 
+
 } // namespace config
 } // namespace ompx
 

--- a/openmp/libomptarget/DeviceRTL/include/Interface.h
+++ b/openmp/libomptarget/DeviceRTL/include/Interface.h
@@ -133,6 +133,10 @@ int omp_get_num_teams(void);
 
 int omp_get_team_num();
 
+int omp_get_max_teams(void);
+
+void omp_set_num_teams(int V);
+
 int omp_get_initial_device(void);
 
 void *llvm_omp_target_dynamic_shared_alloc();

--- a/openmp/libomptarget/DeviceRTL/include/Interface.h
+++ b/openmp/libomptarget/DeviceRTL/include/Interface.h
@@ -135,7 +135,7 @@ int omp_get_team_num();
 
 int omp_get_max_teams(void);
 
-void omp_set_num_teams(int V);
+void omp_set_num_teams(uint32_t V);
 
 int omp_get_initial_device(void);
 

--- a/openmp/libomptarget/DeviceRTL/include/State.h
+++ b/openmp/libomptarget/DeviceRTL/include/State.h
@@ -54,6 +54,7 @@ inline constexpr uint32_t SharedScratchpadSize = SHARED_SCRATCHPAD_SIZE;
 
 struct ICVStateTy {
   uint32_t NThreadsVar;
+  uint32_t NTeamsVar;
   uint32_t LevelVar;
   uint32_t ActiveLevelVar;
   uint32_t Padding0Val;
@@ -131,6 +132,7 @@ KernelLaunchEnvironmentTy &getKernelLaunchEnvironment();
 /// TODO
 enum ValueKind {
   VK_NThreads,
+  VK_NTeams,
   VK_Level,
   VK_ActiveLevel,
   VK_MaxActiveLevels,
@@ -189,6 +191,11 @@ lookup32(ValueKind Kind, bool IsReadonly, IdentTy *Ident, bool ForceTeamState) {
     if (IsReadonly)
       return lookupImpl(&ICVStateTy::NThreadsVar, ForceTeamState);
     return lookupForModify32Impl(&ICVStateTy::NThreadsVar, Ident,
+                                 ForceTeamState);
+  case state::VK_NTeams:
+    if (IsReadonly)
+      return lookupImpl(&ICVStateTy::NTeamsVar, ForceTeamState);
+    return lookupForModify32Impl(&ICVStateTy::NTeamsVar, Ident,
                                  ForceTeamState);
   case state::VK_Level:
     if (IsReadonly)
@@ -359,6 +366,9 @@ namespace icv {
 
 /// TODO
 inline state::Value<uint32_t, state::VK_NThreads> NThreads;
+
+/// TODO
+inline state::Value<uint32_t, state::VK_NTeams> NTeams;
 
 /// TODO
 inline state::Value<uint32_t, state::VK_Level> Level;

--- a/openmp/libomptarget/DeviceRTL/include/State.h
+++ b/openmp/libomptarget/DeviceRTL/include/State.h
@@ -190,8 +190,7 @@ lookup32(ValueKind Kind, bool IsReadonly, IdentTy *Ident, bool ForceTeamState) {
   case state::VK_NThreads:
     if (IsReadonly)
       return lookupImpl(&ICVStateTy::NThreadsVar, ForceTeamState);
-    return lookupForModify32Impl(&ICVStateTy::NThreadsVar, Ident,
-                                 ForceTeamState);
+    return lookupForModify32Impl(&ICVStateTy::NTeamsVar, Ident, ForceTeamState);
   case state::VK_NTeams:
     if (IsReadonly)
       return lookupImpl(&ICVStateTy::NTeamsVar, ForceTeamState);

--- a/openmp/libomptarget/DeviceRTL/include/State.h
+++ b/openmp/libomptarget/DeviceRTL/include/State.h
@@ -190,12 +190,12 @@ lookup32(ValueKind Kind, bool IsReadonly, IdentTy *Ident, bool ForceTeamState) {
   case state::VK_NThreads:
     if (IsReadonly)
       return lookupImpl(&ICVStateTy::NThreadsVar, ForceTeamState);
-    return lookupForModify32Impl(&ICVStateTy::NTeamsVar, Ident, ForceTeamState);
+    return lookupForModify32Impl(&ICVStateTy::NThreadsVar, Ident,
+                                 ForceTeamState);
   case state::VK_NTeams:
     if (IsReadonly)
       return lookupImpl(&ICVStateTy::NTeamsVar, ForceTeamState);
-    return lookupForModify32Impl(&ICVStateTy::NTeamsVar, Ident,
-                                 ForceTeamState);
+    return lookupForModify32Impl(&ICVStateTy::NTeamsVar, Ident, ForceTeamState);
   case state::VK_Level:
     if (IsReadonly)
       return lookupImpl(&ICVStateTy::LevelVar, ForceTeamState);

--- a/openmp/libomptarget/DeviceRTL/include/Utils.h
+++ b/openmp/libomptarget/DeviceRTL/include/Utils.h
@@ -82,6 +82,16 @@ template <typename DstTy, typename SrcTy> inline DstTy convertViaPun(SrcTy V) {
   return *((DstTy *)(&V));
 }
 
+/// Return minimum value out of 2 value arguments provided
+template <typename Ty> const Ty& min(const Ty& a, const Ty& b) {
+  return (b < a) ? b : a;
+}
+
+/// Return maxmimum value out of 2 value arguments provided
+template <typename Ty> const Ty& max(const Ty& a, const Ty& b) {
+  return (b > a) ? b : a;
+}
+
 /// A  pointer variable that has by design an `undef` value. Use with care.
 [[clang::loader_uninitialized]] static void *const UndefPtr;
 

--- a/openmp/libomptarget/DeviceRTL/include/Utils.h
+++ b/openmp/libomptarget/DeviceRTL/include/Utils.h
@@ -83,12 +83,12 @@ template <typename DstTy, typename SrcTy> inline DstTy convertViaPun(SrcTy V) {
 }
 
 /// Return minimum value out of 2 value arguments provided
-template <typename Ty> const Ty& min(const Ty& a, const Ty& b) {
+template <typename Ty> const Ty &min(const Ty &a, const Ty &b) {
   return (b < a) ? b : a;
 }
 
 /// Return maxmimum value out of 2 value arguments provided
-template <typename Ty> const Ty& max(const Ty& a, const Ty& b) {
+template <typename Ty> const Ty &max(const Ty &a, const Ty &b) {
   return (b > a) ? b : a;
 }
 

--- a/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/Configuration.cpp
@@ -75,4 +75,6 @@ bool config::mayUseNestedParallelism() {
   return state::getKernelEnvironment().Configuration.MayUseNestedParallelism;
 }
 
+uint32_t config::getMaxTeams() { return __omp_rtl_device_environment.NumTeams; }
+
 #pragma omp end declare target

--- a/openmp/libomptarget/DeviceRTL/src/State.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/State.cpp
@@ -428,8 +428,9 @@ int omp_get_team_num() { return mapping::getBlockIdInKernel(); }
 int omp_get_max_teams(void) { return icv::NTeams; }
 
 void omp_set_num_teams(int V) {
-  icv::NTeams = (V < 0) ? 0 :
-                (V >= config::getMaxTeams()) ? config::getMaxTeams() : V;
+  icv::NTeams = (V < 0)                        ? 0
+                : (V >= config::getMaxTeams()) ? config::getMaxTeams()
+                                               : V;
 }
 
 int omp_get_initial_device(void) { return -1; }

--- a/openmp/libomptarget/DeviceRTL/src/State.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/State.cpp
@@ -199,6 +199,7 @@ void state::ICVStateTy::assertEqual(const ICVStateTy &Other) const {
 
 void state::TeamStateTy::init(bool IsSPMD) {
   ICVState.NThreadsVar = 0;
+  ICVState.NTeamsVar = config::getMaxTeams();
   ICVState.LevelVar = 0;
   ICVState.ActiveLevelVar = 0;
   ICVState.Padding0Val = 0;
@@ -423,6 +424,13 @@ int omp_get_device_num(void) { return config::getDeviceNum(); }
 int omp_get_num_teams(void) { return mapping::getNumberOfBlocksInKernel(); }
 
 int omp_get_team_num() { return mapping::getBlockIdInKernel(); }
+
+int omp_get_max_teams(void) { return icv::NTeams; }
+
+void omp_set_num_teams(int V) {
+  icv::NTeams = (V < 0) ? 0 :
+                (V >= config::getMaxTeams()) ? config::getMaxTeams() : V;
+}
 
 int omp_get_initial_device(void) { return -1; }
 }

--- a/openmp/libomptarget/DeviceRTL/src/State.cpp
+++ b/openmp/libomptarget/DeviceRTL/src/State.cpp
@@ -427,10 +427,8 @@ int omp_get_team_num() { return mapping::getBlockIdInKernel(); }
 
 int omp_get_max_teams(void) { return icv::NTeams; }
 
-void omp_set_num_teams(int V) {
-  icv::NTeams = (V < 0)                        ? 0
-                : (V >= config::getMaxTeams()) ? config::getMaxTeams()
-                                               : V;
+void omp_set_num_teams(uint32_t V) {
+  icv::NTeams = utils::min(V, config::getMaxTeams());
 }
 
 int omp_get_initial_device(void) { return -1; }

--- a/openmp/libomptarget/include/Environment.h
+++ b/openmp/libomptarget/include/Environment.h
@@ -35,6 +35,7 @@ enum class DeviceDebugKind : uint32_t {
 struct DeviceEnvironmentTy {
   uint32_t DeviceDebugKind;
   uint32_t NumDevices;
+  uint32_t NumTeams;
   uint32_t DeviceNum;
   uint32_t DynamicMemSize;
   uint64_t ClockFrequency;

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
@@ -628,7 +628,7 @@ uint64_t GenericKernelTy::getNumBlocks(GenericDeviceTy &GenericDevice,
 GenericDeviceTy::GenericDeviceTy(int32_t DeviceId, int32_t NumDevices,
                                  const llvm::omp::GV &OMPGridValues)
     : MemoryManager(nullptr), OMP_TeamLimit("OMP_TEAM_LIMIT"),
-      OMP_NumTeams("OMP_NUM_TEAMS"),
+      OMP_NumTeams("OMP_NUM_TEAMS_DEV_" + std::to_string(DeviceId)),
       OMP_TeamsThreadLimit("OMP_TEAMS_THREAD_LIMIT"),
       OMPX_DebugKind("LIBOMPTARGET_DEVICE_RTL_DEBUG"),
       OMPX_SharedMemorySize("LIBOMPTARGET_SHARED_MEMORY_SIZE"),
@@ -854,6 +854,7 @@ Error GenericDeviceTy::setupDeviceEnvironment(GenericPluginTy &Plugin,
   DeviceEnvironmentTy DeviceEnvironment;
   DeviceEnvironment.DeviceDebugKind = OMPX_DebugKind;
   DeviceEnvironment.NumDevices = Plugin.getNumDevices();
+  DeviceEnvironment.NumTeams = (OMP_NumTeams >= 0) ? uint32_t(OMP_NumTeams) : 0;
   // TODO: The device ID used here is not the real device ID used by OpenMP.
   DeviceEnvironment.DeviceNum = DeviceId;
   DeviceEnvironment.DynamicMemSize = OMPX_SharedMemorySize;

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
@@ -628,7 +628,9 @@ uint64_t GenericKernelTy::getNumBlocks(GenericDeviceTy &GenericDevice,
 GenericDeviceTy::GenericDeviceTy(int32_t DeviceId, int32_t NumDevices,
                                  const llvm::omp::GV &OMPGridValues)
     : MemoryManager(nullptr), OMP_TeamLimit("OMP_TEAM_LIMIT"),
-      OMP_NumTeams("OMP_NUM_TEAMS_DEV_" + std::to_string(DeviceId + Plugin::get().getDeviceIdStartIndex())),
+      OMP_NumTeams(
+          "OMP_NUM_TEAMS_DEV_" +
+          std::to_string(DeviceId + Plugin::get().getDeviceIdStartIndex())),
       OMP_TeamsThreadLimit("OMP_TEAMS_THREAD_LIMIT"),
       OMPX_DebugKind("LIBOMPTARGET_DEVICE_RTL_DEBUG"),
       OMPX_SharedMemorySize("LIBOMPTARGET_SHARED_MEMORY_SIZE"),

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
@@ -628,7 +628,7 @@ uint64_t GenericKernelTy::getNumBlocks(GenericDeviceTy &GenericDevice,
 GenericDeviceTy::GenericDeviceTy(int32_t DeviceId, int32_t NumDevices,
                                  const llvm::omp::GV &OMPGridValues)
     : MemoryManager(nullptr), OMP_TeamLimit("OMP_TEAM_LIMIT"),
-      OMP_NumTeams("OMP_NUM_TEAMS_DEV_" + std::to_string(DeviceId)),
+      OMP_NumTeams("OMP_NUM_TEAMS_DEV_" + std::to_string(DeviceId + Plugin::get().getDeviceIdStartIndex())),
       OMP_TeamsThreadLimit("OMP_TEAMS_THREAD_LIMIT"),
       OMPX_DebugKind("LIBOMPTARGET_DEVICE_RTL_DEBUG"),
       OMPX_SharedMemorySize("LIBOMPTARGET_SHARED_MEMORY_SIZE"),
@@ -854,7 +854,7 @@ Error GenericDeviceTy::setupDeviceEnvironment(GenericPluginTy &Plugin,
   DeviceEnvironmentTy DeviceEnvironment;
   DeviceEnvironment.DeviceDebugKind = OMPX_DebugKind;
   DeviceEnvironment.NumDevices = Plugin.getNumDevices();
-  DeviceEnvironment.NumTeams = (OMP_NumTeams >= 0) ? uint32_t(OMP_NumTeams) : 0;
+  DeviceEnvironment.NumTeams = uint32_t(OMP_NumTeams);
   // TODO: The device ID used here is not the real device ID used by OpenMP.
   DeviceEnvironment.DeviceNum = DeviceId;
   DeviceEnvironment.DynamicMemSize = OMPX_SharedMemorySize;

--- a/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
+++ b/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
@@ -4,7 +4,7 @@
 
 // RUN: %libomptarget-compile-generic -fopenmp-offload-mandatory
 // RUN: env OMP_NUM_TEAMS_DEV_0=5 OMP_NUM_TEAMS_DEV_1=-1 \
-// RUN: %libomptarget-run-generic 
+// RUN: %libomptarget-run-generic
 
 // UNSUPPORTED: x86_64-pc-linux-gnu
 // UNSUPPORTED: x86_64-pc-linux-gnu-LTO
@@ -33,8 +33,12 @@ int test_nteams_var_env(void) {
       device_id = omp_get_device_num();
       errors = errors + (device_id != i);
       curr_nteams = omp_get_max_teams();
-      if (device_id == 0) { errors = errors + (curr_nteams != EXPECTED_NTEAMS_DEV_0); } // device 0
-      if (device_id == 1) { errors = errors + (curr_nteams != EXPECTED_NTEAMS_DEV_1); } // device 1
+      if (device_id == 0) {
+        errors = errors + (curr_nteams != EXPECTED_NTEAMS_DEV_0);
+      } // device 0
+      if (device_id == 1) {
+        errors = errors + (curr_nteams != EXPECTED_NTEAMS_DEV_1);
+      } // device 1
     }
     printf("device: %d nteams: %d\n", device_id, curr_nteams);
   }

--- a/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
+++ b/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
@@ -40,7 +40,6 @@ int test_nteams_var_env(void) {
         errors = errors + (curr_nteams != EXPECTED_NTEAMS_DEV_1);
       } // device 1
     }
-    printf("device: %d nteams: %d\n", device_id, curr_nteams);
   }
   return errors;
 }

--- a/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
+++ b/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
@@ -1,0 +1,54 @@
+// Test functionality of omp_get_max_teams() with setting
+// environment variable to 2 GPU devices. If there's only
+// one GPU device, remove the device 1 if statement.
+
+// RUN: %libomptarget-compile-generic -fopenmp-offload-mandatory
+// RUN: env OMP_NUM_TEAMS_DEV_0=5 OMP_NUM_TEAMS_DEV_1=-1 \
+// RUN: %libomptarget-run-generic 
+
+// UNSUPPORTED: x86_64-pc-linux-gnu
+// UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+
+#include <omp.h>
+#include <stdio.h>
+
+const int EXPECTED_NTEAMS_DEV_0 = 5;
+const int EXPECTED_NTEAMS_DEV_1 = 0;
+
+int omp_get_max_teams(void);
+
+int test_nteams_var_env(void) {
+  int errors = 0;
+  int device_id;
+  int n_devs;
+  int curr_nteams = -1;
+#pragma omp target map(tofrom : n_devs)
+  { n_devs = omp_get_num_devices(); }
+
+  for (int i = 0; i < n_devs; i++) {
+#pragma omp target device(i) map(tofrom : curr_nteams, device_id, errors)
+    {
+      device_id = omp_get_device_num();
+      errors = errors + (device_id != i);
+      curr_nteams = omp_get_max_teams();
+      if (device_id == 0) { errors = errors + (curr_nteams != EXPECTED_NTEAMS_DEV_0); } // device 0
+      if (device_id == 1) { errors = errors + (curr_nteams != EXPECTED_NTEAMS_DEV_1); } // device 1
+    }
+    printf("device: %d nteams: %d\n", device_id, curr_nteams);
+  }
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+  errors = test_nteams_var_env();
+  if (errors)
+    printf("FAIL\n");
+  else
+    printf("PASS\n");
+  return errors;
+}
+
+// CHECK: PASS

--- a/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
+++ b/openmp/libomptarget/test/env/omp_get_max_teams_env_var.c
@@ -3,7 +3,7 @@
 // one GPU device, remove the device 1 if statement.
 
 // RUN: %libomptarget-compile-generic -fopenmp-offload-mandatory
-// RUN: env OMP_NUM_TEAMS_DEV_0=5 OMP_NUM_TEAMS_DEV_1=-1 \
+// RUN: env OMP_NUM_TEAMS_DEV_0=5 OMP_NUM_TEAMS_DEV_1=3 LIBOMPTARGET_INFO=16\
 // RUN: %libomptarget-run-generic
 
 // UNSUPPORTED: x86_64-pc-linux-gnu
@@ -15,7 +15,7 @@
 #include <stdio.h>
 
 const int EXPECTED_NTEAMS_DEV_0 = 5;
-const int EXPECTED_NTEAMS_DEV_1 = 0;
+const int EXPECTED_NTEAMS_DEV_1 = 3;
 
 int omp_get_max_teams(void);
 

--- a/openmp/libomptarget/test/env/omp_set_num_teams.c
+++ b/openmp/libomptarget/test/env/omp_set_num_teams.c
@@ -21,17 +21,13 @@ int omp_get_max_teams(void);
 
 int test_set_over_max(void) {
   int errors = 0;
-  int n_devs;
   int curr_nteams = -1;
-
-#pragma omp target map(tofrom : n_devs)
-  { n_devs = omp_get_num_devices(); }
 
 #pragma omp target device(0) map(tofrom : curr_nteams, errors)
   {
-    omp_set_num_teams(3 + 1);
+    omp_set_num_teams(EXPECTED_NTEAMS + 1);
     curr_nteams = omp_get_max_teams();
-    errors = errors + (curr_nteams != 3);
+    errors = errors + (curr_nteams != EXPECTED_NTEAMS);
 
     omp_set_num_teams(-1);
     curr_nteams = omp_get_max_teams();
@@ -39,7 +35,7 @@ int test_set_over_max(void) {
 
     omp_set_num_teams(3);
     curr_nteams = omp_get_max_teams();
-    errors = errors + (curr_nteams != 3);
+    errors = errors + (curr_nteams != EXPECTED_NTEAMS);
   }
   return errors;
 }

--- a/openmp/libomptarget/test/env/omp_set_num_teams.c
+++ b/openmp/libomptarget/test/env/omp_set_num_teams.c
@@ -1,0 +1,57 @@
+// Test functionality of omp_set_num_teams() with setting
+// environment variable as an upper bound. Test for negative
+// value and value that is larger than the upper bound.
+
+// RUN: %libomptarget-compile-generic -fopenmp-offload-mandatory
+// RUN: env OMP_NUM_TEAMS_DEV_0=3 LIBOMPTARGET_INFO=16\
+// RUN: %libomptarget-run-generic
+
+// UNSUPPORTED: x86_64-pc-linux-gnu
+// UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+
+#include <omp.h>
+#include <stdio.h>
+
+const int EXPECTED_NTEAMS = 3;
+
+void omp_set_num_teams(int V);
+int omp_get_max_teams(void);
+
+int test_set_over_max(void) {
+  int errors = 0;
+  int n_devs;
+  int curr_nteams = -1;
+
+#pragma omp target map(tofrom : n_devs)
+  { n_devs = omp_get_num_devices(); }
+
+#pragma omp target device(0) map(tofrom : curr_nteams, errors)
+  {
+    omp_set_num_teams(3 + 1);
+    curr_nteams = omp_get_max_teams();
+    errors = errors + (curr_nteams != 3);
+
+    omp_set_num_teams(-1);
+    curr_nteams = omp_get_max_teams();
+    errors = errors + (curr_nteams != 0);
+
+    omp_set_num_teams(3);
+    curr_nteams = omp_get_max_teams();
+    errors = errors + (curr_nteams != 3);
+  }
+  return errors;
+}
+
+int main() {
+  int errors = 0;
+  errors = test_set_over_max();
+  if (errors)
+    printf("FAIL\n");
+  else
+    printf("PASS\n");
+  return errors;
+}
+
+// CHECK: PASS

--- a/openmp/libomptarget/test/env/omp_set_num_teams.c
+++ b/openmp/libomptarget/test/env/omp_set_num_teams.c
@@ -25,17 +25,18 @@ int test_set_over_max(void) {
 
 #pragma omp target device(0) map(tofrom : curr_nteams, errors)
   {
+    // Setting over specified OMP_NUM_TEAMS_DEV_0 value is not allowed
     omp_set_num_teams(EXPECTED_NTEAMS + 1);
     curr_nteams = omp_get_max_teams();
     errors = errors + (curr_nteams != EXPECTED_NTEAMS);
 
-    omp_set_num_teams(-1);
-    curr_nteams = omp_get_max_teams();
-    errors = errors + (curr_nteams != 0);
-
     omp_set_num_teams(3);
     curr_nteams = omp_get_max_teams();
     errors = errors + (curr_nteams != EXPECTED_NTEAMS);
+
+    omp_set_num_teams(2);
+    curr_nteams = omp_get_max_teams();
+    errors = errors + (curr_nteams != 2);
   }
   return errors;
 }


### PR DESCRIPTION
* `omp_get_max_teams()` returns nteams-var ICV in the device that called it.
* `omp_set_num_teams(int V)` sets nteams-var ICV in the device with an integer value `V`. If `V` is less than 0, it will set the ICV to 0; if `V` is larger than max number of teams set in the device environment (`DeviceEnvironmentTy.NumTeams`), the ICV will be set to that number.
* One can set max number of teams in a device by setting the environment variable `OMP_NUM_TEAMS_DEV_<device>` where `<device>` is the device number/ID.