### PR TITLE
[libc] Add base for target config within cmake

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -249,39 +249,42 @@ include(CMakeParseArguments)
 include(LLVMLibCCheckCpuFeatures)
 include(LLVMLibCRules)
 
-if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/entrypoints.txt")
-  set(entrypoint_file "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/entrypoints.txt")
-elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/entrypoints.txt")
-  set(entrypoint_file "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/entrypoints.txt")
-else()
-  message(FATAL_ERROR "entrypoints.txt file for the target platform '${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}' not found.")
-endif()
-include(${entrypoint_file})
-
-if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/headers.txt")
-  include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/headers.txt")
-elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
-  include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
-endif()
-
+# If the user wants to provide their own list of entrypoints and headers
 if(LIBC_SYSTEM_CONFIG_FILE)
+  # Use the file provided by the user if it exists
   if(EXISTS "${LIBC_SYSTEM_CONFIG_FILE}")
     include("${LIBC_SYSTEM_CONFIG_FILE}")
   else()
     message(FATAL_ERROR "System Config File set to unavailable file '${LIBC_SYSTEM_CONFIG_FILE}'")
   endif()
+else()
+  # Else use the files in config/OS/CPU/ or config/OS/
+  if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/entrypoints.txt")
+    set(entrypoint_file "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/entrypoints.txt")
+  elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/entrypoints.txt")
+    set(entrypoint_file "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/entrypoints.txt")
+  else()
+    message(FATAL_ERROR "entrypoints.txt file for the target platform '${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}' not found.")
+  endif()
+  include(${entrypoint_file})
 
-  #TODO: Set up support for premade configs.
-
-  foreach(removed_entrypoint IN LISTS TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS)
-    if(LIBC_CMAKE_VERBOSE_LOGGING)
-      message(STATUS "Removing entrypoint ${removed_entrypoint}")
-    endif()
-    list(REMOVE_ITEM TARGET_LLVMLIBC_ENTRYPOINTS ${removed_entrypoint})
-    list(REMOVE_ITEM TARGET_LIBC_ENTRYPOINTS ${removed_entrypoint})
-    list(REMOVE_ITEM TARGET_LIBM_ENTRYPOINTS ${removed_entrypoint})
-  endforeach()
+  if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/headers.txt")
+    include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/headers.txt")
+  elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
+    include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
+  endif()
 endif()
+
+# #TODO: Set up support for premade configs.
+
+# foreach(removed_entrypoint IN LISTS TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS)
+#   if(LIBC_CMAKE_VERBOSE_LOGGING)
+#     message(STATUS "Removing entrypoint ${removed_entrypoint}")
+#   endif()
+#   list(REMOVE_ITEM TARGET_LLVMLIBC_ENTRYPOINTS ${removed_entrypoint})
+#   list(REMOVE_ITEM TARGET_LIBC_ENTRYPOINTS ${removed_entrypoint})
+#   list(REMOVE_ITEM TARGET_LIBM_ENTRYPOINTS ${removed_entrypoint})
+# endforeach()
 
 set(TARGET_ENTRYPOINT_NAME_LIST "")
 foreach(entrypoint IN LISTS TARGET_LLVMLIBC_ENTRYPOINTS)

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -103,13 +103,40 @@ option(LLVM_LIBC_ENABLE_LINTING "Enables linting of libc source files" OFF)
 option(LIBC_GPU_BUILD "Build libc for the GPU. All CPU build options will be ignored." OFF)
 set(LIBC_TARGET_TRIPLE "" CACHE STRING "The target triple for the libc build.")
 
-option(LIBC_SYSTEM_CONFIG_FILE "The path to user provided cmake file that configures the build for the target system." OFF)
+option(LIBC_CONFIG_PATH "The path to user provided folder that configures the build for the target system." OFF)
 
 set(LIBC_ENABLE_UNITTESTS ON)
 set(LIBC_ENABLE_HERMETIC_TESTS ${LLVM_LIBC_FULL_BUILD})
 
 # Defines LIBC_TARGET_ARCHITECTURE and associated macros.
 include(LLVMLibCArchitectures)
+
+set(LIBC_CONFIG_JSON_FILE_LIST "")
+
+if(NOT LIBC_CONFIG_PATH)
+  list(APPEND LIBC_CONFIG_JSON_FILE_LIST "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}")
+  if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}")
+    list(APPEND LIBC_CONFIG_JSON_FILE_LIST "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}")
+    set(LIBC_CONFIG_PATH "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}")
+  elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}")
+    set(LIBC_CONFIG_PATH "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}")
+  endif()
+else()
+  list(APPEND LIBC_CONFIG_JSON_FILE_LIST "${LIBC_CONFIG_PATH}")
+endif()
+
+if(NOT LIBC_CONFIG_PATH)
+  message(FATAL_ERROR "Configs for the platform '${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}' do not exist and LIBC_CONFIG_PATH is not set.")
+elseif(LIBC_CMAKE_VERBOSE_LOGGING)
+  message(STATUS "Path for config files is: ${LIBC_CONFIG_PATH}")
+endif()
+
+# option(LIBC_ENABLE_WIDE_CHARACTERS 
+# "Whether to enable wide character functions on supported platforms. This may
+# also set flags to enable or disable wide character support within other
+# functions (e.g. printf)." ON)
+
+#TODO: Add carve-out specific config files to the list here.
 
 include(LibcConfig)
 # Config loading happens in three steps:
