### PR TITLE
[Clang] add user-level sizeless attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4285,3 +4285,10 @@ def PreferredType: InheritableAttr {
   let Args = [TypeArgument<"Type", 1>];
   let Documentation = [PreferredTypeDocumentation];
 }
+
+def SizelessType : DeclOrTypeAttr {
+  let Spellings = [Clang<"sizeless">];
+  let Documentation = [SizelessTypeDocs];
+  let HasCustomParsing = 1;
+}
+

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7095,6 +7095,37 @@ neither type checking rules, nor runtime semantics. In particular:
   }];
 }
 
+def SizelessTypeDocs : Documentation {
+  let Category = DocCatType;
+  let Heading = "sizeless";
+  let Content = [{
+This attribute is used to on types to forbid the use of the sizeof operation.
+This may be useful for code with scalable vectors, which may forbid the use
+of sizeof on that platform already. This attribute enables more consistent
+behavior by forbidding sizeof on all platforms.
+
+The attribute takes no arguments.
+
+For example:
+
+.. code-block:: c++
+
+  int* [[clang::sizeless]] f();
+
+The attribute does not have any effect on the semantics of the type system,
+neither type checking rules, nor runtime semantics. In particular:
+
+- ``std::is_same<T, T [[clang::sizeless]]>`` is true for all types
+  ``T``.
+
+- It is not permissible for overloaded functions or template specializations
+  to differ merely by an ``sizeless`` attribute.
+
+- The presence of an ``sizeless`` attribute will not affect name
+  mangling.
+  }];
+}
+
 def WeakDocs : Documentation {
   let Category = DocCatDecl;
   let Content = [{

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2275,8 +2275,12 @@ public:
     Normal,
 
     /// Relax the normal rules for complete types so that they include
-    /// sizeless built-in types.
+    /// sizeless built-in or sizeless user types.
     AcceptSizeless,
+
+    /// Relax the normal rules for complete types so that they include
+    /// sizeless user types, but not sizeless builtin types.
+    AcceptUserSizeless,
 
     // FIXME: Eventually we should flip the default to Normal and opt in
     // to AcceptSizeless rather than opt out of it.
@@ -2539,6 +2543,14 @@ public:
   bool RequireCompleteSizedType(SourceLocation Loc, QualType T, unsigned DiagID,
                                 const Ts &... Args) {
     SizelessTypeDiagnoser<Ts...> Diagnoser(DiagID, Args...);
+    return RequireCompleteType(Loc, T, CompleteTypeKind::AcceptUserSizeless,
+                               Diagnoser);
+  }
+
+  template <typename... Ts>
+  bool RequireCompleteSizeofType(SourceLocation Loc, QualType T,
+                                 unsigned DiagID, const Ts &...Args) {
+    SizelessTypeDiagnoser<Ts...> Diagnoser(DiagID, Args...);
     return RequireCompleteType(Loc, T, CompleteTypeKind::Normal, Diagnoser);
   }
 
@@ -2566,6 +2578,14 @@ public:
   template <typename... Ts>
   bool RequireCompleteSizedExprType(Expr *E, unsigned DiagID,
                                     const Ts &... Args) {
+    SizelessTypeDiagnoser<Ts...> Diagnoser(DiagID, Args...);
+    return RequireCompleteExprType(E, CompleteTypeKind::AcceptUserSizeless,
+                                   Diagnoser);
+  }
+
+  template <typename... Ts>
+  bool RequireCompleteSizeofExprType(Expr *E, unsigned DiagID,
+                                     const Ts &...Args) {
     SizelessTypeDiagnoser<Ts...> Diagnoser(DiagID, Args...);
     return RequireCompleteExprType(E, CompleteTypeKind::Normal, Diagnoser);
   }

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -1861,6 +1861,9 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   case attr::MSABI: OS << "ms_abi"; break;
   case attr::SysVABI: OS << "sysv_abi"; break;
   case attr::RegCall: OS << "regcall"; break;
+  case attr::SizelessType:
+    OS << "sizeless";
+    break;
   case attr::Pcs: {
     OS << "pcs(";
    QualType t = T->getEquivalentType();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -8837,7 +8837,7 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
     return;
   }
 
-  if (!NewVD->hasLocalStorage() && T->isSizelessType() &&
+  if (!NewVD->hasLocalStorage() && T->isSizelessBuiltinType() &&
       !T.isWebAssemblyReferenceType()) {
     Diag(NewVD->getLocation(), diag::err_sizeless_nonlocal) << T;
     NewVD->setInvalidDecl();

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -4491,13 +4491,13 @@ bool Sema::CheckUnaryExprOrTypeTraitOperand(Expr *E,
   // be complete (and will attempt to complete it if it's an array of unknown
   // bound).
   if (ExprKind == UETT_AlignOf || ExprKind == UETT_PreferredAlignOf) {
-    if (RequireCompleteSizedType(
+    if (RequireCompleteSizeofType(
             E->getExprLoc(), Context.getBaseElementType(E->getType()),
             diag::err_sizeof_alignof_incomplete_or_sizeless_type,
             getTraitSpelling(ExprKind), E->getSourceRange()))
       return true;
   } else {
-    if (RequireCompleteSizedExprType(
+    if (RequireCompleteSizeofExprType(
             E, diag::err_sizeof_alignof_incomplete_or_sizeless_type,
             getTraitSpelling(ExprKind), E->getSourceRange()))
       return true;
@@ -4772,22 +4772,22 @@ bool Sema::CheckUnaryExprOrTypeTraitOperand(QualType ExprType,
                                       ExprKind))
     return false;
 
-  if (RequireCompleteSizedType(
-          OpLoc, ExprType, diag::err_sizeof_alignof_incomplete_or_sizeless_type,
-          KWName, ExprRange))
-    return true;
-
-  if (ExprType->isFunctionType()) {
-    Diag(OpLoc, diag::err_sizeof_alignof_function_type) << KWName << ExprRange;
-    return true;
-  }
-
   // WebAssembly tables are always illegal operands to unary expressions and
   // type traits.
   if (Context.getTargetInfo().getTriple().isWasm() &&
       ExprType->isWebAssemblyTableType()) {
     Diag(OpLoc, diag::err_wasm_table_invalid_uett_operand)
         << getTraitSpelling(ExprKind);
+    return true;
+  }
+
+  if (RequireCompleteSizeofType(
+          OpLoc, ExprType, diag::err_sizeof_alignof_incomplete_or_sizeless_type,
+          KWName, ExprRange))
+    return true;
+
+  if (ExprType->isFunctionType()) {
+    Diag(OpLoc, diag::err_sizeof_alignof_function_type) << KWName << ExprRange;
     return true;
   }
 

--- a/clang/test/Sema/sizeless.c
+++ b/clang/test/Sema/sizeless.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 %s -fsyntax-only -verify
+
+struct T { // expected-note {{forward declaration of 'struct T'}}  expected-note {{forward declaration of 'struct T'}}  expected-note {{forward declaration of 'struct T'}}  expected-note {{forward declaration of 'struct T'}}
+	int __attribute__((sizeless)) x;
+	float y;
+};
+
+void f(void) {
+  int size_intty[sizeof(int __attribute__((sizeless))) == 0 ? 1 : -1];        // expected-error {{invalid application of 'sizeof' to sizeless type 'int __attribute__((sizeless))'}}
+  int align_intty[__alignof__(int __attribute__((sizeless))) == 16 ? 1 : -1]; // expected-error {{invalid application of '__alignof' to sizeless type 'int __attribute__((sizeless))'}}
+  
+  int __attribute__((sizeless)) var1;
+  int size_int[sizeof(var1) == 0 ? 1 : -1];        // expected-error {{invalid application of 'sizeof' to sizeless type 'int __attribute__((sizeless))'}}
+  int align_int[__alignof__(var1) == 16 ? 1 : -1]; // expected-error {{invalid application of '__alignof' to sizeless type 'int __attribute__((sizeless))'}}
+
+  int size_struct[sizeof(struct T) == 0 ? 1 : -1];        // expected-error {{invalid application of 'sizeof' to sizeless type 'struct T'}}
+  int align_struct[__alignof__(struct T) == 16 ? 1 : -1]; // expected-error {{invalid application of '__alignof' to sizeless type 'struct T'}}
+  
+  struct T var2;
+  int size_structty[sizeof(var2) == 0 ? 1 : -1];        // expected-error {{invalid application of 'sizeof' to sizeless type 'struct T'}}
+  int align_structty[__alignof__(var2) == 16 ? 1 : -1]; // expected-error {{invalid application of '__alignof' to sizeless type 'struct T'}}
+}


### PR DESCRIPTION
As discussed in [this RFC](https://discourse.llvm.org/t/rfc-attribute-no-sizeof/74695) this PR implements a. new user-level sizeless attribute.

This prevents types or variables marked with this attribute from having sizeof or alignof taken, including of struct or other types which contain sizeless types.