### PR TITLE
[flang] Change `uniqueCGIdent` separator from `.` to `X`

### DIFF
--- a/flang/docs/BijectiveInternalNameUniquing.md
+++ b/flang/docs/BijectiveInternalNameUniquing.md
@@ -236,3 +236,14 @@ The uniqued name of `yourtype` where `k1=4` and `k2=-6` (at compile-time):
 Compiler generated names do not have to be mapped back to Fortran. This
 includes names prefixed with `_QQ`, tag `D` for a type bound procedure
 dispatch table, and tags `Y` and `YI` for runtime type descriptors.
+Combinations of internal names are separated with the `X` tag.
+
+Given:
+```
+    _QQcl, 9a37c0
+```
+
+The uniqued name of `_QQcl` and `9a37c0`:
+```
+    _QQclX9a37c0
+```

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -966,13 +966,13 @@ std::string fir::factory::uniqueCGIdent(llvm::StringRef prefix,
     llvm::SmallString<32> str;
     llvm::MD5::stringifyResult(result, str);
     std::string hashName = prefix.str();
-    hashName.append(".").append(str.c_str());
+    hashName.append("_").append(str.c_str());
     return fir::NameUniquer::doGenerated(hashName);
   }
   // "Short" identifiers use a reversible hex string
   std::string nm = prefix.str();
   return fir::NameUniquer::doGenerated(
-      nm.append(".").append(llvm::toHex(name)));
+      nm.append("_").append(llvm::toHex(name)));
 }
 
 mlir::Value fir::factory::locationToFilename(fir::FirOpBuilder &builder,

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -966,13 +966,13 @@ std::string fir::factory::uniqueCGIdent(llvm::StringRef prefix,
     llvm::SmallString<32> str;
     llvm::MD5::stringifyResult(result, str);
     std::string hashName = prefix.str();
-    hashName.append("_").append(str.c_str());
+    hashName.append("X").append(str.c_str());
     return fir::NameUniquer::doGenerated(hashName);
   }
   // "Short" identifiers use a reversible hex string
   std::string nm = prefix.str();
   return fir::NameUniquer::doGenerated(
-      nm.append("_").append(llvm::toHex(name)));
+      nm.append("X").append(llvm::toHex(name)));
 }
 
 mlir::Value fir::factory::locationToFilename(fir::FirOpBuilder &builder,

--- a/flang/test/Driver/compiler_options.f90
+++ b/flang/test/Driver/compiler_options.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang -S -emit-llvm -o - %s | FileCheck %s
 ! Test communication of COMPILER_OPTIONS from flang-new to flang-new -fc1.
-! CHECK: [[OPTSVAR:@_QQcl\.[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} -S -emit-llvm -o - {{.*}}compiler_options.f90"
+! CHECK: [[OPTSVAR:@_QQcl_[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} -S -emit-llvm -o - {{.*}}compiler_options.f90"
 program main
     use ISO_FORTRAN_ENV, only: compiler_options
     implicit none

--- a/flang/test/Driver/compiler_options.f90
+++ b/flang/test/Driver/compiler_options.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang -S -emit-llvm -o - %s | FileCheck %s
 ! Test communication of COMPILER_OPTIONS from flang-new to flang-new -fc1.
-! CHECK: [[OPTSVAR:@_QQcl_[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} -S -emit-llvm -o - {{.*}}compiler_options.f90"
+! CHECK: [[OPTSVAR:@_QQclX[0-9a-f]+]] = {{[a-z]+}} constant [[[OPTSLEN:[0-9]+]] x i8] c"{{.*}}flang-new{{(\.exe)?}} -S -emit-llvm -o - {{.*}}compiler_options.f90"
 program main
     use ISO_FORTRAN_ENV, only: compiler_options
     implicit none

--- a/flang/test/Fir/array-value-copy-4.fir
+++ b/flang/test/Fir/array-value-copy-4.fir
@@ -38,7 +38,7 @@ func.func @_QMmodPsub1(%arg0: !fir.box<!fir.array<?x!fir.type<_QMmodTrec1{dat:!f
     %20 = fir.embox %19 : (!fir.ref<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>
     %21 = fir.embox %18 : (!fir.ref<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>
     fir.store %20 to %0 : !fir.ref<!fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>>
-    %22 = fir.address_of(@_QQcl_2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
+    %22 = fir.address_of(@_QQclX2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
     %c9_i32 = arith.constant 9 : i32
     %23 = fir.convert %0 : (!fir.ref<!fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>>) -> !fir.ref<!fir.box<none>>
     %24 = fir.convert %21 : (!fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.box<none>

--- a/flang/test/Fir/array-value-copy-4.fir
+++ b/flang/test/Fir/array-value-copy-4.fir
@@ -38,7 +38,7 @@ func.func @_QMmodPsub1(%arg0: !fir.box<!fir.array<?x!fir.type<_QMmodTrec1{dat:!f
     %20 = fir.embox %19 : (!fir.ref<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>
     %21 = fir.embox %18 : (!fir.ref<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>
     fir.store %20 to %0 : !fir.ref<!fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>>
-    %22 = fir.address_of(@_QQcl.2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
+    %22 = fir.address_of(@_QQcl_2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
     %c9_i32 = arith.constant 9 : i32
     %23 = fir.convert %0 : (!fir.ref<!fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>>) -> !fir.ref<!fir.box<none>>
     %24 = fir.convert %21 : (!fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>) -> !fir.box<none>

--- a/flang/test/Fir/boxproc.fir
+++ b/flang/test/Fir/boxproc.fir
@@ -33,7 +33,7 @@ func.func @_QPtest_proc_dummy() {
   %3 = fir.address_of(@_QFtest_proc_dummyPtest_proc_dummy_a) : (!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> ()
   %4 = fir.emboxproc %3, %1 : ((!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> (), !fir.ref<tuple<!fir.ref<i32>>>) -> !fir.boxproc<() -> ()>
   fir.call @_QPtest_proc_dummy_other(%4) : (!fir.boxproc<() -> ()>) -> ()
-  %5 = fir.address_of(@_QQcl_2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
+  %5 = fir.address_of(@_QQclX2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
   %6 = fir.convert %5 : (!fir.ref<!fir.char<1,8>>) -> !fir.ref<i8>
   %7 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %6, %c5_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   %8 = fir.load %0 : !fir.ref<i32>
@@ -163,7 +163,7 @@ func.func @_QPtest_proc_dummy_char() {
   %4 = fir.convert %1 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
   %5 = fir.emboxchar %4, %c10 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   fir.store %5 to %3 : !fir.ref<!fir.boxchar<1>>
-  %6 = fir.address_of(@_QQcl_486920746865726521) : !fir.ref<!fir.char<1,9>>
+  %6 = fir.address_of(@_QQclX486920746865726521) : !fir.ref<!fir.char<1,9>>
   %7 = fir.convert %c9 : (index) -> i64
   %8 = fir.convert %1 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
   %9 = fir.convert %6 : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
@@ -182,7 +182,7 @@ func.func @_QPtest_proc_dummy_char() {
   %18 = arith.subi %13, %c1 : index
   cf.br ^bb1(%17, %18 : index, index)
 ^bb3:  // pred: ^bb1
-  %19 = fir.address_of(@_QQcl_2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
+  %19 = fir.address_of(@_QQclX2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
   %20 = fir.convert %19 : (!fir.ref<!fir.char<1,8>>) -> !fir.ref<i8>
   %21 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %20, %c6_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   %22 = fir.address_of(@_QFtest_proc_dummy_charPgen_message) : (!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>
@@ -242,7 +242,7 @@ func.func @_QPget_message(%arg0: !fir.ref<!fir.char<1,40>>, %arg1: index, %arg2:
   %c32_i8 = arith.constant 32 : i8
   %c0 = arith.constant 0 : index
   %0 = fir.convert %arg0 : (!fir.ref<!fir.char<1,40>>) -> !fir.ref<!fir.char<1,?>>
-  %1 = fir.address_of(@_QQcl_6D6573736167652069733A20) : !fir.ref<!fir.char<1,12>>
+  %1 = fir.address_of(@_QQclX6D6573736167652069733A20) : !fir.ref<!fir.char<1,12>>
   %2 = fir.extract_value %arg2, [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
   %3 = fir.box_addr %2 : (!fir.boxproc<() -> ()>) -> (() -> ())
   %4 = fir.extract_value %arg2, [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64
@@ -297,18 +297,18 @@ func.func @_QPget_message(%arg0: !fir.ref<!fir.char<1,40>>, %arg1: index, %arg2:
   %40 = fir.emboxchar %0, %c40 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   return %40 : !fir.boxchar<1>
 }
-fir.global linkonce @_QQcl_486920746865726521 constant : !fir.char<1,9> {
+fir.global linkonce @_QQclX486920746865726521 constant : !fir.char<1,9> {
   %0 = fir.string_lit "Hi there!"(9) : !fir.char<1,9>
   fir.has_value %0 : !fir.char<1,9>
 }
 func.func private @llvm.memmove.p0.p0.i64(!fir.ref<i8>, !fir.ref<i8>, i64, i1)
-fir.global linkonce @_QQcl_2E2F682E66393000 constant : !fir.char<1,8> {
+fir.global linkonce @_QQclX2E2F682E66393000 constant : !fir.char<1,8> {
   %0 = fir.string_lit "./h.f90\00"(8) : !fir.char<1,8>
   fir.has_value %0 : !fir.char<1,8>
 }
 func.func private @llvm.stacksave.p0() -> !fir.ref<i8>
 func.func private @llvm.stackrestore.p0(!fir.ref<i8>)
-fir.global linkonce @_QQcl_6D6573736167652069733A20 constant : !fir.char<1,12> {
+fir.global linkonce @_QQclX6D6573736167652069733A20 constant : !fir.char<1,12> {
   %0 = fir.string_lit "message is: "(12) : !fir.char<1,12>
   fir.has_value %0 : !fir.char<1,12>
 }

--- a/flang/test/Fir/boxproc.fir
+++ b/flang/test/Fir/boxproc.fir
@@ -33,7 +33,7 @@ func.func @_QPtest_proc_dummy() {
   %3 = fir.address_of(@_QFtest_proc_dummyPtest_proc_dummy_a) : (!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> ()
   %4 = fir.emboxproc %3, %1 : ((!fir.ref<i32>, !fir.ref<tuple<!fir.ref<i32>>>) -> (), !fir.ref<tuple<!fir.ref<i32>>>) -> !fir.boxproc<() -> ()>
   fir.call @_QPtest_proc_dummy_other(%4) : (!fir.boxproc<() -> ()>) -> ()
-  %5 = fir.address_of(@_QQcl.2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
+  %5 = fir.address_of(@_QQcl_2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
   %6 = fir.convert %5 : (!fir.ref<!fir.char<1,8>>) -> !fir.ref<i8>
   %7 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %6, %c5_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   %8 = fir.load %0 : !fir.ref<i32>
@@ -163,7 +163,7 @@ func.func @_QPtest_proc_dummy_char() {
   %4 = fir.convert %1 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
   %5 = fir.emboxchar %4, %c10 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   fir.store %5 to %3 : !fir.ref<!fir.boxchar<1>>
-  %6 = fir.address_of(@_QQcl.486920746865726521) : !fir.ref<!fir.char<1,9>>
+  %6 = fir.address_of(@_QQcl_486920746865726521) : !fir.ref<!fir.char<1,9>>
   %7 = fir.convert %c9 : (index) -> i64
   %8 = fir.convert %1 : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
   %9 = fir.convert %6 : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
@@ -182,7 +182,7 @@ func.func @_QPtest_proc_dummy_char() {
   %18 = arith.subi %13, %c1 : index
   cf.br ^bb1(%17, %18 : index, index)
 ^bb3:  // pred: ^bb1
-  %19 = fir.address_of(@_QQcl.2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
+  %19 = fir.address_of(@_QQcl_2E2F682E66393000) : !fir.ref<!fir.char<1,8>>
   %20 = fir.convert %19 : (!fir.ref<!fir.char<1,8>>) -> !fir.ref<i8>
   %21 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %20, %c6_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   %22 = fir.address_of(@_QFtest_proc_dummy_charPgen_message) : (!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>
@@ -242,7 +242,7 @@ func.func @_QPget_message(%arg0: !fir.ref<!fir.char<1,40>>, %arg1: index, %arg2:
   %c32_i8 = arith.constant 32 : i8
   %c0 = arith.constant 0 : index
   %0 = fir.convert %arg0 : (!fir.ref<!fir.char<1,40>>) -> !fir.ref<!fir.char<1,?>>
-  %1 = fir.address_of(@_QQcl.6D6573736167652069733A20) : !fir.ref<!fir.char<1,12>>
+  %1 = fir.address_of(@_QQcl_6D6573736167652069733A20) : !fir.ref<!fir.char<1,12>>
   %2 = fir.extract_value %arg2, [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
   %3 = fir.box_addr %2 : (!fir.boxproc<() -> ()>) -> (() -> ())
   %4 = fir.extract_value %arg2, [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64
@@ -297,18 +297,18 @@ func.func @_QPget_message(%arg0: !fir.ref<!fir.char<1,40>>, %arg1: index, %arg2:
   %40 = fir.emboxchar %0, %c40 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
   return %40 : !fir.boxchar<1>
 }
-fir.global linkonce @_QQcl.486920746865726521 constant : !fir.char<1,9> {
+fir.global linkonce @_QQcl_486920746865726521 constant : !fir.char<1,9> {
   %0 = fir.string_lit "Hi there!"(9) : !fir.char<1,9>
   fir.has_value %0 : !fir.char<1,9>
 }
 func.func private @llvm.memmove.p0.p0.i64(!fir.ref<i8>, !fir.ref<i8>, i64, i1)
-fir.global linkonce @_QQcl.2E2F682E66393000 constant : !fir.char<1,8> {
+fir.global linkonce @_QQcl_2E2F682E66393000 constant : !fir.char<1,8> {
   %0 = fir.string_lit "./h.f90\00"(8) : !fir.char<1,8>
   fir.has_value %0 : !fir.char<1,8>
 }
 func.func private @llvm.stacksave.p0() -> !fir.ref<i8>
 func.func private @llvm.stackrestore.p0(!fir.ref<i8>)
-fir.global linkonce @_QQcl.6D6573736167652069733A20 constant : !fir.char<1,12> {
+fir.global linkonce @_QQcl_6D6573736167652069733A20 constant : !fir.char<1,12> {
   %0 = fir.string_lit "message is: "(12) : !fir.char<1,12>
   fir.has_value %0 : !fir.char<1,12>
 }

--- a/flang/test/Fir/polymorphic.fir
+++ b/flang/test/Fir/polymorphic.fir
@@ -25,7 +25,7 @@ func.func @_QMpolymorphic_testPtest_allocate_unlimited_polymorphic_non_derived()
 func.func @_QMpolymorphic_testPtest_rebox() {
   %0 = fir.address_of(@_QFEx) : !fir.ref<!fir.class<!fir.ptr<!fir.array<?xnone>>>>
   %c-1_i32 = arith.constant -1 : i32
-  %9 = fir.address_of(@_QQcl.2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
+  %9 = fir.address_of(@_QQcl_2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
   %10 = fir.convert %9 : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
   %c8_i32 = arith.constant 8 : i32
   %11 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %10, %c8_i32) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -119,7 +119,7 @@ fir.global internal @_QFEy target : !fir.array<1xi32> {
 func.func private @_FortranAioBeginExternalListOutput(i32, !fir.ref<i8>, i32) -> !fir.ref<i8> attributes {fir.io, fir.runtime}
 func.func private @_FortranAioOutputDescriptor(!fir.ref<i8>, !fir.box<none>) -> i1 attributes {fir.io, fir.runtime}
 func.func private @_FortranAioEndIoStatement(!fir.ref<i8>) -> i32 attributes {fir.io, fir.runtime}
-fir.global linkonce @_QQcl.2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
+fir.global linkonce @_QQcl_2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
   %0 = fir.string_lit "./dummy.f90\00"(12) : !fir.char<1,12>
   fir.has_value %0 : !fir.char<1,12>
 }

--- a/flang/test/Fir/polymorphic.fir
+++ b/flang/test/Fir/polymorphic.fir
@@ -25,7 +25,7 @@ func.func @_QMpolymorphic_testPtest_allocate_unlimited_polymorphic_non_derived()
 func.func @_QMpolymorphic_testPtest_rebox() {
   %0 = fir.address_of(@_QFEx) : !fir.ref<!fir.class<!fir.ptr<!fir.array<?xnone>>>>
   %c-1_i32 = arith.constant -1 : i32
-  %9 = fir.address_of(@_QQcl_2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
+  %9 = fir.address_of(@_QQclX2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
   %10 = fir.convert %9 : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
   %c8_i32 = arith.constant 8 : i32
   %11 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %10, %c8_i32) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -119,7 +119,7 @@ fir.global internal @_QFEy target : !fir.array<1xi32> {
 func.func private @_FortranAioBeginExternalListOutput(i32, !fir.ref<i8>, i32) -> !fir.ref<i8> attributes {fir.io, fir.runtime}
 func.func private @_FortranAioOutputDescriptor(!fir.ref<i8>, !fir.box<none>) -> i1 attributes {fir.io, fir.runtime}
 func.func private @_FortranAioEndIoStatement(!fir.ref<i8>) -> i32 attributes {fir.io, fir.runtime}
-fir.global linkonce @_QQcl_2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
+fir.global linkonce @_QQclX2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
   %0 = fir.string_lit "./dummy.f90\00"(12) : !fir.char<1,12>
   fir.has_value %0 : !fir.char<1,12>
 }

--- a/flang/test/Fir/target-rewrite-integer.fir
+++ b/flang/test/Fir/target-rewrite-integer.fir
@@ -23,7 +23,7 @@
 func.func @_QPtest_i1(%arg0: !fir.ref<!fir.logical<4>> {fir.bindc_name = "x"}) {
   %c3_i32 = arith.constant 3 : i32
   %c-1_i32 = arith.constant -1 : i32
-  %0 = fir.address_of(@_QQcl.2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
+  %0 = fir.address_of(@_QQcl_2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
   %1 = fir.convert %0 : (!fir.ref<!fir.char<1,11>>) -> !fir.ref<i8>
   %2 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %1, %c3_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   %3 = fir.load %arg0 : !fir.ref<!fir.logical<4>>
@@ -33,7 +33,7 @@ func.func @_QPtest_i1(%arg0: !fir.ref<!fir.logical<4>> {fir.bindc_name = "x"}) {
   return
 }
 func.func private @_FortranAioBeginExternalListOutput(i32, !fir.ref<i8>, i32) -> !fir.ref<i8> attributes {fir.io, fir.runtime}
-fir.global linkonce @_QQcl.2E2F746573742E66393000 constant : !fir.char<1,11> {
+fir.global linkonce @_QQcl_2E2F746573742E66393000 constant : !fir.char<1,11> {
   %0 = fir.string_lit "./test.f90\00"(11) : !fir.char<1,11>
   fir.has_value %0 : !fir.char<1,11>
 }

--- a/flang/test/Fir/target-rewrite-integer.fir
+++ b/flang/test/Fir/target-rewrite-integer.fir
@@ -23,7 +23,7 @@
 func.func @_QPtest_i1(%arg0: !fir.ref<!fir.logical<4>> {fir.bindc_name = "x"}) {
   %c3_i32 = arith.constant 3 : i32
   %c-1_i32 = arith.constant -1 : i32
-  %0 = fir.address_of(@_QQcl_2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
+  %0 = fir.address_of(@_QQclX2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
   %1 = fir.convert %0 : (!fir.ref<!fir.char<1,11>>) -> !fir.ref<i8>
   %2 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %1, %c3_i32) : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   %3 = fir.load %arg0 : !fir.ref<!fir.logical<4>>
@@ -33,7 +33,7 @@ func.func @_QPtest_i1(%arg0: !fir.ref<!fir.logical<4>> {fir.bindc_name = "x"}) {
   return
 }
 func.func private @_FortranAioBeginExternalListOutput(i32, !fir.ref<i8>, i32) -> !fir.ref<i8> attributes {fir.io, fir.runtime}
-fir.global linkonce @_QQcl_2E2F746573742E66393000 constant : !fir.char<1,11> {
+fir.global linkonce @_QQclX2E2F746573742E66393000 constant : !fir.char<1,11> {
   %0 = fir.string_lit "./test.f90\00"(11) : !fir.char<1,11>
   fir.has_value %0 : !fir.char<1,11>
 }

--- a/flang/test/Fir/target-rewrite-selective.fir
+++ b/flang/test/Fir/target-rewrite-selective.fir
@@ -41,7 +41,7 @@ module {
     fir.store %arg0 to %1 : !fir.ref<!fir.complex<4>>
     %2 = fir.alloca !fir.char<1,10> {bindc_name = "r", uniq_name = "_QFtestEr"}
     %3 = fir.alloca !fir.complex<4> {bindc_name = "test", uniq_name = "_QFtestEtest"}
-    %4 = fir.address_of(@_QQcl_) : !fir.ref<!fir.char<1,0>>
+    %4 = fir.address_of(@_QQclX) : !fir.ref<!fir.char<1,0>>
     %5 = fir.convert %4 : (!fir.ref<!fir.char<1,0>>) -> !fir.ref<!fir.char<1,?>>
     %6 = fir.emboxchar %5, %c0 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
     %7 = fir.load %1 : !fir.ref<!fir.complex<4>>
@@ -59,7 +59,7 @@ module {
     return %15 : !fir.complex<4>
   }
   func.func private @_QPtest1(!fir.boxchar<1>, !fir.complex<4>) -> !fir.complex<4>
-  fir.global linkonce @_QQcl_ constant : !fir.char<1,0> {
+  fir.global linkonce @_QQclX constant : !fir.char<1,0> {
     %0 = fir.string_lit ""(0) : !fir.char<1,0>
     fir.has_value %0 : !fir.char<1,0>
   }

--- a/flang/test/Fir/target-rewrite-selective.fir
+++ b/flang/test/Fir/target-rewrite-selective.fir
@@ -41,7 +41,7 @@ module {
     fir.store %arg0 to %1 : !fir.ref<!fir.complex<4>>
     %2 = fir.alloca !fir.char<1,10> {bindc_name = "r", uniq_name = "_QFtestEr"}
     %3 = fir.alloca !fir.complex<4> {bindc_name = "test", uniq_name = "_QFtestEtest"}
-    %4 = fir.address_of(@_QQcl.) : !fir.ref<!fir.char<1,0>>
+    %4 = fir.address_of(@_QQcl_) : !fir.ref<!fir.char<1,0>>
     %5 = fir.convert %4 : (!fir.ref<!fir.char<1,0>>) -> !fir.ref<!fir.char<1,?>>
     %6 = fir.emboxchar %5, %c0 : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
     %7 = fir.load %1 : !fir.ref<!fir.complex<4>>
@@ -59,7 +59,7 @@ module {
     return %15 : !fir.complex<4>
   }
   func.func private @_QPtest1(!fir.boxchar<1>, !fir.complex<4>) -> !fir.complex<4>
-  fir.global linkonce @_QQcl. constant : !fir.char<1,0> {
+  fir.global linkonce @_QQcl_ constant : !fir.char<1,0> {
     %0 = fir.string_lit ""(0) : !fir.char<1,0>
     fir.has_value %0 : !fir.char<1,0>
   }

--- a/flang/test/Fir/tbaa-codegen2.fir
+++ b/flang/test/Fir/tbaa-codegen2.fir
@@ -39,7 +39,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
       fir.store %18 to %19 : !fir.ref<i32>
     }
     fir.store %2 to %0 : !fir.ref<!fir.box<!fir.array<?xi32>>>
-    %8 = fir.address_of(@_QQcl.2F746D702F73696D706C652E66393000) : !fir.ref<!fir.char<1,16>>
+    %8 = fir.address_of(@_QQcl_2F746D702F73696D706C652E66393000) : !fir.ref<!fir.char<1,16>>
     %9 = fir.convert %0 : (!fir.ref<!fir.box<!fir.array<?xi32>>>) -> !fir.ref<!fir.box<none>>
     %10 = fir.convert %7 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
     %11 = fir.convert %8 : (!fir.ref<!fir.char<1,16>>) -> !fir.ref<i8>
@@ -54,7 +54,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return
   }
   func.func private @_FortranAAssign(!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> none attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2F746D702F73696D706C652E66393000 constant : !fir.char<1,16> {
+  fir.global linkonce @_QQcl_2F746D702F73696D706C652E66393000 constant : !fir.char<1,16> {
     %0 = fir.string_lit "/tmp/simple.f90\00"(16) : !fir.char<1,16>
     fir.has_value %0 : !fir.char<1,16>
   }

--- a/flang/test/Fir/tbaa-codegen2.fir
+++ b/flang/test/Fir/tbaa-codegen2.fir
@@ -39,7 +39,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
       fir.store %18 to %19 : !fir.ref<i32>
     }
     fir.store %2 to %0 : !fir.ref<!fir.box<!fir.array<?xi32>>>
-    %8 = fir.address_of(@_QQcl_2F746D702F73696D706C652E66393000) : !fir.ref<!fir.char<1,16>>
+    %8 = fir.address_of(@_QQclX2F746D702F73696D706C652E66393000) : !fir.ref<!fir.char<1,16>>
     %9 = fir.convert %0 : (!fir.ref<!fir.box<!fir.array<?xi32>>>) -> !fir.ref<!fir.box<none>>
     %10 = fir.convert %7 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
     %11 = fir.convert %8 : (!fir.ref<!fir.char<1,16>>) -> !fir.ref<i8>
@@ -54,7 +54,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return
   }
   func.func private @_FortranAAssign(!fir.ref<!fir.box<none>>, !fir.box<none>, !fir.ref<i8>, i32) -> none attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2F746D702F73696D706C652E66393000 constant : !fir.char<1,16> {
+  fir.global linkonce @_QQclX2F746D702F73696D706C652E66393000 constant : !fir.char<1,16> {
     %0 = fir.string_lit "/tmp/simple.f90\00"(16) : !fir.char<1,16>
     fir.has_value %0 : !fir.char<1,16>
   }

--- a/flang/test/Fir/tbaa.fir
+++ b/flang/test/Fir/tbaa.fir
@@ -91,7 +91,7 @@ module {
     %c8_i32 = arith.constant 8 : i32
     %c-1_i32 = arith.constant -1 : i32
     %0 = fir.address_of(@_QFEx) : !fir.ref<!fir.class<!fir.ptr<!fir.array<?xnone>>>>
-    %1 = fir.address_of(@_QQcl_2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
+    %1 = fir.address_of(@_QQclX2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
     %2 = fir.convert %1 : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
     %3 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %2, %c8_i32) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
     %4 = fir.load %0 : !fir.ref<!fir.class<!fir.ptr<!fir.array<?xnone>>>>
@@ -105,7 +105,7 @@ module {
   func.func private @_FortranAioBeginExternalListOutput(i32, !fir.ref<i8>, i32) -> !fir.ref<i8> attributes {fir.io, fir.runtime}
   func.func private @_FortranAioOutputDescriptor(!fir.ref<i8>, !fir.box<none>) -> i1 attributes {fir.io, fir.runtime}
   func.func private @_FortranAioEndIoStatement(!fir.ref<i8>) -> i32 attributes {fir.io, fir.runtime}
-  fir.global linkonce @_QQcl_2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
+  fir.global linkonce @_QQclX2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
     %0 = fir.string_lit "./dummy.f90\00"(12) : !fir.char<1,12>
     fir.has_value %0 : !fir.char<1,12>
   }
@@ -131,7 +131,7 @@ module {
 // CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(8 : i32) : i32
 // CHECK:           %[[VAL_6:.*]] = llvm.mlir.constant(-1 : i32) : i32
 // CHECK:           %[[VAL_7:.*]] = llvm.mlir.addressof @_QFEx : !llvm.ptr
-// CHECK:           %[[VAL_8:.*]] = llvm.mlir.addressof @_QQcl_2E2F64756D6D792E66393000 : !llvm.ptr
+// CHECK:           %[[VAL_8:.*]] = llvm.mlir.addressof @_QQclX2E2F64756D6D792E66393000 : !llvm.ptr
 // CHECK:           %[[VAL_10:.*]] = llvm.call @_FortranAioBeginExternalListOutput(%[[VAL_6]], %[[VAL_8]], %[[VAL_5]]) {fastmathFlags = #llvm.fastmath<contract>} : (i32, !llvm.ptr, i32) -> !llvm.ptr
 // CHECK:           %[[VAL_11:.*]] = llvm.load %[[VAL_7]] {tbaa = [#[[$BOXT]]]} : !llvm.ptr -> !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>, ptr, array<1 x i64>)>
 // CHECK:           llvm.store %[[VAL_11]], %[[VAL_3]] {tbaa = [#[[$BOXT]]]} : !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>, ptr, array<1 x i64>)>, !llvm.ptr
@@ -192,7 +192,7 @@ module {
 // CHECK:         llvm.func @_FortranAioOutputDescriptor(!llvm.ptr, !llvm.ptr) -> i1 attributes {fir.io, fir.runtime, sym_visibility = "private"}
 // CHECK:         llvm.func @_FortranAioEndIoStatement(!llvm.ptr) -> i32 attributes {fir.io, fir.runtime, sym_visibility = "private"}
 
-// CHECK-LABEL:   llvm.mlir.global linkonce constant @_QQcl_2E2F64756D6D792E66393000() comdat(@__llvm_comdat::@_QQcl_2E2F64756D6D792E66393000) {addr_space = 0 : i32} : !llvm.array<12 x i8> {
+// CHECK-LABEL:   llvm.mlir.global linkonce constant @_QQclX2E2F64756D6D792E66393000() comdat(@__llvm_comdat::@_QQclX2E2F64756D6D792E66393000) {addr_space = 0 : i32} : !llvm.array<12 x i8> {
 // CHECK:           %[[VAL_0:.*]] = llvm.mlir.constant("./dummy.f90\00") : !llvm.array<12 x i8>
 // CHECK:           llvm.return %[[VAL_0]] : !llvm.array<12 x i8>
 // CHECK:         }

--- a/flang/test/Fir/tbaa.fir
+++ b/flang/test/Fir/tbaa.fir
@@ -91,7 +91,7 @@ module {
     %c8_i32 = arith.constant 8 : i32
     %c-1_i32 = arith.constant -1 : i32
     %0 = fir.address_of(@_QFEx) : !fir.ref<!fir.class<!fir.ptr<!fir.array<?xnone>>>>
-    %1 = fir.address_of(@_QQcl.2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
+    %1 = fir.address_of(@_QQcl_2E2F64756D6D792E66393000) : !fir.ref<!fir.char<1,12>>
     %2 = fir.convert %1 : (!fir.ref<!fir.char<1,12>>) -> !fir.ref<i8>
     %3 = fir.call @_FortranAioBeginExternalListOutput(%c-1_i32, %2, %c8_i32) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
     %4 = fir.load %0 : !fir.ref<!fir.class<!fir.ptr<!fir.array<?xnone>>>>
@@ -105,7 +105,7 @@ module {
   func.func private @_FortranAioBeginExternalListOutput(i32, !fir.ref<i8>, i32) -> !fir.ref<i8> attributes {fir.io, fir.runtime}
   func.func private @_FortranAioOutputDescriptor(!fir.ref<i8>, !fir.box<none>) -> i1 attributes {fir.io, fir.runtime}
   func.func private @_FortranAioEndIoStatement(!fir.ref<i8>) -> i32 attributes {fir.io, fir.runtime}
-  fir.global linkonce @_QQcl.2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
+  fir.global linkonce @_QQcl_2E2F64756D6D792E66393000 constant : !fir.char<1,12> {
     %0 = fir.string_lit "./dummy.f90\00"(12) : !fir.char<1,12>
     fir.has_value %0 : !fir.char<1,12>
   }
@@ -131,7 +131,7 @@ module {
 // CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(8 : i32) : i32
 // CHECK:           %[[VAL_6:.*]] = llvm.mlir.constant(-1 : i32) : i32
 // CHECK:           %[[VAL_7:.*]] = llvm.mlir.addressof @_QFEx : !llvm.ptr
-// CHECK:           %[[VAL_8:.*]] = llvm.mlir.addressof @_QQcl.2E2F64756D6D792E66393000 : !llvm.ptr
+// CHECK:           %[[VAL_8:.*]] = llvm.mlir.addressof @_QQcl_2E2F64756D6D792E66393000 : !llvm.ptr
 // CHECK:           %[[VAL_10:.*]] = llvm.call @_FortranAioBeginExternalListOutput(%[[VAL_6]], %[[VAL_8]], %[[VAL_5]]) {fastmathFlags = #llvm.fastmath<contract>} : (i32, !llvm.ptr, i32) -> !llvm.ptr
 // CHECK:           %[[VAL_11:.*]] = llvm.load %[[VAL_7]] {tbaa = [#[[$BOXT]]]} : !llvm.ptr -> !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>, ptr, array<1 x i64>)>
 // CHECK:           llvm.store %[[VAL_11]], %[[VAL_3]] {tbaa = [#[[$BOXT]]]} : !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8, array<1 x array<3 x i64>>, ptr, array<1 x i64>)>, !llvm.ptr
@@ -192,7 +192,7 @@ module {
 // CHECK:         llvm.func @_FortranAioOutputDescriptor(!llvm.ptr, !llvm.ptr) -> i1 attributes {fir.io, fir.runtime, sym_visibility = "private"}
 // CHECK:         llvm.func @_FortranAioEndIoStatement(!llvm.ptr) -> i32 attributes {fir.io, fir.runtime, sym_visibility = "private"}
 
-// CHECK-LABEL:   llvm.mlir.global linkonce constant @_QQcl.2E2F64756D6D792E66393000() comdat(@__llvm_comdat::@_QQcl.2E2F64756D6D792E66393000) {addr_space = 0 : i32} : !llvm.array<12 x i8> {
+// CHECK-LABEL:   llvm.mlir.global linkonce constant @_QQcl_2E2F64756D6D792E66393000() comdat(@__llvm_comdat::@_QQcl_2E2F64756D6D792E66393000) {addr_space = 0 : i32} : !llvm.array<12 x i8> {
 // CHECK:           %[[VAL_0:.*]] = llvm.mlir.constant("./dummy.f90\00") : !llvm.array<12 x i8>
 // CHECK:           llvm.return %[[VAL_0]] : !llvm.array<12 x i8>
 // CHECK:         }

--- a/flang/test/HLFIR/assign-codegen.fir
+++ b/flang/test/HLFIR/assign-codegen.fir
@@ -417,7 +417,7 @@ func.func @test_upoly_expr_assignment(%arg0: !fir.class<!fir.array<?xnone>> {fir
 // CHECK:             %[[VAL_21:.*]] = fir.array_coor %[[VAL_8]](%[[VAL_20]]) %[[VAL_17]] : (!fir.class<!fir.heap<!fir.array<?xnone>>>, !fir.shift<1>, index) -> !fir.ref<none>
 // CHECK:             %[[VAL_22:.*]] = fir.embox %[[VAL_21]] source_box %[[VAL_8]] : (!fir.ref<none>, !fir.class<!fir.heap<!fir.array<?xnone>>>) -> !fir.class<none>
 // CHECK:             fir.store %[[VAL_22]] to %[[VAL_1]] : !fir.ref<!fir.class<none>>
-// CHECK:             %[[VAL_23:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+// CHECK:             %[[VAL_23:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 // CHECK:             %[[VAL_24:.*]] = arith.constant {{.*}} : index
 // CHECK:             %[[VAL_25:.*]] = arith.constant {{.*}} : i32
 // CHECK:             %[[VAL_26:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.class<none>>) -> !fir.ref<!fir.box<none>>

--- a/flang/test/HLFIR/assign-codegen.fir
+++ b/flang/test/HLFIR/assign-codegen.fir
@@ -417,7 +417,7 @@ func.func @test_upoly_expr_assignment(%arg0: !fir.class<!fir.array<?xnone>> {fir
 // CHECK:             %[[VAL_21:.*]] = fir.array_coor %[[VAL_8]](%[[VAL_20]]) %[[VAL_17]] : (!fir.class<!fir.heap<!fir.array<?xnone>>>, !fir.shift<1>, index) -> !fir.ref<none>
 // CHECK:             %[[VAL_22:.*]] = fir.embox %[[VAL_21]] source_box %[[VAL_8]] : (!fir.ref<none>, !fir.class<!fir.heap<!fir.array<?xnone>>>) -> !fir.class<none>
 // CHECK:             fir.store %[[VAL_22]] to %[[VAL_1]] : !fir.ref<!fir.class<none>>
-// CHECK:             %[[VAL_23:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+// CHECK:             %[[VAL_23:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 // CHECK:             %[[VAL_24:.*]] = arith.constant {{.*}} : index
 // CHECK:             %[[VAL_25:.*]] = arith.constant {{.*}} : i32
 // CHECK:             %[[VAL_26:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.class<none>>) -> !fir.ref<!fir.box<none>>

--- a/flang/test/HLFIR/boxchar_emboxing.f90
+++ b/flang/test/HLFIR/boxchar_emboxing.f90
@@ -15,9 +15,9 @@
 ! CHECK:           cf.br ^bb3
 ! CHECK:         ^bb2:
 ! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_1]]#1 {uniq_name = "_QFtest1Ex"} : (!fir.class<none>) -> (!fir.class<none>, !fir.class<none>)
-! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQcl.4641494C) : !fir.ref<!fir.char<1,4>>
+! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQcl_4641494C) : !fir.ref<!fir.char<1,4>>
 ! CHECK:           %[[VAL_10:.*]] = arith.constant 4 : index
-! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_9]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl.4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
+! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_9]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_11]]#1 : (!fir.ref<!fir.char<1,4>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (index) -> i64
 ! CHECK:           %[[VAL_14:.*]] = arith.constant false
@@ -59,9 +59,9 @@ end subroutine test1
 ! CHECK:           cf.br ^bb3
 ! CHECK:         ^bb2:
 ! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_1]]#1 {uniq_name = "_QFtest2Ex"} : (!fir.class<!fir.array<10xnone>>) -> (!fir.class<!fir.array<10xnone>>, !fir.class<!fir.array<10xnone>>)
-! CHECK:           %[[VAL_11:.*]] = fir.address_of(@_QQcl.4641494C) : !fir.ref<!fir.char<1,4>>
+! CHECK:           %[[VAL_11:.*]] = fir.address_of(@_QQcl_4641494C) : !fir.ref<!fir.char<1,4>>
 ! CHECK:           %[[VAL_12:.*]] = arith.constant 4 : index
-! CHECK:           %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_11]] typeparams %[[VAL_12]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl.4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
+! CHECK:           %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_11]] typeparams %[[VAL_12]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
 ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_13]]#1 : (!fir.ref<!fir.char<1,4>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (index) -> i64
 ! CHECK:           %[[VAL_16:.*]] = arith.constant false

--- a/flang/test/HLFIR/boxchar_emboxing.f90
+++ b/flang/test/HLFIR/boxchar_emboxing.f90
@@ -15,9 +15,9 @@
 ! CHECK:           cf.br ^bb3
 ! CHECK:         ^bb2:
 ! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_1]]#1 {uniq_name = "_QFtest1Ex"} : (!fir.class<none>) -> (!fir.class<none>, !fir.class<none>)
-! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQcl_4641494C) : !fir.ref<!fir.char<1,4>>
+! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQclX4641494C) : !fir.ref<!fir.char<1,4>>
 ! CHECK:           %[[VAL_10:.*]] = arith.constant 4 : index
-! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_9]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
+! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_9]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQclX4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_11]]#1 : (!fir.ref<!fir.char<1,4>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (index) -> i64
 ! CHECK:           %[[VAL_14:.*]] = arith.constant false
@@ -59,9 +59,9 @@ end subroutine test1
 ! CHECK:           cf.br ^bb3
 ! CHECK:         ^bb2:
 ! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_1]]#1 {uniq_name = "_QFtest2Ex"} : (!fir.class<!fir.array<10xnone>>) -> (!fir.class<!fir.array<10xnone>>, !fir.class<!fir.array<10xnone>>)
-! CHECK:           %[[VAL_11:.*]] = fir.address_of(@_QQcl_4641494C) : !fir.ref<!fir.char<1,4>>
+! CHECK:           %[[VAL_11:.*]] = fir.address_of(@_QQclX4641494C) : !fir.ref<!fir.char<1,4>>
 ! CHECK:           %[[VAL_12:.*]] = arith.constant 4 : index
-! CHECK:           %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_11]] typeparams %[[VAL_12]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
+! CHECK:           %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_11]] typeparams %[[VAL_12]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQclX4641494C"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
 ! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_13]]#1 : (!fir.ref<!fir.char<1,4>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (index) -> i64
 ! CHECK:           %[[VAL_16:.*]] = arith.constant false

--- a/flang/test/HLFIR/bufferize-destroy-for-derived.fir
+++ b/flang/test/HLFIR/bufferize-destroy-for-derived.fir
@@ -52,7 +52,7 @@ func.func @_QPtest2(%arg0: !fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.bo
 // CHECK:             hlfir.assign %{{.*}}#0 to %{{.*}} temporary_lhs : !fir.ref<!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>, !fir.ref<!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>
 // CHECK:           hlfir.assign %[[VAL_7:.*]]#0 to %{{.*}}#0 : !fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>, !fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>
 // CHECK-NEXT:      %[[VAL_18:.*]] = fir.box_addr %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>) -> !fir.heap<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>
-// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 // CHECK-NEXT:      %[[VAL_20:.*]] = arith.constant {{[0-9]*}} : index
 // CHECK-NEXT:      %[[VAL_21:.*]] = arith.constant {{[0-9]*}} : i32
 // CHECK-NEXT:      %[[VAL_22:.*]] = fir.convert %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>) -> !fir.box<none>
@@ -86,7 +86,7 @@ func.func @_QPtest3(%arg0: !fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>
 // CHECK:             hlfir.assign %{{.*}}#0 to %{{.*}} temporary_lhs : !fir.ref<!fir.type<_QMtypesTt3{x:f32}>>, !fir.ref<!fir.type<_QMtypesTt3{x:f32}>>
 // CHECK:           hlfir.assign %[[VAL_7:.*]]#0 to %{{.*}}#0 : !fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>, !fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>
 // CHECK-NEXT:      %[[VAL_18:.*]] = fir.box_addr %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>) -> !fir.heap<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>
-// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 // CHECK-NEXT:      %[[VAL_20:.*]] = arith.constant {{[0-9]*}} : index
 // CHECK-NEXT:      %[[VAL_21:.*]] = arith.constant {{[0-9]*}} : i32
 // CHECK-NEXT:      %[[VAL_22:.*]] = fir.convert %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>) -> !fir.box<none>

--- a/flang/test/HLFIR/bufferize-destroy-for-derived.fir
+++ b/flang/test/HLFIR/bufferize-destroy-for-derived.fir
@@ -52,7 +52,7 @@ func.func @_QPtest2(%arg0: !fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.bo
 // CHECK:             hlfir.assign %{{.*}}#0 to %{{.*}} temporary_lhs : !fir.ref<!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>, !fir.ref<!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>
 // CHECK:           hlfir.assign %[[VAL_7:.*]]#0 to %{{.*}}#0 : !fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>, !fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>
 // CHECK-NEXT:      %[[VAL_18:.*]] = fir.box_addr %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>) -> !fir.heap<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>
-// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 // CHECK-NEXT:      %[[VAL_20:.*]] = arith.constant {{[0-9]*}} : index
 // CHECK-NEXT:      %[[VAL_21:.*]] = arith.constant {{[0-9]*}} : i32
 // CHECK-NEXT:      %[[VAL_22:.*]] = fir.convert %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt2{x:!fir.box<!fir.heap<f32>>}>>>) -> !fir.box<none>
@@ -86,7 +86,7 @@ func.func @_QPtest3(%arg0: !fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>
 // CHECK:             hlfir.assign %{{.*}}#0 to %{{.*}} temporary_lhs : !fir.ref<!fir.type<_QMtypesTt3{x:f32}>>, !fir.ref<!fir.type<_QMtypesTt3{x:f32}>>
 // CHECK:           hlfir.assign %[[VAL_7:.*]]#0 to %{{.*}}#0 : !fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>, !fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>
 // CHECK-NEXT:      %[[VAL_18:.*]] = fir.box_addr %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>) -> !fir.heap<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>
-// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+// CHECK-NEXT:      %[[VAL_19:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 // CHECK-NEXT:      %[[VAL_20:.*]] = arith.constant {{[0-9]*}} : index
 // CHECK-NEXT:      %[[VAL_21:.*]] = arith.constant {{[0-9]*}} : i32
 // CHECK-NEXT:      %[[VAL_22:.*]] = fir.convert %[[VAL_7]]#0 : (!fir.box<!fir.array<?x!fir.type<_QMtypesTt3{x:f32}>>>) -> !fir.box<none>

--- a/flang/test/HLFIR/bufferize01.fir
+++ b/flang/test/HLFIR/bufferize01.fir
@@ -24,7 +24,7 @@
 // CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_11]](%[[VAL_12]]) typeparams %[[VAL_4]] : (!fir.heap<!fir.array<1x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>
 // CHECK:           fir.store %[[VAL_13]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>
 // CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
-// CHECK:           %[[VAL_15:.*]] = fir.address_of(@_QQcl.ce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1>>
+// CHECK:           %[[VAL_15:.*]] = fir.address_of(@_QQcl_ce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1>>
 // CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
 // CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<i8>
 // CHECK:           %[[VAL_18:.*]] = fir.call @_FortranAInitArrayConstructorVector(%[[VAL_14]], %[[VAL_16]], %[[VAL_2]], %[[VAL_1]], %[[VAL_17]], %[[VAL_0]]) fastmath<contract> : (!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none
@@ -98,7 +98,7 @@ func.func @_QPtest1() {
   %8 = fir.embox %6(%7) typeparams %c0 : (!fir.heap<!fir.array<1x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>
   fir.store %8 to %1 : !fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>
   %9 = fir.convert %0 : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
-  %10 = fir.address_of(@_QQcl.ce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1,1>>
+  %10 = fir.address_of(@_QQcl_ce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1,1>>
   %11 = fir.convert %1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %10 : (!fir.ref<!fir.char<1,1>>) -> !fir.ref<i8>
   %13 = fir.call @_FortranAInitArrayConstructorVector(%9, %11, %true, %c80_i32, %12, %c1_i32) fastmath<contract> : (!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none
@@ -138,7 +138,7 @@ func.func @_QPtest1() {
   return
 }
 func.func private @_FortranAInitArrayConstructorVector(!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none attributes {fir.runtime}
-fir.global linkonce @_QQcl.ce30ef70ff16a711a97719fb946c0b3d constant : !fir.char<1,1> {
+fir.global linkonce @_QQcl_ce30ef70ff16a711a97719fb946c0b3d constant : !fir.char<1,1> {
   %0 = fir.string_lit "\00"(1) : !fir.char<1,1>
   fir.has_value %0 : !fir.char<1,1>
 }

--- a/flang/test/HLFIR/bufferize01.fir
+++ b/flang/test/HLFIR/bufferize01.fir
@@ -24,7 +24,7 @@
 // CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_11]](%[[VAL_12]]) typeparams %[[VAL_4]] : (!fir.heap<!fir.array<1x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>
 // CHECK:           fir.store %[[VAL_13]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>
 // CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
-// CHECK:           %[[VAL_15:.*]] = fir.address_of(@_QQcl_ce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1>>
+// CHECK:           %[[VAL_15:.*]] = fir.address_of(@_QQclXce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1>>
 // CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
 // CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<!fir.char<1>>) -> !fir.ref<i8>
 // CHECK:           %[[VAL_18:.*]] = fir.call @_FortranAInitArrayConstructorVector(%[[VAL_14]], %[[VAL_16]], %[[VAL_2]], %[[VAL_1]], %[[VAL_17]], %[[VAL_0]]) fastmath<contract> : (!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none
@@ -98,7 +98,7 @@ func.func @_QPtest1() {
   %8 = fir.embox %6(%7) typeparams %c0 : (!fir.heap<!fir.array<1x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>
   fir.store %8 to %1 : !fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>
   %9 = fir.convert %0 : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
-  %10 = fir.address_of(@_QQcl_ce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1,1>>
+  %10 = fir.address_of(@_QQclXce30ef70ff16a711a97719fb946c0b3d) : !fir.ref<!fir.char<1,1>>
   %11 = fir.convert %1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %10 : (!fir.ref<!fir.char<1,1>>) -> !fir.ref<i8>
   %13 = fir.call @_FortranAInitArrayConstructorVector(%9, %11, %true, %c80_i32, %12, %c1_i32) fastmath<contract> : (!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none
@@ -138,7 +138,7 @@ func.func @_QPtest1() {
   return
 }
 func.func private @_FortranAInitArrayConstructorVector(!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none attributes {fir.runtime}
-fir.global linkonce @_QQcl_ce30ef70ff16a711a97719fb946c0b3d constant : !fir.char<1,1> {
+fir.global linkonce @_QQclXce30ef70ff16a711a97719fb946c0b3d constant : !fir.char<1,1> {
   %0 = fir.string_lit "\00"(1) : !fir.char<1,1>
   fir.has_value %0 : !fir.char<1,1>
 }

--- a/flang/test/HLFIR/copy-in-out-codegen.fir
+++ b/flang/test/HLFIR/copy-in-out-codegen.fir
@@ -117,7 +117,7 @@ func.func @test_copy_in_poly(%poly : !fir.class<!fir.array<?x!fir.type<test_copy
 // CHECK:             %[[VAL_7:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
 // CHECK:             %[[VAL_8:.*]] = fir.embox %[[VAL_5]](%[[VAL_7]]) : (!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>>
 // CHECK:             fir.store %[[VAL_8]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>>>
-// CHECK:             %[[VAL_9:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+// CHECK:             %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 // CHECK:             %[[VAL_10:.*]] = arith.constant {{.*}} : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant {{.*}} : i32
 // CHECK:             %[[VAL_12:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>>>) -> !fir.ref<!fir.box<none>>

--- a/flang/test/HLFIR/copy-in-out-codegen.fir
+++ b/flang/test/HLFIR/copy-in-out-codegen.fir
@@ -117,7 +117,7 @@ func.func @test_copy_in_poly(%poly : !fir.class<!fir.array<?x!fir.type<test_copy
 // CHECK:             %[[VAL_7:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
 // CHECK:             %[[VAL_8:.*]] = fir.embox %[[VAL_5]](%[[VAL_7]]) : (!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>>
 // CHECK:             fir.store %[[VAL_8]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>>>
-// CHECK:             %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+// CHECK:             %[[VAL_9:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 // CHECK:             %[[VAL_10:.*]] = arith.constant {{.*}} : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant {{.*}} : i32
 // CHECK:             %[[VAL_12:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<test_copy_in_polyTt1{i:i32}>>>>>) -> !fir.ref<!fir.box<none>>

--- a/flang/test/HLFIR/elemental-codegen.fir
+++ b/flang/test/HLFIR/elemental-codegen.fir
@@ -185,7 +185,7 @@ func.func @test_polymorphic(%arg0: !fir.class<!fir.type<_QMtypesTt>> {fir.bindc_
 // CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_18]] : (index) -> i64
 // CHECK:           %[[VAL_29:.*]] = fir.convert %[[EX1]] : (index) -> i64
 // CHECK:           %[[VAL_30:.*]] = fir.call @_FortranAAllocatableSetBounds(%[[VAL_26]], %[[VAL_27]], %[[VAL_28]], %[[VAL_29]]) : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> none
-// CHECK:           %[[VAL_31:.*]] = fir.address_of(@_QQcl.
+// CHECK:           %[[VAL_31:.*]] = fir.address_of(@_QQcl_
 // CHECK:           %[[VAL_32:.*]] = arith.constant {{.*}} : index
 // CHECK:           %[[VAL_33:.*]] = arith.constant {{.*}} : i32
 // CHECK:           %[[VAL_34:.*]] = arith.constant false

--- a/flang/test/HLFIR/elemental-codegen.fir
+++ b/flang/test/HLFIR/elemental-codegen.fir
@@ -185,7 +185,7 @@ func.func @test_polymorphic(%arg0: !fir.class<!fir.type<_QMtypesTt>> {fir.bindc_
 // CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_18]] : (index) -> i64
 // CHECK:           %[[VAL_29:.*]] = fir.convert %[[EX1]] : (index) -> i64
 // CHECK:           %[[VAL_30:.*]] = fir.call @_FortranAAllocatableSetBounds(%[[VAL_26]], %[[VAL_27]], %[[VAL_28]], %[[VAL_29]]) : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> none
-// CHECK:           %[[VAL_31:.*]] = fir.address_of(@_QQcl_
+// CHECK:           %[[VAL_31:.*]] = fir.address_of(@_QQclX
 // CHECK:           %[[VAL_32:.*]] = arith.constant {{.*}} : index
 // CHECK:           %[[VAL_33:.*]] = arith.constant {{.*}} : i32
 // CHECK:           %[[VAL_34:.*]] = arith.constant false

--- a/flang/test/HLFIR/get_length_codegen.fir
+++ b/flang/test/HLFIR/get_length_codegen.fir
@@ -7,8 +7,8 @@ func.func @_QPtest_char_get_length(%arg0: !fir.boxchar<1> {fir.bindc_name = "ch"
   %1:2 = hlfir.declare %0#0 typeparams %0#1 {uniq_name = "_QFtest_char_get_lengthEch"} : (!fir.ref<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)
   %2 = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_char_get_lengthEx"}
   %3:2 = hlfir.declare %2 {uniq_name = "_QFtest_char_get_lengthEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-  %4 = fir.address_of(@_QQcl_616263) : !fir.ref<!fir.char<1,3>>
-  %5:2 = hlfir.declare %4 typeparams %c3 {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
+  %4 = fir.address_of(@_QQclX616263) : !fir.ref<!fir.char<1,3>>
+  %5:2 = hlfir.declare %4 typeparams %c3 {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQclX616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
   %6 = arith.addi %0#1, %c3 : index
   %7 = hlfir.concat %5#0, %1#0 len %6 : (!fir.ref<!fir.char<1,3>>, !fir.boxchar<1>, index) -> !hlfir.expr<!fir.char<1,?>>
   %8:3 = hlfir.associate %7 typeparams %6 {uniq_name = ".tmp.assign"} : (!hlfir.expr<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>, i1)
@@ -18,7 +18,7 @@ func.func @_QPtest_char_get_length(%arg0: !fir.boxchar<1> {fir.bindc_name = "ch"
   hlfir.end_associate %8#1, %8#2 : !fir.ref<!fir.char<1,?>>, i1
   return %10 : index
 }
-fir.global linkonce @_QQcl_616263 constant : !fir.char<1,3> {
+fir.global linkonce @_QQclX616263 constant : !fir.char<1,3> {
   %0 = fir.string_lit "abc"(3) : !fir.char<1,3>
   fir.has_value %0 : !fir.char<1,3>
 }

--- a/flang/test/HLFIR/get_length_codegen.fir
+++ b/flang/test/HLFIR/get_length_codegen.fir
@@ -7,8 +7,8 @@ func.func @_QPtest_char_get_length(%arg0: !fir.boxchar<1> {fir.bindc_name = "ch"
   %1:2 = hlfir.declare %0#0 typeparams %0#1 {uniq_name = "_QFtest_char_get_lengthEch"} : (!fir.ref<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)
   %2 = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_char_get_lengthEx"}
   %3:2 = hlfir.declare %2 {uniq_name = "_QFtest_char_get_lengthEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-  %4 = fir.address_of(@_QQcl.616263) : !fir.ref<!fir.char<1,3>>
-  %5:2 = hlfir.declare %4 typeparams %c3 {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl.616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
+  %4 = fir.address_of(@_QQcl_616263) : !fir.ref<!fir.char<1,3>>
+  %5:2 = hlfir.declare %4 typeparams %c3 {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
   %6 = arith.addi %0#1, %c3 : index
   %7 = hlfir.concat %5#0, %1#0 len %6 : (!fir.ref<!fir.char<1,3>>, !fir.boxchar<1>, index) -> !hlfir.expr<!fir.char<1,?>>
   %8:3 = hlfir.associate %7 typeparams %6 {uniq_name = ".tmp.assign"} : (!hlfir.expr<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>, i1)
@@ -18,7 +18,7 @@ func.func @_QPtest_char_get_length(%arg0: !fir.boxchar<1> {fir.bindc_name = "ch"
   hlfir.end_associate %8#1, %8#2 : !fir.ref<!fir.char<1,?>>, i1
   return %10 : index
 }
-fir.global linkonce @_QQcl.616263 constant : !fir.char<1,3> {
+fir.global linkonce @_QQcl_616263 constant : !fir.char<1,3> {
   %0 = fir.string_lit "abc"(3) : !fir.char<1,3>
   fir.has_value %0 : !fir.char<1,3>
 }

--- a/flang/test/Lower/HLFIR/array-ctor-as-runtime-temp.f90
+++ b/flang/test/Lower/HLFIR/array-ctor-as-runtime-temp.f90
@@ -18,7 +18,7 @@ end subroutine
 ! CHECK:           %[[VAL_7:.*]] = arith.constant false
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
 ! CHECK:           %[[VAL_9:.*]] = arith.constant 80 : i32
-! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_11:.*]] = arith.constant 7 : i32
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/HLFIR/array-ctor-as-runtime-temp.f90
+++ b/flang/test/Lower/HLFIR/array-ctor-as-runtime-temp.f90
@@ -18,7 +18,7 @@ end subroutine
 ! CHECK:           %[[VAL_7:.*]] = arith.constant false
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
 ! CHECK:           %[[VAL_9:.*]] = arith.constant 80 : i32
-! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_11:.*]] = arith.constant 7 : i32
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/HLFIR/assignment-intrinsics.f90
+++ b/flang/test/Lower/HLFIR/assignment-intrinsics.f90
@@ -105,7 +105,7 @@ subroutine scalar_character_2(x)
 end subroutine
 ! CHECK-LABEL: func.func @_QPscalar_character_2(
 ! CHECK:  %[[VAL_2:.*]]:2 = hlfir.declare {{.*}} {uniq_name = "_QFscalar_character_2Ex"} : (!fir.ref<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)
-! CHECK:  %[[VAL_5:.*]]:2 = hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl.68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
+! CHECK:  %[[VAL_5:.*]]:2 = hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
 ! CHECK:  hlfir.assign %[[VAL_5]]#0 to %[[VAL_2]]#0 : !fir.ref<!fir.char<1,5>>, !fir.boxchar<1>
 
 ! -----------------------------------------------------------------------------

--- a/flang/test/Lower/HLFIR/assignment-intrinsics.f90
+++ b/flang/test/Lower/HLFIR/assignment-intrinsics.f90
@@ -105,7 +105,7 @@ subroutine scalar_character_2(x)
 end subroutine
 ! CHECK-LABEL: func.func @_QPscalar_character_2(
 ! CHECK:  %[[VAL_2:.*]]:2 = hlfir.declare {{.*}} {uniq_name = "_QFscalar_character_2Ex"} : (!fir.ref<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)
-! CHECK:  %[[VAL_5:.*]]:2 = hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
+! CHECK:  %[[VAL_5:.*]]:2 = hlfir.declare {{.*}} {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQclX68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
 ! CHECK:  hlfir.assign %[[VAL_5]]#0 to %[[VAL_2]]#0 : !fir.ref<!fir.char<1,5>>, !fir.boxchar<1>
 
 ! -----------------------------------------------------------------------------

--- a/flang/test/Lower/HLFIR/constant-character.f90
+++ b/flang/test/Lower/HLFIR/constant-character.f90
@@ -8,10 +8,10 @@ subroutine repro(c1, c4)
   print *, 4_""
 end subroutine
 !CHECK-LABEL: func.func @_QPrepro
-!CHECK:    fir.address_of(@_QQcl.) : !fir.ref<!fir.char<1,0>>
+!CHECK:    fir.address_of(@_QQcl_) : !fir.ref<!fir.char<1,0>>
 !CHECK:    fir.call @_FortranAioOutputAscii
-!CHECK:    fir.address_of(@_QQcl4.) : !fir.ref<!fir.char<4,0>>
+!CHECK:    fir.address_of(@_QQcl4_) : !fir.ref<!fir.char<4,0>>
 !CHECK:    fir.call @_FortranAioOutputDescriptor(
 
-!CHECK-DAG:  fir.global linkonce @_QQcl. constant : !fir.char<1,0>
-!CHECK-DAG:  fir.global linkonce @_QQcl4. constant : !fir.char<4,0>
+!CHECK-DAG:  fir.global linkonce @_QQcl_ constant : !fir.char<1,0>
+!CHECK-DAG:  fir.global linkonce @_QQcl4_ constant : !fir.char<4,0>

--- a/flang/test/Lower/HLFIR/constant-character.f90
+++ b/flang/test/Lower/HLFIR/constant-character.f90
@@ -8,10 +8,10 @@ subroutine repro(c1, c4)
   print *, 4_""
 end subroutine
 !CHECK-LABEL: func.func @_QPrepro
-!CHECK:    fir.address_of(@_QQcl_) : !fir.ref<!fir.char<1,0>>
+!CHECK:    fir.address_of(@_QQclX) : !fir.ref<!fir.char<1,0>>
 !CHECK:    fir.call @_FortranAioOutputAscii
-!CHECK:    fir.address_of(@_QQcl4_) : !fir.ref<!fir.char<4,0>>
+!CHECK:    fir.address_of(@_QQcl4X) : !fir.ref<!fir.char<4,0>>
 !CHECK:    fir.call @_FortranAioOutputDescriptor(
 
-!CHECK-DAG:  fir.global linkonce @_QQcl_ constant : !fir.char<1,0>
-!CHECK-DAG:  fir.global linkonce @_QQcl4_ constant : !fir.char<4,0>
+!CHECK-DAG:  fir.global linkonce @_QQclX constant : !fir.char<1,0>
+!CHECK-DAG:  fir.global linkonce @_QQcl4X constant : !fir.char<4,0>

--- a/flang/test/Lower/HLFIR/convert-mbox-to-value.f90
+++ b/flang/test/Lower/HLFIR/convert-mbox-to-value.f90
@@ -9,7 +9,7 @@ end subroutine test_int_allocatable
 ! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>> {fir.bindc_name = "a"}) {
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest_int_allocatableEa"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:           %[[VAL_2:.*]] = arith.constant -1 : i32
-! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_4]], %[[VAL_5]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -29,7 +29,7 @@ end subroutine test_int_pointer
 ! CHECK-SAME:                                   %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<i32>>> {fir.bindc_name = "p"}) {
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest_int_pointerEp"} : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> (!fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.ref<!fir.box<!fir.ptr<i32>>>)
 ! CHECK:           %[[VAL_2:.*]] = arith.constant -1 : i32
-! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_4]], %[[VAL_5]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/HLFIR/convert-mbox-to-value.f90
+++ b/flang/test/Lower/HLFIR/convert-mbox-to-value.f90
@@ -9,7 +9,7 @@ end subroutine test_int_allocatable
 ! CHECK-SAME:                                       %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>> {fir.bindc_name = "a"}) {
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest_int_allocatableEa"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:           %[[VAL_2:.*]] = arith.constant -1 : i32
-! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_4]], %[[VAL_5]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -29,7 +29,7 @@ end subroutine test_int_pointer
 ! CHECK-SAME:                                   %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.ptr<i32>>> {fir.bindc_name = "p"}) {
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest_int_pointerEp"} : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> (!fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.ref<!fir.box<!fir.ptr<i32>>>)
 ! CHECK:           %[[VAL_2:.*]] = arith.constant -1 : i32
-! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_4]], %[[VAL_5]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/HLFIR/structure-constructor.f90
+++ b/flang/test/Lower/HLFIR/structure-constructor.f90
@@ -46,7 +46,7 @@ end subroutine test1
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_5]] typeparams %[[VAL_6]] {uniq_name = "_QFtest1Ex"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
 ! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>, !fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>)
 ! CHECK:           %[[VAL_9:.*]] = fir.embox %[[VAL_8]]#0 : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>
-! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_11:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -74,7 +74,7 @@ end subroutine test2
 ! CHECK:           %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_0]](%[[VAL_5]]) {uniq_name = "_QFtest2Ex"} : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xi32>>, !fir.ref<!fir.array<10xi32>>)
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>) -> (!fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>, !fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>)
 ! CHECK:           %[[VAL_8:.*]] = fir.embox %[[VAL_7]]#0 : (!fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>) -> !fir.box<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>
-! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_10:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.box<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -99,7 +99,7 @@ end subroutine test3
 ! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}> {bindc_name = "res", uniq_name = "_QFtest3Eres"}
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QFtest3Eres"} : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_3]]#1 : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_6:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -107,7 +107,7 @@ end subroutine test3
 ! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest3Ex"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.embox %[[VAL_11]]#0 : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_14:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -135,7 +135,7 @@ end subroutine test4
 ! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}> {bindc_name = "res", uniq_name = "_QFtest4Eres"}
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QFtest4Eres"} : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>, !fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>)
 ! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_3]]#1 : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>
-! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_6:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -144,7 +144,7 @@ end subroutine test4
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_0]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest4Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>>, index) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>>)
 ! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>, !fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>)
 ! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_12]]#0 : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>
-! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_15:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -177,7 +177,7 @@ end subroutine test5
 ! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}> {bindc_name = "res", uniq_name = "_QFtest5Eres"}
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QFtest5Eres"} : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>, !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>)
 ! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_3]]#1 : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
-! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_6:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -185,7 +185,7 @@ end subroutine test5
 ! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest5Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>)
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>, !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.embox %[[VAL_11]]#0 : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
-! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_14:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -226,7 +226,7 @@ end subroutine test6
 ! CHECK:           %[[VAL_11:.*]] = fir.alloca !fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}> {bindc_name = "res", uniq_name = "_QFtest6Eres"}
 ! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_11]] {uniq_name = "_QFtest6Eres"} : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>, !fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>)
 ! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_12]]#1 : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>
-! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_15:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -234,7 +234,7 @@ end subroutine test6
 ! CHECK:           %[[VAL_19:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest6Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>)
 ! CHECK:           %[[VAL_20:.*]]:2 = hlfir.declare %[[VAL_6]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>, !fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>)
 ! CHECK:           %[[VAL_21:.*]] = fir.embox %[[VAL_20]]#0 : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>
-! CHECK:           %[[VAL_22:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_22:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_23:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_21]] : (!fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_22]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -242,7 +242,7 @@ end subroutine test6
 ! CHECK:           %[[VAL_27:.*]] = hlfir.designate %[[VAL_20]]#0{"t5"}   : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
 ! CHECK:           %[[VAL_28:.*]]:2 = hlfir.declare %[[VAL_5]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>, !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>)
 ! CHECK:           %[[VAL_29:.*]] = fir.embox %[[VAL_28]]#0 : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
-! CHECK:           %[[VAL_30:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_30:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_31:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_29]] : (!fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_30]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -270,14 +270,14 @@ end subroutine test6
 ! CHECK:           %[[VAL_50:.*]] = arith.constant false
 ! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
 ! CHECK:           %[[VAL_52:.*]] = arith.constant 80 : i32
-! CHECK:           %[[VAL_53:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_53:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_54:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_55:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_56:.*]] = fir.convert %[[VAL_53]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_57:.*]] = fir.call @_FortranAInitArrayConstructorVector(%[[VAL_51]], %[[VAL_55]], %[[VAL_50]], %[[VAL_52]], %[[VAL_56]], %[[VAL_54]]) fastmath<contract> : (!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none
 ! CHECK:           %[[VAL_58:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>, !fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>)
 ! CHECK:           %[[VAL_59:.*]] = fir.embox %[[VAL_58]]#0 : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>
-! CHECK:           %[[VAL_60:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_60:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_61:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_62:.*]] = fir.convert %[[VAL_59]] : (!fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_63:.*]] = fir.convert %[[VAL_60]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -312,14 +312,14 @@ end subroutine test7
 ! CHECK:           %[[VAL_3:.*]] = fir.alloca !fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "x", uniq_name = "_QFtest7Ex"}
 ! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_3]] {uniq_name = "_QFtest7Ex"} : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_5:.*]] = fir.embox %[[VAL_4]]#1 : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_7:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_10:.*]] = fir.call @_FortranAInitialize(%[[VAL_8]], %[[VAL_9]], %[[VAL_7]]) fastmath<contract> : (!fir.box<none>, !fir.ref<i8>, i32) -> none
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.embox %[[VAL_11]]#0 : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_14:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -344,7 +344,7 @@ end subroutine test8
 ! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}> {bindc_name = "res", uniq_name = "_QFtest8Eres"}
 ! CHECK:           %[[VAL_2:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "_QFtest8Eres"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_3:.*]] = fir.embox %[[VAL_2]]#1 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -357,7 +357,7 @@ end subroutine test8
 ! CHECK:           %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_9]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest8Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, index) -> (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, !fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>)
 ! CHECK:           %[[VAL_14:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_15:.*]] = fir.embox %[[VAL_14]]#0 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_16:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_16:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_17:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_15]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -391,7 +391,7 @@ end subroutine test9
 ! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}> {bindc_name = "res", uniq_name = "_QFtest9Eres"}
 ! CHECK:           %[[VAL_2:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "_QFtest9Eres"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_3:.*]] = fir.embox %[[VAL_2]]#1 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -401,7 +401,7 @@ end subroutine test9
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_10]] typeparams %[[VAL_9]] {uniq_name = "_QFtest9Ex"} : (!fir.ref<!fir.char<1,12>>, index) -> (!fir.ref<!fir.char<1,12>>, !fir.ref<!fir.char<1,12>>)
 ! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_12]]#0 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_15:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -434,7 +434,7 @@ end subroutine test10
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_3]] typeparams %[[VAL_4]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest10Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, index) -> (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, !fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>)
 ! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>, !fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>)
 ! CHECK:           %[[VAL_9:.*]] = fir.embox %[[VAL_8]]#0 : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>
-! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_11:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/HLFIR/structure-constructor.f90
+++ b/flang/test/Lower/HLFIR/structure-constructor.f90
@@ -46,7 +46,7 @@ end subroutine test1
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_5]] typeparams %[[VAL_6]] {uniq_name = "_QFtest1Ex"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
 ! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>, !fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>)
 ! CHECK:           %[[VAL_9:.*]] = fir.embox %[[VAL_8]]#0 : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>
-! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_11:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -74,7 +74,7 @@ end subroutine test2
 ! CHECK:           %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_0]](%[[VAL_5]]) {uniq_name = "_QFtest2Ex"} : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xi32>>, !fir.ref<!fir.array<10xi32>>)
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>) -> (!fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>, !fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>)
 ! CHECK:           %[[VAL_8:.*]] = fir.embox %[[VAL_7]]#0 : (!fir.ref<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>) -> !fir.box<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>
-! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_10:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.box<!fir.type<_QMtypesTt2{i:!fir.array<10xi32>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -99,7 +99,7 @@ end subroutine test3
 ! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}> {bindc_name = "res", uniq_name = "_QFtest3Eres"}
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QFtest3Eres"} : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_3]]#1 : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_6:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -107,7 +107,7 @@ end subroutine test3
 ! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFtest3Ex"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.embox %[[VAL_11]]#0 : (!fir.ref<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_14:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.type<_QMtypesTt3{r:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -135,7 +135,7 @@ end subroutine test4
 ! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}> {bindc_name = "res", uniq_name = "_QFtest4Eres"}
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QFtest4Eres"} : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>, !fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>)
 ! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_3]]#1 : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>
-! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_6:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -144,7 +144,7 @@ end subroutine test4
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_0]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest4Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>>, index) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>>)
 ! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>, !fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>)
 ! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_12]]#0 : (!fir.ref<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>
-! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_15:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.box<!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -177,7 +177,7 @@ end subroutine test5
 ! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}> {bindc_name = "res", uniq_name = "_QFtest5Eres"}
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "_QFtest5Eres"} : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>, !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>)
 ! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_3]]#1 : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
-! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_6:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -185,7 +185,7 @@ end subroutine test5
 ! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest5Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>)
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>, !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.embox %[[VAL_11]]#0 : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
-! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_14:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -226,7 +226,7 @@ end subroutine test6
 ! CHECK:           %[[VAL_11:.*]] = fir.alloca !fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}> {bindc_name = "res", uniq_name = "_QFtest6Eres"}
 ! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_11]] {uniq_name = "_QFtest6Eres"} : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>, !fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>)
 ! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_12]]#1 : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>
-! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_15:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -234,7 +234,7 @@ end subroutine test6
 ! CHECK:           %[[VAL_19:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest6Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>>)
 ! CHECK:           %[[VAL_20:.*]]:2 = hlfir.declare %[[VAL_6]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>, !fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>)
 ! CHECK:           %[[VAL_21:.*]] = fir.embox %[[VAL_20]]#0 : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>
-! CHECK:           %[[VAL_22:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_22:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_23:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_21]] : (!fir.box<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_22]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -242,7 +242,7 @@ end subroutine test6
 ! CHECK:           %[[VAL_27:.*]] = hlfir.designate %[[VAL_20]]#0{"t5"}   : (!fir.ref<!fir.type<_QMtypesTt6{t5:!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>,t6m:!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>}>>) -> !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
 ! CHECK:           %[[VAL_28:.*]]:2 = hlfir.declare %[[VAL_5]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>, !fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>)
 ! CHECK:           %[[VAL_29:.*]] = fir.embox %[[VAL_28]]#0 : (!fir.ref<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>
-! CHECK:           %[[VAL_30:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_30:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_31:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_29]] : (!fir.box<!fir.type<_QMtypesTt5{t5m:!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMtypesTt4{c:!fir.box<!fir.heap<!fir.array<?x!fir.char<1,2>>>>}>>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_30]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -270,14 +270,14 @@ end subroutine test6
 ! CHECK:           %[[VAL_50:.*]] = arith.constant false
 ! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<!fir.array<10xi64>>) -> !fir.llvm_ptr<i8>
 ! CHECK:           %[[VAL_52:.*]] = arith.constant 80 : i32
-! CHECK:           %[[VAL_53:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_53:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_54:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_55:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<1x!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_56:.*]] = fir.convert %[[VAL_53]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_57:.*]] = fir.call @_FortranAInitArrayConstructorVector(%[[VAL_51]], %[[VAL_55]], %[[VAL_50]], %[[VAL_52]], %[[VAL_56]], %[[VAL_54]]) fastmath<contract> : (!fir.llvm_ptr<i8>, !fir.ref<!fir.box<none>>, i1, i32, !fir.ref<i8>, i32) -> none
 ! CHECK:           %[[VAL_58:.*]]:2 = hlfir.declare %[[VAL_2]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>, !fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>)
 ! CHECK:           %[[VAL_59:.*]] = fir.embox %[[VAL_58]]#0 : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>
-! CHECK:           %[[VAL_60:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_60:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_61:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_62:.*]] = fir.convert %[[VAL_59]] : (!fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_63:.*]] = fir.convert %[[VAL_60]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -312,14 +312,14 @@ end subroutine test7
 ! CHECK:           %[[VAL_3:.*]] = fir.alloca !fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "x", uniq_name = "_QFtest7Ex"}
 ! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_3]] {uniq_name = "_QFtest7Ex"} : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_5:.*]] = fir.embox %[[VAL_4]]#1 : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_7:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_5]] : (!fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_10:.*]] = fir.call @_FortranAInitialize(%[[VAL_8]], %[[VAL_9]], %[[VAL_7]]) fastmath<contract> : (!fir.box<none>, !fir.ref<i8>, i32) -> none
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>)
 ! CHECK:           %[[VAL_12:.*]] = fir.embox %[[VAL_11]]#0 : (!fir.ref<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_14:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_12]] : (!fir.box<!fir.type<_QMtypesTt7{c1:i32,c2:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -344,7 +344,7 @@ end subroutine test8
 ! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}> {bindc_name = "res", uniq_name = "_QFtest8Eres"}
 ! CHECK:           %[[VAL_2:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "_QFtest8Eres"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_3:.*]] = fir.embox %[[VAL_2]]#1 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -357,7 +357,7 @@ end subroutine test8
 ! CHECK:           %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_9]] typeparams %[[VAL_10]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest8Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, index) -> (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, !fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>)
 ! CHECK:           %[[VAL_14:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_15:.*]] = fir.embox %[[VAL_14]]#0 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_16:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_16:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_17:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_15]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -391,7 +391,7 @@ end subroutine test9
 ! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}> {bindc_name = "res", uniq_name = "_QFtest9Eres"}
 ! CHECK:           %[[VAL_2:.*]]:2 = hlfir.declare %[[VAL_1]] {uniq_name = "_QFtest9Eres"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_3:.*]] = fir.embox %[[VAL_2]]#1 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_4:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_5:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -401,7 +401,7 @@ end subroutine test9
 ! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_10]] typeparams %[[VAL_9]] {uniq_name = "_QFtest9Ex"} : (!fir.ref<!fir.char<1,12>>, index) -> (!fir.ref<!fir.char<1,12>>, !fir.ref<!fir.char<1,12>>)
 ! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>, !fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>)
 ! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_12]]#0 : (!fir.ref<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>
-! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_15:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.box<!fir.type<_QMtypesTt8{c:!fir.box<!fir.heap<!fir.char<1,11>>>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>
@@ -434,7 +434,7 @@ end subroutine test10
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_3]] typeparams %[[VAL_4]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFtest10Ex"} : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, index) -> (!fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>, !fir.ref<!fir.box<!fir.heap<!fir.char<1,12>>>>)
 ! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "ctor.temp"} : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>, !fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>)
 ! CHECK:           %[[VAL_9:.*]] = fir.embox %[[VAL_8]]#0 : (!fir.ref<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>
-! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK:           %[[VAL_11:.*]] = arith.constant {{[0-9]*}} : i32
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.type<_QMtypesTt1{c:!fir.char<1,4>}>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{[0-9]*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/HLFIR/user-defined-assignment.f90
+++ b/flang/test/Lower/HLFIR/user-defined-assignment.f90
@@ -317,9 +317,9 @@ end subroutine test_char_get_length
 ! CHECK:           %[[VAL_3:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_char_get_lengthEx"}
 ! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_3]] {uniq_name = "_QFtest_char_get_lengthEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           hlfir.region_assign {
-! CHECK:             %[[VAL_5:.*]] = fir.address_of(@_QQcl.616263) : !fir.ref<!fir.char<1,3>>
+! CHECK:             %[[VAL_5:.*]] = fir.address_of(@_QQcl_616263) : !fir.ref<!fir.char<1,3>>
 ! CHECK:             %[[VAL_6:.*]] = arith.constant 3 : index
-! CHECK:             %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_5]] typeparams %[[VAL_6]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl.616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
+! CHECK:             %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_5]] typeparams %[[VAL_6]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
 ! CHECK:             %[[VAL_8:.*]] = arith.addi %[[VAL_6]], %[[VAL_1]]#1 : index
 ! CHECK:             %[[VAL_9:.*]] = hlfir.concat %[[VAL_7]]#0, %[[VAL_2]]#0 len %[[VAL_8]] : (!fir.ref<!fir.char<1,3>>, !fir.boxchar<1>, index) -> !hlfir.expr<!fir.char<1,?>>
 ! CHECK:             hlfir.yield %[[VAL_9]] : !hlfir.expr<!fir.char<1,?>>

--- a/flang/test/Lower/HLFIR/user-defined-assignment.f90
+++ b/flang/test/Lower/HLFIR/user-defined-assignment.f90
@@ -317,9 +317,9 @@ end subroutine test_char_get_length
 ! CHECK:           %[[VAL_3:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFtest_char_get_lengthEx"}
 ! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_3]] {uniq_name = "_QFtest_char_get_lengthEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           hlfir.region_assign {
-! CHECK:             %[[VAL_5:.*]] = fir.address_of(@_QQcl_616263) : !fir.ref<!fir.char<1,3>>
+! CHECK:             %[[VAL_5:.*]] = fir.address_of(@_QQclX616263) : !fir.ref<!fir.char<1,3>>
 ! CHECK:             %[[VAL_6:.*]] = arith.constant 3 : index
-! CHECK:             %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_5]] typeparams %[[VAL_6]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
+! CHECK:             %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_5]] typeparams %[[VAL_6]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQclX616263"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
 ! CHECK:             %[[VAL_8:.*]] = arith.addi %[[VAL_6]], %[[VAL_1]]#1 : index
 ! CHECK:             %[[VAL_9:.*]] = hlfir.concat %[[VAL_7]]#0, %[[VAL_2]]#0 len %[[VAL_8]] : (!fir.ref<!fir.char<1,3>>, !fir.boxchar<1>, index) -> !hlfir.expr<!fir.char<1,?>>
 ! CHECK:             hlfir.yield %[[VAL_9]] : !hlfir.expr<!fir.char<1,?>>

--- a/flang/test/Lower/HLFIR/vector-subscript-lhs.f90
+++ b/flang/test/Lower/HLFIR/vector-subscript-lhs.f90
@@ -109,7 +109,7 @@ end subroutine
 ! CHECK:  hlfir.region_assign {
 ! CHECK:    %[[VAL_6:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,5>>
 ! CHECK:    %[[VAL_7:.*]] = arith.constant 5 : index
-! CHECK:    %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_6]] typeparams %[[VAL_7]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl.68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
+! CHECK:    %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_6]] typeparams %[[VAL_7]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
 ! CHECK:    hlfir.yield %[[VAL_8]]#0 : !fir.ref<!fir.char<1,5>>
 ! CHECK:  } to {
 ! CHECK:    %[[VAL_9:.*]] = arith.constant 10 : index

--- a/flang/test/Lower/HLFIR/vector-subscript-lhs.f90
+++ b/flang/test/Lower/HLFIR/vector-subscript-lhs.f90
@@ -109,7 +109,7 @@ end subroutine
 ! CHECK:  hlfir.region_assign {
 ! CHECK:    %[[VAL_6:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,5>>
 ! CHECK:    %[[VAL_7:.*]] = arith.constant 5 : index
-! CHECK:    %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_6]] typeparams %[[VAL_7]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQcl_68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
+! CHECK:    %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_6]] typeparams %[[VAL_7]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QQclX68656C6C6F"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
 ! CHECK:    hlfir.yield %[[VAL_8]]#0 : !fir.ref<!fir.char<1,5>>
 ! CHECK:  } to {
 ! CHECK:    %[[VAL_9:.*]] = arith.constant 10 : index

--- a/flang/test/Lower/Intrinsics/get_environment_variable.f90
+++ b/flang/test/Lower/Intrinsics/get_environment_variable.f90
@@ -48,7 +48,7 @@ subroutine name_and_length_only(name, length)
 ! CHECK-NEXT: %true = arith.constant true
 ! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
-! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 9]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[length:.*]] = fir.convert %[[lengthBox]] : (!fir.box<i[[DEFAULT_INTEGER_SIZE]]>) -> !fir.box<none>
@@ -70,7 +70,7 @@ subroutine name_and_status_only(name, status)
 ! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[length:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
-! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 9]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[sourceFileLength]]>>) -> !fir.ref<i8>
@@ -107,7 +107,7 @@ subroutine name_and_errmsg_only(name, errmsg)
 ! CHECK-NEXT: %true = arith.constant true
 ! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[length:.*]] = fir.absent !fir.box<none>
-! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 11]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.convert %[[errmsgBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
@@ -149,7 +149,7 @@ subroutine all_arguments(name, value, length, status, trim_name, errmsg)
 ! CHECK-NEXT:   %[[trueVal:.*]] = arith.constant true
 ! CHECK-NEXT:   fir.result %[[trueVal]] : i1
 ! CHECK-NEXT: }
-! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQcl.[[fileString:.*]]) : !fir.ref<!fir.char<1,[[fileStringLength:.*]]>>
+! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_[[fileString:.*]]) : !fir.ref<!fir.char<1,[[fileStringLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 22]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBoxed]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[value:.*]] = fir.convert %[[valueBoxed]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>

--- a/flang/test/Lower/Intrinsics/get_environment_variable.f90
+++ b/flang/test/Lower/Intrinsics/get_environment_variable.f90
@@ -48,7 +48,7 @@ subroutine name_and_length_only(name, length)
 ! CHECK-NEXT: %true = arith.constant true
 ! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
-! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 9]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[length:.*]] = fir.convert %[[lengthBox]] : (!fir.box<i[[DEFAULT_INTEGER_SIZE]]>) -> !fir.box<none>
@@ -70,7 +70,7 @@ subroutine name_and_status_only(name, status)
 ! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[length:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.absent !fir.box<none>
-! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 9]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[sourceFile:.*]] = fir.convert %[[sourceFileString]] : (!fir.ref<!fir.char<1,[[sourceFileLength]]>>) -> !fir.ref<i8>
@@ -107,7 +107,7 @@ subroutine name_and_errmsg_only(name, errmsg)
 ! CHECK-NEXT: %true = arith.constant true
 ! CHECK-NEXT: %[[value:.*]] = fir.absent !fir.box<none>
 ! CHECK-NEXT: %[[length:.*]] = fir.absent !fir.box<none>
-! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
+! CHECK-NEXT: %[[sourceFileString:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,[[sourceFileLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 11]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[errmsg:.*]] = fir.convert %[[errmsgBox]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
@@ -149,7 +149,7 @@ subroutine all_arguments(name, value, length, status, trim_name, errmsg)
 ! CHECK-NEXT:   %[[trueVal:.*]] = arith.constant true
 ! CHECK-NEXT:   fir.result %[[trueVal]] : i1
 ! CHECK-NEXT: }
-! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQcl_[[fileString:.*]]) : !fir.ref<!fir.char<1,[[fileStringLength:.*]]>>
+! CHECK: %[[sourceFileString:.*]] = fir.address_of(@_QQclX[[fileString:.*]]) : !fir.ref<!fir.char<1,[[fileStringLength:.*]]>>
 ! CHECK-NEXT: %[[sourceLine:.*]] = arith.constant [[# @LINE - 22]] : i32
 ! CHECK-NEXT: %[[name:.*]] = fir.convert %[[nameBoxed]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>
 ! CHECK-NEXT: %[[value:.*]] = fir.convert %[[valueBoxed]] : (!fir.box<!fir.char<1,32>>) -> !fir.box<none>

--- a/flang/test/Lower/Intrinsics/transfer.f90
+++ b/flang/test/Lower/Intrinsics/transfer.f90
@@ -9,7 +9,7 @@ subroutine trans_test(store, word)
     ! CHECK:         %[[VAL_5:.*]] = fir.zero_bits !fir.heap<i32>
     ! CHECK:         %[[VAL_6:.*]] = fir.embox %[[VAL_5]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
     ! CHECK:         fir.store %[[VAL_6]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>
-    ! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+    ! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
     ! CHECK:         %[[VAL_8:.*]] = arith.constant {{.*}} : i32
     ! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
     ! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_3]] : (!fir.box<f32>) -> !fir.box<none>
@@ -43,7 +43,7 @@ subroutine trans_test(store, word)
   ! CHECK:         %[[VAL_12:.*]] = fir.shape %[[VAL_11]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_13:.*]] = fir.embox %[[VAL_10]](%[[VAL_12]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   ! CHECK:         fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK:         %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK:         %[[VAL_14:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK:         %[[VAL_15:.*]] = arith.constant {{.*}} : i32
   ! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_7]] : (!fir.box<f32>) -> !fir.box<none>
@@ -88,7 +88,7 @@ subroutine trans_test(store, word)
     ! CHECK:         %[[VAL_7:.*]] = fir.zero_bits !fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>
     ! CHECK:         %[[VAL_8:.*]] = fir.embox %[[VAL_7]] : (!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>) -> !fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>
     ! CHECK:         fir.store %[[VAL_8]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>>
-    ! CHECK:         %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+    ! CHECK:         %[[VAL_9:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
     ! CHECK:         %[[VAL_10:.*]] = arith.constant {{.*}} : i32
     ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>>) -> !fir.ref<!fir.box<none>>
     ! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_5]] : (!fir.box<i32>) -> !fir.box<none>
@@ -99,7 +99,7 @@ subroutine trans_test(store, word)
     ! CHECK:         %[[VAL_17:.*]] = fir.box_addr %[[VAL_16]] : (!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>) -> !fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>
     ! CHECK:         %[[VAL_18:.*]] = fir.embox %[[VAL_3]] : (!fir.ref<!fir.type<_QFtrans_test3Tobj{x:i32}>>) -> !fir.box<!fir.type<_QFtrans_test3Tobj{x:i32}>>
     ! CHECK:         fir.store %[[VAL_18]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.type<_QFtrans_test3Tobj{x:i32}>>>
-    ! CHECK:         %[[VAL_19:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+    ! CHECK:         %[[VAL_19:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
     ! CHECK:         %[[VAL_20:.*]] = arith.constant {{.*}} : i32
     ! CHECK:         %[[VAL_21:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.type<_QFtrans_test3Tobj{x:i32}>>>) -> !fir.ref<!fir.box<none>>
     ! CHECK:         %[[VAL_22:.*]] = fir.convert %[[VAL_16]] : (!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>) -> !fir.box<none>

--- a/flang/test/Lower/Intrinsics/transfer.f90
+++ b/flang/test/Lower/Intrinsics/transfer.f90
@@ -9,7 +9,7 @@ subroutine trans_test(store, word)
     ! CHECK:         %[[VAL_5:.*]] = fir.zero_bits !fir.heap<i32>
     ! CHECK:         %[[VAL_6:.*]] = fir.embox %[[VAL_5]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
     ! CHECK:         fir.store %[[VAL_6]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>
-    ! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+    ! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
     ! CHECK:         %[[VAL_8:.*]] = arith.constant {{.*}} : i32
     ! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
     ! CHECK:         %[[VAL_10:.*]] = fir.convert %[[VAL_3]] : (!fir.box<f32>) -> !fir.box<none>
@@ -43,7 +43,7 @@ subroutine trans_test(store, word)
   ! CHECK:         %[[VAL_12:.*]] = fir.shape %[[VAL_11]] : (index) -> !fir.shape<1>
   ! CHECK:         %[[VAL_13:.*]] = fir.embox %[[VAL_10]](%[[VAL_12]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   ! CHECK:         fir.store %[[VAL_13]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK:         %[[VAL_14:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK:         %[[VAL_14:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK:         %[[VAL_15:.*]] = arith.constant {{.*}} : i32
   ! CHECK:         %[[VAL_16:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_7]] : (!fir.box<f32>) -> !fir.box<none>
@@ -88,7 +88,7 @@ subroutine trans_test(store, word)
     ! CHECK:         %[[VAL_7:.*]] = fir.zero_bits !fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>
     ! CHECK:         %[[VAL_8:.*]] = fir.embox %[[VAL_7]] : (!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>) -> !fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>
     ! CHECK:         fir.store %[[VAL_8]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>>
-    ! CHECK:         %[[VAL_9:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+    ! CHECK:         %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
     ! CHECK:         %[[VAL_10:.*]] = arith.constant {{.*}} : i32
     ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>>) -> !fir.ref<!fir.box<none>>
     ! CHECK:         %[[VAL_12:.*]] = fir.convert %[[VAL_5]] : (!fir.box<i32>) -> !fir.box<none>
@@ -99,7 +99,7 @@ subroutine trans_test(store, word)
     ! CHECK:         %[[VAL_17:.*]] = fir.box_addr %[[VAL_16]] : (!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>) -> !fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>
     ! CHECK:         %[[VAL_18:.*]] = fir.embox %[[VAL_3]] : (!fir.ref<!fir.type<_QFtrans_test3Tobj{x:i32}>>) -> !fir.box<!fir.type<_QFtrans_test3Tobj{x:i32}>>
     ! CHECK:         fir.store %[[VAL_18]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.type<_QFtrans_test3Tobj{x:i32}>>>
-    ! CHECK:         %[[VAL_19:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+    ! CHECK:         %[[VAL_19:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
     ! CHECK:         %[[VAL_20:.*]] = arith.constant {{.*}} : i32
     ! CHECK:         %[[VAL_21:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.type<_QFtrans_test3Tobj{x:i32}>>>) -> !fir.ref<!fir.box<none>>
     ! CHECK:         %[[VAL_22:.*]] = fir.convert %[[VAL_16]] : (!fir.box<!fir.heap<!fir.type<_QFtrans_test3Tobj{x:i32}>>>) -> !fir.box<none>

--- a/flang/test/Lower/Intrinsics/verify.f90
+++ b/flang/test/Lower/Intrinsics/verify.f90
@@ -14,7 +14,7 @@ integer function verify_test(s1, s2)
 ! CHECK: %[[VAL_10:.*]] = fir.zero_bits !fir.heap<i32>
 ! CHECK: %[[VAL_11:.*]] = fir.embox %[[VAL_10]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
 ! CHECK: fir.store %[[VAL_11]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK: %[[VAL_12:.*]] = fir.address_of(@_QQcl.{{[0-9a-z]+}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK: %[[VAL_12:.*]] = fir.address_of(@_QQcl_{{[0-9a-z]+}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK: %[[VAL_13:.*]] = arith.constant {{[0-9]+}} : i32
 ! CHECK: %[[VAL_14:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK: %[[VAL_15:.*]] = fir.convert %[[VAL_8]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>

--- a/flang/test/Lower/Intrinsics/verify.f90
+++ b/flang/test/Lower/Intrinsics/verify.f90
@@ -14,7 +14,7 @@ integer function verify_test(s1, s2)
 ! CHECK: %[[VAL_10:.*]] = fir.zero_bits !fir.heap<i32>
 ! CHECK: %[[VAL_11:.*]] = fir.embox %[[VAL_10]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
 ! CHECK: fir.store %[[VAL_11]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK: %[[VAL_12:.*]] = fir.address_of(@_QQcl_{{[0-9a-z]+}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
+! CHECK: %[[VAL_12:.*]] = fir.address_of(@_QQclX{{[0-9a-z]+}}) : !fir.ref<!fir.char<1,{{[0-9]*}}>>
 ! CHECK: %[[VAL_13:.*]] = arith.constant {{[0-9]+}} : i32
 ! CHECK: %[[VAL_14:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK: %[[VAL_15:.*]] = fir.convert %[[VAL_8]] : (!fir.box<!fir.char<1,?>>) -> !fir.box<none>

--- a/flang/test/Lower/OpenMP/FIR/parallel-lastprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/FIR/parallel-lastprivate-clause-scalar.f90
@@ -14,7 +14,7 @@
 ! Check that we are accessing the clone inside the loop
 !CHECK-DAG: omp.wsloop for (%[[INDX_WS:.*]]) : {{.*}} {
 !CHECK-DAG: %[[NEG_ONE:.*]] = arith.constant -1 : i32
-!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQcl_
+!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQclX
 !CHECK-NEXT: %[[CVT0:.*]] = fir.convert %[[ADDR]] 
 !CHECK-NEXT: %[[CNST:.*]] = arith.constant
 !CHECK-NEXT: %[[CALL_BEGIN_IO:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[NEG_ONE]], %[[CVT0]], %[[CNST]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/OpenMP/FIR/parallel-lastprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/FIR/parallel-lastprivate-clause-scalar.f90
@@ -14,7 +14,7 @@
 ! Check that we are accessing the clone inside the loop
 !CHECK-DAG: omp.wsloop for (%[[INDX_WS:.*]]) : {{.*}} {
 !CHECK-DAG: %[[NEG_ONE:.*]] = arith.constant -1 : i32
-!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQcl.
+!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQcl_
 !CHECK-NEXT: %[[CVT0:.*]] = fir.convert %[[ADDR]] 
 !CHECK-NEXT: %[[CNST:.*]] = arith.constant
 !CHECK-NEXT: %[[CALL_BEGIN_IO:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[NEG_ONE]], %[[CVT0]], %[[CNST]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
@@ -16,7 +16,7 @@
 ! Check that we are accessing the clone inside the loop
 !CHECK-DAG: omp.wsloop for (%[[INDX_WS:.*]]) : {{.*}} {
 !CHECK-DAG: %[[NEG_ONE:.*]] = arith.constant -1 : i32
-!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQcl.
+!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQcl_
 !CHECK-NEXT: %[[CVT0:.*]] = fir.convert %[[ADDR]] 
 !CHECK-NEXT: %[[CNST:.*]] = arith.constant
 !CHECK-NEXT: %[[CALL_BEGIN_IO:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[NEG_ONE]], %[[CVT0]], %[[CNST]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
@@ -16,7 +16,7 @@
 ! Check that we are accessing the clone inside the loop
 !CHECK-DAG: omp.wsloop for (%[[INDX_WS:.*]]) : {{.*}} {
 !CHECK-DAG: %[[NEG_ONE:.*]] = arith.constant -1 : i32
-!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQcl_
+!CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQclX
 !CHECK-NEXT: %[[CVT0:.*]] = fir.convert %[[ADDR]] 
 !CHECK-NEXT: %[[CNST:.*]] = arith.constant
 !CHECK-NEXT: %[[CALL_BEGIN_IO:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[NEG_ONE]], %[[CVT0]], %[[CNST]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/allocatable-assignment.f90
+++ b/flang/test/Lower/allocatable-assignment.f90
@@ -181,7 +181,7 @@ subroutine test_dyn_char_scalar(x, n)
 ! CHECK:  %[[c0_i32:.*]] = arith.constant 0 : i32
 ! CHECK:  %[[VAL_2B:.*]] = arith.cmpi sgt, %[[VAL_2A]], %[[c0_i32]] : i32
 ! CHECK:  %[[VAL_2:.*]] = arith.select %[[VAL_2B]], %[[VAL_2A]], %[[c0_i32]] : i32
-! CHECK:  %[[VAL_3:.*]] = fir.address_of(@_QQcl_48656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
+! CHECK:  %[[VAL_3:.*]] = fir.address_of(@_QQclX48656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
 ! CHECK:  %[[VAL_4:.*]] = arith.constant 12 : index
 ! CHECK:  %[[VAL_5:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
 ! CHECK:  %[[VAL_6:.*]] = fir.box_addr %[[VAL_5]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>

--- a/flang/test/Lower/allocatable-assignment.f90
+++ b/flang/test/Lower/allocatable-assignment.f90
@@ -181,7 +181,7 @@ subroutine test_dyn_char_scalar(x, n)
 ! CHECK:  %[[c0_i32:.*]] = arith.constant 0 : i32
 ! CHECK:  %[[VAL_2B:.*]] = arith.cmpi sgt, %[[VAL_2A]], %[[c0_i32]] : i32
 ! CHECK:  %[[VAL_2:.*]] = arith.select %[[VAL_2B]], %[[VAL_2A]], %[[c0_i32]] : i32
-! CHECK:  %[[VAL_3:.*]] = fir.address_of(@_QQcl.48656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
+! CHECK:  %[[VAL_3:.*]] = fir.address_of(@_QQcl_48656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
 ! CHECK:  %[[VAL_4:.*]] = arith.constant 12 : index
 ! CHECK:  %[[VAL_5:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
 ! CHECK:  %[[VAL_6:.*]] = fir.box_addr %[[VAL_5]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>

--- a/flang/test/Lower/allocatable-polymorphic.f90
+++ b/flang/test/Lower/allocatable-polymorphic.f90
@@ -569,17 +569,17 @@ end
 ! LLVM-LABEL: define void @_QMpolyPtest_allocatable()
 
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p1, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl.{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p1, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl.{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p2, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl.{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p1, i32 1, i32 0)
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableSetBounds(ptr %{{.*}}, i32 0, i64 1, i64 10)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl.{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p2, i32 1, i32 0)
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableSetBounds(ptr %{{.*}}, i32 0, i64 1, i64 20)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl.{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
 ! LLVM-COUNT-2:  call void %{{.*}}()
 
 ! LLVM: %[[C1_LOAD:.*]] = load { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, ptr %{{.*}}
@@ -660,5 +660,5 @@ end
 ! LLVM: %[[LOAD:.*]] = load { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, ptr %[[ALLOCA1]]
 ! LLVM: store { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } %[[LOAD]], ptr %[[ALLOCA2:[0-9]*]]
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %[[ALLOCA2]], ptr @_QMpolyE.dt.p1, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %[[ALLOCA2]], i1 false, ptr null, ptr @_QQcl.{{.*}}, i32 {{.*}})
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableDeallocatePolymorphic(ptr %[[ALLOCA2]], ptr {{.*}}, i1 false, ptr null, ptr @_QQcl.{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %[[ALLOCA2]], i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableDeallocatePolymorphic(ptr %[[ALLOCA2]], ptr {{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})

--- a/flang/test/Lower/allocatable-polymorphic.f90
+++ b/flang/test/Lower/allocatable-polymorphic.f90
@@ -569,17 +569,17 @@ end
 ! LLVM-LABEL: define void @_QMpolyPtest_allocatable()
 
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p1, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQclX{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p1, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQclX{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p2, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQclX{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p1, i32 1, i32 0)
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableSetBounds(ptr %{{.*}}, i32 0, i64 1, i64 10)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQclX{{.*}}, i32 {{.*}})
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %{{.*}}, ptr @_QMpolyE.dt.p2, i32 1, i32 0)
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableSetBounds(ptr %{{.*}}, i32 0, i64 1, i64 20)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %{{.*}}, i1 false, ptr null, ptr @_QQclX{{.*}}, i32 {{.*}})
 ! LLVM-COUNT-2:  call void %{{.*}}()
 
 ! LLVM: %[[C1_LOAD:.*]] = load { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, ptr %{{.*}}
@@ -660,5 +660,5 @@ end
 ! LLVM: %[[LOAD:.*]] = load { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, ptr %[[ALLOCA1]]
 ! LLVM: store { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } %[[LOAD]], ptr %[[ALLOCA2:[0-9]*]]
 ! LLVM: %{{.*}} = call {} @_FortranAAllocatableInitDerivedForAllocate(ptr %[[ALLOCA2]], ptr @_QMpolyE.dt.p1, i32 0, i32 0)
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %[[ALLOCA2]], i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
-! LLVM: %{{.*}} = call i32 @_FortranAAllocatableDeallocatePolymorphic(ptr %[[ALLOCA2]], ptr {{.*}}, i1 false, ptr null, ptr @_QQcl_{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableAllocate(ptr %[[ALLOCA2]], i1 false, ptr null, ptr @_QQclX{{.*}}, i32 {{.*}})
+! LLVM: %{{.*}} = call i32 @_FortranAAllocatableDeallocatePolymorphic(ptr %[[ALLOCA2]], ptr {{.*}}, i1 false, ptr null, ptr @_QQclX{{.*}}, i32 {{.*}})

--- a/flang/test/Lower/array-character.f90
+++ b/flang/test/Lower/array-character.f90
@@ -60,7 +60,7 @@ program p
   ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant -1 : i32
   ! CHECK: %[[VAL_5:.*]] = fir.alloca !fir.array<3x!fir.char<1,4>> {bindc_name = "c1", uniq_name = "_QFEc1"}
   ! CHECK: %[[VAL_6:.*]] = fir.address_of(@_QFEc2) : !fir.ref<!fir.array<3x!fir.char<1,4>>>
-  ! CHECK: %[[VAL_7:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK: %[[VAL_7:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK: %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
   ! CHECK: %[[VAL_9:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_8]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   ! CHECK: %[[VAL_10:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
@@ -97,7 +97,7 @@ subroutine charlit
   ! CHECK-DAG: %[[VAL_5:.*]] = arith.constant 4 : index
   ! CHECK-DAG: %[[VAL_6:.*]] = arith.constant 0 : index
   ! CHECK-DAG: %[[VAL_7:.*]] = arith.constant 1 : index
-  ! CHECK: %[[VAL_8:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK: %[[VAL_8:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK: %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
   ! CHECK: %[[VAL_10:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_0]], %[[VAL_9]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   ! CHECK: %[[VAL_11:.*]] = fir.address_of(@_QQro.4x3xc1.0) : !fir.ref<!fir.array<4x!fir.char<1,3>>>

--- a/flang/test/Lower/array-character.f90
+++ b/flang/test/Lower/array-character.f90
@@ -60,7 +60,7 @@ program p
   ! CHECK-DAG: %[[VAL_2:.*]] = arith.constant -1 : i32
   ! CHECK: %[[VAL_5:.*]] = fir.alloca !fir.array<3x!fir.char<1,4>> {bindc_name = "c1", uniq_name = "_QFEc1"}
   ! CHECK: %[[VAL_6:.*]] = fir.address_of(@_QFEc2) : !fir.ref<!fir.array<3x!fir.char<1,4>>>
-  ! CHECK: %[[VAL_7:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK: %[[VAL_7:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK: %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
   ! CHECK: %[[VAL_9:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_8]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   ! CHECK: %[[VAL_10:.*]] = fir.shape %[[VAL_1]] : (index) -> !fir.shape<1>
@@ -97,7 +97,7 @@ subroutine charlit
   ! CHECK-DAG: %[[VAL_5:.*]] = arith.constant 4 : index
   ! CHECK-DAG: %[[VAL_6:.*]] = arith.constant 0 : index
   ! CHECK-DAG: %[[VAL_7:.*]] = arith.constant 1 : index
-  ! CHECK: %[[VAL_8:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK: %[[VAL_8:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK: %[[VAL_9:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
   ! CHECK: %[[VAL_10:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_0]], %[[VAL_9]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
   ! CHECK: %[[VAL_11:.*]] = fir.address_of(@_QQro.4x3xc1.0) : !fir.ref<!fir.array<4x!fir.char<1,3>>>

--- a/flang/test/Lower/array-derived-assignments.f90
+++ b/flang/test/Lower/array-derived-assignments.f90
@@ -88,7 +88,7 @@ subroutine test_deep_copy(t1, t2)
   ! CHECK:         %[[VAL_14:.*]] = fir.embox %[[VAL_13]] : (!fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
   ! CHECK:         %[[VAL_15:.*]] = fir.embox %[[VAL_12]] : (!fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
   ! CHECK:         fir.store %[[VAL_14]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>
-  ! CHECK:         %[[VAL_16:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK:         %[[VAL_16:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_15]] : (!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
   ! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/array-derived-assignments.f90
+++ b/flang/test/Lower/array-derived-assignments.f90
@@ -88,7 +88,7 @@ subroutine test_deep_copy(t1, t2)
   ! CHECK:         %[[VAL_14:.*]] = fir.embox %[[VAL_13]] : (!fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
   ! CHECK:         %[[VAL_15:.*]] = fir.embox %[[VAL_12]] : (!fir.ref<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
   ! CHECK:         fir.store %[[VAL_14]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>
-  ! CHECK:         %[[VAL_16:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK:         %[[VAL_16:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK:         %[[VAL_17:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_15]] : (!fir.box<!fir.type<_QMarray_derived_assignTdeep_copy{i:i32,a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
   ! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -96,10 +96,10 @@
 ! CHECK:         %[[VAL_81:.*]] = arith.cmpf une, %[[VAL_78]], %[[VAL_80]] : f32
 ! CHECK:         cond_br %[[VAL_81]], ^bb10, ^bb11
 ! CHECK:       ^bb10:
-! CHECK:         %[[VAL_82:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_82:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_84:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_83]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_85:.*]] = fir.address_of(@_QQcl_6D69736D617463682031) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_85:.*]] = fir.address_of(@_QQclX6D69736D617463682031) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_86:.*]] = fir.convert %[[VAL_85]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_87:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_88:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_84]], %[[VAL_86]], %[[VAL_87]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -117,10 +117,10 @@
 ! CHECK:         %[[VAL_98:.*]] = arith.cmpf une, %[[VAL_95]], %[[VAL_97]] : f32
 ! CHECK:         cond_br %[[VAL_98]], ^bb12, ^bb13
 ! CHECK:       ^bb12:
-! CHECK:         %[[VAL_99:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_99:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_100:.*]] = fir.convert %[[VAL_99]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_101:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_100]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_102:.*]] = fir.address_of(@_QQcl_6D69736D617463682032) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_102:.*]] = fir.address_of(@_QQclX6D69736D617463682032) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_103:.*]] = fir.convert %[[VAL_102]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_104:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_105:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_101]], %[[VAL_103]], %[[VAL_104]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -138,10 +138,10 @@
 ! CHECK:         %[[VAL_115:.*]] = arith.cmpf une, %[[VAL_112]], %[[VAL_114]] : f32
 ! CHECK:         cond_br %[[VAL_115]], ^bb14, ^bb15
 ! CHECK:       ^bb14:
-! CHECK:         %[[VAL_116:.*]] = fir.address_of(@_QQcl_{{.*}} : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_116:.*]] = fir.address_of(@_QQclX{{.*}} : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_117:.*]] = fir.convert %[[VAL_116]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_118:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_117]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_119:.*]] = fir.address_of(@_QQcl_6D69736D617463682033) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_119:.*]] = fir.address_of(@_QQclX6D69736D617463682033) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_120:.*]] = fir.convert %[[VAL_119]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_121:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_122:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_118]], %[[VAL_120]], %[[VAL_121]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -173,10 +173,10 @@
 ! CHECK:         %[[VAL_141:.*]] = arith.cmpf une, %[[VAL_138]], %[[VAL_140]] : f32
 ! CHECK:         cond_br %[[VAL_141]], ^bb19, ^bb20
 ! CHECK:       ^bb19:
-! CHECK:         %[[VAL_142:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_142:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_143:.*]] = fir.convert %[[VAL_142]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_144:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_143]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_145:.*]] = fir.address_of(@_QQcl_6D69736D617463682034) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_145:.*]] = fir.address_of(@_QQclX6D69736D617463682034) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_146:.*]] = fir.convert %[[VAL_145]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_147:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_148:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_144]], %[[VAL_146]], %[[VAL_147]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -193,10 +193,10 @@
 ! CHECK:         %[[VAL_157:.*]] = arith.cmpf une, %[[VAL_154]], %[[VAL_156]] : f32
 ! CHECK:         cond_br %[[VAL_157]], ^bb21, ^bb22
 ! CHECK:       ^bb21:
-! CHECK:         %[[VAL_158:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_158:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_159:.*]] = fir.convert %[[VAL_158]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_160:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_159]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_161:.*]] = fir.address_of(@_QQcl_6D69736D617463682035) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_161:.*]] = fir.address_of(@_QQclX6D69736D617463682035) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_162:.*]] = fir.convert %[[VAL_161]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_163:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_164:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_160]], %[[VAL_162]], %[[VAL_163]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -213,10 +213,10 @@
 ! CHECK:         %[[VAL_173:.*]] = arith.cmpf une, %[[VAL_170]], %[[VAL_172]] : f32
 ! CHECK:         cond_br %[[VAL_173]], ^bb23, ^bb24
 ! CHECK:       ^bb23:
-! CHECK:         %[[VAL_174:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_174:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_175:.*]] = fir.convert %[[VAL_174]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_176:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_175]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_177:.*]] = fir.address_of(@_QQcl_6D69736D617463682036) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_177:.*]] = fir.address_of(@_QQclX6D69736D617463682036) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_178:.*]] = fir.convert %[[VAL_177]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_179:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_180:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_176]], %[[VAL_178]], %[[VAL_179]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -286,10 +286,10 @@
 ! CHECK:         %[[VAL_226:.*]] = arith.cmpf une, %[[VAL_224]], %[[VAL_225]] : f32
 ! CHECK:         cond_br %[[VAL_226]], ^bb35, ^bb36
 ! CHECK:       ^bb35:
-! CHECK:         %[[VAL_227:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_227:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_228:.*]] = fir.convert %[[VAL_227]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_229:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_228]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_230:.*]] = fir.address_of(@_QQcl_6D69736D617463682037) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_230:.*]] = fir.address_of(@_QQclX6D69736D617463682037) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_231:.*]] = fir.convert %[[VAL_230]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_232:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_233:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_229]], %[[VAL_231]], %[[VAL_232]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -305,10 +305,10 @@
 ! CHECK:         %[[VAL_241:.*]] = arith.cmpf une, %[[VAL_239]], %[[VAL_240]] : f32
 ! CHECK:         cond_br %[[VAL_241]], ^bb37, ^bb38
 ! CHECK:       ^bb37:
-! CHECK:         %[[VAL_242:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_242:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_243:.*]] = fir.convert %[[VAL_242]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_244:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_243]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_245:.*]] = fir.address_of(@_QQcl_6D69736D617463682038) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_245:.*]] = fir.address_of(@_QQclX6D69736D617463682038) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_246:.*]] = fir.convert %[[VAL_245]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_247:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_248:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_244]], %[[VAL_246]], %[[VAL_247]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -324,10 +324,10 @@
 ! CHECK:         %[[VAL_256:.*]] = arith.cmpf une, %[[VAL_254]], %[[VAL_255]] : f32
 ! CHECK:         cond_br %[[VAL_256]], ^bb39, ^bb40
 ! CHECK:       ^bb39:
-! CHECK:         %[[VAL_257:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_257:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_258:.*]] = fir.convert %[[VAL_257]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_259:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_258]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_260:.*]] = fir.address_of(@_QQcl_6D69736D617463682039) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_260:.*]] = fir.address_of(@_QQclX6D69736D617463682039) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_261:.*]] = fir.convert %[[VAL_260]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_262:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_263:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_259]], %[[VAL_261]], %[[VAL_262]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -389,10 +389,10 @@ end program p
 ! CHECK-DAG:     %[[VAL_7:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_8:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<10x!fir.char<1>>>
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_12:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_6]], %[[VAL_11]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.address_of(@_QQcl_61203D20) : !fir.ref<!fir.char<1,4>>
+! CHECK:         %[[VAL_13:.*]] = fir.address_of(@_QQclX61203D20) : !fir.ref<!fir.char<1,4>>
 ! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,4>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_4]] : (index) -> i64
 ! CHECK:         %[[VAL_16:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_12]], %[[VAL_14]], %[[VAL_15]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1

--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -96,10 +96,10 @@
 ! CHECK:         %[[VAL_81:.*]] = arith.cmpf une, %[[VAL_78]], %[[VAL_80]] : f32
 ! CHECK:         cond_br %[[VAL_81]], ^bb10, ^bb11
 ! CHECK:       ^bb10:
-! CHECK:         %[[VAL_82:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_82:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_84:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_83]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_85:.*]] = fir.address_of(@_QQcl.6D69736D617463682031) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_85:.*]] = fir.address_of(@_QQcl_6D69736D617463682031) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_86:.*]] = fir.convert %[[VAL_85]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_87:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_88:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_84]], %[[VAL_86]], %[[VAL_87]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -117,10 +117,10 @@
 ! CHECK:         %[[VAL_98:.*]] = arith.cmpf une, %[[VAL_95]], %[[VAL_97]] : f32
 ! CHECK:         cond_br %[[VAL_98]], ^bb12, ^bb13
 ! CHECK:       ^bb12:
-! CHECK:         %[[VAL_99:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_99:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_100:.*]] = fir.convert %[[VAL_99]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_101:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_100]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_102:.*]] = fir.address_of(@_QQcl.6D69736D617463682032) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_102:.*]] = fir.address_of(@_QQcl_6D69736D617463682032) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_103:.*]] = fir.convert %[[VAL_102]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_104:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_105:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_101]], %[[VAL_103]], %[[VAL_104]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -138,10 +138,10 @@
 ! CHECK:         %[[VAL_115:.*]] = arith.cmpf une, %[[VAL_112]], %[[VAL_114]] : f32
 ! CHECK:         cond_br %[[VAL_115]], ^bb14, ^bb15
 ! CHECK:       ^bb14:
-! CHECK:         %[[VAL_116:.*]] = fir.address_of(@_QQcl.{{.*}} : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_116:.*]] = fir.address_of(@_QQcl_{{.*}} : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_117:.*]] = fir.convert %[[VAL_116]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_118:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_117]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_119:.*]] = fir.address_of(@_QQcl.6D69736D617463682033) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_119:.*]] = fir.address_of(@_QQcl_6D69736D617463682033) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_120:.*]] = fir.convert %[[VAL_119]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_121:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_122:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_118]], %[[VAL_120]], %[[VAL_121]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -173,10 +173,10 @@
 ! CHECK:         %[[VAL_141:.*]] = arith.cmpf une, %[[VAL_138]], %[[VAL_140]] : f32
 ! CHECK:         cond_br %[[VAL_141]], ^bb19, ^bb20
 ! CHECK:       ^bb19:
-! CHECK:         %[[VAL_142:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_142:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_143:.*]] = fir.convert %[[VAL_142]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_144:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_143]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_145:.*]] = fir.address_of(@_QQcl.6D69736D617463682034) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_145:.*]] = fir.address_of(@_QQcl_6D69736D617463682034) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_146:.*]] = fir.convert %[[VAL_145]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_147:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_148:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_144]], %[[VAL_146]], %[[VAL_147]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -193,10 +193,10 @@
 ! CHECK:         %[[VAL_157:.*]] = arith.cmpf une, %[[VAL_154]], %[[VAL_156]] : f32
 ! CHECK:         cond_br %[[VAL_157]], ^bb21, ^bb22
 ! CHECK:       ^bb21:
-! CHECK:         %[[VAL_158:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_158:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_159:.*]] = fir.convert %[[VAL_158]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_160:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_159]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_161:.*]] = fir.address_of(@_QQcl.6D69736D617463682035) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_161:.*]] = fir.address_of(@_QQcl_6D69736D617463682035) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_162:.*]] = fir.convert %[[VAL_161]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_163:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_164:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_160]], %[[VAL_162]], %[[VAL_163]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -213,10 +213,10 @@
 ! CHECK:         %[[VAL_173:.*]] = arith.cmpf une, %[[VAL_170]], %[[VAL_172]] : f32
 ! CHECK:         cond_br %[[VAL_173]], ^bb23, ^bb24
 ! CHECK:       ^bb23:
-! CHECK:         %[[VAL_174:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_174:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_175:.*]] = fir.convert %[[VAL_174]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_176:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_175]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_177:.*]] = fir.address_of(@_QQcl.6D69736D617463682036) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_177:.*]] = fir.address_of(@_QQcl_6D69736D617463682036) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_178:.*]] = fir.convert %[[VAL_177]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_179:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_180:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_176]], %[[VAL_178]], %[[VAL_179]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -286,10 +286,10 @@
 ! CHECK:         %[[VAL_226:.*]] = arith.cmpf une, %[[VAL_224]], %[[VAL_225]] : f32
 ! CHECK:         cond_br %[[VAL_226]], ^bb35, ^bb36
 ! CHECK:       ^bb35:
-! CHECK:         %[[VAL_227:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_227:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_228:.*]] = fir.convert %[[VAL_227]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_229:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_228]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_230:.*]] = fir.address_of(@_QQcl.6D69736D617463682037) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_230:.*]] = fir.address_of(@_QQcl_6D69736D617463682037) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_231:.*]] = fir.convert %[[VAL_230]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_232:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_233:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_229]], %[[VAL_231]], %[[VAL_232]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -305,10 +305,10 @@
 ! CHECK:         %[[VAL_241:.*]] = arith.cmpf une, %[[VAL_239]], %[[VAL_240]] : f32
 ! CHECK:         cond_br %[[VAL_241]], ^bb37, ^bb38
 ! CHECK:       ^bb37:
-! CHECK:         %[[VAL_242:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_242:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_243:.*]] = fir.convert %[[VAL_242]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_244:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_243]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_245:.*]] = fir.address_of(@_QQcl.6D69736D617463682038) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_245:.*]] = fir.address_of(@_QQcl_6D69736D617463682038) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_246:.*]] = fir.convert %[[VAL_245]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_247:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_248:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_244]], %[[VAL_246]], %[[VAL_247]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -324,10 +324,10 @@
 ! CHECK:         %[[VAL_256:.*]] = arith.cmpf une, %[[VAL_254]], %[[VAL_255]] : f32
 ! CHECK:         cond_br %[[VAL_256]], ^bb39, ^bb40
 ! CHECK:       ^bb39:
-! CHECK:         %[[VAL_257:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_257:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_258:.*]] = fir.convert %[[VAL_257]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_259:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_258]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_260:.*]] = fir.address_of(@_QQcl.6D69736D617463682039) : !fir.ref<!fir.char<1,10>>
+! CHECK:         %[[VAL_260:.*]] = fir.address_of(@_QQcl_6D69736D617463682039) : !fir.ref<!fir.char<1,10>>
 ! CHECK:         %[[VAL_261:.*]] = fir.convert %[[VAL_260]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_262:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
 ! CHECK:         %[[VAL_263:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_259]], %[[VAL_261]], %[[VAL_262]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
@@ -389,10 +389,10 @@ end program p
 ! CHECK-DAG:     %[[VAL_7:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_8:.*]]:2 = fir.unboxchar %[[VAL_0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:         %[[VAL_9:.*]] = fir.convert %[[VAL_8]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.array<10x!fir.char<1>>>
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_12:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_6]], %[[VAL_11]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_13:.*]] = fir.address_of(@_QQcl.61203D20) : !fir.ref<!fir.char<1,4>>
+! CHECK:         %[[VAL_13:.*]] = fir.address_of(@_QQcl_61203D20) : !fir.ref<!fir.char<1,4>>
 ! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,4>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_15:.*]] = fir.convert %[[VAL_4]] : (index) -> i64
 ! CHECK:         %[[VAL_16:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_12]], %[[VAL_14]], %[[VAL_15]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1

--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -902,7 +902,7 @@ end subroutine test19e
 ! CHECK:         %[[VAL_7:.*]] = arith.constant 60 : index
 ! CHECK:         %[[VAL_8:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_3]](%[[VAL_8]]) typeparams %[[VAL_2]]#1 : (!fir.ref<!fir.array<60x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.array<60x!fir.char<1,?>>
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl.70726566697820) : !fir.ref<!fir.char<1,7>>
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_70726566697820) : !fir.ref<!fir.char<1,7>>
 ! CHECK:         %[[VAL_11:.*]] = arith.constant 7 : index
 ! CHECK:         %[[VAL_12:.*]] = fir.shape %[[VAL_7]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_13:.*]] = fir.array_load %[[VAL_6]](%[[VAL_12]]) typeparams %[[VAL_5]]#1 : (!fir.ref<!fir.array<60x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.array<60x!fir.char<1,?>>
@@ -1114,7 +1114,7 @@ end subroutine test19h
 ! CHECK:         %[[VAL_7:.*]] = arith.constant 2 : index
 ! CHECK:         %[[VAL_8:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_9:.*]] = arith.constant -1 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_12:.*]] = arith.constant {{.*}} : i32
 ! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_9]], %[[VAL_11]], %[[VAL_12]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/array-expression.f90
+++ b/flang/test/Lower/array-expression.f90
@@ -902,7 +902,7 @@ end subroutine test19e
 ! CHECK:         %[[VAL_7:.*]] = arith.constant 60 : index
 ! CHECK:         %[[VAL_8:.*]] = fir.shape %[[VAL_4]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_9:.*]] = fir.array_load %[[VAL_3]](%[[VAL_8]]) typeparams %[[VAL_2]]#1 : (!fir.ref<!fir.array<60x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.array<60x!fir.char<1,?>>
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_70726566697820) : !fir.ref<!fir.char<1,7>>
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQclX70726566697820) : !fir.ref<!fir.char<1,7>>
 ! CHECK:         %[[VAL_11:.*]] = arith.constant 7 : index
 ! CHECK:         %[[VAL_12:.*]] = fir.shape %[[VAL_7]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_13:.*]] = fir.array_load %[[VAL_6]](%[[VAL_12]]) typeparams %[[VAL_5]]#1 : (!fir.ref<!fir.array<60x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.array<60x!fir.char<1,?>>
