### PR TITLE
[2/2] support build sanitizer lit test case with libc++

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -182,6 +182,8 @@ else()
   set(cxxabi_supported ON)
 endif()
 
+option(SANITIZER_LIT_USE_LIBCXX "Build sanitizer lit test case with libc++" OFF)
+
 option(SANITIZER_ALLOW_CXXABI "Allow use of C++ ABI details in ubsan" ON)
 
 set(SANITIZER_CAN_USE_CXXABI OFF)
@@ -633,8 +635,10 @@ if (SANITIZER_TEST_CXX_LIBNAME STREQUAL "libc++")
     list(APPEND SANITIZER_TEST_CXX_CFLAGS "$<$<TARGET_EXISTS:cxx-headers>:$<IF:$<BOOL:${MSVC}>,/imsvc,-isystem>$<JOIN:$<TARGET_PROPERTY:cxx-headers,INTERFACE_INCLUDE_DIRECTORIES>,$<SEMICOLON>$<IF:$<BOOL:${MSVC}>,/imsvc,-isystem>>>")
     if (SANITIZER_USE_STATIC_TEST_CXX)
       list(APPEND SANITIZER_TEST_CXX_LIBRARIES "$<TARGET_LINKER_FILE:cxx_static>")
+      list(APPEND SANITIZER_TEST_CXX_LIBRARIES "$<TARGET_LINKER_FILE:cxxabi_static>")
     else()
       list(APPEND SANITIZER_TEST_CXX_LIBRARIES "$<TARGET_LINKER_FILE:$<IF:$<TARGET_EXISTS:cxx_shared>,cxx_shared,cxx_static>>")
+      list(APPEND SANITIZER_TEST_CXX_LIBRARIES "-L $<TARGET_LINKER_FILE_DIR:cxxabi_shared>")
     endif()
     # We are using the in tree libc++ so avoid including the default one.
     append_list_if(COMPILER_RT_HAS_NOSTDINCXX_FLAG -nostdinc++ COMPILER_RT_UNITTEST_CFLAGS)

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -17,7 +17,9 @@ pythonize_bool(ZLIB_FOUND)
 pythonize_bool(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
 
 pythonize_bool(COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER)
-
+if (SANITIZER_LIT_USE_LIBCXX)
+  set (LLVM_LIBCXX_USED 1)
+endif ()
 configure_compiler_rt_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.common.configured.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.common.configured)

--- a/compiler-rt/test/hwasan/lit.cfg.py
+++ b/compiler-rt/test/hwasan/lit.cfg.py
@@ -42,9 +42,15 @@ clang_hwasan_oldrt_cflags = clang_hwasan_common_cflags + [
     "-hwasan-instrument-personality-functions=0",
 ]
 
-clang_hwasan_cxxflags = config.cxx_mode_flags + clang_hwasan_cflags
-clang_hwasan_oldrt_cxxflags = config.cxx_mode_flags + clang_hwasan_oldrt_cflags
+if config.libcxx_used == "1":
+    extra_libcxx_flags = config.libcxx_flags
+else:
+    extra_libcxx_flags = []
 
+clang_hwasan_cxxflags = config.cxx_mode_flags + extra_libcxx_flags + clang_hwasan_cflags
+clang_hwasan_oldrt_cxxflags = (
+    config.cxx_mode_flags + extra_libcxx_flags + clang_hwasan_oldrt_cflags
+)
 
 def build_invocation(compile_flags):
     return " " + " ".join([config.clang] + compile_flags) + " "

--- a/compiler-rt/test/lit.common.configured.in
+++ b/compiler-rt/test/lit.common.configured.in
@@ -69,7 +69,9 @@ else:
 set_default("have_internal_symbolizer", @COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER_PYBOOL@)
 set_default("have_zlib", @ZLIB_FOUND_PYBOOL@)
 set_default("libcxx_used", "@LLVM_LIBCXX_USED@")
