### PR TITLE
[libc++] Reduce the compilation time required by SIMD tests

### DIFF
--- a/libcxx/test/std/experimental/simd/simd.reference/reference_assignment.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.reference/reference_assignment.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-// FIXME: Timeouts.
-// UNSUPPORTED: sanitizer-new-delete
-
 // <experimental/simd>
 //
 // [simd.reference]

--- a/libcxx/test/std/experimental/simd/simd.reference/reference_assignment.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.reference/reference_assignment.pass.cpp
@@ -12,8 +12,6 @@
 //
 // [simd.reference]
 // template<class U> reference=(U&& x) && noexcept;
-//
-// XFAIL: LIBCXX-AIX-FIXME
 
 #include "../test_utils.h"
 #include <experimental/simd>

--- a/libcxx/test/std/experimental/simd/test_utils.h
+++ b/libcxx/test/std/experimental/simd/test_utils.h
@@ -36,7 +36,8 @@ struct TestAllSimdAbiFunctor {
     using abis = types::type_list<ex::simd_abi::scalar, ex::simd_abi::native<T>, ex::simd_abi::compatible<T>>;
     types::for_each(abis{}, F<T, 1>());
 
-    instantiate_with_n<T>(std::index_sequence<1, 2, 3, 4, 8, 16, max_simd_size - 2, max_simd_size - 1, max_simd_size>{});
+    instantiate_with_n<T>(
+        std::index_sequence<1, 2, 3, 4, 8, 16, max_simd_size - 2, max_simd_size - 1, max_simd_size>{});
   }
 };
 

--- a/libcxx/test/std/experimental/simd/test_utils.h
+++ b/libcxx/test/std/experimental/simd/test_utils.h
@@ -28,7 +28,7 @@ struct TestAllSimdAbiFunctor {
 
   template <class T, std::size_t... Ns>
   void instantiate_with_n(std::index_sequence<Ns...>) {
-    (types::for_each(sized_abis<T, Ns + 1>{}, F<T, Ns + 1>{}), ...);
+    (types::for_each(sized_abis<T, Ns>{}, F<T, Ns>{}), ...);
   }
 
   template <class T>
@@ -36,7 +36,7 @@ struct TestAllSimdAbiFunctor {
     using abis = types::type_list<ex::simd_abi::scalar, ex::simd_abi::native<T>, ex::simd_abi::compatible<T>>;
     types::for_each(abis{}, F<T, 1>());
 
-    instantiate_with_n<T>(std::make_index_sequence<max_simd_size - 1>{});
+    instantiate_with_n<T>(std::index_sequence<1, 2, 8, 16, max_simd_size - 2, max_simd_size - 1, max_simd_size>{});
   }
 };
 

--- a/libcxx/test/std/experimental/simd/test_utils.h
+++ b/libcxx/test/std/experimental/simd/test_utils.h
@@ -36,7 +36,7 @@ struct TestAllSimdAbiFunctor {
     using abis = types::type_list<ex::simd_abi::scalar, ex::simd_abi::native<T>, ex::simd_abi::compatible<T>>;
     types::for_each(abis{}, F<T, 1>());
 
-    instantiate_with_n<T>(std::index_sequence<1, 2, 8, 16, max_simd_size - 2, max_simd_size - 1, max_simd_size>{});
+    instantiate_with_n<T>(std::index_sequence<1, 2, 3, 4, 8, 16, max_simd_size - 2, max_simd_size - 1, max_simd_size>{});
   }
 };
 


### PR DESCRIPTION
Testing all the SIMD widths exhaustively is nice in theory, however in practice it leads to extremely slow tests. Given that
1. our testing resources are finite and actually pretty costly
2. we have thousands of other tests we also need to run
3. the value of executing these SIMD tests for absolutely all supported SIMD widths is fairly small compared to cherry-picking a few relevant widths

I think it makes a lot of sense to reduce the exhaustiveness of these tests. I'm getting a ~4x speedup for the worst offender (reference_assignment.pass.cpp) after this patch.

I'd also like to make this a reminder to anyone seeing this PR that tests impact everyone's productivity. Slow unit tests contribute to making the CI slower as a whole, and that has a direct impact on everyone's ability to iterate quickly during PRs. Even though we have a pretty robust CI setup in place, we should remember that it doesn't come for free and should strive to keep our tests at a good bang for the buck ratio.