### PR TITLE
[Github] Print diff in code format helper

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -156,6 +156,8 @@ class ClangFormatHelper(FormatHelper):
         if proc.returncode != 0:
             # formatting needed, or the command otherwise failed
             print(f"error: {self.name} exited with code {proc.returncode}")
+            # Print the diff in the log so that it is viewable there
+            print(proc.stdout.decode("utf-8"))
             return proc.stdout.decode("utf-8")
         else:
             sys.stdout.write(proc.stdout.decode("utf-8"))
@@ -200,6 +202,8 @@ class DarkerFormatHelper(FormatHelper):
         if proc.returncode != 0:
             # formatting needed, or the command otherwise failed
             print(f"error: {self.name} exited with code {proc.returncode}")
+            # Print the diff in the log so that it is viewable there
+            print(proc.stdout.decode("utf-8"))
             return proc.stdout.decode("utf-8")
         else:
             sys.stdout.write(proc.stdout.decode("utf-8"))


### PR DESCRIPTION
Currently, when the code format action fails, it leaves no log of the diff in the output within the action itself. This has caused confusion for some users of the action, especially when the comment becomes buried in a 100+ comment review and someone isn't super familiar with the inner workings of the CI. This patch prints the diff produced by the code formatter to stdout so that it is viewable by clicking on the failed action. This should have very little cost and make things slightly less confusing for those that run into this situation.