### PR TITLE
[IR] Add disjoint flag for Or instructions.

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -10016,7 +10016,7 @@ The truth table used for the '``or``' instruction is:
 ``disjoint`` means every bit is known to be zero in at least one of the inputs.
 This allows the Or to be treated as an Add since no carry can occur from any
 bit. If the disjoint keyword is present, the result value of the ``or`` is a
-:ref:`poison value <poisonvalues>` if both inputs have a one in any bit
+:ref:`poison value <poisonvalues>` if both inputs have a one in the same bit
 position. For vectors, only the element containing the bit is poison.
 
 Example:

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -9981,6 +9981,7 @@ Syntax:
 ::
 
       <result> = or <ty> <op1>, <op2>   ; yields ty:result
+      <result> = or disjoint <ty> <op1>, <op2>   ; yields ty:result
 
 Overview:
 """""""""
@@ -10011,6 +10012,12 @@ The truth table used for the '``or``' instruction is:
 +-----+-----+-----+
 |   1 |   1 |   1 |
 +-----+-----+-----+
+
+``disjoint`` means every bit is known to be zero in at least one of the inputs.
+This allows the Or to be treated as an Add since no carry can occur from any
+bit. If the disjoint keyword is present, the result value of the ``or`` is a
+:ref:`poison value <poisonvalues>` if both inputs have a one in any bit
+position. For vectors, only the element containing the bit is poison.
 
 Example:
 """"""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -10013,11 +10013,11 @@ The truth table used for the '``or``' instruction is:
 |   1 |   1 |   1 |
 +-----+-----+-----+
 
-``disjoint`` means for each bit, that bit is known to be zero in at least one of
-the inputs. This allows the Or to be treated as an Add since no carry can occur
-from any bit. If the disjoint keyword is present, the result value of the ``or``
-is a :ref:`poison value <poisonvalues>` if both inputs have a one in the same
-bit position. For vectors, only the element containing the bit is poison.
+``disjoint`` means for each bit, that bit is zero in at least one of the inputs.
+This allows the Or to be treated as an Add since no carry can occur from any
+bit. If the disjoint keyword is present, the result value of the ``or`` is a
+:ref:`poison value <poisonvalues>` if both inputs have a one in the same bit
+position. For vectors, only the element containing the bit is poison.
 
 Example:
 """"""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -10013,9 +10013,9 @@ The truth table used for the '``or``' instruction is:
 |   1 |   1 |   1 |
 +-----+-----+-----+
 
-``disjoint`` means for each bit, that bit is zero in at least one of the inputs.
-This allows the Or to be treated as an Add since no carry can occur from any
-bit. If the disjoint keyword is present, the result value of the ``or`` is a
+``disjoint`` means that for each bit, that bit is zero in at least one of the
+inputs. This allows the Or to be treated as an Add since no carry can occur from
+any bit. If the disjoint keyword is present, the result value of the ``or`` is a
 :ref:`poison value <poisonvalues>` if both inputs have a one in the same bit
 position. For vectors, only the element containing the bit is poison.
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -10013,11 +10013,11 @@ The truth table used for the '``or``' instruction is:
 |   1 |   1 |   1 |
 +-----+-----+-----+
 
-``disjoint`` means every bit is known to be zero in at least one of the inputs.
-This allows the Or to be treated as an Add since no carry can occur from any
-bit. If the disjoint keyword is present, the result value of the ``or`` is a
-:ref:`poison value <poisonvalues>` if both inputs have a one in the same bit
-position. For vectors, only the element containing the bit is poison.
+``disjoint`` means for each bit, that bit is known to be zero in at least one of
+the inputs. This allows the Or to be treated as an Add since no carry can occur
+from any bit. If the disjoint keyword is present, the result value of the ``or``
+is a :ref:`poison value <poisonvalues>` if both inputs have a one in the same
+bit position. For vectors, only the element containing the bit is poison.
 
 Example:
 """"""""

--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -109,6 +109,7 @@ enum Kind {
   kw_nuw,
   kw_nsw,
   kw_exact,
+  kw_disjoint,
   kw_inbounds,
   kw_nneg,
   kw_inrange,

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -512,6 +512,10 @@ enum PossiblyNonNegInstOptionalFlags { PNNI_NON_NEG = 0 };
 /// PossiblyExactOperator's SubclassOptionalData contents.
 enum PossiblyExactOperatorOptionalFlags { PEO_EXACT = 0 };
 
+/// PossiblyDisjointInstOptionalFlags - Flags for serializing
+/// PossiblyDisjointInst's SubclassOptionalData contents.
+enum PossiblyDisjointInstOptionalFlags { PDI_DISJOINT = 0 };
+
 /// Encoded AtomicOrdering values.
 enum AtomicOrderingCodes {
   ORDERING_NOTATOMIC = 0,

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1101,7 +1101,7 @@ private:
   }
 };
 
-// FIXME: these are redundant if CmpInst < ninaryOperator
+// FIXME: these are redundant if CmpInst < BinaryOperator
 template <>
 struct OperandTraits<CmpInst> : public FixedNumOperandTraits<CmpInst, 2> {
 };

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -415,6 +415,22 @@ struct OperandTraits<BinaryOperator> :
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(BinaryOperator, Value)
 
+/// A or instruction, which can be marked as "disjoint", indicating that the
+/// inputs don't have a 1 in the same bit position. Meaning this instruction
+/// can also be treated as an add.
+class PossiblyDisjointInst : public BinaryOperator {
+public:
+  enum { IsDisjoint = (1 << 0) };
+
+  static bool classof(const Instruction *I) {
+    return I->getOpcode() == Instruction::Or;
+  }
+
+  static bool classof(const Value *V) {
+    return isa<Instruction>(V) && classof(cast<Instruction>(V));
+  }
+};
+
 //===----------------------------------------------------------------------===//
 //                               CastInst Class
 //===----------------------------------------------------------------------===//
@@ -1085,7 +1101,7 @@ private:
   }
 };
 
-// FIXME: these are redundant if CmpInst < BinaryOperator
+// FIXME: these are redundant if CmpInst < ninaryOperator
 template <>
 struct OperandTraits<CmpInst> : public FixedNumOperandTraits<CmpInst, 2> {
 };

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -422,15 +422,11 @@ class PossiblyDisjointInst : public BinaryOperator {
 public:
   enum { IsDisjoint = (1 << 0) };
 
-private:
-  friend class Instruction;
-
   void setIsDisjoint(bool B) {
     SubclassOptionalData =
         (SubclassOptionalData & ~IsDisjoint) | (B * IsDisjoint);
   }
 
-public:
   bool isDisjoint() const { return SubclassOptionalData & IsDisjoint; }
 
   static bool classof(const Instruction *I) {

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -415,7 +415,7 @@ struct OperandTraits<BinaryOperator> :
 
 DEFINE_TRANSPARENT_OPERAND_ACCESSORS(BinaryOperator, Value)
 
-/// A or instruction, which can be marked as "disjoint", indicating that the
+/// An or instruction, which can be marked as "disjoint", indicating that the
 /// inputs don't have a 1 in the same bit position. Meaning this instruction
 /// can also be treated as an add.
 class PossiblyDisjointInst : public BinaryOperator {

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -422,6 +422,17 @@ class PossiblyDisjointInst : public BinaryOperator {
 public:
   enum { IsDisjoint = (1 << 0) };
 
+private:
+  friend class Instruction;
+
+  void setIsDisjoint(bool B) {
+    SubclassOptionalData =
+        (SubclassOptionalData & ~IsDisjoint) | (B * IsDisjoint);
+  }
+
+public:
+  bool isDisjoint() const { return SubclassOptionalData & IsDisjoint; }
+
   static bool classof(const Instruction *I) {
     return I->getOpcode() == Instruction::Or;
   }

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -448,6 +448,11 @@ public:
   /// which supports this flag. See LangRef.html for the meaning of this flag.
   void setIsExact(bool b = true);
 
+  /// Set or clear the disjoint flag on this instruction, which must be an
+  /// operator which supports this flag. See LangRef.html for the meaning of
+  /// this flag.
+  void setIsDisjoint(bool b = true);
+
   /// Set or clear the nneg flag on this instruction, which must be a zext
   /// instruction.
   void setNonNeg(bool b = true);
@@ -499,6 +504,9 @@ public:
 
   /// Determine whether the exact flag is set.
   bool isExact() const LLVM_READONLY;
+
+  /// Determine whether the disjoint flag is set.
+  bool isDisjoint() const LLVM_READONLY;
 
   /// Set or clear all fast-math-flags on this instruction, which must be an
   /// operator which supports this flag. See LangRef.html for the meaning of

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -448,11 +448,6 @@ public:
   /// which supports this flag. See LangRef.html for the meaning of this flag.
   void setIsExact(bool b = true);
 
-  /// Set or clear the disjoint flag on this instruction, which must be an
-  /// operator which supports this flag. See LangRef.html for the meaning of
-  /// this flag.
-  void setIsDisjoint(bool b = true);
-
   /// Set or clear the nneg flag on this instruction, which must be a zext
   /// instruction.
   void setNonNeg(bool b = true);
@@ -504,9 +499,6 @@ public:
 
   /// Determine whether the exact flag is set.
   bool isExact() const LLVM_READONLY;
-
-  /// Determine whether the disjoint flag is set.
-  bool isDisjoint() const LLVM_READONLY;
 
   /// Set or clear all fast-math-flags on this instruction, which must be an
   /// operator which supports this flag. See LangRef.html for the meaning of

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -564,6 +564,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(nuw);
   KEYWORD(nsw);
   KEYWORD(exact);
+  KEYWORD(disjoint);
   KEYWORD(inbounds);
   KEYWORD(nneg);
   KEYWORD(inrange);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6372,7 +6372,8 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
     bool Disjoint = EatIfPresent(lltok::kw_disjoint);
     if (parseLogical(Inst, PFS, KeywordVal))
       return true;
-    if (Disjoint) cast<PossiblyDisjointInst>(Inst)->setIsDisjoint(true);
+    if (Disjoint)
+      cast<PossiblyDisjointInst>(Inst)->setIsDisjoint(true);
     return false;
   }
   case lltok::kw_and:

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6368,8 +6368,14 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
   case lltok::kw_srem:
     return parseArithmetic(Inst, PFS, KeywordVal,
                            /*IsFP*/ false);
+  case lltok::kw_or: {
+    bool Disjoint = EatIfPresent(lltok::kw_disjoint);
+    if (parseLogical(Inst, PFS, KeywordVal))
+      return true;
+    if (Disjoint) cast<PossiblyDisjointInst>(Inst)->setIsDisjoint(true);
+    return false;
+  }
   case lltok::kw_and:
-  case lltok::kw_or:
   case lltok::kw_xor:
     return parseLogical(Inst, PFS, KeywordVal);
   case lltok::kw_icmp:

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6373,7 +6373,7 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
     if (parseLogical(Inst, PFS, KeywordVal))
       return true;
     if (Disjoint)
-      cast<BinaryOperator>(Inst)->setIsDisjoint(true);
+      cast<PossiblyDisjointInst>(Inst)->setIsDisjoint(true);
     return false;
   }
   case lltok::kw_and:

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6373,7 +6373,7 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
     if (parseLogical(Inst, PFS, KeywordVal))
       return true;
     if (Disjoint)
-      cast<PossiblyDisjointInst>(Inst)->setIsDisjoint(true);
+      cast<BinaryOperator>(Inst)->setIsDisjoint(true);
     return false;
   }
   case lltok::kw_and:

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4878,7 +4878,6 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
           if (FMF.any())
             I->setFastMathFlags(FMF);
         }
-
       }
       break;
     }

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4870,6 +4870,9 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
                    Opc == Instruction::AShr) {
           if (Record[OpNum] & (1 << bitc::PEO_EXACT))
             cast<BinaryOperator>(I)->setIsExact(true);
+        } else if (Opc == Instruction::Or) {
+          if (Record[OpNum] & (1 << bitc::PDI_DISJOINT))
+            cast<BinaryOperator>(I)->setIsDisjoint(true);
         } else if (isa<FPMathOperator>(I)) {
           FastMathFlags FMF = getDecodedFastMathFlags(Record[OpNum]);
           if (FMF.any())

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4872,7 +4872,7 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
             cast<BinaryOperator>(I)->setIsExact(true);
         } else if (Opc == Instruction::Or) {
           if (Record[OpNum] & (1 << bitc::PDI_DISJOINT))
-            cast<BinaryOperator>(I)->setIsDisjoint(true);
+            cast<PossiblyDisjointInst>(I)->setIsDisjoint(true);
         } else if (isa<FPMathOperator>(I)) {
           FastMathFlags FMF = getDecodedFastMathFlags(Record[OpNum]);
           if (FMF.any())

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1541,6 +1541,9 @@ static uint64_t getOptimizationFlags(const Value *V) {
   } else if (const auto *PEO = dyn_cast<PossiblyExactOperator>(V)) {
     if (PEO->isExact())
       Flags |= 1 << bitc::PEO_EXACT;
+  } else if (const auto *PDI = dyn_cast<PossiblyDisjointInst>(V)) {
+    if (PDI->isDisjoint())
+      Flags |= 1 << bitc::PDI_DISJOINT;
   } else if (const auto *FPMO = dyn_cast<FPMathOperator>(V)) {
     if (FPMO->hasAllowReassoc())
       Flags |= bitc::AllowReassoc;

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1355,6 +1355,10 @@ static void WriteOptimizationInfo(raw_ostream &Out, const User *U) {
                dyn_cast<PossiblyExactOperator>(U)) {
     if (Div->isExact())
       Out << " exact";
+  } else if (const PossiblyDisjointInst *PDI =
+               dyn_cast<PossiblyDisjointInst>(U)) {
+    if (PDI->isDisjoint())
+      Out << " disjoint";
   } else if (const GEPOperator *GEP = dyn_cast<GEPOperator>(U)) {
     if (GEP->isInBounds())
       Out << " inbounds";

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1356,7 +1356,7 @@ static void WriteOptimizationInfo(raw_ostream &Out, const User *U) {
     if (Div->isExact())
       Out << " exact";
   } else if (const PossiblyDisjointInst *PDI =
-               dyn_cast<PossiblyDisjointInst>(U)) {
+                 dyn_cast<PossiblyDisjointInst>(U)) {
     if (PDI->isDisjoint())
       Out << " disjoint";
   } else if (const GEPOperator *GEP = dyn_cast<GEPOperator>(U)) {

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -319,8 +319,9 @@ void Instruction::setIsExact(bool b) {
 
 void Instruction::setIsDisjoint(bool b) {
   assert(isa<PossiblyDisjointInst>(this) && "Must be or");
-  SubclassOptionalData = (SubclassOptionalData & ~PossiblyDisjointInst::IsDisjoint) |
-                         (b * PossiblyDisjointInst::IsDisjoint);
+  SubclassOptionalData =
+      (SubclassOptionalData & ~PossiblyDisjointInst::IsDisjoint) |
+      (b * PossiblyDisjointInst::IsDisjoint);
 }
 
 void Instruction::setNonNeg(bool b) {

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -318,10 +318,7 @@ void Instruction::setIsExact(bool b) {
 }
 
 void Instruction::setIsDisjoint(bool b) {
-  assert(isa<PossiblyDisjointInst>(this) && "Must be or");
-  SubclassOptionalData =
-      (SubclassOptionalData & ~PossiblyDisjointInst::IsDisjoint) |
-      (b * PossiblyDisjointInst::IsDisjoint);
+  cast<PossiblyDisjointInst>(this)->setIsDisjoint(b);
 }
 
 void Instruction::setNonNeg(bool b) {
@@ -431,8 +428,7 @@ bool Instruction::isExact() const {
 }
 
 bool Instruction::isDisjoint() const {
-  assert(isa<PossiblyDisjointInst>(this) && "Must be or");
-  return (SubclassOptionalData & PossiblyDisjointInst::IsDisjoint) != 0;
+  return cast<PossiblyDisjointInst>(this)->isDisjoint();
 }
 
 void Instruction::setFast(bool B) {

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -317,10 +317,6 @@ void Instruction::setIsExact(bool b) {
   cast<PossiblyExactOperator>(this)->setIsExact(b);
 }
 
-void Instruction::setIsDisjoint(bool b) {
-  cast<PossiblyDisjointInst>(this)->setIsDisjoint(b);
-}
-
 void Instruction::setNonNeg(bool b) {
   assert(isa<PossiblyNonNegInst>(this) && "Must be zext");
   SubclassOptionalData = (SubclassOptionalData & ~PossiblyNonNegInst::NonNeg) |
@@ -425,10 +421,6 @@ void Instruction::dropUBImplyingAttrsAndMetadata() {
 
 bool Instruction::isExact() const {
   return cast<PossiblyExactOperator>(this)->isExact();
-}
-
-bool Instruction::isDisjoint() const {
-  return cast<PossiblyDisjointInst>(this)->isDisjoint();
 }
 
 void Instruction::setFast(bool B) {
@@ -544,9 +536,9 @@ void Instruction::copyIRFlags(const Value *V, bool IncludeWrapFlags) {
     if (isa<PossiblyExactOperator>(this))
       setIsExact(PE->isExact());
 
-  if (auto *PD = dyn_cast<PossiblyDisjointInst>(V))
-    if (isa<PossiblyDisjointInst>(this))
-      setIsDisjoint(PD->isDisjoint());
+  if (auto *SrcPD = dyn_cast<PossiblyDisjointInst>(V))
+    if (auto *DestPD = dyn_cast<PossiblyDisjointInst>(this))
+      DestPD->setIsDisjoint(SrcPD->isDisjoint());
 
   // Copy the fast-math flags.
   if (auto *FP = dyn_cast<FPMathOperator>(V))
@@ -574,9 +566,9 @@ void Instruction::andIRFlags(const Value *V) {
     if (isa<PossiblyExactOperator>(this))
       setIsExact(isExact() && PE->isExact());
 
-  if (auto *PE = dyn_cast<PossiblyDisjointInst>(V))
-    if (isa<PossiblyDisjointInst>(this))
-      setIsDisjoint(isDisjoint() && PE->isDisjoint());
+  if (auto *SrcPD = dyn_cast<PossiblyDisjointInst>(V))
+    if (auto *DestPD = dyn_cast<PossiblyDisjointInst>(this))
+      DestPD->setIsDisjoint(DestPD->isDisjoint() && SrcPD->isDisjoint());
 
   if (auto *FP = dyn_cast<FPMathOperator>(V)) {
     if (isa<FPMathOperator>(this)) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -231,8 +231,11 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Value *V, APInt DemandedMask,
     // If either the LHS or the RHS are One, the result is One.
     if (SimplifyDemandedBits(I, 1, DemandedMask, RHSKnown, Depth + 1) ||
         SimplifyDemandedBits(I, 0, DemandedMask & ~RHSKnown.One, LHSKnown,
-                             Depth + 1))
+                             Depth + 1)) {
+      // Disjoint flag may not longer hold.
+      I->dropPoisonGeneratingFlags();
       return I;
+    }
     assert(!RHSKnown.hasConflict() && "Bits known to be one AND zero?");
     assert(!LHSKnown.hasConflict() && "Bits known to be one AND zero?");
 
@@ -252,8 +255,11 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Value *V, APInt DemandedMask,
       return I->getOperand(1);
 
     // If the RHS is a constant, see if we can simplify it.
-    if (ShrinkDemandedConstant(I, 1, DemandedMask))
+    if (ShrinkDemandedConstant(I, 1, DemandedMask)) {
+      // Disjoint flag may not longer hold.
+      I->dropPoisonGeneratingFlags();
       return I;
+    }
 
     break;
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -255,11 +255,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Value *V, APInt DemandedMask,
       return I->getOperand(1);
 
     // If the RHS is a constant, see if we can simplify it.
-    if (ShrinkDemandedConstant(I, 1, DemandedMask)) {
-      // Disjoint flag may not longer hold.
-      I->dropPoisonGeneratingFlags();
+    if (ShrinkDemandedConstant(I, 1, DemandedMask))
       return I;
-    }
 
     break;
   }

--- a/llvm/test/Assembler/flags.ll
+++ b/llvm/test/Assembler/flags.ll
@@ -256,3 +256,8 @@ define i64 @test_zext(i32 %a) {
   ret i64 %res
 }
 
+define i64 @test_or(i64 %a, i64 %b) {
+; CHECK: %res = or disjoint i64 %a, %b
+  %res = or disjoint i64 %a, %b
+  ret i64 %res
+}

--- a/llvm/test/Bitcode/compatibility.ll
+++ b/llvm/test/Bitcode/compatibility.ll
@@ -1359,6 +1359,9 @@ define void @instructions.bitwise_binops(i8 %op1, i8 %op2) {
   xor i8 %op1, %op2
   ; CHECK: xor i8 %op1, %op2
 
+  ; disjoint
+  or disjoint i8 %op1, %op2
+
   ret void
 }
 

--- a/llvm/test/Bitcode/compatibility.ll
+++ b/llvm/test/Bitcode/compatibility.ll
@@ -1361,6 +1361,7 @@ define void @instructions.bitwise_binops(i8 %op1, i8 %op2) {
 
   ; disjoint
   or disjoint i8 %op1, %op2
+  ; CHECK: or disjoint i8 %op1, %op2
 
   ret void
 }

--- a/llvm/test/Bitcode/flags.ll
+++ b/llvm/test/Bitcode/flags.ll
@@ -18,6 +18,8 @@ second:                                           ; preds = %first
   %z = add i32 %a, 0                              ; <i32> [#uses=0]
   %hh = zext nneg i32 %a to i64
   %ll = zext i32 %s to i64
+  %jj = or disjoint i32 %a, 0
+  %oo = or i32 %a, 0
   unreachable
 
 first:                                            ; preds = %entry
@@ -28,5 +30,7 @@ first:                                            ; preds = %entry
   %zz = add i32 %a, 0                             ; <i32> [#uses=0]
   %kk = zext nneg i32 %a to i64
   %rr = zext i32 %ss to i64
+  %mm = or disjoint i32 %a, 0
+  %nn = or i32 %a, 0
   br label %second
 }

--- a/llvm/test/Transforms/InstCombine/freeze.ll
+++ b/llvm/test/Transforms/InstCombine/freeze.ll
@@ -1127,6 +1127,17 @@ define i32 @freeze_zext_nneg(i8 %x) {
   ret i32 %fr
 }
 
+define i32 @propagate_drop_flags_or(i32 %arg) {
+; CHECK-LABEL: @propagate_drop_flags_or(
+; CHECK-NEXT:    [[ARG_FR:%.*]] = freeze i32 [[ARG:%.*]]
+; CHECK-NEXT:    [[V1:%.*]] = or i32 [[ARG_FR]], 2
+; CHECK-NEXT:    ret i32 [[V1]]
+;
+  %v1 = or disjoint i32 %arg, 2
+  %v1.fr = freeze i32 %v1
+  ret i32 %v1.fr
+}
+
 !0 = !{}
 !1 = !{i64 4}
 !2 = !{i32 0, i32 100}

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -1576,3 +1576,10 @@ define <4 x i1> @and_or_not_or_logical_vec(<4 x i32> %ap, <4 x i32> %bp) {
   %Z = or <4 x i1> %X, %Y
   ret <4 x i1> %Z
 }
+
+; Make sure SimplifyDemandedBits drops the disjoint flag.
+define i8 @drop_disjoint(i8 %x) {
+  %a = and i8 %x, -2
+  %b = or disjoint i8 %a, 1
+  ret i8 %b
+}

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -1579,6 +1579,10 @@ define <4 x i1> @and_or_not_or_logical_vec(<4 x i32> %ap, <4 x i32> %bp) {
 
 ; Make sure SimplifyDemandedBits drops the disjoint flag.
 define i8 @drop_disjoint(i8 %x) {
+; CHECK-LABEL: @drop_disjoint(
+; CHECK-NEXT:    [[B:%.*]] = or i8 [[X:%.*]], 1
+; CHECK-NEXT:    ret i8 [[B]]
+;
   %a = and i8 %x, -2
   %b = or disjoint i8 %a, 1
   ret i8 %b

--- a/llvm/test/Transforms/SimplifyCFG/HoistCode.ll
+++ b/llvm/test/Transforms/SimplifyCFG/HoistCode.ll
@@ -124,3 +124,33 @@ F:
   %z2 = zext i8 %x to i32
   ret i32 %z2
 }
+
+define i32 @hoist_or_flags_preserve(i1 %C, i32 %x, i32 %y) {
+; CHECK-LABEL: @hoist_or_flags_preserve(
+; CHECK-NEXT:  common.ret:
+; CHECK-NEXT:    [[Z1:%.*]] = or disjoint i32 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i32 [[Z1]]
+;
+  br i1 %C, label %T, label %F
+T:
+  %z1 = or disjoint i32 %x, %y
+  ret i32 %z1
+F:
+  %z2 = or disjoint i32 %x, %y
+  ret i32 %z2
+}
+
+define i32 @hoist_or_flags_drop(i1 %C, i32 %x, i32 %y) {
+; CHECK-LABEL: @hoist_or_flags_drop(
+; CHECK-NEXT:  common.ret:
+; CHECK-NEXT:    [[Z1:%.*]] = or i32 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i32 [[Z1]]
+;
+  br i1 %C, label %T, label %F
+T:
+  %z1 = or i32 %x, %y
+  ret i32 %z1
+F:
+  %z2 = or disjoint i32 %x, %y
+  ret i32 %z2
+}


### PR DESCRIPTION
This flag indicates that every bit is known to be zero in at least one of the inputs. This allows the Or to be treated as an Add since there is no possibility of a carry from any bit.

If the flag is present and this property does not hold, the result is poison.

This makes it easier to reverse the InstCombine transform that turns Add into Or.

This is inspired by a comment here https://github.com/llvm/llvm-project/pull/71955#discussion_r1391614578

Discourse thread https://discourse.llvm.org/t/rfc-add-or-disjoint-flag/75036