### PR TITLE
Fix lit test clang/test/CodeGenHIP/dpp-const-fold.hip. added

### DIFF
--- a/clang/test/CodeGenHIP/dpp-const-fold.hip
+++ b/clang/test/CodeGenHIP/dpp-const-fold.hip
@@ -1,6 +1,6 @@
 // REQUIRES: amdgpu-registered-target
 
-// RUN: %clang --offload-arch=gfx906 -S -o - -emit-llvm --cuda-device-only \
+// RUN: %clang --offload-arch=gfx906 -S -o - -emit-llvm --cuda-device-only -nogpuinc -nogpulib \
 // RUN:   %s | FileCheck %s
 
 constexpr static int OpCtrl()


### PR DESCRIPTION
during #71139

-nogpulib was missing.