### PR TITLE
[lld] lld/ELF/Writer.cpp: write directly to outs when output is "-"

### DIFF
--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -652,6 +652,13 @@ template <class ELFT> void Writer<ELFT>::run() {
     if (errorCount())
       return;
 
+    if (config->outputFile == "-") {
+      lld::outs() << StringRef((const char *)buffer->getBufferStart(),
+                               buffer->getBufferSize());
+      lld::outs().flush();
+      return;
+    }
+
     if (auto e = buffer->commit())
       fatal("failed to write output '" + buffer->getPath() +
             "': " + toString(std::move(e)));


### PR DESCRIPTION
This PR lets the LLD ELF driver write directly to lld::outs() (the `stdoutOS` argument to `lld::elf::link()`), when the output filename is "-".
This lets the LLD ELF driver be used as a library with its output written to an in-memory buffer.