### PR TITLE
[SDAG] Simplify is-power-of-2 codegen

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -4237,9 +4237,7 @@ static SDValue simplifySetCCWithCTPOP(const TargetLowering &TLI, EVT VT,
     return DAG.getSetCC(dl, VT, Result, DAG.getConstant(0, dl, CTVT), CC);
   }
 
-  // Expand a power-of-2 comparison based on ctpop:
-  // (ctpop x) == 1 --> (x != 0) && ((x & x-1) == 0)
-  // (ctpop x) != 1 --> (x == 0) || ((x & x-1) != 0)
+  // Expand a power-of-2 comparison based on ctpop
   if ((Cond == ISD::SETEQ || Cond == ISD::SETNE) && C1 == 1) {
     // Keep the CTPOP if it is cheap.
     if (TLI.isCtpopFast(CTVT))
@@ -4248,17 +4246,23 @@ static SDValue simplifySetCCWithCTPOP(const TargetLowering &TLI, EVT VT,
     SDValue Zero = DAG.getConstant(0, dl, CTVT);
     SDValue NegOne = DAG.getAllOnesConstant(dl, CTVT);
     assert(CTVT.isInteger());
-    ISD::CondCode InvCond = ISD::getSetCCInverse(Cond, CTVT);
     SDValue Add = DAG.getNode(ISD::ADD, dl, CTVT, CTOp, NegOne);
-    SDValue And = DAG.getNode(ISD::AND, dl, CTVT, CTOp, Add);
-    SDValue RHS = DAG.getSetCC(dl, VT, And, Zero, Cond);
+
     // Its not uncommon for known-never-zero X to exist in (ctpop X) eq/ne 1, so
-    // check before the emit a potentially unnecessary op.
-    if (DAG.isKnownNeverZero(CTOp))
+    // check before emitting a potentially unnecessary op.
+    if (DAG.isKnownNeverZero(CTOp)) {
+      // (ctpop x) == 1 --> (x & x-1) == 0
+      // (ctpop x) != 1 --> (x & x-1) != 0
+      SDValue And = DAG.getNode(ISD::AND, dl, CTVT, CTOp, Add);
+      SDValue RHS = DAG.getSetCC(dl, VT, And, Zero, Cond);
       return RHS;
-    SDValue LHS = DAG.getSetCC(dl, VT, CTOp, Zero, InvCond);
-    unsigned LogicOpcode = Cond == ISD::SETEQ ? ISD::AND : ISD::OR;
-    return DAG.getNode(LogicOpcode, dl, VT, LHS, RHS);
+    }
+
+    // (ctpop x) == 1 --> (x ^ x-1) >  x-1
+    // (ctpop x) != 1 --> (x ^ x-1) <= x-1
+    SDValue Xor = DAG.getNode(ISD::XOR, dl, CTVT, CTOp, Add);
+    ISD::CondCode CmpCond = Cond == ISD::SETEQ ? ISD::SETUGT : ISD::SETULE;
+    return DAG.getSetCC(dl, VT, Xor, Add, CmpCond);
   }
 
   return SDValue();

--- a/llvm/test/CodeGen/AArch64/arm64-popcnt.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-popcnt.ll
@@ -196,17 +196,17 @@ define i32 @ctpop_eq_one(i64 %x) nounwind readnone {
 ; CHECK-LABEL: ctpop_eq_one:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub x8, x0, #1
-; CHECK-NEXT:    tst x0, x8
-; CHECK-NEXT:    ccmp x0, #0, #4, eq
-; CHECK-NEXT:    cset w0, ne
+; CHECK-NEXT:    eor x9, x0, x8
+; CHECK-NEXT:    cmp x9, x8
+; CHECK-NEXT:    cset w0, hi
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-NONEON-LABEL: ctpop_eq_one:
 ; CHECK-NONEON:       // %bb.0:
 ; CHECK-NONEON-NEXT:    sub x8, x0, #1
-; CHECK-NONEON-NEXT:    tst x0, x8
-; CHECK-NONEON-NEXT:    ccmp x0, #0, #4, eq
-; CHECK-NONEON-NEXT:    cset w0, ne
+; CHECK-NONEON-NEXT:    eor x9, x0, x8
+; CHECK-NONEON-NEXT:    cmp x9, x8
+; CHECK-NONEON-NEXT:    cset w0, hi
 ; CHECK-NONEON-NEXT:    ret
 ;
 ; CHECK-CSSC-LABEL: ctpop_eq_one:
@@ -225,17 +225,17 @@ define i32 @ctpop_ne_one(i64 %x) nounwind readnone {
 ; CHECK-LABEL: ctpop_ne_one:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub x8, x0, #1
-; CHECK-NEXT:    tst x0, x8
-; CHECK-NEXT:    ccmp x0, #0, #4, eq
-; CHECK-NEXT:    cset w0, eq
+; CHECK-NEXT:    eor x9, x0, x8
+; CHECK-NEXT:    cmp x9, x8
+; CHECK-NEXT:    cset w0, ls
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-NONEON-LABEL: ctpop_ne_one:
 ; CHECK-NONEON:       // %bb.0:
 ; CHECK-NONEON-NEXT:    sub x8, x0, #1
-; CHECK-NONEON-NEXT:    tst x0, x8
-; CHECK-NONEON-NEXT:    ccmp x0, #0, #4, eq
-; CHECK-NONEON-NEXT:    cset w0, eq
+; CHECK-NONEON-NEXT:    eor x9, x0, x8
+; CHECK-NONEON-NEXT:    cmp x9, x8
+; CHECK-NONEON-NEXT:    cset w0, ls
 ; CHECK-NONEON-NEXT:    ret
 ;
 ; CHECK-CSSC-LABEL: ctpop_ne_one:
@@ -254,17 +254,17 @@ define i1 @ctpop32_ne_one(i32 %x) nounwind readnone {
 ; CHECK-LABEL: ctpop32_ne_one:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    sub w8, w0, #1
-; CHECK-NEXT:    tst w0, w8
-; CHECK-NEXT:    ccmp w0, #0, #4, eq
-; CHECK-NEXT:    cset w0, eq
+; CHECK-NEXT:    eor w9, w0, w8
+; CHECK-NEXT:    cmp w9, w8
+; CHECK-NEXT:    cset w0, ls
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-NONEON-LABEL: ctpop32_ne_one:
 ; CHECK-NONEON:       // %bb.0:
 ; CHECK-NONEON-NEXT:    sub w8, w0, #1
-; CHECK-NONEON-NEXT:    tst w0, w8
-; CHECK-NONEON-NEXT:    ccmp w0, #0, #4, eq
-; CHECK-NONEON-NEXT:    cset w0, eq
+; CHECK-NONEON-NEXT:    eor w9, w0, w8
+; CHECK-NONEON-NEXT:    cmp w9, w8
+; CHECK-NONEON-NEXT:    cset w0, ls
 ; CHECK-NONEON-NEXT:    ret
 ;
 ; CHECK-CSSC-LABEL: ctpop32_ne_one:

--- a/llvm/test/CodeGen/ARM/popcnt.ll
+++ b/llvm/test/CodeGen/ARM/popcnt.ll
@@ -286,14 +286,12 @@ define i32 @ctpop_eq_one(i64 %x) nounwind readnone {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    subs r2, r0, #1
 ; CHECK-NEXT:    sbc r3, r1, #0
-; CHECK-NEXT:    and r2, r0, r2
-; CHECK-NEXT:    and r3, r1, r3
-; CHECK-NEXT:    orr r2, r2, r3
-; CHECK-NEXT:    rsbs r3, r2, #0
-; CHECK-NEXT:    adc r2, r2, r3
-; CHECK-NEXT:    orrs r0, r0, r1
-; CHECK-NEXT:    movne r0, #1
-; CHECK-NEXT:    and r0, r0, r2
+; CHECK-NEXT:    eor r12, r1, r3
+; CHECK-NEXT:    eor r1, r0, r2
+; CHECK-NEXT:    subs r1, r2, r1
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    sbcs r1, r3, r12
+; CHECK-NEXT:    movlo r0, #1
 ; CHECK-NEXT:    mov pc, lr
   %count = tail call i64 @llvm.ctpop.i64(i64 %x)
   %cmp = icmp eq i64 %count, 1

--- a/llvm/test/CodeGen/RISCV/rv32zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbb.ll
@@ -350,10 +350,8 @@ define i1 @ctpop_i32_eq_one(i32 signext %a) nounwind {
 ; RV32I-LABEL: ctpop_i32_eq_one:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    addi a1, a0, -1
-; RV32I-NEXT:    and a1, a0, a1
-; RV32I-NEXT:    seqz a1, a1
-; RV32I-NEXT:    snez a0, a0
-; RV32I-NEXT:    and a0, a0, a1
+; RV32I-NEXT:    xor a0, a0, a1
+; RV32I-NEXT:    sltu a0, a1, a0
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_i32_eq_one:
@@ -371,10 +369,9 @@ define i1 @ctpop_i32_ne_one(i32 signext %a) nounwind {
 ; RV32I-LABEL: ctpop_i32_ne_one:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    addi a1, a0, -1
-; RV32I-NEXT:    and a1, a0, a1
-; RV32I-NEXT:    snez a1, a1
-; RV32I-NEXT:    seqz a0, a0
-; RV32I-NEXT:    or a0, a0, a1
+; RV32I-NEXT:    xor a0, a0, a1
+; RV32I-NEXT:    sltu a0, a1, a0
+; RV32I-NEXT:    xori a0, a0, 1
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_i32_ne_one:
@@ -508,15 +505,11 @@ define <2 x i1> @ctpop_v2i32_eq_one(<2 x i32> %a) nounwind {
 ; RV32I-LABEL: ctpop_v2i32_eq_one:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    and a2, a0, a2
-; RV32I-NEXT:    seqz a2, a2
-; RV32I-NEXT:    snez a0, a0
-; RV32I-NEXT:    and a0, a0, a2
+; RV32I-NEXT:    xor a0, a0, a2
+; RV32I-NEXT:    sltu a0, a2, a0
 ; RV32I-NEXT:    addi a2, a1, -1
-; RV32I-NEXT:    and a2, a1, a2
-; RV32I-NEXT:    seqz a2, a2
-; RV32I-NEXT:    snez a1, a1
-; RV32I-NEXT:    and a1, a1, a2
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    sltu a1, a2, a1
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_v2i32_eq_one:
@@ -537,15 +530,13 @@ define <2 x i1> @ctpop_v2i32_ne_one(<2 x i32> %a) nounwind {
 ; RV32I-LABEL: ctpop_v2i32_ne_one:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    and a2, a0, a2
-; RV32I-NEXT:    snez a2, a2
-; RV32I-NEXT:    seqz a0, a0
-; RV32I-NEXT:    or a0, a0, a2
+; RV32I-NEXT:    xor a0, a0, a2
+; RV32I-NEXT:    sltu a0, a2, a0
+; RV32I-NEXT:    xori a0, a0, 1
 ; RV32I-NEXT:    addi a2, a1, -1
-; RV32I-NEXT:    and a2, a1, a2
-; RV32I-NEXT:    snez a2, a2
-; RV32I-NEXT:    seqz a1, a1
-; RV32I-NEXT:    or a1, a1, a2
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    sltu a1, a2, a1
+; RV32I-NEXT:    xori a1, a1, 1
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_v2i32_ne_one:
@@ -685,16 +676,17 @@ define i1 @ctpop_i64_ugt_one(i64 %a) nounwind {
 define i1 @ctpop_i64_eq_one(i64 %a) nounwind {
 ; RV32I-LABEL: ctpop_i64_eq_one:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    and a2, a0, a2
-; RV32I-NEXT:    seqz a3, a0
-; RV32I-NEXT:    sub a3, a1, a3
-; RV32I-NEXT:    and a3, a1, a3
-; RV32I-NEXT:    or a2, a2, a3
-; RV32I-NEXT:    seqz a2, a2
-; RV32I-NEXT:    or a0, a0, a1
-; RV32I-NEXT:    snez a0, a0
-; RV32I-NEXT:    and a0, a0, a2
+; RV32I-NEXT:    beqz a1, .LBB17_2
+; RV32I-NEXT:  # %bb.1:
+; RV32I-NEXT:    seqz a0, a0
+; RV32I-NEXT:    sub a0, a1, a0
+; RV32I-NEXT:    xor a1, a1, a0
+; RV32I-NEXT:    sltu a0, a0, a1
+; RV32I-NEXT:    ret
+; RV32I-NEXT:  .LBB17_2:
+; RV32I-NEXT:    addi a1, a0, -1
+; RV32I-NEXT:    xor a0, a0, a1
+; RV32I-NEXT:    sltu a0, a1, a0
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_i64_eq_one:
@@ -713,16 +705,19 @@ define i1 @ctpop_i64_eq_one(i64 %a) nounwind {
 define i1 @ctpop_i64_ne_one(i64 %a) nounwind {
 ; RV32I-LABEL: ctpop_i64_ne_one:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    addi a2, a0, -1
-; RV32I-NEXT:    and a2, a0, a2
-; RV32I-NEXT:    seqz a3, a0
-; RV32I-NEXT:    sub a3, a1, a3
-; RV32I-NEXT:    and a3, a1, a3
-; RV32I-NEXT:    or a2, a2, a3
-; RV32I-NEXT:    snez a2, a2
-; RV32I-NEXT:    or a0, a0, a1
+; RV32I-NEXT:    beqz a1, .LBB18_2
+; RV32I-NEXT:  # %bb.1:
 ; RV32I-NEXT:    seqz a0, a0
-; RV32I-NEXT:    or a0, a0, a2
+; RV32I-NEXT:    sub a0, a1, a0
+; RV32I-NEXT:    xor a1, a1, a0
+; RV32I-NEXT:    sltu a0, a0, a1
+; RV32I-NEXT:    xori a0, a0, 1
+; RV32I-NEXT:    ret
+; RV32I-NEXT:  .LBB18_2:
+; RV32I-NEXT:    addi a1, a0, -1
+; RV32I-NEXT:    xor a0, a0, a1
+; RV32I-NEXT:    sltu a0, a1, a0
+; RV32I-NEXT:    xori a0, a0, 1
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_i64_ne_one:
@@ -950,30 +945,34 @@ define <2 x i1> @ctpop_v2i64_ugt_one(<2 x i64> %a) nounwind {
 define <2 x i1> @ctpop_v2i64_eq_one(<2 x i64> %a) nounwind {
 ; RV32I-LABEL: ctpop_v2i64_eq_one:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    lw a1, 0(a0)
+; RV32I-NEXT:    mv a1, a0
 ; RV32I-NEXT:    lw a2, 12(a0)
-; RV32I-NEXT:    lw a3, 8(a0)
 ; RV32I-NEXT:    lw a0, 4(a0)
-; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    and a4, a1, a4
-; RV32I-NEXT:    seqz a5, a1
-; RV32I-NEXT:    sub a5, a0, a5
-; RV32I-NEXT:    and a5, a0, a5
-; RV32I-NEXT:    or a4, a4, a5
-; RV32I-NEXT:    seqz a4, a4
-; RV32I-NEXT:    or a0, a1, a0
-; RV32I-NEXT:    snez a0, a0
-; RV32I-NEXT:    and a0, a0, a4
-; RV32I-NEXT:    addi a1, a3, -1
-; RV32I-NEXT:    and a1, a3, a1
-; RV32I-NEXT:    seqz a4, a3
-; RV32I-NEXT:    sub a4, a2, a4
-; RV32I-NEXT:    and a4, a2, a4
-; RV32I-NEXT:    or a1, a1, a4
+; RV32I-NEXT:    lw a3, 0(a1)
+; RV32I-NEXT:    beqz a0, .LBB22_3
+; RV32I-NEXT:  # %bb.1:
+; RV32I-NEXT:    seqz a3, a3
+; RV32I-NEXT:    sub a3, a0, a3
+; RV32I-NEXT:    xor a0, a0, a3
+; RV32I-NEXT:    sltu a0, a3, a0
+; RV32I-NEXT:    lw a1, 8(a1)
+; RV32I-NEXT:    bnez a2, .LBB22_4
+; RV32I-NEXT:  .LBB22_2:
+; RV32I-NEXT:    addi a2, a1, -1
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    sltu a1, a2, a1
+; RV32I-NEXT:    ret
+; RV32I-NEXT:  .LBB22_3:
+; RV32I-NEXT:    addi a0, a3, -1
+; RV32I-NEXT:    xor a3, a3, a0
+; RV32I-NEXT:    sltu a0, a0, a3
+; RV32I-NEXT:    lw a1, 8(a1)
+; RV32I-NEXT:    beqz a2, .LBB22_2
+; RV32I-NEXT:  .LBB22_4:
 ; RV32I-NEXT:    seqz a1, a1
-; RV32I-NEXT:    or a2, a3, a2
-; RV32I-NEXT:    snez a2, a2
-; RV32I-NEXT:    and a1, a2, a1
+; RV32I-NEXT:    sub a1, a2, a1
+; RV32I-NEXT:    xor a2, a2, a1
+; RV32I-NEXT:    sltu a1, a1, a2
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_v2i64_eq_one:
@@ -1001,30 +1000,36 @@ define <2 x i1> @ctpop_v2i64_eq_one(<2 x i64> %a) nounwind {
 define <2 x i1> @ctpop_v2i64_ne_one(<2 x i64> %a) nounwind {
 ; RV32I-LABEL: ctpop_v2i64_ne_one:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    lw a1, 0(a0)
-; RV32I-NEXT:    lw a2, 12(a0)
+; RV32I-NEXT:    lw a1, 12(a0)
+; RV32I-NEXT:    lw a2, 4(a0)
+; RV32I-NEXT:    lw a3, 0(a0)
+; RV32I-NEXT:    beqz a2, .LBB23_2
+; RV32I-NEXT:  # %bb.1:
+; RV32I-NEXT:    seqz a3, a3
+; RV32I-NEXT:    sub a3, a2, a3
+; RV32I-NEXT:    xor a2, a2, a3
+; RV32I-NEXT:    sltu a2, a3, a2
+; RV32I-NEXT:    j .LBB23_3
+; RV32I-NEXT:  .LBB23_2:
+; RV32I-NEXT:    addi a2, a3, -1
+; RV32I-NEXT:    xor a3, a3, a2
+; RV32I-NEXT:    sltu a2, a2, a3
+; RV32I-NEXT:  .LBB23_3:
 ; RV32I-NEXT:    lw a3, 8(a0)
-; RV32I-NEXT:    lw a0, 4(a0)
-; RV32I-NEXT:    addi a4, a1, -1
-; RV32I-NEXT:    and a4, a1, a4
-; RV32I-NEXT:    seqz a5, a1
-; RV32I-NEXT:    sub a5, a0, a5
-; RV32I-NEXT:    and a5, a0, a5
-; RV32I-NEXT:    or a4, a4, a5
-; RV32I-NEXT:    snez a4, a4
-; RV32I-NEXT:    or a0, a1, a0
-; RV32I-NEXT:    seqz a0, a0
-; RV32I-NEXT:    or a0, a0, a4
+; RV32I-NEXT:    xori a0, a2, 1
+; RV32I-NEXT:    beqz a1, .LBB23_5
+; RV32I-NEXT:  # %bb.4:
+; RV32I-NEXT:    seqz a2, a3
+; RV32I-NEXT:    sub a2, a1, a2
+; RV32I-NEXT:    xor a1, a1, a2
+; RV32I-NEXT:    sltu a1, a2, a1
+; RV32I-NEXT:    xori a1, a1, 1
+; RV32I-NEXT:    ret
+; RV32I-NEXT:  .LBB23_5:
 ; RV32I-NEXT:    addi a1, a3, -1
-; RV32I-NEXT:    and a1, a3, a1
-; RV32I-NEXT:    seqz a4, a3
-; RV32I-NEXT:    sub a4, a2, a4
-; RV32I-NEXT:    and a4, a2, a4
-; RV32I-NEXT:    or a1, a1, a4
-; RV32I-NEXT:    snez a1, a1
-; RV32I-NEXT:    or a2, a3, a2
-; RV32I-NEXT:    seqz a2, a2
-; RV32I-NEXT:    or a1, a2, a1
+; RV32I-NEXT:    xor a3, a3, a1
+; RV32I-NEXT:    sltu a1, a1, a3
+; RV32I-NEXT:    xori a1, a1, 1
 ; RV32I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: ctpop_v2i64_ne_one:

--- a/llvm/test/CodeGen/RISCV/rv64zbb.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbb.ll
@@ -619,10 +619,8 @@ define i1 @ctpop_i32_eq_one(i32 signext %a) nounwind {
 ; RV64I-LABEL: ctpop_i32_eq_one:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addiw a1, a0, -1
-; RV64I-NEXT:    and a1, a0, a1
-; RV64I-NEXT:    seqz a1, a1
-; RV64I-NEXT:    snez a0, a0
-; RV64I-NEXT:    and a0, a0, a1
+; RV64I-NEXT:    xor a0, a0, a1
+; RV64I-NEXT:    sltu a0, a1, a0
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_i32_eq_one:
@@ -640,10 +638,9 @@ define i1 @ctpop_i32_ne_one(i32 signext %a) nounwind {
 ; RV64I-LABEL: ctpop_i32_ne_one:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addiw a1, a0, -1
-; RV64I-NEXT:    and a1, a0, a1
-; RV64I-NEXT:    snez a1, a1
-; RV64I-NEXT:    seqz a0, a0
-; RV64I-NEXT:    or a0, a0, a1
+; RV64I-NEXT:    xor a0, a0, a1
+; RV64I-NEXT:    sltu a0, a1, a0
+; RV64I-NEXT:    xori a0, a0, 1
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_i32_ne_one:
@@ -820,20 +817,14 @@ define <2 x i1> @ctpop_v2i32_ugt_one(<2 x i32> %a) nounwind {
 define <2 x i1> @ctpop_v2i32_eq_one(<2 x i32> %a) nounwind {
 ; RV64I-LABEL: ctpop_v2i32_eq_one:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    sext.w a2, a1
-; RV64I-NEXT:    sext.w a3, a0
-; RV64I-NEXT:    addi a4, a0, -1
-; RV64I-NEXT:    and a0, a0, a4
+; RV64I-NEXT:    addiw a2, a0, -1
+; RV64I-NEXT:    xor a0, a0, a2
 ; RV64I-NEXT:    sext.w a0, a0
-; RV64I-NEXT:    seqz a0, a0
-; RV64I-NEXT:    snez a3, a3
-; RV64I-NEXT:    and a0, a3, a0
-; RV64I-NEXT:    addi a3, a1, -1
-; RV64I-NEXT:    and a1, a1, a3
+; RV64I-NEXT:    sltu a0, a2, a0
+; RV64I-NEXT:    addiw a2, a1, -1
+; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    sext.w a1, a1
-; RV64I-NEXT:    seqz a1, a1
-; RV64I-NEXT:    snez a2, a2
-; RV64I-NEXT:    and a1, a2, a1
+; RV64I-NEXT:    sltu a1, a2, a1
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_v2i32_eq_one:
@@ -853,20 +844,16 @@ define <2 x i1> @ctpop_v2i32_eq_one(<2 x i32> %a) nounwind {
 define <2 x i1> @ctpop_v2i32_ne_one(<2 x i32> %a) nounwind {
 ; RV64I-LABEL: ctpop_v2i32_ne_one:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    sext.w a2, a1
-; RV64I-NEXT:    sext.w a3, a0
-; RV64I-NEXT:    addi a4, a0, -1
-; RV64I-NEXT:    and a0, a0, a4
+; RV64I-NEXT:    addiw a2, a0, -1
+; RV64I-NEXT:    xor a0, a0, a2
 ; RV64I-NEXT:    sext.w a0, a0
-; RV64I-NEXT:    snez a0, a0
-; RV64I-NEXT:    seqz a3, a3
-; RV64I-NEXT:    or a0, a3, a0
-; RV64I-NEXT:    addi a3, a1, -1
-; RV64I-NEXT:    and a1, a1, a3
+; RV64I-NEXT:    sltu a0, a2, a0
+; RV64I-NEXT:    xori a0, a0, 1
+; RV64I-NEXT:    addiw a2, a1, -1
+; RV64I-NEXT:    xor a1, a1, a2
 ; RV64I-NEXT:    sext.w a1, a1
-; RV64I-NEXT:    snez a1, a1
-; RV64I-NEXT:    seqz a2, a2
-; RV64I-NEXT:    or a1, a2, a1
+; RV64I-NEXT:    sltu a1, a2, a1
+; RV64I-NEXT:    xori a1, a1, 1
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_v2i32_ne_one:
@@ -971,10 +958,8 @@ define i1 @ctpop_i64_eq_one(i64 %a) nounwind {
 ; RV64I-LABEL: ctpop_i64_eq_one:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addi a1, a0, -1
-; RV64I-NEXT:    and a1, a0, a1
-; RV64I-NEXT:    seqz a1, a1
-; RV64I-NEXT:    snez a0, a0
-; RV64I-NEXT:    and a0, a0, a1
+; RV64I-NEXT:    xor a0, a0, a1
+; RV64I-NEXT:    sltu a0, a1, a0
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_i64_eq_one:
@@ -992,10 +977,9 @@ define i1 @ctpop_i64_ne_one(i64 %a) nounwind {
 ; RV64I-LABEL: ctpop_i64_ne_one:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addi a1, a0, -1
-; RV64I-NEXT:    and a1, a0, a1
-; RV64I-NEXT:    snez a1, a1
-; RV64I-NEXT:    seqz a0, a0
-; RV64I-NEXT:    or a0, a0, a1
+; RV64I-NEXT:    xor a0, a0, a1
+; RV64I-NEXT:    sltu a0, a1, a0
+; RV64I-NEXT:    xori a0, a0, 1
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_i64_ne_one:
@@ -1137,15 +1121,11 @@ define <2 x i1> @ctpop_v2i64_eq_one(<2 x i64> %a) nounwind {
 ; RV64I-LABEL: ctpop_v2i64_eq_one:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addi a2, a0, -1
-; RV64I-NEXT:    and a2, a0, a2
-; RV64I-NEXT:    seqz a2, a2
-; RV64I-NEXT:    snez a0, a0
-; RV64I-NEXT:    and a0, a0, a2
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    sltu a0, a2, a0
 ; RV64I-NEXT:    addi a2, a1, -1
-; RV64I-NEXT:    and a2, a1, a2
-; RV64I-NEXT:    seqz a2, a2
-; RV64I-NEXT:    snez a1, a1
-; RV64I-NEXT:    and a1, a1, a2
+; RV64I-NEXT:    xor a1, a1, a2
+; RV64I-NEXT:    sltu a1, a2, a1
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_v2i64_eq_one:
@@ -1166,15 +1146,13 @@ define <2 x i1> @ctpop_v2i64_ne_one(<2 x i64> %a) nounwind {
 ; RV64I-LABEL: ctpop_v2i64_ne_one:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addi a2, a0, -1
-; RV64I-NEXT:    and a2, a0, a2
-; RV64I-NEXT:    snez a2, a2
-; RV64I-NEXT:    seqz a0, a0
-; RV64I-NEXT:    or a0, a0, a2
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    sltu a0, a2, a0
+; RV64I-NEXT:    xori a0, a0, 1
 ; RV64I-NEXT:    addi a2, a1, -1
-; RV64I-NEXT:    and a2, a1, a2
-; RV64I-NEXT:    snez a2, a2
-; RV64I-NEXT:    seqz a1, a1
-; RV64I-NEXT:    or a1, a1, a2
+; RV64I-NEXT:    xor a1, a1, a2
+; RV64I-NEXT:    sltu a1, a2, a1
+; RV64I-NEXT:    xori a1, a1, 1
 ; RV64I-NEXT:    ret
 ;
 ; RV64ZBB-LABEL: ctpop_v2i64_ne_one:

--- a/llvm/test/CodeGen/RISCV/rvv/ctpop-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/ctpop-sdnode.ll
@@ -635,10 +635,8 @@ define <vscale x 16 x i1> @ctpop_nxv16i32_eq_one(<vscale x 16 x i32> %va) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vadd.vi v16, v8, -1
-; CHECK-NEXT:    vand.vv v16, v8, v16
-; CHECK-NEXT:    vmseq.vi v24, v16, 0
-; CHECK-NEXT:    vmsne.vi v16, v8, 0
-; CHECK-NEXT:    vmand.mm v0, v16, v24
+; CHECK-NEXT:    vxor.vv v8, v8, v16
+; CHECK-NEXT:    vmsltu.vv v0, v16, v8
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-ZVBB-LABEL: ctpop_nxv16i32_eq_one:
@@ -657,10 +655,8 @@ define <vscale x 16 x i1> @ctpop_nxv16i32_ne_one(<vscale x 16 x i32> %va) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vadd.vi v16, v8, -1
-; CHECK-NEXT:    vand.vv v16, v8, v16
-; CHECK-NEXT:    vmsne.vi v24, v16, 0
-; CHECK-NEXT:    vmseq.vi v16, v8, 0
-; CHECK-NEXT:    vmor.mm v0, v16, v24
+; CHECK-NEXT:    vxor.vv v8, v8, v16
+; CHECK-NEXT:    vmsleu.vv v0, v8, v16
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-ZVBB-LABEL: ctpop_nxv16i32_ne_one:
@@ -1053,10 +1049,8 @@ define <vscale x 8 x i1> @ctpop_nxv8i64_eq_one(<vscale x 8 x i64> %va) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli a0, zero, e64, m8, ta, ma
 ; CHECK-NEXT:    vadd.vi v16, v8, -1
-; CHECK-NEXT:    vand.vv v16, v8, v16
-; CHECK-NEXT:    vmseq.vi v24, v16, 0
-; CHECK-NEXT:    vmsne.vi v16, v8, 0
-; CHECK-NEXT:    vmand.mm v0, v16, v24
+; CHECK-NEXT:    vxor.vv v8, v8, v16
+; CHECK-NEXT:    vmsltu.vv v0, v16, v8
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-ZVBB-LABEL: ctpop_nxv8i64_eq_one:
@@ -1075,10 +1069,8 @@ define <vscale x 8 x i1> @ctpop_nxv8i64_ne_one(<vscale x 8 x i64> %va) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli a0, zero, e64, m8, ta, ma
 ; CHECK-NEXT:    vadd.vi v16, v8, -1
-; CHECK-NEXT:    vand.vv v16, v8, v16
-; CHECK-NEXT:    vmsne.vi v24, v16, 0
-; CHECK-NEXT:    vmseq.vi v16, v8, 0
-; CHECK-NEXT:    vmor.mm v0, v16, v24
+; CHECK-NEXT:    vxor.vv v8, v8, v16
+; CHECK-NEXT:    vmsleu.vv v0, v8, v16
 ; CHECK-NEXT:    ret
 ;
 ; CHECK-ZVBB-LABEL: ctpop_nxv8i64_ne_one:

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-ctpop.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-ctpop.ll
@@ -629,10 +629,8 @@ define <8 x i1> @ctpop_v8i32_eq_one(ptr %x, ptr %y) {
 ; LMULMAX2-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; LMULMAX2-NEXT:    vle32.v v8, (a0)
 ; LMULMAX2-NEXT:    vadd.vi v10, v8, -1
-; LMULMAX2-NEXT:    vand.vv v10, v8, v10
-; LMULMAX2-NEXT:    vmseq.vi v12, v10, 0
-; LMULMAX2-NEXT:    vmsne.vi v10, v8, 0
-; LMULMAX2-NEXT:    vmand.mm v0, v10, v12
+; LMULMAX2-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX2-NEXT:    vmsltu.vv v0, v10, v8
 ; LMULMAX2-NEXT:    ret
 ;
 ; LMULMAX1-LABEL: ctpop_v8i32_eq_one:
@@ -641,34 +639,22 @@ define <8 x i1> @ctpop_v8i32_eq_one(ptr %x, ptr %y) {
 ; LMULMAX1-NEXT:    vle32.v v8, (a0)
 ; LMULMAX1-NEXT:    addi a0, a0, 16
 ; LMULMAX1-NEXT:    vle32.v v9, (a0)
-; LMULMAX1-NEXT:    vmsne.vi v0, v8, 0
+; LMULMAX1-NEXT:    vadd.vi v10, v8, -1
+; LMULMAX1-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX1-NEXT:    vmsltu.vv v0, v10, v8
 ; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; LMULMAX1-NEXT:    vmv.v.i v10, 0
-; LMULMAX1-NEXT:    vmerge.vim v11, v10, 1, v0
-; LMULMAX1-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; LMULMAX1-NEXT:    vmsne.vi v0, v9, 0
-; LMULMAX1-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
-; LMULMAX1-NEXT:    vmv.v.i v12, 0
-; LMULMAX1-NEXT:    vmerge.vim v13, v12, 1, v0
-; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; LMULMAX1-NEXT:    vslideup.vi v11, v13, 4
-; LMULMAX1-NEXT:    vmsne.vi v11, v11, 0
-; LMULMAX1-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; LMULMAX1-NEXT:    vadd.vi v13, v8, -1
-; LMULMAX1-NEXT:    vand.vv v8, v8, v13
-; LMULMAX1-NEXT:    vmseq.vi v0, v8, 0
-; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; LMULMAX1-NEXT:    vmerge.vim v8, v10, 1, v0
+; LMULMAX1-NEXT:    vmv.v.i v8, 0
+; LMULMAX1-NEXT:    vmerge.vim v8, v8, 1, v0
 ; LMULMAX1-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; LMULMAX1-NEXT:    vadd.vi v10, v9, -1
-; LMULMAX1-NEXT:    vand.vv v9, v9, v10
-; LMULMAX1-NEXT:    vmseq.vi v0, v9, 0
+; LMULMAX1-NEXT:    vxor.vv v9, v9, v10
+; LMULMAX1-NEXT:    vmsltu.vv v0, v10, v9
 ; LMULMAX1-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
-; LMULMAX1-NEXT:    vmerge.vim v9, v12, 1, v0
+; LMULMAX1-NEXT:    vmv.v.i v9, 0
+; LMULMAX1-NEXT:    vmerge.vim v9, v9, 1, v0
 ; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; LMULMAX1-NEXT:    vslideup.vi v8, v9, 4
-; LMULMAX1-NEXT:    vmsne.vi v8, v8, 0
-; LMULMAX1-NEXT:    vmand.mm v0, v11, v8
+; LMULMAX1-NEXT:    vmsne.vi v0, v8, 0
 ; LMULMAX1-NEXT:    ret
 ;
 ; ZVBB-LABEL: ctpop_v8i32_eq_one:
@@ -690,10 +676,8 @@ define <8 x i1> @ctpop_v8i32_ne_one(ptr %x, ptr %y) {
 ; LMULMAX2-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; LMULMAX2-NEXT:    vle32.v v8, (a0)
 ; LMULMAX2-NEXT:    vadd.vi v10, v8, -1
-; LMULMAX2-NEXT:    vand.vv v10, v8, v10
-; LMULMAX2-NEXT:    vmsne.vi v12, v10, 0
-; LMULMAX2-NEXT:    vmseq.vi v10, v8, 0
-; LMULMAX2-NEXT:    vmor.mm v0, v10, v12
+; LMULMAX2-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX2-NEXT:    vmsleu.vv v0, v8, v10
 ; LMULMAX2-NEXT:    ret
 ;
 ; LMULMAX1-LABEL: ctpop_v8i32_ne_one:
@@ -702,34 +686,22 @@ define <8 x i1> @ctpop_v8i32_ne_one(ptr %x, ptr %y) {
 ; LMULMAX1-NEXT:    vle32.v v8, (a0)
 ; LMULMAX1-NEXT:    addi a0, a0, 16
 ; LMULMAX1-NEXT:    vle32.v v9, (a0)
-; LMULMAX1-NEXT:    vmseq.vi v0, v8, 0
+; LMULMAX1-NEXT:    vadd.vi v10, v8, -1
+; LMULMAX1-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX1-NEXT:    vmsleu.vv v0, v8, v10
 ; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; LMULMAX1-NEXT:    vmv.v.i v10, 0
-; LMULMAX1-NEXT:    vmerge.vim v11, v10, 1, v0
-; LMULMAX1-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; LMULMAX1-NEXT:    vmseq.vi v0, v9, 0
-; LMULMAX1-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
-; LMULMAX1-NEXT:    vmv.v.i v12, 0
-; LMULMAX1-NEXT:    vmerge.vim v13, v12, 1, v0
-; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; LMULMAX1-NEXT:    vslideup.vi v11, v13, 4
-; LMULMAX1-NEXT:    vmsne.vi v11, v11, 0
-; LMULMAX1-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; LMULMAX1-NEXT:    vadd.vi v13, v8, -1
-; LMULMAX1-NEXT:    vand.vv v8, v8, v13
-; LMULMAX1-NEXT:    vmsne.vi v0, v8, 0
-; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; LMULMAX1-NEXT:    vmerge.vim v8, v10, 1, v0
+; LMULMAX1-NEXT:    vmv.v.i v8, 0
+; LMULMAX1-NEXT:    vmerge.vim v8, v8, 1, v0
 ; LMULMAX1-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; LMULMAX1-NEXT:    vadd.vi v10, v9, -1
-; LMULMAX1-NEXT:    vand.vv v9, v9, v10
-; LMULMAX1-NEXT:    vmsne.vi v0, v9, 0
+; LMULMAX1-NEXT:    vxor.vv v9, v9, v10
+; LMULMAX1-NEXT:    vmsleu.vv v0, v9, v10
 ; LMULMAX1-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
-; LMULMAX1-NEXT:    vmerge.vim v9, v12, 1, v0
+; LMULMAX1-NEXT:    vmv.v.i v9, 0
+; LMULMAX1-NEXT:    vmerge.vim v9, v9, 1, v0
 ; LMULMAX1-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
 ; LMULMAX1-NEXT:    vslideup.vi v8, v9, 4
-; LMULMAX1-NEXT:    vmsne.vi v8, v8, 0
-; LMULMAX1-NEXT:    vmor.mm v0, v11, v8
+; LMULMAX1-NEXT:    vmsne.vi v0, v8, 0
 ; LMULMAX1-NEXT:    ret
 ;
 ; ZVBB-LABEL: ctpop_v8i32_ne_one:
@@ -1103,10 +1075,8 @@ define <4 x i1> @ctpop_v4i64_eq_one(ptr %x, ptr %y) {
 ; LMULMAX2-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
 ; LMULMAX2-NEXT:    vle64.v v8, (a0)
 ; LMULMAX2-NEXT:    vadd.vi v10, v8, -1
-; LMULMAX2-NEXT:    vand.vv v10, v8, v10
-; LMULMAX2-NEXT:    vmseq.vi v12, v10, 0
-; LMULMAX2-NEXT:    vmsne.vi v10, v8, 0
-; LMULMAX2-NEXT:    vmand.mm v0, v10, v12
+; LMULMAX2-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX2-NEXT:    vmsltu.vv v0, v10, v8
 ; LMULMAX2-NEXT:    ret
 ;
 ; LMULMAX1-RV32-LABEL: ctpop_v4i64_eq_one:
@@ -1116,38 +1086,24 @@ define <4 x i1> @ctpop_v4i64_eq_one(ptr %x, ptr %y) {
 ; LMULMAX1-RV32-NEXT:    vle64.v v8, (a1)
 ; LMULMAX1-RV32-NEXT:    vle64.v v9, (a0)
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v10, 0
+; LMULMAX1-RV32-NEXT:    vmv.v.i v10, -1
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmsne.vv v0, v9, v10
+; LMULMAX1-RV32-NEXT:    vadd.vv v11, v9, v10
+; LMULMAX1-RV32-NEXT:    vxor.vv v9, v9, v11
+; LMULMAX1-RV32-NEXT:    vmsltu.vv v0, v11, v9
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v11, 0
-; LMULMAX1-RV32-NEXT:    vmerge.vim v12, v11, 1, v0
+; LMULMAX1-RV32-NEXT:    vmv.v.i v9, 0
+; LMULMAX1-RV32-NEXT:    vmerge.vim v9, v9, 1, v0
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmsne.vv v0, v8, v10
+; LMULMAX1-RV32-NEXT:    vadd.vv v10, v8, v10
+; LMULMAX1-RV32-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX1-RV32-NEXT:    vmsltu.vv v0, v10, v8
 ; LMULMAX1-RV32-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v13, 0
-; LMULMAX1-RV32-NEXT:    vmerge.vim v14, v13, 1, v0
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV32-NEXT:    vslideup.vi v12, v14, 2
-; LMULMAX1-RV32-NEXT:    vmsne.vi v12, v12, 0
-; LMULMAX1-RV32-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v14, -1
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vadd.vv v15, v9, v14
-; LMULMAX1-RV32-NEXT:    vand.vv v9, v9, v15
-; LMULMAX1-RV32-NEXT:    vmseq.vv v0, v9, v10
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV32-NEXT:    vmerge.vim v9, v11, 1, v0
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vadd.vv v11, v8, v14
-; LMULMAX1-RV32-NEXT:    vand.vv v8, v8, v11
-; LMULMAX1-RV32-NEXT:    vmseq.vv v0, v8, v10
-; LMULMAX1-RV32-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV32-NEXT:    vmerge.vim v8, v13, 1, v0
+; LMULMAX1-RV32-NEXT:    vmv.v.i v8, 0
+; LMULMAX1-RV32-NEXT:    vmerge.vim v8, v8, 1, v0
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
 ; LMULMAX1-RV32-NEXT:    vslideup.vi v9, v8, 2
-; LMULMAX1-RV32-NEXT:    vmsne.vi v8, v9, 0
-; LMULMAX1-RV32-NEXT:    vmand.mm v0, v12, v8
+; LMULMAX1-RV32-NEXT:    vmsne.vi v0, v9, 0
 ; LMULMAX1-RV32-NEXT:    ret
 ;
 ; LMULMAX1-RV64-LABEL: ctpop_v4i64_eq_one:
@@ -1156,34 +1112,22 @@ define <4 x i1> @ctpop_v4i64_eq_one(ptr %x, ptr %y) {
 ; LMULMAX1-RV64-NEXT:    vle64.v v8, (a0)
 ; LMULMAX1-RV64-NEXT:    addi a0, a0, 16
 ; LMULMAX1-RV64-NEXT:    vle64.v v9, (a0)
-; LMULMAX1-RV64-NEXT:    vmsne.vi v0, v8, 0
+; LMULMAX1-RV64-NEXT:    vadd.vi v10, v8, -1
+; LMULMAX1-RV64-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX1-RV64-NEXT:    vmsltu.vv v0, v10, v8
 ; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV64-NEXT:    vmv.v.i v10, 0
-; LMULMAX1-RV64-NEXT:    vmerge.vim v11, v10, 1, v0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV64-NEXT:    vmsne.vi v0, v9, 0
-; LMULMAX1-RV64-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV64-NEXT:    vmv.v.i v12, 0
-; LMULMAX1-RV64-NEXT:    vmerge.vim v13, v12, 1, v0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV64-NEXT:    vslideup.vi v11, v13, 2
-; LMULMAX1-RV64-NEXT:    vmsne.vi v11, v11, 0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV64-NEXT:    vadd.vi v13, v8, -1
-; LMULMAX1-RV64-NEXT:    vand.vv v8, v8, v13
-; LMULMAX1-RV64-NEXT:    vmseq.vi v0, v8, 0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV64-NEXT:    vmerge.vim v8, v10, 1, v0
+; LMULMAX1-RV64-NEXT:    vmv.v.i v8, 0
+; LMULMAX1-RV64-NEXT:    vmerge.vim v8, v8, 1, v0
 ; LMULMAX1-RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; LMULMAX1-RV64-NEXT:    vadd.vi v10, v9, -1
-; LMULMAX1-RV64-NEXT:    vand.vv v9, v9, v10
-; LMULMAX1-RV64-NEXT:    vmseq.vi v0, v9, 0
+; LMULMAX1-RV64-NEXT:    vxor.vv v9, v9, v10
+; LMULMAX1-RV64-NEXT:    vmsltu.vv v0, v10, v9
 ; LMULMAX1-RV64-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV64-NEXT:    vmerge.vim v9, v12, 1, v0
+; LMULMAX1-RV64-NEXT:    vmv.v.i v9, 0
+; LMULMAX1-RV64-NEXT:    vmerge.vim v9, v9, 1, v0
 ; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
 ; LMULMAX1-RV64-NEXT:    vslideup.vi v8, v9, 2
-; LMULMAX1-RV64-NEXT:    vmsne.vi v8, v8, 0
-; LMULMAX1-RV64-NEXT:    vmand.mm v0, v11, v8
+; LMULMAX1-RV64-NEXT:    vmsne.vi v0, v8, 0
 ; LMULMAX1-RV64-NEXT:    ret
 ;
 ; ZVBB-LABEL: ctpop_v4i64_eq_one:
@@ -1205,10 +1149,8 @@ define <4 x i1> @ctpop_v4i64_ne_one(ptr %x, ptr %y) {
 ; LMULMAX2-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
 ; LMULMAX2-NEXT:    vle64.v v8, (a0)
 ; LMULMAX2-NEXT:    vadd.vi v10, v8, -1
-; LMULMAX2-NEXT:    vand.vv v10, v8, v10
-; LMULMAX2-NEXT:    vmsne.vi v12, v10, 0
-; LMULMAX2-NEXT:    vmseq.vi v10, v8, 0
-; LMULMAX2-NEXT:    vmor.mm v0, v10, v12
+; LMULMAX2-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX2-NEXT:    vmsleu.vv v0, v8, v10
 ; LMULMAX2-NEXT:    ret
 ;
 ; LMULMAX1-RV32-LABEL: ctpop_v4i64_ne_one:
@@ -1218,38 +1160,24 @@ define <4 x i1> @ctpop_v4i64_ne_one(ptr %x, ptr %y) {
 ; LMULMAX1-RV32-NEXT:    vle64.v v8, (a1)
 ; LMULMAX1-RV32-NEXT:    vle64.v v9, (a0)
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v10, 0
+; LMULMAX1-RV32-NEXT:    vmv.v.i v10, -1
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmseq.vv v0, v9, v10
+; LMULMAX1-RV32-NEXT:    vadd.vv v11, v9, v10
+; LMULMAX1-RV32-NEXT:    vxor.vv v9, v9, v11
+; LMULMAX1-RV32-NEXT:    vmsleu.vv v0, v9, v11
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v11, 0
-; LMULMAX1-RV32-NEXT:    vmerge.vim v12, v11, 1, v0
+; LMULMAX1-RV32-NEXT:    vmv.v.i v9, 0
+; LMULMAX1-RV32-NEXT:    vmerge.vim v9, v9, 1, v0
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmseq.vv v0, v8, v10
+; LMULMAX1-RV32-NEXT:    vadd.vv v10, v8, v10
+; LMULMAX1-RV32-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX1-RV32-NEXT:    vmsleu.vv v0, v8, v10
 ; LMULMAX1-RV32-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v13, 0
-; LMULMAX1-RV32-NEXT:    vmerge.vim v14, v13, 1, v0
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV32-NEXT:    vslideup.vi v12, v14, 2
-; LMULMAX1-RV32-NEXT:    vmsne.vi v12, v12, 0
-; LMULMAX1-RV32-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vmv.v.i v14, -1
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vadd.vv v15, v9, v14
-; LMULMAX1-RV32-NEXT:    vand.vv v9, v9, v15
-; LMULMAX1-RV32-NEXT:    vmsne.vv v0, v9, v10
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV32-NEXT:    vmerge.vim v9, v11, 1, v0
-; LMULMAX1-RV32-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV32-NEXT:    vadd.vv v11, v8, v14
-; LMULMAX1-RV32-NEXT:    vand.vv v8, v8, v11
-; LMULMAX1-RV32-NEXT:    vmsne.vv v0, v8, v10
-; LMULMAX1-RV32-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV32-NEXT:    vmerge.vim v8, v13, 1, v0
+; LMULMAX1-RV32-NEXT:    vmv.v.i v8, 0
+; LMULMAX1-RV32-NEXT:    vmerge.vim v8, v8, 1, v0
 ; LMULMAX1-RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
 ; LMULMAX1-RV32-NEXT:    vslideup.vi v9, v8, 2
-; LMULMAX1-RV32-NEXT:    vmsne.vi v8, v9, 0
-; LMULMAX1-RV32-NEXT:    vmor.mm v0, v12, v8
+; LMULMAX1-RV32-NEXT:    vmsne.vi v0, v9, 0
 ; LMULMAX1-RV32-NEXT:    ret
 ;
 ; LMULMAX1-RV64-LABEL: ctpop_v4i64_ne_one:
@@ -1258,34 +1186,22 @@ define <4 x i1> @ctpop_v4i64_ne_one(ptr %x, ptr %y) {
 ; LMULMAX1-RV64-NEXT:    vle64.v v8, (a0)
 ; LMULMAX1-RV64-NEXT:    addi a0, a0, 16
 ; LMULMAX1-RV64-NEXT:    vle64.v v9, (a0)
-; LMULMAX1-RV64-NEXT:    vmseq.vi v0, v8, 0
+; LMULMAX1-RV64-NEXT:    vadd.vi v10, v8, -1
+; LMULMAX1-RV64-NEXT:    vxor.vv v8, v8, v10
+; LMULMAX1-RV64-NEXT:    vmsleu.vv v0, v8, v10
 ; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV64-NEXT:    vmv.v.i v10, 0
-; LMULMAX1-RV64-NEXT:    vmerge.vim v11, v10, 1, v0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV64-NEXT:    vmseq.vi v0, v9, 0
-; LMULMAX1-RV64-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV64-NEXT:    vmv.v.i v12, 0
-; LMULMAX1-RV64-NEXT:    vmerge.vim v13, v12, 1, v0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV64-NEXT:    vslideup.vi v11, v13, 2
-; LMULMAX1-RV64-NEXT:    vmsne.vi v11, v11, 0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
-; LMULMAX1-RV64-NEXT:    vadd.vi v13, v8, -1
-; LMULMAX1-RV64-NEXT:    vand.vv v8, v8, v13
-; LMULMAX1-RV64-NEXT:    vmsne.vi v0, v8, 0
-; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; LMULMAX1-RV64-NEXT:    vmerge.vim v8, v10, 1, v0
+; LMULMAX1-RV64-NEXT:    vmv.v.i v8, 0
+; LMULMAX1-RV64-NEXT:    vmerge.vim v8, v8, 1, v0
 ; LMULMAX1-RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; LMULMAX1-RV64-NEXT:    vadd.vi v10, v9, -1
-; LMULMAX1-RV64-NEXT:    vand.vv v9, v9, v10
-; LMULMAX1-RV64-NEXT:    vmsne.vi v0, v9, 0
+; LMULMAX1-RV64-NEXT:    vxor.vv v9, v9, v10
+; LMULMAX1-RV64-NEXT:    vmsleu.vv v0, v9, v10
 ; LMULMAX1-RV64-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
-; LMULMAX1-RV64-NEXT:    vmerge.vim v9, v12, 1, v0
+; LMULMAX1-RV64-NEXT:    vmv.v.i v9, 0
+; LMULMAX1-RV64-NEXT:    vmerge.vim v9, v9, 1, v0
 ; LMULMAX1-RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
 ; LMULMAX1-RV64-NEXT:    vslideup.vi v8, v9, 2
-; LMULMAX1-RV64-NEXT:    vmsne.vi v8, v8, 0
-; LMULMAX1-RV64-NEXT:    vmor.mm v0, v11, v8
+; LMULMAX1-RV64-NEXT:    vmsne.vi v0, v8, 0
 ; LMULMAX1-RV64-NEXT:    ret
 ;
 ; ZVBB-LABEL: ctpop_v4i64_ne_one:

--- a/llvm/test/CodeGen/X86/ctpop-combine.ll
+++ b/llvm/test/CodeGen/X86/ctpop-combine.ll
@@ -120,13 +120,11 @@ define i32 @ctpop_eq_one(i64 %x) nounwind readnone {
 ;
 ; NO-POPCOUNT-LABEL: ctpop_eq_one:
 ; NO-POPCOUNT:       # %bb.0:
-; NO-POPCOUNT-NEXT:    leaq -1(%rdi), %rax
-; NO-POPCOUNT-NEXT:    testq %rax, %rdi
-; NO-POPCOUNT-NEXT:    sete %al
-; NO-POPCOUNT-NEXT:    testq %rdi, %rdi
-; NO-POPCOUNT-NEXT:    setne %cl
-; NO-POPCOUNT-NEXT:    andb %al, %cl
-; NO-POPCOUNT-NEXT:    movzbl %cl, %eax
+; NO-POPCOUNT-NEXT:    leaq -1(%rdi), %rcx
+; NO-POPCOUNT-NEXT:    xorq %rcx, %rdi
+; NO-POPCOUNT-NEXT:    xorl %eax, %eax
+; NO-POPCOUNT-NEXT:    cmpq %rcx, %rdi
+; NO-POPCOUNT-NEXT:    seta %al
 ; NO-POPCOUNT-NEXT:    retq
   %count = tail call i64 @llvm.ctpop.i64(i64 %x)
   %cmp = icmp eq i64 %count, 1
@@ -145,13 +143,11 @@ define i32 @ctpop_ne_one(i64 %x) nounwind readnone {
 ;
 ; NO-POPCOUNT-LABEL: ctpop_ne_one:
 ; NO-POPCOUNT:       # %bb.0:
-; NO-POPCOUNT-NEXT:    leaq -1(%rdi), %rax
-; NO-POPCOUNT-NEXT:    testq %rax, %rdi
-; NO-POPCOUNT-NEXT:    setne %al
-; NO-POPCOUNT-NEXT:    testq %rdi, %rdi
-; NO-POPCOUNT-NEXT:    sete %cl
-; NO-POPCOUNT-NEXT:    orb %al, %cl
-; NO-POPCOUNT-NEXT:    movzbl %cl, %eax
+; NO-POPCOUNT-NEXT:    leaq -1(%rdi), %rcx
+; NO-POPCOUNT-NEXT:    xorq %rcx, %rdi
+; NO-POPCOUNT-NEXT:    xorl %eax, %eax
+; NO-POPCOUNT-NEXT:    cmpq %rcx, %rdi
+; NO-POPCOUNT-NEXT:    setbe %al
 ; NO-POPCOUNT-NEXT:    retq
   %count = tail call i64 @llvm.ctpop.i64(i64 %x)
   %cmp = icmp ne i64 %count, 1
@@ -162,29 +158,26 @@ define i32 @ctpop_ne_one(i64 %x) nounwind readnone {
 define i1 @ctpop_trunc_non_power2(i255 %x) nounwind {
 ; CHECK-LABEL: ctpop_trunc_non_power2:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    movabsq $9223372036854775807, %rax # imm = 0x7FFFFFFFFFFFFFFF
-; CHECK-NEXT:    movq %rcx, %r8
-; CHECK-NEXT:    andq %rax, %r8
-; CHECK-NEXT:    movq %rdi, %r9
-; CHECK-NEXT:    addq $-1, %r9
-; CHECK-NEXT:    movq %rsi, %r10
-; CHECK-NEXT:    adcq $-1, %r10
-; CHECK-NEXT:    movq %rdx, %r11
-; CHECK-NEXT:    adcq $-1, %r11
-; CHECK-NEXT:    adcq %rax, %rcx
-; CHECK-NEXT:    andq %rdi, %r9
-; CHECK-NEXT:    andq %rdx, %r11
-; CHECK-NEXT:    orq %r9, %r11
-; CHECK-NEXT:    andq %r8, %rcx
-; CHECK-NEXT:    andq %rsi, %r10
-; CHECK-NEXT:    orq %rcx, %r10
-; CHECK-NEXT:    orq %r11, %r10
-; CHECK-NEXT:    sete %cl
-; CHECK-NEXT:    orq %rdx, %rdi
-; CHECK-NEXT:    orq %rsi, %r8
-; CHECK-NEXT:    orq %rdi, %r8
-; CHECK-NEXT:    setne %al
-; CHECK-NEXT:    andb %cl, %al
+; CHECK-NEXT:    movq %rdi, %rax
+; CHECK-NEXT:    addq $-1, %rax
+; CHECK-NEXT:    movq %rsi, %r8
+; CHECK-NEXT:    adcq $-1, %r8
+; CHECK-NEXT:    movq %rdx, %r9
+; CHECK-NEXT:    adcq $-1, %r9
+; CHECK-NEXT:    movabsq $9223372036854775807, %r10 # imm = 0x7FFFFFFFFFFFFFFF
+; CHECK-NEXT:    movq %rcx, %r11
+; CHECK-NEXT:    adcq %r10, %r11
+; CHECK-NEXT:    xorq %r11, %rcx
+; CHECK-NEXT:    andq %r10, %r11
+; CHECK-NEXT:    andq %r10, %rcx
+; CHECK-NEXT:    xorq %r9, %rdx
+; CHECK-NEXT:    xorq %r8, %rsi
+; CHECK-NEXT:    xorq %rax, %rdi
+; CHECK-NEXT:    cmpq %rdi, %rax
+; CHECK-NEXT:    sbbq %rsi, %r8
+; CHECK-NEXT:    sbbq %rdx, %r9
+; CHECK-NEXT:    sbbq %rcx, %r11
+; CHECK-NEXT:    setb %al
 ; CHECK-NEXT:    retq
   %a = call i255 @llvm.ctpop.i255(i255 %x)
   %b = trunc i255 %a to i8 ; largest value from ctpop is 255, fits in 8 bits.

--- a/llvm/test/CodeGen/X86/ispow2.ll
+++ b/llvm/test/CodeGen/X86/ispow2.ll
@@ -28,25 +28,14 @@ define i1 @is_pow2_non_zero(i32 %xin) {
 }
 
 define i1 @is_pow2_non_zero_x_maybe_z(i32 %x) {
-; CHECK-NOBMI-LABEL: is_pow2_non_zero_x_maybe_z:
-; CHECK-NOBMI:       # %bb.0:
-; CHECK-NOBMI-NEXT:    # kill: def $edi killed $edi def $rdi
-; CHECK-NOBMI-NEXT:    leal -1(%rdi), %eax
-; CHECK-NOBMI-NEXT:    testl %eax, %edi
-; CHECK-NOBMI-NEXT:    sete %cl
-; CHECK-NOBMI-NEXT:    testl %edi, %edi
-; CHECK-NOBMI-NEXT:    setne %al
-; CHECK-NOBMI-NEXT:    andb %cl, %al
-; CHECK-NOBMI-NEXT:    retq
-;
-; CHECK-BMI2-LABEL: is_pow2_non_zero_x_maybe_z:
-; CHECK-BMI2:       # %bb.0:
-; CHECK-BMI2-NEXT:    testl %edi, %edi
-; CHECK-BMI2-NEXT:    setne %cl
-; CHECK-BMI2-NEXT:    blsrl %edi, %eax
-; CHECK-BMI2-NEXT:    sete %al
-; CHECK-BMI2-NEXT:    andb %cl, %al
-; CHECK-BMI2-NEXT:    retq
+; CHECK-LABEL: is_pow2_non_zero_x_maybe_z:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    # kill: def $edi killed $edi def $rdi
+; CHECK-NEXT:    leal -1(%rdi), %eax
+; CHECK-NEXT:    xorl %eax, %edi
+; CHECK-NEXT:    cmpl %eax, %edi
+; CHECK-NEXT:    seta %al
+; CHECK-NEXT:    retq
   %cnt = call i32 @llvm.ctpop.i32(i32 %x)
   %r = icmp eq i32 %cnt, 1
   ret i1 %r
@@ -180,44 +169,40 @@ define <4 x i1> @neither_pow2_non_zero_4xv64(<4 x i64> %xin) {
 define <4 x i1> @neither_pow2_non_zero_4xv64_x_maybe_z(<4 x i64> %x) {
 ; CHECK-NOBMI-LABEL: neither_pow2_non_zero_4xv64_x_maybe_z:
 ; CHECK-NOBMI:       # %bb.0:
-; CHECK-NOBMI-NEXT:    pxor %xmm2, %xmm2
-; CHECK-NOBMI-NEXT:    pcmpeqd %xmm3, %xmm3
-; CHECK-NOBMI-NEXT:    movdqa %xmm1, %xmm4
-; CHECK-NOBMI-NEXT:    paddq %xmm3, %xmm4
-; CHECK-NOBMI-NEXT:    pand %xmm1, %xmm4
-; CHECK-NOBMI-NEXT:    pcmpeqd %xmm2, %xmm1
-; CHECK-NOBMI-NEXT:    pshufd {{.*#+}} xmm5 = xmm1[1,0,3,2]
-; CHECK-NOBMI-NEXT:    pand %xmm1, %xmm5
-; CHECK-NOBMI-NEXT:    pcmpeqd %xmm2, %xmm4
-; CHECK-NOBMI-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[1,0,3,2]
-; CHECK-NOBMI-NEXT:    pand %xmm4, %xmm1
+; CHECK-NOBMI-NEXT:    pcmpeqd %xmm2, %xmm2
+; CHECK-NOBMI-NEXT:    movdqa %xmm1, %xmm3
+; CHECK-NOBMI-NEXT:    paddq %xmm2, %xmm3
+; CHECK-NOBMI-NEXT:    movdqa {{.*#+}} xmm4 = [9223372039002259456,9223372039002259456]
+; CHECK-NOBMI-NEXT:    pxor %xmm4, %xmm3
 ; CHECK-NOBMI-NEXT:    pxor %xmm3, %xmm1
-; CHECK-NOBMI-NEXT:    por %xmm5, %xmm1
+; CHECK-NOBMI-NEXT:    movdqa %xmm1, %xmm5
+; CHECK-NOBMI-NEXT:    pcmpgtd %xmm3, %xmm5
+; CHECK-NOBMI-NEXT:    movdqa %xmm0, %xmm6
+; CHECK-NOBMI-NEXT:    paddq %xmm2, %xmm6
+; CHECK-NOBMI-NEXT:    pxor %xmm4, %xmm6
+; CHECK-NOBMI-NEXT:    pxor %xmm6, %xmm0
 ; CHECK-NOBMI-NEXT:    movdqa %xmm0, %xmm4
-; CHECK-NOBMI-NEXT:    pcmpeqd %xmm2, %xmm4
-; CHECK-NOBMI-NEXT:    pshufd {{.*#+}} xmm5 = xmm4[1,0,3,2]
-; CHECK-NOBMI-NEXT:    pand %xmm4, %xmm5
-; CHECK-NOBMI-NEXT:    movdqa %xmm0, %xmm4
-; CHECK-NOBMI-NEXT:    paddq %xmm3, %xmm4
-; CHECK-NOBMI-NEXT:    pand %xmm4, %xmm0
-; CHECK-NOBMI-NEXT:    pcmpeqd %xmm2, %xmm0
-; CHECK-NOBMI-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,0,3,2]
-; CHECK-NOBMI-NEXT:    pand %xmm2, %xmm0
-; CHECK-NOBMI-NEXT:    pxor %xmm3, %xmm0
-; CHECK-NOBMI-NEXT:    por %xmm5, %xmm0
-; CHECK-NOBMI-NEXT:    shufps {{.*#+}} xmm0 = xmm0[0,2],xmm1[0,2]
+; CHECK-NOBMI-NEXT:    pcmpgtd %xmm6, %xmm4
+; CHECK-NOBMI-NEXT:    movdqa %xmm4, %xmm7
+; CHECK-NOBMI-NEXT:    shufps {{.*#+}} xmm7 = xmm7[0,2],xmm5[0,2]
+; CHECK-NOBMI-NEXT:    pcmpeqd %xmm3, %xmm1
+; CHECK-NOBMI-NEXT:    pcmpeqd %xmm6, %xmm0
+; CHECK-NOBMI-NEXT:    shufps {{.*#+}} xmm0 = xmm0[1,3],xmm1[1,3]
+; CHECK-NOBMI-NEXT:    andps %xmm7, %xmm0
+; CHECK-NOBMI-NEXT:    shufps {{.*#+}} xmm4 = xmm4[1,3],xmm5[1,3]
+; CHECK-NOBMI-NEXT:    orps %xmm4, %xmm0
+; CHECK-NOBMI-NEXT:    xorps %xmm2, %xmm0
 ; CHECK-NOBMI-NEXT:    retq
 ;
 ; CHECK-AVX2-LABEL: neither_pow2_non_zero_4xv64_x_maybe_z:
 ; CHECK-AVX2:       # %bb.0:
-; CHECK-AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; CHECK-AVX2-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm2
-; CHECK-AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; CHECK-AVX2-NEXT:    vpaddq %ymm3, %ymm0, %ymm4
-; CHECK-AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
-; CHECK-AVX2-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm0
-; CHECK-AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm0
-; CHECK-AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
+; CHECK-AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; CHECK-AVX2-NEXT:    vpaddq %ymm1, %ymm0, %ymm2
+; CHECK-AVX2-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
+; CHECK-AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
+; CHECK-AVX2-NEXT:    vpxor %ymm0, %ymm2, %ymm0
+; CHECK-AVX2-NEXT:    vpcmpgtq %ymm2, %ymm0, %ymm0
+; CHECK-AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
 ; CHECK-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; CHECK-AVX2-NEXT:    vpackssdw %xmm1, %xmm0, %xmm0
 ; CHECK-AVX2-NEXT:    vzeroupper

--- a/llvm/test/CodeGen/X86/vector-popcnt-128.ll
+++ b/llvm/test/CodeGen/X86/vector-popcnt-128.ll
@@ -720,85 +720,37 @@ define <16 x i8> @foldv16i8() nounwind {
 }
 
 define <2 x i64> @eq_1_v2i64(<2 x i64> %0) {
-; SSE2-LABEL: eq_1_v2i64:
-; SSE2:       # %bb.0:
-; SSE2-NEXT:    pxor %xmm1, %xmm1
-; SSE2-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE2-NEXT:    paddq %xmm0, %xmm2
-; SSE2-NEXT:    pand %xmm0, %xmm2
-; SSE2-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-NEXT:    pcmpeqd %xmm1, %xmm3
-; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,0,3,2]
-; SSE2-NEXT:    pand %xmm3, %xmm0
-; SSE2-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,0,3,2]
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm1, %xmm0
-; SSE2-NEXT:    retq
-;
-; SSE3-LABEL: eq_1_v2i64:
-; SSE3:       # %bb.0:
-; SSE3-NEXT:    pxor %xmm1, %xmm1
-; SSE3-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE3-NEXT:    paddq %xmm0, %xmm2
-; SSE3-NEXT:    pand %xmm0, %xmm2
-; SSE3-NEXT:    movdqa %xmm0, %xmm3
-; SSE3-NEXT:    pcmpeqd %xmm1, %xmm3
-; SSE3-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,0,3,2]
-; SSE3-NEXT:    pand %xmm3, %xmm0
-; SSE3-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSE3-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,0,3,2]
-; SSE3-NEXT:    pand %xmm2, %xmm1
-; SSE3-NEXT:    pandn %xmm1, %xmm0
-; SSE3-NEXT:    retq
-;
-; SSSE3-LABEL: eq_1_v2i64:
-; SSSE3:       # %bb.0:
-; SSSE3-NEXT:    pxor %xmm1, %xmm1
-; SSSE3-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSSE3-NEXT:    paddq %xmm0, %xmm2
-; SSSE3-NEXT:    pand %xmm0, %xmm2
-; SSSE3-NEXT:    movdqa %xmm0, %xmm3
-; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm3
-; SSSE3-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,0,3,2]
-; SSSE3-NEXT:    pand %xmm3, %xmm0
-; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSSE3-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,0,3,2]
-; SSSE3-NEXT:    pand %xmm2, %xmm1
-; SSSE3-NEXT:    pandn %xmm1, %xmm0
-; SSSE3-NEXT:    retq
-;
-; SSE41-LABEL: eq_1_v2i64:
-; SSE41:       # %bb.0:
-; SSE41-NEXT:    pxor %xmm1, %xmm1
-; SSE41-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE41-NEXT:    paddq %xmm0, %xmm2
-; SSE41-NEXT:    pand %xmm0, %xmm2
-; SSE41-NEXT:    pcmpeqq %xmm1, %xmm0
-; SSE41-NEXT:    pcmpeqq %xmm1, %xmm2
-; SSE41-NEXT:    pandn %xmm2, %xmm0
-; SSE41-NEXT:    retq
+; SSE-LABEL: eq_1_v2i64:
+; SSE:       # %bb.0:
+; SSE-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE-NEXT:    paddq %xmm0, %xmm1
+; SSE-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; SSE-NEXT:    pxor %xmm1, %xmm0
+; SSE-NEXT:    movdqa %xmm0, %xmm2
+; SSE-NEXT:    pcmpgtd %xmm1, %xmm2
+; SSE-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[0,0,2,2]
+; SSE-NEXT:    pcmpeqd %xmm1, %xmm0
+; SSE-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,3,3]
+; SSE-NEXT:    pand %xmm3, %xmm1
+; SSE-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; SSE-NEXT:    por %xmm1, %xmm0
+; SSE-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: eq_1_v2i64:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddq %xmm3, %xmm0, %xmm3
-; AVX1OR2-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddq %xmm1, %xmm0, %xmm1
+; AVX1OR2-NEXT:    vpxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpxor %xmm0, %xmm1, %xmm0
+; AVX1OR2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v2i64:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqq %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddq %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqq %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpand %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddq %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtuq %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: eq_1_v2i64:
@@ -818,24 +770,24 @@ define <2 x i64> @eq_1_v2i64(<2 x i64> %0) {
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v2i64:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG_NOVLX-NEXT:    vpaddq %xmm3, %xmm0, %xmm3
-; BITALG_NOVLX-NEXT:    vpand %xmm3, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG_NOVLX-NEXT:    vpaddq %xmm1, %xmm0, %xmm1
+; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpminuq %zmm1, %zmm0, %zmm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm0
-; BITALG_NOVLX-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; BITALG_NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 killed $zmm0
+; BITALG_NOVLX-NEXT:    vzeroupper
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: eq_1_v2i64:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm2
-; BITALG-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG-NEXT:    vpaddq %xmm3, %xmm0, %xmm3
-; BITALG-NEXT:    vpand %xmm3, %xmm0, %xmm0
+; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG-NEXT:    vpaddq %xmm1, %xmm0, %xmm1
+; BITALG-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG-NEXT:    vpminuq %xmm1, %xmm0, %xmm1
 ; BITALG-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm0
-; BITALG-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; BITALG-NEXT:    vpternlogq $15, %xmm0, %xmm0, %xmm0
 ; BITALG-NEXT:    retq
   %2 = tail call <2 x i64> @llvm.ctpop.v2i64(<2 x i64> %0)
   %3 = icmp eq <2 x i64> %2, <i64 1, i64 1>
@@ -844,95 +796,40 @@ define <2 x i64> @eq_1_v2i64(<2 x i64> %0) {
 }
 
 define <2 x i64> @ne_1_v2i64(<2 x i64> %0) {
-; SSE2-LABEL: ne_1_v2i64:
-; SSE2:       # %bb.0:
-; SSE2-NEXT:    pxor %xmm1, %xmm1
-; SSE2-NEXT:    movdqa %xmm0, %xmm2
-; SSE2-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSE2-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[1,0,3,2]
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm0, %xmm4
-; SSE2-NEXT:    paddq %xmm2, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm0
-; SSE2-NEXT:    pcmpeqd %xmm1, %xmm0
-; SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,0,3,2]
-; SSE2-NEXT:    pand %xmm1, %xmm0
-; SSE2-NEXT:    pxor %xmm2, %xmm0
-; SSE2-NEXT:    por %xmm3, %xmm0
-; SSE2-NEXT:    retq
-;
-; SSE3-LABEL: ne_1_v2i64:
-; SSE3:       # %bb.0:
-; SSE3-NEXT:    pxor %xmm1, %xmm1
-; SSE3-NEXT:    movdqa %xmm0, %xmm2
-; SSE3-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSE3-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[1,0,3,2]
-; SSE3-NEXT:    pand %xmm2, %xmm3
-; SSE3-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE3-NEXT:    movdqa %xmm0, %xmm4
-; SSE3-NEXT:    paddq %xmm2, %xmm4
-; SSE3-NEXT:    pand %xmm4, %xmm0
-; SSE3-NEXT:    pcmpeqd %xmm1, %xmm0
-; SSE3-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,0,3,2]
-; SSE3-NEXT:    pand %xmm1, %xmm0
-; SSE3-NEXT:    pxor %xmm2, %xmm0
-; SSE3-NEXT:    por %xmm3, %xmm0
-; SSE3-NEXT:    retq
-;
-; SSSE3-LABEL: ne_1_v2i64:
-; SSSE3:       # %bb.0:
-; SSSE3-NEXT:    pxor %xmm1, %xmm1
-; SSSE3-NEXT:    movdqa %xmm0, %xmm2
-; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSSE3-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[1,0,3,2]
-; SSSE3-NEXT:    pand %xmm2, %xmm3
-; SSSE3-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSSE3-NEXT:    movdqa %xmm0, %xmm4
-; SSSE3-NEXT:    paddq %xmm2, %xmm4
-; SSSE3-NEXT:    pand %xmm4, %xmm0
-; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm0
-; SSSE3-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,0,3,2]
-; SSSE3-NEXT:    pand %xmm1, %xmm0
-; SSSE3-NEXT:    pxor %xmm2, %xmm0
-; SSSE3-NEXT:    por %xmm3, %xmm0
-; SSSE3-NEXT:    retq
-;
-; SSE41-LABEL: ne_1_v2i64:
-; SSE41:       # %bb.0:
-; SSE41-NEXT:    pxor %xmm1, %xmm1
-; SSE41-NEXT:    movdqa %xmm0, %xmm2
-; SSE41-NEXT:    pcmpeqq %xmm1, %xmm2
-; SSE41-NEXT:    pcmpeqd %xmm3, %xmm3
-; SSE41-NEXT:    movdqa %xmm0, %xmm4
-; SSE41-NEXT:    paddq %xmm3, %xmm4
-; SSE41-NEXT:    pand %xmm4, %xmm0
-; SSE41-NEXT:    pcmpeqq %xmm1, %xmm0
-; SSE41-NEXT:    pxor %xmm3, %xmm0
-; SSE41-NEXT:    por %xmm2, %xmm0
-; SSE41-NEXT:    retq
+; SSE-LABEL: ne_1_v2i64:
+; SSE:       # %bb.0:
+; SSE-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE-NEXT:    movdqa %xmm0, %xmm2
+; SSE-NEXT:    paddq %xmm1, %xmm2
+; SSE-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
+; SSE-NEXT:    pxor %xmm2, %xmm0
+; SSE-NEXT:    movdqa %xmm0, %xmm3
+; SSE-NEXT:    pcmpgtd %xmm2, %xmm3
+; SSE-NEXT:    pshufd {{.*#+}} xmm4 = xmm3[0,0,2,2]
+; SSE-NEXT:    pcmpeqd %xmm2, %xmm0
+; SSE-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
+; SSE-NEXT:    pand %xmm4, %xmm2
+; SSE-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; SSE-NEXT:    por %xmm2, %xmm0
+; SSE-NEXT:    pxor %xmm1, %xmm0
+; SSE-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: ne_1_v2i64:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddq %xmm3, %xmm0, %xmm4
-; AVX1OR2-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpxor %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddq %xmm1, %xmm0, %xmm2
+; AVX1OR2-NEXT:    vpxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2, %xmm2
+; AVX1OR2-NEXT:    vpxor %xmm0, %xmm2, %xmm0
+; AVX1OR2-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v2i64:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqq %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddq %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqq %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddq %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleuq %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: ne_1_v2i64:
@@ -955,26 +852,21 @@ define <2 x i64> @ne_1_v2i64(<2 x i64> %0) {
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v2i64:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG_NOVLX-NEXT:    vpaddq %xmm3, %xmm0, %xmm3
-; BITALG_NOVLX-NEXT:    vpand %xmm3, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG_NOVLX-NEXT:    vpaddq %xmm1, %xmm0, %xmm1
+; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpminuq %zmm1, %zmm0, %zmm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm0
-; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; BITALG_NOVLX-NEXT:    vpor %xmm0, %xmm2, %xmm0
 ; BITALG_NOVLX-NEXT:    vzeroupper
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: ne_1_v2i64:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm2
-; BITALG-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG-NEXT:    vpaddq %xmm3, %xmm0, %xmm4
-; BITALG-NEXT:    vpand %xmm4, %xmm0, %xmm0
+; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG-NEXT:    vpaddq %xmm1, %xmm0, %xmm1
+; BITALG-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG-NEXT:    vpminuq %xmm1, %xmm0, %xmm1
 ; BITALG-NEXT:    vpcmpeqq %xmm1, %xmm0, %xmm0
-; BITALG-NEXT:    vpternlogq $222, %xmm3, %xmm2, %xmm0
 ; BITALG-NEXT:    retq
   %2 = tail call <2 x i64> @llvm.ctpop.v2i64(<2 x i64> %0)
   %3 = icmp ne <2 x i64> %2, <i64 1, i64 1>
@@ -983,37 +875,60 @@ define <2 x i64> @ne_1_v2i64(<2 x i64> %0) {
 }
 
 define <4 x i32> @eq_1_v4i32(<4 x i32> %0) {
-; SSE-LABEL: eq_1_v4i32:
-; SSE:       # %bb.0:
-; SSE-NEXT:    pxor %xmm1, %xmm1
-; SSE-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE-NEXT:    paddd %xmm0, %xmm2
-; SSE-NEXT:    pand %xmm0, %xmm2
-; SSE-NEXT:    pcmpeqd %xmm1, %xmm0
-; SSE-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSE-NEXT:    pandn %xmm2, %xmm0
-; SSE-NEXT:    retq
+; SSE2-LABEL: eq_1_v4i32:
+; SSE2:       # %bb.0:
+; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE2-NEXT:    paddd %xmm0, %xmm1
+; SSE2-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; SSE2-NEXT:    pxor %xmm1, %xmm0
+; SSE2-NEXT:    pcmpgtd %xmm1, %xmm0
+; SSE2-NEXT:    retq
+;
+; SSE3-LABEL: eq_1_v4i32:
+; SSE3:       # %bb.0:
+; SSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE3-NEXT:    paddd %xmm0, %xmm1
+; SSE3-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; SSE3-NEXT:    pxor %xmm1, %xmm0
+; SSE3-NEXT:    pcmpgtd %xmm1, %xmm0
+; SSE3-NEXT:    retq
+;
+; SSSE3-LABEL: eq_1_v4i32:
+; SSSE3:       # %bb.0:
+; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSSE3-NEXT:    paddd %xmm0, %xmm1
+; SSSE3-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; SSSE3-NEXT:    pxor %xmm1, %xmm0
+; SSSE3-NEXT:    pcmpgtd %xmm1, %xmm0
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: eq_1_v4i32:
+; SSE41:       # %bb.0:
+; SSE41-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE41-NEXT:    movdqa %xmm0, %xmm2
+; SSE41-NEXT:    paddd %xmm1, %xmm2
+; SSE41-NEXT:    pxor %xmm2, %xmm0
+; SSE41-NEXT:    pminud %xmm0, %xmm2
+; SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; SSE41-NEXT:    pxor %xmm1, %xmm0
+; SSE41-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: eq_1_v4i32:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddd %xmm3, %xmm0, %xmm3
-; AVX1OR2-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddd %xmm1, %xmm0, %xmm2
+; AVX1OR2-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpminud %xmm2, %xmm0, %xmm2
+; AVX1OR2-NEXT:    vpcmpeqd %xmm2, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v4i32:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqd %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddd %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqd %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpand %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddd %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtud %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: eq_1_v4i32:
@@ -1034,24 +949,24 @@ define <4 x i32> @eq_1_v4i32(<4 x i32> %0) {
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v4i32:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG_NOVLX-NEXT:    vpaddd %xmm3, %xmm0, %xmm3
-; BITALG_NOVLX-NEXT:    vpand %xmm3, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG_NOVLX-NEXT:    vpaddd %xmm1, %xmm0, %xmm1
+; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpminud %xmm1, %xmm0, %xmm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm0
-; BITALG_NOVLX-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; BITALG_NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 killed $zmm0
+; BITALG_NOVLX-NEXT:    vzeroupper
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: eq_1_v4i32:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm2
-; BITALG-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG-NEXT:    vpaddd %xmm3, %xmm0, %xmm3
-; BITALG-NEXT:    vpand %xmm3, %xmm0, %xmm0
+; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG-NEXT:    vpaddd %xmm1, %xmm0, %xmm1
+; BITALG-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG-NEXT:    vpminud %xmm1, %xmm0, %xmm1
 ; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm0
-; BITALG-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; BITALG-NEXT:    vpternlogq $15, %xmm0, %xmm0, %xmm0
 ; BITALG-NEXT:    retq
   %2 = tail call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %0)
   %3 = icmp eq <4 x i32> %2, <i32 1, i32 1, i32 1, i32 1>
@@ -1060,41 +975,63 @@ define <4 x i32> @eq_1_v4i32(<4 x i32> %0) {
 }
 
 define <4 x i32> @ne_1_v4i32(<4 x i32> %0) {
-; SSE-LABEL: ne_1_v4i32:
-; SSE:       # %bb.0:
-; SSE-NEXT:    pxor %xmm1, %xmm1
-; SSE-NEXT:    movdqa %xmm0, %xmm2
-; SSE-NEXT:    pcmpeqd %xmm1, %xmm2
-; SSE-NEXT:    pcmpeqd %xmm3, %xmm3
-; SSE-NEXT:    movdqa %xmm0, %xmm4
-; SSE-NEXT:    paddd %xmm3, %xmm4
-; SSE-NEXT:    pand %xmm4, %xmm0
-; SSE-NEXT:    pcmpeqd %xmm1, %xmm0
-; SSE-NEXT:    pxor %xmm3, %xmm0
-; SSE-NEXT:    por %xmm2, %xmm0
-; SSE-NEXT:    retq
+; SSE2-LABEL: ne_1_v4i32:
+; SSE2:       # %bb.0:
+; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE2-NEXT:    movdqa %xmm0, %xmm2
+; SSE2-NEXT:    paddd %xmm1, %xmm2
+; SSE2-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
+; SSE2-NEXT:    pxor %xmm2, %xmm0
+; SSE2-NEXT:    pcmpgtd %xmm2, %xmm0
+; SSE2-NEXT:    pxor %xmm1, %xmm0
+; SSE2-NEXT:    retq
+;
+; SSE3-LABEL: ne_1_v4i32:
+; SSE3:       # %bb.0:
+; SSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE3-NEXT:    movdqa %xmm0, %xmm2
+; SSE3-NEXT:    paddd %xmm1, %xmm2
+; SSE3-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
+; SSE3-NEXT:    pxor %xmm2, %xmm0
+; SSE3-NEXT:    pcmpgtd %xmm2, %xmm0
+; SSE3-NEXT:    pxor %xmm1, %xmm0
+; SSE3-NEXT:    retq
+;
+; SSSE3-LABEL: ne_1_v4i32:
+; SSSE3:       # %bb.0:
+; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSSE3-NEXT:    movdqa %xmm0, %xmm2
+; SSSE3-NEXT:    paddd %xmm1, %xmm2
+; SSSE3-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
+; SSSE3-NEXT:    pxor %xmm2, %xmm0
+; SSSE3-NEXT:    pcmpgtd %xmm2, %xmm0
+; SSSE3-NEXT:    pxor %xmm1, %xmm0
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: ne_1_v4i32:
+; SSE41:       # %bb.0:
+; SSE41-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE41-NEXT:    paddd %xmm0, %xmm1
+; SSE41-NEXT:    pxor %xmm1, %xmm0
+; SSE41-NEXT:    pminud %xmm0, %xmm1
+; SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
+; SSE41-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: ne_1_v4i32:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddd %xmm3, %xmm0, %xmm4
-; AVX1OR2-NEXT:    vpand %xmm4, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddd %xmm1, %xmm0, %xmm1
+; AVX1OR2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpminud %xmm1, %xmm0, %xmm1
 ; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpxor %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpor %xmm0, %xmm2, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v4i32:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqd %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddd %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqd %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddd %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleud %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: ne_1_v4i32:
@@ -1118,26 +1055,20 @@ define <4 x i32> @ne_1_v4i32(<4 x i32> %0) {
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v4i32:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG_NOVLX-NEXT:    vpaddd %xmm3, %xmm0, %xmm3
-; BITALG_NOVLX-NEXT:    vpand %xmm3, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG_NOVLX-NEXT:    vpaddd %xmm1, %xmm0, %xmm1
+; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG_NOVLX-NEXT:    vpminud %xmm1, %xmm0, %xmm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm0
-; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; BITALG_NOVLX-NEXT:    vpor %xmm0, %xmm2, %xmm0
-; BITALG_NOVLX-NEXT:    vzeroupper
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: ne_1_v4i32:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm2
-; BITALG-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; BITALG-NEXT:    vpaddd %xmm3, %xmm0, %xmm4
-; BITALG-NEXT:    vpand %xmm4, %xmm0, %xmm0
+; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; BITALG-NEXT:    vpaddd %xmm1, %xmm0, %xmm1
+; BITALG-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; BITALG-NEXT:    vpminud %xmm1, %xmm0, %xmm1
 ; BITALG-NEXT:    vpcmpeqd %xmm1, %xmm0, %xmm0
-; BITALG-NEXT:    vpternlogd $222, %xmm3, %xmm2, %xmm0
 ; BITALG-NEXT:    retq
   %2 = tail call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %0)
   %3 = icmp ne <4 x i32> %2, <i32 1, i32 1, i32 1, i32 1>
@@ -1146,49 +1077,83 @@ define <4 x i32> @ne_1_v4i32(<4 x i32> %0) {
 }
 
 define <8 x i16> @eq_1_v8i16(<8 x i16> %0) {
-; SSE-LABEL: eq_1_v8i16:
-; SSE:       # %bb.0:
-; SSE-NEXT:    pxor %xmm1, %xmm1
-; SSE-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE-NEXT:    paddw %xmm0, %xmm2
-; SSE-NEXT:    pand %xmm0, %xmm2
-; SSE-NEXT:    pcmpeqw %xmm1, %xmm0
-; SSE-NEXT:    pcmpeqw %xmm1, %xmm2
-; SSE-NEXT:    pandn %xmm2, %xmm0
-; SSE-NEXT:    retq
+; SSE2-LABEL: eq_1_v8i16:
+; SSE2:       # %bb.0:
+; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE2-NEXT:    paddw %xmm0, %xmm1
+; SSE2-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; SSE2-NEXT:    pxor %xmm1, %xmm0
+; SSE2-NEXT:    pcmpgtw %xmm1, %xmm0
+; SSE2-NEXT:    retq
+;
+; SSE3-LABEL: eq_1_v8i16:
+; SSE3:       # %bb.0:
+; SSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE3-NEXT:    paddw %xmm0, %xmm1
+; SSE3-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; SSE3-NEXT:    pxor %xmm1, %xmm0
+; SSE3-NEXT:    pcmpgtw %xmm1, %xmm0
+; SSE3-NEXT:    retq
+;
+; SSSE3-LABEL: eq_1_v8i16:
+; SSSE3:       # %bb.0:
+; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSSE3-NEXT:    paddw %xmm0, %xmm1
+; SSSE3-NEXT:    pxor {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
+; SSSE3-NEXT:    pxor %xmm1, %xmm0
+; SSSE3-NEXT:    pcmpgtw %xmm1, %xmm0
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: eq_1_v8i16:
+; SSE41:       # %bb.0:
+; SSE41-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE41-NEXT:    movdqa %xmm0, %xmm2
+; SSE41-NEXT:    paddw %xmm1, %xmm2
+; SSE41-NEXT:    pxor %xmm2, %xmm0
+; SSE41-NEXT:    pminuw %xmm0, %xmm2
+; SSE41-NEXT:    pcmpeqw %xmm2, %xmm0
+; SSE41-NEXT:    pxor %xmm1, %xmm0
+; SSE41-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: eq_1_v8i16:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddw %xmm3, %xmm0, %xmm3
-; AVX1OR2-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddw %xmm1, %xmm0, %xmm2
+; AVX1OR2-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpminuw %xmm2, %xmm0, %xmm2
+; AVX1OR2-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v8i16:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqw %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddw %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqw %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpand %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddw %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtuw %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
-; AVX512-LABEL: eq_1_v8i16:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm2
-; AVX512-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX512-NEXT:    vpaddw %xmm3, %xmm0, %xmm3
-; AVX512-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX512-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
-; AVX512-NEXT:    vpandn %xmm0, %xmm2, %xmm0
-; AVX512-NEXT:    retq
+; AVX512VPOPCNTDQ-LABEL: eq_1_v8i16:
+; AVX512VPOPCNTDQ:       # %bb.0:
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX512VPOPCNTDQ-NEXT:    vpaddw %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQ-NEXT:    vpminuw %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-NEXT:    # kill: def $xmm0 killed $xmm0 killed $zmm0
+; AVX512VPOPCNTDQ-NEXT:    vzeroupper
+; AVX512VPOPCNTDQ-NEXT:    retq
+;
+; AVX512VPOPCNTDQVL-LABEL: eq_1_v8i16:
+; AVX512VPOPCNTDQVL:       # %bb.0:
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX512VPOPCNTDQVL-NEXT:    vpaddw %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQVL-NEXT:    vpminuw %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $15, %xmm0, %xmm0, %xmm0
+; AVX512VPOPCNTDQVL-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v8i16:
 ; BITALG_NOVLX:       # %bb.0:
@@ -1210,66 +1175,70 @@ define <8 x i16> @eq_1_v8i16(<8 x i16> %0) {
 }
 
 define <8 x i16> @ne_1_v8i16(<8 x i16> %0) {
-; SSE-LABEL: ne_1_v8i16:
-; SSE:       # %bb.0:
-; SSE-NEXT:    pxor %xmm1, %xmm1
-; SSE-NEXT:    movdqa %xmm0, %xmm2
-; SSE-NEXT:    pcmpeqw %xmm1, %xmm2
-; SSE-NEXT:    pcmpeqd %xmm3, %xmm3
-; SSE-NEXT:    movdqa %xmm0, %xmm4
-; SSE-NEXT:    paddw %xmm3, %xmm4
-; SSE-NEXT:    pand %xmm4, %xmm0
-; SSE-NEXT:    pcmpeqw %xmm1, %xmm0
-; SSE-NEXT:    pxor %xmm3, %xmm0
-; SSE-NEXT:    por %xmm2, %xmm0
-; SSE-NEXT:    retq
+; SSE2-LABEL: ne_1_v8i16:
+; SSE2:       # %bb.0:
+; SSE2-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE2-NEXT:    paddw %xmm0, %xmm1
+; SSE2-NEXT:    pxor %xmm1, %xmm0
+; SSE2-NEXT:    psubusw %xmm1, %xmm0
+; SSE2-NEXT:    pxor %xmm1, %xmm1
+; SSE2-NEXT:    pcmpeqw %xmm1, %xmm0
+; SSE2-NEXT:    retq
+;
+; SSE3-LABEL: ne_1_v8i16:
+; SSE3:       # %bb.0:
+; SSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE3-NEXT:    paddw %xmm0, %xmm1
+; SSE3-NEXT:    pxor %xmm1, %xmm0
+; SSE3-NEXT:    psubusw %xmm1, %xmm0
+; SSE3-NEXT:    pxor %xmm1, %xmm1
+; SSE3-NEXT:    pcmpeqw %xmm1, %xmm0
+; SSE3-NEXT:    retq
+;
+; SSSE3-LABEL: ne_1_v8i16:
+; SSSE3:       # %bb.0:
+; SSSE3-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSSE3-NEXT:    paddw %xmm0, %xmm1
+; SSSE3-NEXT:    pxor %xmm1, %xmm0
+; SSSE3-NEXT:    psubusw %xmm1, %xmm0
+; SSSE3-NEXT:    pxor %xmm1, %xmm1
+; SSSE3-NEXT:    pcmpeqw %xmm1, %xmm0
+; SSSE3-NEXT:    retq
+;
+; SSE41-LABEL: ne_1_v8i16:
+; SSE41:       # %bb.0:
+; SSE41-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE41-NEXT:    paddw %xmm0, %xmm1
+; SSE41-NEXT:    pxor %xmm1, %xmm0
+; SSE41-NEXT:    pminuw %xmm0, %xmm1
+; SSE41-NEXT:    pcmpeqw %xmm1, %xmm0
+; SSE41-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: ne_1_v8i16:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddw %xmm3, %xmm0, %xmm4
-; AVX1OR2-NEXT:    vpand %xmm4, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddw %xmm1, %xmm0, %xmm1
+; AVX1OR2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpminuw %xmm1, %xmm0, %xmm1
 ; AVX1OR2-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpxor %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpor %xmm0, %xmm2, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v8i16:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqw %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddw %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqw %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddw %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleuw %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
-; AVX512VPOPCNTDQ-LABEL: ne_1_v8i16:
-; AVX512VPOPCNTDQ:       # %bb.0:
-; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm2
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX512VPOPCNTDQ-NEXT:    vpaddw %xmm3, %xmm0, %xmm3
-; AVX512VPOPCNTDQ-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
-; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NEXT:    vpor %xmm0, %xmm2, %xmm0
-; AVX512VPOPCNTDQ-NEXT:    vzeroupper
-; AVX512VPOPCNTDQ-NEXT:    retq
-;
-; AVX512VPOPCNTDQVL-LABEL: ne_1_v8i16:
-; AVX512VPOPCNTDQVL:       # %bb.0:
-; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm2
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX512VPOPCNTDQVL-NEXT:    vpaddw %xmm3, %xmm0, %xmm4
-; AVX512VPOPCNTDQVL-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
-; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $222, %xmm3, %xmm2, %xmm0
-; AVX512VPOPCNTDQVL-NEXT:    retq
+; AVX512-LABEL: ne_1_v8i16:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX512-NEXT:    vpaddw %xmm1, %xmm0, %xmm1
+; AVX512-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX512-NEXT:    vpminuw %xmm1, %xmm0, %xmm1
+; AVX512-NEXT:    vpcmpeqw %xmm1, %xmm0, %xmm0
+; AVX512-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v8i16:
 ; BITALG_NOVLX:       # %bb.0:
@@ -1296,47 +1265,54 @@ define <8 x i16> @ne_1_v8i16(<8 x i16> %0) {
 define <16 x i8> @eq_1_v16i8(<16 x i8> %0) {
 ; SSE-LABEL: eq_1_v16i8:
 ; SSE:       # %bb.0:
-; SSE-NEXT:    pxor %xmm1, %xmm1
-; SSE-NEXT:    pcmpeqd %xmm2, %xmm2
-; SSE-NEXT:    paddb %xmm0, %xmm2
-; SSE-NEXT:    pand %xmm0, %xmm2
-; SSE-NEXT:    pcmpeqb %xmm1, %xmm0
-; SSE-NEXT:    pcmpeqb %xmm1, %xmm2
-; SSE-NEXT:    pandn %xmm2, %xmm0
+; SSE-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE-NEXT:    movdqa %xmm0, %xmm2
+; SSE-NEXT:    paddb %xmm1, %xmm2
+; SSE-NEXT:    pxor %xmm2, %xmm0
+; SSE-NEXT:    pminub %xmm0, %xmm2
+; SSE-NEXT:    pcmpeqb %xmm2, %xmm0
+; SSE-NEXT:    pxor %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: eq_1_v16i8:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddb %xmm3, %xmm0, %xmm3
-; AVX1OR2-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpandn %xmm0, %xmm2, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddb %xmm1, %xmm0, %xmm2
+; AVX1OR2-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpminub %xmm2, %xmm0, %xmm2
+; AVX1OR2-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v16i8:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqb %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddb %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqb %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpand %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddb %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtub %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
-; AVX512-LABEL: eq_1_v16i8:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm2
-; AVX512-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX512-NEXT:    vpaddb %xmm3, %xmm0, %xmm3
-; AVX512-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX512-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
-; AVX512-NEXT:    vpandn %xmm0, %xmm2, %xmm0
-; AVX512-NEXT:    retq
+; AVX512VPOPCNTDQ-LABEL: eq_1_v16i8:
+; AVX512VPOPCNTDQ:       # %bb.0:
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX512VPOPCNTDQ-NEXT:    vpaddb %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQ-NEXT:    vpminub %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-NEXT:    # kill: def $xmm0 killed $xmm0 killed $zmm0
+; AVX512VPOPCNTDQ-NEXT:    vzeroupper
+; AVX512VPOPCNTDQ-NEXT:    retq
+;
+; AVX512VPOPCNTDQVL-LABEL: eq_1_v16i8:
+; AVX512VPOPCNTDQVL:       # %bb.0:
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX512VPOPCNTDQVL-NEXT:    vpaddb %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQVL-NEXT:    vpminub %xmm1, %xmm0, %xmm1
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
+; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $15, %xmm0, %xmm0, %xmm0
+; AVX512VPOPCNTDQVL-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v16i8:
 ; BITALG_NOVLX:       # %bb.0:
@@ -1360,64 +1336,38 @@ define <16 x i8> @eq_1_v16i8(<16 x i8> %0) {
 define <16 x i8> @ne_1_v16i8(<16 x i8> %0) {
 ; SSE-LABEL: ne_1_v16i8:
 ; SSE:       # %bb.0:
-; SSE-NEXT:    pxor %xmm1, %xmm1
-; SSE-NEXT:    movdqa %xmm0, %xmm2
-; SSE-NEXT:    pcmpeqb %xmm1, %xmm2
-; SSE-NEXT:    pcmpeqd %xmm3, %xmm3
-; SSE-NEXT:    movdqa %xmm0, %xmm4
-; SSE-NEXT:    paddb %xmm3, %xmm4
-; SSE-NEXT:    pand %xmm4, %xmm0
+; SSE-NEXT:    pcmpeqd %xmm1, %xmm1
+; SSE-NEXT:    paddb %xmm0, %xmm1
+; SSE-NEXT:    pxor %xmm1, %xmm0
+; SSE-NEXT:    pminub %xmm0, %xmm1
 ; SSE-NEXT:    pcmpeqb %xmm1, %xmm0
-; SSE-NEXT:    pxor %xmm3, %xmm0
-; SSE-NEXT:    por %xmm2, %xmm0
 ; SSE-NEXT:    retq
 ;
 ; AVX1OR2-LABEL: ne_1_v16i8:
 ; AVX1OR2:       # %bb.0:
-; AVX1OR2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX1OR2-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm2
-; AVX1OR2-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX1OR2-NEXT:    vpaddb %xmm3, %xmm0, %xmm4
-; AVX1OR2-NEXT:    vpand %xmm4, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX1OR2-NEXT:    vpaddb %xmm1, %xmm0, %xmm1
+; AVX1OR2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX1OR2-NEXT:    vpminub %xmm1, %xmm0, %xmm1
 ; AVX1OR2-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpxor %xmm3, %xmm0, %xmm0
-; AVX1OR2-NEXT:    vpor %xmm0, %xmm2, %xmm0
 ; AVX1OR2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v16i8:
 ; XOP:       # %bb.0:
-; XOP-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqb %xmm1, %xmm0, %xmm2
-; XOP-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; XOP-NEXT:    vpaddb %xmm3, %xmm0, %xmm3
-; XOP-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqb %xmm1, %xmm0, %xmm0
-; XOP-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; XOP-NEXT:    vpaddb %xmm1, %xmm0, %xmm1
+; XOP-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleub %xmm1, %xmm0, %xmm0
 ; XOP-NEXT:    retq
 ;
-; AVX512VPOPCNTDQ-LABEL: ne_1_v16i8:
-; AVX512VPOPCNTDQ:       # %bb.0:
-; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm2
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX512VPOPCNTDQ-NEXT:    vpaddb %xmm3, %xmm0, %xmm3
-; AVX512VPOPCNTDQ-NEXT:    vpand %xmm3, %xmm0, %xmm0
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
-; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NEXT:    vpor %xmm0, %xmm2, %xmm0
-; AVX512VPOPCNTDQ-NEXT:    vzeroupper
-; AVX512VPOPCNTDQ-NEXT:    retq
-;
-; AVX512VPOPCNTDQVL-LABEL: ne_1_v16i8:
-; AVX512VPOPCNTDQVL:       # %bb.0:
-; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm2
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %xmm3, %xmm3, %xmm3
-; AVX512VPOPCNTDQVL-NEXT:    vpaddb %xmm3, %xmm0, %xmm4
-; AVX512VPOPCNTDQVL-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
-; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $222, %xmm3, %xmm2, %xmm0
-; AVX512VPOPCNTDQVL-NEXT:    retq
+; AVX512-LABEL: ne_1_v16i8:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    vpcmpeqd %xmm1, %xmm1, %xmm1
+; AVX512-NEXT:    vpaddb %xmm1, %xmm0, %xmm1
+; AVX512-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX512-NEXT:    vpminub %xmm1, %xmm0, %xmm1
+; AVX512-NEXT:    vpcmpeqb %xmm1, %xmm0, %xmm0
+; AVX512-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v16i8:
 ; BITALG_NOVLX:       # %bb.0:

--- a/llvm/test/CodeGen/X86/vector-popcnt-256.ll
+++ b/llvm/test/CodeGen/X86/vector-popcnt-256.ll
@@ -448,48 +448,41 @@ define <4 x i64> @eq_1_v4i64(<4 x i64> %0) {
 ; AVX1-LABEL: eq_1_v4i64:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddq %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddq %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddq %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vmovddup {{.*#+}} xmm4 = [9223372036854775808,9223372036854775808]
+; AVX1-NEXT:    # xmm4 = mem[0,0]
+; AVX1-NEXT:    vpxor %xmm4, %xmm3, %xmm3
+; AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
+; AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddq %xmm2, %xmm0, %xmm2
+; AVX1-NEXT:    vpxor %xmm4, %xmm2, %xmm2
+; AVX1-NEXT:    vpxor %xmm0, %xmm2, %xmm0
+; AVX1-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vandnps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: eq_1_v4i64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddq %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddq %ymm1, %ymm0, %ymm1
+; AVX2-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
+; AVX2-NEXT:    vpxor %ymm2, %ymm1, %ymm1
+; AVX2-NEXT:    vpxor %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpcmpgtq %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v4i64:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomneqq %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomneqq %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddq %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqq %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddq %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqq %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddq %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomgtuq %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddq %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtuq %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vandps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: eq_1_v4i64:
@@ -509,24 +502,23 @@ define <4 x i64> @eq_1_v4i64(<4 x i64> %0) {
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v4i64:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG_NOVLX-NEXT:    vpaddq %ymm3, %ymm0, %ymm3
-; BITALG_NOVLX-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG_NOVLX-NEXT:    vpaddq %ymm1, %ymm0, %ymm1
+; BITALG_NOVLX-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpminuq %zmm1, %zmm0, %zmm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm0
-; BITALG_NOVLX-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; BITALG_NOVLX-NEXT:    # kill: def $ymm0 killed $ymm0 killed $zmm0
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: eq_1_v4i64:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm2
-; BITALG-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG-NEXT:    vpaddq %ymm3, %ymm0, %ymm3
-; BITALG-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG-NEXT:    vpaddq %ymm1, %ymm0, %ymm1
+; BITALG-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG-NEXT:    vpminuq %ymm1, %ymm0, %ymm1
 ; BITALG-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm0
-; BITALG-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; BITALG-NEXT:    vpternlogq $15, %ymm0, %ymm0, %ymm0
 ; BITALG-NEXT:    retq
   %2 = tail call <4 x i64> @llvm.ctpop.v4i64(<4 x i64> %0)
   %3 = icmp eq <4 x i64> %2, <i64 1, i64 1, i64 1, i64 1>
@@ -538,51 +530,44 @@ define <4 x i64> @ne_1_v4i64(<4 x i64> %0) {
 ; AVX1-LABEL: ne_1_v4i64:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddq %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpxor %xmm4, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddq %xmm4, %xmm0, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm0, %xmm0
-; AVX1-NEXT:    vpcmpeqq %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm4, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddq %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vmovddup {{.*#+}} xmm4 = [9223372036854775808,9223372036854775808]
+; AVX1-NEXT:    # xmm4 = mem[0,0]
+; AVX1-NEXT:    vpxor %xmm4, %xmm3, %xmm3
+; AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
+; AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpxor %xmm2, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddq %xmm2, %xmm0, %xmm3
+; AVX1-NEXT:    vpxor %xmm4, %xmm3, %xmm3
+; AVX1-NEXT:    vpxor %xmm0, %xmm3, %xmm0
+; AVX1-NEXT:    vpcmpgtq %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: ne_1_v4i64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddq %ymm3, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
-; AVX2-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddq %ymm1, %ymm0, %ymm2
+; AVX2-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
+; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
+; AVX2-NEXT:    vpxor %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpcmpgtq %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v4i64:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomeqq %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomeqq %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddq %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqq %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddq %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqq %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddq %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomleuq %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddq %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleuq %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: ne_1_v4i64:
@@ -605,25 +590,20 @@ define <4 x i64> @ne_1_v4i64(<4 x i64> %0) {
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v4i64:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG_NOVLX-NEXT:    vpaddq %ymm3, %ymm0, %ymm3
-; BITALG_NOVLX-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG_NOVLX-NEXT:    vpaddq %ymm1, %ymm0, %ymm1
+; BITALG_NOVLX-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpminuq %zmm1, %zmm0, %zmm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm0
-; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; BITALG_NOVLX-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: ne_1_v4i64:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm2
-; BITALG-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG-NEXT:    vpaddq %ymm3, %ymm0, %ymm4
-; BITALG-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG-NEXT:    vpaddq %ymm1, %ymm0, %ymm1
+; BITALG-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG-NEXT:    vpminuq %ymm1, %ymm0, %ymm1
 ; BITALG-NEXT:    vpcmpeqq %ymm1, %ymm0, %ymm0
-; BITALG-NEXT:    vpternlogq $222, %ymm3, %ymm2, %ymm0
 ; BITALG-NEXT:    retq
   %2 = tail call <4 x i64> @llvm.ctpop.v4i64(<4 x i64> %0)
   %3 = icmp ne <4 x i64> %2, <i64 1, i64 1, i64 1, i64 1>
@@ -635,48 +615,41 @@ define <8 x i32> @eq_1_v8i32(<8 x i32> %0) {
 ; AVX1-LABEL: eq_1_v8i32:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddd %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddd %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddd %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpminud %xmm3, %xmm1, %xmm3
+; AVX1-NEXT:    vpcmpeqd %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpxor %xmm2, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddd %xmm2, %xmm0, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpminud %xmm3, %xmm0, %xmm3
+; AVX1-NEXT:    vpcmpeqd %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vandnps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: eq_1_v8i32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddd %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddd %ymm1, %ymm0, %ymm2
+; AVX2-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpminud %ymm2, %ymm0, %ymm2
+; AVX2-NEXT:    vpcmpeqd %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v8i32:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomneqd %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomneqd %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddd %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqd %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddd %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqd %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddd %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomgtud %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddd %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtud %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vandps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: eq_1_v8i32:
@@ -696,24 +669,23 @@ define <8 x i32> @eq_1_v8i32(<8 x i32> %0) {
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v8i32:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG_NOVLX-NEXT:    vpaddd %ymm3, %ymm0, %ymm3
-; BITALG_NOVLX-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG_NOVLX-NEXT:    vpaddd %ymm1, %ymm0, %ymm1
+; BITALG_NOVLX-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpminud %ymm1, %ymm0, %ymm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm0
-; BITALG_NOVLX-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; BITALG_NOVLX-NEXT:    # kill: def $ymm0 killed $ymm0 killed $zmm0
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: eq_1_v8i32:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm2
-; BITALG-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG-NEXT:    vpaddd %ymm3, %ymm0, %ymm3
-; BITALG-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG-NEXT:    vpaddd %ymm1, %ymm0, %ymm1
+; BITALG-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG-NEXT:    vpminud %ymm1, %ymm0, %ymm1
 ; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm0
-; BITALG-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; BITALG-NEXT:    vpternlogq $15, %ymm0, %ymm0, %ymm0
 ; BITALG-NEXT:    retq
   %2 = tail call <8 x i32> @llvm.ctpop.v8i32(<8 x i32> %0)
   %3 = icmp eq <8 x i32> %2, <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
@@ -725,51 +697,38 @@ define <8 x i32> @ne_1_v8i32(<8 x i32> %0) {
 ; AVX1-LABEL: ne_1_v8i32:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddd %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpxor %xmm4, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddd %xmm4, %xmm0, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddd %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpminud %xmm3, %xmm1, %xmm3
+; AVX1-NEXT:    vpcmpeqd %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddd %xmm2, %xmm0, %xmm2
+; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpminud %xmm2, %xmm0, %xmm2
 ; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm4, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: ne_1_v8i32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddd %ymm3, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddd %ymm1, %ymm0, %ymm1
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpminud %ymm1, %ymm0, %ymm1
 ; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v8i32:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomeqd %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomeqd %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddd %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqd %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddd %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqd %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddd %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomleud %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddd %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleud %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: ne_1_v8i32:
@@ -792,25 +751,20 @@ define <8 x i32> @ne_1_v8i32(<8 x i32> %0) {
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v8i32:
 ; BITALG_NOVLX:       # %bb.0:
-; BITALG_NOVLX-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm2
-; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG_NOVLX-NEXT:    vpaddd %ymm3, %ymm0, %ymm3
-; BITALG_NOVLX-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG_NOVLX-NEXT:    vpaddd %ymm1, %ymm0, %ymm1
+; BITALG_NOVLX-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG_NOVLX-NEXT:    vpminud %ymm1, %ymm0, %ymm1
 ; BITALG_NOVLX-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm0
-; BITALG_NOVLX-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; BITALG_NOVLX-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; BITALG_NOVLX-NEXT:    retq
 ;
 ; BITALG-LABEL: ne_1_v8i32:
 ; BITALG:       # %bb.0:
-; BITALG-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm2
-; BITALG-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; BITALG-NEXT:    vpaddd %ymm3, %ymm0, %ymm4
-; BITALG-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; BITALG-NEXT:    vpaddd %ymm1, %ymm0, %ymm1
+; BITALG-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; BITALG-NEXT:    vpminud %ymm1, %ymm0, %ymm1
 ; BITALG-NEXT:    vpcmpeqd %ymm1, %ymm0, %ymm0
-; BITALG-NEXT:    vpternlogd $222, %ymm3, %ymm2, %ymm0
 ; BITALG-NEXT:    retq
   %2 = tail call <8 x i32> @llvm.ctpop.v8i32(<8 x i32> %0)
   %3 = icmp ne <8 x i32> %2, <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
@@ -822,70 +776,62 @@ define <16 x i16> @eq_1_v16i16(<16 x i16> %0) {
 ; AVX1-LABEL: eq_1_v16i16:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddw %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddw %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddw %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpminuw %xmm3, %xmm1, %xmm3
+; AVX1-NEXT:    vpcmpeqw %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpxor %xmm2, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddw %xmm2, %xmm0, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpminuw %xmm3, %xmm0, %xmm3
+; AVX1-NEXT:    vpcmpeqw %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vandnps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: eq_1_v16i16:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddw %ymm1, %ymm0, %ymm2
+; AVX2-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpminuw %ymm2, %ymm0, %ymm2
+; AVX2-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v16i16:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomneqw %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomneqw %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddw %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqw %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddw %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqw %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddw %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomgtuw %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddw %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtuw %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vandps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: eq_1_v16i16:
 ; AVX512VPOPCNTDQ:       # %bb.0:
-; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpaddw %ymm3, %ymm0, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpaddw %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpminuw %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQ-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQ-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-NEXT:    # kill: def $ymm0 killed $ymm0 killed $zmm0
 ; AVX512VPOPCNTDQ-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQVL-LABEL: eq_1_v16i16:
 ; AVX512VPOPCNTDQVL:       # %bb.0:
-; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQVL-NEXT:    vpaddw %ymm3, %ymm0, %ymm3
-; AVX512VPOPCNTDQVL-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpaddw %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpminuw %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQVL-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $15, %ymm0, %ymm0, %ymm0
 ; AVX512VPOPCNTDQVL-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v16i16:
@@ -910,74 +856,56 @@ define <16 x i16> @ne_1_v16i16(<16 x i16> %0) {
 ; AVX1-LABEL: ne_1_v16i16:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddw %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpxor %xmm4, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddw %xmm4, %xmm0, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddw %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpminuw %xmm3, %xmm1, %xmm3
+; AVX1-NEXT:    vpcmpeqw %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddw %xmm2, %xmm0, %xmm2
+; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpminuw %xmm2, %xmm0, %xmm2
 ; AVX1-NEXT:    vpcmpeqw %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm4, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: ne_1_v16i16:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddw %ymm3, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddw %ymm1, %ymm0, %ymm1
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpminuw %ymm1, %ymm0, %ymm1
 ; AVX2-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v16i16:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomeqw %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomeqw %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddw %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqw %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddw %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqw %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddw %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomleuw %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddw %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleuw %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: ne_1_v16i16:
 ; AVX512VPOPCNTDQ:       # %bb.0:
-; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpaddw %ymm3, %ymm0, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpaddw %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpminuw %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQ-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX512VPOPCNTDQ-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQVL-LABEL: ne_1_v16i16:
 ; AVX512VPOPCNTDQVL:       # %bb.0:
-; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQVL-NEXT:    vpaddw %ymm3, %ymm0, %ymm4
-; AVX512VPOPCNTDQVL-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpaddw %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpminuw %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqw %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $222, %ymm3, %ymm2, %ymm0
 ; AVX512VPOPCNTDQVL-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v16i16:
@@ -1005,70 +933,62 @@ define <32 x i8> @eq_1_v32i8(<32 x i8> %0) {
 ; AVX1-LABEL: eq_1_v32i8:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddb %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddb %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddb %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpminub %xmm3, %xmm1, %xmm3
+; AVX1-NEXT:    vpcmpeqb %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpxor %xmm2, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddb %xmm2, %xmm0, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpminub %xmm3, %xmm0, %xmm3
+; AVX1-NEXT:    vpcmpeqb %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vandnps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: eq_1_v32i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddb %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddb %ymm1, %ymm0, %ymm2
+; AVX2-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpminub %ymm2, %ymm0, %ymm2
+; AVX2-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: eq_1_v32i8:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomneqb %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomneqb %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddb %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomeqb %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddb %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomeqb %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddb %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomgtub %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddb %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomgtub %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vandps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: eq_1_v32i8:
 ; AVX512VPOPCNTDQ:       # %bb.0:
-; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpaddb %ymm3, %ymm0, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpaddb %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpminub %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQ-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQ-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-NEXT:    # kill: def $ymm0 killed $ymm0 killed $zmm0
 ; AVX512VPOPCNTDQ-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQVL-LABEL: eq_1_v32i8:
 ; AVX512VPOPCNTDQVL:       # %bb.0:
-; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQVL-NEXT:    vpaddb %ymm3, %ymm0, %ymm3
-; AVX512VPOPCNTDQVL-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpaddb %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpminub %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQVL-NEXT:    vpandn %ymm0, %ymm2, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $15, %ymm0, %ymm0, %ymm0
 ; AVX512VPOPCNTDQVL-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: eq_1_v32i8:
@@ -1093,74 +1013,56 @@ define <32 x i8> @ne_1_v32i8(<32 x i8> %0) {
 ; AVX1-LABEL: ne_1_v32i8:
 ; AVX1:       # %bb.0:
 ; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; AVX1-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm3
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; AVX1-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; AVX1-NEXT:    vpaddb %xmm4, %xmm1, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpxor %xmm4, %xmm1, %xmm1
-; AVX1-NEXT:    vpaddb %xmm4, %xmm0, %xmm5
-; AVX1-NEXT:    vpand %xmm5, %xmm0, %xmm0
+; AVX1-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; AVX1-NEXT:    vpaddb %xmm2, %xmm1, %xmm3
+; AVX1-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpminub %xmm3, %xmm1, %xmm3
+; AVX1-NEXT:    vpcmpeqb %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vpaddb %xmm2, %xmm0, %xmm2
+; AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpminub %xmm2, %xmm0, %xmm2
 ; AVX1-NEXT:    vpcmpeqb %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm4, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: ne_1_v32i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX2-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm2
-; AVX2-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX2-NEXT:    vpaddb %ymm3, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX2-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX2-NEXT:    vpaddb %ymm1, %ymm0, %ymm1
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpminub %ymm1, %ymm0, %ymm1
 ; AVX2-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; XOP-LABEL: ne_1_v32i8:
 ; XOP:       # %bb.0:
 ; XOP-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; XOP-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; XOP-NEXT:    vpcomeqb %xmm2, %xmm1, %xmm3
-; XOP-NEXT:    vpcomeqb %xmm2, %xmm0, %xmm4
-; XOP-NEXT:    vinsertf128 $1, %xmm3, %ymm4, %ymm3
-; XOP-NEXT:    vpcmpeqd %xmm4, %xmm4, %xmm4
-; XOP-NEXT:    vpaddb %xmm4, %xmm1, %xmm5
-; XOP-NEXT:    vpand %xmm5, %xmm1, %xmm1
-; XOP-NEXT:    vpcomneqb %xmm2, %xmm1, %xmm1
-; XOP-NEXT:    vpaddb %xmm4, %xmm0, %xmm4
-; XOP-NEXT:    vpand %xmm4, %xmm0, %xmm0
-; XOP-NEXT:    vpcomneqb %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcmpeqd %xmm2, %xmm2, %xmm2
+; XOP-NEXT:    vpaddb %xmm2, %xmm1, %xmm3
+; XOP-NEXT:    vpxor %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpcomleub %xmm3, %xmm1, %xmm1
+; XOP-NEXT:    vpaddb %xmm2, %xmm0, %xmm2
+; XOP-NEXT:    vpxor %xmm2, %xmm0, %xmm0
+; XOP-NEXT:    vpcomleub %xmm2, %xmm0, %xmm0
 ; XOP-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; XOP-NEXT:    vorps %ymm0, %ymm3, %ymm0
 ; XOP-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-LABEL: ne_1_v32i8:
 ; AVX512VPOPCNTDQ:       # %bb.0:
-; AVX512VPOPCNTDQ-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpaddb %ymm3, %ymm0, %ymm3
-; AVX512VPOPCNTDQ-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpaddb %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQ-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NEXT:    vpminub %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQ-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQ-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX512VPOPCNTDQ-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQVL-LABEL: ne_1_v32i8:
 ; AVX512VPOPCNTDQVL:       # %bb.0:
-; AVX512VPOPCNTDQVL-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm2
-; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm3, %ymm3, %ymm3
-; AVX512VPOPCNTDQVL-NEXT:    vpaddb %ymm3, %ymm0, %ymm4
-; AVX512VPOPCNTDQVL-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqd %ymm1, %ymm1, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpaddb %ymm1, %ymm0, %ymm1
+; AVX512VPOPCNTDQVL-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX512VPOPCNTDQVL-NEXT:    vpminub %ymm1, %ymm0, %ymm1
 ; AVX512VPOPCNTDQVL-NEXT:    vpcmpeqb %ymm1, %ymm0, %ymm0
-; AVX512VPOPCNTDQVL-NEXT:    vpternlogq $222, %ymm3, %ymm2, %ymm0
 ; AVX512VPOPCNTDQVL-NEXT:    retq
 ;
 ; BITALG_NOVLX-LABEL: ne_1_v32i8:

--- a/llvm/test/CodeGen/X86/vector-popcnt-512.ll
+++ b/llvm/test/CodeGen/X86/vector-popcnt-512.ll
@@ -293,8 +293,8 @@ define <8 x i64> @eq_1_v8i64(<8 x i64> %0) {
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512F-NEXT:    vpaddq %zmm1, %zmm0, %zmm1
-; AVX512F-NEXT:    vptestnmq %zmm1, %zmm0, %k1
-; AVX512F-NEXT:    vptestmq %zmm0, %zmm0, %k1 {%k1}
+; AVX512F-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512F-NEXT:    vpcmpnleuq %zmm1, %zmm0, %k1
 ; AVX512F-NEXT:    vpternlogq $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512F-NEXT:    retq
 ;
@@ -302,8 +302,8 @@ define <8 x i64> @eq_1_v8i64(<8 x i64> %0) {
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddq %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestnmq %zmm1, %zmm0, %k1
-; AVX512BW-NEXT:    vptestmq %zmm0, %zmm0, %k1 {%k1}
+; AVX512BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpnleuq %zmm1, %zmm0, %k1
 ; AVX512BW-NEXT:    vpternlogq $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512BW-NEXT:    retq
 ;
@@ -318,8 +318,8 @@ define <8 x i64> @eq_1_v8i64(<8 x i64> %0) {
 ; BITALG:       # %bb.0:
 ; BITALG-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; BITALG-NEXT:    vpaddq %zmm1, %zmm0, %zmm1
-; BITALG-NEXT:    vptestnmq %zmm1, %zmm0, %k1
-; BITALG-NEXT:    vptestmq %zmm0, %zmm0, %k1 {%k1}
+; BITALG-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; BITALG-NEXT:    vpcmpnleuq %zmm1, %zmm0, %k1
 ; BITALG-NEXT:    vpternlogq $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; BITALG-NEXT:    retq
   %2 = tail call <8 x i64> @llvm.ctpop.v8i64(<8 x i64> %0)
@@ -333,9 +333,8 @@ define <8 x i64> @ne_1_v8i64(<8 x i64> %0) {
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512F-NEXT:    vpaddq %zmm1, %zmm0, %zmm1
-; AVX512F-NEXT:    vptestmq %zmm1, %zmm0, %k0
-; AVX512F-NEXT:    vptestnmq %zmm0, %zmm0, %k1
-; AVX512F-NEXT:    korw %k0, %k1, %k1
+; AVX512F-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512F-NEXT:    vpcmpleuq %zmm1, %zmm0, %k1
 ; AVX512F-NEXT:    vpternlogq $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512F-NEXT:    retq
 ;
@@ -343,9 +342,8 @@ define <8 x i64> @ne_1_v8i64(<8 x i64> %0) {
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddq %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestmq %zmm1, %zmm0, %k0
-; AVX512BW-NEXT:    vptestnmq %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
+; AVX512BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpleuq %zmm1, %zmm0, %k1
 ; AVX512BW-NEXT:    vpternlogq $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512BW-NEXT:    retq
 ;
@@ -360,9 +358,8 @@ define <8 x i64> @ne_1_v8i64(<8 x i64> %0) {
 ; BITALG:       # %bb.0:
 ; BITALG-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; BITALG-NEXT:    vpaddq %zmm1, %zmm0, %zmm1
-; BITALG-NEXT:    vptestmq %zmm1, %zmm0, %k0
-; BITALG-NEXT:    vptestnmq %zmm0, %zmm0, %k1
-; BITALG-NEXT:    korw %k0, %k1, %k1
+; BITALG-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; BITALG-NEXT:    vpcmpleuq %zmm1, %zmm0, %k1
 ; BITALG-NEXT:    vpternlogq $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; BITALG-NEXT:    retq
   %2 = tail call <8 x i64> @llvm.ctpop.v8i64(<8 x i64> %0)
@@ -376,8 +373,8 @@ define <16 x i32> @eq_1_v16i32(<16 x i32> %0) {
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512F-NEXT:    vpaddd %zmm1, %zmm0, %zmm1
-; AVX512F-NEXT:    vptestnmd %zmm1, %zmm0, %k1
-; AVX512F-NEXT:    vptestmd %zmm0, %zmm0, %k1 {%k1}
+; AVX512F-NEXT:    vpxord %zmm1, %zmm0, %zmm0
+; AVX512F-NEXT:    vpcmpnleud %zmm1, %zmm0, %k1
 ; AVX512F-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512F-NEXT:    retq
 ;
@@ -385,8 +382,8 @@ define <16 x i32> @eq_1_v16i32(<16 x i32> %0) {
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddd %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestnmd %zmm1, %zmm0, %k1
-; AVX512BW-NEXT:    vptestmd %zmm0, %zmm0, %k1 {%k1}
+; AVX512BW-NEXT:    vpxord %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpnleud %zmm1, %zmm0, %k1
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512BW-NEXT:    retq
 ;
@@ -401,8 +398,8 @@ define <16 x i32> @eq_1_v16i32(<16 x i32> %0) {
 ; BITALG:       # %bb.0:
 ; BITALG-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; BITALG-NEXT:    vpaddd %zmm1, %zmm0, %zmm1
-; BITALG-NEXT:    vptestnmd %zmm1, %zmm0, %k1
-; BITALG-NEXT:    vptestmd %zmm0, %zmm0, %k1 {%k1}
+; BITALG-NEXT:    vpxord %zmm1, %zmm0, %zmm0
+; BITALG-NEXT:    vpcmpnleud %zmm1, %zmm0, %k1
 ; BITALG-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; BITALG-NEXT:    retq
   %2 = tail call <16 x i32> @llvm.ctpop.v16i32(<16 x i32> %0)
@@ -416,9 +413,8 @@ define <16 x i32> @ne_1_v16i32(<16 x i32> %0) {
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512F-NEXT:    vpaddd %zmm1, %zmm0, %zmm1
-; AVX512F-NEXT:    vptestmd %zmm1, %zmm0, %k0
-; AVX512F-NEXT:    vptestnmd %zmm0, %zmm0, %k1
-; AVX512F-NEXT:    korw %k0, %k1, %k1
+; AVX512F-NEXT:    vpxord %zmm1, %zmm0, %zmm0
+; AVX512F-NEXT:    vpcmpleud %zmm1, %zmm0, %k1
 ; AVX512F-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512F-NEXT:    retq
 ;
@@ -426,9 +422,8 @@ define <16 x i32> @ne_1_v16i32(<16 x i32> %0) {
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddd %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestmd %zmm1, %zmm0, %k0
-; AVX512BW-NEXT:    vptestnmd %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
+; AVX512BW-NEXT:    vpxord %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpleud %zmm1, %zmm0, %k1
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; AVX512BW-NEXT:    retq
 ;
@@ -443,9 +438,8 @@ define <16 x i32> @ne_1_v16i32(<16 x i32> %0) {
 ; BITALG:       # %bb.0:
 ; BITALG-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; BITALG-NEXT:    vpaddd %zmm1, %zmm0, %zmm1
-; BITALG-NEXT:    vptestmd %zmm1, %zmm0, %k0
-; BITALG-NEXT:    vptestnmd %zmm0, %zmm0, %k1
-; BITALG-NEXT:    korw %k0, %k1, %k1
+; BITALG-NEXT:    vpxord %zmm1, %zmm0, %zmm0
+; BITALG-NEXT:    vpcmpleud %zmm1, %zmm0, %k1
 ; BITALG-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0 {%k1} {z}
 ; BITALG-NEXT:    retq
   %2 = tail call <16 x i32> @llvm.ctpop.v16i32(<16 x i32> %0)
@@ -458,54 +452,50 @@ define <32 x i16> @eq_1_v32i16(<32 x i16> %0) {
 ; AVX512F-LABEL: eq_1_v32i16:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512F-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm3
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm4
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512F-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512F-NEXT:    vpaddw %ymm4, %ymm1, %ymm5
-; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm1
-; AVX512F-NEXT:    vpaddw %ymm4, %ymm0, %ymm4
-; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512F-NEXT:    vpaddw %ymm2, %ymm1, %ymm3
+; AVX512F-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpminuw %ymm3, %ymm1, %ymm3
+; AVX512F-NEXT:    vpcmpeqw %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpaddw %ymm2, %ymm0, %ymm2
+; AVX512F-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512F-NEXT:    vpminuw %ymm2, %ymm0, %ymm2
 ; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm0
 ; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512F-NEXT:    vpandnq %zmm0, %zmm3, %zmm0
+; AVX512F-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BW-LABEL: eq_1_v32i16:
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddw %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestnmw %zmm1, %zmm0, %k1
-; AVX512BW-NEXT:    vptestmw %zmm0, %zmm0, %k0 {%k1}
+; AVX512BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpnleuw %zmm1, %zmm0, %k0
 ; AVX512BW-NEXT:    vpmovm2w %k0, %zmm0
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-NOBW-LABEL: eq_1_v32i16:
 ; AVX512VPOPCNTDQ-NOBW:       # %bb.0:
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm4, %ymm1, %ymm5
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm4, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm2, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminuw %ymm3, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm2, %ymm0, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminuw %ymm2, %ymm0, %ymm2
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm0
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpandnq %zmm0, %zmm3, %zmm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-BW-LABEL: eq_1_v32i16:
 ; AVX512VPOPCNTDQ-BW:       # %bb.0:
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpaddw %zmm1, %zmm0, %zmm1
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestnmw %zmm1, %zmm0, %k1
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestmw %zmm0, %zmm0, %k0 {%k1}
+; AVX512VPOPCNTDQ-BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-BW-NEXT:    vpcmpnleuw %zmm1, %zmm0, %k0
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpmovm2w %k0, %zmm0
 ; AVX512VPOPCNTDQ-BW-NEXT:    retq
 ;
@@ -525,58 +515,48 @@ define <32 x i16> @ne_1_v32i16(<32 x i16> %0) {
 ; AVX512F-LABEL: ne_1_v32i16:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512F-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm3
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm4
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512F-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512F-NEXT:    vpaddw %ymm4, %ymm1, %ymm5
-; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm1
-; AVX512F-NEXT:    vpaddw %ymm4, %ymm0, %ymm4
-; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512F-NEXT:    vpaddw %ymm2, %ymm1, %ymm3
+; AVX512F-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpminuw %ymm3, %ymm1, %ymm3
+; AVX512F-NEXT:    vpcmpeqw %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpaddw %ymm2, %ymm0, %ymm2
+; AVX512F-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512F-NEXT:    vpminuw %ymm2, %ymm0, %ymm2
 ; AVX512F-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm1
-; AVX512F-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0
-; AVX512F-NEXT:    vpternlogq $222, %zmm1, %zmm3, %zmm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BW-LABEL: ne_1_v32i16:
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddw %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestmw %zmm1, %zmm0, %k0
-; AVX512BW-NEXT:    vptestnmw %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    kord %k0, %k1, %k0
+; AVX512BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpleuw %zmm1, %zmm0, %k0
 ; AVX512BW-NEXT:    vpmovm2w %k0, %zmm0
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-NOBW-LABEL: ne_1_v32i16:
 ; AVX512VPOPCNTDQ-NOBW:       # %bb.0:
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm4, %ymm1, %ymm5
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm4, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm2, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminuw %ymm3, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddw %ymm2, %ymm0, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminuw %ymm2, %ymm0, %ymm2
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqw %ymm2, %ymm0, %ymm0
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpternlogq $222, %zmm1, %zmm3, %zmm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-BW-LABEL: ne_1_v32i16:
 ; AVX512VPOPCNTDQ-BW:       # %bb.0:
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpaddw %zmm1, %zmm0, %zmm1
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestmw %zmm1, %zmm0, %k0
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestnmw %zmm0, %zmm0, %k1
-; AVX512VPOPCNTDQ-BW-NEXT:    kord %k0, %k1, %k0
+; AVX512VPOPCNTDQ-BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-BW-NEXT:    vpcmpleuw %zmm1, %zmm0, %k0
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpmovm2w %k0, %zmm0
 ; AVX512VPOPCNTDQ-BW-NEXT:    retq
 ;
@@ -596,54 +576,50 @@ define <64 x i8> @eq_1_v64i8(<64 x i8> %0) {
 ; AVX512F-LABEL: eq_1_v64i8:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512F-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm3
-; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm4
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512F-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512F-NEXT:    vpaddb %ymm4, %ymm1, %ymm5
-; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm1
-; AVX512F-NEXT:    vpaddb %ymm4, %ymm0, %ymm4
-; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512F-NEXT:    vpaddb %ymm2, %ymm1, %ymm3
+; AVX512F-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpminub %ymm3, %ymm1, %ymm3
+; AVX512F-NEXT:    vpcmpeqb %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpaddb %ymm2, %ymm0, %ymm2
+; AVX512F-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512F-NEXT:    vpminub %ymm2, %ymm0, %ymm2
 ; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm0
 ; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512F-NEXT:    vpandnq %zmm0, %zmm3, %zmm0
+; AVX512F-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BW-LABEL: eq_1_v64i8:
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddb %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestnmb %zmm1, %zmm0, %k1
-; AVX512BW-NEXT:    vptestmb %zmm0, %zmm0, %k0 {%k1}
+; AVX512BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpnleub %zmm1, %zmm0, %k0
 ; AVX512BW-NEXT:    vpmovm2b %k0, %zmm0
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-NOBW-LABEL: eq_1_v64i8:
 ; AVX512VPOPCNTDQ-NOBW:       # %bb.0:
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm4, %ymm1, %ymm5
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm4, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm2, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminub %ymm3, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm2, %ymm0, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminub %ymm2, %ymm0, %ymm2
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm0
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpandnq %zmm0, %zmm3, %zmm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpternlogq $15, %zmm0, %zmm0, %zmm0
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-BW-LABEL: eq_1_v64i8:
 ; AVX512VPOPCNTDQ-BW:       # %bb.0:
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpaddb %zmm1, %zmm0, %zmm1
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestnmb %zmm1, %zmm0, %k1
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestmb %zmm0, %zmm0, %k0 {%k1}
+; AVX512VPOPCNTDQ-BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-BW-NEXT:    vpcmpnleub %zmm1, %zmm0, %k0
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpmovm2b %k0, %zmm0
 ; AVX512VPOPCNTDQ-BW-NEXT:    retq
 ;
@@ -663,58 +639,48 @@ define <64 x i8> @ne_1_v64i8(<64 x i8> %0) {
 ; AVX512F-LABEL: ne_1_v64i8:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512F-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm3
-; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm4
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512F-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512F-NEXT:    vpaddb %ymm4, %ymm1, %ymm5
-; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm1
-; AVX512F-NEXT:    vpaddb %ymm4, %ymm0, %ymm4
-; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512F-NEXT:    vpaddb %ymm2, %ymm1, %ymm3
+; AVX512F-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpminub %ymm3, %ymm1, %ymm3
+; AVX512F-NEXT:    vpcmpeqb %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpaddb %ymm2, %ymm0, %ymm2
+; AVX512F-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512F-NEXT:    vpminub %ymm2, %ymm0, %ymm2
 ; AVX512F-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm1
-; AVX512F-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0
-; AVX512F-NEXT:    vpternlogq $222, %zmm1, %zmm3, %zmm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BW-LABEL: ne_1_v64i8:
 ; AVX512BW:       # %bb.0:
 ; AVX512BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512BW-NEXT:    vpaddb %zmm1, %zmm0, %zmm1
-; AVX512BW-NEXT:    vptestmb %zmm1, %zmm0, %k0
-; AVX512BW-NEXT:    vptestnmb %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    korq %k0, %k1, %k0
+; AVX512BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpcmpleub %zmm1, %zmm0, %k0
 ; AVX512BW-NEXT:    vpmovm2b %k0, %zmm0
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-NOBW-LABEL: ne_1_v64i8:
 ; AVX512VPOPCNTDQ-NOBW:       # %bb.0:
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm3, %zmm4, %zmm3
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm4, %ymm4, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm4, %ymm1, %ymm5
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm1, %ymm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm4, %ymm0, %ymm4
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqd %ymm2, %ymm2, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm2, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminub %ymm3, %ymm1, %ymm3
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm3, %ymm1, %ymm1
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpaddb %ymm2, %ymm0, %ymm2
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpxor %ymm2, %ymm0, %ymm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vpminub %ymm2, %ymm0, %ymm2
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    vpcmpeqb %ymm2, %ymm0, %ymm0
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm1
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpternlogd $255, %zmm0, %zmm0, %zmm0
-; AVX512VPOPCNTDQ-NOBW-NEXT:    vpternlogq $222, %zmm1, %zmm3, %zmm0
+; AVX512VPOPCNTDQ-NOBW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
 ; AVX512VPOPCNTDQ-NOBW-NEXT:    retq
 ;
 ; AVX512VPOPCNTDQ-BW-LABEL: ne_1_v64i8:
 ; AVX512VPOPCNTDQ-BW:       # %bb.0:
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpternlogd $255, %zmm1, %zmm1, %zmm1
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpaddb %zmm1, %zmm0, %zmm1
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestmb %zmm1, %zmm0, %k0
-; AVX512VPOPCNTDQ-BW-NEXT:    vptestnmb %zmm0, %zmm0, %k1
-; AVX512VPOPCNTDQ-BW-NEXT:    korq %k0, %k1, %k0
+; AVX512VPOPCNTDQ-BW-NEXT:    vpxorq %zmm1, %zmm0, %zmm0
+; AVX512VPOPCNTDQ-BW-NEXT:    vpcmpleub %zmm1, %zmm0, %k0
 ; AVX512VPOPCNTDQ-BW-NEXT:    vpmovm2b %k0, %zmm0
 ; AVX512VPOPCNTDQ-BW-NEXT:    retq
 ;


### PR DESCRIPTION
When x is not known to be nonzero, ctpop(x) == 1 is expanded to

    x != 0 && (x & (x - 1)) == 0

resulting in codegen like

    leal    -1(%rdi), %eax
    testl   %eax, %edi
    sete    %cl
    testl   %edi, %edi
    setne   %al
    andb    %cl, %al

But another expression that works is

    (x ^ (x - 1)) > x - 1

which has nicer codegen:

    leal    -1(%rdi), %eax
    xorl    %eax, %edi
    cmpl    %eax, %edi
    seta    %al
