### PR TITLE
[clang][Interp] Fix float->int casts overflowing

### DIFF
--- a/clang/lib/AST/Interp/Interp.h
+++ b/clang/lib/AST/Interp/Interp.h
@@ -1619,7 +1619,11 @@ bool CastFloatingIntegral(InterpState &S, CodePtr OpPC) {
       QualType Type = E->getType();
 
       S.CCEDiag(E, diag::note_constexpr_overflow) << F.getAPFloat() << Type;
-      return S.noteUndefinedBehavior();
+      if (S.noteUndefinedBehavior()) {
+        S.Stk.push<T>(T(Result));
+        return true;
+      }
+      return false;
     }
 
     S.Stk.push<T>(T(Result));

--- a/clang/test/AST/Interp/floats.cpp
+++ b/clang/test/AST/Interp/floats.cpp
@@ -39,6 +39,10 @@ constexpr float m = 5.0f / 0.0f; // ref-error {{must be initialized by a constan
 static_assert(~2.0f == 3, ""); // ref-error {{invalid argument type 'float' to unary expression}} \
                                // expected-error {{invalid argument type 'float' to unary expression}}
 
+
+typedef int tdb[(long long)4e20]; //expected-error {{variable length}} \
+                                  //ref-error {{variable length}}
+
 /// Initialized by a double.
 constexpr float df = 0.0;
 /// The other way around.


### PR DESCRIPTION
If S.noteUndefinedBehavior() returns true, we will continue evaluation and need a value on the stack.