### PR TITLE
[libc++][AIX] Adjust support of timespec_get test

### DIFF
--- a/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp
@@ -11,14 +11,15 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 // ::timespec_get is provided by the C library, but it's marked as
 // unavailable until macOS 10.15
 // XFAIL: stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
 
 // ::timespec_get is available starting with Android Q (API 29)
 // XFAIL: target={{.+}}-android{{(eabi)?(21|22|23|24|25|26|27|28)}}
+
+// ::timespec_get is available starting with AIX 7.3 TL2
+// XFAIL: target={{.+}}-aix{{7.2.*|7.3.0.*|7.3.1.*}}
 
 #include <ctime>
 #include <type_traits>


### PR DESCRIPTION
The function `timespec_get` is not available without an update to the time.h header in AIX 7.3 TL2 (7.3.2.*).