### PR TITLE
[AArch64] (NFC) Fix test after loosening requirements for register re…

### DIFF
--- a/llvm/test/CodeGen/AArch64/stp-opt-with-renaming-undef-assert.mir
+++ b/llvm/test/CodeGen/AArch64/stp-opt-with-renaming-undef-assert.mir
@@ -4,8 +4,8 @@
 # assertion:
 # "Rename register used between paired instruction, trashing the content".
 #
-# The assertion was previously triggered because q16 is picked as renamable
-# register, which overlap with renamable undef d16 used by ZIP2 instruction.
+# The assertion was previously triggered because q0 is picked as renamable
+# register, which overlap with renamable undef d0 used by ZIP2 instruction.
 # However, the content of an undef register is not used in meaningful way,
 # aarch64 load store optimizer should not throw an assertion if a renamable
 # register picked overlap with a renamable undef register.
@@ -20,7 +20,7 @@
 # CHECK-NEXT: $q0 = EXTv16i8 renamable $q23, renamable $q23, 8
 # CHECK-NEXT: renamable $q20 = EXTv16i8 renamable $q14, renamable $q14, 8
 # CHECK-NEXT: STRQui killed renamable $q20, $sp, 4 :: (store (s128))
-# CHECK-NEXT: renamable $d6 = ZIP2v8i8 renamable $d23, undef renamable $d16
+# CHECK-NEXT: renamable $d6 = ZIP2v8i8 renamable $d23, undef renamable $d0
 # CHECK-NEXT: STRDui killed renamable $d6, $sp, 11 :: (store (s64))
 # CHECK-NEXT: renamable $q6 = EXTv16i8 renamable $q13, renamable $q13, 8
 # CHECK-NEXT: STPQi killed renamable $q6, killed $q0, $sp, 6 :: (store (s128))
@@ -46,7 +46,7 @@ body:             |
     STRQui killed renamable $q20, $sp, 7 :: (store (s128))
     renamable $q20 = EXTv16i8 renamable $q14, renamable $q14, 8
     STRQui killed renamable $q20, $sp, 4 :: (store (s128))
-    renamable $d6 = ZIP2v8i8 renamable $d23, undef renamable $d16
+    renamable $d6 = ZIP2v8i8 renamable $d23, undef renamable $d0
     STRDui killed renamable $d6, $sp, 11 :: (store (s64))
     renamable $q6 = EXTv16i8 renamable $q13, renamable $q13, 8
     STRQui killed renamable $q6, $sp, 6 :: (store (s128))


### PR DESCRIPTION
…naming

The landing of https://reviews.llvm.org/D88663 renders the existing stp-opt-with-renaming-undef-assert test useless because the picked register for renaming becomes q0 instead of q16.