### PR TITLE
[flang][openacc] Correctly lower acc routine in interface block

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -3201,8 +3201,21 @@ void Fortran::lower::genOpenACCRoutineConstruct(
     funcName = converter.mangleName(*name->symbol);
     funcOp = builder.getNamedFunction(mod, funcName);
   } else {
-    funcOp = builder.getFunction();
-    funcName = funcOp.getName();
+    Fortran::semantics::Scope &scope =
+        semanticsContext.FindScope(routineConstruct.source);
+    const Fortran::semantics::Scope &progUnit{GetProgramUnitContaining(scope)};
+    const auto *subpDetails{
+        progUnit.symbol()
+            ? progUnit.symbol()
+                  ->detailsIf<Fortran::semantics::SubprogramDetails>()
+            : nullptr};
+    if (subpDetails && subpDetails->isInterface()) {
+      funcName = converter.mangleName(*progUnit.symbol());
+      funcOp = builder.getNamedFunction(mod, funcName);
+    } else {
+      funcOp = builder.getFunction();
+      funcName = funcOp.getName();
+    }
   }
   bool hasSeq = false, hasGang = false, hasWorker = false, hasVector = false,
        hasNohost = false;

--- a/flang/test/Lower/OpenACC/acc-routine03.f90
+++ b/flang/test/Lower/OpenACC/acc-routine03.f90
@@ -1,0 +1,36 @@
+! This test checks lowering of OpenACC routine directive in interfaces.
+
+! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+
+subroutine sub1(a)
+  !$acc routine worker bind(sub2)
+  real :: a(:)
+end subroutine
+
+subroutine sub2(a)
+  !$acc routine worker nohost
+  real :: a(:)
+end subroutine
+
+subroutine test
+
+interface
+  subroutine sub1(a)
+    !$acc routine worker bind(sub2)
+    real :: a(:)
+  end subroutine
+ 
+  subroutine sub2(a)
+    !$acc routine worker nohost
+    real :: a(:)
+  end subroutine
+end interface
+
+end subroutine
+
+! CHECK: acc.routine @acc_routine_1 func(@_QPsub2) worker nohost
+! CHECK: acc.routine @acc_routine_0 func(@_QPsub1) bind("_QPsub2") worker
+! CHECK: func.func @_QPsub1(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
+! CHECK: func.func @_QPsub2(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "a"}) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_1]>}


### PR DESCRIPTION
When the acc routine directive was in an interface block in a subroutine, the routine information was attached to the wrong subroutine. This patch fixes this be retrieving the subroutine name in the interface. 