### PR TITLE
[clang-tidy] Improve performance-enum-size to exclude empty enums

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
@@ -23,6 +23,8 @@ namespace clang::tidy::performance {
 
 namespace {
 
+AST_MATCHER(EnumDecl, hasEnumerators) { return !Node.enumerators().empty(); }
+
 const std::uint64_t Min8 =
     std::imaxabs(std::numeric_limits<std::int8_t>::min());
 const std::uint64_t Max8 = std::numeric_limits<std::int8_t>::max();
@@ -93,6 +95,7 @@ bool EnumSizeCheck::isLanguageVersionSupported(
 void EnumSizeCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       enumDecl(unless(isExpansionInSystemHeader()), isDefinition(),
+               hasEnumerators(),
                unless(matchers::matchesAnyListedName(EnumIgnoreList)))
           .bind("e"),
       this);

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/enum-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/enum-size.rst
@@ -58,6 +58,8 @@ terms of memory usage and cache performance. However, it's important to
 consider the trade-offs and potential impact on code readability and
 maintainability.
 
+Enums without enumerators (empty) are excluded from analysis.
+
 Requires C++11 or above.
 Does not provide auto-fixes.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/enum-size.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/enum-size.cpp
@@ -102,4 +102,7 @@ enum class IgnoredSecondEnum
     unused2 = 2
 };
 
+enum class EnumClassWithoutValues : int {};
+enum EnumWithoutValues {};
+
 }


### PR DESCRIPTION
Enums without enumerators (empty) are now excluded from analysis as it's not possible to peroperly determinate new narrowed type, and such enums can be used in diffrent way, like as strong-types.

Closes #71544