### PR TITLE
[AVR] make the AVR ABI Swift compatible

### DIFF
--- a/clang/lib/CodeGen/Targets/AVR.cpp
+++ b/clang/lib/CodeGen/Targets/AVR.cpp
@@ -112,7 +112,10 @@ public:
 class AVRTargetCodeGenInfo : public TargetCodeGenInfo {
 public:
   AVRTargetCodeGenInfo(CodeGenTypes &CGT, unsigned NPR, unsigned NRR)
-      : TargetCodeGenInfo(std::make_unique<AVRABIInfo>(CGT, NPR, NRR)) {}
+      : TargetCodeGenInfo(std::make_unique<AVRABIInfo>(CGT, NPR, NRR)) {
+    SwiftInfo =
+        std::make_unique<SwiftABIInfo>(CGT, /*SwiftErrorInRegister=*/true);
+  }
 
   LangAS getGlobalVarAddressSpace(CodeGenModule &CGM,
                                   const VarDecl *D) const override {


### PR DESCRIPTION
This patch is needed to add support to clang's AVR ABI for the Swift language. It is a pre-requisite for adding AVR support to the public Swift compiler itself.

I'm open to any suggestions how I might create suitable unit tests for this?

@benshi001 @rjmccall