### PR TITLE
[flang] Don't accept NULL() actual for assumed-rank dummy

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -93,6 +93,9 @@ end
   non-global name in the same scope.  This is not conforming,
   but it is useful and unambiguous.
 * The argument to `RANDOM_NUMBER` may not be an assumed-size array.
+* `NULL()` without `MOLD=` is not allowed to be associated as an
+  actual argument corresponding to an assumed-rank dummy argument;
+  its rank in the called procedure would not be well-defined.
 
 ## Extensions, deletions, and legacy features supported by default
 

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1077,6 +1077,10 @@ static void CheckExplicitInterfaceArg(evaluate::ActualArgument &arg,
                 } else if (object.type.type().IsTypelessIntrinsicArgument() &&
                     evaluate::IsNullObjectPointer(*expr)) {
                   // ok, ASSOCIATED(NULL(without MOLD=))
+                } else if (object.type.attrs().test(characteristics::
+                                   TypeAndShape::Attr::AssumedRank)) {
+                  messages.Say(
+                      "NULL() without MOLD= must not be associated with an assumed-rank dummy argument"_err_en_US);
                 } else if ((object.attrs.test(characteristics::DummyDataObject::
                                     Attr::Pointer) ||
                                object.attrs.test(characteristics::

--- a/flang/test/Semantics/call39.f90
+++ b/flang/test/Semantics/call39.f90
@@ -23,5 +23,9 @@ module m
     call s1(null(a1)) ! ok
     call sa(null(a0)) ! ok
     call sa(null(a1)) ! ok
+    !ERROR: NULL() without MOLD= must not be associated with an assumed-rank dummy argument
+    call sa(null())
+    !ERROR: NULL() without MOLD= must not be associated with an assumed-rank dummy argument
+    call sa(null())
   end
 end


### PR DESCRIPTION
A NULL() pointer without MOLD= cannot be allowed to be associated with an assumed-rank dummy argument, as its rank is not well-defined and neither the RANK() intrinsic function or the SELECT RANK construct will work in the callee.