### PR TITLE
[libunwind] Remove unnecessary dependencies on fprintf and stdio.h for increased baremetal friendliness

### DIFF
--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -13,7 +13,6 @@
 #define __ADDRESSSPACE_HPP__
 
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -672,7 +671,10 @@ inline bool LocalAddressSpace::findFunctionName(pint_t addr, char *buf,
   Dl_info dyldInfo;
   if (dladdr((void *)addr, &dyldInfo)) {
     if (dyldInfo.dli_sname != NULL) {
-      snprintf(buf, bufLen, "%s", dyldInfo.dli_sname);
+      size_t nameLen = strlen(dyldInfo.dli_sname);
+      size_t len = nameLen < (bufLen - 1) ? nameLen : (bufLen - 1);
+      memcpy(buf, dyldInfo.dli_sname, len);
+      buf[len] = '\0';
       *offset = (addr - (pint_t) dyldInfo.dli_saddr);
       return true;
     }
@@ -681,7 +683,9 @@ inline bool LocalAddressSpace::findFunctionName(pint_t addr, char *buf,
   uint16_t nameLen;
   char *funcName = getFuncNameFromTBTable(addr, nameLen, offset);
   if (funcName != NULL) {
-    snprintf(buf, bufLen, "%.*s", nameLen, funcName);
+    size_t len = nameLen < (bufLen - 1) ? nameLen : (bufLen - 1);
+    memcpy(buf, funcName, len);
+    buf[len] = '\0';
     return true;
   }
 #else

--- a/libunwind/src/DwarfInstructions.hpp
+++ b/libunwind/src/DwarfInstructions.hpp
@@ -12,8 +12,8 @@
 #ifndef __DWARF_INSTRUCTIONS_HPP__
 #define __DWARF_INSTRUCTIONS_HPP__
 
+#include <assert.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "DwarfParser.hpp"
@@ -416,24 +416,22 @@ typename A::pint_t
 DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
                                             const R &registers,
                                             pint_t initialStackValue) {
-  const bool log = false;
   pint_t p = expression;
   pint_t expressionEnd = expression + 20; // temp, until len read
   pint_t length = (pint_t)addressSpace.getULEB128(p, expressionEnd);
   expressionEnd = p + length;
-  if (log)
-    fprintf(stderr, "evaluateExpression(): length=%" PRIu64 "\n",
-            (uint64_t)length);
+  _LIBUNWIND_TRACE_DWARF_EVAL("evaluateExpression(): length=%" PRIu64 "\n",
+                              (uint64_t)length);
   pint_t stack[100];
   pint_t *sp = stack;
   *(++sp) = initialStackValue;
 
   while (p < expressionEnd) {
-    if (log) {
-      for (pint_t *t = sp; t > stack; --t) {
-        fprintf(stderr, "sp[] = 0x%" PRIx64 "\n", (uint64_t)(*t));
-      }
+#if _LIBUNWIND_TRACING_DWARF_EVAL
+    for (pint_t *t = sp; t > stack; --t) {
+      _LIBUNWIND_TRACE_DWARF_EVAL("sp[] = 0x%" PRIx64 "\n", (uint64_t)(*t));
     }
+#endif
     uint8_t opcode = addressSpace.get8(p++);
     sint_t svalue, svalue2;
     pint_t value;
@@ -444,16 +442,15 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       value = addressSpace.getP(p);
       p += sizeof(pint_t);
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)value);
       break;
 
     case DW_OP_deref:
       // pop stack, dereference, push result
       value = *sp--;
       *(++sp) = addressSpace.getP(value);
-      if (log)
-        fprintf(stderr, "dereference 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("dereference 0x%" PRIx64 "\n",
+                                  (uint64_t)value);
       break;
 
     case DW_OP_const1u:
@@ -461,8 +458,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       value = addressSpace.get8(p);
       p += 1;
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)value);
       break;
 
     case DW_OP_const1s:
@@ -470,8 +466,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       svalue = (int8_t) addressSpace.get8(p);
       p += 1;
       *(++sp) = (pint_t)svalue;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)svalue);
       break;
 
     case DW_OP_const2u:
@@ -479,8 +474,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       value = addressSpace.get16(p);
       p += 2;
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)value);
       break;
 
     case DW_OP_const2s:
