### PR TITLE
[YAMLParser] Fix handling escaped line breaks in double-quoted scalars

### DIFF
--- a/llvm/lib/Support/YAMLParser.cpp
+++ b/llvm/lib/Support/YAMLParser.cpp
@@ -2107,14 +2107,13 @@ StringRef ScalarNode::unescapeDoubleQuoted( StringRef UnquotedValue
           return "";
         }
       case '\r':
+        // Shrink the Windows-style EOL.
+        if (UnquotedValue.size() >= 2 && UnquotedValue[1] == '\n')
+          UnquotedValue = UnquotedValue.drop_front(1);
+        [[fallthrough]];
       case '\n':
-        // Remove the new line.
-        if (   UnquotedValue.size() > 1
-            && (UnquotedValue[1] == '\r' || UnquotedValue[1] == '\n'))
-          UnquotedValue = UnquotedValue.substr(1);
-        // If this was just a single byte newline, it will get skipped
-        // below.
-        break;
+        UnquotedValue = UnquotedValue.drop_front(1).ltrim(" \t");
+        continue;
       case '0':
         Storage.push_back(0x00);
         break;

--- a/llvm/test/YAMLParser/spec-09-02.test
+++ b/llvm/test/YAMLParser/spec-09-02.test
@@ -1,5 +1,5 @@
 # RUN: yaml-bench -canonical %s 2>&1 | FileCheck %s --strict-whitespace
-# CHECK: "as space\n trimmed \n specific\L\n escaped\t \n none"
+# CHECK: "as space\n trimmed \n specific\L\n escaped\t\n none"
 
 ## Note: The example was originally taken from Spec 1.1, but the parsing rules
 ## have been changed since then.

--- a/llvm/test/YAMLParser/spec-09-04.test
+++ b/llvm/test/YAMLParser/spec-09-04.test
@@ -1,5 +1,5 @@
 # RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
-# CHECK: "first\n \tinner 1\t\n  inner 2  last"
+# CHECK: "first\n \tinner 1\t\n  inner 2 last"
 
  "first
  	inner 1	

--- a/llvm/test/YAMLParser/spec1.2-07-05.test
+++ b/llvm/test/YAMLParser/spec1.2-07-05.test
@@ -1,5 +1,5 @@
 # RUN: yaml-bench -canonical %s | FileCheck %s --strict-whitespace
-# CHECK: "folded \nto a space,\t\n \nto a line feed, or \t  \tnon-content"
+# CHECK: "folded \nto a space,\t\n \nto a line feed, or \t \tnon-content"
 
 "folded 
 to a space,	


### PR DESCRIPTION
Leading white spaces on the line following an escaped line break should be excluded from the content.
See https://yaml.org/spec/1.2.2/#731-double-quoted-style.

Depends on #71774 