-
+set_default("libcxx_flags", ["-nostdinc++ -nostdlib++ " + \
+                            "-isystem @LLVM_BINARY_DIR@/include/c++/v1 -L @LLVM_BINARY_DIR@/lib@LLVM_LIBDIR_SUFFIX@ " + \
+                            "-Wl,-rpath,@LLVM_BINARY_DIR@/lib@LLVM_LIBDIR_SUFFIX@ -lc++"])
 # LLVM tools dir can be passed in lit parameters, so try to
 # apply substitution.
 config.llvm_tools_dir = lit_config.substitute(config.llvm_tools_dir)

--- a/compiler-rt/test/lsan/lit.common.cfg.py
+++ b/compiler-rt/test/lsan/lit.common.cfg.py
@@ -71,7 +71,13 @@ if lit.util.which("strace"):
 clang_cflags = ["-O0", config.target_cflags] + config.debug_info_flags
 if config.android:
     clang_cflags = clang_cflags + ["-fno-emulated-tls"]
-clang_cxxflags = config.cxx_mode_flags + clang_cflags
+
+if config.libcxx_used == "1":
+    extra_libcxx_flags = config.libcxx_flags
+else:
+    extra_libcxx_flags = []
+
+clang_cxxflags = config.cxx_mode_flags + extra_libcxx_flags + clang_cflags
 lsan_incdir = config.test_source_root + "/../"
 clang_lsan_cflags = clang_cflags + lsan_cflags + ["-I%s" % lsan_incdir]
 clang_lsan_cxxflags = clang_cxxflags + lsan_cflags + ["-I%s" % lsan_incdir]

--- a/compiler-rt/test/msan/lit.cfg.py
+++ b/compiler-rt/test/msan/lit.cfg.py
@@ -25,7 +25,13 @@ if config.host_os == "FreeBSD":
 # On SystemZ we need -mbackchain to make the fast unwinder work.
 if config.target_arch == "s390x":
     clang_msan_cflags.append("-mbackchain")
