### PR TITLE
[RISCV] Add documentation in the LangRef on GHC CC

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -317,8 +317,8 @@ added in the future:
     not be used lightly but only for specific situations such as an
     alternative to the *register pinning* performance technique often
     used when implementing functional programming languages. At the
-    moment only X86 and AArch64 support this convention. The following
-    limitations exist:
+    moment only X86, AArch64, and RISCV support this convention. The 
+    following limitations exist:
 
     -  On *X86-32* only up to 4 bit type parameters are supported. No
        floating-point types are supported.
@@ -326,7 +326,9 @@ added in the future:
        floating-point parameters are supported.
     -  On *AArch64* only up to 4 32-bit floating-point parameters,
        4 64-bit floating-point parameters, and 10 bit type parameters
-       are supported.
+    -  *RISCV64* only supports up to 11 bit type parameters, 4
+       32-bit floating-point parameters, and 4 64-bit floating-point
+       parameters.
 
     This calling convention supports `tail call
     optimization <CodeGenerator.html#tail-call-optimization>`_ but requires

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -326,6 +326,7 @@ added in the future:
        floating-point parameters are supported.
     -  On *AArch64* only up to 4 32-bit floating-point parameters,
        4 64-bit floating-point parameters, and 10 bit type parameters
+       are supported.
     -  *RISCV64* only supports up to 11 bit type parameters, 4
        32-bit floating-point parameters, and 4 64-bit floating-point
        parameters.


### PR DESCRIPTION
The GHC CC got added to RISCV in a8dc2110cd4dd69212a204bc1074729f95d5402a but it never got documented in the LangRef. This adds documentation in the LangRef noting that RISCV is supports the GHC calling convention and notes the specific limitations of the GHC CC on RISCV.