### PR TITLE
[ASan] Allow for passing AddressSanitizer command line options through the AddressSanitizerOptions struct.

### DIFF
--- a/llvm/include/llvm/Transforms/Instrumentation/AddressSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/AddressSanitizer.h
@@ -26,6 +26,9 @@ struct AddressSanitizerOptions {
   bool UseAfterScope = false;
   AsanDetectStackUseAfterReturnMode UseAfterReturn =
       AsanDetectStackUseAfterReturnMode::Runtime;
+  int InstrumentationWithCallsThreshold = 7000;
+  uint32_t MaxInlinePoisoningSize = 64;
+  bool InsertVersionCheck = true;
 };
 
 /// Public interface to the address sanitizer module pass for instrumenting code


### PR DESCRIPTION
This patch adds the ability to pass values for the command line options of -max-inline-poisoning-size, -instrumentation-with-calls-threshold and -asan-guard-against-version-mismatch through the AddressSanitizerOptions struct. The motivation is to use these new options when using the pass in Swift.

rdar://118470958