### PR TITLE
[Docs][RISCV] : The zcmt extension is already supported,but the documents related to riscv have not been updated

### DIFF
--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -109,7 +109,7 @@ on support follow.
      ``Zcd``          Supported
      ``Zcf``          Supported
      ``Zcmp``         Supported
-     ``Zcmt``         Assembly Support
+     ``Zcmt``         Supported
      ``Zdinx``        Supported
      ``Zfa``          Supported
      ``Zfh``          Supported


### PR DESCRIPTION
# This PR changes the status of  RISC-V extension zcmt to supported.
https://github.com/llvm/llvm-project/commit/0aecddcee98057300bdf2e2cd00f0eeefced3c81
In the above submission, zce has been supported, that is, zcmt is also supported in the backend of riscv, but the relevant documents about riscv have not been updated. This PR changes the extension status of zcmt to supported.

