### PR TITLE
[mlir][mesh] Add collective communication operations

### DIFF
--- a/mlir/docs/Dialects/Mesh.md
+++ b/mlir/docs/Dialects/Mesh.md
@@ -1,0 +1,34 @@
+# 'mesh' Dialect
+
+The `mesh` dialect contains a set of attributes, operations and interfaces that
+are useful for representing sharding and communication on a device mesh
+cluster.
+
+[TOC]
+
+## Collective Communication Operations
+There are a number of operations in the Mesh dialect to facilitate
+communication between devices in a mesh.
+It is assumed that the user is familiar with collective operations.
+[Wikipedia](https://en.wikipedia.org/wiki/Collective_operation) has a good
+explanation.
+The main addition is that the collectives in this dialect have mesh
+semantics.
+The operation attributes `mesh` and `mesh_axes` specifies a set of device mesh
+axes that partition the devices into disjoint groups.
+The collective operation is performed between devices in the same group.
+Devices that have the same coordinates outside of axes `mesh_axes` are in the
+same group.
+For example if we have a device mesh of size `2x3x4x5` and the partition mesh
+axes set is `{0, 1}` then devices are partitioned into the groups
+`{ { (i, j, k, m) | 0<=i<2, 0<=j<3 } | 0<=k<4, 0<=m<5 }`.
+Devices (1, 0, 2, 3) and (1, 1, 2, 3) will be in the same group.
+Device (1, 0, 2, 4) will be in another group.
+
+## Operations
+
+[include "Dialects/MeshOps.md"]
+
+## Attributes
+
+[include "Dialects/MeshAttributes.md"]

--- a/mlir/docs/Dialects/Mesh.md
+++ b/mlir/docs/Dialects/Mesh.md
@@ -14,16 +14,25 @@ It is assumed that the user is familiar with collective operations.
 explanation.
 The main addition is that the collectives in this dialect have mesh
 semantics.
-The operation attributes `mesh` and `mesh_axes` specifies a set of device mesh
+
+The operation attributes `mesh` and `mesh_axes` specifies a list of device mesh
 axes that partition the devices into disjoint groups.
 The collective operation is performed between devices in the same group.
 Devices that have the same coordinates outside of axes `mesh_axes` are in the
 same group.
 For example if we have a device mesh of size `2x3x4x5` and the partition mesh
-axes set is `{0, 1}` then devices are partitioned into the groups
+axes list is `[0, 1]` then devices are partitioned into the groups
 `{ { (i, j, k, m) | 0<=i<2, 0<=j<3 } | 0<=k<4, 0<=m<5 }`.
 Devices (1, 0, 2, 3) and (1, 1, 2, 3) will be in the same group.
 Device (1, 0, 2, 4) will be in another group.
+Some collective operations like all-to-all and all-gather care about the
+order of devices.
+The order of device in a device group is induced by the order of axes in
+`mesh_axes`.
+The axes are ordered from outer to inner.
+If we have an axis list `[3, 1]` then device `(i, 1, k, 0)` will precede
+both devices `(i, 0, k, 1)` and `(i, 2, k, 0)`.
+
 
 ## Operations
 

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshBase.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshBase.td
@@ -23,9 +23,7 @@ def Mesh_Dialect : Dialect {
   let cppNamespace = "::mlir::mesh";
 
   let description = [{
-    The `mesh` dialect contains a set of attributes, operations, interfaces that
-    are useful for representing sharding and communication on device mesh
-    cluster.
+    See [Mesh dialect documentation](mlir/docs/Dialects/Mesh.md).
   }];
 
   let dependentDialects = [
@@ -47,6 +45,10 @@ def Mesh_Partial : I32EnumAttr<"Partial", "partial type of a distributed tensor"
 ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::mesh";
+}
+
+def Mesh_PartialAttr : EnumAttr<Mesh_Dialect, Mesh_Partial, "partial"> {
+  let assemblyFormat = "`<` $value `>`";
 }
 
 // Mesh_IteratorType and Mesh_Partial are used to annotate different aspects of

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.h
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.h
@@ -10,9 +10,11 @@
 #define MLIR_DIALECT_MESH_IR_MESHOPS_H
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include <algorithm>
 
 #include "mlir/Dialect/Mesh/IR/MeshOpsDialect.h.inc"
 

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.h
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.h
@@ -11,6 +11,7 @@
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
@@ -13,6 +13,8 @@ include "mlir/Dialect/Mesh/IR/MeshBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinTypes.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 //===----------------------------------------------------------------------===//
@@ -76,6 +78,15 @@ def Mesh_ClusterOp : Mesh_Op<"cluster", [Symbol]> {
   let assemblyFormat = [{
     $sym_name `(` `rank` `=` $rank (`,` `dim_sizes` `=` $dim_sizes^)? `)`
       attr-dict
+  }];
+  let extraClassDeclaration = [{
+    ::mlir::SmallVector<int64_t> canonicalDimSizes();
+
+    template <typename OutIt>
+    void canonicalDimSizes(OutIt outIt) {
+      std::copy(getDimSizes().begin(), getDimSizes().end(), outIt);
+      std::fill_n(outIt, getRank() - getDimSizes().size(), 0);
+    }
   }];
   let hasVerifier = 1;
 }
@@ -169,6 +180,211 @@ def Mesh_ShardOp : Mesh_Op<"shard", [Pure, SameOperandsAndResultType]> {
     $src `to` $shard (`annotate_for_users` $annotate_for_users^)? attr-dict `:`
       type($result)
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// collective communication ops
+//===----------------------------------------------------------------------===//
+
+class Mesh_CollectiveCommunicationOpBase<
+    string mnemonic, list<Trait> traits = []> :
+    Mesh_Op<mnemonic,
+      !listconcat(traits,
+      [SymbolUserOpInterface])> {
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($result)";
+  code extraClassDeclarationBase = [{
+    ::mlir::LogicalResult verifySymbolUses(
+          ::mlir::SymbolTableCollection &symbolTable);
+  }];
+}
+
+def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
+    SameOperandsAndResultElementType,
+    SameOperandsAndResultRank
+  ]> {
+  let summary = "All-gather over a device mesh.";
+  let description = [{
+    Gathers along the `gather_axis` tensor axis.
+    The order of input tensors in the resulting tensor is the same as the
+    order of the corresponding devices' multi-index in the mesh.
+
+    Example:
+    ```mlir
+    mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 2])
+    ...
+    %1 = mesh.all_gather %0 {
+        mesh = @mesh0, mesh_axes = array<i16: 1>, gather_axis = 1 : index
+      } : tensor<2x2xi8> -> tensor<2x4xi8>
+    ```
+    Input:
+    ```
+                     +-------+-------+
+    device (0, 0) -> |  1  2 |  5  6 | <- device (0, 1)
+                     |  3  4 |  7  8 |
+                     +-------+-------+
+    device (1, 0) -> |  9 10 | 13 14 | <- device (1, 1)
+                     | 11 12 | 15 16 |
+                     +-------+-------+
+    ```
+    Result:
+    ```
+    +-------------+
+    |  1  2  5  6 | <- devices (0, 0) and (0, 1)
+    |  3  4  7  8 |
+    +-------------+
+    |  9 10 13 14 | <- devices (1, 0) and (1, 1)
+    | 11 12 15 16 |
+    +-------------+
+    ```
+  }];
+  let arguments = (ins
+    AnyNon0RankedTensor:$input,
+    FlatSymbolRefAttr:$mesh,
+    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
+    APIntAttr:$gather_axis
+  );
+  let results = (outs
+    AnyNon0RankedTensor:$result
+  );
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+  let extraClassDeclaration = extraClassDeclarationBase;
+}
+
+def Mesh_AllReduceOp : Mesh_CollectiveCommunicationOpBase<"all_reduce", [
+    SameOperandsAndResultShape]> {
+  let summary = "All-reduce over a device mesh.";
+  let description = [{
+    The accumulation element type is specified by the result type and
+    it does not need to match the input element type.
+    The input element is converted to the result element type before
+    performing the reduction.
+
+    Attributes:
+    `reduction`: Indicates the reduction method.
+
+    Example:
+    ```
+    %1 = mesh.all_reduce %0 {
+        mesh = @mesh0, mesh_axes = array<i16: 1, 0>, reduction = #mesh.partial<max>
+      } : tensor<3x4xf32> -> tensor<3x4xf64>
+    ```
+  }];
+  let arguments = (ins
+    AnyRankedTensor:$input,
+    FlatSymbolRefAttr:$mesh,
+    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
+    DefaultValuedOptionalAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction
+  );
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+  let hasCanonicalizer = 1;
+  let extraClassDeclaration = extraClassDeclarationBase;
+}
+
+def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
+    SameOperandsAndResultElementType,
+    SameOperandsAndResultRank]> {
+  let summary = "All-to-all over a device mesh.";
+  let description = [{
+    Performs an all-to-all on tensor pieces split along `split_axis`.
+    The resulting pieces are concatenated along `concat_axis` on ech device.
+    Example:
+    ```
+    mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
+    ...
+    %1 = mesh.all_to_all %0 {
+        mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0, concat_axis = 0
+      } : tensor<3x6xi8> -> tensor<3x6xi8>
+    ```
+    Input:
+    ```
+     device  device  device
+     (0)     (1)     (2)
+    +-------+-------+-------+
+    | 11 12 | 21 22 | 31 32 |
+    | 13 14 | 23 24 | 33 34 |
+    | 15 16 | 25 26 | 35 36 |
+    +-------+-------+-------+
+    ```
+    Result:
+    ```
+     device  device  device
+     (0)     (1)     (2)
+    +-------+-------+-------+
+    | 11 12 | 13 14 | 15 16 |
+    | 21 22 | 23 24 | 25 26 |
+    | 31 32 | 33 34 | 35 36 |
+    +-------+-------+-------+
+    ```
+  }];
+  let arguments = (ins
+    AnyNon0RankedTensor:$input,
+    FlatSymbolRefAttr:$mesh,
+    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
+    APIntAttr:$split_axis,
+    APIntAttr:$concat_axis
+  );
+  let results = (outs
+    AnyNon0RankedTensor:$result
+  );
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+  let extraClassDeclaration = extraClassDeclarationBase;
+}
+
+def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", [
+    SameOperandsAndResultRank]> {
+  let summary = "Reduce-scatter over a device mesh.";
+  let description = [{
+    After the reduction scatters the result within each device group.
+    The tensor is split along `scatter_axis` and the pieces distributed
+    across the device group.
+    Example:
+    ```
+    mesh.cluster @mesh0(rank = 1, dim_sizes = [2, 2])
+    ...
+    %1 = mesh.reduce_scatter %0 {
+        mesh = @mesh0, mesh_axes = array<i16: 1>, reduction = #mesh.partial<max>, scatter_axis = 0
+      } : tensor<3x4xf32> -> tensor<1x4xf64>
+    ```
+    Input:
+    ```
+                     +-------+-------+
+    device (0, 0) -> |  1  2 |  5  6 | <- device (0, 1)
+                     |  3  4 |  7  8 |
+                     +-------+-------+
+    device (1, 0) -> |  9 10 | 13 14 | <- device (1, 1)
+                     | 11 12 | 15 16 |
+                     +-------+-------+
+    ```
+    Result:
+    ```
+    +-------+
+    |  6  8 | <- devices (0, 0)
+    +-------+
+    | 10 12 | <- devices (0, 1)
+    +-------+
+    | 22 24 | <- devices (1, 0)
+    +-------+
+    | 26 28 | <- devices (1, 1)
+    +-------+
+    ```
+  }];
+  let arguments = (ins
+    AnyNon0RankedTensor:$input,
+    FlatSymbolRefAttr:$mesh,
+    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
+    DefaultValuedOptionalAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction,
+    APIntAttr:$scatter_axis
+  );
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+  let hasCanonicalizer = 1;
+  let hasVerifier = 1;
+  let extraClassDeclaration = extraClassDeclarationBase;
 }
 
 #endif // MLIR_DIALECT_MESH_IR_MESHOPS_TD

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
@@ -80,6 +80,9 @@ def Mesh_ClusterOp : Mesh_Op<"cluster", [Symbol]> {
       attr-dict
   }];
   let extraClassDeclaration = [{
+    // The `dim_sizes` attribute may have size less than the rank of the mesh.
+    // Returns the shape of the mesh with missing trailing dimensions
+    // explicitly set as dynamic.
     ::mlir::SmallVector<int64_t> canonicalDimSizes();
 
     template <typename OutIt>

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
@@ -190,12 +190,12 @@ class Mesh_CollectiveCommunicationOpBase<
     string mnemonic, list<Trait> traits = []> :
     Mesh_Op<mnemonic,
       !listconcat(traits,
-      [SymbolUserOpInterface])> {
+      [DeclareOpInterfaceMethods<SymbolUserOpInterface>])> {
   let assemblyFormat = "$input attr-dict `:` type($input) `->` type($result)";
-  code extraClassDeclarationBase = [{
-    ::mlir::LogicalResult verifySymbolUses(
-          ::mlir::SymbolTableCollection &symbolTable);
-  }];
+  dag commonArgs = (ins
+    FlatSymbolRefAttr:$mesh,
+    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes
+  );
 }
 
 def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
@@ -237,18 +237,14 @@ def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
     +-------------+
     ```
   }];
-  let arguments = (ins
+  let arguments = !con(commonArgs, (ins
     AnyNon0RankedTensor:$input,
-    FlatSymbolRefAttr:$mesh,
-    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
     APIntAttr:$gather_axis
-  );
+  ));
   let results = (outs
     AnyNon0RankedTensor:$result
   );
-  let hasCanonicalizer = 1;
   let hasVerifier = 1;
-  let extraClassDeclaration = extraClassDeclarationBase;
 }
 
 def Mesh_AllReduceOp : Mesh_CollectiveCommunicationOpBase<"all_reduce", [
@@ -270,17 +266,14 @@ def Mesh_AllReduceOp : Mesh_CollectiveCommunicationOpBase<"all_reduce", [
       } : tensor<3x4xf32> -> tensor<3x4xf64>
     ```
   }];
