### PR TITLE
[PowerPC] Forbid f128 SELECT_CC optimized into fsel

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -8080,7 +8080,8 @@ SDValue PPCTargetLowering::LowerSELECT_CC(SDValue Op, SelectionDAG &DAG) const {
   // For more information, see section F.3 of the 2.06 ISA specification.
   // With ISA 3.0
   if ((!DAG.getTarget().Options.NoInfsFPMath && !Flags.hasNoInfs()) ||
-      (!DAG.getTarget().Options.NoNaNsFPMath && !Flags.hasNoNaNs()))
+      (!DAG.getTarget().Options.NoNaNsFPMath && !Flags.hasNoNaNs()) ||
+      ResVT == MVT::f128)
     return Op;
 
   // If the RHS of the comparison is a 0.0, we don't need to do the

--- a/llvm/test/CodeGen/PowerPC/scalar-min-max-p10.ll
+++ b/llvm/test/CodeGen/PowerPC/scalar-min-max-p10.ll
@@ -70,3 +70,20 @@ entry:
   %0 = tail call fast fp128 @llvm.minnum.f128(fp128 %a, fp128 %b)
   ret fp128 %0
 }
+
+define fp128 @olt_sel(fp128 %a, fp128 %b) {
+; CHECK-LABEL: olt_sel:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    plxv vs36, .LCPI6_0@PCREL(0), 1
+; CHECK-NEXT:    xscmpuqp cr0, v2, v4
+; CHECK-NEXT:    blt cr0, .LBB6_2
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    vmr v3, v4
+; CHECK-NEXT:  .LBB6_2: # %entry
+; CHECK-NEXT:    vmr v2, v3
+; CHECK-NEXT:    blr
+entry:
+  %0 = fcmp fast olt fp128 %a, 0xL00000000000000000000000000000000
+  %1 = select i1 %0, fp128 %b, fp128 0xL00000000000000000000000000000000
+  ret fp128 %1
+}


### PR DESCRIPTION
fsel only supports f32 and f64.