### PR TITLE
[GitHub] Add Greeting comment to new contributor's PRs with useful information

### DIFF
--- a/.github/workflows/pr-greeter.yml
+++ b/.github/workflows/pr-greeter.yml
@@ -1,0 +1,29 @@
+name: PR Greeter
+
+on:
+  pull_request_target:
+   types: [ opened ]
+
+permissions:
+  content: read
+
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.repository == 'llvm/llvm-project' && (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' || github.event.pull_request.author_association == 'FIRST_TIMER')
+    steps:
+      - name: Setup Automation Script
+        run: |
+          curl -O -L --fail https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/main/llvm/utils/git/github-automation.py
+          curl -O -L --fail https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/main/llvm/utils/git/requirements.txt
+          chmod a+x github-automation.py
+          pip install -r requirements.txt
+
+      - name: Greet Author
+        run: |
+          ./github-automation.py \
+            --token '${{ secrets.GITHUB_TOKEN }}' \
+            pr-greeter \
+            --issue-number "${{ github.event.pull_request.number }}"

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -211,6 +211,36 @@ Author: {self.pr.user.name} ({self.pr.user.login})
         return None
 
 
+class PRGreeter:
+    def __init__(self, token: str, repo: str, pr_number: int):
+        repo = github.Github(token).get_repo(repo)
+        self.pr = repo.get_issue(pr_number).as_pull_request()
+
+    def run(self) -> bool:
+        # We assume that this is only called for a PR that has just been opened
+        # by a user new to LLVM and/or GitHub itself.
+
+        # This text is using Markdown formatting.
+        comment = f"""\
+Thank you for submitting a Pull Request (PR) to the LLVM Project!
+
+You can add reviewers by using the "Reviewers" section on this page.
+
+If this is not working for you, it's probably because you don't have write
+permissions for the repository. In which case you can instead tag reviewers by
+name in a comment by using `@` followed by their GitHub username.
+
+If you have received no comments on your PR for a week, you can request a review
+by "ping"ing the PR by adding a comment “Ping”. The common courtesy "ping" rate
+is once a week. Please remember that you are asking for valuable time from other developers.
+
+If you have further questions, they may be answered by the [LLVM GitHub User Guide](https://llvm.org/docs/GitHub.html).
+
+You can also ask questions in a comment on this PR, on the [LLVM Discord](https://discord.com/invite/xS7Z362) or on the [forums](https://discourse.llvm.org/)."""
+        self.pr.as_issue().create_comment(comment)
+        return True
+
+
 def setup_llvmbot_git(git_dir="."):
     """
     Configure the git repo in `git_dir` with the llvmbot account so
@@ -655,6 +685,9 @@ pr_subscriber_parser = subparsers.add_parser("pr-subscriber")
 pr_subscriber_parser.add_argument("--label-name", type=str, required=True)
 pr_subscriber_parser.add_argument("--issue-number", type=int, required=True)
 
+pr_greeter_parser = subparsers.add_parser("pr-greeter")
+pr_greeter_parser.add_argument("--issue-number", type=int, required=True)
+
 release_workflow_parser = subparsers.add_parser("release-workflow")
 release_workflow_parser.add_argument(
     "--llvm-project-dir",
@@ -705,6 +738,9 @@ elif args.command == "pr-subscriber":
         args.token, args.repo, args.issue_number, args.label_name
     )
     pr_subscriber.run()
+elif args.command == "pr-greeter":
+    pr_greeter = PRGreeter(args.token, args.repo, args.issue_number)
+    pr_greeter.run()
 elif args.command == "release-workflow":
     release_workflow = ReleaseWorkflow(
         args.token,


### PR DESCRIPTION
This adds a new workflow that responds to PRs that are opened
by new contributors with a comment thanking the author for their contribution,
and provides answers to common problems (problem for now, could expand later).

According to my testing, and the docs here:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

`opened` will only trigger on the first opening, not a re-open.

I considered including this comment in the one the labeller adds,
but that means that it would be emailed to all subscribers not just
the author.

This comment is only left for authors new to the LLVM repo or to
GitHub itself. This is done by checking the value in: 
https://docs.github.com/en/graphql/reference/enums#commentauthorassociation