### PR TITLE
[ASan][Windows] Synchronizing ASAN init on Windows

### DIFF
--- a/compiler-rt/lib/asan/asan_internal.h
+++ b/compiler-rt/lib/asan/asan_internal.h
@@ -132,6 +132,19 @@ void InstallAtForkHandler();
   if (&__asan_on_error) \
   __asan_on_error()
 
+// Depending on the loading thread and when ASAN is loaded on Windows,
+// race conditions can appear causing incorrect states or internal check
+// failures.
+//
+// From a multithreaded managed environment, if an ASAN instrumented dll
+// is loading on a spawned thread, an intercepted function may be called on
+// multiple threads while ASAN is still in the process of initialization. This
+// can also cause the ASAN thread registry to create the "main" thread after
+// another thread, resulting in a TID != 0.
+//
+// Two threads can also race to initialize ASAN, resulting in either incorrect
+// state or internal check failures for init already running.
+//
 bool AsanInited();
 extern bool replace_intrin_cached;
 extern void (*death_callback)(void);

--- a/compiler-rt/lib/asan/asan_thread.cpp
+++ b/compiler-rt/lib/asan/asan_thread.cpp
@@ -100,6 +100,7 @@ AsanThread *AsanThread::Create(const void *start_data, uptr data_size,
 #if SANITIZER_WINDOWS
   while (atomic_load(&main_thread_created, memory_order_acquire) == 0) {
     // If another thread is trying to be created before the main thread, wait.
+    internal_sched_yield();
   }
 #endif
   uptr PageSize = GetPageSizeCached();

--- a/compiler-rt/lib/asan/asan_thread.cpp
+++ b/compiler-rt/lib/asan/asan_thread.cpp
@@ -27,6 +27,10 @@ namespace __asan {
 
 // AsanThreadContext implementation.
 
+#if SANITIZER_WINDOWS
+static atomic_uint8_t main_thread_created{0};
+#endif
+
 void AsanThreadContext::OnCreated(void *arg) {
   CreateThreadContextArgs *args = static_cast<CreateThreadContextArgs *>(arg);
   if (args->stack)
@@ -93,6 +97,11 @@ AsanThreadContext *GetThreadContextByTidLocked(u32 tid) {
 AsanThread *AsanThread::Create(const void *start_data, uptr data_size,
                                u32 parent_tid, StackTrace *stack,
                                bool detached) {
+#if SANITIZER_WINDOWS
+  while (atomic_load(&main_thread_created, memory_order_acquire) == 0) {
+    // If another thread is trying to be created before the main thread, wait.
+  }
+#endif
   uptr PageSize = GetPageSizeCached();
   uptr size = RoundUpTo(sizeof(AsanThread), PageSize);
   AsanThread *thread = (AsanThread *)MmapOrDie(size, __func__);
@@ -288,11 +297,25 @@ void AsanThread::ThreadStart(tid_t os_id) {
 }
 
 AsanThread *CreateMainThread() {
+// Depending on the loading thread, specifically in managed scenarios, the main
+// thread can be created after other threads on Windows. This ensures we start
+// the main thread before those threads.
+#  if SANITIZER_WINDOWS
+  uptr PageSize = GetPageSizeCached();
+  uptr size = RoundUpTo(sizeof(AsanThread), PageSize);
+  AsanThread *main_thread = (AsanThread *)MmapOrDie(size, __func__);
+  AsanThreadContext::CreateThreadContextArgs args = {main_thread, nullptr};
+  asanThreadRegistry().CreateThread(0, true, kMainTid, &args);
+  SetCurrentThread(main_thread);
+  main_thread->ThreadStart(internal_getpid());
+  atomic_store(&main_thread_created, 1, memory_order_release);
+#  else
   AsanThread *main_thread = AsanThread::Create(
       /* parent_tid */ kMainTid,
       /* stack */ nullptr, /* detached */ true);
   SetCurrentThread(main_thread);
   main_thread->ThreadStart(internal_getpid());
+#  endif
   return main_thread;
 }
 


### PR DESCRIPTION
This is an attempt to synchronize ASAN initialization using `__sanitizer::atomic`s on Windows. One case in particular is a C# application that loads an ASan instrumented library.

This addresses:
 
1. [This check failure](https://github.com/llvm/llvm-project/blob/1df5ea29b43690b6622db2cad7b745607ca4de6a/compiler-rt/lib/asan/asan_interceptors.h#L29C36-L29C36) if a function is intercepted on T1 and called on T2 before T1 is done with ASAN initialization.
2. [This check failure](https://github.com/llvm/llvm-project/blob/1df5ea29b43690b6622db2cad7b745607ca4de6a/compiler-rt/lib/asan/asan_rtl.cpp#L387) can happen in parallel when two threads call `ENSURE_ASAN_INITED`.
3. [This check failure](https://github.com/llvm/llvm-project/blob/1df5ea29b43690b6622db2cad7b745607ca4de6a/compiler-rt/lib/asan/asan_rtl.cpp#L481) when thread is created before the main thread gets a chance to get created due to when `CreateThread` is intercepted.

Currently, everything is blocked by `#if SANITIZER_WINDOWS` because I'm not 100% sure about how ASan is loaded on other platforms and the implications.
