### PR TITLE
[mlir][ArmSME] Add constructor for `-convert-vector-to-arm-sme` pass (NFC)

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -1204,6 +1204,7 @@ def ConvertVectorToSCF : Pass<"convert-vector-to-scf"> {
 def ConvertVectorToArmSME : Pass<"convert-vector-to-arm-sme"> {
   let summary = "Lower the operations from the vector dialect into the ArmSME "
                 "dialect";
+  let constructor = "mlir::createConvertVectorToArmSMEPass()";
   let description = [{
     Pass that converts vector dialect operations into equivalent ArmSME dialect
     operations.

--- a/mlir/include/mlir/Conversion/VectorToArmSME/VectorToArmSME.h
+++ b/mlir/include/mlir/Conversion/VectorToArmSME/VectorToArmSME.h
@@ -21,6 +21,9 @@ class Pass;
 void populateVectorToArmSMEPatterns(RewritePatternSet &patterns,
                                     MLIRContext &ctx);
 
+/// Create a pass to lower operations from the vector dialect to Arm SME.
+std::unique_ptr<Pass> createConvertVectorToArmSMEPass();
+
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_VECTORTOARMSME_VECTORTOARMSME_H_

--- a/mlir/lib/Conversion/VectorToArmSME/VectorToArmSMEPass.cpp
+++ b/mlir/lib/Conversion/VectorToArmSME/VectorToArmSMEPass.cpp
@@ -34,3 +34,7 @@ void ConvertVectorToArmSMEPass::runOnOperation() {
 
   (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
 }
+
+std::unique_ptr<Pass> mlir::createConvertVectorToArmSMEPass() {
+  return std::make_unique<ConvertVectorToArmSMEPass>();
+}


### PR DESCRIPTION
This will be needed to construct the pass downstream (i.e. in IREE).