### PR TITLE
[OpenMP][mlir] Add `enter` capture attribute to declare target

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -115,13 +115,14 @@ def DeclareTargetDeviceTypeAttr : EnumAttr<OpenMP_Dialect, DeclareTargetDeviceTy
   let assemblyFormat = "`(` $value `)`";
 }
 
-def CaptureClauseLink : I32EnumAttrCase<"to", 0>;
-def CaptureClauseTo   : I32EnumAttrCase<"link", 1>;
+def CaptureClauseTo : I32EnumAttrCase<"to", 0>;
+def CaptureClauseLink   : I32EnumAttrCase<"link", 1>;
+def CaptureClauseEnter   : I32EnumAttrCase<"enter", 2>;
 
 def DeclareTargetCaptureClause : I32EnumAttr<
     "DeclareTargetCaptureClause",
     "capture clause",
-    [CaptureClauseLink, CaptureClauseTo]> {
+    [CaptureClauseTo, CaptureClauseLink, CaptureClauseEnter]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::omp";
 }

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -1560,10 +1560,10 @@ convertToCaptureClauseKind(
   switch (captureClasue) {
   case mlir::omp::DeclareTargetCaptureClause::to:
     return llvm::OffloadEntriesInfoManager::OMPTargetGlobalVarEntryTo;
-    break;
   case mlir::omp::DeclareTargetCaptureClause::link:
     return llvm::OffloadEntriesInfoManager::OMPTargetGlobalVarEntryLink;
-    break;
+  case mlir::omp::DeclareTargetCaptureClause::enter:
+    return llvm::OffloadEntriesInfoManager::OMPTargetGlobalVarEntryEnter;
   }
   llvm_unreachable("unhandled capture clause");
 }

--- a/mlir/test/Dialect/OpenMP/attr.mlir
+++ b/mlir/test/Dialect/OpenMP/attr.mlir
@@ -71,6 +71,12 @@ func.func @omp_decl_tar_host_link() -> () attributes {omp.declare_target = #omp.
   return
 }
 
