### PR TITLE
[coroutines] Introduce [[clang::coro_return_type]] and [[clang::coro_wrapper]]

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -300,6 +300,11 @@ Attribute Changes in Clang
   to reduce the size of the destroy functions for coroutines which are known to
   be destroyed after having reached the final suspend point.
 
+- Clang now introduced ``[[clang::coro_return_type]]`` and ``[[clang::coro_wrapper]]``
+  attributes. A function returning a type marked with ``[[clang::coro_return_type]]``
+  should be a coroutine. A non-coroutine function marked with ``[[clang::coro_wrapper]]``
+  is still allowed to return the such a type.
+
 Improvements to Clang's diagnostics
 -----------------------------------
 - Clang constexpr evaluator now prints template arguments when displaying

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -303,7 +303,7 @@ Attribute Changes in Clang
 - Clang now introduced ``[[clang::coro_return_type]]`` and ``[[clang::coro_wrapper]]``
   attributes. A function returning a type marked with ``[[clang::coro_return_type]]``
   should be a coroutine. A non-coroutine function marked with ``[[clang::coro_wrapper]]``
-  is still allowed to return the such a type.
+  is still allowed to return the such a type. This is helpful for analyzers to recognize coroutines from the function signatures.
 
 Improvements to Clang's diagnostics
 -----------------------------------

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1094,6 +1094,22 @@ def CoroOnlyDestroyWhenComplete : InheritableAttr {
   let SimpleHandler = 1;
 }
 
+def CoroReturnType : InheritableAttr {
+  let Spellings = [Clang<"coro_return_type">];
+  let Subjects = SubjectList<[CXXRecord]>;
+  let LangOpts = [CPlusPlus];
+  let Documentation = [CoroReturnTypeAndWrapperDoc];
+  let SimpleHandler = 1;
+}
+
+def CoroWrapper : InheritableAttr {
+  let Spellings = [Clang<"coro_wrapper">];
+  let Subjects = SubjectList<[Function]>;
+  let LangOpts = [CPlusPlus];
+  let Documentation = [CoroReturnTypeAndWrapperDoc];
+  let SimpleHandler = 1;
+}
+
 // OSObject-based attributes.
 def OSConsumed : InheritableParamAttr {
   let Spellings = [Clang<"os_consumed">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7482,3 +7482,70 @@ generation of the other destruction cases, optimizing the above `foo.destroy` to
 
   }];
 }
+
+
+def CoroReturnTypeAndWrapperDoc : Documentation {
+  let Category = DocCatDecl;
+  let Content = [{
+The `coro_only_destroy_when_complete` attribute should be marked on a C++ class. The coroutines
+whose return type is marked with the attribute are assumed to be destroyed only after the coroutine has
+reached the final suspend point.
+
+This is helpful for the optimizers to reduce the size of the destroy function for the coroutines.
+
+For example,
+
+.. code-block:: c++
+
+  A foo() {
+    dtor d;
+    co_await something();
+    dtor d1;
+    co_await something();
+    dtor d2;
+    co_return 43;
+  }
+
+The compiler may generate the following pseudocode:
+
+.. code-block:: c++
+
+  void foo.destroy(foo.Frame *frame) {
+    switch(frame->suspend_index()) {
+      case 1:
+        frame->d.~dtor();
+        break;
+      case 2:
+        frame->d.~dtor();
+        frame->d1.~dtor();
+        break;
+      case 3:
+        frame->d.~dtor();
+        frame->d1.~dtor();
+        frame->d2.~dtor();
+        break;
+      default: // coroutine completed or haven't started
+        break;
+    }
+
+    frame->promise.~promise_type();
+    delete frame;
+  }
+
+The `foo.destroy()` function's purpose is to release all of the resources
+initialized for the coroutine when it is destroyed in a suspended state.
+However, if the coroutine is only ever destroyed at the final suspend state,
+the rest of the conditions are superfluous.
+
+The user can use the `coro_only_destroy_when_complete` attributo suppress
+generation of the other destruction cases, optimizing the above `foo.destroy` to:
+
+.. code-block:: c++
+
+  void foo.destroy(foo.Frame *frame) {
+    frame->promise.~promise_type();
+    delete frame;
+  }
+
+  }];
+}

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7507,7 +7507,7 @@ is not a coroutine itself and is marked with ``[[clang::coro_wrapper]]``.
 From a language perspective, it is not possible to differentiate between a coroutine and a
 function returning a CRT by merely looking at the function signature.
 
