### PR TITLE
[lldb][DWARFASTParserClang] DWARFv5: support DW_TAG_variable static data members declarations

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -144,7 +144,7 @@ static bool ShouldIgnoreArtificialField(llvm::StringRef FieldName) {
 
 std::optional<DWARFFormValue>
 DWARFASTParserClang::FindConstantOnVariableDefinition(DWARFDIE die) {
-  assert(die.Tag() == llvm::dwarf::DW_TAG_member);
+  assert(die.Tag() == DW_TAG_member || die.Tag() == DW_TAG_variable);
 
   auto *dwarf = die.GetDWARF();
   if (!dwarf)
@@ -2889,7 +2889,7 @@ void DWARFASTParserClang::CreateStaticMemberVariable(
     const DWARFDIE &die, const MemberAttributes &attrs,
     const lldb_private::CompilerType &class_clang_type) {
   Log *log = GetLog(DWARFLog::TypeCompletion | DWARFLog::Lookups);
-  assert(die.Tag() == DW_TAG_member);
+  assert(die.Tag() == DW_TAG_member || die.Tag() == DW_TAG_variable);
 
   Type *var_type = die.ResolveTypeUID(attrs.encoding_form.Reference());
 
@@ -3195,6 +3195,10 @@ bool DWARFASTParserClang::ParseChildMembers(
       }
       break;
 
+    case DW_TAG_variable: {
+      const MemberAttributes attrs(die, parent_die, module_sp);
+      CreateStaticMemberVariable(die, attrs, class_clang_type);
+    } break;
     case DW_TAG_member:
       ParseSingleMember(die, parent_die, class_clang_type,
                         default_accessibility, layout_info, last_field_info);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2965,6 +2965,7 @@ void DWARFASTParserClang::ParseSingleMember(
   // data members is DW_AT_declaration, so we check it instead.
   // FIXME: Since DWARFv5, static data members are marked DW_AT_variable so we
   // can consistently detect them on both GCC and Clang without below heuristic.
+  // Remove this block if we ever drop DWARFv4 support.
   if (attrs.member_byte_offset == UINT32_MAX &&
       attrs.data_bit_offset == UINT64_MAX && attrs.is_declaration) {
     CreateStaticMemberVariable(die, attrs, class_clang_type);


### PR DESCRIPTION
The accepted DWARFv5 issue 161118.1: "DW_TAG for C++ static data members" specifies that static data member declaration be described by DW_TAG_variable. Make sure we recognize such members.

Depends on:
* https://github.com/llvm/llvm-project/pull/72234
* https://github.com/llvm/llvm-project/pull/72235