### PR TITLE
ExtractAPI: use zero-based indices for line/column in symbol graph

### DIFF
--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -109,8 +109,8 @@ Object serializeSourcePosition(const PresumedLoc &Loc) {
   assert(Loc.isValid() && "invalid source position");
 
   Object SourcePosition;
-  SourcePosition["line"] = Loc.getLine();
-  SourcePosition["character"] = Loc.getColumn();
+  SourcePosition["line"] = Loc.getLine() - 1;
+  SourcePosition["character"] = Loc.getColumn() - 1;
 
   return SourcePosition;
 }

--- a/clang/test/ExtractAPI/anonymous_record_no_typedef.c
+++ b/clang/test/ExtractAPI/anonymous_record_no_typedef.c
@@ -105,12 +105,12 @@ struct Vehicle {
           {
             "range": {
               "end": {
-                "character": 29,
-                "line": 3
+                "character": 28,
+                "line": 2
               },
               "start": {
-                "character": 9,
-                "line": 3
+                "character": 8,
+                "line": 2
               }
             },
             "text": "The type of vehicle."
@@ -127,8 +127,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 4
+          "character": 4,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -163,8 +163,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -206,8 +206,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 6
+          "character": 8,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -256,12 +256,12 @@ struct Vehicle {
           {
             "range": {
               "end": {
-                "character": 14,
-                "line": 1
+                "character": 13,
+                "line": 0
               },
               "start": {
-                "character": 5,
-                "line": 1
+                "character": 4,
+                "line": 0
               }
             },
             "text": "A Vehicle"
@@ -278,8 +278,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 2
+          "character": 7,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -332,8 +332,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 7
+          "character": 6,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -387,8 +387,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 13
+          "character": 6,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/availability.c
+++ b/clang/test/ExtractAPI/availability.c
@@ -98,8 +98,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -172,8 +172,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 3
+          "character": 5,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -256,8 +256,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 5
+          "character": 5,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -356,8 +356,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 7
+          "character": 5,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -438,8 +438,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 9
+          "character": 5,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/bool.c
+++ b/clang/test/ExtractAPI/bool.c
@@ -75,8 +75,8 @@ bool IsFoo(bool Bar);
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 2
+          "character": 5,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -176,8 +176,8 @@ bool IsFoo(bool Bar);
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 4
+          "character": 5,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/bool.cpp
+++ b/clang/test/ExtractAPI/bool.cpp
@@ -74,8 +74,8 @@ bool IsFoo(bool Bar);
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -175,8 +175,8 @@ bool IsFoo(bool Bar);
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 3
+          "character": 5,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/class.cpp
+++ b/clang/test/ExtractAPI/class.cpp
@@ -106,8 +106,8 @@ public:
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -161,8 +161,8 @@ public:
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 3
+          "character": 6,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -225,8 +225,8 @@ public:
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 4
+          "character": 14,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -281,8 +281,8 @@ public:
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 7
+          "character": 6,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -337,8 +337,8 @@ public:
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 10
+          "character": 6,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/class_template.cpp
+++ b/clang/test/ExtractAPI/class_template.cpp
@@ -96,8 +96,8 @@ template<typename T> class Foo {};
       },
       "location": {
         "position": {
-          "character": 28,
-          "line": 1
+          "character": 27,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/class_template_param_inheritance.cpp
+++ b/clang/test/ExtractAPI/class_template_param_inheritance.cpp
@@ -103,8 +103,8 @@ template<typename T> class Foo : public T {};
       },
       "location": {
         "position": {
-          "character": 28,
-          "line": 1
+          "character": 27,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/class_template_partial_spec.cpp
+++ b/clang/test/ExtractAPI/class_template_partial_spec.cpp
@@ -114,8 +114,8 @@ template<typename Z> class Foo<Z, int> {};
       },
       "location": {
         "position": {
-          "character": 40,
-          "line": 1
+          "character": 39,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -224,8 +224,8 @@ template<typename Z> class Foo<Z, int> {};
       },
       "location": {
         "position": {
-          "character": 28,
-          "line": 3
+          "character": 27,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/class_template_spec.cpp
+++ b/clang/test/ExtractAPI/class_template_spec.cpp
@@ -98,8 +98,8 @@ template<> class Foo<int> {};
       },
       "location": {
         "position": {
-          "character": 28,
-          "line": 1
+          "character": 27,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -178,8 +178,8 @@ template<> class Foo<int> {};
       },
       "location": {
         "position": {
-          "character": 18,
-          "line": 3
+          "character": 17,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/concept.cpp
+++ b/clang/test/ExtractAPI/concept.cpp
@@ -96,8 +96,8 @@ template<typename T> concept Foo = true;
       },
       "location": {
         "position": {
-          "character": 30,
-          "line": 1
+          "character": 29,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/constructor_destructor.cpp
+++ b/clang/test/ExtractAPI/constructor_destructor.cpp
@@ -87,8 +87,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -142,8 +142,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 2
+          "character": 2,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -198,8 +198,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 3
+          "character": 2,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/conversions.cpp
+++ b/clang/test/ExtractAPI/conversions.cpp
@@ -87,8 +87,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -150,8 +150,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 2
+          "character": 2,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -222,8 +222,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 3
+          "character": 11,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/emit-symbol-graph/multi_file.c
+++ b/clang/test/ExtractAPI/emit-symbol-graph/multi_file.c
@@ -183,8 +183,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 7
+          "character": 4,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -247,8 +247,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 8
+          "character": 5,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -311,8 +311,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 3
+          "character": 4,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/main.c"
       },
@@ -361,8 +361,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -411,8 +411,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -571,8 +571,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 7
+          "character": 4,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -635,8 +635,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 8
+          "character": 5,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -685,8 +685,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -735,8 +735,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/test.h"
       },

--- a/clang/test/ExtractAPI/emit-symbol-graph/single_file.c
+++ b/clang/test/ExtractAPI/emit-symbol-graph/single_file.c
@@ -85,8 +85,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 4
+          "character": 4,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/main.c"
       },
@@ -135,8 +135,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/main.c"
       },
@@ -185,8 +185,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 2
+          "character": 8,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/main.c"
       },

--- a/clang/test/ExtractAPI/enum.c
+++ b/clang/test/ExtractAPI/enum.c
@@ -164,12 +164,12 @@ enum {
           {
             "range": {
               "end": {
-                "character": 22,
-                "line": 1
+                "character": 21,
+                "line": 0
               },
               "start": {
-                "character": 5,
-                "line": 1
+                "character": 4,
+                "line": 0
               }
             },
             "text": "Kinds of vehicles"
@@ -186,8 +186,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 2
+          "character": 5,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -228,8 +228,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 3
+          "character": 2,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -271,8 +271,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 4
+          "character": 2,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -309,12 +309,12 @@ enum {
           {
             "range": {
               "end": {
-                "character": 45,
-                "line": 5
+                "character": 44,
+                "line": 4
               },
               "start": {
-                "character": 15,
-                "line": 5
+                "character": 14,
+                "line": 4
               }
             },
             "text": "Move this to the top! -Sheldon"
@@ -331,8 +331,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 5
+          "character": 2,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -374,8 +374,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 6
+          "character": 2,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -417,8 +417,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 7
+          "character": 2,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -481,8 +481,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 10
+          "character": 5,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -523,8 +523,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 11
+          "character": 2,
+          "line": 10
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -566,8 +566,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 12
+          "character": 2,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -609,8 +609,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 13
+          "character": 2,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -652,8 +652,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 14
+          "character": 2,
+          "line": 13
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -708,8 +708,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 17
+          "character": 0,
+          "line": 16
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -744,8 +744,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 18
+          "character": 2,
+          "line": 17
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -800,8 +800,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 21
+          "character": 0,
+          "line": 20
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -836,8 +836,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 22
+          "character": 2,
+          "line": 21
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/field_template.cpp
+++ b/clang/test/ExtractAPI/field_template.cpp
@@ -81,8 +81,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -168,8 +168,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 33,
-          "line": 2
+          "character": 32,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/function_noexcepts.cpp
+++ b/clang/test/ExtractAPI/function_noexcepts.cpp
@@ -97,8 +97,8 @@ void getFooBar() noexcept(false);
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -181,8 +181,8 @@ void getFooBar() noexcept(false);
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 3
+          "character": 5,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -265,8 +265,8 @@ void getFooBar() noexcept(false);
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 5
+          "character": 5,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_func_template.cpp
+++ b/clang/test/ExtractAPI/global_func_template.cpp
@@ -144,8 +144,8 @@ template<typename T> T Fizz(int Buzz);
       },
       "location": {
         "position": {
-          "character": 27,
-          "line": 1
+          "character": 26,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -278,8 +278,8 @@ template<typename T> T Fizz(int Buzz);
       },
       "location": {
         "position": {
-          "character": 24,
-          "line": 3
+          "character": 23,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_func_template_spec.cpp
+++ b/clang/test/ExtractAPI/global_func_template_spec.cpp
@@ -144,8 +144,8 @@ template<> void Foo<int>(int Bar);
       },
       "location": {
         "position": {
-          "character": 27,
-          "line": 1
+          "character": 26,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -271,8 +271,8 @@ template<> void Foo<int>(int Bar);
       },
       "location": {
         "position": {
-          "character": 17,
-          "line": 3
+          "character": 16,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_record.c
+++ b/clang/test/ExtractAPI/global_record.c
@@ -84,8 +84,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 1
+          "character": 4,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -201,12 +201,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 3
+                "character": 3,
+                "line": 2
               },
               "start": {
-                "character": 4,
-                "line": 3
+                "character": 3,
+                "line": 2
               }
             },
             "text": ""
@@ -214,12 +214,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 27,
-                "line": 4
+                "character": 26,
+                "line": 3
               },
               "start": {
-                "character": 3,
-                "line": 4
+                "character": 2,
+                "line": 3
               }
             },
             "text": " \\brief Add two numbers."
@@ -227,12 +227,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 30,
-                "line": 5
+                "character": 29,
+                "line": 4
               },
               "start": {
-                "character": 3,
-                "line": 5
+                "character": 2,
+                "line": 4
               }
             },
             "text": " \\param [in]  x   A number."
@@ -240,12 +240,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 36,
-                "line": 6
+                "character": 35,
+                "line": 5
               },
               "start": {
-                "character": 3,
-                "line": 6
+                "character": 2,
+                "line": 5
               }
             },
             "text": " \\param [in]  y   Another number."
@@ -253,12 +253,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 41,
-                "line": 7
+                "character": 40,
+                "line": 6
               },
               "start": {
-                "character": 3,
-                "line": 7
+                "character": 2,
+                "line": 6
               }
             },
             "text": " \\param [out] res The result of x + y."
@@ -266,12 +266,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 8
+                "character": 3,
+                "line": 7
               },
               "start": {
-                "character": 1,
-                "line": 8
+                "character": 0,
+                "line": 7
               }
             },
             "text": " "
@@ -369,8 +369,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 9
+          "character": 5,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_record_multifile.c
+++ b/clang/test/ExtractAPI/global_record_multifile.c
@@ -86,8 +86,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 1
+          "character": 4,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input1.h"
       },
@@ -203,12 +203,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 1
+                "character": 3,
+                "line": 0
               },
               "start": {
-                "character": 4,
-                "line": 1
+                "character": 3,
+                "line": 0
               }
             },
             "text": ""
