### PR TITLE
[AIX] Disable flaky ClangScanDeps tests

### DIFF
--- a/clang/test/ClangScanDeps/regular_cdb.cpp
+++ b/clang/test/ClangScanDeps/regular_cdb.cpp
@@ -1,3 +1,5 @@
+// UNSUPPORTED:  target={{.*}}-aix{{.*}}
+
 // RUN: rm -rf %t.dir
 // RUN: rm -rf %t.cdb
 // RUN: rm -rf %t_clangcl.cdb

--- a/clang/test/ClangScanDeps/relative_directory.cpp
+++ b/clang/test/ClangScanDeps/relative_directory.cpp
@@ -1,3 +1,5 @@
+// UNSUPPORTED:  target={{.*}}-aix{{.*}}
+
 // RUN: rm -rf %t.dir
 // RUN: rm -rf %t.cdb
 // RUN: mkdir -p %t.dir


### PR DESCRIPTION
These tests are failing intermittently on the AIX bot, possibly due to some issue with `getpwuid_r`. Disable them for now while they are investigated. 