### PR TITLE
[flang][OpenMP] Add semantic check for device clause

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2748,6 +2748,17 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Device &x) {
   const auto &device{std::get<1>(deviceClause.t)};
   RequiresPositiveParameter(
       llvm::omp::Clause::OMPC_device, device, "device expression");
+  std::optional<parser::OmpDeviceClause::DeviceModifier> modifier =
+      std::get<0>(deviceClause.t);
+  if (modifier &&
+      *modifier == parser::OmpDeviceClause::DeviceModifier::Ancestor) {
+    if (GetContext().directive != llvm::omp::OMPD_target) {
+      context_.Say(GetContext().clauseSource,
+          "The ANCESTOR device-modifier must not appear on the DEVICE clause on"
+          " any directive other than the TARGET construct. Found on %s construct."_err_en_US,
+          parser::ToUpperCaseLetters(getDirectiveName(GetContext().directive)));
+    }
+  }
 }
 
 void OmpStructureChecker::Enter(const parser::OmpClause::Depend &x) {

--- a/flang/test/Semantics/OpenMP/device-clause01.f90
+++ b/flang/test/Semantics/OpenMP/device-clause01.f90
@@ -1,0 +1,31 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+! OpenMP Version 5.2
+! 13.2 Device clause
+
+subroutine foo
+
+  integer :: a
+
+  !$omp target device(ancestor:0)
+  !$omp end target
+  !$omp target device(device_num:0)
+  !$omp end target
+  
+  !ERROR: The ANCESTOR device-modifier must not appear on the DEVICE clause on any directive other than the TARGET construct. Found on TARGET DATA construct.
+  !$omp target data device(ancestor:0) map(tofrom:a)
+  !$omp end target data
+  !$omp target data device(device_num:0) map(tofrom:a)
+  !$omp end target data
+
+  
+  !ERROR: The ANCESTOR device-modifier must not appear on the DEVICE clause on any directive other than the TARGET construct. Found on TARGET ENTER DATA construct.
+  !$omp target enter data device(ancestor:0) map(to:a)
+  !$omp target exit data map(from:a)
+  !$omp target enter data device(device_num:0) map(to:a)
+  !$omp target exit data map(from:a)
+
+  !ERROR: The ANCESTOR device-modifier must not appear on the DEVICE clause on any directive other than the TARGET construct. Found on TARGET UPDATE construct.
+  !$omp target update device(ancestor:0) to(a)
+  !$omp target update device(device_num:0) to(a)
+
+end subroutine foo


### PR DESCRIPTION
This patch adds the following semantic check:

```
The ancestor device-modifier must not appear on the device clause on any
directive other than the target construct.
```