@@ -216,12 +216,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 27,
-                "line": 2
+                "character": 26,
+                "line": 1
               },
               "start": {
-                "character": 3,
-                "line": 2
+                "character": 2,
+                "line": 1
               }
             },
             "text": " \\brief Add two numbers."
@@ -229,12 +229,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 30,
-                "line": 3
+                "character": 29,
+                "line": 2
               },
               "start": {
-                "character": 3,
-                "line": 3
+                "character": 2,
+                "line": 2
               }
             },
             "text": " \\param [in]  x   A number."
@@ -242,12 +242,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 36,
-                "line": 4
+                "character": 35,
+                "line": 3
               },
               "start": {
-                "character": 3,
-                "line": 4
+                "character": 2,
+                "line": 3
               }
             },
             "text": " \\param [in]  y   Another number."
@@ -255,12 +255,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 41,
-                "line": 5
+                "character": 40,
+                "line": 4
               },
               "start": {
-                "character": 3,
-                "line": 5
+                "character": 2,
+                "line": 4
               }
             },
             "text": " \\param [out] res The result of x + y."
@@ -268,12 +268,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 6
+                "character": 3,
+                "line": 5
               },
               "start": {
-                "character": 1,
-                "line": 6
+                "character": 0,
+                "line": 5
               }
             },
             "text": " "
