### PR TITLE
[builtins][test] Don't XFAIL divtc3_test.c on 32-bit Solaris/sparc fo…

### DIFF
--- a/compiler-rt/test/builtins/Unit/divtc3_test.c
+++ b/compiler-rt/test/builtins/Unit/divtc3_test.c
@@ -3,8 +3,8 @@
 // REQUIRES: c99-complex
 
 //
-// Bug 42493
-// XFAIL: sparc-target-arch
+// This test should be XFAILed on 32-bit sparc (sparc-target-arch, Issue
+// #41838), but that is currently hidden, which caused an XPASS (Issue #72398).
 //
 #include <stdio.h>
 


### PR DESCRIPTION
As detailed in Issue #72398, the recent builtins rework and 77d75dc9be5c4bb1d9986a475e1c661718067c6a caused `Builtins-sparc-sunos:: divtc3_test.c` to `XPASS` on 32-bit Solaris/SPARC.  Since there are several underlying issues, un-`XFAIL` the test for now until those are resolved, to turn the Solaris/sparcv9 buildbot green again after 5 days.

Tested on `sparcv9-sun-solaris2.11` and `x86_64-pc-linux-gnu`.