### PR TITLE
[flang] Fix missing CGPasses.h.inc

### DIFF
--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -15,6 +15,7 @@ add_flang_library(flangFrontend
 
   DEPENDS
   FIRDialect
+  FIROptCodeGenPassIncGen
   FIROptTransformsPassIncGen
   HLFIRDialect
   MLIRIR


### PR DESCRIPTION
I could reproduce using unix makefiles with -j1 option, with version 16.0.6
Closes #61543
Closes #57680