### PR TITLE
[lld] lld::makeThreadLocal: omit `thread_local` when threads disabled

### DIFF
--- a/lld/include/lld/Common/Memory.h
+++ b/lld/include/lld/Common/Memory.h
@@ -65,7 +65,11 @@ template <typename T, typename... U> T *make(U &&... args) {
 template <typename T>
 inline llvm::SpecificBumpPtrAllocator<T> &
 getSpecificAllocSingletonThreadLocal() {
+#if LLVM_ENABLE_THREADS
   thread_local SpecificAlloc<T> instance;
+#else
+  static SpecificAlloc<T> instance;
+#endif
   return instance.alloc;
 }
 


### PR DESCRIPTION
This PR lets lld be used as a library in single-threaded environments without TLS.