### PR TITLE
[mlir][vector] Remove obsolete mask docs in transfer_write op

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1455,10 +1455,6 @@ def Vector_TransferWriteOp :
     any permutation. Elements whose corresponding mask element is `0` are
     masked out.
 
-    An optional SSA value `mask` of the same shape as the vector type may be
-    specified to mask out elements. Elements whose corresponding mask element
-    is `0` are masked out.
-
     An optional boolean array attribute `in_bounds` specifies for every vector
     dimension if the transfer is guaranteed to be within the source bounds. If
     specified, the `in_bounds` array length has to be equal to the vector rank.


### PR DESCRIPTION
The previous paragraph actually is the current definition
of the mask semantics.