### PR TITLE
Add llvm-dlltool to the toolchain list

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1307,6 +1307,7 @@ if(NOT LLVM_TOOLCHAIN_TOOLS)
     llvm-ar
     llvm-cov
     llvm-cxxfilt
+    llvm-dlltool
     llvm-dwp
     llvm-ranlib
     llvm-lib


### PR DESCRIPTION
This adds dlltool to the list of tools which don't get excluded from installation when LLVM_INSTALL_TOOLCHAIN_ONLY is set.

The most important effect here is that this tool will now be included in the official Windows release.

While llvm-lib reuses the dlltool machinary internally and has many of the same capabilities, it does not expose the functionality controller by the '-k' flag, which is currently the only way to create import libraries for i386 with stdcall symbols from a module definition alone.

We avoid changing llvm-lib tool, since it is designed to emulate LIB.EXE from MSVC toolchain, and as this functionality is not supported there, we would have had to introduce an LLVM extension flag in order to support it.

See https://reviews.llvm.org/D36548 for reference on rationale for dlltool '-k' flag.