### PR TITLE
[mlir][affine][nfc] cleanup deprecated T.cast style functions

### DIFF
--- a/mlir/include/mlir/IR/AffineExpr.h
+++ b/mlir/include/mlir/IR/AffineExpr.h
@@ -82,13 +82,17 @@ public:
   bool operator!() const { return expr == nullptr; }
 
   template <typename U>
-  constexpr bool isa() const;
+  [[deprecated("Use llvm::isa<U>() instead")]] constexpr bool isa() const;
+
   template <typename U>
-  U dyn_cast() const;
+  [[deprecated("Use llvm::dyn_cast<U>() instead")]] U dyn_cast() const;
+
   template <typename U>
-  U dyn_cast_or_null() const;
+  [[deprecated("Use llvm::dyn_cast_or_null<U>() instead")]] U
+  dyn_cast_or_null() const;
+
   template <typename U>
-  U cast() const;
+  [[deprecated("Use llvm::cast<U>() instead")]] U cast() const;
 
   MLIRContext *getContext() const;
 
@@ -194,6 +198,8 @@ public:
         reinterpret_cast<ImplType *>(const_cast<void *>(pointer)));
   }
 
+  ImplType *getImpl() const { return expr; }
+
 protected:
   ImplType *expr{nullptr};
 };
@@ -281,18 +287,15 @@ constexpr bool AffineExpr::isa() const {
 }
 template <typename U>
 U AffineExpr::dyn_cast() const {
-  if (isa<U>())
-    return U(expr);
-  return U(nullptr);
+  return llvm::dyn_cast<U>(*this);
 }
 template <typename U>
 U AffineExpr::dyn_cast_or_null() const {
-  return (!*this || !isa<U>()) ? U(nullptr) : U(expr);
+  return llvm::dyn_cast_or_null<U>(*this);
 }
 template <typename U>
 U AffineExpr::cast() const {
-  assert(isa<U>());
-  return U(expr);
+  return llvm::cast<U>(*this);
 }
 
 /// Simplify an affine expression by flattening and some amount of simple
@@ -388,6 +391,35 @@ struct DenseMapInfo<mlir::AffineExpr> {
   static bool isEqual(mlir::AffineExpr LHS, mlir::AffineExpr RHS) {
     return LHS == RHS;
   }
+};
+
+/// Add support for llvm style casts. We provide a cast between To and From if
+/// From is mlir::AffineExpr or derives from it.
+template <typename To, typename From>
+struct CastInfo<To, From,
+                std::enable_if_t<std::is_same_v<mlir::AffineExpr,
+                                                std::remove_const_t<From>> ||
+                                 std::is_base_of_v<mlir::AffineExpr, From>>>
+    : NullableValueCastFailed<To>,
+      DefaultDoCastIfPossible<To, From, CastInfo<To, From>> {
+
+  static inline bool isPossible(mlir::AffineExpr expr) {
+    /// Return a constant true instead of a dynamic true when casting to self or
+    /// up the hierarchy.
+    if constexpr (std::is_base_of_v<To, From>) {
+      return true;
+    } else {
+      if constexpr (std::is_same_v<To, ::mlir::AffineBinaryOpExpr>)
+        return expr.getKind() <= ::mlir::AffineExprKind::LAST_AFFINE_BINARY_OP;
+      if constexpr (std::is_same_v<To, ::mlir::AffineDimExpr>)
+        return expr.getKind() == ::mlir::AffineExprKind::DimId;
+      if constexpr (std::is_same_v<To, ::mlir::AffineSymbolExpr>)
+        return expr.getKind() == ::mlir::AffineExprKind::SymbolId;
+      if constexpr (std::is_same_v<To, ::mlir::AffineConstantExpr>)
+        return expr.getKind() == ::mlir::AffineExprKind::Constant;
+    }
+  }
+  static inline To doCast(mlir::AffineExpr expr) { return To(expr.getImpl()); }
 };
 
 } // namespace llvm

--- a/mlir/include/mlir/IR/AffineExprVisitor.h
+++ b/mlir/include/mlir/IR/AffineExprVisitor.h
@@ -77,39 +77,39 @@ public:
                   "Must instantiate with a derived type of AffineExprVisitor");
     switch (expr.getKind()) {
     case AffineExprKind::Add: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       walkOperandsPostOrder(binOpExpr);
       return static_cast<SubClass *>(this)->visitAddExpr(binOpExpr);
     }
     case AffineExprKind::Mul: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       walkOperandsPostOrder(binOpExpr);
       return static_cast<SubClass *>(this)->visitMulExpr(binOpExpr);
     }
     case AffineExprKind::Mod: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       walkOperandsPostOrder(binOpExpr);
       return static_cast<SubClass *>(this)->visitModExpr(binOpExpr);
     }
     case AffineExprKind::FloorDiv: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       walkOperandsPostOrder(binOpExpr);
       return static_cast<SubClass *>(this)->visitFloorDivExpr(binOpExpr);
     }
     case AffineExprKind::CeilDiv: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       walkOperandsPostOrder(binOpExpr);
       return static_cast<SubClass *>(this)->visitCeilDivExpr(binOpExpr);
     }
     case AffineExprKind::Constant:
       return static_cast<SubClass *>(this)->visitConstantExpr(
-          expr.cast<AffineConstantExpr>());
+          cast<AffineConstantExpr>(expr));
     case AffineExprKind::DimId:
       return static_cast<SubClass *>(this)->visitDimExpr(
-          expr.cast<AffineDimExpr>());
+          cast<AffineDimExpr>(expr));
     case AffineExprKind::SymbolId:
       return static_cast<SubClass *>(this)->visitSymbolExpr(
-          expr.cast<AffineSymbolExpr>());
+          cast<AffineSymbolExpr>(expr));
     }
   }
 
