### PR TITLE
[Support]Look up in top-level subcommand as a fallback when looking options for a custom subcommand.

### DIFF
--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -1667,6 +1667,13 @@ bool CommandLineParser::ParseCommandLineOptions(int argc,
       Handler = LookupLongOption(*ChosenSubCommand, ArgName, Value,
                                  LongOptionsUseDoubleDash, HaveDoubleDash);
 
+      // If Handler is not found in a specialized subcommand, look up handler
+      // in the top-level subcommand.
+      // cl::opt without cl::sub belongs to top-level subcommand.
+      if (!Handler && ChosenSubCommand != &SubCommand::getTopLevel())
+        Handler = LookupLongOption(SubCommand::getTopLevel(), ArgName, Value,
+                                   LongOptionsUseDoubleDash, HaveDoubleDash);
+
       // Check to see if this "option" is really a prefixed or grouped argument.
       if (!Handler && !(LongOptionsUseDoubleDash && HaveDoubleDash))
         Handler = HandlePrefixedOrGroupedOption(ArgName, Value, ErrorParsing,

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -525,7 +525,7 @@ TEST(CommandLineTest, LookupFailsInWrongSubCommand) {
   EXPECT_FALSE(Errs.empty());
 }
 
-TEST(CommandLineTest, SubcommandOptions) {
+TEST(CommandLineTest, TopLevelOptInSubcommand) {
   enum LiteralOptionEnum {
     foo,
     bar,
@@ -542,19 +542,19 @@ TEST(CommandLineTest, SubcommandOptions) {
                                    cl::desc("A top-level option."));
 
   StackSubCommand SC("sc", "Subcommand");
-  // The positional argument.
   StackOption<std::string> PositionalOpt(
       cl::Positional, cl::desc("positional argument test coverage"),
       cl::sub(SC));
-  // The literal argument.
   StackOption<LiteralOptionEnum> LiteralOpt(
       cl::desc("literal argument test coverage"), cl::sub(SC), cl::init(bar),
       cl::values(clEnumVal(foo, "foo"), clEnumVal(bar, "bar"),
                  clEnumVal(baz, "baz")));
-  StackOption<bool> BoolOpt("enable", cl::sub(SC), cl::init(false));
+  StackOption<bool> EnableOpt("enable", cl::sub(SC), cl::init(false));
+  StackOption<int> ThresholdOpt("threshold", cl::sub(SC), cl::init(1));
 
   const char *PositionalOptVal = "input-file";
-  const char *args[] = {"prog", "sc", PositionalOptVal, "-enable", "--str=csv"};
+  const char *args[] = {"prog",    "sc",        PositionalOptVal,
+                        "-enable", "--str=csv", "--threshold=2"};
 
   // cl::ParseCommandLineOptions returns true on success. Otherwise, it will
   // print the error message to stderr and exit in this setting (`Errs` ostream
@@ -562,9 +562,10 @@ TEST(CommandLineTest, SubcommandOptions) {
   ASSERT_TRUE(cl::ParseCommandLineOptions(sizeof(args) / sizeof(args[0]), args,
                                           StringRef()));
   EXPECT_STREQ(PositionalOpt.getValue().c_str(), PositionalOptVal);
-  EXPECT_TRUE(BoolOpt);
+  EXPECT_TRUE(EnableOpt);
   // Tests that the value of `str` option is `csv` as specified.
   EXPECT_STREQ(TopLevelOpt.getValue().c_str(), "csv");
+  EXPECT_EQ(ThresholdOpt, 2);
 
   for (auto &[LiteralOptVal, WantLiteralOpt] :
        {std::pair{"--bar", bar}, {"--foo", foo}, {"--baz", baz}}) {

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -567,8 +567,7 @@ TEST(CommandLineTest, SubcommandOptions) {
   EXPECT_STREQ(TopLevelOpt.getValue().c_str(), "csv");
 
   for (auto &[LiteralOptVal, WantLiteralOpt] :
-       {std::pair{"--bar", bar}, std::pair{"--foo", foo},
-        std::pair{"--baz", baz}}) {
+       {std::pair{"--bar", bar}, {"--foo", foo}, {"--baz", baz}}) {
     const char *args[] = {"prog", "sc", LiteralOptVal};
     ASSERT_TRUE(cl::ParseCommandLineOptions(sizeof(args) / sizeof(args[0]),
                                             args, StringRef()));

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -553,28 +553,28 @@ TEST(CommandLineTest, SubcommandOptions) {
                  clEnumVal(baz, "baz")));
   StackOption<bool> BoolOpt("enable", cl::sub(SC), cl::init(false));
 
-  const char *positionalOptVal = "input-file";
-  const char *args[] = {"prog", "sc", positionalOptVal, "-enable", "--str=csv"};
+  const char *PositionalOptVal = "input-file";
+  const char *args[] = {"prog", "sc", PositionalOptVal, "-enable", "--str=csv"};
 
   // cl::ParseCommandLineOptions returns true on success. Otherwise, it will
   // print the error message to stderr and exit in this setting (`Errs` ostream
   // is not set).
   ASSERT_TRUE(cl::ParseCommandLineOptions(sizeof(args) / sizeof(args[0]), args,
                                           StringRef()));
-  EXPECT_STREQ(PositionalOpt.getValue().c_str(), positionalOptVal);
+  EXPECT_STREQ(PositionalOpt.getValue().c_str(), PositionalOptVal);
   EXPECT_TRUE(BoolOpt);
   // Tests that the value of `str` option is `csv` as specified.
   EXPECT_STREQ(TopLevelOpt.getValue().c_str(), "csv");
 
-  for (auto &[literalOptVal, wantLiteralOpt] :
-       {std::make_pair("--bar", bar), std::make_pair("--foo", foo),
-        std::make_pair("--baz", baz)}) {
-    const char *args[] = {"prog", "sc", literalOptVal};
+  for (auto &[LiteralOptVal, WantLiteralOpt] :
+       {std::pair{"--bar", bar}, std::pair{"--foo", foo},
+        std::pair{"--baz", baz}}) {
+    const char *args[] = {"prog", "sc", LiteralOptVal};
     ASSERT_TRUE(cl::ParseCommandLineOptions(sizeof(args) / sizeof(args[0]),
                                             args, StringRef()));
 
     // Tests that literal options are parsed correctly.
-    EXPECT_EQ(LiteralOpt, wantLiteralOpt);
+    EXPECT_EQ(LiteralOpt, WantLiteralOpt);
   }
 }
 


### PR DESCRIPTION
**Context:**

- In https://lists.llvm.org/pipermail/llvm-dev/2016-June/101804.html and commit 07670b3e984db32f291373fe12c392959f2aff67, `cl::SubCommand` is introduced.
- Options that don't specify subcommand goes into a special 'top level' subcommand.

**Motivating Use Case:**
- The motivating use case is to refactor `llvm-profdata` to use `cl::SubCommand` to organize subcommands. See [pr/71328](https://github.com/llvm/llvm-project/pull/71328). A valid use case that's not supported before this patch

```
  // show-option{1,2} are associated with 'show' subcommand.
  // top-level-option3 is in top-level subcomand (e.g., `profile-isfs` in SampleProfReader.cpp)
  llvm-profdata show --show-option1 --show-option2 --top-level-option3
```

- Before this patch, option handler look-up will fail with the following error message "Unknown command line argument --top-level-option3".
- After this patch, option handler look-up will look up in sub-command options first, and use top-level subcommand as a fallback, so 'top-level-option3' is parsed correctly.