### PR TITLE
[mlir][execution engine] turn on ENABLE_AGGREGATION for runtimes

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -301,7 +301,7 @@ endfunction()
 #   are compatible with building an object library.
 function(add_mlir_library name)
   cmake_parse_arguments(ARG
-    "SHARED;INSTALL_WITH_TOOLCHAIN;EXCLUDE_FROM_LIBMLIR;DISABLE_INSTALL;ENABLE_AGGREGATION"
+    "SHARED;INSTALL_WITH_TOOLCHAIN;INSTALL_OBJECT_LIB;EXCLUDE_FROM_LIBMLIR;DISABLE_INSTALL;ENABLE_AGGREGATION"
     ""
     "ADDITIONAL_HEADERS;DEPENDS;LINK_COMPONENTS;LINK_LIBS"
     ${ARGN})
@@ -309,7 +309,7 @@ function(add_mlir_library name)
 
   # Is an object library needed.
   set(NEEDS_OBJECT_LIB OFF)
-  if(ARG_ENABLE_AGGREGATION)
+  if(ARG_ENABLE_AGGREGATION OR ARG_INSTALL_OBJECT_LIB)
     set(NEEDS_OBJECT_LIB ON)
   endif()
 
@@ -375,7 +375,7 @@ function(add_mlir_library name)
     # For each declared dependency, transform it into a generator expression
     # which excludes it if the ultimate link target is excluding the library.
     set(NEW_LINK_LIBRARIES)
-    get_target_property(CURRENT_LINK_LIBRARIES  ${name} LINK_LIBRARIES)
+    get_target_property(CURRENT_LINK_LIBRARIES ${name} LINK_LIBRARIES)
     get_mlir_filtered_link_libraries(NEW_LINK_LIBRARIES ${CURRENT_LINK_LIBRARIES})
     set_target_properties(${name} PROPERTIES LINK_LIBRARIES "${NEW_LINK_LIBRARIES}")
     list(APPEND AGGREGATE_DEPS ${NEW_LINK_LIBRARIES})
@@ -390,6 +390,12 @@ function(add_mlir_library name)
     # In order for out-of-tree projects to build aggregates of this library,
     # we need to install the OBJECT library.
     if(MLIR_INSTALL_AGGREGATE_OBJECTS AND NOT ARG_DISABLE_INSTALL)
+      add_mlir_library_install(obj.${name})
+    endif()
+  endif()
+  if(ARG_INSTALL_OBJECT_LIB)
+    if(TARGET install-obj.${name})
+    else ()
       add_mlir_library_install(obj.${name})
     endif()
   endif()

--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -59,6 +59,7 @@ add_mlir_library(MLIRExecutionEngine
   ExecutionEngine.cpp
 
   EXCLUDE_FROM_LIBMLIR
+  INSTALL_OBJECT_LIB
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/ExecutionEngine
@@ -93,13 +94,14 @@ add_mlir_library(MLIRExecutionEngine
   MLIRLLVMToLLVMIRTranslation
   MLIROpenMPToLLVMIRTranslation
   MLIRTargetLLVMIRExport
-  )
+)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 add_mlir_library(MLIRJitRunner
   JitRunner.cpp
 
   EXCLUDE_FROM_LIBMLIR
+  INSTALL_OBJECT_LIB
 
   DEPENDS
   intrinsics_gen
@@ -130,7 +132,8 @@ if(LLVM_ENABLE_PIC)
     Float16bits.cpp
 
     EXCLUDE_FROM_LIBMLIR
-    )
+    INSTALL_OBJECT_LIB
+  )
   set_property(TARGET mlir_float16_utils PROPERTY CXX_STANDARD 17)
   target_compile_definitions(mlir_float16_utils PRIVATE mlir_float16_utils_EXPORTS)
 
@@ -142,12 +145,13 @@ if(LLVM_ENABLE_PIC)
     SparseTensorRuntime.cpp
 
     EXCLUDE_FROM_LIBMLIR
+    INSTALL_OBJECT_LIB
 
     LINK_LIBS PUBLIC
     mlir_float16_utils
     MLIRSparseTensorEnums
     MLIRSparseTensorRuntime
-    )
+  )
   set_property(TARGET mlir_c_runner_utils PROPERTY CXX_STANDARD 17)
   target_compile_definitions(mlir_c_runner_utils PRIVATE mlir_c_runner_utils_EXPORTS)
 
@@ -156,6 +160,7 @@ if(LLVM_ENABLE_PIC)
     RunnerUtils.cpp
 
     EXCLUDE_FROM_LIBMLIR
+    INSTALL_OBJECT_LIB
   )
   target_compile_definitions(mlir_runner_utils PRIVATE mlir_runner_utils_EXPORTS)
 
@@ -164,6 +169,7 @@ if(LLVM_ENABLE_PIC)
     AsyncRuntime.cpp
 
     EXCLUDE_FROM_LIBMLIR
+    INSTALL_OBJECT_LIB
 
     LINK_LIBS PUBLIC
     ${LLVM_PTHREAD_LIB}
@@ -197,6 +203,7 @@ if(LLVM_ENABLE_PIC)
       CudaRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+      INSTALL_OBJECT_LIB
     )
     set_property(TARGET mlir_cuda_runtime PROPERTY CXX_STANDARD 14)
 
@@ -293,6 +300,7 @@ if(LLVM_ENABLE_PIC)
       RocmRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+      INSTALL_OBJECT_LIB
     )
 
     # Supress compiler warnings from HIP headers
@@ -348,6 +356,7 @@ if(LLVM_ENABLE_PIC)
       SyclRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+      INSTALL_OBJECT_LIB
     )
 
     check_cxx_compiler_flag("-frtti" CXX_HAS_FRTTI_FLAG)

--- a/mlir/lib/ExecutionEngine/SparseTensor/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/SparseTensor/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_library(MLIRSparseTensorRuntime
   Storage.cpp
 
   EXCLUDE_FROM_LIBMLIR
+  INSTALL_OBJECT_LIB
 
   LINK_LIBS PUBLIC
   MLIRSparseTensorEnums


### PR DESCRIPTION
It would be good to distribute the object files for the runtimes for those people that want to reuse them.