### PR TITLE
[lld][ELF] Add armeb support when incoming bc is arm big endian

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1582,7 +1582,9 @@ static uint16_t getBitcodeMachineKind(StringRef path, const Triple &t) {
   case Triple::r600:
     return EM_AMDGPU;
   case Triple::arm:
+  case Triple::armeb:
   case Triple::thumb:
+  case Triple::thumbeb:
     return EM_ARM;
   case Triple::avr:
     return EM_AVR;

--- a/lld/test/ELF/lto/arm.ll
+++ b/lld/test/ELF/lto/arm.ll
@@ -7,13 +7,15 @@
 ; RUN: ld.lld %t/arm.o -o %t/arm
 ; RUN: llvm-readobj -h %t/arm | FileCheck %s --check-prefix=ARM
 ; RUN: llvm-as %t/armeb.ll -o %t/armeb.o
-; RUN: not ld.lld %t/armeb.o -o %t/armeb
+; RUN: ld.lld %t/armeb.o -o %t/armeb
+; RUN: llvm-readobj -h %t/armeb | FileCheck %s --check-prefix=ARMEB
 
 ; RUN: llvm-as %t/thumb.ll -o %t/thumb.o
 ; RUN: ld.lld %t/thumb.o -o %t/thumb
 ; RUN: llvm-readobj -h %t/thumb | FileCheck %s --check-prefix=THUMB
 ; RUN: llvm-as %t/thumbeb.ll -o %t/thumbeb.o
-; RUN: not ld.lld %t/thumbeb.o -o %t/thumbeb
+; RUN: ld.lld %t/thumbeb.o -o %t/thumbeb
+; RUN: llvm-readobj -h %t/thumbeb | FileCheck %s --check-prefix=THUMBEB
 
 ; ARM:       Class: 32-bit
 ; ARM:       DataEncoding: LittleEndian
@@ -25,6 +27,9 @@
 ; THUMB:     Class: 32-bit
 ; THUMB:     DataEncoding: LittleEndian
 ; THUMB:   Machine: EM_ARM (
+; THUMBEB:   Class: 32-bit
+; THUMBEB:   DataEncoding: BigEndian
+; THUMBEB: Machine: EM_ARM (
 
 ;--- arm.ll
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"


### PR DESCRIPTION
Add armeb support when incoming bc is arm big endian:
Fix error: could not infer e_machine from bitcode target triple armebv7-linux-gnueabi.