### PR TITLE
[CodeGen][LLT] Add isFixedVector and isScalableVector

### DIFF
--- a/llvm/include/llvm/CodeGen/LowLevelType.h
+++ b/llvm/include/llvm/CodeGen/LowLevelType.h
@@ -163,6 +163,14 @@ public:
                      : getFieldValue(VectorScalableFieldInfo);
   }
 
+  /// Returns true if the LLT is a fixed vector. Returns false otherwise, even
+  /// if the LLT is not a vector type.
+  constexpr bool isFixedVector() const { return isVector() && !isScalable(); }
+
+  /// Returns true if the LLT is a scalable vector. Returns false otherwise,
+  /// even if the LLT is not a vector type.
+  constexpr bool isScalableVector() const { return isVector() && isScalable(); }
+
   constexpr ElementCount getElementCount() const {
     assert(IsVector && "cannot get number of elements on scalar/aggregate");
     return ElementCount::get(IsPointer

--- a/llvm/unittests/CodeGen/LowLevelTypeTest.cpp
+++ b/llvm/unittests/CodeGen/LowLevelTypeTest.cpp
@@ -412,4 +412,18 @@ TEST(LowLevelTypeTest, ConstExpr) {
   EXPECT_EQ(LLT::pointer(0, 32), CEP0);
   EXPECT_EQ(LLT::scalable_vector(2, 32), CESV2S32);
 }
+
+TEST(LowLevelTypeTest, IsFixedVector) {
+  EXPECT_FALSE(LLT::scalar(32).isFixedVector());
+  EXPECT_TRUE(LLT::fixed_vector(2, 32).isFixedVector());
+  EXPECT_FALSE(LLT::scalable_vector(2, 32).isFixedVector());
+  EXPECT_FALSE(LLT::scalable_vector(1, 32).isFixedVector());
+}
+
+TEST(LowLevelTypeTest, IsScalableVector) {
+  EXPECT_FALSE(LLT::scalar(32).isScalableVector());
+  EXPECT_FALSE(LLT::fixed_vector(2, 32).isScalableVector());
+  EXPECT_TRUE(LLT::scalable_vector(2, 32).isScalableVector());
+  EXPECT_TRUE(LLT::scalable_vector(1, 32).isScalableVector());
+}
 }


### PR DESCRIPTION
The current isScalable function requires a user to call isVector before hand in order to avoid an assertion failure in the case that the LLT is not a vector.

This patch addds helper functions that allow a user to query whether the LLT is fixed or scalable, not wanting an assertion failure in the case that the LLT was never a vector in the first place.