### PR TITLE
[mlir][vector] Add support for distributing masked writes

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
@@ -502,6 +502,14 @@ struct WarpOpTransferWrite : public OpRewritePattern<vector::TransferWriteOp> {
     // 2.5 Compute the distributed type for the new mask;
     VectorType maskType;
     if (writeOp.getMask()) {
+      // TODO: Distribution of masked writes with non-trivial permutation maps
+      // requires the distribution of the mask to elementwise match the
+      // distribution of the permuted written vector. Currently the details
+      // of which lane is responsible for which element is captured strictly
+      // by shape information on the warp op, and thus requires materializing
+      // the permutation in IR.
+      if (!writeOp.getPermutationMap().isMinorIdentity())
+        return failure();
       maskType =
           getDistributedType(writeOp.getMask().getType().cast<VectorType>(),
                              map, warpOp.getWarpSize());

--- a/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
@@ -511,8 +511,7 @@ struct WarpOpTransferWrite : public OpRewritePattern<vector::TransferWriteOp> {
       if (!writeOp.getPermutationMap().isMinorIdentity())
         return failure();
       maskType =
-          getDistributedType(writeOp.getMask().getType().cast<VectorType>(),
-                             map, warpOp.getWarpSize());
+          getDistributedType(writeOp.getMaskType(), map, warpOp.getWarpSize());
     }
 
     // 3. clone the write into a new WarpExecuteOnLane0Op to separate it from


### PR DESCRIPTION
Because the mask applies to the un-permuted write vector, we can simply distribute the mask identically to the vector, if present.