### PR TITLE
[mlir][pass] Allow reregistration of pass with same typeids

### DIFF
--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -129,7 +129,7 @@ void mlir::registerPass(const PassAllocatorFunction &function) {
                              "' pass that does not override `getArgument()`");
   StringRef description = pass->getDescription();
   PassInfo passInfo(arg, description, function);
-  passRegistry->try_emplace(arg, passInfo);
+  passRegistry->insert_or_assign(arg, passInfo);
 
   // Verify that the registered pass has the same ID as any registered to this
   // arg before it.

--- a/mlir/unittests/Pass/CMakeLists.txt
+++ b/mlir/unittests/Pass/CMakeLists.txt
@@ -6,4 +6,5 @@ add_mlir_unittest(MLIRPassTests
 target_link_libraries(MLIRPassTests
   PRIVATE
   MLIRFuncDialect
+  MLIRParser
   MLIRPass)


### PR DESCRIPTION
I would like to be able to "dynamically" reregister the same pass (i.e., same `TypeID`) but with different "configuration" (e.g., different constructor args). 

Note that just below (in PassRegistry) there's a check to verify that the pass arg isn't being overwritten by a different pass:

```cpp
  // Verify that the registered pass has the same ID as any registered to this
  // arg before it.
  TypeID entryTypeID = pass->getTypeID();
  auto it = passRegistryTypeIDs->try_emplace(arg, entryTypeID).first;
  if (it->second != entryTypeID)
    llvm::report_fatal_error(
        "pass allocator creates a different pass than previously "
        "registered for pass " +
        arg);
```

so as far as I can tell, there's no danger here of someone "hijacking" a pass arg.