### PR TITLE
[Statepoint] Return undef value for the statepoint of the none token

### DIFF
--- a/llvm/lib/IR/IntrinsicInst.cpp
+++ b/llvm/lib/IR/IntrinsicInst.cpp
@@ -870,6 +870,11 @@ const Value *GCProjectionInst::getStatepoint() const {
   if (isa<UndefValue>(Token))
     return Token;
 
+  // Treat none token as if it was undef here
+  if (isa<ConstantTokenNone>(Token)) {
+    return UndefValue::get(Token->getType());
+  }
+
   // This takes care both of relocates for call statepoints and relocates
   // on normal path of invoke statepoint.
   if (!isa<LandingPadInst>(Token))

--- a/llvm/lib/IR/IntrinsicInst.cpp
+++ b/llvm/lib/IR/IntrinsicInst.cpp
@@ -871,9 +871,8 @@ const Value *GCProjectionInst::getStatepoint() const {
     return Token;
 
   // Treat none token as if it was undef here
-  if (isa<ConstantTokenNone>(Token)) {
+  if (isa<ConstantTokenNone>(Token))
     return UndefValue::get(Token->getType());
-  }
 
   // This takes care both of relocates for call statepoints and relocates
   // on normal path of invoke statepoint.

--- a/llvm/test/Verifier/gc_none_token.ll
+++ b/llvm/test/Verifier/gc_none_token.ll
@@ -1,0 +1,18 @@
+; RUN: not opt -passes=verify -S %s 2>&1 | FileCheck %s
+; Check that verifier doesn't crash on relocate with none token
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @check_verify_none_token() gc "statepoint-example" {
+
+entry:
+    ret i32 0
+
+unreach:
+    ; CHECK: gc relocate is incorrectly tied to the statepoint
+    ; CHECK: (undef, undef)
+    %token_call = call i32 addrspace(1)* @llvm.experimental.gc.relocate.p1i32(token none, i32 0, i32 0)
+    ret i32 1
+}
+
+declare i32 addrspace(1)* @llvm.experimental.gc.relocate.p1i32(token, i32, i32)


### PR DESCRIPTION
Helps avoid the crash in verifier when it tries to print the error. `none` token might be produced by llvm-reduce, since it's a default value, so by extension this also fixes llvm-reduce crash, allowing it to just discard invalid IR.

We might special-case tokens in ReduceArguments and to use some other value, other than `getDefaultValue` (or change the `getDefaultValue` to use something other than `getNullValue` for token), but it still wouldn't fix the fact that verifier would crash trying to print an error message if it ever encounters such relocation.
I wasn't able to come up with any potential issues with handling `none` token as if it was `undef`, but it doesn't mean that there isn't any =)