### PR TITLE
[LoongArch][MC] Pre-commit tests for instr bl fixupkind testing

### DIFF
--- a/llvm/test/CodeGen/LoongArch/test_bl_fixupkind.mir
+++ b/llvm/test/CodeGen/LoongArch/test_bl_fixupkind.mir
@@ -1,0 +1,66 @@
+## Tagged as "Expectedly Failed" until the following patch fix it
+# XFAIL: *
+# RUN: llc --mtriple=loongarch64 --filetype=obj %s -o - | \
+# RUN: llvm-objdump -d - | FileCheck %s
+
+# REQUIRES: asserts
+
+## Check that bl can get fixupkind correctly.
+## When BL has target-flags(loongarch-call), there is no error. But without
+## this flag, an assertion error will appear:
+## Assertion `FixupKind != LoongArch::fixup_loongarch_invalid && "Unhandled expression!"' failed.
+
+--- |
+  target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+  target triple = "loongarch64"
+  
+  define dso_local void @test_bl_fixupkind_with_flag() {
+  ; CHECK-LABEL: test_bl_fixupkind_with_flag
+  ; CHECK:         addi.d $sp, $sp, -16
+  ; CHECK-NEXT:    st.d $ra, $sp, 8
+  ; CHECK-NEXT:    bl 0 <test_bl_fixupkind_with_flag+0x8>
+  ; CHECK-NEXT:    ld.d $ra, $sp, 8
+  ; CHECK-NEXT:    addi.d $sp, $sp, 16
+  ; CHECK-NEXT:    ret
+  entry:
+    call void @foo()
+    ret void
+  }
+  
+  define dso_local void @test_bl_fixupkind_without_flag() {
+  ; CHECK-LABEL: test_bl_fixupkind_without_flag
+  ; CHECK:         addi.d $sp, $sp, -16
+  ; CHECK-NEXT:    st.d $ra, $sp, 8
+  ; CHECK-NEXT:    bl 0 <test_bl_fixupkind_without_flag+0x8>
+  ; CHECK-NEXT:    ld.d $ra, $sp, 8
+  ; CHECK-NEXT:    addi.d $sp, $sp, 16
+  ; CHECK-NEXT:    ret
+  entry:
+    call void @foo()
+    ret void
+  }
+  
+  declare dso_local void @foo(...)
+...
+---
+name:            test_bl_fixupkind_with_flag
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    ADJCALLSTACKDOWN 0, 0, implicit-def dead $r3, implicit $r3
+    BL target-flags(loongarch-call) @foo, csr_ilp32d_lp64d, implicit-def $r1, implicit-def dead $r1, implicit-def $r3
+    ADJCALLSTACKUP 0, 0, implicit-def dead $r3, implicit $r3
+    PseudoRET
+
+...
+---
+name:            test_bl_fixupkind_without_flag
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    ADJCALLSTACKDOWN 0, 0, implicit-def dead $r3, implicit $r3
+    BL @foo, csr_ilp32d_lp64d, implicit-def $r1, implicit-def dead $r1, implicit-def $r3
+    ADJCALLSTACKUP 0, 0, implicit-def dead $r3, implicit $r3
+    PseudoRET
+
+...


### PR DESCRIPTION
This patch is used to test whether fixupkind for bl can be returned correctly. When BL has target-flags(loongarch-call), there is no error. But without this flag, an assertion error will appear. So the test is just tagged as "Expectedly Failed" now until the following patch fix it.