### PR TITLE
[mlir][python] remove eager loading of dialect module (for type and value casting)

### DIFF
--- a/mlir/lib/Bindings/Python/IRModule.cpp
+++ b/mlir/lib/Bindings/Python/IRModule.cpp
@@ -132,10 +132,8 @@ PyGlobals::lookupAttributeBuilder(const std::string &attributeKind) {
 
 std::optional<py::function> PyGlobals::lookupTypeCaster(MlirTypeID mlirTypeID,
                                                         MlirDialect dialect) {
-  // Make sure dialect module is loaded.
-  if (!loadDialectModule(unwrap(mlirDialectGetNamespace(dialect))))
-    return std::nullopt;
-
+  // Try to load dialect module.
+  (void)loadDialectModule(unwrap(mlirDialectGetNamespace(dialect)));
   const auto foundIt = typeCasterMap.find(mlirTypeID);
   if (foundIt != typeCasterMap.end()) {
     assert(foundIt->second && "type caster is defined");
@@ -146,7 +144,8 @@ std::optional<py::function> PyGlobals::lookupTypeCaster(MlirTypeID mlirTypeID,
 
 std::optional<py::function> PyGlobals::lookupValueCaster(MlirTypeID mlirTypeID,
                                                          MlirDialect dialect) {
-  loadDialectModule(unwrap(mlirDialectGetNamespace(dialect)));
+  // Try to load dialect module.
+  (void)loadDialectModule(unwrap(mlirDialectGetNamespace(dialect)));
   const auto foundIt = valueCasterMap.find(mlirTypeID);
   if (foundIt != valueCasterMap.end()) {
     assert(foundIt->second && "value caster is defined");

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -44,6 +44,17 @@ declare_mlir_python_sources(MLIRPythonCAPI.HeaderSources
   SOURCES_GLOB "mlir-c/*.h"
 )
 
+# The builtin dialect is special (e.g., type casters and such expect it to be loaded
+# in order to work) so we add it to Core instead of Dialects so that anyone depending on
+# Core will get it automatically.
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT MLIRPythonSources.Core
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  TD_FILE dialects/BuiltinOps.td
+  SOURCES
+    dialects/builtin.py
+  DIALECT_NAME builtin)
+
 ################################################################################
 # Dialect bindings
 ################################################################################
@@ -83,14 +94,6 @@ declare_mlir_dialect_python_bindings(
   GEN_ENUM_BINDINGS_TD_FILE
     "../../include/mlir/Dialect/Bufferization/IR/BufferizationEnums.td"
 )
-
-declare_mlir_dialect_python_bindings(
-  ADD_TO_PARENT MLIRPythonSources.Dialects
-  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
-  TD_FILE dialects/BuiltinOps.td
-  SOURCES
-    dialects/builtin.py
-  DIALECT_NAME builtin)
 
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT MLIRPythonSources.Dialects

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -44,17 +44,6 @@ declare_mlir_python_sources(MLIRPythonCAPI.HeaderSources
   SOURCES_GLOB "mlir-c/*.h"
 )
 
-# The builtin dialect is special (e.g., type casters and such expect it to be loaded
-# in order to work) so we add it to Core instead of Dialects so that anyone depending on
-# Core will get it automatically.
-declare_mlir_dialect_python_bindings(
-  ADD_TO_PARENT MLIRPythonSources.Core
-  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
-  TD_FILE dialects/BuiltinOps.td
-  SOURCES
-    dialects/builtin.py
-  DIALECT_NAME builtin)
-
 ################################################################################
 # Dialect bindings
 ################################################################################
@@ -94,6 +83,14 @@ declare_mlir_dialect_python_bindings(
   GEN_ENUM_BINDINGS_TD_FILE
     "../../include/mlir/Dialect/Bufferization/IR/BufferizationEnums.td"
 )
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT MLIRPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir"
+  TD_FILE dialects/BuiltinOps.td
+  SOURCES
+    dialects/builtin.py
+  DIALECT_NAME builtin)
 
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT MLIRPythonSources.Dialects


### PR DESCRIPTION
So it turns out there are funny people ([CIRCT ahem...](https://github.com/llvm/circt/pull/6404#issuecomment-1811749752)) that depend on `MLIRPythonSources.Core` sources but choose not to build/depend on any of the upstream dialects, in particular `builtin`. Unfortunately this breaks all of the type casters and such after https://github.com/llvm/llvm-project/pull/70831 because all of the fancy `lookup...` functions will [early exit if `loadDialectModule` fails](https://github.com/llvm/llvm-project/commit/5192e299cf444040025ccf3e75bfad36b4624050#diff-1f295ae31d665f9a778ea210c0816a22c621c34d54bf5b83b21686bf0432a918R126). So let's do these funny people a favor and automatically include the `builtin` dialect for them with `MLIRPythonSources.Core`.

cc @mikeurbach 

**EDIT**: okay cutting the gordian knot: dialect module loading prior to type caster or value caster use is "best effort" - i.e., we ignore the return value for only those two lookups (`lookupDialectClass` and `lookupOperationClass` stay strict). It was probably overly cautious anyway - the worst that happens if you don't early exit after a failed (absent) dialect module load is the type caster lookup also fails (i.e., not really an error, just a return to the default behavior).

**EDIT2**: I propose we remove eager dialect module loading from `lookupTypeCaster` and `lookupValueCaster` entirely. I don't remember who it was that asked for that kind of safety but IMHO if you want type casting to your own dialect's types, it's not unreasonable to ask you to first register those type casters - whether that be by importing a python module that performs the registration using the decorator syntax, or importing the C extension module that implements `mlir_type_subclass`. I don't think an explicit import if you want to avail yourself of type casting to a type in your dialect is an excessive complexity/boilerplate burden. And it's failsafe - if the type/value caster isn't registered then nbd - the corresponding map (`typeCasterMap`, `valueCasterMap`) will not hit and default types (`ir.Type`) will be returned. **But note:** `builtin` types and attributes _will_ be cast successfully (because casters for `builtin` are registered in the pybind code itself). The current PR commit implements this proposal.