### PR TITLE
[flang] Switch lowering to use the HLFIR step by default

### DIFF
--- a/flang/include/flang/Lower/LoweringOptions.def
+++ b/flang/include/flang/Lower/LoweringOptions.def
@@ -27,14 +27,14 @@ ENUM_LOWERINGOPT(OptimizeTranspose, unsigned, 1, 1)
 /// If true, enable polymorphic type lowering feature. Off by default.
 ENUM_LOWERINGOPT(PolymorphicTypeImpl, unsigned, 1, 0)
 
-/// If true, lower to High level FIR before lowering to FIR.
-/// Off by default until fully ready.
-ENUM_LOWERINGOPT(LowerToHighLevelFIR, unsigned, 1, 0)
+/// If true, lower to High level FIR before lowering to FIR. On by default.
+ENUM_LOWERINGOPT(LowerToHighLevelFIR, unsigned, 1, 1)
 
 /// If true, reverse PowerPC native vector element order.
 ENUM_LOWERINGOPT(NoPPCNativeVecElemOrder, unsigned, 1, 0)
 
-/// If true, assume external names will be suffixed with an underscore. On by default.
+/// If true, assume external names will be suffixed with an underscore.
+/// On by default.
 ENUM_LOWERINGOPT(Underscoring, unsigned, 1, 1)
 
 #undef LOWERINGOPT

--- a/flang/test/HLFIR/hlfir-flags.f90
+++ b/flang/test/HLFIR/hlfir-flags.f90
@@ -1,20 +1,22 @@
-! Test -flang-experimental-hlfir (flang-new), -hlfir (bbc), -emit-hlfir, -emit-fir flags
+! Test -flang-deprecated-hlfir, -flang-experimental-hlfir (flang-new), and
+! -hlfir (bbc), -emit-hlfir, -emit-fir flags
 ! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck --check-prefix HLFIR --check-prefix ALL %s
 ! RUN: bbc -emit-hlfir -o - %s | FileCheck --check-prefix HLFIR --check-prefix ALL %s
-! RUN: %flang_fc1 -emit-hlfir -flang-experimental-hlfir -o - %s | FileCheck --check-prefix HLFIR --check-prefix ALL %s
+! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck --check-prefix HLFIR --check-prefix ALL %s
 ! RUN: bbc -emit-hlfir -hlfir -o - %s | FileCheck --check-prefix HLFIR --check-prefix ALL %s
-! RUN: %flang_fc1 -emit-fir -o - %s | FileCheck %s --check-prefix NO-HLFIR --check-prefix ALL
+! RUN: %flang_fc1 -emit-fir -o - %s | FileCheck --check-prefix FIR --check-prefix ALL %s
 ! RUN: %flang_fc1 -emit-fir -flang-deprecated-no-hlfir -o - %s | FileCheck %s --check-prefix NO-HLFIR --check-prefix ALL
-! RUN: bbc -emit-fir -o - %s | FileCheck %s --check-prefix NO-HLFIR --check-prefix ALL
-! RUN: %flang_fc1 -emit-fir -flang-experimental-hlfir -o - %s | FileCheck --check-prefix FIR --check-prefix ALL %s
-! RUN: bbc -emit-fir -hlfir -o - %s | FileCheck --check-prefix FIR --check-prefix ALL %s
+! RUN: %flang_fc1 -emit-fir -flang-experimental-hlfir -o - %s | FileCheck %s --check-prefix FIR --check-prefix ALL
+! RUN: bbc -emit-fir -o - %s | FileCheck --check-prefix FIR --check-prefix ALL %s
+! RUN: bbc -emit-fir -hlfir=false -o - %s | FileCheck %s --check-prefix NO-HLFIR --check-prefix ALL
 
-! | Action      | -flang-experimental-hlfir / -hlfir? | Result                          |
-! | =========== | =================================== | =============================== |
-! | -emit-hlfir | N                                   | Outputs HLFIR                   |
-! | -emit-hlfir | Y                                   | Outputs HLFIR                   |
-! | -emit-fir   | N                                   | Outputs FIR, using old lowering |
-! | -emit-fir   | Y                                   | Outputs FIR, lowering via HLFIR |
+! | Action      | -flang-deprecated-no-hlfir  | Result                          |
+! |             | / -hlfir=false?             |                                 |
+! | =========== | =========================== | =============================== |
+! | -emit-hlfir | N                           | Outputs HLFIR                   |
+! | -emit-hlfir | Y                           | Outputs HLFIR                   |
+! | -emit-fir   | N                           | Outputs FIR, lowering via HLFIR |
+! | -emit-fir   | Y                           | Outputs FIR, using old lowering |
 
 subroutine test(a, res)
   real :: a(:), res

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -193,7 +193,7 @@ static llvm::cl::opt<bool> enableNoPPCNativeVecElemOrder(
 
 static llvm::cl::opt<bool> useHLFIR("hlfir",
                                     llvm::cl::desc("Lower to high level FIR"),
-                                    llvm::cl::init(false));
+                                    llvm::cl::init(true));
 
 static llvm::cl::opt<bool> enableCUDA("fcuda",
                                       llvm::cl::desc("enable CUDA Fortran"),


### PR DESCRIPTION
Patch 3/3 of the transition step 1 described in
https://discourse.llvm.org/t/rfc-enabling-the-hlfir-lowering-by-default/72778/7

This patch changes bbc and flang-new driver to use HLFIR lowering by default.

`-hlfir=false` can be used with bbc and `-flang-deprecated-no-hlfir` with flang-new to get the previous default lowering behavior, but these options will only be available for a limited period of time.

If any user needs these options to workaround bugs, they should open an issue against flang in llvm github repo so that the regression can be fixed in HLFIR.