### PR TITLE
[RISCV,GISel] Unconditionally use MO_PLT for calls

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
@@ -496,24 +496,8 @@ bool RISCVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
   // TODO: Support tail calls.
   Info.IsTailCall = false;
 
-  // If the callee is a GlobalAddress or ExternalSymbol and cannot be assumed as
-  // DSOLocal, then use MO_PLT. Otherwise use MO_CALL.
-  if (Info.Callee.isGlobal()) {
-    const GlobalValue *GV = Info.Callee.getGlobal();
-    unsigned OpFlags = RISCVII::MO_CALL;
-    if (!getTLI()->getTargetMachine().shouldAssumeDSOLocal(*GV->getParent(),
-                                                           GV))
-      OpFlags = RISCVII::MO_PLT;
-
-    Info.Callee.setTargetFlags(OpFlags);
-  } else if (Info.Callee.isSymbol()) {
-    unsigned OpFlags = RISCVII::MO_CALL;
-    if (!getTLI()->getTargetMachine().shouldAssumeDSOLocal(
-            *MF.getFunction().getParent(), nullptr))
-      OpFlags = RISCVII::MO_PLT;
-
-    Info.Callee.setTargetFlags(OpFlags);
-  }
+  // Select the recommended relocation type R_RISCV_CALL_PLT.
+  Info.Callee.setTargetFlags(RISCVII::MO_PLT);
 
   MachineInstrBuilder Call =
       MIRBuilder

--- a/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/calls.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/irtranslator/calls.ll
@@ -427,14 +427,14 @@ define void @test_call_local() {
   ; RV32I-LABEL: name: test_call_local
   ; RV32I: bb.1.entry:
   ; RV32I-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $x2, implicit $x2
-  ; RV32I-NEXT:   PseudoCALL target-flags(riscv-call) @dso_local_function, csr_ilp32_lp64, implicit-def $x1
+  ; RV32I-NEXT:   PseudoCALL target-flags(riscv-plt) @dso_local_function, csr_ilp32_lp64, implicit-def $x1
   ; RV32I-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $x2, implicit $x2
   ; RV32I-NEXT:   PseudoRET
   ;
   ; RV64I-LABEL: name: test_call_local
   ; RV64I: bb.1.entry:
   ; RV64I-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $x2, implicit $x2
-  ; RV64I-NEXT:   PseudoCALL target-flags(riscv-call) @dso_local_function, csr_ilp32_lp64, implicit-def $x1
+  ; RV64I-NEXT:   PseudoCALL target-flags(riscv-plt) @dso_local_function, csr_ilp32_lp64, implicit-def $x1
   ; RV64I-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $x2, implicit $x2
   ; RV64I-NEXT:   PseudoRET
 entry:


### PR DESCRIPTION
All known linkers handle R_RISCV_CALL and R_RISCV_CALL_PLT in the same
way (GNU ld since
https://sourceware.org/pipermail/binutils/2020-August/112750.html).

MO_CALL is for R_RISCV_CALL, a deprecated relocation type. We don't
migrate away from MO_CALL for SelectionDAG mostly because it is an
unnecessary change. For GISel we don't have the concern and should weigh
more on simplicity.
