### PR TITLE
[lldb][AArch64][Linux] Add field information for the mte_ctrl register

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1224,6 +1224,17 @@ class Base(unittest2.TestCase):
     # (enables reading of the current test configuration)
     # ====================================================
 
+    def hasXMLSupport(self):
+        """Returns True if lldb was built with XML support. Use this check to
+        enable parts of tests, if you want to skip a whole test use skipIfXmlSupportMissing
+        instead."""
+        return (
+            lldb.SBDebugger.GetBuildConfiguration()
+            .GetValueForKey("xml")
+            .GetValueForKey("value")
+            .GetBooleanValue(False)
+        )
+
     def isMIPS(self):
         """Returns true if the architecture is MIPS."""
         arch = self.getArchitecture()

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
@@ -25,6 +25,19 @@
 using namespace lldb_private;
 
 LinuxArm64RegisterFlags::Fields
+LinuxArm64RegisterFlags::DetectMTECtrlFields(uint64_t hwcap, uint64_t hwcap2) {
+  (void)hwcap;
+  (void)hwcap2;
+  // Represents the contents of NT_ARM_TAGGED_ADDR_CTRL and the value passed
+  // to prctl(PR_TAGGED_ADDR_CTRL...). Fields are derived from the defines
+  // used to build the value.
+  return {{"TAGS", 3, 18}, // 16 bit bitfield shifted up by PR_MTE_TAG_SHIFT.
+          {"TCF_ASYNC", 2},
+          {"TCF_SYNC", 1},
+          {"TAGGED_ADDR_ENABLE", 0}};
+}
+
+LinuxArm64RegisterFlags::Fields
 LinuxArm64RegisterFlags::DetectFPCRFields(uint64_t hwcap, uint64_t hwcap2) {
   std::vector<RegisterFlags::Field> fpcr_fields{
       {"AHP", 26}, {"DN", 25}, {"FZ", 24}, {"RMMode", 22, 23},

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
@@ -58,6 +58,7 @@ private:
   static Fields DetectCPSRFields(uint64_t hwcap, uint64_t hwcap2);
   static Fields DetectFPSRFields(uint64_t hwcap, uint64_t hwcap2);
   static Fields DetectFPCRFields(uint64_t hwcap, uint64_t hwcap2);
+  static Fields DetectMTECtrlFields(uint64_t hwcap, uint64_t hwcap2);
 
   struct RegisterEntry {
     RegisterEntry(llvm::StringRef name, unsigned size, DetectorFn detector)
@@ -67,10 +68,11 @@ private:
     llvm::StringRef m_name;
     RegisterFlags m_flags;
     DetectorFn m_detector;
-  } m_registers[3] = {
+  } m_registers[4] = {
       RegisterEntry("cpsr", 4, DetectCPSRFields),
       RegisterEntry("fpsr", 4, DetectFPSRFields),
       RegisterEntry("fpcr", 4, DetectFPCRFields),
+      RegisterEntry("mte_ctrl", 8, DetectMTECtrlFields),
   };
 
   // Becomes true once field detection has been run for all registers.

--- a/lldb/test/API/linux/aarch64/mte_core_file/TestAArch64LinuxMTEMemoryTagCoreFile.py
+++ b/lldb/test/API/linux/aarch64/mte_core_file/TestAArch64LinuxMTEMemoryTagCoreFile.py
@@ -235,4 +235,11 @@ class AArch64LinuxMTEMemoryTagCoreFileTestCase(TestBase):
         # * Allowed tags value of 0xFFFF, shifted up by 3 resulting in 0x7fff8.
         # * Bit 1 set to enable synchronous tag faults.
         # * Bit 0 set to enable the tagged address ABI.
-        self.expect("register read mte_ctrl", substrs=["mte_ctrl = 0x000000000007fffb"])
+        expected = ["mte_ctrl = 0x000000000007fffb"]
+
+        if self.hasXMLSupport():
+            expected.append(
+                "(TAGS = 65535, TCF_ASYNC = 0, TCF_SYNC = 1, TAGGED_ADDR_ENABLE = 1)"
+            )
+
+        self.expect("register read mte_ctrl", substrs=expected)


### PR DESCRIPTION
This is a Linux pseudo register provided by the NT_ARM_TAGGED_ADDR_CTRL register set. It reflects the value passed to prctl PR_SET_TAGGED_ADDR_CTRL.

https://docs.kernel.org/arch/arm64/memory-tagging-extension.html

The fields are made from the #defines the kernel provides for setting the value. Its contents are constant so no runtime detection is needed (once we've decided we have this register in the first place).

The permitted generated tags is technically a bitfield but at this time we don't have a way to mark a field as preferring hex formatting.

```
(lldb) register read mte_ctrl
mte_ctrl = 0x000000000007fffb
         = (TAGS = 65535, TCF_ASYNC = 0, TCF_SYNC = 1, TAGGED_ADDR_ENABLE = 1)
```

(4 bit tags mean 16 possible tags, 16 bit bitfield)

Testing has been added to TestMTECtrlRegister.py, which needed a more granular way to check for XML support, so I've added hasXMLSupport that can be used within a test case instead of skipping whole tests if XML isn't supported.

Same for the core file tests.