### PR TITLE
[libc++] Remove outdated _LIBCPP_CLANG_VER check

### DIFF
--- a/libcxx/include/__atomic/atomic_init.h
+++ b/libcxx/include/__atomic/atomic_init.h
@@ -15,13 +15,13 @@
 #  pragma GCC system_header
 #endif
 
-#define ATOMIC_FLAG_INIT {false}
-#define ATOMIC_VAR_INIT(__v) {__v}
+#define ATOMIC_FLAG_INIT                                                                                               \
+  { false }
+#define ATOMIC_VAR_INIT(__v)                                                                                           \
+  { __v }
 
 #if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
-# if defined(_LIBCPP_CLANG_VER) && _LIBCPP_CLANG_VER >= 1400
 #  pragma clang deprecated(ATOMIC_VAR_INIT)
-# endif
 #endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
 
 #endif // _LIBCPP___ATOMIC_ATOMIC_INIT_H

--- a/libcxx/include/__atomic/atomic_init.h
+++ b/libcxx/include/__atomic/atomic_init.h
@@ -22,6 +22,6 @@
 
 #if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
 #  pragma clang deprecated(ATOMIC_VAR_INIT)
-#endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
+#endif
 
 #endif // _LIBCPP___ATOMIC_ATOMIC_INIT_H

--- a/libcxx/utils/data/ignore_format.txt
+++ b/libcxx/utils/data/ignore_format.txt
@@ -89,7 +89,6 @@ libcxx/include/array
 libcxx/include/__atomic/atomic_base.h
 libcxx/include/__atomic/atomic_flag.h
 libcxx/include/__atomic/atomic.h
-libcxx/include/__atomic/atomic_init.h
 libcxx/include/__atomic/atomic_lock_free.h
 libcxx/include/__atomic/atomic_sync.h
 libcxx/include/__atomic/check_memory_order.h


### PR DESCRIPTION
We always use Clang >= 16 now, so the check for Clang >= 14 is tautological. As a drive-by, clang-format the header.