### PR TITLE
Shard the public llvm-config.h in multiple files (NFC)

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1063,13 +1063,18 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
 
 endif()
 
-# Configure the three LLVM configuration header files.
+# Configure the LLVM configurations header files.
 configure_file(
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Config/config.h.cmake
   ${LLVM_INCLUDE_DIR}/llvm/Config/config.h)
-configure_file(
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/Config/llvm-config.h.cmake
-  ${LLVM_INCLUDE_DIR}/llvm/Config/llvm-config.h)
+
+# Configure all the llvm-config*.h.cmake files.
+file(GLOB LLVM_CONFIGS_H_FILES ${LLVM_MAIN_INCLUDE_DIR}/llvm/Config/llvm-config*.cmake)
+foreach(LLVM_CONFIGS_H_FILE ${LLVM_CONFIGS_H_FILES})
+  string( REPLACE ".cmake" "" LLVM_CONFIGS_H_FILE_DEST "${LLVM_CONFIGS_H_FILE}")
+  string( REPLACE "${LLVM_MAIN_INCLUDE_DIR}" "${LLVM_INCLUDE_DIR}" LLVM_CONFIGS_H_FILE_DEST "${LLVM_CONFIGS_H_FILE_DEST}")
+  configure_file(${LLVM_CONFIGS_H_FILE} ${LLVM_CONFIGS_H_FILE_DEST})
+endforeach()
 configure_file(
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Config/abi-breaking.h.cmake
   ${LLVM_INCLUDE_DIR}/llvm/Config/abi-breaking.h)

--- a/llvm/include/llvm/Config/llvm-config-build-llvm-dylib.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-build-llvm-dylib.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-build-llvm-dylib.h.cmake -----*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_BUILD_LLVM_DYLIB_H
+#define LLVM_CONFIG_BUILD_LLVM_DYLIB_H
+
+/* Define if building libLLVM shared library */
+#cmakedefine LLVM_BUILD_LLVM_DYLIB ${LLVM_BUILD_LLVM_DYLIB}
+
+#endif // LLVM_CONFIG_BUILD_LLVM_DYLIB_H

--- a/llvm/include/llvm/Config/llvm-config-build-shared-libs.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-build-shared-libs.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-build-shared-libs.h.cmake ----*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_BUILD_SHARED_LIBS_H
+#define LLVM_CONFIG_BUILD_SHARED_LIBS_H
+
+/* Define if building LLVM with BUILD_SHARED_LIBS */
+#cmakedefine LLVM_BUILD_SHARED_LIBS ${LLVM_BUILD_SHARED_LIBS}
+
+#endif // LLVM_CONFIG_BUILD_SHARED_LIBS_H

--- a/llvm/include/llvm/Config/llvm-config-enable-curl.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-curl.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-enable-curl.h.cmake ----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_CURL_H
+#define LLVM_CONFIG_ENABLE_CURL_H
+
+/* Define if we have curl and want to use it */
+#cmakedefine LLVM_ENABLE_CURL ${LLVM_ENABLE_CURL}
+
+#endif // LLVM_CONFIG_ENABLE_CURL_H

--- a/llvm/include/llvm/Config/llvm-config-enable-dia-sdk.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-dia-sdk.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-enable-dia-sdk.h.cmake -------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_DIA_SDK_H
+#define LLVM_CONFIG_ENABLE_DIA_SDK_H
+
+/* Define to 1 if you have the DIA SDK installed, and to 0 if you don't. */
+#cmakedefine01 LLVM_ENABLE_DIA_SDK
+
+#endif // LLVM_CONFIG_ENABLE_DIA_SDK_H

--- a/llvm/include/llvm/Config/llvm-config-enable-dump.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-dump.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-enable-dump.h.cmake ----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_DUMP_H
+#define LLVM_CONFIG_ENABLE_DUMP_H
+
+/* Define if LLVM_ENABLE_DUMP is enabled */
+#cmakedefine LLVM_ENABLE_DUMP ${LLVM_ENABLE_DUMP}
+
+#endif // LLVM_CONFIG_ENABLE_DUMP_H

--- a/llvm/include/llvm/Config/llvm-config-enable-httplib.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-httplib.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-httplib.h --------------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_HTTPLIB_H
+#define LLVM_CONFIG_ENABLE_HTTPLIB_H
+
+/* Define if we have cpp-httplib and want to use it */
+#cmakedefine LLVM_ENABLE_HTTPLIB ${LLVM_ENABLE_HTTPLIB}
+
+#endif // LLVM_CONFIG_ENABLE_HTTPLIB_H

