### PR TITLE
[lldb/Interpreter] Make Scripted*Interface base class abstract

### DIFF
--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedPlatformInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedPlatformInterface.h
@@ -22,9 +22,7 @@ public:
   virtual llvm::Expected<StructuredData::GenericSP>
   CreatePluginObject(llvm::StringRef class_name, ExecutionContext &exe_ctx,
                      StructuredData::DictionarySP args_sp,
-                     StructuredData::Generic *script_obj = nullptr) {
-    return {llvm::make_error<UnimplementedError>()};
-  }
+                     StructuredData::Generic *script_obj = nullptr) = 0;
 
   virtual StructuredData::DictionarySP ListProcesses() { return {}; }
 

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedProcessInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedProcessInterface.h
@@ -24,9 +24,7 @@ public:
   virtual llvm::Expected<StructuredData::GenericSP>
   CreatePluginObject(llvm::StringRef class_name, ExecutionContext &exe_ctx,
                      StructuredData::DictionarySP args_sp,
-                     StructuredData::Generic *script_obj = nullptr) {
-    return {llvm::make_error<UnimplementedError>()};
-  }
+                     StructuredData::Generic *script_obj = nullptr) = 0;
 
   virtual StructuredData::DictionarySP GetCapabilities() { return {}; }
 

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadInterface.h
@@ -23,9 +23,7 @@ public:
   virtual llvm::Expected<StructuredData::GenericSP>
   CreatePluginObject(llvm::StringRef class_name, ExecutionContext &exe_ctx,
                      StructuredData::DictionarySP args_sp,
-                     StructuredData::Generic *script_obj = nullptr) {
-    return {llvm::make_error<UnimplementedError>()};
-  }
+                     StructuredData::Generic *script_obj = nullptr) = 0;
 
   virtual lldb::tid_t GetThreadID() { return LLDB_INVALID_THREAD_ID; }
 

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -151,10 +151,7 @@ public:
     eScriptReturnTypeOpaqueObject
   };
 
-  ScriptInterpreter(
-      Debugger &debugger, lldb::ScriptLanguage script_lang,
-      lldb::ScriptedPlatformInterfaceUP scripted_platform_interface_up =
-          std::make_unique<ScriptedPlatformInterface>());
+  ScriptInterpreter(Debugger &debugger, lldb::ScriptLanguage script_lang);
 
   virtual StructuredData::DictionarySP GetInterpreterInfo();
 
@@ -559,19 +556,19 @@ public:
   lldb::ScriptLanguage GetLanguage() { return m_script_lang; }
 
   virtual lldb::ScriptedProcessInterfaceUP CreateScriptedProcessInterface() {
-    return std::make_unique<ScriptedProcessInterface>();
+    return {};
   }
 
   virtual lldb::ScriptedThreadInterfaceSP CreateScriptedThreadInterface() {
-    return std::make_shared<ScriptedThreadInterface>();
+    return {};
   }
 
   virtual lldb::OperatingSystemInterfaceSP CreateOperatingSystemInterface() {
-    return std::make_shared<OperatingSystemInterface>();
+    return {};
   }
 
-  ScriptedPlatformInterface &GetScriptedPlatformInterface() {
-    return *m_scripted_platform_interface_up;
+  virtual lldb::ScriptedPlatformInterfaceUP GetScriptedPlatformInterface() {
+    return {};
   }
 
   virtual StructuredData::ObjectSP
@@ -599,7 +596,6 @@ public:
 protected:
   Debugger &m_debugger;
   lldb::ScriptLanguage m_script_lang;
-  lldb::ScriptedPlatformInterfaceUP m_scripted_platform_interface_up;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -27,12 +27,9 @@
 using namespace lldb;
 using namespace lldb_private;
 
-ScriptInterpreter::ScriptInterpreter(
-    Debugger &debugger, lldb::ScriptLanguage script_lang,
-    lldb::ScriptedPlatformInterfaceUP scripted_platform_interface_up)
-    : m_debugger(debugger), m_script_lang(script_lang),
-      m_scripted_platform_interface_up(
-          std::move(scripted_platform_interface_up)) {}
+ScriptInterpreter::ScriptInterpreter(Debugger &debugger,
+                                     lldb::ScriptLanguage script_lang)
+    : m_debugger(debugger), m_script_lang(script_lang) {}
 
 void ScriptInterpreter::CollectDataForBreakpointCommandCallback(
     std::vector<std::reference_wrapper<BreakpointOptions>> &bp_options_vec,

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -427,8 +427,6 @@ ScriptInterpreterPythonImpl::ScriptInterpreterPythonImpl(Debugger &debugger)
       m_active_io_handler(eIOHandlerNone), m_session_is_active(false),
       m_pty_secondary_is_open(false), m_valid_session(true), m_lock_count(0),
       m_command_thread_state(nullptr) {
-  m_scripted_platform_interface_up =
-      std::make_unique<ScriptedPlatformPythonInterface>(*this);
 
   m_dictionary_name.append("_dict");
   StreamString run_string;


### PR DESCRIPTION
This patch makes the various Scripted Interface base class abstract by making the `CreatePluginObject` method pure virtual.

This means that we cannot construct a Scripted Interface base class instance, so this patch also updates the various `ScriptedInterpreter::CreateScripted*Interface` methods to return a `nullptr` instead.`

This patch also removes the `ScriptedPlatformInterface` member from the `ScriptInterpreter` class since it the interpreter can be owned by the `ScriptedPlatform` instance itself, like we do for `ScriptedProcess` objects.