### PR TITLE
[ObjC] Fix offsets following `[[no_unique_address]]` for `@encode()`

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -8535,14 +8535,12 @@ void ASTContext::getObjCEncodingForStructureImpl(RecordDecl *RDecl,
     }
   }
 
-  unsigned i = 0;
   for (FieldDecl *Field : RDecl->fields()) {
     if (!Field->isZeroLengthBitField(*this) && Field->isZeroSize(*this))
       continue;
-    uint64_t offs = layout.getFieldOffset(i);
+    uint64_t offs = layout.getFieldOffset(Field->getFieldIndex());
     FieldOrBaseOffsets.insert(FieldOrBaseOffsets.upper_bound(offs),
                               std::make_pair(offs, Field));
-    ++i;
   }
 
   if (CXXRec && includeVBases) {

--- a/clang/test/CodeGenObjCXX/encode.mm
+++ b/clang/test/CodeGenObjCXX/encode.mm
@@ -339,3 +339,17 @@ const char *a0 = @encode(Array0);
 const char *inner0 = @encode(Outer0<int>::Inner0 *);
 const char *inner1 = @encode(Outer0<int>::Inner1<float> *);
 }
+
+#if __cplusplus >= 202002L
+namespace GH71250 {
+  struct Empty {};
+  struct S {
+    [[no_unique_address]] Empty a;
+    long b;
+    long c;
+  };
+
+  // CHECKCXX20: @_ZN7GH712501sE =  constant [7 x i8] c"{S=qq}\00", align 1
+  extern const char s[] = @encode(S);
+}
+#endif


### PR DESCRIPTION
Commit 46ca880fca made `@encode` skip fields that are made zero-sized by `[[no_unique_address]]`. When iterating the fields, the index which is passed to `getFieldOffset` failed to be incremented for those due to the use of an early `continue`, so subsequent fields reported an incorrect offset. This caused an assertion to be triggered in `getObjCEncodingForStructureImpl`.

Fixes #71250