--- a/llvm/include/llvm/Config/llvm-config-enable-plugins.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-plugins.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-enable-plugins.h.cmake -------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_PLUGINS_H
+#define LLVM_CONFIG_ENABLE_PLUGINS_H
+
+/* Define if plugins enabled */
+#cmakedefine LLVM_ENABLE_PLUGINS ${LLVM_ENABLE_PLUGINS}
+
+#endif // LLVM_CONFIG_ENABLE_PLUGINS_H

--- a/llvm/include/llvm/Config/llvm-config-enable-threads.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-threads.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-threads.h --------------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_THREADS_H
+#define LLVM_CONFIG_ENABLE_THREADS_H
+
+/* Define if threads enabled */
+#cmakedefine01 LLVM_ENABLE_THREADS
+
+#endif // LLVM_CONFIG_ENABLE_THREADS_H

--- a/llvm/include/llvm/Config/llvm-config-enable-zlib.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-zlib.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-enable-zlib.h.cmake ----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_ZLIB_H
+#define LLVM_CONFIG_ENABLE_ZLIB_H
+
+/* Define if zlib compression is available */
+#cmakedefine01 LLVM_ENABLE_ZLIB
+
+#endif // LLVM_CONFIG_ENABLE_ZLIB_H

--- a/llvm/include/llvm/Config/llvm-config-enable-zstd.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-enable-zstd.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-enable-zstd.h.cmake ----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ENABLE_ZSTD_H
+#define LLVM_CONFIG_ENABLE_ZSTD_H
+
+/* Define if zstd compression is available */
+#cmakedefine01 LLVM_ENABLE_ZSTD
+
+#endif // LLVM_CONFIG_ENABLE_ZSTD_H

--- a/llvm/include/llvm/Config/llvm-config-force-enable-stats.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-force-enable-stats.h.cmake
@@ -1,0 +1,18 @@
+/*===------- llvm/Config/llvm-config-force-enable-stats.h.cmake ---*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_FORCE_ENABLE_STATS_H
+#define LLVM_CONFIG_FORCE_ENABLE_STATS_H
+
+/* Whether LLVM records statistics for use with GetStatistics(),
+ * PrintStatistics() or PrintStatisticsJSON()
+ */
+#cmakedefine01 LLVM_FORCE_ENABLE_STATS
+
+#endif // LLVM_CONFIG_FORCE_ENABLE_STATS_H

--- a/llvm/include/llvm/Config/llvm-config-force-use-old-toolchain.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-force-use-old-toolchain.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-force-use-old-toolchain.h ----*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_FORCE_USE_OLD_TOOLCHAIN_H
+#define LLVM_CONFIG_FORCE_USE_OLD_TOOLCHAIN_H
+
+/* Define if building LLVM with LLVM_FORCE_USE_OLD_TOOLCHAIN_LIBS */
+#cmakedefine LLVM_FORCE_USE_OLD_TOOLCHAIN ${LLVM_FORCE_USE_OLD_TOOLCHAIN}
+
+#endif // LLVM_CONFIG_FORCE_USE_OLD_TOOLCHAIN_H

--- a/llvm/include/llvm/Config/llvm-config-has-atomics.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-has-atomics.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-has-atomics.h.cmake ----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_HAS_ATOMICS_H
+#define LLVM_CONFIG_HAS_ATOMICS_H
+
+/* Has gcc/MSVC atomic intrinsics */
+#cmakedefine01 LLVM_HAS_ATOMICS
+
+#endif // LLVM_CONFIG_HAS_ATOMICS_H

--- a/llvm/include/llvm/Config/llvm-config-have-sysexits.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-have-sysexits.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-have-sysexits.h.cmake --------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_HAVE_SYSEXITS_H_H
+#define LLVM_CONFIG_HAVE_SYSEXITS_H_H
+
+/* Define to 1 if you have the <sysexits.h> header file. */
+#cmakedefine HAVE_SYSEXITS_H ${HAVE_SYSEXITS_H}
+
+#endif // LLVM_CONFIG_HAVE_SYSEXITS_H_H

--- a/llvm/include/llvm/Config/llvm-config-have-tflite.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-have-tflite.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-have-tflite.h.cmake ----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_HAVE_TFLITE_H
+#define LLVM_CONFIG_HAVE_TFLITE_H
+
+/* Define if LLVM is using tflite */
+#cmakedefine LLVM_HAVE_TFLITE ${LLVM_HAVE_TFLITE}
+
+#endif // LLVM_CONFIG_HAVE_TFLITE_H

