### PR TITLE
[lldb][AArch64][Linux] Add register field information for SME's SVCR register

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.cpp
@@ -25,6 +25,19 @@
 using namespace lldb_private;
 
 LinuxArm64RegisterFlags::Fields
+LinuxArm64RegisterFlags::DetectSVCRFields(uint64_t hwcap, uint64_t hwcap2) {
+  (void)hwcap;
+  (void)hwcap2;
+  // Represents the pseudo register that lldb-server builds, which itself
+  // matches the architectural register SCVR. The fields match SVCR in the Arm
+  // manual.
+  return {
+      {"ZA", 1},
+      {"SM", 0},
+  };
+}
+
+LinuxArm64RegisterFlags::Fields
 LinuxArm64RegisterFlags::DetectMTECtrlFields(uint64_t hwcap, uint64_t hwcap2) {
   (void)hwcap;
   (void)hwcap2;

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsLinux_arm64.h
@@ -59,6 +59,7 @@ private:
   static Fields DetectFPSRFields(uint64_t hwcap, uint64_t hwcap2);
   static Fields DetectFPCRFields(uint64_t hwcap, uint64_t hwcap2);
   static Fields DetectMTECtrlFields(uint64_t hwcap, uint64_t hwcap2);
+  static Fields DetectSVCRFields(uint64_t hwcap, uint64_t hwcap2);
 
   struct RegisterEntry {
     RegisterEntry(llvm::StringRef name, unsigned size, DetectorFn detector)
@@ -68,11 +69,12 @@ private:
     llvm::StringRef m_name;
     RegisterFlags m_flags;
     DetectorFn m_detector;
-  } m_registers[4] = {
+  } m_registers[5] = {
       RegisterEntry("cpsr", 4, DetectCPSRFields),
       RegisterEntry("fpsr", 4, DetectFPSRFields),
       RegisterEntry("fpcr", 4, DetectFPCRFields),
       RegisterEntry("mte_ctrl", 8, DetectMTECtrlFields),
+      RegisterEntry("svcr", 8, DetectSVCRFields),
   };
 
   // Becomes true once field detection has been run for all registers.

--- a/lldb/test/API/linux/aarch64/sme_core_file/TestAArch64LinuxSMECoreFile.py
+++ b/lldb/test/API/linux/aarch64/sme_core_file/TestAArch64LinuxSMECoreFile.py
@@ -5,17 +5,17 @@ Check that LLDB can read Scalable Matrix Extension (SME) data from core files.
 
 import lldb
 import itertools
-from enum import Enum
+from enum import IntEnum
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
-class Mode(Enum):
+class Mode(IntEnum):
     SVE = 0
     SSVE = 1
 
 
-class ZA(Enum):
+class ZA(IntEnum):
     Disabled = 0
     Enabled = 1
 
@@ -56,7 +56,12 @@ class AArch64LinuxSMECoreFileTestCase(TestBase):
         svcr = 1 if sve_mode == Mode.SSVE else 0
         if za == ZA.Enabled:
             svcr |= 2
-        self.expect("register read svcr", substrs=["0x{:016x}".format(svcr)])
+
+        expected_svcr = ["0x{:016x}".format(svcr)]
+        if self.hasXMLSupport():
+            expected_svcr.append("(ZA = {:d}, SM = {})".format(za, sve_mode))
+
+        self.expect("register read svcr", substrs=expected_svcr)
 
         repeat_bytes = lambda v, n: " ".join(["0x{:02x}".format(v)] * n)
 


### PR DESCRIPTION
This register is a pseudo register but mirrors the architectural
register's contents. See:
https://developer.arm.com/documentation/ddi0616/latest/

For the full details. Example output:
```
(lldb) register read svcr
    svcr = 0x0000000000000002
         = (ZA = 1, SM = 0)
```