### PR TITLE
[flang][openacc] Avoid creation of duplicate global ctor

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2964,7 +2964,6 @@ static void genGlobalCtors(Fortran::lower::AbstractConverter &converter,
                 }
                 builder.restoreInsertionPoint(crtPos);
               }
-
             },
             [&](const Fortran::parser::Name &name) {
               TODO(operandLocation, "OpenACC Global Ctor from parser::Name");

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2906,6 +2906,11 @@ static void genGlobalCtors(Fortran::lower::AbstractConverter &converter,
                 std::stringstream asFortran;
                 asFortran << name->symbol->name().ToString();
 
+                if (builder.getModule()
+                        .lookupSymbol<mlir::acc::GlobalConstructorOp>(
+                            declareGlobalCtorName.str()))
+                  return;
+
                 if (!globalOp) {
                   if (Fortran::semantics::FindEquivalenceSet(*name->symbol)) {
                     for (Fortran::semantics::EquivalenceObject eqObj :
@@ -2959,6 +2964,7 @@ static void genGlobalCtors(Fortran::lower::AbstractConverter &converter,
                 }
                 builder.restoreInsertionPoint(crtPos);
               }
+
             },
             [&](const Fortran::parser::Name &name) {
               TODO(operandLocation, "OpenACC Global Ctor from parser::Name");

--- a/flang/test/Lower/OpenACC/HLFIR/acc-declare.f90
+++ b/flang/test/Lower/OpenACC/HLFIR/acc-declare.f90
@@ -304,3 +304,12 @@ end module
 ! ALL:         acc.delete accPtr(%[[DEVICEPTR]] : !fir.ref<!fir.array<40xi8>>) {dataClause = #acc<data_clause acc_create>, name = "v2", structured = false}
 ! ALL:         acc.terminator
 ! ALL:       }
+
+module acc_declare_allocatable_test2
+  integer, allocatable :: data1(:)
+  integer, allocatable :: data2(:)
+  !$acc declare create(data1, data2, data1)
+end module
+
+! ALL-LABEL: acc.global_ctor @_QMacc_declare_allocatable_test2Edata1_acc_ctor
+! ALL-LABEL: acc.global_ctor @_QMacc_declare_allocatable_test2Edata2_acc_ctor


### PR DESCRIPTION
PR #70698 relax the duplication rule in acc declare clauses. This lead to potential duplicate creation of the global constructor/destructor. This patch make sure to not generate a duplicate ctor/dtor.