### PR TITLE
[mlir][vector] Take dim sizes into account in DropInnerMostUnitDims.

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1185,9 +1185,12 @@ class DropInnerMostUnitDims : public OpRewritePattern<vector::TransferReadOp> {
       return failure();
 
     size_t dimsToDrop = 0;
-    for (size_t i = 1; i < srcStrides.size(); ++i) {
-      int dim = srcType.getRank() - i - 1;
-      if (srcStrides[dim] == 1) {
+    int rankDiff = srcType.getRank() - readOp.getVectorType().getRank();
+    for (int64_t i = 0; i < targetType.getRank(); ++i) {
+      int dim = targetType.getRank() - i - 1;
+      if (srcStrides[dim + rankDiff] == 1 &&
+          srcType.getDimSize(dim + rankDiff) == 1 &&
+          targetType.getDimSize(dim) == 1) {
         dimsToDrop++;
       } else {
         break;

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1185,7 +1185,7 @@ class DropInnerMostUnitDims : public OpRewritePattern<vector::TransferReadOp> {
       return failure();
 
     size_t dimsToDrop = 0;
-    int rankDiff = srcType.getRank() - readOp.getVectorType().getRank();
+    int rankDiff = srcType.getRank() - targetType.getRank();
     for (int64_t i = 0; i < targetType.getRank(); ++i) {
       int dim = targetType.getRank() - i - 1;
       if (srcStrides[dim + rankDiff] == 1 &&

--- a/mlir/test/Dialect/Vector/vector-transfer-collapse-inner-most-dims.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-collapse-inner-most-dims.mlir
@@ -69,6 +69,8 @@ func.func @contiguous_inner_most_dim_out_of_bounds_2d(%arg0: memref<1x1xf32>) ->
   %0 = vector.transfer_read %arg0[%c0, %c0], %cst : memref<1x1xf32>, vector<4x8xf32>
   return %0 : vector<4x8xf32>
 }
+// The inner most unit dim can not be dropped. In this context, we do not
+// generate rank-reduced memref.subview ops.
 //      CHECK: func.func @contiguous_inner_most_dim_out_of_bounds_2d
 // CHECK-SAME:   %[[SRC:[a-zA-Z0-9]+]]
 //  CHECK-NOT:   memref.subview

--- a/mlir/test/Dialect/Vector/vector-transfer-collapse-inner-most-dims.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-collapse-inner-most-dims.mlir
@@ -60,3 +60,17 @@ func.func @contiguous_inner_most_dim_bounds_2d(%A: memref<1000x1x1xf32>, %i:inde
 //      CHECK:   %[[V:.+]] = vector.transfer_read %[[SRC_1]]
 // CHECK-SAME:       {in_bounds = [true]}
 // CHECK-SAME:       vector<4xf32>
+
+// -----
+
+func.func @contiguous_inner_most_dim_out_of_bounds_2d(%arg0: memref<1x1xf32>) -> vector<4x8xf32> {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = vector.transfer_read %arg0[%c0, %c0], %cst : memref<1x1xf32>, vector<4x8xf32>
+  return %0 : vector<4x8xf32>
+}
+//      CHECK: func.func @contiguous_inner_most_dim_out_of_bounds_2d
+// CHECK-SAME:   %[[SRC:[a-zA-Z0-9]+]]
+//  CHECK-NOT:   memref.subview
+//      CHECK:   %[[READ:.+]] = vector.transfer_read %[[SRC]]
+//      CHECK:   return %[[READ]] : vector<4x8xf32>


### PR DESCRIPTION
The `stride == 1` does not imply that we can drop it. Because it could load more than 1 elements. We should also take source sizes and vector sizes into account. Otherwise it generates invalid IRs. E.g.,

```mlir
func.func @foo(%arg0: memref<1x1xf32>) -> vector<4x8xf32> {
  %c0 = arith.constant 0 : index
  %cst = arith.constant 0.000000e+00 : f32
  %0 = vector.transfer_read %arg0[%c0, %c0], %cst : memref<1x1xf32>, vector<4x8xf32>
  return %0 : vector<4x8xf32>
}
```

Fixes https://github.com/openxla/iree/issues/15493