### PR TITLE
[scudo] change allocation buffer size with env var

### DIFF
--- a/compiler-rt/lib/scudo/standalone/flags.cpp
+++ b/compiler-rt/lib/scudo/standalone/flags.cpp
@@ -11,7 +11,6 @@
 #include "flags_parser.h"
 
 #include "scudo/interface.h"
-#include <stdlib.h>
 
 namespace scudo {
 
@@ -69,12 +68,8 @@ void initFlags() {
   Parser.parseString(getCompileDefinitionScudoDefaultOptions());
   Parser.parseString(getScudoDefaultOptions());
   Parser.parseString(getEnv("SCUDO_OPTIONS"));
-  if (const char *V = getEnv("SCUDO_ALLOCATION_RING_BUFFER_SIZE")) {
-    char *End = nullptr;
-    int I = static_cast<int>(strtol(V, &End, 10));
-    if (End && *End == '\0') {
-      F->allocation_ring_buffer_size = I;
-    }
+  if (const char* V = getEnv("SCUDO_ALLOCATION_RING_BUFFER_SIZE")) {
+    Parser.parseStringPair("allocation_ring_buffer_size=", V);
   }
 }
 

--- a/compiler-rt/lib/scudo/standalone/flags.cpp
+++ b/compiler-rt/lib/scudo/standalone/flags.cpp
@@ -69,8 +69,8 @@ void initFlags() {
   Parser.parseString(getCompileDefinitionScudoDefaultOptions());
   Parser.parseString(getScudoDefaultOptions());
   Parser.parseString(getEnv("SCUDO_OPTIONS"));
-  if (const char* V = getEnv("SCUDO_ALLOCATION_RING_BUFFER_SIZE")) {
-    char* End = nullptr;
+  if (const char *V = getEnv("SCUDO_ALLOCATION_RING_BUFFER_SIZE")) {
+    char *End = nullptr;
     int I = static_cast<int>(strtol(V, &End, 10));
     if (End && *End == '\0') {
       F->allocation_ring_buffer_size = I;

--- a/compiler-rt/lib/scudo/standalone/flags.cpp
+++ b/compiler-rt/lib/scudo/standalone/flags.cpp
@@ -68,8 +68,8 @@ void initFlags() {
   Parser.parseString(getCompileDefinitionScudoDefaultOptions());
   Parser.parseString(getScudoDefaultOptions());
   Parser.parseString(getEnv("SCUDO_OPTIONS"));
-  if (const char* V = getEnv("SCUDO_ALLOCATION_RING_BUFFER_SIZE")) {
-    Parser.parseStringPair("allocation_ring_buffer_size=", V);
+  if (const char *V = getEnv("SCUDO_ALLOCATION_RING_BUFFER_SIZE")) {
+    Parser.parseStringPair("allocation_ring_buffer_size", V);
   }
 }
 

--- a/compiler-rt/lib/scudo/standalone/flags.cpp
+++ b/compiler-rt/lib/scudo/standalone/flags.cpp
@@ -11,6 +11,7 @@
 #include "flags_parser.h"
 
 #include "scudo/interface.h"
+#include <stdlib.h>
 
 namespace scudo {
 
@@ -68,6 +69,13 @@ void initFlags() {
   Parser.parseString(getCompileDefinitionScudoDefaultOptions());
   Parser.parseString(getScudoDefaultOptions());
   Parser.parseString(getEnv("SCUDO_OPTIONS"));
+  if (const char* V = getEnv("SCUDO_ALLOCATION_RING_BUFFER_SIZE")) {
+    char* End = nullptr;
+    int I = static_cast<int>(strtol(V, &End, 10));
+    if (End && *End == '\0') {
+      F->allocation_ring_buffer_size = I;
+    }
+  }
 }
 
 } // namespace scudo

--- a/compiler-rt/lib/scudo/standalone/flags_parser.cpp
+++ b/compiler-rt/lib/scudo/standalone/flags_parser.cpp
@@ -80,7 +80,7 @@ void FlagParser::parseFlag() {
       ++Pos;
     Value = Buffer + ValueStart;
   }
-  if (!runHandler(Name, Value))
+  if (!runHandler(Name, Value, '='))
     reportError("flag parsing failed.");
 }
 
@@ -122,10 +122,15 @@ inline bool parseBool(const char *Value, bool *b) {
   return false;
 }
 
-bool FlagParser::runHandler(const char *Name, const char *Value) {
+void FlagParser::parseStringPair(const char *Name, const char *Value) {
+    if (!runHandler(Name, Value, '\0'))
+      reportError("flag parsing failed.");
+}
+
+bool FlagParser::runHandler(const char *Name, const char *Value, const char Sep) {
   for (u32 I = 0; I < NumberOfFlags; ++I) {
     const uptr Len = strlen(Flags[I].Name);
-    if (strncmp(Name, Flags[I].Name, Len) != 0 || Name[Len] != '=')
+    if (strncmp(Name, Flags[I].Name, Len) != 0 || Name[Len] != Sep)
       continue;
     bool Ok = false;
     switch (Flags[I].Type) {

--- a/compiler-rt/lib/scudo/standalone/flags_parser.cpp
+++ b/compiler-rt/lib/scudo/standalone/flags_parser.cpp
@@ -123,11 +123,12 @@ inline bool parseBool(const char *Value, bool *b) {
 }
 
 void FlagParser::parseStringPair(const char *Name, const char *Value) {
-    if (!runHandler(Name, Value, '\0'))
-      reportError("flag parsing failed.");
+  if (!runHandler(Name, Value, '\0'))
+    reportError("flag parsing failed.");
 }
 
-bool FlagParser::runHandler(const char *Name, const char *Value, const char Sep) {
+bool FlagParser::runHandler(const char *Name, const char *Value,
+                            const char Sep) {
   for (u32 I = 0; I < NumberOfFlags; ++I) {
     const uptr Len = strlen(Flags[I].Name);
     if (strncmp(Name, Flags[I].Name, Len) != 0 || Name[Len] != Sep)

--- a/compiler-rt/lib/scudo/standalone/flags_parser.h
+++ b/compiler-rt/lib/scudo/standalone/flags_parser.h
@@ -27,6 +27,7 @@ public:
                     void *Var);
   void parseString(const char *S);
   void printFlagDescriptions();
+  void parseStringPair(const char *Name, const char *Value);
 
 private:
   static const u32 MaxFlags = 20;
@@ -45,7 +46,7 @@ private:
   void skipWhitespace();
   void parseFlags();
   void parseFlag();
-  bool runHandler(const char *Name, const char *Value);
+  bool runHandler(const char *Name, const char *Value, char Sep);
 };
 
 void reportUnrecognizedFlags();


### PR DESCRIPTION
We don't allow SCUDO_OPTIONS to be preserved across SELinux transitions, so introducing a more constrained one that we can preserve.