### PR TITLE
[M68k] Fix ODR violation in GISel code

### DIFF
--- a/llvm/lib/Target/M68k/GISel/M68kCallLowering.h
+++ b/llvm/lib/Target/M68k/GISel/M68kCallLowering.h
@@ -63,23 +63,6 @@ private:
                            MachinePointerInfo &MPO,
                            ISD::ArgFlagsTy Flags) override;
 };
-
-struct FormalArgHandler : public M68kIncomingValueHandler {
-  FormalArgHandler(MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI)
-      : M68kIncomingValueHandler(MIRBuilder, MRI) {}
-};
-
-struct CallReturnHandler : public M68kIncomingValueHandler {
-  CallReturnHandler(MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI,
-                    MachineInstrBuilder &MIB)
-      : M68kIncomingValueHandler(MIRBuilder, MRI), MIB(MIB) {}
-
-private:
-  void assignValueToReg(Register ValVReg, Register PhysReg,
-                        const CCValAssign &VA) override;
-
-  MachineInstrBuilder &MIB;
-};
 } // end namespace llvm
 
 #endif // LLVM_LIB_TARGET_M68K_GLSEL_M68KCALLLOWERING_H


### PR DESCRIPTION
It prevents LLVM from being linked with LLD at least on Windows, with errors like this:

```
  = note: ld.lld: error: duplicate symbol: vtable for llvm::FormalArgHandler
          >>> defined at librustc_llvm-a81737dd65a7c126.rlib(M68kCallLowering.cpp.obj)
          >>> defined at librustc_llvm-a81737dd65a7c126.rlib(PPCCallLowering.cpp.obj)
```

Binutils linker also complains about this, but only with warnings.

`FormalArgHandler` has a base class `M68kIncomingValueHandler` which doesn't have a virtual method `markPhysRegUsed` like `IncomingValueHandler`s for all other targets including PPC, so it results in a conflict.
The simplest fix is to rename the `FormalArgHandler` structure (rather than to add virtual methods for compatibility).

cc https://github.com/rust-lang/rust/issues/107668