### PR TITLE
[ClangModule] Fix decl-params-determinisim test after serialization change

### DIFF
--- a/clang/test/Modules/decl-params-determinisim.m
+++ b/clang/test/Modules/decl-params-determinisim.m
@@ -19,7 +19,7 @@
 // RUN: diff %t1.pcm %t2.pcm
 
 /// Spot check entries to make sure they are in current ordering.
-/// op13 encodes the anonymous decl number which should be in order.
+/// op6 encodes the anonymous decl number which should be in order.
 
 /// NOTE: This test case is on determinism of TypeID for function declaration.
 /// Change related to TypeID (or PredefinedTypeIDs) will affect the result and

--- a/clang/test/Modules/decl-params-determinisim.m
+++ b/clang/test/Modules/decl-params-determinisim.m
@@ -23,27 +23,28 @@
 
 /// NOTE: This test case is on determinism of TypeID for function declaration.
 /// Change related to TypeID (or PredefinedTypeIDs) will affect the result and
-/// will require update for this test case.
+/// will require update for this test case. Currently, TypeID is at op6 and the
+/// test checks the IDs are in strict ordering.
 
 // CHECK: <TYPE_FUNCTION_PROTO
 // CHECK-NEXT: <DECL_PARM_VAR
-// CHECK-SAME: op11=4040
+// CHECK-SAME: op6=2
 // CHECK-NEXT: <DECL_PARM_VAR
-// CHECK-SAME: op11=4048
+// CHECK-SAME: op6=3
 // CHECK-NEXT: <DECL_PARM_VAR
-// CHECK-SAME: op11=4056
+// CHECK-SAME: op6=4
 // CHECK-NEXT: <DECL_PARM_VAR
-// CHECK-SAME: op11=4064
+// CHECK-SAME: op6=5
 
 /// Decl records start at 43
 // CHECK: <DECL_RECORD
-// CHECK-SAME: op9=4368
+// CHECK-SAME: op6=43
 // CHECK-NEXT: <DECL_RECORD
-// CHECK-SAME: op9=4376
+// CHECK-SAME: op6=44
 // CHECK-NEXT: <DECL_RECORD
-// CHECK-SAME: op9=4384
+// CHECK-SAME: op6=45
 // CHECK-NEXT: <DECL_RECORD
-// CHECK-SAME: op9=4392
+// CHECK-SAME: op6=46
 
 //--- headers/a.h
 void f(struct A0 *a0,


### PR DESCRIPTION
Fix decl-params-determinisim test after 48be81e1 packed some information in the clang module. The test is to make sure the decls are appearing in a strict ordering and it relies on check the correct field in the bitcode format.

Add more explanation in the comments to help future updates when serialization format affects this test.