### PR TITLE
[SystemZ] Do not run mbackchain-4.c test without SystemZ target

### DIFF
--- a/clang/test/CodeGen/SystemZ/mbackchain-4.c
+++ b/clang/test/CodeGen/SystemZ/mbackchain-4.c
@@ -1,3 +1,4 @@
+// REQUIRES: systemz-registered-target
 // RUN: %clang --target=s390x-linux -O1 -S -o - %s | FileCheck %s
 
 __attribute__((target("backchain")))


### PR DESCRIPTION
mbackchain-4.c requires running the backend and causes CI failures when this target is not configured.