### PR TITLE
Revert "[lldb] Read Checksum from DWARF line tables"

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -229,15 +229,8 @@ ParseSupportFilesFromPrologue(const lldb::ModuleSP &module,
         remapped_file = std::move(*file_path);
     }
 
-    Checksum checksum;
-    if (prologue.ContentTypes.HasMD5) {
-      const llvm::DWARFDebugLine::FileNameEntry &file_name_entry =
-          prologue.getFileNameEntry(idx);
-      checksum = file_name_entry.Checksum;
-    }
-
     // Unconditionally add an entry, so the indices match up.
-    support_files.EmplaceBack(remapped_file, style, checksum);
+    support_files.EmplaceBack(remapped_file, style);
   }
 
   return support_files;


### PR DESCRIPTION
Reverts llvm/llvm-project#71458 as it might have caused cross-project-test failures. 