### PR TITLE
[clang-tidy] Fixes to readability-implicit-bool-conversion

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -174,6 +174,11 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-override>` check to also remove any trailing
   whitespace when deleting the ``virtual`` keyword.
 
+- Improved :doc:`readability-implicit-bool-conversion
+  <clang-tidy/checks/readability/implicit-bool-conversion>` check to provide
+  valid fix suggestions for ``static_cast`` without a preceding space and
+  fixed problem with duplicate parentheses in double implicit casts.
+
 - Improved :doc:`readability-redundant-inline-specifier
   <clang-tidy/checks/readability/redundant-inline-specifier>` check to properly
   emit warnings for static data member with an in-class initializer.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -524,3 +524,12 @@ namespace PR71867 {
     // CHECK-FIXES: return (x ? 1 : 0) != 0;
   }
 }
+
+namespace PR71848 {
+  int fun() {
+    bool foo = false;
+    return( foo );
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
+// CHECK-FIXES: return static_cast<int>( foo );
+  }
+}


### PR DESCRIPTION
- Fixed issue with invalid code being generated when static_cast is put into fix, and no space were added before it.
- Fixed issue with duplicate parentheses being added when double implicit cast is used.

Closes #71848 