### PR TITLE
Simplify `(a % b) lt/ge (b-1)` into `(a % b) eq/ne (b-1)`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -2519,6 +2519,30 @@ Instruction *InstCombinerImpl::foldICmpShrConstant(ICmpInst &Cmp,
 Instruction *InstCombinerImpl::foldICmpSRemConstant(ICmpInst &Cmp,
                                                     BinaryOperator *SRem,
                                                     const APInt &C) {
+  {
+    const APInt *C1;
+    ICmpInst::Predicate Pred = Cmp.getPredicate();
+    if ((match(SRem->getOperand(1), m_NonNegative(C1))) &&
+        ((Pred == ICmpInst::ICMP_SLT && C == *C1 - 1) ||
+         (Pred == ICmpInst::ICMP_SGT && C == *C1 - 2) ||
+         (Pred == ICmpInst::ICMP_SGT && C == -*C1 + 1) ||
+         (Pred == ICmpInst::ICMP_SLT && C == -*C1 + 2))) {
+      // icmp slt (X s% C), (C - 1) --> icmp ne (X s% C), (C - 1), if C >= 0
+      // icmp sgt (X s% C), (C - 2) --> icmp eq (X s% C), (C - 1), if C >= 0
+      // icmp sgt (X s% C), (-C + 1) --> icmp ne (X s% C), (-C + 1), if C >= 0
+      // icmp slt (X s% C), (-C + 2) --> icmp eq (X s% C), (-C + 1), if C >= 0
+      return new ICmpInst(
+          ((Pred == ICmpInst::ICMP_SLT && C == *C1 - 1) ||
+           (Pred == ICmpInst::ICMP_SGT && C == -*C1 + 1))
+              ? ICmpInst::ICMP_NE
+              : ICmpInst::ICMP_EQ,
+          SRem,
+          ConstantInt::get(SRem->getType(), C == -*C1 + 1 || C == -*C1 + 2
+                                                ? -*C1 + 1
+                                                : *C1 - 1));
+    }
+  }
+
   // Match an 'is positive' or 'is negative' comparison of remainder by a
   // constant power-of-2 value:
   // (X % pow2C) sgt/slt 0
@@ -2564,6 +2588,23 @@ Instruction *InstCombinerImpl::foldICmpSRemConstant(ICmpInst &Cmp,
   // bit is set. Example:
   // (i16 X % 4) s< 0 --> (X & 32771) u> 32768
   return new ICmpInst(ICmpInst::ICMP_UGT, And, ConstantInt::get(Ty, SignMask));
+}
+
+Instruction *InstCombinerImpl::foldICmpURemConstant(ICmpInst &Cmp,
+                                                    BinaryOperator *URem,
+                                                    const APInt &C) {
+  const APInt *C1;
+  ICmpInst::Predicate Pred = Cmp.getPredicate();
+  if (match(URem->getOperand(1), m_APInt(C1)) &&
+      ((Pred == ICmpInst::ICMP_ULT && C == *C1 - 1) ||
+       (Pred == ICmpInst::ICMP_UGT && C == *C1 - 2 && C.ugt(1)))) {
+    // icmp ult (X u% C), (C - 1) --> icmp ne (X u% C), (C - 1)
+    // icmp ugt (X u% C), (C - 2) --> icmp eq (X u% C), (C - 1), if C >u 1
+    return new ICmpInst(Pred == ICmpInst::ICMP_UGT ? ICmpInst::ICMP_EQ
+                                                   : ICmpInst::ICMP_NE,
+                        URem, ConstantInt::get(URem->getType(), *C1 - 1));
+  }
+  return nullptr;
 }
 
 /// Fold icmp (udiv X, Y), C.
@@ -3701,6 +3742,10 @@ Instruction *InstCombinerImpl::foldICmpBinOpWithConstant(ICmpInst &Cmp,
     break;
   case Instruction::SRem:
     if (Instruction *I = foldICmpSRemConstant(Cmp, BO, C))
+      return I;
+    break;
+  case Instruction::URem:
+    if (Instruction *I = foldICmpURemConstant(Cmp, BO, C))
       return I;
     break;
   case Instruction::UDiv:

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -663,6 +663,8 @@ public:
                                    const APInt &C);
   Instruction *foldICmpSRemConstant(ICmpInst &Cmp, BinaryOperator *UDiv,
                                     const APInt &C);
+  Instruction *foldICmpURemConstant(ICmpInst &Cmp, BinaryOperator *UDiv,
+                                    const APInt &C);
   Instruction *foldICmpUDivConstant(ICmpInst &Cmp, BinaryOperator *UDiv,
                                     const APInt &C);
   Instruction *foldICmpDivConstant(ICmpInst &Cmp, BinaryOperator *Div,

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -10,6 +10,311 @@ declare void @use_i8(i8)
 declare void @use_i32(i32)
 declare void @use_i64(i64)
 
+; tests for (x % c) >=/ < (c - 1), where c >= 0
+define i1 @srem_sgt_test1(i64 %x) {
+; CHECK-LABEL: @srem_sgt_test1(
+; CHECK-NEXT:    [[Y:%.*]] = srem i64 [[X:%.*]], 34360750831
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i64 [[Y]], 34360750829
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i64 %x, 34360750831
+  %cmp = icmp sgt i64 %y, 34360750829
+  ret i1 %cmp
+}
+
+define i1 @srem_slt_test1(i64 %x) {
+; CHECK-LABEL: @srem_slt_test1(
+; CHECK-NEXT:    [[Y:%.*]] = srem i64 [[X:%.*]], 34360750831
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i64 [[Y]], 34360750830
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i64 %x, 34360750831
+  %cmp = icmp slt i64 %y, 34360750830
+  ret i1 %cmp
+}
+
+define i1 @srem_sgt_test2(i32 %x) {
+; CHECK-LABEL: @srem_sgt_test2(
+; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[X:%.*]], 1074977277
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[Y]], 1074977275
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i32 %x, 1074977277
+  %cmp = icmp sgt i32 %y, 1074977275
+  ret i1 %cmp
+}
+
+define i1 @srem_slt_test2(i32 %x) {
+; CHECK-LABEL: @srem_slt_test2(
+; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[X:%.*]], 1074977277
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[Y]], 1074977276
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i32 %x, 1074977277
+  %cmp = icmp slt i32 %y, 1074977276
+  ret i1 %cmp
+}
+
+define i1 @srem_sgt_test3(i16 %x) {
+; CHECK-LABEL: @srem_sgt_test3(
+; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i16 [[Y]], 2257
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i16 %x, 2259
+  %cmp = icmp sgt i16 %y, 2257
+  ret i1 %cmp
+}
+
+define i1 @srem_slt_test3(i16 %x) {
+; CHECK-LABEL: @srem_slt_test3(
+; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i16 [[Y]], 2258
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i16 %x, 2259
+  %cmp = icmp slt i16 %y, 2258
+  ret i1 %cmp
+}
+
+define i1 @srem_sgt_test4(i8 %x) {
+; CHECK-LABEL: @srem_sgt_test4(
+; CHECK-NEXT:    [[Y:%.*]] = srem i8 [[X:%.*]], 50
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[Y]], 48
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i8 %x, 50
+  %cmp = icmp sgt i8 %y, 48
+  ret i1 %cmp
+}
+
+define i1 @srem_slt_test4(i8 %x) {
+; CHECK-LABEL: @srem_slt_test4(
+; CHECK-NEXT:    [[Y:%.*]] = srem i8 [[X:%.*]], 50
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[Y]], 49
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i8 %x, 50
+  %cmp = icmp slt i8 %y, 49
+  ret i1 %cmp
+}
+
+define i1 @test_srem_slt_constant(i32 %a) {
+; CHECK-LABEL: @test_srem_slt_constant(
+; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[A:%.*]], 512
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[Y]], 511
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i32 %a, 512
+  %cmp = icmp slt i32 %y, 511
+  ret i1 %cmp
+}
+
+define i1 @test_srem_sgt_constant(i32 %a) {
+; CHECK-LABEL: @test_srem_sgt_constant(
+; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[A:%.*]], 512
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[Y]], 510
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i32 %a, 512
+  %cmp = icmp sgt i32 %y, 510
+  ret i1 %cmp
+}
+
+define <2 x i1> @test_srem_slt_constant_splat(<2 x i32> %a) {
+; CHECK-LABEL: @test_srem_slt_constant_splat(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt <2 x i32> [[Y]], <i32 511, i32 511>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 512, i32 512>
+  %cmp = icmp slt <2 x i32> %y, <i32 511, i32 511>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @test_srem_sgt_constant_splat(<2 x i32> %a) {
+; CHECK-LABEL: @test_srem_sgt_constant_splat(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <2 x i32> [[Y]], <i32 510, i32 510>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 512, i32 512>
+  %cmp = icmp sgt <2 x i32> %y, <i32 510, i32 510>
+  ret <2 x i1> %cmp
+}
+
+; tests for (x % c) <=/> (c + 1), where y < 0
+define i1 @srem_sgt_test(i16 %x) {
+; CHECK-LABEL: @srem_sgt_test(
+; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i16 [[Y]], -2258
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i16 %x, -2259
+  %cmp = icmp sgt i16 %y, -2258
+  ret i1 %cmp
+}
+
+define i1 @srem_sle_test(i16 %x) {
+; CHECK-LABEL: @srem_sle_test(
+; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i16 [[Y]], -2257
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i16 %x, -2259
+  %cmp = icmp slt i16 %y, -2257
+  ret i1 %cmp
+}
+
+define <2 x i1> @test_srem_sgt_constant_splat_neg(<2 x i32> %a) {
+; CHECK-LABEL: @test_srem_sgt_constant_splat_neg(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <2 x i32> [[Y]], <i32 -511, i32 -511>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 -512, i32 -512>
+  %cmp = icmp sgt <2 x i32> %y, <i32 -511, i32 -511>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @test_srem_slt_constant_splat_neg(<2 x i32> %a) {
+; CHECK-LABEL: @test_srem_slt_constant_splat_neg(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt <2 x i32> [[Y]], <i32 -510, i32 -510>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 -512, i32 -512>
+  %cmp = icmp slt <2 x i32> %y, <i32 -510, i32 -510>
+  ret <2 x i1> %cmp
+}
+
+; tests for handling urem w/ slt/sge/uge/ult
+define i1 @test_urem_slt(i32 %x) {
+; CHECK-LABEL: @test_urem_slt(
+; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 12235
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[Y]], 12234
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = urem i32 %x, 12235
+  %cmp = icmp slt i32 %y, 12234
+  ret i1 %cmp
+}
+
+define i1 @test_urem_sge(i32 %x) {
+; CHECK-LABEL: @test_urem_sge(
+; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 13546
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[Y]], 13544
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = urem i32 %x, 13546
+  %cmp = icmp sge i32 %y, 13545
+  ret i1 %cmp
+}
+
+define i1 @test_urem_uge(i32 %x) {
+; CHECK-LABEL: @test_urem_uge(
+; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 18642
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[Y]], 18640
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = urem i32 %x, 18642
+  %cmp = icmp ugt i32 %y, 18640
+  ret i1 %cmp
+}
+
+define i1 @test_urem_ult(i32 %x) {
+; CHECK-LABEL: @test_urem_ult(
+; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 15344
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[Y]], 15343
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = urem i32 %x, 15344
+  %cmp = icmp ult i32 %y, 15343
+  ret i1 %cmp
+}
+
+define <2 x i1> @test_urem_slt_constant_splat(<2 x i32> %a) {
+; CHECK-LABEL: @test_urem_slt_constant_splat(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt <2 x i32> [[Y]], <i32 511, i32 511>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 512, i32 512>
+  %cmp = icmp slt <2 x i32> %y, <i32 511, i32 511>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @test_urem_sgt_constant_splat(<2 x i32> %a) {
+; CHECK-LABEL: @test_urem_sgt_constant_splat(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <2 x i32> [[Y]], <i32 510, i32 510>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 512, i32 512>
+  %cmp = icmp sgt <2 x i32> %y, <i32 510, i32 510>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @test_urem_ugt_constant_splat(<2 x i32> %a) {
+; CHECK-LABEL: @test_urem_ugt_constant_splat(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt <2 x i32> [[Y]], <i32 510, i32 510>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 512, i32 512>
+  %cmp = icmp ugt <2 x i32> %y, <i32 510, i32 510>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @test_urem_ult_constant_splat(<2 x i32> %a) {
+; CHECK-LABEL: @test_urem_ult_constant_splat(
+; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x i32> [[Y]], <i32 511, i32 511>
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %y = srem <2 x i32> %a, <i32 512, i32 512>
+  %cmp = icmp ult <2 x i32> %y, <i32 511, i32 511>
+  ret <2 x i1> %cmp
+}
+
+; negative tests
+define i1 @srem_slt_neg_test(i8 %x, i8 %C) {
+; CHECK-LABEL: @srem_slt_neg_test(
+; CHECK-NEXT:    [[CMINUS1:%.*]] = add i8 [[C:%.*]], -1
+; CHECK-NEXT:    [[Y:%.*]] = srem i8 [[X:%.*]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[Y]], [[CMINUS1]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %Cminus1 = add i8 %C, -1
+  %y = srem i8 %x, %C
+  %cmp = icmp slt i8 %y, %Cminus1
+  ret i1 %cmp
+}
+
+define i1 @srem_sge_neg_test(i8 %x, i8 %C) {
+; CHECK-LABEL: @srem_sge_neg_test(
+; CHECK-NEXT:    [[CMINUS1:%.*]] = add i8 [[C:%.*]], -1
+; CHECK-NEXT:    [[Y:%.*]] = srem i8 [[X:%.*]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i8 [[Y]], [[CMINUS1]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %Cminus1 = add i8 %C, -1
+  %y = srem i8 %x, %C
+  %cmp = icmp sge i8 %y, %Cminus1
+  ret i1 %cmp
+}
+
+; negative tests for urem
+; if C <= 1 in ugt
+define i1 @test_neg_ult_1(i32 %x) {
+; CHECK-LABEL: @test_neg_ult_1(
+; CHECK-NEXT:    ret i1 true
+;
+  %y = urem i32 %x, 1
+  %cmp = icmp ult i32 %y, -1
+  ret i1 %cmp
+}
+
 define i32 @test1(i32 %X) {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:    [[X_LOBIT:%.*]] = lshr i32 [[X:%.*]], 31
@@ -18,6 +323,50 @@ define i32 @test1(i32 %X) {
   %a = icmp slt i32 %X, 0
   %b = zext i1 %a to i32
   ret i32 %b
+}
+
+; negative tests off by one
+define i1 @test_urem_ult_neg(i32 %x) {
+; CHECK-LABEL: @test_urem_ult_neg(
+; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 15344
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[Y]], 15342
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = urem i32 %x, 15344
+  %cmp = icmp ult i32 %y, 15342
+  ret i1 %cmp
+}
+
+define i1 @srem_slt_neg(i64 %x) {
+; CHECK-LABEL: @srem_slt_neg(
+; CHECK-NEXT:    [[Y:%.*]] = srem i64 [[X:%.*]], 34360750831
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i64 [[Y]], 34360750829
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i64 %x, 34360750831
+  %cmp = icmp slt i64 %y, 34360750829
+  ret i1 %cmp
+}
+
+define i1 @srem_sgt_neg(i32 %x) {
+; CHECK-LABEL: @srem_sgt_neg(
+; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[X:%.*]], 1074977277
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[Y]], 1074977274
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %y = srem i32 %x, 1074977277
+  %cmp = icmp sgt i32 %y, 1074977274
+  ret i1 %cmp
+}
+
+
+define i1 @srem_sle_neg_neg(i16 %x) {
+; CHECK-LABEL: @srem_sle_neg_neg(
+; CHECK-NEXT:    ret i1 false
+;
+  %y = srem i16 %x, -2259
+  %cmp = icmp slt i16 %y, -2258
+  ret i1 %cmp
 }
 
 define <2 x i32> @test1vec(<2 x i32> %X) {

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -14,7 +14,7 @@ declare void @use_i64(i64)
 define i1 @srem_sgt_test1(i64 %x) {
 ; CHECK-LABEL: @srem_sgt_test1(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i64 [[X:%.*]], 34360750831
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i64 [[Y]], 34360750829
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[Y]], 34360750830
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i64 %x, 34360750831
@@ -25,7 +25,7 @@ define i1 @srem_sgt_test1(i64 %x) {
 define i1 @srem_slt_test1(i64 %x) {
 ; CHECK-LABEL: @srem_slt_test1(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i64 [[X:%.*]], 34360750831
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i64 [[Y]], 34360750830
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[Y]], 34360750830
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i64 %x, 34360750831
@@ -36,7 +36,7 @@ define i1 @srem_slt_test1(i64 %x) {
 define i1 @srem_sgt_test2(i32 %x) {
 ; CHECK-LABEL: @srem_sgt_test2(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[X:%.*]], 1074977277
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[Y]], 1074977275
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[Y]], 1074977276
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i32 %x, 1074977277
@@ -47,7 +47,7 @@ define i1 @srem_sgt_test2(i32 %x) {
 define i1 @srem_slt_test2(i32 %x) {
 ; CHECK-LABEL: @srem_slt_test2(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[X:%.*]], 1074977277
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[Y]], 1074977276
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[Y]], 1074977276
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i32 %x, 1074977277
@@ -58,7 +58,7 @@ define i1 @srem_slt_test2(i32 %x) {
 define i1 @srem_sgt_test3(i16 %x) {
 ; CHECK-LABEL: @srem_sgt_test3(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i16 [[Y]], 2257
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[Y]], 2258
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i16 %x, 2259
@@ -69,7 +69,7 @@ define i1 @srem_sgt_test3(i16 %x) {
 define i1 @srem_slt_test3(i16 %x) {
 ; CHECK-LABEL: @srem_slt_test3(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i16 [[Y]], 2258
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 [[Y]], 2258
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i16 %x, 2259
@@ -80,7 +80,7 @@ define i1 @srem_slt_test3(i16 %x) {
 define i1 @srem_sgt_test4(i8 %x) {
 ; CHECK-LABEL: @srem_sgt_test4(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i8 [[X:%.*]], 50
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[Y]], 48
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i8 [[Y]], 49
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i8 %x, 50
@@ -91,7 +91,7 @@ define i1 @srem_sgt_test4(i8 %x) {
 define i1 @srem_slt_test4(i8 %x) {
 ; CHECK-LABEL: @srem_slt_test4(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i8 [[X:%.*]], 50
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i8 [[Y]], 49
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i8 [[Y]], 49
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i8 %x, 50
@@ -101,8 +101,8 @@ define i1 @srem_slt_test4(i8 %x) {
 
 define i1 @test_srem_slt_constant(i32 %a) {
 ; CHECK-LABEL: @test_srem_slt_constant(
-; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[A:%.*]], 512
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[Y]], 511
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[A:%.*]], -2147483137
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[TMP1]], 511
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i32 %a, 512
@@ -112,8 +112,8 @@ define i1 @test_srem_slt_constant(i32 %a) {
 
 define i1 @test_srem_sgt_constant(i32 %a) {
 ; CHECK-LABEL: @test_srem_sgt_constant(
-; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[A:%.*]], 512
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[Y]], 510
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[A:%.*]], -2147483137
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[TMP1]], 511
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i32 %a, 512
@@ -123,8 +123,8 @@ define i1 @test_srem_sgt_constant(i32 %a) {
 
 define <2 x i1> @test_srem_slt_constant_splat(<2 x i32> %a) {
 ; CHECK-LABEL: @test_srem_slt_constant_splat(
-; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt <2 x i32> [[Y]], <i32 511, i32 511>
+; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[A:%.*]], <i32 -2147483137, i32 -2147483137>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i32> [[TMP1]], <i32 511, i32 511>
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %y = srem <2 x i32> %a, <i32 512, i32 512>
@@ -134,8 +134,8 @@ define <2 x i1> @test_srem_slt_constant_splat(<2 x i32> %a) {
 
 define <2 x i1> @test_srem_sgt_constant_splat(<2 x i32> %a) {
 ; CHECK-LABEL: @test_srem_sgt_constant_splat(
-; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <2 x i32> [[Y]], <i32 510, i32 510>
+; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[A:%.*]], <i32 -2147483137, i32 -2147483137>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i32> [[TMP1]], <i32 511, i32 511>
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %y = srem <2 x i32> %a, <i32 512, i32 512>
@@ -147,7 +147,7 @@ define <2 x i1> @test_srem_sgt_constant_splat(<2 x i32> %a) {
 define i1 @srem_sgt_test(i16 %x) {
 ; CHECK-LABEL: @srem_sgt_test(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i16 [[Y]], -2258
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 [[Y]], -2258
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i16 %x, -2259
@@ -158,7 +158,7 @@ define i1 @srem_sgt_test(i16 %x) {
 define i1 @srem_sle_test(i16 %x) {
 ; CHECK-LABEL: @srem_sle_test(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i16 [[X:%.*]], 2259
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i16 [[Y]], -2257
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[Y]], -2258
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = srem i16 %x, -2259
@@ -169,7 +169,7 @@ define i1 @srem_sle_test(i16 %x) {
 define <2 x i1> @test_srem_sgt_constant_splat_neg(<2 x i32> %a) {
 ; CHECK-LABEL: @test_srem_sgt_constant_splat_neg(
 ; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <2 x i32> [[Y]], <i32 -511, i32 -511>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i32> [[Y]], <i32 -511, i32 -511>
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %y = srem <2 x i32> %a, <i32 -512, i32 -512>
@@ -180,7 +180,7 @@ define <2 x i1> @test_srem_sgt_constant_splat_neg(<2 x i32> %a) {
 define <2 x i1> @test_srem_slt_constant_splat_neg(<2 x i32> %a) {
 ; CHECK-LABEL: @test_srem_slt_constant_splat_neg(
 ; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt <2 x i32> [[Y]], <i32 -510, i32 -510>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i32> [[Y]], <i32 -511, i32 -511>
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %y = srem <2 x i32> %a, <i32 -512, i32 -512>
@@ -192,7 +192,7 @@ define <2 x i1> @test_srem_slt_constant_splat_neg(<2 x i32> %a) {
 define i1 @test_urem_slt(i32 %x) {
 ; CHECK-LABEL: @test_urem_slt(
 ; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 12235
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[Y]], 12234
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[Y]], 12234
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = urem i32 %x, 12235
@@ -203,7 +203,7 @@ define i1 @test_urem_slt(i32 %x) {
 define i1 @test_urem_sge(i32 %x) {
 ; CHECK-LABEL: @test_urem_sge(
 ; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 13546
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[Y]], 13544
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[Y]], 13545
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = urem i32 %x, 13546
@@ -214,7 +214,7 @@ define i1 @test_urem_sge(i32 %x) {
 define i1 @test_urem_uge(i32 %x) {
 ; CHECK-LABEL: @test_urem_uge(
 ; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 18642
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[Y]], 18640
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[Y]], 18641
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = urem i32 %x, 18642
@@ -225,7 +225,7 @@ define i1 @test_urem_uge(i32 %x) {
 define i1 @test_urem_ult(i32 %x) {
 ; CHECK-LABEL: @test_urem_ult(
 ; CHECK-NEXT:    [[Y:%.*]] = urem i32 [[X:%.*]], 15344
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[Y]], 15343
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[Y]], 15343
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %y = urem i32 %x, 15344
@@ -235,8 +235,8 @@ define i1 @test_urem_ult(i32 %x) {
 
 define <2 x i1> @test_urem_slt_constant_splat(<2 x i32> %a) {
 ; CHECK-LABEL: @test_urem_slt_constant_splat(
-; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt <2 x i32> [[Y]], <i32 511, i32 511>
+; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[A:%.*]], <i32 -2147483137, i32 -2147483137>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <2 x i32> [[TMP1]], <i32 511, i32 511>
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %y = srem <2 x i32> %a, <i32 512, i32 512>
@@ -246,8 +246,8 @@ define <2 x i1> @test_urem_slt_constant_splat(<2 x i32> %a) {
 
 define <2 x i1> @test_urem_sgt_constant_splat(<2 x i32> %a) {
 ; CHECK-LABEL: @test_urem_sgt_constant_splat(
-; CHECK-NEXT:    [[Y:%.*]] = srem <2 x i32> [[A:%.*]], <i32 512, i32 512>
-; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt <2 x i32> [[Y]], <i32 510, i32 510>
+; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[A:%.*]], <i32 -2147483137, i32 -2147483137>
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i32> [[TMP1]], <i32 511, i32 511>
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
   %y = srem <2 x i32> %a, <i32 512, i32 512>


### PR DESCRIPTION
- [InstCombine] Add test coverage for (a % b) lt/le/ge/gt (b(-/+)1) (NFC).
- [InstCombine] Fold (a (s/u)% b) (s/u)(le/ge/lt/gt) (b (-/+) 1)
Alive2: https://alive2.llvm.org/ce/z/i7zYtE
Fixes: https://github.com/llvm/llvm-project/issues/71280
