### PR TITLE
[BOLT] Fix LSDA section handling

### DIFF
--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -391,12 +391,6 @@ private:
   /// Manage a pipeline of metadata handlers.
   class MetadataManager MetadataManager;
 
-  /// Get the contents of the LSDA section for this binary.
-  ArrayRef<uint8_t> getLSDAData();
-
-  /// Get the mapped address of the LSDA section for this binary.
-  uint64_t getLSDAAddress();
-
   static const char TimerGroupName[];
 
   static const char TimerGroupDesc[];
@@ -540,7 +534,6 @@ private:
   }
 
   /// Exception handling and stack unwinding information in this binary.
-  ErrorOr<BinarySection &> LSDASection{std::errc::bad_address};
   ErrorOr<BinarySection &> EHFrameSection{std::errc::bad_address};
 
   /// .note.gnu.build-id section.

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1706,13 +1706,6 @@ void RewriteInstance::relocateEHFrameSection() {
   check_error(std::move(E), "failed to patch EH frame");
 }
 
-ArrayRef<uint8_t> RewriteInstance::getLSDAData() {
-  return ArrayRef<uint8_t>(LSDASection->getData(),
-                           LSDASection->getContents().size());
-}
-
-uint64_t RewriteInstance::getLSDAAddress() { return LSDASection->getAddress(); }
-
 Error RewriteInstance::readSpecialSections() {
   NamedRegionTimer T("readSpecialSections", "read special sections",
                      TimerGroupName, TimerGroupDesc, opts::TimeRewrite);
@@ -1751,7 +1744,6 @@ Error RewriteInstance::readSpecialSections() {
 
   HasTextRelocations = (bool)BC->getUniqueSectionByName(".rela.text");
   HasSymbolTable = (bool)BC->getUniqueSectionByName(".symtab");
-  LSDASection = BC->getUniqueSectionByName(".gcc_except_table");
   EHFrameSection = BC->getUniqueSectionByName(".eh_frame");
   BuildIDSection = BC->getUniqueSectionByName(".note.gnu.build-id");
 
@@ -3109,8 +3101,14 @@ void RewriteInstance::disassembleFunctions() {
 
     // Parse LSDA.
     if (Function.getLSDAAddress() != 0 &&
-        !BC->getFragmentsToSkip().count(&Function))
-      Function.parseLSDA(getLSDAData(), getLSDAAddress());
+        !BC->getFragmentsToSkip().count(&Function)) {
+      ErrorOr<BinarySection &> LSDASection =
+          BC->getSectionForAddress(Function.getLSDAAddress());
+      check_error(LSDASection.getError(), "failed to get LSDA section");
+      ArrayRef<uint8_t> LSDAData = ArrayRef<uint8_t>(
+          LSDASection->getData(), LSDASection->getContents().size());
+      Function.parseLSDA(LSDAData, LSDASection->getAddress());
+    }
   }
 }
 

--- a/bolt/test/Inputs/lsda.ldscript
+++ b/bolt/test/Inputs/lsda.ldscript
@@ -1,0 +1,7 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .gcc_except_table.main : { *(.gcc_except_table*) }
+  . = 0x20000;
+  .eh_frame : { *(.eh_frame) }
+  . = 0x80000;
+}

--- a/bolt/test/lsda.cpp
+++ b/bolt/test/lsda.cpp
@@ -1,0 +1,47 @@
+// This test check that LSDA section named by .gcc_except_table.main is
+// disassembled by BOLT.
+
+// RUN: %clang++ %cxxflags -O3 -flto=thin -no-pie -c %s -o %t.o
+// RUN: %clang++ %cxxflags -flto=thin -no-pie -fuse-ld=lld %t.o -o %t.exe \
+// RUN:   -Wl,-q -Wl,--script=%S/Inputs/lsda.ldscript
+// RUN: llvm-readelf -SW %t.exe | FileCheck %s
+// RUN: llvm-bolt %t.exe -o %t.bolt
+
+// CHECK: .gcc_except_table.main
+
+#include <iostream>
+
+class MyException : public std::exception {
+public:
+  const char *what() const throw() {
+    return "Custom Exception: an error occurred!";
+  }
+};
+
+int divide(int a, int b) {
+  if (b == 0) {
+    throw MyException();
+  }
+  return a / b;
+}
+
+int main() {
+  try {
+    int result = divide(10, 2); // normal case
+    std::cout << "Result: " << result << std::endl;
+    result = divide(5, 0); // will cause exception
+    std::cout << "Result: " << result << std::endl;
+    // this line will not execute
+  } catch (const MyException &e) {
+    // catch custom exception
+    std::cerr << "Caught exception: " << e.what() << std::endl;
+  } catch (const std::exception &e) {
+    // catch other C++ exceptions
+    std::cerr << "Caught exception: " << e.what() << std::endl;
+  } catch (...) {
+    // catch all other exceptions
+    std::cerr << "Caught unknown exception" << std::endl;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Currently BOLT finds LSDA secition by it's name .gcc_except_table.main .
But sometimes it might have suffix e.g. .gcc_except_table.main. Find
LSDA section by it's address, rather by it's name.
Fixes #71804
