### PR TITLE
[DAG] Set nneg flag when forming zext in demanded bits

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -2468,8 +2468,12 @@ bool TargetLowering::SimplifyDemandedBits(
     if (Known.isNonNegative()) {
       unsigned Opc =
           IsVecInReg ? ISD::ZERO_EXTEND_VECTOR_INREG : ISD::ZERO_EXTEND;
-      if (!TLO.LegalOperations() || isOperationLegal(Opc, VT))
-        return TLO.CombineTo(Op, TLO.DAG.getNode(Opc, dl, VT, Src));
+      if (!TLO.LegalOperations() || isOperationLegal(Opc, VT)) {
+        SDNodeFlags Flags;
+        if (!IsVecInReg)
+          Flags.setNonNeg(true);
+        return TLO.CombineTo(Op, TLO.DAG.getNode(Opc, dl, VT, Src, Flags));
+      }
     }
 
     // Attempt to avoid multi-use ops if we don't need anything from them.


### PR DESCRIPTION
We do the same for the analogous transform in DAGCombine, but this case was missed in the recent patch which added support for zext nneg.

Sorry for the lack of test coverage.  Not sure how to exercise this piece of logic.  It appears to have only minimal impact on LIT tests (only test/CodeGen/X86/wide-scalar-shift-by-byte-multiple-legalization.ll), and even then, the changes without it appear uninteresting.  Maybe we should remove this transform instead?