--- a/llvm/include/llvm/Config/llvm-config-on-unix.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-on-unix.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-on-unix.cmake.h --------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_ON_UNIX_H
+#define LLVM_CONFIG_ON_UNIX_H
+
+/* Define if this is Unixish platform */
+#cmakedefine LLVM_ON_UNIX ${LLVM_ON_UNIX}
+
+#endif // LLVM_CONFIG_ON_UNIX_H

--- a/llvm/include/llvm/Config/llvm-config-target-AArch64.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-AArch64.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-AArch64.h -------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_AARCH64_H
+#define LLVM_CONFIG_TARGET_AARCH64_H
+
+/* Define if the AArch64 target is built in */
+#cmakedefine01 LLVM_HAS_AARCH64_TARGET
+
+#endif // LLVM_CONFIG_TARGET_AARCH64_H

--- a/llvm/include/llvm/Config/llvm-config-target-AMDGPU.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-AMDGPU.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-AMDGPU.h --------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_AMDGPU_H
+#define LLVM_CONFIG_TARGET_AMDGPU_H
+
+/* Define if the AMDGPU target is built in */
+#cmakedefine01 LLVM_HAS_AMDGPU_TARGET
+
+#endif // LLVM_CONFIG_TARGET_AMDGPU_H

--- a/llvm/include/llvm/Config/llvm-config-target-ARC.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-ARC.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-ARC.h -----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_ARC_H
+#define LLVM_CONFIG_TARGET_ARC_H
+
+/* Define if the ARC target is built in */
+#cmakedefine01 LLVM_HAS_ARC_TARGET
+
+#endif // LLVM_CONFIG_TARGET_ARC_H

--- a/llvm/include/llvm/Config/llvm-config-target-ARM.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-ARM.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-ARM.h -----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_ARM_H
+#define LLVM_CONFIG_TARGET_ARM_H
+
+/* Define if the ARM target is built in */
+#cmakedefine01 LLVM_HAS_ARM_TARGET
+
+#endif // LLVM_CONFIG_TARGET_ARM_H

--- a/llvm/include/llvm/Config/llvm-config-target-AVR.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-AVR.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-AVR.h -----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_AVR_H
+#define LLVM_CONFIG_TARGET_AVR_H
+
+/* Define if the AVR target is built in */
+#cmakedefine01 LLVM_HAS_AVR_TARGET
+
+#endif // LLVM_CONFIG_TARGET_AVR_H

--- a/llvm/include/llvm/Config/llvm-config-target-BPF.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-BPF.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-BPF.h -----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_BPF_H
+#define LLVM_CONFIG_TARGET_BPF_H
+
+/* Define if the BPF target is built in */
+#cmakedefine01 LLVM_HAS_BPF_TARGET
+
+#endif // LLVM_CONFIG_TARGET_BPF_H

--- a/llvm/include/llvm/Config/llvm-config-target-CSKY.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-CSKY.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-CSKY.h ----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_CSKY_H
+#define LLVM_CONFIG_TARGET_CSKY_H
+
+/* Define if the CSKY target is built in */
+#cmakedefine01 LLVM_HAS_CSKY_TARGET
+
+#endif // LLVM_CONFIG_TARGET_CSKY_H

--- a/llvm/include/llvm/Config/llvm-config-target-DirectX.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-DirectX.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-DirectX.h -------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_DIRECTX_H
+#define LLVM_CONFIG_TARGET_DIRECTX_H
+
+/* Define if the DirectX target is built in */
+#cmakedefine01 LLVM_HAS_DIRECTX_TARGET
+
+#endif // LLVM_CONFIG_TARGET_DIRECTX_H

--- a/llvm/include/llvm/Config/llvm-config-target-Hexagon.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-Hexagon.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-Hexagon.h -------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_HEXAGON_H
+#define LLVM_CONFIG_TARGET_HEXAGON_H
+
+/* Define if the Hexagon target is built in */
+#cmakedefine01 LLVM_HAS_HEXAGON_TARGET
+
+#endif // LLVM_CONFIG_TARGET_HEXAGON_H

--- a/llvm/include/llvm/Config/llvm-config-target-Lanai.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-Lanai.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-Lanai.h ---------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_LANAI_H
+#define LLVM_CONFIG_TARGET_LANAI_H
+
+/* Define if the Lanai target is built in */
+#cmakedefine01 LLVM_HAS_LANAI_TARGET
+
+#endif // LLVM_CONFIG_TARGET_LANAI_H

--- a/llvm/include/llvm/Config/llvm-config-target-LoongArch.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-LoongArch.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-LoongArch.h -----------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_LOONGARCH_H
+#define LLVM_CONFIG_TARGET_LOONGARCH_H
+
+/* Define if the LoongArch target is built in */
+#cmakedefine01 LLVM_HAS_LOONGARCH_TARGET
+
+#endif // LLVM_CONFIG_TARGET_LOONGARCH_H