+// CHECK-LABEL: func @omp_decl_tar_host_enter
+// CHECK-SAME: {{.*}} attributes {omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (enter)>} {
+func.func @omp_decl_tar_host_enter() -> () attributes {omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (enter)>} {
+  return
+}
+
 // CHECK-LABEL: func @omp_decl_tar_nohost_to
 // CHECK-SAME: {{.*}} attributes {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (to)>} {
 func.func @omp_decl_tar_nohost_to() -> () attributes {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (to)>} {
@@ -80,6 +86,12 @@ func.func @omp_decl_tar_nohost_to() -> () attributes {omp.declare_target = #omp.
 // CHECK-LABEL: func @omp_decl_tar_nohost_link
 // CHECK-SAME: {{.*}} attributes {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (link)>} {
 func.func @omp_decl_tar_nohost_link() -> () attributes {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (link)>} {
+  return
+}
+
+// CHECK-LABEL: func @omp_decl_tar_nohost_enter
+// CHECK-SAME: {{.*}} attributes {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (enter)>} {
+func.func @omp_decl_tar_nohost_enter() -> () attributes {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (enter)>} {
   return
 }
 
@@ -95,6 +107,12 @@ func.func @omp_decl_tar_any_link() -> () attributes {omp.declare_target = #omp.d
   return
 }
 
+// CHECK-LABEL: func @omp_decl_tar_any_enter
+// CHECK-SAME: {{.*}} attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} {
+func.func @omp_decl_tar_any_enter() -> () attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} {
+  return
+}
+
 // CHECK-LABEL: global external @omp_decl_tar_data_host_to
 // CHECK-SAME: {{.*}} {{{.*}}omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (to)>}
 llvm.mlir.global external @omp_decl_tar_data_host_to() {omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (to)>} : i32 {
@@ -105,6 +123,13 @@ llvm.mlir.global external @omp_decl_tar_data_host_to() {omp.declare_target = #om
 // CHECK-LABEL: global external @omp_decl_tar_data_host_link
 // CHECK-SAME: {{.*}} {{{.*}}omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (link)>}
 llvm.mlir.global external @omp_decl_tar_data_host_link() {omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (link)>} : i32 {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: global external @omp_decl_tar_data_host_enter
+// CHECK-SAME: {{.*}} {{{.*}}omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (enter)>}
+llvm.mlir.global external @omp_decl_tar_data_host_enter() {omp.declare_target = #omp.declaretarget<device_type = (host), capture_clause = (enter)>} : i32 {
   %0 = llvm.mlir.constant(1 : i32) : i32
   llvm.return %0 : i32
 }
@@ -123,6 +148,13 @@ llvm.mlir.global external @omp_decl_tar_data_nohost_link() {omp.declare_target =
   llvm.return %0 : i32
 }
 
+// CHECK-LABEL: global external @omp_decl_tar_data_nohost_enter
+// CHECK-SAME: {{.*}} {{{.*}}omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (enter)>}
+llvm.mlir.global external @omp_decl_tar_data_nohost_enter() {omp.declare_target = #omp.declaretarget<device_type = (nohost), capture_clause = (enter)>} : i32 {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  llvm.return %0 : i32
+}
+
 // CHECK-LABEL: global external @omp_decl_tar_data_any_to
 // CHECK-SAME: {{.*}} {{{.*}}omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>}
 llvm.mlir.global external @omp_decl_tar_data_any_to() {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} : i32 {
@@ -133,6 +165,13 @@ llvm.mlir.global external @omp_decl_tar_data_any_to() {omp.declare_target = #omp
 // CHECK-LABEL: global external @omp_decl_tar_data_any_link
 // CHECK-SAME: {{.*}} {{{.*}}omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link)>}
 llvm.mlir.global external @omp_decl_tar_data_any_link() {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (link)>} : i32 {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  llvm.return %0 : i32
+}
+
+// CHECK-LABEL: global external @omp_decl_tar_data_any_enter
+// CHECK-SAME: {{.*}} {{{.*}}omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>}
+llvm.mlir.global external @omp_decl_tar_data_any_enter() {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} : i32 {
   %0 = llvm.mlir.constant(1 : i32) : i32
   llvm.return %0 : i32
 }

--- a/mlir/test/Target/LLVMIR/omptarget-declare-target-llvm-host.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-declare-target-llvm-host.mlir
@@ -60,11 +60,29 @@ module attributes {llvm.target_triple = "x86_64-unknown-linux-gnu", omp.is_targe
     llvm.return %0 : f32
   }
 
+  // CHECK-DAG: @_QMtest_0Edata_extended_enter_1 = global float 2.000000e+00
+  // CHECK-DAG: @.omp_offloading.entry_name{{.*}} = internal unnamed_addr constant [32 x i8] c"_QMtest_0Edata_extended_enter_1\00"
+  // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_extended_enter_1 = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_extended_enter_1, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
+  // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_extended_enter_1", i32 {{.*}}, i32 {{.*}}}
+  llvm.mlir.global external @_QMtest_0Edata_extended_enter_1() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} : f32 {
+    %0 = llvm.mlir.constant(2.000000e+00 : f32) : f32
+    llvm.return %0 : f32
+  }
+
   // CHECK-DAG: @_QMtest_0Edata_extended_to_2 = global float 3.000000e+00
   // CHECK-DAG: @.omp_offloading.entry_name{{.*}} = internal unnamed_addr constant [29 x i8] c"_QMtest_0Edata_extended_to_2\00"
   // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_extended_to_2 = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_extended_to_2, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
   // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_extended_to_2", i32 {{.*}}, i32 {{.*}}}
   llvm.mlir.global external @_QMtest_0Edata_extended_to_2() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} : f32 {
+    %0 = llvm.mlir.constant(3.000000e+00 : f32) : f32
+    llvm.return %0 : f32
+  }
+
+  // CHECK-DAG: @_QMtest_0Edata_extended_enter_2 = global float 3.000000e+00
+  // CHECK-DAG: @.omp_offloading.entry_name{{.*}} = internal unnamed_addr constant [32 x i8] c"_QMtest_0Edata_extended_enter_2\00"
+  // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_extended_enter_2 = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_extended_enter_2, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
+  // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_extended_enter_2", i32 {{.*}}, i32 {{.*}}}
+  llvm.mlir.global external @_QMtest_0Edata_extended_enter_2() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} : f32 {
     %0 = llvm.mlir.constant(3.000000e+00 : f32) : f32
     llvm.return %0 : f32
   }
@@ -79,11 +97,20 @@ module attributes {llvm.target_triple = "x86_64-unknown-linux-gnu", omp.is_targe
     llvm.return %0 : i32
   }
 
-  // CHECK-DAG: @_QMtest_0Edata_int_clauseless = global i32 1
-  // CHECK-DAG: @.omp_offloading.entry_name{{.*}} = internal unnamed_addr constant [30 x i8] c"_QMtest_0Edata_int_clauseless\00"
-  // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_int_clauseless = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_int_clauseless, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
-  // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_int_clauseless", i32 {{.*}}, i32 {{.*}}}
-  llvm.mlir.global external @_QMtest_0Edata_int_clauseless() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} : i32 {
+  // CHECK-DAG: @_QMtest_0Edata_int_clauseless_to = global i32 1
+  // CHECK-DAG: @.omp_offloading.entry_name{{.*}} = internal unnamed_addr constant [33 x i8] c"_QMtest_0Edata_int_clauseless_to\00"
+  // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_int_clauseless_to = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_int_clauseless_to, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
+  // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_int_clauseless_to", i32 {{.*}}, i32 {{.*}}}
+  llvm.mlir.global external @_QMtest_0Edata_int_clauseless_to() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} : i32 {
+    %0 = llvm.mlir.constant(1 : i32) : i32
+    llvm.return %0 : i32
+  }
+
+  // CHECK-DAG: @_QMtest_0Edata_int_clauseless_enter = global i32 1
+  // CHECK-DAG: @.omp_offloading.entry_name{{.*}} = internal unnamed_addr constant [36 x i8] c"_QMtest_0Edata_int_clauseless_enter\00"
+  // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_int_clauseless_enter = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_int_clauseless_enter, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
+  // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_int_clauseless_enter", i32 {{.*}}, i32 {{.*}}}
+  llvm.mlir.global external @_QMtest_0Edata_int_clauseless_enter() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} : i32 {
     %0 = llvm.mlir.constant(1 : i32) : i32
     llvm.return %0 : i32
   }
@@ -93,6 +120,15 @@ module attributes {llvm.target_triple = "x86_64-unknown-linux-gnu", omp.is_targe
   // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_int_to = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_int_to, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
   // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_int_to", i32 {{.*}}, i32 {{.*}}}
   llvm.mlir.global external @_QMtest_0Edata_int_to() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>} : i32 {
+    %0 = llvm.mlir.constant(5 : i32) : i32
+    llvm.return %0 : i32
+  }
+
+  // CHECK-DAG: @_QMtest_0Edata_int_enter = global i32 5
+  // CHECK-DAG: @.omp_offloading.entry_name{{.*}} = internal unnamed_addr constant [25 x i8] c"_QMtest_0Edata_int_enter\00"
+  // CHECK-DAG: @.omp_offloading.entry._QMtest_0Edata_int_enter = weak constant %struct.__tgt_offload_entry { ptr @_QMtest_0Edata_int_enter, ptr @.omp_offloading.entry_name{{.*}}, i64 4, i32 0, i32 0 }, section "omp_offloading_entries", align 1
+  // CHECK-DAG: !{{.*}} = !{i32 {{.*}}, !"_QMtest_0Edata_int_enter", i32 {{.*}}, i32 {{.*}}}
+  llvm.mlir.global external @_QMtest_0Edata_int_enter() {addr_space = 0 : i32, omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (enter)>} : i32 {
     %0 = llvm.mlir.constant(5 : i32) : i32
     llvm.return %0 : i32
   }

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -2552,6 +2552,28 @@ module attributes {omp.is_target_device = false} {
 
 // -----
 
+module attributes {omp.is_target_device = false} {
+  // CHECK: define void @filter_nohost
+  llvm.func @filter_nohost() -> ()
+      attributes {
+        omp.declare_target =
+          #omp.declaretarget<device_type = (nohost), capture_clause = (enter)>
+      } {
+    llvm.return
+  }
+
+  // CHECK: define void @filter_host
+  llvm.func @filter_host() -> ()
+      attributes {
+        omp.declare_target =
+          #omp.declaretarget<device_type = (host), capture_clause = (enter)>
+      } {
+    llvm.return
+  }
+}
+
+// -----
+
 module attributes {omp.is_target_device = true} {
   // CHECK: define void @filter_nohost
   llvm.func @filter_nohost() -> ()
@@ -2567,6 +2589,28 @@ module attributes {omp.is_target_device = true} {
       attributes {
         omp.declare_target =
           #omp.declaretarget<device_type = (host), capture_clause = (to)>
+      } {
+    llvm.return
+  }
+}
+
+// -----
+
+module attributes {omp.is_target_device = true} {
+  // CHECK: define void @filter_nohost
+  llvm.func @filter_nohost() -> ()
+      attributes {
+        omp.declare_target =
+          #omp.declaretarget<device_type = (nohost), capture_clause = (enter)>
+      } {
+    llvm.return
+  }
+
+  // CHECK-NOT: define void @filter_host
+  llvm.func @filter_host() -> ()
+      attributes {
+        omp.declare_target =
+          #omp.declaretarget<device_type = (host), capture_clause = (enter)>
       } {
     llvm.return
   }


### PR DESCRIPTION
This patch adds support for enter attribute in declare target. As the enter attribute is a replacement for `to` attribute, it has the same tests.