### PR TITLE
[clang] Print static_assert values of arithmetic binary operators

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -481,12 +481,14 @@ Improvements to Clang's diagnostics
 - Clang will now print ``static_assert`` failure details for arithmetic binary operators.
   Example:
 
-  .. code-block:: c++
+  .. code-block:: cpp
+
     static_assert(1 << 4 == 15);
 
   will now print:
 
   .. code-block:: text
+
     error: static assertion failed due to requirement '1 << 4 == 15'
        48 | static_assert(1 << 4 == 15);
           |               ^~~~~~~~~~~~

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -478,6 +478,22 @@ Improvements to Clang's diagnostics
   with GCC.
 - Clang will warn on deprecated specializations used in system headers when their instantiation
   is caused by user code.
+- Clang will now print ``static_assert`` failure details for arithmetic binary operators.
+  Example:
+
+  .. code-block:: c++
+    static_assert(1 << 4 == 15);
+
+  will now print:
+
+  .. code-block:: text
+    error: static assertion failed due to requirement '1 << 4 == 15'
+       48 | static_assert(1 << 4 == 15);
+          |               ^~~~~~~~~~~~
+    note: expression evaluates to '16 == 15'
+       48 | static_assert(1 << 4 == 15);
+          |               ~~~~~~~^~~~~
+
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17218,10 +17218,10 @@ static bool UsefulToPrintExpr(const Expr *E) {
   if (const auto *UnaryOp = dyn_cast<UnaryOperator>(E))
     return UsefulToPrintExpr(UnaryOp->getSubExpr());
 
-  // Ignore nested binary operators. This could be a FIXME for improvements
-  // to the diagnostics in the future.
-  if (isa<BinaryOperator>(E))
-    return false;
+  // Only print nested arithmetic operators.
+  if (const auto *BO = dyn_cast<BinaryOperator>(E))
+    return (BO->isShiftOp() || BO->isAdditiveOp() || BO->isMultiplicativeOp() ||
+            BO->isBitwiseOp());
 
   return true;
 }

--- a/clang/test/SemaCXX/complex-folding.cpp
+++ b/clang/test/SemaCXX/complex-folding.cpp
@@ -3,7 +3,8 @@
 // Test the constant folding of builtin complex numbers.
 
 static_assert((0.0 + 0.0j) == (0.0 + 0.0j));
-static_assert((0.0 + 0.0j) != (0.0 + 0.0j)); // expected-error {{static assertion}}
+static_assert((0.0 + 0.0j) != (0.0 + 0.0j)); // expected-error {{static assertion}} \
+                                             // expected-note {{evaluates to}}
 
 static_assert((0.0 + 0.0j) == 0.0);
 static_assert(0.0 == (0.0 + 0.0j));
@@ -14,21 +15,29 @@ static_assert(0.0 != 1.0j);
 
 // Walk around the complex plane stepping between angular differences and
 // equality.
-static_assert((1.0 + 0.0j) == (0.0 + 0.0j)); // expected-error {{static assertion}}
+static_assert((1.0 + 0.0j) == (0.0 + 0.0j)); // expected-error {{static assertion}} \
+                                             // expected-note {{evaluates to}}
 static_assert((1.0 + 0.0j) == (1.0 + 0.0j));
-static_assert((1.0 + 1.0j) == (1.0 + 0.0j)); // expected-error {{static assertion}}
+static_assert((1.0 + 1.0j) == (1.0 + 0.0j)); // expected-error {{static assertion}} \
+                                             // expected-note {{evaluates to}}
 static_assert((1.0 + 1.0j) == (1.0 + 1.0j));
-static_assert((0.0 + 1.0j) == (1.0 + 1.0j)); // expected-error {{static assertion}}
+static_assert((0.0 + 1.0j) == (1.0 + 1.0j)); // expected-error {{static assertion}} \
+                                             // expected-note {{evaluates to}}
 static_assert((0.0 + 1.0j) == (0.0 + 1.0j));
-static_assert((-1.0 + 1.0j) == (0.0 + 1.0j)); // expected-error {{static assertion}}
+static_assert((-1.0 + 1.0j) == (0.0 + 1.0j)); // expected-error {{static assertion}} \
+                                              // expected-note {{evaluates to}}
 static_assert((-1.0 + 1.0j) == (-1.0 + 1.0j));
-static_assert((-1.0 + 0.0j) == (-1.0 + 1.0j)); // expected-error {{static assertion}}
+static_assert((-1.0 + 0.0j) == (-1.0 + 1.0j)); // expected-error {{static assertion}} \
+                                               // expected-note {{evaluates to}}
 static_assert((-1.0 + 0.0j) == (-1.0 + 0.0j));
-static_assert((-1.0 - 1.0j) == (-1.0 + 0.0j)); // expected-error {{static assertion}}
+static_assert((-1.0 - 1.0j) == (-1.0 + 0.0j)); // expected-error {{static assertion}} \
+                                               // expected-note {{evaluates to}}
 static_assert((-1.0 - 1.0j) == (-1.0 - 1.0j));
-static_assert((0.0 - 1.0j) == (-1.0 - 1.0j)); // expected-error {{static assertion}}
+static_assert((0.0 - 1.0j) == (-1.0 - 1.0j)); // expected-error {{static assertion}} \
+                                              // expected-note {{evaluates to}}
 static_assert((0.0 - 1.0j) == (0.0 - 1.0j));
-static_assert((1.0 - 1.0j) == (0.0 - 1.0j)); // expected-error {{static assertion}}
+static_assert((1.0 - 1.0j) == (0.0 - 1.0j)); // expected-error {{static assertion}} \
+                                             // expected-note {{evaluates to}}
 static_assert((1.0 - 1.0j) == (1.0 - 1.0j));
 
 // Test basic mathematical folding of both complex and real operands.

--- a/clang/test/SemaCXX/static-assert.cpp
+++ b/clang/test/SemaCXX/static-assert.cpp
@@ -351,4 +351,14 @@ namespace Diagnostics {
     ""
   );
 
+  static_assert(1 + 1 != 2, ""); // expected-error {{failed}} \
+                                 // expected-note {{evaluates to '2 != 2'}}
+  static_assert(1 - 1 == 2, ""); // expected-error {{failed}} \
+                                 // expected-note {{evaluates to '0 == 2'}}
+  static_assert(1 * 1 == 2, ""); // expected-error {{failed}} \
+                                 // expected-note {{evaluates to '1 == 2'}}
+  static_assert(1 / 1 == 2, ""); // expected-error {{failed}} \
+                                 // expected-note {{evaluates to '1 == 2'}}
+  static_assert(1 << 3 != 8, ""); // expected-error {{failed}} \
+                                 // expected-note {{evaluates to '8 != 8'}}
 }


### PR DESCRIPTION
These are actually quite useful to print.