### PR TITLE
[flang][openacc] Allow acc routine before implicit part

### DIFF
--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -413,7 +413,8 @@ struct ImplicitPartStmt {
       Statement<common::Indirection<OldParameterStmt>>,
       Statement<common::Indirection<FormatStmt>>,
       Statement<common::Indirection<EntryStmt>>,
-      common::Indirection<CompilerDirective>>
+      common::Indirection<CompilerDirective>,
+      common::Indirection<OpenACCDeclarativeConstruct>>
       u;
 };
 

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -114,7 +114,8 @@ TYPE_PARSER(first(
     construct<ImplicitPartStmt>(statement(indirect(oldParameterStmt))),
     construct<ImplicitPartStmt>(statement(indirect(formatStmt))),
     construct<ImplicitPartStmt>(statement(indirect(entryStmt))),
-    construct<ImplicitPartStmt>(indirect(compilerDirective))))
+    construct<ImplicitPartStmt>(indirect(compilerDirective)),
+    construct<ImplicitPartStmt>(indirect(openaccDeclarativeConstruct))))
 
 // R512 internal-subprogram -> function-subprogram | subroutine-subprogram
 // Internal subprograms are not program units, so their END statements

--- a/flang/test/Lower/OpenACC/acc-routine04.f90
+++ b/flang/test/Lower/OpenACC/acc-routine04.f90
@@ -32,3 +32,4 @@ end program
 ! CHECK: acc.routine @acc_routine_0 func(@_QMdummy_modPsub1) seq
 ! CHECK: func.func @_QMdummy_modPsub1(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
 ! CHECK: func.func @_QQmain() attributes {fir.bindc_name = "test_acc_routine"}
+! CHECK: func.func @_QFPsub2() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_1]>}

--- a/flang/test/Lower/OpenACC/acc-routine04.f90
+++ b/flang/test/Lower/OpenACC/acc-routine04.f90
@@ -1,0 +1,34 @@
+! This test checks correct lowering when OpenACC routine directive is placed
+! before implicit none.
+
+! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+module dummy_mod
+contains
+
+  subroutine sub1(i)
+    !$acc routine seq
+    integer :: i
+  end subroutine
+end module
+
+program test_acc_routine
+  use dummy_mod
+  
+  !$acc routine(sub2) seq
+  
+  implicit none
+  
+  integer :: i
+
+contains
+  subroutine sub2()
+  end subroutine
+  
+end program
+
+! CHECK: acc.routine @acc_routine_1 func(@_QFPsub2) seq
+! CHECK: acc.routine @acc_routine_0 func(@_QMdummy_modPsub1) seq
+! CHECK: func.func @_QMdummy_modPsub1(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
+! CHECK: func.func @_QQmain() attributes {fir.bindc_name = "test_acc_routine"}


### PR DESCRIPTION
Allow position of the acc routine in the implicit part. 