### PR TITLE
'Soft Stop' solution on offset overflow issue: By Produceing a truncated but valid DWP file, discarding any DWO files that would not fit within the 32 bit/4GB limits of the format.

### DIFF
--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -61,7 +61,7 @@ struct CompileUnitIdentifiers {
 };
 
 Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
-            bool ContinueOnCuIndexOverflow);
+            bool ContinueOnCuIndexOverflow, bool SoftStopOnCuIndexOverflow);
 
 unsigned getContributionIndex(DWARFSectionKind Kind, uint32_t IndexVersion);
 

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -67,7 +67,7 @@ struct CompileUnitIdentifiers {
 };
 
 Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
-            bool ContinueOnCuIndexOverflow, bool SoftStopOnCuIndexOverflow);
+            const OnCuIndexOverflow &OverflowOptValue);
 
 unsigned getContributionIndex(DWARFSectionKind Kind, uint32_t IndexVersion);
 

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -67,7 +67,7 @@ struct CompileUnitIdentifiers {
 };
 
 Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
-            const OnCuIndexOverflow &OverflowOptValue);
+            OnCuIndexOverflow OverflowOptValue);
 
 unsigned getContributionIndex(DWARFSectionKind Kind, uint32_t IndexVersion);
 

--- a/llvm/include/llvm/DWP/DWP.h
+++ b/llvm/include/llvm/DWP/DWP.h
@@ -15,6 +15,12 @@
 #include <vector>
 
 namespace llvm {
+enum OnCuIndexOverflow {
+  HardStop,
+  SoftStop,
+  Continue,
+};
+
 struct UnitIndexEntry {
   DWARFUnitIndex::Entry::SectionContribution Contributions[8];
   std::string Name;

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -242,8 +242,10 @@ static Error addAllTypesFromDWP(
                                                     "Types", OverflowOptValue,
                                                     AnySectionOverflow))
         return Err;
-      if (AnySectionOverflow)
+      if (AnySectionOverflow) {
+        TypesOffset = OldOffset;
         return Error::success();
+      }
     }
   }
   return Error::success();
@@ -286,8 +288,10 @@ static Error addAllTypesFromTypesSection(
                                                       "Types", OverflowOptValue,
                                                       AnySectionOverflow))
           return Err;
-        if (AnySectionOverflow)
+        if (AnySectionOverflow) {
+          TypesOffset = OldOffset;
           return Error::success();
+        }
       }
     }
   }

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -738,8 +738,12 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
                     InfoSectionOffset, InfoSectionOffset + C.getLength32(),
                     "debug_info", OverflowOptValue, AnySectionOverflow))
               return Err;
