### PR TITLE
[clang-format] Fix a bug in isStartOfName() on macro definitions

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2206,8 +2206,10 @@ private:
       return false;
 
     if (const auto *NextNonComment = Tok.getNextNonComment();
-        !NextNonComment || NextNonComment->isPointerOrReference() ||
-        NextNonComment->isOneOf(tok::identifier, tok::string_literal)) {
+        (!NextNonComment && !Line.InMacroBody) ||
+        (NextNonComment &&
+         (NextNonComment->isPointerOrReference() ||
+          NextNonComment->isOneOf(tok::identifier, tok::string_literal)))) {
       return false;
     }
 

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2390,7 +2390,7 @@ TEST_F(TokenAnnotatorTest, UnderstandsDoWhile) {
   EXPECT_TOKEN(Tokens[4], tok::kw_while, TT_DoWhile);
 }
 
-TEST_F(TokenAnnotatorTest, NotStartOfName) {
+TEST_F(TokenAnnotatorTest, StartOfName) {
   auto Tokens = annotate("#pragma clang diagnostic push");
   ASSERT_EQ(Tokens.size(), 6u) << Tokens;
   EXPECT_TOKEN(Tokens[2], tok::identifier, TT_Unknown);
@@ -2402,6 +2402,12 @@ TEST_F(TokenAnnotatorTest, NotStartOfName) {
   EXPECT_TOKEN(Tokens[2], tok::identifier, TT_Unknown);
   EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
   EXPECT_TOKEN(Tokens[4], tok::identifier, TT_Unknown);
+
+  Tokens = annotate("#define FOO Foo foo");
+  ASSERT_EQ(Tokens.size(), 6u) << Tokens;
+  EXPECT_TOKEN(Tokens[2], tok::identifier, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
+  EXPECT_TOKEN(Tokens[4], tok::identifier, TT_StartOfName);
 }
 
 } // namespace


### PR DESCRIPTION
Fixed #72751.