### PR TITLE
[AMDGPU] Pre-commit fdot2 test. NFC.

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.fdot2.bf16.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.fdot2.bf16.bf16.ll
@@ -72,4 +72,23 @@ entry:
   ret void
 }
 
+; FIXME: This test violates constant bus restriction.
+
+define amdgpu_ps void @test_llvm_amdgcn_fdot2_bf16_bf16_sis(
+; GFX11-LABEL: test_llvm_amdgcn_fdot2_bf16_bf16_sis:
+; GFX11:       ; %bb.0: ; %entry
+; GFX11-NEXT:    v_dot2_bf16_bf16 v2, s0, 0x10001, s1
+; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX11-NEXT:    s_nop 0
+; GFX11-NEXT:    s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)
+; GFX11-NEXT:    s_endpgm
+    ptr addrspace(1) %r,
+    <2 x i16> inreg %a,
+    i16 inreg %c) {
+entry:
+  %r.val = call i16 @llvm.amdgcn.fdot2.bf16.bf16(<2 x i16> %a, <2 x i16> <i16 1, i16 1>, i16 %c)
+  store i16 %r.val, ptr addrspace(1) %r
+  ret void
+}
+
 declare i32 @llvm.amdgcn.update.dpp.i32(i32, i32, i32, i32, i32, i1)


### PR DESCRIPTION
This test exposes a bug where we violate constant bus restriction.