### PR TITLE
[flang][NFC] Document an extension

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -290,7 +290,7 @@ end
   it's an error only if the resolution is ambiguous.
 * An entity may appear in a `DATA` statement before its explicit
   type declaration under `IMPLICIT NONE(TYPE)`.
-* INCLUDE lines can start in any column, can be preceded in
+* `INCLUDE` lines can start in any column, can be preceded in
   fixed form source by a '0' in column 6, can contain spaces
   between the letters of the word INCLUDE, and can have a
   numeric character literal kind prefix on the file name.
@@ -309,6 +309,9 @@ end
   a portability warning.
   The Fortran standard doesn't allow `SIZE=` with formatted input
   modes that might require look-ahead, perhaps to ease implementations.
+* When a file included via an `INCLUDE` line or `#include` directive
+  has a continuation marker at the end of its last line in free form,
+  Fortran line continuation works.
 
 ### Extensions supported when enabled by options
 
@@ -436,7 +439,7 @@ end
   This is especially desirable when two generics of the same
   name are combined due to USE association and the mixture may
   be inadvertent.
-* Since Fortran 90, INCLUDE lines have been allowed to have
+* Since Fortran 90, `INCLUDE` lines have been allowed to have
   a numeric kind parameter prefix on the file name.  No other
   Fortran compiler supports them that I can find.
 * A `SEQUENCE` derived type is required (F'2023 C745) to have


### PR DESCRIPTION
Fortran free form line continuation with '&' works with this compiler even across the end of an included source file, as it does with most other Fortran compilers.  This extension should be documented.