### PR TITLE
[gn build] Add a generic `compiler_wrapper` gn arg

### DIFF
--- a/llvm/utils/gn/build/toolchain/BUILD.gn
+++ b/llvm/utils/gn/build/toolchain/BUILD.gn
@@ -1,13 +1,9 @@
 import("//llvm/utils/gn/build/toolchain/compiler.gni")
 
-declare_args() {
-  # If is_goma is true, the location of the goma client install.
-  # Set this to the output of `goma_ctl goma_dir`.
-  goma_dir = ""
-}
-
 assert(!use_goma || goma_dir != "",
        "set `goma_dir` to the output of `goma_ctl goma_dir` in your args.gn")
+assert(!use_goma || compiler_wrapper == "",
+       "`use_goma` and `compiler_wrapper` are mutually exclusive")
 
 unix_copy_command = "ln -f {{source}} {{output}} 2>/dev/null || (rm -rf {{output}} && cp -af {{source}} {{output}})"
 
@@ -31,6 +27,9 @@ template("unix_toolchain") {
     if (use_goma) {
       cc = "$goma_dir/gomacc $cc"
       cxx = "$goma_dir/gomacc $cxx"
+    } else if (compiler_wrapper != "") {
+      cc = "$compiler_wrapper $cc"
+      cxx = "$compiler_wrapper $cxx"
     }
 
     tool("cc") {
@@ -304,6 +303,8 @@ template("win_toolchain") {
 
     if (use_goma) {
       cl = "$goma_dir/gomacc $cl"
+    } else if (compiler_wrapper != "") {
+      cl = "$compiler_wrapper $cl"
     }
 
     tool("cc") {

--- a/llvm/utils/gn/build/toolchain/compiler.gni
+++ b/llvm/utils/gn/build/toolchain/compiler.gni
@@ -2,6 +2,14 @@ declare_args() {
   # Whether to use goma (https://chromium.googlesource.com/infra/goma/client/)
   use_goma = false
 
+  # If is_goma is true, the location of the goma client install.
+  # Set this to the output of `goma_ctl goma_dir`.
+  goma_dir = ""
+
+  # If set, this is prepended to compile action command lines (e.g. `"ccache"`).
+  # Cannot be used with use_goma/goma_dir.
+  compiler_wrapper = ""
+
   # Set this to a clang build directory. If set, that clang is used as compiler.
   # goma only works with compiler binaries it knows about, so useful both for
   # using a goma-approved compiler and for compiling clang with a locally-built


### PR DESCRIPTION
Since goma is going away soon, we need to experiment with other wrappers.

We can clean up the goma stuff once it's fully non-functional.