### PR TITLE
[libc++] Update Clang version check in __config

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -33,8 +33,8 @@
 // Warn if a compiler version is used that is not supported anymore
 // LLVM RELEASE Update the minimum compiler versions
 #  if defined(_LIBCPP_CLANG_VER)
-#    if _LIBCPP_CLANG_VER < 1500
-#      warning "Libc++ only supports Clang 15 and later"
+#    if _LIBCPP_CLANG_VER < 1600
+#      warning "Libc++ only supports Clang 16 and later"
 #    endif
 #  elif defined(_LIBCPP_APPLE_CLANG_VER)
 #    if _LIBCPP_APPLE_CLANG_VER < 1500


### PR DESCRIPTION
We only support Clang >= 16, but we seem to have forgotten to update the version theck in __config to reflect that.