### PR TITLE
[llvm][Support] Add indirection to call correct validate(...) function

### DIFF
--- a/llvm/unittests/Support/YAMLIOTest.cpp
+++ b/llvm/unittests/Support/YAMLIOTest.cpp
@@ -2623,6 +2623,9 @@ template <> struct MappingContextTraits<SimpleMap, MappingContext> {
     ++Context.A;
     io.mapRequired("Context", Context.A);
   }
+  static std::string validate(IO &io, SimpleMap &sm, MappingContext &Context) {
+    return "";
+  }
 };
 
 template <> struct MappingTraits<NestedMap> {


### PR DESCRIPTION
    Previously "yamlize" overload for validatedMappingTraits was
    unconditionally calling "MappingTraits<T>::validate" even if
    "MappingContextTraits<T, Context>" was passed to it. Therefore
    compilation failed when specifying
    "MappingContextTraits<T,Context>::validate()"