### PR TITLE
[AMDGPU] Defaults for missing dimensions in SYCL required wg size

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
@@ -81,7 +81,8 @@ protected:
 
   std::string getTypeName(Type *Ty, bool Signed) const;
 
-  msgpack::ArrayDocNode getWorkGroupDimensions(MDNode *Node) const;
+  msgpack::ArrayDocNode getWorkGroupDimensions(const Function &Func,
+                                               MDNode *Node) const;
 
   msgpack::MapDocNode getHSAKernelProps(const MachineFunction &MF,
                                         const SIProgramInfo &ProgramInfo,

--- a/llvm/test/CodeGen/AMDGPU/required_work_group_size_sycl.ll
+++ b/llvm/test/CodeGen/AMDGPU/required_work_group_size_sycl.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -verify-machineinstrs < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck %s
 
 ; Make sure that SYCL kernels with less than 3 dimensions specified in required
 ; work group size, have those dimensions padded up with 1.
@@ -8,7 +8,7 @@
 ; CHECK-NEXT:      - 3
 ; CHECK-NEXT:      - 1
 ; CHECK-NEXT:      - 1
-define weak_odr protected amdgpu_kernel void @sycl_kernel_1dim() #1 !reqd_work_group_size !0 {
+define protected amdgpu_kernel void @sycl_kernel_1dim() #1 !reqd_work_group_size !0 {
 entry:
   ret void
 }
@@ -18,7 +18,7 @@ entry:
 ; CHECK-NEXT:      - 5
 ; CHECK-NEXT:      - 7
 ; CHECK-NEXT:      - 1
-define weak_odr protected amdgpu_kernel void @sycl_kernel_2dim() #1 !reqd_work_group_size !1 {
+define protected amdgpu_kernel void @sycl_kernel_2dim() #1 !reqd_work_group_size !1 {
 entry:
   ret void
 }
@@ -28,7 +28,7 @@ entry:
 ; CHECK-NEXT:      - 11 
 ; CHECK-NEXT:      - 13
 ; CHECK-NEXT:      - 17
-define weak_odr protected amdgpu_kernel void @sycl_kernel_3dim() #1 !reqd_work_group_size !2 {
+define protected amdgpu_kernel void @sycl_kernel_3dim() #1 !reqd_work_group_size !2 {
 entry:
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/required_work_group_size_sycl.ll
+++ b/llvm/test/CodeGen/AMDGPU/required_work_group_size_sycl.ll
@@ -1,0 +1,42 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -verify-machineinstrs < %s | FileCheck %s
+
+; Make sure that SYCL kernels with less than 3 dimensions specified in required
+; work group size, have those dimensions padded up with 1.
+
+; CHECK-LABEL: .name:           sycl_kernel_1dim
+; CHECK:    .reqd_workgroup_size:
+; CHECK-NEXT:      - 3
+; CHECK-NEXT:      - 1
+; CHECK-NEXT:      - 1
+define weak_odr protected amdgpu_kernel void @sycl_kernel_1dim() #1 !reqd_work_group_size !0 {
+entry:
+  ret void
+}
+
+; CHECK-LABEL: .name:           sycl_kernel_2dim
+; CHECK:    .reqd_workgroup_size:
+; CHECK-NEXT:      - 5
+; CHECK-NEXT:      - 7
+; CHECK-NEXT:      - 1
+define weak_odr protected amdgpu_kernel void @sycl_kernel_2dim() #1 !reqd_work_group_size !1 {
+entry:
+  ret void
+}
+
+; CHECK-LABEL: .name:           sycl_kernel_3dim
+; CHECK:    .reqd_workgroup_size:
+; CHECK-NEXT:      - 11 
+; CHECK-NEXT:      - 13
+; CHECK-NEXT:      - 17
+define weak_odr protected amdgpu_kernel void @sycl_kernel_3dim() #1 !reqd_work_group_size !2 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind speculatable memory(none) }
+attributes #1 = { "sycl-module-id"="reqd_work_group_size_check_exception.cpp" }
+
+
+!0 = !{i32 3}
+!1 = !{i32 5, i32 7}
+!2 = !{i32 11, i32 13, i32 17}


### PR DESCRIPTION
SYCL allows for required work group to be partially specified (i.e. not all 3 dimensions):
* https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:kernel.attributes

This fails AMDGPU's attribute verification. The patch aims to provide the default values for missing dimensions when dealing with SYCL kernels. Rather than modifying the module's metadata it uses internal data to padd missing values.