### PR TITLE
[lldb][test] TestVTableValue.py: skip test for older versions of clang

### DIFF
--- a/lldb/test/API/functionalities/vtable/TestVTableValue.py
+++ b/lldb/test/API/functionalities/vtable/TestVTableValue.py
@@ -14,6 +14,7 @@ class TestVTableValue(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIf(compiler="clang", compiler_version=["<", "9.0"])
     @skipUnlessPlatform(["linux", "macosx"])
     def test_vtable(self):
         self.build()


### PR DESCRIPTION
This fails on the matrix build bot for Clang versions < 9.0

https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake-matrix/7309/execution/node/102/log/?consoleFull

```
FAIL: LLDB :: test_vtable (TestVTableValue.TestVTableValue)
<bound method SBProcess.Kill of SBProcess: pid = 35338, state = stopped, threads = 1, executable = a.out>: success

======================================================================
FAIL: test_base_class_ptr (TestVTableValue.TestVTableValue)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "lldb/test/API/functionalities/vtable/TestVTableValue.py", line 90, in test_base_class_ptr
    self.assertEquals(shape_ptr_vtable.GetNumChildren(), 5)
AssertionError: 6 != 5
======================================================================
FAIL: test_vtable (TestVTableValue.TestVTableValue)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "lldb/test/API/functionalities/vtable/TestVTableValue.py", line 67, in test_vtable
    self.assertEquals(vtable.GetNumChildren(), 5)
AssertionError: 6 != 5
----------------------------------------------------------------------
Ran 4 tests in 2.799s

RESULT: FAILED (2 passes, 2 failures, 0 errors, 0 skipped, 0 expected failures, 0 unexpected successes)
```