### PR TITLE
[libc++] Fixed get count threads multi-CPU system with NUMA architecture (#72267)

### DIFF
--- a/libcxx/src/thread.cpp
+++ b/libcxx/src/thread.cpp
@@ -81,9 +81,43 @@ thread::hardware_concurrency() noexcept
         return 0;
     return static_cast<unsigned>(result);
 #elif defined(_LIBCPP_WIN32API)
+  // This implementation supports both conventional single-cpu PC configurations
+  // and multi-cpu system on NUMA (Non-uniform_memory_access) architecture
+  DWORD length = 0;
+  const auto single_cpu_concurrency = []() noexcept -> unsigned int {
     SYSTEM_INFO info;
     GetSystemInfo(&info);
     return info.dwNumberOfProcessors;
+  };
+  if (GetLogicalProcessorInformationEx(RelationAll, nullptr, &length) != FALSE) {
+    return single_cpu_concurrency();
+  }
+  if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    return single_cpu_concurrency();
+  }
+  std::unique_ptr<void, void (*)(void*)> buffer(std::malloc(length), std::free);
+  if (!buffer) {
+    return single_cpu_concurrency();
+  }
+  auto* mem = reinterpret_cast<unsigned char*>(buffer.get());
+  if (GetLogicalProcessorInformationEx(
+          RelationAll, reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(mem), &length) == false) {
+    return single_cpu_concurrency();
+  }
+  DWORD i = 0;
+  unsigned int concurrency = 0;
+  while (i < length) {
+    const auto* proc = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(mem + i);
+    if (proc->Relationship == RelationProcessorCore) {
+      for (WORD group = 0; group < proc->Processor.GroupCount; ++group) {
+        for (KAFFINITY mask = proc->Processor.GroupMask[group].Mask; mask != 0; mask >>= 1) {
+          concurrency += mask & 1;
+        }
+      }
+    }
+    i += proc->Size;
+  }
+  return concurrency;
 #else  // defined(CTL_HW) && defined(HW_NCPU)
     // TODO: grovel through /proc or check cpuid on x86 and similar
     // instructions on other architectures.


### PR DESCRIPTION
Fixed very old problem on any Windows NT and modern Windows Server 😆 

https://developercommunity.visualstudio.com/t/hardware-concurrency-returns-an-incorrect-result/350854

https://stackoverflow.com/questions/31209256/reliable-way-to-programmatically-get-the-number-of-hardware-threads-on-windows

Fixes #72267