### PR TITLE
[mlir][emitc] Fix literal translation

### DIFF
--- a/mlir/test/Target/Cpp/literal.mlir
+++ b/mlir/test/Target/Cpp/literal.mlir
@@ -10,6 +10,5 @@ func.func @emitc_literal(%arg0: f32) {
 // CPP-DEFAULT: float [[V2:[^ ]*]] = [[V0:[^ ]*]] + M_PI
 
 // CPP-DECLTOP: void emitc_literal(float [[V0:[^ ]*]]) {
-// CPP-DECLTOP: float M_PI;
 // CPP-DECLTOP: float [[V1:[^ ]*]];
 // CPP-DECLTOP: [[V1]] = [[V0:[^ ]*]] + M_PI

--- a/mlir/test/Target/Cpp/literal_call_operand.mlir
+++ b/mlir/test/Target/Cpp/literal_call_operand.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
 // RUN: mlir-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
-// XFAIL: *
 
 func.func @emitc_call_operand() {
   %p0 = emitc.literal "M_PI" : f32
@@ -11,6 +10,5 @@ func.func @emitc_call_operand() {
 // CPP-DEFAULT-NEXT: float v1 = foo(M_PI);
 
 // CPP-DECLTOP: void emitc_call_operand() {
-// CPP-DECLTOP-NEXT: float M_PI;
 // CPP-DECLTOP-NEXT: float v1;
 // CPP-DECLTOP-NEXT: v1 = foo(M_PI);


### PR DESCRIPTION
- Do not emit variables-at-top for literals
- Do not emit an error for a missing name for literals used as call operands.
