### PR TITLE
[WIP][clangd] Resolve the dependent type from its single instantiation. Take 1

### DIFF
--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -16,12 +16,14 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DeclVisitor.h"
 #include "clang/AST/DeclarationName.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
+#include "clang/AST/StmtVisitor.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/Builtins.h"
@@ -636,7 +638,7 @@ static NamedDecl *getOnlyInstantiationImpl(TemplateDeclTy *TD) {
   return Only;
 }
 
-NamedDecl *getOnlyInstantiation(NamedDecl *TemplatedDecl) {
+NamedDecl *getOnlyInstantiation(const NamedDecl *TemplatedDecl) {
   if (TemplateDecl *TD = TemplatedDecl->getDescribedTemplate()) {
     if (auto *CTD = llvm::dyn_cast<ClassTemplateDecl>(TD))
       return getOnlyInstantiationImpl(CTD);
@@ -646,6 +648,197 @@ NamedDecl *getOnlyInstantiation(NamedDecl *TemplatedDecl) {
       return getOnlyInstantiationImpl(VTD);
   }
   return nullptr;
+}
+
+NamedDecl *getOnlyInstantiatedDecls(const NamedDecl *DependentDecl) {
+  if (auto *Instantiation = getOnlyInstantiation(DependentDecl))
+    return Instantiation;
+  NamedDecl *OuterTemplate = nullptr;
+  for (auto *DC = DependentDecl->getDeclContext(); isa<CXXRecordDecl>(DC);
+       DC = DC->getParent()) {
+    auto *RD = cast<CXXRecordDecl>(DC);
+    if (auto *I = getOnlyInstantiation(RD)) {
+      OuterTemplate = I;
+      break;
+    }
+  }
+
+  if (!OuterTemplate)
+    return nullptr;
+
+  struct Visitor : DeclVisitor<Visitor, NamedDecl *> {
+    const NamedDecl *TemplatedDecl;
+    Visitor(const NamedDecl *TemplatedDecl) : TemplatedDecl(TemplatedDecl) {}
+
+    NamedDecl *VisitCXXRecordDecl(CXXRecordDecl *RD) {
+      if (RD->getTemplateInstantiationPattern() == TemplatedDecl)
+        return RD;
+      for (auto *F : RD->decls()) {
+        if (auto *Injected = llvm::dyn_cast<CXXRecordDecl>(F);
+            Injected && Injected->isInjectedClassName())
+          continue;
+        if (NamedDecl *ND = Visit(F))
+          return ND;
+      }
+      return nullptr;
+    }
+
+    NamedDecl *VisitClassTemplateDecl(ClassTemplateDecl *CTD) {
+      unsigned Size = llvm::range_size(CTD->specializations());
+      if (Size != 1)
+        return nullptr;
+      return Visit(*CTD->spec_begin());
+    }
+
+    NamedDecl *VisitFunctionTemplateDecl(FunctionTemplateDecl *FTD) {
+      unsigned Size = llvm::range_size(FTD->specializations());
+      if (Size != 1)
+        return nullptr;
+      return Visit(*FTD->spec_begin());
+    }
+
+    NamedDecl *VisitFunctionDecl(FunctionDecl *FD) {
+      if (FD->getTemplateInstantiationPattern() == TemplatedDecl)
+        return FD;
+      return nullptr;
+    }
+
+    NamedDecl *VisitVarDecl(VarDecl *VD) {
+      if (VD->getCanonicalDecl()->getSourceRange() ==
+          TemplatedDecl->getCanonicalDecl()->getSourceRange())
+        return VD;
+      return nullptr;
+    }
+
+    NamedDecl *VisitFieldDecl(FieldDecl *FD) {
+      if (FD->getCanonicalDecl()->getSourceRange() ==
+          TemplatedDecl->getCanonicalDecl()->getSourceRange())
+        return FD;
+      return nullptr;
+    }
+  };
+  return Visitor(DependentDecl).Visit(OuterTemplate);
+}
+
+std::optional<DynTypedNode>
+getOnlyInstantiatedNode(const DeclContext *StartingPoint,
+                        const DynTypedNode &DependentNode) {
+  if (auto *CTD = DependentNode.get<ClassTemplateDecl>())
+    return getOnlyInstantiatedNode(
+        StartingPoint, DynTypedNode::create(*CTD->getTemplatedDecl()));
+  if (auto *FTD = DependentNode.get<FunctionTemplateDecl>())
+    return getOnlyInstantiatedNode(
+        StartingPoint, DynTypedNode::create(*FTD->getTemplatedDecl()));
+
+  if (auto *FD = DependentNode.get<FunctionDecl>()) {
+    auto *ID = getOnlyInstantiatedDecls(FD);
+    if (!ID)
+      return std::nullopt;
+    return DynTypedNode::create(*ID);
+  }
+  if (auto *RD = DependentNode.get<CXXRecordDecl>()) {
+    auto *ID = getOnlyInstantiatedDecls(RD);
+    if (!ID)
+      return std::nullopt;
+    return DynTypedNode::create(*ID);
+  }
+
+  NamedDecl *InstantiatedEnclosingDecl = nullptr;
+  for (auto *DC = StartingPoint; DC;
+       DC = DC->getParent()) {
+    auto *ND = llvm::dyn_cast<NamedDecl>(DC);
+    if (!ND)
+      continue;
+    InstantiatedEnclosingDecl = getOnlyInstantiatedDecls(ND);
+    if (InstantiatedEnclosingDecl)
+      break;
+  }
+
+  if (!InstantiatedEnclosingDecl)
+    return std::nullopt;
+
+  auto *InstantiatedFunctionDecl =
+      llvm::dyn_cast<FunctionDecl>(InstantiatedEnclosingDecl);
+  if (!InstantiatedFunctionDecl)
+    return std::nullopt;
+
+  struct FullExprVisitor : RecursiveASTVisitor<FullExprVisitor> {
+    const DynTypedNode &DependentNode;
+    Stmt *Result;
+    FullExprVisitor(const DynTypedNode &DependentNode)
+        : DependentNode(DependentNode), Result(nullptr) {}
+
+    bool shouldVisitTemplateInstantiations() const { return true; }
+
+    bool shouldVisitImplicitCode() const { return true; }
+
+    bool VisitStmt(Stmt *S) {
+      if (S->getSourceRange() == DependentNode.getSourceRange()) {
+        Result = S;
+        return false;
+      }
+      return true;
+    }
+  };
+
+  FullExprVisitor Visitor(DependentNode);
+  Visitor.TraverseFunctionDecl(InstantiatedFunctionDecl);
+  if (Visitor.Result)
+    return DynTypedNode::create(*Visitor.Result);
+  return std::nullopt;
+}
+
+NamedDecl *
+getOnlyInstantiationForMemberFunction(const CXXMethodDecl *TemplatedDecl) {
+  if (auto *MemberInstantiation = getOnlyInstantiation(TemplatedDecl))
+    return MemberInstantiation;
+  NamedDecl *OuterTemplate = nullptr;
+  for (auto *DC = TemplatedDecl->getDeclContext(); isa<CXXRecordDecl>(DC);
+       DC = DC->getParent()) {
+    auto *RD = cast<CXXRecordDecl>(DC);
+    if (auto *I = getOnlyInstantiation(RD)) {
+      OuterTemplate = I;
+      break;
+    }
+  }
+  if (!OuterTemplate)
+    return nullptr;
+  struct Visitor : DeclVisitor<Visitor, NamedDecl *> {
+    const CXXMethodDecl *TD;
+    Visitor(const CXXMethodDecl *TemplatedDecl) : TD(TemplatedDecl) {}
+    NamedDecl *VisitCXXRecordDecl(CXXRecordDecl *RD) {
+      for (auto *F : RD->decls()) {
+        if (!isa<NamedDecl>(F))
+          continue;
+        if (NamedDecl *ND = Visit(F))
+          return ND;
+      }
+      return nullptr;
+    }
+
+    NamedDecl *VisitClassTemplateDecl(ClassTemplateDecl *CTD) {
+      unsigned Size = llvm::range_size(CTD->specializations());
+      if (Size != 1)
+        return nullptr;
+      return Visit(*CTD->spec_begin());
+    }
+
+    NamedDecl *VisitFunctionTemplateDecl(FunctionTemplateDecl *FTD) {
+      unsigned Size = llvm::range_size(FTD->specializations());
+      if (Size != 1)
+        return nullptr;
+      return Visit(*FTD->spec_begin());
+    }
+
+    NamedDecl *VisitCXXMethodDecl(CXXMethodDecl *MD) {
+      auto *Pattern = MD->getTemplateInstantiationPattern();
+      if (Pattern == TD)
+        return MD;
+      return nullptr;
+    }
+
+  };
+  return Visitor(TemplatedDecl).Visit(OuterTemplate);
 }
 
 std::vector<const Attr *> getAttributes(const DynTypedNode &N) {

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -177,7 +177,14 @@ TemplateTypeParmTypeLoc getContainedAutoParamType(TypeLoc TL);
 
 // If TemplatedDecl is the generic body of a template, and the template has
 // exactly one visible instantiation, return the instantiated body.
-NamedDecl *getOnlyInstantiation(NamedDecl *TemplatedDecl);
+NamedDecl *getOnlyInstantiation(const NamedDecl *TemplatedDecl);
+
+NamedDecl *
+getOnlyInstantiationForMemberFunction(const CXXMethodDecl *TemplatedDecl);
+
+std::optional<DynTypedNode>
+getOnlyInstantiatedNode(const DeclContext *StartingPoint,
+                        const DynTypedNode &DependentNode);
 
 /// Return attributes attached directly to a node.
 std::vector<const Attr *> getAttributes(const DynTypedNode &);

--- a/clang-tools-extra/clangd/FindTarget.h
+++ b/clang-tools-extra/clangd/FindTarget.h
@@ -81,14 +81,14 @@ class DeclRelationSet;
 /// FIXME: some AST nodes cannot be DynTypedNodes, these cannot be specified.
 llvm::SmallVector<const NamedDecl *, 1>
 targetDecl(const DynTypedNode &, DeclRelationSet Mask,
-           const HeuristicResolver *Resolver);
+           const HeuristicResolver &Resolver);
 
 /// Similar to targetDecl(), however instead of applying a filter, all possible
 /// decls are returned along with their DeclRelationSets.
 /// This is suitable for indexing, where everything is recorded and filtering
 /// is applied later.
 llvm::SmallVector<std::pair<const NamedDecl *, DeclRelationSet>, 1>
-allTargetDecls(const DynTypedNode &, const HeuristicResolver *);
+allTargetDecls(const DynTypedNode &, const HeuristicResolver &);
 
 enum class DeclRelation : unsigned {
   // Template options apply when the declaration is an instantiated template.
@@ -147,13 +147,13 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, ReferenceLoc R);
 /// FIXME: extend to report location information about declaration names too.
 void findExplicitReferences(const Stmt *S,
                             llvm::function_ref<void(ReferenceLoc)> Out,
-                            const HeuristicResolver *Resolver);
+                            const HeuristicResolver &Resolver);
 void findExplicitReferences(const Decl *D,
                             llvm::function_ref<void(ReferenceLoc)> Out,
-                            const HeuristicResolver *Resolver);
+                            const HeuristicResolver &Resolver);
 void findExplicitReferences(const ASTContext &AST,
                             llvm::function_ref<void(ReferenceLoc)> Out,
-                            const HeuristicResolver *Resolver);
+                            const HeuristicResolver &Resolver);
 
 /// Find declarations explicitly referenced in the source code defined by \p N.
 /// For templates, will prefer to return a template instantiation whenever
