### PR TITLE
[LLD] [COFF] Mark the symbol _tls_used as a GC root

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2472,6 +2472,10 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
   // resolve symbols and write indices, but don't generate native code or link).
   ctx.symtab.compileBitcodeFiles();
 
+  if (Defined *d =
+          dyn_cast_or_null<Defined>(ctx.symtab.findUnderscore("_tls_used")))
+    config->gcroot.push_back(d);
+
   // If -thinlto-index-only is given, we should create only "index
   // files" and not object files. Index file creation is already done
   // in addCombinedLTOObject, so we are done if that's the case.

--- a/lld/test/COFF/tls-used-gc.s
+++ b/lld/test/COFF/tls-used-gc.s
@@ -1,0 +1,21 @@
+# REQUIRES: x86
+# RUN: llvm-mc -triple=x86_64-windows-gnu -filetype=obj -o %t.obj %s
+# RUN: lld-link %t.obj /out:%t.exe /entry:main /subsystem:console /opt:ref
+# RUN: llvm-readobj --file-headers %t.exe | FileCheck %s
+
+# CHECK: TLSTableRVA: 0x1000
+# CHECK: TLSTableSize: 0x28
+
+  .section .text@main,"xr",one_only,main
+  .globl main
+main:
+  ret
+
+  .section .tls$aaa
+tlsvar:
+  .long 1
+
+  .section .rdata$_tls_used,"dr",one_only,_tls_used
+  .globl _tls_used
+_tls_used:
+  .zero 40


### PR DESCRIPTION
This is necessary if the object file containing _tls_used is built with -fdata-sections; if this symbol is present, lld is going to include references to it in the PE header, in the TLS_TABLE data directory.

Therefore, treat the symbol as a GC root, i.e. retain it (and whatever other symbols the section chunk references) when doing doing GC (/opt:ref), if the symbol is present.