-clang_msan_cxxflags = config.cxx_mode_flags + clang_msan_cflags
+
+if config.libcxx_used == "1":
+    extra_libcxx_flags = config.libcxx_flags
+else:
+    extra_libcxx_flags = []
+
+clang_msan_cxxflags = config.cxx_mode_flags + extra_libcxx_flags + clang_msan_cflags
 
 # Flags for KMSAN invocation. This is C-only, we're not interested in C++.
 clang_kmsan_cflags = (

--- a/compiler-rt/test/ubsan/lit.common.cfg.py
+++ b/compiler-rt/test/ubsan/lit.common.cfg.py
@@ -61,9 +61,14 @@ def build_invocation(compile_flags):
     return " " + " ".join([config.clang] + compile_flags) + " "
 
 
+if config.libcxx_used == "1":
+    extra_libcxx_flags = config.libcxx_flags
+else:
+    extra_libcxx_flags = []
+
 target_cflags = [get_required_attr(config, "target_cflags")]
 clang_ubsan_cflags += target_cflags
-clang_ubsan_cxxflags = config.cxx_mode_flags + clang_ubsan_cflags
+clang_ubsan_cxxflags = config.cxx_mode_flags + extra_libcxx_flags + clang_ubsan_cflags
 
 # Define %clang and %clangxx substitutions to use in test RUN lines.
 config.substitutions.append(("%clang ", build_invocation(clang_ubsan_cflags)))

--- a/compiler-rt/test/ubsan_minimal/lit.common.cfg.py
+++ b/compiler-rt/test/ubsan_minimal/lit.common.cfg.py
@@ -23,9 +23,14 @@ def build_invocation(compile_flags):
     return " " + " ".join([config.clang] + compile_flags) + " "
 
 
+if config.libcxx_used == "1":
+    extra_libcxx_flags = config.libcxx_flags
+else:
+    extra_libcxx_flags = []
+
 target_cflags = [get_required_attr(config, "target_cflags")]
 clang_ubsan_cflags = ["-fsanitize-minimal-runtime"] + target_cflags
-clang_ubsan_cxxflags = config.cxx_mode_flags + clang_ubsan_cflags
+clang_ubsan_cxxflags = config.cxx_mode_flags + extra_libcxx_flags + clang_ubsan_cflags
 
 # Define %clang and %clangxx substitutions to use in test RUN lines.
 config.substitutions.append(("%clang ", build_invocation(clang_ubsan_cflags)))


### PR DESCRIPTION
fix https://github.com/llvm/llvm-project/issues/72200

this patch provide a solution for build sanitizer lit test case with libc++

we add an option `SANITIZER_LIT_USE_LIBCXX` to indicate whether to use libc++ to build lit test cases.

the libc++ is from the same LLVM repo, which means `-DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi"` is required.

the option `SANITIZER_LIT_USE_LIBCXX` works for all sanitizers (asan, hwasan, lsan, msan, ubsan) except for tsan.

the tsan has separate logic for handling libc++. It only uses the header files but does not link against the libc++ library.

https://github.com/llvm/llvm-project/blob/main/compiler-rt/test/tsan/lit.cfg.py#L62C1-L79C1


- enable `SANITIZER_LIT_USE_LIBCXX `

```
+ ldd runtimes/runtimes-bins/compiler-rt/test/asan/X86_64LinuxConfig/TestCases/Output/contiguous_container.cpp.tmp
	libc++.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++.so.1 (0x00007f559edea000)
	libc++abi.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++abi.so.1 (0x00007f559eda3000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/msan/X86_64/Linux/Output/b64.cpp.tmp
	libc++.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++.so.1 (0x00007fd1929d3000)
	libc++abi.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++abi.so.1 (0x00007fd19298c000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/lsan/X86_64AsanConfig/TestCases/Linux/Output/leak_check_segv.cpp.tmp
	libc++.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++.so.1 (0x00007f1e622a7000)
	libc++abi.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++abi.so.1 (0x00007f1e62260000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/hwasan/X86_64/TestCases/Output/allocator_returns_null.cpp.tmp
	libc++.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++.so.1 (0x00007f7ad0e0b000)
	libc++abi.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++abi.so.1 (0x00007f7ad0dc4000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/tsan/X86_64Config/Linux/Output/epoll_norace.cpp.tmp
+ ldd runtimes/runtimes-bins/compiler-rt/test/ubsan/Standalone-x86_64/TestCases/Float/Output/cast-overflow.cpp.tmp
	libc++.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++.so.1 (0x00007f7ed997d000)
	libc++abi.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++abi.so.1 (0x00007f7ed9936000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/ubsan_minimal/x86_64/TestCases/Output/uadd-overflow.cpp.tmp
	libc++.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++.so.1 (0x00007fa98fd98000)
	libc++abi.so.1 => /llvm/build_compiler_rt_test_with_libcxx/lib64/libc++abi.so.1 (0x00007fa98fd51000)
```

- disable `SANITIZER_LIT_USE_LIBCXX `

```
+ ldd runtimes/runtimes-bins/compiler-rt/test/asan/X86_64LinuxConfig/TestCases/Output/contiguous_container.cpp.tmp
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f7de83ae000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/msan/X86_64/Linux/Output/b64.cpp.tmp
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fd758bc1000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/lsan/X86_64AsanConfig/TestCases/Linux/Output/leak_check_segv.cpp.tmp
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f8b9e688000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/hwasan/X86_64/TestCases/Output/allocator_returns_null.cpp.tmp
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007efc12746000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/tsan/X86_64Config/Linux/Output/epoll_norace.cpp.tmp
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fc4646e8000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/ubsan/Standalone-x86_64/TestCases/Float/Output/cast-overflow.cpp.tmp
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f6907c20000)
+ ldd runtimes/runtimes-bins/compiler-rt/test/ubsan_minimal/x86_64/TestCases/Output/uadd-overflow.cpp.tmp
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fa30c740000)
```