### PR TITLE
[llvm-exegesis] Add explicit error message with segfault address

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-segfault.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-segfault.s
@@ -2,10 +2,10 @@
 
 # RUN: llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -snippets-file=%s -execution-mode=subprocess | FileCheck %s
 
-# CHECK: error:           'The benchmarking subprocess sent unexpected signal: Segmentation fault'
+# CHECK: error:           A segmentation fault occurred at address 10000
 
 # TODO: Sometimes transiently fails on PTRACE_ATTACH
 # ALLOW_RETRIES: 2
 
-# LLVM-EXEGESIS-DEFREG RBX 0
+# LLVM-EXEGESIS-DEFREG RBX 10000
 movq (%rbx), %rax

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -343,6 +343,12 @@ private:
                                  Twine(strerror(errno)));
     }
 
+    if (ChildSignalInfo.si_signo == SIGSEGV)
+      return make_error<SnippetCrash>(
+          "A segmentation fault occurred at address " +
+          Twine::utohexstr(
+              reinterpret_cast<intptr_t>(ChildSignalInfo.si_addr)));
+
     return make_error<SnippetCrash>(
         "The benchmarking subprocess sent unexpected signal: " +
         Twine(strsignal(ChildSignalInfo.si_signo)));


### PR DESCRIPTION
This patch special cases the segfault case for the subprocess executor, giving the exact address of a segfault when one occurs in the subprocess. This makes it a lot easier to debug where things are going wrong in the snippet.