### PR TITLE
[mlir][sparse] disable aarch64 test to fix buildbot error.

### DIFF
--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_block_matmul.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_block_matmul.mlir
@@ -17,6 +17,9 @@
 // DEFINE: %{env} =
 //--------------------------------------------------------------------------------------------------
 
+// FIXME: make aarch64 working
+// UNSUPPORTED: target={{.*aarch64.*}}
+
 // RUN: %{compile} | %{run} | FileCheck %s
 //
 // Do the same run, but now with direct IR generation.


### PR DESCRIPTION
To fix https://github.com/llvm/llvm-project/pull/71448