### PR TITLE
[Github] Fix github automation script on empty descriptions

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -48,6 +48,11 @@ def _get_curent_team(team_name, teams) -> Optional[github.Team.Team]:
 
 
 def escape_description(str):
+    # If the description of an issue/pull request is empty, the Github API
+    # library returns None instead of an empty string. Handle this here to
+    # avoid failures from trying to manipulate None.
+    if str is None:
+        return ""
     # https://github.com/github/markup/issues/1168#issuecomment-494946168
     str = html.escape(str, False)
     # '@' followed by alphanum is a user name


### PR DESCRIPTION
Before this patch, the github automation script would fail when trying to escape the text of a PR/issue description that was empty as the Github library returns None instead of an empty string in those scenarios. This patch special cases this and makes the escape function return an empty string when given a value of None.