### PR TITLE
[STLExtras] Remove incorrect hack to make indexed_accessor_range operator== compatible with C++20

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1291,15 +1291,11 @@ public:
   }
 
   /// Compare this range with another.
-  template <typename OtherT>
-  friend bool operator==(const indexed_accessor_range_base &lhs,
-                         const OtherT &rhs) {
-    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+  template <typename OtherT> bool operator==(const OtherT &rhs) const {
+    return std::equal(begin(), end(), rhs.begin(), rhs.end());
   }
-  template <typename OtherT>
-  friend bool operator!=(const indexed_accessor_range_base &lhs,
-                         const OtherT &rhs) {
-    return !(lhs == rhs);
+  template <typename OtherT> bool operator!=(const OtherT &rhs) const {
+    return !(*this == rhs);
   }
 
   /// Return the size of this range.


### PR DESCRIPTION
This partially reverts c312f025940d79b858166b80c50526558864d54e

The motivation behind this is unclear and the change predates the clang [implementation](https://github.com/llvm/llvm-project/commit/38b9d313e6945804fffc654f849cfa05ba2c713d) of [p2468r2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2468r2.html) so I am not sure if it was ever intended to work. Rewritten template operators were broken since the beginning.

Moreover, moving away from `friend` would be beneficial as these would only accepted once clang revises its implementation for fixing https://github.com/llvm/llvm-project/issues/70210. It also helps in making sure that older compilers still compile LLVM (in C++20).