### PR TITLE
Use LLVM_DEFAULT_TARGET_TRIPLE to find target libs

### DIFF
--- a/cmake/Modules/HandleCompilerRT.cmake
+++ b/cmake/Modules/HandleCompilerRT.cmake
@@ -61,6 +61,8 @@ function(find_compiler_rt_library name variable)
   set(target "${ARG_TARGET}")
   if(NOT target AND CMAKE_CXX_COMPILER_TARGET)
     set(target "${CMAKE_CXX_COMPILER_TARGET}")
+  elseif(LLVM_DEFAULT_TARGET_TRIPLE)
+    set(target "${LLVM_DEFAULT_TARGET_TRIPLE}")
   endif()
   if(NOT DEFINED COMPILER_RT_LIBRARY_builtins_${target})
     # If the cache variable is not defined, invoke Clang and then


### PR DESCRIPTION
find_compiler_rt_library uses CMAKE_CXX_COMPILER_TARGET to find target triple in case it is not supplied as an argument. However in some situations CMAKE_CXX_COMPILER_TARGET may not be set and this patch allows usage of LLVM_DEFAULT_TARGET_TRIPLE for finding compiler rt libs.