### PR TITLE
[clang-format] Indent Verilog case statements with comments

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1208,8 +1208,10 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
 
   // Indentation of the statement following a Verilog case label is taken care
   // of in moveStateToNextToken.
-  if (Style.isVerilog() && Keywords.isVerilogEndOfLabel(Previous))
+  if (Style.isVerilog() && PreviousNonComment &&
+      Keywords.isVerilogEndOfLabel(*PreviousNonComment)) {
     return State.FirstIndent;
+  }
 
   if (Style.BreakBeforeBraces == FormatStyle::BS_Whitesmiths &&
       State.Line->First->is(tok::kw_enum)) {
@@ -1612,6 +1614,7 @@ unsigned ContinuationIndenter::moveStateToNextToken(LineState &State,
       State.NextToken->MustBreakBefore &&
       Keywords.isVerilogEndOfLabel(Current)) {
     State.FirstIndent += Style.IndentWidth;
+    CurrentState.Indent = State.FirstIndent;
   }
 
   unsigned Penalty =

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -344,6 +344,20 @@ TEST_F(FormatTestVerilog, Case) {
                "        longfunction( //\n"
                "            arg);\n"
                "endcase");
+  verifyFormat("case (data)\n"
+               "  16'd0:\n"
+               "    //\n"
+               "    result = //\n"
+               "        10'b0111111111;\n"
+               "endcase");
+  verifyFormat("case (data)\n"
+               "  16'd0:\n"
+               "    //\n"
+               "\n"
+               "    //\n"
+               "    result = //\n"
+               "        10'b0111111111;\n"
+               "endcase");
   Style = getDefaultStyle();
   Style.ContinuationIndentWidth = 1;
   verifyFormat("case (data)\n"


### PR DESCRIPTION
If a line contains a comment outside of (fake) parentheses, the part following it is indented according to `CurrentState.Indent`.  A Verilog case label and the statement that follows are broken with mustBreakBefore.  So the part that follows the case label needs some special handling.  Previously, that variable was left out.  So the indentation was wrong when there was a comment.

old:

```Verilog
case (data)
  16'd0:
    result = //
        10'b0111111111;
endcase
case (data)
  16'd0:
    //

  //
  result = //
  10'b0111111111;
endcase
```

new:

```Verilog
case (data)
  16'd0:
    result = //
        10'b0111111111;
endcase
case (data)
  16'd0:
    //

    //
    result = //
        10'b0111111111;
endcase
```