### PR TITLE
[clang] fix test PR69717.cpp

### DIFF
--- a/clang/test/Sema/PR69717.cpp
+++ b/clang/test/Sema/PR69717.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -verify -fsyntax-only %s
 // REQUIRES: x86-registered-target
 // expected-no-diagnostics
 


### PR DESCRIPTION
Test still fail on ARM machine (no float_control support)