### PR TITLE
Improve VSCode DAP logpoint value summary

### DIFF
--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
@@ -48,7 +48,7 @@ class TestDAP_logpoints(lldbdap_testcase.DAPTestCaseBase):
         # 1. First at the loop line with logMessage
         # 2. Second guard breakpoint at a line after loop
         logMessage_prefix = "This is log message for { -- "
-        message_addr_pattern = r'\b0x[0-9A-Fa-f]+\b'
+        message_addr_pattern = r"\b0x[0-9A-Fa-f]+\b"
         message = '"Hello from main!"'
         logMessage = logMessage_prefix + "{i + 3}, {message}"
         [loop_breakpoint_id, post_loop_breakpoint_id] = self.set_source_breakpoints(

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
@@ -48,8 +48,6 @@ class TestDAP_logpoints(lldbdap_testcase.DAPTestCaseBase):
         # 1. First at the loop line with logMessage
         # 2. Second guard breakpoint at a line after loop
         logMessage_prefix = "This is log message for { -- "
-        message_addr_pattern = r"\b0x[0-9A-Fa-f]+\b"
-        message = '"Hello from main!"'
         logMessage = logMessage_prefix + "{i + 3}, {message}"
         [loop_breakpoint_id, post_loop_breakpoint_id] = self.set_source_breakpoints(
             self.main_path,
@@ -74,10 +72,12 @@ class TestDAP_logpoints(lldbdap_testcase.DAPTestCaseBase):
         loop_count = 10
         self.assertEqual(len(logMessage_output), loop_count)
 
+        message_addr_pattern = r"\b0x[0-9A-Fa-f]+\b"
+        message_content = '"Hello from main!"'
         # Verify log message match
         for idx, logMessage_line in enumerate(logMessage_output):
             result = idx + 3
-            reg_str = f"{logMessage_prefix}{result}, {message_addr_pattern} {message}"
+            reg_str = f"{logMessage_prefix}{result}, {message_addr_pattern} {message_content}"
             self.assertRegex(logMessage_line, reg_str)
 
     @skipIfWindows

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
@@ -48,7 +48,8 @@ class TestDAP_logpoints(lldbdap_testcase.DAPTestCaseBase):
         # 1. First at the loop line with logMessage
         # 2. Second guard breakpoint at a line after loop
         logMessage_prefix = "This is log message for { -- "
-        logMessage = logMessage_prefix + "{i + 3}"
+        message = '"Hello from main!"'
+        logMessage = logMessage_prefix + "{i + 3}, {message}"
         [loop_breakpoint_id, post_loop_breakpoint_id] = self.set_source_breakpoints(
             self.main_path,
             [loop_line, after_loop_line],
@@ -75,7 +76,7 @@ class TestDAP_logpoints(lldbdap_testcase.DAPTestCaseBase):
         # Verify log message match
         for idx, logMessage_line in enumerate(logMessage_output):
             result = idx + 3
-            self.assertEqual(logMessage_line, logMessage_prefix + str(result))
+            self.assertEqual(logMessage_line, f"{logMessage_prefix}{result}, {message}")
 
     @skipIfWindows
     @skipIfRemote

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_logpoints.py
@@ -48,6 +48,7 @@ class TestDAP_logpoints(lldbdap_testcase.DAPTestCaseBase):
         # 1. First at the loop line with logMessage
         # 2. Second guard breakpoint at a line after loop
         logMessage_prefix = "This is log message for { -- "
+        message_addr_pattern = r'\b0x[0-9A-Fa-f]+\b'
         message = '"Hello from main!"'
         logMessage = logMessage_prefix + "{i + 3}, {message}"
         [loop_breakpoint_id, post_loop_breakpoint_id] = self.set_source_breakpoints(
@@ -76,7 +77,8 @@ class TestDAP_logpoints(lldbdap_testcase.DAPTestCaseBase):
         # Verify log message match
         for idx, logMessage_line in enumerate(logMessage_output):
             result = idx + 3
-            self.assertEqual(logMessage_line, f"{logMessage_prefix}{result}, {message}")
+            reg_str = f"{logMessage_prefix}{result}, {message_addr_pattern} {message}"
+            self.assertRegex(logMessage_line, reg_str)
 
     @skipIfWindows
     @skipIfRemote

--- a/lldb/test/API/tools/lldb-dap/breakpoint/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char const *argv[]) {
     exit(1);
   }
 
+  const char * message = "Hello from main!";
   int (*foo)(int) = (int (*)(int))dlsym(handle, "foo");
   if (foo == nullptr) {
     fprintf(stderr, "%s\n", dlerror());
@@ -38,6 +39,7 @@ int main(int argc, char const *argv[]) {
   for (int i = 0; i < 10; ++i) {
     int x = twelve(i) + thirteen(i) + a::fourteen(i); // break loop
   }
+  printf("%s\n", message);
   try {
     throw std::invalid_argument("throwing exception for testing");
   } catch (...) {

--- a/lldb/test/API/tools/lldb-dap/breakpoint/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char const *argv[]) {
     exit(1);
   }
 
-  const char * message = "Hello from main!";
+  const char *message = "Hello from main!";
   int (*foo)(int) = (int (*)(int))dlsym(handle, "foo");
   if (foo == nullptr) {
     fprintf(stderr, "%s\n", dlerror());

--- a/lldb/tools/lldb-dap/BreakpointBase.cpp
+++ b/lldb/tools/lldb-dap/BreakpointBase.cpp
@@ -296,7 +296,7 @@ bool BreakpointBase::BreakpointHitCallback(
           frame.GetValueForVariablePath(expr, lldb::eDynamicDontRunTarget);
       if (value.GetError().Fail())
         value = frame.EvaluateExpression(expr);
-      output += ValeuToString(value);
+      output += ValueToString(value);
     } else {
       output += messagePart.text;
     }

--- a/lldb/tools/lldb-dap/BreakpointBase.cpp
+++ b/lldb/tools/lldb-dap/BreakpointBase.cpp
@@ -8,6 +8,7 @@
 
 #include "BreakpointBase.h"
 #include "DAP.h"
+#include "JSONUtils.h"
 #include "llvm/ADT/StringExtras.h"
 
 using namespace lldb_dap;
@@ -295,11 +296,7 @@ bool BreakpointBase::BreakpointHitCallback(
           frame.GetValueForVariablePath(expr, lldb::eDynamicDontRunTarget);
       if (value.GetError().Fail())
         value = frame.EvaluateExpression(expr);
-      llvm::StringRef summary_str = value.GetSummary();
-      if (!summary_str.empty())
-        output += summary_str.str();
-      else
-        output += value.GetValue();
+      output += ValeuToString(value);
     } else {
       output += messagePart.text;
     }

--- a/lldb/tools/lldb-dap/BreakpointBase.cpp
+++ b/lldb/tools/lldb-dap/BreakpointBase.cpp
@@ -295,9 +295,11 @@ bool BreakpointBase::BreakpointHitCallback(
           frame.GetValueForVariablePath(expr, lldb::eDynamicDontRunTarget);
       if (value.GetError().Fail())
         value = frame.EvaluateExpression(expr);
-      const char *expr_val = value.GetValue();
-      if (expr_val)
-        output += expr_val;
+      llvm::StringRef summary_str = value.GetSummary();
+      if (!summary_str.empty())
+        output += summary_str.str();
+      else
+        output += value.GetValue();
     } else {
       output += messagePart.text;
     }

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -210,7 +210,7 @@ static std::optional<std::string> TryCreateAutoSummary(lldb::SBValue value) {
   return TryCreateAutoSummaryForContainer(value);
 }
 
-std::string ValeuToString(lldb::SBValue v) {
+std::string ValueToString(lldb::SBValue v) {
   std::string result;
   llvm::raw_string_ostream strm(result);
 
@@ -246,7 +246,7 @@ std::string ValeuToString(lldb::SBValue v) {
 
 void SetValueForKey(lldb::SBValue &v, llvm::json::Object &object,
                     llvm::StringRef key) {
-  std::string result = ValeuToString(v);
+  std::string result = ValueToString(v);
   EmplaceSafeString(object, key, result);
 }
 

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -210,8 +210,7 @@ static std::optional<std::string> TryCreateAutoSummary(lldb::SBValue value) {
   return TryCreateAutoSummaryForContainer(value);
 }
 
-void SetValueForKey(lldb::SBValue &v, llvm::json::Object &object,
-                    llvm::StringRef key) {
+std::string ValeuToString(lldb::SBValue v) {
   std::string result;
   llvm::raw_string_ostream strm(result);
 
@@ -242,6 +241,12 @@ void SetValueForKey(lldb::SBValue &v, llvm::json::Object &object,
       }
     }
   }
+  return result;
+}
+
+void SetValueForKey(lldb::SBValue &v, llvm::json::Object &object,
+                    llvm::StringRef key) {
+  std::string result = ValeuToString(v);
   EmplaceSafeString(object, key, result);
 }
 

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -168,7 +168,7 @@ void FillResponse(const llvm::json::Object &request,
                   llvm::json::Object &response);
 
 /// Utility function to convert SBValue \v into a string.
-std::string ValeuToString(lldb::SBValue v);
+std::string ValueToString(lldb::SBValue v);
 
 /// Emplace the string value from an SBValue into the supplied object
 /// using \a key as the key that will contain the value.

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -167,6 +167,9 @@ std::vector<std::string> GetStrings(const llvm::json::Object *obj,
 void FillResponse(const llvm::json::Object &request,
                   llvm::json::Object &response);
 
+/// Utility function to convert SBValue \v into a string.
+std::string ValeuToString(lldb::SBValue v);
+
 /// Emplace the string value from an SBValue into the supplied object
 /// using \a key as the key that will contain the value.
 ///


### PR DESCRIPTION
Currently VSCode logpoint uses `SBValue::GetValue` to get the value for printing. This is not providing an intuitive result for std::string or char * -- it shows the pointer value instead of the string content.

This patch improves by prefers `SBValue::GetSummary()` before using `SBValue::GetValue()`. 