### PR TITLE
Add new API in SBTarget for loading core from SBFile

### DIFF
--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -184,6 +184,7 @@ public:
 
   SBProcess LoadCore(const char *core_file);
   SBProcess LoadCore(const char *core_file, lldb::SBError &error);
+  SBProcess LoadCore(const SBFile &file, lldb::SBError &error);
 
   /// Launch a new process with sensible defaults.
   ///

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -16,6 +16,7 @@
 #include "lldb/API/SBEnvironment.h"
 #include "lldb/API/SBEvent.h"
 #include "lldb/API/SBExpressionOptions.h"
+#include "lldb/API/SBFile.h"
 #include "lldb/API/SBFileSpec.h"
 #include "lldb/API/SBListener.h"
 #include "lldb/API/SBModule.h"
@@ -244,6 +245,31 @@ SBProcess SBTarget::LoadCore(const char *core_file, lldb::SBError &error) {
   TargetSP target_sp(GetSP());
   if (target_sp) {
     FileSpec filespec(core_file);
+    FileSystem::Instance().Resolve(filespec);
+    ProcessSP process_sp(target_sp->CreateProcess(
+        target_sp->GetDebugger().GetListener(), "", &filespec, false));
+    if (process_sp) {
+      error.SetError(process_sp->LoadCore());
+      if (error.Success())
+        sb_process.SetSP(process_sp);
+    } else {
+      error.SetErrorString("Failed to create the process");
+    }
+  } else {
+    error.SetErrorString("SBTarget is invalid");
+  }
+  return sb_process;
+}
+
+SBProcess SBTarget::LoadCore(const SBFile &file, lldb::SBError &error) {
+  LLDB_INSTRUMENT_VA(this, file, error);
+
+  SBProcess sb_process;
+  TargetSP target_sp(GetSP());
+  if (target_sp) {
+    FileSP file_sp = file.GetFile();
+    FileSpec filespec;
+    file_sp->GetFileSpec(filespec);
     FileSystem::Instance().Resolve(filespec);
     ProcessSP process_sp(target_sp->CreateProcess(
         target_sp->GetDebugger().GetListener(), "", &filespec, false));

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -53,6 +53,11 @@ class LinuxCoreTestCase(TestBase):
         """Test that lldb can read the process information from an x86_64 linux core file."""
         self.do_test("linux-x86_64", self._x86_64_pid, self._x86_64_regions, "a.out")
 
+    @skipIfLLVMTargetMissing("X86")
+    def test_x86_64_fd(self):
+        """Test that lldb can read the process information from an x86_64 linux core file."""
+        self.do_test_fd("linux-x86_64", self._x86_64_pid, self._x86_64_regions, "a.out")
+
     @skipIfLLVMTargetMissing("SystemZ")
     def test_s390x(self):
         """Test that lldb can read the process information from an s390x linux core file."""
@@ -751,6 +756,19 @@ class LinuxCoreTestCase(TestBase):
         self.check_all(process, pid, region_count, thread_name)
 
         self.dbg.DeleteTarget(target)
+
+    def do_test_fd(self, filename, pid, region_count, thread_name):
+        file_object = open(filename + ".core", "r")
+        fd = file_object.fileno()
+        file = lldb.SBFile(fd, "r", True)
+        target = self.dbg.CreateTarget(filename + ".out")
+        error = lldb.SBError()
+        process = target.LoadCore(file, error)
+
+        self.check_all(process, pid, region_count, thread_name)
+
+        self.dbg.DeleteTarget(target)
+
 
 
 def replace_path(binary, replace_from, replace_to):


### PR DESCRIPTION
Add a new API in SBTarget to Load Core from a SBFile.
This will enable a target to load core from a file descriptor.
So that in coredumper, we don't need to write core file to disk, instead we can pass the input file descriptor to lldb directly.


Test:
```
(lldb) script
Python Interactive Interpreter. To exit, type 'quit()', 'exit()' or Ctrl-D.
>>> file_object = open("/home/hyubo/210hda79ms32sr0h", "r")
>>> fd=file_object.fileno()
>>> file = lldb.SBFile(fd,'r', True)
>>> error = lldb.SBError()
>>> target = lldb.debugger.CreateTarget(None)
>>> target.LoadCore(file,error)
SBProcess: pid = 56415, state = stopped, threads = 1
```