@@ -166,7 +166,7 @@ void findExplicitReferences(const ASTContext &AST,
 /// \p Mask should not contain TemplatePattern or TemplateInstantiation.
 llvm::SmallVector<const NamedDecl *, 1>
 explicitReferenceTargets(DynTypedNode N, DeclRelationSet Mask,
-                         const HeuristicResolver *Resolver);
+                         const HeuristicResolver &Resolver);
 
 // Boring implementation details of bitfield.
 

--- a/clang-tools-extra/clangd/HeuristicResolver.cpp
+++ b/clang-tools-extra/clangd/HeuristicResolver.cpp
@@ -247,12 +247,13 @@ std::vector<const NamedDecl *> HeuristicResolver::resolveMemberExpr(
     BaseType = getPointeeType(BaseType);
   }
 
+  if (!BaseType)
+    return {};
+
   if (BaseType->isDependentType())
     if (auto *MaybeResolved = resolveTypeFromInstantiatedTemplate(ME))
       BaseType = MaybeResolved;
 
-  if (!BaseType)
-    return {};
   if (const auto *BT = BaseType->getAs<BuiltinType>()) {
     // If BaseType is the type of a dependent expression, it's just
     // represented as BuiltinType::Dependent which gives us no information. We

--- a/clang-tools-extra/clangd/HeuristicResolver.cpp
+++ b/clang-tools-extra/clangd/HeuristicResolver.cpp
@@ -7,10 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "HeuristicResolver.h"
+#include "AST.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/CXXInheritance.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Type.h"
 
 namespace clang {
@@ -44,6 +48,98 @@ const Type *resolveDeclsToType(const std::vector<const NamedDecl *> &Decls,
     return VD->getType().getTypePtrOrNull();
   }
   return nullptr;
+}
+
+// Visitor that helps to extract deduced type from instantiated entities.
+// This merely performs the source location comparison against each Decl
+// until it finds a Decl with the same location as the
+// dependent one. Its associated type will then be extracted.
+struct InstantiatedDeclVisitor : RecursiveASTVisitor<InstantiatedDeclVisitor> {
+
+  InstantiatedDeclVisitor(NamedDecl *DependentDecl) : DependentDecl(DependentDecl) {}
+
+  bool shouldVisitTemplateInstantiations() const { return true; }
+
+  bool shouldVisitLambdaBody() const { return true; }
+
+  bool shouldVisitImplicitCode() const { return true; }
+
+  template <typename D>
+  bool onDeclVisited(D *MaybeInstantiated) {
+    if (MaybeInstantiated->getDeclContext()->isDependentContext())
+      return true;
+    auto *Dependent = dyn_cast<D>(DependentDecl);
+    if (!Dependent)
+      return true;
+    auto LHS = MaybeInstantiated->getTypeSourceInfo(),
+         RHS = Dependent->getTypeSourceInfo();
+    if (!LHS || !RHS)
+      return true;
+    if (LHS->getTypeLoc().getSourceRange() !=
+        RHS->getTypeLoc().getSourceRange())
+      return true;
+    DeducedType = MaybeInstantiated->getType();
+    return false;
+  }
+
+  bool VisitFieldDecl(FieldDecl *FD) {
+    return onDeclVisited(FD);
+  }
+
+  bool VisitVarDecl(VarDecl *VD) {
+    return onDeclVisited(VD);
+  }
+
+  NamedDecl *DependentDecl;
+  QualType DeducedType;
+};
+
+/// Attempt to resolve the dependent type from the surrounding context for which
+/// a single instantiation is available.
+const Type *
+resolveTypeFromInstantiatedTemplate(const CXXDependentScopeMemberExpr *Expr) {
+  if (Expr->isImplicitAccess())
+    return nullptr;
+
+  auto *Base = Expr->getBase();
+  NamedDecl *ND = nullptr;
+  if (auto *CXXMember = dyn_cast<MemberExpr>(Base))
+    ND = CXXMember->getMemberDecl();
+
+  if (auto *DRExpr = dyn_cast<DeclRefExpr>(Base))
+    ND = DRExpr->getFoundDecl();
+
+  // FIXME: Handle CXXUnresolvedConstructExpr. This kind of type doesn't have
+  // available Decls to be matched against. Which inhibits the current heuristic
+  // from resolving expressions such as `T().fo^o()`, where T is a
+  // single-instantiated template parameter.
+  if (!ND)
+    return nullptr;
+
+  NamedDecl *Instantiation = nullptr;
+
+  // Find out a single instantiation that we can start with. The enclosing
+  // context for the current Decl might not be a templated entity (e.g. a member
+  // function inside a class template), hence we shall walk up the decl
+  // contexts first.
+  for (auto *EnclosingContext = ND->getDeclContext(); EnclosingContext;
+       EnclosingContext = EnclosingContext->getParent()) {
+    if (auto *ND = dyn_cast<NamedDecl>(EnclosingContext)) {
+      Instantiation = getOnlyInstantiation(ND);
+      if (Instantiation)
+        break;
+    }
+  }
+
+  if (!Instantiation)
+    return nullptr;
+
+  // This will traverse down the instantiation entity, visit each Decl, and
+  // extract the deduced type for the undetermined Decl `ND`.
+  InstantiatedDeclVisitor Visitor(ND);
+  Visitor.TraverseDecl(Instantiation);
+
+  return Visitor.DeducedType.getTypePtrOrNull();
 }
 
 } // namespace
