### PR TITLE
Enable Custom Lowering for fabs.v8f16 on AVX

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -1396,6 +1396,8 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
       setOperationAction(ISD::FMINIMUM,          VT, Custom);
     }
 
+    setOperationAction(ISD::FABS, MVT::v8f16, Custom);
+
     // (fp_to_int:v8i16 (v8f32 ..)) requires the result type to be promoted
     // even though v8i16 is a legal type.
     setOperationPromotedToType(ISD::FP_TO_SINT,        MVT::v8i16, MVT::v8i32);
@@ -2241,9 +2243,6 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
       setOperationAction(ISD::STORE, MVT::v4f16, Custom);
     }
   }
-
-  if (!Subtarget.useSoftFloat() && Subtarget.hasAVX())
-    setOperationAction(ISD::FABS, MVT::v8f16, Custom);
 
   if (!Subtarget.useSoftFloat() &&
       (Subtarget.hasAVXNECONVERT() || Subtarget.hasBF16())) {

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -2242,6 +2242,9 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
     }
   }
 
+  if (Subtarget.hasAVX())
+    setOperationAction(ISD::FABS, MVT::v8f16, Custom);
+
   if (!Subtarget.useSoftFloat() &&
       (Subtarget.hasAVXNECONVERT() || Subtarget.hasBF16())) {
     addRegisterClass(MVT::v8bf16, Subtarget.hasAVX512() ? &X86::VR128XRegClass

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -2242,7 +2242,7 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
     }
   }
 
