### PR TITLE
[analyzer][solver] On SymSym RelOps, check EQClass members for contradictions

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
@@ -2234,6 +2234,16 @@ bool ConstraintAssignor::handleEquivalentAlternativeSymOperands(
   SymbolSet SymbolsEqWithRHS = RHSClass.getClassMembers(State);
   llvm::SmallVector<SymSymExpr, 10> AlternativeSymSyms;
 
+  // FIXME: We don't do a full cross-product (leftAlts x rightAlts) to try all
+  // possible combinations, instead what we do is:
+  // (LHS OP rightAlts) union (leftAlts OP RHS)
+
+  // We don't do it, because it still wouldn't be enough. For example, if a
+  // sub-symbol of an operand should be substituted to discover the
+  // contradiction. Doing a cross-product of the operand alternatives is likely
+  // too expensive for the practical gain, let alone doing the cross-product
+  // with all possible equivalent sub-symbols - but I haven't measured.
+
   // Gather left alternatives.
   for (SymbolRef AlternativeLHS : SymbolsEqWithLHS) {
     if (AlternativeLHS == LHS)

--- a/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RangeConstraintManager.cpp
@@ -2252,9 +2252,9 @@ bool ConstraintAssignor::handleEquivalentAlternativeSymOperands(
 
   // Crosscheck the inferred ranges.
   for (SymSymExpr AltSymSym : AlternativeSymSyms) {
-    RangeSet AltSymSymConstrant =
+    RangeSet AltSymSymConstraint =
         SymbolicRangeInferrer::inferRange(RangeFactory, State, &AltSymSym);
-    Constraint = intersect(RangeFactory, Constraint, AltSymSymConstrant);
+    Constraint = intersect(RangeFactory, Constraint, AltSymSymConstraint);
 
     // Check if we witnessed a contradiction with the equivalent alternative
     // operand.

--- a/clang/test/Analysis/constraint-assignor.c
+++ b/clang/test/Analysis/constraint-assignor.c
@@ -82,3 +82,51 @@ void remainder_with_adjustment_of_composit_lhs(int x, int y) {
   clang_analyzer_eval(x + y != -1);    // expected-warning{{TRUE}}
   (void)(x * y); // keep the constraints alive.
 }
+
+void gh_62215(int x, int y, int z) {
+  if (x != y) return; // x == y
+  if (z <= x) return; // z > x
+  if (z >= y) return; // z < y
+  clang_analyzer_warnIfReached(); // no-warning: This should be dead code.
+  (void)(x + y + z); // keep the constraints alive.
+}
+
+void gh_62215_contradicting_right_equivalent(int x, int y, int z) {
+  if (x == y && z > x) {
+    clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}}
+
+    // `z < y` should mean the same thing as `z < x`, which would contradict with `z > x`
+    if (z < y) {
+      clang_analyzer_warnIfReached(); // no-warning: dead code
+    }
+  }
+  (void)(x + y + z); // keep the constraints alive.
+}
+
+void gh_62215_contradicting_left_equivalent(int x, int y, int z) {
+  if (x == y && z > x) {
+    clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}}
+
+    // `y > z` should mean the same thing as `x > z`, which would contradict with `z > x`
+    if (y > z) {
+      clang_analyzer_warnIfReached(); // no-warning
+    }
+  }
+  (void)(x + y + z); // keep the constraints alive.
+}
+
+void gh_62215_contradicting_nested_right_equivalent(int x, int y, int z) {
+  if (y > 1 && y < 10) { // y: [2,9]
+    if (x == y && z > x) {
+      clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}}
+
+      // `z < (y - 1)` should mean the same thing as `z < (x - 1)`, which
+      // should contradict with `z > x` (assuming x,y: [2,9])
+      if (z < (y - 1)) {
+        // FIXME: This should be dead code.
+        clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}} Z3 crosscheck eliminate this btw
+      }
+    }
+  }
+  (void)(x + y + z); // keep the constraints alive.
+}

--- a/clang/test/Analysis/constraint-assignor.c
+++ b/clang/test/Analysis/constraint-assignor.c
@@ -115,6 +115,17 @@ void gh_62215_contradicting_left_equivalent(int x, int y, int z) {
   (void)(x + y + z); // keep the constraints alive.
 }
 
+void gh_62215_left_and_right(int x, int y, int z, int w) {
+  if (x != y) return; // x == y
+  if (z != w) return; // z == w
+  if (z <= x) return; // z > x
+  if (w >= y) return; // w < y
+  // FIXME: We fail to recognize that `w` and `y` are equivalent with `x` and `z`
+  // respectively and recognize the contradiction.
+  clang_analyzer_warnIfReached(); // expected-warning{{REACHABLE}} should be dead code
+  (void)(x + y + z + w);
+}
+
 void gh_62215_contradicting_nested_right_equivalent(int x, int y, int z) {
   if (y > 1 && y < 10) { // y: [2,9]
     if (x == y && z > x) {


### PR DESCRIPTION
The idea is that if we see a `X RELOP Y` being constrained to a RangeSet `S`, then check the eqclasses of X and Y respectively and for `X' RELOP Y'` SymSymExprs and try to infer their ranges.
If there is no contradiction with any of the equivalent alternatives, then intersecting all these RangeSets should never be empty - aka. there should be a value satisfying the constraints we have.

It costs around `|eqclass(X)| + |eqclass(y)|`.

The approach has its limitations, as demonstrated by `gh_62215_contradicting_nested_right_equivalent`, where we would need to apply the same logic, but on a sub-expression of a direct operand.

Before the patch, line 90, 100, and 112 would be reachable; and become unreachable after this. Line 127 will remain still reachable, but keep in mind that when cross-checking with Z3 (aka. Z3 refutation), then all 4 reports would be eliminated.

The idea comes from
https://github.com/llvm/llvm-project/issues/62215#issuecomment-1792878474

Fixes #62215