### PR TITLE
[clangd] Add way to remove file from CDB via LSP

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1385,7 +1385,10 @@ void ClangdLSPServer::applyConfiguration(
                                 std::move(Entry.second.compilationCommand),
                                 /*Output=*/"");
     if (Old != New) {
-      CDB->setCompileCommand(File, std::move(New));
+      if (New.CommandLine.empty() && New.Directory.empty())
+        CDB->setCompileCommand(File, std::nullopt);
+      else
+        CDB->setCompileCommand(File, std::move(New));
       ModifiedFiles.insert(File);
     }
   }


### PR DESCRIPTION
Currently, impossible to remove irrelevant files from CDB via LSP notification `workspace/didChangeConfiguration`. This PR change clangd behavior to remove file from CDB, when LSP pass empty parameters for them.