-Clang will enforce that all functions that return a ``CRT``  are either coroutines or marked 
+Clang will enforce that all functions that return a ``CRT``  are either coroutines or marked
 with `[[clang::coro_wrapper]]`. Coroutine wrappers, in particular, are susceptible to capturing
 references to temporaries and other lifetime issues. This allows to avoid such lifetime
 issues with coroutine wrappers.

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7487,6 +7487,8 @@ generation of the other destruction cases, optimizing the above `foo.destroy` to
 def CoroReturnTypeAndWrapperDoc : Documentation {
   let Category = DocCatDecl;
   let Content = [{
+The `[[clang::coro_return_type]]` attribute is used to help static analyzers to recognize coroutines from the function signatures.
+
 The ``coro_return_type`` attribute should be marked on a C++ class to mark it as
 a **coroutine return type (CRT)**.
 
@@ -7495,7 +7497,7 @@ is marked by ``[[clang::coro_return_type]]`` and  ``R`` has a promise type assoc
 (i.e., std​::​coroutine_traits<R, P1, .., PN>​::​promise_type is a valid promise type).
 
 If the return type of a function is a ``CRT`` then the function must be a coroutine.
-Otherwise it is invalid. It is allowed for a non-coroutine to return a ``CRT``
+Otherwise the program is invalid. It is allowed for a non-coroutine to return a ``CRT``
 if the function is marked with ``[[clang::coro_wrapper]]``.
 
 The ``coro_wrapper`` attribute should be marked on a C++ function to mark it as

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7488,7 +7488,7 @@ def CoroReturnTypeAndWrapperDoc : Documentation {
   let Category = DocCatDecl;
   let Content = [{
 The ``coro_return_type`` attribute should be marked on a C++ class to mark it as
-a **coroutine return type (CRT)**. 
+a **coroutine return type (CRT)**.
 
 A function ``R func(P1, .., PN)`` has a coroutine return type (CRT) ``R`` if ``R``
 is marked by ``[[clang::coro_return_type]]`` and  ``R`` has a promise type associated to it
@@ -7498,8 +7498,8 @@ If the return type of a function is a ``CRT`` then the function must be a corout
 Otherwise it is invalid. It is allowed for a non-coroutine to return a ``CRT``
 if the function is marked with ``[[clang::coro_wrapper]]``.
 
-The ``coro_wrapper`` attribute should be marked on a C++ function to mark it as 
-a **coroutine wrapper**. A coroutine wrapper is a function which returns a ``CRT``, 
+The ``coro_wrapper`` attribute should be marked on a C++ function to mark it as
+a **coroutine wrapper**. A coroutine wrapper is a function which returns a ``CRT``,
 is not a coroutine itself and is marked with ``[[clang::coro_wrapper]]``.
 
 From a language perspective, it is not possible to differentiate between a coroutine and a
@@ -7527,6 +7527,6 @@ For example,
     // a coroutine wrapper.
     std::function<Task<int>(int)> f = increment;
   }
-  
+
 }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7487,11 +7487,47 @@ generation of the other destruction cases, optimizing the above `foo.destroy` to
 def CoroReturnTypeAndWrapperDoc : Documentation {
   let Category = DocCatDecl;
   let Content = [{
-The `coro_only_destroy_when_complete` attribute should be marked on a C++ class. The coroutines
-whose return type is marked with the attribute are assumed to be destroyed only after the coroutine has
-reached the final suspend point.
+The ``coro_return_type`` attribute should be marked on a C++ class to mark it as
+a **coroutine return type (CRT)**. 
 
-This is helpful for the optimizers to reduce the size of the destroy function for the coroutines.
+A function ``R func(P1, .., PN)`` has a coroutine return type (CRT) ``R`` if ``R``
+is marked by ``[[clang::coro_return_type]]`` and  ``R`` has a promise type associated to it
+(i.e., std​::​coroutine_traits<R, P1, .., PN>​::​promise_type is a valid promise type).
+
+If the return type of a function is a ``CRT`` then the function must be a coroutine.
+Otherwise it is invalid. It is allowed for a non-coroutine to return a ``CRT``
+if the function is marked with ``[[clang::coro_wrapper]]``.
+
+The ``coro_wrapper`` attribute should be marked on a C++ function to mark it as 
+a **coroutine wrapper**. A coroutine wrapper is a function which returns a ``CRT``, 
+is not a coroutine itself and is marked with ``[[clang::coro_wrapper]]``.
+
+From a language perspective, it is not possible to differentiate between a coroutine and a
+function returning a CRT by merely looking at the function signature.
+These two annotations allows implementations to enforce that only coroutines and explicitly marked
+coroutine wrappers are allowed to return a ``CRT``.
+
+For example,
+
+.. code-block:: c++
+
+  // This is a CRT.
+  template <typename T> struct [[clang::coro_return_type]] Task {
+    using promise_type = some_promise_type;
+  };
+
+  Task<int> increment(int a) { co_return a + 1; } // Fine. This is a coroutine.
+  Task<int> foo() { return increment(1); } // Error. foo is not a coroutine.
+
+  // Fine for a coroutine wrapper to return a CRT.
+  Task<int> [[clang::coro_wrapper]] foo() { return increment(1); }
+
+  void bar() {
+    // Invalid. This intantiates a function which returns a CRT but is not marked as
+    // a coroutine wrapper.
+    std::function<Task<int>(int)> f = increment;
+  }
+
 
 For example,
 
@@ -7507,45 +7543,6 @@ For example,
   }
 
 The compiler may generate the following pseudocode:
-
-.. code-block:: c++
-
-  void foo.destroy(foo.Frame *frame) {
-    switch(frame->suspend_index()) {
-      case 1:
-        frame->d.~dtor();
-        break;
-      case 2:
-        frame->d.~dtor();
-        frame->d1.~dtor();
-        break;
-      case 3:
-        frame->d.~dtor();
-        frame->d1.~dtor();
-        frame->d2.~dtor();
-        break;
-      default: // coroutine completed or haven't started
-        break;
-    }
-
-    frame->promise.~promise_type();
-    delete frame;
-  }
-
-The `foo.destroy()` function's purpose is to release all of the resources
-initialized for the coroutine when it is destroyed in a suspended state.
-However, if the coroutine is only ever destroyed at the final suspend state,
-the rest of the conditions are superfluous.
-
-The user can use the `coro_only_destroy_when_complete` attributo suppress
-generation of the other destruction cases, optimizing the above `foo.destroy` to:
-
-.. code-block:: c++
-
-  void foo.destroy(foo.Frame *frame) {
-    frame->promise.~promise_type();
-    delete frame;
-  }
 
   }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7527,22 +7527,6 @@ For example,
     // a coroutine wrapper.
     std::function<Task<int>(int)> f = increment;
   }
-
-
-For example,
-
-.. code-block:: c++
-
-  A foo() {
-    dtor d;
-    co_await something();
-    dtor d1;
-    co_await something();
-    dtor d2;
-    co_return 43;
-  }
-
-The compiler may generate the following pseudocode:
-
-  }];
+  
+}];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7504,8 +7504,11 @@ is not a coroutine itself and is marked with ``[[clang::coro_wrapper]]``.
 
 From a language perspective, it is not possible to differentiate between a coroutine and a
 function returning a CRT by merely looking at the function signature.