-  let arguments = (ins
+  let arguments = !con(commonArgs, (ins
     AnyRankedTensor:$input,
-    FlatSymbolRefAttr:$mesh,
-    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
     DefaultValuedOptionalAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction
-  );
+  ));
   let results = (outs
     AnyRankedTensor:$result
   );
-  let hasCanonicalizer = 1;
-  let extraClassDeclaration = extraClassDeclarationBase;
+  let hasVerifier = 1;
 }
 
 def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
@@ -319,19 +312,15 @@ def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
     +-------+-------+-------+
     ```
   }];
-  let arguments = (ins
+  let arguments = !con(commonArgs, (ins
     AnyNon0RankedTensor:$input,
-    FlatSymbolRefAttr:$mesh,
-    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
     APIntAttr:$split_axis,
     APIntAttr:$concat_axis
-  );
+  ));
   let results = (outs
     AnyNon0RankedTensor:$result
   );
-  let hasCanonicalizer = 1;
   let hasVerifier = 1;
-  let extraClassDeclaration = extraClassDeclarationBase;
 }
 
 def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", [
@@ -372,19 +361,15 @@ def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", 
     +-------+
     ```
   }];
-  let arguments = (ins
+  let arguments = !con(commonArgs, (ins
     AnyNon0RankedTensor:$input,
-    FlatSymbolRefAttr:$mesh,
-    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes,
     DefaultValuedOptionalAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction,
     APIntAttr:$scatter_axis
-  );
+  ));
   let results = (outs
     AnyRankedTensor:$result
   );
-  let hasCanonicalizer = 1;
   let hasVerifier = 1;
-  let extraClassDeclaration = extraClassDeclarationBase;
 }
 
 #endif // MLIR_DIALECT_MESH_IR_MESHOPS_TD

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
@@ -251,6 +251,7 @@ def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
     attr-dict `:` type($input) `->` type($result)
   }];
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Mesh_AllReduceOp : Mesh_CollectiveCommunicationOpBase<"all_reduce", [
@@ -283,6 +284,7 @@ def Mesh_AllReduceOp : Mesh_CollectiveCommunicationOpBase<"all_reduce", [
     attr-dict `:` type($input) `->` type($result)
   }];
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
@@ -336,6 +338,7 @@ def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
     attr-dict `:` type($input) `->` type($result)
   }];
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", [
@@ -397,6 +400,7 @@ def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", 
     attr-dict `:` type($input) `->` type($result)
   }];
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 #endif // MLIR_DIALECT_MESH_IR_MESHOPS_TD

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
@@ -292,19 +292,20 @@ def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
   let description = [{
     Performs an all-to-all on tensor pieces split along `split_axis`.
     The resulting pieces are concatenated along `concat_axis` on ech device.
+
     Example:
     ```
     mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
     ...
     %1 = mesh.all_to_all %0 on @mesh0 mesh_axes = [0]
       split_axis = 0 concat_axis = 0
-      : tensor<3x6xi8> -> tensor<3x6xi8>
+      : tensor<3x2xi8> -> tensor<3x2xi8>
     ```
     Input:
     ```
      device  device  device
      (0)     (1)     (2)
-    +-------+-------+-------+  | split and concat
+    +-------+-------+-------+  | split and concat along
     | 11 12 | 21 22 | 31 32 |  | tensor axis 0
     | 13 14 | 23 24 | 33 34 |  ↓
     | 15 16 | 25 26 | 35 36 |

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
@@ -250,7 +250,6 @@ def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
     $input `on` $mesh (`mesh_axes` `=` $mesh_axes^)? `gather_axis` `=` $gather_axis
     attr-dict `:` type($input) `->` type($result)
   }];
-  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -283,7 +282,6 @@ def Mesh_AllReduceOp : Mesh_CollectiveCommunicationOpBase<"all_reduce", [
     $input `on` $mesh (`mesh_axes` `=` $mesh_axes^)? (`reduction` `=` $reduction^)?
     attr-dict `:` type($input) `->` type($result)
   }];
-  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -337,7 +335,6 @@ def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
     `concat_axis` `=` $concat_axis
     attr-dict `:` type($input) `->` type($result)
   }];
-  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -399,7 +396,6 @@ def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", 
     `scatter_axis` `=` $scatter_axis
     attr-dict `:` type($input) `->` type($result)
   }];
-  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 

--- a/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
+++ b/mlir/include/mlir/Dialect/Mesh/IR/MeshOps.td
@@ -191,10 +191,9 @@ class Mesh_CollectiveCommunicationOpBase<
     Mesh_Op<mnemonic,
       !listconcat(traits,
       [DeclareOpInterfaceMethods<SymbolUserOpInterface>])> {
-  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($result)";
   dag commonArgs = (ins
     FlatSymbolRefAttr:$mesh,
-    DefaultValuedOptionalAttr<DenseI16ArrayAttr, "{}">:$mesh_axes
+    DefaultValuedAttr<DenseI16ArrayAttr, "{}">:$mesh_axes
   );
 }
 
@@ -205,16 +204,13 @@ def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
   let summary = "All-gather over a device mesh.";
   let description = [{
     Gathers along the `gather_axis` tensor axis.
-    The order of input tensors in the resulting tensor is the same as the
-    order of the corresponding devices' multi-index in the mesh.
 
     Example:
     ```mlir
     mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 2])
     ...
-    %1 = mesh.all_gather %0 {
-        mesh = @mesh0, mesh_axes = array<i16: 1>, gather_axis = 1 : index
-      } : tensor<2x2xi8> -> tensor<2x4xi8>
+    %1 = mesh.all_gather %0 on @mesh0 mesh_axes = [1] gather_axis = 1
+      : tensor<2x2xi8> -> tensor<2x4xi8>
     ```
     Input:
     ```
@@ -228,6 +224,9 @@ def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
     ```
     Result:
     ```
+    gather tensor
+    axis 1
+    ------------>
     +-------------+
     |  1  2  5  6 | <- devices (0, 0) and (0, 1)
     |  3  4  7  8 |
@@ -239,11 +238,15 @@ def Mesh_AllGatherOp : Mesh_CollectiveCommunicationOpBase<"all_gather", [
   }];
   let arguments = !con(commonArgs, (ins
     AnyNon0RankedTensor:$input,
-    APIntAttr:$gather_axis
+    IndexAttr:$gather_axis
   ));
   let results = (outs
     AnyNon0RankedTensor:$result
   );
+  let assemblyFormat = [{
+    $input `on` $mesh (`mesh_axes` `=` $mesh_axes^)? `gather_axis` `=` $gather_axis
+    attr-dict `:` type($input) `->` type($result)
+  }];
   let hasVerifier = 1;
 }
 
@@ -261,18 +264,21 @@ def Mesh_AllReduceOp : Mesh_CollectiveCommunicationOpBase<"all_reduce", [
 
     Example:
     ```
-    %1 = mesh.all_reduce %0 {
-        mesh = @mesh0, mesh_axes = array<i16: 1, 0>, reduction = #mesh.partial<max>
-      } : tensor<3x4xf32> -> tensor<3x4xf64>
+    %1 = mesh.all_reduce %0 on @mesh0 mesh_axes = [1, 0] reduction = <max>
+      : tensor<3x4xf32> -> tensor<3x4xf64>
     ```
   }];
   let arguments = !con(commonArgs, (ins
     AnyRankedTensor:$input,
-    DefaultValuedOptionalAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction
+    DefaultValuedAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction
   ));
   let results = (outs
     AnyRankedTensor:$result
   );
+  let assemblyFormat = [{
+    $input `on` $mesh (`mesh_axes` `=` $mesh_axes^)? (`reduction` `=` $reduction^)?
+    attr-dict `:` type($input) `->` type($result)
+  }];
   let hasVerifier = 1;
 }
 
@@ -287,17 +293,17 @@ def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
     ```
     mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
     ...
-    %1 = mesh.all_to_all %0 {
-        mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0, concat_axis = 0
-      } : tensor<3x6xi8> -> tensor<3x6xi8>
+    %1 = mesh.all_to_all %0 on @mesh0 mesh_axes = [0]
+      split_axis = 0 concat_axis = 0
+      : tensor<3x6xi8> -> tensor<3x6xi8>
     ```
     Input:
     ```
      device  device  device
      (0)     (1)     (2)
-    +-------+-------+-------+
-    | 11 12 | 21 22 | 31 32 |
-    | 13 14 | 23 24 | 33 34 |
+    +-------+-------+-------+  | split and concat
+    | 11 12 | 21 22 | 31 32 |  | tensor axis 0
+    | 13 14 | 23 24 | 33 34 |  ↓
     | 15 16 | 25 26 | 35 36 |
     +-------+-------+-------+
     ```
@@ -314,12 +320,18 @@ def Mesh_AllToAllOp : Mesh_CollectiveCommunicationOpBase<"all_to_all", [
   }];
   let arguments = !con(commonArgs, (ins
     AnyNon0RankedTensor:$input,
-    APIntAttr:$split_axis,
-    APIntAttr:$concat_axis
+    IndexAttr:$split_axis,
+    IndexAttr:$concat_axis
   ));
   let results = (outs
     AnyNon0RankedTensor:$result
   );
+  let assemblyFormat = [{
+    $input `on` $mesh (`mesh_axes` `=` $mesh_axes^)?
+    `split_axis` `=` $split_axis
+    `concat_axis` `=` $concat_axis
+    attr-dict `:` type($input) `->` type($result)
+  }];
   let hasVerifier = 1;
 }
 
