### PR TITLE
Llvm modules on demand bmi

### DIFF
--- a/clang/include/clang/CodeGen/ObjectFilePCHContainerOperations.h
+++ b/clang/include/clang/CodeGen/ObjectFilePCHContainerOperations.h
@@ -27,6 +27,12 @@ class ObjectFilePCHContainerWriter : public PCHContainerWriter {
                               const std::string &OutputFileName,
                               std::unique_ptr<llvm::raw_pwrite_stream> OS,
                               std::shared_ptr<PCHBuffer> Buffer) const override;
+
+  std::unique_ptr<ASTConsumer> CreatePCHDeferredContainerGenerator(
+      CompilerInstance &CI, const std::string &MainFileName,
+      const std::string &OutputFileName,
+      std::unique_ptr<llvm::raw_pwrite_stream> OS,
+      std::shared_ptr<PCHBuffer> Buffer) const override;
 };
 
 /// A PCHContainerReader implementation that uses LLVM to

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2389,6 +2389,11 @@ public:
 
   bool isModuleVisible(const Module *M, bool ModulePrivate = false);
 
+  /// Determine if the current module scope is the implementation.
+  bool isModuleImplementation() const {
+    return ModuleScopes.empty() ? false : !ModuleScopes.back().ModuleInterface;
+  }
+
   // When loading a non-modular PCH files, this is used to restore module
   // visibility.
   void makeModuleVisible(Module *Mod, SourceLocation ImportLoc) {

--- a/clang/include/clang/Serialization/ASTWriter.h
+++ b/clang/include/clang/Serialization/ASTWriter.h
@@ -807,6 +807,7 @@ class PCHGenerator : public SemaConsumer {
   ASTWriter Writer;
   bool AllowASTWithErrors;
   bool ShouldCacheASTInMemory;
+  bool IsForBMI;
 
 protected:
   ASTWriter &getWriter() { return Writer; }
@@ -820,7 +821,7 @@ public:
                ArrayRef<std::shared_ptr<ModuleFileExtension>> Extensions,
                bool AllowASTWithErrors = false, bool IncludeTimestamps = true,
                bool BuildingImplicitModule = false,
-               bool ShouldCacheASTInMemory = false);
+               bool ShouldCacheASTInMemory = false, bool IsForBMI = false);
   ~PCHGenerator() override;
 
   void InitializeSema(Sema &S) override { SemaPtr = &S; }

--- a/clang/include/clang/Serialization/PCHContainerOperations.h
+++ b/clang/include/clang/Serialization/PCHContainerOperations.h
@@ -26,6 +26,7 @@ class CompilerInstance;
 
 struct PCHBuffer {
   ASTFileSignature Signature;
+  std::string PresumedFileName;
   llvm::SmallVector<char, 0> Data;
   bool IsComplete;
 };
@@ -47,6 +48,15 @@ public:
                               const std::string &OutputFileName,
                               std::unique_ptr<llvm::raw_pwrite_stream> OS,
                               std::shared_ptr<PCHBuffer> Buffer) const = 0;
+
+  /// Return an ASTConsumer that can be chained with a
+  /// PCHGenerator that produces a wrapper file format containing a
+  /// serialized AST bitstream.
+  virtual std::unique_ptr<ASTConsumer> CreatePCHDeferredContainerGenerator(
+      CompilerInstance &CI, const std::string &MainFileName,
+      const std::string &OutputFileName,
+      std::unique_ptr<llvm::raw_pwrite_stream> OS,
+      std::shared_ptr<PCHBuffer> Buffer) const = 0;
 };
 
 /// This abstract interface provides operations for unwrapping
@@ -74,6 +84,12 @@ class RawPCHContainerWriter : public PCHContainerWriter {
                               const std::string &OutputFileName,
                               std::unique_ptr<llvm::raw_pwrite_stream> OS,
                               std::shared_ptr<PCHBuffer> Buffer) const override;
+
+  std::unique_ptr<ASTConsumer> CreatePCHDeferredContainerGenerator(
+      CompilerInstance &CI, const std::string &MainFileName,
+      const std::string &OutputFileName,
+      std::unique_ptr<llvm::raw_pwrite_stream> OS,
+      std::shared_ptr<PCHBuffer> Buffer) const override;
 };
 
 /// Implements read operations for a raw pass-through PCH container.

--- a/clang/lib/CodeGen/ObjectFilePCHContainerOperations.cpp
+++ b/clang/lib/CodeGen/ObjectFilePCHContainerOperations.cpp
@@ -357,6 +357,16 @@ ArrayRef<StringRef> ObjectFilePCHContainerReader::getFormats() const {
   return Formats;
 }
 
