### PR TITLE
[flang] Adjust checks of ICHAR/IACHAR argument length

### DIFF
--- a/flang/lib/Evaluate/fold-integer.cpp
+++ b/flang/lib/Evaluate/fold-integer.cpp
@@ -676,10 +676,16 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
     auto *someChar{UnwrapExpr<Expr<SomeCharacter>>(args[0])};
     CHECK(someChar);
     if (auto len{ToInt64(someChar->LEN())}) {
-      if (len.value() != 1) {
+      if (len.value() < 1) {
+        context.messages().Say(
+            "Character in intrinsic function %s must have length one"_err_en_US,
+            name);
+      } else if (len.value() > 1 &&
+          context.languageFeatures().ShouldWarn(
+              common::UsageWarning::Portability)) {
         // Do not die, this was not checked before
         context.messages().Say(
-            "Character in intrinsic function %s must have length one"_warn_en_US,
+            "Character in intrinsic function %s should have length one"_port_en_US,
             name);
       } else {
         return common::visit(

--- a/flang/test/Semantics/ichar01.f90
+++ b/flang/test/Semantics/ichar01.f90
@@ -1,0 +1,13 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
+!ERROR: Character in intrinsic function ichar must have length one
+print *, ichar('')
+!ERROR: Character in intrinsic function iachar must have length one
+print *, iachar('')
+print *, ichar('a')
+print *, iachar('a')
+!PORTABILITY: Character in intrinsic function ichar should have length one
+print *, ichar('ab')
+!PORTABILITY: Character in intrinsic function iachar should have length one
+print *, iachar('ab')
+end
+


### PR DESCRIPTION
The compiler will now emit an error for length == 0 and an off-by-default portability warning for length > 1.  Previously, the message was an unconditional warning for length /= 1.