### PR TITLE
[libc++] Fixes lit portability issues.

### DIFF
--- a/libcxx/test/lit.local.cfg
+++ b/libcxx/test/lit.local.cfg
@@ -29,13 +29,7 @@ def appendToSubstitution(substitutions, key, value):
     return [(k, v + " " + value) if k == key else (k, v) for (k, v) in substitutions]
 
 
-# External users of the LLVM test suite might not have set the substitutions.
-std = ""
-try:
-    std = getSubstitution("%{cxx_std}", config)
-except:
-    pass
-
+std = getSubstitution("%{cxx_std}", config)
 if std == "cxx26":
     std = "26"
 elif std == "cxx23":

--- a/libcxx/test/lit.local.cfg
+++ b/libcxx/test/lit.local.cfg
@@ -29,7 +29,13 @@ def appendToSubstitution(substitutions, key, value):
     return [(k, v + " " + value) if k == key else (k, v) for (k, v) in substitutions]
 
 
-std = getSubstitution("%{cxx_std}", config)
+# External users of the LLVM test suite might not have set the substitutions.
+std = ""
+try:
+    std = getSubstitution("%{cxx_std}", config)
+except:
+    pass
+
 if std == "cxx26":
     std = "26"
 elif std == "cxx23":

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -114,7 +114,7 @@ DEFAULT_PARAMETERS = [
         ),
         actions=lambda std: [
             AddFeature(std),
-            AddSubstitution("%{cxx_std}", re.sub("\+", "x", std)),
+            AddSubstitution("%{cxx_std}", re.sub(r"\+", "x", std)),
             AddCompileFlag(lambda cfg: getStdFlag(cfg, std)),
         ],
     ),
@@ -187,7 +187,7 @@ DEFAULT_PARAMETERS = [
                 AddFeature("stdlib={}".format(stdlib)),
                 # Also add an umbrella feature 'stdlib=libc++' for all flavors of libc++, to simplify
                 # the test suite.
-                AddFeature("stdlib=libc++") if re.match(".+-libc\+\+", stdlib) else None,
+                AddFeature("stdlib=libc++") if re.match(r".+-libc\+\+", stdlib) else None,
             ],
         ),
     ),


### PR DESCRIPTION
@StephanTLavavej mentioned the libc++ tests no longer works for MSVC STL. The regex changes have been provided by Stephan.