### PR TITLE
[sanitizers] improve debug output for failed suppression parse

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_suppressions.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_suppressions.cpp
@@ -139,6 +139,10 @@ void SuppressionContext::Parse(const char *str) {
       }
       if (type == suppression_types_num_) {
         Printf("%s: failed to parse suppressions\n", SanitizerToolName);
+        Printf("Supported suppression types are:\n");
+        for (type = 0; type < suppression_types_num_; type++) {
+          Printf("- %s\n", suppression_types_[type]);
+        }
         Die();
       }
       Suppression s;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_suppressions.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_suppressions.cpp
@@ -138,7 +138,7 @@ void SuppressionContext::Parse(const char *str) {
         }
       }
       if (type == suppression_types_num_) {
-        Printf("%s: failed to parse suppressions\n", SanitizerToolName);
+        Printf("%s: failed to parse suppressions.\n", SanitizerToolName);
         Printf("Supported suppression types are:\n");
         for (type = 0; type < suppression_types_num_; type++) {
           Printf("- %s\n", suppression_types_[type]);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_suppressions.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_suppressions.cpp
@@ -140,9 +140,8 @@ void SuppressionContext::Parse(const char *str) {
       if (type == suppression_types_num_) {
         Printf("%s: failed to parse suppressions.\n", SanitizerToolName);
         Printf("Supported suppression types are:\n");
-        for (type = 0; type < suppression_types_num_; type++) {
+        for (type = 0; type < suppression_types_num_; type++)
           Printf("- %s\n", suppression_types_[type]);
-        }
         Die();
       }
       Suppression s;

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_suppressions_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_suppressions_test.cpp
@@ -130,9 +130,15 @@ TEST_F(SuppressionContextTest, HasSuppressionType) {
 }
 
 TEST_F(SuppressionContextTest, RegressionTestForBufferOverflowInSuppressions) {
-  EXPECT_DEATH(ctx_.Parse("race"), "failed to parse suppressions");
-  EXPECT_DEATH(ctx_.Parse("foo"), "failed to parse suppressions");
+  const char *expected_output =
+    "failed to parse suppressions.\n"
+    "Supported suppression types are:\n"
+    "- race\n"
+    "- thread\n"
+    "- mutex\n"
+    "- signal\n";
+  EXPECT_DEATH(ctx_.Parse("race"), expected_output);
+  EXPECT_DEATH(ctx_.Parse("foo"), expected_output);
 }
-
 
 }  // namespace __sanitizer

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_suppressions_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_suppressions_test.cpp
@@ -131,12 +131,12 @@ TEST_F(SuppressionContextTest, HasSuppressionType) {
 
 TEST_F(SuppressionContextTest, RegressionTestForBufferOverflowInSuppressions) {
   const char *expected_output =
-    "failed to parse suppressions.\n"
-    "Supported suppression types are:\n"
-    "- race\n"
-    "- thread\n"
-    "- mutex\n"
-    "- signal\n";
+      "failed to parse suppressions.\n"
+      "Supported suppression types are:\n"
+      "- race\n"
+      "- thread\n"
+      "- mutex\n"
+      "- signal\n";
   EXPECT_DEATH(ctx_.Parse("race"), expected_output);
   EXPECT_DEATH(ctx_.Parse("foo"), expected_output);
 }


### PR DESCRIPTION
If a sanitizer suppression file can not be parsed, add the supported suppression types to the error message.

See https://github.com/llvm/llvm-project/issues/72060.