### PR TITLE
[Flang][Docs] Fix GettingStarted.md with correct depth for in-tree build section

### DIFF
--- a/flang/docs/GettingStarted.md
+++ b/flang/docs/GettingStarted.md
@@ -247,7 +247,7 @@ code.  Note that the packaging of the libraries is different
 between [Clang](https://clang.llvm.org/docs/OffloadingDesign.html#linking-target-device-code) and NVCC, so the library must be linked using
 compatible compiler drivers.
 
-### Bulding in-tree
+#### Building in-tree
 One may build Flang runtime library along with building Flang itself
 by providing these additional CMake variables on top of the Flang in-tree
 build config:


### PR DESCRIPTION
Just a minor fix for the section depth for the patch in https://reviews.llvm.org/D155029.