### PR TITLE
[GitHub] Add codeowners for mlir/spirv

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,9 +35,15 @@
 
 # SPIR-V in MLIR.
 /mlir/include/mlir/Dialect/SPIRV/ @antiagainst @kuhar
-/mlir/lib/Dialect/SPIRV/ @antiagainst @kuhar
+/mlir/include/mlir/Target/SPIRV/ @antiagainst @kuhar
 /mlir/include/mlir/Conversion/SPIRVTo*/ @antiagainst @kuhar
 /mlir/include/mlir/Conversion/*ToSPIRV/ @antiagainst @kuhar
+/mlir/lib/Dialect/SPIRV/ @antiagainst @kuhar
+/mlir/lib/Target/SPIRV/ @antiagainst @kuhar
 /mlir/lib/Conversion/SPIRVTo*/ @antiagainst @kuhar
 /mlir/lib/Conversion/*ToSPIRV/ @antiagainst @kuhar
+/mlir/test/Dialect/SPIRV/ @antiagainst @kuhar
+/mlir/test/Target/SPIRV/ @antiagainst @kuhar
+/mlir/test/lib/Dialect/SPIRV/ @antiagainst @kuhar
+/mlir/unittests/Dialect/SPIRV/ @antiagainst @kuhar
 /mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp @antiagainst @kuhar

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,3 +32,12 @@
 /clang/www/make_cxx_dr_status @Endilll
 
 /lldb/ @JDevlieghere
+
+# SPIR-V in MLIR.
+/mlir/include/mlir/Dialect/SPIRV/ @antiagainst @kuhar
+/mlir/lib/Dialect/SPIRV/ @antiagainst @kuhar
+/mlir/include/mlir/Conversion/SPIRVTo*/ @antiagainst @kuhar
+/mlir/include/mlir/Conversion/*ToSPIRV/ @antiagainst @kuhar
+/mlir/lib/Conversion/SPIRVTo*/ @antiagainst @kuhar
+/mlir/lib/Conversion/*ToSPIRV/ @antiagainst @kuhar
+/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp @antiagainst @kuhar


### PR DESCRIPTION
Add @antiagainst and @kuhar as codeowners for SPIR-V in MLIR. This is to assign reviewers automatically.

We already have a self-serve mechanism for subscribing to mlir/spirv issues (@llvm/pr-subscribers-mlir-spirv), but this codeowners change reflects a narrower set of core authors/maintainers for this part of the mlir.