### PR TITLE
[InstrProf] Adding utility weights to BalancedPartitioning

### DIFF
--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -61,9 +61,9 @@ public:
   using IDT = uint64_t;
   /// The type of UtilityNode
   struct UtilityNodeT {
-    UtilityNodeT(uint32_t id, uint32_t weight = 1) : id(id), weight(weight) {}
-    uint32_t id;
-    uint32_t weight;
+    UtilityNodeT(uint32_t Id, uint32_t Weight = 1) : Id(Id), Weight(Weight) {}
+    uint32_t Id;
+    uint32_t Weight;
   };
 
   /// \param UtilityNodes the set of utility nodes (must be unique'd)

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -64,6 +64,19 @@ public:
     UtilityNodeT(uint32_t Id, uint32_t Weight = 1) : Id(Id), Weight(Weight) {}
     uint32_t Id;
     uint32_t Weight;
+
+    // Deduplicate utility nodes for a given function.
+    // TODO: One may experiment with accumulating the weights of duplicates.
+    static void sortAndDeduplicate(SmallVector<UtilityNodeT, 4> &UNs) {
+      llvm::sort(UNs, [](const UtilityNodeT &L, const UtilityNodeT &R) {
+        return L.Id < R.Id;
+      });
+      UNs.erase(std::unique(UNs.begin(), UNs.end(),
+                            [](const UtilityNodeT &L, const UtilityNodeT &R) {
+                              return L.Id == R.Id;
+                            }),
+                UNs.end());
+    }
   };
 
   /// \param UtilityNodes the set of utility nodes (must be unique'd)

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -75,8 +75,6 @@ public:
 
   void dump(raw_ostream &OS) const;
 
-  std::optional<unsigned> getBucket() const { return Bucket; };
-
 protected:
   /// The list of utility nodes associated with this node
   SmallVector<UtilityNodeT, 4> UtilityNodes;
@@ -86,8 +84,7 @@ protected:
   uint64_t InputOrderIndex = 0;
 
   friend class BPFunctionNodeTest_Basic_Test;
