### PR TITLE
[lldb] Pass important options to dsymForUUID

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -356,7 +356,11 @@ class CrashLog(symbolication.Symbolicator):
             # Keep track of unresolved source paths.
             unavailable_source_paths = set()
             if os.path.exists(self.dsymForUUIDBinary):
-                dsym_for_uuid_command = "%s %s" % (self.dsymForUUIDBinary, uuid_str)
+                dsym_for_uuid_command = (
+                    "{} --copyExecutable --ignoreNegativeCache {}".format(
+                        self.dsymForUUIDBinary, uuid_str
+                    )
+                )
                 s = subprocess.check_output(dsym_for_uuid_command, shell=True)
                 if s:
                     try:


### PR DESCRIPTION
On macOS, we usually use the DebugSymbols framework to find dSYMs, but we have a few places (including crashlog.py) that calls out directly to dsymForUUID. Currently, this invocation is missing two important options:

  * `--ignoreNegativeCache`: Poor network connectivity or lack of VPN can lead to a negative cache hit. Avoiding those issues is worth the penalty of skipping these caches.
  * `--copyExecutable`: Ensure we copy the executable as it might not be available at its original location.

rdar://118480731