@@ -371,8 +371,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 7
+          "character": 5,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input2.h"
       },

--- a/clang/test/ExtractAPI/global_var_template.cpp
+++ b/clang/test/ExtractAPI/global_var_template.cpp
@@ -96,8 +96,8 @@ template<typename T> T Foo = T(3.14);
       },
       "location": {
         "position": {
-          "character": 24,
-          "line": 1
+          "character": 23,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_var_template_partial_spec.cpp
+++ b/clang/test/ExtractAPI/global_var_template_partial_spec.cpp
@@ -114,8 +114,8 @@ template<typename Z> int Foo<int, Z> = 0;
       },
       "location": {
         "position": {
-          "character": 38,
-          "line": 1
+          "character": 37,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -225,8 +225,8 @@ template<typename Z> int Foo<int, Z> = 0;
       },
       "location": {
         "position": {
-          "character": 26,
-          "line": 3
+          "character": 25,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_var_template_spec.cpp
+++ b/clang/test/ExtractAPI/global_var_template_spec.cpp
@@ -98,8 +98,8 @@ template<> int Foo<int>;
       },
       "location": {
         "position": {
-          "character": 24,
-          "line": 1
+          "character": 23,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -179,8 +179,8 @@ template<> int Foo<int>;
       },
       "location": {
         "position": {
-          "character": 16,
-          "line": 3
+          "character": 15,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/known_files_only.c
+++ b/clang/test/ExtractAPI/known_files_only.c
@@ -82,8 +82,8 @@ struct Foo { int a; };
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 1
+          "character": 4,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input1.h"
       },

--- a/clang/test/ExtractAPI/language.c
+++ b/clang/test/ExtractAPI/language.c
@@ -86,8 +86,8 @@ char objc;
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/c.h"
       },
@@ -170,8 +170,8 @@ char objc;
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/objc.h"
       },

--- a/clang/test/ExtractAPI/macro_undefined.c
+++ b/clang/test/ExtractAPI/macro_undefined.c
@@ -89,8 +89,8 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 3
+          "character": 0,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -241,8 +241,8 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 4
+          "character": 0,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -291,8 +291,8 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/macros.c
+++ b/clang/test/ExtractAPI/macros.c
@@ -74,8 +74,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -124,8 +124,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 2
+          "character": 8,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -186,8 +186,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 3
+          "character": 8,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -264,8 +264,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -326,8 +326,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -388,8 +388,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 6
+          "character": 8,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/method_template.cpp
+++ b/clang/test/ExtractAPI/method_template.cpp
@@ -81,8 +81,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -206,8 +206,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 29,
-          "line": 2
+          "character": 28,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/method_template_spec.cpp
+++ b/clang/test/ExtractAPI/method_template_spec.cpp
@@ -89,8 +89,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -214,8 +214,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 29,
-          "line": 2
+          "character": 28,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -342,8 +342,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 19,
-          "line": 4
+          "character": 18,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/methods.cpp
+++ b/clang/test/ExtractAPI/methods.cpp
@@ -106,8 +106,8 @@ protected:
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -170,8 +170,8 @@ protected:
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 2
+          "character": 6,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -284,8 +284,8 @@ protected:
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 4
+          "character": 7,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -365,8 +365,8 @@ protected:
       },
       "location": {
         "position": {
-          "character": 17,
-          "line": 10
+          "character": 16,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -438,8 +438,8 @@ protected:
       },
       "location": {
         "position": {
-          "character": 17,
-          "line": 7
+          "character": 16,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/multiple_inheritance.cpp
+++ b/clang/test/ExtractAPI/multiple_inheritance.cpp
@@ -103,8 +103,8 @@ class FooBar : public Foo, public Bar{};
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -157,8 +157,8 @@ class FooBar : public Foo, public Bar{};
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 3
+          "character": 6,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -211,8 +211,8 @@ class FooBar : public Foo, public Bar{};
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 5
+          "character": 6,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -265,8 +265,8 @@ class FooBar : public Foo, public Bar{};
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 7
+          "character": 6,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/namespace.cpp
+++ b/clang/test/ExtractAPI/namespace.cpp
@@ -81,8 +81,8 @@ namespace Foo {
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -135,8 +135,8 @@ namespace Foo {
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 2
+          "character": 8,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/nested_namespaces.cpp
+++ b/clang/test/ExtractAPI/nested_namespaces.cpp
@@ -81,8 +81,8 @@ namespace Foo {
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -135,8 +135,8 @@ namespace Foo {
       },
       "location": {
         "position": {
-          "character": 13,
-          "line": 2
+          "character": 12,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_category.m
+++ b/clang/test/ExtractAPI/objc_category.m
@@ -103,8 +103,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 3
+          "character": 11,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -171,8 +171,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 8
+          "character": 0,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -244,8 +244,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 9
+          "character": 0,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -308,8 +308,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 7
+          "character": 14,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_id_protocol.m
+++ b/clang/test/ExtractAPI/objc_id_protocol.m
@@ -87,8 +87,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 4
+          "character": 11,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -162,8 +162,8 @@
       },
       "location": {
         "position": {
-          "character": 43,
-          "line": 5
+          "character": 42,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -230,8 +230,8 @@
       },
       "location": {
         "position": {
-          "character": 38,
-          "line": 6
+          "character": 37,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -281,8 +281,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_instancetype.m
+++ b/clang/test/ExtractAPI/objc_instancetype.m
@@ -84,8 +84,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 1
+          "character": 11,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -150,8 +150,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 2
+          "character": 0,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -221,8 +221,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 3
+          "character": 0,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_interface.m
+++ b/clang/test/ExtractAPI/objc_interface.m
@@ -124,8 +124,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 3
+          "character": 11,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -231,8 +231,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 5
+          "character": 0,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -392,8 +392,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 6
+          "character": 0,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -480,8 +480,8 @@
       },
       "location": {
         "position": {
-          "character": 50,
-          "line": 4
+          "character": 49,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -540,8 +540,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 9
+          "character": 11,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -595,8 +595,8 @@
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 10
+          "character": 7,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -664,8 +664,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 12
+          "character": 0,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_module_category.m
+++ b/clang/test/ExtractAPI/objc_module_category.m
@@ -128,12 +128,12 @@
           {
             "range": {
               "end": {
-                "character": 18,
-                "line": 3
+                "character": 17,
+                "line": 2
               },
               "start": {
-                "character": 5,
-                "line": 3
+                "character": 4,
+                "line": 2
               }
             },
             "text": "Doc comment 1"
@@ -150,8 +150,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 4
+          "character": 11,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -218,8 +218,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 5
+          "character": 0,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -281,12 +281,12 @@
           {
             "range": {
               "end": {
-                "character": 18,
-                "line": 8
+                "character": 17,
+                "line": 7
               },
               "start": {
-                "character": 5,
-                "line": 8
+                "character": 4,
+                "line": 7
               }
             },
             "text": "Doc comment 2"
@@ -303,8 +303,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 9
+          "character": 11,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -371,8 +371,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 10
+          "character": 0,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_property.m
+++ b/clang/test/ExtractAPI/objc_property.m
@@ -122,8 +122,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 6
+          "character": 11,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -189,8 +189,8 @@
       },
       "location": {
         "position": {
-          "character": 22,
-          "line": 7
+          "character": 21,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -249,8 +249,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 8
+          "character": 14,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -317,8 +317,8 @@
       },
       "location": {
         "position": {
-          "character": 22,
-          "line": 12
+          "character": 21,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -377,8 +377,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 13
+          "character": 14,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -428,8 +428,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -495,8 +495,8 @@
       },
       "location": {
         "position": {
-          "character": 22,
-          "line": 2
+          "character": 21,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -555,8 +555,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 3
+          "character": 14,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_protocol.m
+++ b/clang/test/ExtractAPI/objc_protocol.m
@@ -80,8 +80,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -143,8 +143,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 4
+          "character": 10,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_various_categories.m
+++ b/clang/test/ExtractAPI/objc_various_categories.m
@@ -123,8 +123,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 1
+          "character": 11,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/myclass_1.h"
       },
@@ -191,8 +191,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 5
+          "character": 0,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -270,8 +270,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 8
+          "character": 11,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -338,8 +338,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 9
+          "character": 0,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -406,8 +406,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 12
+          "character": 11,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -474,8 +474,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 13
+          "character": 0,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/operator_overload.cpp
+++ b/clang/test/ExtractAPI/operator_overload.cpp
@@ -80,8 +80,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -181,8 +181,8 @@ class Foo {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 2
+          "character": 6,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/relative_include.m
+++ b/clang/test/ExtractAPI/relative_include.m
@@ -118,8 +118,8 @@ int OtherInt;
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 2
+          "character": 4,
+          "line": 1
         },
         "uri": "file://SRCROOT/MyHeader.h"
       },
@@ -173,8 +173,8 @@ int OtherInt;
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://SRCROOT/QuotedHeader.h"
       },

--- a/clang/test/ExtractAPI/simple_inheritance.cpp
+++ b/clang/test/ExtractAPI/simple_inheritance.cpp
@@ -80,8 +80,8 @@ class Bar : public Foo {};
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 1
+          "character": 6,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -134,8 +134,8 @@ class Bar : public Foo {};
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 3
+          "character": 6,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/struct.c
+++ b/clang/test/ExtractAPI/struct.c
@@ -100,12 +100,12 @@ struct Color {
           {
             "range": {
               "end": {
-                "character": 18,
-                "line": 1
+                "character": 17,
+                "line": 0
               },
               "start": {
-                "character": 5,
-                "line": 1
+                "character": 4,
+                "line": 0
               }
             },
             "text": "Color in RGBA"
@@ -122,8 +122,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 2
+          "character": 7,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -177,8 +177,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 3
+          "character": 11,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -233,8 +233,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 4
+          "character": 11,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -289,8 +289,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 5
+          "character": 11,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -340,12 +340,12 @@ struct Color {
           {
             "range": {
               "end": {
-                "character": 37,
-                "line": 6
+                "character": 36,
+                "line": 5
               },
               "start": {
-                "character": 7,
-                "line": 6
+                "character": 6,
+                "line": 5
               }
             },
             "text": "Alpha channel for transparency"
@@ -362,8 +362,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 7
+          "character": 11,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef.c
+++ b/clang/test/ExtractAPI/typedef.c
@@ -82,8 +82,8 @@ typedef int MyInt;
       },
       "location": {
         "position": {
-          "character": 13,
-          "line": 1
+          "character": 12,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef_anonymous_record.c
+++ b/clang/test/ExtractAPI/typedef_anonymous_record.c
@@ -91,8 +91,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -127,8 +127,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 16,
-          "line": 4
+          "character": 15,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -190,8 +190,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -247,8 +247,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 18,
-          "line": 2
+          "character": 17,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -311,8 +311,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 24,
-          "line": 3
+          "character": 23,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -375,8 +375,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 16,
-          "line": 5
+          "character": 15,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -439,8 +439,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 20,
-          "line": 6
+          "character": 19,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef_chain.c
+++ b/clang/test/ExtractAPI/typedef_chain.c
@@ -84,8 +84,8 @@ typedef MyIntInt MyIntIntInt;
       },
       "location": {
         "position": {
-          "character": 13,
-          "line": 1
+          "character": 12,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -148,8 +148,8 @@ typedef MyIntInt MyIntIntInt;
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 2
+          "character": 14,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -212,8 +212,8 @@ typedef MyIntInt MyIntIntInt;
       },
       "location": {
         "position": {
-          "character": 18,
-          "line": 3
+          "character": 17,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef_struct_enum.c
+++ b/clang/test/ExtractAPI/typedef_struct_enum.c
@@ -122,8 +122,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 14,
-          "line": 4
+          "character": 13,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -164,8 +164,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 5
+          "character": 2,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -235,8 +235,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 16,
-          "line": 1
+          "character": 15,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -289,8 +289,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 10
+          "character": 7,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -344,8 +344,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 11
+          "character": 8,
+          "line": 10
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -416,8 +416,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 20,
-          "line": 9
+          "character": 19,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/underscored.c
+++ b/clang/test/ExtractAPI/underscored.c
@@ -101,8 +101,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 5
+          "character": 4,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -155,8 +155,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 12
+          "character": 7,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -210,8 +210,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 13
+          "character": 6,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -261,8 +261,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 23
+          "character": 8,
+          "line": 22
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -324,8 +324,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 13,
-          "line": 18
+          "character": 12,
+          "line": 17
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -388,8 +388,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 24,
-          "line": 19
+          "character": 23,
+          "line": 18
         },
         "uri": "file://INPUT_DIR/input.h"
       },


### PR DESCRIPTION
Other implementations of the symbol graph format use zero-based indices for source locations, which causes problems when combined with clang's current one-based indices. This commit sets ExtractAPI's symbol graph output to use zero-based indices to align with other implementations.

rdar://107639783