### PR TITLE
[NFC][SHT_LLVM_BB_ADDR_MAP] Define and use constructor and accessors for BBAddrMap fields.

### DIFF
--- a/llvm/include/llvm/Object/ELFTypes.h
+++ b/llvm/include/llvm/Object/ELFTypes.h
@@ -794,7 +794,6 @@ template <class ELFT> struct Elf_Mips_ABIFlags {
 
 // Struct representing the BBAddrMap for one function.
 struct BBAddrMap {
-  uint64_t Addr; // Function address
   // Struct representing the BBAddrMap information for one basic block.
   struct BBEntry {
     struct Metadata {
@@ -856,13 +855,24 @@ struct BBAddrMap {
     bool canFallThrough() const { return MD.CanFallThrough; }
     bool hasIndirectBranch() const { return MD.HasIndirectBranch; }
   };
-  std::vector<BBEntry> BBEntries; // Basic block entries for this function.
+
+  BBAddrMap(uint64_t Addr, std::vector<BBEntry> BBEntries)
+      : Addr(Addr), BBEntries(std::move(BBEntries)) {}
+
+  // Returns the address of the corresponding function.
+  uint64_t getFunctionAddress() const { return Addr; }
+
+  // Returns the basic block entries for this function.
+  const std::vector<BBEntry> &getBBEntries() const { return BBEntries; }
 
   // Equality operator for unit testing.
   bool operator==(const BBAddrMap &Other) const {
     return Addr == Other.Addr && std::equal(BBEntries.begin(), BBEntries.end(),
                                             Other.BBEntries.begin());
   }
+
+  uint64_t Addr;                  // Function address
+  std::vector<BBEntry> BBEntries; // Basic block entries for this function.
 };
 
 } // end namespace object.

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -745,7 +745,7 @@ ELFFile<ELFT>::decodeBBAddrMap(const Elf_Shdr &Sec,
       }
       BBEntries.push_back({ID, Offset, Size, *MetadataOrErr});
     }
-    FunctionEntries.push_back({Address, std::move(BBEntries)});
+    FunctionEntries.emplace_back(Address, std::move(BBEntries));
   }
   // Either Cur is in the error state, or we have an error in ULEBSizeErr or
   // MetadataDecodeErr (but not both), but we join all errors here to be safe.

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1275,8 +1275,8 @@ collectBBAddrMapLabels(const std::unordered_map<uint64_t, BBAddrMap> &AddrToBBAd
   auto Iter = AddrToBBAddrMap.find(StartAddress);
   if (Iter == AddrToBBAddrMap.end())
     return;
-  for (const BBAddrMap::BBEntry &BBEntry : Iter->second.BBEntries) {
-    uint64_t BBAddress = BBEntry.Offset + Iter->second.Addr;
+  for (const BBAddrMap::BBEntry &BBEntry : Iter->second.getBBEntries()) {
+    uint64_t BBAddress = BBEntry.Offset + Iter->second.getFunctionAddress();
     if (BBAddress >= EndAddress)
       continue;
     Labels[BBAddress].push_back(("BB" + Twine(BBEntry.ID)).str());

--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -661,10 +661,10 @@ Sections:
             Metadata:      0x18
 )");
 
-  BBAddrMap E1 = {0x11111, {{1, 0x0, 0x1, {false, true, false, false, false}}}};
-  BBAddrMap E2 = {0x22222, {{2, 0x0, 0x2, {false, false, true, false, false}}}};
-  BBAddrMap E3 = {0x33333, {{0, 0x0, 0x3, {false, true, true, false, false}}}};
-  BBAddrMap E4 = {0x44444, {{0, 0x0, 0x4, {false, false, false, true, true}}}};
+  BBAddrMap E1(0x11111, {{1, 0x0, 0x1, {false, true, false, false, false}}});
+  BBAddrMap E2(0x22222, {{2, 0x0, 0x2, {false, false, true, false, false}}});
+  BBAddrMap E3(0x33333, {{0, 0x0, 0x3, {false, true, true, false, false}}});
+  BBAddrMap E4(0x44444, {{0, 0x0, 0x4, {false, false, false, true, true}}});
 
   std::vector<BBAddrMap> Section0BBAddrMaps = {E4};
   std::vector<BBAddrMap> Section1BBAddrMaps = {E3};


### PR DESCRIPTION
The fields are still kept as public for now since our tooling accesses them. Will change them to private visibility in a later patch.
