### PR TITLE
[lldb][AArch64][Linux] Add fields for FPCR register

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
@@ -12,13 +12,53 @@
 // This file is built on all systems because it is used by native processes and
 // core files, so we manually define the needed HWCAP values here.
 
-#define HWCAP_DIT (1 << 24)
-#define HWCAP_SSBS (1 << 28)
+#define HWCAP_FPHP (1UL << 9)
+#define HWCAP_ASIMDHP (1UL << 10)
+#define HWCAP_DIT (1UL << 24)
+#define HWCAP_SSBS (1UL << 28)
 
-#define HWCAP2_BTI (1 << 17)
-#define HWCAP2_MTE (1 << 18)
+#define HWCAP2_BTI (1UL << 17)
+#define HWCAP2_MTE (1UL << 18)
+#define HWCAP2_AFP (1UL << 20)
+#define HWCAP2_EBF16 (1UL << 32)
 
 using namespace lldb_private;
+
+LinuxArm64RegisterFlags::Fields
+LinuxArm64RegisterFlags::DetectFPCRFields(uint64_t hwcap, uint64_t hwcap2) {
+  std::vector<RegisterFlags::Field> fpcr_fields{
+      {"AHP", 26}, {"DN", 25}, {"FZ", 24}, {"RMMode", 22, 23},
+      // Bits 21-20 are "Stride" which is unused in AArch64 state.
+  };
+
+  // FEAT_FP16 is indicated by the presence of FPHP (floating point half
+  // precision) and ASIMDHP (Advanced SIMD half precision) features.
+  if ((hwcap & HWCAP_FPHP) && (hwcap & HWCAP_ASIMDHP))
+    fpcr_fields.push_back({"FZ16", 19});
+
+  // Bits 18-16 are "Len" which is unused in AArch64 state.
+
+  fpcr_fields.push_back({"IDE", 15});
+
+  // Bit 14 is unused.
+  if (hwcap2 & HWCAP2_EBF16)
+    fpcr_fields.push_back({"EBF", 13});
+
+  fpcr_fields.push_back({"IXE", 12});
+  fpcr_fields.push_back({"UFE", 11});
+  fpcr_fields.push_back({"OFE", 10});
+  fpcr_fields.push_back({"DZE", 9});
+  fpcr_fields.push_back({"IOE", 8});
+  // Bits 7-3 reserved.
+
+  if (hwcap2 & HWCAP2_AFP) {
+    fpcr_fields.push_back({"NEP", 2});
+    fpcr_fields.push_back({"AH", 1});
+    fpcr_fields.push_back({"FIZ", 0});
+  }
+
+  return fpcr_fields;
+}
 
 LinuxArm64RegisterFlags::Fields
 LinuxArm64RegisterFlags::DetectFPSRFields(uint64_t hwcap, uint64_t hwcap2) {

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
@@ -57,6 +57,7 @@ private:
 
   static Fields DetectCPSRFields(uint64_t hwcap, uint64_t hwcap2);
   static Fields DetectFPSRFields(uint64_t hwcap, uint64_t hwcap2);
+  static Fields DetectFPCRFields(uint64_t hwcap, uint64_t hwcap2);
 
   struct RegisterEntry {
     RegisterEntry(llvm::StringRef name, unsigned size, DetectorFn detector)
@@ -66,9 +67,10 @@ private:
     llvm::StringRef m_name;
     RegisterFlags m_flags;
     DetectorFn m_detector;
-  } m_registers[2] = {
+  } m_registers[3] = {
       RegisterEntry("cpsr", 4, DetectCPSRFields),
       RegisterEntry("fpsr", 4, DetectFPSRFields),
+      RegisterEntry("fpcr", 4, DetectFPCRFields),
   };
 
   // Becomes true once field detection has been run for all registers.

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -630,6 +630,10 @@ class RegisterCommandsTestCase(TestBase):
         # N/Z/C/V bits will always be present, so check only for those.
         self.expect("register read cpsr", substrs=["= (N = 0, Z = 1, C = 1, V = 0"])
         self.expect("register read fpsr", substrs=["= (QC = 0, IDC = 0, IXC = 0"])
+        # AHP/DN/FZ/RMMode always present, others may vary.
+        self.expect(
+            "register read fpcr", substrs=["= (AHP = 0, DN = 0, FZ = 0, RMMode = 0"]
+        )
 
     @skipUnlessPlatform(["linux"])
     @skipIf(archs=no_match(["x86_64"]))

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -578,6 +578,10 @@ class LinuxCoreTestCase(TestBase):
         # The N/Z/C/V bits are always present so just check for those.
         self.expect("register read cpsr", substrs=["= (N = 0, Z = 0, C = 0, V = 0"])
         self.expect("register read fpsr", substrs=["= (QC = 0, IDC = 0, IXC = 0"])
+        # AHP/DN/FZ/RMMode always present, others may vary.
+        self.expect(
+            "register read fpcr", substrs=["= (AHP = 0, DN = 0, FZ = 0, RMMode = 0"]
+        )
 
     @skipIfLLVMTargetMissing("AArch64")
     def test_aarch64_pac_regs(self):


### PR DESCRIPTION
Follows the format laid out in the Arm manual, AArch32 only fields are ignored.

```
(lldb) register read fpcr
    fpcr = 0x00000000
         = (AHP = 0, DN = 0, FZ = 0, RMMode = 0, FZ16 = 0, IDE = 0, IXE = 0, UFE = 0, OFE = 0, DZE = 0, IOE = 0)
```

Tests use the first 4 fields that we know are always present.

Converted all the HCWAP defines to `UL` because I'm bound to
forget one if I don't do it now.