### PR TITLE
[Github] Prevent scorecard action from running on forks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,6 +22,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    if: github.repository = 'llvm/llvm-project'
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
Currently, the scorecard action runs on forks. This means that every recent fork will be periodically running a job that doesn't really make a lot of sense to run outside the main monorepo. This patch fixes that by restricting the job to only run in the monorepo.