@@ -1114,7 +1114,7 @@ end subroutine test19h
 ! CHECK:         %[[VAL_7:.*]] = arith.constant 2 : index
 ! CHECK:         %[[VAL_8:.*]] = arith.constant 10 : index
 ! CHECK:         %[[VAL_9:.*]] = arith.constant -1 : i32
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_12:.*]] = arith.constant {{.*}} : i32
 ! CHECK:         %[[VAL_13:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_9]], %[[VAL_11]], %[[VAL_12]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/call-implicit.f90
+++ b/flang/test/Lower/call-implicit.f90
@@ -6,7 +6,7 @@ subroutine s2
 ! CHECK:  %[[a0:.*]] = fir.alloca !fir.array<3xi32> {bindc_name = "i", uniq_name = "_QFs2Ei"}
   ! CHECK: fir.call @_QPsub2(%[[a0]]) {{.*}}: (!fir.ref<!fir.array<3xi32>>) -> ()
   call sub2(i)
-! CHECK:  %[[a1:.*]] = fir.address_of(@_QQcl_3031323334) : !fir.ref<!fir.char<1,5>>
+! CHECK:  %[[a1:.*]] = fir.address_of(@_QQclX3031323334) : !fir.ref<!fir.char<1,5>>
 ! CHECK:  %[[a2:.*]] = fir.convert %[[a1]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<!fir.array<3xi32>>
   ! CHECK: fir.call @_QPsub2(%[[a2]]) {{.*}}: (!fir.ref<!fir.array<3xi32>>) -> ()
   call sub2("01234")

--- a/flang/test/Lower/call-implicit.f90
+++ b/flang/test/Lower/call-implicit.f90
@@ -6,7 +6,7 @@ subroutine s2
 ! CHECK:  %[[a0:.*]] = fir.alloca !fir.array<3xi32> {bindc_name = "i", uniq_name = "_QFs2Ei"}
   ! CHECK: fir.call @_QPsub2(%[[a0]]) {{.*}}: (!fir.ref<!fir.array<3xi32>>) -> ()
   call sub2(i)
-! CHECK:  %[[a1:.*]] = fir.address_of(@_QQcl.3031323334) : !fir.ref<!fir.char<1,5>>
+! CHECK:  %[[a1:.*]] = fir.address_of(@_QQcl_3031323334) : !fir.ref<!fir.char<1,5>>
 ! CHECK:  %[[a2:.*]] = fir.convert %[[a1]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<!fir.array<3xi32>>
   ! CHECK: fir.call @_QPsub2(%[[a2]]) {{.*}}: (!fir.ref<!fir.array<3xi32>>) -> ()
   call sub2("01234")

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -102,7 +102,7 @@ end subroutine
     ! CHECK:   return
   end subroutine
 
-! CHECK-LABEL: fir.global linkonce @_QQcl_48656C6C6F20576F726C64
+! CHECK-LABEL: fir.global linkonce @_QQclX48656C6C6F20576F726C64
 ! CHECK: %[[lit:.*]] = fir.string_lit "Hello World"(11) : !fir.char<1,11>
 ! CHECK: fir.has_value %[[lit]] : !fir.char<1,11>
 ! CHECK: }

--- a/flang/test/Lower/character-assignment.f90
+++ b/flang/test/Lower/character-assignment.f90
@@ -102,7 +102,7 @@ end subroutine
     ! CHECK:   return
   end subroutine
 
-! CHECK-LABEL: fir.global linkonce @_QQcl.48656C6C6F20576F726C64
+! CHECK-LABEL: fir.global linkonce @_QQcl_48656C6C6F20576F726C64
 ! CHECK: %[[lit:.*]] = fir.string_lit "Hello World"(11) : !fir.char<1,11>
 ! CHECK: fir.has_value %[[lit]] : !fir.char<1,11>
 ! CHECK: }

--- a/flang/test/Lower/character-substrings.f90
+++ b/flang/test/Lower/character-substrings.f90
@@ -5,7 +5,7 @@
 ! CHECK-LABEL: func @_QPscalar_substring_embox(
 ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine scalar_substring_embox(i, j)
-  ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,18>>
+  ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,18>>
   ! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
   ! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
   ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_3]] : (i64) -> index
@@ -147,7 +147,7 @@ end subroutine substring_assignment
 ! CHECK:         %[[VAL_15:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_16:.*]] = fir.slice %[[VAL_4]], %[[VAL_8]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
 ! CHECK:         %[[VAL_17:.*]] = fir.array_load %[[VAL_2]](%[[VAL_15]]) {{\[}}%[[VAL_16]]] : (!fir.ref<!fir.array<6x!fir.char<1,5>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<6x!fir.char<1,5>>
-! CHECK:         %[[VAL_18:.*]] = fir.address_of(@_QQcl_424144) : !fir.ref<!fir.char<1,3>>
+! CHECK:         %[[VAL_18:.*]] = fir.address_of(@_QQclX424144) : !fir.ref<!fir.char<1,3>>
 ! CHECK:         %[[VAL_19:.*]] = arith.constant 3 : index
 ! CHECK:         %[[VAL_20:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_21:.*]] = arith.constant 0 : index
@@ -235,7 +235,7 @@ end subroutine array_substring_assignment
 ! CHECK:         %[[cmp:.*]] = arith.cmpi sgt, %[[div]], %[[c0]] : index
 ! CHECK:         %[[select:.*]] = arith.select %[[cmp]], %[[div]], %[[c0]] : index
 ! CHECK:         %[[VAL_6:.*]] = fir.array_load %[[VAL_0]](%[[VAL_3]]) {{\[}}%[[VAL_5]]] : (!fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment2Tt{ch:!fir.char<1,7>}>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<8x!fir.char<1,7>>
-! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQcl_6E696365) : !fir.ref<!fir.char<1,4>>
+! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQclX6E696365) : !fir.ref<!fir.char<1,4>>
 ! CHECK:         %[[VAL_8:.*]] = arith.constant 4 : index
 ! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_10:.*]] = arith.constant 0 : index

--- a/flang/test/Lower/character-substrings.f90
+++ b/flang/test/Lower/character-substrings.f90
@@ -5,7 +5,7 @@
 ! CHECK-LABEL: func @_QPscalar_substring_embox(
 ! CHECK-SAME:  %[[VAL_0:.*]]: !fir.ref<i64>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i64>{{.*}}) {
 subroutine scalar_substring_embox(i, j)
-  ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,18>>
+  ! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,18>>
   ! CHECK:         %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
   ! CHECK:         %[[VAL_4:.*]] = fir.load %[[VAL_1]] : !fir.ref<i64>
   ! CHECK:         %[[VAL_5:.*]] = fir.convert %[[VAL_3]] : (i64) -> index
@@ -147,7 +147,7 @@ end subroutine substring_assignment
 ! CHECK:         %[[VAL_15:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
 ! CHECK:         %[[VAL_16:.*]] = fir.slice %[[VAL_4]], %[[VAL_8]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
 ! CHECK:         %[[VAL_17:.*]] = fir.array_load %[[VAL_2]](%[[VAL_15]]) {{\[}}%[[VAL_16]]] : (!fir.ref<!fir.array<6x!fir.char<1,5>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<6x!fir.char<1,5>>
-! CHECK:         %[[VAL_18:.*]] = fir.address_of(@_QQcl.424144) : !fir.ref<!fir.char<1,3>>
+! CHECK:         %[[VAL_18:.*]] = fir.address_of(@_QQcl_424144) : !fir.ref<!fir.char<1,3>>
 ! CHECK:         %[[VAL_19:.*]] = arith.constant 3 : index
 ! CHECK:         %[[VAL_20:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_21:.*]] = arith.constant 0 : index
@@ -235,7 +235,7 @@ end subroutine array_substring_assignment
 ! CHECK:         %[[cmp:.*]] = arith.cmpi sgt, %[[div]], %[[c0]] : index
 ! CHECK:         %[[select:.*]] = arith.select %[[cmp]], %[[div]], %[[c0]] : index
 ! CHECK:         %[[VAL_6:.*]] = fir.array_load %[[VAL_0]](%[[VAL_3]]) {{\[}}%[[VAL_5]]] : (!fir.ref<!fir.array<8x!fir.type<_QFarray_substring_assignment2Tt{ch:!fir.char<1,7>}>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.array<8x!fir.char<1,7>>
-! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQcl.6E696365) : !fir.ref<!fir.char<1,4>>
+! CHECK:         %[[VAL_7:.*]] = fir.address_of(@_QQcl_6E696365) : !fir.ref<!fir.char<1,4>>
 ! CHECK:         %[[VAL_8:.*]] = arith.constant 4 : index
 ! CHECK:         %[[VAL_9:.*]] = arith.constant 1 : index
 ! CHECK:         %[[VAL_10:.*]] = arith.constant 0 : index

--- a/flang/test/Lower/components.f90
+++ b/flang/test/Lower/components.f90
@@ -133,7 +133,7 @@ subroutine lhs_char_section(a)
   ! CHECK: %[[VAL_6:.*]] = fir.field_index c, !fir.type<_QFlhs_char_sectionTt{c:!fir.char<1,5>}>
   ! CHECK: %[[VAL_7:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
   ! CHECK: %[[VAL_8:.*]] = fir.slice %[[VAL_5]], %[[VAL_3]], %[[VAL_5]] path %[[VAL_6]] : (index, index, index, !fir.field) -> !fir.slice<1>
-  ! CHECK: %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,5>>
+  ! CHECK: %[[VAL_9:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,5>>
   ! CHECK: br ^bb1(%[[VAL_4]], %[[VAL_3]] : index, index)
   ! CHECK: ^bb1(%[[VAL_10:.*]]: index, %[[VAL_11:.*]]: index):
   ! CHECK: %[[VAL_12:.*]] = arith.cmpi sgt, %[[VAL_11]], %[[VAL_4]] : index

--- a/flang/test/Lower/components.f90
+++ b/flang/test/Lower/components.f90
@@ -133,7 +133,7 @@ subroutine lhs_char_section(a)
   ! CHECK: %[[VAL_6:.*]] = fir.field_index c, !fir.type<_QFlhs_char_sectionTt{c:!fir.char<1,5>}>
   ! CHECK: %[[VAL_7:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
   ! CHECK: %[[VAL_8:.*]] = fir.slice %[[VAL_5]], %[[VAL_3]], %[[VAL_5]] path %[[VAL_6]] : (index, index, index, !fir.field) -> !fir.slice<1>
-  ! CHECK: %[[VAL_9:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,5>>
+  ! CHECK: %[[VAL_9:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,5>>
   ! CHECK: br ^bb1(%[[VAL_4]], %[[VAL_3]] : index, index)
   ! CHECK: ^bb1(%[[VAL_10:.*]]: index, %[[VAL_11:.*]]: index):
   ! CHECK: %[[VAL_12:.*]] = arith.cmpi sgt, %[[VAL_11]], %[[VAL_4]] : index

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -261,7 +261,7 @@ function f1(n1) result(res1)
   ! CHECK:   fir.store %[[V_6]] to %[[V_5]] : !fir.ref<!fir.boxchar<1>>
   ! CHECK:   br ^bb1
   ! CHECK: ^bb1:  // pred: ^bb0
-  ! CHECK:   %[[V_7:[0-9]+]] = fir.address_of(@_QQcl.6120612061) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_7:[0-9]+]] = fir.address_of(@_QQcl_6120612061) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_10:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_11:[0-9]+]] = arith.muli %c1{{.*}}_i64, %[[V_10]] : i64
   ! CHECK:   %[[V_12:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -280,7 +280,7 @@ function f1(n1) result(res1)
   ! CHECK: ^bb4:  // pred: ^bb3
   ! CHECK:   cf.br ^bb6
   ! CHECK: ^bb5:  // pred: ^bb3
-  ! CHECK:   %[[V_21:[0-9]+]] = fir.address_of(@_QQcl.4320432043) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_21:[0-9]+]] = fir.address_of(@_QQcl_4320432043) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_24:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_25:[0-9]+]] = arith.muli %c1{{.*}}, %[[V_24]] : i64
   ! CHECK:   %[[V_26:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -316,7 +316,7 @@ entry f2(n2)
   ! CHECK: ^bb2:  // pred: ^bb1
   ! CHECK:   br ^bb4
   ! CHECK: ^bb3:  // pred: ^bb1
-  ! CHECK:   %[[V_9:[0-9]+]] = fir.address_of(@_QQcl.4320432043) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_9:[0-9]+]] = fir.address_of(@_QQcl_4320432043) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_12:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_13:[0-9]+]] = arith.muli %c1{{.*}}, %[[V_12]] : i64
   ! CHECK:   %[[V_14:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -345,7 +345,7 @@ entry f3
   ! CHECK:   fir.store %[[V_7]] to %[[V_6]] : !fir.ref<!fir.boxchar<1>>
   ! CHECK:   br ^bb1
   ! CHECK: ^bb1:  // pred: ^bb0
-  ! CHECK:   %[[V_8:[0-9]+]] = fir.address_of(@_QQcl.4320432043) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_8:[0-9]+]] = fir.address_of(@_QQcl_4320432043) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_11:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_12:[0-9]+]] = arith.muli %c1{{.*}}_i64, %[[V_11]] : i64
   ! CHECK:   %[[V_13:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -365,7 +365,7 @@ contains
     ! CHECK:   %[[V_0:[0-9]+]] = fir.coordinate_of %arg0, %c0{{.*}}_i32 : (!fir.ref<tuple<!fir.boxchar<1>, !fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_1:[0-9]+]] = fir.load %[[V_0]] : !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_2:[0-9]+]]:2 = fir.unboxchar %[[V_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQcl.6220622062) : !fir.ref<!fir.char<1,5>>
+    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQcl_6220622062) : !fir.ref<!fir.char<1,5>>
     ! CHECK:   %[[V_4:[0-9]+]] = arith.cmpi slt, %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_5:[0-9]+]] = arith.select %[[V_4]], %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_6:[0-9]+]] = fir.convert %[[V_5]] : (index) -> i64
@@ -391,7 +391,7 @@ contains
     ! CHECK:   %[[V_0:[0-9]+]] = fir.coordinate_of %arg0, %c1{{.*}}_i32 : (!fir.ref<tuple<!fir.boxchar<1>, !fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_1:[0-9]+]] = fir.load %[[V_0]] : !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_2:[0-9]+]]:2 = fir.unboxchar %[[V_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQcl.6320632063) : !fir.ref<!fir.char<1,5>>
+    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQcl_6320632063) : !fir.ref<!fir.char<1,5>>
     ! CHECK:   %[[V_4:[0-9]+]] = arith.cmpi slt, %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_5:[0-9]+]] = arith.select %[[V_4]], %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_6:[0-9]+]] = fir.convert %[[V_5]] : (index) -> i64

--- a/flang/test/Lower/entry-statement.f90
+++ b/flang/test/Lower/entry-statement.f90
@@ -261,7 +261,7 @@ function f1(n1) result(res1)
   ! CHECK:   fir.store %[[V_6]] to %[[V_5]] : !fir.ref<!fir.boxchar<1>>
   ! CHECK:   br ^bb1
   ! CHECK: ^bb1:  // pred: ^bb0
-  ! CHECK:   %[[V_7:[0-9]+]] = fir.address_of(@_QQcl_6120612061) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_7:[0-9]+]] = fir.address_of(@_QQclX6120612061) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_10:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_11:[0-9]+]] = arith.muli %c1{{.*}}_i64, %[[V_10]] : i64
   ! CHECK:   %[[V_12:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -280,7 +280,7 @@ function f1(n1) result(res1)
   ! CHECK: ^bb4:  // pred: ^bb3
   ! CHECK:   cf.br ^bb6
   ! CHECK: ^bb5:  // pred: ^bb3
-  ! CHECK:   %[[V_21:[0-9]+]] = fir.address_of(@_QQcl_4320432043) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_21:[0-9]+]] = fir.address_of(@_QQclX4320432043) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_24:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_25:[0-9]+]] = arith.muli %c1{{.*}}, %[[V_24]] : i64
   ! CHECK:   %[[V_26:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -316,7 +316,7 @@ entry f2(n2)
   ! CHECK: ^bb2:  // pred: ^bb1
   ! CHECK:   br ^bb4
   ! CHECK: ^bb3:  // pred: ^bb1
-  ! CHECK:   %[[V_9:[0-9]+]] = fir.address_of(@_QQcl_4320432043) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_9:[0-9]+]] = fir.address_of(@_QQclX4320432043) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_12:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_13:[0-9]+]] = arith.muli %c1{{.*}}, %[[V_12]] : i64
   ! CHECK:   %[[V_14:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -345,7 +345,7 @@ entry f3
   ! CHECK:   fir.store %[[V_7]] to %[[V_6]] : !fir.ref<!fir.boxchar<1>>
   ! CHECK:   br ^bb1
   ! CHECK: ^bb1:  // pred: ^bb0
-  ! CHECK:   %[[V_8:[0-9]+]] = fir.address_of(@_QQcl_4320432043) : !fir.ref<!fir.char<1,5>>
+  ! CHECK:   %[[V_8:[0-9]+]] = fir.address_of(@_QQclX4320432043) : !fir.ref<!fir.char<1,5>>
   ! CHECK:   %[[V_11:[0-9]+]] = fir.convert %c5{{.*}} : (index) -> i64
   ! CHECK:   %[[V_12:[0-9]+]] = arith.muli %c1{{.*}}_i64, %[[V_11]] : i64
   ! CHECK:   %[[V_13:[0-9]+]] = fir.convert %[[V_0]] : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
@@ -365,7 +365,7 @@ contains
     ! CHECK:   %[[V_0:[0-9]+]] = fir.coordinate_of %arg0, %c0{{.*}}_i32 : (!fir.ref<tuple<!fir.boxchar<1>, !fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_1:[0-9]+]] = fir.load %[[V_0]] : !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_2:[0-9]+]]:2 = fir.unboxchar %[[V_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQcl_6220622062) : !fir.ref<!fir.char<1,5>>
+    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQclX6220622062) : !fir.ref<!fir.char<1,5>>
     ! CHECK:   %[[V_4:[0-9]+]] = arith.cmpi slt, %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_5:[0-9]+]] = arith.select %[[V_4]], %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_6:[0-9]+]] = fir.convert %[[V_5]] : (index) -> i64
