### PR TITLE
workflows/release-binaries: Do a preliminary build to fill ccache

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -57,17 +57,52 @@ jobs:
         fi
         bash .github/workflows/set-release-binary-outputs.sh "${{ github.actor }}" "$tag" "$upload"
 
+  # Try to get around the 6 hour timeout by first running a job to fill
+  # the build cache.
+  fill-cache:
+    name: "Fill Cache ${{ matrix.os }}"
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-22.04
+    steps:
+    - name: Checkout LLVM
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag || github.ref_name }}
+
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@main
+
+    - name: Setup sccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        max-size: 250M
+        key: sccache-${{ matrix.os }}-release
+        variant: sccache
+
+    - name: Build Clang
+      run: |
+        cmake -G Ninja  -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_ENABLE_ASSERTIONS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DLLVM_ENABLE_PROJECTS=clang -S llvm -B build
+        ninja -v -C build
+
+
   build-binaries:
     name: ${{ matrix.target.triple }}
     permissions:
       contents: write # To upload assets to release.
-    needs: prepare
+    needs:
+      - prepare
+      - fill-cache
     runs-on: ${{ matrix.target.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         target:
           - triple: x86_64-linux-gnu-ubuntu-22.04
+            os: ubuntu-22.04
             runs-on: ubuntu-22.04-16x64
             debian-build-deps: >
               chrpath
@@ -80,6 +115,14 @@ jobs:
       with:
         ref: ${{ needs.prepare.outputs.ref }}
         path: ${{ needs.prepare.outputs.build-dir }}/llvm-project
+
+    - name: Setup sccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        max-size: 250M
+        key: sccache-${{ matrix.target.os }}-release
+        save: false
+        variant: sccache
 
     - name: Install Brew build dependencies
       if: matrix.target.brew-build-deps != ''
@@ -102,7 +145,8 @@ jobs:
         -triple ${{ matrix.target.triple }} \
         -use-ninja \
         -no-checkout \
-        -no-test-suite
+        -no-test-suite \
+        -configure-flags "-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
 
     - name: Upload binaries
       if: ${{ always() && needs.prepare.outputs.upload == 'true' }}


### PR DESCRIPTION
Build clang with the host compiler and ccache enabled in order to speed up the phase 1 builds.  This helps reduce the amount of time spent running on the non-free builders.