### PR TITLE
[mlir][gpu] Clean GPU `Passes.h` from external SPIRV includes

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/GPU/Transforms/Passes.h
@@ -15,7 +15,6 @@
 
 #include "Utils.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Pass/Pass.h"
 #include <optional>
 

--- a/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
@@ -227,7 +227,7 @@ def GpuSPIRVAttachTarget: Pass<"spirv-attach-target", ""> {
            /*default=*/ "\"Unknown\"",
            "Device Type">,
     Option<"deviceId", "device_id", "uint32_t",
-           /*default=*/ "mlir::spirv::TargetEnvAttr::kUnknownDeviceID",
+           /*default=*/ "",
            "Device ID">,
   ];
 }

--- a/mlir/lib/Dialect/GPU/Transforms/SPIRVAttachTarget.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/SPIRVAttachTarget.cpp
@@ -57,6 +57,9 @@ void SPIRVAttachTarget::runOnOperation() {
   auto deviceTypeSymbol = symbolizeDeviceType(deviceType);
   if (!deviceTypeSymbol)
     return signalPassFailure();
+  // Set the default device ID if none was given
+  if (!deviceId.hasValue())
+    deviceId = mlir::spirv::TargetEnvAttr::kUnknownDeviceID;
 
   Version version = versionSymbol.value();
   SmallVector<Capability, 4> capabilities;

--- a/mlir/test/Dialect/GPU/spirv-attach-targets.mlir
+++ b/mlir/test/Dialect/GPU/spirv-attach-targets.mlir
@@ -1,16 +1,16 @@
-// RUN: mlir-opt %s --spirv-attach-target='module=spirv.* ver=v1.0 caps=Kernel' | FileCheck %s
-// RUN: mlir-opt %s --spirv-attach-target='module=spirv_warm.* ver=v1.0 caps=Kernel' | FileCheck %s --check-prefix=CHECK_WARM
+// RUN: mlir-opt %s --spirv-attach-target='module=spirv.* ver=v1.0 caps=Kernel vendor=Intel device_type=Other' | FileCheck %s
+// RUN: mlir-opt %s --spirv-attach-target='module=spirv_warm.* ver=v1.0 caps=Kernel vendor=Intel device_type=Other device_id=0' | FileCheck %s --check-prefix=CHECK_WARM
 
 module attributes {gpu.container_module} {
-//      CHECK: @spirv_hot_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, #spirv.resource_limits<>>]
+//      CHECK: @spirv_hot_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, Intel:Other, #spirv.resource_limits<>>]
 // CHECK_WARM: @spirv_hot_module {
 gpu.module @spirv_hot_module {
 }
-//      CHECK: @spirv_warm_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, #spirv.resource_limits<>>]
-// CHECK_WARM: @spirv_warm_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, #spirv.resource_limits<>>]
+//      CHECK: @spirv_warm_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, Intel:Other, #spirv.resource_limits<>>]
+// CHECK_WARM: @spirv_warm_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, Intel:Other:0, #spirv.resource_limits<>>]
 gpu.module @spirv_warm_module {
 }
-//      CHECK: @spirv_cold_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, #spirv.resource_limits<>>]
+//      CHECK: @spirv_cold_module [#spirv.target_env<#spirv.vce<v1.0, [Kernel], []>, Intel:Other, #spirv.resource_limits<>>]
 // CHECK_WARM: @spirv_cold_module {
 gpu.module @spirv_cold_module {
 }


### PR DESCRIPTION
Removes the `SPIRVAttributes.h` header from `GPU/Transforms/Passes.h`