### PR TITLE
[CGSCCPassManagerTest] Replace no-op bitcast to create constant using the old function

### DIFF
--- a/llvm/unittests/Analysis/CGSCCPassManagerTest.cpp
+++ b/llvm/unittests/Analysis/CGSCCPassManagerTest.cpp
@@ -1631,7 +1631,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses8) {
           FnF->getEntryBlock().front().moveBefore(RI);
         ASSERT_NE(FnF, nullptr);
 
-        // Create an unsused constant that is referencing the old (=replaced)
+        // Create an unused constant that is referencing the old (=replaced)
         // function.
         ConstantExpr::getPtrToInt(FnF, Type::getInt64Ty(FnF->getContext()));
 

--- a/llvm/unittests/Analysis/CGSCCPassManagerTest.cpp
+++ b/llvm/unittests/Analysis/CGSCCPassManagerTest.cpp
@@ -1633,8 +1633,7 @@ TEST_F(CGSCCPassManagerTest, TestUpdateCGAndAnalysisManagerForPasses8) {
 
         // Create an unsused constant that is referencing the old (=replaced)
         // function.
-        ConstantExpr::getBitCast(FnF,
-                                 PointerType::getUnqual(FnF->getContext()));
+        ConstantExpr::getPtrToInt(FnF, Type::getInt64Ty(FnF->getContext()));
 
         // Use the CallGraphUpdater to update the call graph.
         CallGraphUpdater CGU;


### PR DESCRIPTION
With opaque pointers enabled, the existing ptr-to-ptr bitcast is a no-op and no longer creates a constant that references the old function.

Replace the no-op bitcast with code that creates a constant that references the old function. The test now fails if the 1 new line of code added to `CallGraphUpdater::replaceFunctionWith()` in cb0ecc5c33bd56a3eed0fa30ac787accec45d637 is removed (test passes if kept intact).