### PR TITLE
Fix a little thinko in sending events to secondary listeners.

### DIFF
--- a/lldb/source/Utility/Broadcaster.cpp
+++ b/lldb/source/Utility/Broadcaster.cpp
@@ -280,13 +280,13 @@ void Broadcaster::BroadcasterImpl::PrivateBroadcastEvent(EventSP &event_sp,
     // Make sure to do this before adding the event to the primary or it might
     // start handling the event before we're done adding all the pending
     // listeners.
+    // Also, don't redo the check for unique here, since otherwise that could
+    // be racy, and if we send the event to the primary listener then we SHOULD 
+    // send it to the secondary listeners or they will get out of sync with the
+    // primary listener.
     if (!hijacking_listener_sp) {
-      for (auto &pair : GetListeners(event_type, false)) {
-        if (unique && pair.first->PeekAtNextEventForBroadcasterWithType(
-                          &m_broadcaster, event_type))
-          continue;
+      for (auto &pair : GetListeners(event_type, false))
         event_sp->AddPendingListener(pair.first);
-      }
     }
     primary_listener_sp->AddEvent(event_sp);
   } else {


### PR DESCRIPTION
If `unique` is true, I was redoing the uniqueness check for the secondary listeners, which is racy since a "duplicate" event could come in between deciding to send the event to the main listener and checking for the shadow listener, and then the two streams would get out of sync.

There's not a good way to write a direct test for this, but the test_shadow_listeners test has been flakey and this is the only racy part of that system I can find.  So the test would be that that test_shadow_listeners becomes not flakey.