### PR TITLE
[clang-tidy][NFC][DOC] Add missing HICPP rule id's

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-c-arrays.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-c-arrays.rst
@@ -8,3 +8,4 @@ hicpp-avoid-c-arrays
 The hicpp-avoid-c-arrays check is an alias, please see
 :doc:`modernize-avoid-c-arrays <../modernize/avoid-c-arrays>`
 for more information.
+It partly enforces the `rule 4.1.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-conversions>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
@@ -6,6 +6,6 @@ hicpp-avoid-goto
 ================
 
 The `hicpp-avoid-goto` check is an alias, please see
-:doc:`cppcoreguidelines-avoid-goto <../cppcoreguidelines/avoid-goto>`.
+:doc:`cppcoreguidelines-avoid-goto <../cppcoreguidelines/avoid-goto>`
 for more information.
 It enforces the `rule 6.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
@@ -5,10 +5,7 @@
 hicpp-avoid-goto
 ================
 
-The `hicpp-avoid-goto` check is an alias to
+The `hicpp-avoid-goto` check is an alias, please see
 :doc:`cppcoreguidelines-avoid-goto <../cppcoreguidelines/avoid-goto>`.
-Rule `6.3.1 High Integrity C++ <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_
-requires that ``goto`` only skips parts of a block and is not used for other
-reasons.
-
-Both coding guidelines implement the same exception to the usage of ``goto``.
+for more information.
+It enforces the `rule 6.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-assembler.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-assembler.rst
@@ -1,10 +1,10 @@
 .. title:: clang-tidy - hicpp-no-assembler
 
 hicpp-no-assembler
-===================
+==================
 
-Check for assembler statements. No fix is offered.
+Checks for assembler statements. Use of inline assembly should be avoided since
+it restricts the portability of the code.
 
-Inline assembler is forbidden by the `High Integrity C++ Coding Standard
-<https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations>`_
-as it restricts the portability of code.
+This enforces `rule 7.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations>`_
+of the High Integrity C++ Coding Standard.


### PR DESCRIPTION
Add HICPP rule identities to the documentation for `hicpp-avoid-c-arrays` and `hicpp-no-assembler`.

Includes an update of `hicpp-avoid-goto` to look like other aliased checks.

References:
* avoid-c-arrays 
  Commit: 2634bd599567842385e11d1fd70f5486c166f935