### PR TITLE
[LLDB] Don't forcefully initialize the process trace plugin

### DIFF
--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -68,9 +68,6 @@ llvm::Error SystemInitializerFull::Initialize() {
 #define LLDB_PLUGIN(p) LLDB_PLUGIN_INITIALIZE(p);
 #include "Plugins/Plugins.def"
 
-  // Initialize plug-ins in core LLDB
-  ProcessTrace::Initialize();
-
   // Scan for any system or user LLDB plug-ins
   PluginManager::Initialize();
 

--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleLoader.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleLoader.cpp
@@ -103,10 +103,11 @@ TraceIntelPTBundleLoader::CreateEmptyProcess(lldb::pid_t pid,
   ParsedProcess parsed_process;
   parsed_process.target_sp = target_sp;
 
-  ProcessSP process_sp = target_sp->CreateProcess(
-      /*listener*/ nullptr, "trace",
-      /*crash_file*/ nullptr,
-      /*can_connect*/ false);
+  // This should instead try to directly create an instance of ProcessTrace.
+  // ProcessSP process_sp = target_sp->CreateProcess(
+  //    /*listener*/ nullptr, "trace",
+  //    /*crash_file*/ nullptr,
+  //    /*can_connect*/ false);
 
   process_sp->SetID(static_cast<lldb::pid_t>(pid));
 


### PR DESCRIPTION
This was causing some process to wrongfully be handled by ProcessTrace.
    
The only place this was being used is in the intel pt plugin, but it doesn't even build anymore, so I'm sure no one is using it.