### PR TITLE
[Docs] Instructions for new contributors to find reviewers

### DIFF
--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -98,7 +98,10 @@ To make sure the right people see your patch, please select suitable reviewers
 and add them to your patch when requesting a review. Suitable reviewers are the
 code owner (see CODE_OWNERS.txt) and other people doing work in the area your
 patch touches. Github will normally suggest some reviewers based on rules or
-people that have worked on the code before.
+people that have worked on the code before. If you are a new contributor, you
+will not be able to select reviewers in such way, in which case you can still
+get the attention of potential reviewers by CC'ing them in a comment -- just
+@name them.
 
 A reviewer may request changes or ask questions during the review. If you are
 uncertain on how to provide test cases, documentation, etc., feel free to ask

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -99,7 +99,7 @@ and add them to your patch when requesting a review. Suitable reviewers are the
 code owner (see CODE_OWNERS.txt) and other people doing work in the area your
 patch touches. Github will normally suggest some reviewers based on rules or
 people that have worked on the code before. If you are a new contributor, you
-will not be able to select reviewers in such way, in which case you can still
+will not be able to select reviewers in such a way, in which case you can still
 get the attention of potential reviewers by CC'ing them in a comment -- just
 @name them.
 


### PR DESCRIPTION
Right now, the documentation does not clarify what new contributors should do to find potential reviewers, since new contributors don't have write access and thus cannot select them as explained in the docs. 

This patch extends the guidelines for new people, as discussed in https://discourse.llvm.org/t/how-to-find-reviewers/74803

cc: @kbeyls @DavidSpickett 