-  friend class BalancedPartitioningTest_Basic_Test;
-  friend class BalancedPartitioningTest_Large_Test;
+  friend class BalancedPartitioningTest;
 };
 
 /// Algorithm parameters; default values are tuned on real-world binaries

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -57,8 +57,14 @@ class BPFunctionNode {
   friend class BalancedPartitioning;
 
 public:
+  /// The type of ID
   using IDT = uint64_t;
-  using UtilityNodeT = uint32_t;
+  /// The type of UtilityNode
+  struct UtilityNodeT {
+    UtilityNodeT(uint32_t id, uint32_t weight = 1) : id(id), weight(weight) {}
+    uint32_t id;
+    uint32_t weight;
+  };
 
   /// \param UtilityNodes the set of utility nodes (must be unique'd)
   BPFunctionNode(IDT Id, ArrayRef<UtilityNodeT> UtilityNodes)
@@ -68,6 +74,8 @@ public:
   IDT Id;
 
   void dump(raw_ostream &OS) const;
+
+  std::optional<unsigned> getBucket() const { return Bucket; };
 
 protected:
   /// The list of utility nodes associated with this node
@@ -188,6 +196,8 @@ private:
     float CachedGainRL;
     /// Whether \p CachedGainLR and \p CachedGainRL are valid
     bool CachedGainIsValid = false;
+    /// The weight of this utility node
+    uint32_t Weight = 1;
   };
 
 protected:

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -929,15 +929,9 @@ std::vector<BPFunctionNode> TemporalProfTraceTy::createBPFunctionNodes(
   for (uint32_t TraceIdx = 0; TraceIdx < Traces.size(); TraceIdx++) {
     auto &Trace = Traces[TraceIdx].FunctionNameRefs;
     for (size_t Timestamp = 0; Timestamp < Trace.size(); Timestamp++) {
-<<<<<<< HEAD
       for (int I = Log2_64(Timestamp + 1); I < N; I++) {
         auto FunctionId = Trace[Timestamp];
-        UtilityNodeT GroupId = TraceIdx * N + I;
-=======
-      for (int I = std::floor(std::log2(Timestamp + 1)); I < N; I++) {
-        auto &FunctionId = Trace[Timestamp];
         UtilityNodeT GroupId(TraceIdx * N + I);
->>>>>>> 0c3051fa80e6 (addressing review)
         FuncGroups[FunctionId].push_back(GroupId);
       }
     }

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -905,20 +905,6 @@ void InstrProfRecord::addValueData(uint32_t ValueKind, uint32_t Site,
     ValueSites.emplace_back(VData, VData + N);
 }
 
-// Deduplicate utility nodes for a given function.
-// TODO: One may experiment with accumulating the weights of duplicates.
-void sortAndDeduplicate(SmallVector<BPFunctionNode::UtilityNodeT, 4> &UNs) {
-  using UtilityNodeT = BPFunctionNode::UtilityNodeT;
-  llvm::sort(UNs, [](const UtilityNodeT &L, const UtilityNodeT &R) {
-    return L.Id < R.Id;
-  });
-  UNs.erase(std::unique(UNs.begin(), UNs.end(),
-                        [](const UtilityNodeT &L, const UtilityNodeT &R) {
-                          return L.Id == R.Id;
-                        }),
-            UNs.end());
-}
-
 std::vector<BPFunctionNode> TemporalProfTraceTy::createBPFunctionNodes(
     ArrayRef<TemporalProfTraceTy> Traces) {
   using IDT = BPFunctionNode::IDT;
@@ -954,7 +940,7 @@ std::vector<BPFunctionNode> TemporalProfTraceTy::createBPFunctionNodes(
   std::vector<BPFunctionNode> Nodes;
   for (auto Id : FunctionIds) {
     auto &UNs = FuncGroups[Id];
-    sortAndDeduplicate(UNs);
+    UtilityNodeT::sortAndDeduplicate(UNs);
     Nodes.emplace_back(Id, UNs);
   }
   return Nodes;

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -929,9 +929,15 @@ std::vector<BPFunctionNode> TemporalProfTraceTy::createBPFunctionNodes(
   for (uint32_t TraceIdx = 0; TraceIdx < Traces.size(); TraceIdx++) {
     auto &Trace = Traces[TraceIdx].FunctionNameRefs;
     for (size_t Timestamp = 0; Timestamp < Trace.size(); Timestamp++) {
+<<<<<<< HEAD
       for (int I = Log2_64(Timestamp + 1); I < N; I++) {
         auto FunctionId = Trace[Timestamp];
         UtilityNodeT GroupId = TraceIdx * N + I;
+=======
+      for (int I = std::floor(std::log2(Timestamp + 1)); I < N; I++) {
+        auto &FunctionId = Trace[Timestamp];
+        UtilityNodeT GroupId(TraceIdx * N + I);
+>>>>>>> 0c3051fa80e6 (addressing review)
         FuncGroups[FunctionId].push_back(GroupId);
       }
     }
@@ -940,10 +946,9 @@ std::vector<BPFunctionNode> TemporalProfTraceTy::createBPFunctionNodes(
   std::vector<BPFunctionNode> Nodes;
   for (auto Id : FunctionIds) {
     auto &UNs = FuncGroups[Id];
-    llvm::sort(UNs.begin(), UNs.end(),
-               [](const UtilityNodeT &L, const UtilityNodeT &R) {
-                 return L.id < R.id;
-               });
+    llvm::sort(UNs, [](const UtilityNodeT &L, const UtilityNodeT &R) {
+      return L.id < R.id;
+    });
     UNs.erase(std::unique(UNs.begin(), UNs.end(),
                           [](const UtilityNodeT &L, const UtilityNodeT &R) {
                             return L.id == R.id;

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -905,6 +905,20 @@ void InstrProfRecord::addValueData(uint32_t ValueKind, uint32_t Site,
     ValueSites.emplace_back(VData, VData + N);
 }
 
+// Deduplicate utility nodes for a given function.
+// TODO: One may experiment with accumulating the weights of duplicates.
+void sortAndDeduplicate(SmallVector<BPFunctionNode::UtilityNodeT, 4> &UNs) {
+  using UtilityNodeT = BPFunctionNode::UtilityNodeT;
+  llvm::sort(UNs, [](const UtilityNodeT &L, const UtilityNodeT &R) {
+    return L.Id < R.Id;
+  });
+  UNs.erase(std::unique(UNs.begin(), UNs.end(),
+                        [](const UtilityNodeT &L, const UtilityNodeT &R) {
+                          return L.Id == R.Id;
+                        }),
+            UNs.end());
+}
+
 std::vector<BPFunctionNode> TemporalProfTraceTy::createBPFunctionNodes(
     ArrayRef<TemporalProfTraceTy> Traces) {
   using IDT = BPFunctionNode::IDT;
@@ -940,14 +954,7 @@ std::vector<BPFunctionNode> TemporalProfTraceTy::createBPFunctionNodes(
   std::vector<BPFunctionNode> Nodes;
   for (auto Id : FunctionIds) {
     auto &UNs = FuncGroups[Id];
-    llvm::sort(UNs, [](const UtilityNodeT &L, const UtilityNodeT &R) {
-      return L.id < R.id;
-    });
-    UNs.erase(std::unique(UNs.begin(), UNs.end(),
-                          [](const UtilityNodeT &L, const UtilityNodeT &R) {
-                            return L.id == R.id;
-                          }),
-              UNs.end());
+    sortAndDeduplicate(UNs);
     Nodes.emplace_back(Id, UNs);
   }
   return Nodes;

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -202,7 +202,13 @@ void BalancedPartitioning::runIterations(const FunctionNodeRange Nodes,
         Signatures[UN.id].LeftCount++;
       else
         Signatures[UN.id].RightCount++;
-      Signatures[UN.id].Weight = UN.weight;
+      // Identical utility nodes (having the same UN.id) are guaranteed to have
+      // the same weight; thus, we can get a new weight only when the signature
+      // is uninitialized.
+      if (Signatures[UN.id].Weight != UN.weight) {
+        assert(Signatures[UN.id].Weight == 1);
+        Signatures[UN.id].Weight = UN.weight;
+      }
     }
   }
 

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -203,9 +203,8 @@ void BalancedPartitioning::runIterations(const FunctionNodeRange Nodes,
         Signatures[UN.Id].RightCount++;
       // Identical utility nodes (having the same UN.Id) have the same weight
       // (unless there are hash collisions mapping utilities to the same Id);
-      // thus, we can get a new weight only when the signature is uninitialized.
-      if (Signatures[UN.Id].Weight != UN.Weight)
-        Signatures[UN.Id].Weight = UN.Weight;
+      // thus, we get a new weight only when the signature is uninitialized.
+      Signatures[UN.Id].Weight = UN.Weight;
     }
   }
 

--- a/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
+++ b/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
@@ -13,8 +13,8 @@
 #include "gtest/gtest.h"
 
 using testing::Field;
+using testing::Matcher;
 using testing::UnorderedElementsAre;
-using testing::UnorderedElementsAreArray;
 
 namespace llvm {
 
@@ -24,29 +24,35 @@ void PrintTo(const BPFunctionNode &Node, std::ostream *OS) {
 }
 
 TEST(BPFunctionNodeTest, Basic) {
+  auto UNIdsAre = [](auto... Ids) {
+    return UnorderedElementsAre(Field("id", &BPFunctionNode::UtilityNodeT::id,
+                                      std::forward<uint32_t>(Ids))...);
+  };
   auto NodeIs = [](BPFunctionNode::IDT Id,
-                   ArrayRef<BPFunctionNode::UtilityNodeT> UNs) {
-    return AllOf(Field("Id", &BPFunctionNode::Id, Id),
-                 Field("UtilityNodes", &BPFunctionNode::UtilityNodes,
-                       UnorderedElementsAreArray(UNs)));
+                   Matcher<ArrayRef<BPFunctionNode::UtilityNodeT>> UNsMatcher) {
+    return AllOf(
+        Field("Id", &BPFunctionNode::Id, Id),
+        Field("UtilityNodes", &BPFunctionNode::UtilityNodes, UNsMatcher));
   };
 
   auto Nodes = TemporalProfTraceTy::createBPFunctionNodes({
       TemporalProfTraceTy({0, 1, 2, 3}),
   });
-  EXPECT_THAT(Nodes,
-              UnorderedElementsAre(NodeIs(0, {0, 1, 2}), NodeIs(1, {1, 2}),
-                                   NodeIs(2, {1, 2}), NodeIs(3, {2})));
+  EXPECT_THAT(Nodes, UnorderedElementsAre(NodeIs(0, UNIdsAre(0, 1, 2)),
+                                          NodeIs(1, UNIdsAre(1, 2)),
+                                          NodeIs(2, UNIdsAre(1, 2)),
+                                          NodeIs(3, UNIdsAre(2))));
 
   Nodes = TemporalProfTraceTy::createBPFunctionNodes({
       TemporalProfTraceTy({0, 1, 2, 3, 4}),
       TemporalProfTraceTy({4, 2}),
   });
 
-  EXPECT_THAT(Nodes,
-              UnorderedElementsAre(NodeIs(0, {0, 1, 2}), NodeIs(1, {1, 2}),
-                                   NodeIs(2, {1, 2, 4, 5}), NodeIs(3, {2}),
-                                   NodeIs(4, {2, 3, 4, 5})));
+  EXPECT_THAT(Nodes, UnorderedElementsAre(NodeIs(0, UNIdsAre(0, 1, 2)),
+                                          NodeIs(1, UNIdsAre(1, 2)),
+                                          NodeIs(2, UNIdsAre(1, 2, 4, 5)),
+                                          NodeIs(3, UNIdsAre(2)),
+                                          NodeIs(4, UNIdsAre(2, 3, 4, 5))));
 }
 
 } // end namespace llvm

--- a/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
+++ b/llvm/unittests/ProfileData/BPFunctionNodeTest.cpp
@@ -25,7 +25,7 @@ void PrintTo(const BPFunctionNode &Node, std::ostream *OS) {
 
 TEST(BPFunctionNodeTest, Basic) {
   auto UNIdsAre = [](auto... Ids) {
-    return UnorderedElementsAre(Field("id", &BPFunctionNode::UtilityNodeT::id,
+    return UnorderedElementsAre(Field("Id", &BPFunctionNode::UtilityNodeT::Id,
                                       std::forward<uint32_t>(Ids))...);
   };
   auto NodeIs = [](BPFunctionNode::IDT Id,


### PR DESCRIPTION
Adding weights to utility nodes in BP so that we can give more importance to 
certain utilities. This is useful when we optimize several objectives jointly.