### PR TITLE
[lldb] Fix assert in ScriptedProcess destructor

### DIFF
--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -130,6 +130,12 @@ ScriptedProcess::ScriptedProcess(lldb::TargetSP target_sp,
 
 ScriptedProcess::~ScriptedProcess() {
   Clear();
+  // If the interface is not valid, we can't call Finalize(). When that happens
+  // it means that the Scripted Process instanciation failed and the
+  // CreateProcess function returns a nullptr, so no one besides this class
+  // should have access to that bogus process object.
+  if (!m_interface_up)
+    return;
   // We need to call finalize on the process before destroying ourselves to
   // make sure all of the broadcaster cleanup goes as planned. If we destruct
   // this class, then Process::~Process() might have problems trying to fully


### PR DESCRIPTION
This patch should fix a test failure in `Expr/TestIRMemoryMapWindows.test`:

https://lab.llvm.org/buildbot/#/builders/219/builds/6786

The problem here is that since 7991412 landed, all the `ScriptInterpreter::CreateScripted*Interface` now return a `nullptr` when using the base `ScriptInterpreter` instance, instead of `ScriptInterpreterPython` for instance.

This nullptr is actually well handled in the various places where we create a Scripted Interface, however, because of the way to instanciate a process, the process plugin manager have to iterate over every process plugin and call the `CreateInstance` static function that should instanciate the right object.

So in the ScriptedProcess case, because we are getting a `nullptr` when trying to create a `ScriptedProcessInterface`, we try to discard the process object, which calls the Process destructor, which in turns calls the `ScriptedProcess` plugin `IsAlive` method. That method will fire an assertion if the scripted interface pointer is not allocated.

This patch address that issue by setting a flag when destroying the ScriptedProcess object, and checks that flag when calling `IsAlive`.