### PR TITLE
[MLIR][Bufferization] Bail on automatic deallocation to enable reentrant behaviour

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
@@ -867,7 +867,8 @@ BufferDeallocation::handleInterface(MemoryEffectOpInterface op) {
       // the compiler on perfectly valid code.
       if (!op->hasAttr(BufferizationDialect::kManualDeallocation)) {
         state.resetOwnerships(operand, block);
-        state.updateOwnership(operand, buildBoolValue(builder, op.getLoc(), false));
+        state.updateOwnership(operand,
+                              buildBoolValue(builder, op.getLoc(), false));
         continue;
       }
 

--- a/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
@@ -861,10 +861,10 @@ BufferDeallocation::handleInterface(MemoryEffectOpInterface op) {
 
   for (auto operand : llvm::make_filter_range(op->getOperands(), isMemref)) {
     if (op.getEffectOnValue<MemoryEffects::Free>(operand).has_value()) {
-      // This should not be an error because the ownership based buffer
-      // deallocation introduces deallocs itself, so running it twice over (say
-      // when piping IR over different tools with their own pipelines) crashes
-      // the compiler on perfectly valid code.
+      // If we encounter an automatic allocation, some other pass (or this one
+      // in a previous invocation) has added it and we shouldn't try to guess it
+      // if was right or wrong, but we can't do anything, so we just ignore this
+      // operand.
       if (!op->hasAttr(BufferizationDialect::kManualDeallocation)) {
         state.resetOwnerships(operand, block);
         state.updateOwnership(operand,

--- a/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/invalid-buffer-deallocation-reentrant.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/invalid-buffer-deallocation-reentrant.mlir
@@ -1,0 +1,20 @@
+// RUN: mlir-opt -ownership-based-buffer-deallocation -split-input-file %s | \
+// RUN: mlir-opt -ownership-based-buffer-deallocation -split-input-file %s
+
+// This should not be an error because the ownership based buffer deallocation introduces
+// deallocs itself, so running it twice over (say when piping IR over different tools with
+// their own pipelines) crashes the compiler on perfectly valid code.
+
+func.func @free_effect() {
+  %alloc = memref.alloc() : memref<2xi32>
+  %new_alloc = memref.realloc %alloc : memref<2xi32> to memref<4xi32>
+  return
+}
+
+// -----
+
+func.func @free_effect() {
+  %alloc = memref.alloc() : memref<2xi32>
+  memref.dealloc %alloc : memref<2xi32>
+  return
+}

--- a/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/invalid-buffer-deallocation.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation/invalid-buffer-deallocation.mlir
@@ -67,24 +67,6 @@ func.func @do_loop_alloc(
 // -----
 
 func.func @free_effect() {
-  %alloc = memref.alloc() : memref<2xi32>
-  // expected-error @below {{memory free side-effect on MemRef value not supported!}}
-  %new_alloc = memref.realloc %alloc : memref<2xi32> to memref<4xi32>
-  return
-}
-
-// -----
-
-func.func @free_effect() {
-  %alloc = memref.alloc() : memref<2xi32>
-  // expected-error @below {{memory free side-effect on MemRef value not supported!}}
-  memref.dealloc %alloc : memref<2xi32>
-  return
-}
-
-// -----
-
-func.func @free_effect() {
   %true = arith.constant true
   %alloc = memref.alloc() : memref<2xi32>
   // expected-error @below {{No deallocation operations must be present when running this pass!}}


### PR DESCRIPTION
Currently, the ownership based dealloc pass fails hard on existing deallocations, but it introduces its own deallocs, and if we run the pass twice (ex. when piping the IR through different tools with their own pipelines), we get a hard crash.

However, having the deallocs is not an IR error or verification failure, it's just a pattern that the pass itself cannot handle, and therefore the correct behaviour is to bail, not crash.