### PR TITLE
[LLD][COFF] Add -build-id flag to generate .buildid section.

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -317,6 +317,7 @@ struct Configuration {
   bool writeCheckSum = false;
   EmitKind emit = EmitKind::Obj;
   bool allowDuplicateWeak = false;
+  bool buildID = false;
 };
 
 } // namespace lld::coff

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -102,6 +102,12 @@ enum class ICFLevel {
         // behavior.
 };
 
+enum class BuildIDHash {
+  None,
+  PDB,
+  Binary,
+};
+
 // Global configuration.
 struct Configuration {
   enum ManifestKind { Default, SideBySide, Embed, No };
@@ -317,7 +323,8 @@ struct Configuration {
   bool writeCheckSum = false;
   EmitKind emit = EmitKind::Obj;
   bool allowDuplicateWeak = false;
-  bool buildID = false;
+  bool shouldCreatePDB = false;
+  BuildIDHash buildIDHash = BuildIDHash::None;
 };
 
 } // namespace lld::coff

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -323,7 +323,6 @@ struct Configuration {
   bool writeCheckSum = false;
   EmitKind emit = EmitKind::Obj;
   bool allowDuplicateWeak = false;
-  bool shouldCreatePDB = false;
   BuildIDHash buildIDHash = BuildIDHash::None;
 };
 

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2332,6 +2332,11 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
     }
   }
 
+  // Generate build id hash in .buildid section when:
+  // 1. /build-id
+  // 2. /lldmingw + /debug and not generating pdb file.
+  config->buildID = args.hasArg(OPT_build_id) ||
+                    (config->mingw && config->debug && !shouldCreatePDB);
   // Set default image base if /base is not given.
   if (config->imageBase == uint64_t(-1))
     config->imageBase = getDefaultImageBase();

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2332,12 +2332,10 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
     }
   }
 
-  // Generate build id hash in .buildid section if /build-id is given or
-  // /lldmingw + /debug are given:
+  // Generate build id hash in .buildid section if /build-id is given:
   // 1. If PDB is generated, the build id hash will be the hash of PDB content.
   // 2. Otherwise, the build id hash will be the hash of executable content.
-  if (args.hasFlag(OPT_build_id, OPT_build_id_no,
-                   config->mingw && config->debug))
+  if (args.hasFlag(OPT_build_id, OPT_build_id_no, false))
     config->buildIDHash =
         config->shouldCreatePDB ? BuildIDHash::PDB : BuildIDHash::Binary;
 

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1672,10 +1672,10 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       config->driverUponly || config->driverWdm || args.hasArg(OPT_driver);
 
   // Handle /pdb
-  config->shouldCreatePDB =
+  bool shouldCreatePDB =
       (debug == DebugKind::Full || debug == DebugKind::GHash ||
        debug == DebugKind::NoGHash);
