### PR TITLE
[LLD] [COFF] Fix deducing the machine type from LTO objects for ARM/Thumb

### DIFF
--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -1090,6 +1090,7 @@ MachineTypes BitcodeFile::getMachineType() {
   case Triple::x86:
     return I386;
   case Triple::arm:
+  case Triple::thumb:
     return ARMNT;
   case Triple::aarch64:
     return ARM64;

--- a/lld/test/COFF/lto-arm.ll
+++ b/lld/test/COFF/lto-arm.ll
@@ -1,0 +1,19 @@
+; REQUIRES: arm
+
+; RUN: llvm-as %s -o %t.obj
+
+; RUN: lld-link /entry:entry %t.obj /out:%t.exe /subsystem:console 2>&1 | FileCheck %s --check-prefix=ERR --allow-empty
+; RUN: llvm-readobj %t.exe | FileCheck %s
+
+; ERR-NOT: /machine is not specified
+
+; CHECK: Format: COFF-ARM{{$}}
+; CHECK: Arch: thumb
+
+target datalayout = "e-m:w-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
+target triple = "thumbv7-w64-windows-gnu"
+
+define dso_local arm_aapcs_vfpcc void @entry() {
+entry:
+  ret void
+}


### PR DESCRIPTION
In practice, all the Windows ARMNT IR objects show the architecture type Thumb, not ARM.

Most other switch cases for architecture in lld/COFF check for and treat `arm` and `thumb` equally.