### PR TITLE
[libc][arm] Use __ARM_FP to detect floating point support for FEnvImpl.

### DIFF
--- a/libc/src/__support/FPUtil/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/FEnvImpl.h
@@ -29,8 +29,7 @@
 // the apple condition here should be removed.
 #elif defined(LIBC_TARGET_ARCH_IS_X86) && !defined(__APPLE__)
 #include "x86_64/FEnvImpl.h"
-#elif defined(LIBC_TARGET_ARCH_IS_ARM) &&                                      \
-    LIBC_HAS_BUILTIN(__builtin_arm_get_fpscr)
+#elif defined(LIBC_TARGET_ARCH_IS_ARM) && defined(__ARM_FP)
 #include "arm/FEnvImpl.h"
 #elif defined(LIBC_TARGET_ARCH_IS_ANY_RISCV)
 #include "riscv/FEnvImpl.h"


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/72157