### PR TITLE
[clang-repl] Fix BUILD_SHARED_LIBS symbols from libclangInterpreter on MinGW

### DIFF
--- a/clang/lib/Interpreter/CMakeLists.txt
+++ b/clang/lib/Interpreter/CMakeLists.txt
@@ -38,3 +38,14 @@ add_clang_library(clangInterpreter
   clangSema
   clangSerialization
   )
+
+if ((MINGW OR CYGWIN) AND BUILD_SHARED_LIBS)
+  # The DLLs are supposed to export all symbols (except for ones that are
+  # explicitly hidden). Normally, this is what happens anyway, but if there
+  # are symbols that are marked explicitly as dllexport, we'd only export them
+  # and nothing else. The Interpreter contains a few cases of such dllexports
+  # (for symbols that need to be exported even from standalone exe files);
+  # therefore, add --export-all-symbols to make sure we export all symbols
+  # despite potential dllexports.
+  target_link_options(clangInterpreter PRIVATE LINKER:--export-all-symbols)
+endif()


### PR DESCRIPTION
A few symbols within libclangInterpreter have got explicit dllexport attributes, in order to make them exported (and thus visible at runtime) in any build, not only when they are part of e.g. a DLL libclang-cpp, but also when they are part of a plain .exe.

Due to the explicit dllexports, these symbols would sidestep the regular MinGW logic of exporting all symbols if there are no dllexports. Therefore, for libclang-cpp, a separate fix was made in 592e935e115ffb451eb9b782376711dab6558fe0, to pass --export-all-symbols to the build of libclang-cpp.

If building with BUILD_SHARED_LIBS enabled, then the same issue appears in libclangInterpreter; pass the same flag --export-all-symbols there as well, to make sure all symbols are visible, not only the ones that are explicitly marked as dllexport.