### PR TITLE
[Transform]Export LowerSwitch Utility Function

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LowerSwitch.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerSwitch.h
@@ -15,12 +15,15 @@
 #ifndef LLVM_TRANSFORMS_UTILS_LOWERSWITCH_H
 #define LLVM_TRANSFORMS_UTILS_LOWERSWITCH_H
 
+#include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/LazyValueInfo.h"
 #include "llvm/IR/PassManager.h"
 
 namespace llvm {
 struct LowerSwitchPass : public PassInfoMixin<LowerSwitchPass> {
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
+bool LowerSwitch(Function &F, LazyValueInfo *LVI, AssumptionCache *AC);
 } // namespace llvm
 
 #endif // LLVM_TRANSFORMS_UTILS_LOWERSWITCH_H


### PR DESCRIPTION
This re-exports LowerSwitch Utility Function so transform passes that requires LowerSwitch internally doesnt have to mess with pass pipeline