### PR TITLE
[Github] Add build Flang docs in CI if autogenerated files change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,7 @@ on:
       - 'openmp/docs/**'
       - 'polly/docs/**'
       - 'flang/docs/**'
+      - 'flang/include/flang/Optimizer/Dialect/FIROps.td'
   pull_request:
     paths:
       - 'llvm/docs/**'
@@ -37,6 +38,7 @@ on:
       - 'openmp/docs/**'
       - 'polly/docs/**'
       - 'flang/docs/**'
+      - 'flang/include/flang/Optimizer/Dialect/FIROps.td'
 
 jobs:
   check-docs-build:
@@ -80,6 +82,7 @@ jobs:
               - 'polly/docs/**'
             flang:
               - 'flang/docs/**'
+              - 'flang/include/flang/Optimizer/Dialect/FIROps.td'
       - name: Fetch LLVM sources (PR)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently, when changes are made to the tablegen files that build the docs, the docs build is not tested. This should rarely cause breakages, but it's cheap to test and there isn't a major reason not to.