### PR TITLE
[clangd] Add container field to remote index Refs grpc method

### DIFF
--- a/clang-tools-extra/clangd/index/YAMLSerialization.cpp
+++ b/clang-tools-extra/clangd/index/YAMLSerialization.cpp
@@ -319,6 +319,7 @@ template <> struct MappingTraits<Ref> {
     MappingNormalization<NormalizedRefKind, RefKind> NKind(IO, R.Kind);
     IO.mapRequired("Kind", NKind->Kind);
     IO.mapRequired("Location", R.Location);
+    IO.mapOptional("Container", R.Container);
   }
 };
 

--- a/clang-tools-extra/clangd/index/remote/Index.proto
+++ b/clang-tools-extra/clangd/index/remote/Index.proto
@@ -81,6 +81,7 @@ message Symbol {
 message Ref {
   optional SymbolLocation location = 1;
   optional uint32 kind = 2;
+  optional string container = 3;
 }
 
 message SymbolInfo {

--- a/clang-tools-extra/clangd/index/remote/marshalling/Marshalling.cpp
+++ b/clang-tools-extra/clangd/index/remote/marshalling/Marshalling.cpp
@@ -203,6 +203,9 @@ llvm::Expected<clangd::Ref> Marshaller::fromProtobuf(const Ref &Message) {
     return Location.takeError();
   Result.Location = *Location;
   Result.Kind = static_cast<RefKind>(Message.kind());
+  auto ContainerID = SymbolID::fromStr(Message.container());
+  if (ContainerID)
+    Result.Container = *ContainerID;
   return Result;
 }
 
@@ -340,6 +343,7 @@ llvm::Expected<Ref> Marshaller::toProtobuf(const clangd::Ref &From) {
   if (!Location)
     return Location.takeError();
   *Result.mutable_location() = *Location;
+  Result.set_container(From.Container.str());
   return Result;
 }
 

--- a/clang-tools-extra/clangd/unittests/remote/MarshallingTests.cpp
+++ b/clang-tools-extra/clangd/unittests/remote/MarshallingTests.cpp
@@ -223,6 +223,7 @@ TEST(RemoteMarshallingTest, RefSerialization) {
   Location.FileURI = testPathURI(
       "llvm-project/llvm/clang-tools-extra/clangd/Protocol.h", Strings);
   Ref.Location = Location;
+  Ref.Container = llvm::cantFail(SymbolID::fromStr("0000000000000001"));
 
   Marshaller ProtobufMarshaller(testPath("llvm-project/"),
                                 testPath("llvm-project/"));


### PR DESCRIPTION
call hierarchy cannot be enhanced via the remote index because the Refs returned by the remote index do not have the ID of its container. 