### PR TITLE
[clang] Enhance handling of Apple-specific '-arch'/'-target' option values

### DIFF
--- a/clang/test/Driver/apple-specific-options.c
+++ b/clang/test/Driver/apple-specific-options.c
@@ -1,0 +1,60 @@
+// Without '-target' explicitly passed, construct the default triple.
+// If the LLVM_DEFAULT_TARGET_TRIPLE is a Darwin triple, change it's architecture
+// to a one passed via '-arch'. Otherwise, use '<arch>-apple-darwin10'.
+
+// RUN: %clang -arch x86_64 -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARCH
+
+// ARCH: "-triple" "x86_64-apple-
+
+// For non-Darwin explicitly passed '-target', ignore '-arch'.
+
+// RUN: %clang -arch arm64 -target x86_64-unknown-linux -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARCH_NON_DARWIN1
+
+// ARCH_NON_DARWIN1: "-triple" "x86_64-unknown-linux"
+
+// RUN: %clang -arch arm64 -target x86_64-apple -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARCH_NON_DARWIN2
+
+// ARCH_NON_DARWIN2: "-triple" "x86_64-apple"
+
+
+// For Darwin explicitly passed '-target', the '-arch' option overrides the architecture
+
+// RUN: %clang -arch arm64 -target x86_64-apple-ios7.0.0 -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARCH_DARWIN
+
+// ARCH_DARWIN: "-triple" "arm64-apple-ios7.0.0"
+
+
+// For 'arm64e' and 'arm64e-apple' explicitly passed as '-target',
+// construct the default 'arm64e-apple-darwin10' triple.
+
+// RUN: %clang -target arm64e -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARM64E
+// RUN: %clang -target arm64e-apple -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARM64E
+// ARM64E: "-triple" "arm64e-apple-macosx10.6.0"
+
+
+// For non-Darwin explicitly passed '-target', keep it unchanged if not 'arm64e' and
+// 'arm64e-apple', which we implicitly narrow to the default 'arm64e-apple-darwin10'.
+
+// RUN: %clang -target arm64e-pc -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARM64E_NON_DARWIN1
+
+// ARM64E_NON_DARWIN1: "-triple" "arm64e-pc"
+
+// RUN: %clang -target arm64e-unknown-linux -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARM64E_NON_DARWIN2
+
+// ARM64E_NON_DARWIN2: "-triple" "arm64e-unknown-linux"
+
+
+// For Darwin explicitly passed '-target', keep it unchanged
+
+// RUN: %clang -target arm64e-apple-ios7.0.0 -c %s -### 2>&1 | \
+// RUN:   FileCheck %s --check-prefix ARM64E_DARWIN
+
+// ARM64E_DARWIN: "-triple" "arm64e-apple-ios7.0.0"


### PR DESCRIPTION
The '-arch' option itself is Apple-specific, so, if '-target' is not passed explicitely, we try to construct an Apple triple. If the default triple is Apple-specific, we just update it's arch so it matches the one passed via '-arch' option, otherwise, we construct a '<arch>-apple-darwin10' triple "from scratch". Passing just '-arch' without '-target' seems as a common practice in Apple's tests, and it previously led to undesireable triple values deduced if a person had, say, linux-specific LLVM_DEFAULT_TARGET_TRIPLE set.

The arm64e arch value is also Apple-specific, so, if we have 'arm64e' or 'arm64e-apple' triple, append missing parts to it so it becomes 'arm64e-apple-darwin10'.

See tests in Driver/apple-specific-options.c for detailed description of how different cases are handled.