### PR TITLE
[SimplifyCFG] Fix uint32_t overflow in cbranch to cbranch merge prevention check.

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -4351,10 +4351,10 @@ static bool SimplifyCondBranchToCondBranch(BranchInst *PBI, BranchInst *BI,
   SmallVector<uint32_t, 2> PredWeights;
   if (!PBI->getMetadata(LLVMContext::MD_unpredictable) &&
       extractBranchWeights(*PBI, PredWeights) &&
-      (PredWeights[0] + PredWeights[1]) != 0) {
+      ((uint64_t)PredWeights[0] + PredWeights[1]) != 0) {
 
     BranchProbability CommonDestProb = BranchProbability::getBranchProbability(
-        PredWeights[PBIOp], PredWeights[0] + PredWeights[1]);
+        PredWeights[PBIOp], (uint64_t)PredWeights[0] + PredWeights[1]);
 
     BranchProbability Likely = TTI.getPredictableBranchThreshold();
     if (CommonDestProb >= Likely)

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -4351,10 +4351,11 @@ static bool SimplifyCondBranchToCondBranch(BranchInst *PBI, BranchInst *BI,
   SmallVector<uint32_t, 2> PredWeights;
   if (!PBI->getMetadata(LLVMContext::MD_unpredictable) &&
       extractBranchWeights(*PBI, PredWeights) &&
-      ((uint64_t)PredWeights[0] + PredWeights[1]) != 0) {
+      (static_cast<uint64_t>(PredWeights[0]) + PredWeights[1]) != 0) {
 
     BranchProbability CommonDestProb = BranchProbability::getBranchProbability(
-        PredWeights[PBIOp], (uint64_t)PredWeights[0] + PredWeights[1]);
+        PredWeights[PBIOp],
+        static_cast<uint64_t>(PredWeights[0]) + PredWeights[1]);
 
     BranchProbability Likely = TTI.getPredictableBranchThreshold();
     if (CommonDestProb >= Likely)

--- a/llvm/test/Transforms/SimplifyCFG/branch-cond-dont-merge.ll
+++ b/llvm/test/Transforms/SimplifyCFG/branch-cond-dont-merge.ll
@@ -79,6 +79,25 @@ exit:
   ret void
 }
 
+define void @uint32_overflow_test(i1 %arg, i1 %arg1) {
+; CHECK-LABEL: @uint32_overflow_test(
+; CHECK-NEXT:  bb:
+; CHECK-NEXT:    ret void
+;
+bb:
+  br i1 %arg, label %bb4, label %bb2, !prof !3
+
+bb2:
+  br i1 %arg1, label %bb4, label %bb3
+
+bb3:
+  br label %bb4
+
+bb4:
+  ret void
+}
+
 !0 = !{!"branch_weights", i32 1, i32 1000}
 !1 = !{!"branch_weights", i32 1000, i32 1}
 !2 = !{!"branch_weights", i32 3, i32 2}
+!3 = !{!"branch_weights", i32 -258677585, i32 -1212131848}

--- a/llvm/test/Transforms/SimplifyCFG/branch-cond-dont-merge.ll
+++ b/llvm/test/Transforms/SimplifyCFG/branch-cond-dont-merge.ll
@@ -82,6 +82,7 @@ exit:
 define void @uint32_overflow_test(i1 %arg, i1 %arg1) {
 ; CHECK-LABEL: @uint32_overflow_test(
 ; CHECK-NEXT:  bb:
+; CHECK-NEXT:    [[BRMERGE:%.*]] = select i1 [[ARG:%.*]], i1 true, i1 [[ARG1:%.*]]
 ; CHECK-NEXT:    ret void
 ;
 bb:


### PR DESCRIPTION
This fixes https://github.com/llvm/llvm-project/issues/72323.

Resulted from https://github.com/llvm/llvm-project/commit/f054947c0da99ec8b3c4bb043e5225672420a313