### PR TITLE
[mlir][resources] Add elideLargeResourceString OpPrintingFlags API

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1131,6 +1131,12 @@ public:
   /// elements.
   OpPrintingFlags &elideLargeElementsAttrs(int64_t largeElementLimit = 16);
 
+  /// Enables the elision of large resources strings by omitting them from the
+  /// `dialect_resources` section. The `largeResourceLimit` is used to configure
+  /// what is considered to be a "large" resource by providing an upper limit to
+  /// the string size.
+  OpPrintingFlags &elideLargeResourceString(int64_t largeResourceLimit = 64);
+
   /// Enable or disable printing of debug information (based on `enable`). If
   /// 'prettyForm' is set to true, debug information is printed in a more
   /// readable 'pretty' form. Note: The IR generated with 'prettyForm' is not

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -226,6 +226,12 @@ OpPrintingFlags::elideLargeElementsAttrs(int64_t largeElementLimit) {
   return *this;
 }
 
+OpPrintingFlags &
+OpPrintingFlags::elideLargeResourceString(int64_t largeResourceLimit) {
+  resourceStringCharLimit = largeResourceLimit;
+  return *this;
+}
+
 /// Enable printing of debug information. If 'prettyForm' is set to true,
 /// debug information is printed in a more readable 'pretty' form.
 OpPrintingFlags &OpPrintingFlags::enableDebugInfo(bool enable,


### PR DESCRIPTION
Allows to set `resourceStringCharLimit` through an OpPrintingFlags API
to avoid printing resources larger than the privided limit.
