### PR TITLE
[lldb] Fix MaxSummaryLength target property type

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -95,7 +95,7 @@ let Definition = "target" in {
   def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
     DefaultUnsignedValue<0xFFFFFFFF>,
     Desc<"Maximum depth to expand children.">;
-  def MaxSummaryLength: Property<"max-string-summary-length", "SInt64">,
+  def MaxSummaryLength: Property<"max-string-summary-length", "UInt64">,
     DefaultUnsignedValue<1024>,
     Desc<"Maximum number of characters to show when using %s in summary strings.">;
   def MaxMemReadSize: Property<"max-memory-read-size", "SInt64">,


### PR DESCRIPTION
Hi, there seems to be a regression since https://github.com/llvm/llvm-project/commit/6f8b33f6dfd0a0f8d2522b6c832bd6298ae2f3f3. `Max String Summary Length` target property is not read properly and the default value (1024) is being used instead.

16.0.6:
```
(lldb) settings set target.max-string-summary-length 16
(lldb) var
(std::string) longStdString = "0123456789101112131415161718192021222324252627282930313233343536"
(const char *) longCharPointer = 0x000055555556f310 "0123456789101112131415161718192021222324252627282930313233343536"
```

17.0.4:
```
(lldb) settings set target.max-string-summary-length 16
(lldb) var
(std::string) longStdString = "0123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899100101102103104105106107108109110111112113114115116117118119120121122123124125126127128129130131132133134135136137138139140141142143144145146147148149150151152153154155156157158159160161162163164165166167168169170171172173174175176177178179180181182183184185186187188189190191192193194195196197198199200201202203204205206207208209210211212213214215216217218219220221222223224225226227228229230231232233234235236237238239240241242243244245246247248249250251252253254255256257258259260261262263264265266267268269270271272273274275276277278279280281282283284285286287288289290291292293294295296297298299300301302303304305306307308309310311312313314315316317318319320321322323324325326327328329330331332333334335336337338339340341342343344345346347348349350351352353354355356357358359360361362363364365366367368369370371372373374375376377"...
(const char *) longCharPointer = 0x000055555556f310 "*same as line above*"...
```

Comparison fails here:
https://github.com/llvm/llvm-project/blob/9cb1673fa5d267148ac81ee31b37f1d2f7c0f2b8/lldb/source/Interpreter/OptionValue.cpp#L256

Due to the type difference:
https://github.com/llvm/llvm-project/blob/9cb1673fa5d267148ac81ee31b37f1d2f7c0f2b8/lldb/source/Target/Target.cpp#L4611
https://github.com/llvm/llvm-project/blob/9cb1673fa5d267148ac81ee31b37f1d2f7c0f2b8/lldb/source/Target/TargetProperties.td#L98