### PR TITLE
[clangd] Carefully handle PseudoObjectExprs for inlay hints

### DIFF
--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -591,13 +591,13 @@ public:
 
   bool dataTraverseStmtPre(Stmt *S) {
     // Do not show inlay hints for PseudoObjectExprs. They're never
-    // genuine user codes in C++.
+    // genuine user codes.
     //
     // For example, __builtin_dump_struct would expand to a PseudoObjectExpr
     // that includes a couple of calls to a printf function. Printing parameter
     // names for that anyway would end up with duplicate parameter names (which,
     // however, got de-duplicated after visiting) for the printf function.
-    if (AST.getLangOpts().CPlusPlus && isa<PseudoObjectExpr>(S))
+    if (isa<PseudoObjectExpr>(S))
       return false;
     return true;
   }

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -589,6 +589,19 @@ public:
     return true;
   }
 
+  bool dataTraverseStmtPre(Stmt *S) {
+    // Do not show inlay hints for PseudoObjectExprs. They're never
+    // genuine user codes in C++.
+    //
+    // For example, __builtin_dump_struct would expand to a PseudoObjectExpr
+    // that includes a couple of calls to a printf function. Printing parameter
+    // names for that anyway would end up with duplicate parameter names (which,
+    // however, got de-duplicated after visiting) for the printf function.
+    if (AST.getLangOpts().CPlusPlus && isa<PseudoObjectExpr>(S))
+      return false;
+    return true;
+  }
+
   bool VisitCallExpr(CallExpr *E) {
     if (!Cfg.InlayHints.Parameters)
       return true;

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -590,15 +590,15 @@ public:
   }
 
   bool dataTraverseStmtPre(Stmt *S) {
-    // Do not show inlay hints for PseudoObjectExprs. They're never
-    // genuine user codes.
-    //
-    // For example, __builtin_dump_struct would expand to a PseudoObjectExpr
-    // that includes a couple of calls to a printf function. Printing parameter
-    // names for that anyway would end up with duplicate parameter names (which,
-    // however, got de-duplicated after visiting) for the printf function.
-    if (isa<PseudoObjectExpr>(S))
-      return false;
+    // Do not show inlay hints for the __builtin_dump_struct, which would expand
+    // to a PseudoObjectExpr that includes a couple of calls to a printf
+    // function. Printing parameter names for that anyway would end up with
+    // duplicate parameter names (which, however, got de-duplicated after
+    // visiting) for the printf function.
+    if (auto *POE = dyn_cast<PseudoObjectExpr>(S))
+      if (auto *CE = dyn_cast<CallExpr>(POE->getSyntacticForm());
+          CE && CE->getBuiltinCallee() == Builtin::BI__builtin_dump_struct)
+        return false;
     return true;
   }
 

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -589,17 +589,22 @@ public:
     return true;
   }
 
-  bool dataTraverseStmtPre(Stmt *S) {
-    // Do not show inlay hints for the __builtin_dump_struct, which would expand
-    // to a PseudoObjectExpr that includes a couple of calls to a printf
-    // function. Printing parameter names for that anyway would end up with
-    // duplicate parameter names (which, however, got de-duplicated after
+  bool TraversePseudoObjectExpr(PseudoObjectExpr *E) {
+    // Do not show inlay hints for the __builtin_dump_struct, which would
+    // expand to a PseudoObjectExpr that includes a couple of calls to a
+    // printf function. Printing parameter names for that anyway would end up
+    // with duplicate parameter names (which, however, got de-duplicated after
     // visiting) for the printf function.
-    if (auto *POE = dyn_cast<PseudoObjectExpr>(S))
-      if (auto *CE = dyn_cast<CallExpr>(POE->getSyntacticForm());
-          CE && CE->getBuiltinCallee() == Builtin::BI__builtin_dump_struct)
-        return false;
-    return true;
+    if (auto *CE = dyn_cast<CallExpr>(E->getSyntacticForm());
+        CE && CE->getBuiltinCallee() == Builtin::BI__builtin_dump_struct)
+      // Only traverse the syntactic forms. This leaves the door open in case
+      // the arguments in the syntactic form for __builtin_dump_struct could
+      // possibly get parameter names.
+      return RecursiveASTVisitor<InlayHintVisitor>::TraverseStmt(
+          E->getSyntacticForm());
+    // FIXME: Shall we ignore semantic forms for other pseudo object
+    // expressions?
+    return RecursiveASTVisitor<InlayHintVisitor>::TraversePseudoObjectExpr(E);
   }
 
   bool VisitCallExpr(CallExpr *E) {

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1729,7 +1729,7 @@ TEST(ParameterHints, PseudoObjectExpr) {
     struct S {
       __declspec(property(get=GetX, put=PutX)) int x[];
       int GetX(int y, int z) { return 42 + y; }
-      void PutX(int y) { x = y; } // Not `x = y: y`
+      void PutX(int y) { x = $one[[y]]; } // FIXME: Undesired `x = y: y` for this ill-formed expression.
     };
 
     int printf(const char *Format, ...);
@@ -1738,14 +1738,17 @@ TEST(ParameterHints, PseudoObjectExpr) {
       S s;
       __builtin_dump_struct(&s, printf); // Not `Format: __builtin_dump_struct()`
       printf($Param[["Hello, %d"]], 42); // Normal calls are not affected.
-      return s.x[1][2]; // Not `x[y: 1][z: 2]`
+      return s.x[ $two[[1]] ][ $three[[2]] ]; // `x[y: 1][z: 2]`
     }
   )cpp");
   auto TU = TestTU::withCode(Code.code());
   TU.ExtraArgs.push_back("-fms-extensions");
   auto AST = TU.build();
   EXPECT_THAT(inlayHints(AST, std::nullopt),
-              ElementsAre(HintMatcher(ExpectedHint{"Format: ", "Param"}, Code)));
+              ElementsAre(HintMatcher(ExpectedHint{"y: ", "one"}, Code),
+                          HintMatcher(ExpectedHint{"Format: ", "Param"}, Code),
+                          HintMatcher(ExpectedHint{"y: ", "two"}, Code),
+                          HintMatcher(ExpectedHint{"z: ", "three"}, Code)));
 }
 
 TEST(ParameterHints, ArgPacksAndConstructors) {

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1724,6 +1724,30 @@ TEST(InlayHints, RestrictRange) {
               ElementsAre(labelIs(": int"), labelIs(": char")));
 }
 
