### PR TITLE
[NVPTX] Skip processing BasicBlocks with single unreachable instruction in `nvptx-lower-unreachable` pass.

### DIFF
--- a/llvm/test/CodeGen/NVPTX/unreachable-switch-case.ll
+++ b/llvm/test/CodeGen/NVPTX/unreachable-switch-case.ll
@@ -1,0 +1,31 @@
+; RUN: llc < %s -march=nvptx -mcpu=sm_20 -verify-machineinstrs | FileCheck %s  
+
+declare noundef i32 @llvm.nvvm.read.ptx.sreg.tid.x() #1
+
+define void @kernel_func() {
+
+  %1 = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+
+  switch i32 %1, label %unreachabledefault [
+    i32 0, label %bb0
+    i32 1, label %bb1
+    i32 2, label %bb1
+    i32 3, label %bb2
+  ]
+
+  bb0:
+    ret void
+
+  bb1:
+    ret void
+
+  bb2:
+    ret void
+
+  unreachabledefault:
+    unreachable
+
+; CHECK:  @kernel_func
+; CHECK-NOT: unreachabledefault
+; CHECK:  -- End function
+}


### PR DESCRIPTION
Addressing [Lower unreachable to exit to allow ptxas to accurately reconstruct the CFG](https://reviews.llvm.org/D152789) resulted in performance regression In scenarios where a BasicBlock contains only one unreachable instruction. Before the patch, in such a case the joint action of `nvptx-isel` and `unreachable-mbb-elimination` effectively optimized the BasicBlock out. However, adding an exit command to such a BasicBlock, as introduced by [Lower unreachable to exit to allow ptxas to accurately reconstruct the CFG](https://reviews.llvm.org/D152789), preserves it within the Control Flow Graph (CFG), thereby negatively impacting size and performance. To counteract this undesirable consequence, we choose to refrain from processing BasicBlocks with just one unreachable instruction in this pass.