### PR TITLE
[libclang/python] Expose Rewriter to the libclang python binding.

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3574,8 +3574,10 @@ class Rewriter(ClangObject):
     def overwriteChangedFiles(self):
         """
         Save all changed files to disk.
+
+        Returns 1 if any files were not saved successfully, returns 0 otherwise.
         """
-        conf.lib.clang_CXRewriter_overwriteChangedFiles(self)
+        return conf.lib.clang_CXRewriter_overwriteChangedFiles(self)
 
     def writeMainFileToStdOut(self):
         """

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3584,8 +3584,6 @@ class Rewriter(ClangObject):
         conf.lib.clang_CXRewriter_writeMainFileToStdOut(self)
 
 
-
-
 # Now comes the plumbing to hook up the C library.
 
 # Register callback types in common container.

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3531,6 +3531,61 @@ class Token(Structure):
         return cursor
 
 
+class Rewriter(ClangObject):
+    """
+    The Rewriter is a wrapper class around clang::Rewriter
+
+    It enables rewriting buffers.
+    """
+
+    @staticmethod
+    def create(tu):
+        """
+        Creates a new Rewriter
+        Parameters:
+        tu -- The translation unit for the target AST.
+        """
+        return Rewriter(conf.lib.clang_CXRewriter_create(tu))
+
+    def __init__(self, ptr):
+        ClangObject.__init__(self, ptr)
+
+    def __del__(self):
+        conf.lib.clang_CXRewriter_dispose(self)
+
+    def insertTextBefore(self, loc, insert):
+        """
+        Insert the specified string at the specified location in the original buffer.
+        """
+        conf.lib.clang_CXRewriter_insertTextBefore(self, loc, insert)
+
+    def replaceText(self, toBeReplaced, replacement):
+        """
+        This method replaces a range of characters in the input buffer with a new string.
+        """
+        conf.lib.clang_CXRewriter_replaceText(self, toBeReplaced, replacement)
+
+    def removeText(self, toBeRemoved):
+        """
+        Remove the specified text region.
+        """
+        conf.lib.clang_CXRewriter_removeText(self, toBeRemoved)
+
+    def overwriteChangedFiles(self):
+        """
+        Save all changed files to disk.
+        """
+        conf.lib.clang_CXRewriter_overwriteChangedFiles(self)
+
+    def writeMainFileToStdOut(self):
+        """
+        Writes the main file to stdout.
+        """
+        conf.lib.clang_CXRewriter_writeMainFileToStdOut(self)
+
+
+
+
 # Now comes the plumbing to hook up the C library.
 
 # Register callback types in common container.
@@ -3596,6 +3651,13 @@ functionList = [
     ("clang_codeCompleteGetNumDiagnostics", [CodeCompletionResults], c_int),
     ("clang_createIndex", [c_int, c_int], c_object_p),
     ("clang_createTranslationUnit", [Index, c_interop_string], c_object_p),
+    ("clang_CXRewriter_create", [TranslationUnit], c_object_p),
+    ("clang_CXRewriter_dispose", [Rewriter]),
+    ("clang_CXRewriter_insertTextBefore", [Rewriter, SourceLocation, c_interop_string]),
+    ("clang_CXRewriter_overwriteChangedFiles", [Rewriter], c_int),
+    ("clang_CXRewriter_removeText", [Rewriter, SourceRange]),
+    ("clang_CXRewriter_replaceText", [Rewriter, SourceRange, c_interop_string]),
+    ("clang_CXRewriter_writeMainFileToStdOut", [Rewriter]),
     ("clang_CXXConstructor_isConvertingConstructor", [Cursor], bool),
     ("clang_CXXConstructor_isCopyConstructor", [Cursor], bool),
     ("clang_CXXConstructor_isDefaultConstructor", [Cursor], bool),

--- a/clang/bindings/python/tests/cindex/test_rewrite.py
+++ b/clang/bindings/python/tests/cindex/test_rewrite.py
@@ -16,10 +16,6 @@ int f(int c) {
 }
 '''
 
-    @classmethod
-    def setUpClass(cls):
-        Config.set_compatibility_check(False)
-
     def setUp(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix='.cpp', buffering=0)
         self.tmp.write(TestRewrite.code.encode('utf-8'))

--- a/clang/bindings/python/tests/cindex/test_rewrite.py
+++ b/clang/bindings/python/tests/cindex/test_rewrite.py
@@ -3,7 +3,10 @@ import io
 import unittest
 import tempfile
 
-from clang.cindex import Rewriter, TranslationUnit, Config, File, SourceLocation, SourceRange
+from clang.cindex import (
+    Rewriter, TranslationUnit, Config, File, SourceLocation, SourceRange
+    )
+
 
 class TestRewrite(unittest.TestCase):
     code = '''

--- a/clang/bindings/python/tests/cindex/test_rewrite.py
+++ b/clang/bindings/python/tests/cindex/test_rewrite.py
@@ -4,12 +4,17 @@ import unittest
 import tempfile
 
 from clang.cindex import (
-    Rewriter, TranslationUnit, Config, File, SourceLocation, SourceRange
-    )
+    Rewriter,
+    TranslationUnit,
+    Config,
+    File,
+    SourceLocation,
+    SourceRange,
+)
 
 
 class TestRewrite(unittest.TestCase):
-    code = '''
+    code = """
 int test1;
 
 void test2(void);
@@ -17,11 +22,11 @@ void test2(void);
 int f(int c) {
     return c;
 }