-  if (Subtarget.hasAVX())
+  if (!Subtarget.useSoftFloat() && Subtarget.hasAVX())
     setOperationAction(ISD::FABS, MVT::v8f16, Custom);
 
   if (!Subtarget.useSoftFloat() &&

--- a/llvm/test/CodeGen/X86/vec_fabs.ll
+++ b/llvm/test/CodeGen/X86/vec_fabs.ll
@@ -140,7 +140,10 @@ declare <4 x double> @llvm.fabs.v4f64(<4 x double> %p)
 define <8 x half> @fabs_v8f16(ptr %p) {
 ; X86-AVX-LABEL: fabs_v8f16:
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> f2f313666780 (Enable Custom Lowering for fabs.v8f16 on AVX)
 ; X86-AVX:       # %bb.0:
 ; X86-AVX-NEXT:    movl 4(%esp), [[ADDRREG:%.*]]
 ; X86-AVX-NEXT:    vmovaps ([[ADDRREG]]), %xmm0

--- a/llvm/test/CodeGen/X86/vec_fabs.ll
+++ b/llvm/test/CodeGen/X86/vec_fabs.ll
@@ -137,6 +137,45 @@ define <4 x double> @fabs_v4f64(<4 x double> %p) {
 }
 declare <4 x double> @llvm.fabs.v4f64(<4 x double> %p)
 
+define <8 x half> @fabs_v8f16(ptr %p) {
+; X86-AVX-LABEL: fabs_v8f16:
+; X86-AVX:       # %bb.0:
+; X86-AVX-NEXT:    movl 4(%esp), [[ADDRREG:%.*]]
+; X86-AVX-NEXT:    vmovaps ([[ADDRREG]]), %xmm0
+; X86-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-AVX-NEXT:    retl
+
+; X86-AVX2-LABEL: fabs_v8f16:
+; X86-AVX2:       # %bb.0:
+; X86-AVX2-NEXT:    movl 4(%esp), [[REG:%.*]]
+; X86-AVX2-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
+; X86-AVX2-NEXT:    vpand ([[REG]]), %xmm0, %xmm0
+; X86-AVX2-NEXT:    retl
+
+; X64-AVX512VL-LABEL: fabs_v8f16:
+; X64-AVX512VL:       # %bb.0:
+; X64-AVX512VL-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+; X64-AVX512VL-NEXT:    vpand (%rdi), %xmm0, %xmm0
+; X64-AVX512VL-NEXT:    retq
+
+; X64-AVX-LABEL: fabs_v8f16:
+; X64-AVX:       # %bb.0:
+; X64-AVX-NEXT:    vmovaps (%rdi), %xmm0
+; X64-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-AVX-NEXT:    retq
+
+; X64-AVX2-LABEL: fabs_v8f16:
+; X64-AVX2:       # %bb.0:
+; X64-AVX2-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+; X64-AVX2-NEXT:    vpand (%rdi), %xmm0, %xmm0
+; X64-AVX2-NEXT:    retq
+
+  %v = load <8 x half>, ptr %p, align 16
+  %nnv = call <8 x half> @llvm.fabs.v8f16(<8 x half> %v)
+  ret <8 x half> %nnv
+}
+declare <8 x half> @llvm.fabs.v8f16(<8 x half> %p)
+
 define <8 x float> @fabs_v8f32(<8 x float> %p) {
 ; X86-AVX1-LABEL: fabs_v8f32:
 ; X86-AVX1:       # %bb.0:

--- a/llvm/test/CodeGen/X86/vec_fabs.ll
+++ b/llvm/test/CodeGen/X86/vec_fabs.ll
@@ -139,6 +139,48 @@ declare <4 x double> @llvm.fabs.v4f64(<4 x double> %p)
 
 define <8 x half> @fabs_v8f16(ptr %p) {
 ; X86-AVX-LABEL: fabs_v8f16:
+<<<<<<< HEAD
+=======
+; X86-AVX:       # %bb.0:
+; X86-AVX-NEXT:    movl 4(%esp), [[ADDRREG:%.*]]
+; X86-AVX-NEXT:    vmovaps ([[ADDRREG]]), %xmm0
+; X86-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-AVX-NEXT:    retl
+
+; X86-AVX2-LABEL: fabs_v8f16:
+; X86-AVX2:       # %bb.0:
+; X86-AVX2-NEXT:    movl 4(%esp), [[REG:%.*]]
+; X86-AVX2-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
+; X86-AVX2-NEXT:    vpand ([[REG]]), %xmm0, %xmm0
+; X86-AVX2-NEXT:    retl
+
+; X64-AVX512VL-LABEL: fabs_v8f16:
+; X64-AVX512VL:       # %bb.0:
+; X64-AVX512VL-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+; X64-AVX512VL-NEXT:    vpand (%rdi), %xmm0, %xmm0
+; X64-AVX512VL-NEXT:    retq
+
+; X64-AVX-LABEL: fabs_v8f16:
+; X64-AVX:       # %bb.0:
+; X64-AVX-NEXT:    vmovaps (%rdi), %xmm0
+; X64-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-AVX-NEXT:    retq
+
+; X64-AVX2-LABEL: fabs_v8f16:
+; X64-AVX2:       # %bb.0:
+; X64-AVX2-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+; X64-AVX2-NEXT:    vpand (%rdi), %xmm0, %xmm0
+; X64-AVX2-NEXT:    retq
+
+  %v = load <8 x half>, ptr %p, align 16
+  %nnv = call <8 x half> @llvm.fabs.v8f16(<8 x half> %v)
+  ret <8 x half> %nnv
+}
+declare <8 x half> @llvm.fabs.v8f16(<8 x half> %p)
+
+define <8 x float> @fabs_v8f32(<8 x float> %p) {
+; X86-AVX-LABEL: fabs_v8f32:
+>>>>>>> 6032b965f854 (Enable Custom Lowering for fabs.v8f16 on AVX)
 ; X86-AVX:       # %bb.0:
 ; X86-AVX-NEXT:    movl 4(%esp), [[ADDRREG:%.*]]
 ; X86-AVX-NEXT:    vmovaps ([[ADDRREG]]), %xmm0

--- a/llvm/test/CodeGen/X86/vec_fabs.ll
+++ b/llvm/test/CodeGen/X86/vec_fabs.ll
@@ -138,17 +138,12 @@ define <4 x double> @fabs_v4f64(<4 x double> %p) {
 declare <4 x double> @llvm.fabs.v4f64(<4 x double> %p)
 
 define <8 x half> @fabs_v8f16(ptr %p) {
-; X86-AVX-LABEL: fabs_v8f16:
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> f2f313666780 (Enable Custom Lowering for fabs.v8f16 on AVX)
-; X86-AVX:       # %bb.0:
-; X86-AVX-NEXT:    movl 4(%esp), [[ADDRREG:%.*]]
-; X86-AVX-NEXT:    vmovaps ([[ADDRREG]]), %xmm0
-; X86-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
-; X86-AVX-NEXT:    retl
+; X86-AVX1-LABEL: fabs_v8f16:
+; X86-AVX1:       # %bb.0:
+; X86-AVX1-NEXT:    movl 4(%esp), [[ADDRREG:%.*]]
+; X86-AVX1-NEXT:    vmovaps ([[ADDRREG]]), %xmm0
+; X86-AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-AVX1-NEXT:    retl
 
 ; X86-AVX2-LABEL: fabs_v8f16:
 ; X86-AVX2:       # %bb.0:
@@ -163,51 +158,11 @@ define <8 x half> @fabs_v8f16(ptr %p) {
 ; X64-AVX512VL-NEXT:    vpand (%rdi), %xmm0, %xmm0
 ; X64-AVX512VL-NEXT:    retq
 
-; X64-AVX-LABEL: fabs_v8f16:
-; X64-AVX:       # %bb.0:
-; X64-AVX-NEXT:    vmovaps (%rdi), %xmm0
-; X64-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
-; X64-AVX-NEXT:    retq
-
-; X64-AVX2-LABEL: fabs_v8f16:
-; X64-AVX2:       # %bb.0:
-; X64-AVX2-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
-; X64-AVX2-NEXT:    vpand (%rdi), %xmm0, %xmm0
-; X64-AVX2-NEXT:    retq
-
-  %v = load <8 x half>, ptr %p, align 16
-  %nnv = call <8 x half> @llvm.fabs.v8f16(<8 x half> %v)
-  ret <8 x half> %nnv
-}
-declare <8 x half> @llvm.fabs.v8f16(<8 x half> %p)
-
-define <8 x float> @fabs_v8f32(<8 x float> %p) {
-; X86-AVX-LABEL: fabs_v8f32:
->>>>>>> 6032b965f854 (Enable Custom Lowering for fabs.v8f16 on AVX)
-; X86-AVX:       # %bb.0:
-; X86-AVX-NEXT:    movl 4(%esp), [[ADDRREG:%.*]]
-; X86-AVX-NEXT:    vmovaps ([[ADDRREG]]), %xmm0
-; X86-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
-; X86-AVX-NEXT:    retl
-
-; X86-AVX2-LABEL: fabs_v8f16:
-; X86-AVX2:       # %bb.0:
-; X86-AVX2-NEXT:    movl 4(%esp), [[REG:%.*]]
-; X86-AVX2-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
-; X86-AVX2-NEXT:    vpand ([[REG]]), %xmm0, %xmm0
-; X86-AVX2-NEXT:    retl
-
-; X64-AVX512VL-LABEL: fabs_v8f16:
-; X64-AVX512VL:       # %bb.0:
-; X64-AVX512VL-NEXT:    vpbroadcastw {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
-; X64-AVX512VL-NEXT:    vpand (%rdi), %xmm0, %xmm0
-; X64-AVX512VL-NEXT:    retq
-
-; X64-AVX-LABEL: fabs_v8f16:
-; X64-AVX:       # %bb.0:
-; X64-AVX-NEXT:    vmovaps (%rdi), %xmm0
-; X64-AVX-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
-; X64-AVX-NEXT:    retq
+; X64-AVX1-LABEL: fabs_v8f16:
+; X64-AVX1:       # %bb.0:
+; X64-AVX1-NEXT:    vmovaps (%rdi), %xmm0
+; X64-AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-AVX1-NEXT:    retq
 
 ; X64-AVX2-LABEL: fabs_v8f16:
 ; X64-AVX2:       # %bb.0:


### PR DESCRIPTION
[X86]: Enable custom lowering for fabs.v8f16 on AVX

Currently, custom lowering of fabs.v8f16 requires AVX512FP16, which is too restrictive. For v8f16 fabs lowering, no instructions in AVX512FP16 are needed.  Without the fix, horribly inefficient code is generated without AVX512FP16. Note instcombiner generates calls to intrinsics @llvm.fabs.v8f16 when simplifyping AND <8 x half> operations.