### PR TITLE
[libc++] Refactor the creation of the global and classic locales

### DIFF
--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -127,6 +127,9 @@ private:
     class __imp;
     __imp* __locale_;
 
+    template <class> friend struct no_destroy;
+    _LIBCPP_HIDE_FROM_ABI explicit locale(__imp* __loc) : __locale_(__loc) {}
+
     void __install_ctor(const locale&, facet*, long);
     static locale& __global();
     bool has_facet(id&) const;

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -128,7 +128,8 @@ private:
     __imp* __locale_;
 
     template <class> friend struct no_destroy;
-    _LIBCPP_HIDE_FROM_ABI explicit locale(__imp* __loc) : __locale_(__loc) {}
+    struct __private_tag { };
+    _LIBCPP_HIDE_FROM_ABI explicit locale(__private_tag, __imp* __loc) : __locale_(__loc) {}
 
     void __install_ctor(const locale&, facet*, long);
     static locale& __global();

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -127,7 +127,7 @@ private:
     class __imp;
     __imp* __locale_;
 
-    template <class> friend struct no_destroy;
+    template <class> friend struct __no_destroy;
     struct __private_tag { };
     _LIBCPP_HIDE_FROM_ABI explicit locale(__private_tag, __imp* __loc) : __locale_(__loc) {}
 

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -555,7 +555,7 @@ struct no_destroy {
 };
 
 const locale& locale::classic() {
-    static const no_destroy<locale> c(&make<__imp>(1u));
+    static const no_destroy<locale> c(__private_tag{}, &make<__imp>(1u));
     return c.get();
 }
 

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <__utility/unreachable.h>
 #include <algorithm>
 #include <clocale>
 #include <codecvt>
@@ -15,9 +14,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <locale>
+#include <new>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
@@ -154,8 +155,6 @@ public:
         {return static_cast<size_t>(id) < facets_.size() && facets_[static_cast<size_t>(id)];}
     const locale::facet* use_facet(long id) const;
 
-    static const locale& make_classic();
-    static       locale& make_global();
 private:
     void install(facet* f, long id);
     template <class F> void install(F* f) {install(f, f->id.__get());}
@@ -538,37 +537,31 @@ locale::__imp::use_facet(long id) const
 
 // locale
 
-const locale&
-locale::__imp::make_classic()
-{
-    // only one thread can get in here and it only gets in once
-    alignas(locale) static std::byte buf[sizeof(locale)];
-    locale* c = reinterpret_cast<locale*>(&buf);
-    c->__locale_ = &make<__imp>(1u);
-    return *c;
+// This class basically implements __attribute__((no_destroy)), which isn't supported
+// by GCC as of writing this.
+template <class T>
+struct no_destroy {
+    template <class... Args>
+    explicit no_destroy(Args&&... args) {
+        T* obj = reinterpret_cast<T*>(&buf);
+        new (obj) T(std::forward<Args>(args)...);
+    }
+
+    T& get() { return *reinterpret_cast<T*>(&buf); }
+    T const& get() const { return *reinterpret_cast<T const*>(&buf); }
+
+  private:
+    alignas(T) byte buf[sizeof(T)];
+};
+
+const locale& locale::classic() {
+    static const no_destroy<locale> c(&make<__imp>(1u));
+    return c.get();
 }
 
-const locale&
-locale::classic()
-{
-    static const locale& c = __imp::make_classic();
-    return c;
-}
-
-locale&
-locale::__imp::make_global()
-{
-    // only one thread can get in here and it only gets in once
-    alignas(locale) static std::byte buf[sizeof(locale)];
-    auto *obj = ::new (&buf) locale(locale::classic());
-    return *obj;
-}
-
-locale&
-locale::__global()
-{
-    static locale& g = __imp::make_global();
-    return g;
+locale& locale::__global() {
+    static no_destroy<locale> g(locale::classic());
+    return g.get();
 }
 
 locale::locale() noexcept

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -540,9 +540,9 @@ locale::__imp::use_facet(long id) const
 // This class basically implements __attribute__((no_destroy)), which isn't supported
 // by GCC as of writing this.
 template <class T>
-struct no_destroy {
+struct __no_destroy {
     template <class... Args>
-    explicit no_destroy(Args&&... args) {
+    explicit __no_destroy(Args&&... args) {
         T* obj = reinterpret_cast<T*>(&buf);
         new (obj) T(std::forward<Args>(args)...);
     }
@@ -555,12 +555,12 @@ struct no_destroy {
 };
 
 const locale& locale::classic() {
-    static const no_destroy<locale> c(__private_tag{}, &make<__imp>(1u));
+    static const __no_destroy<locale> c(__private_tag{}, &make<__imp>(1u));
     return c.get();
 }
 
 locale& locale::__global() {
-    static no_destroy<locale> g(locale::classic());
+    static __no_destroy<locale> g(locale::classic());
     return g.get();
 }
 

--- a/libcxx/test/std/localization/locales/locale/locale.cons/char_pointer.pass.cpp
+++ b/libcxx/test/std/localization/locales/locale/locale.cons/char_pointer.pass.cpp
@@ -81,21 +81,25 @@ int main(int, char**)
         assert(!(loc == loc3));
         assert(loc != loc3);
 #ifndef TEST_HAS_NO_EXCEPTIONS
-        try
-        {
+        try {
             std::locale((const char*)0);
             assert(false);
+        } catch (std::runtime_error&) {
+            // pass
         }
-        catch (std::runtime_error&)
-        {
+
+        try {
+            std::locale(nullptr);
+            assert(false);
+        } catch (std::runtime_error&) {
+            // pass
         }
-        try
-        {
+
+        try {
             std::locale("spazbot");
             assert(false);
-        }
-        catch (std::runtime_error&)
-        {
+        } catch (std::runtime_error&) {
+            // pass
         }
 #endif
         std::locale ok("");


### PR DESCRIPTION
The creation of the global and the classic locales was pretty twisty. This patch refactors how this is done to reduce the amount of indirections and prepare the terrain for a future where GCC implements the no_destroy attribute.