### PR TITLE
[Driver] Allow -e entry but reject -eentry

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1452,7 +1452,7 @@ def extract_api_ignores_EQ: CommaJoined<["--"], "extract-api-ignores=">,
   Visibility<[ClangOption, CC1Option]>,
     HelpText<"Comma separated list of files containing a new line separated list of API symbols to ignore when extracting API information.">,
     MarshallingInfoStringVector<FrontendOpts<"ExtractAPIIgnoresFileList">>;
-def e : JoinedOrSeparate<["-"], "e">, Flags<[LinkerInput]>, Group<Link_Group>;
+def e : Separate<["-"], "e">, Flags<[LinkerInput]>, Group<Link_Group>;
 def fmax_tokens_EQ : Joined<["-"], "fmax-tokens=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Max total number of preprocessed tokens for -Wmax-tokens.">,

--- a/clang/test/Driver/entry.s
+++ b/clang/test/Driver/entry.s
@@ -1,0 +1,5 @@
+/// To prevent mistaking -exxx as --entry=xxx, we allow -e xxx but reject -exxx.
+/// GCC -export-dynamic is rejected as well.
+// RUN: not %clang -### --target=x86_64-linux-gnu -export-dynamic %s 2>&1 | FileCheck %s
+
+// CHECK: error: unknown argument: '-export-dynamic'


### PR DESCRIPTION
This short option taking an argument is unfortunate.

* If a cc1-only option starts with `-e`, using it for driver will not be
  reported as an error (e.g. commit
  6cd9886c88d16d288c74846495d89f2fe84ff827).
* If another `-e` driver option is intended but a typo is made, the
  option will be recognized as a `-e`.

`gcc -export-dynamic` passes `-export-dynamic` to ld. It's not clear
whether some options behave this way.

It seems `-Wl,-eentry` and `-Wl,--entry=entry` are primarily used. There
may also be a few `gcc -e entry`, but `gcc -eentry` is extremely rare or
not used at all. Therefore, we probably should reject the Joined form of
`-e`.
