### PR TITLE
[flang] Add dependent-lib option to flang -fc1 on Windows

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6796,9 +6796,6 @@ def vectorize_loops : Flag<["-"], "vectorize-loops">,
 def vectorize_slp : Flag<["-"], "vectorize-slp">,
   HelpText<"Run the SLP vectorization passes">,
   MarshallingInfoFlag<CodeGenOpts<"VectorizeSLP">>;
-def dependent_lib : Joined<["--"], "dependent-lib=">,
-  HelpText<"Add dependent library">,
-  MarshallingInfoStringVector<CodeGenOpts<"DependentLibraries">>;
 def linker_option : Joined<["--"], "linker-option=">,
   HelpText<"Add linker option">,
   MarshallingInfoStringVector<CodeGenOpts<"LinkerOptions">>;
@@ -7368,6 +7365,11 @@ def pic_level : Separate<["-"], "pic-level">,
 def pic_is_pie : Flag<["-"], "pic-is-pie">,
   HelpText<"File is for a position independent executable">,
   MarshallingInfoFlag<LangOpts<"PIE">>;
+
+
+def dependent_lib : Joined<["--"], "dependent-lib=">,
+  HelpText<"Add dependent library">,
+  MarshallingInfoStringVector<CodeGenOpts<"DependentLibraries">>;
 
 } // let Visibility = [CC1Option, FC1Option]
 

--- a/flang/include/flang/Frontend/CodeGenOptions.h
+++ b/flang/include/flang/Frontend/CodeGenOptions.h
@@ -70,6 +70,9 @@ public:
   /// The format used for serializing remarks (default: YAML)
   std::string OptRecordFormat;
 
+  /// Options to add to the linker for the object file
+  std::vector<std::string> DependentLibs;
+
   // The RemarkKind enum class and OptRemark struct are identical to what Clang
   // has
   // TODO: Share with clang instead of re-implementing here

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -203,6 +203,26 @@ static void setMLIRDataLayout(mlir::ModuleOp &mlirModule,
   mlirModule->setAttr(mlir::DLTIDialect::kDataLayoutAttrName, dlSpec);
 }
 