-'''
+"""
 
     def setUp(self):
-        self.tmp = tempfile.NamedTemporaryFile(suffix='.cpp', buffering=0)
-        self.tmp.write(TestRewrite.code.encode('utf-8'))
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".cpp", buffering=0)
+        self.tmp.write(TestRewrite.code.encode("utf-8"))
         self.tmp.flush()
         self.tu = TranslationUnit.from_source(self.tmp.name)
         self.rew = Rewriter.create(self.tu)
@@ -30,44 +35,41 @@ int f(int c) {
     def tearDown(self):
         self.tmp.close()
 
-
     def test_insert(self):
-        snip = '#include <cstdio>\n'
+        snip = "#include <cstdio>\n"
 
         beginning = SourceLocation.from_offset(self.tu, self.file, 0)
         self.rew.insertTextBefore(beginning, snip)
         self.rew.overwriteChangedFiles()
 
-        with open(self.tmp.name, 'r', encoding='utf-8') as f:
+        with open(self.tmp.name, "r", encoding="utf-8") as f:
             self.assertEqual(f.read(), snip + TestRewrite.code)
 
-
     def test_replace(self):
-        pattern = 'test2'
-        replacement = 'func'
+        pattern = "test2"
+        replacement = "func"
 
         offset = TestRewrite.code.find(pattern)
         pattern_range = SourceRange.from_locations(
             SourceLocation.from_offset(self.tu, self.file, offset),
-            SourceLocation.from_offset(self.tu, self.file, offset + len(pattern))
-            )
+            SourceLocation.from_offset(self.tu, self.file, offset + len(pattern)),
+        )
         self.rew.replaceText(pattern_range, replacement)
         self.rew.overwriteChangedFiles()
 
-        with open(self.tmp.name, 'r', encoding='utf-8') as f:
+        with open(self.tmp.name, "r", encoding="utf-8") as f:
             self.assertEqual(f.read(), TestRewrite.code.replace(pattern, replacement))
 
-
     def test_remove(self):
-        pattern = 'int c'
+        pattern = "int c"
 
         offset = TestRewrite.code.find(pattern)
         pattern_range = SourceRange.from_locations(
             SourceLocation.from_offset(self.tu, self.file, offset),
-            SourceLocation.from_offset(self.tu, self.file, offset + len(pattern))
-            )
+            SourceLocation.from_offset(self.tu, self.file, offset + len(pattern)),
+        )
         self.rew.removeText(pattern_range)
         self.rew.overwriteChangedFiles()
 
-        with open(self.tmp.name, 'r', encoding='utf-8') as f:
-            self.assertEqual(f.read(), TestRewrite.code.replace(pattern, ''))
+        with open(self.tmp.name, "r", encoding="utf-8") as f:
+            self.assertEqual(f.read(), TestRewrite.code.replace(pattern, ""))

--- a/clang/bindings/python/tests/cindex/test_rewrite.py
+++ b/clang/bindings/python/tests/cindex/test_rewrite.py
@@ -1,0 +1,74 @@
+import sys
+import io
+import unittest
+import tempfile
+
+from clang.cindex import Rewriter, TranslationUnit, Config, File, SourceLocation, SourceRange
+
+class TestRewrite(unittest.TestCase):
+    code = '''
+int test1;
+
+void test2(void);
+
+int f(int c) {
+    return c;
+}
+'''
+
+    @classmethod
+    def setUpClass(cls):
+        Config.set_compatibility_check(False)
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.cpp', buffering=0)
+        self.tmp.write(TestRewrite.code.encode('utf-8'))
+        self.tmp.flush()
+        self.tu = TranslationUnit.from_source(self.tmp.name)
+        self.rew = Rewriter.create(self.tu)
+        self.file = File.from_name(self.tu, self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.close()
+
+
+    def test_insert(self):
+        snip = '#include <cstdio>\n'
+
+        beginning = SourceLocation.from_offset(self.tu, self.file, 0)
+        self.rew.insertTextBefore(beginning, snip)
+        self.rew.overwriteChangedFiles()
+
+        with open(self.tmp.name, 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), snip + TestRewrite.code)
+
+
+    def test_replace(self):
+        pattern = 'test2'
+        replacement = 'func'
+
+        offset = TestRewrite.code.find(pattern)
+        pattern_range = SourceRange.from_locations(
+            SourceLocation.from_offset(self.tu, self.file, offset),
+            SourceLocation.from_offset(self.tu, self.file, offset + len(pattern))
+            )
+        self.rew.replaceText(pattern_range, replacement)
+        self.rew.overwriteChangedFiles()
+
+        with open(self.tmp.name, 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), TestRewrite.code.replace(pattern, replacement))
+
+
+    def test_remove(self):
+        pattern = 'int c'
+
+        offset = TestRewrite.code.find(pattern)
+        pattern_range = SourceRange.from_locations(
+            SourceLocation.from_offset(self.tu, self.file, offset),
+            SourceLocation.from_offset(self.tu, self.file, offset + len(pattern))
+            )
+        self.rew.removeText(pattern_range)
+        self.rew.overwriteChangedFiles()
+
+        with open(self.tmp.name, 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), TestRewrite.code.replace(pattern, ''))


### PR DESCRIPTION
Exposes `CXRewriter` API to the python binding as in https://github.com/llvm/llvm-project/commit/69e5abb57b70570cf04671a93246e5e624023650.