### PR TITLE
[flang] Identify misparsed statement function in BLOCK in ASSOCIATE

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -3496,6 +3496,7 @@ bool SubprogramVisitor::HandleStmtFunction(const parser::StmtFunctionStmt &x) {
   if (auto *symbol{FindSymbol(name)}) {
     Symbol &ultimate{symbol->GetUltimate()};
     if (ultimate.has<ObjectEntityDetails>() ||
+        ultimate.has<AssocEntityDetails>() ||
         CouldBeDataPointerValuedFunction(&ultimate)) {
       misparsedStmtFuncFound_ = true;
       return false;

--- a/flang/test/Semantics/blockconstruct01.f90
+++ b/flang/test/Semantics/blockconstruct01.f90
@@ -64,3 +64,13 @@ subroutine s7_c1107
     arr(x) = x - 1 ! ok
   end block
 end
+
+subroutine s8
+  real x(1)
+  associate (sf=>x)
+    block
+      integer :: j = 1
+      sf(j) = j ! looks like a statement function, but isn't one
+    end block
+  end associate
+end


### PR DESCRIPTION
When a BLOCK construct is within an ASSOCIATE or related construct, don't misinterpret an assignment to an array element of a construct entity as being an impermissible definition of a local statement function.