### PR TITLE
[OpenACC] Implement compound construct parsing

### DIFF
--- a/clang/include/clang/Basic/OpenACCKinds.h
+++ b/clang/include/clang/Basic/OpenACCKinds.h
@@ -33,7 +33,10 @@ enum class OpenACCDirectiveKind {
   Loop,
   // FIXME: 'cache'
 
-  // FIXME: Combined Constructs.
+  // Combined Constructs.
+  ParallelLoop,
+  SerialLoop,
+  KernelsLoop,
 
   // FIXME: atomic Construct variants.
 

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -22,7 +22,9 @@ using namespace llvm;
 
 namespace {
 
-// Translate single-token string representations to the OpenACC Directive Kind.
+// This doesn't completely comprehend 'Compound Constructs' (as it just
+// identifies the first token) just the first token of each.  So
+// this should only be used by `ParseOpenACCDirectiveKind`.
 OpenACCDirectiveKind GetOpenACCDirectiveKind(StringRef Name) {
   return llvm::StringSwitch<OpenACCDirectiveKind>(Name)
       .Case("parallel", OpenACCDirectiveKind::Parallel)
@@ -49,6 +51,35 @@ OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
 
   if (DirKind == OpenACCDirectiveKind::Invalid)
     P.Diag(FirstTok, diag::err_acc_invalid_directive) << FirstTokSpelling;
+
+  // Combined Constructs allows parallel loop, serial loop, or kernels loop. Any
+  // other attempt at a combined construct will be diagnosed as an invalid
+  // clause.
+  Token SecondTok = P.getCurToken();
+  switch (DirKind) {
+  default:
+    // Nothing to do except in the below cases, as they should be diagnosed as
+    // a clause.
+    break;
+  case OpenACCDirectiveKind::Parallel:
+    if (P.getPreprocessor().getSpelling(SecondTok) == "loop") {
+      P.ConsumeToken();
+      return OpenACCDirectiveKind::ParallelLoop;
+    }
+    break;
+  case OpenACCDirectiveKind::Serial:
+    if (P.getPreprocessor().getSpelling(SecondTok) == "loop") {
+      P.ConsumeToken();
+      return OpenACCDirectiveKind::SerialLoop;
+    }
+    break;
+  case OpenACCDirectiveKind::Kernels:
+    if (P.getPreprocessor().getSpelling(SecondTok) == "loop") {
+      P.ConsumeToken();
+      return OpenACCDirectiveKind::KernelsLoop;
+    }
+    break;
+  }
 
   return DirKind;
 }

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -58,22 +58,20 @@ OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
   Token SecondTok = P.getCurToken();
   if (!SecondTok.isAnnotation() &&
       P.getPreprocessor().getSpelling(SecondTok) == "loop") {
-    OpenACCDirectiveKind ReturnKind;
     switch (DirKind) {
     default:
       // Nothing to do except in the below cases, as they should be diagnosed as
       // a clause.
       break;
     case OpenACCDirectiveKind::Parallel:
-      ReturnKind = OpenACCDirectiveKind::ParallelLoop;
-      LLVM_FALLTHROUGH;
-    case OpenACCDirectiveKind::Serial:
-      ReturnKind = OpenACCDirectiveKind::SerialLoop;
-      LLVM_FALLTHROUGH;
-    case OpenACCDirectiveKind::Kernels:
-      ReturnKind = OpenACCDirectiveKind::KernelsLoop;
       P.ConsumeToken();
-      return ReturnKind;
+      return OpenACCDirectiveKind::ParallelLoop;
+    case OpenACCDirectiveKind::Serial:
+      P.ConsumeToken();
+      return OpenACCDirectiveKind::SerialLoop;
+    case OpenACCDirectiveKind::Kernels:
+      P.ConsumeToken();
+      return OpenACCDirectiveKind::KernelsLoop;
     }
   }
 

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -41,6 +41,42 @@ OpenACCDirectiveKind getOpenACCDirectiveKind(StringRef Name) {
       .Default(OpenACCDirectiveKind::Invalid);
 }
 
+bool isOpenACCDirectiveKind(OpenACCDirectiveKind Kind, StringRef Tok) {
+  switch (Kind) {
+  case OpenACCDirectiveKind::Parallel:
+    return Tok == "parallel";
+  case OpenACCDirectiveKind::Serial:
+    return Tok == "serial";
+  case OpenACCDirectiveKind::Kernels:
+    return Tok == "kernels";
+  case OpenACCDirectiveKind::Data:
+    return Tok == "data";
+  case OpenACCDirectiveKind::HostData:
+    return Tok == "host_data";
+  case OpenACCDirectiveKind::Loop:
+    return Tok == "loop";
+
+  case OpenACCDirectiveKind::ParallelLoop:
+  case OpenACCDirectiveKind::SerialLoop:
+  case OpenACCDirectiveKind::KernelsLoop:
+    return false;
+
+  case OpenACCDirectiveKind::Declare:
+    return Tok == "declare";
+  case OpenACCDirectiveKind::Init:
+    return Tok == "init";
+  case OpenACCDirectiveKind::Shutdown:
+    return Tok == "shutdown";
+  case OpenACCDirectiveKind::Set:
+    return Tok == "set";
+  case OpenACCDirectiveKind::Update:
+    return Tok == "update";
+  case OpenACCDirectiveKind::Invalid:
+    return false;
+  }
+  llvm_unreachable("Unknown 'Kind' Passed");
+}
+
 // Parse and consume the tokens for OpenACC Directive/Construct kinds.
 OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
   Token FirstTok = P.getCurToken();
@@ -57,7 +93,8 @@ OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
   // clause.
   Token SecondTok = P.getCurToken();
   if (!SecondTok.isAnnotation() &&
-      P.getPreprocessor().getSpelling(SecondTok) == "loop") {
+      isOpenACCDirectiveKind(OpenACCDirectiveKind::Loop,
+                             P.getPreprocessor().getSpelling(SecondTok))) {
     switch (DirKind) {
     default:
       // Nothing to do except in the below cases, as they should be diagnosed as

--- a/clang/test/ParserOpenACC/parse-constructs.c
+++ b/clang/test/ParserOpenACC/parse-constructs.c
@@ -42,13 +42,23 @@ void func() {
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc parallel loop clause list
   for(;;){}
+
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc parallel loop
+  for(;;){}
   // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc serial loop clause list
   for(;;){}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc serial loop
+  for(;;){}
   // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc kernels loop clause list
+  for(;;){}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc kernels loop
   for(;;){}
 
   // expected-warning@+2{{OpenACC clause parsing not yet implemented}}


### PR DESCRIPTION
This patch implements the compound construct parsing, which allows 'parallel loop', 'serial loop', and 'kernel loop' to act as their own constructs.