-These two annotations allows implementations to enforce that only coroutines and explicitly marked
-coroutine wrappers are allowed to return a ``CRT``.
+
+Clang will enforce that all functions that return a ``CRT``  are either coroutines or marked 
+with `[[clang::coro_wrapper]]`. Coroutine wrappers, in particular, are susceptible to capturing
+references to temporaries and other lifetime issues. This allows to avoid such lifetime
+issues with coroutine wrappers.
 
 For example,
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7487,7 +7487,8 @@ generation of the other destruction cases, optimizing the above `foo.destroy` to
 def CoroReturnTypeAndWrapperDoc : Documentation {
   let Category = DocCatDecl;
   let Content = [{
-The `[[clang::coro_return_type]]` attribute is used to help static analyzers to recognize coroutines from the function signatures.
+The ``[[clang::coro_return_type]]`` attribute is used to help static analyzers to recognize
+coroutines from the function signatures.
 
 The ``coro_return_type`` attribute should be marked on a C++ class to mark it as
 a **coroutine return type (CRT)**.
@@ -7500,15 +7501,17 @@ If the return type of a function is a ``CRT`` then the function must be a corout
 Otherwise the program is invalid. It is allowed for a non-coroutine to return a ``CRT``
 if the function is marked with ``[[clang::coro_wrapper]]``.
 
-The ``coro_wrapper`` attribute should be marked on a C++ function to mark it as
+The ``[[clang::coro_wrapper]]`` attribute should be marked on a C++ function to mark it as
 a **coroutine wrapper**. A coroutine wrapper is a function which returns a ``CRT``,
 is not a coroutine itself and is marked with ``[[clang::coro_wrapper]]``.
+
+Clang will enforce that all functions that return a ``CRT`` are either coroutines or marked
+with ``[[clang::coro_wrapper]]``. Clang will enforce this with an error.
 
 From a language perspective, it is not possible to differentiate between a coroutine and a
 function returning a CRT by merely looking at the function signature.
 
-Clang will enforce that all functions that return a ``CRT``  are either coroutines or marked
-with `[[clang::coro_wrapper]]`. Coroutine wrappers, in particular, are susceptible to capturing
+Coroutine wrappers, in particular, are susceptible to capturing
 references to temporaries and other lifetime issues. This allows to avoid such lifetime
 issues with coroutine wrappers.
 
@@ -7533,5 +7536,7 @@ For example,
     std::function<Task<int>(int)> f = increment;
   }
 
+  Note: ``a_promise_type::get_return_object`` is exempted from this analysis as it is a necessary
+  implementation detail of any coroutine library.
 }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7536,7 +7536,7 @@ For example,
     std::function<Task<int>(int)> f = increment;
   }
 
