### PR TITLE
[DebugInfo][RemoveDIs] Add flag to use "new" debug-info  in opt

### DIFF
--- a/llvm/tools/opt/opt.cpp
+++ b/llvm/tools/opt/opt.cpp
@@ -279,7 +279,8 @@ static cl::list<std::string>
     PassPlugins("load-pass-plugin",
                 cl::desc("Load passes from plugin library"));
 
-static cl::opt<bool> TryUseNewDbgInfoFormat("try-experimental-debuginfo-iterators",
+static cl::opt<bool> TryUseNewDbgInfoFormat(
+    "try-experimental-debuginfo-iterators",
     cl::desc("Enable debuginfo iterator positions, if they're built in"),
     cl::init(false));
 

--- a/llvm/tools/opt/opt.cpp
+++ b/llvm/tools/opt/opt.cpp
@@ -460,16 +460,14 @@ int main(int argc, char **argv) {
 
   // RemoveDIs debug-info transition: tests may request that we /try/ to use the
   // new debug-info format, if it's built in.
-  if (TryUseNewDbgInfoFormat) {
 #ifdef EXPERIMENTAL_DEBUGINFO_ITERATORS
+  if (TryUseNewDbgInfoFormat) {
     // If LLVM was built with support for this, turn the new debug-info format
     // on.
     UseNewDbgInfoFormat = true;
-#else
-    // It it wasn't, do nothing.
-    ;
-#endif
   }
+#endif
+  (void)TryUseNewDbgInfoFormat;
 
   LLVMContext Context;
 

--- a/llvm/tools/opt/opt.cpp
+++ b/llvm/tools/opt/opt.cpp
@@ -444,19 +444,6 @@ int main(int argc, char **argv) {
   initializeReplaceWithVeclibLegacyPass(Registry);
   initializeJMCInstrumenterPass(Registry);
 
-  // RemoveDIs debug-info transition: tests may request that we /try/ to use the
-  // new debug-info format, if it's built in.
-  if (TryUseNewDbgInfoFormat) {
-#ifdef EXPERIMENTAL_DEBUGINFO_ITERATORS
-    // If LLVM was built with support for this, turn the new debug-info format
-    // on.
-    UseNewDbgInfoFormat = true;
-#else
-    // It it wasn't, do nothing.
-    ;
-#endif
-  }
-
   SmallVector<PassPlugin, 1> PluginList;
   PassPlugins.setCallback([&](const std::string &PluginPath) {
     auto Plugin = PassPlugin::Load(PluginPath);
@@ -470,6 +457,19 @@ int main(int argc, char **argv) {
 
   cl::ParseCommandLineOptions(argc, argv,
     "llvm .bc -> .bc modular optimizer and analysis printer\n");
+
+  // RemoveDIs debug-info transition: tests may request that we /try/ to use the
+  // new debug-info format, if it's built in.
+  if (TryUseNewDbgInfoFormat) {
+#ifdef EXPERIMENTAL_DEBUGINFO_ITERATORS
+    // If LLVM was built with support for this, turn the new debug-info format
+    // on.
+    UseNewDbgInfoFormat = true;
+#else
+    // It it wasn't, do nothing.
+    ;
+#endif
+  }
 
   LLVMContext Context;
 


### PR DESCRIPTION
Our option to turn on the non-intrinsic form of debug-info (`--experimental-debuginfo-iterators`) currently requires that LLVM is built with the `LLVM_EXPERIMENTAL_DEBUGINFO_ITERATORS` cmake flag enabled, so that some (slight) performance regressions aren't on-by-default during the prototype/testing period. However, we still want to be able to _optionally_ run tests, if support is built into LLVM.

To allow optionally exercising the non-intrinsic debug-info code, this patch adds `--try-experimental-debuginfo-iterators` to opt, which turns the `--experimental-debuginfo-iterators` flag on if support is built in, or leaves it off. This means we can run tests that:
 * Use normal dbg.value intrinsics if there's no support, or
 * Uses non-instruction DPValues if there is support.
  
Which means we can start getting test coverage of DPValues/RemoveDIs behaviour, from in-tree tests, on our RemoveDIs buildbot. All the code to do with automagically converting from one form to the other landed in 10a9e7442c4c4e.