### PR TITLE
CodeGen: replace assertions with explicit errors for landinpad lowering

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2795,9 +2795,13 @@ bool IRTranslator::translateLandingPad(const User &U,
   MIRBuilder.buildUndef(Undef);
 
   SmallVector<LLT, 2> Tys;
-  for (Type *Ty : cast<StructType>(LP.getType())->elements())
-    Tys.push_back(getLLTForType(*Ty, *DL));
-  assert(Tys.size() == 2 && "Only two-valued landingpads are supported");
+  if (LP.getType()->isStructTy()) {
+    for (Type *Ty : cast<StructType>(LP.getType())->elements())
+      Tys.push_back(getLLTForType(*Ty, *DL));
+  }
+  if (Tys.size() != 2) {
+    report_fatal_error("Only two-valued landingpads are supported");
+  }
 
   // Mark exception register as live in.
   Register ExceptionReg = TLI.getExceptionPointerRegister(PersonalityFn);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3166,7 +3166,9 @@ void SelectionDAGBuilder::visitLandingPad(const LandingPadInst &LP) {
   SmallVector<EVT, 2> ValueVTs;
   SDLoc dl = getCurSDLoc();
   ComputeValueVTs(TLI, DAG.getDataLayout(), LP.getType(), ValueVTs);
-  assert(ValueVTs.size() == 2 && "Only two-valued landingpads are supported");
+  if (ValueVTs.size() != 2) {
+    report_fatal_error("Only two-valued landingpads are supported");
+  }
 
   // Get the two live-in registers as SDValues. The physregs have already been
   // copied into virtual registers.

--- a/llvm/test/CodeGen/Generic/landingpad_wrong_type.ll
+++ b/llvm/test/CodeGen/Generic/landingpad_wrong_type.ll
@@ -1,0 +1,18 @@
+; UNSUPPORTED: system-windows
+; RUN: not --crash llc %s 2>&1 | FileCheck %s
+; RUN: not --crash llc --global-isel %s 2>&1 | FileCheck %s
+
+declare i32 @pers(...)
+declare void @f()
+
+define void @main() personality ptr @pers {
+  invoke void @f() to label %normal unwind label %lp
+
+normal:
+  ret void
+
+lp:
+  landingpad {ptr} cleanup
+  ret void
+}
+; CHECK:LLVM ERROR: Only two-valued landingpads are supported


### PR DESCRIPTION
Report explicit error messages instead of silently crashing in release mode.

These checks can be moved to Verifier, but it breaks compatibility tests.