### PR TITLE
[AArch64] Update comment on GHC CC

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -333,7 +333,7 @@ def CC_AArch64_DarwinPCS_ILP32_VarArg : CallingConv<[
 // The only documentation is the GHC source code, specifically the C header
 // file:
 //
-//     https://github.com/ghc/ghc/blob/master/includes/stg/MachRegs.h
+//    https://github.com/ghc/ghc/blob/master/rts/include/stg/MachRegs.h
 //
 // which defines the registers for the Spineless Tagless G-Machine (STG) that
 // GHC uses to implement lazy evaluation. The generic STG machine has a set of
@@ -344,8 +344,10 @@ def CC_AArch64_DarwinPCS_ILP32_VarArg : CallingConv<[
 //
 //    https://ghc.haskell.org/trac/ghc/wiki/Commentary/Compiler/GeneratedCode
 //
-// The AArch64 register mapping is under the heading "The ARMv8/AArch64 ABI
-// register mapping".
+// The AArch64 register mapping is defined in the following header file:
+//
+//    https://github.com/ghc/ghc/blob/master/rts/include/stg/MachRegs/arm32.h
+//
 
 let Entry = 1 in
 def CC_AArch64_GHC : CallingConv<[

--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -346,7 +346,7 @@ def CC_AArch64_DarwinPCS_ILP32_VarArg : CallingConv<[
 //
 // The AArch64 register mapping is defined in the following header file:
 //
-//    https://github.com/ghc/ghc/blob/master/rts/include/stg/MachRegs/arm32.h
+//    https://github.com/ghc/ghc/blob/master/rts/include/stg/MachRegs/arm64.h
 //
 
 let Entry = 1 in


### PR DESCRIPTION
Currently, there are a couple dead links in the comment surrounding the tablegen implementtion of the GHC calling convention in AArch64. There was some refactoring in GHC that moved things around. This patch fixes up the comment to match the current state of the repository to make it easier for future readers to reference the relevant documentation.