+std::unique_ptr<ASTConsumer>
+ObjectFilePCHContainerWriter::CreatePCHDeferredContainerGenerator(
+    CompilerInstance &CI, const std::string &MainFileName,
+    const std::string &OutputFileName,
+    std::unique_ptr<llvm::raw_pwrite_stream> OS,
+    std::shared_ptr<PCHBuffer> Buffer) const {
+  assert(0 && "Did not mean to arrive here");
+  return nullptr;
+}
+
 StringRef
 ObjectFilePCHContainerReader::ExtractPCH(llvm::MemoryBufferRef Buffer) const {
   StringRef PCH;

--- a/clang/lib/Serialization/GeneratePCH.cpp
+++ b/clang/lib/Serialization/GeneratePCH.cpp
@@ -13,6 +13,7 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/Lex/HeaderSearch.h"
+#include "clang/Lex/HeaderSearchOptions.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/SemaConsumer.h"
 #include "clang/Serialization/ASTWriter.h"
@@ -25,13 +26,13 @@ PCHGenerator::PCHGenerator(
     StringRef OutputFile, StringRef isysroot, std::shared_ptr<PCHBuffer> Buffer,
     ArrayRef<std::shared_ptr<ModuleFileExtension>> Extensions,
     bool AllowASTWithErrors, bool IncludeTimestamps,
-    bool BuildingImplicitModule, bool ShouldCacheASTInMemory)
+    bool BuildingImplicitModule, bool ShouldCacheASTInMemory, bool IsForBMI)
     : PP(PP), OutputFile(OutputFile), isysroot(isysroot.str()),
       SemaPtr(nullptr), Buffer(std::move(Buffer)), Stream(this->Buffer->Data),
       Writer(Stream, this->Buffer->Data, ModuleCache, Extensions,
              IncludeTimestamps, BuildingImplicitModule),
       AllowASTWithErrors(AllowASTWithErrors),
-      ShouldCacheASTInMemory(ShouldCacheASTInMemory) {
+      ShouldCacheASTInMemory(ShouldCacheASTInMemory), IsForBMI(IsForBMI) {
   this->Buffer->IsComplete = false;
 }
 
@@ -48,23 +49,46 @@ void PCHGenerator::HandleTranslationUnit(ASTContext &Ctx) {
     return;
 
   Module *Module = nullptr;
-  if (PP.getLangOpts().isCompilingModule()) {
+  if (PP.getLangOpts().isCompilingModule() || IsForBMI) {
     Module = PP.getHeaderSearchInfo().lookupModule(
         PP.getLangOpts().CurrentModule, SourceLocation(),
         /*AllowSearch*/ false);
     if (!Module) {
-      assert(hasErrors && "emitting module but current module doesn't exist");
+      // If we have errors, then that might have prevented the creation of the
+      // module - otherwise, for the case we are compiling a module, it must be
+      // present.
+      // Conversely, IsForBMI output is speculative and only produced for TUs
+      // in which module interfaces are discovered, thus it is not an error to
+      // find that there is no module in this case.
+      assert((hasErrors || IsForBMI) &&
+             "emitting module but current module doesn't exist");
       return;
     }
-  }
+  } // else, non-modular PCH.
 
   // Errors that do not prevent the PCH from being written should not cause the
   // overall compilation to fail either.
   if (AllowASTWithErrors)
     PP.getDiagnostics().getClient()->clear();
 
-  // Emit the PCH file to the Buffer.
   assert(SemaPtr && "No Sema?");
+
+  // A module implementation implicitly pulls in its interface module.
+  // Since it has the same name as the implementation, it will be found
+  // by the lookup above.  Fortunately, Sema records the difference in
+  // the ModuleScopes; We do not need to output the BMI in that case.
+  if (IsForBMI && SemaPtr->isModuleImplementation())
+    return;
+
+  if (IsForBMI) {
+
+    assert(Module && !Module->IsFromModuleFile &&
+           "trying to re-write a module?");
+
+    // So now attach that name to the buffer we are about to create.
+    Buffer->PresumedFileName = OutputFile;
+  }
+
   Buffer->Signature = Writer.WriteAST(*SemaPtr, OutputFile, Module, isysroot,
                                       ShouldCacheASTInMemory);
 

--- a/clang/lib/Serialization/PCHContainerOperations.cpp
+++ b/clang/lib/Serialization/PCHContainerOperations.cpp
@@ -77,6 +77,7 @@ public:
           OS.reset(new llvm::raw_fd_ostream(FD, /*shouldClose=*/true));
           *OS << Buffer->Data;
           OS->flush(); // Make sure it hits disk now.
+          // Here we would notify P1184 servers that the module is created
         } else
           llvm::dbgs() << " Problem creating : " << Buffer->PresumedFileName
                        << "\n";

--- a/clang/lib/Serialization/PCHContainerOperations.cpp
+++ b/clang/lib/Serialization/PCHContainerOperations.cpp
@@ -12,8 +12,11 @@
 
 #include "clang/Serialization/PCHContainerOperations.h"
 #include "clang/AST/ASTConsumer.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/ModuleLoader.h"
 #include "llvm/Bitstream/BitstreamReader.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include <utility>
 
@@ -48,6 +51,45 @@ public:
   }
 };
 
