### PR TITLE
[Flang][Doc] Add a FIROperations section

### DIFF
--- a/flang/docs/FIR/FIRLangRef_Header.md
+++ b/flang/docs/FIR/FIRLangRef_Header.md
@@ -1,3 +1,5 @@
 # FIR Language Reference
 
 This page contains an overview of the Fortran IR operations, their syntax, and example usages.
+
+## FIR Operations


### PR DESCRIPTION
Adding this section ensures that the documentation generated by mlir-tblgen for all the FIR operations are at the correct depth. FIROperations are at depth 3, the new section is at depth 2. This fixes the "Non-consecutive header level increase; H1 to H3" warning in FIRLangRef.md.