### PR TITLE
[Github] Build clang docs in CI if autogenerated files change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,9 @@ on:
     paths:
       - 'llvm/docs/**'
       - 'clang/docs/**'
+      - 'clang/include/clang/Basic/AttrDocs.td'
+      - 'clang/include/clang/Driver/ClangOptionDocs.td'
+      - 'clang/include/clang/Basic/DiagnosticDocs.td'
       - 'clang-tools-extra/docs/**'
       - 'lldb/docs/**'
       - 'libunwind/docs/**'
@@ -28,6 +31,9 @@ on:
     paths:
       - 'llvm/docs/**'
       - 'clang/docs/**'
+      - 'clang/include/clang/Basic/AttrDocs.td'
+      - 'clang/include/clang/Driver/ClangOptionDocs.td'
+      - 'clang/include/clang/Basic/DiagnosticDocs.td'
       - 'clang-tools-extra/docs/**'
       - 'lldb/docs/**'
       - 'libunwind/docs/**'
@@ -62,6 +68,9 @@ jobs:
               - 'llvm/docs/**'
             clang:
               - 'clang/docs/**'
+              - 'clang/include/clang/Basic/AttrDocs.td'
+              - 'clang/include/clang/Driver/ClangOptionDocs.td'
+              - 'clang/include/clang/Basic/DiagnosticDocs.td'
             clang-tools-extra:
               - 'clang-tools-extra/docs/**'
             lldb:


### PR DESCRIPTION
These are unlikely to produce errors in the build, assuming that the tablegen emitter works as expected, but we're still losing some documentation build testing coverage but not building upon changes to these files.