### PR TITLE
Revert "[Clang] Remove unneeded template keyword"

### DIFF
--- a/clang/include/clang/AST/Redeclarable.h
+++ b/clang/include/clang/AST/Redeclarable.h
@@ -114,7 +114,9 @@ protected:
 
     bool isFirst() const {
       return Link.is<KnownLatest>() ||
-             Link.get<NotKnownLatest>().is<UninitializedLatest>();
+             // FIXME: 'template' is required on the next line due to an
+             // apparent clang bug.
+             Link.get<NotKnownLatest>().template is<UninitializedLatest>();
     }
 
     decl_type *getPrevious(const decl_type *D) const {


### PR DESCRIPTION
Reverts llvm/llvm-project#71435

This is failing on some build bots e.g.: https://green.lab.llvm.org/green/view/LLDB/job/lldb-cmake/62315/consoleFull#-3939952849ba4694-19c4-4d7e-bec5-911270d8a58c