### PR TITLE
[clang-tidy] Fix macros handling in cppcoreguidelines-prefer-member-initializer

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
@@ -261,9 +261,9 @@ void PreferMemberInitializerCheck::check(
 
       SmallString<128> Insertion(
           {UseAssignment ? " = " : "{",
-           Lexer::getSourceText(
-               CharSourceRange(InitValue->getSourceRange(), true),
-               *Result.SourceManager, getLangOpts()),
+           Lexer::getSourceText(Result.SourceManager->getExpansionRange(
+                                    InitValue->getSourceRange()),
+                                *Result.SourceManager, getLangOpts()),
            UseAssignment ? "" : "}"});
 
       Diag << FixItHint::CreateInsertion(FieldEnd, Insertion)
@@ -346,7 +346,7 @@ void PreferMemberInitializerCheck::check(
       if (InvalidFix)
         continue;
       StringRef NewInit = Lexer::getSourceText(
-          CharSourceRange(InitValue->getSourceRange(), true),
+          Result.SourceManager->getExpansionRange(InitValue->getSourceRange()),
           *Result.SourceManager, getLangOpts());
       if (HasInitAlready) {
         if (InsertPos.isValid())

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -262,7 +262,8 @@ Changes in existing checks
 - Improved :doc:`cppcoreguidelines-prefer-member-initializer
   <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>` check to
   ignore delegate constructors and ignore re-assignment for reference or when
-  initialization depend on field that is initialized before.
+  initialization depend on field that is initialized before. Additionally, it
+  now provides valid fixes for member variables initialized with macros.
 
 - Improved :doc:`cppcoreguidelines-pro-bounds-array-to-pointer-decay
   <clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay>` check

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -586,3 +586,33 @@ struct ReassignmentAfterUnsafetyAssignment {
   }
   int m_i;
 };
+
+namespace PR70189 {
+#define RGB(r,g,b) ((unsigned long)(((unsigned char)(r)|((unsigned short)((unsigned char)(g))<<8))|(((unsigned long)(unsigned char)(b))<<16)))
+#define INVALID_HANDLE_VALUE ((void*)(unsigned long long)-1)
+#define SIMPLE 12
+
+class Foo {
+public:
+  Foo() {
+// CHECK-FIXES: Foo() : m_color(RGB(255, 128, 0)), m_handle(INVALID_HANDLE_VALUE), m_myval(SIMPLE) {
+    m_color = RGB(255, 128, 0);
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'm_color' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
+// CHECK-FIXES: {{^\ *$}}
+    m_handle = INVALID_HANDLE_VALUE;
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'm_handle' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
+// CHECK-FIXES: {{^\ *$}}
+    m_myval = SIMPLE;
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: 'm_myval' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
+// CHECK-FIXES: {{^\ *$}}
+  }
+private:
+  unsigned long m_color;
+  void* m_handle;
+  int m_myval;
+};
+
+#undef SIMPLE
+#undef INVALID_HANDLE_VALUE
+#undef RGB
+}


### PR DESCRIPTION
Produces now valid fixes for a member variables initialized with macros. Correctly uses expansion location instead of location inside macro to get init code.

Close #70189