### PR TITLE
[CodeGenPrepare] Return false in AddressingModeMatcher::matchOperationAddr if zext has nneg flag

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -4886,6 +4886,10 @@ bool AddressingModeMatcher::matchOperationAddr(User *AddrInst, unsigned Opcode,
     if (!Ext)
       return false;
 
+    // TODO: add comments.
+    if (Ext->hasNonNeg())
+      return false;
+
     // Try to move this ext out of the way of the addressing mode.
     // Ask for a method for doing so.
     TypePromotionHelper::Action TPH =


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/72046