### PR TITLE
[llvm-exegesis] Fix race condition in subprocess mode

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations-livein.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations-livein.s
@@ -8,9 +8,6 @@
 # CHECK: measurements:
 # CHECK-NEXT: value: {{.*}}, per_snippet_value: {{.*}}
 
-# TODO: Sometimes transiently fails on PTRACE_ATTACH
-# ALLOW_RETRIES: 2
-
 # LLVM-EXEGESIS-MEM-DEF test1 4096 2147483647
 # LLVM-EXEGESIS-MEM-MAP test1 1048576
 # LLVM-EXEGESIS-LIVEIN R14

--- a/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/memory-annotations.s
@@ -10,9 +10,6 @@
 # CHECK: measurements:
 # CHECK-NEXT: value: {{.*}}, per_snippet_value: {{.*}}
 
-# TODO: Sometimes transiently fails on PTRACE_ATTACH
-# ALLOW_RETRIES: 2
-
 # LLVM-EXEGESIS-MEM-DEF test1 4096 2147483647
 # LLVM-EXEGESIS-MEM-MAP test1 1048576
 

--- a/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-abnormal-exit-code.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-abnormal-exit-code.s
@@ -4,9 +4,6 @@
 
 # CHECK: error: 'Child benchmarking process exited with non-zero exit code: Child process returned with unknown exit code'
 
-# TODO: Sometimes transiently fails on PTRACE_ATTACH
-# ALLOW_RETRIES: 2
-
 movl $60, %eax
 movl $127, %edi
 syscall

--- a/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-preserved-registers.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-preserved-registers.s
@@ -2,10 +2,6 @@
 
 # RUN: llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -snippets-file=%s -execution-mode=subprocess | FileCheck %s
 
-# See comment in ./subprocess-abnormal-exit-code.s on the transient
-# PTRACE_ATTACH failure.
-# ALLOW_RETRIES: 2
-
 # Check that the value of the registers preserved in subprocess mode while
 # making the ioctl system call are actually preserved correctly.
 

--- a/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-segfault.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/subprocess-segfault.s
@@ -4,8 +4,5 @@
 
 # CHECK: error:           'The benchmarking subprocess sent unexpected signal: Segmentation fault'
 
-# TODO: Sometimes transiently fails on PTRACE_ATTACH
-# ALLOW_RETRIES: 2
-
 # LLVM-EXEGESIS-DEFREG RBX 0
 movq (%rbx), %rax

--- a/llvm/test/tools/llvm-exegesis/X86/latency/subprocess.s
+++ b/llvm/test/tools/llvm-exegesis/X86/latency/subprocess.s
@@ -5,9 +5,6 @@
 # CHECK: measurements:
 # CHECK-NEXT: value: {{.*}}, per_snippet_value: {{.*}}
 
-# TODO: Sometimes transiently fails on PTRACE_ATTACH
-# ALLOW_RETRIES: 2
-
 # LLVM-EXEGESIS-DEFREG XMM1 42
 # LLVM-EXEGESIS-DEFREG XMM2 42
 # LLVM-EXEGESIS-DEFREG XMM3 42


### PR DESCRIPTION
If there were some scheduler effects where something like the parent process got interrupted while the child process continued to run, there would be nothing blocking it from exiting before the parent process issued a PTRACE_ATTACH call. This would cause transient failures as this occurred pretty rarely. This patch removes the possibility of a transient failure by ensuring that the parent process attaches to the child process before sending the counter file descriptor through the socket, ensuring that the child process has at most progressed to being blocked in the read call for the counter file descriptor.