### PR TITLE
[OpenMP][SystemZ] Compile __kmpc_omp_task_begin_if0() with backchain

### DIFF
--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -839,6 +839,14 @@ static void __kmpc_omp_task_begin_if0_ompt(ident_t *loc_ref, kmp_int32 gtid,
 // loc_ref: source location information; points to beginning of task block.
 // gtid: global thread number.
 // task: task thunk for the started task.
+#ifdef __s390x__
+// This is required for OMPT_GET_FRAME_ADDRESS(1) to compile on s390x.
+// In order for it to work correctly, the caller also needs to be compiled with
+// backchain. If a caller is compiled without backchain,
+// OMPT_GET_FRAME_ADDRESS(1) will produce an incorrect value, but will not
+// crash.
+__attribute__((target("backchain")))
+#endif
 void __kmpc_omp_task_begin_if0(ident_t *loc_ref, kmp_int32 gtid,
                                kmp_task_t *task) {
 #if OMPT_SUPPORT


### PR DESCRIPTION
OpenMP runtime fails to build on SystemZ with clang with the following error message:

    LLVM ERROR: Unsupported stack frame traversal count

__kmpc_omp_task_begin_if0() uses OMPT_GET_FRAME_ADDRESS(1), which delegates to __builtin_frame_address(), which in turn works with nonzero values on SystemZ only if backchain is in use. If backchain is not in use, the above error is emitted.

Compile __kmpc_omp_task_begin_if0() with backchain. Note that this only resolves the build error. If at runtime its caller is compiled without backchain, __builtin_frame_address() will produce an incorrect value, but will not cause a crash. Since the value is relevant only for OMPT, this is acceptable.