### PR TITLE
[XCOFF] Ensure .file is emitted before any .info pseudo-ops

### DIFF
--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-data.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-data.ll
@@ -45,8 +45,8 @@
 
 ; CHECK-NOT: .toc
 
-; CHECK:      .csect [PR],5
-; CHECK-NEXT:  .file
+; CHECK:  .file
+; CHECK-NEXT:      .csect [PR],5
 
 ; CHECK:      .csect .data[RW],5
 ; CHECK-NEXT: .globl  ivar

--- a/llvm/test/DebugInfo/XCOFF/empty.ll
+++ b/llvm/test/DebugInfo/XCOFF/empty.ll
@@ -35,8 +35,8 @@ entry:
 !11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !12 = !DILocation(line: 3, column: 3, scope: !8)
 
-; ASM32:               .csect [PR],5
-; ASM32-NEXT:          .file   "1.c"
+; ASM32:          .file   "1.c"
+; ASM32-NEXT:               .csect [PR],5
 ; ASM32-NEXT:          .globl  main[DS]                        # -- Begin function main
 ; ASM32-NEXT:          .globl  .main
 ; ASM32-NEXT:          .align  2
@@ -236,8 +236,8 @@ entry:
 ; ASM32-NEXT:          .byte   1
 ; ASM32-NEXT:  L..debug_line_end0:
 
-; ASM64:               .csect [PR],5
-; ASM64-NEXT:          .file   "1.c"
+; ASM64:          .file   "1.c"
+; ASM64-NEXT:               .csect [PR],5
 ; ASM64-NEXT:          .globl  main[DS]                        # -- Begin function main
 ; ASM64-NEXT:          .globl  .main
 ; ASM64-NEXT:          .align  2

--- a/llvm/test/DebugInfo/XCOFF/empty.ll
+++ b/llvm/test/DebugInfo/XCOFF/empty.ll
@@ -35,8 +35,8 @@ entry:
 !11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !12 = !DILocation(line: 3, column: 3, scope: !8)
 
-; ASM32:          .file   "1.c"
-; ASM32-NEXT:               .csect [PR],5
+; ASM32:               .file   "1.c"
+; ASM32-NEXT:          .csect [PR],5
 ; ASM32-NEXT:          .globl  main[DS]                        # -- Begin function main
 ; ASM32-NEXT:          .globl  .main
 ; ASM32-NEXT:          .align  2
@@ -236,8 +236,8 @@ entry:
 ; ASM32-NEXT:          .byte   1
 ; ASM32-NEXT:  L..debug_line_end0:
 
-; ASM64:          .file   "1.c"
-; ASM64-NEXT:               .csect [PR],5
+; ASM64:               .file   "1.c"
+; ASM64-NEXT:          .csect [PR],5
 ; ASM64-NEXT:          .globl  main[DS]                        # -- Begin function main
 ; ASM64-NEXT:          .globl  .main
 ; ASM64-NEXT:          .align  2

--- a/llvm/test/DebugInfo/XCOFF/explicit-section.ll
+++ b/llvm/test/DebugInfo/XCOFF/explicit-section.ll
@@ -42,8 +42,8 @@ entry:
 !15 = !DILocation(line: 3, column: 10, scope: !14)
 !16 = !DILocation(line: 3, column: 3, scope: !14)
 
-; CHECK:          .file   "2.c"
-; CHECK-NEXT:               .csect [PR],5
+; CHECK:               .file   "2.c"
+; CHECK-NEXT:          .csect [PR],5
 ; CHECK-NEXT:          .globl  bar[DS]                         # -- Begin function bar
 ; CHECK-NEXT:          .globl  .bar
 ; CHECK-NEXT:          .align  2

--- a/llvm/test/DebugInfo/XCOFF/explicit-section.ll
+++ b/llvm/test/DebugInfo/XCOFF/explicit-section.ll
@@ -42,8 +42,8 @@ entry:
 !15 = !DILocation(line: 3, column: 10, scope: !14)
 !16 = !DILocation(line: 3, column: 3, scope: !14)
 
-; CHECK:               .csect [PR],5
-; CHECK-NEXT:          .file   "2.c"
+; CHECK:          .file   "2.c"
+; CHECK-NEXT:               .csect [PR],5
 ; CHECK-NEXT:          .globl  bar[DS]                         # -- Begin function bar
 ; CHECK-NEXT:          .globl  .bar
 ; CHECK-NEXT:          .align  2

--- a/llvm/test/DebugInfo/XCOFF/function-sections.ll
+++ b/llvm/test/DebugInfo/XCOFF/function-sections.ll
@@ -37,8 +37,8 @@ entry:
 !13 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 6, type: !9, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !14 = !DILocation(line: 8, column: 3, scope: !13)
 
-; CHECK:          .file   "1.c"
-; CHECK-NEXT:               .csect [PR],5
+; CHECK:               .file   "1.c"
+; CHECK-NEXT:          .csect [PR],5
 ; CHECK-NEXT:          .csect .foo[PR],5
 ; CHECK-NEXT:          .globl  foo[DS]                         # -- Begin function foo
 ; CHECK-NEXT:          .globl  .foo[PR]

--- a/llvm/test/DebugInfo/XCOFF/function-sections.ll
+++ b/llvm/test/DebugInfo/XCOFF/function-sections.ll
@@ -37,8 +37,8 @@ entry:
 !13 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 6, type: !9, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !14 = !DILocation(line: 8, column: 3, scope: !13)
 
-; CHECK:               .csect [PR],5
-; CHECK-NEXT:          .file   "1.c"
+; CHECK:          .file   "1.c"
+; CHECK-NEXT:               .csect [PR],5
 ; CHECK-NEXT:          .csect .foo[PR],5
 ; CHECK-NEXT:          .globl  foo[DS]                         # -- Begin function foo
 ; CHECK-NEXT:          .globl  .foo[PR]


### PR DESCRIPTION
When generating the assembly code for AIX/XCOFF, the .file pseudo-op needs to be emitted first, before any csects are generated.  Otherwise, information such as the embedded command line will be associated with part of the object file rather than the entire object file.