### PR TITLE
[clang][ASTImporter] Fix import of variable template redeclarations.

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6378,10 +6378,7 @@ ExpectedDecl ASTNodeImporter::VisitVarTemplateSpecializationDecl(
         // variable.
         return Importer.MapImported(D, FoundDef);
       }
-      // FIXME HandleNameConflict
-      return make_error<ASTImportError>(ASTImportError::NameConflict);
     }
-    return Importer.MapImported(D, D2);
   } else {
     TemplateArgumentListInfo ToTAInfo;
     if (const ASTTemplateArgumentListInfo *Args = D->getTemplateArgsInfo()) {

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -5050,6 +5050,111 @@ TEST_P(ImportFriendClasses, RecordVarTemplateDecl) {
   EXPECT_EQ(ToTUX, ToX);
 }
 
+TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateDeclConflict) {
+  Decl *ToTU = getToTuDecl(
+      R"(
+      template <class U>
+      constexpr int X = 1;
+      )",
+      Lang_CXX14);
+
+  Decl *FromTU = getTuDecl(
+      R"(
+      template <class U>
+      constexpr int X = 2;
+      )",
+      Lang_CXX14, "input1.cc");
+  auto *FromX = FirstDeclMatcher<VarTemplateDecl>().match(
+      FromTU, varTemplateDecl(hasName("X")));
+  auto *ToX = Import(FromX, Lang_CXX11);
+  // FIXME: This import should fail.
+  EXPECT_TRUE(ToX);
+}
+
+TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateStaticDefinition) {
+  Decl *ToTU = getToTuDecl(
+      R"(
+      struct A {
+        template <class U, class V>
+        static int X;
+      };
+      )",
+      Lang_CXX14);
+  auto *ToX = FirstDeclMatcher<VarTemplateDecl>().match(
+      ToTU, varTemplateDecl(hasName("X")));
+  ASSERT_FALSE(ToX->isThisDeclarationADefinition());
+
+  Decl *FromTU = getTuDecl(
+      R"(
+      struct A {
+        template <class U>
+        static int X;
+      };
+      template <class U>
+      int A::X = 2;
+      )",
+      Lang_CXX14, "input1.cc");
+  auto *FromXDef = LastDeclMatcher<VarTemplateDecl>().match(
+      FromTU, varTemplateDecl(hasName("X")));
+  ASSERT_TRUE(FromXDef->isThisDeclarationADefinition());
+  auto *ToXDef = Import(FromXDef, Lang_CXX14);
+  EXPECT_TRUE(ToXDef);
+  EXPECT_TRUE(ToXDef->isThisDeclarationADefinition());
+  EXPECT_EQ(ToXDef->getPreviousDecl(), ToX);
+}
+
+TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateSpecializationDeclValue) {
+  Decl *ToTU = getToTuDecl(
+      R"(
+      template <class U>
+      constexpr int X = U::Value;
+      struct A { static constexpr int Value = 1; };
+      constexpr int Y = X<A>;
+      )",
+      Lang_CXX14);
+
+  auto *ToTUX = FirstDeclMatcher<VarTemplateSpecializationDecl>().match(
+      ToTU, varTemplateSpecializationDecl(hasName("X")));
+  Decl *FromTU = getTuDecl(
+      R"(
+      template <class U>
+      constexpr int X = U::Value;
+      struct A { static constexpr int Value = 1; };
+      constexpr int Y = X<A>;
+      )",
+      Lang_CXX14, "input1.cc");
+  auto *FromX = FirstDeclMatcher<VarTemplateSpecializationDecl>().match(
+      FromTU, varTemplateSpecializationDecl(hasName("X")));
+  auto *ToX = Import(FromX, Lang_CXX14);
+  EXPECT_TRUE(ToX);
+  EXPECT_EQ(ToTUX, ToX);
+}
+
+TEST_P(ASTImporterOptionSpecificTestBase,
+       VarTemplateSpecializationDeclValueConflict) {
+  Decl *ToTU = getToTuDecl(
+      R"(
+      template <class U>
+      constexpr int X = U::Value;
+      struct A { static constexpr int Value = 1; };
+      constexpr int Y = X<A>;
+      )",
+      Lang_CXX14);
+
+  Decl *FromTU = getTuDecl(
+      R"(
+      template <class U>
+      constexpr int X = U::Value;
+      struct A { static constexpr int Value = 2; };
+      constexpr int Y = X<A>;
+      )",
+      Lang_CXX14, "input1.cc");
+  auto *FromX = FirstDeclMatcher<VarTemplateSpecializationDecl>().match(
+      FromTU, varTemplateSpecializationDecl(hasName("X")));
+  auto *ToX = Import(FromX, Lang_CXX14);
+  EXPECT_FALSE(ToX);
+}
+
 TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateParameterDeclContext) {
   constexpr auto Code =
       R"(

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -5051,7 +5051,7 @@ TEST_P(ImportFriendClasses, RecordVarTemplateDecl) {
 }
 
 TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateDeclConflict) {
-  Decl *ToTU = getToTuDecl(
+  getToTuDecl(
       R"(
       template <class U>
       constexpr int X = 1;
@@ -5101,58 +5101,6 @@ TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateStaticDefinition) {
   EXPECT_TRUE(ToXDef);
   EXPECT_TRUE(ToXDef->isThisDeclarationADefinition());
   EXPECT_EQ(ToXDef->getPreviousDecl(), ToX);
-}
-
-TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateSpecializationDeclValue) {
-  Decl *ToTU = getToTuDecl(
-      R"(
-      template <class U>
-      constexpr int X = U::Value;
-      struct A { static constexpr int Value = 1; };
-      constexpr int Y = X<A>;
-      )",
-      Lang_CXX14);
-
-  auto *ToTUX = FirstDeclMatcher<VarTemplateSpecializationDecl>().match(
-      ToTU, varTemplateSpecializationDecl(hasName("X")));
-  Decl *FromTU = getTuDecl(
-      R"(
-      template <class U>
-      constexpr int X = U::Value;
-      struct A { static constexpr int Value = 1; };
-      constexpr int Y = X<A>;
-      )",
-      Lang_CXX14, "input1.cc");
-  auto *FromX = FirstDeclMatcher<VarTemplateSpecializationDecl>().match(
-      FromTU, varTemplateSpecializationDecl(hasName("X")));
-  auto *ToX = Import(FromX, Lang_CXX14);
-  EXPECT_TRUE(ToX);
-  EXPECT_EQ(ToTUX, ToX);
-}
-
-TEST_P(ASTImporterOptionSpecificTestBase,
-       VarTemplateSpecializationDeclValueConflict) {
-  Decl *ToTU = getToTuDecl(
-      R"(
-      template <class U>
-      constexpr int X = U::Value;
-      struct A { static constexpr int Value = 1; };
-      constexpr int Y = X<A>;
-      )",
-      Lang_CXX14);
-
-  Decl *FromTU = getTuDecl(
-      R"(
-      template <class U>
-      constexpr int X = U::Value;
-      struct A { static constexpr int Value = 2; };
-      constexpr int Y = X<A>;
-      )",
-      Lang_CXX14, "input1.cc");
-  auto *FromX = FirstDeclMatcher<VarTemplateSpecializationDecl>().match(
-      FromTU, varTemplateSpecializationDecl(hasName("X")));
-  auto *ToX = Import(FromX, Lang_CXX14);
-  EXPECT_FALSE(ToX);
 }
 
 TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateParameterDeclContext) {

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -5075,7 +5075,7 @@ TEST_P(ASTImporterOptionSpecificTestBase, VarTemplateStaticDefinition) {
   Decl *ToTU = getToTuDecl(
       R"(
       struct A {
-        template <class U, class V>
+        template <class U>
         static int X;
       };
       )",


### PR DESCRIPTION
In some cases variable templates (specially if static member of record) were not correctly imported and an assertion "Missing call to MapImported?" could happen.