@@ -327,26 +339,32 @@ def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", 
     SameOperandsAndResultRank]> {
   let summary = "Reduce-scatter over a device mesh.";
   let description = [{
-    After the reduction scatters the result within each device group.
+    After the reduction, the result is scattered within each device group.
     The tensor is split along `scatter_axis` and the pieces distributed
     across the device group.
     Example:
     ```
     mesh.cluster @mesh0(rank = 1, dim_sizes = [2, 2])
     ...
-    %1 = mesh.reduce_scatter %0 {
-        mesh = @mesh0, mesh_axes = array<i16: 1>, reduction = #mesh.partial<max>, scatter_axis = 0
-      } : tensor<3x4xf32> -> tensor<1x4xf64>
+    %1 = mesh.reduce_scatter %0 on @mesh0 mesh_axes = [1]
+      reduction = <max> scatter_axis = 0
+      : tensor<3x4xf32> -> tensor<1x4xf64>
     ```
     Input:
     ```
+                              device
+                              (0, 1)
+                                 ↓
+                     +-------+-------+  | scatter tensor
+    device (0, 0) -> |  1  2 |  5  6 |  | axis 0
+                     |  3  4 |  7  8 |  ↓
                      +-------+-------+
-    device (0, 0) -> |  1  2 |  5  6 | <- device (0, 1)
-                     |  3  4 |  7  8 |
-                     +-------+-------+
-    device (1, 0) -> |  9 10 | 13 14 | <- device (1, 1)
+    device (1, 0) -> |  9 10 | 13 14 |
                      | 11 12 | 15 16 |
                      +-------+-------+
+                                ↑
+                              device
+                              (1, 1)
     ```
     Result:
     ```
@@ -363,12 +381,18 @@ def Mesh_ReduceScatterOp : Mesh_CollectiveCommunicationOpBase<"reduce_scatter", 
   }];
   let arguments = !con(commonArgs, (ins
     AnyNon0RankedTensor:$input,
-    DefaultValuedOptionalAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction,
-    APIntAttr:$scatter_axis
+    DefaultValuedAttr<Mesh_PartialAttr, "::mlir::mesh::Partial::Sum">:$reduction,
+    IndexAttr:$scatter_axis
   ));
   let results = (outs
     AnyRankedTensor:$result
   );
+  let assemblyFormat = [{
+    $input `on` $mesh (`mesh_axes` `=` $mesh_axes^)?
+    (`reduction` `=` $reduction^)?
+    `scatter_axis` `=` $scatter_axis
+    attr-dict `:` type($input) `->` type($result)
+  }];
   let hasVerifier = 1;
 }
 

--- a/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
+++ b/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
@@ -8,10 +8,26 @@
 
 #include "mlir/Dialect/Mesh/IR/MeshOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
 
 #define DEBUG_TYPE "mesh-ops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE << "]: ")
@@ -20,6 +36,60 @@ using namespace mlir;
 using namespace mlir::mesh;
 
 #include "mlir/Dialect/Mesh/IR/MeshOpsDialect.cpp.inc"
+
+namespace {
+
+template <typename It>
+It canonicalizeSetAsArray(It begin, It end) {
+  std::sort(begin, end);
+  return std::unique(begin, end);
+}
+
+template <typename R>
+auto canonicalizeSetAsArray(R &&range) {
+  return canonicalizeSetAsArray(adl_begin(range), adl_end(range));
+}
+
+template <typename T>
+SmallVector<T> &canonicalizeSetAsVector(SmallVector<T> &vec) {
+  auto newEnd = canonicalizeSetAsArray(vec);
+  vec.resize(newEnd - vec.begin());
+  return vec;
+}
+
+template <typename DimSize>
+bool isMeshDimensionDynamic(DimSize size) {
+  return size <= DimSize(0);
+}
+
+using MeshAxis = int16_t;
+
+struct DimensionSize {
+  static DimensionSize dynamic() { return DimensionSize(ShapedType::kDynamic); }
+  DimensionSize(int64_t val) : val(val) {}
+  int64_t value() const { return val; }
+  operator int64_t() const { return val; }
+  bool isDynamic() const { return ShapedType::isDynamic(val); }
+
+private:
+  int64_t val;
+};
+
+DimensionSize operator/(DimensionSize lhs, DimensionSize rhs) {
+  if (lhs.isDynamic() || rhs.isDynamic()) {
+    return DimensionSize::dynamic();
+  }
+  return lhs.value() / rhs.value();
+}
+
+DimensionSize operator*(DimensionSize lhs, DimensionSize rhs) {
+  if (lhs.isDynamic() || rhs.isDynamic()) {
+    return DimensionSize::dynamic();
+  }
+  return lhs.value() * rhs.value();
+}
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Mesh dialect
@@ -96,6 +166,12 @@ LogicalResult ClusterOp::verify() {
   return success();
 }
 
+SmallVector<int64_t> ClusterOp::canonicalDimSizes() {
+  SmallVector<int64_t> result;
+  canonicalDimSizes(std::back_inserter(result));
+  return result;
+}
+
 //===----------------------------------------------------------------------===//
 // mesh.shard op
 //===----------------------------------------------------------------------===//
@@ -127,6 +203,347 @@ MeshShardingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   if (failed(checkMeshAxis(partialAxes)))
     return failure();
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// collective communication ops
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+std::optional<DenseI16ArrayAttr>
+canonicalizeAxesSetAttribute(DenseI16ArrayAttr attr) {
+  if (!attr) {
+    return std::nullopt;
+  }
+  SmallVector<int16_t> axes = llvm::to_vector(attr.asArrayRef());
+  canonicalizeSetAsVector(axes);
+  if (axes.empty()) {
+    return std::nullopt;
+  }
+  return DenseI16ArrayAttr::get(attr.getContext(), axes);
+}
+
+template <typename Op>
+struct AxesSetCanonicalizationPattern : OpRewritePattern<Op> {
+  AxesSetCanonicalizationPattern(MLIRContext *context, StringRef axisSetAttr)
+      : OpRewritePattern<Op>(context), axisSetAttr(axisSetAttr) {}
+  LogicalResult matchAndRewrite(Op op,
+                                PatternRewriter &rewriter) const override {
+    auto canonicalMeshAxesAttr = canonicalizeAxesSetAttribute(
+        op->template getAttrOfType<DenseI16ArrayAttr>(axisSetAttr));
+    if (!canonicalMeshAxesAttr) {
+      op->removeAttr(axisSetAttr);
+    } else {
+      op->setAttr(axisSetAttr, canonicalMeshAxesAttr.value());
+    }
+    return success();
+  }
+
+  std::string axisSetAttr;
+};
+
+template <typename Op>
+void populateMeshAxesSetCanonicalizationPatterns(RewritePatternSet &patterns,
+                                                 MLIRContext *context) {
+  patterns.add<AxesSetCanonicalizationPattern<Op>>(context, "mesh_axes");
+}
+
+template <typename Op>
+LogicalResult verifyMeshSymbolUses(Op op, SymbolTableCollection &symbolTable) {
+  FlatSymbolRefAttr symbolAttr = op.getMeshAttr();
+  if (!symbolAttr) {
+    return op.emitError() << "Unspecified \"mesh\" symbol attribute.";
+  }
+  SymbolTableCollection symbolTableCollection;
+  mesh::ClusterOp mesh =
+      symbolTableCollection.lookupNearestSymbolFrom<mesh::ClusterOp>(
+          op.getOperation(), symbolAttr);
+  if (!mesh) {
+    return op.emitError() << "Undefined required mesh symbol \""
+                          << symbolAttr.getValue() << "\".";
+  }
+  DenseI16ArrayAttr meshAxes = op.getMeshAxesAttr();
+  if (!meshAxes) {
+    return success();
+  }
+  MeshAxis rank = mesh.getRank();
+  for (auto axis : meshAxes.asArrayRef()) {
+    if (axis >= rank || axis < 0) {
+      return op.emitError()
+             << "0-based mesh axis index " << axis
+             << " is out of bounds. The referenced mesh \""
+             << symbolAttr.getValue() << "\" is of rank " << rank << ".";
+    }
+  }
+
+  return success();
+}
+
+template <typename It>
+auto product(It begin, It end) {
+  using ElementType = std::decay_t<decltype(*begin)>;
+  return std::accumulate(begin, end, ElementType(1),
+                         std::multiplies<ElementType>());
+}
+
+template <typename R>
+auto product(R &&range) {
+  return product(adl_begin(range), adl_end(range));
+}
+
+int64_t collectiveDeviceGroupSize(ArrayRef<MeshAxis> meshAxes,
+                                  ArrayRef<int64_t> meshShape) {
+  int64_t res = 1;
+  for (MeshAxis axis = 0; axis < MeshAxis(meshShape.size()); ++axis) {
+    if (llvm::find(meshAxes, axis) == meshAxes.end()) {
+      continue;
+    }
+    if (isMeshDimensionDynamic(meshShape[axis])) {
+      return ShapedType::kDynamic;
+    }
+    res *= meshShape[axis];
+  }
+  return res;
+}
+
+LogicalResult verifyDimensionCompatibility(Location loc,
+                                           int64_t expectedDimSize,
+                                           int64_t resultDimSize,
+                                           int64_t resultAxis) {
+  if (!ShapedType::isDynamic(resultDimSize) &&
+      expectedDimSize != resultDimSize) {
+    return emitError(loc) << "Dimension size mismatch for result axis "
+                          << resultAxis << ". Expected "
+                          << (ShapedType::isDynamic(expectedDimSize)
+                                  ? Twine("dynamic")
+                                  : Twine(expectedDimSize))
+                          << ", but got " << resultDimSize << ".";
+  }
+
+  return success();
+}
+
+LogicalResult verifyGatherOperandAndResultShape(Value operand, Value result,
+                                                int64_t gatherAxis,
+                                                ArrayRef<MeshAxis> meshAxes,
+                                                ArrayRef<int64_t> meshShape) {
+  ShapedType operandType = operand.getType().cast<ShapedType>();
+  ShapedType resultType = result.getType().cast<ShapedType>();
+  auto deviceGroupSize =
+      DimensionSize(collectiveDeviceGroupSize(meshAxes, meshShape));
+  for (int64_t axis = 0; axis < operandType.getRank(); ++axis) {
+    auto operandDimSize = DimensionSize(operandType.getDimSize(axis));
+    auto resultDimSize = DimensionSize(resultType.getDimSize(axis));
+    auto expectedResultDimSize =
+        axis == gatherAxis ? deviceGroupSize * operandDimSize : operandDimSize;
+    if (failed(verifyDimensionCompatibility(
+            result.getLoc(), expectedResultDimSize, resultDimSize, axis))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+template <typename Op>
+FailureOr<ClusterOp> getMesh(Op op) {
+  SymbolTableCollection symbolTableCollection;
+  if (failed(verifyMeshSymbolUses(op, symbolTableCollection))) {
+    // We need to check the symbol here since this runs before
+    // SymbolUserOpInterface.
+    return failure();
+  }
+  return symbolTableCollection.lookupNearestSymbolFrom<mesh::ClusterOp>(
+      op.getOperation(), op.getMeshAttr());
+}
+
+template <typename Op>
+LogicalResult verifyGather(Op op) {
+  auto rank = op.getResult().getType().template cast<ShapedType>().getRank();
+  auto gatherAxis = op.getGatherAxis().getSExtValue();
+  if (gatherAxis < 0 || gatherAxis >= rank) {
+    return op.emitError() << "Gather axis " << gatherAxis
+                          << " is out of bounds [0, " << rank << ").";
+  }
+
+  auto mesh = getMesh(op);
+  if (failed(mesh)) {
+    return failure();
+  }
+  return verifyGatherOperandAndResultShape(op.getOperand(), op.getResult(),
+                                           gatherAxis, op.getMeshAxes(),
+                                           mesh.value().canonicalDimSizes());
+}
+
+LogicalResult verifyAllToAllOperandAndResultShape(Value operand, Value result,
+                                                  int64_t splitAxis,
+                                                  int64_t concatAxis,
+                                                  ArrayRef<MeshAxis> meshAxes,
+                                                  ArrayRef<int64_t> meshShape) {
+  ShapedType operandType = operand.getType().cast<ShapedType>();
+  ShapedType resultType = result.getType().cast<ShapedType>();
+  for (int64_t axis = 0; axis < operandType.getRank(); ++axis) {
+    if ((axis != splitAxis && axis != concatAxis) || splitAxis == concatAxis) {
+      if (failed(verifyDimensionCompatibility(
+              result.getLoc(), operandType.getDimSize(axis),
+              resultType.getDimSize(axis), axis))) {
+        return failure();
+      }
+    }
+  }
+
+  if (splitAxis == concatAxis) {
+    return success();
+  }
+
+  auto deviceGroupSize =
+      DimensionSize(collectiveDeviceGroupSize(meshAxes, meshShape));
+  auto operandConcatDimSize = DimensionSize(operandType.getDimSize(concatAxis));
+  auto operandSplitDimSize = DimensionSize(operandType.getDimSize(splitAxis));
+  if (!operandSplitDimSize.isDynamic() && !deviceGroupSize.isDynamic() &&
+      int64_t(operandSplitDimSize) % int64_t(deviceGroupSize) != 0) {
+    return emitError(result.getLoc())
+           << "Operand dimension size " << int64_t(operandSplitDimSize)
+           << " is not divisible by collective device group size "
+           << int64_t(deviceGroupSize) << " for split axis " << splitAxis
+           << ".";
+  }
+  DimensionSize expectedResultConcatDimSize =
+      operandConcatDimSize * deviceGroupSize;
+  DimensionSize expectedResultSplitDimSize =
+      operandSplitDimSize / deviceGroupSize;
+  if (failed(verifyDimensionCompatibility(
+          result.getLoc(), expectedResultConcatDimSize.value(),
+          resultType.getDimSize(concatAxis), concatAxis))) {
+    return failure();
+  }
+  if (failed(verifyDimensionCompatibility(
+          result.getLoc(), expectedResultSplitDimSize.value(),
+          resultType.getDimSize(splitAxis), splitAxis))) {
+    return failure();
+  }
+
+  return success();
+}
+
+LogicalResult verifyReduceScatterOperandAndResultShape(
+    Value operand, Value result, int64_t scatterAxis,
+    ArrayRef<MeshAxis> meshAxes, ArrayRef<int64_t> meshShape) {
+  ShapedType operandType = operand.getType().cast<ShapedType>();
+  ShapedType resultType = result.getType().cast<ShapedType>();
+  for (int64_t axis = 0; axis < operandType.getRank(); ++axis) {
+    if (axis != scatterAxis) {
+      if (failed(verifyDimensionCompatibility(
+              result.getLoc(), operandType.getDimSize(axis),
+              resultType.getDimSize(axis), axis))) {
+        return failure();
+      }
+    }
+  }
+
+  auto deviceGroupSize =
+      DimensionSize(collectiveDeviceGroupSize(meshAxes, meshShape));
+  auto operandScatterDimSize =
+      DimensionSize(operandType.getDimSize(scatterAxis));
+  if (!operandScatterDimSize.isDynamic() && !deviceGroupSize.isDynamic() &&
+      int64_t(operandScatterDimSize) % int64_t(deviceGroupSize) != 0) {
+    return emitError(result.getLoc())
+           << "Operand dimension size " << int64_t(operandScatterDimSize)
+           << " is not divisible by collective device group size "
+           << int64_t(deviceGroupSize) << " for scatter axis " << scatterAxis
+           << ".";
+  }
+  DimensionSize expectedResultScatterDimSize =
+      operandScatterDimSize / deviceGroupSize;
+  if (failed(verifyDimensionCompatibility(
+          result.getLoc(), expectedResultScatterDimSize.value(),
+          resultType.getDimSize(scatterAxis), scatterAxis))) {
+    return failure();
+  }
+
+  return success();
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// mesh.all_reduce op
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+mlir::mesh::AllReduceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyMeshSymbolUses(*this, symbolTable);
+}
+
+void mlir::mesh::AllReduceOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  populateMeshAxesSetCanonicalizationPatterns<AllReduceOp>(patterns, context);
+}
+
+//===----------------------------------------------------------------------===//
+// mesh.all_gather op
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+mlir::mesh::AllGatherOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyMeshSymbolUses(*this, symbolTable);
+}
+
+void mlir::mesh::AllGatherOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  populateMeshAxesSetCanonicalizationPatterns<AllGatherOp>(patterns, context);
+}
+
+LogicalResult mlir::mesh::AllGatherOp::verify() { return verifyGather(*this); }
+
+//===----------------------------------------------------------------------===//
+// mesh.all_to_all op
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+mlir::mesh::AllToAllOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyMeshSymbolUses(*this, symbolTable);
+}
+
+void mlir::mesh::AllToAllOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  populateMeshAxesSetCanonicalizationPatterns<AllToAllOp>(patterns, context);
+}
+
+LogicalResult mlir::mesh::AllToAllOp::verify() {
+  auto mesh = ::getMesh(*this);
+  if (failed(mesh)) {
+    return failure();
+  }
+  return verifyAllToAllOperandAndResultShape(
+      getOperand(), getResult(), getSplitAxis().getSExtValue(),
+      getConcatAxis().getSExtValue(), getMeshAxes(),
+      mesh.value().canonicalDimSizes());
+}
+
+//===----------------------------------------------------------------------===//
+// mesh.reduce_scatter op
+//===----------------------------------------------------------------------===//
+
+LogicalResult mlir::mesh::ReduceScatterOp::verifySymbolUses(
+    SymbolTableCollection &symbolTable) {
+  return verifyMeshSymbolUses(*this, symbolTable);
+}
+
+void mlir::mesh::ReduceScatterOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  populateMeshAxesSetCanonicalizationPatterns<ReduceScatterOp>(patterns,
+                                                               context);
+}
+
+LogicalResult mlir::mesh::ReduceScatterOp::verify() {
+  auto mesh = ::getMesh(*this);
+  if (failed(mesh)) {
+    return failure();
+  }
+  return verifyReduceScatterOperandAndResultShape(
+      getOperand(), getResult(), getScatterAxis().getSExtValue(), getMeshAxes(),
+      mesh.value().canonicalDimSizes());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
+++ b/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
@@ -249,9 +249,6 @@ static LogicalResult verifyMeshSymbolUses(Operation *op,
     return op->emitError() << "Undefined required mesh symbol \""
                            << meshSymbol.getValue() << "\".";
   }
-  if (!meshAxes) {
-    return success();
-  }
   MeshAxis rank = mesh.getRank();
   for (auto axis : meshAxes.asArrayRef()) {
     if (axis >= rank || axis < 0) {

--- a/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
+++ b/mlir/lib/Dialect/Mesh/IR/MeshOps.cpp
@@ -391,18 +391,14 @@ static LogicalResult verifyAllToAllOperandAndResultShape(
       DimensionSize(collectiveDeviceGroupSize(meshAxes, meshShape));
   auto operandConcatDimSize = DimensionSize(operandType.getDimSize(concatAxis));
   auto operandSplitDimSize = DimensionSize(operandType.getDimSize(splitAxis));
-  if (!operandSplitDimSize.isDynamic() && !deviceGroupSize.isDynamic() &&
-      int64_t(operandSplitDimSize) % int64_t(deviceGroupSize) != 0) {
-    return emitError(result.getLoc())
-           << "Operand dimension size " << int64_t(operandSplitDimSize)
-           << " is not divisible by collective device group size "
-           << int64_t(deviceGroupSize) << " for split axis " << splitAxis
-           << ".";
-  }
   DimensionSize expectedResultConcatDimSize =
       operandConcatDimSize * deviceGroupSize;
   DimensionSize expectedResultSplitDimSize =
       operandSplitDimSize / deviceGroupSize;
+  if (!expectedResultSplitDimSize.isDynamic() &&
+      int64_t(operandSplitDimSize) % int64_t(deviceGroupSize) != 0) {
+    expectedResultSplitDimSize = DimensionSize::dynamic();
+  }
   if (failed(verifyDimensionCompatibility(
           result.getLoc(), expectedResultConcatDimSize.value(),
           resultType.getDimSize(concatAxis), concatAxis))) {

--- a/mlir/test/Dialect/Mesh/canonicalization.mlir
+++ b/mlir/test/Dialect/Mesh/canonicalization.mlir
@@ -1,0 +1,72 @@
+// RUN: mlir-opt --canonicalize %s | FileCheck %s
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
+
+// CHECK-LABEL: func @all_reduce_mesh_axes
+func.func @all_reduce_mesh_axes(
+    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+// CHECK: mesh_axes = array<i16: 0, 1>
+  %0 = mesh.all_reduce %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 1, 0, 0>, reduction = #mesh.partial<sum>
+    } : tensor<4xf32> -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+// CHECK-LABEL: func @all_reduce_empty_mesh_axes_and_default_reduction
+func.func @all_reduce_empty_mesh_axes_and_default_reduction(
+    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+  %0 = mesh.all_reduce %arg0 {
+    mesh = @mesh0,
+// CHECK-NOT: mesh_axes
+    mesh_axes = array<i16>,
+// CHECK-NOT: reduction
+    reduction = #mesh.partial<sum>
+    } : tensor<4xf32> -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+// CHECK-LABEL: func @all_gather_empty_mesh_axes
+func.func @all_gather_empty_mesh_axes(
+    %arg0 : tensor<4xf32>) -> tensor<4xf32> {
+  %0 = mesh.all_gather %arg0 {
+    gather_axis = 0 : index,
+    mesh = @mesh0,
+// CHECK-NOT: mesh_axes
+    mesh_axes = array<i16>
+    } : tensor<4xf32> -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// CHECK-LABEL: func @all_gather_mesh_axes
+func.func @all_gather_mesh_axes(
+    %arg0 : tensor<4xf32>) -> tensor<32xf32> {
+// CHECK: mesh_axes = array<i16: 0, 1>
+  %0 = mesh.all_gather %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 1, 0, 0>, gather_axis = 0
+    } : tensor<4xf32> -> tensor<32xf32>
+  return %0 : tensor<32xf32>
+}
+
+// CHECK-LABEL: func @reduce_scatter_mesh_axes
+func.func @reduce_scatter_mesh_axes(
+    %arg0 : tensor<8xf32>) -> tensor<1xf64> {
+// CHECK: mesh_axes = array<i16: 0, 1>
+  %0 = mesh.reduce_scatter %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 1, 0, 0>, scatter_axis = 0
+    } : tensor<8xf32> -> tensor<1xf64>
+  return %0 : tensor<1xf64>
+}
+
+// CHECK-LABEL: func @reduce_scatter_empty_mesh_axes_and_default_reduction
+func.func @reduce_scatter_empty_mesh_axes_and_default_reduction(
+    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+  %0 = mesh.reduce_scatter %arg0 {
+    mesh = @mesh0,
+// CHECK-NOT: mesh_axes
+    mesh_axes = array<i16>,
+// CHECK-NOT: reduction
+    reduction = #mesh.partial<sum>,
+    scatter_axis = 0
+    } : tensor<4xf32> -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}

--- a/mlir/test/Dialect/Mesh/canonicalization.mlir
+++ b/mlir/test/Dialect/Mesh/canonicalization.mlir
@@ -2,15 +2,6 @@
 
 mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 
-// CHECK-LABEL: func @all_reduce_mesh_axes
-func.func @all_reduce_mesh_axes(
-    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
-// CHECK: mesh_axes = array<i16: 0, 1>
-  %0 = mesh.all_reduce %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 1, 0, 0>, reduction = #mesh.partial<sum>
-    } : tensor<4xf32> -> tensor<4xf64>
-  return %0 : tensor<4xf64>
-}
 
 // CHECK-LABEL: func @all_reduce_empty_mesh_axes_and_default_reduction
 func.func @all_reduce_empty_mesh_axes_and_default_reduction(
@@ -35,26 +26,6 @@ func.func @all_gather_empty_mesh_axes(
     mesh_axes = array<i16>
     } : tensor<4xf32> -> tensor<4xf32>
   return %0 : tensor<4xf32>
-}
-
-// CHECK-LABEL: func @all_gather_mesh_axes
-func.func @all_gather_mesh_axes(
-    %arg0 : tensor<4xf32>) -> tensor<32xf32> {
-// CHECK: mesh_axes = array<i16: 0, 1>
-  %0 = mesh.all_gather %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 1, 0, 0>, gather_axis = 0
-    } : tensor<4xf32> -> tensor<32xf32>
-  return %0 : tensor<32xf32>
-}
-
-// CHECK-LABEL: func @reduce_scatter_mesh_axes
-func.func @reduce_scatter_mesh_axes(
-    %arg0 : tensor<8xf32>) -> tensor<1xf64> {
-// CHECK: mesh_axes = array<i16: 0, 1>
-  %0 = mesh.reduce_scatter %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 1, 0, 0>, scatter_axis = 0
-    } : tensor<8xf32> -> tensor<1xf64>
-  return %0 : tensor<1xf64>
 }
 
 // CHECK-LABEL: func @reduce_scatter_empty_mesh_axes_and_default_reduction

--- a/mlir/test/Dialect/Mesh/canonicalization.mlir
+++ b/mlir/test/Dialect/Mesh/canonicalization.mlir
@@ -2,13 +2,34 @@
 
 mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 
+// CHECK-LABEL: func @all_reduce_empty_mesh_axes
+func.func @all_reduce_empty_mesh_axes(
+// CHECK-SAME: %[[ARG:.*]]: tensor<4xf32>
+    %arg0 : tensor<4xf32>) -> tensor<4xf32> {
+// CHECK-NOT: mesh.all_reduce
+  %0 = mesh.all_reduce %arg0 on @mesh0
+    mesh_axes = []
+    : tensor<4xf32> -> tensor<4xf32>
+// CHECK: return %[[ARG]]
+  return %0 : tensor<4xf32>
+}
 
-// CHECK-LABEL: func @all_reduce_empty_mesh_axes_and_default_reduction
-func.func @all_reduce_empty_mesh_axes_and_default_reduction(
+// CHECK-LABEL: func @all_reduce_empty_mesh_axes_different_return_type
+func.func @all_reduce_empty_mesh_axes_different_return_type(
     %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+// CHECK: mesh.all_reduce
   %0 = mesh.all_reduce %arg0 on @mesh0
 // CHECK-NOT: mesh_axes
     mesh_axes = []
+    : tensor<4xf32> -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+// CHECK-LABEL: func @all_reduce_default_reduction
+func.func @all_reduce_default_reduction(
+    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+  %0 = mesh.all_reduce %arg0 on @mesh0
+    mesh_axes = [0]
 // CHECK-NOT: reduction
     reduction = <sum>
     : tensor<4xf32> -> tensor<4xf64>
@@ -17,36 +38,64 @@ func.func @all_reduce_empty_mesh_axes_and_default_reduction(
 
 // CHECK-LABEL: func @all_to_all_empty_mesh_axes
 func.func @all_to_all_empty_mesh_axes(
+// CHECK-SAME: %[[ARG:.*]]: tensor<8xf32>
     %arg0 : tensor<8xf32>) -> tensor<8xf32> {
+// CHECK-NOT: mesh.all_to_all
   %0 = mesh.all_to_all %arg0 on @mesh0
-// CHECK-NOT: mesh_axes
     mesh_axes = []
     split_axis = 0
     concat_axis = 0
     : tensor<8xf32> -> tensor<8xf32>
+// CHECK: return %[[ARG]]
   return %0 : tensor<8xf32>
 }
 
 // CHECK-LABEL: func @all_gather_empty_mesh_axes
 func.func @all_gather_empty_mesh_axes(
+// CHECK-SAME: %[[ARG:.*]]: tensor<4xf32>
     %arg0 : tensor<4xf32>) -> tensor<4xf32> {
+// CHECK-NOT: mesh.all_gather
   %0 = mesh.all_gather %arg0 on @mesh0
-// CHECK-NOT: mesh_axes
     mesh_axes = []
     gather_axis = 0
     : tensor<4xf32> -> tensor<4xf32>
+// CHECK: return %[[ARG]]
   return %0 : tensor<4xf32>
 }
 
-// CHECK-LABEL: func @reduce_scatter_empty_mesh_axes_and_default_reduction
-func.func @reduce_scatter_empty_mesh_axes_and_default_reduction(
+// CHECK-LABEL: func @reduce_scatter_empty_mesh_axes
+func.func @reduce_scatter_empty_mesh_axes(
+// CHECK-SAME: %[[ARG:.*]]: tensor<4xf32>
+    %arg0 : tensor<4xf32>) -> tensor<4xf32> {
+// CHECK-NOT: mesh.reduce_scatter
+  %0 = mesh.reduce_scatter %arg0 on @mesh0
+    mesh_axes = []
+    scatter_axis = 0
+    : tensor<4xf32> -> tensor<4xf32>
+// CHECK: return %[[ARG]]
+  return %0 : tensor<4xf32>
+}
+
+// CHECK-LABEL: func @reduce_scatter_empty_mesh_axes_different_return_type
+func.func @reduce_scatter_empty_mesh_axes_different_return_type(
     %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+// CHECK: mesh.reduce_scatter
   %0 = mesh.reduce_scatter %arg0 on @mesh0
 // CHECK-NOT: mesh_axes
     mesh_axes = []
-// CHECK-NOT: reduction
-    reduction = <sum>
     scatter_axis = 0
     : tensor<4xf32> -> tensor<4xf64>
   return %0 : tensor<4xf64>
+}
+
+// CHECK-LABEL: func @reduce_scatter_default_reduction
+func.func @reduce_scatter_default_reduction(
+    %arg0 : tensor<4xf32>) -> tensor<2xf64> {
+  %0 = mesh.reduce_scatter %arg0 on @mesh0
+    mesh_axes = [0]
+// CHECK-NOT: reduction
+    reduction = <sum>
+    scatter_axis = 0
+    : tensor<4xf32> -> tensor<2xf64>
+  return %0 : tensor<2xf64>
 }

--- a/mlir/test/Dialect/Mesh/canonicalization.mlir
+++ b/mlir/test/Dialect/Mesh/canonicalization.mlir
@@ -6,38 +6,35 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 // CHECK-LABEL: func @all_reduce_empty_mesh_axes_and_default_reduction
 func.func @all_reduce_empty_mesh_axes_and_default_reduction(
     %arg0 : tensor<4xf32>) -> tensor<4xf64> {
-  %0 = mesh.all_reduce %arg0 {
-    mesh = @mesh0,
+  %0 = mesh.all_reduce %arg0 on @mesh0
 // CHECK-NOT: mesh_axes
-    mesh_axes = array<i16>,
+    mesh_axes = []
 // CHECK-NOT: reduction
-    reduction = #mesh.partial<sum>
-    } : tensor<4xf32> -> tensor<4xf64>
+    reduction = <sum>
+    : tensor<4xf32> -> tensor<4xf64>
   return %0 : tensor<4xf64>
 }
 
 // CHECK-LABEL: func @all_gather_empty_mesh_axes
 func.func @all_gather_empty_mesh_axes(
     %arg0 : tensor<4xf32>) -> tensor<4xf32> {
-  %0 = mesh.all_gather %arg0 {
-    gather_axis = 0 : index,
-    mesh = @mesh0,
+  %0 = mesh.all_gather %arg0 on @mesh0
 // CHECK-NOT: mesh_axes
-    mesh_axes = array<i16>
-    } : tensor<4xf32> -> tensor<4xf32>
+    mesh_axes = []
+    gather_axis = 0
+    : tensor<4xf32> -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
 // CHECK-LABEL: func @reduce_scatter_empty_mesh_axes_and_default_reduction
 func.func @reduce_scatter_empty_mesh_axes_and_default_reduction(
     %arg0 : tensor<4xf32>) -> tensor<4xf64> {
-  %0 = mesh.reduce_scatter %arg0 {
-    mesh = @mesh0,
+  %0 = mesh.reduce_scatter %arg0 on @mesh0
 // CHECK-NOT: mesh_axes
-    mesh_axes = array<i16>,
+    mesh_axes = []
 // CHECK-NOT: reduction
-    reduction = #mesh.partial<sum>,
+    reduction = <sum>
     scatter_axis = 0
-    } : tensor<4xf32> -> tensor<4xf64>
+    : tensor<4xf32> -> tensor<4xf64>
   return %0 : tensor<4xf64>
 }

--- a/mlir/test/Dialect/Mesh/canonicalization.mlir
+++ b/mlir/test/Dialect/Mesh/canonicalization.mlir
@@ -15,6 +15,18 @@ func.func @all_reduce_empty_mesh_axes_and_default_reduction(
   return %0 : tensor<4xf64>
 }
 
+// CHECK-LABEL: func @all_to_all_empty_mesh_axes
+func.func @all_to_all_empty_mesh_axes(
+    %arg0 : tensor<8xf32>) -> tensor<8xf32> {
+  %0 = mesh.all_to_all %arg0 on @mesh0
+// CHECK-NOT: mesh_axes
+    mesh_axes = []
+    split_axis = 0
+    concat_axis = 0
+    : tensor<8xf32> -> tensor<8xf32>
+  return %0 : tensor<8xf32>
+}
+
 // CHECK-LABEL: func @all_gather_empty_mesh_axes
 func.func @all_gather_empty_mesh_axes(
     %arg0 : tensor<4xf32>) -> tensor<4xf32> {

--- a/mlir/test/Dialect/Mesh/invalid.mlir
+++ b/mlir/test/Dialect/Mesh/invalid.mlir
@@ -67,3 +67,243 @@ func.func @mesh_axis_negtive_in_partial(
             tensor<4x8xf32, #mesh.shard<@mesh0, [[0]], partial=max[-1]>> {
   return %arg0 : tensor<4x8xf32, #mesh.shard<@mesh0, [[0]], partial=max[-1]>>
 }
+
+// -----
+
+func.func @all_reduce_invalid_mesh_symbol(
+    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+  // expected-error@+1 {{Undefined required mesh symbol "this_mesh_symbol_does_not_exist".}}
+  %0 = mesh.all_reduce %arg0 {
+    mesh = @this_mesh_symbol_does_not_exist, reduction = #mesh.partial<sum>
+    } : tensor<4xf32> -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
+
+func.func @all_reduce_invalid_mesh_axis(
+    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+  // expected-error@+1 {{0-based mesh axis index 2 is out of bounds. The referenced mesh "mesh0" is of rank 2.}}
+  %0 = mesh.all_reduce %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 2>, reduction = #mesh.partial<sum>
+    } : tensor<4xf32> -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
+
+func.func @all_reduce_invalid_tensor_dimension_size(
+    %arg0 : tensor<4xf32>) -> tensor<5xf64> {
+  // expected-error@+1 {{'mesh.all_reduce' op requires the same shape for all operands and results}}
+  %0 = mesh.all_reduce %arg0 { mesh = @mesh0 } : tensor<4xf32> -> tensor<5xf64>
+  return %0 : tensor<5xf64>
+}
+
+// -----
+
+func.func @all_gather_invalid_mesh_symbol(
+    %arg0 : tensor<4xf32>) -> tensor<4xf32> {
+  // expected-error@+1 {{Undefined required mesh symbol "this_mesh_symbol_does_not_exist".}}
+  %0 = mesh.all_gather %arg0 {
+    mesh = @this_mesh_symbol_does_not_exist, gather_axis = 0 : index
+    } : tensor<4xf32> -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
+
+func.func @all_gather_invalid_mesh_axis(
+    %arg0 : tensor<4xf32>) -> tensor<4xf32> {
+  // expected-error@+1 {{0-based mesh axis index 2 is out of bounds. The referenced mesh "mesh0" is of rank 2.}}
+  %0 = mesh.all_gather %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 2>, gather_axis = 0 : index
+    } : tensor<4xf32> -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
+
+func.func @all_gather_invalid_non_gather_axis_dimension_size(
+    %arg0 : tensor<3x4xf32>) -> tensor<3x5xf32> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected 4, but got 5.}}
+  %0 = mesh.all_gather %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 0>, gather_axis = 0 : index
+    } : tensor<3x4xf32> -> tensor<3x5xf32>
+  return %0 : tensor<3x5xf32>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [1, 2])
+
+func.func @all_gather_invalid_gather_axis_dimension_size(
+    %arg0 : tensor<3x4xf32>) -> tensor<3x5xf32> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected 8, but got 5.}}
+  %0 = mesh.all_gather %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 1>, gather_axis = 1 : index
+    } : tensor<3x4xf32> -> tensor<3x5xf32>
+  return %0 : tensor<3x5xf32>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
+
+func.func @all_gather_invalid_gather_axis_dynamic_dimension(
+    %arg0 : tensor<?xf32>) -> tensor<3xf32> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected dynamic, but got 3.}}
+  %0 = mesh.all_gather %arg0 {
+    gather_axis = 0 : index,
+    mesh = @mesh0
+    } : tensor<?xf32> -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
+
+func.func @all_gather_invalid_gather_axis(
+    %arg0 : tensor<3xf32>) -> tensor<3xf32> {
+  // expected-error@+1 {{Gather axis 1 is out of bounds [0, 1).}}
+  %0 = mesh.all_gather %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 0>, gather_axis = 1 : index
+    } : tensor<3xf32> -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
+
+func.func @all_gather_invalid_negative_gather_axis(
+    %arg0 : tensor<3xf32>) -> tensor<3xf32> {
+  // expected-error@+1 {{Gather axis -1 is out of bounds [0, 1).}}
+  %0 = mesh.all_gather %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 0>, gather_axis = -1 : index
+    } : tensor<3xf32> -> tensor<3xf32>
+  return %0 : tensor<3xf32>
+}
+
+// -----
+
+func.func @all_to_all_gather_invalid_mesh_symbol(
+    %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
+  // expected-error@+1 {{Undefined required mesh symbol "this_mesh_symbol_does_not_exist".}}
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 0, mesh = @this_mesh_symbol_does_not_exist, split_axis = 1
+    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  return %0 : tensor<3x6xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [0, 1])
+
+func.func @all_to_all_invalid_non_dynamic_result_dimension_induced_by_dynamic_device_group(
+    %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected dynamic, but got 6.}}
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0
+    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  return %0 : tensor<3x6xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [1, 1])
+
+func.func @all_to_all_invalid_non_dynamic_result_split_dimension_induced_by_dynamic_operand_dimension(
+    %arg0 : tensor<?x6xi8>) -> tensor<3x?xi8> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected dynamic, but got 3.}}
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 1>, split_axis = 0
+    } : tensor<?x6xi8> -> tensor<3x?xi8>
+  return %0 : tensor<3x?xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [1, 1])
+
+func.func @all_to_all_invalid_non_dynamic_result_concat_dimension_induced_by_dynamic_operand_dimension(
+    %arg0 : tensor<3x?xi8>) -> tensor<?x3xi8> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected dynamic, but got 3.}}
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 1>, split_axis = 0
+    } : tensor<3x?xi8> -> tensor<?x3xi8>
+  return %0 : tensor<?x3xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
+
+func.func @all_to_all_invalid_non_dynamic_result_concat_dimension_size(
+    %arg0 : tensor<3x2xi8>) -> tensor<1x7xi8> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected 6, but got 7.}}
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0
+    } : tensor<3x2xi8> -> tensor<1x7xi8>
+  return %0 : tensor<1x7xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
+
+func.func @all_to_all_invalid_non_dynamic_result_split_dimension_size(
+    %arg0 : tensor<3x2xi8>) -> tensor<2x6xi8> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected 1, but got 2.}}
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0
+    } : tensor<3x2xi8> -> tensor<2x6xi8>
+  return %0 : tensor<2x6xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
+
+func.func @reduce_scatter_invalid_dynamic_dimension(
+    %arg0 : tensor<?xf32>) -> tensor<2xf64> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected dynamic, but got 2.}}
+  %0 = mesh.reduce_scatter %arg0 {
+      mesh = @mesh0, scatter_axis = 0
+    } : tensor<?xf32> -> tensor<2xf64>
+  return %0 : tensor<2xf64>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
+
+func.func @reduce_scatter_invalid_static_dimension_size(
+    %arg0 : tensor<3xf32>) -> tensor<2xf64> {
+  // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected 1, but got 2.}}
+  %0 = mesh.reduce_scatter %arg0 {
+      mesh = @mesh0, mesh_axes = array<i16: 0>, scatter_axis = 0
+    } : tensor<3xf32> -> tensor<2xf64>
+  return %0 : tensor<2xf64>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
+
+func.func @reduce_scatter_invalid_operand_static_dimension_size(
+    %arg0 : tensor<4xf32>) -> tensor<?xf64> {
+  // expected-error@+1 {{Operand dimension size 4 is not divisible by collective device group size 3 for scatter axis 0.}}
+  %0 = mesh.reduce_scatter %arg0 {
+      mesh = @mesh0, mesh_axes = array<i16: 0>, scatter_axis = 0
+    } : tensor<4xf32> -> tensor<?xf64>
+  return %0 : tensor<?xf64>
+}

--- a/mlir/test/Dialect/Mesh/invalid.mlir
+++ b/mlir/test/Dialect/Mesh/invalid.mlir
@@ -96,6 +96,19 @@ func.func @all_reduce_invalid_mesh_axis(
 
 mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 
+func.func @all_reduce_duplicate_mesh_axis(
+    %arg0 : tensor<4xf32>) -> tensor<4xf64> {
+  // expected-error@+1 {{Mesh axes contains duplicate elements.}}
+  %0 = mesh.all_reduce %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 0, 1, 0>, reduction = #mesh.partial<sum>
+    } : tensor<4xf32> -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
+
 func.func @all_reduce_invalid_tensor_dimension_size(
     %arg0 : tensor<4xf32>) -> tensor<5xf64> {
   // expected-error@+1 {{'mesh.all_reduce' op requires the same shape for all operands and results}}
@@ -123,6 +136,19 @@ func.func @all_gather_invalid_mesh_axis(
   // expected-error@+1 {{0-based mesh axis index 2 is out of bounds. The referenced mesh "mesh0" is of rank 2.}}
   %0 = mesh.all_gather %arg0 {
     mesh = @mesh0, mesh_axes = array<i16: 2>, gather_axis = 0 : index
+    } : tensor<4xf32> -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
+
+func.func @all_reduce_duplicate_mesh_axis(
+    %arg0 : tensor<4xf32>) -> tensor<4xf32> {
+  // expected-error@+1 {{Mesh axes contains duplicate elements.}}
+  %0 = mesh.all_gather %arg0 {
+    mesh = @mesh0, mesh_axes = array<i16: 2, 2>, gather_axis = 0 : index
     } : tensor<4xf32> -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
@@ -195,11 +221,24 @@ func.func @all_gather_invalid_negative_gather_axis(
 
 // -----
 
-func.func @all_to_all_gather_invalid_mesh_symbol(
+func.func @all_to_all_invalid_mesh_symbol(
     %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
   // expected-error@+1 {{Undefined required mesh symbol "this_mesh_symbol_does_not_exist".}}
   %0 = mesh.all_to_all %arg0 {
       concat_axis = 0, mesh = @this_mesh_symbol_does_not_exist, split_axis = 1
+    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  return %0 : tensor<3x6xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
+
+func.func @all_to_all_duplicate_mesh_axis(
+    %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
+  // expected-error@+1 {{Mesh axes contains duplicate elements.}}
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 0, mesh = @mesh0, mesh_axes = array<i16: 0, 0>, split_axis = 0
     } : tensor<3x6xi8> -> tensor<3x6xi8>
   return %0 : tensor<3x6xi8>
 }
@@ -267,6 +306,19 @@ func.func @all_to_all_invalid_non_dynamic_result_split_dimension_size(
       concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0
     } : tensor<3x2xi8> -> tensor<2x6xi8>
   return %0 : tensor<2x6xi8>
+}
+
+// -----
+
+mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
+
+func.func @reduce_scatter_duplicate_mesh_axis(
+    %arg0 : tensor<?xf32>) -> tensor<?xf64> {
+  // expected-error@+1 {{Mesh axes contains duplicate elements.}}
+  %0 = mesh.reduce_scatter %arg0 {
+      mesh = @mesh0, scatter_axis = 0, mesh_axes = array<i16: 0, 0>
+    } : tensor<?xf32> -> tensor<?xf64>
+  return %0 : tensor<?xf64>
 }
 
 // -----

--- a/mlir/test/Dialect/Mesh/invalid.mlir
+++ b/mlir/test/Dialect/Mesh/invalid.mlir
@@ -73,9 +73,8 @@ func.func @mesh_axis_negtive_in_partial(
 func.func @all_reduce_invalid_mesh_symbol(
     %arg0 : tensor<4xf32>) -> tensor<4xf64> {
   // expected-error@+1 {{Undefined required mesh symbol "this_mesh_symbol_does_not_exist".}}
-  %0 = mesh.all_reduce %arg0 {
-    mesh = @this_mesh_symbol_does_not_exist, reduction = #mesh.partial<sum>
-    } : tensor<4xf32> -> tensor<4xf64>
+  %0 = mesh.all_reduce %arg0 on @this_mesh_symbol_does_not_exist reduction = <sum>
+    : tensor<4xf32> -> tensor<4xf64>
   return %0 : tensor<4xf64>
 }
 
@@ -86,9 +85,8 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 func.func @all_reduce_invalid_mesh_axis(
     %arg0 : tensor<4xf32>) -> tensor<4xf64> {
   // expected-error@+1 {{0-based mesh axis index 2 is out of bounds. The referenced mesh "mesh0" is of rank 2.}}
-  %0 = mesh.all_reduce %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 2>, reduction = #mesh.partial<sum>
-    } : tensor<4xf32> -> tensor<4xf64>
+  %0 = mesh.all_reduce %arg0 on @mesh0 mesh_axes = [2] reduction = <sum>
+    : tensor<4xf32> -> tensor<4xf64>
   return %0 : tensor<4xf64>
 }
 
@@ -99,9 +97,8 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 func.func @all_reduce_duplicate_mesh_axis(
     %arg0 : tensor<4xf32>) -> tensor<4xf64> {
   // expected-error@+1 {{Mesh axes contains duplicate elements.}}
-  %0 = mesh.all_reduce %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 0, 1, 0>, reduction = #mesh.partial<sum>
-    } : tensor<4xf32> -> tensor<4xf64>
+  %0 = mesh.all_reduce %arg0 on @mesh0 mesh_axes = [0, 1, 0] reduction = <sum>
+    : tensor<4xf32> -> tensor<4xf64>
   return %0 : tensor<4xf64>
 }
 
@@ -112,7 +109,7 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 func.func @all_reduce_invalid_tensor_dimension_size(
     %arg0 : tensor<4xf32>) -> tensor<5xf64> {
   // expected-error@+1 {{'mesh.all_reduce' op requires the same shape for all operands and results}}
-  %0 = mesh.all_reduce %arg0 { mesh = @mesh0 } : tensor<4xf32> -> tensor<5xf64>
+  %0 = mesh.all_reduce %arg0 on @mesh0 : tensor<4xf32> -> tensor<5xf64>
   return %0 : tensor<5xf64>
 }
 
@@ -121,9 +118,8 @@ func.func @all_reduce_invalid_tensor_dimension_size(
 func.func @all_gather_invalid_mesh_symbol(
     %arg0 : tensor<4xf32>) -> tensor<4xf32> {
   // expected-error@+1 {{Undefined required mesh symbol "this_mesh_symbol_does_not_exist".}}
-  %0 = mesh.all_gather %arg0 {
-    mesh = @this_mesh_symbol_does_not_exist, gather_axis = 0 : index
-    } : tensor<4xf32> -> tensor<4xf32>
+  %0 = mesh.all_gather %arg0 on @this_mesh_symbol_does_not_exist gather_axis = 0
+    : tensor<4xf32> -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
@@ -134,9 +130,8 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 func.func @all_gather_invalid_mesh_axis(
     %arg0 : tensor<4xf32>) -> tensor<4xf32> {
   // expected-error@+1 {{0-based mesh axis index 2 is out of bounds. The referenced mesh "mesh0" is of rank 2.}}
-  %0 = mesh.all_gather %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 2>, gather_axis = 0 : index
-    } : tensor<4xf32> -> tensor<4xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [2] gather_axis = 0
+    : tensor<4xf32> -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
@@ -147,9 +142,8 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [2, 4])
 func.func @all_reduce_duplicate_mesh_axis(
     %arg0 : tensor<4xf32>) -> tensor<4xf32> {
   // expected-error@+1 {{Mesh axes contains duplicate elements.}}
-  %0 = mesh.all_gather %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 2, 2>, gather_axis = 0 : index
-    } : tensor<4xf32> -> tensor<4xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [2, 2] gather_axis = 0
+    : tensor<4xf32> -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
@@ -160,9 +154,8 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
 func.func @all_gather_invalid_non_gather_axis_dimension_size(
     %arg0 : tensor<3x4xf32>) -> tensor<3x5xf32> {
   // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected 4, but got 5.}}
-  %0 = mesh.all_gather %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 0>, gather_axis = 0 : index
-    } : tensor<3x4xf32> -> tensor<3x5xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [0] gather_axis = 0
+    : tensor<3x4xf32> -> tensor<3x5xf32>
   return %0 : tensor<3x5xf32>
 }
 
@@ -173,9 +166,8 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [1, 2])
 func.func @all_gather_invalid_gather_axis_dimension_size(
     %arg0 : tensor<3x4xf32>) -> tensor<3x5xf32> {
   // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected 8, but got 5.}}
-  %0 = mesh.all_gather %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 1>, gather_axis = 1 : index
-    } : tensor<3x4xf32> -> tensor<3x5xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [1] gather_axis = 1
+    : tensor<3x4xf32> -> tensor<3x5xf32>
   return %0 : tensor<3x5xf32>
 }
 
@@ -186,10 +178,8 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
 func.func @all_gather_invalid_gather_axis_dynamic_dimension(
     %arg0 : tensor<?xf32>) -> tensor<3xf32> {
   // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected dynamic, but got 3.}}
-  %0 = mesh.all_gather %arg0 {
-    gather_axis = 0 : index,
-    mesh = @mesh0
-    } : tensor<?xf32> -> tensor<3xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 gather_axis = 0
+    : tensor<?xf32> -> tensor<3xf32>
   return %0 : tensor<3xf32>
 }
 
@@ -200,9 +190,8 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
 func.func @all_gather_invalid_gather_axis(
     %arg0 : tensor<3xf32>) -> tensor<3xf32> {
   // expected-error@+1 {{Gather axis 1 is out of bounds [0, 1).}}
-  %0 = mesh.all_gather %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 0>, gather_axis = 1 : index
-    } : tensor<3xf32> -> tensor<3xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [0] gather_axis = 1
+    : tensor<3xf32> -> tensor<3xf32>
   return %0 : tensor<3xf32>
 }
 
@@ -213,9 +202,8 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
 func.func @all_gather_invalid_negative_gather_axis(
     %arg0 : tensor<3xf32>) -> tensor<3xf32> {
   // expected-error@+1 {{Gather axis -1 is out of bounds [0, 1).}}
-  %0 = mesh.all_gather %arg0 {
-    mesh = @mesh0, mesh_axes = array<i16: 0>, gather_axis = -1 : index
-    } : tensor<3xf32> -> tensor<3xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [0] gather_axis = -1
+    : tensor<3xf32> -> tensor<3xf32>
   return %0 : tensor<3xf32>
 }
 
@@ -224,9 +212,9 @@ func.func @all_gather_invalid_negative_gather_axis(
 func.func @all_to_all_invalid_mesh_symbol(
     %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
   // expected-error@+1 {{Undefined required mesh symbol "this_mesh_symbol_does_not_exist".}}
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 0, mesh = @this_mesh_symbol_does_not_exist, split_axis = 1
-    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  %0 = mesh.all_to_all %arg0 on @this_mesh_symbol_does_not_exist
+    split_axis = 1 concat_axis = 0
+    : tensor<3x6xi8> -> tensor<3x6xi8>
   return %0 : tensor<3x6xi8>
 }
 
@@ -237,9 +225,9 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [1])
 func.func @all_to_all_duplicate_mesh_axis(
     %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
   // expected-error@+1 {{Mesh axes contains duplicate elements.}}
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 0, mesh = @mesh0, mesh_axes = array<i16: 0, 0>, split_axis = 0
-    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh0 mesh_axes = [0, 0]
+    split_axis = 0 concat_axis = 0
+    : tensor<3x6xi8> -> tensor<3x6xi8>
   return %0 : tensor<3x6xi8>
 }
 
@@ -250,9 +238,9 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [0, 1])
 func.func @all_to_all_invalid_non_dynamic_result_dimension_induced_by_dynamic_device_group(
     %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
   // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected dynamic, but got 6.}}
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0
-    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh0 mesh_axes = [0]
+    split_axis = 0 concat_axis = 1
+    : tensor<3x6xi8> -> tensor<3x6xi8>
   return %0 : tensor<3x6xi8>
 }
 
@@ -263,9 +251,9 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [1, 1])
 func.func @all_to_all_invalid_non_dynamic_result_split_dimension_induced_by_dynamic_operand_dimension(
     %arg0 : tensor<?x6xi8>) -> tensor<3x?xi8> {
   // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected dynamic, but got 3.}}
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 1>, split_axis = 0
-    } : tensor<?x6xi8> -> tensor<3x?xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh0 mesh_axes = [1]
+    split_axis = 0 concat_axis = 1
+    : tensor<?x6xi8> -> tensor<3x?xi8>
   return %0 : tensor<3x?xi8>
 }
 
@@ -276,9 +264,9 @@ mesh.cluster @mesh0(rank = 2, dim_sizes = [1, 1])
 func.func @all_to_all_invalid_non_dynamic_result_concat_dimension_induced_by_dynamic_operand_dimension(
     %arg0 : tensor<3x?xi8>) -> tensor<?x3xi8> {
   // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected dynamic, but got 3.}}
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 1>, split_axis = 0
-    } : tensor<3x?xi8> -> tensor<?x3xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh0 mesh_axes = [1]
+    split_axis = 0 concat_axis = 1
+    : tensor<3x?xi8> -> tensor<?x3xi8>
   return %0 : tensor<?x3xi8>
 }
 
@@ -289,9 +277,9 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
 func.func @all_to_all_invalid_non_dynamic_result_concat_dimension_size(
     %arg0 : tensor<3x2xi8>) -> tensor<1x7xi8> {
   // expected-error@+1 {{Dimension size mismatch for result axis 1. Expected 6, but got 7.}}
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0
-    } : tensor<3x2xi8> -> tensor<1x7xi8>
+  %0 = mesh.all_to_all %arg0  on @mesh0 mesh_axes = [0]
+    split_axis = 0 concat_axis = 1
+    : tensor<3x2xi8> -> tensor<1x7xi8>
   return %0 : tensor<1x7xi8>
 }
 
@@ -302,9 +290,9 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
 func.func @all_to_all_invalid_non_dynamic_result_split_dimension_size(
     %arg0 : tensor<3x2xi8>) -> tensor<2x6xi8> {
   // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected 1, but got 2.}}
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 1, mesh = @mesh0, mesh_axes = array<i16: 0>, split_axis = 0
-    } : tensor<3x2xi8> -> tensor<2x6xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh0 mesh_axes = [0]
+    split_axis = 0 concat_axis = 1
+    : tensor<3x2xi8> -> tensor<2x6xi8>
   return %0 : tensor<2x6xi8>
 }
 
@@ -315,9 +303,8 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
 func.func @reduce_scatter_duplicate_mesh_axis(
     %arg0 : tensor<?xf32>) -> tensor<?xf64> {
   // expected-error@+1 {{Mesh axes contains duplicate elements.}}
-  %0 = mesh.reduce_scatter %arg0 {
-      mesh = @mesh0, scatter_axis = 0, mesh_axes = array<i16: 0, 0>
-    } : tensor<?xf32> -> tensor<?xf64>
+  %0 = mesh.reduce_scatter %arg0 on @mesh0 mesh_axes = [0, 0] scatter_axis = 0
+    : tensor<?xf32> -> tensor<?xf64>
   return %0 : tensor<?xf64>
 }
 
@@ -328,9 +315,8 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
 func.func @reduce_scatter_invalid_dynamic_dimension(
     %arg0 : tensor<?xf32>) -> tensor<2xf64> {
   // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected dynamic, but got 2.}}
-  %0 = mesh.reduce_scatter %arg0 {
-      mesh = @mesh0, scatter_axis = 0
-    } : tensor<?xf32> -> tensor<2xf64>
+  %0 = mesh.reduce_scatter %arg0 on @mesh0 scatter_axis = 0
+    : tensor<?xf32> -> tensor<2xf64>
   return %0 : tensor<2xf64>
 }
 
@@ -341,9 +327,8 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
 func.func @reduce_scatter_invalid_static_dimension_size(
     %arg0 : tensor<3xf32>) -> tensor<2xf64> {
   // expected-error@+1 {{Dimension size mismatch for result axis 0. Expected 1, but got 2.}}
-  %0 = mesh.reduce_scatter %arg0 {
-      mesh = @mesh0, mesh_axes = array<i16: 0>, scatter_axis = 0
-    } : tensor<3xf32> -> tensor<2xf64>
+  %0 = mesh.reduce_scatter %arg0 on @mesh0 mesh_axes = [0] scatter_axis = 0
+    : tensor<3xf32> -> tensor<2xf64>
   return %0 : tensor<2xf64>
 }
 
@@ -354,8 +339,7 @@ mesh.cluster @mesh0(rank = 1, dim_sizes = [3])
 func.func @reduce_scatter_invalid_operand_static_dimension_size(
     %arg0 : tensor<4xf32>) -> tensor<?xf64> {
   // expected-error@+1 {{Operand dimension size 4 is not divisible by collective device group size 3 for scatter axis 0.}}
-  %0 = mesh.reduce_scatter %arg0 {
-      mesh = @mesh0, mesh_axes = array<i16: 0>, scatter_axis = 0
-    } : tensor<4xf32> -> tensor<?xf64>
+  %0 = mesh.reduce_scatter %arg0 on @mesh0 mesh_axes = [0] scatter_axis = 0
+    : tensor<4xf32> -> tensor<?xf64>
   return %0 : tensor<?xf64>
 }

--- a/mlir/test/Dialect/Mesh/ops.mlir
+++ b/mlir/test/Dialect/Mesh/ops.mlir
@@ -12,6 +12,8 @@ mesh.cluster @mesh2(rank = 2, dim_sizes = [0, 4])
 // CHECK: mesh.cluster @mesh3
 mesh.cluster @mesh3(rank = 2)
 
+mesh.cluster @mesh4(rank = 1, dim_sizes = [3])
+
 // CHECK-LABEL: func @mesh_shard_encoding_fully_replicated
 func.func @mesh_shard_encoding_fully_replicated(
     // CHECK-SAME: %[[ARG:.*]]: tensor<4x8xf32, #mesh.shard<@mesh0, {{\[\[}}]]>>
@@ -125,4 +127,121 @@ func.func @mesh_shard_op_two_users(%arg0 : tensor<4x8xf32>) ->
   // CHECK-DAG: mesh.shard %[[V0]] to <@mesh0, {{\[\[}}2]]> annotate_for_users : tensor<4x8xf32>
   %2 = mesh.shard %0 to <@mesh0, [[2]]> annotate_for_users : tensor<4x8xf32>
   return %1, %2 : tensor<4x8xf32>, tensor<4x8xf32>
+}
+
+// CHECK-LABEL: func @all_reduce
+func.func @all_reduce(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<3x4xf32>
+    %arg0 : tensor<3x4xf32>) -> tensor<3x4xf64> {
+  // CHECK-NEXT: mesh.all_reduce %[[ARG]]
+  // CHECK-SAME: {mesh = @mesh0, mesh_axes = array<i16: 1, 0>, reduction = #mesh.partial<max>}
+  // CHECK-SAME: : tensor<3x4xf32> -> tensor<3x4xf64>
+  %0 = mesh.all_reduce %arg0 {
+      mesh = @mesh0, mesh_axes = array<i16: 1, 0>, reduction = #mesh.partial<max>
+    } : tensor<3x4xf32> -> tensor<3x4xf64>
+  return %0 : tensor<3x4xf64>
+}
+
+// CHECK-LABEL: func @all_gather
+func.func @all_gather(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<3x4xf32>
+    %arg0 : tensor<3x4xf32>) -> tensor<3x16xf32> {
+  // CHECK-NEXT: mesh.all_gather %[[ARG]]
+  // CHECK-SAME: {gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>}
+  // CHECK-SAME: : tensor<3x4xf32> -> tensor<3x16xf32>
+  %0 = mesh.all_gather %arg0 {
+      gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>
+    } : tensor<3x4xf32> -> tensor<3x16xf32>
+  return %0 : tensor<3x16xf32>
+}
+
+// CHECK-LABEL: func @all_gather_dynamic_dims_in_tensor
+func.func @all_gather_dynamic_dims_in_tensor(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<?x?xf32>
+    %arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // CHECK-NEXT: mesh.all_gather %[[ARG]]
+  // CHECK-SAME: {gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>}
+  // CHECK-SAME: : tensor<?x?xf32> -> tensor<?x?xf32>
+  %0 = mesh.all_gather %arg0 {
+      gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>
+    } : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: func @all_gather_dynamic_dims_in_mesh
+func.func @all_gather_dynamic_dims_in_mesh(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<5x6xf32>
+    %arg0 : tensor<5x6xf32>) -> tensor<5x?xf32> {
+  // CHECK-NEXT: mesh.all_gather %[[ARG]]
+  // CHECK-SAME: {gather_axis = 1 : index, mesh = @mesh3, mesh_axes = array<i16: 1>}
+  // CHECK-SAME: : tensor<5x6xf32> -> tensor<5x?xf32>
+  %0 = mesh.all_gather %arg0 {
+      gather_axis = 1 : index, mesh = @mesh3, mesh_axes = array<i16: 1>
+    } : tensor<5x6xf32> -> tensor<5x?xf32>
+  return %0 : tensor<5x?xf32>
+}
+
+// CHECK-LABEL: func @all_to_all
+func.func @all_to_all(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<3x6xi8>
+    %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
+  // CHECK-NEXT: mesh.all_to_all %[[ARG]]
+  // CHECK-SAME: {concat_axis = 0 : i64, mesh = @mesh4, split_axis = 1 : i64}
+  // CHECK-SAME: : tensor<3x6xi8> -> tensor<3x6xi8>
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 0, mesh = @mesh4, split_axis = 1
+    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  return %0 : tensor<3x6xi8>
+}
+
+// CHECK-LABEL: func @all_to_all_dynamic_dims_in_result
+func.func @all_to_all_dynamic_dims_in_result(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<3x6xi8>
+    %arg0 : tensor<3x6xi8>) -> tensor<3x?xi8> {
+  // CHECK-NEXT: mesh.all_to_all %[[ARG]]
+  // CHECK-SAME: {concat_axis = 0 : i64, mesh = @mesh4, split_axis = 1 : i64}
+  // CHECK-SAME: : tensor<3x6xi8> -> tensor<3x?xi8>
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 0, mesh = @mesh4, split_axis = 1
+    } : tensor<3x6xi8> -> tensor<3x?xi8>
+  return %0 : tensor<3x?xi8>
+}
+
+// CHECK-LABEL: func @all_to_all
+func.func @all_to_all_same_split_concat_dim_with_dynamic_device_group_size(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<3xi8>
+    %arg0 : tensor<3xi8>) -> tensor<3xi8> {
+  // CHECK-NEXT: mesh.all_to_all %[[ARG]]
+  // CHECK-SAME: {concat_axis = 0 : i64, mesh = @mesh4, split_axis = 0 : i64}
+  // CHECK-SAME: : tensor<3xi8> -> tensor<3xi8>
+  %0 = mesh.all_to_all %arg0 {
+      concat_axis = 0, mesh = @mesh4, split_axis = 0
+    } : tensor<3xi8> -> tensor<3xi8>
+  return %0 : tensor<3xi8>
+}
+
+// CHECK-LABEL: func @reduce_scatter_static_dimensions
+func.func @reduce_scatter_static_dimensions(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<3x4xf32>
+    %arg0 : tensor<3x4xf32>) -> tensor<3x1xf64> {
+  // CHECK-NEXT: mesh.reduce_scatter %[[ARG]]
+  // CHECK-SAME: {mesh = @mesh0, mesh_axes = array<i16: 2>, reduction = #mesh.partial<max>, scatter_axis = 1 : i64}
+  // CHECK-SAME: : tensor<3x4xf32> -> tensor<3x1xf64>
+  %0 = mesh.reduce_scatter %arg0 {
+      mesh = @mesh0, mesh_axes = array<i16: 2>, reduction = #mesh.partial<max>, scatter_axis = 1
+    } : tensor<3x4xf32> -> tensor<3x1xf64>
+  return %0 : tensor<3x1xf64>
+}
+
+// CHECK-LABEL: func @reduce_scatter_dynamic_dimensions
+func.func @reduce_scatter_dynamic_dimensions(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<?xf32>
+    %arg0 : tensor<?xf32>) -> tensor<?xf64> {
+  // CHECK-NEXT: mesh.reduce_scatter %[[ARG]]
+  // CHECK-SAME: {mesh = @mesh3, mesh_axes = array<i16: 0, 1>, scatter_axis = 0 : i64}
+  // CHECK-SAME: : tensor<?xf32> -> tensor<?xf64>
+  %0 = mesh.reduce_scatter %arg0 {
+      mesh = @mesh3, mesh_axes = array<i16: 0, 1>, scatter_axis = 0
+    } : tensor<?xf32> -> tensor<?xf64>
+  return %0 : tensor<?xf64>
 }

--- a/mlir/test/Dialect/Mesh/ops.mlir
+++ b/mlir/test/Dialect/Mesh/ops.mlir
@@ -133,12 +133,10 @@ func.func @mesh_shard_op_two_users(%arg0 : tensor<4x8xf32>) ->
 func.func @all_reduce(
     // CHECK-SAME: %[[ARG:.*]]: tensor<3x4xf32>
     %arg0 : tensor<3x4xf32>) -> tensor<3x4xf64> {
-  // CHECK-NEXT: mesh.all_reduce %[[ARG]]
-  // CHECK-SAME: {mesh = @mesh0, mesh_axes = array<i16: 1, 0>, reduction = #mesh.partial<max>}
+  // CHECK-NEXT: mesh.all_reduce %[[ARG]] on @mesh0 mesh_axes = [1, 0] reduction = <max>
   // CHECK-SAME: : tensor<3x4xf32> -> tensor<3x4xf64>
-  %0 = mesh.all_reduce %arg0 {
-      mesh = @mesh0, mesh_axes = array<i16: 1, 0>, reduction = #mesh.partial<max>
-    } : tensor<3x4xf32> -> tensor<3x4xf64>
+  %0 = mesh.all_reduce %arg0 on @mesh0 mesh_axes = [1, 0] reduction = <max>
+    : tensor<3x4xf32> -> tensor<3x4xf64>
   return %0 : tensor<3x4xf64>
 }
 
@@ -146,12 +144,10 @@ func.func @all_reduce(
 func.func @all_gather(
     // CHECK-SAME: %[[ARG:.*]]: tensor<3x4xf32>
     %arg0 : tensor<3x4xf32>) -> tensor<3x16xf32> {
-  // CHECK-NEXT: mesh.all_gather %[[ARG]]
-  // CHECK-SAME: {gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>}
+  // CHECK-NEXT: mesh.all_gather %[[ARG]] on @mesh0 mesh_axes = [2] gather_axis = 1
   // CHECK-SAME: : tensor<3x4xf32> -> tensor<3x16xf32>
-  %0 = mesh.all_gather %arg0 {
-      gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>
-    } : tensor<3x4xf32> -> tensor<3x16xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [2] gather_axis = 1
+    : tensor<3x4xf32> -> tensor<3x16xf32>
   return %0 : tensor<3x16xf32>
 }
 
@@ -159,12 +155,10 @@ func.func @all_gather(
 func.func @all_gather_dynamic_dims_in_tensor(
     // CHECK-SAME: %[[ARG:.*]]: tensor<?x?xf32>
     %arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // CHECK-NEXT: mesh.all_gather %[[ARG]]
-  // CHECK-SAME: {gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>}
+  // CHECK-NEXT: mesh.all_gather %[[ARG]] on @mesh0 mesh_axes = [2] gather_axis = 1
   // CHECK-SAME: : tensor<?x?xf32> -> tensor<?x?xf32>
-  %0 = mesh.all_gather %arg0 {
-      gather_axis = 1 : index, mesh = @mesh0, mesh_axes = array<i16: 2>
-    } : tensor<?x?xf32> -> tensor<?x?xf32>
+  %0 = mesh.all_gather %arg0 on @mesh0 mesh_axes = [2] gather_axis = 1
+    : tensor<?x?xf32> -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
 
@@ -172,12 +166,10 @@ func.func @all_gather_dynamic_dims_in_tensor(
 func.func @all_gather_dynamic_dims_in_mesh(
     // CHECK-SAME: %[[ARG:.*]]: tensor<5x6xf32>
     %arg0 : tensor<5x6xf32>) -> tensor<5x?xf32> {
-  // CHECK-NEXT: mesh.all_gather %[[ARG]]
-  // CHECK-SAME: {gather_axis = 1 : index, mesh = @mesh3, mesh_axes = array<i16: 1>}
+  // CHECK-NEXT: mesh.all_gather %[[ARG]] on @mesh3 mesh_axes = [1] gather_axis = 1
   // CHECK-SAME: : tensor<5x6xf32> -> tensor<5x?xf32>
-  %0 = mesh.all_gather %arg0 {
-      gather_axis = 1 : index, mesh = @mesh3, mesh_axes = array<i16: 1>
-    } : tensor<5x6xf32> -> tensor<5x?xf32>
+  %0 = mesh.all_gather %arg0 on @mesh3 mesh_axes = [1] gather_axis = 1
+    : tensor<5x6xf32> -> tensor<5x?xf32>
   return %0 : tensor<5x?xf32>
 }
 
@@ -186,11 +178,11 @@ func.func @all_to_all(
     // CHECK-SAME: %[[ARG:.*]]: tensor<3x6xi8>
     %arg0 : tensor<3x6xi8>) -> tensor<3x6xi8> {
   // CHECK-NEXT: mesh.all_to_all %[[ARG]]
-  // CHECK-SAME: {concat_axis = 0 : i64, mesh = @mesh4, split_axis = 1 : i64}
+  // CHECK-SAME: on @mesh4 split_axis = 1 concat_axis = 0
   // CHECK-SAME: : tensor<3x6xi8> -> tensor<3x6xi8>
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 0, mesh = @mesh4, split_axis = 1
-    } : tensor<3x6xi8> -> tensor<3x6xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh4
+    split_axis = 1 concat_axis = 0
+    : tensor<3x6xi8> -> tensor<3x6xi8>
   return %0 : tensor<3x6xi8>
 }
 
@@ -199,11 +191,11 @@ func.func @all_to_all_dynamic_dims_in_result(
     // CHECK-SAME: %[[ARG:.*]]: tensor<3x6xi8>
     %arg0 : tensor<3x6xi8>) -> tensor<3x?xi8> {
   // CHECK-NEXT: mesh.all_to_all %[[ARG]]
-  // CHECK-SAME: {concat_axis = 0 : i64, mesh = @mesh4, split_axis = 1 : i64}
+  // CHECK-SAME: on @mesh4 split_axis = 1 concat_axis = 0
   // CHECK-SAME: : tensor<3x6xi8> -> tensor<3x?xi8>
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 0, mesh = @mesh4, split_axis = 1
-    } : tensor<3x6xi8> -> tensor<3x?xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh4
+    split_axis = 1 concat_axis = 0
+    : tensor<3x6xi8> -> tensor<3x?xi8>
   return %0 : tensor<3x?xi8>
 }
 
@@ -212,11 +204,11 @@ func.func @all_to_all_same_split_concat_dim_with_dynamic_device_group_size(
     // CHECK-SAME: %[[ARG:.*]]: tensor<3xi8>
     %arg0 : tensor<3xi8>) -> tensor<3xi8> {
   // CHECK-NEXT: mesh.all_to_all %[[ARG]]
-  // CHECK-SAME: {concat_axis = 0 : i64, mesh = @mesh4, split_axis = 0 : i64}
+  // CHECK-SAME: @mesh4 split_axis = 0 concat_axis = 0
   // CHECK-SAME: : tensor<3xi8> -> tensor<3xi8>
-  %0 = mesh.all_to_all %arg0 {
-      concat_axis = 0, mesh = @mesh4, split_axis = 0
-    } : tensor<3xi8> -> tensor<3xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh4
+    split_axis = 0 concat_axis = 0
+    : tensor<3xi8> -> tensor<3xi8>
   return %0 : tensor<3xi8>
 }
 
@@ -225,11 +217,11 @@ func.func @reduce_scatter_static_dimensions(
     // CHECK-SAME: %[[ARG:.*]]: tensor<3x4xf32>
     %arg0 : tensor<3x4xf32>) -> tensor<3x1xf64> {
   // CHECK-NEXT: mesh.reduce_scatter %[[ARG]]
-  // CHECK-SAME: {mesh = @mesh0, mesh_axes = array<i16: 2>, reduction = #mesh.partial<max>, scatter_axis = 1 : i64}
+  // CHECK-SAME: on @mesh0 mesh_axes = [2] reduction = <max> scatter_axis = 1
   // CHECK-SAME: : tensor<3x4xf32> -> tensor<3x1xf64>
-  %0 = mesh.reduce_scatter %arg0 {
-      mesh = @mesh0, mesh_axes = array<i16: 2>, reduction = #mesh.partial<max>, scatter_axis = 1
-    } : tensor<3x4xf32> -> tensor<3x1xf64>
+  %0 = mesh.reduce_scatter %arg0 on @mesh0 mesh_axes = [2]
+    reduction = <max> scatter_axis = 1
+    : tensor<3x4xf32> -> tensor<3x1xf64>
   return %0 : tensor<3x1xf64>
 }
 
@@ -238,10 +230,9 @@ func.func @reduce_scatter_dynamic_dimensions(
     // CHECK-SAME: %[[ARG:.*]]: tensor<?xf32>
     %arg0 : tensor<?xf32>) -> tensor<?xf64> {
   // CHECK-NEXT: mesh.reduce_scatter %[[ARG]]
-  // CHECK-SAME: {mesh = @mesh3, mesh_axes = array<i16: 0, 1>, scatter_axis = 0 : i64}
+  // CHECK-SAME: on @mesh3 mesh_axes = [0, 1] scatter_axis = 0
   // CHECK-SAME: : tensor<?xf32> -> tensor<?xf64>
-  %0 = mesh.reduce_scatter %arg0 {
-      mesh = @mesh3, mesh_axes = array<i16: 0, 1>, scatter_axis = 0
-    } : tensor<?xf32> -> tensor<?xf64>
+  %0 = mesh.reduce_scatter %arg0 on @mesh3 mesh_axes = [0, 1] scatter_axis = 0
+    : tensor<?xf32> -> tensor<?xf64>
   return %0 : tensor<?xf64>
 }

--- a/mlir/test/Dialect/Mesh/ops.mlir
+++ b/mlir/test/Dialect/Mesh/ops.mlir
@@ -199,7 +199,7 @@ func.func @all_to_all_dynamic_dims_in_result(
   return %0 : tensor<3x?xi8>
 }
 
-// CHECK-LABEL: func @all_to_all
+// CHECK-LABEL: func @all_to_all_same_split_concat_dim_with_dynamic_device_group_size
 func.func @all_to_all_same_split_concat_dim_with_dynamic_device_group_size(
     // CHECK-SAME: %[[ARG:.*]]: tensor<3xi8>
     %arg0 : tensor<3xi8>) -> tensor<3xi8> {
@@ -210,6 +210,19 @@ func.func @all_to_all_same_split_concat_dim_with_dynamic_device_group_size(
     split_axis = 0 concat_axis = 0
     : tensor<3xi8> -> tensor<3xi8>
   return %0 : tensor<3xi8>
+}
+
+// CHECK-LABEL: func @all_to_all_non_divisible_split_axis_size
+func.func @all_to_all_non_divisible_split_axis_size(
+    // CHECK-SAME: %[[ARG:.*]]: tensor<2x3xi8>
+    %arg0 : tensor<2x3xi8>) -> tensor<?x12xi8> {
+  // CHECK-NEXT: mesh.all_to_all %[[ARG]]
+  // CHECK-SAME: @mesh0 mesh_axes = [0, 1] split_axis = 0 concat_axis = 1
+  // CHECK-SAME: : tensor<2x3xi8> -> tensor<?x12xi8>
+  %0 = mesh.all_to_all %arg0 on @mesh0 mesh_axes = [0, 1]
+    split_axis = 0 concat_axis = 1
+    : tensor<2x3xi8> -> tensor<?x12xi8>
+  return %0 : tensor<?x12xi8>
 }
 
 // CHECK-LABEL: func @reduce_scatter_static_dimensions


### PR DESCRIPTION
Add all-gather, all-reduce, all-to-all and reduce-scatter. These operations have device mesh semantics.

I have not included ops like reduce, gather, send and recv to see first if reviewers notice any systemic issues. Also this PR is already big enough.
