### PR TITLE
[libc++] Stop checking for trailing whitespace in check-generated-output

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -262,9 +262,6 @@ check-generated-output)
            --exclude 'transcoding.pass.cpp' \
            --exclude 'underflow.pass.cpp' \
            || false
-
-    # Reject code with trailing whitespace
-    ! grep -rn '[[:blank:]]$' libcxx/include libcxx/src libcxx/test libcxx/benchmarks || false
 ;;
 #
 # Various Standard modes


### PR DESCRIPTION
Trailing whitespace is removed by clang-format, so if someone tries to check-in new code with trailing whitespaces, it'll be caught by the clang-format job. Removing this duplication helps reduce the confusion around our numerous ways of enforcing formatting rules.