### PR TITLE
[GitHub] Compress mlir/spirv patterns in CODEOWNERS. NFCI.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,16 +34,7 @@
 /lldb/ @JDevlieghere
 
 # SPIR-V in MLIR.
-/mlir/include/mlir/Dialect/SPIRV/ @antiagainst @kuhar
-/mlir/include/mlir/Target/SPIRV/ @antiagainst @kuhar
-/mlir/include/mlir/Conversion/SPIRVTo*/ @antiagainst @kuhar
-/mlir/include/mlir/Conversion/*ToSPIRV/ @antiagainst @kuhar
-/mlir/lib/Dialect/SPIRV/ @antiagainst @kuhar
-/mlir/lib/Target/SPIRV/ @antiagainst @kuhar
-/mlir/lib/Conversion/SPIRVTo*/ @antiagainst @kuhar
-/mlir/lib/Conversion/*ToSPIRV/ @antiagainst @kuhar
-/mlir/test/Dialect/SPIRV/ @antiagainst @kuhar
-/mlir/test/Target/SPIRV/ @antiagainst @kuhar
-/mlir/test/lib/Dialect/SPIRV/ @antiagainst @kuhar
-/mlir/unittests/Dialect/SPIRV/ @antiagainst @kuhar
+/mlir/**/SPIRV/ @antiagainst @kuhar
+/mlir/**/SPIRVTo*/ @antiagainst @kuhar
+/mlir/**/*ToSPIRV/ @antiagainst @kuhar
 /mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp @antiagainst @kuhar


### PR DESCRIPTION
Suggested by @joker-eph in
https://github.com/llvm/llvm-project/pull/72412#discussion_r1395210901.