### PR TITLE
[JITLink][AArch32] Fix applyFixup Data_Pointer32 range with unsigned write

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -430,9 +430,12 @@ Error applyFixupData(LinkGraph &G, Block &B, const Edge &E) {
   }
   case Data_Pointer32: {
     int64_t Value = TargetAddress + Addend;
-    if (!isInt<32>(Value))
+    if (!isUInt<32>(Value))
       return makeTargetOutOfRangeError(G, B, E);
-    Write32(Value);
+    if (LLVM_LIKELY(G.getEndianness() == llvm::endianness::little))
+      endian::write32<llvm::endianness::little>(FixupPtr, Value);
+    else
+      endian::write32<llvm::endianness::big>(FixupPtr, Value);
     return Error::success();
   }
   default:


### PR DESCRIPTION
Data_Pointer32 when used as a pointer was giving out of range errors.
This fixes it by checking the value as unsigned 32 bits and writing
it as an unsigned value. This will allow using Data_Pointer32 for
GOT/PLT as well.
