### PR TITLE
[IntegerRangeAnalysis] remove constraint on integer-typed results

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
@@ -8,7 +8,10 @@
 //
 // This file declares the dataflow analysis class for integer range inference
 // so that it can be used in transformations over the `arith` dialect such as
-// branch elimination or signed->unsigned rewriting
+// branch elimination or signed->unsigned rewriting.
+//
+// One can also implement InferIntRangeInterface on ops in custom dialects,
+// and then use this analysis to propagate ranges with custom semantics.
 //
 //===----------------------------------------------------------------------===//
 
@@ -81,6 +84,9 @@ public:
 /// Integer range analysis determines the integer value range of SSA values
 /// using operations that define `InferIntRangeInterface` and also sets the
 /// range of iteration indices of loops with known bounds.
+///
+/// This analysis depends on DeadCodeAnalysis, and will be a silent no-op
+/// if DeadCodeAnalysis is not loaded in the same solver context.
 class IntegerRangeAnalysis
     : public SparseForwardDataFlowAnalysis<IntegerValueRangeLattice> {
 public:

--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -79,22 +79,6 @@ void IntegerRangeAnalysis::visitOperation(
     return;
   }
 
-  // Ignore non-integer outputs - return early if the op has no scalar
-  // integer results
-  bool hasIntegerResult = false;
-  for (auto it : llvm::zip(results, op->getResults())) {
-    Value value = std::get<1>(it);
-    if (value.getType().isIntOrIndex()) {
-      hasIntegerResult = true;
-    } else {
-      IntegerValueRangeLattice *lattice = std::get<0>(it);
-      propagateIfChanged(lattice,
-                         lattice->join(IntegerValueRange::getMaxRange(value)));
-    }
-  }
-  if (!hasIntegerResult)
-    return;
-
   auto inferrable = dyn_cast<InferIntRangeInterface>(op);
   if (!inferrable)
     return setAllToEntryStates(results);


### PR DESCRIPTION
I have an out-of-tree situation in which I'd like to run this analysis, but with custom ops and integer ranges attached to types that are not classical integers. No upstream tests depend on this condition, and so relaxing it seems like a natural way to make it more useful out of tree.

I'm open to making any additional changes if the reviewer foresees some unexpected problems as a result of this change. E.g., if having this analysis available in an IR with mixed arith/non-arith ops would cause a pass like `IntRangeOptimizationsPass` to misbehave, but I imagine it would not because the patterns match against specific arith ops.

I can add a regression test if there's a strong desire, but I feel the chance of this regressing is relatively low compared to the effort to write the test.

I have a demonstration out of tree in https://github.com/j2kun/mlir-tutorial/pull/28, which passes tests when I remove this check locally.