@@ -391,7 +391,7 @@ contains
     ! CHECK:   %[[V_0:[0-9]+]] = fir.coordinate_of %arg0, %c1{{.*}}_i32 : (!fir.ref<tuple<!fir.boxchar<1>, !fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_1:[0-9]+]] = fir.load %[[V_0]] : !fir.ref<!fir.boxchar<1>>
     ! CHECK:   %[[V_2:[0-9]+]]:2 = fir.unboxchar %[[V_1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQcl_6320632063) : !fir.ref<!fir.char<1,5>>
+    ! CHECK:   %[[V_3:[0-9]+]] = fir.address_of(@_QQclX6320632063) : !fir.ref<!fir.char<1,5>>
     ! CHECK:   %[[V_4:[0-9]+]] = arith.cmpi slt, %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_5:[0-9]+]] = arith.select %[[V_4]], %[[V_2]]#1, %c5{{.*}} : index
     ! CHECK:   %[[V_6:[0-9]+]] = fir.convert %[[V_5]] : (index) -> i64

--- a/flang/test/Lower/forall/forall-allocatable-2.f90
+++ b/flang/test/Lower/forall/forall-allocatable-2.f90
@@ -19,7 +19,7 @@ end subroutine forall_with_allocatable2
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "thing", uniq_name = "_QFforall_with_allocatable2Ething"}
 ! CHECK:         %[[VAL_3:.*]] = fir.embox %[[VAL_2]] : (!fir.ref<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-! CHECK:         %[[VAL_4:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_4:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_5:.*]] = arith.constant {{.*}} : i32
 ! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/forall/forall-allocatable-2.f90
+++ b/flang/test/Lower/forall/forall-allocatable-2.f90
@@ -19,7 +19,7 @@ end subroutine forall_with_allocatable2
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
 ! CHECK:         %[[VAL_2:.*]] = fir.alloca !fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}> {bindc_name = "thing", uniq_name = "_QFforall_with_allocatable2Ething"}
 ! CHECK:         %[[VAL_3:.*]] = fir.embox %[[VAL_2]] : (!fir.ref<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-! CHECK:         %[[VAL_4:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_4:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_5:.*]] = arith.constant {{.*}} : i32
 ! CHECK:         %[[VAL_6:.*]] = fir.convert %[[VAL_3]] : (!fir.box<!fir.type<_QFforall_with_allocatable2Tt{i:i32,arr:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.box<none>
 ! CHECK:         %[[VAL_7:.*]] = fir.convert %[[VAL_4]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>

--- a/flang/test/Lower/global-format-strings.f90
+++ b/flang/test/Lower/global-format-strings.f90
@@ -8,7 +8,7 @@ program other
   ! CHECK:  fir.address_of(@{{.*}}) :
 1008 format('ok')
 end
-! CHECK-LABEL: fir.global linkonce @_QQcl_28276F6B2729 constant
+! CHECK-LABEL: fir.global linkonce @_QQclX28276F6B2729 constant
 ! CHECK: %[[lit:.*]] = fir.string_lit "('ok')"(6) : !fir.char<1,6>
 ! CHECK: fir.has_value %[[lit]] : !fir.char<1,6>
 ! CHECK: }

--- a/flang/test/Lower/global-format-strings.f90
+++ b/flang/test/Lower/global-format-strings.f90
@@ -8,7 +8,7 @@ program other
   ! CHECK:  fir.address_of(@{{.*}}) :
 1008 format('ok')
 end
-! CHECK-LABEL: fir.global linkonce @_QQcl.28276F6B2729 constant
+! CHECK-LABEL: fir.global linkonce @_QQcl_28276F6B2729 constant
 ! CHECK: %[[lit:.*]] = fir.string_lit "('ok')"(6) : !fir.char<1,6>
 ! CHECK: fir.has_value %[[lit]] : !fir.char<1,6>
 ! CHECK: }

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -488,7 +488,7 @@ end subroutine test_proc_dummy_other
 ! CHECK:         %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_13]], %[[VAL_1]] : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
 ! CHECK:         %[[VAL_16:.*]] = fir.emboxchar %[[VAL_12]], %[[VAL_0]] : (!fir.ref<!fir.char<1,10>>, index) -> !fir.boxchar<1>
 ! CHECK:         fir.store %[[VAL_16]] to %[[VAL_14]] : !fir.ref<!fir.boxchar<1>>
-! CHECK:         %[[VAL_17:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,9>>
+! CHECK:         %[[VAL_17:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,9>>
 ! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_2]] : (index) -> i64
 ! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_20:.*]] = fir.convert %[[VAL_17]] : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
@@ -507,7 +507,7 @@ end subroutine test_proc_dummy_other
 ! CHECK:         %[[VAL_29:.*]] = arith.subi %[[VAL_24]], %[[VAL_4]] : index
 ! CHECK:         br ^bb1(%[[VAL_28]], %[[VAL_29]] : index, index)
 ! CHECK:       ^bb3:
