### PR TITLE
[builtins] Guard the divtc3_test.c test with CRT_HAS_TF_MODE

### DIFF
--- a/compiler-rt/test/builtins/Unit/divtc3_test.c
+++ b/compiler-rt/test/builtins/Unit/divtc3_test.c
@@ -14,6 +14,7 @@
 #include <math.h>
 
 // Returns: the quotient of (a + ib) / (c + id)
+#if defined(CRT_HAS_TF_MODE)
 
 COMPILER_RT_ABI Qcomplex __divtc3(tf_float __a, tf_float __b, tf_float __c,
                                   tf_float __d);
@@ -363,3 +364,12 @@ int main() {
   fprintf(stderr, "No errors found.\n");
   return 0;
 }
+
+#else
+
+int main() {
+  printf("skipped\n");
+  return 0;
+}
+
+#endif // CRT_HAS_TF_MODE


### PR DESCRIPTION
The bots on https://green.lab.llvm.org/green/job/clang-stage1-RA/ were
failing this test.
