### PR TITLE
[Tooling/Inclusion] Avoid narrowing conversions in macro expansion

### DIFF
--- a/clang/lib/Tooling/Inclusions/Stdlib/StandardLibrary.cpp
+++ b/clang/lib/Tooling/Inclusions/Stdlib/StandardLibrary.cpp
@@ -141,7 +141,9 @@ static int initialize(Lang Language) {
     unsigned NSLen;
     const char *HeaderName;
   };
-#define SYMBOL(Name, NS, Header) {#NS #Name, StringRef(#NS).size(), #Header},
+#define SYMBOL(Name, NS, Header)                                               \
+  {#NS #Name, static_cast<decltype(Symbol::NSLen)>(StringRef(#NS).size()),     \
+   #Header},
   switch (Language) {
   case Lang::C: {
     static constexpr Symbol CSymbols[] = {


### PR DESCRIPTION
```
clang/lib/Tooling/Inclusions/Stdlib/StandardLibrary.cpp:144:65: warning: narrowing conversion of ‘llvm::StringRef(((const char*)"std::experimental::filesystem::")).llvm::StringRef::size()’ from ‘size_t’ {aka ‘long un signed int’} to ‘unsigned int’ [-Wnarrowing]
  144 | #define SYMBOL(Name, NS, Header) {#NS #Name, StringRef(#NS).size(), #Header},
      |                                              ~~~~~~~~~~~~~~~~~~~^~
clang/lib/Tooling/Inclusions/Stdlib/StdTsSymbolMap.inc:51:1: note: in expansion of macro ‘SYMBOL’
   51 | SYMBOL(temp_directory_path, std::experimental::filesystem::, <experimental/filesystem>)
      | ^~~~~~
```