### PR TITLE
[Clang] Remove unneeded template keyword

### DIFF
--- a/clang/include/clang/AST/Redeclarable.h
+++ b/clang/include/clang/AST/Redeclarable.h
@@ -114,9 +114,7 @@ protected:
 
     bool isFirst() const {
       return Link.is<KnownLatest>() ||
-             // FIXME: 'template' is required on the next line due to an
-             // apparent clang bug.
-             Link.get<NotKnownLatest>().template is<UninitializedLatest>();
+             Link.get<NotKnownLatest>().is<UninitializedLatest>();
     }
 
     decl_type *getPrevious(const decl_type *D) const {


### PR DESCRIPTION
As noted in this bug report: https://github.com/llvm/llvm-project/issues/37647

Due to this clang bug we added the template keyword in Redeclarable.h. The bug has been fixed since then, so removing it.