### PR TITLE
[HIP] fix stack marking for -fgpu-rdc

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPUtility.cpp
+++ b/clang/lib/Driver/ToolChains/HIPUtility.cpp
@@ -150,6 +150,8 @@ void HIP::constructGenerateObjFileFromHIPFatBinary(
   ObjStream << "  .incbin ";
   llvm::sys::printArg(ObjStream, BundleFile, /*Quote=*/true);
   ObjStream << "\n";
+  if (HostTriple.isOSLinux() && HostTriple.isOSBinFormatELF())
+    ObjStream << "  .section .note.GNU-stack, \"\", @progbits\n";
   ObjStream.flush();
 
   // Dump the contents of the temp object file gen if the user requested that.

--- a/clang/test/Driver/hip-toolchain-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-rdc.hip
@@ -32,6 +32,8 @@
 // CHECK: .p2align 12
 // CHECK: __hip_fatbin:
 // CHECK: .incbin "[[BUNDLE:.*hipfb]]"
+// LNX: .section .note.GNU-stack, "", @progbits
+// MSVC-NOT: .note.GNU-stack
 
 // emit objects for host side path
 // CHECK: [[CLANG:".*clang.*"]] "-cc1" "-triple" [[HOST:"x86_64-[^"]+"]]


### PR DESCRIPTION
HIP toolchain uses llvm-mc to generate a host object embedding device binary for -fgpu-rdc. Due to lack of .note.GNU-stack section, the generated relocatable has executable stack marking, which disables protection from executable stack for any HIP programs compiled with -fgpu-rdc.

This patch adds .note.GNU-stack section to the input to llvm-mc to fix the executable stack marking.

Fixes: https://github.com/llvm/llvm-project/issues/71711