### PR TITLE
[SelectionDAG] Add support to filter SelectionDAG dumps during ISel by function names

### DIFF
--- a/llvm/docs/CodeGenerator.rst
+++ b/llvm/docs/CodeGenerator.rst
@@ -857,6 +857,12 @@ SelectionDAG-based instruction selection consists of the following steps:
 After all of these steps are complete, the SelectionDAG is destroyed and the
 rest of the code generation passes are run.
 
+One of the most common ways to debug these steps is using ``-debug-only=isel``,
+which prints out the DAG, along with other information like debug info,
+after each of these steps. Alternatively, ``-debug-only=isel-dump`` shows only
+the DAG dumps, but the results can be filtered by function names using
+``-filter-print-funcs=<function names>``.
+
 One great way to visualize what is going on here is to take advantage of a few
 LLC command line options.  The following options pop up a window displaying the
 SelectionDAG at specific times (if you only get errors printed to the console

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -201,6 +201,14 @@ Changes to the C API
 Changes to the CodeGen infrastructure
 -------------------------------------
 
+* A new debug type ``isel-dump`` is added to show only the SelectionDAG dumps
+  after each ISel phase (i.e. ``-debug-onlu=isel-dump``). This new debug type
+  can be filtered by function names using ``-filter-print-funcs=<function names>``,
+  the same flag used to filter IR dumps after each Pass. Note that to be
+  compatible with the existing ``-debug-only=isel``, the latter will still
+  print SelectionDAG dumps of every single functions regardless of
+  ``-filter-print-funcs``'s values.
+
 * ``PrologEpilogInserter`` no longer supports register scavenging
   during forwards frame index elimination. Targets should use
   backwards frame index elimination instead.

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -202,11 +202,11 @@ Changes to the CodeGen infrastructure
 -------------------------------------
 
 * A new debug type ``isel-dump`` is added to show only the SelectionDAG dumps
-  after each ISel phase (i.e. ``-debug-onlu=isel-dump``). This new debug type
+  after each ISel phase (i.e. ``-debug-only=isel-dump``). This new debug type
   can be filtered by function names using ``-filter-print-funcs=<function names>``,
-  the same flag used to filter IR dumps after each Pass. Note that to be
-  compatible with the existing ``-debug-only=isel``, the latter will still
-  print SelectionDAG dumps of every single functions regardless of
+  the same flag used to filter IR dumps after each Pass. Note that the existing
+  ``-debug-only=isel`` will take precedence over the new behavior and
+  print SelectionDAG dumps of every single function regardless of
   ``-filter-print-funcs``'s values.
 
 * ``PrologEpilogInserter`` no longer supports register scavenging

--- a/llvm/include/llvm/CodeGen/SelectionDAGISel.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGISel.h
@@ -61,6 +61,10 @@ public:
   /// Used to report things like combines and FastISel failures.
   std::unique_ptr<OptimizationRemarkEmitter> ORE;
 
+  /// True if the function currently processing is in the function printing list
+  /// (i.e. `-filter-print-funcs`).
+  bool MatchFilterFuncName = false;
+
   explicit SelectionDAGISel(char &ID, TargetMachine &tm,
                             CodeGenOptLevel OL = CodeGenOptLevel::Default);
   ~SelectionDAGISel() override;

--- a/llvm/include/llvm/CodeGen/SelectionDAGISel.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGISel.h
@@ -63,6 +63,9 @@ public:
 
   /// True if the function currently processing is in the function printing list
   /// (i.e. `-filter-print-funcs`).
+  /// This is primarily used by ISEL_DUMP, which spans in multiple member
+  /// functions. Storing the filter result here so that we only need to do the
+  /// filtering once.
   bool MatchFilterFuncName = false;
 
   explicit SelectionDAGISel(char &ID, TargetMachine &tm,

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -192,6 +192,8 @@ static const bool ViewDAGCombine1 = false, ViewLegalizeTypesDAGs = false,
 /// traces subject to filter.
 static bool MatchFilterFuncs = false;
 
+/// LLVM_DEBUG messages that are specific to functions filtered by
+/// `-filter-print-dags-funcs`.
 #define ISEL_TRACE(X)                                                          \
   do {                                                                         \
     if (MatchFilterFuncs) {                                                    \

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -186,7 +186,7 @@ static const bool ViewDAGCombine1 = false, ViewLegalizeTypesDAGs = false,
   do {                                                                         \
     if (llvm::DebugFlag &&                                                     \
         (isCurrentDebugType(DEBUG_TYPE) ||                                     \
-         (isCurrentDebugType(ISEL_DUMP_DEBUG_TYPE) && MatchFilterFuncName))) {     \
+         (isCurrentDebugType(ISEL_DUMP_DEBUG_TYPE) && MatchFilterFuncName))) { \
       X;                                                                       \
     }                                                                          \
   } while (false)

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -192,9 +192,7 @@ static const bool ViewDAGCombine1 = false, ViewLegalizeTypesDAGs = false,
     }                                                                          \
   } while (false)
 #else
-#define ISEL_DUMP(X)                                                           \
-  do {                                                                         \
-  } while (false)
+#define ISEL_DUMP(X) do { } while (false)
 #endif
 
 //===---------------------------------------------------------------------===//

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -182,6 +182,7 @@ static const bool ViewDAGCombine1 = false, ViewLegalizeTypesDAGs = false,
                   ViewSchedDAGs = false, ViewSUnitDAGs = false;
 #endif
 
+#ifndef NDEBUG
 #define ISEL_DUMP(X)                                                           \
   do {                                                                         \
     if (llvm::DebugFlag &&                                                     \
@@ -190,6 +191,11 @@ static const bool ViewDAGCombine1 = false, ViewLegalizeTypesDAGs = false,
       X;                                                                       \
     }                                                                          \
   } while (false)
+#else
+#define ISEL_DUMP(X)                                                           \
+  do {                                                                         \
+  } while (false)
+#endif
 
 //===---------------------------------------------------------------------===//
 ///

--- a/llvm/test/CodeGen/Generic/selectiondag-dump-filter.ll
+++ b/llvm/test/CodeGen/Generic/selectiondag-dump-filter.ll
@@ -1,0 +1,28 @@
+; RUN: llc -debug-only=isel -filter-print-dags-funcs=foo < %s 2>&1 | FileCheck %s --check-prefix=FOO
+; RUN: llc -debug-only=isel -filter-print-dags-funcs=bar < %s 2>&1 | FileCheck %s --check-prefix=BAR
+; RUN: llc -debug-only=isel -filter-print-dags-funcs=foo,zap < %s 2>&1 | FileCheck %s --check-prefixes=FOO,ZAP
+; REQUIRES: asserts
+
+; FOO:     === foo
+; BAR-NOT: === foo
+; FOO: # Machine code for function foo
+define i32 @foo(i32 %a, i32 %b) {
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+; BAR:     === bar
+; FOO-NOT: === bar
+; BAR: # Machine code for function bar
+define i32 @bar(i32 %a, i32 %b) {
+  %r = mul i32 %a, %b
+  ret i32 %r
+}
+
+; ZAP:     === zap
+; BAR-NOT: === zap
+; ZAP: # Machine code for function zap
+define i32 @zap(i32 %a, i32 %b) {
+  %r = sub i32 %a, %b
+  ret i32 %r
+}

--- a/llvm/test/CodeGen/Generic/selectiondag-dump-filter.ll
+++ b/llvm/test/CodeGen/Generic/selectiondag-dump-filter.ll
@@ -1,10 +1,13 @@
-; RUN: llc -debug-only=isel -filter-print-dags-funcs=foo < %s 2>&1 | FileCheck %s --check-prefix=FOO
-; RUN: llc -debug-only=isel -filter-print-dags-funcs=bar < %s 2>&1 | FileCheck %s --check-prefix=BAR
-; RUN: llc -debug-only=isel -filter-print-dags-funcs=foo,zap < %s 2>&1 | FileCheck %s --check-prefixes=FOO,ZAP
+; RUN: llc -debug-only=isel-dump -filter-print-funcs=foo < %s 2>&1 | FileCheck %s --check-prefix=FOO
+; RUN: llc -debug-only=isel-dump -filter-print-funcs=bar < %s 2>&1 | FileCheck %s --check-prefix=BAR
+; RUN: llc -debug-only=isel-dump -filter-print-funcs=foo,zap < %s 2>&1 | FileCheck %s --check-prefixes=FOO,ZAP
+; Make sure the original -debug-only=isel still works.
+; RUN: llc -debug-only=isel < %s 2>&1 | FileCheck %s  --check-prefixes=FOO,BAR,ZAP
 ; REQUIRES: asserts
 
 ; FOO:     === foo
 ; BAR-NOT: === foo
+; ZAP-NOT: === foo
 ; FOO: # Machine code for function foo
 define i32 @foo(i32 %a, i32 %b) {
   %r = add i32 %a, %b
@@ -13,6 +16,7 @@ define i32 @foo(i32 %a, i32 %b) {
 
 ; BAR:     === bar
 ; FOO-NOT: === bar
+; ZAP-NOT: === bar
 ; BAR: # Machine code for function bar
 define i32 @bar(i32 %a, i32 %b) {
   %r = mul i32 %a, %b
@@ -20,6 +24,7 @@ define i32 @bar(i32 %a, i32 %b) {
 }
 
 ; ZAP:     === zap
+; FOO-NOT: === zap
 ; BAR-NOT: === zap
 ; ZAP: # Machine code for function zap
 define i32 @zap(i32 %a, i32 %b) {


### PR DESCRIPTION
`-debug-only=isel-dump` is the new debug type for printing SelectionDAG after each ISel phase. This can be furthered filter by `-filter-print-funcs=<function names>`.