### PR TITLE
[XCOFF]refactor isFunction, NFC

### DIFF
--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -838,7 +838,7 @@ public:
   }
 
   Expected<StringRef> getName() const;
-  bool isFunction() const;
+  Expected<bool> isFunction() const;
   bool isCsectSymbol() const;
   Expected<XCOFFCsectAuxRef> getXCOFFCsectAuxRef() const;
 

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -299,7 +299,11 @@ Expected<SymbolRef::Type>
 XCOFFObjectFile::getSymbolType(DataRefImpl Symb) const {
   XCOFFSymbolRef XCOFFSym = toSymbolRef(Symb);
 
-  if (XCOFFSym.isFunction())
+  Expected<bool> IsFunction = XCOFFSym.isFunction();
+  if (Error E = IsFunction.takeError())
+    return std::move(E);
+
+  if (*IsFunction)
     return SymbolRef::ST_Function;
 
   if (XCOFF::C_FILE == XCOFFSym.getStorageClass())
@@ -1225,7 +1229,7 @@ std::optional<StringRef> XCOFFObjectFile::tryGetCPUName() const {
   return StringRef("future");
 }
 
-bool XCOFFSymbolRef::isFunction() const {
+Expected<bool> XCOFFSymbolRef::isFunction() const {
   if (!isCsectSymbol())
     return false;
 
@@ -1233,12 +1237,8 @@ bool XCOFFSymbolRef::isFunction() const {
     return true;
 
   Expected<XCOFFCsectAuxRef> ExpCsectAuxEnt = getXCOFFCsectAuxRef();
-  if (!ExpCsectAuxEnt) {
-    // If we could not get the CSECT auxiliary entry, then treat this symbol as
-    // if it isn't a function. Consume the error and return `false` to move on.
-    consumeError(ExpCsectAuxEnt.takeError());
-    return false;
-  }
+  if (Error E = ExpCsectAuxEnt.takeError())
+    return std::move(E);
 
   const XCOFFCsectAuxRef CsectAuxRef = ExpCsectAuxEnt.get();
 
@@ -1253,12 +1253,8 @@ bool XCOFFSymbolRef::isFunction() const {
 
   const int16_t SectNum = getSectionNumber();
   Expected<DataRefImpl> SI = getObject()->getSectionByNum(SectNum);
-  if (!SI) {
-    // If we could not get the section, then this symbol should not be
-    // a function. So consume the error and return `false` to move on.
-    consumeError(SI.takeError());
-    return false;
-  }
+  if (Error E = SI.takeError())
+    return std::move(E);
 
   return (getObject()->getSectionFlags(SI.get()) & XCOFF::STYP_TEXT);
 }

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -300,8 +300,8 @@ XCOFFObjectFile::getSymbolType(DataRefImpl Symb) const {
   XCOFFSymbolRef XCOFFSym = toSymbolRef(Symb);
 
   Expected<bool> IsFunction = XCOFFSym.isFunction();
-  if (Error E = IsFunction.takeError())
-    return std::move(E);
+  if (!IsFunction)
+    return IsFunction.takeError();
 
   if (*IsFunction)
     return SymbolRef::ST_Function;
@@ -1237,8 +1237,8 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
     return true;
 
   Expected<XCOFFCsectAuxRef> ExpCsectAuxEnt = getXCOFFCsectAuxRef();
-  if (Error E = ExpCsectAuxEnt.takeError())
-    return std::move(E);
+  if (!ExpCsectAuxEnt)
+    return ExpCsectAuxEnt.takeError();
 
   const XCOFFCsectAuxRef CsectAuxRef = ExpCsectAuxEnt.get();
 
@@ -1253,8 +1253,8 @@ Expected<bool> XCOFFSymbolRef::isFunction() const {
 
   const int16_t SectNum = getSectionNumber();
   Expected<DataRefImpl> SI = getObject()->getSectionByNum(SectNum);
-  if (Error E = SI.takeError())
-    return std::move(E);
+  if (!SI)
+    return SI.takeError();
 
   return (getObject()->getSectionFlags(SI.get()) & XCOFF::STYP_TEXT);
 }


### PR DESCRIPTION
suggested in review of https://github.com/llvm/llvm-project/pull/69553

This is actually not an NFC as isFunction() does not return false for some "invalid" object, instead it returns the errors to its caller. But since there is no such invalid object in the LIT tests, so no case changes.