### PR TITLE
[clang-tidy] readability-identifier-naming: add support for concepts

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -124,6 +124,7 @@ namespace readability {
     m(TypeAlias) \
     m(MacroDefinition) \
     m(ObjcIvar) \
+    m(Concept) \
 
 enum StyleKind : int {
 #define ENUMERATE(v) SK_ ## v,
@@ -1390,6 +1391,9 @@ StyleKind IdentifierNamingCheck::findStyleKind(
 
     return SK_Invalid;
   }
+
+  if (isa<ConceptDecl>(D) && NamingStyles[SK_Concept])
+    return SK_Concept;
 
   return SK_Invalid;
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -399,6 +399,7 @@ Changes in existing checks
   ``Leading_upper_snake_case`` naming convention. The handling of ``typedef``
   has been enhanced, particularly within complex types like function pointers
   and cases where style checks were omitted when functions started with macros.
+  Added support for C++20 ``concept`` declarations.
 
 - Improved :doc:`readability-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check to take

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
@@ -46,6 +46,7 @@ The following options are described below:
  - :option:`ClassConstantCase`, :option:`ClassConstantPrefix`, :option:`ClassConstantSuffix`, :option:`ClassConstantIgnoredRegexp`, :option:`ClassConstantHungarianPrefix`
  - :option:`ClassMemberCase`, :option:`ClassMemberPrefix`, :option:`ClassMemberSuffix`, :option:`ClassMemberIgnoredRegexp`, :option:`ClassMemberHungarianPrefix`
  - :option:`ClassMethodCase`, :option:`ClassMethodPrefix`, :option:`ClassMethodSuffix`, :option:`ClassMethodIgnoredRegexp`
+ - :option:`ConceptCase`, :option:`ConceptPrefix`, :option:`ConceptSuffix`, :option:`ConceptIgnoredRegexp`
  - :option:`ConstantCase`, :option:`ConstantPrefix`, :option:`ConstantSuffix`, :option:`ConstantIgnoredRegexp`, :option:`ConstantHungarianPrefix`
  - :option:`ConstantMemberCase`, :option:`ConstantMemberPrefix`, :option:`ConstantMemberSuffix`, :option:`ConstantMemberIgnoredRegexp`, :option:`ConstantMemberHungarianPrefix`
  - :option:`ConstantParameterCase`, :option:`ConstantParameterPrefix`, :option:`ConstantParameterSuffix`, :option:`ConstantParameterIgnoredRegexp`, :option:`ConstantParameterHungarianPrefix`
@@ -409,6 +410,46 @@ After:
     public:
       int pre_class_member_post();
     };
+
+.. option:: ConceptCase
+
+    When defined, the check will ensure concept names conform to the
+    selected casing.
+
+.. option:: ConceptPrefix
+
+    When defined, the check will ensure concept names will add the
+    prefixed with the given value (regardless of casing).
+
+.. option:: ConceptIgnoredRegexp
+
+    Identifier naming checks won't be enforced for concept names
+    matching this regular expression.
+
+.. option:: ConceptSuffix
+
+    When defined, the check will ensure concept names will add the
+    suffix with the given value (regardless of casing).
+
+For example using values of:
+
+   - ConceptCase of ``CamelCase``
+   - ConceptPrefix of ``Pre``
+   - ConceptSuffix of ``Post``
+
+Identifies and/or transforms concept names as follows:
+
+Before:
+
+.. code-block:: c++
+
+    template<typename T> concept my_concept = requires (T t) { {t++}; };
+
+After:
+
+.. code-block:: c++
+
+    template<typename T> concept PreMyConceptPost = requires (T t) { {t++}; };
 
 .. option:: ConstantCase
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming.cpp
@@ -11,6 +11,7 @@
 // RUN:     readability-identifier-naming.ClassConstantPrefix: 'k', \
 // RUN:     readability-identifier-naming.ClassMemberCase: CamelCase, \
 // RUN:     readability-identifier-naming.ClassMethodCase: camelBack, \
+// RUN:     readability-identifier-naming.ConceptCase: CamelCase, \
 // RUN:     readability-identifier-naming.ConstantCase: UPPER_CASE, \
 // RUN:     readability-identifier-naming.ConstantSuffix: '_CST', \
 // RUN:     readability-identifier-naming.ConstexprFunctionCase: lower_case, \
@@ -250,6 +251,15 @@ class my_derived_class : public virtual my_class {};
 
 class CMyWellNamedClass {};
 // No warning expected as this class is well named.
+
+template<typename t_t>
+concept MyConcept = requires (t_t a_t) { {a_t++}; };
+// No warning expected as this concept is well named.
+
+template<typename t_t>
+concept my_concept_2 = requires (t_t a_t) { {a_t++}; };
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for concept 'my_concept_2'
+// CHECK-FIXES: {{^}}concept MyConcept2 = requires (t_t a_t) { {a_t++}; };{{$}}
 
 template <typename t_t>
 class CMyWellNamedClass2 : public my_class {


### PR DESCRIPTION
Added support for C++20 ``concept`` declarations.