### PR TITLE
Add --copyExecutable and --ignoreNegativeCache to dsymForUUID invoke

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -356,7 +356,10 @@ class CrashLog(symbolication.Symbolicator):
             # Keep track of unresolved source paths.
             unavailable_source_paths = set()
             if os.path.exists(self.dsymForUUIDBinary):
-                dsym_for_uuid_command = "%s %s" % (self.dsymForUUIDBinary, uuid_str)
+                dsym_for_uuid_command = (
+                    "%s --copyExecutable --ignoreNegativeCache %s"
+                    % (self.dsymForUUIDBinary, uuid_str)
+                )
                 s = subprocess.check_output(dsym_for_uuid_command, shell=True)
                 if s:
                     try:


### PR DESCRIPTION
On macOS lldb normally goes through the DebugSymbols framework to find dSYMs -- by spotlight search on the local computer, or specially laid out directories, or possibly calling a program which can download the dSYM and/or executable to the local computer and return paths to those in a plist (xml).  For certain special debug scenarios, we have an additional mechanism where we force a download if we have a local utility, instead of making the user enable expensive downloads for all binaries in all debug sessions.

This is all done in SymbolLocatorDebugSymbols::DownloadObjectAndSymbolFile where we invoke this dsymForUUID utility with --copyExecutable and --ignoreNegativeCache.  This patch updates crashlog.py to invoke this utility the same way if it is available.

rdar://118480731 