### PR TITLE
[Clang][OpenMP] fixed crash due to invalid binary expression in checking atomic semantics

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -11605,6 +11605,9 @@ class OpenMPAtomicUpdateChecker {
     /// RHS binary operation does not have reference to the updated LHS
     /// part.
     NotAnUpdateExpression,
+    /// An expression contains semantical error not related to
+    /// 'omp atomic [update]'
+    NotAValidExpression,
     /// No errors is found.
     NoError
   };
@@ -11780,6 +11783,10 @@ bool OpenMPAtomicUpdateChecker::checkStatement(Stmt *S, unsigned DiagId,
         }
       } else if (!AtomicBody->isInstantiationDependent()) {
         ErrorFound = NotABinaryOrUnaryExpression;
+        NoteLoc = ErrorLoc = AtomicBody->getExprLoc();
+        NoteRange = ErrorRange = AtomicBody->getSourceRange();
+      } else if (AtomicBody->containsErrors()) {
+        ErrorFound = NotAValidExpression;
         NoteLoc = ErrorLoc = AtomicBody->getExprLoc();
         NoteRange = ErrorRange = AtomicBody->getSourceRange();
       }

--- a/clang/test/SemaOpenMP/atomic-capture-const-no-crash.c
+++ b/clang/test/SemaOpenMP/atomic-capture-const-no-crash.c
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fopenmp-simd -fsyntax-only -verify %s
+// see https://github.com/llvm/llvm-project/issues/69069 
+// or https://github.com/llvm/llvm-project/pull/71480
+
+void test() {
+  int v; const int x; // expected-note {{variable 'x' declared const here}}
+#pragma omp atomic capture
+  { 
+    v = x; 
+    x = 1; // expected-error {{cannot assign to variable 'x' with const-qualified type 'const int'}} 
+  }
+}


### PR DESCRIPTION
This PR fixes https://github.com/llvm/llvm-project/issues/69069 . 
