### PR TITLE
[openacc] Remove duplicate operand from LoopOp getDataOperand

### DIFF
--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -893,7 +893,6 @@ Value LoopOp::getDataOperand(unsigned i) {
   numOptional += getGangStatic() ? 1 : 0;
   numOptional += getVectorLength() ? 1 : 0;
   numOptional += getWorkerNum() ? 1 : 0;
-  numOptional += getVectorLength() ? 1 : 0;
   numOptional += getTileOperands().size();
   numOptional += getCacheOperands().size();
   return getOperand(numOptional + i);


### PR DESCRIPTION
vectorLength operand was counted twice - should only be counted once.