-  Note: ``a_promise_type::get_return_object`` is exempted from this analysis as it is a necessary
-  implementation detail of any coroutine library.
+Note: ``a_promise_type::get_return_object`` is exempted from this analysis as it is a necessary
+implementation detail of any coroutine library.
 }];
 }

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11591,6 +11591,10 @@ def err_conflicting_aligned_options : Error <
 def err_coro_invalid_addr_of_label : Error<
   "the GNU address of label extension is not allowed in coroutines."
 >;
+def err_coroutine_return_type : Error<
+  "function returns a coroutine return type %0 but is neither a coroutine nor a coroutine wrapper; "
+  "non-coroutines should be marked with [[clang::coro_wrapper]] to allow returning coroutine return type"
+>;
 } // end of coroutines issue category
 
 let CategoryName = "Documentation Issue" in {

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11592,7 +11592,7 @@ def err_coro_invalid_addr_of_label : Error<
   "the GNU address of label extension is not allowed in coroutines."
 >;
 def err_coroutine_return_type : Error<
-  "function returns a coroutine return type %0 but is neither a coroutine nor a coroutine wrapper; "
+  "function returns a type %0 makred with [[clang::coro_return_type]] but is neither a coroutine nor a coroutine wrapper; "
   "non-coroutines should be marked with [[clang::coro_wrapper]] to allow returning coroutine return type"
 >;
 } // end of coroutines issue category

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11183,6 +11183,7 @@ public:
   bool buildCoroutineParameterMoves(SourceLocation Loc);
   VarDecl *buildCoroutinePromise(SourceLocation Loc);
   void CheckCompletedCoroutineBody(FunctionDecl *FD, Stmt *&Body);
