### PR TITLE
[GitHub] Add greeting comment to opened PRs from new contributors

### DIFF
--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -15,16 +15,43 @@ on:
       - synchronize
 
 jobs:
-  automate-prs-labels:
+  greeter:
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    # Only comment on PRs that have been opened for the first time, by someone
+    # new to LLVM or to GitHub as a whole.
+    if: >-
+      (github.repository == 'llvm/llvm-project') &&
+      (github.event.action == 'opened') &&
+      (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+       github.event.pull_request.author_association == 'FIRST_TIMER')
+    steps:
+      - name: Setup Automation Script
+        run: |
+          curl -O -L --fail https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/main/llvm/utils/git/github-automation.py
+          curl -O -L --fail https://raw.githubusercontent.com/"$GITHUB_REPOSITORY"/main/llvm/utils/git/requirements.txt
+          chmod a+x github-automation.py
+          pip install -r requirements.txt
+
+      - name: Greet Author
+        run: |
+          ./github-automation.py \
+            --token '${{ secrets.GITHUB_TOKEN }}' \
+            pr-greeter \
+            --issue-number "${{ github.event.pull_request.number }}"
+
+  automate-prs-labels:
+    # Greet first so that only the author gets that notification.
+    needs: greeter
     runs-on: ubuntu-latest
     # Ignore PRs with more than 10 commits.  Pull requests with a lot of
     # commits tend to be accidents usually when someone made a mistake while trying
     # to rebase.  We want to ignore these pull requests to avoid excessive
     # notifications.
+    # always() means that even if greeter is skipped, this job will run.
     if: >
-      github.repository == 'llvm/llvm-project' &&
+      always() && github.repository == 'llvm/llvm-project' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.commits < 10
     steps:

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -211,6 +211,36 @@ Author: {self.pr.user.name} ({self.pr.user.login})
         return None
 
 
+class PRGreeter:
+    def __init__(self, token: str, repo: str, pr_number: int):
+        repo = github.Github(token).get_repo(repo)
+        self.pr = repo.get_issue(pr_number).as_pull_request()
+
+    def run(self) -> bool:
+        # We assume that this is only called for a PR that has just been opened
+        # by a user new to LLVM and/or GitHub itself.
+
+        # This text is using Markdown formatting.
+        comment = f"""\
+Thank you for submitting a Pull Request (PR) to the LLVM Project!
+
+You can add reviewers by using the "Reviewers" section on this page.
+
+If this is not working for you, it's probably because you don't have write
+permissions for the repository. In which case you can instead tag reviewers by
+name in a comment by using `@` followed by their GitHub username.
+
+If you have received no comments on your PR for a week, you can request a review
+by "ping"ing the PR by adding a comment “Ping”. The common courtesy "ping" rate
+is once a week. Please remember that you are asking for valuable time from other developers.
+
+If you have further questions, they may be answered by the [LLVM GitHub User Guide](https://llvm.org/docs/GitHub.html).
+
+You can also ask questions in a comment on this PR, on the [LLVM Discord](https://discord.com/invite/xS7Z362) or on the [forums](https://discourse.llvm.org/)."""
+        self.pr.as_issue().create_comment(comment)
+        return True
+
+
 def setup_llvmbot_git(git_dir="."):
     """
     Configure the git repo in `git_dir` with the llvmbot account so
@@ -655,6 +685,9 @@ pr_subscriber_parser = subparsers.add_parser("pr-subscriber")
 pr_subscriber_parser.add_argument("--label-name", type=str, required=True)
 pr_subscriber_parser.add_argument("--issue-number", type=int, required=True)
 
+pr_greeter_parser = subparsers.add_parser("pr-greeter")
+pr_greeter_parser.add_argument("--issue-number", type=int, required=True)
+
 release_workflow_parser = subparsers.add_parser("release-workflow")
 release_workflow_parser.add_argument(
     "--llvm-project-dir",
@@ -705,6 +738,9 @@ elif args.command == "pr-subscriber":
         args.token, args.repo, args.issue_number, args.label_name
     )
     pr_subscriber.run()
+elif args.command == "pr-greeter":
+    pr_greeter = PRGreeter(args.token, args.repo, args.issue_number)
+    pr_greeter.run()
 elif args.command == "release-workflow":
     release_workflow = ReleaseWorkflow(
         args.token,

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -224,9 +224,12 @@ class PRGreeter:
         comment = f"""\
 Thank you for submitting a Pull Request (PR) to the LLVM Project!
 
-You can add reviewers by using the "Reviewers" section on this page.
+This PR will be automatically labeled and the relevant teams will be
+notified.
 
-If this is not working for you, it's probably because you don't have write
+If you wish to, you can add reviewers by using the "Reviewers" section on this page.
+
+If this is not working for you, it is probably because you do not have write
 permissions for the repository. In which case you can instead tag reviewers by
 name in a comment by using `@` followed by their GitHub username.
 


### PR DESCRIPTION
This includes some commonly needed information like how to add reviewers.

This is implemented as a job before the labeler, so that on a new PR the comment is added before there are any subscribers and only the author gets a nofitication.

The labeler job depends on the greeter having run or having been skipped. So if the PR wasn't just opened, or it's from a regular contributor, the labeling still happens.

But we can be sure that when a greeting comment is left, it's the very first thing we do.