@@ -488,8 +482,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       svalue = (int16_t) addressSpace.get16(p);
       p += 2;
       *(++sp) = (pint_t)svalue;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)svalue);
       break;
 
     case DW_OP_const4u:
@@ -497,8 +490,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       value = addressSpace.get32(p);
       p += 4;
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)value);
       break;
 
     case DW_OP_const4s:
@@ -506,8 +498,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       svalue = (int32_t)addressSpace.get32(p);
       p += 4;
       *(++sp) = (pint_t)svalue;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)svalue);
       break;
 
     case DW_OP_const8u:
@@ -515,8 +506,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       value = (pint_t)addressSpace.get64(p);
       p += 8;
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)value);
       break;
 
     case DW_OP_const8s:
@@ -524,47 +514,41 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       value = (pint_t)addressSpace.get64(p);
       p += 8;
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)value);
       break;
 
     case DW_OP_constu:
       // push immediate ULEB128 value
       value = (pint_t)addressSpace.getULEB128(p, expressionEnd);
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)value);
       break;
 
     case DW_OP_consts:
       // push immediate SLEB128 value
       svalue = (sint_t)addressSpace.getSLEB128(p, expressionEnd);
       *(++sp) = (pint_t)svalue;
-      if (log)
-        fprintf(stderr, "push 0x%" PRIx64 "\n", (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push 0x%" PRIx64 "\n", (uint64_t)svalue);
       break;
 
     case DW_OP_dup:
       // push top of stack
       value = *sp;
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "duplicate top of stack\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("duplicate top of stack\n");
       break;
 
     case DW_OP_drop:
       // pop
       --sp;
-      if (log)
-        fprintf(stderr, "pop top of stack\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("pop top of stack\n");
       break;
 
     case DW_OP_over:
       // dup second
       value = sp[-1];
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "duplicate second in stack\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("duplicate second in stack\n");
       break;
 
     case DW_OP_pick:
@@ -573,8 +557,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       p += 1;
       value = sp[-(int)reg];
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "duplicate %d in stack\n", reg);
+      _LIBUNWIND_TRACE_DWARF_EVAL("duplicate %d in stack\n", reg);
       break;
 
     case DW_OP_swap:
@@ -582,8 +565,7 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       value = sp[0];
       sp[0] = sp[-1];
       sp[-1] = value;
-      if (log)
-        fprintf(stderr, "swap top of stack\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("swap top of stack\n");
       break;
 
     case DW_OP_rot:
@@ -592,133 +574,116 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       sp[0] = sp[-1];
       sp[-1] = sp[-2];
       sp[-2] = value;
-      if (log)
-        fprintf(stderr, "rotate top three of stack\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("rotate top three of stack\n");
       break;
 
     case DW_OP_xderef:
       // pop stack, dereference, push result
       value = *sp--;
       *sp = *((pint_t*)value);
-      if (log)
-        fprintf(stderr, "x-dereference 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("x-dereference 0x%" PRIx64 "\n",
+                                  (uint64_t)value);
       break;
 
     case DW_OP_abs:
       svalue = (sint_t)*sp;
       if (svalue < 0)
         *sp = (pint_t)(-svalue);
-      if (log)
-        fprintf(stderr, "abs\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("abs\n");
       break;
 
     case DW_OP_and:
       value = *sp--;
       *sp &= value;
-      if (log)
-        fprintf(stderr, "and\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("and\n");
       break;
 
     case DW_OP_div:
       svalue = (sint_t)(*sp--);
       svalue2 = (sint_t)*sp;
       *sp = (pint_t)(svalue2 / svalue);
-      if (log)
-        fprintf(stderr, "div\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("div\n");
       break;
 
     case DW_OP_minus:
       value = *sp--;
       *sp = *sp - value;
-      if (log)
-        fprintf(stderr, "minus\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("minus\n");
       break;
 
     case DW_OP_mod:
       svalue = (sint_t)(*sp--);
       svalue2 = (sint_t)*sp;
       *sp = (pint_t)(svalue2 % svalue);
-      if (log)
-        fprintf(stderr, "module\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("module\n");
       break;
 
     case DW_OP_mul:
       svalue = (sint_t)(*sp--);
       svalue2 = (sint_t)*sp;
       *sp = (pint_t)(svalue2 * svalue);
-      if (log)
-        fprintf(stderr, "mul\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("mul\n");
       break;
 
     case DW_OP_neg:
       *sp = 0 - *sp;
-      if (log)
-        fprintf(stderr, "neg\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("neg\n");
       break;
 
     case DW_OP_not:
       svalue = (sint_t)(*sp);
       *sp = (pint_t)(~svalue);
-      if (log)
-        fprintf(stderr, "not\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("not\n");
       break;
 
     case DW_OP_or:
       value = *sp--;
       *sp |= value;
-      if (log)
-        fprintf(stderr, "or\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("or\n");
       break;
 
     case DW_OP_plus:
       value = *sp--;
       *sp += value;
-      if (log)
-        fprintf(stderr, "plus\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("plus\n");
       break;
 
     case DW_OP_plus_uconst:
       // pop stack, add uelb128 constant, push result
       *sp += static_cast<pint_t>(addressSpace.getULEB128(p, expressionEnd));
-      if (log)
-        fprintf(stderr, "add constant\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("add constant\n");
       break;
 
     case DW_OP_shl:
       value = *sp--;
       *sp = *sp << value;
-      if (log)
-        fprintf(stderr, "shift left\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("shift left\n");
       break;
 
     case DW_OP_shr:
       value = *sp--;
       *sp = *sp >> value;
-      if (log)
-        fprintf(stderr, "shift left\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("shift left\n");
       break;
 
     case DW_OP_shra:
       value = *sp--;
       svalue = (sint_t)*sp;
       *sp = (pint_t)(svalue >> value);
-      if (log)
-        fprintf(stderr, "shift left arithmetic\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("shift left arithmetic\n");
       break;
 
     case DW_OP_xor:
       value = *sp--;
       *sp ^= value;
-      if (log)
-        fprintf(stderr, "xor\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("xor\n");
       break;
 
     case DW_OP_skip:
       svalue = (int16_t) addressSpace.get16(p);
       p += 2;
       p = (pint_t)((sint_t)p + svalue);
-      if (log)
-        fprintf(stderr, "skip %" PRIu64 "\n", (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("skip %" PRIu64 "\n", (uint64_t)svalue);
       break;
 
     case DW_OP_bra:
@@ -726,50 +691,43 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       p += 2;
       if (*sp--)
         p = (pint_t)((sint_t)p + svalue);
-      if (log)
-        fprintf(stderr, "bra %" PRIu64 "\n", (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("bra %" PRIu64 "\n", (uint64_t)svalue);
       break;
 
     case DW_OP_eq:
       value = *sp--;
       *sp = (*sp == value);
-      if (log)
-        fprintf(stderr, "eq\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("eq\n");
       break;
 
     case DW_OP_ge:
       value = *sp--;
       *sp = (*sp >= value);
-      if (log)
-        fprintf(stderr, "ge\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("ge\n");
       break;
 
     case DW_OP_gt:
       value = *sp--;
       *sp = (*sp > value);
-      if (log)
-        fprintf(stderr, "gt\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("gt\n");
       break;
 
     case DW_OP_le:
       value = *sp--;
       *sp = (*sp <= value);
-      if (log)
-        fprintf(stderr, "le\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("le\n");
       break;
 
     case DW_OP_lt:
       value = *sp--;
       *sp = (*sp < value);
-      if (log)
-        fprintf(stderr, "lt\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("lt\n");
       break;
 
     case DW_OP_ne:
       value = *sp--;
       *sp = (*sp != value);
-      if (log)
-        fprintf(stderr, "ne\n");
+      _LIBUNWIND_TRACE_DWARF_EVAL0("ne\n");
       break;
 
     case DW_OP_lit0:
@@ -806,8 +764,8 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
     case DW_OP_lit31:
       value = static_cast<pint_t>(opcode - DW_OP_lit0);
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "push literal 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push literal 0x%" PRIx64 "\n",
+                                  (uint64_t)value);
       break;
 
     case DW_OP_reg0:
@@ -844,15 +802,14 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
     case DW_OP_reg31:
       reg = static_cast<uint32_t>(opcode - DW_OP_reg0);
       *(++sp) = registers.getRegister((int)reg);
-      if (log)
-        fprintf(stderr, "push reg %d\n", reg);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push reg %d\n", reg);
       break;
 
     case DW_OP_regx:
       reg = static_cast<uint32_t>(addressSpace.getULEB128(p, expressionEnd));
       *(++sp) = registers.getRegister((int)reg);
-      if (log)
-        fprintf(stderr, "push reg %d + 0x%" PRIx64 "\n", reg, (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push reg %d + 0x%" PRIx64 "\n", reg,
+                                  (uint64_t)svalue);
       break;
 
     case DW_OP_breg0:
@@ -891,8 +848,8 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       svalue = (sint_t)addressSpace.getSLEB128(p, expressionEnd);
       svalue += static_cast<sint_t>(registers.getRegister((int)reg));
       *(++sp) = (pint_t)(svalue);
-      if (log)
-        fprintf(stderr, "push reg %d + 0x%" PRIx64 "\n", reg, (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push reg %d + 0x%" PRIx64 "\n", reg,
+                                  (uint64_t)svalue);
       break;
 
     case DW_OP_bregx:
@@ -900,8 +857,8 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
       svalue = (sint_t)addressSpace.getSLEB128(p, expressionEnd);
       svalue += static_cast<sint_t>(registers.getRegister((int)reg));
       *(++sp) = (pint_t)(svalue);
-      if (log)
-        fprintf(stderr, "push reg %d + 0x%" PRIx64 "\n", reg, (uint64_t)svalue);
+      _LIBUNWIND_TRACE_DWARF_EVAL("push reg %d + 0x%" PRIx64 "\n", reg,
+                                  (uint64_t)svalue);
       break;
 
     case DW_OP_fbreg:
@@ -932,8 +889,8 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
         _LIBUNWIND_ABORT("DW_OP_deref_size with bad size");
       }
       *(++sp) = value;
-      if (log)
-        fprintf(stderr, "sized dereference 0x%" PRIx64 "\n", (uint64_t)value);
+      _LIBUNWIND_TRACE_DWARF_EVAL("sized dereference 0x%" PRIx64 "\n",
+                                  (uint64_t)value);
       break;
 
     case DW_OP_xderef_size:
@@ -947,12 +904,10 @@ DwarfInstructions<A, R>::evaluateExpression(pint_t expression, A &addressSpace,
     }
 
   }
-  if (log)
-    fprintf(stderr, "expression evaluates to 0x%" PRIx64 "\n", (uint64_t)*sp);
+  _LIBUNWIND_TRACE_DWARF_EVAL("expression evaluates to 0x%" PRIx64 "\n",
+                              (uint64_t)*sp);
   return *sp;
 }
-
-
 
 } // namespace libunwind
 

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -12,9 +12,9 @@
 #ifndef __DWARF_PARSER_HPP__
 #define __DWARF_PARSER_HPP__
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "libunwind.h"

--- a/libunwind/src/Unwind-EHABI.cpp
+++ b/libunwind/src/Unwind-EHABI.cpp
@@ -13,10 +13,10 @@
 
 #if defined(_LIBUNWIND_ARM_EHABI)
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -13,7 +13,6 @@
 
 #include "shadow_stack_unwind.h"
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <unwind.h>
 
@@ -1722,10 +1721,9 @@ bool UnwindCursor<A, R>::getInfoFromDwarfSection(pint_t pc,
 template <typename A, typename R>
 bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
                                               const UnwindInfoSections &sects) {
-  const bool log = false;
-  if (log)
-    fprintf(stderr, "getInfoFromCompactEncodingSection(pc=0x%llX, mh=0x%llX)\n",
-            (uint64_t)pc, (uint64_t)sects.dso_base);
+  _LIBUNWIND_TRACE_COMPACT_UNWIND(
+      "getInfoFromCompactEncodingSection(pc=0x%llX, mh=0x%llX)\n", (uint64_t)pc,
+      (uint64_t)sects.dso_base);
 
   const UnwindSectionHeader<A> sectionHeader(_addressSpace,
                                                 sects.compact_unwind_section);
@@ -1742,8 +1740,8 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
   uint32_t last = high - 1;
   while (low < high) {
     uint32_t mid = (low + high) / 2;
-    //if ( log ) fprintf(stderr, "\tmid=%d, low=%d, high=%d, *mid=0x%08X\n",
-    //mid, low, high, topIndex.functionOffset(mid));
+    // _LIBUNWIND_TRACE_COMPACT_UNWIND("\tmid=%d, low=%d, high=%d,
+    //     *mid=0x%08X\n", mid, low, high, topIndex.functionOffset(mid));
     if (topIndex.functionOffset(mid) <= targetFunctionOffset) {
       if ((mid == last) ||
           (topIndex.functionOffset(mid + 1) > targetFunctionOffset)) {
@@ -1765,10 +1763,9 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
       sects.compact_unwind_section + topIndex.lsdaIndexArraySectionOffset(low);
   const pint_t lsdaArrayEndAddr =
       sects.compact_unwind_section + topIndex.lsdaIndexArraySectionOffset(low+1);
-  if (log)
-    fprintf(stderr, "\tfirst level search for result index=%d "
-                    "to secondLevelAddr=0x%llX\n",
-                    low, (uint64_t) secondLevelAddr);
+  _LIBUNWIND_TRACE_COMPACT_UNWIND(
+      "\tfirst level search for result index=%d to secondLevelAddr=0x%llX\n",
+      low, (uint64_t)secondLevelAddr);
   // do a binary search of second level page index
   uint32_t encoding = 0;
   pint_t funcStart = 0;
@@ -1784,10 +1781,10 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
         _addressSpace, secondLevelAddr + pageHeader.entryPageOffset());
     // binary search looks for entry with e where index[e].offset <= pc <
     // index[e+1].offset
-    if (log)
-      fprintf(stderr, "\tbinary search for targetFunctionOffset=0x%08llX in "
-                      "regular page starting at secondLevelAddr=0x%llX\n",
-              (uint64_t) targetFunctionOffset, (uint64_t) secondLevelAddr);
+    _LIBUNWIND_TRACE_COMPACT_UNWIND(
+        "\tbinary search for targetFunctionOffset=0x%08llX in "
+        "regular page starting at secondLevelAddr=0x%llX\n",
+        (uint64_t)targetFunctionOffset, (uint64_t)secondLevelAddr);
     low = 0;
     high = pageHeader.entryCount();
     while (low < high) {
@@ -1813,19 +1810,15 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
     encoding = pageIndex.encoding(low);
     funcStart = pageIndex.functionOffset(low) + sects.dso_base;
     if (pc < funcStart) {
-      if (log)
-        fprintf(
-            stderr,
-            "\tpc not in table, pc=0x%llX, funcStart=0x%llX, funcEnd=0x%llX\n",
-            (uint64_t) pc, (uint64_t) funcStart, (uint64_t) funcEnd);
+      _LIBUNWIND_TRACE_COMPACT_UNWIND(
+          "\tpc not in table, pc=0x%llX, funcStart=0x%llX, funcEnd=0x%llX\n",
+          (uint64_t)pc, (uint64_t)funcStart, (uint64_t)funcEnd);
       return false;
     }
     if (pc > funcEnd) {
-      if (log)
-        fprintf(
-            stderr,
-            "\tpc not in table, pc=0x%llX, funcStart=0x%llX, funcEnd=0x%llX\n",
-            (uint64_t) pc, (uint64_t) funcStart, (uint64_t) funcEnd);
+      _LIBUNWIND_TRACE_COMPACT_UNWIND(
+          "\tpc not in table, pc=0x%llX, funcStart=0x%llX, funcEnd=0x%llX\n",
+          (uint64_t)pc, (uint64_t)funcStart, (uint64_t)funcEnd);
       return false;
     }
   } else if (pageKind == UNWIND_SECOND_LEVEL_COMPRESSED) {
@@ -1838,10 +1831,10 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
         (uint32_t)(targetFunctionOffset - firstLevelFunctionOffset);
     // binary search looks for entry with e where index[e].offset <= pc <
     // index[e+1].offset
-    if (log)
-      fprintf(stderr, "\tbinary search of compressed page starting at "
-                      "secondLevelAddr=0x%llX\n",
-              (uint64_t) secondLevelAddr);
+    _LIBUNWIND_TRACE_COMPACT_UNWIND(
+        "\tbinary search of compressed page starting at "
+        "secondLevelAddr=0x%llX\n",
+        (uint64_t)secondLevelAddr);
     low = 0;
     last = pageHeader.entryCount() - 1;
     high = pageHeader.entryCount();
@@ -1871,14 +1864,14 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
       _LIBUNWIND_DEBUG_LOG("malformed __unwind_info, pc=0x%llX "
                            "not in second level compressed unwind table. "
                            "funcStart=0x%llX",
-                            (uint64_t) pc, (uint64_t) funcStart);
+                           (uint64_t)pc, (uint64_t)funcStart);
       return false;
     }
     if (pc > funcEnd) {
       _LIBUNWIND_DEBUG_LOG("malformed __unwind_info, pc=0x%llX "
                            "not in second level compressed unwind table. "
                            "funcEnd=0x%llX",
-                           (uint64_t) pc, (uint64_t) funcEnd);
+                           (uint64_t)pc, (uint64_t)funcEnd);
       return false;
     }
     uint16_t encodingIndex = pageIndex.encodingIndex(low);
@@ -1911,10 +1904,9 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
     high = (uint32_t)(lsdaArrayEndAddr - lsdaArrayStartAddr) /
                     sizeof(unwind_info_section_header_lsda_index_entry);
     // binary search looks for entry with exact match for functionOffset
-    if (log)
-      fprintf(stderr,
-              "\tbinary search of lsda table for targetFunctionOffset=0x%08X\n",
-              funcStartOffset);
+    _LIBUNWIND_TRACE_COMPACT_UNWIND(
+        "\tbinary search of lsda table for targetFunctionOffset=0x%08X\n",
+        funcStartOffset);
     while (low < high) {
       uint32_t mid = (low + high) / 2;
       if (lsdaIndex.functionOffset(mid) == funcStartOffset) {
@@ -1952,16 +1944,16 @@ bool UnwindCursor<A, R>::getInfoFromCompactEncodingSection(pint_t pc,
         personalityIndex * sizeof(uint32_t));
     pint_t personalityPointer = sects.dso_base + (pint_t)personalityDelta;
     personality = _addressSpace.getP(personalityPointer);
-    if (log)
-      fprintf(stderr, "getInfoFromCompactEncodingSection(pc=0x%llX), "
-                      "personalityDelta=0x%08X, personality=0x%08llX\n",
-              (uint64_t) pc, personalityDelta, (uint64_t) personality);
+    _LIBUNWIND_TRACE_COMPACT_UNWIND(
+        "getInfoFromCompactEncodingSection(pc=0x%llX), "
+        "personalityDelta=0x%08X, personality=0x%08llX\n",
+        (uint64_t)pc, personalityDelta, (uint64_t)personality);
   }
 
-  if (log)
-    fprintf(stderr, "getInfoFromCompactEncodingSection(pc=0x%llX), "
-                    "encoding=0x%08X, lsda=0x%08llX for funcStart=0x%llX\n",
-            (uint64_t) pc, encoding, (uint64_t) lsda, (uint64_t) funcStart);
+  _LIBUNWIND_TRACE_COMPACT_UNWIND(
+      "getInfoFromCompactEncodingSection(pc=0x%llX), "
+      "encoding=0x%08X, lsda=0x%08llX for funcStart=0x%llX\n",
+      (uint64_t)pc, encoding, (uint64_t)lsda, (uint64_t)funcStart);
   _info.start_ip = funcStart;
   _info.end_ip = funcEnd;
   _info.lsda = lsda;

--- a/libunwind/src/UnwindLevel1-gcc-ext.c
+++ b/libunwind/src/UnwindLevel1-gcc-ext.c
@@ -12,7 +12,6 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/libunwind/src/UnwindLevel1.c
+++ b/libunwind/src/UnwindLevel1.c
@@ -19,10 +19,9 @@
 #define _LIBUNWIND_UNWIND_LEVEL1_EXTERNAL_LINKAGE 1
 
 #include <inttypes.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "config.h"

--- a/libunwind/src/config.h
+++ b/libunwind/src/config.h
@@ -13,8 +13,6 @@
 #ifndef LIBUNWIND_CONFIG_H
 #define LIBUNWIND_CONFIG_H
 
-#include <assert.h>
-#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -221,6 +219,41 @@
       if (logDWARF())                                                          \
         fprintf(stderr, __VA_ARGS__);                                          \
     } while (0)
+#endif
+
+#define _LIBUNWIND_TRACING_COMPACT_UNWIND (0)
+#if !_LIBUNWIND_TRACING_COMPACT_UNWIND
+#define _LIBUNWIND_TRACE_COMPACT_UNWIND0(msg)
+#define _LIBUNWIND_TRACE_COMPACT_UNWIND(msg, ...)
+#else
+#define _LIBUNWIND_TRACE_COMPACT_UNWIND0(msg)                                  \
+  do {                                                                         \
+    fprintf(stderr, msg);                                                      \
+  } while (0)
+#define _LIBUNWIND_TRACE_COMPACT_UNWIND(msg, ...)                              \
+  do {                                                                         \
+    fprintf(stderr, msg, __VA_ARGS__);                                         \
+  } while (0)
+#endif
+
+#define _LIBUNWIND_TRACING_DWARF_EVAL (0)
+#if !_LIBUNWIND_TRACING_DWARF_EVAL
+#define _LIBUNWIND_TRACE_DWARF_EVAL0(msg)
+#define _LIBUNWIND_TRACE_DWARF_EVAL(msg, ...)
+#else
+#define _LIBUNWIND_TRACE_DWARF_EVAL0(msg)                                      \
+  do {                                                                         \
+    fprintf(stderr, msg);                                                      \
+  } while (0)
+#define _LIBUNWIND_TRACE_DWARF_EVAL(msg, ...)                                  \
+  do {                                                                         \
+    fprintf(stderr, msg, __VA_ARGS__);                                         \
+  } while (0)
+#endif
+
+#if !defined(NDEBUG) || !defined(_LIBUNWIND_IS_BAREMETAL) ||                   \
+    _LIBUNWIND_TRACING_COMPACT_UNWIND || _LIBUNWIND_TRACING_DWARF_EVAL
+#include <stdio.h>
 #endif
 
 #ifdef __cplusplus

--- a/libunwind/test/aix_signal_unwind.pass.sh.S
+++ b/libunwind/test/aix_signal_unwind.pass.sh.S
@@ -28,7 +28,7 @@
 #undef NDEBUG
 #include <assert.h>
 #include <signal.h>
-#include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/debug.h>

--- a/libunwind/test/bad_unwind_info.pass.cpp
+++ b/libunwind/test/bad_unwind_info.pass.cpp
@@ -21,7 +21,6 @@
 #undef NDEBUG
 #include <assert.h>
 #include <libunwind.h>
-#include <stdio.h>
 
 __attribute__((naked)) void bad_unwind_info() {
 #if defined(__aarch64__)

--- a/libunwind/test/forceunwind.pass.cpp
+++ b/libunwind/test/forceunwind.pass.cpp
@@ -19,7 +19,6 @@
 #include <assert.h>
 #include <signal.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/libunwind/test/frameheadercache_test.pass.cpp
+++ b/libunwind/test/frameheadercache_test.pass.cpp
@@ -17,7 +17,7 @@
     defined(_LIBUNWIND_USE_FRAME_HEADER_CACHE)
 
 #include <link.h>
-#include <stdio.h>
+#include <string.h>
 
 // This file defines several of the data structures needed here,
 // and includes FrameHeaderCache.hpp as well.

--- a/libunwind/test/signal_unwind.pass.cpp
+++ b/libunwind/test/signal_unwind.pass.cpp
@@ -23,7 +23,6 @@
 #undef NDEBUG
 #include <assert.h>
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/libunwind/test/unwind_leaffunction.pass.cpp
+++ b/libunwind/test/unwind_leaffunction.pass.cpp
@@ -23,7 +23,6 @@
 #undef NDEBUG
 #include <assert.h>
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>


### PR DESCRIPTION
libunwind already puts logging facilities behind macros so that they can be turned on and off. The two places where this isn't done yet are for debug output tracing during DWARF evaluation and compact unwinding. The code there directly calls `fprintf`. This becomes a problem when one wants to build libunwind for a baremetal target where `fprintf` isn't available. This change introduces a set of `_LIBUNWIND_TRACE_DWARF_EVAL` and `_LIBUNWIND_TRACE_COMPACT_UNWIND` macros in the style of the already existing macros to remove the direct use of `fprintf`. It also removes unnecessary includes of `stdio.h`.