### PR TITLE
[lldb] Remove 2nd "error: " substring in output to developer

### DIFF
--- a/lldb/include/lldb/Expression/DiagnosticManager.h
+++ b/lldb/include/lldb/Expression/DiagnosticManager.h
@@ -10,6 +10,7 @@
 #define LLDB_EXPRESSION_DIAGNOSTICMANAGER_H
 
 #include "lldb/lldb-defines.h"
+#include "lldb/lldb-private-enumerations.h"
 #include "lldb/lldb-types.h"
 
 #include "llvm/ADT/STLExtras.h"
@@ -19,20 +20,6 @@
 #include <vector>
 
 namespace lldb_private {
-
-enum DiagnosticOrigin {
-  eDiagnosticOriginUnknown = 0,
-  eDiagnosticOriginLLDB,
-  eDiagnosticOriginClang,
-  eDiagnosticOriginSwift,
-  eDiagnosticOriginLLVM
-};
-
-enum DiagnosticSeverity {
-  eDiagnosticSeverityError,
-  eDiagnosticSeverityWarning,
-  eDiagnosticSeverityRemark
-};
 
 const uint32_t LLDB_INVALID_COMPILER_ID = UINT32_MAX;
 

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -688,6 +688,9 @@ private:
                               StringList &commands_help,
                               const CommandObject::CommandMap &command_map);
 
+  void PrintCaretIndicator(StatusDetail detail, IOHandler &io_handler,
+                           std::string &command_line);
+
   // An interruptible wrapper around the stream output
   void PrintCommandOutput(IOHandler &io_handler, llvm::StringRef str,
                           bool is_stdout);

--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -139,6 +139,8 @@ public:
 
   void SetStatus(lldb::ReturnStatus status);
 
+  std::vector<StatusDetail> GetStatusDetails() const;
+
   bool Succeeded() const;
 
   bool HasResult() const;
@@ -162,6 +164,7 @@ private:
   StreamTee m_err_stream;
 
   lldb::ReturnStatus m_status = lldb::eReturnStatusStarted;
+  std::vector<StatusDetail> m_status_details;
 
   bool m_did_change_process_state = false;
   bool m_suppress_immediate_output = false;

--- a/lldb/include/lldb/lldb-private-enumerations.h
+++ b/lldb/include/lldb/lldb-private-enumerations.h
@@ -231,6 +231,20 @@ enum LoadDependentFiles {
   eLoadDependentsNo,
 };
 
+enum DiagnosticOrigin {
+  eDiagnosticOriginUnknown = 0,
+  eDiagnosticOriginLLDB,
+  eDiagnosticOriginClang,
+  eDiagnosticOriginSwift,
+  eDiagnosticOriginLLVM
+};
+
+enum DiagnosticSeverity {
+  eDiagnosticSeverityError,
+  eDiagnosticSeverityWarning,
+  eDiagnosticSeverityRemark
+};
+
 inline std::string GetStatDescription(lldb_private::StatisticKind K) {
    switch (K) {
    case StatisticKind::ExpressionSuccessful:

--- a/lldb/source/Utility/Status.cpp
+++ b/lldb/source/Utility/Status.cpp
@@ -284,3 +284,11 @@ void llvm::format_provider<lldb_private::Status>::format(
   llvm::format_provider<llvm::StringRef>::format(error.AsCString(), OS,
                                                  Options);
 }
+
+void Status::AddDetail(StatusDetail detail) {
+  m_status_details.push_back(detail);
+}
+
+std::vector<StatusDetail> Status::GetDetails() const {
+  return m_status_details;
+}


### PR DESCRIPTION
This patch serves 2 goals:
- Remove a second "error: " substring in error messages from debugging Swift.
- Print caret (^) line with optional leading/trailing tildes (~) below the line the developer last entered.

Here' an example from a Swift app:
```
(lldb) p abc
error: <EXPR>:3:1: error: cannot find 'abc' in scope
abc
^~~
```

And here's what that same error message is after the patch
```
(lldb) p abc
         ^~~
error: <EXPR>:3:1: cannot find 'abc' in scope
abc
^~~
```

To make this work, the patch passes the diagnostics up the call stack to `CommandInterpreter::IOHandlerInputComplete(...)` because the deepest call frame that knows what the developer entered at the prompt. This is important for commands like DWIM print (and its aliases 'p' and 'po') where the length of the actual command they typed in gets us the correct spacing to pad before the line with the caret.

To get the diagnostics up to that level, I added a vector of `Diagnostic` instances into `Status` and `CommandReturnObject`. I originally prototyped this by hoisting a `DiagnosticManager` manager instance but it's a bit heavy handed for what we need to accomplish the goal.