### PR TITLE
[scudo] default disable allocation ring buffer for trusty

### DIFF
--- a/compiler-rt/lib/scudo/standalone/flags.inc
+++ b/compiler-rt/lib/scudo/standalone/flags.inc
@@ -46,6 +46,6 @@ SCUDO_FLAG(int, release_to_os_interval_ms, SCUDO_ANDROID ? INT32_MIN : 5000,
            "Interval (in milliseconds) at which to attempt release of unused "
            "memory to the OS. Negative values disable the feature.")
 
-SCUDO_FLAG(int, allocation_ring_buffer_size, 32768,
+SCUDO_FLAG(int, allocation_ring_buffer_size, SCUDO_TRUSTY ? 0 : 32768,
            "Entries to keep in the allocation ring buffer for scudo. "
            "Values less or equal to zero disable the buffer.")


### PR DESCRIPTION
this is currently done on AOSP trusty-main. it's easier to do it upstream and remove the divergence.