### PR TITLE
[lldb] BreakpointResolver{*}::CreateFromStructuredData should return shared pointers

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
@@ -30,7 +30,7 @@ public:
 
   ~BreakpointResolverAddress() override = default;
 
-  static BreakpointResolver *
+  static lldb::BreakpointResolverSP
   CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
                            const StructuredData::Dictionary &options_dict,
                            Status &error);

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverFileLine.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverFileLine.h
@@ -27,7 +27,7 @@ public:
       const SourceLocationSpec &location_spec,
       std::optional<llvm::StringRef> removed_prefix_opt = std::nullopt);
 
-  static BreakpointResolver *
+  static lldb::BreakpointResolverSP
   CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
                            const StructuredData::Dictionary &data_dict,
                            Status &error);

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverFileRegex.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverFileRegex.h
@@ -27,7 +27,7 @@ public:
       const lldb::BreakpointSP &bkpt, RegularExpression regex,
       const std::unordered_set<std::string> &func_name_set, bool exact_match);
 
-  static BreakpointResolver *
+  static lldb::BreakpointResolverSP
   CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
                            const StructuredData::Dictionary &options_dict,
                            Status &error);

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
@@ -50,7 +50,7 @@ public:
                          lldb::LanguageType language, lldb::addr_t offset,
                          bool skip_prologue);
 
-  static BreakpointResolver *
+  static lldb::BreakpointResolverSP
   CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
                            const StructuredData::Dictionary &data_dict,
                            Status &error);

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverScripted.h
@@ -30,7 +30,7 @@ public:
 
   ~BreakpointResolverScripted() override = default;
 
-  static BreakpointResolver *
+  static lldb::BreakpointResolverSP
   CreateFromStructuredData(const lldb::BreakpointSP &bkpt,
                            const StructuredData::Dictionary &options_dict,
                            Status &error);

--- a/lldb/source/Breakpoint/BreakpointResolver.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolver.cpp
@@ -110,26 +110,25 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
     return result_sp;
   }
 
