### PR TITLE
[compiler-rt][www] replace deprecated LLVM_CONFIG_PATH with LLVM_CMAKE_DIR

### DIFF
--- a/compiler-rt/www/index.html
+++ b/compiler-rt/www/index.html
@@ -123,7 +123,7 @@
   <li>cd llvm-project</li>
   <li>mkdir build-compiler-rt</li>
   <li>cd build-compiler-rt</li>
-  <li>cmake ../compiler-rt -DLLVM_CONFIG_PATH=/path/to/llvm-config</li>
+  <li>cmake ../compiler-rt -DLLVM_CMAKE_DIR=/path/to/llvm-project/cmake</li>
   <li>make</li>
   </ul>
 

--- a/compiler-rt/www/index.html
+++ b/compiler-rt/www/index.html
@@ -123,7 +123,7 @@
   <li>cd llvm-project</li>
   <li>mkdir build-compiler-rt</li>
   <li>cd build-compiler-rt</li>
-  <li>cmake ../compiler-rt -DLLVM_CMAKE_DIR=/path/to/llvm-project/cmake</li>
+  <li>cmake ../compiler-rt -DLLVM_CMAKE_DIR=/path/to/llvm-project/cmake/modules</li>
   <li>make</li>
   </ul>
 


### PR DESCRIPTION
This updates the standalone build docs for compiler-rt to replace deprecated LLVM_CONFIG_PATH with LLVM_CMAKE_DIR. A warning (added in D137024) is emitted for the current instructions.