### PR TITLE
TableGen support for RegisterBankInfo

### DIFF
--- a/llvm/test/TableGen/RegisterBankEmitter.td
+++ b/llvm/test/TableGen/RegisterBankEmitter.td
@@ -22,3 +22,4 @@ def GPRRegBank : RegisterBank<"GPR", [ClassA]>;
 // CHECK: PMI_ClassA,
 // CHECK: const int BankIDToRegisterClassCount
 // CHECK: 1,
+

--- a/llvm/test/TableGen/RegisterBankEmitter.td
+++ b/llvm/test/TableGen/RegisterBankEmitter.td
@@ -21,3 +21,4 @@ def GPRRegBank : RegisterBank<"GPR", [ClassA]>;
 // CHECK: const PartialMappingIdx BankIDToFirstRegisterClassIdx
 // CHECK: PMI_ClassA,
 // CHECK: const int BankIDToRegisterClassCount
+// CHECK: 1,

--- a/llvm/test/TableGen/RegisterBankEmitter.td
+++ b/llvm/test/TableGen/RegisterBankEmitter.td
@@ -16,10 +16,16 @@ def GPRRegBank : RegisterBank<"GPR", [ClassA]>;
 
 // CHECK: enum PartialMappingIdx
 // CHECK: PMI_ClassA = 0,
-// CHECK: const RegisterBankInfo::PartialMapping PartMappings
+// CHECK: const RegisterBankInfo::PartialMapping PartialMappings
 // CHECK: { 0, 32, GPRRegBank },
 // CHECK: const PartialMappingIdx BankIDToFirstRegisterClassIdx
 // CHECK: PMI_ClassA,
 // CHECK: const int BankIDToRegisterClassCount
 // CHECK: 1,
+// CHECK: const RegisterBankInfo::ValueMapping ValueMappings
+// CHECK: PMI_ClassA
+// CHECK: PMI_ClassA
+// CHECK: PMI_ClassA
+// CHECK: enum ValueMappingIdx
+// CHECK: VMI_ClassA
 

