### PR TITLE
[LoongArch] Set isBarrier to true for instruction 'b'

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
@@ -646,6 +646,7 @@ class Br_I26<bits<32> op>
     : FmtI26<op, (outs), (ins simm26_b:$imm26), "$imm26"> {
   let isBranch = 1;
   let isTerminator = 1;
+  let isBarrier = 1;
 }
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0
 

--- a/llvm/unittests/Target/LoongArch/MCInstrAnalysisTest.cpp
+++ b/llvm/unittests/Target/LoongArch/MCInstrAnalysisTest.cpp
@@ -94,17 +94,13 @@ TEST_P(InstrAnalysisTest, IsBranch) {
 
 TEST_P(InstrAnalysisTest, IsConditionalBranch) {
   EXPECT_TRUE(Analysis->isConditionalBranch(beq()));
-  // FIXME: Instr 'b' is not a ConditionalBranch, so the analysis here is
-  // wrong. The following patch will fix it.
-  EXPECT_TRUE(Analysis->isConditionalBranch(b()));
+  EXPECT_FALSE(Analysis->isConditionalBranch(b()));
   EXPECT_FALSE(Analysis->isConditionalBranch(bl()));
 }
 
 TEST_P(InstrAnalysisTest, IsUnconditionalBranch) {
   EXPECT_FALSE(Analysis->isUnconditionalBranch(beq()));
-  // FIXME: Instr 'b' is an UnconditionalBranch, so the analysis here is
-  // wrong. The following patch will fix it.
-  EXPECT_FALSE(Analysis->isUnconditionalBranch(b()));
+  EXPECT_TRUE(Analysis->isUnconditionalBranch(b()));
   EXPECT_FALSE(Analysis->isUnconditionalBranch(bl()));
   EXPECT_TRUE(Analysis->isUnconditionalBranch(jirl(LoongArch::R0)));
   EXPECT_FALSE(Analysis->isUnconditionalBranch(jirl(LoongArch::R1)));


### PR DESCRIPTION
Instr "b offs26" represent to an unconditional branch in LoongArch. Set isBarrier to 1 in tablegen for it, so that MCInstrAnalysis can return correctly.

Fixes https://github.com/llvm/llvm-project/pull/71903.