### PR TITLE
[flang][OpenMP] Add semantic check for target data

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -919,12 +919,28 @@ void OmpStructureChecker::ChecksOnOrderedAsBlock() {
   }
 }
 
+void OmpStructureChecker::CheckTargetData() {
+  const parser::OmpClause *mapClause = FindClause(llvm::omp::Clause::OMPC_map);
+  const parser::OmpClause *useDevicePtrClause =
+      FindClause(llvm::omp::Clause::OMPC_use_device_ptr);
+  const parser::OmpClause *useDeviceAddrClause =
+      FindClause(llvm::omp::OMPC_use_device_addr);
+  if (!mapClause && !useDevicePtrClause && !useDeviceAddrClause) {
+    context_.Say(GetContext().directiveSource,
+        "At least one MAP, USE_DEVICE_ADDR or USE_DEVICE_PTR clause must "
+        "appear on the TARGET DATA directive."_err_en_US);
+  }
+}
+
 void OmpStructureChecker::Leave(const parser::OmpBeginBlockDirective &) {
   switch (GetContext().directive) {
   case llvm::omp::Directive::OMPD_ordered:
     // [5.1] 2.19.9 Ordered Construct Restriction
     ChecksOnOrderedAsBlock();
     break;
+  case llvm::omp::Directive::OMPD_target_data:
+    CheckTargetData();
+    return;
   default:
     break;
   }

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -184,6 +184,7 @@ private:
   void CheckSIMDNest(const parser::OpenMPConstruct &x);
   void CheckTargetNest(const parser::OpenMPConstruct &x);
   void CheckTargetUpdate();
+  void CheckTargetData();
   void CheckCancellationNest(
       const parser::CharBlock &source, const parser::OmpCancelType::Type &type);
   std::int64_t GetOrdCollapseLevel(const parser::OpenMPLoopConstruct &x);

--- a/flang/test/Semantics/OpenMP/device-constructs.f90
+++ b/flang/test/Semantics/OpenMP/device-constructs.f90
@@ -135,7 +135,7 @@ program main
   enddo
   !$omp end target data
 
-  !ERROR: At least one of MAP clause must appear on the TARGET DATA directive
+  !ERROR: At least one MAP, USE_DEVICE_ADDR or USE_DEVICE_PTR clause must appear on the TARGET DATA directive.
   !$omp target data device(0)
   do i = 1, N
      a = 3.14

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -705,14 +705,12 @@ def OMP_Nothing : Directive<"nothing"> {}
 def OMP_TargetData : Directive<"target data"> {
   let allowedClauses = [
     VersionedClause<OMPC_UseDevicePtr>,
-    VersionedClause<OMPC_UseDeviceAddr, 50>
+    VersionedClause<OMPC_UseDeviceAddr, 50>,
+    VersionedClause<OMPC_Map>
   ];
   let allowedOnceClauses = [
     VersionedClause<OMPC_Device>,
     VersionedClause<OMPC_If>
-  ];
-  let requiredClauses = [
-    VersionedClause<OMPC_Map>
   ];
 }
 def OMP_TargetEnterData : Directive<"target enter data"> {


### PR DESCRIPTION
This patch adds the following semantic check on target data

```
At least one map, use_device_addr or use_device_ptr clause must appear
on the target data directive.
```