### PR TITLE
[UTC] Escape multiple {{ or }} in input for check lines.

### DIFF
--- a/llvm/test/Analysis/LoopAccessAnalysis/loops-with-indirect-reads-and-writes.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/loops-with-indirect-reads-and-writes.ll
@@ -34,7 +34,7 @@ define void @test_indirect_read_write_loop_also_modifies_pointer_array(ptr nound
 ; CHECK-NEXT:      Grouped accesses:
 ; CHECK-NEXT:        Group [[GRP1]]:
 ; CHECK-NEXT:          (Low: {(64 + %arr),+,64}<%loop.1> High: {(8064 + %arr),+,64}<%loop.1>)
-; CHECK-NEXT:            Member: {{\{{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
+; CHECK-NEXT:            Member: {{\{\{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
 ; CHECK-NEXT:        Group [[GRP2]]:
 ; CHECK-NEXT:          (Low: %arr High: (8000 + %arr))
 ; CHECK-NEXT:            Member: {%arr,+,8}<nuw><%loop.2>
@@ -105,7 +105,7 @@ define void @test_indirect_read_loop_also_modifies_pointer_array(ptr noundef %ar
 ; CHECK-NEXT:      Grouped accesses:
 ; CHECK-NEXT:        Group [[GRP3]]:
 ; CHECK-NEXT:          (Low: {(64 + %arr),+,64}<%loop.1> High: {(8064 + %arr),+,64}<%loop.1>)
-; CHECK-NEXT:            Member: {{\{{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
+; CHECK-NEXT:            Member: {{\{\{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
 ; CHECK-NEXT:        Group [[GRP4]]:
 ; CHECK-NEXT:          (Low: %arr High: (8000 + %arr))
 ; CHECK-NEXT:            Member: {%arr,+,8}<nuw><%loop.2>
@@ -175,7 +175,7 @@ define void @test_indirect_write_loop_also_modifies_pointer_array(ptr noundef %a
 ; CHECK-NEXT:      Grouped accesses:
 ; CHECK-NEXT:        Group [[GRP5]]:
 ; CHECK-NEXT:          (Low: {(64 + %arr),+,64}<%loop.1> High: {(8064 + %arr),+,64}<%loop.1>)
-; CHECK-NEXT:            Member: {{\{{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
+; CHECK-NEXT:            Member: {{\{\{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
 ; CHECK-NEXT:        Group [[GRP6]]:
 ; CHECK-NEXT:          (Low: %arr High: (8000 + %arr))
 ; CHECK-NEXT:            Member: {%arr,+,8}<nuw><%loop.2>
@@ -244,7 +244,7 @@ define void @test_indirect_read_write_loop_does_not_modify_pointer_array(ptr nou
 ; CHECK-NEXT:      Grouped accesses:
 ; CHECK-NEXT:        Group [[GRP7]]:
 ; CHECK-NEXT:          (Low: {(64 + %arr),+,64}<%loop.1> High: {(8064 + %arr),+,64}<%loop.1>)
-; CHECK-NEXT:            Member: {{\{{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
+; CHECK-NEXT:            Member: {{\{\{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
 ; CHECK-NEXT:        Group [[GRP8]]:
 ; CHECK-NEXT:          (Low: %arr High: (8000 + %arr))
 ; CHECK-NEXT:            Member: {%arr,+,8}<nuw><%loop.2>

--- a/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/Inputs/loop-access-analysis.ll.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/Inputs/loop-access-analysis.ll.expected
@@ -81,7 +81,7 @@ define void @test_brace_escapes(ptr noundef %arr) {
 ; CHECK-NEXT:      Grouped accesses:
 ; CHECK-NEXT:        Group [[GRP4]]:
 ; CHECK-NEXT:          (Low: {(64 + %arr),+,64}<%loop.1> High: {(8064 + %arr),+,64}<%loop.1>)
-; CHECK-NEXT:            Member: {{(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
+; CHECK-NEXT:            Member: {{\{{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
 ; CHECK-NEXT:        Group [[GRP5]]:
 ; CHECK-NEXT:          (Low: %arr High: (8000 + %arr))
 ; CHECK-NEXT:            Member: {%arr,+,8}<nuw><%loop.2>

--- a/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/Inputs/loop-access-analysis.ll.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_analyze_test_checks/Inputs/loop-access-analysis.ll.expected
@@ -81,7 +81,7 @@ define void @test_brace_escapes(ptr noundef %arr) {
 ; CHECK-NEXT:      Grouped accesses:
 ; CHECK-NEXT:        Group [[GRP4]]:
 ; CHECK-NEXT:          (Low: {(64 + %arr),+,64}<%loop.1> High: {(8064 + %arr),+,64}<%loop.1>)
-; CHECK-NEXT:            Member: {{\{{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
+; CHECK-NEXT:            Member: {{\{\{}}(64 + %arr),+,64}<%loop.1>,+,8}<%loop.2>
 ; CHECK-NEXT:        Group [[GRP5]]:
 ; CHECK-NEXT:          (Low: %arr High: (8000 + %arr))
 ; CHECK-NEXT:            Member: {%arr,+,8}<nuw><%loop.2>

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -1173,13 +1173,7 @@ def generalize_check_lines_common(
     lines_with_def = []
     multiple_braces_re = re.compile(r"({{+)|(}}+)")
     def escape_braces(match_obj):
-        s = match_obj.group(0)
-        escaped = ''
-        if s[0] == '{':
-            escaped = s.replace('{', '\\{')
-        else:
-            escaped = s.replace('}', '\\}')
-        return ''.join(['{{', escaped, '}}'])
+        return ''.join(['{{', re.escape(match_obj.group(0)), '}}'])
 
     for i, line in enumerate(lines):
         if not is_asm and not is_analyze:

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -1173,7 +1173,7 @@ def generalize_check_lines_common(
     lines_with_def = []
     multiple_braces_re = re.compile(r"({{+)|(}}+)")
     def escape_braces(match_obj):
-        return ''.join(['{{', re.escape(match_obj.group(0)), '}}'])
+        return '{{' + re.escape(match_obj.group(0)) + '}}'
 
     for i, line in enumerate(lines):
         if not is_asm and not is_analyze:

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -1171,6 +1171,7 @@ def generalize_check_lines_common(
         return match.group(1) + rv + match.group(match.lastindex)
 
     lines_with_def = []
+    multiple_braces_re = re.compile(r"(({{+)|(}}+))")
 
     for i, line in enumerate(lines):
         if not is_asm and not is_analyze:
@@ -1200,6 +1201,10 @@ def generalize_check_lines_common(
                 (lines[i], changed) = nameless_value_regex.subn(
                     transform_line_vars, lines[i], count=1
                 )
+        if is_analyze:
+            # Escape multiple {{ or }} as {{}} denotes a FileCheck regex.
+            scrubbed_line = multiple_braces_re.sub(r"{{\\\1}}", lines[i])
+            lines[i] = scrubbed_line
     return lines
 
 

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -1171,7 +1171,15 @@ def generalize_check_lines_common(
         return match.group(1) + rv + match.group(match.lastindex)
 
     lines_with_def = []
-    multiple_braces_re = re.compile(r"(({{+)|(}}+))")
+    multiple_braces_re = re.compile(r"({{+)|(}}+)")
+    def escape_braces(match_obj):
+        s = match_obj.group(0)
+        escaped = ''
+        if s[0] == '{':
+            escaped = s.replace('{', '\\{')
+        else:
+            escaped = s.replace('}', '\\}')
+        return ''.join(['{{', escaped, '}}'])
 
     for i, line in enumerate(lines):
         if not is_asm and not is_analyze:
@@ -1203,7 +1211,7 @@ def generalize_check_lines_common(
                 )
         if is_analyze:
             # Escape multiple {{ or }} as {{}} denotes a FileCheck regex.
-            scrubbed_line = multiple_braces_re.sub(r"{{\\\1}}", lines[i])
+            scrubbed_line = multiple_braces_re.sub(escape_braces, lines[i])
             lines[i] = scrubbed_line
     return lines
 


### PR DESCRIPTION
SCEV expressions may contain multiple {{ or }} in the debug output, which needs escaping.

See llvm/test/Analysis/LoopAccessAnalysis/loops-with-indirect-reads-and-writes.ll for a test that needs escaping.