### PR TITLE
[X86] Return more accurate getNumSupportedRegs() (NFC)

### DIFF
--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -634,7 +634,15 @@ unsigned X86RegisterInfo::getNumSupportedRegs(const MachineFunction &MF) const {
          (X86::K6_K7 + 1 == X86::TMMCFG) &&
          (X86::TMM7 + 1 == X86::NUM_TARGET_REGS) &&
          "Register number may be incorrect");
-  return X86::NUM_TARGET_REGS;
+
+  const X86Subtarget &ST = MF.getSubtarget<X86Subtarget>();
+  if (ST.hasAMXTILE())
+    return X86::TMM7 + 1;
+  if (ST.hasAVX512())
+    return X86::K6_K7 + 1;
+  if (ST.hasAVX())
+    return X86::YMM15 + 1;
+  return X86::R15WH + 1;
 }
 
 bool X86RegisterInfo::isArgumentRegister(const MachineFunction &MF,


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/70222 introduced a hook to return a more accurate number of registers supported for a specific subtarget (rather than target). However, while x86 registers were reordered to allow using this, the implementation currently still always returns NUM_TARGET_REGS.

Adjust it to return a smaller number of registers depending on availability of avx/avx512/amx.

The actual impact of this seems to be pretty small, on the order of 0.05% (http://llvm-compile-time-tracker.com/compare.php?from=d687057de8babc215d1cc883514085704ede5ab4&to=d218b6dece5d492e3a258524f4679b17c5d565d8&stat=instructions:u).