### PR TITLE
[analyzer] Switch to PostStmt callbacks in ArrayBoundV2

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -39,11 +39,13 @@ struct Messages {
   std::string Short, Full;
 };
 
-// NOTE: This is a `PostStmt` checker because the implementation passes the
-// whole subscript or unary operator expression to `CheckerContext::getSVal()`,
-// so those two callback wouldn't work as `PreStmt` (unless this checker
-// duplicated the code evaluating those expressions). The `MemberExpr` callback
-// would work as `PreStmt`, but it's `PostStmt` for the sake of consistency.
+// NOTE: The `ArraySubscriptExpr` and `UnaryOperator` callbacks are `PostStmt`
+// instead of `PreStmt` because the current implementation passes the whole
+// expression to `CheckerContext::getSVal()` which only works after the
+// symbolic evaluation of the expression. (To turn them into `PreStmt`
+// callbacks, we'd need to duplicate the logic that evaluates these
+// expressions.) The `MemberExpr` callback would work as `PreStmt` but it's
+// defined as `PostStmt` for the sake of consistency with the other callbacks.
 class ArrayBoundCheckerV2 : public Checker<check::PostStmt<ArraySubscriptExpr>,
                                            check::PostStmt<UnaryOperator>,
                                            check::PostStmt<MemberExpr>> {

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -38,6 +38,11 @@ struct Messages {
   std::string Short, Full;
 };
 
+// NOTE: This is a `PostStmt` checker because the implementation passes the
+// whole subscript or unary operator expression to `CheckerContext::getSVal()`,
+// so those two callback wouldn't work as `PreStmt` (unless this checker
+// duplicated the code evaluating those expressions). The `MemberExpr` callback
+// would work as `PreStmt`, but it's `PostStmt` for the sake of consistency.
 class ArrayBoundCheckerV2 : public Checker<check::PostStmt<ArraySubscriptExpr>,
                                            check::PostStmt<UnaryOperator>,
                                            check::PostStmt<MemberExpr>> {

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundCheckerV2.cpp
@@ -472,9 +472,8 @@ bool ArrayBoundCheckerV2::isInAddressOf(const Stmt *S, ASTContext &ACtx) {
       return false;
     S = Parents[0].get<Stmt>();
   } while (isa_and_nonnull<ParenExpr, ImplicitCastExpr>(S));
-  if (const auto *UnaryOp = dyn_cast_or_null<UnaryOperator>(S))
-    return UnaryOp->getOpcode() == UO_AddrOf;
-  return false;
+  const auto *UnaryOp = dyn_cast_or_null<UnaryOperator>(S);
+  return UnaryOp && UnaryOp->getOpcode() == UO_AddrOf;
 }
 
 void ento::registerArrayBoundCheckerV2(CheckerManager &mgr) {

--- a/clang/test/Analysis/out-of-bounds-diagnostics.c
+++ b/clang/test/Analysis/out-of-bounds-diagnostics.c
@@ -29,6 +29,27 @@ void taintedIndex(void) {
   // expected-note@-2 {{Access of 'array' with a tainted index that may be too large}}
 }
 
+int *taintedIndexAfterTheEndPtr(void) {
+  // NOTE: Technically speaking, this testcase does not trigger any UB because
+  // &array[10] is the after-the-end pointer which is well-defined; but this is
+  // a bug-prone situation and far from the idiomatic use of `&array[size]`, so
+  // it's better to report an error. This report can be easily silenced by
+  // writing array+index instead of &array[index].
+  int index;
+  scanf("%d", &index);
+  // expected-note@-1 {{Taint originated here}}
+  // expected-note@-2 {{Taint propagated to the 2nd argument}}
+  if (index < 0 || index > 10)
+    return array;
+  // expected-note@-2 {{Assuming 'index' is >= 0}}
+  // expected-note@-3 {{Left side of '||' is false}}
+  // expected-note@-4 {{Assuming 'index' is <= 10}}
+  // expected-note@-5 {{Taking false branch}}
+  return &array[index];
+  // expected-warning@-1 {{Potential out of bound access to 'array' with tainted index}}
+  // expected-note@-2 {{Access of 'array' with a tainted index that may be too large}}
+}
+
 void taintedOffset(void) {
   int index;
   scanf("%d", &index);
@@ -53,11 +74,13 @@ void flippedOverflow(void) {
 }
 
 int *afterTheEndPtr(void) {
-  // FIXME: this is an unusual but standard-compliant way of writing (array + 10).
-  // I think people who rely on this confusing corner case deserve a warning,
-  // but if this is widespread, then we could introduce a special case for it
-  // in the checker.
-  return &array[10];
+  // This is an unusual but standard-compliant way of writing (array + 10).
+  return &array[10]; // no-warning
+}
+
+int useAfterTheEndPtr(void) {
+  // ... but dereferencing the after-the-end pointer is still invalid.
+  return *afterTheEndPtr();
   // expected-warning@-1 {{Out of bound access to memory after the end of 'array'}}
   // expected-note@-2 {{Access of 'array' at index 10, while it holds only 10 'int' elements}}
 }
@@ -67,6 +90,22 @@ int *afterAfterTheEndPtr(void) {
   return &array[11];
   // expected-warning@-1 {{Out of bound access to memory after the end of 'array'}}
   // expected-note@-2 {{Access of 'array' at index 11, while it holds only 10 'int' elements}}
+}
+
+int *potentialAfterTheEndPtr(int idx) {
+  if (idx < 10) { /* ...do something... */ }
+  // expected-note@-1 {{Assuming 'idx' is >= 10}}
+  // expected-note@-2 {{Taking false branch}}
+  return &array[idx];
+  // expected-warning@-1 {{Out of bound access to memory after the end of 'array'}}
+  // expected-note@-2 {{Access of 'array' at an overflowing index, while it holds only 10 'int' elements}}
+  // NOTE: On the idx >= 10 branch the normal "optimistic" behavior would've
+  // been continuing with the assumption that idx == 10 and the return value is
+  // a legitimate after-the-end pointer. The checker deviates from this by
+  // reporting an error because this situation is very suspicious and far from
+  // the idiomatic `&array[size]` expressions. If the report is FP, the
+  // developer can easily silence it by writing array+idx instead of
+  // &array[idx].
 }
 
 int scalar;

--- a/clang/test/Analysis/out-of-bounds-diagnostics.c
+++ b/clang/test/Analysis/out-of-bounds-diagnostics.c
@@ -104,13 +104,13 @@ struct item {
   int a, b;
 } itemArray[20] = {0};
 
-int structOfArrays(void) {
+int arrayOfStructs(void) {
   return itemArray[35].a;
   // expected-warning@-1 {{Out of bound access to memory after the end of 'itemArray'}}
   // expected-note@-2 {{Access of 'itemArray' at index 35, while it holds only 20 'struct item' elements}}
 }
 
-int structOfArraysArrow(void) {
+int arrayOfStructsArrow(void) {
   return (itemArray + 35)->b;
   // expected-warning@-1 {{Out of bound access to memory after the end of 'itemArray'}}
   // expected-note@-2 {{Access of 'itemArray' at index 35, while it holds only 20 'struct item' elements}}

--- a/clang/test/Analysis/out-of-bounds-new.cpp
+++ b/clang/test/Analysis/out-of-bounds-new.cpp
@@ -154,3 +154,17 @@ void test_dynamic_size2(unsigned m,unsigned n){
   unsigned *U = nullptr;
   U = new unsigned[m + n + 1];
 }
+
+//Test creating invalid references, which break the invariant that a reference
+//is always holding a value, and could lead to nasty runtime errors.
+//(This is not related to operator new, but placed in this file because the
+//other test files are not C++.)
+int array[10] = {0};
+
+void test_after_the_end_reference() {
+  int &ref = array[10]; // expected-warning{{Out of bound access to memory}}
+}
+
+void test_after_after_the_end_reference() {
+  int &ref = array[11]; // expected-warning{{Out of bound access to memory}}
+}

--- a/clang/test/Analysis/out-of-bounds-new.cpp
+++ b/clang/test/Analysis/out-of-bounds-new.cpp
@@ -168,3 +168,15 @@ void test_after_the_end_reference() {
 void test_after_after_the_end_reference() {
   int &ref = array[11]; // expected-warning{{Out of bound access to memory}}
 }
+
+int test_reference_that_might_be_after_the_end(int idx) {
+  // This TC produces no warning because separate analysis of (idx == 10) is
+  // only introduced _after_ the creation of the reference ref.
+  if (idx < 0 || idx > 10)
+    return -2;
+  int &ref = array[idx];
+  if (idx == 10)
+    return -1;
+  return ref;
+}
+

--- a/clang/test/Analysis/taint-diagnostic-visitor.c
+++ b/clang/test/Analysis/taint-diagnostic-visitor.c
@@ -29,8 +29,8 @@ int taintDiagnosticOutOfBound(void) {
   int Array[] = {1, 2, 3, 4, 5};
   scanf("%d", &index); // expected-note {{Taint originated here}}
                        // expected-note@-1 {{Taint propagated to the 2nd argument}}
-  return Array[index]; // expected-warning {{Potential out of bound access to 'Array' with tainted offset}}
-                       // expected-note@-1 {{Access of 'Array' with a tainted offset that may be too large}}
+  return Array[index]; // expected-warning {{Potential out of bound access to 'Array' with tainted index}}
+                       // expected-note@-1 {{Access of 'Array' with a tainted index that may be too large}}
 }
 
 int taintDiagnosticDivZero(int operand) {


### PR DESCRIPTION
...instead of the currently used, more abstract Location callback. The main advantage of this change is that after it the checker will check `array[index].field` while the previous implementation ignored this situation (because here the ElementRegion is wrapped in a FieldRegion object). This improvement fixes PR #70187.

Note that after this change `&array[idx]` will be handled as an access to the `idx`th element of `array`, which is technically incorrect but matches the programmer intuitions. In my opinion it's more helpful if the report points to the source location where the indexing happens (instead of the location where a pointer is finally dereferenced).

This change introduces false positives in the exceptional corner case when the past-the-end pointer of an array is formed as `&arr[length]`. I think this is just unimportant pedantery (because it's cleaner to write the past-the-end pointer as `(arr+length)` and that form isn't affected by this checker), but if it does appear in real code, then we could introduce a special case for it.

In addition to this primary improvement, this change tweaks the message for the tainted index/offset case (using the more concrete information that's available now) and clarifies/improves a few testcases.

The main change of this commit (replacing `check::Location` with `check::PostStmt<...>` callbacks) was already proposed in my change https://reviews.llvm.org/D150446 and https://reviews.llvm.org/D159107 by steakhal. Those reviews were both abandoned, but the problems that led to abandonment were unrelated to the change that is introduced in this PR.