### PR TITLE
[clang][Interp] Fix classify for glvalues of function type

### DIFF
--- a/clang/lib/AST/Interp/ByteCodeExprGen.h
+++ b/clang/lib/AST/Interp/ByteCodeExprGen.h
@@ -130,7 +130,13 @@ protected:
 
   /// Classifies a type.
   std::optional<PrimType> classify(const Expr *E) const {
-    return E->isGLValue() ? PT_Ptr : classify(E->getType());
+    if (E->isGLValue()) {
+      if (E->getType()->isFunctionType())
+        return PT_FnPtr;
+      return PT_Ptr;
+    }
+
+    return classify(E->getType());
   }
   std::optional<PrimType> classify(QualType Ty) const {
     return Ctx.classify(Ty);


### PR DESCRIPTION
This can't be tested right now but will show up once we use the new interpreter in evaluateAsConstantExpression() as well.

Pulled out from https://github.com/llvm/llvm-project/pull/70763