### PR TITLE
[lldb][AArch64][Linux] Add field information for the fpsr register

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
@@ -21,6 +21,26 @@
 using namespace lldb_private;
 
 LinuxArm64RegisterFlags::Fields
+LinuxArm64RegisterFlags::DetectFPSRFields(uint64_t hwcap, uint64_t hwcap2) {
+  // fpsr's contents are constant.
+  (void)hwcap;
+  (void)hwcap2;
+
+  return {
+      // Bits 31-28 are N/Z/C/V, only used by AArch32.
+      {"QC", 27},
+      // Bits 26-8 reserved.
+      {"IDC", 7},
+      // Bits 6-5 reserved.
+      {"IXC", 4},
+      {"UFC", 3},
+      {"OFC", 2},
+      {"DZC", 1},
+      {"IOC", 0},
+  };
+}
+
+LinuxArm64RegisterFlags::Fields
 LinuxArm64RegisterFlags::DetectCPSRFields(uint64_t hwcap, uint64_t hwcap2) {
   // The fields here are a combination of the Arm manual's SPSR_EL1,
   // plus a few changes where Linux has decided not to make use of them at all,

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
@@ -56,6 +56,7 @@ private:
   using DetectorFn = std::function<Fields(uint64_t, uint64_t)>;
 
   static Fields DetectCPSRFields(uint64_t hwcap, uint64_t hwcap2);
+  static Fields DetectFPSRFields(uint64_t hwcap, uint64_t hwcap2);
 
   struct RegisterEntry {
     RegisterEntry(llvm::StringRef name, unsigned size, DetectorFn detector)
@@ -65,8 +66,9 @@ private:
     llvm::StringRef m_name;
     RegisterFlags m_flags;
     DetectorFn m_detector;
-  } m_registers[1] = {
+  } m_registers[2] = {
       RegisterEntry("cpsr", 4, DetectCPSRFields),
+      RegisterEntry("fpsr", 4, DetectFPSRFields),
   };
 
   // Becomes true once field detection has been run for all registers.

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -622,13 +622,14 @@ class RegisterCommandsTestCase(TestBase):
     @skipUnlessPlatform(["linux"])
     @skipIf(archs=no_match(["aarch64"]))
     def test_register_read_fields(self):
-        """Test that when debugging a live process, we see the fields of the
-        CPSR register."""
+        """Test that when debugging a live process, we see the fields of certain
+        registers."""
         self.build()
         self.common_setup()
 
         # N/Z/C/V bits will always be present, so check only for those.
         self.expect("register read cpsr", substrs=["= (N = 0, Z = 1, C = 1, V = 0"])
+        self.expect("register read fpsr", substrs=["= (QC = 0, IDC = 0, IXC = 0"])
 
     @skipUnlessPlatform(["linux"])
     @skipIf(archs=no_match(["x86_64"]))

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -577,6 +577,7 @@ class LinuxCoreTestCase(TestBase):
         # Register field information should work with core files as it does a live process.
         # The N/Z/C/V bits are always present so just check for those.
         self.expect("register read cpsr", substrs=["= (N = 0, Z = 0, C = 0, V = 0"])
+        self.expect("register read fpsr", substrs=["= (QC = 0, IDC = 0, IXC = 0"])
 
     @skipIfLLVMTargetMissing("AArch64")
     def test_aarch64_pac_regs(self):


### PR DESCRIPTION
This one is easy because none of the fields depend on extensions. Only thing to note is that I've ignored some AArch32 only fields.

```
(lldb) register read fpsr
    fpsr = 0x00000000
         = (QC = 0, IDC = 0, IXC = 0, UFC = 0, OFC = 0, DZC = 0, IOC = 0)
```