### PR TITLE
[MLIR] Add 'const' qualifier to some functions

### DIFF
--- a/mlir/include/mlir/IR/Value.h
+++ b/mlir/include/mlir/IR/Value.h
@@ -182,10 +182,10 @@ public:
   /// Replace all uses of 'this' value with 'newValue' if the given callback
   /// returns true.
   void replaceUsesWithIf(Value newValue,
-                         function_ref<bool(OpOperand &)> shouldReplace);
+                         function_ref<bool(OpOperand &)> shouldReplace) const;
 
   /// Returns true if the value is used outside of the given block.
-  bool isUsedOutsideOfBlock(Block *block);
+  bool isUsedOutsideOfBlock(Block *block) const;
 
   /// Shuffle the use list order according to the provided indices. It is
   /// responsibility of the caller to make sure that the indices map the current

--- a/mlir/lib/IR/Value.cpp
+++ b/mlir/lib/IR/Value.cpp
@@ -79,15 +79,15 @@ void Value::replaceAllUsesExcept(Value newValue,
 
 /// Replace all uses of 'this' value with 'newValue' if the given callback
 /// returns true.
-void Value::replaceUsesWithIf(Value newValue,
-                              function_ref<bool(OpOperand &)> shouldReplace) {
+void Value::replaceUsesWithIf(
+    Value newValue, function_ref<bool(OpOperand &)> shouldReplace) const {
   for (OpOperand &use : llvm::make_early_inc_range(getUses()))
     if (shouldReplace(use))
       use.set(newValue);
 }
 
 /// Returns true if the value is used outside of the given block.
-bool Value::isUsedOutsideOfBlock(Block *block) {
+bool Value::isUsedOutsideOfBlock(Block *block) const {
   return llvm::any_of(getUsers(), [block](Operation *user) {
     return user->getBlock() != block;
   });


### PR DESCRIPTION
Add '`const`' qualifier to `mlir::Value::isUsedOutsideOfBlock` and `mlir::Value::replaceUsesWithIf`.