### PR TITLE
[lldb] Add Checksum class to lldbUtility

### DIFF
--- a/lldb/include/lldb/Utility/Checksum.h
+++ b/lldb/include/lldb/Utility/Checksum.h
@@ -1,0 +1,36 @@
+//===-- Checksum.h ----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UTILITY_CHECKSUM_H
+#define LLDB_UTILITY_CHECKSUM_H
+
+#include "llvm/Support/MD5.h"
+
+namespace lldb_private {
+class Checksum {
+public:
+  static llvm::MD5::MD5Result g_sentinel;
+
+  Checksum(llvm::MD5::MD5Result md5 = g_sentinel);
+  Checksum(const Checksum &checksum);
+  Checksum &operator=(const Checksum &checksum);
+
+  explicit operator bool() const;
+  bool operator==(const Checksum &checksum) const;
+  bool operator!=(const Checksum &checksum) const;
+
+  std::string digest() const;
+
+private:
+  void SetMD5(llvm::MD5::MD5Result);
+
+  llvm::MD5::MD5Result m_checksum;
+};
+} // namespace lldb_private
+
+#endif // LLDB_UTILITY_CHECKSUM_H

--- a/lldb/source/Utility/CMakeLists.txt
+++ b/lldb/source/Utility/CMakeLists.txt
@@ -29,6 +29,7 @@ add_lldb_library(lldbUtility NO_INTERNAL_DEPENDENCIES
   Args.cpp
   Baton.cpp
   Broadcaster.cpp
+  Checksum.cpp
   CompletionRequest.cpp
   Connection.cpp
   ConstString.cpp

--- a/lldb/source/Utility/Checksum.cpp
+++ b/lldb/source/Utility/Checksum.cpp
@@ -1,0 +1,44 @@
+//===-- Checksum.cpp ------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Utility/Checksum.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
+
+using namespace lldb_private;
+
+Checksum::Checksum(llvm::MD5::MD5Result md5) { SetMD5(md5); }
+
+Checksum::Checksum(const Checksum &checksum) { SetMD5(checksum.m_checksum); }
+
+Checksum &Checksum::operator=(const Checksum &checksum) {
+  SetMD5(checksum.m_checksum);
+  return *this;
+}
+
+void Checksum::SetMD5(llvm::MD5::MD5Result md5) {
+  const constexpr size_t md5_length = 16;
+  std::uninitialized_copy_n(md5.begin(), md5_length, m_checksum.begin());
+}
+
+Checksum::operator bool() const { return !llvm::equal(m_checksum, g_sentinel); }
+
+bool Checksum::operator==(const Checksum &checksum) const {
+  return llvm::equal(m_checksum, checksum.m_checksum);
+}
+
+bool Checksum::operator!=(const Checksum &checksum) const {
+  return !(*this == checksum);
+}
+
+std::string Checksum::digest() const {
+  return std::string(m_checksum.digest());
+}
+
+llvm::MD5::MD5Result Checksum::g_sentinel = {0, 0, 0, 0, 0, 0, 0, 0,
+                                             0, 0, 0, 0, 0, 0, 0, 0};

--- a/lldb/unittests/Utility/CMakeLists.txt
+++ b/lldb/unittests/Utility/CMakeLists.txt
@@ -4,6 +4,7 @@ add_lldb_unittest(UtilityTests
   OptionsWithRawTest.cpp
   ArchSpecTest.cpp
   BroadcasterTest.cpp
+  ChecksumTest.cpp
   ConstStringTest.cpp
   CompletionRequestTest.cpp
   DataBufferTest.cpp

--- a/lldb/unittests/Utility/ChecksumTest.cpp
+++ b/lldb/unittests/Utility/ChecksumTest.cpp
@@ -1,0 +1,57 @@
+//===-- ChecksumTest.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "lldb/Utility/Checksum.h"
+
+using namespace lldb_private;
+
+static llvm::MD5::MD5Result hash1 = {0, 1, 2,  3,  4,  5,  6,  7,
+                                     8, 9, 10, 11, 12, 13, 14, 15};
+
+static llvm::MD5::MD5Result hash2 = {0, 1, 2,  3,  4,  5,  6,  7,
+                                     8, 9, 10, 11, 12, 13, 14, 15};
+
+static llvm::MD5::MD5Result hash3 = {8, 9, 10, 11, 12, 13, 14, 15,
+                                     0, 1, 2,  3,  4,  5,  6,  7};
+
+TEST(ChecksumTest, TestConstructor) {
+  Checksum checksum1;
+  EXPECT_FALSE(static_cast<bool>(checksum1));
+  EXPECT_EQ(checksum1, Checksum());
+
+  Checksum checksum2 = Checksum(hash1);
+  EXPECT_EQ(checksum2, Checksum(hash1));
+
+  Checksum checksum3(checksum2);
+  EXPECT_EQ(checksum3, Checksum(hash1));
+}
+
+TEST(ChecksumTest, TestCopyConstructor) {
+  Checksum checksum1;
+  EXPECT_FALSE(static_cast<bool>(checksum1));
+  EXPECT_EQ(checksum1, Checksum());
+
+  Checksum checksum2 = checksum1;
+  EXPECT_EQ(checksum2, checksum1);
+
+  Checksum checksum3(checksum1);
+  EXPECT_EQ(checksum3, checksum1);
+}
+
+TEST(ChecksumTest, TestMD5) {
+  Checksum checksum1(hash1);
+  EXPECT_TRUE(static_cast<bool>(checksum1));
+
+  // Make sure two checksums with the same underlying hashes are the same.
+  EXPECT_EQ(Checksum(hash1), Checksum(hash2));
+
+  // Make sure two checksums with different underlying hashes are different.
+  EXPECT_NE(Checksum(hash1), Checksum(hash3));
+}


### PR DESCRIPTION
This commit adds an MD5 checksum (`Checksum`) class to LLDB. Its purpose is to store the MD5 hash added to the DWARF 5 line table.