-  if (config->shouldCreatePDB) {
+  if (shouldCreatePDB) {
     if (auto *arg = args.getLastArg(OPT_pdb))
       config->pdbPath = arg->getValue();
     if (auto *arg = args.getLastArg(OPT_pdbaltpath))
@@ -2309,7 +2309,12 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
     config->lldmapFile.clear();
   }
 
-  if (config->shouldCreatePDB) {
+  // If should create PDB, use the hash of PDB content for build id. Otherwise,
+  // generate using the hash of executable content.
+  if (args.hasFlag(OPT_build_id, OPT_build_id_no, false))
+    config->buildIDHash = BuildIDHash::Binary;
+
+  if (shouldCreatePDB) {
     // Put the PDB next to the image if no /pdb flag was passed.
     if (config->pdbPath.empty()) {
       config->pdbPath = config->outputFile;
@@ -2330,14 +2335,8 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       // Don't do this earlier, so that ctx.OutputFile is ready.
       parsePDBAltPath();
     }
+    config->buildIDHash = BuildIDHash::PDB;
   }
-
-  // Generate build id hash in .buildid section if /build-id is given:
-  // 1. If PDB is generated, the build id hash will be the hash of PDB content.
-  // 2. Otherwise, the build id hash will be the hash of executable content.
-  if (args.hasFlag(OPT_build_id, OPT_build_id_no, false))
-    config->buildIDHash =
-        config->shouldCreatePDB ? BuildIDHash::PDB : BuildIDHash::Binary;
 
   // Set default image base if /base is not given.
   if (config->imageBase == uint64_t(-1))

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -299,6 +299,8 @@ def : Flag<["--"], "time-trace">, Alias<time_trace_eq>,
 def time_trace_granularity_eq: Joined<["--"], "time-trace-granularity=">,
     HelpText<"Minimum time granularity (in microseconds) traced by time profiler">;
 
+def build_id: F<"build-id">, HelpText<"Generate build ID">;
+
 // Flags for debugging
 def lldmap : F<"lldmap">;
 def lldmap_file : P_priv<"lldmap">;

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -299,7 +299,7 @@ def : Flag<["--"], "time-trace">, Alias<time_trace_eq>,
 def time_trace_granularity_eq: Joined<["--"], "time-trace-granularity=">,
     HelpText<"Minimum time granularity (in microseconds) traced by time profiler">;
 
-def build_id: F<"build-id">, HelpText<"Generate build ID">;
+defm build_id: B<"build-id", "Generate build ID", "Do not Generate build ID">;
 
 // Flags for debugging
 def lldmap : F<"lldmap">;

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -299,7 +299,10 @@ def : Flag<["--"], "time-trace">, Alias<time_trace_eq>,
 def time_trace_granularity_eq: Joined<["--"], "time-trace-granularity=">,
     HelpText<"Minimum time granularity (in microseconds) traced by time profiler">;
 
-defm build_id: B<"build-id", "Generate build ID", "Do not Generate build ID">;
+defm build_id: B<
+     "build-id", 
+     "Generate build ID (always on when generating PDB)",
+     "Do not Generate build ID">;
 
 // Flags for debugging
 def lldmap : F<"lldmap">;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -123,7 +123,7 @@ public:
     records.emplace_back(type, c);
   }
 
-  Chunk* getBuildIdChunk() {
+  Chunk *getBuildIdChunk() {
     for (const std::pair<COFF::DebugType, Chunk *> &record : records) {
       if (record.first == COFF::IMAGE_DEBUG_TYPE_CODEVIEW)
         return record.second;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1079,10 +1079,9 @@ void Writer::createMiscChunks() {
     debugInfoSec->addChunk(r.second);
     debugDirectory->addRecord(r.first, r.second);
   }
-
-  // Create extra .buildid section if build id was stored in .rdata.
-  if (debugInfoSec != buildidSec &&
-      config->buildIDHash == BuildIDHash::Binary) {
+  // Create extra .buildid section if build id was stored in .rdata and
+  // /build-id is given.
+  if (debugInfoSec != buildidSec && config->buildIDHash != BuildIDHash::None) {
     DebugDirectoryChunk *debugDirectory =
         make<DebugDirectoryChunk>(ctx, config->repro);
     debugDirectory->setAlignment(4);
@@ -2083,8 +2082,7 @@ void Writer::writeBuildId() {
   }
 
   // If using PDB hash, build id in .buildid section is not set yet.
-  if (debugInfoSec != buildidSec &&
-      config->buildIDHash == BuildIDHash::Binary) {
+  if (debugInfoSec != buildidSec && config->buildIDHash != BuildIDHash::None) {
     auto *buildIdChunk = buildidSec->chunks.back();
     codeview::DebugInfo *buildIdInfo =
         cast<CVDebugRecordChunk>(buildIdChunk)->buildId;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1044,9 +1044,9 @@ void Writer::createMiscChunks() {
 
   // Create Debug Information Chunks
   std::vector<std::pair<COFF::DebugType, Chunk *>> debugRecords;
-  // The default debug info section is .rdata. It set to .buildid section only
-  // when not generating PDB and /build-id flag is given. If .rdata is chosen
-  // and /build-id is given, an extra .buildid section will be generated.
+  // The default debug info section is .rdata. It is set to .buildid section
+  // only when not generating PDB and /build-id flag is given. If .rdata is
+  // chosen and /build-id is given, an extra .buildid section will be generated.
   debugInfoSec =
       config->shouldCreatePDB || config->buildIDHash != BuildIDHash::Binary
           ? rdataSec

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -311,8 +311,12 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
         warn("unsupported build id hashing: " + v + ", using default hashing.");
       add("-build-id");
     }
-  } else
-    add("-build-id");
+  } else {
+    if (args.hasArg(OPT_strip_debug) || args.hasArg(OPT_strip_all))
+      add("-build-id:no");
+    else
+      add("-build-id");
+  }
 
   if (args.hasFlag(OPT_fatal_warnings, OPT_no_fatal_warnings, false))
     add("-WX");

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -302,7 +302,16 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   } else if (!args.hasArg(OPT_strip_all)) {
     add("-debug:dwarf");
   }
-  add(args.hasArg(OPT_no_build_id) ? "-build-id:no" : "-build-id");
+  if (auto *a = args.getLastArg(OPT_build_id)) {
+    StringRef v = a->getValue();
+    if (v == "none")
+      add("-build-id:no");
+    else if (v.empty())
+      add("-build-id");
+    else
+      warn("unsupported build id hashing: " + a->getSpelling());
+  } else
+    add("-build-id");
 
   if (args.hasFlag(OPT_fatal_warnings, OPT_no_fatal_warnings, false))
     add("-WX");

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -302,6 +302,7 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   } else if (!args.hasArg(OPT_strip_all)) {
     add("-debug:dwarf");
   }
+  add(args.hasArg(OPT_no_build_id) ? "-build-id:no" : "-build-id");
 
   if (args.hasFlag(OPT_fatal_warnings, OPT_no_fatal_warnings, false))
     add("-WX");

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -306,10 +306,12 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     StringRef v = a->getValue();
     if (v == "none")
       add("-build-id:no");
-    else if (v.empty())
+    else {
+      if (!v.empty())
+        warn("unsupported build id hashing: " + v +
+             ", using default hashing.");
       add("-build-id");
-    else
-      warn("unsupported build id hashing: " + a->getSpelling());
+    }
   } else
     add("-build-id");
 

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -308,8 +308,7 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       add("-build-id:no");
     else {
       if (!v.empty())
-        warn("unsupported build id hashing: " + v +
-             ", using default hashing.");
+        warn("unsupported build id hashing: " + v + ", using default hashing.");
       add("-build-id");
     }
   } else

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -196,6 +196,7 @@ defm guard_longjmp : B<"guard-longjmp",
   "Do not enable Control Flow Guard long jump hardening">;
 defm error_limit:
   EqLong<"error-limit", "Maximum number of errors to emit before stopping (0 = no limit)">;
+def build_id: F<"build-id">, HelpText<"Generate build ID">;
 
 // Alias
 def alias_Bdynamic_call_shared: Flag<["-"], "call_shared">, Alias<Bdynamic>;
@@ -213,7 +214,6 @@ def alias_undefined_u: JoinedOrSeparate<["-"], "u">, Alias<undefined>;
 // Ignored options
 def: Joined<["-"], "O">;
 def: F<"as-needed">;
-def: F<"build-id">;
 def: F<"disable-auto-image-base">;
 def: F<"enable-auto-image-base">;
 def: F<"end-group">;

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -198,6 +198,7 @@ defm error_limit:
   EqLong<"error-limit", "Maximum number of errors to emit before stopping (0 = no limit)">;
 def build_id: J<"build-id=">, HelpText<"Generate build ID note (pass none to disable)">, 
   MetaVarName<"<arg>">;
+def : F<"build-id">, Alias<build_id>, HelpText<"Alias for --build-id=">;
 
 // Alias
 def alias_Bdynamic_call_shared: Flag<["-"], "call_shared">, Alias<Bdynamic>;

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -196,7 +196,8 @@ defm guard_longjmp : B<"guard-longjmp",
   "Do not enable Control Flow Guard long jump hardening">;
 defm error_limit:
   EqLong<"error-limit", "Maximum number of errors to emit before stopping (0 = no limit)">;
-defm build_id: B<"build-id", "Generate build ID", "Do not Generate build ID">;
+def build_id: J<"build-id=">, HelpText<"Generate build ID note (pass none to disable)">, 
+  MetaVarName<"<arg>">;
 
 // Alias
 def alias_Bdynamic_call_shared: Flag<["-"], "call_shared">, Alias<Bdynamic>;

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -196,6 +196,7 @@ defm guard_longjmp : B<"guard-longjmp",
   "Do not enable Control Flow Guard long jump hardening">;
 defm error_limit:
   EqLong<"error-limit", "Maximum number of errors to emit before stopping (0 = no limit)">;
+defm build_id: B<"build-id", "Generate build ID", "Do not Generate build ID">;
 
 // Alias
 def alias_Bdynamic_call_shared: Flag<["-"], "call_shared">, Alias<Bdynamic>;

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -196,7 +196,6 @@ defm guard_longjmp : B<"guard-longjmp",
   "Do not enable Control Flow Guard long jump hardening">;
 defm error_limit:
   EqLong<"error-limit", "Maximum number of errors to emit before stopping (0 = no limit)">;
-def build_id: F<"build-id">, HelpText<"Generate build ID">;
 
 // Alias
 def alias_Bdynamic_call_shared: Flag<["-"], "call_shared">, Alias<Bdynamic>;

--- a/lld/test/COFF/debug-reloc.s
+++ b/lld/test/COFF/debug-reloc.s
@@ -2,7 +2,7 @@
 
 # RUN: llvm-mc -triple=x86_64-windows-gnu %s -filetype=obj -o %t.obj
 
-# RUN: lld-link -lldmingw -debug:dwarf -out:%t.exe -entry:mainfunc -subsystem:console %t.obj
+# RUN: lld-link -lldmingw -debug:dwarf -build-id -out:%t.exe -entry:mainfunc -subsystem:console %t.obj
 # RUN: llvm-readobj --sections %t.exe | FileCheck %s -check-prefix SECTIONS
 # RUN: llvm-readobj --coff-basereloc %t.exe | FileCheck %s -check-prefix RELOCS
 # RUN: llvm-readobj --file-headers %t.exe | FileCheck %s -check-prefix HEADERS

--- a/lld/test/COFF/rsds.test
+++ b/lld/test/COFF/rsds.test
@@ -35,10 +35,26 @@
 # RUN: rm -f %t.dll %t.pdb
 # RUN: lld-link /build-id /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
+# RUN: llvm-readobj --coff-debug-directory %t.dll | grep "PDBGUID: " > %t.binary.guid
 
+# When generating PDB, generate extra .buildid section.
 # RUN: rm -f %t.dll %t.pdb
 # RUN: lld-link /build-id /debug /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
+# RUN: llvm-readobj -S %t.dll | FileCheck --check-prefix BUILDID_SEC %s
+
+# RUN: llvm-readobj --coff-debug-directory %t.dll | grep "PDBGUID: " > %t.pdb.guid
+# PDB hash should be different from binary hash.
+# RUN: not diff %t.binary.guid %t.pdb.guid
+
+# Do not generate .buildid section under /lldmingw + /debug:dwarf + /build-id:no
+# RUN: rm -f %t.dll %t.pdb
+# RUN: lld-link /lldmingw /debug:dwarf /build-id:no /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix NO_BUILDID %s
+
+# RUN: rm -f %t.dll %t.pdb
+# RUN: lld-link /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix NO_BUILDID %s
 
 # CHECK: File: [[FILE:.*]].dll
 # CHECK: DebugDirectory [
@@ -181,6 +197,11 @@
 # BUILDID:     }
 # BUILDID:   }
 # BUILDID: ]
+
+# NO_BUILDID: DebugDirectory [
+# NO_BUILDID: ]
+
+# BUILDID_SEC: Name: .buildid
 --- !COFF
 header:
   Machine:         IMAGE_FILE_MACHINE_I386

--- a/lld/test/COFF/rsds.test
+++ b/lld/test/COFF/rsds.test
@@ -22,9 +22,23 @@
 # RUN: lld-link /Brepro /debug /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix REPRODEBUG %s
 
+# Generate .buildid section when /lldmingw + /debug:dwarf are given and not generating pdb file.
 # RUN: rm -f %t.dll %t.pdb
 # RUN: lld-link /lldmingw /debug:dwarf /dll /out:%t.dll /entry:DllMain %t.obj
-# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix MINGW %s
+# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
+
+# RUN: rm -f %t.dll %t.pdb
+# RUN: lld-link /lldmingw /debug:dwarf /build-id /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
+
+# Generate .buildid section when /build-id is given.
+# RUN: rm -f %t.dll %t.pdb
+# RUN: lld-link /build-id /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
+
+# RUN: rm -f %t.dll %t.pdb
+# RUN: lld-link /build-id /debug /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
 
 # CHECK: File: [[FILE:.*]].dll
 # CHECK: DebugDirectory [
@@ -148,25 +162,25 @@
 # REPRODEBUG:   }
 # REPRODEBUG: ]
 
-# MINGW: File: {{.*}}.dll
-# MINGW: DebugDirectory [
-# MINGW:   DebugEntry {
-# MINGW:     Characteristics: 0x0
-# MINGW:     TimeDateStamp:
-# MINGW:     MajorVersion: 0x0
-# MINGW:     MinorVersion: 0x0
-# MINGW:     Type: CodeView (0x2)
-# MINGW:     SizeOfData: 0x{{[^0]}}
-# MINGW:     AddressOfRawData: 0x{{[^0]}}
-# MINGW:     PointerToRawData: 0x{{[^0]}}
-# MINGW:     PDBInfo {
-# MINGW:       PDBSignature: 0x53445352
-# MINGW:       PDBGUID: [[GUID:\(([A-Za-z0-9]{2} ?){16}\)]]
-# MINGW:       PDBAge: 1
-# MINGW:       PDBFileName:
-# MINGW:     }
-# MINGW:   }
-# MINGW: ]
+# BUILDID: File: {{.*}}.dll
+# BUILDID: DebugDirectory [
+# BUILDID:   DebugEntry {
+# BUILDID:     Characteristics: 0x0
+# BUILDID:     TimeDateStamp:
+# BUILDID:     MajorVersion: 0x0
+# BUILDID:     MinorVersion: 0x0
+# BUILDID:     Type: CodeView (0x2)
+# BUILDID:     SizeOfData: 0x{{[^0]}}
+# BUILDID:     AddressOfRawData: 0x{{[^0]}}
+# BUILDID:     PointerToRawData: 0x{{[^0]}}
+# BUILDID:     PDBInfo {
+# BUILDID:       PDBSignature: 0x53445352
+# BUILDID:       PDBGUID: [[GUID:\(([A-Za-z0-9]{2} ?){16}\)]]
+# BUILDID:       PDBAge: 1
+# BUILDID:       PDBFileName:
+# BUILDID:     }
+# BUILDID:   }
+# BUILDID: ]
 --- !COFF
 header:
   Machine:         IMAGE_FILE_MACHINE_I386

--- a/lld/test/COFF/rsds.test
+++ b/lld/test/COFF/rsds.test
@@ -22,15 +22,6 @@
 # RUN: lld-link /Brepro /debug /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix REPRODEBUG %s
 
-# Generate .buildid section when /lldmingw + /debug:dwarf are given and not generating pdb file.
-# RUN: rm -f %t.dll %t.pdb
-# RUN: lld-link /lldmingw /debug:dwarf /dll /out:%t.dll /entry:DllMain %t.obj
-# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
-
-# RUN: rm -f %t.dll %t.pdb
-# RUN: lld-link /lldmingw /debug:dwarf /build-id /dll /out:%t.dll /entry:DllMain %t.obj
-# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
-
 # Generate .buildid section when /build-id is given.
 # RUN: rm -f %t.dll %t.pdb
 # RUN: lld-link /build-id /dll /out:%t.dll /entry:DllMain %t.obj
@@ -47,9 +38,9 @@
 # PDB hash should be different from binary hash.
 # RUN: not diff %t.binary.guid %t.pdb.guid
 
-# Do not generate .buildid section under /lldmingw + /debug:dwarf + /build-id:no
+# Do not generate .buildid section under /build-id:no
 # RUN: rm -f %t.dll %t.pdb
-# RUN: lld-link /lldmingw /debug:dwarf /build-id:no /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: lld-link /build-id:no /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix NO_BUILDID %s
 
 # RUN: rm -f %t.dll %t.pdb

--- a/lld/test/COFF/rsds.test
+++ b/lld/test/COFF/rsds.test
@@ -189,8 +189,8 @@
 # BUILDID:   }
 # BUILDID: ]
 
-# NO_BUILDID: DebugDirectory [
-# NO_BUILDID: ]
+# NO_BUILDID:      DebugDirectory [
+# NO_BUILDID-NEXT: ]
 
 # BUILDID_SEC: Name: .buildid
 --- !COFF

--- a/lld/test/COFF/rsds.test
+++ b/lld/test/COFF/rsds.test
@@ -22,21 +22,21 @@
 # RUN: lld-link /Brepro /debug /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix REPRODEBUG %s
 
-# Generate .buildid section when /build-id is given.
+# Generate .buildid section using binary hash under /lldmingw and /build-id
+# RUN: rm -f %t.dll %t.pdb
+# RUN: lld-link /lldmingw /build-id /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
+
+# Generate debug directory with use binary hash when /build-id is given and not 
+# generating PDB.
 # RUN: rm -f %t.dll %t.pdb
 # RUN: lld-link /build-id /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
-# RUN: llvm-readobj --coff-debug-directory %t.dll | grep "PDBGUID: " > %t.binary.guid
 
-# When generating PDB, generate extra .buildid section.
+# If generate PDB, PDB hash is used and /build-id is ignored.
 # RUN: rm -f %t.dll %t.pdb
-# RUN: lld-link /build-id /debug /dll /out:%t.dll /entry:DllMain %t.obj
+# RUN: lld-link /build-id /debug /pdbaltpath:test.pdb /dll /out:%t.dll /entry:DllMain %t.obj
 # RUN: llvm-readobj --coff-debug-directory %t.dll | FileCheck --check-prefix BUILDID %s
-# RUN: llvm-readobj -S %t.dll | FileCheck --check-prefix BUILDID_SEC %s
-
-# RUN: llvm-readobj --coff-debug-directory %t.dll | grep "PDBGUID: " > %t.pdb.guid
-# PDB hash should be different from binary hash.
-# RUN: not diff %t.binary.guid %t.pdb.guid
 
 # Do not generate .buildid section under /build-id:no
 # RUN: rm -f %t.dll %t.pdb

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -399,4 +399,6 @@ BUILD_ID_WARN: unsupported build id hashing: fast, using default hashing.
 BUILD_ID_WARN: -build-id{{ }}
 
 RUN: ld.lld -### foo.o -m i386pep --build-id=none 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
+RUN: ld.lld -### foo.o -m i386pep -s 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
+RUN: ld.lld -### foo.o -m i386pep -S 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
 NO_BUILD_ID: -build-id:no

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -393,5 +393,5 @@ RUN: ld.lld -### foo.o -m i386pep -plugin C:/msys64/mingw64/bin/../lib/gcc/x86_6
 RUN: ld.lld -### foo.o -m i386pep 2>&1 | FileCheck -check-prefix=BUILD_ID %s
 BUILD_ID:-build-id
 
-RUN: ld.lld -### foo.o -m i386pep -no-build-id 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
+RUN: ld.lld -### foo.o -m i386pep -build-id=none 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
 NO_BUILD_ID:-build-id:no

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -392,10 +392,13 @@ RUN: ld.lld -### foo.o -m i386pep -plugin C:/msys64/mingw64/bin/../lib/gcc/x86_6
 
 RUN: ld.lld -### foo.o -m i386pep 2>&1 | FileCheck -check-prefix=BUILD_ID %s
 RUN: ld.lld -### foo.o -m i386pep --build-id 2>&1 | FileCheck -check-prefix=BUILD_ID %s
-BUILD_ID:-build-id
+BUILD_ID: -build-id
+BUILD_ID-NOT: -build-id:no
 
 RUN: ld.lld -### foo.o -m i386pep --build-id=fast 2>&1 | FileCheck -check-prefix=BUILD_ID_WARN %s
 BUILD_ID_WARN: unsupported build id hashing: fast, using default hashing.
+BUILD_ID_WARN: -build-id
+BUILD_ID_WARN-NOT: -build-id:no
 
 RUN: ld.lld -### foo.o -m i386pep --build-id=none 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
-NO_BUILD_ID:-build-id:no
+NO_BUILD_ID: -build-id:no

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -391,7 +391,7 @@ RUN: ld.lld -### foo.o -m i386pep -plugin /usr/lib/gcc/x86_64-w64-mingw32/10-pos
 RUN: ld.lld -### foo.o -m i386pep -plugin C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/liblto_plugin.dll -plugin-opt=C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/lto-wrapper.exe -plugin-opt=-fresolution=C:/msys64/tmp/cckbC7wB.res -plugin-opt=-pass-through=-lmingw32 2> /dev/null
 
 RUN: ld.lld -### foo.o -m i386pep 2>&1 | FileCheck -check-prefix=BUILD_ID %s
-RUN: ld.lld -### foo.o -m i386pep --build-id=none 2>&1 | FileCheck -check-prefix=BUILD_ID %s
+RUN: ld.lld -### foo.o -m i386pep --build-id 2>&1 | FileCheck -check-prefix=BUILD_ID %s
 BUILD_ID: -build-id{{ }}
 
 RUN: ld.lld -### foo.o -m i386pep --build-id=fast 2>&1 | FileCheck -check-prefix=BUILD_ID_WARN %s

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -391,14 +391,12 @@ RUN: ld.lld -### foo.o -m i386pep -plugin /usr/lib/gcc/x86_64-w64-mingw32/10-pos
 RUN: ld.lld -### foo.o -m i386pep -plugin C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/liblto_plugin.dll -plugin-opt=C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/lto-wrapper.exe -plugin-opt=-fresolution=C:/msys64/tmp/cckbC7wB.res -plugin-opt=-pass-through=-lmingw32 2> /dev/null
 
 RUN: ld.lld -### foo.o -m i386pep 2>&1 | FileCheck -check-prefix=BUILD_ID %s
-RUN: ld.lld -### foo.o -m i386pep --build-id 2>&1 | FileCheck -check-prefix=BUILD_ID %s
-BUILD_ID: -build-id
-BUILD_ID-NOT: -build-id:no
+RUN: ld.lld -### foo.o -m i386pep --build-id=none 2>&1 | FileCheck -check-prefix=BUILD_ID %s
+BUILD_ID: -build-id{{ }}
 
 RUN: ld.lld -### foo.o -m i386pep --build-id=fast 2>&1 | FileCheck -check-prefix=BUILD_ID_WARN %s
 BUILD_ID_WARN: unsupported build id hashing: fast, using default hashing.
-BUILD_ID_WARN: -build-id
-BUILD_ID_WARN-NOT: -build-id:no
+BUILD_ID_WARN: -build-id{{ }}
 
 RUN: ld.lld -### foo.o -m i386pep --build-id=none 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
 NO_BUILD_ID: -build-id:no

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -389,3 +389,9 @@ Test GCC specific LTO options that GCC passes unconditionally, that we ignore.
 
 RUN: ld.lld -### foo.o -m i386pep -plugin /usr/lib/gcc/x86_64-w64-mingw32/10-posix/liblto_plugin.so -plugin-opt=/usr/lib/gcc/x86_64-w64-mingw32/10-posix/lto-wrapper -plugin-opt=-fresolution=/tmp/ccM9d4fP.res -plugin-opt=-pass-through=-lmingw32 2> /dev/null
 RUN: ld.lld -### foo.o -m i386pep -plugin C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/liblto_plugin.dll -plugin-opt=C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/lto-wrapper.exe -plugin-opt=-fresolution=C:/msys64/tmp/cckbC7wB.res -plugin-opt=-pass-through=-lmingw32 2> /dev/null
+
+RUN: ld.lld -### foo.o -m i386pep 2>&1 | FileCheck -check-prefix=BUILD_ID %s
+BUILD_ID:-build-id
+
+RUN: ld.lld -### foo.o -m i386pep -no-build-id 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
+NO_BUILD_ID:-build-id:no

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -391,7 +391,11 @@ RUN: ld.lld -### foo.o -m i386pep -plugin /usr/lib/gcc/x86_64-w64-mingw32/10-pos
 RUN: ld.lld -### foo.o -m i386pep -plugin C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/liblto_plugin.dll -plugin-opt=C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/lto-wrapper.exe -plugin-opt=-fresolution=C:/msys64/tmp/cckbC7wB.res -plugin-opt=-pass-through=-lmingw32 2> /dev/null
 
 RUN: ld.lld -### foo.o -m i386pep 2>&1 | FileCheck -check-prefix=BUILD_ID %s
+RUN: ld.lld -### foo.o -m i386pep --build-id 2>&1 | FileCheck -check-prefix=BUILD_ID %s
 BUILD_ID:-build-id
 
-RUN: ld.lld -### foo.o -m i386pep -build-id=none 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
+RUN: ld.lld -### foo.o -m i386pep --build-id=fast 2>&1 | FileCheck -check-prefix=BUILD_ID_WARN %s
+BUILD_ID_WARN: unsupported build id hashing: fast, using default hashing.
+
+RUN: ld.lld -### foo.o -m i386pep --build-id=none 2>&1 | FileCheck -check-prefix=NO_BUILD_ID %s
 NO_BUILD_ID:-build-id:no


### PR DESCRIPTION
[RFC](https://discourse.llvm.org/t/rfc-add-build-id-flag-to-lld-link/74661)

Before, lld-link only generate the debug directory containing guid when generating PDB with the hash of PDB content.

With this change, lld-link can generate the debug directory when only `/build-id` is given:
1. If generating PDB, `/build-id` is ignored. Same behaviour as before.
2. Not generating PDB, using hash of the binary.
   - Not under MinGW, the debug directory is still in `.rdata` section.
   - Under MinGW, place the debug directory into new `.buildid` section.