### PR TITLE
[llvm-rtdyld] Precalculate required memory upfront

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
+++ b/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
@@ -194,6 +194,11 @@ public:
   RuntimeDyld &operator=(const RuntimeDyld &) = delete;
   ~RuntimeDyld();
 
+  /// TODO
+  Error precalculateMemorySize(const object::ObjectFile &Obj,
+    uint64_t &CodeSize, Align &CodeAlign, uint64_t &RODataSize, Align
+    &RODataAlign, uint64_t &RWDataSize, Align &RWDataAlign);
+
   /// Add the referenced object file to the list of objects to be loaded and
   /// relocated.
   std::unique_ptr<LoadedObjectInfo> loadObject(const object::ObjectFile &O);

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
@@ -421,19 +421,15 @@ protected:
   /// Resolve relocations to external symbols.
   Error resolveExternalSymbols();
 
-  // Compute an upper bound of the memory that is required to load all
-  // sections
-  Error computeTotalAllocSize(const ObjectFile &Obj, uint64_t &CodeSize,
-                              Align &CodeAlign, uint64_t &RODataSize,
-                              Align &RODataAlign, uint64_t &RWDataSize,
-                              Align &RWDataAlign);
-
   // Compute GOT size
   unsigned computeGOTSize(const ObjectFile &Obj);
 
   // Compute the stub buffer size required for a section
   unsigned computeSectionStubBufSize(const ObjectFile &Obj,
                                      const SectionRef &Section);
+
+
+
 
   // Implementation of the generic part of the loadObject algorithm.
   Expected<ObjSectionToIDMap> loadObjectImpl(const object::ObjectFile &Obj);
@@ -463,6 +459,14 @@ public:
   }
 
   virtual ~RuntimeDyldImpl();
+
+// Compute an upper bound of the memory that is required to load all
+  // sections
+  Error computeTotalAllocSize(const ObjectFile &Obj, uint64_t &CodeSize,
+                              Align &CodeAlign, uint64_t &RODataSize,
+                              Align &RODataAlign, uint64_t &RWDataSize,
+                              Align &RWDataAlign);
+
 
   void setProcessAllSections(bool ProcessAllSections) {
     this->ProcessAllSections = ProcessAllSections;


### PR DESCRIPTION
This changes the behaviour of llvm-rtdyld to calculate and allocate all required memory for objects and its data/code section upfront as opposed to doing this on-demand.

Allocation of the memory upfront avoids fragmentation of the memory, which is a workaround for relocations getting out of range as explained and discussed here:

https://discourse.llvm.org/t/llvm-rtdyld-aarch64-abi-relocation-restrictions/74616