### PR TITLE
[clang] Turn invented Exprs' source locations in __builtin_dump_struct to empty

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -454,13 +454,13 @@ namespace {
 struct BuiltinDumpStructGenerator {
   Sema &S;
   CallExpr *TheCall;
-  SourceLocation Loc = TheCall->getBeginLoc();
+  SourceLocation Loc;
   SmallVector<Expr *, 32> Actions;
   DiagnosticErrorTrap ErrorTracker;
   PrintingPolicy Policy;
 
   BuiltinDumpStructGenerator(Sema &S, CallExpr *TheCall)
-      : S(S), TheCall(TheCall), ErrorTracker(S.getDiagnostics()),
+      : S(S), TheCall(TheCall), Loc(), ErrorTracker(S.getDiagnostics()),
         Policy(S.Context.getPrintingPolicy()) {
     Policy.AnonymousTagLocations = false;
   }
@@ -491,7 +491,7 @@ struct BuiltinDumpStructGenerator {
     // Register a note to explain why we're performing the call.
     Sema::CodeSynthesisContext Ctx;
     Ctx.Kind = Sema::CodeSynthesisContext::BuildingBuiltinDumpStructCall;
-    Ctx.PointOfInstantiation = Loc;
+    Ctx.PointOfInstantiation = TheCall->getBeginLoc();
     Ctx.CallArgs = Args.data();
     Ctx.NumCallArgs = Args.size();
     S.pushCodeSynthesisContext(Ctx);


### PR DESCRIPTION
This reflects the comment in https://github.com/llvm/llvm-project/pull/71366#issuecomment-1817271492.

As that PR suggests, the invented CallExpr's source location previously pointed to the beginning of the `__builtin_dump_struct`. These spurious AST nodes confused clangd while displaying parameter inlay hints.

This patch takes another approach to address the same issue, by turning the location for each _argument_ within an invented call to printf to empty, (maybe) at the risk of breaking the invariant for CallExpr -- The source location for an argument could be invalid from now on.