### PR TITLE
[AIX] Enable tests relating to 64-bit XCOFF object files

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -332,43 +332,6 @@ if config.have_llvm_driver:
     config.available_features.add("llvm-driver")
 
 
-def exclude_unsupported_files_for_aix(dirname):
-    for filename in os.listdir(dirname):
-        source_path = os.path.join(dirname, filename)
-        if os.path.isdir(source_path):
-            continue
-        f = open(source_path, "r", encoding="ISO-8859-1")
-        try:
-            data = f.read()
-            # 64-bit object files are not supported on AIX, so exclude the tests.
-            if (
-                any(
-                    option in data
-                    for option in (
-                        "-emit-obj",
-                        "-fmodule-format=obj",
-                        "-fintegrated-as",
-                    )
-                )
-                and "64" in config.target_triple
-            ):
-                config.excludes += [filename]
-        finally:
-            f.close()
-
-
-if "aix" in config.target_triple:
-    for directory in (
-        "/CodeGenCXX",
-        "/Misc",
-        "/Modules",
-        "/PCH",
-        "/Driver",
-        "/ASTMerge/anonymous-fields",
-        "/ASTMerge/injected-class-name-decl",
-    ):
-        exclude_unsupported_files_for_aix(config.test_source_root + directory)
-
 # Some tests perform deep recursion, which requires a larger pthread stack size
 # than the relatively low default of 192 KiB for 64-bit processes on AIX. The
 # `AIXTHREAD_STK` environment variable provides a non-intrusive way to request

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -601,34 +601,6 @@ if "MemoryWithOrigins" in config.llvm_use_sanitizer:
     config.available_features.add("use_msan_with_origins")
 
 
-def exclude_unsupported_files_for_aix(dirname):
-    for filename in os.listdir(dirname):
-        source_path = os.path.join(dirname, filename)
-        if os.path.isdir(source_path):
-            continue
-        f = open(source_path, "r")
-        try:
-            data = f.read()
-            # 64-bit object files are not supported on AIX, so exclude the tests.
-            if (
-                "-emit-obj" in data or "-filetype=obj" in data
-            ) and "64" in config.target_triple:
-                config.excludes += [filename]
-        finally:
-            f.close()
-
-
-if "aix" in config.target_triple:
-    for directory in (
-        "/CodeGen/X86",
-        "/DebugInfo",
-        "/DebugInfo/X86",
-        "/DebugInfo/Generic",
-        "/LTO/X86",
-        "/Linker",
-    ):
-        exclude_unsupported_files_for_aix(config.test_source_root + directory)
-
 # Some tools support an environment variable "OBJECT_MODE" on AIX OS, which
 # controls the kind of objects they will support. If there is no "OBJECT_MODE"
 # environment variable specified, the default behaviour is to support 32-bit

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugInfoTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugInfoTest.cpp
@@ -33,6 +33,12 @@
 #include "gtest/gtest.h"
 #include <string>
 
+// AIX doesn't support debug_str_offsets or debug_addr sections
+#ifdef _AIX
+#define NO_SUPPORT_DEBUG_STR_OFFSETS
+#define NO_SUPPORT_DEBUG_ADDR
+#endif
+
 using namespace llvm;
 using namespace dwarf;
 using namespace utils;
