### PR TITLE
[lldb] Add template method for getting const or mutable regs from DynamicRegisterInfo

### DIFF
--- a/lldb/include/lldb/Target/DynamicRegisterInfo.h
+++ b/lldb/include/lldb/Target/DynamicRegisterInfo.h
@@ -90,7 +90,7 @@ public:
 
   typedef std::vector<lldb_private::RegisterInfo> reg_collection;
 
-  template <typename T> T registers();
+  template <typename T> T registers() = delete;
 
   typedef llvm::iterator_range<reg_collection::const_iterator>
       reg_collection_const_range;

--- a/lldb/include/lldb/Target/DynamicRegisterInfo.h
+++ b/lldb/include/lldb/Target/DynamicRegisterInfo.h
@@ -89,12 +89,18 @@ public:
   GetRegisterInfo(llvm::StringRef reg_name) const;
 
   typedef std::vector<lldb_private::RegisterInfo> reg_collection;
-  llvm::iterator_range<reg_collection::const_iterator> registers() const {
-    return llvm::iterator_range<reg_collection::const_iterator>(m_regs);
+
+  template <typename T> T registers();
+
+  typedef llvm::iterator_range<reg_collection::const_iterator>
+      reg_collection_const_range;
+  template <> reg_collection_const_range registers() {
+    return reg_collection_const_range(m_regs);
   }
 
-  llvm::iterator_range<reg_collection::iterator> registers_mutable() {
-    return llvm::iterator_range<reg_collection::iterator>(m_regs);
+  typedef llvm::iterator_range<reg_collection::iterator> reg_collection_range;
+  template <> reg_collection_range registers() {
+    return reg_collection_range(m_regs);
   }
 
   void ConfigureOffsets();

--- a/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
+++ b/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
@@ -38,11 +38,9 @@ ArchitectureAArch64::Create(const ArchSpec &arch) {
   return std::unique_ptr<Architecture>(new ArchitectureAArch64());
 }
 
-static void UpdateARM64SVERegistersInfos(
-    llvm::iterator_range<
-        lldb_private::DynamicRegisterInfo::reg_collection::iterator>
-        regs,
-    uint64_t vg) {
+static void
+UpdateARM64SVERegistersInfos(DynamicRegisterInfo::reg_collection_range regs,
+                             uint64_t vg) {
   // SVE Z register size is vg x 8 bytes.
   uint32_t z_reg_byte_size = vg * 8;
 
@@ -62,11 +60,9 @@ static void UpdateARM64SVERegistersInfos(
   }
 }
 
-static void UpdateARM64SMERegistersInfos(
-    llvm::iterator_range<
-        lldb_private::DynamicRegisterInfo::reg_collection::iterator>
-        regs,
-    uint64_t svg) {
+static void
+UpdateARM64SMERegistersInfos(DynamicRegisterInfo::reg_collection_range regs,
+                             uint64_t svg) {
   for (auto &reg : regs) {
     if (strcmp(reg.name, "za") == 0) {
       // ZA is a register with size (svg*8) * (svg*8). A square essentially.
@@ -108,10 +104,11 @@ bool ArchitectureAArch64::ReconfigureRegisterInfo(DynamicRegisterInfo &reg_info,
   if (!vg_reg_value && !svg_reg_value)
     return false;
 
+  auto regs = reg_info.registers<DynamicRegisterInfo::reg_collection_range>();
   if (vg_reg_value)
-    UpdateARM64SVERegistersInfos(reg_info.registers_mutable(), *vg_reg_value);
+    UpdateARM64SVERegistersInfos(regs, *vg_reg_value);
   if (svg_reg_value)
-    UpdateARM64SMERegistersInfos(reg_info.registers_mutable(), *svg_reg_value);
+    UpdateARM64SMERegistersInfos(regs, *svg_reg_value);
 
   // At this point if we have updated any registers, their offsets will all be
   // invalid. If we did, we need to update them all.

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
@@ -228,7 +228,9 @@ bool GDBRemoteRegisterContext::ReadRegisterBytes(const RegisterInfo *reg_info) {
           SetAllRegisterValid(true);
           return true;
         } else if (buffer_sp->GetByteSize() > 0) {
-          for (auto x : llvm::enumerate(m_reg_info_sp->registers())) {
+          for (auto x : llvm::enumerate(
+                   m_reg_info_sp->registers<
+                       DynamicRegisterInfo::reg_collection_const_range>())) {
             const struct RegisterInfo &reginfo = x.value();
             m_reg_valid[x.index()] =
                 (reginfo.byte_offset + reginfo.byte_size <=


### PR DESCRIPTION
GDBRemoteRegisterContext only needs to iterate them, ArchitectureAArch64 needs to mutate them if scalable registers change size.