+  void CheckCoroutineWrapper(FunctionDecl *FD);
   /// Lookup 'coroutine_traits' in std namespace and std::experimental
   /// namespace. The namespace found is recorded in Namespace.
   ClassTemplateDecl *lookupCoroutineTraits(SourceLocation KwLoc,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11183,6 +11183,10 @@ public:
   bool buildCoroutineParameterMoves(SourceLocation Loc);
   VarDecl *buildCoroutinePromise(SourceLocation Loc);
   void CheckCompletedCoroutineBody(FunctionDecl *FD, Stmt *&Body);
+
+  // As a clang extension, enforces that a function returning a type marked with
+  // [[clang::coro_return_type]] must be a coroutine. A function marked with
+  // [[clang::coro_wrapper]] are still allowed to return such a type.
   void CheckCoroutineWrapper(FunctionDecl *FD);
   /// Lookup 'coroutine_traits' in std namespace and std::experimental
   /// namespace. The namespace found is recorded in Namespace.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11184,9 +11184,10 @@ public:
   VarDecl *buildCoroutinePromise(SourceLocation Loc);
   void CheckCompletedCoroutineBody(FunctionDecl *FD, Stmt *&Body);
 
-  // As a clang extension, enforces that a function returning a type marked with
-  // [[clang::coro_return_type]] must be a coroutine. A function marked with
-  // [[clang::coro_wrapper]] are still allowed to return such a type.
+  // As a clang extension, enforces that a non-coroutine function must be marked
+  // with [[clang::coro_wrapper]] if it returns a type marked with
+  // [[clang::coro_return_type]].
+  // Expects that FD is not a coroutine.
   void CheckCoroutineWrapper(FunctionDecl *FD);
   /// Lookup 'coroutine_traits' in std namespace and std::experimental
   /// namespace. The namespace found is recorded in Namespace.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -17,6 +17,7 @@
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/CommentDiagnostic.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
@@ -15811,6 +15812,23 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
           << FixItHint::CreateInsertion(P.first, "self->");
 }
 
