### PR TITLE
Reland "[Pass][CodeGen] Add some necessary passes for codegen"

### DIFF
--- a/llvm/include/llvm/CodeGen/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/CodeGen/CodeGenPassBuilder.h
@@ -105,7 +105,18 @@ namespace llvm {
     }                                                                          \
     static AnalysisKey Key;                                                    \
   };
-#include "MachinePassRegistry.def"
+#define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)          \
+  struct PASS_NAME : public AnalysisInfoMixin<PASS_NAME> {                     \
+    template <typename... Ts> PASS_NAME(Ts &&...) {}                           \
+    using Result = struct {};                                                  \
+    template <typename IRUnitT, typename AnalysisManagerT,                     \
+              typename... ExtraArgTs>                                          \
+    Result run(IRUnitT &, AnalysisManagerT &, ExtraArgTs &&...) {              \
+      return {};                                                               \
+    }                                                                          \
+    static AnalysisKey Key;                                                    \
+  };
+#include "llvm/CodeGen/MachinePassRegistry.def"
 
 /// This class provides access to building LLVM's passes.
 ///

--- a/llvm/include/llvm/CodeGen/MachinePassRegistry.def
+++ b/llvm/include/llvm/CodeGen/MachinePassRegistry.def
@@ -44,8 +44,8 @@ FUNCTION_PASS("cfguard", CFGuardPass, ())
 FUNCTION_PASS("consthoist", ConstantHoistingPass, ())
 FUNCTION_PASS("dwarf-eh-prepare", DwarfEHPreparePass, (TM))
 FUNCTION_PASS("ee-instrument", EntryExitInstrumenterPass, (false))
-FUNCTION_PASS("expand-large-div-rem", ExpandLargeDivRemPass, ())
-FUNCTION_PASS("expand-large-fp-convert", ExpandLargeFpConvertPass, ())
+FUNCTION_PASS("expand-large-div-rem", ExpandLargeDivRemPass, (TM))
+FUNCTION_PASS("expand-large-fp-convert", ExpandLargeFpConvertPass, (TM))
 FUNCTION_PASS("expand-memcmp", ExpandMemCmpPass, (TM))
 FUNCTION_PASS("expand-reductions", ExpandReductionsPass, ())
 FUNCTION_PASS("expandvp", ExpandVectorPredicationPass, ())
@@ -146,17 +146,26 @@ DUMMY_MODULE_PASS("lower-emutls", LowerEmuTLSPass, ())
 #define DUMMY_MACHINE_MODULE_PASS(NAME, PASS_NAME, CONSTRUCTOR)
 #endif
 DUMMY_MACHINE_MODULE_PASS("machine-outliner", MachineOutlinerPass, ())
+DUMMY_MACHINE_MODULE_PASS("pseudo-probe-inserter", PseudoProbeInserterPass, ())
+DUMMY_MACHINE_MODULE_PASS("mir-debugify", DebugifyMachineModule, ())
+DUMMY_MACHINE_MODULE_PASS("mir-check-debugify", CheckDebugMachineModulePass, ())
+DUMMY_MACHINE_MODULE_PASS("mir-strip-debug", StripDebugMachineModulePass,
+                          (OnlyDebugified))
 #undef DUMMY_MACHINE_MODULE_PASS
 
 #ifndef DUMMY_MACHINE_FUNCTION_PASS
 #define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)
 #endif
