### PR TITLE
[clang][Interp] Decay arrays to the first element

### DIFF
--- a/clang/lib/AST/Interp/Interp.h
+++ b/clang/lib/AST/Interp/Interp.h
@@ -1822,10 +1822,12 @@ inline bool ArrayElemPtr(InterpState &S, CodePtr OpPC) {
 /// Just takes a pointer and checks if its' an incomplete
 /// array type.
 inline bool ArrayDecay(InterpState &S, CodePtr OpPC) {
-  const Pointer &Ptr = S.Stk.peek<Pointer>();
+  const Pointer &Ptr = S.Stk.pop<Pointer>();
 
-  if (!Ptr.isUnknownSizeArray())
+  if (!Ptr.isUnknownSizeArray()) {
+    S.Stk.push<Pointer>(Ptr.atIndex(0));
     return true;
+  }
 
   const SourceInfo &E = S.Current->getSource(OpPC);
   S.FFDiag(E, diag::note_constexpr_unsupported_unsized_array);

--- a/clang/test/AST/Interp/arrays.cpp
+++ b/clang/test/AST/Interp/arrays.cpp
@@ -27,6 +27,10 @@ static_assert(foo[2][3] == &m, "");
 static_assert(foo[2][4] == nullptr, "");
 
 
+constexpr int SomeInt[] = {1};
+constexpr int getSomeInt() { return *SomeInt; }
+static_assert(getSomeInt() == 1, "");
+
 /// A init list for a primitive value.
 constexpr int f{5};
 static_assert(f == 5, "");


### PR DESCRIPTION
I _think_ this makes sense to do here. This way we have a pointer to the first element on the stack.