--- a/llvm/include/llvm/Config/llvm-config-target-M68k.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-M68k.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-M68k.h ----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_M68K_H
+#define LLVM_CONFIG_TARGET_M68K_H
+
+/* Define if the M68k target is built in */
+#cmakedefine01 LLVM_HAS_M68K_TARGET
+
+#endif // LLVM_CONFIG_TARGET_M68K_H

--- a/llvm/include/llvm/Config/llvm-config-target-MSP430.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-MSP430.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-MSP430.h --------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_MSP430_H
+#define LLVM_CONFIG_TARGET_MSP430_H
+
+/* Define if the MSP430 target is built in */
+#cmakedefine01 LLVM_HAS_MSP430_TARGET
+
+#endif // LLVM_CONFIG_TARGET_MSP430_H

--- a/llvm/include/llvm/Config/llvm-config-target-Mips.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-Mips.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-Mips.h ----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_MIPS_H
+#define LLVM_CONFIG_TARGET_MIPS_H
+
+/* Define if the Mips target is built in */
+#cmakedefine01 LLVM_HAS_MIPS_TARGET
+
+#endif // LLVM_CONFIG_TARGET_MIPS_H

--- a/llvm/include/llvm/Config/llvm-config-target-NVPTX.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-NVPTX.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-NVPTX.h ---------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_NVPTX_H
+#define LLVM_CONFIG_TARGET_NVPTX_H
+
+/* Define if the NVPTX target is built in */
+#cmakedefine01 LLVM_HAS_NVPTX_TARGET
+
+#endif // LLVM_CONFIG_TARGET_NVPTX_H

--- a/llvm/include/llvm/Config/llvm-config-target-PowerPC.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-PowerPC.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-PowerPC.h -------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_POWERPC_H
+#define LLVM_CONFIG_TARGET_POWERPC_H
+
+/* Define if the PowerPC target is built in */
+#cmakedefine01 LLVM_HAS_POWERPC_TARGET
+
+#endif // LLVM_CONFIG_TARGET_POWERPC_H

--- a/llvm/include/llvm/Config/llvm-config-target-RISCV.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-RISCV.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-RISCV.h ---------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_RISCV_H
+#define LLVM_CONFIG_TARGET_RISCV_H
+
+/* Define if the RISCV target is built in */
+#cmakedefine01 LLVM_HAS_RISCV_TARGET
+
+#endif // LLVM_CONFIG_TARGET_RISCV_H

--- a/llvm/include/llvm/Config/llvm-config-target-SPIRV.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-SPIRV.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-SPIRV.h ---------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_SPIRV_H
+#define LLVM_CONFIG_TARGET_SPIRV_H
+
+/* Define if the SPIRV target is built in */
+#cmakedefine01 LLVM_HAS_SPIRV_TARGET
+
+#endif // LLVM_CONFIG_TARGET_SPIRV_H

--- a/llvm/include/llvm/Config/llvm-config-target-Sparc.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-Sparc.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-Sparc.h ---------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_SPARC_H
+#define LLVM_CONFIG_TARGET_SPARC_H
+
+/* Define if the Sparc target is built in */
+#cmakedefine01 LLVM_HAS_SPARC_TARGET
+
+#endif // LLVM_CONFIG_TARGET_SPARC_H

--- a/llvm/include/llvm/Config/llvm-config-target-SystemZ.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-SystemZ.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-SystemZ.h -------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_SYSTEMZ_H
+#define LLVM_CONFIG_TARGET_SYSTEMZ_H
+
+/* Define if the SystemZ target is built in */
+#cmakedefine01 LLVM_HAS_SYSTEMZ_TARGET
+
+#endif // LLVM_CONFIG_TARGET_SYSTEMZ_H

--- a/llvm/include/llvm/Config/llvm-config-target-VE.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-VE.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-VE.h ------------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_VE_H
+#define LLVM_CONFIG_TARGET_VE_H
+
+/* Define if the VE target is built in */
+#cmakedefine01 LLVM_HAS_VE_TARGET
+
+#endif // LLVM_CONFIG_TARGET_VE_H

--- a/llvm/include/llvm/Config/llvm-config-target-WebAssembly.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-WebAssembly.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-WebAssembly.h ---------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_WEBASSEMBLY_H
+#define LLVM_CONFIG_TARGET_WEBASSEMBLY_H
+
+/* Define if the WebAssembly target is built in */
+#cmakedefine01 LLVM_HAS_WEBASSEMBLY_TARGET
+
+#endif // LLVM_CONFIG_TARGET_WEBASSEMBLY_H

