### PR TITLE
[mlir][python] factor out pure python core sources

### DIFF
--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -7,14 +7,16 @@ include(AddMLIRPython)
 declare_mlir_python_sources(MLIRPythonSources)
 declare_mlir_python_sources(MLIRPythonSources.Dialects
   ADD_TO_PARENT MLIRPythonSources)
+declare_mlir_python_sources(MLIRPythonSources.Core
+  ADD_TO_PARENT MLIRPythonSources)
 
 ################################################################################
 # Pure python sources and generated code
 ################################################################################
 
-declare_mlir_python_sources(MLIRPythonSources.Core
+declare_mlir_python_sources(MLIRPythonSources.Core.Python
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
-  ADD_TO_PARENT MLIRPythonSources
+  ADD_TO_PARENT MLIRPythonSources.Core
   SOURCES
     _mlir_libs/__init__.py
     ir.py


### PR DESCRIPTION
I'd like to be able to install just the Python core sources (without building/including the pybind sources).