### PR TITLE
[flang][OpenMP] Added semantic checks for target update

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -10,7 +10,6 @@
 #include "definable.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/tools.h"
-#include <algorithm>
 
 namespace Fortran::semantics {
 
@@ -1394,6 +1393,16 @@ void OmpStructureChecker::CheckOrderedDependClause(
   }
 }
 
+void OmpStructureChecker::CheckTargetUpdate() {
+  const parser::OmpClause *toClause = FindClause(llvm::omp::Clause::OMPC_to);
+  const parser::OmpClause *fromClause =
+      FindClause(llvm::omp::Clause::OMPC_from);
+  if (!toClause && !fromClause) {
+    context_.Say(GetContext().directiveSource,
+        "At least one motion-clause (TO/FROM) must be specified on TARGET UPDATE construct."_err_en_US);
+  }
+}
+
 void OmpStructureChecker::Enter(
     const parser::OpenMPSimpleStandaloneConstruct &x) {
   const auto &dir{std::get<parser::OmpSimpleStandaloneDirective>(x.t)};
@@ -1402,11 +1411,14 @@ void OmpStructureChecker::Enter(
 }
 
 void OmpStructureChecker::Leave(
-    const parser::OpenMPSimpleStandaloneConstruct &) {
+    const parser::OpenMPSimpleStandaloneConstruct &x) {
   switch (GetContext().directive) {
   case llvm::omp::Directive::OMPD_ordered:
     // [5.1] 2.19.9 Ordered Construct Restriction
     ChecksOnOrderedAsStandalone();
+    break;
+  case llvm::omp::Directive::OMPD_target_update:
+    CheckTargetUpdate();
     break;
   default:
     break;

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -182,6 +182,7 @@ private:
   void CheckDistLinear(const parser::OpenMPLoopConstruct &x);
   void CheckSIMDNest(const parser::OpenMPConstruct &x);
   void CheckTargetNest(const parser::OpenMPConstruct &x);
+  void CheckTargetUpdate();
   void CheckCancellationNest(
       const parser::CharBlock &source, const parser::OmpCancelType::Type &type);
   std::int64_t GetOrdCollapseLevel(const parser::OpenMPLoopConstruct &x);

--- a/flang/test/Parser/OpenMP/if-clause.f90
+++ b/flang/test/Parser/OpenMP/if-clause.f90
@@ -7,12 +7,12 @@ program openmp_parse_if
   ! CHECK: OmpSimpleStandaloneDirective -> llvm::omp::Directive = target update
   ! CHECK-NEXT: OmpClause -> If -> OmpIfClause
   ! CHECK-NOT: DirectiveNameModifier
-  !$omp target update if(cond)
+  !$omp target update if(cond) to(i)
 
   ! CHECK: OmpSimpleStandaloneDirective -> llvm::omp::Directive = target update
   ! CHECK-NEXT: OmpClause -> If -> OmpIfClause
   ! CHECK-NEXT: DirectiveNameModifier = TargetUpdate
-  !$omp target update if(target update: cond)
+  !$omp target update if(target update: cond) to(i)
 
   ! CHECK: OmpSimpleStandaloneDirective -> llvm::omp::Directive = target enter data
   ! CHECK: OmpClause -> If -> OmpIfClause

--- a/flang/test/Semantics/OpenMP/if-clause.f90
+++ b/flang/test/Semantics/OpenMP/if-clause.f90
@@ -451,15 +451,15 @@ program main
   ! ----------------------------------------------------------------------------
   ! TARGET UPDATE
   ! ----------------------------------------------------------------------------
-  !$omp target update if(.true.)
+  !$omp target update to(i) if(.true.)
   
-  !$omp target update if(target update: .true.)
+  !$omp target update to(i) if(target update: .true.)
 
   !ERROR: Unmatched directive name modifier TARGET on the IF clause
-  !$omp target update if(target: .true.)
+  !$omp target update to(i) if(target: .true.)
 
   !ERROR: At most one IF clause can appear on the TARGET UPDATE directive
-  !$omp target update if(.true.) if(target update: .false.)
+  !$omp target update to(i) if(.true.) if(target update: .false.)
 
   ! ----------------------------------------------------------------------------
   ! TASK

--- a/flang/test/Semantics/OpenMP/target-update01.f90
+++ b/flang/test/Semantics/OpenMP/target-update01.f90
@@ -1,0 +1,16 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+
+subroutine foo(x)
+  integer :: x
+  !ERROR: At least one motion-clause (TO/FROM) must be specified on TARGET UPDATE construct.
+  !$omp target update
+
+  !ERROR: At least one motion-clause (TO/FROM) must be specified on TARGET UPDATE construct.
+  !$omp target update nowait
+
+  !$omp target update to(x) nowait
+
+  !ERROR: At most one NOWAIT clause can appear on the TARGET UPDATE directive
+  !$omp target update to(x) nowait nowait
+
+end subroutine


### PR DESCRIPTION
This patch adds the following semantic check for target update

```
At least one motion-clause must be specified.
```

A motion clause is either a `to` or a `from` clause.

This patch also adds a test for the following semantic check which was already supported.

```
At most one nowait clause can appear on the directive.
```