### PR TITLE
[asan][Darwin] Use Apples blocks extension only when supported (#72639)

### DIFF
--- a/compiler-rt/lib/asan/asan_mac.cpp
+++ b/compiler-rt/lib/asan/asan_mac.cpp
@@ -139,9 +139,11 @@ typedef void (*dispatch_mach_handler_function_t)(void *context,
                                                  dispatch_mach_reason reason,
                                                  dispatch_mach_msg_t message,
                                                  mach_error_t error);
+#  if !defined(MISSING_BLOCKS_SUPPORT)
 typedef void (^dispatch_mach_handler_t)(dispatch_mach_reason reason,
                                         dispatch_mach_msg_t message,
                                         mach_error_t error);
+#  endif
 
 // A wrapper for the ObjC blocks used to support libdispatch.
 typedef struct {


### PR DESCRIPTION
Issue #72639

The commit at 020cdaf broke build of asan on macOS with GCC. GCC does not support the Apple blocks extension (yet). Uses of blocks in other parts of the sanitisers are protected by MISSING_BLOCKS_SUPPORT. But the type definition is not.

_This applies FX's patch from the issue._