+TEST(ParameterHints, PseudoObjectExpr) {
+  Annotations Code(R"cpp(
+    struct S {
+      __declspec(property(get=GetX, put=PutX)) int x[];
+      int GetX(int y, int z) { return 42 + y; }
+      void PutX(int y) { x = y; } // Not `x = y: y`
+    };
+
+    int printf(const char *Format, ...);
+
+    int main() {
+      S s;
+      __builtin_dump_struct(&s, printf); // Not `Format: __builtin_dump_struct()`
+      printf($Param[["Hello, %d"]], 42); // Normal calls are not affected.
+      return s.x[1][2]; // Not `x[y: 1][z: 2]`
+    }
+  )cpp");
+  auto TU = TestTU::withCode(Code.code());
+  TU.ExtraArgs.push_back("-fms-extensions");
+  auto AST = TU.build();
+  EXPECT_THAT(inlayHints(AST, std::nullopt),
+              ElementsAre(HintMatcher(ExpectedHint{"Format: ", "Param"}, Code)));
+}
+
 TEST(ParameterHints, ArgPacksAndConstructors) {
   assertParameterHints(
       R"cpp(

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1729,7 +1729,8 @@ TEST(ParameterHints, PseudoObjectExpr) {
     struct S {
       __declspec(property(get=GetX, put=PutX)) int x[];
       int GetX(int y, int z) { return 42 + y; }
-      void PutX(int y) { x = $one[[y]]; } // FIXME: Undesired `x = y: y` for this ill-formed expression.
+      // FIXME: Undesired hint `x = y: y`.
+      void PutX(int y) { x = $one[[y]]; }
     };
 
     int printf(const char *Format, ...);
@@ -1738,6 +1739,8 @@ TEST(ParameterHints, PseudoObjectExpr) {
       S s;
       __builtin_dump_struct(&s, printf); // Not `Format: __builtin_dump_struct()`
       printf($Param[["Hello, %d"]], 42); // Normal calls are not affected.
+      // This builds a PseudoObjectExpr, but here it's useful for showing the
+      // arguments from the semantic form.
       return s.x[ $two[[1]] ][ $three[[2]] ]; // `x[y: 1][z: 2]`
     }
   )cpp");

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1729,7 +1729,7 @@ TEST(ParameterHints, PseudoObjectExpr) {
     struct S {
       __declspec(property(get=GetX, put=PutX)) int x[];
       int GetX(int y, int z) { return 42 + y; }
-      // FIXME: Undesired hint `x = y: y`.
+      // FIXME: Undesired hint `x = y: y`. This builds a PseudoObjectExpr too.
       void PutX(int y) { x = $one[[y]]; }
     };
 


### PR DESCRIPTION
This closes https://github.com/clangd/clangd/issues/1813.

Not all subexpressions for a PseudoObjectExpr are interesting, and they probably mess up inlay hints.