+void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
+  if (!getLangOpts().Coroutines || !FD || getCurFunction()->isCoroutine())
+    return;
+  RecordDecl *RD = FD->getReturnType()->getAsRecordDecl();
+  if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())
+    return;
+  // Allow `promise_type::get_return_object`.
+  if (FD->getName() == "get_return_object") {
+    if (auto *GRT = dyn_cast<CXXMethodDecl>(FD)) {
+      if (auto *PT = GRT->getParent(); PT && PT->getName() == "promise_type")
+        return;
+    }
+  }
+  if (!FD->hasAttr<CoroWrapperAttr>())
+    Diag(FD->getLocation(), diag::err_coroutine_return_type) << RD;
+}
+
 Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
                                     bool IsInstantiation) {
   FunctionScopeInfo *FSI = getCurFunction();
@@ -15822,8 +15840,11 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
   sema::AnalysisBasedWarnings::Policy WP = AnalysisWarnings.getDefaultPolicy();
   sema::AnalysisBasedWarnings::Policy *ActivePolicy = nullptr;
 
-  if (getLangOpts().Coroutines && FSI->isCoroutine())
-    CheckCompletedCoroutineBody(FD, Body);
+  if (getLangOpts().Coroutines) {
+    if (FSI->isCoroutine())
+      CheckCompletedCoroutineBody(FD, Body);
+    CheckCoroutineWrapper(FD);
+  }
 
   {
     // Do not call PopExpressionEvaluationContext() if it is a lambda because

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -27,6 +27,7 @@
 #include "clang/AST/NonTrivialTypeVisitor.h"
 #include "clang/AST/Randstruct.h"
 #include "clang/AST/StmtCXX.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/HLSLRuntime.h"
 #include "clang/Basic/PartialDiagnostic.h"
@@ -15812,6 +15813,19 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
           << FixItHint::CreateInsertion(P.first, "self->");
 }
 
+// Return whether FD is `promise_type::get_return_object`.
+bool isGetReturnObject(FunctionDecl *FD) {
+  if (!FD->getDeclName().isIdentifier() ||
+      !FD->getName().equals("get_return_object") || !FD->param_empty())
+    return false;
+  CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(FD);
+  if (!MD || !MD->isCXXInstanceMember())
+    return false;
+  RecordDecl *PromiseType = MD->getParent();
+  return PromiseType && PromiseType->getDeclName().isIdentifier() &&
+         PromiseType->getName().equals("promise_type");
+}
+
 void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
   if (!getLangOpts().Coroutines || !FD || getCurFunction()->isCoroutine())
     return;
@@ -15819,12 +15833,8 @@ void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
   if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())
     return;
   // Allow `promise_type::get_return_object`.
-  if (FD->getName() == "get_return_object") {
-    if (auto *GRT = dyn_cast<CXXMethodDecl>(FD)) {
-      if (auto *PT = GRT->getParent(); PT && PT->getName() == "promise_type")
-        return;
-    }
-  }
+  if (isGetReturnObject(FD))
+    return;
   if (!FD->hasAttr<CoroWrapperAttr>())
     Diag(FD->getLocation(), diag::err_coroutine_return_type) << RD;
 }

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15814,7 +15814,7 @@ static void diagnoseImplicitlyRetainedSelf(Sema &S) {
 }
 
 void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
-  if (!FD || getCurFunction()->isCoroutine())
+  if (!FD)
     return;
   RecordDecl *RD = FD->getReturnType()->getAsRecordDecl();
   if (!RD || !RD->getUnderlyingDecl()->hasAttr<CoroReturnTypeAttr>())