+/// A PCHContainerGenerator that writes out the PCH to a flat file if the
+/// action is needed (and the filename is determined at the time the output
+/// is done).
+class RawPCHDeferredContainerGenerator : public ASTConsumer {
+  std::shared_ptr<PCHBuffer> Buffer;
+
+public:
+  RawPCHDeferredContainerGenerator(std::shared_ptr<PCHBuffer> Buffer)
+      : Buffer(std::move(Buffer)) {}
+
+  ~RawPCHDeferredContainerGenerator() override = default;
+
+  void HandleTranslationUnit(ASTContext &Ctx) override {
+    if (Buffer->IsComplete && !Buffer->PresumedFileName.empty()) {
+      std::error_code EC;
+      StringRef Parent = llvm::sys::path::parent_path(Buffer->PresumedFileName);
+      if (!Parent.empty())
+        EC = llvm::sys::fs::create_directory(Parent);
+      if (!EC) {
+        int FD;
+        EC = llvm::sys::fs::openFileForWrite(Buffer->PresumedFileName, FD);
+        if (!EC) {
+          std::unique_ptr<raw_pwrite_stream> OS;
+          OS.reset(new llvm::raw_fd_ostream(FD, /*shouldClose=*/true));
+          *OS << Buffer->Data;
+          OS->flush(); // Make sure it hits disk now.
+        } else
+          llvm::dbgs() << " Problem creating : " << Buffer->PresumedFileName
+                       << "\n";
+      } else
+        llvm::dbgs() << " Problem creating dir : " << Parent << "\n";
+    }
+
+    // Free the space of the temporary buffer.
+    llvm::SmallVector<char, 0> Empty;
+    Buffer->Data = std::move(Empty);
+  }
+};
+
 } // anonymous namespace
 
 std::unique_ptr<ASTConsumer> RawPCHContainerWriter::CreatePCHContainerGenerator(
@@ -60,6 +102,15 @@ std::unique_ptr<ASTConsumer> RawPCHContainerWriter::CreatePCHContainerGenerator(
 ArrayRef<llvm::StringRef> RawPCHContainerReader::getFormats() const {
   static StringRef Raw("raw");
   return ArrayRef(Raw);
+}
+
+std::unique_ptr<ASTConsumer>
+RawPCHContainerWriter::CreatePCHDeferredContainerGenerator(
+    CompilerInstance &CI, const std::string &MainFileName,
+    const std::string &OutputFileName,
+    std::unique_ptr<llvm::raw_pwrite_stream> OS,
+    std::shared_ptr<PCHBuffer> Buffer) const {
+  return std::make_unique<RawPCHDeferredContainerGenerator>(Buffer);
 }
 
 StringRef


### PR DESCRIPTION
Here is a **draft** of the patch series that allows for emitting both an object and a BMI from the same compiler invocation.

Because of point 1) below it's fairly limited in the command lines supported, you can do things like:

` clang++  -std=c++20 foo.cpp -c -fmodule-file=X=some/dir/X,pcm `
which will generate `foo.o` in the `CWD` and `X.pcm`  in `CWD/some/dir`

Note that, like GCC's impl you no longer need to have a special name for module files, any C++ suffix should work (actually, I'm not 100% sure if the .cppm will work without some driver-side mods)

In terms of the mechanism to do the split, I'd hope it's pretty close.

Where more development will be required:
 1. in the process(es) used for finding the BMI name
 2. in the AST consumer on the BMI side doing suitable filtering to eliminate the content that is not part of the interface, that is either not needed (or in some cases positively unhelpful to consumers).

However, neither 1 or 2 should prevent this being a first step....

I"m interested in feedback on the impl.

@ChuanqiXu9 @dwblaikie @Bigcheese @mathstuf @boris-kolpackov @tahonermann 