### PR TITLE
[flang][openacc] Support variable from equivalence in data clauses

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -722,7 +722,7 @@ mlir::Type getTypeFromBounds(llvm::SmallVector<mlir::Value> &bounds,
     if (shape.empty() || shape.size() != bounds.size())
       return ty;
     auto newSeqTy = fir::SequenceType::get(shape, seqTy.getEleTy());
-    if (mlir::isa<fir::ReferenceType>(ty))
+    if (mlir::isa<fir::ReferenceType, fir::PointerType>(ty))
       return fir::ReferenceType::get(newSeqTy);
     return newSeqTy;
   }


### PR DESCRIPTION
The value for a var in an equivalence is represented by a `fir.ptr`. Support this type in the recipe creation. 