+DUMMY_MACHINE_FUNCTION_PASS("bbsections-prepare", BasicBlockSectionsPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("bbsections-profile-reader",
+                            BasicBlockSectionsProfileReaderPass, (Buf))
 DUMMY_MACHINE_FUNCTION_PASS("block-placement", MachineBlockPlacementPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("block-placement-stats",
                             MachineBlockPlacementStatsPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("branch-folder", BranchFolderPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("break-false-deps", BreakFalseDepsPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("cfguard-longjmp", CFGuardLongjmpPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("cfi-fixup", CFIFixupPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("cfi-instr-inserter", CFIInstrInserterPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("dead-mi-elimination",
                             DeadMachineInstructionElimPass, ())
@@ -167,12 +176,18 @@ DUMMY_MACHINE_FUNCTION_PASS("early-machinelicm", EarlyMachineLICMPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("early-tailduplication", EarlyTailDuplicatePass, ())
 DUMMY_MACHINE_FUNCTION_PASS("fentry-insert", FEntryInserterPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("finalize-isel", FinalizeISelPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("fixup-statepoint-caller-saved",
+                            FixupStatepointCallerSavedPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("free-machine-function", FreeMachineFunctionPass,
                             ())
+DUMMY_MACHINE_FUNCTION_PASS("fs-profile-loader", MIRProfileLoaderNewPass,
+                            (File, ProfileFile, P, FS))
 DUMMY_MACHINE_FUNCTION_PASS("funclet-layout", FuncletLayoutPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("gc-empty-basic-blocks", GCEmptyBasicBlocksPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("implicit-null-checks", ImplicitNullChecksPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("instruction-select", InstructionSelectPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("irtranslator", IRTranslatorPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("kcfi", MachineKCFIPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("legalizer", LegalizerPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("livedebugvalues", LiveDebugValuesPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("liveintervals", LiveIntervalsPass, ())
@@ -181,6 +196,8 @@ DUMMY_MACHINE_FUNCTION_PASS("lrshrink", LiveRangeShrinkPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("machine-combiner", MachineCombinerPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("machine-cp", MachineCopyPropagationPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("machine-cse", MachineCSEPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("machine-function-splitter",
+                            MachineFunctionSplitterPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("machine-latecleanup", MachineLateInstrsCleanupPass,
                             ())
 DUMMY_MACHINE_FUNCTION_PASS("machine-sanmd", MachineSanitizerBinaryMetadata, ())
@@ -188,9 +205,13 @@ DUMMY_MACHINE_FUNCTION_PASS("machine-scheduler", MachineSchedulerPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("machine-sink", MachineSinkingPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("machine-uniformity",
                             MachineUniformityInfoWrapperPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("machineinstr-printer", MachineFunctionPrinterPass,
+                            (OS, Banner))
 DUMMY_MACHINE_FUNCTION_PASS("machinelicm", MachineLICMPass, ())
-DUMMY_MACHINE_FUNCTION_PASS("machineverifier", MachineVerifierPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("machineverifier", MachineVerifierPass, (Banner))
 DUMMY_MACHINE_FUNCTION_PASS("mir-printer", PrintMIRPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("mirfs-discriminators", MIRAddFSDiscriminatorsPass,
+                            (P))
 DUMMY_MACHINE_FUNCTION_PASS("opt-phis", OptimizePHIsPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("patchable-function", PatchableFunctionPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("peephole-opt", PeepholeOptimizerPass, ())
@@ -205,6 +226,8 @@ DUMMY_MACHINE_FUNCTION_PASS("print-machine-uniformity",
                             MachineUniformityInfoPrinterPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("processimpdefs", ProcessImplicitDefsPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("prologepilog", PrologEpilogInserterPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("prologepilog-code", PrologEpilogCodeInserterPass,
+                            ())
 DUMMY_MACHINE_FUNCTION_PASS("ra-basic", RABasicPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("ra-fast", RAFastPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("ra-greedy", RAGreedyPass, ())
@@ -214,6 +237,7 @@ DUMMY_MACHINE_FUNCTION_PASS("reg-usage-collector", RegUsageInfoCollectorPass,
 DUMMY_MACHINE_FUNCTION_PASS("reg-usage-propagation",
                             RegUsageInfoPropagationPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("regalloc", RegAllocPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("regallocscoringpass", RegAllocScoringPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("regbankselect", RegBankSelectPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("removeredundantdebugvalues",
                             RemoveRedundantDebugValuesPass, ())
@@ -225,11 +249,21 @@ DUMMY_MACHINE_FUNCTION_PASS("shrink-wrap", ShrinkWrapPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("simple-register-coalescing", RegisterCoalescerPass,
                             ())
 DUMMY_MACHINE_FUNCTION_PASS("stack-coloring", StackColoringPass, ())
+DUMMY_MACHINE_FUNCTION_PASS("stack-frame-layout", StackFrameLayoutAnalysisPass,
+                            ())
 DUMMY_MACHINE_FUNCTION_PASS("stack-slot-coloring", StackSlotColoringPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("stackmap-liveness", StackMapLivenessPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("tailduplication", TailDuplicatePass, ())
 DUMMY_MACHINE_FUNCTION_PASS("twoaddressinstruction", TwoAddressInstructionPass,
                             ())
+DUMMY_MACHINE_FUNCTION_PASS("unpack-mi-bundles", UnpackMachineBundlesPass,
+                            (Ftor))
 DUMMY_MACHINE_FUNCTION_PASS("virtregrewriter", VirtRegRewriterPass, ())
 DUMMY_MACHINE_FUNCTION_PASS("xray-instrumentation", XRayInstrumentationPass, ())
 #undef DUMMY_MACHINE_FUNCTION_PASS
+
+#ifndef DUMMY_MACHINE_FUNCTION_ANALYSIS
+#define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)
+#endif
+DUMMY_MACHINE_FUNCTION_ANALYSIS("gc-analysis", GCMachineCodeAnalysisPass, ())
+#undef DUMMY_MACHINE_FUNCTION_ANALYSIS

--- a/llvm/lib/CodeGen/CodeGenPassBuilder.cpp
+++ b/llvm/lib/CodeGen/CodeGenPassBuilder.cpp
@@ -21,5 +21,7 @@ namespace llvm {
 #include "llvm/CodeGen/MachinePassRegistry.def"
 #define DUMMY_MACHINE_FUNCTION_PASS(NAME, PASS_NAME, CONSTRUCTOR)              \
   AnalysisKey PASS_NAME::Key;
+#define DUMMY_MACHINE_FUNCTION_ANALYSIS(NAME, PASS_NAME, CONSTRUCTOR)          \
+  AnalysisKey PASS_NAME::Key;
 #include "llvm/CodeGen/MachinePassRegistry.def"
 } // namespace llvm


### PR DESCRIPTION
Unfortunately, there are two `KCFI` passes in source tree, `CodeGen/KCFI.cpp` and `Transforms/Instrumentation/KCFI.cpp`, use `MachineKCFIPass` for machine function pass.
`MIRProfileLoaderPass` is resolved to the legacy one when `LLVM_ENABLE_MODULES=ON`, use `MIRProfileLoaderNewPass` as a workaround.