### PR TITLE
[X86][AVX10] Fix a bug when using -march with no-evex512 attribute

### DIFF
--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -122,7 +122,7 @@ bool X86TargetInfo::initFeatureMap(
   std::vector<std::string> UpdatedAVX10FeaturesVec;
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
-  bool HasAVX512F = Features.count("avx512f") && Features["avx512f"];
+  bool HasAVX512F = Features.lookup("avx512f");
   bool HasAVX10 = false;
   bool HasAVX10_512 = false;
   std::string LastAVX10;

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -122,7 +122,7 @@ bool X86TargetInfo::initFeatureMap(
   std::vector<std::string> UpdatedAVX10FeaturesVec;
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
-  bool HasAVX512F = false;
+  bool HasAVX512F = Features["avx512f"];
   bool HasAVX10 = false;
   bool HasAVX10_512 = false;
   std::string LastAVX10;

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -122,7 +122,7 @@ bool X86TargetInfo::initFeatureMap(
   std::vector<std::string> UpdatedAVX10FeaturesVec;
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
-  bool HasAVX512F = Features["avx512f"];
+  bool HasAVX512F = Features.count("avx512f") && Features["avx512f"];
   bool HasAVX10 = false;
   bool HasAVX10_512 = false;
   std::string LastAVX10;

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -122,7 +122,7 @@ bool X86TargetInfo::initFeatureMap(
   std::vector<std::string> UpdatedAVX10FeaturesVec;
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
-  bool HasAVX512F = Features["avx512f"];
+  bool HasAVX512F = false;
   bool HasAVX10 = false;
   bool HasAVX10_512 = false;
   std::string LastAVX10;
@@ -180,6 +180,8 @@ bool X86TargetInfo::initFeatureMap(
       Diags.Report(diag::warn_invalid_feature_combination)
           << LastAVX10 + (HasEVEX512 == FE_TRUE ? " +evex512" : " -evex512");
     UpdatedFeaturesVec.push_back(HasAVX10_512 ? "+evex512" : "-evex512");
+  } else if (HasEVEX512 == FE_FALSE) {
+    UpdatedFeaturesVec.push_back("-evex512");
   }
 
   if (!TargetInfo::initFeatureMap(Features, Diags, CPU, UpdatedFeaturesVec))

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -122,7 +122,7 @@ bool X86TargetInfo::initFeatureMap(
   std::vector<std::string> UpdatedAVX10FeaturesVec;
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
-  bool HasAVX512F = false;
+  bool HasAVX512F = Features["avx512f"];
   bool HasAVX10 = false;
   bool HasAVX10_512 = false;
   std::string LastAVX10;
@@ -180,8 +180,6 @@ bool X86TargetInfo::initFeatureMap(
       Diags.Report(diag::warn_invalid_feature_combination)
           << LastAVX10 + (HasEVEX512 == FE_TRUE ? " +evex512" : " -evex512");
     UpdatedFeaturesVec.push_back(HasAVX10_512 ? "+evex512" : "-evex512");
-  } else if (HasEVEX512 == FE_FALSE) {
-    UpdatedFeaturesVec.push_back("-evex512");
   }
 
   if (!TargetInfo::initFeatureMap(Features, Diags, CPU, UpdatedFeaturesVec))

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -123,8 +123,8 @@ bool X86TargetInfo::initFeatureMap(
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
   bool HasAVX512F = Features["avx512f"];
-  bool HasAVX10 = false;
-  bool HasAVX10_512 = false;
+  bool HasAVX10 = Features["avx10.1-256"];
+  bool HasAVX10_512 = Features["avx10.1-512"];
   std::string LastAVX10;
   std::string LastAVX512;
   for (const auto &Feature : FeaturesVec) {

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -123,8 +123,8 @@ bool X86TargetInfo::initFeatureMap(
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
   bool HasAVX512F = Features["avx512f"];
-  bool HasAVX10 = Features["avx10.1-256"];
-  bool HasAVX10_512 = Features["avx10.1-512"];
+  bool HasAVX10 = false;
+  bool HasAVX10_512 = false;
   std::string LastAVX10;
   std::string LastAVX512;
   for (const auto &Feature : FeaturesVec) {

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -123,8 +123,8 @@ bool X86TargetInfo::initFeatureMap(
   enum { FE_NOSET = -1, FE_FALSE, FE_TRUE };
   int HasEVEX512 = FE_NOSET;
   bool HasAVX512F = Features.lookup("avx512f");
-  bool HasAVX10 = false;
-  bool HasAVX10_512 = false;
+  bool HasAVX10 = Features.lookup("avx10.1-256");
+  bool HasAVX10_512 = Features.lookup("avx10.1-512");
   std::string LastAVX10;
   std::string LastAVX512;
   for (const auto &Feature : FeaturesVec) {

--- a/clang/test/CodeGen/X86/pr72106.c
+++ b/clang/test/CodeGen/X86/pr72106.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -ffreestanding -target-cpu cannonlake -emit-llvm < %s | FileCheck %s
+
+#include <immintrin.h>
+
+int main(int argc, char **argv) {
+  // CHECK-LABEL: @main
+  // CHECK: @llvm.masked.load.v4i64.p0
+  __m256i ptrs = _mm256_maskz_loadu_epi64(0, argv);
+  return 0;
+}


### PR DESCRIPTION
#71318 failed to clear EVEX512 feature for intended intrinsics.

Fixes #72106