### PR TITLE
[flang][runtime] Fix BACKSPACE-WRITE on variable-length unformatted file

### DIFF
--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -825,10 +825,6 @@ void ExternalFileUnit::BackspaceVariableUnformattedRecord(
     return;
   }
   frameOffsetInFile_ -= *recordLength + 2 * headerBytes;
-  if (frameOffsetInFile_ >= headerBytes) {
-    frameOffsetInFile_ -= headerBytes;
-    recordOffsetInFrame_ = headerBytes;
-  }
   auto need{static_cast<std::size_t>(
       recordOffsetInFrame_ + sizeof header + *recordLength)};
   got = ReadFrame(frameOffsetInFile_, need, handler);


### PR DESCRIPTION
A subtle bug in buffer management is being caused by a WRITE on an unformatted file with variable-length records after one or more BACKSPACEs and some READs.  An attempt at a minor optimization in BACKSPACE kept the footer of the previous record in the unit's buffer, in case more BACKSPACEs were to follow.  If a later WRITE takes place instead, the buffer's frame would still cover that footer, but its content would be lost when the buffer became dirty on its first modification, and the footer in the file would be overwritten with stale buffer contents.  As WriteFrame() implies the intent to define all the bytes in the identified range, the trick being used in BACKSPACE with its adjustment to frameOffsetInFile_ breaks any later WRITE... and so we just can't do it.

Fixes https://github.com/llvm/llvm-project/issues/72599.