### PR TITLE
[mlir][gpu] Allow integer attribute in `dynamic_shared_memory_size`

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
@@ -15,9 +15,9 @@
 #define MLIR_DIALECT_GPU_IR_GPUDIALECT_H
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/DLTI/Traits.h"
 #include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
@@ -17,6 +17,7 @@
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/DLTI/Traits.h"
 #include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
@@ -15,7 +15,6 @@
 #define MLIR_DIALECT_GPU_IR_GPUDIALECT_H
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/DLTI/Traits.h"
 #include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
 #include "mlir/IR/Builders.h"

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -733,10 +733,13 @@ def GPU_LaunchOp : GPU_Op<"launch", [
     static StringRef getDynamicSharedMemorySizeConstantKeyword() { 
       return "dynamicSharedMemorySizeConstant"; 
     }
-
-    static int getDynamicSharedMemorySizeDynamicValue() { 
+    
+    /// Returns dynamic value of the dynamic shared memory size. This is used 
+    /// if dynamic_shared_memory_size is SSA value
+    static uint32_t getDynamicSharedMemorySizeDynamicValue() { 
       return std::numeric_limits<uint32_t>::max(); 
     }
+    
     /// Returns a value of the dynamic shared memory size. 
     /// If it is a constant, it builds one
     mlir::OpFoldResult getDynamicSharedMemorySizeValue(OpBuilder &b) { 

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -587,7 +587,8 @@ def GPU_LaunchOp : GPU_Op<"launch", [
     Arguments<(ins Variadic<GPU_AsyncToken>:$asyncDependencies,
                Index:$gridSizeX, Index:$gridSizeY, Index:$gridSizeZ,
                Index:$blockSizeX, Index:$blockSizeY, Index:$blockSizeZ,
-               Optional<I32>:$dynamicSharedMemorySize)>,
+               Optional<I32>:$dynamicSharedMemorySize,
+               OptionalAttr<SI32Attr>:$dynamicSharedMemorySizeConstant)>,
     Results<(outs Optional<GPU_AsyncToken>:$asyncToken)> {
   let summary = "GPU kernel launch operation";
 
@@ -693,7 +694,8 @@ def GPU_LaunchOp : GPU_Op<"launch", [
       CArg<"Type", "nullptr">:$asyncTokenType,
       CArg<"ValueRange", "{}">:$asyncDependencies,
       CArg<"TypeRange", "{}">:$workgroupAttributions,
-      CArg<"TypeRange", "{}">:$privateAttributions)>
+      CArg<"TypeRange", "{}">:$privateAttributions,
+      CArg<"IntegerAttr", "IntegerAttr()">:$dynamicSharedMemorySizeConstant)>
   ];
 
   let extraClassDeclaration = [{
@@ -728,6 +730,24 @@ def GPU_LaunchOp : GPU_Op<"launch", [
     /// Returns the keywords used in the custom syntax for this Op.
     static StringRef getWorkgroupKeyword() { return "workgroup"; }
     static StringRef getPrivateKeyword() { return "private"; }
+    static StringRef getDynamicSharedMemorySizeConstantKeyword() { 
+      return "dynamicSharedMemorySizeConstant"; 
+    }
+
+    static int getDynamicSharedMemorySizeDynamicValue() { 
+      return std::numeric_limits<int32_t>::min(); 
+    }
+    /// Returns a value of the dynamic shared memory size. 
+    /// If it is a constant, it builds one
+    mlir::Value getDynamicSharedMemorySizeValue(OpBuilder &b) { 
+      int32_t kDynamic = getDynamicSharedMemorySizeDynamicValue();
+      if (getDynamicSharedMemorySizeConstant().value_or(kDynamic) == kDynamic)
+        return getDynamicSharedMemorySize();
+      return b.create<mlir::arith::ConstantOp>(
+            getLoc(), b.getIntegerType(32),
+            b.getI32IntegerAttr(
+                getDynamicSharedMemorySizeConstant().value()));
+    }
 
     /// Returns the number of buffers located in the workgroup memory.
     unsigned getNumWorkgroupAttributions() {

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -588,7 +588,7 @@ def GPU_LaunchOp : GPU_Op<"launch", [
                Index:$gridSizeX, Index:$gridSizeY, Index:$gridSizeZ,
                Index:$blockSizeX, Index:$blockSizeY, Index:$blockSizeZ,
                Optional<I32>:$dynamicSharedMemorySize,
-               OptionalAttr<SI32Attr>:$dynamicSharedMemorySizeConstant)>,
+               OptionalAttr<I32Attr>:$dynamicSharedMemorySizeConstant)>,
     Results<(outs Optional<GPU_AsyncToken>:$asyncToken)> {
   let summary = "GPU kernel launch operation";
 
@@ -735,18 +735,15 @@ def GPU_LaunchOp : GPU_Op<"launch", [
     }
 
     static int getDynamicSharedMemorySizeDynamicValue() { 
-      return std::numeric_limits<int32_t>::min(); 
+      return std::numeric_limits<uint32_t>::max(); 
     }
     /// Returns a value of the dynamic shared memory size. 
     /// If it is a constant, it builds one
-    mlir::Value getDynamicSharedMemorySizeValue(OpBuilder &b) { 
-      int32_t kDynamic = getDynamicSharedMemorySizeDynamicValue();
+    mlir::OpFoldResult getDynamicSharedMemorySizeValue(OpBuilder &b) { 
+      uint32_t kDynamic = getDynamicSharedMemorySizeDynamicValue();
       if (getDynamicSharedMemorySizeConstant().value_or(kDynamic) == kDynamic)
         return getDynamicSharedMemorySize();
-      return b.create<mlir::arith::ConstantOp>(
-            getLoc(), b.getIntegerType(32),
-            b.getI32IntegerAttr(
-                getDynamicSharedMemorySizeConstant().value()));
+      return b.getI32IntegerAttr(getDynamicSharedMemorySizeConstant().value());
     }
 
     /// Returns the number of buffers located in the workgroup memory.

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -727,6 +727,10 @@ def GPU_LaunchOp : GPU_Op<"launch", [
     /// placed in the leading positions of the argument list.
     static constexpr unsigned kNumConfigRegionAttributes = 12;
 
+    /// Dynamic value of the dynamic shared memory size. This is used 
+    /// when dynamic_shared_memory_size is SSA value
+    static constexpr uint32_t kDynamic = std::numeric_limits<uint32_t>::max(); 
+
     /// Returns the keywords used in the custom syntax for this Op.
     static StringRef getWorkgroupKeyword() { return "workgroup"; }
     static StringRef getPrivateKeyword() { return "private"; }
@@ -734,16 +738,9 @@ def GPU_LaunchOp : GPU_Op<"launch", [
       return "dynamicSharedMemorySizeConstant"; 
     }
     
-    /// Returns dynamic value of the dynamic shared memory size. This is used 
-    /// if dynamic_shared_memory_size is SSA value
-    static uint32_t getDynamicSharedMemorySizeDynamicValue() { 
-      return std::numeric_limits<uint32_t>::max(); 
-    }
-    
     /// Returns a value of the dynamic shared memory size. 
     /// If it is a constant, it builds one
     mlir::OpFoldResult getDynamicSharedMemorySizeValue(OpBuilder &b) { 
-      uint32_t kDynamic = getDynamicSharedMemorySizeDynamicValue();
       if (getDynamicSharedMemorySizeConstant().value_or(kDynamic) == kDynamic)
         return getDynamicSharedMemorySize();
       return b.getI32IntegerAttr(getDynamicSharedMemorySizeConstant().value());
@@ -800,6 +797,7 @@ def GPU_LaunchOp : GPU_Op<"launch", [
   let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
   let hasRegionVerifier = 1;
+  let hasVerifier = 1;
 }
 
 def GPU_PrintfOp : GPU_Op<"printf", [MemoryEffects<[MemWrite]>]>,

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -764,7 +764,7 @@ void LaunchOp::print(OpAsmPrinter &p) {
       << getDynamicSharedMemorySize();
   else if (getDynamicSharedMemorySizeConstantAttr()) {
     p << ' ' << getDynamicSharedMemorySizeKeyword() << ' '
-      << getDynamicSharedMemorySizeConstantAttr().getSInt();
+      << getDynamicSharedMemorySizeConstantAttr().getInt();
   }
 
   printAttributions(p, getWorkgroupKeyword(), getWorkgroupAttributions());
@@ -864,10 +864,10 @@ ParseResult LaunchOp::parse(OpAsmParser &parser, OperationState &result) {
           LaunchOp::getDynamicSharedMemorySizeKeyword())) {
     IntegerAttr shmemAttr;
     OptionalParseResult shmemAttrResult = parser.parseOptionalAttribute(
-        shmemAttr, parser.getBuilder().getIntegerType(32, true));
+        shmemAttr, parser.getBuilder().getIntegerType(32));
     if (!shmemAttrResult.has_value()) {
       hasDynamicSharedMemorySize = true;
-      shmemAttr = parser.getBuilder().getSI32IntegerAttr(
+      shmemAttr = parser.getBuilder().getI32IntegerAttr(
           getDynamicSharedMemorySizeDynamicValue());
       if (parser.parseOperand(dynamicSharedMemorySize) ||
           parser.resolveOperand(dynamicSharedMemorySize,

--- a/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
@@ -289,8 +289,7 @@ static void convertToLaunchFuncOp(gpu::LaunchOp launchOp,
   }
   auto launchFunc = builder.create<gpu::LaunchFuncOp>(
       launchOp.getLoc(), kernelFunc, launchOp.getGridSizeOperandValues(),
-      launchOp.getBlockSizeOperandValues(),
-      dynamicSharedSize, operands,
+      launchOp.getBlockSizeOperandValues(), dynamicSharedSize, operands,
       asyncToken ? asyncToken.getType() : nullptr,
       launchOp.getAsyncDependencies());
   launchOp.replaceAllUsesWith(launchFunc);

--- a/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
@@ -281,7 +281,7 @@ static void convertToLaunchFuncOp(gpu::LaunchOp launchOp,
   auto launchFunc = builder.create<gpu::LaunchFuncOp>(
       launchOp.getLoc(), kernelFunc, launchOp.getGridSizeOperandValues(),
       launchOp.getBlockSizeOperandValues(),
-      launchOp.getDynamicSharedMemorySize(), operands,
+      launchOp.getDynamicSharedMemorySizeValue(builder), operands,
       asyncToken ? asyncToken.getType() : nullptr,
       launchOp.getAsyncDependencies());
   launchOp.replaceAllUsesWith(launchFunc);

--- a/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/KernelOutlining.cpp
@@ -278,10 +278,19 @@ static void convertToLaunchFuncOp(gpu::LaunchOp launchOp,
   // The launch op has an optional dynamic shared memory size. If it doesn't
   // exist, we use zero.
   Value asyncToken = launchOp.getAsyncToken();
+  Value dynamicSharedSize;
+  OpFoldResult shmem = launchOp.getDynamicSharedMemorySizeValue(builder);
+  if (auto shmemValue = llvm::dyn_cast<Value>(shmem)) {
+    dynamicSharedSize = shmemValue;
+  } else if (auto shmemConst = getConstantIntValue(shmem)) {
+    dynamicSharedSize = builder.create<mlir::arith::ConstantOp>(
+        launchOp->getLoc(), builder.getIntegerType(32),
+        builder.getI32IntegerAttr(shmemConst.value()));
+  }
   auto launchFunc = builder.create<gpu::LaunchFuncOp>(
       launchOp.getLoc(), kernelFunc, launchOp.getGridSizeOperandValues(),
       launchOp.getBlockSizeOperandValues(),
-      launchOp.getDynamicSharedMemorySizeValue(builder), operands,
+      dynamicSharedSize, operands,
       asyncToken ? asyncToken.getType() : nullptr,
       launchOp.getAsyncDependencies());
   launchOp.replaceAllUsesWith(launchFunc);

--- a/mlir/test/Dialect/GPU/outlining.mlir
+++ b/mlir/test/Dialect/GPU/outlining.mlir
@@ -372,3 +372,36 @@ func.func @launch_memory_attributions_1(%arg0 : memref<*xf32>) {
 }
 
 // CHECK-DL-LABEL: gpu.module @launch_memory_attributions_1_kernel attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>}
+
+
+// -----
+
+// CHECK-LABEL: func.func @dynamic_shared_memory(
+// CHECK-SAME: %[[arg0:.+]]: i32
+func.func @dynamic_shared_memory(%shmemSize : i32) {  
+  %c1 = arith.constant 1 : index
+  gpu.launch blocks(%bx, %by, %bz) in (%sbx = %c1, %sby = %c1, %sbz = %c1)
+             threads(%tx, %ty, %tz) in (%stx = %c1, %sty = %c1, %stz = %c1) 
+             dynamic_shared_memory_size %shmemSize
+  {
+    gpu.terminator
+  }
+  gpu.launch blocks(%bx, %by, %bz) in (%sbx = %c1, %sby = %c1, %sbz = %c1)
+             threads(%tx, %ty, %tz) in (%stx = %c1, %sty = %c1, %stz = %c1) 
+             dynamic_shared_memory_size 200
+  {
+    gpu.terminator
+  }
+    gpu.launch blocks(%bx, %by, %bz) in (%sbx = %c1, %sby = %c1, %sbz = %c1)
+             threads(%tx, %ty, %tz) in (%stx = %c1, %sty = %c1, %stz = %c1)              
+  {
+    gpu.terminator
+  }
+
+
+// CHECK: gpu.launch_func  @dynamic_shared_memory_kernel::@dynamic_shared_memory_kernel blocks in (%{{.+}}, %{{.+}}, %{{.+}}) threads in (%{{.+}}, %{{.+}}, %{{.+}})  dynamic_shared_memory_size %[[arg0]]
+// CHECK: %[[c200:.+]] = arith.constant 200 : i32
+// CHECK: gpu.launch_func  @dynamic_shared_memory_kernel_0::@dynamic_shared_memory_kernel blocks in (%{{.+}}, %{{.+}}, %{{.+}}) threads in (%{{.+}}, %{{.+}}, %{{.+}})  dynamic_shared_memory_size %[[c200]]
+  return
+}
+

--- a/mlir/test/Dialect/GPU/outlining.mlir
+++ b/mlir/test/Dialect/GPU/outlining.mlir
@@ -388,7 +388,7 @@ func.func @dynamic_shared_memory(%shmemSize : i32) {
   }
   gpu.launch blocks(%bx, %by, %bz) in (%sbx = %c1, %sby = %c1, %sbz = %c1)
              threads(%tx, %ty, %tz) in (%stx = %c1, %sty = %c1, %stz = %c1) 
-             dynamic_shared_memory_size 200
+             dynamic_shared_memory_size 8192
   {
     gpu.terminator
   }
@@ -398,10 +398,10 @@ func.func @dynamic_shared_memory(%shmemSize : i32) {
     gpu.terminator
   }
 
-
 // CHECK: gpu.launch_func  @dynamic_shared_memory_kernel::@dynamic_shared_memory_kernel blocks in (%{{.+}}, %{{.+}}, %{{.+}}) threads in (%{{.+}}, %{{.+}}, %{{.+}})  dynamic_shared_memory_size %[[arg0]]
-// CHECK: %[[c200:.+]] = arith.constant 200 : i32
-// CHECK: gpu.launch_func  @dynamic_shared_memory_kernel_0::@dynamic_shared_memory_kernel blocks in (%{{.+}}, %{{.+}}, %{{.+}}) threads in (%{{.+}}, %{{.+}}, %{{.+}})  dynamic_shared_memory_size %[[c200]]
+// CHECK: %[[c8192:.+]] = arith.constant 8192 : i32
+// CHECK: gpu.launch_func  @dynamic_shared_memory_kernel_0::@dynamic_shared_memory_kernel blocks in (%{{.+}}, %{{.+}}, %{{.+}}) threads in (%{{.+}}, %{{.+}}, %{{.+}})  dynamic_shared_memory_size %[[c8192]]
+// CHECK: return 
   return
 }
 


### PR DESCRIPTION
This PR allows integer attributes as `dynamic_shared_memory_size` parameter of `gpu.launch`. See the example IR below, `200` doesn't have to be SSA value anymore.

```
gpu.launch blocks(..) threads(...)
             dynamic_shared_memory_size 128
```

**Motivation:**

When shared memory size is known, we can leverage it for the IR verification. 

```
gpu.launch blocks(..) threads(...) dynamic_shared_memory_size 128
{
  %0 = gpu.dynamic_shared_memory memref<?xi8,3>
  %1 = memref.view %0[][] : memref<100xf32,3>    // overflow 100 x sizeof(f32) > 128
}
```

