### PR TITLE
[clang][modules] Avoid modules diagnostics for `__has_include()`

### DIFF
--- a/clang/test/Modules/has_include_non_modular.c
+++ b/clang/test/Modules/has_include_non_modular.c
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- module.modulemap
+module Mod { header "mod.h" }
+//--- mod.h
+#if __has_include("textual.h")
+#endif
+//--- textual.h
+
+//--- tu.c
+#include "mod.h"
+
+// RUN: %clang -fsyntax-only %t/tu.c -fmodules -fmodules-cache-path=%t/cache -Werror=non-modular-include-in-module


### PR DESCRIPTION
After #70144 Clang started resolving module maps even for `__has_include()` expressions. This had the unintended consequence of emitting diagnostics around header misuse. These don't make sense if you actually don't bring contents of the header into the importer, so should be skipped for `__has_include()`. This patch moves emission of these diagnostics out of `Preprocessor::LookupFile()` up into `Preprocessor::LookupHeaderIncludeOrImport()`.