-! CHECK:         %[[VAL_30:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_30:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_32:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_6]], %[[VAL_31]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_33:.*]] = fir.address_of(@_QFtest_proc_dummy_charPgen_message) : (!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>
@@ -573,7 +573,7 @@ end subroutine test_proc_dummy_other
 ! CHECK-DAG:     %[[VAL_6:.*]] = arith.constant 1 : index
 ! CHECK-DAG:     %[[VAL_7:.*]] = arith.constant 32 : i8
 ! CHECK-DAG:     %[[VAL_8:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,12>>
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,12>>
 ! CHECK:         %[[VAL_11:.*]] = fir.extract_value %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
 ! CHECK:         %[[VAL_12:.*]] = fir.box_addr %[[VAL_11]] : (!fir.boxproc<() -> ()>) -> (() -> ())
 ! CHECK:         %[[VAL_13:.*]] = fir.extract_value %[[VAL_2]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -488,7 +488,7 @@ end subroutine test_proc_dummy_other
 ! CHECK:         %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_13]], %[[VAL_1]] : (!fir.ref<tuple<!fir.boxchar<1>>>, i32) -> !fir.ref<!fir.boxchar<1>>
 ! CHECK:         %[[VAL_16:.*]] = fir.emboxchar %[[VAL_12]], %[[VAL_0]] : (!fir.ref<!fir.char<1,10>>, index) -> !fir.boxchar<1>
 ! CHECK:         fir.store %[[VAL_16]] to %[[VAL_14]] : !fir.ref<!fir.boxchar<1>>
-! CHECK:         %[[VAL_17:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,9>>
+! CHECK:         %[[VAL_17:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,9>>
 ! CHECK:         %[[VAL_18:.*]] = fir.convert %[[VAL_2]] : (index) -> i64
 ! CHECK:         %[[VAL_19:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_20:.*]] = fir.convert %[[VAL_17]] : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
@@ -507,7 +507,7 @@ end subroutine test_proc_dummy_other
 ! CHECK:         %[[VAL_29:.*]] = arith.subi %[[VAL_24]], %[[VAL_4]] : index
 ! CHECK:         br ^bb1(%[[VAL_28]], %[[VAL_29]] : index, index)
 ! CHECK:       ^bb3:
-! CHECK:         %[[VAL_30:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_30:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_32:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_6]], %[[VAL_31]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_33:.*]] = fir.address_of(@_QFtest_proc_dummy_charPgen_message) : (!fir.ref<!fir.char<1,10>>, index, !fir.ref<tuple<!fir.boxchar<1>>>) -> !fir.boxchar<1>
@@ -573,7 +573,7 @@ end subroutine test_proc_dummy_other
 ! CHECK-DAG:     %[[VAL_6:.*]] = arith.constant 1 : index
 ! CHECK-DAG:     %[[VAL_7:.*]] = arith.constant 32 : i8
 ! CHECK-DAG:     %[[VAL_8:.*]] = arith.constant 0 : index
-! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,12>>
+! CHECK:         %[[VAL_10:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,12>>
 ! CHECK:         %[[VAL_11:.*]] = fir.extract_value %[[VAL_2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
 ! CHECK:         %[[VAL_12:.*]] = fir.box_addr %[[VAL_11]] : (!fir.boxproc<() -> ()>) -> (() -> ())
 ! CHECK:         %[[VAL_13:.*]] = fir.extract_value %[[VAL_2]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> i64

--- a/flang/test/Lower/io-char-array.f90
+++ b/flang/test/Lower/io-char-array.f90
@@ -22,6 +22,6 @@ end subroutine
 ! CHECK: %[[SLICE:.*]] = fir.slice %[[C1_IDX_0]], %[[C2_IDX]], %[[C1_IDX_1]] : (index, index, index) -> !fir.slice<1>
 ! CHECK: %[[BOX_R:.*]] = fir.embox %[[R]](%[[SHAPE]]) [%[[SLICE]]] : (!fir.ref<!fir.array<2x!fir.char<1,12>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<2x!fir.char<1,12>>>
 ! CHECK: %[[BOX_R_NONE:.*]] = fir.convert %[[BOX_R]] : (!fir.box<!fir.array<2x!fir.char<1,12>>>) -> !fir.box<none>
-! CHECK: %[[DATA:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,14>>
+! CHECK: %[[DATA:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,14>>
 ! CHECK: %[[DATA_PTR:.*]] = fir.convert %8 : (!fir.ref<!fir.char<1,14>>) -> !fir.ref<i8>
 ! CHECK: %{{.*}} = fir.call @_FortranAioBeginInternalArrayFormattedOutput(%[[BOX_R_NONE]], %[[DATA_PTR]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i64, !fir.box<none>, !fir.ref<!fir.llvm_ptr<i8>>, i64, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/io-char-array.f90
+++ b/flang/test/Lower/io-char-array.f90
@@ -22,6 +22,6 @@ end subroutine
 ! CHECK: %[[SLICE:.*]] = fir.slice %[[C1_IDX_0]], %[[C2_IDX]], %[[C1_IDX_1]] : (index, index, index) -> !fir.slice<1>
 ! CHECK: %[[BOX_R:.*]] = fir.embox %[[R]](%[[SHAPE]]) [%[[SLICE]]] : (!fir.ref<!fir.array<2x!fir.char<1,12>>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<2x!fir.char<1,12>>>
 ! CHECK: %[[BOX_R_NONE:.*]] = fir.convert %[[BOX_R]] : (!fir.box<!fir.array<2x!fir.char<1,12>>>) -> !fir.box<none>
-! CHECK: %[[DATA:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,14>>
+! CHECK: %[[DATA:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,14>>
 ! CHECK: %[[DATA_PTR:.*]] = fir.convert %8 : (!fir.ref<!fir.char<1,14>>) -> !fir.ref<i8>
 ! CHECK: %{{.*}} = fir.call @_FortranAioBeginInternalArrayFormattedOutput(%[[BOX_R_NONE]], %[[DATA_PTR]], %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i64, !fir.box<none>, !fir.ref<!fir.llvm_ptr<i8>>, i64, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -29,7 +29,7 @@ end
 ! CHECK-LABEL: func @_QPpass_array_slice_read(
 ! CHECK-SAME:            %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 5 : i32
-! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.char<1,{{[0-9]+}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant {{[0-9]+}} : i32
 ! CHECK:         %[[VAL_5:.*]] = fir.call @_FortranAioBeginExternalListInput(%[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -55,7 +55,7 @@ end
 ! CHECK-LABEL: func @_QPpass_array_slice_write(
 ! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.char<1,{{[0-9]+}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant {{[0-9]+}} : i32
 ! CHECK:         %[[VAL_5:.*]] = fir.call @_FortranAioBeginUnformattedOutput(%[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/io-item-list.f90
+++ b/flang/test/Lower/io-item-list.f90
@@ -29,7 +29,7 @@ end
 ! CHECK-LABEL: func @_QPpass_array_slice_read(
 ! CHECK-SAME:            %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 5 : i32
-! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.char<1,{{[0-9]+}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant {{[0-9]+}} : i32
 ! CHECK:         %[[VAL_5:.*]] = fir.call @_FortranAioBeginExternalListInput(%[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
@@ -55,7 +55,7 @@ end
 ! CHECK-LABEL: func @_QPpass_array_slice_write(
 ! CHECK-SAME:                   %[[VAL_0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+! CHECK:         %[[VAL_2:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
 ! CHECK:         %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.char<1,{{[0-9]+}}>>) -> !fir.ref<i8>
 ! CHECK:         %[[VAL_4:.*]] = arith.constant {{[0-9]+}} : i32
 ! CHECK:         %[[VAL_5:.*]] = fir.call @_FortranAioBeginUnformattedOutput(%[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/io-write.f90
+++ b/flang/test/Lower/io-write.f90
@@ -27,7 +27,7 @@
 ! CHECK:  %[[Const_0_i64:.*]] = arith.constant 0 : i64
 ! CHECK:  %[[Val_15:.*]] = fir.convert %[[Const_0_i64]] : (i64) -> !fir.ref<!fir.llvm_ptr<i8>>
 ! CHECK:  %[[Const_0_i64_0:.*]] = arith.constant 0 : i64
-! CHECK:  %[[Val_16:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:  %[[Val_16:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK:  %[[Val_17:.*]] = fir.convert %[[Val_16]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:  %[[Val_18:.*]] = fir.call @_FortranAioBeginInternalFormattedOutput(%[[Val_2]], %[[Val_3]], %[[Val_12]], %[[Val_13]],
 ! %[[Val_14]], %[[Val_15]], %[[Const_0_i64_0]], %17, %{{.*}}) : (!fir.ref<i8>, i64, !fir.ref<i8>, i64, !fir.box<none>, !fir.ref<!fir.llvm_ptr<i8>>, i64, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/io-write.f90
+++ b/flang/test/Lower/io-write.f90
@@ -27,7 +27,7 @@
 ! CHECK:  %[[Const_0_i64:.*]] = arith.constant 0 : i64
 ! CHECK:  %[[Val_15:.*]] = fir.convert %[[Const_0_i64]] : (i64) -> !fir.ref<!fir.llvm_ptr<i8>>
 ! CHECK:  %[[Const_0_i64_0:.*]] = arith.constant 0 : i64
-! CHECK:  %[[Val_16:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:  %[[Val_16:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK:  %[[Val_17:.*]] = fir.convert %[[Val_16]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
 ! CHECK:  %[[Val_18:.*]] = fir.call @_FortranAioBeginInternalFormattedOutput(%[[Val_2]], %[[Val_3]], %[[Val_12]], %[[Val_13]],
 ! %[[Val_14]], %[[Val_15]], %[[Const_0_i64_0]], %17, %{{.*}}) : (!fir.ref<i8>, i64, !fir.ref<i8>, i64, !fir.box<none>, !fir.ref<!fir.llvm_ptr<i8>>, i64, !fir.ref<i8>, i32) -> !fir.ref<i8>

--- a/flang/test/Lower/namelist.f90
+++ b/flang/test/Lower/namelist.f90
@@ -83,6 +83,6 @@ subroutine global_pointer
   write(10, nml=mygroup)
 end
 
-  ! CHECK-DAG: fir.global linkonce @_QQcl_6A6A6A00 constant : !fir.char<1,4>
-  ! CHECK-DAG: fir.global linkonce @_QQcl_63636300 constant : !fir.char<1,4>
-  ! CHECK-DAG: fir.global linkonce @_QQcl_6E6E6E00 constant : !fir.char<1,4>
+  ! CHECK-DAG: fir.global linkonce @_QQclX6A6A6A00 constant : !fir.char<1,4>
+  ! CHECK-DAG: fir.global linkonce @_QQclX63636300 constant : !fir.char<1,4>
+  ! CHECK-DAG: fir.global linkonce @_QQclX6E6E6E00 constant : !fir.char<1,4>

--- a/flang/test/Lower/namelist.f90
+++ b/flang/test/Lower/namelist.f90
@@ -83,6 +83,6 @@ subroutine global_pointer
   write(10, nml=mygroup)
 end
 
-  ! CHECK-DAG: fir.global linkonce @_QQcl.6A6A6A00 constant : !fir.char<1,4>
-  ! CHECK-DAG: fir.global linkonce @_QQcl.63636300 constant : !fir.char<1,4>
-  ! CHECK-DAG: fir.global linkonce @_QQcl.6E6E6E00 constant : !fir.char<1,4>
+  ! CHECK-DAG: fir.global linkonce @_QQcl_6A6A6A00 constant : !fir.char<1,4>
+  ! CHECK-DAG: fir.global linkonce @_QQcl_63636300 constant : !fir.char<1,4>
+  ! CHECK-DAG: fir.global linkonce @_QQcl_6E6E6E00 constant : !fir.char<1,4>

--- a/flang/test/Lower/optional-value-caller.f90
+++ b/flang/test/Lower/optional-value-caller.f90
@@ -328,7 +328,7 @@ subroutine test_array_ptr(i)
 ! CHECK:             %[[VAL_16:.*]] = fir.shape %[[VAL_14]]#1 : (index) -> !fir.shape<1>
 ! CHECK:             %[[VAL_17:.*]] = fir.embox %[[VAL_15]](%[[VAL_16]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xi32>>
 ! CHECK:             fir.store %[[VAL_17]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.array<?xi32>>>
-! CHECK:             %[[VAL_18:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:             %[[VAL_18:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK:             %[[VAL_19:.*]] = arith.constant {{.*}} : i32
 ! CHECK:             %[[VAL_20:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.array<?xi32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             %[[VAL_21:.*]] = fir.convert %[[VAL_7]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.box<none>
@@ -434,7 +434,7 @@ subroutine test_char_array(c)
 ! CHECK:             %[[VAL_19:.*]] = fir.shape %[[VAL_16]]#1 : (index) -> !fir.shape<1>
 ! CHECK:             %[[VAL_20:.*]] = fir.embox %[[VAL_18]](%[[VAL_19]]) typeparams %[[VAL_17]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
 ! CHECK:             fir.store %[[VAL_20]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.array<?x!fir.char<1,?>>>>
-! CHECK:             %[[VAL_21:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:             %[[VAL_21:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK:             %[[VAL_22:.*]] = arith.constant {{.*}} : i32
 ! CHECK:             %[[VAL_23:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.array<?x!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             %[[VAL_24:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.box<none>

--- a/flang/test/Lower/optional-value-caller.f90
+++ b/flang/test/Lower/optional-value-caller.f90
@@ -328,7 +328,7 @@ subroutine test_array_ptr(i)
 ! CHECK:             %[[VAL_16:.*]] = fir.shape %[[VAL_14]]#1 : (index) -> !fir.shape<1>
 ! CHECK:             %[[VAL_17:.*]] = fir.embox %[[VAL_15]](%[[VAL_16]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<?xi32>>
 ! CHECK:             fir.store %[[VAL_17]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.array<?xi32>>>
-! CHECK:             %[[VAL_18:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:             %[[VAL_18:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK:             %[[VAL_19:.*]] = arith.constant {{.*}} : i32
 ! CHECK:             %[[VAL_20:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.array<?xi32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             %[[VAL_21:.*]] = fir.convert %[[VAL_7]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.box<none>
@@ -434,7 +434,7 @@ subroutine test_char_array(c)
 ! CHECK:             %[[VAL_19:.*]] = fir.shape %[[VAL_16]]#1 : (index) -> !fir.shape<1>
 ! CHECK:             %[[VAL_20:.*]] = fir.embox %[[VAL_18]](%[[VAL_19]]) typeparams %[[VAL_17]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.array<?x!fir.char<1,?>>>
 ! CHECK:             fir.store %[[VAL_20]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.array<?x!fir.char<1,?>>>>
-! CHECK:             %[[VAL_21:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:             %[[VAL_21:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK:             %[[VAL_22:.*]] = arith.constant {{.*}} : i32
 ! CHECK:             %[[VAL_23:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.array<?x!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             %[[VAL_24:.*]] = fir.convert %[[VAL_9]] : (!fir.box<!fir.array<?x!fir.char<1,?>>>) -> !fir.box<none>

--- a/flang/test/Lower/pointer-references.f90
+++ b/flang/test/Lower/pointer-references.f90
@@ -26,7 +26,7 @@ subroutine char_ptr(p)
   character(12), pointer :: p
   character(12) :: x
 
-  ! CHECK-DAG: %[[str:.*]] = fir.address_of(@_QQcl.68656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
+  ! CHECK-DAG: %[[str:.*]] = fir.address_of(@_QQcl_68656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
   ! CHECK: %[[boxload:.*]] = fir.load %[[arg0]]
   ! CHECK: %[[addr:.*]] = fir.box_addr %[[boxload]]
   ! CHECK-DAG: %[[one:.*]] = arith.constant 1

--- a/flang/test/Lower/pointer-references.f90
+++ b/flang/test/Lower/pointer-references.f90
@@ -26,7 +26,7 @@ subroutine char_ptr(p)
   character(12), pointer :: p
   character(12) :: x
 
-  ! CHECK-DAG: %[[str:.*]] = fir.address_of(@_QQcl_68656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
+  ! CHECK-DAG: %[[str:.*]] = fir.address_of(@_QQclX68656C6C6F20776F726C6421) : !fir.ref<!fir.char<1,12>>
   ! CHECK: %[[boxload:.*]] = fir.load %[[arg0]]
   ! CHECK: %[[addr:.*]] = fir.box_addr %[[boxload]]
   ! CHECK-DAG: %[[one:.*]] = arith.constant 1

--- a/flang/test/Lower/polymorphic.f90
+++ b/flang/test/Lower/polymorphic.f90
@@ -330,7 +330,7 @@ module polymorphic_test
   end subroutine
 
 ! CHECK-LABEL: func.func @_QMpolymorphic_testPpass_trivial_to_up() {
-! CHECK: %[[CHAR:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,5>>
+! CHECK: %[[CHAR:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,5>>
 ! CHECK: %[[BOX_CHAR:.*]] = fir.embox %[[CHAR]] : (!fir.ref<!fir.char<1,5>>) -> !fir.class<none>
 ! CHECK: fir.call @_QMpolymorphic_testPup_input(%[[BOX_CHAR]]) {{.*}} : (!fir.class<none>) -> ()
 

--- a/flang/test/Lower/polymorphic.f90
+++ b/flang/test/Lower/polymorphic.f90
@@ -330,7 +330,7 @@ module polymorphic_test
   end subroutine
 
 ! CHECK-LABEL: func.func @_QMpolymorphic_testPpass_trivial_to_up() {
-! CHECK: %[[CHAR:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,5>>
+! CHECK: %[[CHAR:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,5>>
 ! CHECK: %[[BOX_CHAR:.*]] = fir.embox %[[CHAR]] : (!fir.ref<!fir.char<1,5>>) -> !fir.class<none>
 ! CHECK: fir.call @_QMpolymorphic_testPup_input(%[[BOX_CHAR]]) {{.*}} : (!fir.class<none>) -> ()
 

--- a/flang/test/Lower/read-write-buffer.f90
+++ b/flang/test/Lower/read-write-buffer.f90
@@ -25,11 +25,11 @@ subroutine some()
   character(LEN=255):: buffer
   character(LEN=255):: greeting
 10 format (A255)
-  ! CHECK:  fir.address_of(@_QQcl_636F6D70696C6572) :
+  ! CHECK:  fir.address_of(@_QQclX636F6D70696C6572) :
   write (buffer, 10) "compiler"
   read (buffer, 10) greeting
 end
-! CHECK-LABEL: fir.global linkonce @_QQcl_636F6D70696C6572
+! CHECK-LABEL: fir.global linkonce @_QQclX636F6D70696C6572
 ! CHECK: %[[lit:.*]] = fir.string_lit "compiler"(8) : !fir.char<1,8>
 ! CHECK: fir.has_value %[[lit]] : !fir.char<1,8>
 ! CHECK: }

--- a/flang/test/Lower/read-write-buffer.f90
+++ b/flang/test/Lower/read-write-buffer.f90
@@ -25,11 +25,11 @@ subroutine some()
   character(LEN=255):: buffer
   character(LEN=255):: greeting
 10 format (A255)
-  ! CHECK:  fir.address_of(@_QQcl.636F6D70696C6572) :
+  ! CHECK:  fir.address_of(@_QQcl_636F6D70696C6572) :
   write (buffer, 10) "compiler"
   read (buffer, 10) greeting
 end
-! CHECK-LABEL: fir.global linkonce @_QQcl.636F6D70696C6572
+! CHECK-LABEL: fir.global linkonce @_QQcl_636F6D70696C6572
 ! CHECK: %[[lit:.*]] = fir.string_lit "compiler"(8) : !fir.char<1,8>
 ! CHECK: fir.has_value %[[lit]] : !fir.char<1,8>
 ! CHECK: }

--- a/flang/test/Lower/select-type-2.fir
+++ b/flang/test/Lower/select-type-2.fir
@@ -60,7 +60,7 @@
 // CHECK:         ^bb3(%[[VAL_17:.*]]: !fir.class<!fir.ptr<none>>):
 // CHECK:           %[[VAL_18:.*]] = fir.rebox %[[VAL_17]] : (!fir.class<!fir.ptr<none>>) -> !fir.class<none>
 // CHECK:           fir.call @_QPfoo(%[[VAL_18]]) fastmath<contract> : (!fir.class<none>) -> ()
-// CHECK:           %[[VAL_19:.*]] = fir.address_of(@_QQcl.6661696C2074797065) : !fir.ref<!fir.char<1,9>>
+// CHECK:           %[[VAL_19:.*]] = fir.address_of(@_QQcl_6661696C2074797065) : !fir.ref<!fir.char<1,9>>
 // CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
 // CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_2]] : (index) -> i64
 // CHECK:           %[[VAL_22:.*]] = fir.call @_FortranAStopStatementText(%[[VAL_20]], %[[VAL_21]], %[[VAL_1]], %[[VAL_1]]) fastmath<contract> : (!fir.ref<i8>, i64, i1, i1) -> none
@@ -93,7 +93,7 @@ func.func @_QPtest() {
 ^bb2(%7: !fir.class<!fir.ptr<none>>):  // 2 preds: ^bb0, ^bb1
   %8 = fir.rebox %7 : (!fir.class<!fir.ptr<none>>) -> !fir.class<none>
   fir.call @_QPfoo(%8) fastmath<contract> : (!fir.class<none>) -> ()
-  %9 = fir.address_of(@_QQcl.6661696C2074797065) : !fir.ref<!fir.char<1,9>>
+  %9 = fir.address_of(@_QQcl_6661696C2074797065) : !fir.ref<!fir.char<1,9>>
   %10 = fir.convert %9 : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
   %11 = fir.convert %c9 : (index) -> i64
   %12 = fir.call @_FortranAStopStatementText(%10, %11, %false, %false) fastmath<contract> : (!fir.ref<i8>, i64, i1, i1) -> none

--- a/flang/test/Lower/select-type-2.fir
+++ b/flang/test/Lower/select-type-2.fir
@@ -60,7 +60,7 @@
 // CHECK:         ^bb3(%[[VAL_17:.*]]: !fir.class<!fir.ptr<none>>):
 // CHECK:           %[[VAL_18:.*]] = fir.rebox %[[VAL_17]] : (!fir.class<!fir.ptr<none>>) -> !fir.class<none>
 // CHECK:           fir.call @_QPfoo(%[[VAL_18]]) fastmath<contract> : (!fir.class<none>) -> ()
-// CHECK:           %[[VAL_19:.*]] = fir.address_of(@_QQcl_6661696C2074797065) : !fir.ref<!fir.char<1,9>>
+// CHECK:           %[[VAL_19:.*]] = fir.address_of(@_QQclX6661696C2074797065) : !fir.ref<!fir.char<1,9>>
 // CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
 // CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_2]] : (index) -> i64
 // CHECK:           %[[VAL_22:.*]] = fir.call @_FortranAStopStatementText(%[[VAL_20]], %[[VAL_21]], %[[VAL_1]], %[[VAL_1]]) fastmath<contract> : (!fir.ref<i8>, i64, i1, i1) -> none
@@ -93,7 +93,7 @@ func.func @_QPtest() {
 ^bb2(%7: !fir.class<!fir.ptr<none>>):  // 2 preds: ^bb0, ^bb1
   %8 = fir.rebox %7 : (!fir.class<!fir.ptr<none>>) -> !fir.class<none>
   fir.call @_QPfoo(%8) fastmath<contract> : (!fir.class<none>) -> ()
-  %9 = fir.address_of(@_QQcl_6661696C2074797065) : !fir.ref<!fir.char<1,9>>
+  %9 = fir.address_of(@_QQclX6661696C2074797065) : !fir.ref<!fir.char<1,9>>
   %10 = fir.convert %9 : (!fir.ref<!fir.char<1,9>>) -> !fir.ref<i8>
   %11 = fir.convert %c9 : (index) -> i64
   %12 = fir.call @_FortranAStopStatementText(%10, %11, %false, %false) fastmath<contract> : (!fir.ref<i8>, i64, i1, i1) -> none

--- a/flang/test/Lower/statement-function.f90
+++ b/flang/test/Lower/statement-function.f90
@@ -159,7 +159,7 @@ end subroutine
 
 ! CHECK-LABEL: @_QPtruncate_arg
 ! CHECK: %[[c4:.*]] = arith.constant 4 : i32
-! CHECK: %[[arg:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,10>>
+! CHECK: %[[arg:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,10>>
 ! CHECK: %[[cast_arg:.*]] = fir.convert %[[arg]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
 ! CHECK: %[[c10:.*]] = arith.constant 10 : i64
 ! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1,10> {bindc_name = ".chrtmp"}

--- a/flang/test/Lower/statement-function.f90
+++ b/flang/test/Lower/statement-function.f90
@@ -159,7 +159,7 @@ end subroutine
 
 ! CHECK-LABEL: @_QPtruncate_arg
 ! CHECK: %[[c4:.*]] = arith.constant 4 : i32
-! CHECK: %[[arg:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,10>>
+! CHECK: %[[arg:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,10>>
 ! CHECK: %[[cast_arg:.*]] = fir.convert %[[arg]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<!fir.char<1,?>>
 ! CHECK: %[[c10:.*]] = arith.constant 10 : i64
 ! CHECK: %[[temp:.*]] = fir.alloca !fir.char<1,10> {bindc_name = ".chrtmp"}

--- a/flang/test/Lower/transformational-intrinsics.f90
+++ b/flang/test/Lower/transformational-intrinsics.f90
@@ -192,7 +192,7 @@ end subroutine
   ! CHECK:         %[[VAL_63:.*]] = fir.embox %[[VAL_60]](%[[VAL_62]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   ! CHECK:         fir.store %[[VAL_63]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
   ! CHECK:         %[[VAL_64:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
-  ! CHECK:         %[[VAL_65:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK:         %[[VAL_65:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK:         %[[VAL_66:.*]] = arith.constant {{[0-9]+}} : i32
   ! CHECK:         %[[VAL_67:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK:         %[[VAL_68:.*]] = fir.convert %[[VAL_59]] : (!fir.box<!fir.array<6xi32>>) -> !fir.box<none>

--- a/flang/test/Lower/transformational-intrinsics.f90
+++ b/flang/test/Lower/transformational-intrinsics.f90
@@ -192,7 +192,7 @@ end subroutine
   ! CHECK:         %[[VAL_63:.*]] = fir.embox %[[VAL_60]](%[[VAL_62]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   ! CHECK:         fir.store %[[VAL_63]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
   ! CHECK:         %[[VAL_64:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
-  ! CHECK:         %[[VAL_65:.*]] = fir.address_of(@_QQcl.{{.*}}) : !fir.ref<!fir.char<1,
+  ! CHECK:         %[[VAL_65:.*]] = fir.address_of(@_QQcl_{{.*}}) : !fir.ref<!fir.char<1,
   ! CHECK:         %[[VAL_66:.*]] = arith.constant {{[0-9]+}} : i32
   ! CHECK:         %[[VAL_67:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   ! CHECK:         %[[VAL_68:.*]] = fir.convert %[[VAL_59]] : (!fir.box<!fir.array<6xi32>>) -> !fir.box<none>

--- a/flang/test/Transforms/simplifyintrinsics.fir
+++ b/flang/test/Transforms/simplifyintrinsics.fir
@@ -9,7 +9,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F6973756D5F322E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F6973756D5F322E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -21,7 +21,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F322E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F322E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_2.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -70,7 +70,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x10xi32>>, !fir.shape<2>) -> !fir.box<!fir.array<10x10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F6973756D5F332E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F6973756D5F332E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10x10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -82,7 +82,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F332E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F332E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_3.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -134,7 +134,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -146,7 +146,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : f64
   }
   func.func private @_FortranASumReal8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f64 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_5.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -194,7 +194,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xf32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -206,7 +206,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : f32
   }
   func.func private @_FortranASumReal4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_5.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -255,7 +255,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %3 = fir.embox %arg0(%2) : (!fir.ref<!fir.array<10x!fir.complex<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.complex<4>>>
     %4 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %5 = fir.address_of(@_QQcl.2E2F6973756D5F362E66393000) : !fir.ref<!fir.char<1,13>>
+    %5 = fir.address_of(@_QQcl_2E2F6973756D5F362E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %6 = fir.convert %0 : (!fir.ref<!fir.complex<4>>) -> !fir.ref<complex<f32>>
     %7 = fir.convert %3 : (!fir.box<!fir.array<10x!fir.complex<4>>>) -> !fir.box<none>
@@ -269,7 +269,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %13 : !fir.complex<4>
   }
   func.func private @_FortranACppSumComplex4(!fir.ref<complex<f32>>, !fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> none attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F362E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F362E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_6.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -293,7 +293,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -311,7 +311,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<20xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<20xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
     %c12_i32 = arith.constant 12 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<20xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -323,7 +323,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F372E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F372E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_7.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -362,7 +362,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %6 = fir.embox %arg0(%4) [%5] : (!fir.ref<!fir.array<20xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xi32>>
     %7 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %8 = fir.address_of(@_QQcl.2E2F6973756D5F382E66393000) : !fir.ref<!fir.char<1,13>>
+    %8 = fir.address_of(@_QQcl_2E2F6973756D5F382E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %9 = fir.convert %6 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
     %10 = fir.convert %8 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -374,7 +374,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %14 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F382E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F382E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_8.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -440,7 +440,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %0 = fir.alloca i32 {bindc_name = "test_sum_1", uniq_name = "_QFtest_sum_1Etest_sum_1"}
     %1 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %2 = fir.address_of(@_QQcl.2E2F696D61785F312E66393000) : !fir.ref<!fir.char<1,13>>
+    %2 = fir.address_of(@_QQcl_2E2F696D61785F312E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %3 = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
     %4 = fir.convert %2 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -452,7 +452,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %8 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F696D61785F312E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F696D61785F312E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./imax_1.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -466,7 +466,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
 
 func.func @dot_f32(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f32 {
   %0 = fir.alloca f32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -516,7 +516,7 @@ func.func @dot_f32(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %a
 
 func.func @dot_f64(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "b"}) -> f64 {
   %0 = fir.alloca f64 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
@@ -527,7 +527,7 @@ func.func @dot_f64(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}, %a
   return %6 : f64
 }
 func.func private @_FortranADotProductReal8(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -543,7 +543,7 @@ fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_f80(%arg0: !fir.box<!fir.array<?xf80>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf80>> {fir.bindc_name = "b"}) -> f80 {
   %0 = fir.alloca f80 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
@@ -554,7 +554,7 @@ func.func @dot_f80(%arg0: !fir.box<!fir.array<?xf80>> {fir.bindc_name = "a"}, %a
   return %6 : f80
 }
 func.func private @_FortranADotProductReal10(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f80 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -570,7 +570,7 @@ fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_f128(%arg0: !fir.box<!fir.array<?xf128>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf128>> {fir.bindc_name = "b"}) -> f128 {
   %0 = fir.alloca f128 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
@@ -581,7 +581,7 @@ func.func @dot_f128(%arg0: !fir.box<!fir.array<?xf128>> {fir.bindc_name = "a"}, 
   return %6 : f128
 }
 func.func private @_FortranADotProductReal16(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f128 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -597,7 +597,7 @@ fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i32(%arg0: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "b"}) -> i32 {
   %0 = fir.alloca i32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
@@ -608,7 +608,7 @@ func.func @dot_i32(%arg0: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"}, %a
   return %6 : i32
 }
 func.func private @_FortranADotProductInteger4(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i32 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -653,7 +653,7 @@ fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i8(%arg0: !fir.box<!fir.array<?xi8>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi8>> {fir.bindc_name = "b"}) -> i8 {
   %0 = fir.alloca i8 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
@@ -664,7 +664,7 @@ func.func @dot_i8(%arg0: !fir.box<!fir.array<?xi8>> {fir.bindc_name = "a"}, %arg
   return %6 : i8
 }
 func.func private @_FortranADotProductInteger1(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i8 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -680,7 +680,7 @@ fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i16(%arg0: !fir.box<!fir.array<?xi16>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi16>> {fir.bindc_name = "b"}) -> i16 {
   %0 = fir.alloca i16 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
@@ -691,7 +691,7 @@ func.func @dot_i16(%arg0: !fir.box<!fir.array<?xi16>> {fir.bindc_name = "a"}, %a
   return %6 : i16
 }
 func.func private @_FortranADotProductInteger2(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i16 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -707,7 +707,7 @@ fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i64(%arg0: !fir.box<!fir.array<?xi64>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi64>> {fir.bindc_name = "b"}) -> i64 {
   %0 = fir.alloca i64 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
@@ -718,7 +718,7 @@ func.func @dot_i64(%arg0: !fir.box<!fir.array<?xi64>> {fir.bindc_name = "a"}, %a
   return %6 : i64
 }
 func.func private @_FortranADotProductInteger8(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -738,7 +738,7 @@ fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_f64_f32(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f64 {
   %0 = fir.alloca f64 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -749,7 +749,7 @@ func.func @dot_f64_f32(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}
   return %6 : f64
 }
 func.func private @_FortranADotProductReal4(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -802,7 +802,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F696D61785F322E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F696D61785F322E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -814,7 +814,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranAMaxvalInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F696D61785F322E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F696D61785F322E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./imax_2.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -858,7 +858,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl.2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -870,7 +870,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : f64
   }
   func.func private @_FortranAMaxvalReal8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f64 attributes {fir.runtime}
-  fir.global linkonce @_QQcl.2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./imaxval_5.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -932,7 +932,7 @@ func.func @sum_sliced_embox_i64(%arg0: !fir.ref<!fir.array<10x10x10xi64>> {fir.b
   %11 = fir.embox %arg0(%9) [%10] : (!fir.ref<!fir.array<10x10x10xi64>>, !fir.shape<3>, !fir.slice<3>) -> !fir.box<!fir.array<?x?xi64>>
   %12 = fir.absent !fir.box<i1>
   %c0 = arith.constant 0 : index
-  %13 = fir.address_of(@_QQcl.2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
+  %13 = fir.address_of(@_QQcl_2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
   %c3_i32 = arith.constant 3 : i32
   %14 = fir.convert %11 : (!fir.box<!fir.array<?x?xi64>>) -> !fir.box<none>
   %15 = fir.convert %13 : (!fir.ref<!fir.char<1,11>>) -> !fir.ref<i8>
@@ -944,7 +944,7 @@ func.func @sum_sliced_embox_i64(%arg0: !fir.ref<!fir.array<10x10x10xi64>> {fir.b
   return %19 : f32
 }
 func.func private @_FortranASumInteger8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F746573742E66393000 constant : !fir.char<1,11> {
+fir.global linkonce @_QQcl_2E2F746573742E66393000 constant : !fir.char<1,11> {
   %0 = fir.string_lit "./test.f90\00"(11) : !fir.char<1,11>
   fir.has_value %0 : !fir.char<1,11>
 }
@@ -979,7 +979,7 @@ func.func @_QPsum_sliced_rebox_i64(%arg0: !fir.box<!fir.array<?x?x?xi64>> {fir.b
   %12 = fir.rebox %arg0 [%11] : (!fir.box<!fir.array<?x?x?xi64>>, !fir.slice<3>) -> !fir.box<!fir.array<?x?xi64>>
   %13 = fir.absent !fir.box<i1>
   %c0_3 = arith.constant 0 : index
-  %14 = fir.address_of(@_QQcl.2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
+  %14 = fir.address_of(@_QQcl_2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
   %c8_i32 = arith.constant 8 : i32
   %15 = fir.convert %12 : (!fir.box<!fir.array<?x?xi64>>) -> !fir.box<none>
   %16 = fir.convert %14 : (!fir.ref<!fir.char<1,11>>) -> !fir.ref<i8>
@@ -991,7 +991,7 @@ func.func @_QPsum_sliced_rebox_i64(%arg0: !fir.box<!fir.array<?x?x?xi64>> {fir.b
   return %20 : f32
 }
 func.func private @_FortranASumInteger8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F746573742E66393000 constant : !fir.char<1,11> {
+fir.global linkonce @_QQcl_2E2F746573742E66393000 constant : !fir.char<1,11> {
   %0 = fir.string_lit "./test.f90\00"(11) : !fir.char<1,11>
   fir.has_value %0 : !fir.char<1,11>
 }
@@ -1004,7 +1004,7 @@ fir.global linkonce @_QQcl.2E2F746573742E66393000 constant : !fir.char<1,11> {
 
 func.func @dot_f32_contract_reassoc(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f32 {
   %0 = fir.alloca f32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -1017,7 +1017,7 @@ func.func @dot_f32_contract_reassoc(%arg0: !fir.box<!fir.array<?xf32>> {fir.bind
 
 func.func @dot_f32_fast(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f32 {
   %0 = fir.alloca f32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl.2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -1029,7 +1029,7 @@ func.func @dot_f32_fast(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"
 }
 
 func.func private @_FortranADotProductReal4(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -1054,7 +1054,7 @@ func.func @sum_1d_real_contract_reassoc(%arg0: !fir.ref<!fir.array<10xf64>> {fir
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
   %3 = fir.absent !fir.box<i1>
   %c0 = arith.constant 0 : index
-  %4 = fir.address_of(@_QQcl.2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+  %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
   %c5_i32 = arith.constant 5 : i32
   %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
   %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -1073,7 +1073,7 @@ func.func @sum_1d_real_fast(%arg0: !fir.ref<!fir.array<10xf64>> {fir.bindc_name 
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
   %3 = fir.absent !fir.box<i1>
   %c0 = arith.constant 0 : index
-  %4 = fir.address_of(@_QQcl.2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+  %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
   %c5_i32 = arith.constant 5 : i32
   %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
   %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -1086,7 +1086,7 @@ func.func @sum_1d_real_fast(%arg0: !fir.ref<!fir.array<10xf64>> {fir.bindc_name 
 }
 
 func.func private @_FortranASumReal8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f64 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
   %0 = fir.string_lit "./isum_5.f90\00"(13) : !fir.char<1,13>
   fir.has_value %0 : !fir.char<1,13>
 }
@@ -1110,7 +1110,7 @@ func.func @_QMtestPcount_generate_mask(%arg0: !fir.ref<f32> {fir.bindc_name = "a
   %2 = fir.shape %c10 : (index) -> !fir.shape<1>
   %3 = fir.embox %1(%2) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<4>>>
   %c0 = arith.constant 0 : index
-  %4 = fir.address_of(@_QQcl.2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
+  %4 = fir.address_of(@_QQcl_2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
   %c10_i32 = arith.constant 10 : i32
   %5 = fir.convert %3 : (!fir.box<!fir.array<10x!fir.logical<4>>>) -> !fir.box<none>
   %6 = fir.convert %4 : (!fir.ref<!fir.char<1,15>>) -> !fir.ref<i8>
@@ -1122,7 +1122,7 @@ func.func @_QMtestPcount_generate_mask(%arg0: !fir.ref<f32> {fir.bindc_name = "a
   return %10 : i32
 }
 func.func private @_FortranACount(!fir.box<none>, !fir.ref<i8>, i32, i32) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl.2E2F746573746661696C2E66393000 constant : !fir.char<1,15> {
+fir.global linkonce @_QQcl_2E2F746573746661696C2E66393000 constant : !fir.char<1,15> {
   %0 = fir.string_lit "./test.f90\00"(15) : !fir.char<1,15>
   fir.has_value %0 : !fir.char<1,15>
 }
@@ -1171,7 +1171,7 @@ func.func @_QPdiffkind(%arg0: !fir.ref<!fir.array<10x!fir.logical<2>>> {fir.bind
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<2>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<2>>>
   %c0 = arith.constant 0 : index
-  %3 = fir.address_of(@_QQcl.916d74b25894ddf7881ff7f913a677f5) : !fir.ref<!fir.char<1,52>>
+  %3 = fir.address_of(@_QQcl_916d74b25894ddf7881ff7f913a677f5) : !fir.ref<!fir.char<1,52>>
   %c5_i32 = arith.constant 5 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<2>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,52>>) -> !fir.ref<i8>
@@ -1230,7 +1230,7 @@ func.func @_QMtestPcount_generate_mask(%arg0: !fir.ref<!fir.array<10x10x!fir.log
   %7 = fir.shape %c0 : (index) -> !fir.shape<1>
   %8 = fir.embox %6(%7) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %9 = fir.address_of(@_QQcl.2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
+  %9 = fir.address_of(@_QQcl_2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
   %c11_i32 = arith.constant 11 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10x10x!fir.logical<4>>>) -> !fir.box<none>
@@ -1270,7 +1270,7 @@ func.func private @_FortranACountDim(!fir.ref<!fir.box<none>>, !fir.box<none>, i
 func.func @_QPmc(%arg0: !fir.box<!fir.array<?x?x?x!fir.logical<4>>> {fir.bindc_name = "m"}) -> i32 {
   %0 = fir.alloca i32 {bindc_name = "mc", uniq_name = "_QFmcEmc"}
   %c0 = arith.constant 0 : index
-  %1 = fir.address_of(@_QQcl.95529933117f47914fc21e220c1a0896) : !fir.ref<!fir.char<1,58>>
+  %1 = fir.address_of(@_QQcl_95529933117f47914fc21e220c1a0896) : !fir.ref<!fir.char<1,58>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?x?x?x!fir.logical<4>>>) -> !fir.box<none>
   %3 = fir.convert %1 : (!fir.ref<!fir.char<1,58>>) -> !fir.ref<i8>
@@ -1298,7 +1298,7 @@ func.func @_QPtestAny_NoDimArg(%arg0: !fir.ref<!fir.array<10x!fir.logical<4>>> {
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<4>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<4>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1351,7 +1351,7 @@ func.func @_QPtestAny_NoDimArgLogical8(%arg0: !fir.ref<!fir.array<10x!fir.logica
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<8>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<8>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<8>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1414,7 +1414,7 @@ func.func @_QPtestAny_DimArg(%arg0: !fir.ref<!fir.array<10x10x!fir.logical<4>>> 
   %7 = fir.shape %c0 : (index) -> !fir.shape<1>
   %8 = fir.embox %6(%7) : (!fir.heap<!fir.array<?x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>
-  %9 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %9 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10x10x!fir.logical<4>>>) -> !fir.box<none>
@@ -1453,7 +1453,7 @@ func.func private @_FortranAAnyDim(!fir.ref<!fir.box<none>>, !fir.box<none>, i32
 func.func @_QPtestAny_UnknownDim(%arg0: !fir.box<!fir.array<?x!fir.logical<4>>> {fir.bindc_name = "a"}) -> !fir.logical<4> {
   %0 = fir.alloca !fir.logical<4> {bindc_name = "testAny_UnknownDim", uniq_name = "_QFtestAny_UnknownDimEtestAny_UnknownDim"}
   %c1 = arith.constant 1 : index
-  %1 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %1 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
   %3 = fir.convert %1 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1482,7 +1482,7 @@ func.func @_QPtestAny_2D(%arg0: !fir.ref<!fir.array<10x0x!fir.logical<4>>> {fir.
     %1 = fir.shape %c10, %c0 : (index, index) -> !fir.shape<2>
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x0x!fir.logical<4>>>, !fir.shape<2>) -> !fir.box<!fir.array<10x0x!fir.logical<4>>>
     %c1 = arith.constant 1 : index
-    %3 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+    %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
     %c3_i32 = arith.constant 3 : i32
     %4 = fir.convert %2 : (!fir.box<!fir.array<10x0x!fir.logical<4>>>) -> !fir.box<none>
     %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1540,7 +1540,7 @@ func.func @_QPtestAll_NoDimArg(%arg0: !fir.ref<!fir.array<10x!fir.logical<4>>> {
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<4>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<4>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1591,7 +1591,7 @@ func.func @_QPtestAll_NoDimArgLogical1(%arg0: !fir.ref<!fir.array<10x!fir.logica
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<1>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<1>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<1>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1653,7 +1653,7 @@ func.func @_QPtestAll_DimArg(%arg0: !fir.ref<!fir.array<10x10x!fir.logical<4>>> 
   %7 = fir.shape %c0 : (index) -> !fir.shape<1>
   %8 = fir.embox %6(%7) : (!fir.heap<!fir.array<?x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>
-  %9 = fir.address_of(@_QQcl.04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %9 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10x10x!fir.logical<4>>>) -> !fir.box<none>
@@ -1707,7 +1707,7 @@ func.func @_QPtestminloc_works1d(%arg0: !fir.ref<!fir.array<10xi32>> {fir.bindc_
   %9 = fir.shape %c0 : (index) -> !fir.shape<1>
   %10 = fir.embox %8(%9) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %10 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %11 = fir.address_of(@_QQcl.ea5bcf7f706678e1796661f8916f3379) : !fir.ref<!fir.char<1,55>>
+  %11 = fir.address_of(@_QQcl_ea5bcf7f706678e1796661f8916f3379) : !fir.ref<!fir.char<1,55>>
   %c5_i32 = arith.constant 5 : i32
   %12 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %13 = fir.convert %5 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
@@ -1837,7 +1837,7 @@ func.func @_QPtestminloc_works2d_nomask(%arg0: !fir.ref<!fir.array<10x10xi32>> {
   %8 = fir.shape %c0 : (index) -> !fir.shape<1>
   %9 = fir.embox %7(%8) : (!fir.heap<!fir.array<?xi64>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi64>>>
   fir.store %9 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi64>>>>
-  %10 = fir.address_of(@_QQcl.cba8b79c45ccae77d79d66a39ac99823) : !fir.ref<!fir.char<1,62>>
+  %10 = fir.address_of(@_QQcl_cba8b79c45ccae77d79d66a39ac99823) : !fir.ref<!fir.char<1,62>>
   %c4_i32 = arith.constant 4 : i32
   %11 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi64>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %5 : (!fir.box<!fir.array<10x10xi32>>) -> !fir.box<none>
@@ -1964,7 +1964,7 @@ func.func @_QPtestminloc_works1d_scalarmask_f64(%arg0: !fir.ref<!fir.array<10xf6
   %8 = fir.shape %c0 : (index) -> !fir.shape<1>
   %9 = fir.embox %7(%8) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %9 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %10 = fir.address_of(@_QQcl.66951c28c5b8bab5cdb25c1ac762b978) : !fir.ref<!fir.char<1,65>>
+  %10 = fir.address_of(@_QQcl_66951c28c5b8bab5cdb25c1ac762b978) : !fir.ref<!fir.char<1,65>>
   %c6_i32 = arith.constant 6 : i32
   %11 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %5 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
@@ -2080,7 +2080,7 @@ func.func @_QPtestminloc_doesntwork1d_back(%arg0: !fir.ref<!fir.array<10xi32>> {
   %8 = fir.shape %c0 : (index) -> !fir.shape<1>
   %9 = fir.embox %7(%8) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %9 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %10 = fir.address_of(@_QQcl.3791f01d699716ba5914ae524c6a8dee) : !fir.ref<!fir.char<1,62>>
+  %10 = fir.address_of(@_QQcl_3791f01d699716ba5914ae524c6a8dee) : !fir.ref<!fir.char<1,62>>
   %c4_i32 = arith.constant 4 : i32
   %11 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %5 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
@@ -2133,7 +2133,7 @@ func.func @_QPtestminloc_doesntwork1d_dim(%arg0: !fir.ref<!fir.array<10xi32>> {f
   %7 = fir.zero_bits !fir.heap<i32>
   %8 = fir.embox %7 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-  %9 = fir.address_of(@_QQcl.cfcf4329f25d06a4b02a0c8f532ee9df) : !fir.ref<!fir.char<1,61>>
+  %9 = fir.address_of(@_QQcl_cfcf4329f25d06a4b02a0c8f532ee9df) : !fir.ref<!fir.char<1,61>>
   %c4_i32 = arith.constant 4 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
@@ -2179,7 +2179,7 @@ func.func @_QPtestminloc_doesntwork1d_unknownsize(%arg0: !fir.box<!fir.array<?xi
   %6 = fir.shape %c0 : (index) -> !fir.shape<1>
   %7 = fir.embox %5(%6) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %7 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %8 = fir.address_of(@_QQcl.2064f5e9298c2127417d52b69eac898e) : !fir.ref<!fir.char<1,69>>
+  %8 = fir.address_of(@_QQcl_2064f5e9298c2127417d52b69eac898e) : !fir.ref<!fir.char<1,69>>
   %c4_i32 = arith.constant 4 : i32
   %9 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %10 = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
@@ -2234,7 +2234,7 @@ func.func @_QPtestminloc_doesntwork1d_chars(%arg0: !fir.boxchar<1> {fir.bindc_na
   %10 = fir.shape %c0 : (index) -> !fir.shape<1>
   %11 = fir.embox %9(%10) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %11 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %12 = fir.address_of(@_QQcl.74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
+  %12 = fir.address_of(@_QQcl_74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
   %c4_i32 = arith.constant 4 : i32
   %13 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %14 = fir.convert %7 : (!fir.box<!fir.array<10x!fir.char<1>>>) -> !fir.box<none>
@@ -2315,7 +2315,7 @@ func.func @_QPtestminloc_doesntwork1d_unknownmask(%arg0: !fir.ref<!fir.array<10x
   %28 = fir.shape %c0_1 : (index) -> !fir.shape<1>
   %29 = fir.embox %27(%28) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %29 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %30 = fir.address_of(@_QQcl.74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
+  %30 = fir.address_of(@_QQcl_74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
   %c7_i32 = arith.constant 7 : i32
   %31 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %32 = fir.convert %16 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>

--- a/flang/test/Transforms/simplifyintrinsics.fir
+++ b/flang/test/Transforms/simplifyintrinsics.fir
@@ -9,7 +9,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F6973756D5F322E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F6973756D5F322E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -21,7 +21,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F322E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F322E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_2.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -70,7 +70,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x10xi32>>, !fir.shape<2>) -> !fir.box<!fir.array<10x10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F6973756D5F332E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F6973756D5F332E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10x10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -82,7 +82,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F332E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F332E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_3.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -134,7 +134,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -146,7 +146,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : f64
   }
   func.func private @_FortranASumReal8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f64 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_5.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -194,7 +194,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xf32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -206,7 +206,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : f32
   }
   func.func private @_FortranASumReal4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_5.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -255,7 +255,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %3 = fir.embox %arg0(%2) : (!fir.ref<!fir.array<10x!fir.complex<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.complex<4>>>
     %4 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %5 = fir.address_of(@_QQcl_2E2F6973756D5F362E66393000) : !fir.ref<!fir.char<1,13>>
+    %5 = fir.address_of(@_QQclX2E2F6973756D5F362E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %6 = fir.convert %0 : (!fir.ref<!fir.complex<4>>) -> !fir.ref<complex<f32>>
     %7 = fir.convert %3 : (!fir.box<!fir.array<10x!fir.complex<4>>>) -> !fir.box<none>
@@ -269,7 +269,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %13 : !fir.complex<4>
   }
   func.func private @_FortranACppSumComplex4(!fir.ref<complex<f32>>, !fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> none attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F362E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F362E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_6.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -293,7 +293,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -311,7 +311,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<20xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<20xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F6973756D5F372E66393000) : !fir.ref<!fir.char<1,13>>
     %c12_i32 = arith.constant 12 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<20xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -323,7 +323,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F372E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F372E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_7.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -362,7 +362,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %6 = fir.embox %arg0(%4) [%5] : (!fir.ref<!fir.array<20xi32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xi32>>
     %7 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %8 = fir.address_of(@_QQcl_2E2F6973756D5F382E66393000) : !fir.ref<!fir.char<1,13>>
+    %8 = fir.address_of(@_QQclX2E2F6973756D5F382E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %9 = fir.convert %6 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
     %10 = fir.convert %8 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -374,7 +374,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %14 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F382E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F382E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./isum_8.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -440,7 +440,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %0 = fir.alloca i32 {bindc_name = "test_sum_1", uniq_name = "_QFtest_sum_1Etest_sum_1"}
     %1 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %2 = fir.address_of(@_QQcl_2E2F696D61785F312E66393000) : !fir.ref<!fir.char<1,13>>
+    %2 = fir.address_of(@_QQclX2E2F696D61785F312E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %3 = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
     %4 = fir.convert %2 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -452,7 +452,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %8 : i32
   }
   func.func private @_FortranASumInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F696D61785F312E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F696D61785F312E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./imax_1.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -466,7 +466,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
 
 func.func @dot_f32(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f32 {
   %0 = fir.alloca f32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -516,7 +516,7 @@ func.func @dot_f32(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %a
 
 func.func @dot_f64(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "b"}) -> f64 {
   %0 = fir.alloca f64 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
@@ -527,7 +527,7 @@ func.func @dot_f64(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}, %a
   return %6 : f64
 }
 func.func private @_FortranADotProductReal8(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -543,7 +543,7 @@ fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_f80(%arg0: !fir.box<!fir.array<?xf80>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf80>> {fir.bindc_name = "b"}) -> f80 {
   %0 = fir.alloca f80 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
@@ -554,7 +554,7 @@ func.func @dot_f80(%arg0: !fir.box<!fir.array<?xf80>> {fir.bindc_name = "a"}, %a
   return %6 : f80
 }
 func.func private @_FortranADotProductReal10(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f80 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -570,7 +570,7 @@ fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_f128(%arg0: !fir.box<!fir.array<?xf128>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf128>> {fir.bindc_name = "b"}) -> f128 {
   %0 = fir.alloca f128 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
@@ -581,7 +581,7 @@ func.func @dot_f128(%arg0: !fir.box<!fir.array<?xf128>> {fir.bindc_name = "a"}, 
   return %6 : f128
 }
 func.func private @_FortranADotProductReal16(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f128 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -597,7 +597,7 @@ fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i32(%arg0: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "b"}) -> i32 {
   %0 = fir.alloca i32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
@@ -608,7 +608,7 @@ func.func @dot_i32(%arg0: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "a"}, %a
   return %6 : i32
 }
 func.func private @_FortranADotProductInteger4(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i32 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -653,7 +653,7 @@ fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i8(%arg0: !fir.box<!fir.array<?xi8>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi8>> {fir.bindc_name = "b"}) -> i8 {
   %0 = fir.alloca i8 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
@@ -664,7 +664,7 @@ func.func @dot_i8(%arg0: !fir.box<!fir.array<?xi8>> {fir.bindc_name = "a"}, %arg
   return %6 : i8
 }
 func.func private @_FortranADotProductInteger1(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i8 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -680,7 +680,7 @@ fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i16(%arg0: !fir.box<!fir.array<?xi16>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi16>> {fir.bindc_name = "b"}) -> i16 {
   %0 = fir.alloca i16 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
@@ -691,7 +691,7 @@ func.func @dot_i16(%arg0: !fir.box<!fir.array<?xi16>> {fir.bindc_name = "a"}, %a
   return %6 : i16
 }
 func.func private @_FortranADotProductInteger2(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i16 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -707,7 +707,7 @@ fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_i64(%arg0: !fir.box<!fir.array<?xi64>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xi64>> {fir.bindc_name = "b"}) -> i64 {
   %0 = fir.alloca i64 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
@@ -718,7 +718,7 @@ func.func @dot_i64(%arg0: !fir.box<!fir.array<?xi64>> {fir.bindc_name = "a"}, %a
   return %6 : i64
 }
 func.func private @_FortranADotProductInteger8(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -738,7 +738,7 @@ fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
 
 func.func @dot_f64_f32(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f64 {
   %0 = fir.alloca f64 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -749,7 +749,7 @@ func.func @dot_f64_f32(%arg0: !fir.box<!fir.array<?xf64>> {fir.bindc_name = "a"}
   return %6 : f64
 }
 func.func private @_FortranADotProductReal4(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -802,7 +802,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xi32>>, !fir.shape<1>) -> !fir.box<!fir.array<10xi32>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F696D61785F322E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F696D61785F322E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -814,7 +814,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : i32
   }
   func.func private @_FortranAMaxvalInteger4(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i32 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F696D61785F322E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F696D61785F322E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./imax_2.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -858,7 +858,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
     %3 = fir.absent !fir.box<i1>
     %c0 = arith.constant 0 : index
-    %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+    %4 = fir.address_of(@_QQclX2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
     %c5_i32 = arith.constant 5 : i32
     %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
     %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -870,7 +870,7 @@ module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.targ
     return %10 : f64
   }
   func.func private @_FortranAMaxvalReal8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f64 attributes {fir.runtime}
-  fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+  fir.global linkonce @_QQclX2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
     %0 = fir.string_lit "./imaxval_5.f90\00"(13) : !fir.char<1,13>
     fir.has_value %0 : !fir.char<1,13>
   }
@@ -932,7 +932,7 @@ func.func @sum_sliced_embox_i64(%arg0: !fir.ref<!fir.array<10x10x10xi64>> {fir.b
   %11 = fir.embox %arg0(%9) [%10] : (!fir.ref<!fir.array<10x10x10xi64>>, !fir.shape<3>, !fir.slice<3>) -> !fir.box<!fir.array<?x?xi64>>
   %12 = fir.absent !fir.box<i1>
   %c0 = arith.constant 0 : index
-  %13 = fir.address_of(@_QQcl_2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
+  %13 = fir.address_of(@_QQclX2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
   %c3_i32 = arith.constant 3 : i32
   %14 = fir.convert %11 : (!fir.box<!fir.array<?x?xi64>>) -> !fir.box<none>
   %15 = fir.convert %13 : (!fir.ref<!fir.char<1,11>>) -> !fir.ref<i8>
@@ -944,7 +944,7 @@ func.func @sum_sliced_embox_i64(%arg0: !fir.ref<!fir.array<10x10x10xi64>> {fir.b
   return %19 : f32
 }
 func.func private @_FortranASumInteger8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F746573742E66393000 constant : !fir.char<1,11> {
+fir.global linkonce @_QQclX2E2F746573742E66393000 constant : !fir.char<1,11> {
   %0 = fir.string_lit "./test.f90\00"(11) : !fir.char<1,11>
   fir.has_value %0 : !fir.char<1,11>
 }
@@ -979,7 +979,7 @@ func.func @_QPsum_sliced_rebox_i64(%arg0: !fir.box<!fir.array<?x?x?xi64>> {fir.b
   %12 = fir.rebox %arg0 [%11] : (!fir.box<!fir.array<?x?x?xi64>>, !fir.slice<3>) -> !fir.box<!fir.array<?x?xi64>>
   %13 = fir.absent !fir.box<i1>
   %c0_3 = arith.constant 0 : index
-  %14 = fir.address_of(@_QQcl_2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
+  %14 = fir.address_of(@_QQclX2E2F746573742E66393000) : !fir.ref<!fir.char<1,11>>
   %c8_i32 = arith.constant 8 : i32
   %15 = fir.convert %12 : (!fir.box<!fir.array<?x?xi64>>) -> !fir.box<none>
   %16 = fir.convert %14 : (!fir.ref<!fir.char<1,11>>) -> !fir.ref<i8>
@@ -991,7 +991,7 @@ func.func @_QPsum_sliced_rebox_i64(%arg0: !fir.box<!fir.array<?x?x?xi64>> {fir.b
   return %20 : f32
 }
 func.func private @_FortranASumInteger8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F746573742E66393000 constant : !fir.char<1,11> {
+fir.global linkonce @_QQclX2E2F746573742E66393000 constant : !fir.char<1,11> {
   %0 = fir.string_lit "./test.f90\00"(11) : !fir.char<1,11>
   fir.has_value %0 : !fir.char<1,11>
 }
@@ -1004,7 +1004,7 @@ fir.global linkonce @_QQcl_2E2F746573742E66393000 constant : !fir.char<1,11> {
 
 func.func @dot_f32_contract_reassoc(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f32 {
   %0 = fir.alloca f32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -1017,7 +1017,7 @@ func.func @dot_f32_contract_reassoc(%arg0: !fir.box<!fir.array<?xf32>> {fir.bind
 
 func.func @dot_f32_fast(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}, %arg1: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "b"}) -> f32 {
   %0 = fir.alloca f32 {bindc_name = "dot", uniq_name = "_QFdotEdot"}
-  %1 = fir.address_of(@_QQcl_2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
+  %1 = fir.address_of(@_QQclX2E2F646F742E66393000) : !fir.ref<!fir.char<1,10>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   %3 = fir.convert %arg1 : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
@@ -1029,7 +1029,7 @@ func.func @dot_f32_fast(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"
 }
 
 func.func private @_FortranADotProductReal4(!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F646F742E66393000 constant : !fir.char<1,10> {
+fir.global linkonce @_QQclX2E2F646F742E66393000 constant : !fir.char<1,10> {
   %0 = fir.string_lit "./dot.f90\00"(10) : !fir.char<1,10>
   fir.has_value %0 : !fir.char<1,10>
 }
@@ -1054,7 +1054,7 @@ func.func @sum_1d_real_contract_reassoc(%arg0: !fir.ref<!fir.array<10xf64>> {fir
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
   %3 = fir.absent !fir.box<i1>
   %c0 = arith.constant 0 : index
-  %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+  %4 = fir.address_of(@_QQclX2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
   %c5_i32 = arith.constant 5 : i32
   %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
   %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -1073,7 +1073,7 @@ func.func @sum_1d_real_fast(%arg0: !fir.ref<!fir.array<10xf64>> {fir.bindc_name 
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10xf64>>, !fir.shape<1>) -> !fir.box<!fir.array<10xf64>>
   %3 = fir.absent !fir.box<i1>
   %c0 = arith.constant 0 : index
-  %4 = fir.address_of(@_QQcl_2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
+  %4 = fir.address_of(@_QQclX2E2F6973756D5F352E66393000) : !fir.ref<!fir.char<1,13>>
   %c5_i32 = arith.constant 5 : i32
   %5 = fir.convert %2 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
   %6 = fir.convert %4 : (!fir.ref<!fir.char<1,13>>) -> !fir.ref<i8>
@@ -1086,7 +1086,7 @@ func.func @sum_1d_real_fast(%arg0: !fir.ref<!fir.array<10xf64>> {fir.bindc_name 
 }
 
 func.func private @_FortranASumReal8(!fir.box<none>, !fir.ref<i8>, i32, i32, !fir.box<none>) -> f64 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
+fir.global linkonce @_QQclX2E2F6973756D5F352E66393000 constant : !fir.char<1,13> {
   %0 = fir.string_lit "./isum_5.f90\00"(13) : !fir.char<1,13>
   fir.has_value %0 : !fir.char<1,13>
 }
@@ -1110,7 +1110,7 @@ func.func @_QMtestPcount_generate_mask(%arg0: !fir.ref<f32> {fir.bindc_name = "a
   %2 = fir.shape %c10 : (index) -> !fir.shape<1>
   %3 = fir.embox %1(%2) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<4>>>
   %c0 = arith.constant 0 : index
-  %4 = fir.address_of(@_QQcl_2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
+  %4 = fir.address_of(@_QQclX2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
   %c10_i32 = arith.constant 10 : i32
   %5 = fir.convert %3 : (!fir.box<!fir.array<10x!fir.logical<4>>>) -> !fir.box<none>
   %6 = fir.convert %4 : (!fir.ref<!fir.char<1,15>>) -> !fir.ref<i8>
@@ -1122,7 +1122,7 @@ func.func @_QMtestPcount_generate_mask(%arg0: !fir.ref<f32> {fir.bindc_name = "a
   return %10 : i32
 }
 func.func private @_FortranACount(!fir.box<none>, !fir.ref<i8>, i32, i32) -> i64 attributes {fir.runtime}
-fir.global linkonce @_QQcl_2E2F746573746661696C2E66393000 constant : !fir.char<1,15> {
+fir.global linkonce @_QQclX2E2F746573746661696C2E66393000 constant : !fir.char<1,15> {
   %0 = fir.string_lit "./test.f90\00"(15) : !fir.char<1,15>
   fir.has_value %0 : !fir.char<1,15>
 }
@@ -1171,7 +1171,7 @@ func.func @_QPdiffkind(%arg0: !fir.ref<!fir.array<10x!fir.logical<2>>> {fir.bind
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<2>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<2>>>
   %c0 = arith.constant 0 : index
-  %3 = fir.address_of(@_QQcl_916d74b25894ddf7881ff7f913a677f5) : !fir.ref<!fir.char<1,52>>
+  %3 = fir.address_of(@_QQclX916d74b25894ddf7881ff7f913a677f5) : !fir.ref<!fir.char<1,52>>
   %c5_i32 = arith.constant 5 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<2>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,52>>) -> !fir.ref<i8>
@@ -1230,7 +1230,7 @@ func.func @_QMtestPcount_generate_mask(%arg0: !fir.ref<!fir.array<10x10x!fir.log
   %7 = fir.shape %c0 : (index) -> !fir.shape<1>
   %8 = fir.embox %6(%7) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %9 = fir.address_of(@_QQcl_2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
+  %9 = fir.address_of(@_QQclX2E2F746573746661696C2E66393000) : !fir.ref<!fir.char<1,15>>
   %c11_i32 = arith.constant 11 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10x10x!fir.logical<4>>>) -> !fir.box<none>
@@ -1270,7 +1270,7 @@ func.func private @_FortranACountDim(!fir.ref<!fir.box<none>>, !fir.box<none>, i
 func.func @_QPmc(%arg0: !fir.box<!fir.array<?x?x?x!fir.logical<4>>> {fir.bindc_name = "m"}) -> i32 {
   %0 = fir.alloca i32 {bindc_name = "mc", uniq_name = "_QFmcEmc"}
   %c0 = arith.constant 0 : index
-  %1 = fir.address_of(@_QQcl_95529933117f47914fc21e220c1a0896) : !fir.ref<!fir.char<1,58>>
+  %1 = fir.address_of(@_QQclX95529933117f47914fc21e220c1a0896) : !fir.ref<!fir.char<1,58>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?x?x?x!fir.logical<4>>>) -> !fir.box<none>
   %3 = fir.convert %1 : (!fir.ref<!fir.char<1,58>>) -> !fir.ref<i8>
@@ -1298,7 +1298,7 @@ func.func @_QPtestAny_NoDimArg(%arg0: !fir.ref<!fir.array<10x!fir.logical<4>>> {
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<4>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<4>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1351,7 +1351,7 @@ func.func @_QPtestAny_NoDimArgLogical8(%arg0: !fir.ref<!fir.array<10x!fir.logica
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<8>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<8>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<8>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1414,7 +1414,7 @@ func.func @_QPtestAny_DimArg(%arg0: !fir.ref<!fir.array<10x10x!fir.logical<4>>> 
   %7 = fir.shape %c0 : (index) -> !fir.shape<1>
   %8 = fir.embox %6(%7) : (!fir.heap<!fir.array<?x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>
-  %9 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %9 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10x10x!fir.logical<4>>>) -> !fir.box<none>
@@ -1453,7 +1453,7 @@ func.func private @_FortranAAnyDim(!fir.ref<!fir.box<none>>, !fir.box<none>, i32
 func.func @_QPtestAny_UnknownDim(%arg0: !fir.box<!fir.array<?x!fir.logical<4>>> {fir.bindc_name = "a"}) -> !fir.logical<4> {
   %0 = fir.alloca !fir.logical<4> {bindc_name = "testAny_UnknownDim", uniq_name = "_QFtestAny_UnknownDimEtestAny_UnknownDim"}
   %c1 = arith.constant 1 : index
-  %1 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %1 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %2 = fir.convert %arg0 : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
   %3 = fir.convert %1 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1482,7 +1482,7 @@ func.func @_QPtestAny_2D(%arg0: !fir.ref<!fir.array<10x0x!fir.logical<4>>> {fir.
     %1 = fir.shape %c10, %c0 : (index, index) -> !fir.shape<2>
     %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x0x!fir.logical<4>>>, !fir.shape<2>) -> !fir.box<!fir.array<10x0x!fir.logical<4>>>
     %c1 = arith.constant 1 : index
-    %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+    %3 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
     %c3_i32 = arith.constant 3 : i32
     %4 = fir.convert %2 : (!fir.box<!fir.array<10x0x!fir.logical<4>>>) -> !fir.box<none>
     %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1540,7 +1540,7 @@ func.func @_QPtestAll_NoDimArg(%arg0: !fir.ref<!fir.array<10x!fir.logical<4>>> {
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<4>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<4>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1591,7 +1591,7 @@ func.func @_QPtestAll_NoDimArgLogical1(%arg0: !fir.ref<!fir.array<10x!fir.logica
   %1 = fir.shape %c10 : (index) -> !fir.shape<1>
   %2 = fir.embox %arg0(%1) : (!fir.ref<!fir.array<10x!fir.logical<1>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.logical<1>>>
   %c1 = arith.constant 1 : index
-  %3 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %3 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %4 = fir.convert %2 : (!fir.box<!fir.array<10x!fir.logical<1>>>) -> !fir.box<none>
   %5 = fir.convert %3 : (!fir.ref<!fir.char<1,48>>) -> !fir.ref<i8>
@@ -1653,7 +1653,7 @@ func.func @_QPtestAll_DimArg(%arg0: !fir.ref<!fir.array<10x10x!fir.logical<4>>> 
   %7 = fir.shape %c0 : (index) -> !fir.shape<1>
   %8 = fir.embox %6(%7) : (!fir.heap<!fir.array<?x!fir.logical<4>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>
-  %9 = fir.address_of(@_QQcl_04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
+  %9 = fir.address_of(@_QQclX04ab56883945fd2c21a3b6d132f0bb37) : !fir.ref<!fir.char<1,48>>
   %c3_i32 = arith.constant 3 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.logical<4>>>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10x10x!fir.logical<4>>>) -> !fir.box<none>
@@ -1707,7 +1707,7 @@ func.func @_QPtestminloc_works1d(%arg0: !fir.ref<!fir.array<10xi32>> {fir.bindc_
   %9 = fir.shape %c0 : (index) -> !fir.shape<1>
   %10 = fir.embox %8(%9) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %10 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %11 = fir.address_of(@_QQcl_ea5bcf7f706678e1796661f8916f3379) : !fir.ref<!fir.char<1,55>>
+  %11 = fir.address_of(@_QQclXea5bcf7f706678e1796661f8916f3379) : !fir.ref<!fir.char<1,55>>
   %c5_i32 = arith.constant 5 : i32
   %12 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %13 = fir.convert %5 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
@@ -1837,7 +1837,7 @@ func.func @_QPtestminloc_works2d_nomask(%arg0: !fir.ref<!fir.array<10x10xi32>> {
   %8 = fir.shape %c0 : (index) -> !fir.shape<1>
   %9 = fir.embox %7(%8) : (!fir.heap<!fir.array<?xi64>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi64>>>
   fir.store %9 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi64>>>>
-  %10 = fir.address_of(@_QQcl_cba8b79c45ccae77d79d66a39ac99823) : !fir.ref<!fir.char<1,62>>
+  %10 = fir.address_of(@_QQclXcba8b79c45ccae77d79d66a39ac99823) : !fir.ref<!fir.char<1,62>>
   %c4_i32 = arith.constant 4 : i32
   %11 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi64>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %5 : (!fir.box<!fir.array<10x10xi32>>) -> !fir.box<none>
@@ -1964,7 +1964,7 @@ func.func @_QPtestminloc_works1d_scalarmask_f64(%arg0: !fir.ref<!fir.array<10xf6
   %8 = fir.shape %c0 : (index) -> !fir.shape<1>
   %9 = fir.embox %7(%8) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %9 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %10 = fir.address_of(@_QQcl_66951c28c5b8bab5cdb25c1ac762b978) : !fir.ref<!fir.char<1,65>>
+  %10 = fir.address_of(@_QQclX66951c28c5b8bab5cdb25c1ac762b978) : !fir.ref<!fir.char<1,65>>
   %c6_i32 = arith.constant 6 : i32
   %11 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %5 : (!fir.box<!fir.array<10xf64>>) -> !fir.box<none>
@@ -2080,7 +2080,7 @@ func.func @_QPtestminloc_doesntwork1d_back(%arg0: !fir.ref<!fir.array<10xi32>> {
   %8 = fir.shape %c0 : (index) -> !fir.shape<1>
   %9 = fir.embox %7(%8) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %9 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %10 = fir.address_of(@_QQcl_3791f01d699716ba5914ae524c6a8dee) : !fir.ref<!fir.char<1,62>>
+  %10 = fir.address_of(@_QQclX3791f01d699716ba5914ae524c6a8dee) : !fir.ref<!fir.char<1,62>>
   %c4_i32 = arith.constant 4 : i32
   %11 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %12 = fir.convert %5 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
@@ -2133,7 +2133,7 @@ func.func @_QPtestminloc_doesntwork1d_dim(%arg0: !fir.ref<!fir.array<10xi32>> {f
   %7 = fir.zero_bits !fir.heap<i32>
   %8 = fir.embox %7 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
   fir.store %8 to %0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-  %9 = fir.address_of(@_QQcl_cfcf4329f25d06a4b02a0c8f532ee9df) : !fir.ref<!fir.char<1,61>>
+  %9 = fir.address_of(@_QQclXcfcf4329f25d06a4b02a0c8f532ee9df) : !fir.ref<!fir.char<1,61>>
   %c4_i32 = arith.constant 4 : i32
   %10 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
   %11 = fir.convert %5 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>
@@ -2179,7 +2179,7 @@ func.func @_QPtestminloc_doesntwork1d_unknownsize(%arg0: !fir.box<!fir.array<?xi
   %6 = fir.shape %c0 : (index) -> !fir.shape<1>
   %7 = fir.embox %5(%6) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %7 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %8 = fir.address_of(@_QQcl_2064f5e9298c2127417d52b69eac898e) : !fir.ref<!fir.char<1,69>>
+  %8 = fir.address_of(@_QQclX2064f5e9298c2127417d52b69eac898e) : !fir.ref<!fir.char<1,69>>
   %c4_i32 = arith.constant 4 : i32
   %9 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %10 = fir.convert %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
@@ -2234,7 +2234,7 @@ func.func @_QPtestminloc_doesntwork1d_chars(%arg0: !fir.boxchar<1> {fir.bindc_na
   %10 = fir.shape %c0 : (index) -> !fir.shape<1>
   %11 = fir.embox %9(%10) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %11 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %12 = fir.address_of(@_QQcl_74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
+  %12 = fir.address_of(@_QQclX74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
   %c4_i32 = arith.constant 4 : i32
   %13 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %14 = fir.convert %7 : (!fir.box<!fir.array<10x!fir.char<1>>>) -> !fir.box<none>
@@ -2315,7 +2315,7 @@ func.func @_QPtestminloc_doesntwork1d_unknownmask(%arg0: !fir.ref<!fir.array<10x
   %28 = fir.shape %c0_1 : (index) -> !fir.shape<1>
   %29 = fir.embox %27(%28) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
   fir.store %29 to %0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  %30 = fir.address_of(@_QQcl_74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
+  %30 = fir.address_of(@_QQclX74460ff3ef22ea53671c22344e1556b9) : !fir.ref<!fir.char<1,41>>
   %c7_i32 = arith.constant 7 : i32
   %31 = fir.convert %0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   %32 = fir.convert %16 : (!fir.box<!fir.array<10xi32>>) -> !fir.box<none>

--- a/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
+++ b/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
@@ -226,17 +226,17 @@ TEST_F(FIRBuilderTest, createGlobal2) {
 
 TEST_F(FIRBuilderTest, uniqueCFIdent) {
   auto str1 = fir::factory::uniqueCGIdent("", "func1");
-  EXPECT_EQ("_QQ_66756E6331", str1);
+  EXPECT_EQ("_QQX66756E6331", str1);
   str1 = fir::factory::uniqueCGIdent("", "");
-  EXPECT_EQ("_QQ_", str1);
+  EXPECT_EQ("_QQX", str1);
   str1 = fir::factory::uniqueCGIdent("pr", "func1");
-  EXPECT_EQ("_QQpr_66756E6331", str1);
+  EXPECT_EQ("_QQprX66756E6331", str1);
   str1 = fir::factory::uniqueCGIdent(
       "", "longnamemorethan32characterneedshashing");
-  EXPECT_EQ("_QQ_c22a886b2f30ea8c064ef1178377fc31", str1);
+  EXPECT_EQ("_QQXc22a886b2f30ea8c064ef1178377fc31", str1);
   str1 = fir::factory::uniqueCGIdent(
       "pr", "longnamemorethan32characterneedshashing");
-  EXPECT_EQ("_QQpr_c22a886b2f30ea8c064ef1178377fc31", str1);
+  EXPECT_EQ("_QQprXc22a886b2f30ea8c064ef1178377fc31", str1);
 }
 
 TEST_F(FIRBuilderTest, locationToLineNo) {

--- a/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
+++ b/flang/unittests/Optimizer/Builder/FIRBuilderTest.cpp
@@ -226,17 +226,17 @@ TEST_F(FIRBuilderTest, createGlobal2) {
 
 TEST_F(FIRBuilderTest, uniqueCFIdent) {
   auto str1 = fir::factory::uniqueCGIdent("", "func1");
-  EXPECT_EQ("_QQ.66756E6331", str1);
+  EXPECT_EQ("_QQ_66756E6331", str1);
   str1 = fir::factory::uniqueCGIdent("", "");
-  EXPECT_EQ("_QQ.", str1);
+  EXPECT_EQ("_QQ_", str1);
   str1 = fir::factory::uniqueCGIdent("pr", "func1");
-  EXPECT_EQ("_QQpr.66756E6331", str1);
+  EXPECT_EQ("_QQpr_66756E6331", str1);
   str1 = fir::factory::uniqueCGIdent(
       "", "longnamemorethan32characterneedshashing");
-  EXPECT_EQ("_QQ.c22a886b2f30ea8c064ef1178377fc31", str1);
+  EXPECT_EQ("_QQ_c22a886b2f30ea8c064ef1178377fc31", str1);
   str1 = fir::factory::uniqueCGIdent(
       "pr", "longnamemorethan32characterneedshashing");
-  EXPECT_EQ("_QQpr.c22a886b2f30ea8c064ef1178377fc31", str1);
+  EXPECT_EQ("_QQpr_c22a886b2f30ea8c064ef1178377fc31", str1);
 }
 
 TEST_F(FIRBuilderTest, locationToLineNo) {


### PR DESCRIPTION
Change the separator in the `uniqueCGIdent` method to `X`. This change is required to enable OpenMP offloading for the NVPTX target, as dots are not valid identifiers in PTX and `uniqueCGIdent` is used to mangle some literals. A follow up patch will add support for the NVPTX target.