### PR TITLE
[mlir][emitc] Fix corner case in translation of literal ops

### DIFF
--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -425,12 +425,13 @@ static LogicalResult printOperation(CppEmitter &emitter, emitc::CallOp callOp) {
       // Index attributes are treated specially as operand index.
       if (t.getType().isIndex()) {
         int64_t idx = t.getInt();
-        if ((idx < 0) || (idx >= op.getNumOperands()))
-          return op.emitOpError("invalid operand index");
-        if (!emitter.hasValueInScope(op.getOperand(idx)))
+        Value operand = op.getOperand(idx);
+        auto literalDef =
+            dyn_cast_if_present<LiteralOp>(operand.getDefiningOp());
+        if (!literalDef && !emitter.hasValueInScope(operand))
           return op.emitOpError("operand ")
                  << idx << "'s value not defined in scope";
-        os << emitter.getOrCreateName(op.getOperand(idx));
+        os << emitter.getOrCreateName(operand);
         return success();
       }
     }

--- a/mlir/test/Target/Cpp/literal_call_operand.mlir
+++ b/mlir/test/Target/Cpp/literal_call_operand.mlir
@@ -12,3 +12,15 @@ func.func @emitc_call_operand() {
 // CPP-DECLTOP: void emitc_call_operand() {
 // CPP-DECLTOP-NEXT: float v1;
 // CPP-DECLTOP-NEXT: v1 = foo(M_PI);
+
+func.func @emitc_call_operand_arg() {
+  %p0 = emitc.literal "M_PI" : f32
+  %1 = emitc.call "bar"(%p0) {args = [42 : i32, 0 : index]} : (f32) -> f32
+  return
+}
+// CPP-DEFAULT: void emitc_call_operand_arg() {
+// CPP-DEFAULT-NEXT: float v1 = bar(42, M_PI);
+
+// CPP-DECLTOP: void emitc_call_operand_arg() {
+// CPP-DECLTOP-NEXT: float v1;
+// CPP-DECLTOP-NEXT: v1 = bar(42, M_PI);


### PR DESCRIPTION
Fix a corner case missed in #71296 when operands generated by literals are mixed with the args attribute of a call op.

Additionally remove a range check that is already handled by the CallOp verifier.