### PR TITLE
[RISCV] Add missing component Scalar

### DIFF
--- a/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -75,6 +75,7 @@ add_llvm_target(RISCVCodeGen
   MC
   RISCVDesc
   RISCVInfo
+  Scalar
   SelectionDAG
   Support
   Target


### PR DESCRIPTION
We added LoopDataPrefetch in 9bb69c1 but Scalar is not linked.