@@ -149,8 +176,14 @@ foreach(opt IN LISTS global_config)
   set(${opt_name} ${opt_value})
 endforeach()
 generate_config_doc(${main_config_file} ${LIBC_SOURCE_DIR}/docs/configure.rst)
-load_libc_config(${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/config.json ${cmd_line_conf})
-load_libc_config(${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/config.json ${cmd_line_conf})
+
+# Load each target specific config.
+foreach(config_path IN LISTS LIBC_CONFIG_JSON_FILE_LIST)
+  if(LIBC_CMAKE_VERBOSE_LOGGING)
+    message(STATUS "Loading additional config: '${config_path}/config.json'")
+  endif()
+  load_libc_config(${config_path}/config.json ${cmd_line_conf})
+endforeach()
 
 if(LIBC_TARGET_ARCHITECTURE_IS_GPU)
   set(LIBC_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
@@ -249,42 +282,40 @@ include(CMakeParseArguments)
 include(LLVMLibCCheckCpuFeatures)
 include(LLVMLibCRules)
 
-# If the user wants to provide their own list of entrypoints and headers
-if(LIBC_SYSTEM_CONFIG_FILE)
-  # Use the file provided by the user if it exists
-  if(EXISTS "${LIBC_SYSTEM_CONFIG_FILE}")
-    include("${LIBC_SYSTEM_CONFIG_FILE}")
-  else()
-    message(FATAL_ERROR "System Config File set to unavailable file '${LIBC_SYSTEM_CONFIG_FILE}'")
-  endif()
-else()
-  # Else use the files in config/OS/CPU/ or config/OS/
-  if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/entrypoints.txt")
-    set(entrypoint_file "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/entrypoints.txt")
-  elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/entrypoints.txt")
-    set(entrypoint_file "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/entrypoints.txt")
-  else()
-    message(FATAL_ERROR "entrypoints.txt file for the target platform '${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}' not found.")
-  endif()
-  include(${entrypoint_file})
+set(TARGET_LLVMLIBC_ENTRYPOINTS "")
+set(TARGET_LIBC_ENTRYPOINTS "")
+set(TARGET_LIBM_ENTRYPOINTS "")
+set(TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS "")
 
-  if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/headers.txt")
-    include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/headers.txt")
-  elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
-    include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
-  endif()
+# Check entrypoints.txt
+if(EXISTS "${LIBC_CONFIG_PATH}/entrypoints.txt")
+    include("${LIBC_CONFIG_PATH}/entrypoints.txt")
+else()
+  message(FATAL_ERROR "${LIBC_CONFIG_PATH}/entrypoints.txt file not found.")
 endif()
 
-# #TODO: Set up support for premade configs.
+# Check headers.txt
+if(EXISTS "${LIBC_CONFIG_PATH}/headers.txt")
+    include("${LIBC_CONFIG_PATH}/headers.txt")
+elseif(LLVM_LIBC_FULL_BUILD)
+  message(FATAL_ERROR "${LIBC_CONFIG_PATH}/headers.txt file not found and fullbuild requested.")
+endif()
 
-# foreach(removed_entrypoint IN LISTS TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS)
-#   if(LIBC_CMAKE_VERBOSE_LOGGING)
-#     message(STATUS "Removing entrypoint ${removed_entrypoint}")
-#   endif()
-#   list(REMOVE_ITEM TARGET_LLVMLIBC_ENTRYPOINTS ${removed_entrypoint})
-#   list(REMOVE_ITEM TARGET_LIBC_ENTRYPOINTS ${removed_entrypoint})
-#   list(REMOVE_ITEM TARGET_LIBM_ENTRYPOINTS ${removed_entrypoint})
-# endforeach()
+# Check exclude.txt that appends to LIBC_EXCLUDE_ENTRYPOINTS list
+if(EXISTS "${LIBC_CONFIG_PATH}/exclude.txt")
+    include("${LIBC_CONFIG_PATH}/exclude.txt")
+endif()
+
+# #TODO: Set up support for premade configs adding their own exclude lists.
+
+foreach(removed_entrypoint IN LISTS TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS)
+  if(LIBC_CMAKE_VERBOSE_LOGGING)
+    message(STATUS "Removing entrypoint ${removed_entrypoint}")
+  endif()
+  list(REMOVE_ITEM TARGET_LLVMLIBC_ENTRYPOINTS ${removed_entrypoint})
+  list(REMOVE_ITEM TARGET_LIBC_ENTRYPOINTS ${removed_entrypoint})
+  list(REMOVE_ITEM TARGET_LIBM_ENTRYPOINTS ${removed_entrypoint})
+endforeach()
 
 set(TARGET_ENTRYPOINT_NAME_LIST "")
 foreach(entrypoint IN LISTS TARGET_LLVMLIBC_ENTRYPOINTS)

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -103,6 +103,8 @@ option(LLVM_LIBC_ENABLE_LINTING "Enables linting of libc source files" OFF)
 option(LIBC_GPU_BUILD "Build libc for the GPU. All CPU build options will be ignored." OFF)
 set(LIBC_TARGET_TRIPLE "" CACHE STRING "The target triple for the libc build.")
 
+option(LIBC_SYSTEM_CONFIG_FILE "The path to user provided cmake file that configures the build for the target system." OFF)
+
 set(LIBC_ENABLE_UNITTESTS ON)
 set(LIBC_ENABLE_HERMETIC_TESTS ${LLVM_LIBC_FULL_BUILD})
 
@@ -260,6 +262,25 @@ if(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTUR
   include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/${LIBC_TARGET_ARCHITECTURE}/headers.txt")
 elseif(EXISTS "${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
   include("${LIBC_SOURCE_DIR}/config/${LIBC_TARGET_OS}/headers.txt")
+endif()
+
+if(LIBC_SYSTEM_CONFIG_FILE)
+  if(EXISTS "${LIBC_SYSTEM_CONFIG_FILE}")
+    include("${LIBC_SYSTEM_CONFIG_FILE}")
+  else()
+    message(FATAL_ERROR "System Config File set to unavailable file '${LIBC_SYSTEM_CONFIG_FILE}'")
+  endif()
+
+  #TODO: Set up support for premade configs.
+
+  foreach(removed_entrypoint IN LISTS TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS)
+    if(LIBC_CMAKE_VERBOSE_LOGGING)
+      message(STATUS "Removing entrypoint ${removed_entrypoint}")
+    endif()
+    list(REMOVE_ITEM TARGET_LLVMLIBC_ENTRYPOINTS ${removed_entrypoint})
+    list(REMOVE_ITEM TARGET_LIBC_ENTRYPOINTS ${removed_entrypoint})
+    list(REMOVE_ITEM TARGET_LIBM_ENTRYPOINTS ${removed_entrypoint})
+  endforeach()
 endif()
 
 set(TARGET_ENTRYPOINT_NAME_LIST "")

--- a/libc/cmake/modules/system_features/check_sys_random.cpp
+++ b/libc/cmake/modules/system_features/check_sys_random.cpp
@@ -1,0 +1,1 @@
+#include <sys/random.h>

--- a/libc/config/CMakeLists.txt
+++ b/libc/config/CMakeLists.txt
@@ -1,1 +1,3 @@
+#TODO: Properly select the correct subdirectory.
+
 add_subdirectory(linux)

--- a/libc/config/linux/x86_64/exclude.txt
+++ b/libc/config/linux/x86_64/exclude.txt
@@ -1,0 +1,16 @@
+# This optional file is used to exclude entrypoints/headers for specific targets.
+
+try_compile(
+  has_sys_random
+  ${CMAKE_CURRENT_BINARY_DIR}
+  SOURCES ${LIBC_SOURCE_DIR}/src/sys/random/linux/getrandom.cpp
+)
+
+# If sys/random isn't available, then this is likely Ubuntu 14, which also
+# doesn't support the syscall we use for sys/stat.
+if(NOT has_sys_random)
+  list(APPEND TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS 
+    libc.src.sys.random.getrandom
+    libc.src.sys.stat.stat
+  )
+endif()

--- a/libc/config/linux/x86_64/exclude.txt
+++ b/libc/config/linux/x86_64/exclude.txt
@@ -1,16 +1,21 @@
 # This optional file is used to exclude entrypoints/headers for specific targets.
 
+# Check if sys/random.h is available. If it isn't that implies we're on an older
+# version of linux, so we probably also don't have the statx syscall.
 try_compile(
   has_sys_random
   ${CMAKE_CURRENT_BINARY_DIR}
-  SOURCES ${LIBC_SOURCE_DIR}/src/sys/random/linux/getrandom.cpp
+  SOURCES ${LIBC_SOURCE_DIR}/cmake/modules/system_features/check_sys_random.cpp
 )
 
-# If sys/random isn't available, then this is likely Ubuntu 14, which also
-# doesn't support the syscall we use for sys/stat.
 if(NOT has_sys_random)
   list(APPEND TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS 
-    libc.src.sys.random.getrandom
     libc.src.sys.stat.stat
   )
+  # If we're doing a fullbuild we provide the random header ourselves.
+  if(NOT LLVM_LIBC_FULL_BUILD)
+    list(APPEND TARGET_LLVMLIBC_REMOVED_ENTRYPOINTS 
+      libc.src.sys.random.getrandom
+    )
+  endif()
 endif()


### PR DESCRIPTION
Currently the only way to add or remove entrypoints is to modify the
entrypoints.txt file for the current target. This isn't ideal since
a user would have to carry a diff for this file when updating their
checkout. This patch adds a basic mechanism to allow the user to remove
entrypoints without modifying the repository. 
