### PR TITLE
[libc++][ASan] Removing clang version checks

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1073,12 +1073,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 #  ifndef _LIBCPP_HAS_NO_ASAN
     extern "C" _LIBCPP_EXPORTED_FROM_ABI void
     __sanitizer_annotate_contiguous_container(const void*, const void*, const void*, const void*);
-#    if _LIBCPP_CLANG_VER >= 1600
 extern "C" _LIBCPP_EXPORTED_FROM_ABI void __sanitizer_annotate_double_ended_contiguous_container(
     const void*, const void*, const void*, const void*, const void*, const void*);
 extern "C" _LIBCPP_EXPORTED_FROM_ABI int
 __sanitizer_verify_double_ended_contiguous_container(const void*, const void*, const void*, const void*);
-#    endif
 #  endif
 
 // Try to find out if RTTI is disabled.

--- a/libcxx/include/__memory/allocator_traits.h
+++ b/libcxx/include/__memory/allocator_traits.h
@@ -408,14 +408,7 @@ struct __is_cpp17_copy_insertable<_Alloc, __enable_if_t<
 
 #ifdef _LIBCPP_HAS_ASAN_CONTAINER_ANNOTATIONS_FOR_ALL_ALLOCATORS
 template <class _Alloc>
-struct __asan_annotate_container_with_allocator
-#   if defined(_LIBCPP_CLANG_VER) && _LIBCPP_CLANG_VER >= 1600
-      : true_type {};
-#   else
-      // TODO(LLVM-18): Remove the special-casing
-      : false_type {};
-#   endif
-
+struct __asan_annotate_container_with_allocator : true_type {};
 template <class _Tp>
 struct __asan_annotate_container_with_allocator<allocator<_Tp> > : true_type {};
 #endif

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -966,7 +966,7 @@ public:
 // __asan_annotate_container_with_allocator to false.
 // For more details, see the "Using libc++" documentation page or
 // the documentation for __sanitizer_annotate_contiguous_container.
-#if !defined(_LIBCPP_HAS_NO_ASAN) && _LIBCPP_CLANG_VER >= 1600
+#if !defined(_LIBCPP_HAS_NO_ASAN)
     // TODO LLVM18: Remove the special-casing
     _LIBCPP_HIDE_FROM_ABI void __annotate_double_ended_contiguous_container(
         const void* __beg,
@@ -982,7 +982,7 @@ public:
 #else
     _LIBCPP_HIDE_FROM_ABI void __annotate_double_ended_contiguous_container(
         const void*, const void*, const void*, const void*, const void*, const void*) const _NOEXCEPT {}
-#endif // !defined(_LIBCPP_HAS_NO_ASAN) && _LIBCPP_CLANG_VER >= 1600
+#endif // !defined(_LIBCPP_HAS_NO_ASAN)
 
     _LIBCPP_HIDE_FROM_ABI
     void __annotate_from_to(size_type __beg, size_type __end, __asan_annotation_type __annotation_type, __asan_annotation_place __place) const _NOEXCEPT {

--- a/libcxx/test/support/asan_testing.h
+++ b/libcxx/test/support/asan_testing.h
@@ -34,7 +34,7 @@ TEST_CONSTEXPR bool is_contiguous_container_asan_correct ( const std::vector<T, 
 }
 #endif // TEST_HAS_FEATURE(address_sanitizer)
 
-#if TEST_HAS_FEATURE(address_sanitizer) && _LIBCPP_CLANG_VER >= 1600
+#if TEST_HAS_FEATURE(address_sanitizer)
 extern "C" int __sanitizer_verify_double_ended_contiguous_container(
     const void* beg, const void* con_beg, const void* con_end, const void* end);
 extern "C" bool __sanitizer_is_annotable(const void* address, const unsigned long size);


### PR DESCRIPTION
This commit removes checks like `_LIBCPP_CLANG_VER >= 1600` related to ASan annotations. As only 2 previous versions are supported, it's a TODO for LLVM18.

`_LIBCPP_CLANG_VER` is referenced in two more places (not related to ASan), I'm not sure if we should update it in the same PR.

https://github.com/llvm/llvm-project/blob/b44399296a7fa4323ab32739df6dbcfc6068af8f/libcxx/include/__atomic/atomic_init.h#L22

https://github.com/llvm/llvm-project/blob/b44399296a7fa4323ab32739df6dbcfc6068af8f/libcxx/include/__config#L33-L47