### PR TITLE
[lldb] Remove unused Status::SetMachError (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/Status.h
+++ b/lldb/include/lldb/Utility/Status.h
@@ -114,15 +114,6 @@ public:
   ///     The error type enumeration value.
   lldb::ErrorType GetType() const;
 
-  /// Set accessor from a kern_return_t.
-  ///
-  /// Set accessor for the error value to \a err and the error type to \c
-  /// MachKernel.
-  ///
-  /// \param[in] err
-  ///     A mach error code.
-  void SetMachError(uint32_t err);
-
   void SetExpressionError(lldb::ExpressionResults, const char *mssg);
 
   int SetExpressionErrorWithFormat(lldb::ExpressionResults, const char *format,

--- a/lldb/source/Utility/Status.cpp
+++ b/lldb/source/Utility/Status.cpp
@@ -180,14 +180,6 @@ ErrorType Status::GetType() const { return m_type; }
 // otherwise non-success result.
 bool Status::Fail() const { return m_code != 0; }
 
-// Set accessor for the error value to "err" and the type to
-// "eErrorTypeMachKernel"
-void Status::SetMachError(uint32_t err) {
-  m_code = err;
-  m_type = eErrorTypeMachKernel;
-  m_string.clear();
-}
-
 void Status::SetExpressionError(lldb::ExpressionResults result,
                                 const char *mssg) {
   m_code = result;


### PR DESCRIPTION
This function is never used, neither here nor downstream in the Swift fork. As far as I can tell, the same is true for the corresponding eErrorTypeMachKernel but as that's part of the SB API we cannot remove that.