--- a/llvm/include/llvm/Config/llvm-config-target-X86.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-X86.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-X86.h -----------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_X86_H
+#define LLVM_CONFIG_TARGET_X86_H
+
+/* Define if the X86 target is built in */
+#cmakedefine01 LLVM_HAS_X86_TARGET
+
+#endif // LLVM_CONFIG_TARGET_X86_H

--- a/llvm/include/llvm/Config/llvm-config-target-XCore.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-XCore.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-XCore.h ---------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_XCORE_H
+#define LLVM_CONFIG_TARGET_XCORE_H
+
+/* Define if the XCore target is built in */
+#cmakedefine01 LLVM_HAS_XCORE_TARGET
+
+#endif // LLVM_CONFIG_TARGET_XCORE_H

--- a/llvm/include/llvm/Config/llvm-config-target-Xtensa.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-Xtensa.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-target-Xtensa.h --------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_TARGET_XTENSA_H
+#define LLVM_CONFIG_TARGET_XTENSA_H
+
+/* Define if the Xtensa target is built in */
+#cmakedefine01 LLVM_HAS_XTENSA_TARGET
+
+#endif // LLVM_CONFIG_TARGET_XTENSA_H

--- a/llvm/include/llvm/Config/llvm-config-target-native.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-native.h.cmake
@@ -1,0 +1,39 @@
+/*===------- llvm/Config/llvm-config-target-native.h --------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+/* This file defines macros about the native target configuration. */
+
+#ifndef LLVM_CONFIG_TARGET_NATIVE_H
+#define LLVM_CONFIG_TARGET_NATIVE_H
+
+/* LLVM architecture name for the native architecture, if available */
+#cmakedefine LLVM_NATIVE_ARCH ${LLVM_NATIVE_ARCH}
+
+/* LLVM name for the native AsmParser init function, if available */
+#cmakedefine LLVM_NATIVE_ASMPARSER LLVMInitialize${LLVM_NATIVE_ARCH}AsmParser
+
+/* LLVM name for the native AsmPrinter init function, if available */
+#cmakedefine LLVM_NATIVE_ASMPRINTER LLVMInitialize${LLVM_NATIVE_ARCH}AsmPrinter
+
+/* LLVM name for the native Disassembler init function, if available */
+#cmakedefine LLVM_NATIVE_DISASSEMBLER LLVMInitialize${LLVM_NATIVE_ARCH}Disassembler
+
+/* LLVM name for the native Target init function, if available */
+#cmakedefine LLVM_NATIVE_TARGET LLVMInitialize${LLVM_NATIVE_ARCH}Target
+
+/* LLVM name for the native TargetInfo init function, if available */
+#cmakedefine LLVM_NATIVE_TARGETINFO LLVMInitialize${LLVM_NATIVE_ARCH}TargetInfo
+
+/* LLVM name for the native target MC init function, if available */
+#cmakedefine LLVM_NATIVE_TARGETMC LLVMInitialize${LLVM_NATIVE_ARCH}TargetMC
+
+/* LLVM name for the native target MCA init function, if available */
+#cmakedefine LLVM_NATIVE_TARGETMCA LLVMInitialize${LLVM_NATIVE_ARCH}TargetMCA
+
+#endif // LLVM_CONFIG_TARGET_NATIVE_H

--- a/llvm/include/llvm/Config/llvm-config-target-triple.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-target-triple.h.cmake
@@ -1,0 +1,22 @@
+/*===------- llvm/Config/llvm-config-target-triple.h --------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+/* This file defines macros about the targets configuration. */
+
+#ifndef LLVM_CONFIG_TARGET_TRIPLE_H
+#define LLVM_CONFIG_TARGET_TRIPLE_H
+
+/* Target triple LLVM will generate code for by default */
+/* Doesn't use `cmakedefine` because it is allowed to be empty. */
+#define LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}"
+
+/* Host triple LLVM will be executed on */
+#cmakedefine LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}"
+
+#endif // LLVM_CONFIG_TARGET_TRIPLE_H

--- a/llvm/include/llvm/Config/llvm-config-unreachable-optimize.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-unreachable-optimize.h.cmake
@@ -1,0 +1,17 @@
+/*===------- llvm/Config/llvm-config-unreachable-optimize.h.cmake -*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_UNREACHABLE_OPTIMIZE_H
+#define LLVM_CONFIG_UNREACHABLE_OPTIMIZE_H
+
+/* Define if llvm_unreachable should be optimized with undefined behavior
+ * in non assert builds */
+#cmakedefine01 LLVM_UNREACHABLE_OPTIMIZE
+
+#endif // LLVM_CONFIG_UNREACHABLE_OPTIMIZE_H

