### PR TITLE
Add SANITIZER_CDECL to __tsan_check_no_mutexes_held

### DIFF
--- a/compiler-rt/include/sanitizer/tsan_interface.h
+++ b/compiler-rt/include/sanitizer/tsan_interface.h
@@ -129,7 +129,7 @@ void SANITIZER_CDECL __tsan_mutex_post_divert(void *addr, unsigned flags);
 
 // Check that the current thread does not hold any mutexes,
 // report a bug report otherwise.
-void __tsan_check_no_mutexes_held();
+void SANITIZER_CDECL __tsan_check_no_mutexes_held();
 
 // External race detection API.
 // Can be used by non-instrumented libraries to detect when their objects are


### PR DESCRIPTION
in https://github.com/llvm/llvm-project/pull/69625 @strega-nil added cdecl to a huge number of sanitizer interface declarations. It looks like she was racing against @kennyyu adding a tsan interface function. I noticed this when merging in the latest changes from llvm/main and corrected it.