### PR TITLE
[flang][openacc] Allow constant variable in data clause

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1123,7 +1123,8 @@ void AccAttributeVisitor::AllowOnlyVariable(const parser::AccObject &object) {
       common::visitors{
           [&](const parser::Designator &designator) {
             const auto &name{GetLastName(designator)};
-            if (name.symbol && !semantics::IsVariableName(*name.symbol)) {
+            if (name.symbol && !semantics::IsVariableName(*name.symbol) &&
+                !semantics::IsNamedConstant(*name.symbol)) {
               context_.Say(designator.source,
                   "Only variables are allowed in data clauses on the %s "
                   "directive"_err_en_US,

--- a/flang/test/Semantics/OpenACC/acc-data.f90
+++ b/flang/test/Semantics/OpenACC/acc-data.f90
@@ -210,4 +210,10 @@ contains
     !$acc data copy(t%t1_proc)
     !$acc end data
   end subroutine
+
+  subroutine sub5()
+    integer, parameter :: iparam = 1024
+    !$acc data copyin(iparam)
+    !$acc end data
+  end subroutine
 end module


### PR DESCRIPTION
The check introduced in #71444 was to restrictive and this patch relax it so data clause can accept constant. 