### PR TITLE
[OpenMP] Fix a condition for KMP_OS_SOLARIS.

### DIFF
--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -72,7 +72,7 @@ struct kmp_sys_timer {
   struct timespec start;
 };
 
-#ifdef KMP_OS_SOLARIS
+#if KMP_OS_SOLARIS
 // Convert timeval to timespec.
 #define TIMEVAL_TO_TIMESPEC(tv, ts)                                            \
   do {                                                                         \


### PR DESCRIPTION
Line 75 of  `z_Linux_util.cpp` checks `#ifdef KMP_OS_SOLARIS` which is always true regardless of the building platform because macro `KMP_OS_SOLARIS` is always defined in line 23 of `kmp_platform.h`: `define KMP_OS_SOLARIS 0`. This causes a compiler warning, such as the following on Linux.
```
.../llvm-project/openmp/runtime/src/z_Linux_util.cpp:77:9: warning: 'TIMEVAL_TO_TIMESPEC' macro redefined [-Wmacro-redefined]
   77 | #define TIMEVAL_TO_TIMESPEC(tv, ts)                                            \
      |         ^
/usr/include/sys/time.h:38:10: note: previous definition is here
   38 | # define TIMEVAL_TO_TIMESPEC(tv, ts) {                                   \
      |          ^
```