### PR TITLE
[lldb][test] TestConstStaticIntegralMember.py: un-XFAIL on Linux

### DIFF
--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -125,7 +125,7 @@ class TestCase(TestBase):
     # wouldn't get indexed into the Names accelerator table preventing LLDB from finding
     # them.
     @expectedFailureAll(compiler=["clang"], compiler_version=["<", "18.0"])
-    @expectedFailureAll(debug_info=no_match(["dsym"]))
+    @expectedFailureAll(debug_info=no_match(["dsym"]), oslist=no_match(["linux"]))
     def test_inline_static_members(self):
         self.build()
         lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
This is a newly added test which XPASSes on Linux