### PR TITLE
[DebugInfo][RemoveDIs] Allow for inserting DPValues at end()

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -146,6 +146,8 @@ void Instruction::insertBefore(BasicBlock &BB,
   bool InsertAtHead = InsertPos.getHeadBit();
   if (!InsertAtHead) {
     DPMarker *SrcMarker = BB.getMarker(InsertPos);
+    if (!SrcMarker)
+      SrcMarker = BB.createMarker(InsertPos);
     DbgMarker->absorbDebugValues(*SrcMarker, false);
   }
 


### PR DESCRIPTION
This trivial patch covers a bit of fallout from https://reviews.llvm.org/D153990, where we moved the storage of trailing DPValues into LLVMContext rather than being stored in each block. As a result, you can now get a null DPMarker pointer from the end() iterator where previously you didn't (and now it has to be explicitly created).

This is a sort-of stopgap measure -- there's another all-singing all-dancing patch further down the line that refactors all of this so that we don't allocate a DPMarker for every single Instruction. When that lands this will all be refactored so that every time we request a DPMarker, one is created if needs be. That's a performance-fix rather than a functionality related patch though, so it'll come later.