### PR TITLE
Add functions peekNextN(unsigned) and assignNewExpr(ArrayRef<uint64_t>) to DIExpressionCursor

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -3199,6 +3199,23 @@ public:
     return *Next;
   }
 
+  std::optional<DIExpression::ExprOperand> peekNextN(unsigned N) const {
+    if (Start == End)
+      return std::nullopt;
+    DIExpression::expr_op_iterator Nth = Start;
+    for (unsigned I = 0; I < N; I++) {
+      Nth = Nth.getNext();
+      if (Nth == End)
+        return std::nullopt;
+    }
+    return *Nth;
+  }
+
+  void assignNewExpr(ArrayRef<uint64_t> Expr) {
+    this->Start = DIExpression::expr_op_iterator(Expr.begin());
+    this->End = DIExpression::expr_op_iterator(Expr.end());
+  }
+
   /// Determine whether there are any operations left in this expression.
   operator bool() const { return Start != End; }
 


### PR DESCRIPTION
This commit adds two functions to the DIExpressionCursor class.

`peekNextN(unsigned)` works like peekNext, but lets you peek the next Nth element
    
`assignNewExpr(ArrayRef<uint64_t>)` lets you assign a new expression to the same DIExpressionCursor object

This is part of a stack of patches, it comes after
https://github.com/llvm/llvm-project/pull/69768