@@ -435,11 +441,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version2Addr4AllForms) {
   TestAllForms<2, AddrType, RefAddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version2Addr8AllForms) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version2Addr8AllForms) {
-#endif
   // Test that we can decode all forms for DWARF32, version 2, with 4 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -457,11 +459,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version3Addr4AllForms) {
   TestAllForms<3, AddrType, RefAddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version3Addr8AllForms) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version3Addr8AllForms) {
-#endif
   // Test that we can decode all forms for DWARF32, version 3, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -479,11 +477,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version4Addr4AllForms) {
   TestAllForms<4, AddrType, RefAddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version4Addr8AllForms) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version4Addr8AllForms) {
-#endif
   // Test that we can decode all forms for DWARF32, version 4, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -492,8 +486,8 @@ TEST(DWARFDebugInfo, TestDWARF32Version4Addr8AllForms) {
   TestAllForms<4, AddrType, RefAddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebigInfo, DISABLED_TestDWARF32Version5Addr4AllForms) {
+#ifdef NO_SUPPORT_DEBUG_STR_OFFSETS
+TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version5Addr4AllForms) {
 #else
 TEST(DWARFDebugInfo, TestDWARF32Version5Addr4AllForms) {
 #endif
@@ -505,8 +499,8 @@ TEST(DWARFDebugInfo, TestDWARF32Version5Addr4AllForms) {
   TestAllForms<5, AddrType, RefAddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebigInfo, DISABLED_TestDWARF32Version5Addr8AllForms) {
+#ifdef NO_SUPPORT_DEBUG_STR_OFFSETS
+TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version5Addr8AllForms) {
 #else
 TEST(DWARFDebugInfo, TestDWARF32Version5Addr8AllForms) {
 #endif
@@ -613,11 +607,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version2Addr4Children) {
   TestChildren<2, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version2Addr8Children) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version2Addr8Children) {
-#endif
   // Test that we can decode all forms for DWARF32, version 2, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -631,11 +621,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version3Addr4Children) {
   TestChildren<3, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version3Addr8Children) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version3Addr8Children) {
-#endif
   // Test that we can decode all forms for DWARF32, version 3, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -649,11 +635,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version4Addr4Children) {
   TestChildren<4, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version4Addr8Children) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version4Addr8Children) {
-#endif
   // Test that we can decode all forms for DWARF32, version 4, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -875,11 +857,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version2Addr4References) {
   TestReferences<2, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version2Addr8References) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version2Addr8References) {
-#endif
   // Test that we can decode all forms for DWARF32, version 2, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -893,11 +871,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version3Addr4References) {
   TestReferences<3, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version3Addr8References) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version3Addr8References) {
-#endif
   // Test that we can decode all forms for DWARF32, version 3, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -911,11 +885,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version4Addr4References) {
   TestReferences<4, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version4Addr8References) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version4Addr8References) {
-#endif
   // Test that we can decode all forms for DWARF32, version 4, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -1059,11 +1029,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version2Addr4Addresses) {
   TestAddresses<2, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version2Addr8Addresses) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version2Addr8Addresses) {
-#endif
   // Test that we can decode address values in DWARF32, version 2, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -1077,11 +1043,7 @@ TEST(DWARFDebugInfo, TestDWARF32Version3Addr4Addresses) {
   TestAddresses<3, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version3Addr8Addresses) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version3Addr8Addresses) {
-#endif
   // Test that we can decode address values in DWARF32, version 3, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
@@ -1095,18 +1057,14 @@ TEST(DWARFDebugInfo, TestDWARF32Version4Addr4Addresses) {
   TestAddresses<4, AddrType>();
 }
 
-#ifdef _AIX
-TEST(DWARFDebugInfo, DISABLED_TestDWARF32Version4Addr8Addresses) {
-#else
 TEST(DWARFDebugInfo, TestDWARF32Version4Addr8Addresses) {
-#endif
   // Test that we can decode address values in DWARF32, version 4, with 8 byte
   // addresses.
   typedef uint64_t AddrType;
   TestAddresses<4, AddrType>();
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_STR_OFFSETS
 TEST(DWARFDebugInfo, DISABLED_TestStringOffsets) {
 #else
 TEST(DWARFDebugInfo, TestStringOffsets) {
@@ -1175,8 +1133,7 @@ TEST(DWARFDebugInfo, TestStringOffsets) {
   EXPECT_STREQ(String1, *Extracted3);
 }
 
-// AIX does not support string offset section.
-#if defined(_AIX)
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST(DWARFDebugInfo, DISABLED_TestEmptyStringOffsets) {
 #else
 TEST(DWARFDebugInfo, TestEmptyStringOffsets) {
@@ -1845,8 +1802,7 @@ TEST(DWARFDebugInfo, TestFindAttrs) {
   EXPECT_EQ(DieMangled, toString(NameOpt, ""));
 }
 
-// AIX does not support debug_addr section.
-#if defined(_AIX)
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST(DWARFDebugInfo, DISABLED_TestImplicitConstAbbrevs) {
 #else
 TEST(DWARFDebugInfo, TestImplicitConstAbbrevs) {

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
@@ -14,6 +14,11 @@
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
+// AIX doesn't support the debug_addr section
+#ifdef _AIX
+#define NO_SUPPORT_DEBUG_ADDR
+#endif
+
 using namespace llvm;
 using namespace dwarf;
 using namespace dwarfgen;
@@ -181,11 +186,7 @@ void checkDefaultPrologue(uint16_t Version, DwarfFormat Format,
   EXPECT_STREQ(*toString(Prologue.FileNames[0].Name), "a file");
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_GetOrParseLineTableAtInvalidOffset) {
-#else
 TEST_F(DebugLineBasicFixture, GetOrParseLineTableAtInvalidOffset) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
   generate();
@@ -207,12 +208,7 @@ TEST_F(DebugLineBasicFixture, GetOrParseLineTableAtInvalidOffset) {
           "offset 0x00000001 is not a valid debug line section offset"));
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_GetOrParseLineTableAtInvalidOffsetAfterData) {
-#else
 TEST_F(DebugLineBasicFixture, GetOrParseLineTableAtInvalidOffsetAfterData) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -233,7 +229,7 @@ TEST_F(DebugLineBasicFixture, GetOrParseLineTableAtInvalidOffsetAfterData) {
           "offset 0x00000001 is not a valid debug line section offset"));
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_P(DebugLineParameterisedFixture, DISABLED_PrologueGetLength) {
 #else
 TEST_P(DebugLineParameterisedFixture, PrologueGetLength) {
@@ -260,7 +256,7 @@ TEST_P(DebugLineParameterisedFixture, PrologueGetLength) {
   EXPECT_EQ((*ExpectedLineTable)->Prologue.getLength(), ExpectedLength);
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_P(DebugLineParameterisedFixture, DISABLED_GetOrParseLineTableValidTable) {
 #else
 TEST_P(DebugLineParameterisedFixture, GetOrParseLineTableValidTable) {
@@ -330,7 +326,7 @@ TEST_P(DebugLineParameterisedFixture, GetOrParseLineTableValidTable) {
   // correctly.
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_P(DebugLineParameterisedFixture, DISABLED_ClearLineValidTable) {
 #else
 TEST_P(DebugLineParameterisedFixture, ClearLineValidTable) {
@@ -406,11 +402,7 @@ TEST_P(DebugLineParameterisedFixture, ClearLineValidTable) {
   EXPECT_EQ(Expected4->Sequences.size(), 2u);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_ErrorForReservedLength) {
-#else
 TEST_F(DebugLineBasicFixture, ErrorForReservedLength) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -433,12 +425,7 @@ struct DebugLineUnsupportedVersionFixture : public TestWithParam<uint16_t>,
   uint16_t Version;
 };
 
-#ifdef _AIX
-TEST_P(DebugLineUnsupportedVersionFixture,
-       DISABLED_ErrorForUnsupportedVersion) {
-#else
 TEST_P(DebugLineUnsupportedVersionFixture, ErrorForUnsupportedVersion) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -460,7 +447,7 @@ INSTANTIATE_TEST_SUITE_P(UnsupportedVersionTestParams,
                          Values(/*1 below min */ 1, /* 1 above max */ 6,
                                 /* Maximum possible */ 0xffff));
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_F(DebugLineBasicFixture, DISABLED_ErrorForInvalidV5IncludeDirTable) {
 #else
 TEST_F(DebugLineBasicFixture, ErrorForInvalidV5IncludeDirTable) {
@@ -505,7 +492,7 @@ TEST_F(DebugLineBasicFixture, ErrorForInvalidV5IncludeDirTable) {
           "found"));
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_P(DebugLineParameterisedFixture, DISABLED_ErrorForTooLargePrologueLength) {
 #else
 TEST_P(DebugLineParameterisedFixture, ErrorForTooLargePrologueLength) {
@@ -545,7 +532,7 @@ TEST_P(DebugLineParameterisedFixture, ErrorForTooLargePrologueLength) {
               .str()));
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_P(DebugLineParameterisedFixture, DISABLED_ErrorForTooShortPrologueLength) {
 #else
 TEST_P(DebugLineParameterisedFixture, ErrorForTooShortPrologueLength) {
@@ -603,12 +590,7 @@ INSTANTIATE_TEST_SUITE_P(
            std::make_pair(4, DWARF64), // Test v4 fields and DWARF64.
            std::make_pair(5, DWARF32), std::make_pair(5, DWARF64)));
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ErrorForExtendedOpcodeLengthSmallerThanExpected) {
-#else
 TEST_F(DebugLineBasicFixture, ErrorForExtendedOpcodeLengthSmallerThanExpected) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -637,12 +619,7 @@ TEST_F(DebugLineBasicFixture, ErrorForExtendedOpcodeLengthSmallerThanExpected) {
   EXPECT_EQ((*ExpectedLineTable)->Rows[1].Discriminator, DW_LNS_negate_stmt);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ErrorForExtendedOpcodeLengthLargerThanExpected) {
-#else
 TEST_F(DebugLineBasicFixture, ErrorForExtendedOpcodeLengthLargerThanExpected) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -671,11 +648,7 @@ TEST_F(DebugLineBasicFixture, ErrorForExtendedOpcodeLengthLargerThanExpected) {
   EXPECT_EQ((*ExpectedLineTable)->Rows[2].IsStmt, 1u);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_ErrorForUnitLengthTooLarge) {
-#else
 TEST_F(DebugLineBasicFixture, ErrorForUnitLengthTooLarge) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -704,11 +677,7 @@ TEST_F(DebugLineBasicFixture, ErrorForUnitLengthTooLarge) {
   EXPECT_EQ((*ExpectedLineTable)->Sequences.size(), 1u);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_ErrorForMismatchedAddressSize) {
-#else
 TEST_F(DebugLineBasicFixture, ErrorForMismatchedAddressSize) {
-#endif
   if (!setupGenerator(4, 8))
     GTEST_SKIP();
 
@@ -737,13 +706,8 @@ TEST_F(DebugLineBasicFixture, ErrorForMismatchedAddressSize) {
   EXPECT_EQ((*ExpectedLineTable)->Rows[1].Address.Address, Addr2);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ErrorForMismatchedAddressSizeUnsetInitialAddress) {
-#else
 TEST_F(DebugLineBasicFixture,
        ErrorForMismatchedAddressSizeUnsetInitialAddress) {
-#endif
   if (!setupGenerator(4, 0))
     GTEST_SKIP();
 
@@ -769,13 +733,8 @@ TEST_F(DebugLineBasicFixture,
   EXPECT_EQ((*ExpectedLineTable)->Rows[1].Address.Address, Addr2);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ErrorForUnsupportedAddressSizeInSetAddressLength) {
-#else
 TEST_F(DebugLineBasicFixture,
        ErrorForUnsupportedAddressSizeInSetAddressLength) {
-#endif
   // Use DWARF v4, and 0 for data extractor address size so that the address
   // size is derived from the opcode length.
   if (!setupGenerator(4, 0))
@@ -807,11 +766,7 @@ TEST_F(DebugLineBasicFixture,
   EXPECT_EQ((*ExpectedLineTable)->Rows[0].Address.Address, 0u);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_ErrorForAddressSizeGreaterThanByteSize) {
-#else
 TEST_F(DebugLineBasicFixture, ErrorForAddressSizeGreaterThanByteSize) {
-#endif
   // Use DWARF v4, and 0 for data extractor address size so that the address
   // size is derived from the opcode length.
   if (!setupGenerator(4, 0))
@@ -835,7 +790,7 @@ TEST_F(DebugLineBasicFixture, ErrorForAddressSizeGreaterThanByteSize) {
   ASSERT_THAT_EXPECTED(ExpectedLineTable, Succeeded());
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_F(DebugLineBasicFixture,
        DISABLED_ErrorForUnsupportedAddressSizeDefinedInHeader) {
 #else
@@ -877,11 +832,7 @@ TEST_F(DebugLineBasicFixture, ErrorForUnsupportedAddressSizeDefinedInHeader) {
   EXPECT_EQ((*ExpectedLineTable)->Rows[0].Address.Address, 0u);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_CallbackUsedForUnterminatedSequence) {
-#else
 TEST_F(DebugLineBasicFixture, CallbackUsedForUnterminatedSequence) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1095,11 +1046,7 @@ struct OpIndexFixture : Test, CommonFixture {
   }
 };
 
-#ifdef _AIX
-TEST_F(OpIndexFixture, DISABLED_OpIndexAdvance) {
-#else
 TEST_F(OpIndexFixture, OpIndexAdvance) {
-#endif
   if (!setupGenerator(4, 4))
     GTEST_SKIP();
 
@@ -1166,11 +1113,7 @@ TEST_F(OpIndexFixture, OpIndexAdvance) {
   VerifyRow((*Table)->Rows[5], 0x50, 4, 110);
 }
 
-#ifdef _AIX
-TEST_F(OpIndexFixture, DISABLED_OpIndexReset) {
-#else
 TEST_F(OpIndexFixture, OpIndexReset) {
-#endif
   if (!setupGenerator(4, 4))
     GTEST_SKIP();
 
@@ -1233,11 +1176,7 @@ TEST_F(OpIndexFixture, OpIndexReset) {
   EXPECT_EQ((*Table)->Rows[7].OpIndex, 0u);
 }
 
-#ifdef _AIX
-TEST_F(OpIndexFixture, DISABLED_MaxOpsZeroDwarf3) {
-#else
 TEST_F(OpIndexFixture, MaxOpsZeroDwarf3) {
-#endif
   if (!setupGenerator(3, 4))
     GTEST_SKIP();
 
@@ -1254,11 +1193,7 @@ TEST_F(OpIndexFixture, MaxOpsZeroDwarf3) {
   ASSERT_THAT_EXPECTED(Table, Succeeded());
 }
 
-#ifdef _AIX
-TEST_F(OpIndexFixture, DISABLED_MaxOpsZeroDwarf4) {
-#else
 TEST_F(OpIndexFixture, MaxOpsZeroDwarf4) {
-#endif
   if (!setupGenerator(4, 4))
     GTEST_SKIP();
 
@@ -1310,11 +1245,7 @@ struct LineRangeFixture : TestWithParam<std::tuple<uint8_t, bool>>,
   uint8_t LineRange;
 };
 
-#ifdef _AIX
-TEST_P(LineRangeFixture, DISABLED_LineRangeProblemsReportedCorrectly) {
-#else
 TEST_P(LineRangeFixture, LineRangeProblemsReportedCorrectly) {
-#endif
   runTest(/*CheckAdvancePC=*/false,
           "but the prologue line_range value is 0. The address and line will "
           "not be adjusted");
@@ -1349,11 +1280,7 @@ struct BadMinInstLenFixture : TestWithParam<std::tuple<uint8_t, bool>>,
   uint8_t MinInstLength;
 };
 
-#ifdef _AIX
-TEST_P(BadMinInstLenFixture, DISABLED_MinInstLengthProblemsReportedCorrectly) {
-#else
 TEST_P(BadMinInstLenFixture, MinInstLengthProblemsReportedCorrectly) {
-#endif
   runTest(/*CheckAdvancePC=*/true,
           "but the prologue minimum_instruction_length value is 0, which "
           "prevents any address advancing");
@@ -1364,11 +1291,7 @@ INSTANTIATE_TEST_SUITE_P(
     Values(std::make_tuple(0, true),    // Test zero value (error).
            std::make_tuple(1, false))); // Test non-zero value (no error).
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_ParserParsesCorrectly) {
-#else
 TEST_F(DebugLineBasicFixture, ParserParsesCorrectly) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1395,11 +1318,7 @@ TEST_F(DebugLineBasicFixture, ParserParsesCorrectly) {
   EXPECT_FALSE(Unrecoverable);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_ParserSkipsCorrectly) {
-#else
 TEST_F(DebugLineBasicFixture, ParserSkipsCorrectly) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1420,11 +1339,7 @@ TEST_F(DebugLineBasicFixture, ParserSkipsCorrectly) {
   EXPECT_FALSE(Unrecoverable);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture, DISABLED_ParserAlwaysDoneForEmptySection) {
-#else
 TEST_F(DebugLineBasicFixture, ParserAlwaysDoneForEmptySection) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1434,12 +1349,7 @@ TEST_F(DebugLineBasicFixture, ParserAlwaysDoneForEmptySection) {
   EXPECT_TRUE(Parser.done());
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ParserMarkedAsDoneForBadLengthWhenParsing) {
-#else
 TEST_F(DebugLineBasicFixture, ParserMarkedAsDoneForBadLengthWhenParsing) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1462,12 +1372,7 @@ TEST_F(DebugLineBasicFixture, ParserMarkedAsDoneForBadLengthWhenParsing) {
           "reserved unit length of value 0xfffffff0"));
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ParserMarkedAsDoneForBadLengthWhenSkipping) {
-#else
 TEST_F(DebugLineBasicFixture, ParserMarkedAsDoneForBadLengthWhenSkipping) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1490,12 +1395,7 @@ TEST_F(DebugLineBasicFixture, ParserMarkedAsDoneForBadLengthWhenSkipping) {
           "reserved unit length of value 0xfffffff0"));
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ParserReportsFirstErrorInEachTableWhenParsing) {
-#else
 TEST_F(DebugLineBasicFixture, ParserReportsFirstErrorInEachTableWhenParsing) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1521,12 +1421,7 @@ TEST_F(DebugLineBasicFixture, ParserReportsFirstErrorInEachTableWhenParsing) {
                         "unsupported version 1"));
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ParserReportsNonPrologueProblemsWhenParsing) {
-#else
 TEST_F(DebugLineBasicFixture, ParserReportsNonPrologueProblemsWhenParsing) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1558,13 +1453,8 @@ TEST_F(DebugLineBasicFixture, ParserReportsNonPrologueProblemsWhenParsing) {
   EXPECT_FALSE(Unrecoverable);
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ParserReportsPrologueErrorsInEachTableWhenSkipping) {
-#else
 TEST_F(DebugLineBasicFixture,
        ParserReportsPrologueErrorsInEachTableWhenSkipping) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1590,12 +1480,7 @@ TEST_F(DebugLineBasicFixture,
                         "unsupported version 1"));
 }
 
-#ifdef _AIX
-TEST_F(DebugLineBasicFixture,
-       DISABLED_ParserIgnoresNonPrologueErrorsWhenSkipping) {
-#else
 TEST_F(DebugLineBasicFixture, ParserIgnoresNonPrologueErrorsWhenSkipping) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -1611,7 +1496,7 @@ TEST_F(DebugLineBasicFixture, ParserIgnoresNonPrologueErrorsWhenSkipping) {
   EXPECT_FALSE(Unrecoverable);
 }
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_F(DebugLineBasicFixture, DISABLED_VerboseOutput) {
 #else
 TEST_F(DebugLineBasicFixture, VerboseOutput) {
@@ -1777,7 +1662,7 @@ struct TruncatedPrologueFixture
   StringRef ExpectedErr;
 };
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_P(TruncatedPrologueFixture, DISABLED_ErrorForTruncatedPrologue) {
 #else
 TEST_P(TruncatedPrologueFixture, ErrorForTruncatedPrologue) {
@@ -1958,12 +1843,7 @@ struct TruncatedExtendedOpcodeFixture
   uint64_t OpcodeLength;
 };
 
-#ifdef _AIX
-TEST_P(TruncatedExtendedOpcodeFixture,
-       DISABLED_ErrorForTruncatedExtendedOpcode) {
-#else
 TEST_P(TruncatedExtendedOpcodeFixture, ErrorForTruncatedExtendedOpcode) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
   LineTable &LT = setupTable();
@@ -2042,12 +1922,7 @@ INSTANTIATE_TEST_SUITE_P(
             "unexpected end of data at offset 0x35 while reading [0x32, "
             "0x36)")));
 
-#ifdef _AIX
-TEST_P(TruncatedStandardOpcodeFixture,
-       DISABLED_ErrorForTruncatedStandardOpcode) {
-#else
 TEST_P(TruncatedStandardOpcodeFixture, ErrorForTruncatedStandardOpcode) {
-#endif
   if (!setupGenerator())
     GTEST_SKIP();
   LineTable &LT = setupTable();
@@ -2103,7 +1978,7 @@ INSTANTIATE_TEST_SUITE_P(
             "unable to decode LEB128 at offset 0x00000032: "
             "malformed uleb128, extends past end")));
 
-#ifdef _AIX
+#ifdef NO_SUPPORT_DEBUG_ADDR
 TEST_F(DebugLineBasicFixture, DISABLED_PrintPathsProperly) {
 #else
 TEST_F(DebugLineBasicFixture, PrintPathsProperly) {


### PR DESCRIPTION
We now have 64-bit XCOFF object file support, so these tests can be enabled again. However, some tests still fail due to unsupported debug sections, so I cleaned up their comments. 