### PR TITLE
[vim] set commentstring

### DIFF
--- a/llvm/utils/vim/ftplugin/llvm.vim
+++ b/llvm/utils/vim/ftplugin/llvm.vim
@@ -10,3 +10,4 @@ let b:did_ftplugin = 1
 setlocal softtabstop=2 shiftwidth=2
 setlocal expandtab
 setlocal comments+=:;
+setlocal commentstring=;\ %s

--- a/llvm/utils/vim/syntax/llvm.vim
+++ b/llvm/utils/vim/syntax/llvm.vim
@@ -270,3 +270,5 @@ if version >= 508 || !exists("did_c_syn_inits")
 endif
 
 let b:current_syntax = "llvm"
+
+setlocal commentstring=;\ %s

--- a/llvm/utils/vim/syntax/llvm.vim
+++ b/llvm/utils/vim/syntax/llvm.vim
@@ -270,5 +270,3 @@ if version >= 508 || !exists("did_c_syn_inits")
 endif
 
 let b:current_syntax = "llvm"
-
-setlocal commentstring=;\ %s


### PR DESCRIPTION
I recently moved from using vim to lunarvim. I noticed that `gcc` (lol)
wasn't able to comment out lines, because commentstring is not set.

Thanks to Chase Colman for the suggestion in
https://github.com/LunarVim/LunarVim/issues/4394.
