### PR TITLE
[BOLT][AArch64] Fix ADR relaxation

### DIFF
--- a/bolt/lib/Passes/ADRRelaxationPass.cpp
+++ b/bolt/lib/Passes/ADRRelaxationPass.cpp
@@ -56,9 +56,14 @@ void ADRRelaxationPass::runOnFunction(BinaryFunction &BF) {
           continue;
       }
 
-      BinaryFunction *TargetBF = BC.getFunctionForSymbol(Symbol);
-      if (TargetBF && TargetBF == &BF)
-        continue;
+      // Don't relax adr if it points to the same function and it is not split
+      // and BF initial size is < 1MB.
+      const unsigned OneMB = 0x100000;
+      if (!BF.isSplit() && BF.getSize() < OneMB) {
+        BinaryFunction *TargetBF = BC.getFunctionForSymbol(Symbol);
+        if (TargetBF && TargetBF == &BF)
+          continue;
+      }
 
       MCPhysReg Reg;
       BC.MIB->getADRReg(Inst, Reg);


### PR DESCRIPTION
Currently we have an optimization that if the ADR points to the same
function we might skip it's relaxation. But it doesn't take into account
that BF might be split, in such situation we still need to relax it. And
just in case also relax if the initial BF size is >= 1MB.
Fixes #71822
