### PR TITLE
[clang][Interp] Fix creating APSInt from IntegralAP

### DIFF
--- a/clang/lib/AST/Interp/IntegralAP.h
+++ b/clang/lib/AST/Interp/IntegralAP.h
@@ -119,8 +119,8 @@ public:
 
   constexpr unsigned bitWidth() const { return V.getBitWidth(); }
 
-  APSInt toAPSInt(unsigned Bits = 0) const { return APSInt(V, Signed); }
-  APValue toAPValue() const { return APValue(APSInt(V, Signed)); }
+  APSInt toAPSInt(unsigned Bits = 0) const { return APSInt(V, !Signed); }
+  APValue toAPValue() const { return APValue(APSInt(V, !Signed)); }
 
   bool isZero() const { return V.isZero(); }
   bool isPositive() const { return V.isNonNegative(); }

--- a/clang/test/AST/Interp/intap.cpp
+++ b/clang/test/AST/Interp/intap.cpp
@@ -56,6 +56,10 @@ namespace i128 {
 
   static const __uint128_t UINT128_MAX =__uint128_t(__int128_t(-1L));
   static_assert(UINT128_MAX == -1, "");
+  static_assert(UINT128_MAX == 1, ""); // expected-error {{static assertion failed}} \
+                                       // expected-note {{'340282366920938463463374607431768211455 == 1'}} \
+                                       // ref-error {{static assertion failed}} \
+                                       // ref-note {{'340282366920938463463374607431768211455 == 1'}}
 
   static const __int128_t INT128_MAX = UINT128_MAX >> (__int128_t)1;
   static_assert(INT128_MAX != 0, "");


### PR DESCRIPTION
The boolean argument in the APSInt constructor is IsUnsigned, not IsSigned.

This marks the 10th time I've run into this issue. Happy anniversary.