+static void addDepdendentLibs(mlir::ModuleOp &mlirModule,
+                              CompilerInstance &ci) {
+  const std::vector<std::string> &libs =
+      ci.getInvocation().getCodeGenOpts().DependentLibs;
+  if (libs.empty()) {
+    return;
+  }
+  // dependent-lib is currently only supported on Windows, so the list should be
+  // empty on non-Windows platforms
+  assert(
+      llvm::Triple(ci.getInvocation().getTargetOpts().triple).isOSWindows() &&
+      "--dependent-lib is only supported on Windows");
+  // Add linker options specified by --dependent-lib
+  auto builder = mlir::OpBuilder(mlirModule.getRegion());
+  for (const std::string &lib : libs) {
+    builder.create<mlir::LLVM::LinkerOptionsOp>(
+        mlirModule.getLoc(), builder.getStrArrayAttr({"/DEFAULTLIB:", lib}));
+  }
+}
+
 bool CodeGenAction::beginSourceFileAction() {
   llvmCtx = std::make_unique<llvm::LLVMContext>();
   CompilerInstance &ci = this->getInstance();
@@ -302,6 +322,9 @@ bool CodeGenAction::beginSourceFileAction() {
   // Create a parse tree and lower it to FIR
   Fortran::parser::Program &parseTree{*ci.getParsing().parseTree()};
   lb.lower(parseTree, ci.getInvocation().getSemanticsContext());
+
+  // Add dependent libraries
+  addDepdendentLibs(*mlirModule, ci);
 
   // run the default passes.
   mlir::PassManager pm((*mlirModule)->getName(),

--- a/flang/test/Driver/dependent-lib.f90
+++ b/flang/test/Driver/dependent-lib.f90
@@ -1,7 +1,15 @@
-
-! RUN: %flang_fc1 -emit-mlir -triple aarch64-pc-windows-msvc --dependent-lib=libtest %s -o - 2>&1 | FileCheck %s
-! RUN: %flang_fc1 -emit-mlir -triple x86_64-pc-windows-msvc --dependent-lib=libtest %s -o - 2>&1 | FileCheck %s
+! DEFINE: %{triple} =
+! DEFINE: %{run} = %flang_fc1 -emit-mlir -triple %{triple} --dependent-lib=libtest %s -o - 2>&1 | FileCheck %s
+! REDEFINE: %{triple} = aarch64-pc-windows-msvc
+! RUN: %{run}
+! REDEFINE: %{triple} = x86_64-pc-windows-msvc
+! RUN: %{run}
+! REDEFINE: %{triple} = x86_64-linux-unknown-gnu
+! RUN: not %{run} --check-prefixes=CHECK-NOWIN
+! REDEFINE: %{triple} = aarch64-apple-darwin
+! RUN: not %{run} --check-prefixes=CHECK-NOWIN
 
 ! CHECK: llvm.linker_options ["/DEFAULTLIB:", "libtest"]
 program test
 end program test
+! CHECK-NOWIN: --dependent-lib is only supported on Windows

--- a/flang/test/Driver/dependent-lib.f90
+++ b/flang/test/Driver/dependent-lib.f90
@@ -1,13 +1,14 @@
+! REQUIRES aarch64-registered-target && x86-registered-target
 ! DEFINE: %{triple} =
-! DEFINE: %{run} = %flang_fc1 -emit-mlir -triple %{triple} --dependent-lib=libtest %s -o - 2>&1 | FileCheck %s
+! DEFINE: %{compile} = %flang_fc1 -emit-mlir -triple %{triple} --dependent-lib=libtest %s -o - 2>&1
 ! REDEFINE: %{triple} = aarch64-pc-windows-msvc
-! RUN: %{run}
+! RUN: %{compile} | FileCheck %s
 ! REDEFINE: %{triple} = x86_64-pc-windows-msvc
-! RUN: %{run}
+! RUN: %{compile} | FileCheck %s
 ! REDEFINE: %{triple} = x86_64-linux-unknown-gnu
-! RUN: not %{run} --check-prefixes=CHECK-NOWIN
+! RUN: not %{compile} | FileCheck %s --check-prefixes=CHECK-NOWIN
 ! REDEFINE: %{triple} = aarch64-apple-darwin
-! RUN: not %{run} --check-prefixes=CHECK-NOWIN
+! RUN: not %{compile} | FileCheck %s --check-prefixes=CHECK-NOWIN
 
 ! CHECK: llvm.linker_options ["/DEFAULTLIB:", "libtest"]
 program test

--- a/flang/test/Driver/dependent-lib.f90
+++ b/flang/test/Driver/dependent-lib.f90
@@ -1,0 +1,7 @@
+
+! RUN: %flang_fc1 -emit-mlir -triple aarch64-pc-windows-msvc --dependent-lib=libtest %s -o - 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -emit-mlir -triple x86_64-pc-windows-msvc --dependent-lib=libtest %s -o - 2>&1 | FileCheck %s
+
+! CHECK: llvm.linker_options ["/DEFAULTLIB:", "libtest"]
+program test
+end program test

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -141,6 +141,7 @@
 ! HELP-FC1-EMPTY:
 ! HELP-FC1-NEXT:OPTIONS:
 ! HELP-FC1-NEXT: -cpp                    Enable predefined and command line preprocessor macros
+! HELP-FC1-NEXT: --dependent-lib=<value> Add dependent library
 ! HELP-FC1-NEXT: -D <macro>=<value>      Define <macro> to <value> (or 1 if <value> omitted)
 ! HELP-FC1-NEXT: -emit-fir               Build the parse tree, then lower it to FIR
 ! HELP-FC1-NEXT: -emit-hlfir             Build the parse tree, then lower it to HLFIR


### PR DESCRIPTION
This patch adds a --dependent-lib option to flang -fc1 on Windows to
embed library link options into the object file. This is needed to
properly select the Windows CRT to link against.