### PR TITLE
[lld/ELF] Warn on conflicting SHF_X86_64_LARGE flag

### DIFF
--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -149,6 +149,15 @@ void OutputSection::commitSection(InputSection *isec) {
       error("incompatible section flags for " + name + "\n>>> " +
             toString(isec) + ": 0x" + utohexstr(isec->flags) +
             "\n>>> output section " + name + ": 0x" + utohexstr(flags));
+    if (config->emachine == EM_X86_64) {
+      if ((flags ^ isec->flags) & SHF_X86_64_LARGE) {
+        InputSection *conflictISec = getFirstInputSection(this);
+        warn("incompatible SHF_X86_64_LARGE section flag for '" + name +
+             "'\n>>> " + toString(conflictISec) + ": 0x" +
+             utohexstr(conflictISec->flags) + "\n>>> " + toString(isec) +
+             ": 0x" + utohexstr(isec->flags));
+      }
+    }
   }
 
   isec->parent = this;

--- a/lld/test/ELF/x86-64-warn-mix-large-section.s
+++ b/lld/test/ELF/x86-64-warn-mix-large-section.s
@@ -1,0 +1,16 @@
+# REQUIRES: x86
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/a.s -o %t/a.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/b.s -o %t/b.o
+# RUN: ld.lld %t/a.o %t/b.o -o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: warning: incompatible SHF_X86_64_LARGE section flag for 'foo'
+# CHECK-NEXT: >>> {{.*}}a.o:(foo): 0x10000003
+# CHECK-NEXT: >>> {{.*}}b.o:(foo): 0x3
+
+#--- a.s
+.section foo,"awl",@progbits
+
+#--- b.s
+.section foo,"aw",@progbits
+


### PR DESCRIPTION
There's no proper way to mix small and large x86-64 sections, so warn on it.
