### PR TITLE
[YAMLParser] Enable tests for flow scalar styles

### DIFF
--- a/llvm/test/YAMLParser/spec-02-17.test
+++ b/llvm/test/YAMLParser/spec-02-17.test
@@ -1,4 +1,4 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s
 
 unicode: "Sosa did fine.\u263A"
 control: "\b1998\t1999\t2000\n"

--- a/llvm/test/YAMLParser/spec-05-13.test
+++ b/llvm/test/YAMLParser/spec-05-13.test
@@ -1,4 +1,5 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "Text containing   \n  both space and\t\n  \ttab\tcharacters"
 
   "Text containing   
   both space and	

--- a/llvm/test/YAMLParser/spec-05-14.test
+++ b/llvm/test/YAMLParser/spec-05-14.test
@@ -1,4 +1,4 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
 
 "Fun with \\
 \" \a \b \e \f \

--- a/llvm/test/YAMLParser/spec-09-01.test
+++ b/llvm/test/YAMLParser/spec-09-01.test
@@ -1,4 +1,13 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!map {
+# CHECK-NEXT:   ? !!str "simple key"
+# CHECK-NEXT:   : !!map {
+# CHECK-NEXT:     ? !!str "also simple"
+# CHECK-NEXT:     : !!str "value",
+# CHECK-NEXT:     ? !!str "not a\n  simple key"
+# CHECK-NEXT:     : !!str "any\n  value",
+# CHECK-NEXT:   },
+# CHECK-NEXT: }
 
 "simple key" : {
   "also simple" : value,

--- a/llvm/test/YAMLParser/spec-09-02.test
+++ b/llvm/test/YAMLParser/spec-09-02.test
@@ -1,14 +1,17 @@
-# RUN: yaml-bench -canonical %s 2>&1 | FileCheck %s
+# RUN: yaml-bench -canonical %s 2>&1 | FileCheck %s --strict-whitespace
+# CHECK: "as space\n trimmed \n specific\L\n escaped\t \n none"
+
+## Note: The example was originally taken from Spec 1.1, but the parsing rules
+## have been changed since then.
+## * The paragraph-separator character '\u2029' is excluded from line-break
+##   characters, so the original sequence "escaped\t\\\u2029" is no longer
+##   considered valid. This is replaced by "escaped\t\\\n" in the test source.
+## See https://yaml.org/spec/1.2.2/ext/changes/ for details.
 
  "as space
- trimmed
+ trimmed 
 
- specific
-
+ specific 
  escaped	\
+ 
  none"
-
-# FIXME: The string below should actually be
-#   "as space trimmed\nspecific\nescaped\tnone", but the parser currently has
-#   a bug when parsing multiline quoted strings.
-# CHECK: !!str "as space\n trimmed\n specific\n escaped\t none"

--- a/llvm/test/YAMLParser/spec-09-03.test
+++ b/llvm/test/YAMLParser/spec-09-03.test
@@ -1,4 +1,9 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!seq [
+# CHECK-NEXT:   !!str "\n  last",
+# CHECK-NEXT:   !!str " \t\n  last",
+# CHECK-NEXT:   !!str " \tfirst\n  last",
+# CHECK-NEXT: ]
 
 - "
   last"

--- a/llvm/test/YAMLParser/spec-09-04.test
+++ b/llvm/test/YAMLParser/spec-09-04.test
@@ -1,4 +1,5 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "first\n \tinner 1\t\n  inner 2  last"
 
  "first
  	inner 1	

--- a/llvm/test/YAMLParser/spec-09-05.test
+++ b/llvm/test/YAMLParser/spec-09-05.test
@@ -1,4 +1,9 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!seq [
+# CHECK-NEXT:   !!str "first\n  \t",
+# CHECK-NEXT:   !!str "first\n  \tlast",
+# CHECK-NEXT:   !!str "first\n inner\n  \tlast",
+# CHECK-NEXT: ]
 
 - "first
   	"

--- a/llvm/test/YAMLParser/spec-09-06.test
+++ b/llvm/test/YAMLParser/spec-09-06.test
@@ -1,3 +1,4 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s
+# CHECK: "here's to \"quotes\""
 
  'here''s to "quotes"'

--- a/llvm/test/YAMLParser/spec-09-07.test
+++ b/llvm/test/YAMLParser/spec-09-07.test
@@ -1,4 +1,13 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!map {
+# CHECK-NEXT:   ? !!str "simple key"
+# CHECK-NEXT:   : !!map {
+# CHECK-NEXT:     ? !!str "also simple"
+# CHECK-NEXT:     : !!str "value",
+# CHECK-NEXT:     ? !!str "not a\n  simple key"
+# CHECK-NEXT:     : !!str "any\n  value",
+# CHECK-NEXT:   },
+# CHECK-NEXT: }
 
 'simple key' : {
   'also simple' : value,

--- a/llvm/test/YAMLParser/spec-09-08.test
+++ b/llvm/test/YAMLParser/spec-09-08.test
@@ -1,3 +1,8 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "as space\t\n trimmed \n \n specific\L\n none"
 
- 'as space	 trimmed  specific  none'
+ 'as space	
+ trimmed 
+ 
+ specific 
+ none'

--- a/llvm/test/YAMLParser/spec-09-09.test
+++ b/llvm/test/YAMLParser/spec-09-09.test
@@ -1,4 +1,9 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!seq [
+# CHECK-NEXT:   !!str "\n  last",
+# CHECK-NEXT:   !!str " \t\n  last",
+# CHECK-NEXT:   !!str " \tfirst\n  last",
+# CHECK-NEXT: ]
 
 - '
   last'

--- a/llvm/test/YAMLParser/spec-09-10.test
+++ b/llvm/test/YAMLParser/spec-09-10.test
@@ -1,4 +1,5 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "first\n \tinner\t\n last"
 
  'first
  	inner	

--- a/llvm/test/YAMLParser/spec-09-11.test
+++ b/llvm/test/YAMLParser/spec-09-11.test
@@ -1,4 +1,8 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!seq [
+# CHECK-NEXT:   !!str "first\n  \t",
+# CHECK-NEXT:   !!str "first\n\n  \tlast",
+# CHECK-NEXT: ]
 
 - 'first
   	'

--- a/llvm/test/YAMLParser/spec-09-13.test
+++ b/llvm/test/YAMLParser/spec-09-13.test
@@ -1,4 +1,13 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!map {
+# CHECK-NEXT:   ? !!str "simple key"
+# CHECK-NEXT:   : !!map {
+# CHECK-NEXT:     ? !!str "also simple"
+# CHECK-NEXT:     : !!str "value",
+# CHECK-NEXT:     ? !!str "not a\n  simple key"
+# CHECK-NEXT:     : !!str "any\n  value",
+# CHECK-NEXT:   },
+# CHECK-NEXT: }
 
 simple key : {
   also simple : value,

--- a/llvm/test/YAMLParser/spec-09-16.test
+++ b/llvm/test/YAMLParser/spec-09-16.test
@@ -1,5 +1,8 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "as space\t\n trimmed \n\n specific\L\n none"
 
-# Tabs are confusing:
-# as space/trimmed/specific/none
- as space  trimmed  specific  none
+ as space	
+ trimmed 
+
+ specific 
+ none

--- a/llvm/test/YAMLParser/spec-09-17.test
+++ b/llvm/test/YAMLParser/spec-09-17.test
@@ -1,4 +1,5 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "first line \n   \n  more line"
 
  first line 
    

--- a/llvm/test/YAMLParser/spec-10-02.test
+++ b/llvm/test/YAMLParser/spec-10-02.test
@@ -1,4 +1,16 @@
-# RUN: yaml-bench -canonical %s
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK:      !!seq [
+# CHECK-NEXT:   !!str "double\n quoted",
+# CHECK-NEXT:   !!str "single\n           quoted",
+# CHECK-NEXT:   !!str "plain\n text",
+# CHECK-NEXT:   !!seq [
+# CHECK-NEXT:     !!str "nested",
+# CHECK-NEXT:   ],
+# CHECK-NEXT:   !!map {
+# CHECK-NEXT:     ? !!str "single"
+# CHECK-NEXT:     : !!str "pair",
+# CHECK-NEXT:   },
+# CHECK-NEXT: ]
 
 [
 "double

--- a/llvm/test/YAMLParser/spec1.2-07-05.test
+++ b/llvm/test/YAMLParser/spec1.2-07-05.test
@@ -1,0 +1,8 @@
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "folded \nto a space,\t\n \nto a line feed, or \t  \tnon-content"
+
+"folded 
+to a space,	
+ 
+to a line feed, or 	\
+ \ 	non-content"

--- a/llvm/test/YAMLParser/spec1.2-07-06.test
+++ b/llvm/test/YAMLParser/spec1.2-07-06.test
@@ -1,0 +1,7 @@
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: " 1st non-empty\n 2nd non-empty \n\t3rd non-empty "
+
+" 1st non-empty
+
+ 2nd non-empty 
+	3rd non-empty "

--- a/llvm/test/YAMLParser/spec1.2-07-09.test
+++ b/llvm/test/YAMLParser/spec1.2-07-09.test
@@ -1,0 +1,7 @@
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: " 1st non-empty\n\n 2nd non-empty \n\t3rd non-empty "
+
+' 1st non-empty
+
+ 2nd non-empty 
+	3rd non-empty '

--- a/llvm/test/YAMLParser/spec1.2-07-12.test
+++ b/llvm/test/YAMLParser/spec1.2-07-12.test
@@ -1,0 +1,7 @@
+# RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
+# CHECK: "1st non-empty\n\n 2nd non-empty \n\t3rd non-empty"
+
+1st non-empty
+
+ 2nd non-empty 
+	3rd non-empty


### PR DESCRIPTION
This is a preparing commit for #70898 and #71775. It activates checks in tests for single-quoted, double-quoted, and plain values and demonstrates how they are handled currently.