### PR TITLE
[clang][AST] Invalidate DecompositionDecl if it has invalid initializer.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -765,6 +765,9 @@ Bug Fixes in This Version
   Fixes (`#77583 <https://github.com/llvm/llvm-project/issues/77583>`_)
 - Fix an issue where CTAD fails for function-type/array-type arguments.
   Fixes (`#51710 <https://github.com/llvm/llvm-project/issues/51710>`_)
+- Fix crashes when using the binding decl from an invalid structured binding.
+  Fixes (`#67495 <https://github.com/llvm/llvm-project/issues/67495>`_) and
+  (`#72198 <https://github.com/llvm/llvm-project/issues/72198>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13609,7 +13609,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
       //  2) if the var decl is decompsition decl with a non-deduced type, and
       //     the initialization fails (e.g. `int [a] = {1, 2};`);
       // Case 1) was already handled elsewhere.
-      if (llvm::isa<DecompositionDecl>(VDecl)) // Case 2)
+      if (isa<DecompositionDecl>(VDecl)) // Case 2)
         VDecl->setInvalidDecl();
       return;
     }

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13606,9 +13606,9 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
       // part in the valid bit of the declaration. There are a few exceptions:
       //  1) if the var decl has a deduced auto type, and the type cannot be
       //     deduced by an invalid initializer;
-      //  2) if the var decl is decompsition decl with a concrete type (e.g.
-      //    `int [a, b] = 1;`), and the initializer is invalid;
-      // Case 1) is already handled earlier in this function.
+      //  2) if the var decl is decompsition decl with a non-deduced type, and
+      //     the initialization fails (e.g. `int [a] = {1, 2};`);
+      // Case 1) was already handled elsewhere.
       if (llvm::isa<DecompositionDecl>(VDecl)) // Case 2)
         VDecl->setInvalidDecl();
       return;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13602,6 +13602,15 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
           CreateRecoveryExpr(Init->getBeginLoc(), Init->getEndLoc(), Args);
       if (RecoveryExpr.get())
         VDecl->setInit(RecoveryExpr.get());
+      // In general, for error recovery purposes, the initalizer doesn't play
+      // part in the valid bit of the declaration. There are a few exceptions:
+      //  1) if the var decl has a deduced auto type, and the type cannot be
+      //     deduced by an invalid initializer;
+      //  2) if the var decl is decompsition decl with a concrete type (e.g.
+      //    `int [a, b] = 1;`), and the initializer is invalid;
+      // Case 1) is already handled earlier in this function.
+      if (llvm::isa<DecompositionDecl>(VDecl)) // Case 2)
+        VDecl->setInvalidDecl();
       return;
     }
 

--- a/clang/test/AST/ast-dump-invalid-initialized.cpp
+++ b/clang/test/AST/ast-dump-invalid-initialized.cpp
@@ -25,3 +25,16 @@ void test() {
   // CHECK: `-VarDecl {{.*}} invalid b5 'auto'
   auto b5 = A{1};
 }
+
+void pr72198() {
+  // CHECK: DecompositionDecl {{.*}} invalid 'int'
+  int [_, b] = {0, 0};
+  [b]{};
+}
+
+int get_point();
+void pr67495() {
+  // CHECK: DecompositionDecl {{.*}} invalid 'int &'
+  auto& [x, y] = get_point();
+  [x, y] {};
+}

--- a/clang/test/AST/ast-dump-invalid-initialized.cpp
+++ b/clang/test/AST/ast-dump-invalid-initialized.cpp
@@ -26,15 +26,17 @@ void test() {
   auto b5 = A{1};
 }
 
-void pr72198() {
+void GH72198() {
   // CHECK: DecompositionDecl {{.*}} invalid 'int'
   int [_, b] = {0, 0};
   [b]{};
 }
 
+namespace GH67495 {
 int get_point();
-void pr67495() {
+void f() {
   // CHECK: DecompositionDecl {{.*}} invalid 'int &'
   auto& [x, y] = get_point();
   [x, y] {};
+}
 }


### PR DESCRIPTION
Fix #67495, #72198

We build ill-formed AST nodes for invalid structured binding. For case `int [_, b] = {0, 0};`, the `DecompositionDecl` is valid, and its children `BindingDecl`s are valid but with a NULL type, this breaks clang invariants in many places, and using these `BindingDecl`s can lead to crashes. This patch fixes them by marking the DecompositionDecl and its children invalid.

CC @ADKaster, @ecnelises