### PR TITLE
[mlir][sparse] re-enable aarch64 test.

### DIFF
--- a/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_block_matmul.mlir
+++ b/mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_block_matmul.mlir
@@ -17,9 +17,6 @@
 // DEFINE: %{env} =
 //--------------------------------------------------------------------------------------------------
 
-// FIXME: make aarch64 working
-// UNSUPPORTED: target={{.*aarch64.*}}
-
 // RUN: %{compile} | %{run} | FileCheck %s
 //
 // Do the same run, but now with direct IR generation.


### PR DESCRIPTION
Should have been fixed by initializing output tensor to zeros in https://github.com/llvm/llvm-project/pull/71845