@@ -150,6 +246,11 @@ std::vector<const NamedDecl *> HeuristicResolver::resolveMemberExpr(
   if (ME->isArrow()) {
     BaseType = getPointeeType(BaseType);
   }
+
+  if (BaseType->isDependentType())
+    if (auto *MaybeResolved = resolveTypeFromInstantiatedTemplate(ME))
+      BaseType = MaybeResolved;
+
   if (!BaseType)
     return {};
   if (const auto *BT = BaseType->getAs<BuiltinType>()) {

--- a/clang-tools-extra/clangd/HeuristicResolver.cpp
+++ b/clang-tools-extra/clangd/HeuristicResolver.cpp
@@ -56,7 +56,8 @@ const Type *resolveDeclsToType(const std::vector<const NamedDecl *> &Decls,
 // dependent one. Its associated type will then be extracted.
 struct InstantiatedDeclVisitor : RecursiveASTVisitor<InstantiatedDeclVisitor> {
 
-  InstantiatedDeclVisitor(NamedDecl *DependentDecl) : DependentDecl(DependentDecl) {}
+  InstantiatedDeclVisitor(NamedDecl *DependentDecl)
+      : DependentDecl(DependentDecl) {}
 
   bool shouldVisitTemplateInstantiations() const { return true; }
 
@@ -64,8 +65,7 @@ struct InstantiatedDeclVisitor : RecursiveASTVisitor<InstantiatedDeclVisitor> {
 
   bool shouldVisitImplicitCode() const { return true; }
 
-  template <typename D>
-  bool onDeclVisited(D *MaybeInstantiated) {
+  template <typename D> bool onDeclVisited(D *MaybeInstantiated) {
     if (MaybeInstantiated->getDeclContext()->isDependentContext())
       return true;
     auto *Dependent = dyn_cast<D>(DependentDecl);
@@ -82,13 +82,9 @@ struct InstantiatedDeclVisitor : RecursiveASTVisitor<InstantiatedDeclVisitor> {
     return false;
   }
 
-  bool VisitFieldDecl(FieldDecl *FD) {
-    return onDeclVisited(FD);
-  }
+  bool VisitFieldDecl(FieldDecl *FD) { return onDeclVisited(FD); }
 
-  bool VisitVarDecl(VarDecl *VD) {
-    return onDeclVisited(VD);
-  }
+  bool VisitVarDecl(VarDecl *VD) { return onDeclVisited(VD); }
 
   NamedDecl *DependentDecl;
   QualType DeducedType;

--- a/clang-tools-extra/clangd/HeuristicResolver.h
+++ b/clang-tools-extra/clangd/HeuristicResolver.h
@@ -45,7 +45,8 @@ namespace clangd {
 // not a specialization. More advanced heuristics may be added in the future.
 class HeuristicResolver {
 public:
-  HeuristicResolver(ASTContext &Ctx) : Ctx(Ctx) {}
+  HeuristicResolver(const ASTContext &Ctx, const DeclContext *EnclosingDecl = nullptr)
+      : Ctx(Ctx), EnclosingDecl(EnclosingDecl) {}
 
   // Try to heuristically resolve certain types of expressions, declarations, or
   // types to one or more likely-referenced declarations.
@@ -76,7 +77,8 @@ public:
   const Type *getPointeeType(const Type *T) const;
 
 private:
-  ASTContext &Ctx;
+  const ASTContext &Ctx;
+  const DeclContext *EnclosingDecl;
 
   // Given a tag-decl type and a member name, heuristically resolve the
   // name to one or more declarations.

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -1358,8 +1358,9 @@ std::optional<HoverInfo> getHover(ParsedAST &AST, Position Pos,
         SelectionTree::createRight(AST.getASTContext(), TB, Offset, Offset);
     if (const SelectionTree::Node *N = ST.commonAncestor()) {
       // FIXME: Fill in HighlightRange with range coming from N->ASTNode.
-      auto Decls = explicitReferenceTargets(N->ASTNode, DeclRelation::Alias,
-                                            AST.getHeuristicResolver());
+      auto Decls = explicitReferenceTargets(
+          N->ASTNode, DeclRelation::Alias,
+          AST.getHeuristicResolver(&N->getDeclContext()));
       if (const auto *DeclToUse = pickDeclToUse(Decls)) {
         HoverCountMetric.record(1, "decl");
         HI = getHoverContents(DeclToUse, PP, Index, TB);

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -627,7 +627,7 @@ public:
         isa<UserDefinedLiteral>(E))
       return true;
 
-    auto CalleeDecls = Resolver->resolveCalleeOfCallExpr(E);
+    auto CalleeDecls = Resolver.resolveCalleeOfCallExpr(E);
     if (CalleeDecls.size() != 1)
       return true;
 
@@ -1274,7 +1274,7 @@ private:
   std::optional<Range> RestrictRange;
   FileID MainFileID;
   StringRef MainFileBuf;
-  const HeuristicResolver *Resolver;
+  HeuristicResolver Resolver;
   PrintingPolicy TypeHintPolicy;
 };
 

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -835,7 +835,6 @@ ParsedAST::ParsedAST(PathRef TUPath, llvm::StringRef Version,
       Marks(std::move(Marks)), Diags(std::move(Diags)),
       LocalTopLevelDecls(std::move(LocalTopLevelDecls)),
       Includes(std::move(Includes)) {
-  Resolver = std::make_unique<HeuristicResolver>(getASTContext());
   assert(this->Clang);
   assert(this->Action);
 }

--- a/clang-tools-extra/clangd/ParsedAST.h
+++ b/clang-tools-extra/clangd/ParsedAST.h
@@ -30,6 +30,7 @@
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/Syntax/Tokens.h"
+#include "HeuristicResolver.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include <memory>
@@ -118,8 +119,9 @@ public:
   /// AST. Might be std::nullopt if no Preamble is used.
   std::optional<llvm::StringRef> preambleVersion() const;
 
-  const HeuristicResolver *getHeuristicResolver() const {
-    return Resolver.get();
+  HeuristicResolver
+  getHeuristicResolver(const DeclContext *EnclosingDecl = nullptr) const {
+    return HeuristicResolver(getASTContext(), EnclosingDecl);
   }
 
 private:
@@ -159,7 +161,6 @@ private:
   // top-level decls from the preamble.
   std::vector<Decl *> LocalTopLevelDecls;
   IncludeStructure Includes;
-  std::unique_ptr<HeuristicResolver> Resolver;
 };
 
 } // namespace clangd

--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -168,7 +168,7 @@ llvm::DenseSet<const NamedDecl *> locateDeclAt(ParsedAST &AST,
   for (const NamedDecl *D :
        targetDecl(SelectedNode->ASTNode,
                   DeclRelation::Alias | DeclRelation::TemplatePattern,
-                  AST.getHeuristicResolver())) {
+                  AST.getHeuristicResolver(&SelectedNode->getDeclContext()))) {
     D = pickInterestingTarget(D);
     Result.insert(canonicalRenameDecl(D));
   }

--- a/clang-tools-extra/clangd/refactor/tweaks/DefineInline.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/DefineInline.cpp
@@ -123,7 +123,7 @@ bool checkDeclsAreVisible(const llvm::DenseSet<const Decl *> &DeclRefs,
 // still valid in context of Target.
 llvm::Expected<std::string> qualifyAllDecls(const FunctionDecl *FD,
                                             const FunctionDecl *Target,
-                                            const HeuristicResolver *Resolver) {
+                                            const HeuristicResolver &Resolver) {
   // There are three types of spellings that needs to be qualified in a function
   // body:
   // - Types:       Foo                 -> ns::Foo
@@ -221,7 +221,7 @@ llvm::Expected<std::string> qualifyAllDecls(const FunctionDecl *FD,
 /// \p Dest to be the same as in \p Source.
 llvm::Expected<tooling::Replacements>
 renameParameters(const FunctionDecl *Dest, const FunctionDecl *Source,
-                 const HeuristicResolver *Resolver) {
+                 const HeuristicResolver &Resolver) {
   llvm::DenseMap<const Decl *, std::string> ParamToNewName;
   llvm::DenseMap<const NamedDecl *, std::vector<SourceLocation>> RefLocs;
   auto HandleParam = [&](const NamedDecl *DestParam,

--- a/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
@@ -181,7 +181,7 @@ deleteTokensWithKind(const syntax::TokenBuffer &TokBuf, tok::TokenKind Kind,
 llvm::Expected<std::string>
 getFunctionSourceCode(const FunctionDecl *FD, llvm::StringRef TargetNamespace,
                       const syntax::TokenBuffer &TokBuf,
-                      const HeuristicResolver *Resolver) {
+                      const HeuristicResolver &Resolver) {
   auto &AST = FD->getASTContext();
   auto &SM = AST.getSourceManager();
   auto TargetContext = findContextForNS(TargetNamespace, FD->getDeclContext());

--- a/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp
@@ -176,7 +176,7 @@ struct ExtractionZone {
   // This performs a partial AST traversal proportional to the size of the
   // enclosing function, so it is possibly expensive.
   bool requiresHoisting(const SourceManager &SM,
-                        const HeuristicResolver *Resolver) const {
+                        const HeuristicResolver &Resolver) const {
     // First find all the declarations that happened inside extraction zone.
     llvm::SmallSet<const Decl *, 1> DeclsInExtZone;
     for (auto *RootStmt : RootStmts) {

--- a/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
+++ b/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
@@ -86,8 +86,8 @@ protected:
     EXPECT_EQ(N->kind(), NodeType) << Selection;
 
     std::vector<PrintedDecl> ActualDecls;
-    for (const auto &Entry :
-         allTargetDecls(N->ASTNode, AST.getHeuristicResolver()))
+    for (const auto &Entry : allTargetDecls(
+             N->ASTNode, AST.getHeuristicResolver(&N->getDeclContext())))
       ActualDecls.emplace_back(Entry.first, Entry.second);
     return ActualDecls;
   }


### PR DESCRIPTION
This is an enhancement to the HeuristicResolver, trying to extract the deduced type from the single instantiation for a template. This partially addresses the point 1 from
https://github.com/clangd/clangd/issues/1768.

This patch doesn't tackle CXXUnresolvedConstructExpr or similarities since I feel that is more arduous and would prefer to leave it for my future work.