@@ -15841,7 +15841,8 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
   if (getLangOpts().Coroutines) {
     if (FSI->isCoroutine())
       CheckCompletedCoroutineBody(FD, Body);
-    CheckCoroutineWrapper(FD);
+    else
+      CheckCoroutineWrapper(FD);
   }
 
   {

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -57,6 +57,8 @@
 // CHECK-NEXT: ConsumableSetOnRead (SubjectMatchRule_record)
 // CHECK-NEXT: Convergent (SubjectMatchRule_function)
 // CHECK-NEXT: CoroOnlyDestroyWhenComplete (SubjectMatchRule_record)
+// CHECK-NEXT: CoroReturnType (SubjectMatchRule_record)
+// CHECK-NEXT: CoroWrapper
 // CHECK-NEXT: CountedBy (SubjectMatchRule_field)
 // CHECK-NEXT: DLLExport (SubjectMatchRule_function, SubjectMatchRule_variable, SubjectMatchRule_record, SubjectMatchRule_objc_interface)
 // CHECK-NEXT: DLLImport (SubjectMatchRule_function, SubjectMatchRule_variable, SubjectMatchRule_record, SubjectMatchRule_objc_interface)

--- a/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
+++ b/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
@@ -1,0 +1,56 @@
+// RUN: %clang_cc1 -triple x86_64-apple-darwin9 %s -std=c++20 -fsyntax-only -verify -Wall -Wextra
+#include "Inputs/std-coroutine.h"
+
+using std::suspend_always;
+using std::suspend_never;
+
+
+template <typename T> struct [[clang::coro_return_type]] Gen {
+  struct promise_type {
+    Gen<T> get_return_object() {
+      return {};
+    }
+    suspend_always initial_suspend();
+    suspend_always final_suspend() noexcept;
+    void unhandled_exception();
+    void return_value(const T &t);
+
+    template <typename U>
+    auto await_transform(const Gen<U> &) {
+      struct awaitable {
+        bool await_ready() noexcept { return false; }
+        void await_suspend(std::coroutine_handle<>) noexcept {}
+        U await_resume() noexcept { return {}; }
+      };
+      return awaitable{};
+    }
+  };
+};
+
+Gen<int> foo_coro(int b);
+Gen<int> foo_coro(int b) { co_return b; }
+
+[[clang::coro_wrapper]] Gen<int> marked_wrapper1(int b) { return foo_coro(b); }
+
+// expected-error@+1 {{neither a coroutine nor a coroutine wrapper}}
+Gen<int> non_marked_wrapper(int b) { return foo_coro(b); }
+
+namespace using_decl {
+template <typename T> using Co = Gen<T>;
+
+[[clang::coro_wrapper]] Co<int> marked_wrapper1(int b) { return foo_coro(b); }
+
+// expected-error@+1 {{neither a coroutine nor a coroutine wrapper}}
+Co<int> non_marked_wrapper(int b) { return foo_coro(b); }
+} // namespace using_decl
+
+namespace lambdas {
+void foo() {
+  auto coro_lambda = []() -> Gen<int> {
+    co_return 1;
+  };
+  auto wrapper_lambda = [&]() -> Gen<int> {
+    return coro_lambda();
+  }
+}
+}

--- a/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
+++ b/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
@@ -54,7 +54,15 @@ void foo() {
     return foo_coro(1);
   };
 }
+
+Co<int> coor_containing_lambda(int b) {
+  // expected-error@+1 {{neither a coroutine nor a coroutine wrapper}}
+  auto wrapper_lambda = []() -> Gen<int> {
+    return foo_coro(1);
+  };
+  co_return wrapper_lambda();
 }
+} // namespace lambdas
 
 namespace std_function {
 namespace std {
@@ -112,6 +120,6 @@ namespace std {
 template<> class coroutine_traits<Task, int> {
     using promise_type = my_promise_type;
 };
-}
+} // namespace std
 // expected-error@+1 {{neither a coroutine nor a coroutine wrapper}}
 Task foo(int) { return Task{}; }

--- a/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
+++ b/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
@@ -56,6 +56,7 @@ void foo() {
 }
 }
 
+namespace std_function {
 namespace std {
 template <typename> class function;
 
@@ -95,3 +96,4 @@ void use_std_function() {
   test2(true);
   test3(true);
 }
+} // namespace std_function

--- a/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
+++ b/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
@@ -97,3 +97,21 @@ void use_std_function() {
   test3(true);
 }
 } // namespace std_function
+
+// different_promise_type
+class [[clang::coro_return_type]] Task{};
+struct my_promise_type {
+  Task get_return_object() {
+    return {};
+  }
+  suspend_always initial_suspend();
+  suspend_always final_suspend() noexcept;
+  void unhandled_exception();
+};
+namespace std {
+template<> class coroutine_traits<Task, int> {
+    using promise_type = my_promise_type;
+};
+}
+// expected-error@+1 {{neither a coroutine nor a coroutine wrapper}}
+Task foo(int) { return Task{}; }


### PR DESCRIPTION
First step in the implementation of [RFC](https://discourse.llvm.org/t/rfc-lifetime-bound-check-for-parameters-of-coroutines/74253) ([final approved doc](https://docs.google.com/document/d/1hkfXHuvIW1Yv5LI-EIkpWzdWgIoUlzO6Zv_KJpknQzM/edit)).

This introduces the concepts of a **coroutine return type** and explicit **coroutine wrapper** functions. 