--- a/llvm/test/TableGen/RegisterBankEmitter.td
+++ b/llvm/test/TableGen/RegisterBankEmitter.td
@@ -13,3 +13,9 @@ let Size = 32 in {
 // CHECK: MyTarget::ClassARegClassID
 // CHECK: MyTarget::ClassBRegClassID
 def GPRRegBank : RegisterBank<"GPR", [ClassA]>;
+
+// CHECK: enum PartialMappingIdx
+// CHECK: const RegisterBankInfo::PartialMapping PartMappings
+// CHECK: const PartialMappingIdx BankIDToFirstRegisterClassIdx
+// CHECK: const int BankIDToRegisterClassCount
+  

--- a/llvm/test/TableGen/RegisterBankEmitter.td
+++ b/llvm/test/TableGen/RegisterBankEmitter.td
@@ -15,7 +15,9 @@ let Size = 32 in {
 def GPRRegBank : RegisterBank<"GPR", [ClassA]>;
 
 // CHECK: enum PartialMappingIdx
+// CHECK: PMI_ClassA = 0,
 // CHECK: const RegisterBankInfo::PartialMapping PartMappings
+// CHECK: { 0, 32, GPRRegBank },
 // CHECK: const PartialMappingIdx BankIDToFirstRegisterClassIdx
+// CHECK: PMI_ClassA,
 // CHECK: const int BankIDToRegisterClassCount
-  

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -295,6 +295,7 @@ void RegisterBankEmitter::emitBaseClassImplementation(
      << "} // end namespace llvm\n";
 }
 
+// RegisterBankInfo tables and enums are discussed in https://discourse.llvm.org/t/74459
 void RegisterBankEmitter::emitRBIHeader(
     raw_ostream &OS, const StringRef TargetName,
     const std::vector<RegisterBank> &Banks) {

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -332,12 +332,15 @@ void RegisterBankEmitter::emitRBIImplementation(
     for (const CodeGenRegisterClass *RC :
          Bank.getExplicitlySpecifiedRegisterClasses(RegisterClassHierarchy)) {
       if (RC->RSI.isSimple()) {
-        // StartIdx is currently 0 in all of the in-tree backends
-        OS << "  { 0, " << RC->RSI.getSimple().RegSize << ", "
-           << Bank.getInstanceVarName() << " },\n";
+        if (RC->getValueTypes()[0].getSimple() != MVT::Untyped) {
+          // StartIdx is currently 0 in all of the in-tree backends
+          OS << "  { 0, " << RC->RSI.getSimple().RegSize << ", "
+             << Bank.getInstanceVarName() << " },\n";
+        } else {
+          OS << "  #error Untyped RegisterClass " << RC->getName() << "\n";
+        }
       } else {
-        // FIXME: dumb workaround for RISCV assert() for now
-        OS << " // non-Simple() RegisterClass " << RC->getName() << "\n";
+        OS << "  #error non-Simple() RegisterClass " << RC->getName() << "\n";
       }
     }
   }

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -299,18 +299,15 @@ void RegisterBankEmitter::emitBaseClassImplementation(
      << "} // end namespace llvm\n";
 }
 
-// TableGen already had some RegisterBankInfo support:
-// TargetGenRegisterBankInfo(), RegBankIDs enum, RegBanks and Sizes.
-// This emitter adds support for PartialMappings, PartialMappingIdx
-// and BankIDToCopyMapIdx.
-//
-// The original implementation was supposed to infer RegisterClasses.
-// But since that wasn't finished, backends instead embedded hand crafted
-// tables and enums. This emitter generates them from .td files
-// but requires that the .td files fully describe their RegisterBanks.
+// This emitter generates PartialMappings, PartialMappingIdx,
+// BankIDToCopyMapIdx and BankIDToRegisterClassCount from the .td files.
+// However it requires that the .td files fully describe their RegisterBanks
+// and otherwise emits #error lines for the offending Registers.
 //
 // These tables and enums are enabled by GET_REGBANKINFO_DECLARATIONS,
 // GET_REGBANKINFO_PARTIALMAPPINGS and GET_REGBANKINFO_VALUEMAPPINGS
+// So a backend which doesn't fully describe its RegisterBanks
+// will not break if it doesn't define these macros.
 //
 // This was discussed in https://discourse.llvm.org/t/74459
 void RegisterBankEmitter::emitRBIHeader(

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -240,8 +240,7 @@ void RegisterBankEmitter::emitBaseClassImplementation(
          << "\n";
       for (const auto &RC : RCs) {
         std::string QualifiedRegClassID =
-            (Twine(RC->Namespace) + "::" + RC->getName()
-            + "RegClassID").str();
+            (Twine(RC->Namespace) + "::" + RC->getName() + "RegClassID").str();
         OS << "    (1u << (" << QualifiedRegClassID << " - " << LowestIdxInWord
            << ")) |\n";
       }

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -116,7 +116,7 @@ private:
   void emitRBIHeader(raw_ostream &OS, const StringRef TargetName,
                      const std::vector<RegisterBank> &Banks);
   void emitRBIImplementation(raw_ostream &OS, const StringRef TargetName,
-                   const std::vector<RegisterBank> &Banks);
+                             const std::vector<RegisterBank> &Banks);
 
 public:
   RegisterBankEmitter(RecordKeeper &R) : Target(R), Records(R) {}
@@ -237,8 +237,8 @@ void RegisterBankEmitter::emitBaseClassImplementation(
       for (const auto &RC : RCs) {
         std::string QualifiedRegClassID =
             (Twine(RC->Namespace) + "::" + RC->getName() + "RegClassID").str();
-        OS << "    (1u << (" << QualifiedRegClassID << " - "
-           << LowestIdxInWord << ")) |\n";
+        OS << "    (1u << (" << QualifiedRegClassID << " - " << LowestIdxInWord
+           << ")) |\n";
       }
       OS << "    0,\n";
       LowestIdxInWord += 32;
@@ -318,9 +318,10 @@ void RegisterBankEmitter::emitRBIHeader(
      << "} // end namespace llvm\n";
 }
 
-void RegisterBankEmitter::emitRBIImplementation(raw_ostream &OS,
-                                      const StringRef TargetName,
-                                      const std::vector<RegisterBank> &Banks) {
+void RegisterBankEmitter::emitRBIImplementation(
+    raw_ostream &OS,
+    const StringRef TargetName,
+    const std::vector<RegisterBank> &Banks) {
   const CodeGenRegBank &RegisterClassHierarchy = Target.getRegBank();
 
   OS << "namespace llvm {\n"

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -325,7 +325,7 @@ void RegisterBankEmitter::emitRBIImplementation(raw_ostream &OS,
 
   OS << "namespace llvm {\n"
      << "namespace " << TargetName << " {\n"
-     << "RegisterBankInfo::PartialMapping PartMappings[] = {\n";
+     << "const RegisterBankInfo::PartialMapping PartMappings[] = {\n";
   for (const auto &Bank : Banks) {
     for (const CodeGenRegisterClass *RC :
          Bank.getExplicitlySpecifiedRegisterClasses(RegisterClassHierarchy)) {
@@ -342,7 +342,7 @@ void RegisterBankEmitter::emitRBIImplementation(raw_ostream &OS,
   OS << "};\n\n";
 
   // emit PartialMappingIdx of the first Register Class of each Register Bank
-  OS << "PartialMappingIdx BankIDToFirstRegisterClassIdx[] = {\n";
+  OS << "const PartialMappingIdx BankIDToFirstRegisterClassIdx[] = {\n";
   for (const auto &Bank : Banks) {
     OS << "  PMI_"
        << Bank.getExplicitlySpecifiedRegisterClasses(RegisterClassHierarchy)[0]
@@ -352,7 +352,7 @@ void RegisterBankEmitter::emitRBIImplementation(raw_ostream &OS,
   OS << "};\n\n";
 
   // emit count of Register Classes of each Register Bank
-  OS << "int BankIDToRegisterClassCount[] = {\n";
+  OS << "const int BankIDToRegisterClassCount[] = {\n";
   for (const auto &Bank : Banks) {
     OS << "  "
        << Bank.getExplicitlySpecifiedRegisterClasses(RegisterClassHierarchy)

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -295,7 +295,8 @@ void RegisterBankEmitter::emitBaseClassImplementation(
      << "} // end namespace llvm\n";
 }
 
-// RegisterBankInfo tables and enums are discussed in https://discourse.llvm.org/t/74459
+// RegisterBankInfo tables and enums
+// are discussed in https://discourse.llvm.org/t/74459
 void RegisterBankEmitter::emitRBIHeader(
     raw_ostream &OS, const StringRef TargetName,
     const std::vector<RegisterBank> &Banks) {

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -319,8 +319,7 @@ void RegisterBankEmitter::emitRBIHeader(
 }
 
 void RegisterBankEmitter::emitRBIImplementation(
-    raw_ostream &OS,
-    const StringRef TargetName,
+    raw_ostream &OS, const StringRef TargetName,
     const std::vector<RegisterBank> &Banks) {
   const CodeGenRegBank &RegisterClassHierarchy = Target.getRegBank();
 


### PR DESCRIPTION
This is a continuation of #70895

TableGen generates boilerplate code from definition files. It already has some RegisterBankInfo support: TargetGenRegisterBankInfo(), RegBankIDs enum, RegBanks and Sizes. But it is missing support for PartialMappingIdx and PartMappings. This adds support for that. It is discussed in

https://discourse.llvm.org/t/rfc-tablegen-support-for-registerbankinfo/