### PR TITLE
fix python syntax warnings from check-all output

### DIFF
--- a/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
+++ b/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py
@@ -25,7 +25,7 @@ class Generator(object):
 
     def GeneratePrologue(self):
 
-        self.implementationContent += """
+        self.implementationContent += r"""
 /*===- Generated file -------------------------------------------*- C++ -*-===*\
 |*                                                                            *|
 |* Introspection of available AST node SourceLocations                        *|

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -797,7 +797,7 @@ for postfix in ["2", "1", ""]:
         config.substitutions.append(
             (
                 "%ld_flags_rpath_exe" + postfix,
-                "-Wl,-z,origin -Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec"
+                r"-Wl,-z,origin -Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec"
                 + postfix,
             )
         )
@@ -806,7 +806,7 @@ for postfix in ["2", "1", ""]:
         config.substitutions.append(
             (
                 "%ld_flags_rpath_exe" + postfix,
-                "-Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
+                r"-Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
             )
         )
         config.substitutions.append(("%ld_flags_rpath_so" + postfix, ""))
@@ -814,7 +814,7 @@ for postfix in ["2", "1", ""]:
         config.substitutions.append(
             (
                 "%ld_flags_rpath_exe" + postfix,
-                "-Wl,-R\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
+                r"-Wl,-R\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
             )
         )
         config.substitutions.append(("%ld_flags_rpath_so" + postfix, ""))

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -61,7 +61,7 @@ def _parseLitOutput(fullOutput):
     injecting additional Lit output around it.
     """
     parsed = ''
-    for output in re.split('[$]\s*":"\s*"RUN: at line \d+"', fullOutput):
+    for output in re.split(r'[$]\s*":"\s*"RUN: at line \d+"', fullOutput):
         if output: # skip blank lines
             commandOutput = re.search("# command output:\n(.+)\n$", output, flags=re.DOTALL)
             if commandOutput:

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -118,7 +118,7 @@ DEFAULT_PARAMETERS = [
         ),
         actions=lambda std: [
             AddFeature(std),
-            AddSubstitution("%{cxx_std}", re.sub("\+", "x", std)),
+            AddSubstitution("%{cxx_std}", re.sub(r"\+", "x", std)),
             AddCompileFlag(lambda cfg: getStdFlag(cfg, std)),
         ],
     ),
@@ -211,7 +211,7 @@ DEFAULT_PARAMETERS = [
                 AddFeature("stdlib={}".format(stdlib)),
                 # Also add an umbrella feature 'stdlib=libc++' for all flavors of libc++, to simplify
                 # the test suite.
-                AddFeature("stdlib=libc++") if re.match(".+-libc\+\+", stdlib) else None,
+                AddFeature("stdlib=libc++") if re.match(r".+-libc\+\+", stdlib) else None,
             ],
         ),
     ),

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -272,7 +272,7 @@ def ptxas_version(ptxas):
     ptxas_cmd = subprocess.Popen([ptxas, "--version"], stdout=subprocess.PIPE)
     ptxas_out = ptxas_cmd.stdout.read().decode("ascii")
     ptxas_cmd.wait()
-    match = re.search("release (\d+)\.(\d+)", ptxas_out)
+    match = re.search(r"release (\d+)\.(\d+)", ptxas_out)
     if match:
         return (int(match.group(1)), int(match.group(2)))
     print("couldn't determine ptxas version")

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -202,7 +202,7 @@ def expand_glob_expressions(args, cwd):
 
 
 def quote_windows_command(seq):
-    """
+    r"""
     Reimplement Python's private subprocess.list2cmdline for MSys compatibility
 
     Based on CPython implementation here:
@@ -1558,7 +1558,7 @@ def applySubstitutions(script, substitutions, conditions={}, recursion_limit=Non
             return cond, ln
 
         def tryParseElse(ln):
-            match = _caching_re_compile("^\s*%else\s*(%{)?").search(ln)
+            match = _caching_re_compile(r"^\s*%else\s*(%{)?").search(ln)
             if not match:
                 return False, ln
             if not match.group(1):


### PR DESCRIPTION
eliminate python SyntaxWarnings from check-all output. Such as:

```
src_dir/clang/lib/Tooling/DumpTool/generate_cxx_src_locs.py:28: SyntaxWarning: invalid escape sequence '\*'    self.implementationContent += """
src_dir/llvm/utils/lit/lit/TestRunner.py:205: SyntaxWarning: invalid escape sequence '\c'                      """
src_dir/llvm/utils/lit/lit/TestRunner.py:1561: SyntaxWarning: invalid escape sequence '\s'                     match = _caching_re_compile("^\s*%else\s*(%{)?").search(ln)
src_dir/libcxx/utils/libcxx/test/format.py:64: SyntaxWarning: invalid escape sequence '\s'                     for output in re.split('[$]\s*":"\s*"RUN: at line \d+"', fullOutput):
src_dir/libcxx/utils/libcxx/test/params.py:121: SyntaxWarning: invalid escape sequence '\+'                    AddSubstitution("%{cxx_std}", re.sub("\+", "x", std)),
src_dir/libcxx/utils/libcxx/test/params.py:214: SyntaxWarning: invalid escape sequence '\+'                    AddFeature("stdlib=libc++") if re.match(".+-libc\+\+", stdlib) else None,
src_dir/compiler-rt/test/lit.common.cfg.py:800: SyntaxWarning: invalid escape sequence '\$'                    "-Wl,-z,origin -Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec"
src_dir/compiler-rt/test/lit.common.cfg.py:809: SyntaxWarning: invalid escape sequence '\$'                    "-Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
src_dir/compiler-rt/test/lit.common.cfg.py:817: SyntaxWarning: invalid escape sequence '\$'                    "-Wl,-R\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
src_dir/llvm/test/lit.cfg.py:275: SyntaxWarning: invalid escape sequence '\d'                                  match = re.search("release (\d+)\.(\d+)", ptxas_out)
```