-            if (AnySectionOverflow)
+            if (AnySectionOverflow) {
+              if (Header.Version < 5 ||
+                  Header.UnitType == dwarf::DW_UT_split_compile)
+                FoundCUUnit = true;
               break;
+            }
           }
 
           UnitOffset += C.getLength32();

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -693,7 +693,7 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
         uint32_t SectionIndex = 0;
         for (auto &Section : Obj.sections()) {
           if (SectionIndex == Index) {
-            if (Error Err sectionOverflowErrorOrWarning(
+            if (Error Err = sectionOverflowErrorOrWarning(
                 OldOffset, ContributionOffsets[Index], *Section.getName(),
                 ContinueOnCuIndexOverflow))
               return Err;

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -197,12 +197,13 @@ static Error sectionOverflowErrorOrWarning(uint32_t PrevOffset,
   return make_error<DWPError>(Msg);
 }
 
-static Error addAllTypesFromDWP(
-    MCStreamer &Out, MapVector<uint64_t, UnitIndexEntry> &TypeIndexEntries,
-    const DWARFUnitIndex &TUIndex, MCSection *OutputTypes, StringRef Types,
-    const UnitIndexEntry &TUEntry, uint32_t &TypesOffset,
-    unsigned TypesContributionIndex, bool ContinueOnCuIndexOverflow,
-    bool &SeeOverflowFlag) {
+static Error
+addAllTypesFromDWP(MCStreamer &Out,
+                   MapVector<uint64_t, UnitIndexEntry> &TypeIndexEntries,
+                   const DWARFUnitIndex &TUIndex, MCSection *OutputTypes,
+                   StringRef Types, const UnitIndexEntry &TUEntry,
+                   uint32_t &TypesOffset, unsigned TypesContributionIndex,
+                   bool ContinueOnCuIndexOverflow, bool &SeeOverflowFlag) {
   Out.switchSection(OutputTypes);
   for (const DWARFUnitIndex::Entry &E : TUIndex.getRows()) {
     auto *I = E.getContributions();
@@ -694,8 +695,8 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
         for (auto &Section : Obj.sections()) {
           if (SectionIndex == Index) {
             if (Error Err = sectionOverflowErrorOrWarning(
-                OldOffset, ContributionOffsets[Index], *Section.getName(),
-                ContinueOnCuIndexOverflow))
+                    OldOffset, ContributionOffsets[Index], *Section.getName(),
+                    ContinueOnCuIndexOverflow))
               return Err;
           }
           ++SectionIndex;
@@ -873,7 +874,8 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
       if (Error Err = addAllTypesFromDWP(
               Out, TypeIndexEntries, TUIndex, OutSection, TypeInputSection,
               CurEntry, ContributionOffsets[TypesContributionIndex],
-              TypesContributionIndex, ContinueOnCuIndexOverflow, SeeOverflowFlag))
+              TypesContributionIndex, ContinueOnCuIndexOverflow,
+              SeeOverflowFlag))
         return Err;
     }
     if (SeeOverflowFlag)

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -593,7 +593,7 @@ Error handleSection(
 }
 
 Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
-            const OnCuIndexOverflow &OverflowOptValue) {
+            OnCuIndexOverflow OverflowOptValue) {
   const auto &MCOFI = *Out.getContext().getObjectFileInfo();
   MCSection *const StrSection = MCOFI.getDwarfStrDWOSection();
   MCSection *const StrOffsetSection = MCOFI.getDwarfStrOffDWOSection();

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -182,7 +182,7 @@ static StringRef getSubsection(StringRef Section,
 
 static Error sectionOverflowErrorOrWarning(
     uint32_t PrevOffset, uint32_t OverflowedOffset, StringRef SectionName,
-    const OnCuIndexOverflow &overflowOptValue, bool &SeeOverflowFlag) {
+    const OnCuIndexOverflow &OverflowOptValue, bool &SeeOverflowFlag) {
   std::string Msg =
       (SectionName +
        Twine(" Section Contribution Offset overflow 4G. Previous Offset ") +
@@ -238,7 +238,7 @@ static Error addAllTypesFromDWP(
     if (OldOffset > TypesOffset) {
       if (Error Err =
               sectionOverflowErrorOrWarning(OldOffset, TypesOffset, "Types",
-                                            overflowOptValue, SeeOverflowFlag))
+                                            OverflowOptValue, SeeOverflowFlag))
         return Err;
       return Error::success();
     }
@@ -280,7 +280,7 @@ static Error addAllTypesFromTypesSection(
       TypesOffset += C.getLength32();
       if (OldOffset > TypesOffset) {
         if (Error Err = sectionOverflowErrorOrWarning(OldOffset, TypesOffset,
-                                                      "Types", overflowOptValue,
+                                                      "Types", OverflowOptValue,
                                                       SeeOverflowFlag))
           return Err;
         return Error::success();

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -783,6 +783,8 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
                 OverflowOptValue, SeeOverflowFlag))
           return Err;
       }
+      if (SeeOverflowFlag)
+        break;
       continue;
     }
 

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -182,7 +182,7 @@ static StringRef getSubsection(StringRef Section,
 
 static Error sectionOverflowErrorOrWarning(
     uint32_t PrevOffset, uint32_t OverflowedOffset, StringRef SectionName,
-    const OnCuIndexOverflow &OverflowOptValue, bool &SeeOverflowFlag) {
+    OnCuIndexOverflow OverflowOptValue, bool &SeeOverflowFlag) {
   std::string Msg =
       (SectionName +
        Twine(" Section Contribution Offset overflow 4G. Previous Offset ") +
@@ -204,7 +204,7 @@ static Error addAllTypesFromDWP(
     MCStreamer &Out, MapVector<uint64_t, UnitIndexEntry> &TypeIndexEntries,
     const DWARFUnitIndex &TUIndex, MCSection *OutputTypes, StringRef Types,
     const UnitIndexEntry &TUEntry, uint32_t &TypesOffset,
-    unsigned TypesContributionIndex, const OnCuIndexOverflow &OverflowOptValue,
+    unsigned TypesContributionIndex, OnCuIndexOverflow OverflowOptValue,
     bool &SeeOverflowFlag) {
   Out.switchSection(OutputTypes);
   for (const DWARFUnitIndex::Entry &E : TUIndex.getRows()) {
@@ -251,7 +251,7 @@ static Error addAllTypesFromTypesSection(
     MCStreamer &Out, MapVector<uint64_t, UnitIndexEntry> &TypeIndexEntries,
     MCSection *OutputTypes, const std::vector<StringRef> &TypesSections,
     const UnitIndexEntry &CUEntry, uint32_t &TypesOffset,
-    const OnCuIndexOverflow &OverflowOptValue, bool &SeeOverflowFlag) {
+    OnCuIndexOverflow OverflowOptValue, bool &SeeOverflowFlag) {
   for (StringRef Types : TypesSections) {
     Out.switchSection(OutputTypes);
     uint64_t Offset = 0;

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -240,7 +240,8 @@ static Error addAllTypesFromDWP(
               sectionOverflowErrorOrWarning(OldOffset, TypesOffset, "Types",
                                             OverflowOptValue, SeeOverflowFlag))
         return Err;
-      return Error::success();
+      if (SeeOverflowFlag)
+        return Error::success();
     }
   }
   return Error::success();
@@ -283,7 +284,8 @@ static Error addAllTypesFromTypesSection(
                                                       "Types", OverflowOptValue,
                                                       SeeOverflowFlag))
           return Err;
-        return Error::success();
+        if (SeeOverflowFlag)
+          return Error::success();
       }
     }
   }

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -202,13 +202,12 @@ static Error sectionOverflowErrorOrWarning(uint32_t PrevOffset,
   return make_error<DWPError>(Msg);
 }
 
-static Error
-addAllTypesFromDWP(MCStreamer &Out,
-                   MapVector<uint64_t, UnitIndexEntry> &TypeIndexEntries,
-                   const DWARFUnitIndex &TUIndex, MCSection *OutputTypes,
-                   StringRef Types, const UnitIndexEntry &TUEntry,
-                   uint32_t &TypesOffset, unsigned TypesContributionIndex,
-                   OnCuIndexOverflow OverflowOptValue, bool &AnySectionOverflow) {
+static Error addAllTypesFromDWP(
+    MCStreamer &Out, MapVector<uint64_t, UnitIndexEntry> &TypeIndexEntries,
+    const DWARFUnitIndex &TUIndex, MCSection *OutputTypes, StringRef Types,
+    const UnitIndexEntry &TUEntry, uint32_t &TypesOffset,
+    unsigned TypesContributionIndex, OnCuIndexOverflow OverflowOptValue,
+    bool &AnySectionOverflow) {
   Out.switchSection(OutputTypes);
   for (const DWARFUnitIndex::Entry &E : TUIndex.getRows()) {
     auto *I = E.getContributions();
@@ -239,9 +238,9 @@ addAllTypesFromDWP(MCStreamer &Out,
     static_assert(sizeof(OldOffset) == sizeof(TypesOffset));
     TypesOffset += C.getLength();
     if (OldOffset > TypesOffset) {
-      if (Error Err =
-              sectionOverflowErrorOrWarning(OldOffset, TypesOffset, "Types",
-                                            OverflowOptValue, AnySectionOverflow))
+      if (Error Err = sectionOverflowErrorOrWarning(OldOffset, TypesOffset,
+                                                    "Types", OverflowOptValue,
+                                                    AnySectionOverflow))
         return Err;
       if (AnySectionOverflow)
         return Error::success();

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -11,3 +11,5 @@ def execFileNames : S<"e", "Specify the executable/library files to get the list
 def outputFileName : S<"o", "Specify the output file.">, MetaVarName<"<filename>">;
 def continueOnCuIndexOverflow: F<"continue-on-cu-index-overflow", "This turns an error when offset for .debug_*.dwo sections "
                                          "overfolws into a warning.">, MetaVarName<"<filename>">;
+def softStopOnCuIndexOverflow: F<"soft-stop-on-cu-index-overflow", "This turns to make a best effort dwp when offset for "
+                                        ".debug_*.dwo sections overfolws into a warning.">, MetaVarName<"<filename>">;

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -9,7 +9,7 @@ def version : F<"version", "Display the version of this program">;
 
 def execFileNames : S<"e", "Specify the executable/library files to get the list of *.dwo from.">, MetaVarName<"<filename>">;
 def outputFileName : S<"o", "Specify the output file.">, MetaVarName<"<filename>">;
-def continueOnCuIndexOverflow: F<"continue-on-cu-index-overflow", "This turns an error when offset for .debug_*.dwo sections "
-                                         "overfolws into a warning.">, MetaVarName<"<filename>">;
-def softStopOnCuIndexOverflow: F<"soft-stop-on-cu-index-overflow", "This turns to make a best effort dwp when offset for "
-                                        ".debug_*.dwo sections overfolws into a warning.">, MetaVarName<"<filename>">;
+def continueOnCuIndexOverflow : S<"continue-on-cu-index-overflow", " =soft-stop, This produces a truncated but valid "
+                                         "DWP file, discarding any DWO files that would not fit within the 32 "
+                                         "bit/4GB limits of the format. =continue, This turns an error when offset "
+                                         "for .debug_*.dwo sections overfolws into a warning.">, MetaVarName<"<filename>">;

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -9,7 +9,7 @@ def version : F<"version", "Display the version of this program">;
 
 def execFileNames : S<"e", "Specify the executable/library files to get the list of *.dwo from.">, MetaVarName<"<filename>">;
 def outputFileName : S<"o", "Specify the output file.">, MetaVarName<"<filename>">;
-def continueOnCuIndexOverflow : S<"continue-on-cu-index-overflow", " =soft-stop, This produces a truncated but valid "
-                                         "DWP file, discarding any DWO files that would not fit within the 32 "
-                                         "bit/4GB limits of the format. =continue, This turns an error when offset "
-                                         "for .debug_*.dwo sections overfolws into a warning.">, MetaVarName<"<filename>">;
+def continueOnCuIndexOverflow : S<"continue-on-cu-index-overflow", "default value = continue, This turns an error when offset "
+                                         "for .debug_*.dwo sections overfolws into a warning. =soft-stop, This produces a "
+                                         "truncated but valid DWP file, discarding any DWO files that would not fit within "
+                                         "the 32 bit/4GB limits of the format.">, MetaVarName<"<filename>">;

--- a/llvm/tools/llvm-dwp/Opts.td
+++ b/llvm/tools/llvm-dwp/Opts.td
@@ -9,7 +9,7 @@ def version : F<"version", "Display the version of this program">;
 
 def execFileNames : S<"e", "Specify the executable/library files to get the list of *.dwo from.">, MetaVarName<"<filename>">;
 def outputFileName : S<"o", "Specify the output file.">, MetaVarName<"<filename>">;
-def continueOnCuIndexOverflow : S<"continue-on-cu-index-overflow", "default value = continue, This turns an error when offset "
-                                         "for .debug_*.dwo sections overfolws into a warning. =soft-stop, This produces a "
+def continueOnCuIndexOverflow : S<"continue-on-cu-index-overflow", "default = continue, This turns an error when offset "
+                                         "for .debug_*.dwo sections overfolws into a warning. = soft-stop, This produces a "
                                          "truncated but valid DWP file, discarding any DWO files that would not fit within "
                                          "the 32 bit/4GB limits of the format.">, MetaVarName<"<filename>">;

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -144,6 +144,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
 
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
   ContinueOnCuIndexOverflow = Args.hasArg(OPT_continueOnCuIndexOverflow);
+  StopOnCuIndexOverflow = Args.hasArg(OPT_stopOnCuIndexOverflow);
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_execFileNames))
     ExecFilenames.emplace_back(A->getValue());
@@ -255,7 +256,8 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (!MS)
     return error("no object streamer for target " + TripleName, Context);
 
-  if (auto Err = write(*MS, DWOFilenames, ContinueOnCuIndexOverflow)) {
+  if (auto Err = write(*MS, DWOFilenames, ContinueOnCuIndexOverflow,
+      StopOnCuIndexOverflow)) {
     logAllUnhandledErrors(std::move(Err), WithColor::error());
     return 1;
   }

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -144,7 +144,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
 
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
   ContinueOnCuIndexOverflow = Args.hasArg(OPT_continueOnCuIndexOverflow);
-  StopOnCuIndexOverflow = Args.hasArg(OPT_stopOnCuIndexOverflow);
+  SoftStopOnCuIndexOverflow = Args.hasArg(OPT_stopOnCuIndexOverflow);
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_execFileNames))
     ExecFilenames.emplace_back(A->getValue());
@@ -257,7 +257,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
     return error("no object streamer for target " + TripleName, Context);
 
   if (auto Err = write(*MS, DWOFilenames, ContinueOnCuIndexOverflow,
-      StopOnCuIndexOverflow)) {
+      SoftStopOnCuIndexOverflow)) {
     logAllUnhandledErrors(std::move(Err), WithColor::error());
     return 1;
   }

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -72,6 +72,7 @@ public:
 static std::vector<std::string> ExecFilenames;
 static std::string OutputFilename;
 static bool ContinueOnCuIndexOverflow;
+static bool SoftStopOnCuIndexOverflow;
 
 static Expected<SmallVector<std::string, 16>>
 getDWOFilenames(StringRef ExecFilename) {
@@ -144,7 +145,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
 
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
   ContinueOnCuIndexOverflow = Args.hasArg(OPT_continueOnCuIndexOverflow);
-  SoftStopOnCuIndexOverflow = Args.hasArg(OPT_stopOnCuIndexOverflow);
+  SoftStopOnCuIndexOverflow = Args.hasArg(OPT_softStopOnCuIndexOverflow);
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_execFileNames))
     ExecFilenames.emplace_back(A->getValue());

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -257,7 +257,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
     return error("no object streamer for target " + TripleName, Context);
 
   if (auto Err = write(*MS, DWOFilenames, ContinueOnCuIndexOverflow,
-      SoftStopOnCuIndexOverflow)) {
+                       SoftStopOnCuIndexOverflow)) {
     logAllUnhandledErrors(std::move(Err), WithColor::error());
     return 1;
   }

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -150,7 +150,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
     if (ContinueOption == "soft-stop") {
       OverflowOptValue = OnCuIndexOverflow::SoftStop;
     } else {
-      ContinueOption = OnCuIndexOverflow::Continue;
+      OverflowOptValue = OnCuIndexOverflow::Continue;
     }
   }
 

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -125,7 +125,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   DwpOptTable Tbl;
   llvm::BumpPtrAllocator A;
   llvm::StringSaver Saver{A};
-  OnCuIndexOverflow OverflowOptValue = OnCuIndexOverflow::HardStop;
+  OnCuIndexOverflow OverflowOptValue = OnCuIndexOverflow::Continue;
   opt::InputArgList Args =
       Tbl.parseArgs(argc, argv, OPT_UNKNOWN, Saver, [&](StringRef Msg) {
         llvm::errs() << Msg << '\n';
@@ -144,12 +144,14 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   }
 
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
-  ContinueOption =
+  if (Args.hasArg(OPT_continueOnCuIndexOverflow)) {
+    ContinueOption =
       Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "hard-stop");
-  if (ContinueOption == "soft-stop") {
-    OverflowOptValue = OnCuIndexOverflow::SoftStop;
-  } else if (ContinueOption == "continue") {
-    OverflowOptValue = OnCuIndexOverflow::Continue;
+    if (ContinueOption == "soft-stop") {
+      OverflowOptValue = OnCuIndexOverflow::SoftStop;
+    } else {
+      ContinueOption = OnCuIndexOverflow::Continue;
+    }
   }
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_execFileNames))

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -125,7 +125,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   DwpOptTable Tbl;
   llvm::BumpPtrAllocator A;
   llvm::StringSaver Saver{A};
-  OnCuIndexOverflow OverflowOptValue = OnCuIndexOverflow::Continue;
+  OnCuIndexOverflow OverflowOptValue = OnCuIndexOverflow::HardStop;
   opt::InputArgList Args =
       Tbl.parseArgs(argc, argv, OPT_UNKNOWN, Saver, [&](StringRef Msg) {
         llvm::errs() << Msg << '\n';
@@ -146,7 +146,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
   if (Args.hasArg(OPT_continueOnCuIndexOverflow)) {
     ContinueOption =
-      Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "hard-stop");
+        Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "continue");
     if (ContinueOption == "soft-stop") {
       OverflowOptValue = OnCuIndexOverflow::SoftStop;
     } else {

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -71,7 +71,7 @@ public:
 // Options
 static std::vector<std::string> ExecFilenames;
 static std::string OutputFilename;
-static std::string continueOption;
+static std::string ContinueOption;
 
 static Expected<SmallVector<std::string, 16>>
 getDWOFilenames(StringRef ExecFilename) {
@@ -125,7 +125,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   DwpOptTable Tbl;
   llvm::BumpPtrAllocator A;
   llvm::StringSaver Saver{A};
-  OnCuIndexOverflow overflowOptValue = OnCuIndexOverflow::HardStop;
+  OnCuIndexOverflow OverflowOptValue = OnCuIndexOverflow::HardStop;
   opt::InputArgList Args =
       Tbl.parseArgs(argc, argv, OPT_UNKNOWN, Saver, [&](StringRef Msg) {
         llvm::errs() << Msg << '\n';
@@ -144,11 +144,12 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   }
 
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
-  continueOption = Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "hard-stop");
-  if (continueOption == "soft-stop") {
-    overflowOptValue = OnCuIndexOverflow::SoftStop;
-  } else if (continueOption == "soft-stop") {
-    overflowOptValue = OnCuIndexOverflow::Continue;
+  continueOption =
+      Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "hard-stop");
+  if (ContinueOption == "soft-stop") {
+    OverflowOptValue = OnCuIndexOverflow::SoftStop;
+  } else if (ContinueOption == "soft-stop") {
+    OverflowOptValue = OnCuIndexOverflow::Continue;
   }
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_execFileNames))
@@ -261,7 +262,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (!MS)
     return error("no object streamer for target " + TripleName, Context);
 
-  if (auto Err = write(*MS, DWOFilenames, overflowOptValue)) {
+  if (auto Err = write(*MS, DWOFilenames, OverflowOptValue)) {
     logAllUnhandledErrors(std::move(Err), WithColor::error());
     return 1;
   }

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -144,7 +144,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   }
 
   OutputFilename = Args.getLastArgValue(OPT_outputFileName, "");
-  continueOption =
+  ContinueOption =
       Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "hard-stop");
   if (ContinueOption == "soft-stop") {
     OverflowOptValue = OnCuIndexOverflow::SoftStop;

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -148,7 +148,7 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
       Args.getLastArgValue(OPT_continueOnCuIndexOverflow, "hard-stop");
   if (ContinueOption == "soft-stop") {
     OverflowOptValue = OnCuIndexOverflow::SoftStop;
-  } else if (ContinueOption == "soft-stop") {
+  } else if (ContinueOption == "continue") {
     OverflowOptValue = OnCuIndexOverflow::Continue;
   }
 


### PR DESCRIPTION
When 'ContinueOnCuIndexOverflow' enables without this modification, the forcibly generated '.dwp' won't be recognized by Debugger(gdb 10.1) correctly.
<img width="657" alt="image" src="https://github.com/llvm/llvm-project/assets/150100070/31732775-2548-453a-a47a-fa04c6d05fe9">
it looks like there's a problem with processing the dwarf header, which makes debugging completely impossible.

**About patch:**
When llvm-dwp enables option '--continue-on-cu-index-overflow=soft-stop' and recognizes the overflow problem , it will stop packing and generate the '.dwp' file at once, discarding any DWO files that would not fit within the 32 bit/4GB limits of the format. 
<img width="625" alt="image" src="https://github.com/llvm/llvm-project/assets/150100070/77d6be24-262b-4f4c-afc0-9a6c49e133c7">