--- a/llvm/include/llvm/Config/llvm-config-use-intel-jit-events.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-use-intel-jit-events.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-use-intel-jit-events.h.cmake -*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_USE_INTEL_JITEVENTS_H
+#define LLVM_CONFIG_USE_INTEL_JITEVENTS_H
+
+/* Define if we have the Intel JIT API runtime support library */
+#cmakedefine01 LLVM_USE_INTEL_JITEVENTS
+
+#endif // LLVM_CONFIG_USE_INTEL_JITEVENTS_H

--- a/llvm/include/llvm/Config/llvm-config-use-oprofile.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-use-oprofile.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-oprofile.h -------------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_USE_OPROFILE_H
+#define LLVM_CONFIG_USE_OPROFILE_H
+
+/* Define if we have the oprofile JIT-support library */
+#cmakedefine01 LLVM_USE_OPROFILE
+
+#endif // LLVM_CONFIG_USE_OPROFILE_H

--- a/llvm/include/llvm/Config/llvm-config-use-perf.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-use-perf.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-use-perf.h.cmake -------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_USE_PERF_H
+#define LLVM_CONFIG_USE_PERF_H
+
+/* Define if we have the perf JIT-support library */
+#cmakedefine01 LLVM_USE_PERF
+
+#endif // LLVM_CONFIG_USE_PERF_H

--- a/llvm/include/llvm/Config/llvm-config-version.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-version.h.cmake
@@ -1,0 +1,27 @@
+/*===------- llvm/Config/llvm-config-version.h - llvm config ------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_VERSION_H
+#define LLVM_CONFIG_VERSION_H
+
+/* This file defines macros for the LLVM version. */
+
+/* Major version of the LLVM API */
+#define LLVM_VERSION_MAJOR ${LLVM_VERSION_MAJOR}
+
+/* Minor version of the LLVM API */
+#define LLVM_VERSION_MINOR ${LLVM_VERSION_MINOR}
+
+/* Patch version of the LLVM API */
+#define LLVM_VERSION_PATCH ${LLVM_VERSION_PATCH}
+
+/* LLVM version string */
+#define LLVM_VERSION_STRING "${PACKAGE_VERSION}"
+
+#endif // LLVM_CONFIG_VERSION_H

--- a/llvm/include/llvm/Config/llvm-config-with-z3.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config-with-z3.h.cmake
@@ -1,0 +1,16 @@
+/*===------- llvm/Config/llvm-config-with-z3.h.cmake --------------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_CONFIG_WITH_Z3_H
+#define LLVM_CONFIG_WITH_Z3_H
+
+/* Define if we have z3 and want to build it */
+#cmakedefine LLVM_WITH_Z3 ${LLVM_WITH_Z3} 
+
+#endif // LLVM_CONFIG_WITH_Z3_H

--- a/llvm/include/llvm/Config/llvm-config.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config.h.cmake
@@ -7,195 +7,38 @@
 /*                                                                            */
 /*===----------------------------------------------------------------------===*/
 
-/* This file enumerates variables from the LLVM configuration so that they
-   can be in exported headers and won't override package specific directives.
-   This is a C header that can be included in the llvm-c headers. */
-
 #ifndef LLVM_CONFIG_H
 #define LLVM_CONFIG_H
 
-/* Define if LLVM_ENABLE_DUMP is enabled */
-#cmakedefine LLVM_ENABLE_DUMP
+// This file is here for backward compatibility: please don't add to it.
+//
+// The configuration is sharded in a few files, it is recommended
+// to include only the one you need to minimize the impact on
+// incremental build and caching.
+#include "llvm-config-build-llvm-dylib.h"
+#include "llvm-config-build-shared-libs.h"
+#include "llvm-config-enable-curl.h"
+#include "llvm-config-enable-dia-sdk.h"
+#include "llvm-config-enable-dump.h"
+#include "llvm-config-enable-httplib.h"
+#include "llvm-config-enable-plugins.h"
+#include "llvm-config-enable-threads.h"
+#include "llvm-config-enable-zlib.h"
+#include "llvm-config-enable-zstd.h"
+#include "llvm-config-force-enable-stats.h"
+#include "llvm-config-force-use-old-toolchain.h"
+#include "llvm-config-has-atomics.h"
+#include "llvm-config-have-sysexits.h"
+#include "llvm-config-have-tflite.h"
+#include "llvm-config-on-unix.h"
+#include "llvm-config-unreachable-optimize.h"
+#include "llvm-config-use-intel-jit-events.h"
+#include "llvm-config-use-oprofile.h"
+#include "llvm-config-use-perf.h"
+#include "llvm-config-with-z3.h"
 
