### PR TITLE
[CFIInstrInserter] Use number of supported registers (NFC)

### DIFF
--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -151,7 +151,7 @@ void CFIInstrInserter::calculateCFAInfo(MachineFunction &MF) {
   Register InitialRegister =
       MF.getSubtarget().getFrameLowering()->getInitialCFARegister(MF);
   InitialRegister = TRI.getDwarfRegNum(InitialRegister, true);
-  unsigned NumRegs = TRI.getNumRegs();
+  unsigned NumRegs = TRI.getNumSupportedRegs(MF);
 
   // Initialize MBBMap.
   for (MachineBasicBlock &MBB : MF) {
@@ -181,7 +181,7 @@ void CFIInstrInserter::calculateOutgoingCFAInfo(MBBCFAInfo &MBBInfo) {
   MachineFunction *MF = MBBInfo.MBB->getParent();
   const std::vector<MCCFIInstruction> &Instrs = MF->getFrameInstructions();
   const TargetRegisterInfo &TRI = *MF->getSubtarget().getRegisterInfo();
-  unsigned NumRegs = TRI.getNumRegs();
+  unsigned NumRegs = TRI.getNumSupportedRegs(*MF);
   BitVector CSRSaved(NumRegs), CSRRestored(NumRegs);
 
   // Determine cfa offset and register set by the block.


### PR DESCRIPTION
This makes use of the more accurate register number introduced in PR #70222 to avoid CFI calculations for unsupported registers.

This has basically no impact right now, but results in the following compile-time improvement when applied on top of https://github.com/llvm/llvm-project/pull/70958: http://llvm-compile-time-tracker.com/compare.php?from=0310d2a00e16d94db50cd811a4013d9f0d4f3317&to=67978ffd8bae44581f23dc7bde6fbf8ab1662d18&stat=instructions:u

The reason is that the extra registers that PR adds push the `BitVector` out of the `SmallVector` space, which results in an outsized impact. (This does make me wonder whether `BitVector` should accept an `N` template parameter to allow using a larger `SmallVector`...)