### PR TITLE
[Flang][Docs] Add or exclude documents to the toc

### DIFF
--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -68,7 +68,7 @@ copyright = "2017-%d, The Flang Team" % date.today().year
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "analyzer"]
+exclude_patterns = ["_build", "analyzer", "FIR/*"]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None

--- a/flang/docs/index.md
+++ b/flang/docs/index.md
@@ -24,6 +24,7 @@ on how to get in touch with us and to learn more about the current status.
 
    C++17
    C++style
+   DesignGuideline
    FortranForCProgrammers
    GettingInvolved
    GettingStarted
@@ -37,35 +38,48 @@ on how to get in touch with us and to learn more about the current status.
 .. toctree::
    :titlesonly:
 
+   Aliasing
+   AliasingAnalysisFIR
    ArrayComposition
    BijectiveInternalNameUniquing
    Calls
    Character
+   ComplexOperations
    ControlFlowGraph
    Directives
    DoConcurrent
    Extensions
+   F202X
+   FIRArrayOperations
    FIRLangRef
    FlangCommandLineReference
    FlangDriver
+   FortranFeatureHistory
    FortranIR
    FortranLLVMTestSuite
+   HighLevelFIR
    IORuntimeInternals
+   InternalProcedureTrampolines
    Intrinsics
    IntrinsicTypes
    LabelResolution
    ModFiles
+   OpenACC
    OpenMP-4.5-grammar.md
    OpenMP-semantics
    OptionComparison
    Overview
+   ParameterizedDerivedTypes
    ParserCombinators
    Parsing
+   PolymorphicEntities
    Preprocessing
+   ProcedurePointer
    RuntimeDescriptor
    RuntimeTypeInfo
    Semantics
    f2018-grammar.md
+   fstack-arrays
 ```
 
 # Indices and tables


### PR DESCRIPTION
This fixes all the warnings of the following type in the CI (https://lab.llvm.org/buildbot/#/builders/89/builds/50248/steps/5/logs/stdio)
-> WARNING: document isn't included in any toctree.