### PR TITLE
Make SmallVectorImpl destructor protected

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -601,15 +601,15 @@ protected:
     RHS.resetToSmall();
   }
 
-public:
-  SmallVectorImpl(const SmallVectorImpl &) = delete;
-
   ~SmallVectorImpl() {
     // Subclass has already destructed this vector's elements.
     // If this wasn't grown from the inline copy, deallocate the old space.
     if (!this->isSmall())
       free(this->begin());
   }
+
+public:
+  SmallVectorImpl(const SmallVectorImpl &) = delete;
 
   void clear() {
     this->destroy_range(this->begin(), this->end());


### PR DESCRIPTION
Because the SmallVectorImpl destructor is not virtual, the destructor of derived classes will not be called if pointers to the SmallVectorImpl class are deleted directly. Making the SmallVectorImpl destructor protected will prevent this.