### PR TITLE
[JITLink][AArch32] Run all error unittests through the main entrypoints applyFixup() and readAddend()

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
@@ -226,28 +226,30 @@ struct FixupInfo<Thumb_MovwAbsNC> : public FixupInfo<Thumb_MovtAbs> {
 };
 
 /// Helper function to read the initial addend for Data-class relocations.
-Expected<int64_t> readAddendData(LinkGraph &G, Block &B, const Edge &E);
+Expected<int64_t> readAddendData(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+                                 Edge::Kind Kind);
 
 /// Helper function to read the initial addend for Arm-class relocations.
-Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, const Edge &E);
+Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+                                Edge::Kind Kind);
 
 /// Helper function to read the initial addend for Thumb-class relocations.
-Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, const Edge &E,
-                                  const ArmConfig &ArmCfg);
+Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+                                  Edge::Kind Kind, const ArmConfig &ArmCfg);
 
 /// Read the initial addend for a REL-type relocation. It's the value encoded
 /// in the immediate field of the fixup location by the compiler.
-inline Expected<int64_t> readAddend(LinkGraph &G, Block &B, const Edge &E,
+inline Expected<int64_t> readAddend(LinkGraph &G, Block &B,
+                                    Edge::OffsetT Offset, Edge::Kind Kind,
                                     const ArmConfig &ArmCfg) {
-  Edge::Kind Kind = E.getKind();
   if (Kind <= LastDataRelocation)
-    return readAddendData(G, B, E);
+    return readAddendData(G, B, Offset, Kind);
 
   if (Kind <= LastArmRelocation)
-    return readAddendArm(G, B, E);
+    return readAddendArm(G, B, Offset, Kind);
 
   if (Kind <= LastThumbRelocation)
-    return readAddendThumb(G, B, E, ArmCfg);
+    return readAddendThumb(G, B, Offset, Kind, ArmCfg);
 
   llvm_unreachable("Relocation must be of class Data, Arm or Thumb");
 }

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
@@ -173,14 +173,13 @@ private:
 
     auto FixupAddress = orc::ExecutorAddr(FixupSect.sh_addr) + Rel.r_offset;
     Edge::OffsetT Offset = FixupAddress - BlockToFix.getAddress();
-    Edge E(*Kind, Offset, *GraphSymbol, 0);
 
     Expected<int64_t> Addend =
-        aarch32::readAddend(*Base::G, BlockToFix, E, ArmCfg);
+        aarch32::readAddend(*Base::G, BlockToFix, Offset, *Kind, ArmCfg);
     if (!Addend)
       return Addend.takeError();
 
-    E.setAddend(*Addend);
+    Edge E(*Kind, Offset, *GraphSymbol, *Addend);
     LLVM_DEBUG({
       dbgs() << "    ";
       printEdge(dbgs(), BlockToFix, E, getELFAArch32EdgeKindName(*Kind));

--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -304,12 +304,11 @@ void writeImmediate(WritableArmRelocation &R, uint32_t Imm) {
   R.Wd = (R.Wd & ~Mask) | Imm;
 }
 
-Expected<int64_t> readAddendData(LinkGraph &G, Block &B, const Edge &E) {
+Expected<int64_t> readAddendData(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+                                 Edge::Kind Kind) {
   llvm::endianness Endian = G.getEndianness();
-
-  Edge::Kind Kind = E.getKind();
   const char *BlockWorkingMem = B.getContent().data();
-  const char *FixupPtr = BlockWorkingMem + E.getOffset();
+  const char *FixupPtr = BlockWorkingMem + Offset;
 
   switch (Kind) {
   case Data_Delta32:
@@ -319,13 +318,13 @@ Expected<int64_t> readAddendData(LinkGraph &G, Block &B, const Edge &E) {
     return make_error<JITLinkError>(
         "In graph " + G.getName() + ", section " + B.getSection().getName() +
         " can not read implicit addend for aarch32 edge kind " +
-        G.getEdgeKindName(E.getKind()));
+        G.getEdgeKindName(Kind));
   }
 }
 
-Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, const Edge &E) {
-  ArmRelocation R(B.getContent().data() + E.getOffset());
-  Edge::Kind Kind = E.getKind();
+Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+                                Edge::Kind Kind) {
+  ArmRelocation R(B.getContent().data() + Offset);
 
   switch (Kind) {
   case Arm_Call:
@@ -352,14 +351,13 @@ Expected<int64_t> readAddendArm(LinkGraph &G, Block &B, const Edge &E) {
     return make_error<JITLinkError>(
         "In graph " + G.getName() + ", section " + B.getSection().getName() +
         " can not read implicit addend for aarch32 edge kind " +
-        G.getEdgeKindName(E.getKind()));
+        G.getEdgeKindName(Kind));
   }
 }
 
-Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, const Edge &E,
-                                  const ArmConfig &ArmCfg) {
-  ThumbRelocation R(B.getContent().data() + E.getOffset());
-  Edge::Kind Kind = E.getKind();
+Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, Edge::OffsetT Offset,
+                                  Edge::Kind Kind, const ArmConfig &ArmCfg) {
+  ThumbRelocation R(B.getContent().data() + Offset);
 
   switch (Kind) {
   case Thumb_Call:
@@ -394,7 +392,7 @@ Expected<int64_t> readAddendThumb(LinkGraph &G, Block &B, const Edge &E,
     return make_error<JITLinkError>(
         "In graph " + G.getName() + ", section " + B.getSection().getName() +
         " can not read implicit addend for aarch32 edge kind " +
-        G.getEdgeKindName(E.getKind()));
+        G.getEdgeKindName(Kind));
   }
 }
 

--- a/llvm/unittests/ExecutionEngine/JITLink/AArch32ErrorTests.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/AArch32ErrorTests.cpp
@@ -46,26 +46,14 @@ TEST(AArch32_ELF, readAddendArmErrors) {
                                      AlignmentOffset);
   Edge::Kind Invalid = Edge::GenericEdgeKind::Invalid;
 
-  // Edge kind is tested, block itself is not significant here. So it is tested
-  // once in Arm
-  EXPECT_THAT_EXPECTED(readAddendData(*G, BArm, SymbolOffset, Invalid),
-                       FailedWithMessage(testing::HasSubstr(
-                           "can not read implicit addend for aarch32 edge kind "
-                           "INVALID RELOCATION")));
-
-  EXPECT_THAT_EXPECTED(readAddendArm(*G, BArm, SymbolOffset, Invalid),
-                       FailedWithMessage(testing::HasSubstr(
-                           "can not read implicit addend for aarch32 edge kind "
-                           "INVALID RELOCATION")));
-
-  EXPECT_THAT_EXPECTED(readAddendThumb(*G, BArm, SymbolOffset, Invalid, ArmCfg),
+  EXPECT_THAT_EXPECTED(readAddend(*G, BArm, SymbolOffset, Invalid, ArmCfg),
                        FailedWithMessage(testing::HasSubstr(
                            "can not read implicit addend for aarch32 edge kind "
                            "INVALID RELOCATION")));
 
   for (Edge::Kind K = FirstArmRelocation; K < LastArmRelocation; K += 1) {
     EXPECT_THAT_EXPECTED(
-        readAddendArm(*G, BArm, SymbolOffset, K),
+        readAddend(*G, BArm, SymbolOffset, K, ArmCfg),
         FailedWithMessage(testing::StartsWith("Invalid opcode")));
   }
 }
@@ -89,7 +77,7 @@ TEST(AArch32_ELF, readAddendThumbErrors) {
 
   for (Edge::Kind K = FirstThumbRelocation; K < LastThumbRelocation; K += 1) {
     EXPECT_THAT_EXPECTED(
-        readAddendThumb(*G, BThumb, SymbolOffset, K, ArmCfg),
+        readAddend(*G, BThumb, SymbolOffset, K, ArmCfg),
         FailedWithMessage(testing::StartsWith("Invalid opcode")));
   }
 }
@@ -110,24 +98,14 @@ TEST(AArch32_ELF, applyFixupArmErrors) {
   Edge InvalidEdge(Edge::GenericEdgeKind::Invalid, 0 /*Offset*/, TargetSymbol,
                    0 /*Addend*/);
 
-  // Edge kind is tested, block itself is not significant here. So it is tested
-  // once in Arm
   EXPECT_THAT_ERROR(
-      applyFixupData(*G, BArm, InvalidEdge),
-      FailedWithMessage(testing::HasSubstr(
-          "encountered unfixable aarch32 edge kind INVALID RELOCATION")));
-  EXPECT_THAT_ERROR(
-      applyFixupArm(*G, BArm, InvalidEdge),
-      FailedWithMessage(testing::HasSubstr(
-          "encountered unfixable aarch32 edge kind INVALID RELOCATION")));
-  EXPECT_THAT_ERROR(
-      applyFixupThumb(*G, BArm, InvalidEdge, ArmCfg),
+      applyFixup(*G, BArm, InvalidEdge, ArmCfg),
       FailedWithMessage(testing::HasSubstr(
           "encountered unfixable aarch32 edge kind INVALID RELOCATION")));
 
   for (Edge::Kind K = FirstArmRelocation; K < LastArmRelocation; K += 1) {
     Edge E(K, 0, TargetSymbol, 0);
-    EXPECT_THAT_ERROR(applyFixupArm(*G, BArm, E),
+    EXPECT_THAT_ERROR(applyFixup(*G, BArm, E, ArmCfg),
                       FailedWithMessage(testing::AllOf(
                           testing::StartsWith("Invalid opcode"),
                           testing::EndsWith(G->getEdgeKindName(K)))));
@@ -168,7 +146,7 @@ TEST(AArch32_ELF, applyFixupThumbErrors) {
 
   for (Edge::Kind K = FirstThumbRelocation; K < LastThumbRelocation; K += 1) {
     Edge E(K, 0, TargetSymbol, 0);
-    EXPECT_THAT_ERROR(applyFixupThumb(*G, BThumb, E, ArmCfg),
+    EXPECT_THAT_ERROR(applyFixup(*G, BThumb, E, ArmCfg),
                       FailedWithMessage(testing::AllOf(
                           testing::StartsWith("Invalid opcode"),
                           testing::EndsWith(G->getEdgeKindName(K)))));

--- a/llvm/unittests/ExecutionEngine/JITLink/AArch32ErrorTests.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/AArch32ErrorTests.cpp
@@ -44,32 +44,28 @@ TEST(AArch32_ELF, readAddendArmErrors) {
                             sizeof(ArmWord));
   auto &BArm = G->createContentBlock(Sec, ArmContent, B1DummyAddr, ArmAlignment,
                                      AlignmentOffset);
-  Symbol &TargetSymbol =
-      G->addAnonymousSymbol(BArm, SymbolOffset, SymbolSize, false, false);
-  Edge InvalidEdge(Edge::GenericEdgeKind::Invalid, 0 /*Offset*/, TargetSymbol,
-                   0 /*Addend*/);
+  Edge::Kind Invalid = Edge::GenericEdgeKind::Invalid;
 
   // Edge kind is tested, block itself is not significant here. So it is tested
   // once in Arm
-  EXPECT_THAT_EXPECTED(readAddendData(*G, BArm, InvalidEdge),
+  EXPECT_THAT_EXPECTED(readAddendData(*G, BArm, SymbolOffset, Invalid),
                        FailedWithMessage(testing::HasSubstr(
                            "can not read implicit addend for aarch32 edge kind "
                            "INVALID RELOCATION")));
 
-  EXPECT_THAT_EXPECTED(readAddendArm(*G, BArm, InvalidEdge),
+  EXPECT_THAT_EXPECTED(readAddendArm(*G, BArm, SymbolOffset, Invalid),
                        FailedWithMessage(testing::HasSubstr(
                            "can not read implicit addend for aarch32 edge kind "
                            "INVALID RELOCATION")));
 
-  EXPECT_THAT_EXPECTED(readAddendThumb(*G, BArm, InvalidEdge, ArmCfg),
+  EXPECT_THAT_EXPECTED(readAddendThumb(*G, BArm, SymbolOffset, Invalid, ArmCfg),
                        FailedWithMessage(testing::HasSubstr(
                            "can not read implicit addend for aarch32 edge kind "
                            "INVALID RELOCATION")));
 
   for (Edge::Kind K = FirstArmRelocation; K < LastArmRelocation; K += 1) {
-    Edge E(K, 0, TargetSymbol, 0);
     EXPECT_THAT_EXPECTED(
-        readAddendArm(*G, BArm, E),
+        readAddendArm(*G, BArm, SymbolOffset, K),
         FailedWithMessage(testing::StartsWith("Invalid opcode")));
   }
 }
@@ -90,15 +86,10 @@ TEST(AArch32_ELF, readAddendThumbErrors) {
                               sizeof(ThumbHalfWords));
   auto &BThumb = G->createContentBlock(Sec, ThumbContent, B2DummyAddr,
                                        ThumbAlignment, AlignmentOffset);
-  Symbol &TargetSymbol =
-      G->addAnonymousSymbol(BThumb, SymbolOffset, SymbolSize, false, false);
-  Edge InvalidEdge(Edge::GenericEdgeKind::Invalid, 0 /*Offset*/, TargetSymbol,
-                   0 /*Addend*/);
 
   for (Edge::Kind K = FirstThumbRelocation; K < LastThumbRelocation; K += 1) {
-    Edge E(K, 0, TargetSymbol, 0);
     EXPECT_THAT_EXPECTED(
-        readAddendThumb(*G, BThumb, E, ArmCfg),
+        readAddendThumb(*G, BThumb, SymbolOffset, K, ArmCfg),
         FailedWithMessage(testing::StartsWith("Invalid opcode")));
   }
 }


### PR DESCRIPTION
First commit: Reading implicit addend from a relocation site doesn't require a complete `LinkGraph` edge. The operation is independent from `TargetSymbol`, but constructing an `Edge` instance required one. This patch fixes the inconsistency and simplifies some setup code from the error unittests.

The second commit is in preparation for the `Arm`/`Thumb`/`Data` helper functions to be turned into implementation details. Exposing them in the API causes unfortunate inconsistencies that we don't want to error-check all the time, e.g. passing `Thumb_Call` to `readAddendArm()`.