@@ -119,34 +119,34 @@ public:
                   "Must instantiate with a derived type of AffineExprVisitor");
     switch (expr.getKind()) {
     case AffineExprKind::Add: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       return static_cast<SubClass *>(this)->visitAddExpr(binOpExpr);
     }
     case AffineExprKind::Mul: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       return static_cast<SubClass *>(this)->visitMulExpr(binOpExpr);
     }
     case AffineExprKind::Mod: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       return static_cast<SubClass *>(this)->visitModExpr(binOpExpr);
     }
     case AffineExprKind::FloorDiv: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       return static_cast<SubClass *>(this)->visitFloorDivExpr(binOpExpr);
     }
     case AffineExprKind::CeilDiv: {
-      auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+      auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
       return static_cast<SubClass *>(this)->visitCeilDivExpr(binOpExpr);
     }
     case AffineExprKind::Constant:
       return static_cast<SubClass *>(this)->visitConstantExpr(
-          expr.cast<AffineConstantExpr>());
+          cast<AffineConstantExpr>(expr));
     case AffineExprKind::DimId:
       return static_cast<SubClass *>(this)->visitDimExpr(
-          expr.cast<AffineDimExpr>());
+          cast<AffineDimExpr>(expr));
     case AffineExprKind::SymbolId:
       return static_cast<SubClass *>(this)->visitSymbolExpr(
-          expr.cast<AffineSymbolExpr>());
+          cast<AffineSymbolExpr>(expr));
     }
     llvm_unreachable("Unknown AffineExpr");
   }

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -648,9 +648,9 @@ SmallVector<T> applyPermutationMap(AffineMap map, llvm::ArrayRef<T> source) {
   SmallVector<T> result;
   result.reserve(map.getNumResults());
   for (AffineExpr expr : map.getResults()) {
-    if (auto dimExpr = expr.dyn_cast<AffineDimExpr>()) {
+    if (auto dimExpr = dyn_cast<AffineDimExpr>(expr)) {
       result.push_back(source[dimExpr.getPosition()]);
-    } else if (auto constExpr = expr.dyn_cast<AffineConstantExpr>()) {
+    } else if (auto constExpr = dyn_cast<AffineConstantExpr>(expr)) {
       assert(constExpr.getValue() == 0 &&
              "Unexpected constant in projected permutation map");
       result.push_back(0);
@@ -669,9 +669,9 @@ static void getMaxDimAndSymbol(ArrayRef<AffineExprContainer> exprsList,
   for (const auto &exprs : exprsList) {
     for (auto expr : exprs) {
       expr.walk([&maxDim, &maxSym](AffineExpr e) {
-        if (auto d = e.dyn_cast<AffineDimExpr>())
+        if (auto d = dyn_cast<AffineDimExpr>(e))
           maxDim = std::max(maxDim, static_cast<int64_t>(d.getPosition()));
-        if (auto s = e.dyn_cast<AffineSymbolExpr>())
+        if (auto s = dyn_cast<AffineSymbolExpr>(e))
           maxSym = std::max(maxSym, static_cast<int64_t>(s.getPosition()));
       });
     }

--- a/mlir/include/mlir/Interfaces/VectorInterfaces.td
+++ b/mlir/include/mlir/Interfaces/VectorInterfaces.td
@@ -120,8 +120,8 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         auto expr = $_op.getPermutationMap().getResult(idx);
-        return expr.template isa<::mlir::AffineConstantExpr>() &&
-               expr.template dyn_cast<::mlir::AffineConstantExpr>().getValue() == 0;
+        return ::llvm::isa<::mlir::AffineConstantExpr>(expr) &&
+               ::llvm::dyn_cast<::mlir::AffineConstantExpr>(expr).getValue() == 0;
       }]
     >,
     InterfaceMethod<
@@ -278,9 +278,9 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
           AffineExpr dim = std::get<0>(vecDims);
           int64_t size = std::get<1>(vecDims);
           // Skip broadcast.
-          if (dim.isa<AffineConstantExpr>())
+          if (isa<AffineConstantExpr>(dim))
             continue;
-          dimSizes[dim.cast<AffineDimExpr>().getPosition()] = size;
+          dimSizes[cast<AffineDimExpr>(dim).getPosition()] = size;
         }
         return dimSizes;
       }]

--- a/mlir/lib/Analysis/FlatLinearValueConstraints.cpp
+++ b/mlir/lib/Analysis/FlatLinearValueConstraints.cpp
@@ -305,7 +305,7 @@ static bool detectAsMod(const FlatLinearConstraints &cst, unsigned pos,
     // `var_n`), we can proceed.
     // TODO: Handle AffineSymbolExpr as well. There is no reason to restrict it
     // to dims themselves.
-    auto dimExpr = dividendExpr.dyn_cast<AffineDimExpr>();
+    auto dimExpr = dyn_cast<AffineDimExpr>(dividendExpr);
     if (!dimExpr)
       continue;
 

--- a/mlir/lib/CAPI/IR/AffineExpr.cpp
+++ b/mlir/lib/CAPI/IR/AffineExpr.cpp
@@ -66,7 +66,7 @@ MlirAffineExpr mlirAffineExprCompose(MlirAffineExpr affineExpr,
 //===----------------------------------------------------------------------===//
 
 bool mlirAffineExprIsADim(MlirAffineExpr affineExpr) {
-  return unwrap(affineExpr).isa<AffineDimExpr>();
+  return isa<AffineDimExpr>(unwrap(affineExpr));
 }
 
 MlirAffineExpr mlirAffineDimExprGet(MlirContext ctx, intptr_t position) {
@@ -74,7 +74,7 @@ MlirAffineExpr mlirAffineDimExprGet(MlirContext ctx, intptr_t position) {
 }
 
 intptr_t mlirAffineDimExprGetPosition(MlirAffineExpr affineExpr) {
-  return unwrap(affineExpr).cast<AffineDimExpr>().getPosition();
+  return cast<AffineDimExpr>(unwrap(affineExpr)).getPosition();
 }
 
 //===----------------------------------------------------------------------===//
@@ -82,7 +82,7 @@ intptr_t mlirAffineDimExprGetPosition(MlirAffineExpr affineExpr) {
 //===----------------------------------------------------------------------===//
 
 bool mlirAffineExprIsASymbol(MlirAffineExpr affineExpr) {
-  return unwrap(affineExpr).isa<AffineSymbolExpr>();
+  return isa<AffineSymbolExpr>(unwrap(affineExpr));
 }
 
 MlirAffineExpr mlirAffineSymbolExprGet(MlirContext ctx, intptr_t position) {
@@ -90,7 +90,7 @@ MlirAffineExpr mlirAffineSymbolExprGet(MlirContext ctx, intptr_t position) {
 }
 
 intptr_t mlirAffineSymbolExprGetPosition(MlirAffineExpr affineExpr) {
-  return unwrap(affineExpr).cast<AffineSymbolExpr>().getPosition();
+  return cast<AffineSymbolExpr>(unwrap(affineExpr)).getPosition();
 }
 
 //===----------------------------------------------------------------------===//
@@ -98,7 +98,7 @@ intptr_t mlirAffineSymbolExprGetPosition(MlirAffineExpr affineExpr) {
 //===----------------------------------------------------------------------===//
 
 bool mlirAffineExprIsAConstant(MlirAffineExpr affineExpr) {
-  return unwrap(affineExpr).isa<AffineConstantExpr>();
+  return isa<AffineConstantExpr>(unwrap(affineExpr));
 }
 
 MlirAffineExpr mlirAffineConstantExprGet(MlirContext ctx, int64_t constant) {
@@ -106,7 +106,7 @@ MlirAffineExpr mlirAffineConstantExprGet(MlirContext ctx, int64_t constant) {
 }
 
 int64_t mlirAffineConstantExprGetValue(MlirAffineExpr affineExpr) {
-  return unwrap(affineExpr).cast<AffineConstantExpr>().getValue();
+  return cast<AffineConstantExpr>(unwrap(affineExpr)).getValue();
 }
 
 //===----------------------------------------------------------------------===//
@@ -181,13 +181,13 @@ MlirAffineExpr mlirAffineCeilDivExprGet(MlirAffineExpr lhs,
 //===----------------------------------------------------------------------===//
 
 bool mlirAffineExprIsABinary(MlirAffineExpr affineExpr) {
-  return unwrap(affineExpr).isa<AffineBinaryOpExpr>();
+  return isa<AffineBinaryOpExpr>(unwrap(affineExpr));
 }
 
 MlirAffineExpr mlirAffineBinaryOpExprGetLHS(MlirAffineExpr affineExpr) {
-  return wrap(unwrap(affineExpr).cast<AffineBinaryOpExpr>().getLHS());
+  return wrap(cast<AffineBinaryOpExpr>(unwrap(affineExpr)).getLHS());
 }
 
 MlirAffineExpr mlirAffineBinaryOpExprGetRHS(MlirAffineExpr affineExpr) {
-  return wrap(unwrap(affineExpr).cast<AffineBinaryOpExpr>().getRHS());
+  return wrap(cast<AffineBinaryOpExpr>(unwrap(affineExpr)).getRHS());
 }

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -1390,7 +1390,7 @@ public:
     for (const auto &en :
          llvm::enumerate(transposeOp.getPermutation().getResults())) {
       int targetPos = en.index();
-      int sourcePos = en.value().cast<AffineDimExpr>().getPosition();
+      int sourcePos = cast<AffineDimExpr>(en.value()).getPosition();
       targetMemRef.setSize(rewriter, loc, targetPos,
                            viewMemRef.size(rewriter, loc, sourcePos));
       targetMemRef.setStride(rewriter, loc, targetPos,

--- a/mlir/lib/Conversion/SCFToGPU/SCFToGPU.cpp
+++ b/mlir/lib/Conversion/SCFToGPU/SCFToGPU.cpp
@@ -318,7 +318,7 @@ static Value deriveStaticUpperBound(Value upperBound,
 
   if (auto minOp = upperBound.getDefiningOp<AffineMinOp>()) {
     for (const AffineExpr &result : minOp.getMap().getResults()) {
-      if (auto constExpr = result.dyn_cast<AffineConstantExpr>()) {
+      if (auto constExpr = dyn_cast<AffineConstantExpr>(result)) {
         return rewriter.create<arith::ConstantIndexOp>(minOp.getLoc(),
                                                        constExpr.getValue());
       }

--- a/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
+++ b/mlir/lib/Conversion/VectorToGPU/VectorToGPU.cpp
@@ -61,7 +61,7 @@ static void getXferIndices(RewriterBase &rewriter, TransferOpType xferOp,
   Location loc = xferOp.getLoc();
   unsigned offsetsIdx = 0;
   for (auto expr : xferOp.getPermutationMap().getResults()) {
-    if (auto dim = expr.template dyn_cast<AffineDimExpr>()) {
+    if (auto dim = dyn_cast<AffineDimExpr>(expr)) {
       Value prevIdx = indices[dim.getPosition()];
       SmallVector<OpFoldResult, 3> dims(dimValues.begin(), dimValues.end());
       dims.push_back(prevIdx);
@@ -549,8 +549,7 @@ convertTransferReadOp(RewriterBase &rewriter, vector::TransferReadOp op,
   bool isTranspose = isTransposeMatrixLoadMap(map);
 
   // Handle broadcast by setting the stride to 0.
-  if (auto cstExpr =
-          map.getResult(isTranspose).dyn_cast<AffineConstantExpr>()) {
+  if (auto cstExpr = dyn_cast<AffineConstantExpr>(map.getResult(isTranspose))) {
     assert(cstExpr.getValue() == 0);
     stride = 0;
   }
@@ -682,8 +681,8 @@ static FailureOr<bool> isTransposed(vector::TransferReadOp op) {
   mlir::AffineExpr dN = map.getResult(1);
 
   //  Find the position of these expressions in the input.
-  auto exprM = dM.dyn_cast<AffineDimExpr>();
-  auto exprN = dN.dyn_cast<AffineDimExpr>();
+  auto exprM = dyn_cast<AffineDimExpr>(dM);
+  auto exprN = dyn_cast<AffineDimExpr>(dN);
 
   if (!exprM || !exprN) {
     LLVM_DEBUG(DBGS() << "Failed because expressions are not affine dim "

--- a/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
+++ b/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
@@ -62,7 +62,7 @@ static std::optional<int64_t> unpackedDim(OpTy xferOp) {
   // TODO: support 0-d corner case.
   assert(xferOp.getTransferRank() > 0 && "unexpected 0-d transfer");
   auto map = xferOp.getPermutationMap();
-  if (auto expr = map.getResult(0).template dyn_cast<AffineDimExpr>()) {
+  if (auto expr = dyn_cast<AffineDimExpr>(map.getResult(0))) {
     return expr.getPosition();
   }
   assert(xferOp.isBroadcastDim(0) &&
@@ -1295,7 +1295,7 @@ get1dMemrefIndices(OpBuilder &b, OpTy xferOp, Value iv,
   memrefIndices.append(indices.begin(), indices.end());
   assert(map.getNumResults() == 1 &&
          "Expected 1 permutation map result for 1D transfer");
-  if (auto expr = map.getResult(0).template dyn_cast<AffineDimExpr>()) {
+  if (auto expr = dyn_cast<AffineDimExpr>(map.getResult(0))) {
     Location loc = xferOp.getLoc();
     auto dim = expr.getPosition();
     AffineExpr d0, d1;

--- a/mlir/lib/Dialect/Affine/Analysis/AffineStructures.cpp
+++ b/mlir/lib/Dialect/Affine/Analysis/AffineStructures.cpp
@@ -167,10 +167,10 @@ FlatAffineValueConstraints::addDomainFromSliceMaps(ArrayRef<AffineMap> lbMaps,
         // iteration (e.g., lbMap.getResult(0) = 0, ubMap.getResult(0) = 1).
         // Make sure we skip those cases by checking that the lb result is not
         // just a constant.
-        !lbMap.getResult(0).isa<AffineConstantExpr>()) {
+        !isa<AffineConstantExpr>(lbMap.getResult(0))) {
       // Limited support: we expect the lb result to be just a loop dimension.
       // Not supported otherwise for now.
-      AffineDimExpr result = lbMap.getResult(0).dyn_cast<AffineDimExpr>();
+      AffineDimExpr result = dyn_cast<AffineDimExpr>(lbMap.getResult(0));
       if (!result)
         return failure();
 

--- a/mlir/lib/Dialect/Affine/Analysis/LoopAnalysis.cpp
+++ b/mlir/lib/Dialect/Affine/Analysis/LoopAnalysis.cpp
@@ -95,7 +95,7 @@ std::optional<uint64_t> mlir::affine::getConstantTripCount(AffineForOp forOp) {
   // Take the min if all trip counts are constant.
   std::optional<uint64_t> tripCount;
   for (auto resultExpr : map.getResults()) {
-    if (auto constExpr = resultExpr.dyn_cast<AffineConstantExpr>()) {
+    if (auto constExpr = dyn_cast<AffineConstantExpr>(resultExpr)) {
       if (tripCount.has_value())
         tripCount =
             std::min(*tripCount, static_cast<uint64_t>(constExpr.getValue()));
@@ -124,7 +124,7 @@ uint64_t mlir::affine::getLargestDivisorOfTripCount(AffineForOp forOp) {
   std::optional<uint64_t> gcd;
   for (auto resultExpr : map.getResults()) {
     uint64_t thisGcd;
-    if (auto constExpr = resultExpr.dyn_cast<AffineConstantExpr>()) {
+    if (auto constExpr = dyn_cast<AffineConstantExpr>(resultExpr)) {
       uint64_t tripCount = constExpr.getValue();
       // 0 iteration loops (greatest divisor is 2^64 - 1).
       if (tripCount == 0)
@@ -235,9 +235,9 @@ static bool isContiguousAccess(Value iv, LoadOrStoreOp memoryOp,
     SmallVector<Value, 4> exprOperands;
     auto resultExpr = accessMap.getResult(i);
     resultExpr.walk([&](AffineExpr expr) {
-      if (auto dimExpr = expr.dyn_cast<AffineDimExpr>())
+      if (auto dimExpr = dyn_cast<AffineDimExpr>(expr))
         exprOperands.push_back(mapOperands[dimExpr.getPosition()]);
-      else if (auto symExpr = expr.dyn_cast<AffineSymbolExpr>())
+      else if (auto symExpr = dyn_cast<AffineSymbolExpr>(expr))
         exprOperands.push_back(mapOperands[numDims + symExpr.getPosition()]);
     });
     // Check access invariance of each operand in 'exprOperands'.

--- a/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
+++ b/mlir/lib/Dialect/Affine/Analysis/Utils.cpp
@@ -758,12 +758,12 @@ std::optional<bool> ComputationSliceState::isSliceMaximalFastCheck() const {
         // iteration (e.g., lbMap.getResult(0) = 0, ubMap.getResult(0) = 1).
         // Make sure we skip those cases by checking that the lb result is not
         // just a constant.
-        lbMap.getResult(0).isa<AffineConstantExpr>())
+        isa<AffineConstantExpr>(lbMap.getResult(0)))
       return std::nullopt;
 
     // Limited support: we expect the lb result to be just a loop dimension for
     // now.
-    AffineDimExpr result = lbMap.getResult(0).dyn_cast<AffineDimExpr>();
+    AffineDimExpr result = dyn_cast<AffineDimExpr>(lbMap.getResult(0));
     if (!result)
       return std::nullopt;
 
@@ -791,10 +791,10 @@ std::optional<bool> ComputationSliceState::isSliceMaximalFastCheck() const {
     AffineExpr dstLbResult = dstLbMap.getResult(0);
     AffineExpr srcUbResult = srcUbMap.getResult(0);
     AffineExpr dstUbResult = dstUbMap.getResult(0);
-    if (!srcLbResult.isa<AffineConstantExpr>() ||
-        !srcUbResult.isa<AffineConstantExpr>() ||
-        !dstLbResult.isa<AffineConstantExpr>() ||
-        !dstUbResult.isa<AffineConstantExpr>())
+    if (!isa<AffineConstantExpr>(srcLbResult) ||
+        !isa<AffineConstantExpr>(srcUbResult) ||
+        !isa<AffineConstantExpr>(dstLbResult) ||
+        !isa<AffineConstantExpr>(dstUbResult))
       return std::nullopt;
 
     // Check if src and dst loop bounds are the same. If not, we can guarantee
@@ -1583,7 +1583,7 @@ static std::optional<uint64_t> getConstDifference(AffineMap lbMap,
   AffineExpr ubExpr(ubMap.getResult(0));
   auto loopSpanExpr = simplifyAffineExpr(ubExpr - lbExpr, lbMap.getNumDims(),
                                          lbMap.getNumSymbols());
-  auto cExpr = loopSpanExpr.dyn_cast<AffineConstantExpr>();
+  auto cExpr = dyn_cast<AffineConstantExpr>(loopSpanExpr);
   if (!cExpr)
     return std::nullopt;
   return cExpr.getValue();

--- a/mlir/lib/Dialect/Affine/Transforms/DecomposeAffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/DecomposeAffineOps.cpp
@@ -102,12 +102,12 @@ FailureOr<AffineApplyOp> mlir::affine::decompose(RewriterBase &rewriter,
     return rewriter.notifyMatchFailure(op, "expected no dims");
 
   AffineExpr remainingExp = m.getResult(0);
-  auto binExpr = remainingExp.dyn_cast<AffineBinaryOpExpr>();
+  auto binExpr = dyn_cast<AffineBinaryOpExpr>(remainingExp);
   if (!binExpr)
     return rewriter.notifyMatchFailure(op, "terminal affine.apply");
 
-  if (!binExpr.getLHS().isa<AffineBinaryOpExpr>() &&
-      !binExpr.getRHS().isa<AffineBinaryOpExpr>())
+  if (!isa<AffineBinaryOpExpr>(binExpr.getLHS()) &&
+      !isa<AffineBinaryOpExpr>(binExpr.getRHS()))
     return rewriter.notifyMatchFailure(op, "terminal affine.apply");
 
   bool supportedKind = ((binExpr.getKind() == AffineExprKind::Add) ||
@@ -123,7 +123,7 @@ FailureOr<AffineApplyOp> mlir::affine::decompose(RewriterBase &rewriter,
   MLIRContext *ctx = op->getContext();
   SmallVector<AffineExpr> subExpressions;
   while (true) {
-    auto currentBinExpr = remainingExp.dyn_cast<AffineBinaryOpExpr>();
+    auto currentBinExpr = dyn_cast<AffineBinaryOpExpr>(remainingExp);
     if (!currentBinExpr || currentBinExpr.getKind() != binExpr.getKind()) {
       subExpressions.push_back(remainingExp);
       LLVM_DEBUG(DBGS() << "--terminal: " << subExpressions.back() << "\n");

--- a/mlir/lib/Dialect/Affine/Transforms/ReifyValueBounds.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/ReifyValueBounds.cpp
@@ -70,9 +70,9 @@ OpFoldResult affine::materializeComputedBound(
         b.getIndexAttr(boundMap.getSingleConstantResult()));
   }
   // No affine.apply op is needed if the bound is a single SSA value.
-  if (auto expr = boundMap.getResult(0).dyn_cast<AffineDimExpr>())
+  if (auto expr = dyn_cast<AffineDimExpr>(boundMap.getResult(0)))
     return static_cast<OpFoldResult>(operands[expr.getPosition()]);
-  if (auto expr = boundMap.getResult(0).dyn_cast<AffineSymbolExpr>())
+  if (auto expr = dyn_cast<AffineSymbolExpr>(boundMap.getResult(0)))
     return static_cast<OpFoldResult>(
         operands[expr.getPosition() + boundMap.getNumDims()]);
   // General case: build affine.apply op.

--- a/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
@@ -2065,7 +2065,7 @@ static LogicalResult generateCopy(
 
     // Set copy start location for this dimension in the lower memory space
     // memref.
-    if (auto caf = offset.dyn_cast<AffineConstantExpr>()) {
+    if (auto caf = dyn_cast<AffineConstantExpr>(offset)) {
       auto indexVal = caf.getValue();
       if (indexVal == 0) {
         memIndices.push_back(zeroIndex);

--- a/mlir/lib/Dialect/Arith/Transforms/ReifyValueBounds.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/ReifyValueBounds.cpp
@@ -24,34 +24,34 @@ static Value buildArithValue(OpBuilder &b, Location loc, AffineMap map,
     switch (e.getKind()) {
     case AffineExprKind::Constant:
       return b.create<ConstantIndexOp>(loc,
-                                       e.cast<AffineConstantExpr>().getValue());
+                                       cast<AffineConstantExpr>(e).getValue());
     case AffineExprKind::DimId:
-      return operands[e.cast<AffineDimExpr>().getPosition()];
+      return operands[cast<AffineDimExpr>(e).getPosition()];
     case AffineExprKind::SymbolId:
-      return operands[e.cast<AffineSymbolExpr>().getPosition() +
+      return operands[cast<AffineSymbolExpr>(e).getPosition() +
                       map.getNumDims()];
     case AffineExprKind::Add: {
-      auto binaryExpr = e.cast<AffineBinaryOpExpr>();
+      auto binaryExpr = cast<AffineBinaryOpExpr>(e);
       return b.create<AddIOp>(loc, buildExpr(binaryExpr.getLHS()),
                               buildExpr(binaryExpr.getRHS()));
     }
     case AffineExprKind::Mul: {
-      auto binaryExpr = e.cast<AffineBinaryOpExpr>();
+      auto binaryExpr = cast<AffineBinaryOpExpr>(e);
       return b.create<MulIOp>(loc, buildExpr(binaryExpr.getLHS()),
                               buildExpr(binaryExpr.getRHS()));
     }
     case AffineExprKind::FloorDiv: {
-      auto binaryExpr = e.cast<AffineBinaryOpExpr>();
+      auto binaryExpr = cast<AffineBinaryOpExpr>(e);
       return b.create<DivSIOp>(loc, buildExpr(binaryExpr.getLHS()),
                                buildExpr(binaryExpr.getRHS()));
     }
     case AffineExprKind::CeilDiv: {
-      auto binaryExpr = e.cast<AffineBinaryOpExpr>();
+      auto binaryExpr = cast<AffineBinaryOpExpr>(e);
       return b.create<CeilDivSIOp>(loc, buildExpr(binaryExpr.getLHS()),
                                    buildExpr(binaryExpr.getRHS()));
     }
     case AffineExprKind::Mod: {
-      auto binaryExpr = e.cast<AffineBinaryOpExpr>();
+      auto binaryExpr = cast<AffineBinaryOpExpr>(e);
       return b.create<RemSIOp>(loc, buildExpr(binaryExpr.getLHS()),
                                buildExpr(binaryExpr.getRHS()));
     }
@@ -106,9 +106,9 @@ reifyValueBound(OpBuilder &b, Location loc, presburger::BoundType type,
         b.getIndexAttr(boundMap.getSingleConstantResult()));
   }
   // No arith ops are needed if the bound is a single SSA value.
-  if (auto expr = boundMap.getResult(0).dyn_cast<AffineDimExpr>())
+  if (auto expr = dyn_cast<AffineDimExpr>(boundMap.getResult(0)))
     return static_cast<OpFoldResult>(operands[expr.getPosition()]);
-  if (auto expr = boundMap.getResult(0).dyn_cast<AffineSymbolExpr>())
+  if (auto expr = dyn_cast<AffineSymbolExpr>(boundMap.getResult(0)))
     return static_cast<OpFoldResult>(
         operands[expr.getPosition() + boundMap.getNumDims()]);
   // General case: build Arith ops.

--- a/mlir/lib/Dialect/GPU/TransformOps/GPUTransformOps.cpp
+++ b/mlir/lib/Dialect/GPU/TransformOps/GPUTransformOps.cpp
@@ -151,7 +151,7 @@ gpuMmaUnrollOrder(vector::ContractionOp contract) {
 
   llvm::SmallDenseSet<int64_t> dims;
   for (AffineExpr expr : contract.getIndexingMapsArray()[0].getResults()) {
-    dims.insert(expr.cast<AffineDimExpr>().getPosition());
+    dims.insert(cast<AffineDimExpr>(expr).getPosition());
   }
   // Then parallel dimensions that are part of Lhs as we want to re-use Lhs.
   for (auto [index, iter] : llvm::enumerate(contract.getIteratorTypes())) {

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -2178,7 +2178,7 @@ static void populateMap(LinalgOp linalgOp, MutableArrayRef<OpOperand> operands,
     for (unsigned i = 0; i < sourceShape.size(); i++) {
       if (sourceType.isDynamicDim(i))
         continue;
-      if (auto affineDimExpr = sourceMap.getResult(i).dyn_cast<AffineDimExpr>())
+      if (auto affineDimExpr = dyn_cast<AffineDimExpr>(sourceMap.getResult(i)))
         affineExprToSize.try_emplace(affineDimExpr, sourceShape[i]);
     }
   }

--- a/mlir/lib/Dialect/Linalg/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -29,10 +29,10 @@ struct IndexOpInterface
     cstr.bound(value) >= 0;
 
     // index < dim size
-    int64_t flatDimPos = linalgOp.getShapesToLoopsMap()
-                             .getResult(indexOp.getDim())
-                             .cast<AffineDimExpr>()
-                             .getPosition();
+    int64_t flatDimPos =
+        cast<AffineDimExpr>(
+            linalgOp.getShapesToLoopsMap().getResult(indexOp.getDim()))
+            .getPosition();
     // Find the `flatDimPos`-th operand dimension.
     int64_t flatDimCtr = 0;
     for (Value operand : linalgOp->getOperands()) {

--- a/mlir/lib/Dialect/Linalg/Transforms/BubbleUpExtractSlice.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/BubbleUpExtractSlice.cpp
@@ -107,7 +107,7 @@ struct BubbleUpExtractSliceOpPattern
                                           rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> tileSizes = sizeBounds;
     for (auto const &result : enumerate(indexingMap.getResults())) {
-      unsigned position = result.value().cast<AffineDimExpr>().getPosition();
+      unsigned position = cast<AffineDimExpr>(result.value()).getPosition();
       tileOffsets[position] = sliceOp.getMixedOffsets()[result.index()];
       tileSizes[position] = sliceOp.getMixedSizes()[result.index()];
     }

--- a/mlir/lib/Dialect/Linalg/Transforms/ConstantFold.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/ConstantFold.cpp
@@ -148,7 +148,7 @@ public:
       SmallVector<unsigned> dims;
       dims.reserve(map.getNumResults());
       for (AffineExpr result : map.getResults()) {
-        dims.push_back(result.cast<AffineDimExpr>().getPosition());
+        dims.push_back(cast<AffineDimExpr>(result).getPosition());
       }
       return dims;
     };

--- a/mlir/lib/Dialect/Linalg/Transforms/DecomposeLinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/DecomposeLinalgOps.cpp
@@ -122,7 +122,7 @@ SmallVector<OpFoldResult> permuteValues(ArrayRef<OpFoldResult> values,
   SmallVector<OpFoldResult> permutedValues(values.size());
   for (const auto &position :
        llvm::enumerate(llvm::map_range(map.getResults(), [](AffineExpr expr) {
-         return expr.cast<AffineDimExpr>().getPosition();
+         return cast<AffineDimExpr>(expr).getPosition();
        })))
     permutedValues[position.value()] = values[position.index()];
   return permutedValues;

--- a/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp
@@ -349,14 +349,14 @@ static UnitExtentReplacementInfo dropUnitExtentFromOperandMetadata(
   ArrayRef<AffineExpr> exprs = indexingMap.getResults();
 
   auto isUnitDim = [&](unsigned dim) {
-    if (auto dimExpr = exprs[dim].dyn_cast<AffineDimExpr>()) {
+    if (auto dimExpr = dyn_cast<AffineDimExpr>(exprs[dim])) {
       unsigned oldPosition = dimExpr.getPosition();
       return !oldDimsToNewDimsMap.count(oldPosition);
     }
     // Handle the other case where the shape is 1, and is accessed using a
     // constant 0.
     if (operandShape[dim] == 1) {
-      auto constAffineExpr = exprs[dim].dyn_cast<AffineConstantExpr>();
+      auto constAffineExpr = dyn_cast<AffineConstantExpr>(exprs[dim]);
       return constAffineExpr && constAffineExpr.getValue() == 0;
     }
     return false;
@@ -411,7 +411,7 @@ LogicalResult linalg::dropUnitDims(RewriterBase &rewriter, GenericOp genericOp,
                                                allowedUnitDims.end());
   llvm::SmallDenseSet<unsigned> unitDims;
   for (const auto &expr : enumerate(invertedMap.getResults())) {
-    if (AffineDimExpr dimExpr = expr.value().dyn_cast<AffineDimExpr>()) {
+    if (AffineDimExpr dimExpr = dyn_cast<AffineDimExpr>(expr.value())) {
       if (dims[dimExpr.getPosition()] == 1 &&
           unitDimsFilter.count(expr.index()))
         unitDims.insert(expr.index());

--- a/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp
@@ -122,7 +122,7 @@ bool mlir::linalg::areElementwiseOpsFusable(OpOperand *fusedOperand) {
 
     auto addToCoveredDims = [&](AffineMap map) {
       for (auto result : map.getResults())
-        if (auto dimExpr = result.dyn_cast<AffineDimExpr>())
+        if (auto dimExpr = dyn_cast<AffineDimExpr>(result))
           coveredDims[dimExpr.getPosition()] = true;
     };
 
@@ -587,7 +587,7 @@ LogicalResult ExpansionInfo::compute(LinalgOp linalgOp,
   SmallVector<unsigned> numExpandedDims(fusedIndexMap.getNumDims(), 1);
   expandedShapeMap.resize(fusedIndexMap.getNumDims());
   for (const auto &resultExpr : llvm::enumerate(fusedIndexMap.getResults())) {
-    unsigned pos = resultExpr.value().cast<AffineDimExpr>().getPosition();
+    unsigned pos = cast<AffineDimExpr>(resultExpr.value()).getPosition();
     AffineMap foldedDims = reassociationMaps[resultExpr.index()];
     numExpandedDims[pos] = foldedDims.getNumResults();
     ArrayRef<int64_t> shape =
@@ -645,7 +645,7 @@ getIndexingMapInExpandedOp(OpBuilder &builder, AffineMap indexingMap,
                            const ExpansionInfo &expansionInfo) {
   SmallVector<AffineExpr> newExprs;
   for (AffineExpr expr : indexingMap.getResults()) {
-    unsigned pos = expr.cast<AffineDimExpr>().getPosition();
+    unsigned pos = cast<AffineDimExpr>(expr).getPosition();
     SmallVector<AffineExpr, 4> expandedExprs = llvm::to_vector<4>(
         llvm::map_range(expansionInfo.getExpandedDims(pos), [&](int64_t v) {
           return builder.getAffineDimExpr(static_cast<unsigned>(v));
@@ -664,7 +664,7 @@ static RankedTensorType getExpandedType(RankedTensorType originalType,
                                         const ExpansionInfo &expansionInfo) {
   SmallVector<int64_t> expandedShape;
   for (AffineExpr expr : indexingMap.getResults()) {
-    unsigned dim = expr.cast<AffineDimExpr>().getPosition();
+    unsigned dim = cast<AffineDimExpr>(expr).getPosition();
     auto dimExpansion = expansionInfo.getExpandedShapeOfDim(dim);
     expandedShape.append(dimExpansion.begin(), dimExpansion.end());
   }
@@ -683,7 +683,7 @@ getReassociationForExpansion(AffineMap indexingMap,
   SmallVector<ReassociationIndices> reassociation;
   unsigned numReshapeDims = 0;
   for (AffineExpr expr : indexingMap.getResults()) {
-    unsigned dim = expr.cast<AffineDimExpr>().getPosition();
+    unsigned dim = cast<AffineDimExpr>(expr).getPosition();
     auto numExpandedDims = expansionInfo.getExpandedDims(dim).size();
     SmallVector<int64_t, 2> indices = llvm::to_vector<2>(
         llvm::seq<int64_t>(numReshapeDims, numReshapeDims + numExpandedDims));
@@ -1002,9 +1002,7 @@ getDomainReassociation(AffineMap indexingMap,
 
   ReassociationIndices domainReassociation = llvm::to_vector<4>(
       llvm::map_range(rangeReassociation, [&](int64_t pos) -> int64_t {
-        return indexingMap.getResults()[pos]
-            .cast<AffineDimExpr>()
-            .getPosition();
+        return cast<AffineDimExpr>(indexingMap.getResults()[pos]).getPosition();
       }));
   // The projected permutation semantics ensures that there is no repetition of
   // the domain indices.
@@ -1026,7 +1024,7 @@ bool mlir::linalg::isDimSequencePreserved(AffineMap indexingMap,
 
   unsigned dimSequenceStart = dimSequence[0];
   for (const auto &expr : enumerate(indexingMap.getResults())) {
-    unsigned dimInMapStart = expr.value().cast<AffineDimExpr>().getPosition();
+    unsigned dimInMapStart = cast<AffineDimExpr>(expr.value()).getPosition();
     // 1.  Check if this start of the sequence.
     if (dimInMapStart == dimSequenceStart) {
       if (expr.index() + dimSequence.size() > indexingMap.getNumResults())
@@ -1034,8 +1032,8 @@ bool mlir::linalg::isDimSequencePreserved(AffineMap indexingMap,
       // 1a. Check if sequence is preserved.
       for (const auto &dimInSequence : enumerate(dimSequence)) {
         unsigned dimInMap =
-            indexingMap.getResult(expr.index() + dimInSequence.index())
-                .cast<AffineDimExpr>()
+            cast<AffineDimExpr>(
+                indexingMap.getResult(expr.index() + dimInSequence.index()))
                 .getPosition();
         if (dimInMap != dimInSequence.value())
           return false;
@@ -1330,7 +1328,7 @@ getCollapsedOpIndexingMap(AffineMap indexingMap,
   auto origOpToCollapsedOpMapping =
       collapsingInfo.getOrigOpToCollapsedOpMapping();
   for (auto expr : indexingMap.getResults()) {
-    unsigned dim = expr.cast<AffineDimExpr>().getPosition();
+    unsigned dim = cast<AffineDimExpr>(expr).getPosition();
     // If the dim is not the first of the collapsed dim, do nothing.
     if (origOpToCollapsedOpMapping[dim].second != 0)
       continue;
@@ -1356,7 +1354,7 @@ getOperandReassociation(AffineMap indexingMap,
       collapsingInfo.getCollapsedOpToOrigOpMapping();
   while (counter < indexingMap.getNumResults()) {
     unsigned dim =
-        indexingMap.getResult(counter).cast<AffineDimExpr>().getPosition();
+        cast<AffineDimExpr>(indexingMap.getResult(counter)).getPosition();
     // This is the start of a collapsed dimensions of the iteration that
     // is gauranteed to be preserved in the indexing map. The number of folded
     // dims is obtained from the collapsed op to original op mapping.

--- a/mlir/lib/Dialect/Linalg/Transforms/Fusion.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Fusion.cpp
@@ -87,10 +87,10 @@ getShapeDefiningLoopRange(LinalgOp op, unsigned loopDepth,
                << "getShapeDefiningLoopRange map: " << map << "\n");
     SmallVector<Value, 8> shapeRanges(map.getNumResults(), nullptr);
     for (const auto &en : llvm::enumerate(map.getResults())) {
-      auto dimExpr = en.value().dyn_cast<AffineDimExpr>();
+      auto dimExpr = dyn_cast<AffineDimExpr>(en.value());
       if (!dimExpr)
         continue;
-      if (loopDepth == en.value().cast<AffineDimExpr>().getPosition()) {
+      if (loopDepth == cast<AffineDimExpr>(en.value()).getPosition()) {
         LLVM_DEBUG(llvm::dbgs() << "getShapeDefiningLoopRange loopDepth: "
                                 << loopDepth << "\n");
         LLVM_DEBUG(llvm::dbgs() << "getShapeDefiningLoopRange shape: "
@@ -196,7 +196,7 @@ static LinalgOp fuse(OpBuilder &b, LinalgOp producerOp, AffineMap producerMap,
   DenseMap<unsigned, Range> fusedLoopsAndRanges;
   Value shapedOperand = consumerOpOperand.get();
   for (const auto &en : llvm::enumerate(producerMap.getResults())) {
-    unsigned posInProducerLoop = en.value().cast<AffineDimExpr>().getPosition();
+    unsigned posInProducerLoop = cast<AffineDimExpr>(en.value()).getPosition();
     fusedLoopsAndRanges[posInProducerLoop] = getRangeFromOperandShape(
         b, consumerOpOperand.getOwner()->getLoc(), shapedOperand, en.index());
   }

--- a/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp
@@ -298,13 +298,13 @@ struct FoldAffineOp : public RewritePattern {
 
     AffineExpr expr = map.getResult(0);
     if (map.getNumInputs() == 0) {
-      if (auto val = expr.dyn_cast<AffineConstantExpr>()) {
+      if (auto val = dyn_cast<AffineConstantExpr>(expr)) {
         rewriter.replaceOpWithNewOp<arith::ConstantIndexOp>(op, val.getValue());
         return success();
       }
       return failure();
     }
-    if (expr.dyn_cast<AffineDimExpr>() || expr.dyn_cast<AffineSymbolExpr>()) {
+    if (dyn_cast<AffineDimExpr>(expr) || dyn_cast<AffineSymbolExpr>(expr)) {
       rewriter.replaceOp(op, op->getOperand(0));
       return success();
     }

--- a/mlir/lib/Dialect/Linalg/Transforms/Tiling.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Tiling.cpp
@@ -553,7 +553,7 @@ tileLinalgOpImpl(RewriterBase &b, LinalgOp op, ArrayRef<OpFoldResult> tileSizes,
     if (!options.interchangeVector.empty()) {
       for (AffineExpr result : invPermutationMap.getResults())
         interchangedIvs.push_back(
-            ivs[result.cast<AffineDimExpr>().getPosition()]);
+            ivs[cast<AffineDimExpr>(result).getPosition()]);
     } else {
       interchangedIvs.assign(ivs.begin(), ivs.end());
     }

--- a/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TilingInterfaceImpl.cpp
@@ -192,7 +192,7 @@ struct LinalgOpTilingInterface
     }
     for (const auto &resultExpr : llvm::enumerate(indexingMap.getResults())) {
       unsigned dimPosition =
-          resultExpr.value().template cast<AffineDimExpr>().getPosition();
+          cast<AffineDimExpr>(resultExpr.value()).getPosition();
       iterationTileOffsets[dimPosition] = offsets[resultExpr.index()];
       iterationTileSizes[dimPosition] = sizes[resultExpr.index()];
     }

--- a/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
@@ -176,8 +176,7 @@ packLinalgMetadataOnce(SmallVectorImpl<AffineMap> &indexingMaps,
     }
 
     // We can only pack AffineDimExpr atm.
-    if (!map.getResult(maybeOperandDimensionToPack.value())
-             .isa<AffineDimExpr>())
+    if (!isa<AffineDimExpr>(map.getResult(maybeOperandDimensionToPack.value())))
       return failure();
 
     // Add `newDim` to the results of the map.

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -1297,7 +1297,7 @@ vectorizeAsLinalgGeneric(RewriterBase &rewriter, VectorizationState &state,
     SmallVector<int64_t> zeroPos;
     auto results = indexingMap.getResults();
     for (const auto &result : llvm::enumerate(results)) {
-      if (result.value().isa<AffineConstantExpr>()) {
+      if (isa<AffineConstantExpr>(result.value())) {
         zeroPos.push_back(result.index());
       }
     }

--- a/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
@@ -65,7 +65,7 @@ struct TileCheck : public AffineExprVisitor<TileCheck> {
     visit(expr.getLHS());
     visit(expr.getRHS());
     if (expr.getKind() == mlir::AffineExprKind::Mul)
-      assert(expr.getRHS().cast<AffineConstantExpr>().getValue() > 0 &&
+      assert(cast<AffineConstantExpr>(expr.getRHS()).getValue() > 0 &&
              "nonpositive multiplying coefficient");
   }
   bool isTiled = false;

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -3188,7 +3188,7 @@ static MemRefType inferTransposeResultType(MemRefType memRefType,
   SmallVector<int64_t> sizes(rank, 0);
   SmallVector<int64_t> strides(rank, 1);
   for (const auto &en : llvm::enumerate(permutationMap.getResults())) {
-    unsigned position = en.value().cast<AffineDimExpr>().getPosition();
+    unsigned position = cast<AffineDimExpr>(en.value()).getPosition();
     sizes[en.index()] = originalSizes[position];
     strides[en.index()] = originalStrides[position];
   }

--- a/mlir/lib/Dialect/Mesh/Interfaces/ShardingInterface.cpp
+++ b/mlir/lib/Dialect/Mesh/Interfaces/ShardingInterface.cpp
@@ -34,7 +34,7 @@ checkOperandAffineExprRecursively(AffineExpr expr,
                                   SmallVectorImpl<bool> &seenIds) {
   switch (expr.getKind()) {
   case AffineExprKind::Add: {
-    auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+    auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
     AffineExpr lhs = binOpExpr.getLHS();
     AffineExpr rhs = binOpExpr.getRHS();
     if (failed(checkOperandAffineExprRecursively(lhs, seenIds)))
@@ -44,7 +44,7 @@ checkOperandAffineExprRecursively(AffineExpr expr,
     return success();
   }
   case AffineExprKind::Mul: {
-    auto binOpExpr = expr.cast<AffineBinaryOpExpr>();
+    auto binOpExpr = cast<AffineBinaryOpExpr>(expr);
     AffineExpr lhs = binOpExpr.getLHS();
     AffineExpr rhs = binOpExpr.getRHS();
     AffineExpr dimExpr;
@@ -56,14 +56,14 @@ checkOperandAffineExprRecursively(AffineExpr expr,
       dimExpr = rhs;
     } else
       return failure();
-    unsigned position = dimExpr.cast<AffineDimExpr>().getPosition();
+    unsigned position = cast<AffineDimExpr>(dimExpr).getPosition();
     if ((size_t)position >= seenIds.size() || seenIds[position])
       return failure();
     seenIds[position] = true;
     return success();
   }
   case AffineExprKind::DimId: {
-    unsigned position = expr.cast<AffineDimExpr>().getPosition();
+    unsigned position = cast<AffineDimExpr>(expr).getPosition();
     if ((size_t)position >= seenIds.size() || seenIds[position])
       return failure();
     seenIds[position] = true;
@@ -280,7 +280,7 @@ FailureOr<ShardingOption> mesh::detail::defaultGetShardingOption(
     for (auto it : llvm::zip(map.getResults(), shardAttr.getSplitAxes())) {
       AffineExpr expr = std::get<0>(it);
       ArrayRef<int32_t> axes = std::get<1>(it).asArrayRef();
-      auto dim = expr.cast<AffineDimExpr>();
+      auto dim = cast<AffineDimExpr>(expr);
       unsigned index = dim.getPosition();
       visitedLoopIndices.insert(index);
       if (failed(fillShardingOption(op, shardingOption, shardAttr.getCluster(),
@@ -416,7 +416,7 @@ static LogicalResult addShardOp(OpBuilder &b, OpResult result,
     AffineExpr expr = it.value();
     // `expr` must be an `AffineDimExpr` because `map` is verified by
     // isProjectedPermutation
-    auto dim = expr.cast<AffineDimExpr>();
+    auto dim = cast<AffineDimExpr>(expr);
     unsigned loopIdx = dim.getPosition();
     if (loopIdx < shardingOption.shardingArray.size())
       splitAxes[it.index()].append(shardingOption.shardingArray[loopIdx]);

--- a/mlir/lib/Dialect/SCF/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/SCF/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -75,11 +75,11 @@ struct ForOpInterface
     // Check if computed bound equals the corresponding iter_arg.
     Value singleValue = nullptr;
     std::optional<int64_t> singleDim;
-    if (auto dimExpr = bound.getResult(0).dyn_cast<AffineDimExpr>()) {
+    if (auto dimExpr = dyn_cast<AffineDimExpr>(bound.getResult(0))) {
       int64_t idx = dimExpr.getPosition();
       singleValue = boundOperands[idx].first;
       singleDim = boundOperands[idx].second;
-    } else if (auto symExpr = bound.getResult(0).dyn_cast<AffineSymbolExpr>()) {
+    } else if (auto symExpr = dyn_cast<AffineSymbolExpr>(bound.getResult(0))) {
       int64_t idx = symExpr.getPosition() + bound.getNumDims();
       singleValue = boundOperands[idx].first;
       singleDim = boundOperands[idx].second;

--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -51,7 +51,7 @@ static void specializeParallelLoopForUnrolling(ParallelOp op) {
       return;
     int64_t minConstant = std::numeric_limits<int64_t>::max();
     for (AffineExpr expr : minOp.getMap().getResults()) {
-      if (auto constantIndex = expr.dyn_cast<AffineConstantExpr>())
+      if (auto constantIndex = dyn_cast<AffineConstantExpr>(expr))
         minConstant = std::min(minConstant, constantIndex.getValue());
     }
     if (minConstant == std::numeric_limits<int64_t>::max())
@@ -87,7 +87,7 @@ static void specializeForLoopForUnrolling(ForOp op) {
     return;
   int64_t minConstant = std::numeric_limits<int64_t>::max();
   for (AffineExpr expr : minOp.getMap().getResults()) {
-    if (auto constantIndex = expr.dyn_cast<AffineConstantExpr>())
+    if (auto constantIndex = dyn_cast<AffineConstantExpr>(expr))
       minConstant = std::min(minConstant, constantIndex.getValue());
   }
   if (minConstant == std::numeric_limits<int64_t>::max())

--- a/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMap.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMap.cpp
@@ -24,61 +24,61 @@ Var DimLvlExpr::castAnyVar() const {
 }
 
 std::optional<Var> DimLvlExpr::dyn_castAnyVar() const {
-  if (const auto s = expr.dyn_cast_or_null<AffineSymbolExpr>())
+  if (const auto s = dyn_cast_or_null<AffineSymbolExpr>(expr))
     return SymVar(s);
-  if (const auto x = expr.dyn_cast_or_null<AffineDimExpr>())
+  if (const auto x = dyn_cast_or_null<AffineDimExpr>(expr))
     return Var(getAllowedVarKind(), x);
   return std::nullopt;
 }
 
 SymVar DimLvlExpr::castSymVar() const {
-  return SymVar(expr.cast<AffineSymbolExpr>());
+  return SymVar(llvm::cast<AffineSymbolExpr>(expr));
 }
 
 std::optional<SymVar> DimLvlExpr::dyn_castSymVar() const {
-  if (const auto s = expr.dyn_cast_or_null<AffineSymbolExpr>())
+  if (const auto s = dyn_cast_or_null<AffineSymbolExpr>(expr))
     return SymVar(s);
   return std::nullopt;
 }
 
 Var DimLvlExpr::castDimLvlVar() const {
-  return Var(getAllowedVarKind(), expr.cast<AffineDimExpr>());
+  return Var(getAllowedVarKind(), llvm::cast<AffineDimExpr>(expr));
 }
 
 std::optional<Var> DimLvlExpr::dyn_castDimLvlVar() const {
-  if (const auto x = expr.dyn_cast_or_null<AffineDimExpr>())
+  if (const auto x = dyn_cast_or_null<AffineDimExpr>(expr))
     return Var(getAllowedVarKind(), x);
   return std::nullopt;
 }
 
 int64_t DimLvlExpr::castConstantValue() const {
-  return expr.cast<AffineConstantExpr>().getValue();
+  return llvm::cast<AffineConstantExpr>(expr).getValue();
 }
 
 std::optional<int64_t> DimLvlExpr::dyn_castConstantValue() const {
-  const auto k = expr.dyn_cast_or_null<AffineConstantExpr>();
+  const auto k = dyn_cast_or_null<AffineConstantExpr>(expr);
   return k ? std::make_optional(k.getValue()) : std::nullopt;
 }
 
 bool DimLvlExpr::hasConstantValue(int64_t val) const {
-  const auto k = expr.dyn_cast_or_null<AffineConstantExpr>();
+  const auto k = dyn_cast_or_null<AffineConstantExpr>(expr);
   return k && k.getValue() == val;
 }
 
 DimLvlExpr DimLvlExpr::getLHS() const {
-  const auto binop = expr.dyn_cast_or_null<AffineBinaryOpExpr>();
+  const auto binop = dyn_cast_or_null<AffineBinaryOpExpr>(expr);
   return DimLvlExpr(kind, binop ? binop.getLHS() : nullptr);
 }
 
 DimLvlExpr DimLvlExpr::getRHS() const {
-  const auto binop = expr.dyn_cast_or_null<AffineBinaryOpExpr>();
+  const auto binop = dyn_cast_or_null<AffineBinaryOpExpr>(expr);
   return DimLvlExpr(kind, binop ? binop.getRHS() : nullptr);
 }
 
 std::tuple<DimLvlExpr, AffineExprKind, DimLvlExpr>
 DimLvlExpr::unpackBinop() const {
   const auto ak = getAffineKind();
-  const auto binop = expr.dyn_cast<AffineBinaryOpExpr>();
+  const auto binop = llvm::dyn_cast<AffineBinaryOpExpr>(expr);
   const DimLvlExpr lhs(kind, binop ? binop.getLHS() : nullptr);
   const DimLvlExpr rhs(kind, binop ? binop.getRHS() : nullptr);
   return {lhs, ak, rhs};

--- a/mlir/lib/Dialect/SparseTensor/Transforms/CodegenUtils.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/CodegenUtils.cpp
@@ -723,19 +723,19 @@ Value sparse_tensor::genMapBuffers(OpBuilder &builder, Location loc,
     uint64_t cf = 0, cm = 0;
     switch (exp.getKind()) {
     case AffineExprKind::DimId: {
-      d = exp.cast<AffineDimExpr>().getPosition();
+      d = cast<AffineDimExpr>(exp).getPosition();
       break;
     }
     case AffineExprKind::FloorDiv: {
-      auto floor = exp.cast<AffineBinaryOpExpr>();
-      d = floor.getLHS().cast<AffineDimExpr>().getPosition();
-      cf = floor.getRHS().cast<AffineConstantExpr>().getValue();
+      auto floor = cast<AffineBinaryOpExpr>(exp);
+      d = cast<AffineDimExpr>(floor.getLHS()).getPosition();
+      cf = cast<AffineConstantExpr>(floor.getRHS()).getValue();
       break;
     }
     case AffineExprKind::Mod: {
-      auto mod = exp.cast<AffineBinaryOpExpr>();
-      d = mod.getLHS().cast<AffineDimExpr>().getPosition();
-      cm = mod.getRHS().cast<AffineConstantExpr>().getValue();
+      auto mod = cast<AffineBinaryOpExpr>(exp);
+      d = cast<AffineDimExpr>(mod.getLHS()).getPosition();
+      cm = cast<AffineConstantExpr>(mod.getRHS()).getValue();
       break;
     }
     default:
@@ -771,17 +771,17 @@ Value sparse_tensor::genMapBuffers(OpBuilder &builder, Location loc,
     uint64_t c = 0;
     switch (exp.getKind()) {
     case AffineExprKind::DimId: {
-      l = exp.cast<AffineDimExpr>().getPosition();
+      l = cast<AffineDimExpr>(exp).getPosition();
       break;
     }
     case AffineExprKind::Add: {
       // Always mul on lhs, symbol/constant on rhs.
-      auto add = exp.cast<AffineBinaryOpExpr>();
+      auto add = cast<AffineBinaryOpExpr>(exp);
       assert(add.getLHS().getKind() == AffineExprKind::Mul);
-      auto mul = add.getLHS().cast<AffineBinaryOpExpr>();
-      ll = mul.getLHS().cast<AffineDimExpr>().getPosition();
-      c = mul.getRHS().cast<AffineConstantExpr>().getValue();
-      l = add.getRHS().cast<AffineDimExpr>().getPosition();
+      auto mul = cast<AffineBinaryOpExpr>(add.getLHS());
+      ll = cast<AffineDimExpr>(mul.getLHS()).getPosition();
+      c = cast<AffineConstantExpr>(mul.getRHS()).getValue();
+      l = cast<AffineDimExpr>(add.getRHS()).getPosition();
       break;
     }
     default:

--- a/mlir/lib/Dialect/SparseTensor/Transforms/LoopEmitter.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/LoopEmitter.cpp
@@ -610,22 +610,22 @@ Value LoopEmitter::genAffine(OpBuilder &builder, Location loc, AffineExpr a) {
     // level-expression, the `getPosition` must in fact be a `Dimension`.
     // However, elsewhere we have been lead to expect that `loopIdToOrd`
     // should be indexed by `LoopId`...
-    const auto loopId = a.cast<AffineDimExpr>().getPosition();
+    const auto loopId = cast<AffineDimExpr>(a).getPosition();
     assert(loopId < loopIdToOrd.size());
     return loopStack[loopIdToOrd[loopId]].iv;
   }
   case AffineExprKind::Add: {
-    auto binOp = a.cast<AffineBinaryOpExpr>();
+    auto binOp = cast<AffineBinaryOpExpr>(a);
     return ADDI(genAffine(builder, loc, binOp.getLHS()),
                 genAffine(builder, loc, binOp.getRHS()));
   }
   case AffineExprKind::Mul: {
-    auto binOp = a.cast<AffineBinaryOpExpr>();
+    auto binOp = cast<AffineBinaryOpExpr>(a);
     return MULI(genAffine(builder, loc, binOp.getLHS()),
                 genAffine(builder, loc, binOp.getRHS()));
   }
   case AffineExprKind::Constant: {
-    int64_t c = a.cast<AffineConstantExpr>().getValue();
+    int64_t c = cast<AffineConstantExpr>(a).getValue();
     return C_IDX(c);
   }
   default:
@@ -1159,7 +1159,7 @@ Operation *LoopEmitter::enterFilterLoopOverTensorAtLvl(
     OpBuilder &builder, Location loc, TensorId tid, Level lvl,
     AffineExpr affine, MutableArrayRef<Value> reduc) {
   assert(isValidLevel(tid, lvl));
-  assert(!affine.isa<AffineDimExpr>() && !isDenseDLT(lvlTypes[tid][lvl]));
+  assert(!isa<AffineDimExpr>(affine) && !isDenseDLT(lvlTypes[tid][lvl]));
   // We can not re-enter the same level.
   assert(!coords[tid][lvl]);
 

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseBufferRewriting.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseBufferRewriting.cpp
@@ -56,7 +56,7 @@ static void getMangledSortHelperFuncName(llvm::raw_svector_ostream &nameOstream,
                                          uint64_t ny, ValueRange operands) {
   nameOstream << namePrefix;
   for (auto res : xPerm.getResults())
-    nameOstream << res.cast<AffineDimExpr>().getPosition() << "_";
+    nameOstream << cast<AffineDimExpr>(res).getPosition() << "_";
 
   nameOstream << getMemRefType(operands[xStartIdx]).getElementType();
   nameOstream << "_coo_" << ny;
@@ -114,7 +114,7 @@ static void forEachIJPairInXs(
   Value iOffset = builder.create<arith::MulIOp>(loc, args[0], cstep);
   Value jOffset = builder.create<arith::MulIOp>(loc, args[1], cstep);
   for (unsigned k = 0, e = xPerm.getNumResults(); k < e; k++) {
-    unsigned actualK = xPerm.getResult(k).cast<AffineDimExpr>().getPosition();
+    unsigned actualK = cast<AffineDimExpr>(xPerm.getResult(k)).getPosition();
     Value ak = constantIndex(builder, loc, actualK);
     Value i = builder.create<arith::AddIOp>(loc, ak, iOffset);
     Value j = builder.create<arith::AddIOp>(loc, ak, jOffset);

--- a/mlir/lib/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.cpp
@@ -24,9 +24,9 @@ getExpandedDimToCollapsedDimMap(ArrayRef<AffineMap> reassociation) {
   llvm::DenseMap<int64_t, int64_t> expandedDimToCollapsedDim;
   for (const auto &map : enumerate(reassociation)) {
     unsigned startPos =
-        map.value().getResults().front().cast<AffineDimExpr>().getPosition();
+        cast<AffineDimExpr>(map.value().getResults().front()).getPosition();
     unsigned endPos =
-        map.value().getResults().back().cast<AffineDimExpr>().getPosition();
+        cast<AffineDimExpr>(map.value().getResults().back()).getPosition();
     for (auto dim : llvm::seq_inclusive(startPos, endPos)) {
       expandedDimToCollapsedDim[dim] = map.index();
     }
@@ -47,8 +47,8 @@ static OpFoldResult getCollapsedOutputDimFromInputShape(
   }
   AffineMap map = reassociationMap[dimIndex];
   unsigned startPos =
-      map.getResults().front().cast<AffineDimExpr>().getPosition();
-  unsigned endPos = map.getResults().back().cast<AffineDimExpr>().getPosition();
+      cast<AffineDimExpr>(map.getResults().front()).getPosition();
+  unsigned endPos = cast<AffineDimExpr>(map.getResults().back()).getPosition();
   AffineExpr expr;
   SmallVector<OpFoldResult> dynamicDims;
   for (auto dim : llvm::seq_inclusive(startPos, endPos)) {
@@ -87,16 +87,12 @@ static OpFoldResult getExpandedOutputDimFromInputShape(
     return builder.getIndexAttr(dstStaticShape[dimIndex]);
   }
   unsigned sourceDimPos = expandedDimToCollapsedDim[dimIndex];
-  unsigned startPos = reassociation[sourceDimPos]
-                          .getResults()
-                          .front()
-                          .cast<AffineDimExpr>()
-                          .getPosition();
-  unsigned endPos = reassociation[sourceDimPos]
-                        .getResults()
-                        .back()
-                        .cast<AffineDimExpr>()
-                        .getPosition();
+  unsigned startPos =
+      cast<AffineDimExpr>(reassociation[sourceDimPos].getResults().front())
+          .getPosition();
+  unsigned endPos =
+      cast<AffineDimExpr>(reassociation[sourceDimPos].getResults().back())
+          .getPosition();
   int64_t linearizedStaticDim = 1;
   for (auto d :
        llvm::enumerate(dstStaticShape.slice(startPos, endPos - startPos + 1))) {

--- a/mlir/lib/Dialect/Utils/ReshapeOpsUtils.cpp
+++ b/mlir/lib/Dialect/Utils/ReshapeOpsUtils.cpp
@@ -149,7 +149,7 @@ unsigned getMaxPosOfType(ArrayRef<ReassociationExprs> exprArrays) {
   for (const auto &exprs : exprArrays) {
     for (auto expr : exprs) {
       expr.walk([&pos](AffineExpr e) {
-        if (auto d = e.dyn_cast<AffineExprTy>())
+        if (auto d = dyn_cast<AffineExprTy>(e))
           pos = std::max(pos, d.getPosition());
       });
     }
@@ -174,7 +174,7 @@ SmallVector<ReassociationIndices, 2> mlir::convertReassociationMapsToIndices(
     ReassociationIndices indices;
     indices.reserve(exprs.size());
     for (const auto &expr : exprs)
-      indices.push_back(expr.cast<AffineDimExpr>().getPosition());
+      indices.push_back(cast<AffineDimExpr>(expr).getPosition());
     reassociationIndices.push_back(indices);
   }
   return reassociationIndices;
@@ -208,7 +208,7 @@ bool mlir::isReassociationValid(ArrayRef<AffineMap> reassociation,
       return false;
     }
     for (auto e : m.getResults()) {
-      auto d = e.dyn_cast<AffineDimExpr>();
+      auto d = dyn_cast<AffineDimExpr>(e);
       if (!d || d.getPosition() != nextExpectedDim++) {
         if (invalidIndex)
           *invalidIndex = it.index();

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -888,14 +888,14 @@ static LogicalResult verifyOutputShape(
                                      /*symCount=*/0, extents, ctx);
     // Compose the resMap with the extentsMap, which is a constant map.
     AffineMap expectedMap = simplifyAffineMap(resMap.compose(extentsMap));
-    assert(llvm::all_of(
-               expectedMap.getResults(),
-               [](AffineExpr e) { return e.isa<AffineConstantExpr>(); }) &&
-           "expected constant extent along all dimensions.");
+    assert(
+        llvm::all_of(expectedMap.getResults(),
+                     [](AffineExpr e) { return isa<AffineConstantExpr>(e); }) &&
+        "expected constant extent along all dimensions.");
     // Extract the expected shape and build the type.
     auto expectedShape = llvm::to_vector<4>(
         llvm::map_range(expectedMap.getResults(), [](AffineExpr e) {
-          return e.cast<AffineConstantExpr>().getValue();
+          return cast<AffineConstantExpr>(e).getValue();
         }));
     auto expected =
         VectorType::get(expectedShape, resVectorType.getElementType(),
@@ -1076,7 +1076,7 @@ void ContractionOp::getIterationIndexMap(
     auto index = it.index();
     auto map = it.value();
     for (unsigned i = 0, e = map.getNumResults(); i < e; ++i) {
-      auto dim = map.getResult(i).cast<AffineDimExpr>();
+      auto dim = cast<AffineDimExpr>(map.getResult(i));
       iterationIndexMap[index][dim.getPosition()] = i;
     }
   }
@@ -3626,8 +3626,8 @@ static LogicalResult verifyPermutationMap(AffineMap permutationMap,
                                           EmitFun emitOpError) {
   SmallVector<bool, 8> seen(permutationMap.getNumInputs(), false);
   for (auto expr : permutationMap.getResults()) {
-    auto dim = expr.dyn_cast<AffineDimExpr>();
-    auto zero = expr.dyn_cast<AffineConstantExpr>();
+    auto dim = dyn_cast<AffineDimExpr>(expr);
+    auto zero = dyn_cast<AffineConstantExpr>(expr);
     if (zero) {
       if (zero.getValue() != 0) {
         return emitOpError(
@@ -3728,7 +3728,7 @@ verifyTransferOp(VectorTransferOpInterface op, ShapedType shapedType,
              << AffineMapAttr::get(permutationMap)
              << " vs inBounds of size: " << inBounds.size();
     for (unsigned int i = 0; i < permutationMap.getNumResults(); ++i)
-      if (permutationMap.getResult(i).isa<AffineConstantExpr>() &&
+      if (isa<AffineConstantExpr>(permutationMap.getResult(i)) &&
           !llvm::cast<BoolAttr>(inBounds.getValue()[i]).getValue())
         return op->emitOpError("requires broadcast dimensions to be in-bounds");
   }
@@ -3920,7 +3920,7 @@ static LogicalResult foldTransferInBoundsAttribute(TransferOp op) {
     }
     // Currently out-of-bounds, check whether we can statically determine it is
     // inBounds.
-    auto dimExpr = permutationMap.getResult(i).dyn_cast<AffineDimExpr>();
+    auto dimExpr = dyn_cast<AffineDimExpr>(permutationMap.getResult(i));
     assert(dimExpr && "Broadcast dims must be in-bounds");
     auto inBounds =
         isInBounds(op, /*resultIdx=*/i, /*indicesIdx=*/dimExpr.getPosition());

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp
@@ -189,7 +189,7 @@ struct TransferWritePermutationLowering
     SmallVector<int64_t> indices;
     llvm::transform(permutationMap.getResults(), std::back_inserter(indices),
                     [](AffineExpr expr) {
-                      return expr.dyn_cast<AffineDimExpr>().getPosition();
+                      return dyn_cast<AffineDimExpr>(expr).getPosition();
                     });
 
     // Transpose in_bounds attribute.
@@ -248,7 +248,7 @@ struct TransferWriteNonPermutationLowering
     // dimension then deduce the missing inner dimensions.
     SmallVector<bool> foundDim(map.getNumDims(), false);
     for (AffineExpr exp : map.getResults())
-      foundDim[exp.cast<AffineDimExpr>().getPosition()] = true;
+      foundDim[cast<AffineDimExpr>(exp).getPosition()] = true;
     SmallVector<AffineExpr> exprs;
     bool foundFirstDim = false;
     SmallVector<int64_t> missingInnerDim;
@@ -308,7 +308,7 @@ struct TransferOpReduceRank : public OpRewritePattern<vector::TransferReadOp> {
     AffineMap map = op.getPermutationMap();
     unsigned numLeadingBroadcast = 0;
     for (auto expr : map.getResults()) {
-      auto dimExpr = expr.dyn_cast<AffineConstantExpr>();
+      auto dimExpr = dyn_cast<AffineConstantExpr>(expr);
       if (!dimExpr || dimExpr.getValue() != 0)
         break;
       numLeadingBroadcast++;

--- a/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
@@ -97,7 +97,7 @@ struct DistributedLoadStoreHelper {
     SmallVector<Value> indices(rank, zero);
     if (val == distributedVal) {
       for (auto dimExpr : distributionMap.getResults()) {
-        int64_t index = dimExpr.cast<AffineDimExpr>().getPosition();
+        int64_t index = cast<AffineDimExpr>(dimExpr).getPosition();
         indices[index] = buildDistributedOffset(b, loc, index);
       }
     }
@@ -142,7 +142,7 @@ struct DistributedLoadStoreHelper {
     SmallVector<Value> indices(sequentialVectorType.getRank(), zero);
     if (type == distributedVectorType) {
       for (auto dimExpr : distributionMap.getResults()) {
-        int64_t index = dimExpr.cast<AffineDimExpr>().getPosition();
+        int64_t index = cast<AffineDimExpr>(dimExpr).getPosition();
         indices[index] = buildDistributedOffset(b, loc, index);
       }
     }
@@ -530,11 +530,11 @@ struct WarpOpTransferWrite : public OpRewritePattern<WarpExecuteOnLane0Op> {
     for (auto it : llvm::zip(indexMap.getResults(), map.getResults())) {
       AffineExpr d0, d1;
       bindDims(newWarpOp.getContext(), d0, d1);
-      auto indexExpr = std::get<0>(it).dyn_cast<AffineDimExpr>();
+      auto indexExpr = dyn_cast<AffineDimExpr>(std::get<0>(it));
       if (!indexExpr)
         continue;
       unsigned indexPos = indexExpr.getPosition();
-      unsigned vectorPos = std::get<1>(it).cast<AffineDimExpr>().getPosition();
+      unsigned vectorPos = cast<AffineDimExpr>(std::get<1>(it)).getPosition();
       auto scale =
           rewriter.getAffineConstantExpr(targetType.getDimSize(vectorPos));
       indices[indexPos] = affine::makeComposedAffineApply(
@@ -877,11 +877,11 @@ struct WarpOpTransferRead : public OpRewritePattern<WarpExecuteOnLane0Op> {
     for (auto it : llvm::zip_equal(indexMap.getResults(), map.getResults())) {
       AffineExpr d0, d1;
       bindDims(read.getContext(), d0, d1);
-      auto indexExpr = std::get<0>(it).dyn_cast<AffineDimExpr>();
+      auto indexExpr = dyn_cast<AffineDimExpr>(std::get<0>(it));
       if (!indexExpr)
         continue;
       unsigned indexPos = indexExpr.getPosition();
-      unsigned vectorPos = std::get<1>(it).cast<AffineDimExpr>().getPosition();
+      unsigned vectorPos = cast<AffineDimExpr>(std::get<1>(it)).getPosition();
       int64_t scale = distributedType.getDimSize(vectorPos);
       indices[indexPos] = affine::makeComposedAffineApply(
           rewriter, read.getLoc(), d0 + scale * d1,

--- a/mlir/lib/Dialect/Vector/Transforms/VectorUnroll.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorUnroll.cpp
@@ -37,7 +37,7 @@ static SmallVector<Value> sliceTransferIndices(ArrayRef<int64_t> elementOffsets,
                                                OpBuilder &builder) {
   MLIRContext *ctx = builder.getContext();
   auto isBroadcast = [](AffineExpr expr) {
-    if (auto constExpr = expr.dyn_cast<AffineConstantExpr>())
+    if (auto constExpr = dyn_cast<AffineConstantExpr>(expr))
       return constExpr.getValue() == 0;
     return false;
   };
@@ -46,7 +46,7 @@ static SmallVector<Value> sliceTransferIndices(ArrayRef<int64_t> elementOffsets,
   for (const auto &dim : llvm::enumerate(permutationMap.getResults())) {
     if (isBroadcast(dim.value()))
       continue;
-    unsigned pos = dim.value().cast<AffineDimExpr>().getPosition();
+    unsigned pos = cast<AffineDimExpr>(dim.value()).getPosition();
     auto expr = getAffineDimExpr(0, builder.getContext()) +
                 getAffineConstantExpr(elementOffsets[dim.index()], ctx);
     auto map = AffineMap::get(/*dimCount=*/1, /*symbolCount=*/0, expr);

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2821,7 +2821,7 @@ void AsmPrinter::Impl::printAffineExprInternal(
   const char *binopSpelling = nullptr;
   switch (expr.getKind()) {
   case AffineExprKind::SymbolId: {
-    unsigned pos = expr.cast<AffineSymbolExpr>().getPosition();
+    unsigned pos = cast<AffineSymbolExpr>(expr).getPosition();
     if (printValueName)
       printValueName(pos, /*isSymbol=*/true);
     else
@@ -2829,7 +2829,7 @@ void AsmPrinter::Impl::printAffineExprInternal(
     return;
   }
   case AffineExprKind::DimId: {
-    unsigned pos = expr.cast<AffineDimExpr>().getPosition();
+    unsigned pos = cast<AffineDimExpr>(expr).getPosition();
     if (printValueName)
       printValueName(pos, /*isSymbol=*/false);
     else
@@ -2837,7 +2837,7 @@ void AsmPrinter::Impl::printAffineExprInternal(
     return;
   }
   case AffineExprKind::Constant:
-    os << expr.cast<AffineConstantExpr>().getValue();
+    os << cast<AffineConstantExpr>(expr).getValue();
     return;
   case AffineExprKind::Add:
     binopSpelling = " + ";
@@ -2856,7 +2856,7 @@ void AsmPrinter::Impl::printAffineExprInternal(
     break;
   }
 
-  auto binOp = expr.cast<AffineBinaryOpExpr>();
+  auto binOp = cast<AffineBinaryOpExpr>(expr);
   AffineExpr lhsExpr = binOp.getLHS();
   AffineExpr rhsExpr = binOp.getRHS();
 
@@ -2866,7 +2866,7 @@ void AsmPrinter::Impl::printAffineExprInternal(
       os << '(';
 
     // Pretty print multiplication with -1.
-    auto rhsConst = rhsExpr.dyn_cast<AffineConstantExpr>();
+    auto rhsConst = dyn_cast<AffineConstantExpr>(rhsExpr);
     if (rhsConst && binOp.getKind() == AffineExprKind::Mul &&
         rhsConst.getValue() == -1) {
       os << "-";
@@ -2892,10 +2892,10 @@ void AsmPrinter::Impl::printAffineExprInternal(
 
   // Pretty print addition to a product that has a negative operand as a
   // subtraction.
-  if (auto rhs = rhsExpr.dyn_cast<AffineBinaryOpExpr>()) {
+  if (auto rhs = dyn_cast<AffineBinaryOpExpr>(rhsExpr)) {
     if (rhs.getKind() == AffineExprKind::Mul) {
       AffineExpr rrhsExpr = rhs.getRHS();
-      if (auto rrhs = rrhsExpr.dyn_cast<AffineConstantExpr>()) {
+      if (auto rrhs = dyn_cast<AffineConstantExpr>(rrhsExpr)) {
         if (rrhs.getValue() == -1) {
           printAffineExprInternal(lhsExpr, BindingStrength::Weak,
                                   printValueName);
@@ -2929,7 +2929,7 @@ void AsmPrinter::Impl::printAffineExprInternal(
   }
 
   // Pretty print addition to a negative number as a subtraction.
-  if (auto rhsConst = rhsExpr.dyn_cast<AffineConstantExpr>()) {
+  if (auto rhsConst = dyn_cast<AffineConstantExpr>(rhsExpr)) {
     if (rhsConst.getValue() < 0) {
       printAffineExprInternal(lhsExpr, BindingStrength::Weak, printValueName);
       os << " - " << -rhsConst.getValue();

--- a/mlir/lib/IR/BuiltinTypes.cpp
+++ b/mlir/lib/IR/BuiltinTypes.cpp
@@ -678,7 +678,7 @@ static void extractStridesFromTerm(AffineExpr e,
                                    AffineExpr multiplicativeFactor,
                                    MutableArrayRef<AffineExpr> strides,
                                    AffineExpr &offset) {
-  if (auto dim = e.dyn_cast<AffineDimExpr>())
+  if (auto dim = dyn_cast<AffineDimExpr>(e))
     strides[dim.getPosition()] =
         strides[dim.getPosition()] + multiplicativeFactor;
   else
@@ -693,7 +693,7 @@ static LogicalResult extractStrides(AffineExpr e,
                                     AffineExpr multiplicativeFactor,
                                     MutableArrayRef<AffineExpr> strides,
                                     AffineExpr &offset) {
-  auto bin = e.dyn_cast<AffineBinaryOpExpr>();
+  auto bin = dyn_cast<AffineBinaryOpExpr>(e);
   if (!bin) {
     extractStridesFromTerm(e, multiplicativeFactor, strides, offset);
     return success();
@@ -705,7 +705,7 @@ static LogicalResult extractStrides(AffineExpr e,
     return failure();
 
   if (bin.getKind() == AffineExprKind::Mul) {
-    auto dim = bin.getLHS().dyn_cast<AffineDimExpr>();
+    auto dim = dyn_cast<AffineDimExpr>(bin.getLHS());
     if (dim) {
       strides[dim.getPosition()] =
           strides[dim.getPosition()] + bin.getRHS() * multiplicativeFactor;
@@ -820,12 +820,12 @@ LogicalResult mlir::getStridesAndOffset(MemRefType t,
   SmallVector<AffineExpr, 4> strideExprs;
   if (failed(::getStridesAndOffset(t, strideExprs, offsetExpr)))
     return failure();
-  if (auto cst = offsetExpr.dyn_cast<AffineConstantExpr>())
+  if (auto cst = dyn_cast<AffineConstantExpr>(offsetExpr))
     offset = cst.getValue();
   else
     offset = ShapedType::kDynamic;
   for (auto e : strideExprs) {
-    if (auto c = e.dyn_cast<AffineConstantExpr>())
+    if (auto c = dyn_cast<AffineConstantExpr>(e))
       strides.push_back(c.getValue());
     else
       strides.push_back(ShapedType::kDynamic);
@@ -888,7 +888,7 @@ MemRefType mlir::canonicalizeStridedLayout(MemRefType t) {
 
   // Corner-case for 0-D affine maps.
   if (m.getNumDims() == 0 && m.getNumSymbols() == 0) {
-    if (auto cst = m.getResult(0).dyn_cast<AffineConstantExpr>())
+    if (auto cst = dyn_cast<AffineConstantExpr>(m.getResult(0)))
       if (cst.getValue() == 0)
         return MemRefType::Builder(t).setLayout({});
     return t;

--- a/mlir/tools/mlir-linalg-ods-gen/mlir-linalg-ods-yaml-gen.cpp
+++ b/mlir/tools/mlir-linalg-ods-gen/mlir-linalg-ods-yaml-gen.cpp
@@ -869,7 +869,7 @@ exprs.push_back(getAffineConstantExpr(cst{1}, context));
           assert(arg.indexAttrMap);
           for (auto [idx, result] :
                llvm::enumerate(arg.indexAttrMap->affineMap().getResults())) {
-            if (auto symbol = result.dyn_cast<AffineSymbolExpr>()) {
+            if (auto symbol = dyn_cast<AffineSymbolExpr>(result)) {
               std::string argName = arg.name;
               argName[0] = toupper(argName[0]);
               symbolBindings[symbol.getPosition()] =


### PR DESCRIPTION
detail see the docment: https://mlir.llvm.org/deprecation/

Not all changes are made manually, most of them are made through a clang tool I wrote https://github.com/lipracer/cpp-refactor.