### PR TITLE
[mlir] Fix handling of "no rank reduction" case in two Patterns

### DIFF
--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -3099,7 +3099,7 @@ struct SubViewReturnTypeCanonicalizer {
 
     // Directly return the non-rank reduced type if there are no dropped dims.
     llvm::SmallBitVector droppedDims = op.getDroppedDims();
-    if (droppedDims.empty())
+    if (droppedDims.none())
       return nonReducedType;
 
     // Take the strides and offset from the non-rank reduced type.

--- a/mlir/lib/Dialect/Tensor/Transforms/MergeConsecutiveInsertExtractSlicePatterns.cpp
+++ b/mlir/lib/Dialect/Tensor/Transforms/MergeConsecutiveInsertExtractSlicePatterns.cpp
@@ -91,7 +91,7 @@ struct DropRedundantInsertSliceRankExpansion
                                 PatternRewriter &rewriter) const override {
     // Nothing to do if no dims are dropped.
     llvm::SmallBitVector droppedDims = extractSliceOp.getDroppedDims();
-    if (droppedDims.empty())
+    if (droppedDims.none())
       return failure();
 
     // Look for tensor.insert_slice op that has an inverse rank expansion.


### PR DESCRIPTION
This patch fixes two checks where a `SmallBitVector` containing the potential dropped dims of a SubView/ExtractSlice operation was queried via `empty()` instead of `none()`.