### PR TITLE
[BOLT][AArch64] Fix ifuncs test header inclusion

### DIFF
--- a/bolt/test/AArch64/ifunc.c
+++ b/bolt/test/AArch64/ifunc.c
@@ -28,9 +28,6 @@
 // O0_CHECK: adr x{{[0-9]+}}, ifoo
 // O3_CHECK: b "{{resolver_foo|ifoo}}{{.*}}@PLT"
 
-#include <stdio.h>
-#include <string.h>
-
 static void foo() {}
 
 static void *resolver_foo(void) { return foo; }


### PR DESCRIPTION
Summary: Do not include stdlib headers as these tests are built with -nostdlib. Tests outside of runtime folder also run cross-platforms, so an x86 machine wouldn't have access to the correct headers used in the aarch64 toolchain, even if it has an aarch64 compiler (clang itself).