### PR TITLE
[scudo] [docs] Remove 32-bit default column

### DIFF
--- a/llvm/docs/ScudoHardenedAllocator.rst
+++ b/llvm/docs/ScudoHardenedAllocator.rst
@@ -210,63 +210,63 @@ Or using the function:
 
 The following "string" options are available:
 
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| Option                          | 64-bit default | 32-bit default | Description                                     |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| quarantine_size_kb              | 0              | 0              | The size (in Kb) of quarantine used to delay    |
-|                                 |                |                | the actual deallocation of chunks. Lower value  |
-|                                 |                |                | may reduce memory usage but decrease the        |
-|                                 |                |                | effectiveness of the mitigation; a negative     |
-|                                 |                |                | value will fallback to the defaults. Setting    |
-|                                 |                |                | *both* this and thread_local_quarantine_size_kb |
-|                                 |                |                | to zero will disable the quarantine entirely.   |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| quarantine_max_chunk_size       | 0              | 0              | Size (in bytes) up to which chunks can be       |
-|                                 |                |                | quarantined.                                    |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| thread_local_quarantine_size_kb | 0              | 0              | The size (in Kb) of per-thread cache use to     |
-|                                 |                |                | offload the global quarantine. Lower value may  |
-|                                 |                |                | reduce memory usage but might increase          |
-|                                 |                |                | contention on the global quarantine. Setting    |
-|                                 |                |                | *both* this and quarantine_size_kb to zero will |
-|                                 |                |                | disable the quarantine entirely.                |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| dealloc_type_mismatch           | false          | false          | Whether or not we report errors on              |
-|                                 |                |                | malloc/delete, new/free, new/delete[], etc.     |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| delete_size_mismatch            | true           | true           | Whether or not we report errors on mismatch     |
-|                                 |                |                | between sizes of new and delete.                |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| zero_contents                   | false          | false          | Whether or not we zero chunk contents on        |
-|                                 |                |                | allocation.                                     |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| pattern_fill_contents           | false          | false          | Whether or not we fill chunk contents with a    |
-|                                 |                |                | byte pattern on allocation.                     |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| may_return_null                 | true           | true           | Whether or not a non-fatal failure can return a |
-|                                 |                |                | NULL pointer (as opposed to terminating).       |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| release_to_os_interval_ms       | 5000           | 5000           | The minimum interval (in ms) at which a release |
-|                                 |                |                | can be attempted (a negative value disables     |
-|                                 |                |                | reclaiming).                                    |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
-| allocation_ring_buffer_size     | 32768          | n/a            | If stack trace collection is requested, how     |
-|                                 |                |                | many previous allocations to keep in the        |
-|                                 |                |                | allocation ring buffer.                         |
-|                                 |                |                |                                                 |
-|                                 |                |                | This buffer is used to provide allocation and   |
-|                                 |                |                | deallocation stack traces for MTE fault         |
-|                                 |                |                | reports. The larger the buffer, the more        |
-|                                 |                |                | unrelated allocations can happen between        |
-|                                 |                |                | (de)allocation and the fault.                   |
-|                                 |                |                | If your sync-mode MTE faults do not have        |
-|                                 |                |                | (de)allocation stack traces, try increasing the |
-|                                 |                |                | buffer size.                                    |
-|                                 |                |                |                                                 |
-|                                 |                |                | Stack trace collection can be requested using   |
-|                                 |                |                | the scudo_malloc_set_track_allocation_stacks    |
-|                                 |                |                | function.                                       |
-+---------------------------------+----------------+----------------+-------------------------------------------------+
++---------------------------------+----------------+-------------------------------------------------+
+| Option                          | Default        | Description                                     |
++---------------------------------+----------------+-------------------------------------------------+
+| quarantine_size_kb              | 0              | The size (in Kb) of quarantine used to delay    |
+|                                 |                | the actual deallocation of chunks. Lower value  |
+|                                 |                | may reduce memory usage but decrease the        |
+|                                 |                | effectiveness of the mitigation; a negative     |
+|                                 |                | value will fallback to the defaults. Setting    |
+|                                 |                | *both* this and thread_local_quarantine_size_kb |
+|                                 |                | to zero will disable the quarantine entirely.   |
++---------------------------------+----------------+-------------------------------------------------+
+| quarantine_max_chunk_size       | 0              | Size (in bytes) up to which chunks can be       |
+|                                 |                | quarantined.                                    |
++---------------------------------+----------------+-------------------------------------------------+
+| thread_local_quarantine_size_kb | 0              | The size (in Kb) of per-thread cache use to     |
+|                                 |                | offload the global quarantine. Lower value may  |
+|                                 |                | reduce memory usage but might increase          |
+|                                 |                | contention on the global quarantine. Setting    |
+|                                 |                | *both* this and quarantine_size_kb to zero will |
+|                                 |                | disable the quarantine entirely.                |
++---------------------------------+----------------+-------------------------------------------------+
+| dealloc_type_mismatch           | false          | Whether or not we report errors on              |
+|                                 |                | malloc/delete, new/free, new/delete[], etc.     |
++---------------------------------+----------------+-------------------------------------------------+
+| delete_size_mismatch            | true           | Whether or not we report errors on mismatch     |
+|                                 |                | between sizes of new and delete.                |
++---------------------------------+----------------+-------------------------------------------------+
+| zero_contents                   | false          | Whether or not we zero chunk contents on        |
+|                                 |                | allocation.                                     |
++---------------------------------+----------------+-------------------------------------------------+
+| pattern_fill_contents           | false          | Whether or not we fill chunk contents with a    |
+|                                 |                | byte pattern on allocation.                     |
++---------------------------------+----------------+-------------------------------------------------+
+| may_return_null                 | true           | Whether or not a non-fatal failure can return a |
+|                                 |                | NULL pointer (as opposed to terminating).       |
++---------------------------------+----------------+-------------------------------------------------+
+| release_to_os_interval_ms       | 5000           | The minimum interval (in ms) at which a release |
+|                                 |                | can be attempted (a negative value disables     |
+|                                 |                | reclaiming).                                    |
++---------------------------------+----------------+-------------------------------------------------+
+| allocation_ring_buffer_size     | 32768          | If stack trace collection is requested, how     |
+|                                 |                | many previous allocations to keep in the        |
+|                                 |                | allocation ring buffer.                         |
+|                                 |                |                                                 |
+|                                 |                | This buffer is used to provide allocation and   |
+|                                 |                | deallocation stack traces for MTE fault         |
+|                                 |                | reports. The larger the buffer, the more        |
+|                                 |                | unrelated allocations can happen between        |
+|                                 |                | (de)allocation and the fault.                   |
+|                                 |                | If your sync-mode MTE faults do not have        |
+|                                 |                | (de)allocation stack traces, try increasing the |
+|                                 |                | buffer size.                                    |
+|                                 |                |                                                 |
+|                                 |                | Stack trace collection can be requested using   |
+|                                 |                | the scudo_malloc_set_track_allocation_stacks    |
+|                                 |                | function.                                       |
++---------------------------------+----------------+-------------------------------------------------+
 
 Additional flags can be specified, for example if Scudo if compiled with
 `GWP-ASan <https://llvm.org/docs/GwpAsan.html>`_ support.


### PR DESCRIPTION
The values are the same as in the 64-bit default column, so collapsing into single "Default" column. If they ever diverge we can add it back.