### PR TITLE
new-prs-labeler: update clang:dataflow paths

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -1,5 +1,9 @@
 clang:dataflow:
-  - clang/**/Analysis/**/*
+  - clang/include/clang/Analysis/FlowSensitive/**/*
+  - clang/lib/Analysis/FlowSensitive/**/*
+  - clang/unittests/Analysis/FlowSensitive/**/*
+  - clang/docs/DataFlowAnalysisIntro.md
+  - clang/docs/DataFlowAnalysisIntroImages/**/*
 
 clang:frontend:
   - clang/lib/AST/**/*


### PR DESCRIPTION
The given glob needed to be fixed; static analyzer-related PRs were also assigned this label erroneously.