### PR TITLE
[lld][LoongArch] Support the R_LARCH_{ADD,SUB}6 relocation type

### DIFF
--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -444,10 +444,12 @@ RelExpr LoongArch::getRelExpr(const RelType type, const Symbol &s,
   case R_LARCH_TLS_LE64_LO20:
   case R_LARCH_TLS_LE64_HI12:
     return R_TPREL;
+  case R_LARCH_ADD6:
   case R_LARCH_ADD8:
   case R_LARCH_ADD16:
   case R_LARCH_ADD32:
   case R_LARCH_ADD64:
+  case R_LARCH_SUB6:
   case R_LARCH_SUB8:
   case R_LARCH_SUB16:
   case R_LARCH_SUB32:
@@ -650,6 +652,9 @@ void LoongArch::relocate(uint8_t *loc, const Relocation &rel,
     write32le(loc, setK12(read32le(loc), extractBits(val, 63, 52)));
     return;
 
+  case R_LARCH_ADD6:
+    *loc = (*loc & 0xc0) | ((*loc + val) & 0x3f);
+    return;
   case R_LARCH_ADD8:
     *loc += val;
     return;
@@ -661,6 +666,9 @@ void LoongArch::relocate(uint8_t *loc, const Relocation &rel,
     return;
   case R_LARCH_ADD64:
     write64le(loc, read64le(loc) + val);
+    return;
+  case R_LARCH_SUB6:
+    *loc = (*loc & 0xc0) | ((*loc - val) & 0x3f);
     return;
   case R_LARCH_SUB8:
     *loc -= val;

--- a/lld/test/ELF/loongarch-add-sub.s
+++ b/lld/test/ELF/loongarch-add-sub.s
@@ -6,7 +6,7 @@
 # RUN: llvm-readelf -x .rodata %t.la64 | FileCheck --check-prefix=CHECK %s
 # CHECK:      section '.rodata':
 # CHECK-NEXT: 0x9876543210 10325476 98badcfe 804602be 79ffffff
-# CHECK-NEXT: 0x9876543220 804602be 804680
+# CHECK-NEXT: 0x9876543220 804602be 80468097
 
 .text
 .global _start
@@ -34,3 +34,7 @@ quux:
     .byte 0
     .reloc quux, R_LARCH_ADD8, 1b
     .reloc quux, R_LARCH_SUB8, 2b
+qux:
+    .byte 0b10000000
+    .reloc qux, R_LARCH_ADD6, qux
+    .reloc qux, R_LARCH_SUB6, 2b


### PR DESCRIPTION
The R_LARCH_{ADD,SUB}6 relocation type are usually used by DwarfCFA to calculate a tiny offset. They appear after binutils 2.41, with GAS enabling relaxation by default.