### PR TITLE
[DebugInfo] Limit jump table test for x86 only

### DIFF
--- a/llvm/test/DebugInfo/Generic/debug-info-jump-table.ll
+++ b/llvm/test/DebugInfo/Generic/debug-info-jump-table.ll
@@ -1,3 +1,4 @@
+; REQUIRES: x86-registered-target
 ; RUN: llc -debug-only=isel %s -o /dev/null 2>&1 | FileCheck --match-full-lines %s
 
 @str = private unnamed_addr constant [2 x i8] c"1\00", align 1

--- a/llvm/test/DebugInfo/Generic/debug-info-jump-table.ll
+++ b/llvm/test/DebugInfo/Generic/debug-info-jump-table.ll
@@ -1,6 +1,9 @@
 ; REQUIRES: x86-registered-target
 ; RUN: llc -debug-only=isel %s -o /dev/null 2>&1 | FileCheck --match-full-lines %s
 
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
 @str = private unnamed_addr constant [2 x i8] c"1\00", align 1
 @str.12 = private unnamed_addr constant [2 x i8] c"2\00", align 1
 @str.13 = private unnamed_addr constant [2 x i8] c"3\00", align 1


### PR DESCRIPTION
32 bit target may generate different SelectionDAG for jump table. 
Temporarily limit this test for 64bit x86 target only.