-/* Target triple LLVM will generate code for by default */
-/* Doesn't use `cmakedefine` because it is allowed to be empty. */
-#define LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}"
-
-/* Define if threads enabled */
-#cmakedefine01 LLVM_ENABLE_THREADS
-
-/* Has gcc/MSVC atomic intrinsics */
-#cmakedefine01 LLVM_HAS_ATOMICS
-
-/* Host triple LLVM will be executed on */
-#cmakedefine LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}"
-
-/* LLVM architecture name for the native architecture, if available */
-#cmakedefine LLVM_NATIVE_ARCH ${LLVM_NATIVE_ARCH}
-
-/* LLVM name for the native AsmParser init function, if available */
-#cmakedefine LLVM_NATIVE_ASMPARSER LLVMInitialize${LLVM_NATIVE_ARCH}AsmParser
-
-/* LLVM name for the native AsmPrinter init function, if available */
-#cmakedefine LLVM_NATIVE_ASMPRINTER LLVMInitialize${LLVM_NATIVE_ARCH}AsmPrinter
-
-/* LLVM name for the native Disassembler init function, if available */
-#cmakedefine LLVM_NATIVE_DISASSEMBLER LLVMInitialize${LLVM_NATIVE_ARCH}Disassembler
-
-/* LLVM name for the native Target init function, if available */
-#cmakedefine LLVM_NATIVE_TARGET LLVMInitialize${LLVM_NATIVE_ARCH}Target
-
-/* LLVM name for the native TargetInfo init function, if available */
-#cmakedefine LLVM_NATIVE_TARGETINFO LLVMInitialize${LLVM_NATIVE_ARCH}TargetInfo
-
-/* LLVM name for the native target MC init function, if available */
-#cmakedefine LLVM_NATIVE_TARGETMC LLVMInitialize${LLVM_NATIVE_ARCH}TargetMC
-
-/* LLVM name for the native target MCA init function, if available */
-#cmakedefine LLVM_NATIVE_TARGETMCA LLVMInitialize${LLVM_NATIVE_ARCH}TargetMCA
-
-/* Define if the AArch64 target is built in */
-#cmakedefine01 LLVM_HAS_AARCH64_TARGET
-
-/* Define if the AMDGPU target is built in */
-#cmakedefine01 LLVM_HAS_AMDGPU_TARGET
-
-/* Define if the ARC target is built in */
-#cmakedefine01 LLVM_HAS_ARC_TARGET
-
-/* Define if the ARM target is built in */
-#cmakedefine01 LLVM_HAS_ARM_TARGET
-
-/* Define if the AVR target is built in */
-#cmakedefine01 LLVM_HAS_AVR_TARGET
-
-/* Define if the BPF target is built in */
-#cmakedefine01 LLVM_HAS_BPF_TARGET
-
-/* Define if the CSKY target is built in */
-#cmakedefine01 LLVM_HAS_CSKY_TARGET
-
-/* Define if the DirectX target is built in */
-#cmakedefine01 LLVM_HAS_DIRECTX_TARGET
-
-/* Define if the Hexagon target is built in */
-#cmakedefine01 LLVM_HAS_HEXAGON_TARGET
-
-/* Define if the Lanai target is built in */
-#cmakedefine01 LLVM_HAS_LANAI_TARGET
-
-/* Define if the LoongArch target is built in */
-#cmakedefine01 LLVM_HAS_LOONGARCH_TARGET
-
-/* Define if the M68k target is built in */
-#cmakedefine01 LLVM_HAS_M68K_TARGET
-
-/* Define if the Mips target is built in */
-#cmakedefine01 LLVM_HAS_MIPS_TARGET
-
-/* Define if the MSP430 target is built in */
-#cmakedefine01 LLVM_HAS_MSP430_TARGET
-
-/* Define if the NVPTX target is built in */
-#cmakedefine01 LLVM_HAS_NVPTX_TARGET
-
-/* Define if the PowerPC target is built in */
-#cmakedefine01 LLVM_HAS_POWERPC_TARGET
-
-/* Define if the RISCV target is built in */
-#cmakedefine01 LLVM_HAS_RISCV_TARGET
-
-/* Define if the Sparc target is built in */
-#cmakedefine01 LLVM_HAS_SPARC_TARGET
-
-/* Define if the SPIRV target is built in */
-#cmakedefine01 LLVM_HAS_SPIRV_TARGET
-
-/* Define if the SystemZ target is built in */
-#cmakedefine01 LLVM_HAS_SYSTEMZ_TARGET
-
-/* Define if the VE target is built in */
-#cmakedefine01 LLVM_HAS_VE_TARGET
-
-/* Define if the WebAssembly target is built in */
-#cmakedefine01 LLVM_HAS_WEBASSEMBLY_TARGET
-
-/* Define if the X86 target is built in */
-#cmakedefine01 LLVM_HAS_X86_TARGET
-
-/* Define if the XCore target is built in */
-#cmakedefine01 LLVM_HAS_XCORE_TARGET
-
-/* Define if the Xtensa target is built in */
-#cmakedefine01 LLVM_HAS_XTENSA_TARGET
-
-/* Define if this is Unixish platform */
-#cmakedefine LLVM_ON_UNIX ${LLVM_ON_UNIX}
-
-/* Define if we have the Intel JIT API runtime support library */
-#cmakedefine01 LLVM_USE_INTEL_JITEVENTS
-
-/* Define if we have the oprofile JIT-support library */
-#cmakedefine01 LLVM_USE_OPROFILE
-
-/* Define if we have the perf JIT-support library */
-#cmakedefine01 LLVM_USE_PERF
-
-/* Major version of the LLVM API */
-#define LLVM_VERSION_MAJOR ${LLVM_VERSION_MAJOR}
-
-/* Minor version of the LLVM API */
-#define LLVM_VERSION_MINOR ${LLVM_VERSION_MINOR}
-
-/* Patch version of the LLVM API */
-#define LLVM_VERSION_PATCH ${LLVM_VERSION_PATCH}
-
-/* LLVM version string */
-#define LLVM_VERSION_STRING "${PACKAGE_VERSION}"
-
-/* Whether LLVM records statistics for use with GetStatistics(),
- * PrintStatistics() or PrintStatisticsJSON()
- */
-#cmakedefine01 LLVM_FORCE_ENABLE_STATS
-
-/* Define if we have z3 and want to build it */
-#cmakedefine LLVM_WITH_Z3 ${LLVM_WITH_Z3}
-
-/* Define if we have curl and want to use it */
-#cmakedefine LLVM_ENABLE_CURL ${LLVM_ENABLE_CURL}
-
-/* Define if we have cpp-httplib and want to use it */
-#cmakedefine LLVM_ENABLE_HTTPLIB ${LLVM_ENABLE_HTTPLIB}
-
-/* Define if zlib compression is available */
-#cmakedefine01 LLVM_ENABLE_ZLIB
-
-/* Define if zstd compression is available */
-#cmakedefine01 LLVM_ENABLE_ZSTD
-
-/* Define if LLVM is using tflite */
-#cmakedefine LLVM_HAVE_TFLITE
-
-/* Define to 1 if you have the <sysexits.h> header file. */
-#cmakedefine HAVE_SYSEXITS_H ${HAVE_SYSEXITS_H}
-
-/* Define if building libLLVM shared library */
-#cmakedefine LLVM_BUILD_LLVM_DYLIB
-
-/* Define if building LLVM with BUILD_SHARED_LIBS */
-#cmakedefine LLVM_BUILD_SHARED_LIBS
-
-/* Define if building LLVM with LLVM_FORCE_USE_OLD_TOOLCHAIN_LIBS */
-#cmakedefine LLVM_FORCE_USE_OLD_TOOLCHAIN ${LLVM_FORCE_USE_OLD_TOOLCHAIN}
-
-/* Define if llvm_unreachable should be optimized with undefined behavior
- * in non assert builds */
-#cmakedefine01 LLVM_UNREACHABLE_OPTIMIZE
-
-/* Define to 1 if you have the DIA SDK installed, and to 0 if you don't. */
-#cmakedefine01 LLVM_ENABLE_DIA_SDK
-
-/* Define if plugins enabled */
-#cmakedefine LLVM_ENABLE_PLUGINS
+#include "llvm-config-target-native.h"
+#include "llvm-config-target-triple.h"
+#include "llvm-config-version.h"
 
 #endif

--- a/mlir/lib/Dialect/GPU/Transforms/SerializeToCubin.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/SerializeToCubin.cpp
@@ -13,6 +13,7 @@
 
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "llvm/Config/llvm-config-target-NVPTX.h"
 #include "llvm/Support/Debug.h"
 
 #if MLIR_GPU_TO_CUBIN_PASS_ENABLE

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 
+#include "llvm/Config/llvm-config-target-NVPTX.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/FormatVariadic.h"


### PR DESCRIPTION
This will allow for more granular include and improve incremental rebuild and caching when switching targets or other options independently.

A single change of a target, default triple, or any option is triggering a monolithic rebuild of any user of a single of these options. We should make it as granular as possible.

As a follow-up we'll update the user of llvm-config.h incrementally.
Another follow-up should be to look into the private config.h the same way.
