### PR TITLE
[clang] Make `-fvisibility={}` and `-ftype-visibility={}` benign options.

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -349,9 +349,9 @@ LANGOPT(
     "type's inheritance model would be determined under the Microsoft ABI")
 
 ENUM_LANGOPT(GC, GCMode, 2, NonGC, "Objective-C Garbage Collection mode")
-ENUM_LANGOPT(ValueVisibilityMode, Visibility, 3, DefaultVisibility,
+BENIGN_ENUM_LANGOPT(ValueVisibilityMode, Visibility, 3, DefaultVisibility,
              "default visibility for functions and variables [-fvisibility]")
-ENUM_LANGOPT(TypeVisibilityMode, Visibility, 3, DefaultVisibility,
+BENIGN_ENUM_LANGOPT(TypeVisibilityMode, Visibility, 3, DefaultVisibility,
              "default visibility for types [-ftype-visibility]")
 LANGOPT(SetVisibilityForExternDecls, 1, 0,
         "apply global symbol visibility to external declarations without an explicit visibility")

--- a/clang/test/ClangScanDeps/strip-visibility.c
+++ b/clang/test/ClangScanDeps/strip-visibility.c
@@ -1,0 +1,59 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -mode preprocess-dependency-directives > %t/result.txt
+
+// RUN: FileCheck %s -input-file %t/result.txt
+
+// Verify that there's a single version of module A.
+
+// CHECK:        "modules": [
+// CHECK-NEXT:     {
+// CHECK:            "command-line": [
+// CHECK-NOT:          "-fvisibility="
+// CHECK-NOT:          "-ftype-visibility="
+// CHECK:            ]
+// CHECK:            "name": "A"
+// CHECK:          }
+// CHECK-NOT:        "name": "A"
+// CHECK:        "translation-units"
+
+//--- cdb.json.template
+[
+  {
+    "directory": "DIR",
+    "command": "clang -Imodules/A -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps -fsyntax-only DIR/t1.c",
+    "file": "DIR/t1.c"
+  },
+  {
+    "directory": "DIR",
+    "command": "clang -Imodules/A -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps -fvisibility=hidden -fsyntax-only DIR/t2.c",
+    "file": "DIR/t2.c"
+  },
+  {
+    "directory": "DIR",
+    "command": "clang -Imodules/A -fmodules -fmodules-cache-path=DIR/module-cache -fimplicit-modules -fimplicit-module-maps -fvisibility=hidden -fvisibility-ms-compat -fsyntax-only DIR/t3.c",
+    "file": "DIR/t3.c"
+  }
+]
+
+//--- modules/A/module.modulemap
+
+module A {
+  umbrella header "A.h"
+}
+
+//--- modules/A/A.h
+
+typedef int A_t;
+extern int a(void);
+
+//--- t1.c
+#include "A.h"
+
+//--- t2.c
+#include "A.h"
+
+//--- t3.c
+#include "A.h"

--- a/clang/test/Modules/codegen-visibility.cpp
+++ b/clang/test/Modules/codegen-visibility.cpp
@@ -1,0 +1,40 @@
+// Test that modules with different visibility mode can be shared.
+// REQUIRES: aarch64-registered-target
+
+// RUN: rm -rf %t && mkdir %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=default -fmodules-codegen -fmodules -emit-module -fmodule-name=foo %t/foo.modulemap -o %t/foo.pcm
+
+// RUN: %clang_cc1 -emit-llvm %t/foo.pcm -o - | FileCheck %s --check-prefix=DEF
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=hidden -fmodules -fmodule-file=%t/foo.pcm -I%t -emit-llvm %t/test.cpp -o - | FileCheck %s --check-prefixes=USE
+
+// DEF: define void @_Z2f4v()
+// DEF: define weak_odr void @_Z2f3v()
+
+// USE: define hidden void @_Z4testv()
+// USE: declare void @_Z2f1v()
+// USE: define internal void @_ZL2f2v()
+// USE: declare void @_Z2f3v()
+// USE: declare void @_Z2f4v()
+
+
+//--- foo.h
+void f1();
+static void f2() {}
+inline void f3() {}
+void f4() {}
+
+//--- test.cpp
+#include "foo.h"
+
+void test() {
+  f1();
+  f2();
+  f3();
+  f4();
+}
+
+//--- foo.modulemap
+module foo { header "foo.h" }
+

--- a/clang/test/Modules/visibility.cpp
+++ b/clang/test/Modules/visibility.cpp
@@ -1,0 +1,44 @@
+// Test that modules with different visibility mode can be shared.
+// REQUIRES: aarch64-registered-target
+
+// RUN: rm -rf %t && mkdir %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=default -fmodules -emit-module -fmodule-name=foo %t/foo.modulemap -o %t/foo.default.pcm
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=hidden  -fmodules -emit-module -fmodule-name=foo %t/foo.modulemap -o %t/foo.hidden.pcm
+
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=default -fmodules -fmodule-file=%t/foo.default.pcm -I%t -emit-llvm %t/test.cpp -o - | FileCheck %s --check-prefixes=DEFAULT,BOTH
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=default -fmodules -fmodule-file=%t/foo.hidden.pcm  -I%t -emit-llvm %t/test.cpp -o - | FileCheck %s --check-prefixes=DEFAULT,BOTH
+
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=hidden -fmodules -fmodule-file=%t/foo.default.pcm -I%t -emit-llvm %t/test.cpp -o - | FileCheck %s --check-prefixes=HIDDEN,BOTH
+// RUN: %clang_cc1 -triple arm64e-apple-macos -x c++ -fvisibility=hidden -fmodules -fmodule-file=%t/foo.hidden.pcm  -I%t -emit-llvm %t/test.cpp -o - | FileCheck %s --check-prefixes=HIDDEN,BOTH
+
+// DEFAULT: define void @_Z2f4v()
+// HIDDEN: define hidden void @_Z2f4v()
+// DEFAULT: define void @_Z4testv()
+// HIDDEN: define hidden void @_Z4testv()
+// BOTH: declare void @_Z2f1v()
+// BOTH: define internal void @_ZL2f2v()
+// DEFAULT: define linkonce_odr void @_Z2f3v()
+// HIDDEN: define linkonce_odr hidden void @_Z2f3v()
+
+
+//--- foo.h
+void f1();
+static void f2() {}
+inline void f3() {}
+void f4() {}
+
+//--- test.cpp
+#include "foo.h"
+
+void test() {
+  f1();
+  f2();
+  f3();
+  f4();
+}
+
+//--- foo.modulemap
+module foo { header "foo.h" }
+


### PR DESCRIPTION
Both options do not affect the AST content that is serialized into the PCM. This
commit includes the following changes:
    
1.) Mark `-fvisibility={}` and `-ftype-visibility={}` as benign options. That
     means they are no longer considered part of the module hash, which can
     reduce the number of module variants.
    
2.) Add a test to verify the generated LLVM IR is not affected by the default
     visibiliy mode in the module.

3.) Add a test to clang-scan-deps to ensure only one module is build, even if
      the above mentioned options are used.
    
This fixes rdar://118246054.