### PR TITLE
[mlir][gpu] Introduce `gpu.dynamic.shared.memory` Op

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/GPUBase.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUBase.td
@@ -52,6 +52,16 @@ def GPU_Dialect : Dialect {
     /// Returns the numeric value used to identify the private memory address
     /// space.
     static AddressSpace getPrivateAddressSpace() { return AddressSpace::Private; }
+    
+    /// Return true if the given MemRefType has an integer address
+    /// space that matches the workgroup memory address space or
+    /// is a gpu::AddressSpaceAttr attribute with value 'workgroup`.
+    static bool hasWorkgroupMemoryAddressSpace(MemRefType type);
+
+    /// Return true if the given Attribute has an integer address
+    /// space that matches the workgroup memory address space or
+    /// is a gpu::AddressSpaceAttr attribute with value 'workgroup`.
+    static bool isWorkgroupMemoryAddressSpace(Attribute memorySpace);  
   }];
 
   let dependentDialects = ["arith::ArithDialect"];

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUDialect.h
@@ -17,6 +17,7 @@
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/DLTI/Traits.h"
 #include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
@@ -31,6 +32,18 @@
 
 namespace mlir {
 namespace gpu {
+
+/// GPU memory space identifiers.
+enum GPUMemorySpace {
+  /// Generic memory space identifier.
+  kGenericMemorySpace = 0,
+
+  /// Global memory space identifier.
+  kGlobalMemorySpace = 1,
+
+  /// Shared memory space identifier.
+  kSharedMemorySpace = 3
+};
 
 /// Utility class for the GPU dialect to represent triples of `Value`s
 /// accessible through `.x`, `.y`, and `.z` similarly to CUDA notation.

--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -433,6 +433,74 @@ def GPU_GPUFuncOp : GPU_Op<"func", [
   let hasVerifier = 1;
 }
 
+def GPU_DynamicSharedMemoryOp : GPU_Op<"dynamic.shared.memory", 
+                              [MemoryEffects<[MemWrite]>] > {
+  let summary = "Get the memref for dynamic shared memory";
+  
+  let description = [{
+    This operation returns shared memory, also referred to as workgroup memory,
+    using given offsets.
+
+    It is possible to use both constants and SSA values as offsets. 
+
+    If this operation is used within a `gpu.launch`, the verifier will make an
+    attempt to verify that the offsets fall within bounds by utilizing the 
+    `dynamic_shared_memory_size` argument of `gpu.launch` when the values are
+    compile-time constants. Otherwise, the verifier does not perform offset 
+    checks.
+    
+    Examples: 
+    ```mlir
+    // Constant value, offset = 32 * 64 * sizeof(f32) * 1
+    %0 = gpu.dynamic.shared.memory [1] : memref<32x64xf32, #gpu.address_space<workgroup>>
+
+    // Multi-dimensional constant values, offset = (32 * 64 * 1 + 8) * sizeof(f32)
+    %0 = gpu.dynamic.shared.memory [1, 0, 8] : memref<32x64xf32, #gpu.address_space<workgroup>>
+
+    // Multi-dimensional dynamic values, offset = (32 * 64 * %1) * sizeof(f32)
+    %0 = gpu.dynamic.shared.memory [%1, 0, 0] : (index) -> memref<32x32xf32>
+
+    // Multi-dimensional mixed values, offset = (32 * 64 * %1 + 8) * sizeof(f32)
+    %0 = gpu.dynamic.shared.memory [%1, 0, 8] : (index) -> memref<32x32xf32>
+    ```
+  }];  
+
+  let arguments = (ins 
+    Variadic<Index>:$dynamic_offsets,
+    DenseI64ArrayAttr:$static_offsets
+  );
+
+  let results = (outs Arg<AnyMemRef, "", [MemWriteAt<0, FullEffect>]>:$resultMemref);
+
+  let assemblyFormat = [{    
+    custom<DynamicIndexList>($dynamic_offsets, $static_offsets)
+    attr-dict 
+    `:` type($resultMemref)
+  }];
+
+   let builders = [
+    OpBuilder<(ins "Type":$memref, "int64_t":$offsets)>,
+    OpBuilder<(ins "Type":$memref, "OpFoldResult":$offsets)>,
+    OpBuilder<(ins "Type":$memref, "ArrayRef<int64_t>":$offsets)>,
+    OpBuilder<(ins "Type":$memref, "ArrayRef<OpFoldResult>":$offsets)>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return a vector with all the static and dynamic offsets indices.
+    SmallVector<OpFoldResult> getMixedOffsets() {
+      OpBuilder builder(getContext());
+      return getMixedValues(getStaticOffsets(), getDynamicOffsets(), builder);
+    }
+
+    bool hasDynamicOffsets() {
+      auto dynPos = getDynamicOffsets();
+      return std::any_of(dynPos.begin(), dynPos.end(),
+                         [](Value operand) { return operand != nullptr; });
+    }
+  }];
+  let hasVerifier = 1;
+}
+
 def LaunchIndx : AnyTypeOf<[Index, I32, I64]>;
 
 def GPU_LaunchFuncOp :GPU_Op<"launch_func", [
@@ -587,7 +655,8 @@ def GPU_LaunchOp : GPU_Op<"launch", [
     Arguments<(ins Variadic<GPU_AsyncToken>:$asyncDependencies,
                Index:$gridSizeX, Index:$gridSizeY, Index:$gridSizeZ,
                Index:$blockSizeX, Index:$blockSizeY, Index:$blockSizeZ,
-               Optional<I32>:$dynamicSharedMemorySize)>,
+               Optional<I32>:$dynamicSharedMemorySize,
+               OptionalAttr<I32Attr>:$guray)>,
     Results<(outs Optional<GPU_AsyncToken>:$asyncToken)> {
   let summary = "GPU kernel launch operation";
 
@@ -693,7 +762,8 @@ def GPU_LaunchOp : GPU_Op<"launch", [
       CArg<"Type", "nullptr">:$asyncTokenType,
       CArg<"ValueRange", "{}">:$asyncDependencies,
       CArg<"TypeRange", "{}">:$workgroupAttributions,
-      CArg<"TypeRange", "{}">:$privateAttributions)>
+      CArg<"TypeRange", "{}">:$privateAttributions,
+      CArg<"IntegerAttr", "IntegerAttr()">:$guray)>
   ];
 
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMDialect.h
@@ -27,6 +27,9 @@
 namespace mlir {
 namespace NVVM {
 
+// Shared memory has 128-bit alignment
+constexpr int kSharedMemoryAlignmentBit = 128;
+
 /// NVVM memory space identifiers.
 enum NVVMMemorySpace {
   /// Global memory space identifier.

--- a/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.h
+++ b/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.h
@@ -14,6 +14,28 @@
 
 namespace mlir {
 
+/// Lowering for gpu.dynamic.shared.memory to LLVM dialect. The pattern first
+/// create a 0-sized global array symbol similar as LLVM expects. Subsequently,
+/// it computes the offset using 'getelementptr' with its offset arguments.
+/// Finally, it constructs a memref descriptor with these values and return it.
+struct GPUDynamicSharedMemoryOpLowering
+    : public ConvertOpToLLVMPattern<gpu::DynamicSharedMemoryOp> {
+  using ConvertOpToLLVMPattern<
+      gpu::DynamicSharedMemoryOp>::ConvertOpToLLVMPattern;
+  GPUDynamicSharedMemoryOpLowering(const LLVMTypeConverter &converter,
+                                   unsigned alignmentBit = 0)
+      : ConvertOpToLLVMPattern<gpu::DynamicSharedMemoryOp>(converter),
+        alignmentBit(alignmentBit) {}
+
+  LogicalResult
+  matchAndRewrite(gpu::DynamicSharedMemoryOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+
+private:
+  // Alignment bit
+  unsigned alignmentBit;
+};
+
 struct GPUFuncOpLowering : ConvertOpToLLVMPattern<gpu::GPUFuncOp> {
   GPUFuncOpLowering(const LLVMTypeConverter &converter,
                     unsigned allocaAddrSpace, unsigned workgroupAddrSpace,

--- a/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
+++ b/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
@@ -325,6 +325,9 @@ void mlir::populateGpuToNVVMConversionPatterns(LLVMTypeConverter &converter,
            GPULaneIdOpToNVVM, GPUShuffleOpLowering, GPUReturnOpLowering>(
           converter);
 
+  patterns.add<GPUDynamicSharedMemoryOpLowering>(
+      converter, NVVM::kSharedMemoryAlignmentBit);
+
   // Explicitly drop memory space when lowering private memory
   // attributions since NVVM models it as `alloca`s in the default
   // memory space and does not support `alloca`s with addrspace(5).

--- a/mlir/test/Dialect/GPU/dynamic-shared-memory.mlir
+++ b/mlir/test/Dialect/GPU/dynamic-shared-memory.mlir
@@ -1,0 +1,64 @@
+// RUN: mlir-opt %s -convert-gpu-to-nvvm -cse -canonicalize | FileCheck %s
+
+gpu.module @modules {
+  // CHECK: llvm.mlir.global internal @__shmem_dynamic_shared_memory_kernel_0() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x f32>
+  
+  // CHECK-LABEL: llvm.func @dynamic_shared_memory_kernel(
+  // CHECK-SAME: %[[arg0:.+]]: i64)
+  gpu.func @dynamic_shared_memory_kernel(%d : index) kernel attributes {gpu.known_block_size = array<i32: 1, 1, 1>, gpu.known_grid_size = array<i32: 1, 1, 1>} {    
+    %c1 = arith.constant 1 : index
+    %c100 = arith.constant 100 : index
+    %0 = gpu.dynamic.shared.memory [1, 0, 0] : memref<32x64xf32, #gpu.address_space<workgroup>>
+    %1 = gpu.dynamic.shared.memory [1, 0, 0] : memref<32x32xf32, 3>
+    %2 = gpu.dynamic.shared.memory [4, 234] : memref<32x32xf32, #gpu.address_space<workgroup>>
+    %3 = gpu.dynamic.shared.memory [%c100, 4] : memref<32x32xf32, #gpu.address_space<workgroup>>
+    %4 = gpu.dynamic.shared.memory [%c100, %d] : memref<128x64xf16, #gpu.address_space<workgroup>>
+    %5 = gpu.dynamic.shared.memory [32, 0, 0] : memref<32x8xf32, #gpu.address_space<workgroup>>
+    "test.use.shared.memory"(%0) : (memref<32x64xf32, #gpu.address_space<workgroup>>) -> ()
+    "test.use.shared.memory"(%1) : (memref<32x32xf32, 3>) -> ()
+    "test.use.shared.memory"(%2) : (memref<32x32xf32, #gpu.address_space<workgroup>>) -> ()
+    "test.use.shared.memory"(%3) : (memref<32x32xf32, #gpu.address_space<workgroup>>) -> ()
+    "test.use.shared.memory"(%4) : (memref<128x64xf16, #gpu.address_space<workgroup>>) -> ()
+    "test.use.shared.memory"(%5) : (memref<32x8xf32, #gpu.address_space<workgroup>>) -> ()
+
+    // CHECK: %[[S2:.+]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK: %[[S3:.+]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK: %[[S4:.+]] = llvm.mlir.constant(64 : index) : i64
+    // CHECK: %[[S5:.+]] = llvm.mlir.constant(32 : index) : i64
+    // CHECK: %[[S6:.+]] = llvm.mlir.addressof @__shmem_dynamic_shared_memory_kernel_0 : !llvm.ptr<3>
+    // CHECK: %[[S7:.+]] = llvm.getelementptr %[[S6]][1, 0, 0] : (!llvm.ptr<3>) -> !llvm.ptr<3>, !llvm.array<32 x array<64 x f32>>
+    // CHECK: %[[S8:.+]] = llvm.mlir.undef : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
+    // CHECK: %[[S9:.+]] = llvm.insertvalue %[[S7]], %[[S8]][0] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> 
+    // CHECK: %[[S10:.+]] = llvm.insertvalue %[[S7]], %[[S9]][1] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> 
+    // CHECK: %[[S11:.+]] = llvm.insertvalue %[[S2]], %[[S10]][2] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> 
+    // CHECK: %[[S12:.+]] = llvm.insertvalue %[[S5]], %[[S11]][3, 0] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> 
+    // CHECK: %[[S13:.+]] = llvm.insertvalue %[[S4]], %[[S12]][3, 1] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> 
+    // CHECK: %[[S14:.+]] = llvm.insertvalue %[[S4]], %[[S13]][4, 0] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> 
+    // CHECK: %[[S15:.+]] = llvm.insertvalue %[[S3]], %[[S14]][4, 1] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> 
+    // CHECK: %[[S16:.+]] = builtin.unrealized_conversion_cast %[[S15]] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> to memref<32x64xf32, #gpu.address_space<workgroup>>
+
+    // CHECK: %[[S17:.+]] = llvm.getelementptr %[[S6]][1, 0, 0] : (!llvm.ptr<3>) -> !llvm.ptr<3>, !llvm.array<32 x array<32 x f32>>
+    // CHECK: %[[S25:.+]] = builtin.unrealized_conversion_cast %{{.*}} : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> to memref<32x32xf32, 3>
+
+    // CHECK: %[[S26:.+]] = llvm.getelementptr %[[S6]][4, 234] : (!llvm.ptr<3>) -> !llvm.ptr<3>, !llvm.array<32 x array<32 x f32>>
+    // CHECK: %[[S34:.+]] = builtin.unrealized_conversion_cast %{{.*}} : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> to memref<32x32xf32, #gpu.address_space<workgroup>>
+
+    // CHECK: %[[S35:.+]] = llvm.getelementptr %[[S6]][100, 4] : (!llvm.ptr<3>) -> !llvm.ptr<3>, !llvm.array<32 x array<32 x f32>>
+    // CHECK: %[[S43:.+]] = builtin.unrealized_conversion_cast %{{.*}} : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> to memref<32x32xf32, #gpu.address_space<workgroup>>
+
+    // CHECK: %[[S44:.+]] = llvm.getelementptr %[[S6]][100, %[[arg0]]] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, !llvm.array<128 x array<64 x f16>>
+    // CHECK: %[[S52:.+]] = builtin.unrealized_conversion_cast %{{.*}} : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> to memref<128x64xf16, #gpu.address_space<workgroup>>
+
+    // CHECK: %[[S53:.+]] = llvm.getelementptr %[[S6]][32, 0, 0] : (!llvm.ptr<3>) -> !llvm.ptr<3>, !llvm.array<32 x array<8 x f32>>
+    // CHECK: %[[S61:.+]] = builtin.unrealized_conversion_cast %{{.*}} : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> to memref<32x8xf32, #gpu.address_space<workgroup>>
+
+    // CHECK: "test.use.shared.memory"(%[[S16]]) : (memref<32x64xf32, #gpu.address_space<workgroup>>) -> ()
+    // CHECK: "test.use.shared.memory"(%[[S25]]) : (memref<32x32xf32, 3>) -> ()
+    // CHECK: "test.use.shared.memory"(%[[S34]]) : (memref<32x32xf32, #gpu.address_space<workgroup>>) -> ()
+    // CHECK: "test.use.shared.memory"(%[[S43]]) : (memref<32x32xf32, #gpu.address_space<workgroup>>) -> ()
+    // CHECK: "test.use.shared.memory"(%[[S52]]) : (memref<128x64xf16, #gpu.address_space<workgroup>>) -> ()
+    // CHECK: "test.use.shared.memory"(%[[S61]]) : (memref<32x8xf32, #gpu.address_space<workgroup>>) -> ()
+
+    gpu.return
+  }
+}


### PR DESCRIPTION
While the `gpu.launch` Op allows setting the size via the `dynamic_shared_memory_size` argument, accessing the dynamic shared memory is very convoluted. This PR implements the proposed Op, `gpu.dynamic.shared.memory` that aims to simplify the utilization of dynamic shared memory.

RFC: https://discourse.llvm.org/t/rfc-simplifying-dynamic-shared-memory-access-in-gpu/

**Proposal from RFC**
This PR `gpu.dynamic.shared.memory` Op to use dynamic shared memory feature efficiently. It is is a powerful feature that enables the allocation of shared memory at runtime with the kernel launch on the host. Afterwards, the memory can be accessed directly from the device. I believe similar story exists for AMDGPU.

**New Op Features**

- No more 0-Sized Global Symbol Generation: The lowering will hide 1st and 3rd steps.
- Simplified Shared Memory Access: No need for reinterpret_cast or subview. The offset argument will be sufficient.
- Compile-time Bound Check: The Op verifier checks dynamic_shared_memory_size < offset if they are compile-time constants.
- Runtime-time Bound Check (TODO): We can add `{dynamicBoundCheck}` attribute that checks dynamic_shared_memory_size < offset on the runtime. This is optional and definitely adds overhead, but it can be beneficial for debugging.

**Current way Using Dynamic Shared Memory with MLIR**

Let me illustrate the challenges of using dynamic shared memory in MLIR with an example below. The process involves several steps:
- memref.global 0-sized array NVPTX expects
- dynamic_shared_memory_size Set the size of dynamic shared memory
- memref.get_global Access the global symbol
- reinterpret_cast and subview Many OPs for pointer arithmetic

```
// Step 1. Create 0-sized global symbol. Manually set the alignment
memref.global "private" @dynamicShmem  : memref<0xf16, 3> { alignment = 16 }
func.func @main() {
  // Step 2. Allocate shared memory
  gpu.launch blocks(...) threads(...)
    dynamic_shared_memory_size %c10000 {
    // Step 3. Access the global object
    %shmem = memref.get_global @dynamicShmem : memref<0xf16, 3>
    // Step 4. A sequence of `memref.reinterpret_cast` and `memref.subview` operations.
    %4 = memref.reinterpret_cast %shmem to offset: [0], sizes: [14, 64, 128],  strides: [8192,128,1] : memref<0xf16, 3> to memref<14x64x128xf16,3>
    %5 = memref.subview %4[7, 0, 0][7, 64, 128][1,1,1] : memref<14x64x128xf16,3> to memref<7x64x128xf16, strided<[8192, 128, 1], offset: 57344>, 3>
    %6 = memref.subview %5[2, 0, 0][1, 64, 128][1,1,1] : memref<7x64x128xf16, strided<[8192, 128, 1], offset: 57344>, 3> to memref<64x128xf16, strided<[128, 1], offset: 73728>, 3>
    %7 = memref.subview %6[0, 0][64, 64][1,1]  : memref<64x128xf16, strided<[128, 1], offset: 73728>, 3> to memref<64x64xf16, strided<[128, 1], offset: 73728>, 3>
    %8 = memref.subview %6[32, 0][64, 64][1,1] : memref<64x128xf16, strided<[128, 1], offset: 73728>, 3> to memref<64x64xf16, strided<[128, 1], offset: 77824>, 3>
    // Step.5 Use
    "test.use.shared.memory"(%7) : (memref<64x64xf16, strided<[128, 1], offset: 73728>, 3>) -> (index)
    "test.use.shared.memory"(%8) : (memref<64x64xf16, strided<[128, 1], offset: 77824>, 3>) -> (index)
    gpu.terminator
  }
```

Let’s write the program above with that:

```
func.func @main() {
    gpu.launch blocks(...) threads(...) dynamic_shared_memory_size %c10000 {
    	%i = arith.constant 18 : index
        // Step 1: Obtain shared memory directly
        %7 = gpu.dynamic.shared.memory [%i,0,0] : memref<64x64xf16, 3>
        %i2 = arith.addi %i, %c1
        %8 = gpu.dynamic.shared.memory [%i2,0,0] : memref<64x64xf16, 3>

        // Step 2: Utilize the shared memory
        "test.use.shared.memory"(%7) : (memref<64x64xf16, 3>) -> (index)
        "test.use.shared.memory"(%8) : (memref<64x64xf16, 3>) -> (index)
    }
}
```