-  BreakpointResolver *resolver = nullptr;
   switch (resolver_type) {
   case FileLineResolver:
-    resolver = BreakpointResolverFileLine::CreateFromStructuredData(
+    result_sp = BreakpointResolverFileLine::CreateFromStructuredData(
         nullptr, *subclass_options, error);
     break;
   case AddressResolver:
-    resolver = BreakpointResolverAddress::CreateFromStructuredData(
+    result_sp = BreakpointResolverAddress::CreateFromStructuredData(
         nullptr, *subclass_options, error);
     break;
   case NameResolver:
-    resolver = BreakpointResolverName::CreateFromStructuredData(
+    result_sp = BreakpointResolverName::CreateFromStructuredData(
         nullptr, *subclass_options, error);
     break;
   case FileRegexResolver:
-    resolver = BreakpointResolverFileRegex::CreateFromStructuredData(
+    result_sp = BreakpointResolverFileRegex::CreateFromStructuredData(
         nullptr, *subclass_options, error);
     break;
   case PythonResolver:
-    resolver = BreakpointResolverScripted::CreateFromStructuredData(
+    result_sp = BreakpointResolverScripted::CreateFromStructuredData(
         nullptr, *subclass_options, error);
     break;
   case ExceptionResolver:
@@ -139,12 +138,12 @@ BreakpointResolverSP BreakpointResolver::CreateFromStructuredData(
     llvm_unreachable("Should never get an unresolvable resolver type.");
   }
 
-  if (!resolver || error.Fail())
-    return result_sp;
+  if (error.Fail() || !result_sp)
+    return {};
 
   // Add on the global offset option:
-  resolver->SetOffset(offset);
-  return BreakpointResolverSP(resolver);
+  result_sp->SetOffset(offset);
+  return result_sp;
 }
 
 StructuredData::DictionarySP BreakpointResolver::WrapOptionsDict(

--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -30,7 +30,7 @@ BreakpointResolverAddress::BreakpointResolverAddress(const BreakpointSP &bkpt,
     : BreakpointResolver(bkpt, BreakpointResolver::AddressResolver),
       m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS) {}
 
-BreakpointResolver *BreakpointResolverAddress::CreateFromStructuredData(
+BreakpointResolverSP BreakpointResolverAddress::CreateFromStructuredData(
     const BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
     Status &error) {
   llvm::StringRef module_name;
@@ -56,7 +56,8 @@ BreakpointResolver *BreakpointResolverAddress::CreateFromStructuredData(
     }
     module_filespec.SetFile(module_name, FileSpec::Style::native);
   }
-  return new BreakpointResolverAddress(bkpt, address, module_filespec);
+  return std::make_shared<BreakpointResolverAddress>(bkpt, address,
+                                                     module_filespec);
 }
 
 StructuredData::ObjectSP

--- a/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -30,7 +30,7 @@ BreakpointResolverFileLine::BreakpointResolverFileLine(
       m_location_spec(location_spec), m_skip_prologue(skip_prologue),
       m_removed_prefix_opt(removed_prefix_opt) {}
 
-BreakpointResolver *BreakpointResolverFileLine::CreateFromStructuredData(
+BreakpointResolverSP BreakpointResolverFileLine::CreateFromStructuredData(
     const BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
     Status &error) {
   llvm::StringRef filename;
@@ -90,8 +90,8 @@ BreakpointResolver *BreakpointResolverFileLine::CreateFromStructuredData(
   if (!location_spec)
     return nullptr;
 
-  return new BreakpointResolverFileLine(bkpt, offset, skip_prologue,
-                                        location_spec);
+  return std::make_shared<BreakpointResolverFileLine>(
+      bkpt, offset, skip_prologue, location_spec);
 }
 
 StructuredData::ObjectSP

--- a/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileRegex.cpp
@@ -26,9 +26,9 @@ BreakpointResolverFileRegex::BreakpointResolverFileRegex(
       m_regex(std::move(regex)), m_exact_match(exact_match),
       m_function_names(func_names) {}
 
-BreakpointResolver *BreakpointResolverFileRegex::CreateFromStructuredData(
-    const lldb::BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
-    Status &error) {
+BreakpointResolverSP BreakpointResolverFileRegex::CreateFromStructuredData(
+    const lldb::BreakpointSP &bkpt,
+    const StructuredData::Dictionary &options_dict, Status &error) {
   bool success;
 
   llvm::StringRef regex_string;
@@ -67,8 +67,8 @@ BreakpointResolver *BreakpointResolverFileRegex::CreateFromStructuredData(
     }
   }
 
-  return new BreakpointResolverFileRegex(bkpt, std::move(regex), names_set,
-                                         exact_match);
+  return std::make_shared<BreakpointResolverFileRegex>(bkpt, std::move(regex),
+                                                       names_set, exact_match);
 }
 
 StructuredData::ObjectSP

--- a/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
@@ -58,13 +58,12 @@ void BreakpointResolverScripted::NotifyBreakpointSet() {
   CreateImplementationIfNeeded(GetBreakpoint());
 }
 
-BreakpointResolver *
-BreakpointResolverScripted::CreateFromStructuredData(
+BreakpointResolverSP BreakpointResolverScripted::CreateFromStructuredData(
     const BreakpointSP &bkpt, const StructuredData::Dictionary &options_dict,
     Status &error) {
   llvm::StringRef class_name;
   bool success;
-  
+
   success = options_dict.GetValueForKeyAsString(
       GetKey(OptionNames::PythonClassName), class_name);
   if (!success) {
@@ -80,8 +79,8 @@ BreakpointResolverScripted::CreateFromStructuredData(
   if (options_dict.GetValueForKeyAsDictionary(GetKey(OptionNames::ScriptArgs),
                                               args_dict))
     args_data_impl.SetObjectSP(args_dict->shared_from_this());
-  return new BreakpointResolverScripted(bkpt, class_name, depth, 
-                                        args_data_impl);
+  return std::make_shared<BreakpointResolverScripted>(bkpt, class_name, depth,
+                                                      args_data_impl);
 }
 
 StructuredData::ObjectSP


### PR DESCRIPTION
BreakpointResolver::CreateFromStructuredData returns a BreakpointResolverSP, but all of the subclasses return raw pointers. Instead of creating a raw pointer and shoving it into a shared pointer, it seems reasonable to just create the shared pointer directly.