### PR TITLE
[clang-format] Fix a bug in aligning comments in vector of structs

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -1465,7 +1465,7 @@ WhitespaceManager::CellDescriptions WhitespaceManager::getCells(unsigned Start,
           // Account for the added token lengths
           Changes[j].Spaces = InitialSpaces - InitialTokenLength;
         }
-      } else if (C.Tok->is(tok::comment)) {
+      } else if (C.Tok->is(tok::comment) && C.Tok->NewlinesBefore == 0) {
         // Trailing comments stay at a space past the last token
         C.Spaces = Changes[i - 1].Tok->is(tok::comma) ? 1 : 2;
       } else if (C.Tok->is(tok::l_brace)) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -21076,6 +21076,11 @@ TEST_F(FormatTest, CatchAlignArrayOfStructuresLeftAlignment) {
                "    {7,  5,                  \"!!\"   }\n"
                "};",
                Style);
+  verifyFormat("Foo foo = {\n"
+               "    // comment\n"
+               "    {1, 2}\n"
+               "};",
+               Style);
 
   Style.ColumnLimit = 20;
   // FIXME: unstable test case


### PR DESCRIPTION
Fixed #71825.