### PR TITLE
[Driver] Add support for -export-dynamic which can match GCC behavior.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1453,6 +1453,7 @@ def extract_api_ignores_EQ: CommaJoined<["--"], "extract-api-ignores=">,
     HelpText<"Comma separated list of files containing a new line separated list of API symbols to ignore when extracting API information.">,
     MarshallingInfoStringVector<FrontendOpts<"ExtractAPIIgnoresFileList">>;
 def e : JoinedOrSeparate<["-"], "e">, Flags<[LinkerInput]>, Group<Link_Group>;
+def export_dynamic : Flag<["-"], "export-dynamic">, Flags<[LinkerInput]>, Group<Link_Group>;
 def fmax_tokens_EQ : Joined<["-"], "fmax-tokens=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Max total number of preprocessed tokens for -Wmax-tokens.">,

--- a/clang/test/Driver/dynamic-linker.c
+++ b/clang/test/Driver/dynamic-linker.c
@@ -23,6 +23,12 @@
 // RUN: %clang -target powerpc64-unknown-linux-gnu -### -static /dev/null -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-STATIC %s
 // RUN: %clang -target x86_64-unknown-linux-gnu -### -static /dev/null -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-STATIC %s
 
+// RUN: %clang -target armv7-unknown-linux-gnueabi -### -export-dynamic /dev/null -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-RDYNAMIC %s
+// RUN: %clang -target i386-unknown-linux-gnu -### -export-dynamic /dev/null -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-RDYNAMIC %s
+// RUN: %clang -target mips64-unknown-linux-gnu -### -export-dynamic /dev/null -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-RDYNAMIC %s
+// RUN: %clang -target powerpc64-unknown-linux-gnu -### -export-dynamic /dev/null -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-RDYNAMIC %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -### -export-dynamic /dev/null -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-RDYNAMIC %s
+
 // CHECK-SHARED: "-shared"
 // CHECK-RDYNAMIC: "-export-dynamic"
 // CHECK-STATIC: "-{{B?}}static"


### PR DESCRIPTION
clang splits -export-dynamic into "-e" and "xport-dynamic", and gets ld warning: cannot find entry symbol xport-dynamic; defaulting to XXXX, which is unexpected from user.

Adjust the driver to support -export-dynamic, which can match GCC behavior.