### PR TITLE
[Flang][Docs] Fix lexer issue in Driver and Trampoline doc

### DIFF
--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -61,7 +61,7 @@ Note that similarly to `-Xclang` in `clang`, you can use `-Xflang` to forward a
 frontend specific flag from the _compiler_ directly to the _frontend_ driver,
 e.g.:
 
-```lang=bash
+```bash
 flang-new -Xflang -fdebug-dump-parse-tree input.f95
 ```
 
@@ -69,7 +69,7 @@ In the invocation above, `-fdebug-dump-parse-tree` is forwarded to `flang-new
 -fc1`. Without the forwarding flag, `-Xflang`, you would see the following
 warning:
 
-```lang=bash
+```bash
 flang-new: warning: argument unused during compilation:
 ```
 

--- a/flang/docs/InternalProcedureTrampolines.md
+++ b/flang/docs/InternalProcedureTrampolines.md
@@ -170,15 +170,15 @@ as an actual argument to `foo()`.
 
 The trampoline has the following structure:
 
-```assembly
+```asm
 callee_trampoline:
-  MOV <static-chain-address>, R#
-  JMP <callee-address>
+  MOV static-chain-address, R#
+  JMP callee-address
 ```
 
 Where:
-- `<callee-address>` is the address of function `callee()`.
-- `<static-chain-address>` - the address of the static chain
+- `callee-address` is the address of function `callee()`.
+- `static-chain-address` - the address of the static chain
   object created inside `host()`.
 - `R#` is a target specific register.
 
@@ -249,7 +249,7 @@ One of the options is to use separate allocations for the trampoline code
 and the trampoline "data".
 
 The trampolines may be located in non-writeable executable memory:
-```assembly
+```asm
 trampoline0:
   MOV (TDATA[0].static_chain_address), R#
   JMP (TDATA[0].callee_address)


### PR DESCRIPTION
Allowed lexers are documented in https://pygments.org/docs/lexers/.