### PR TITLE
[BOLT] Set NOOP size only on X86 (NFC)

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1375,8 +1375,8 @@ add_instruction:
     if (BC.keepOffsetForInstruction(Instruction))
       MIB->setOffset(Instruction, static_cast<uint32_t>(Offset));
 
-    if (BC.MIB->isNoop(Instruction)) {
-      // NOTE: disassembly loses the correct size information for noops.
+    if (BC.isX86() && BC.MIB->isNoop(Instruction)) {
+      // NOTE: disassembly loses the correct size information for noops on x86.
       //       E.g. nopw 0x0(%rax,%rax,1) is 9 bytes, but re-encoded it's only
       //       5 bytes. Preserve the size info using annotations.
       MIB->addAnnotation(Instruction, "Size", static_cast<uint32_t>(Size));


### PR DESCRIPTION
Small fix, we have problems with noop size only on x86, no reason to do
it on other platforms.
