### PR TITLE
[libc++] Don't open-close namespace std in __config

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -836,8 +836,6 @@ typedef __char32_t char32_t;
 #  define _LIBCPP_END_NAMESPACE_STD }}
 #  define _VSTD std
 
-_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
-
 #  if _LIBCPP_STD_VER >= 17
 #    define _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM                                                                         \
        _LIBCPP_BEGIN_NAMESPACE_STD inline namespace __fs { namespace filesystem {


### PR DESCRIPTION
This doesn't seem necessary and it is just kind of weird to do that in __config, so remove it.