### PR TITLE
[ELF] Fix assertion in cdsort

### DIFF
--- a/lld/ELF/CallGraphSort.cpp
+++ b/lld/ELF/CallGraphSort.cpp
@@ -287,7 +287,6 @@ DenseMap<const InputSectionBase *, int> elf::computeCacheDirectedSortOrder() {
     if (res.second) {
       // inSec does not appear before in the graph.
       sections.push_back(inSec);
-      assert(inSec->getSize() > 0 && "found a function with zero size");
       funcSizes.push_back(inSec->getSize());
       funcCounts.push_back(0);
     }

--- a/lld/test/ELF/cgprofile-txt2.s
+++ b/lld/test/ELF/cgprofile-txt2.s
@@ -5,11 +5,13 @@
 # RUN: echo "B C 50" >> %t.call_graph
 # RUN: echo "C D 40" >> %t.call_graph
 # RUN: echo "D B 10" >> %t.call_graph
+# RUN: echo "D E 1" >> %t.call_graph
 # RUN: ld.lld -e A %t --call-graph-ordering-file %t.call_graph --call-graph-profile-sort=hfsort -o %t2
 # RUN: llvm-readobj --symbols %t2 | FileCheck %s --check-prefix=CHECKC3
 # RUN: ld.lld -e A %t --call-graph-ordering-file %t.call_graph --call-graph-profile-sort=cdsort -o %t2
 # RUN: llvm-readobj --symbols %t2 | FileCheck %s --check-prefix=CHECKCDS
 
+## The expected order is [B, C, D, E, A]
 # CHECKC3:      Name: A
 # CHECKC3-NEXT: Value: 0x201123
 # CHECKC3:      Name: B
@@ -18,7 +20,10 @@
 # CHECKC3-NEXT: Value: 0x201121
 # CHECKC3:      Name: D
 # CHECKC3-NEXT: Value: 0x201122
+# CHECKC3:      Name: E
+# CHECKC3-NEXT: Value: 0x201123
 
+## The expected order is [A, B, C, D, E]
 # CHECKCDS:      Name: A
 # CHECKCDS-NEXT: Value: 0x201120
 # CHECKCDS:      Name: B
@@ -27,6 +32,8 @@
 # CHECKCDS-NEXT: Value: 0x201122
 # CHECKCDS:      Name: D
 # CHECKCDS-NEXT: Value: 0x201123
+# CHECKCDS:      Name: E
+# CHECKCDS-NEXT: Value: 0x201124
 
 .section    .text.A,"ax",@progbits
 .globl  A
@@ -47,3 +54,7 @@ C:
 .globl  D
 D:
  nop
+
+.section    .text.E,"ax",@progbits
+.globl  E
+E:


### PR DESCRIPTION
It seems that some functions (.text.unlikely.xxx) may have zero size, which 
makes some builds with enabled assertions fail. Removing the assertion and
extending one test to fix the build.
The sorting can process such zero-sized functions so no changes there are needed