### PR TITLE
[clang] Allow __attribute__((swiftcall)) on all targets

### DIFF
--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1606,6 +1606,8 @@ public:
       default:
         return CCCR_Warning;
       case CC_C:
+      case CC_Swift:
+      case CC_SwiftAsync:
         return CCCR_OK;
     }
   }

--- a/clang/lib/CodeGen/ABIInfo.cpp
+++ b/clang/lib/CodeGen/ABIInfo.cpp
@@ -33,6 +33,10 @@ const CodeGenOptions &ABIInfo::getCodeGenOpts() const {
   return CGT.getCodeGenOpts();
 }
 
+CodeGen::CodeGenTypes &ABIInfo::getCodeGenTypes() const {
+  return CGT;
+}
+
 bool ABIInfo::isAndroid() const { return getTarget().getTriple().isAndroid(); }
 
 bool ABIInfo::isOHOSFamily() const {

--- a/clang/lib/CodeGen/ABIInfo.h
+++ b/clang/lib/CodeGen/ABIInfo.h
@@ -60,6 +60,7 @@ public:
   const llvm::DataLayout &getDataLayout() const;
   const TargetInfo &getTarget() const;
   const CodeGenOptions &getCodeGenOpts() const;
+  CodeGen::CodeGenTypes &getCodeGenTypes() const;
 
   /// Return the calling convention to use for system runtime
   /// functions.

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -67,7 +67,9 @@ LLVM_DUMP_METHOD void ABIArgInfo::dump() const {
 }
 
 TargetCodeGenInfo::TargetCodeGenInfo(std::unique_ptr<ABIInfo> Info)
-    : Info(std::move(Info)) {}
+    : Info(std::move(Info)),
+      SwiftInfo(std::make_unique<SwiftABIInfo>(
+          this->Info->getCodeGenTypes(), /*SwiftErrorInRegister*/ false)) {}
 
 TargetCodeGenInfo::~TargetCodeGenInfo() = default;
 


### PR DESCRIPTION
With Embedded Swift, <https://forums.swift.org/t/embedded-swift/67057>, it becomes possible and useful to produce Swift code for a whole range of CPU targets. This change allows using the 'swiftcall' and 'swiftasynccall)' attributes on any Clang supported target. This isn't in any way adding complete support for those calling conventions for all targets, it's merely removing one obstacle from adding new targets to Swift.