### PR TITLE
[libc++] Fix char_traits deprecation message (LLVM 18 -> 19)

### DIFF
--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -77,7 +77,7 @@ exposition-only to document what members a char_traits specialization should pro
 //
 #if !defined(_LIBCPP_CHAR_TRAITS_REMOVE_BASE_SPECIALIZATION)
 template <class _CharT>
-struct _LIBCPP_DEPRECATED_("char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it.")
+struct _LIBCPP_DEPRECATED_("char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 19, so please migrate off of it.")
     char_traits
 {
     using char_type  = _CharT;


### PR DESCRIPTION
We intend to remove the base specialization in LLVM 19, not LLVM 18. We simply forgot to update the deprecation message accordingly.