### PR TITLE
[Github] Add Pull Request template with links to Github docs/Discord/Forums

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- THIS COMMENT IS NOT VISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT.
+Thank you for submitting a Pull Request (PR) to the LLVM Project!
+
+You can add reviewers by using the "Reviewers" section of the PR page.
+This requires that you have write permissions for the repository, so if this
+does not work for you, you can instead tag reviewers by name in a comment using
+"@<reviewer's GitHub username>".
+
+If you have received no comments on your PR for a week, you can request a review
+by ‘ping’ing the PR by adding a comment “Ping”. The common courtesy ‘ping’
+rate is once a week. Please remember that you are asking for valuable time from
+other developers.
+
+If you have further questions about the PR process, they may be answered by the
+LLVM GitHub User Guide: https://llvm.org/docs/GitHub.html
+
+You can also ask questions in a comment on the PR, or ask on the
+LLVM Discord (https://discord.com/invite/xS7Z362) or
+Discourse forums (https://discourse.llvm.org/).
+-->


### PR DESCRIPTION
Inspired by Compiler Explorer's template, which just adds a hidden comment thanking the submitter, which I appreciated a lot when I contributed there.

Also by this post https://discourse.llvm.org/t/how-to-find-reviewers/74803.

This template gives us a way to direct folks who jump directly into making a PR to the help we have already written up.

I often assume (for better or worse) most GitHub hosted projects have similar processes, so if I was new to LLVM I likely wouldn't know about our docs either.