### PR TITLE
[clang][Interp] Consider bit width in IntegralAP::toAPSInt()

### DIFF
--- a/clang/lib/AST/Interp/IntegralAP.h
+++ b/clang/lib/AST/Interp/IntegralAP.h
@@ -119,8 +119,16 @@ public:
 
   constexpr unsigned bitWidth() const { return V.getBitWidth(); }
 
-  APSInt toAPSInt(unsigned Bits = 0) const { return APSInt(V, !Signed); }
-  APValue toAPValue() const { return APValue(APSInt(V, !Signed)); }
+  APSInt toAPSInt(unsigned Bits = 0) const {
+    if (Bits == 0)
+      Bits = bitWidth();
+
+    if constexpr (Signed)
+      return APSInt(V.sext(Bits), !Signed);
+    else
+      return APSInt(V.zext(Bits), !Signed);
+  }
+  APValue toAPValue() const { return APValue(toAPSInt()); }
 
   bool isZero() const { return V.isZero(); }
   bool isPositive() const { return V.isNonNegative(); }

--- a/clang/test/AST/Interp/intap.cpp
+++ b/clang/test/AST/Interp/intap.cpp
@@ -63,11 +63,16 @@ namespace i128 {
 
   static const __int128_t INT128_MAX = UINT128_MAX >> (__int128_t)1;
   static_assert(INT128_MAX != 0, "");
+  static_assert(INT128_MAX == 0, ""); // expected-error {{failed}} \
+                                      // expected-note {{evaluates to '170141183460469231731687303715884105727 == 0'}} \
+                                      // ref-error {{failed}} \
+                                      // ref-note {{evaluates to '170141183460469231731687303715884105727 == 0'}}
+
   static const __int128_t INT128_MIN = -INT128_MAX - 1;
   constexpr __int128 A = INT128_MAX + 1; // expected-error {{must be initialized by a constant expression}} \
-                                         // expected-note {{outside the range}} \
+                                         // expected-note {{value 170141183460469231731687303715884105728 is outside the range}} \
                                          // ref-error {{must be initialized by a constant expression}} \
-                                         // ref-note {{outside the range}}
+                                         // ref-note {{value 170141183460469231731687303715884105728 is outside the range}}
   constexpr int128_t Two = (int128_t)1 << 1ul;
   static_assert(Two == 2, "");
   static_assert(Two, "");


### PR DESCRIPTION
In `Interp.h`, when a add/sub/mul fails, we call this code and expect to get an `APSInt` back that can handle more than the current bitwidth of the type.