### PR TITLE
[PowerPC] Handle CALL_RM like CALL for 32-bit ELF

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
@@ -5475,7 +5475,8 @@ void PPCDAGToDAGISel::Select(SDNode *N) {
     // generate secure plt code for TLS symbols.
     getGlobalBaseReg();
   } break;
-  case PPCISD::CALL: {
+  case PPCISD::CALL:
+  case PPCISD::CALL_RM: {
     if (PPCLowering->getPointerTy(CurDAG->getDataLayout()) != MVT::i32 ||
         !TM.isPositionIndependent() || !Subtarget->isSecurePlt() ||
         !Subtarget->isTargetELF())
@@ -5491,8 +5492,7 @@ void PPCDAGToDAGISel::Select(SDNode *N) {
       if (ES->getTargetFlags() == PPCII::MO_PLT)
         getGlobalBaseReg();
     }
-  }
-    break;
+  } break;
 
   case PPCISD::GlobalBaseReg:
     ReplaceNode(N, getGlobalBaseReg());

--- a/llvm/test/CodeGen/PowerPC/ppc32-secure-plt-rm.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc32-secure-plt-rm.ll
@@ -1,0 +1,21 @@
+; RUN: llc < %s -mtriple=powerpc-unknown-linux-gnu -mattr=+secure-plt -relocation-model=pic | FileCheck %s
+
+; This variant of ppc32-pic-large.ll checks that a strictfp call sets
+; r30 for the secure PLT.
+
+declare void @call_foo()
+
+define void @foo() {
+entry:
+  call void @call_foo() #0
+  ret void
+}
+
+attributes #0 = { strictfp }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"PIC Level", i32 2}
+
+; CHECK:  addis 30, 30, .LTOC-.L0$pb@ha
+; CHECK:  addi 30, 30, .LTOC-.L0$pb@l
+; CHECK:  bl call_foo@PLT+32768


### PR DESCRIPTION
If a function call has the strictfp attribute, its opcode changes from CALL to CALL_RM.  If the call uses the secure PLT for 32-bit ELF, then it must getGlobalBaseReg() to set r30.

----
This fixes a bug that I described in (OpenBSD) [macppc clang-16 -ftrapping-math crashes Xorg](https://marc.info/?l=openbsd-tech&m=170028494906642&w=2). The short version is that clang -ftrapping-math broke code like `int main(void) { time(NULL); }` by forgetting to set r30 before using the secure PLT.