### PR TITLE
[clang-format] Add space in Verilog tagged unions

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -4727,8 +4727,15 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
         Left.isOneOf(TT_VerilogDimensionedTypeName, Keywords.kw_function)) {
       return true;
     }
+    // In a tagged union expression, there should be a space after the tag.
+    if (Right.isOneOf(tok::period, Keywords.kw_apostrophe) &&
+        Keywords.isVerilogIdentifier(Left) && Left.getPreviousNonComment() &&
+        Left.getPreviousNonComment()->is(Keywords.kw_tagged)) {
+      return true;
+    }
     // Don't add spaces between a casting type and the quote or repetition count
-    // and the brace.
+    // and the brace.  The case of tagged union expressions is handled by the
+    // previous rule.
     if ((Right.is(Keywords.kw_apostrophe) ||
          (Right.is(BK_BracedInit) && Right.is(tok::l_brace))) &&
         !(Left.isOneOf(Keywords.kw_assign, Keywords.kw_unique) ||

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -4734,7 +4734,7 @@ bool TokenAnnotator::spaceRequiredBefore(const AnnotatedLine &Line,
       return true;
     }
     // Don't add spaces between a casting type and the quote or repetition count
-    // and the brace.  The case of tagged union expressions is handled by the
+    // and the brace. The case of tagged union expressions is handled by the
     // previous rule.
     if ((Right.is(Keywords.kw_apostrophe) ||
          (Right.is(BK_BracedInit) && Right.is(tok::l_brace))) &&

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -359,6 +359,11 @@ TEST_F(FormatTestVerilog, Case) {
                "      arg);\n"
                "endcase",
                Style);
+
+  verifyFormat("case (v) matches\n"
+               "  tagged Valid .n:\n"
+               "    ;\n"
+               "endcase");
 }
 
 TEST_F(FormatTestVerilog, Coverage) {
@@ -1278,12 +1283,17 @@ TEST_F(FormatTestVerilog, StructLiteral) {
   verifyFormat("c = '{'{1, 1.0}, '{2, 2.0}};");
   verifyFormat("c = '{a: 0, b: 0.0};");
   verifyFormat("c = '{a: 0, b: 0.0, default: 0};");
+  verifyFormat("d = {int: 1, shortreal: 1.0};");
+  verifyFormat("c = '{default: 0};");
+
+  // The identifier before the quote can be either a tag or a type case.  There
+  // should be a space between the tag and the quote.
   verifyFormat("c = ab'{a: 0, b: 0.0};");
   verifyFormat("c = ab'{cd: cd'{1, 1.0}, ef: ef'{2, 2.0}};");
   verifyFormat("c = ab'{cd'{1, 1.0}, ef'{2, 2.0}};");
-  verifyFormat("d = {int: 1, shortreal: 1.0};");
   verifyFormat("d = ab'{int: 1, shortreal: 1.0};");
-  verifyFormat("c = '{default: 0};");
+  verifyFormat("x = tagged Add '{e1, 4, ed};");
+
   auto Style = getDefaultStyle();
   Style.SpacesInContainerLiterals = true;
   verifyFormat("c = '{a : 0, b : 0.0};", Style);


### PR DESCRIPTION
In a tagged union expression, there should be a space between the field name and the data.  Previously, the tag could be recognized as part of a dotted identifier or a struct literal, and the space would be omitted.