### PR TITLE
[PowerPC] Do not generate `isel` instruction if target doesn't have this instruction

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -12774,7 +12774,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     unsigned CallFrameSize = TII->getCallFrameSizeAt(MI);
     copy0MBB->setCallFrameSize(CallFrameSize);
     sinkMBB->setCallFrameSize(CallFrameSize);
-    
+
     // Transfer the remainder of BB and its successor edges to sinkMBB.
     sinkMBB->splice(sinkMBB->begin(), BB,
                     std::next(MachineBasicBlock::iterator(MI)), BB->end());

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -12689,6 +12689,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   }
 
   const TargetInstrInfo *TII = Subtarget.getInstrInfo();
+  const bool HasISEL = Subtarget.hasISEL();
 
   // To "insert" these instructions we actually have to insert their
   // control-flow patterns.
@@ -12698,9 +12699,10 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   MachineFunction *F = BB->getParent();
   MachineRegisterInfo &MRI = F->getRegInfo();
 
-  if (MI.getOpcode() == PPC::SELECT_CC_I4 ||
-      MI.getOpcode() == PPC::SELECT_CC_I8 || MI.getOpcode() == PPC::SELECT_I4 ||
-      MI.getOpcode() == PPC::SELECT_I8) {
+  if (HasISEL &&
+      (MI.getOpcode() == PPC::SELECT_CC_I4 ||
+       MI.getOpcode() == PPC::SELECT_CC_I8 ||
+       MI.getOpcode() == PPC::SELECT_I4 || MI.getOpcode() == PPC::SELECT_I8)) {
     SmallVector<MachineOperand, 2> Cond;
     if (MI.getOpcode() == PPC::SELECT_CC_I4 ||
         MI.getOpcode() == PPC::SELECT_CC_I8)
@@ -12712,7 +12714,9 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     DebugLoc dl = MI.getDebugLoc();
     TII->insertSelect(*BB, MI, dl, MI.getOperand(0).getReg(), Cond,
                       MI.getOperand(2).getReg(), MI.getOperand(3).getReg());
-  } else if (MI.getOpcode() == PPC::SELECT_CC_F4 ||
+  } else if (MI.getOpcode() == PPC::SELECT_CC_I4 ||
+             MI.getOpcode() == PPC::SELECT_CC_I8 ||
+             MI.getOpcode() == PPC::SELECT_CC_F4 ||
              MI.getOpcode() == PPC::SELECT_CC_F8 ||
              MI.getOpcode() == PPC::SELECT_CC_F16 ||
              MI.getOpcode() == PPC::SELECT_CC_VRRC ||
@@ -12721,6 +12725,8 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
              MI.getOpcode() == PPC::SELECT_CC_VSRC ||
              MI.getOpcode() == PPC::SELECT_CC_SPE4 ||
              MI.getOpcode() == PPC::SELECT_CC_SPE ||
+             MI.getOpcode() == PPC::SELECT_I4 ||
+             MI.getOpcode() == PPC::SELECT_I8 ||
              MI.getOpcode() == PPC::SELECT_F4 ||
              MI.getOpcode() == PPC::SELECT_F8 ||
              MI.getOpcode() == PPC::SELECT_F16 ||

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -12760,7 +12760,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     //  ...
     //   TrueVal = ...
     //   cmpTY ccX, r1, r2
-    //   bCC copy1MBB
+    //   bCC sinkMBB
     //   fallthrough --> copy0MBB
     MachineBasicBlock *thisMBB = BB;
     MachineBasicBlock *copy0MBB = F->CreateMachineBasicBlock(LLVM_BB);
@@ -12769,6 +12769,12 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     F->insert(It, copy0MBB);
     F->insert(It, sinkMBB);
 
+    // Set the call frame size on entry to the new basic blocks.
+    // See https://reviews.llvm.org/D156113.
+    unsigned CallFrameSize = TII->getCallFrameSizeAt(MI);
+    copy0MBB->setCallFrameSize(CallFrameSize);
+    sinkMBB->setCallFrameSize(CallFrameSize);
+    
     // Transfer the remainder of BB and its successor edges to sinkMBB.
     sinkMBB->splice(sinkMBB->begin(), BB,
                     std::next(MachineBasicBlock::iterator(MI)), BB->end());

--- a/llvm/test/CodeGen/PowerPC/2008-10-28-f128-i32.ll
+++ b/llvm/test/CodeGen/PowerPC/2008-10-28-f128-i32.ll
@@ -36,7 +36,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
 ; CHECK-NEXT:  # %bb.1: # %bb5
 ; CHECK-NEXT:    li 3, 0
 ; CHECK-NEXT:    li 4, 0
-; CHECK-NEXT:    b .LBB0_17
+; CHECK-NEXT:    b .LBB0_19
 ; CHECK-NEXT:  .LBB0_2: # %bb1
 ; CHECK-NEXT:    lfd 0, 400(1)
 ; CHECK-NEXT:    lis 3, 15856
@@ -99,24 +99,22 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
 ; CHECK-NEXT:    fadd 1, 28, 29
 ; CHECK-NEXT:    mtfsf 1, 0
 ; CHECK-NEXT:    lfs 0, .LCPI0_1@l(3)
-; CHECK-NEXT:    fctiwz 1, 1
-; CHECK-NEXT:    stfd 1, 152(1)
 ; CHECK-NEXT:    fcmpu 0, 28, 27
-; CHECK-NEXT:    lwz 3, 164(1)
+; CHECK-NEXT:    fctiwz 1, 1
 ; CHECK-NEXT:    fcmpu 1, 29, 0
-; CHECK-NEXT:    lwz 4, 156(1)
 ; CHECK-NEXT:    crandc 20, 6, 0
 ; CHECK-NEXT:    cror 20, 5, 20
-; CHECK-NEXT:    addis 3, 3, -32768
+; CHECK-NEXT:    stfd 1, 152(1)
 ; CHECK-NEXT:    bc 12, 20, .LBB0_4
 ; CHECK-NEXT:  # %bb.3: # %bb1
-; CHECK-NEXT:    ori 30, 4, 0
+; CHECK-NEXT:    lwz 30, 156(1)
 ; CHECK-NEXT:    b .LBB0_5
-; CHECK-NEXT:  .LBB0_4: # %bb1
-; CHECK-NEXT:    addi 30, 3, 0
+; CHECK-NEXT:  .LBB0_4:
+; CHECK-NEXT:    lwz 3, 164(1)
+; CHECK-NEXT:    addis 30, 3, -32768
 ; CHECK-NEXT:  .LBB0_5: # %bb1
-; CHECK-NEXT:    li 4, 0
 ; CHECK-NEXT:    mr 3, 30
+; CHECK-NEXT:    li 4, 0
 ; CHECK-NEXT:    bl __floatditf
 ; CHECK-NEXT:    lis 3, 17392
 ; CHECK-NEXT:    stfd 1, 208(1)
@@ -179,10 +177,10 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
 ; CHECK-NEXT:    lwz 3, 168(1)
 ; CHECK-NEXT:    stw 3, 272(1)
 ; CHECK-NEXT:    lfd 31, 272(1)
-; CHECK-NEXT:    bc 12, 20, .LBB0_14
+; CHECK-NEXT:    bc 12, 20, .LBB0_13
 ; CHECK-NEXT:  # %bb.10: # %bb1
 ; CHECK-NEXT:    cror 20, 1, 3
-; CHECK-NEXT:    bc 12, 20, .LBB0_14
+; CHECK-NEXT:    bc 12, 20, .LBB0_13
 ; CHECK-NEXT:  # %bb.11: # %bb2
 ; CHECK-NEXT:    fneg 29, 31
 ; CHECK-NEXT:    stfd 29, 48(1)
@@ -223,24 +221,17 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
 ; CHECK-NEXT:    fadd 1, 28, 29
 ; CHECK-NEXT:    mtfsf 1, 0
 ; CHECK-NEXT:    lfs 0, .LCPI0_3@l(3)
-; CHECK-NEXT:    fctiwz 1, 1
-; CHECK-NEXT:    stfd 1, 24(1)
 ; CHECK-NEXT:    fcmpu 0, 30, 2
-; CHECK-NEXT:    lwz 3, 36(1)
+; CHECK-NEXT:    fctiwz 1, 1
 ; CHECK-NEXT:    fcmpu 1, 31, 0
-; CHECK-NEXT:    lwz 4, 28(1)
 ; CHECK-NEXT:    crandc 20, 6, 1
 ; CHECK-NEXT:    cror 20, 4, 20
-; CHECK-NEXT:    addis 3, 3, -32768
-; CHECK-NEXT:    bc 12, 20, .LBB0_13
+; CHECK-NEXT:    stfd 1, 24(1)
+; CHECK-NEXT:    bc 12, 20, .LBB0_17
 ; CHECK-NEXT:  # %bb.12: # %bb2
-; CHECK-NEXT:    ori 3, 4, 0
-; CHECK-NEXT:    b .LBB0_13
-; CHECK-NEXT:  .LBB0_13: # %bb2
-; CHECK-NEXT:    subfic 4, 3, 0
-; CHECK-NEXT:    subfe 3, 29, 30
-; CHECK-NEXT:    b .LBB0_17
-; CHECK-NEXT:  .LBB0_14: # %bb3
+; CHECK-NEXT:    lwz 3, 28(1)
+; CHECK-NEXT:    b .LBB0_18
+; CHECK-NEXT:  .LBB0_13: # %bb3
 ; CHECK-NEXT:    stfd 31, 112(1)
 ; CHECK-NEXT:    li 3, 0
 ; CHECK-NEXT:    stw 3, 148(1)
@@ -278,22 +269,29 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
 ; CHECK-NEXT:    fadd 2, 30, 31
 ; CHECK-NEXT:    mtfsf 1, 0
 ; CHECK-NEXT:    lfs 0, .LCPI0_1@l(3)
-; CHECK-NEXT:    fctiwz 2, 2
-; CHECK-NEXT:    stfd 2, 88(1)
 ; CHECK-NEXT:    fcmpu 0, 30, 1
-; CHECK-NEXT:    lwz 3, 100(1)
+; CHECK-NEXT:    fctiwz 1, 2
 ; CHECK-NEXT:    fcmpu 1, 31, 0
-; CHECK-NEXT:    lwz 4, 92(1)
 ; CHECK-NEXT:    crandc 20, 6, 0
 ; CHECK-NEXT:    cror 20, 5, 20
-; CHECK-NEXT:    addis 3, 3, -32768
+; CHECK-NEXT:    stfd 1, 88(1)
 ; CHECK-NEXT:    bc 12, 20, .LBB0_15
+; CHECK-NEXT:  # %bb.14: # %bb3
+; CHECK-NEXT:    lwz 4, 92(1)
 ; CHECK-NEXT:    b .LBB0_16
-; CHECK-NEXT:  .LBB0_15: # %bb3
-; CHECK-NEXT:    addi 4, 3, 0
+; CHECK-NEXT:  .LBB0_15:
+; CHECK-NEXT:    lwz 3, 100(1)
+; CHECK-NEXT:    addis 4, 3, -32768
 ; CHECK-NEXT:  .LBB0_16: # %bb3
 ; CHECK-NEXT:    mr 3, 30
-; CHECK-NEXT:  .LBB0_17: # %bb5
+; CHECK-NEXT:    b .LBB0_19
+; CHECK-NEXT:  .LBB0_17:
+; CHECK-NEXT:    lwz 3, 36(1)
+; CHECK-NEXT:    addis 3, 3, -32768
+; CHECK-NEXT:  .LBB0_18: # %bb2
+; CHECK-NEXT:    subfic 4, 3, 0
+; CHECK-NEXT:    subfe 3, 29, 30
+; CHECK-NEXT:  .LBB0_19: # %bb3
 ; CHECK-NEXT:    lfd 31, 456(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    lfd 30, 448(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    lfd 29, 440(1) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/PowerPC/atomicrmw-uinc-udec-wrap.ll
+++ b/llvm/test/CodeGen/PowerPC/atomicrmw-uinc-udec-wrap.ll
@@ -6,55 +6,50 @@ define i8 @atomicrmw_uinc_wrap_i8(ptr %ptr, i8 %val) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:    mr 5, 3
-; CHECK-NEXT:    rlwinm 7, 5, 3, 27, 28
+; CHECK-NEXT:    rlwinm 6, 5, 3, 27, 28
 ; CHECK-NEXT:    lbz 3, 0(3)
-; CHECK-NEXT:    xori 7, 7, 24
-; CHECK-NEXT:    li 8, 255
-; CHECK-NEXT:    li 6, 0
+; CHECK-NEXT:    xori 6, 6, 24
+; CHECK-NEXT:    li 7, 255
 ; CHECK-NEXT:    clrlwi 4, 4, 24
 ; CHECK-NEXT:    rldicr 5, 5, 0, 61
-; CHECK-NEXT:    slw 8, 8, 7
+; CHECK-NEXT:    slw 7, 7, 6
 ; CHECK-NEXT:    b .LBB0_2
 ; CHECK-NEXT:  .LBB0_1: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    srw 3, 11, 7
-; CHECK-NEXT:    cmplw 3, 9
-; CHECK-NEXT:    beq 0, .LBB0_8
+; CHECK-NEXT:    srw 3, 10, 6
+; CHECK-NEXT:    cmplw 3, 8
+; CHECK-NEXT:    beq 0, .LBB0_7
 ; CHECK-NEXT:  .LBB0_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
-; CHECK-NEXT:    # Child Loop BB0_6 Depth 2
-; CHECK-NEXT:    clrlwi 9, 3, 24
-; CHECK-NEXT:    addi 10, 3, 1
-; CHECK-NEXT:    cmplw 9, 4
-; CHECK-NEXT:    bc 12, 0, .LBB0_4
+; CHECK-NEXT:    # Child Loop BB0_5 Depth 2
+; CHECK-NEXT:    clrlwi 8, 3, 24
+; CHECK-NEXT:    cmplw 8, 4
+; CHECK-NEXT:    li 9, 0
+; CHECK-NEXT:    bge 0, .LBB0_4
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 3, 6, 0
-; CHECK-NEXT:    b .LBB0_5
+; CHECK-NEXT:    addi 9, 3, 1
 ; CHECK-NEXT:  .LBB0_4: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 3, 10, 0
+; CHECK-NEXT:    slw 3, 9, 6
+; CHECK-NEXT:    slw 9, 8, 6
+; CHECK-NEXT:    and 3, 3, 7
+; CHECK-NEXT:    and 9, 9, 7
 ; CHECK-NEXT:  .LBB0_5: # %atomicrmw.start
-; CHECK-NEXT:    #
-; CHECK-NEXT:    slw 11, 9, 7
-; CHECK-NEXT:    slw 3, 3, 7
-; CHECK-NEXT:    and 3, 3, 8
-; CHECK-NEXT:    and 10, 11, 8
-; CHECK-NEXT:  .LBB0_6: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB0_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    lwarx 12, 0, 5
-; CHECK-NEXT:    and 11, 12, 8
-; CHECK-NEXT:    cmpw 11, 10
+; CHECK-NEXT:    lwarx 11, 0, 5
+; CHECK-NEXT:    and 10, 11, 7
+; CHECK-NEXT:    cmpw 10, 9
 ; CHECK-NEXT:    bne 0, .LBB0_1
-; CHECK-NEXT:  # %bb.7: # %atomicrmw.start
+; CHECK-NEXT:  # %bb.6: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    andc 12, 12, 8
-; CHECK-NEXT:    or 12, 12, 3
-; CHECK-NEXT:    stwcx. 12, 0, 5
-; CHECK-NEXT:    bne 0, .LBB0_6
+; CHECK-NEXT:    andc 11, 11, 7
+; CHECK-NEXT:    or 11, 11, 3
+; CHECK-NEXT:    stwcx. 11, 0, 5
+; CHECK-NEXT:    bne 0, .LBB0_5
 ; CHECK-NEXT:    b .LBB0_1
-; CHECK-NEXT:  .LBB0_8: # %atomicrmw.end
+; CHECK-NEXT:  .LBB0_7: # %atomicrmw.end
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    blr
   %result = atomicrmw uinc_wrap ptr %ptr, i8 %val seq_cst
@@ -66,55 +61,51 @@ define i16 @atomicrmw_uinc_wrap_i16(ptr %ptr, i16 %val) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:    mr 5, 3
-; CHECK-NEXT:    li 6, 0
+; CHECK-NEXT:    li 7, 0
 ; CHECK-NEXT:    lhz 3, 0(3)
-; CHECK-NEXT:    rlwinm 7, 5, 3, 27, 27
-; CHECK-NEXT:    xori 7, 7, 16
-; CHECK-NEXT:    ori 8, 6, 65535
+; CHECK-NEXT:    rlwinm 6, 5, 3, 27, 27
+; CHECK-NEXT:    xori 6, 6, 16
+; CHECK-NEXT:    ori 7, 7, 65535
 ; CHECK-NEXT:    clrlwi 4, 4, 16
 ; CHECK-NEXT:    rldicr 5, 5, 0, 61
-; CHECK-NEXT:    slw 8, 8, 7
+; CHECK-NEXT:    slw 7, 7, 6
 ; CHECK-NEXT:    b .LBB1_2
 ; CHECK-NEXT:  .LBB1_1: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    srw 3, 11, 7
-; CHECK-NEXT:    cmplw 3, 9
-; CHECK-NEXT:    beq 0, .LBB1_8
+; CHECK-NEXT:    srw 3, 10, 6
+; CHECK-NEXT:    cmplw 3, 8
+; CHECK-NEXT:    beq 0, .LBB1_7
 ; CHECK-NEXT:  .LBB1_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
-; CHECK-NEXT:    # Child Loop BB1_6 Depth 2
-; CHECK-NEXT:    clrlwi 9, 3, 16
-; CHECK-NEXT:    addi 10, 3, 1
-; CHECK-NEXT:    cmplw 9, 4
-; CHECK-NEXT:    bc 12, 0, .LBB1_4
+; CHECK-NEXT:    # Child Loop BB1_5 Depth 2
+; CHECK-NEXT:    clrlwi 8, 3, 16
+; CHECK-NEXT:    cmplw 8, 4
+; CHECK-NEXT:    li 9, 0
+; CHECK-NEXT:    bge 0, .LBB1_4
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 3, 6, 0
-; CHECK-NEXT:    b .LBB1_5
+; CHECK-NEXT:    addi 9, 3, 1
 ; CHECK-NEXT:  .LBB1_4: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 3, 10, 0
+; CHECK-NEXT:    slw 3, 9, 6
+; CHECK-NEXT:    slw 9, 8, 6
+; CHECK-NEXT:    and 3, 3, 7
+; CHECK-NEXT:    and 9, 9, 7
 ; CHECK-NEXT:  .LBB1_5: # %atomicrmw.start
-; CHECK-NEXT:    #
-; CHECK-NEXT:    slw 11, 9, 7
-; CHECK-NEXT:    slw 3, 3, 7
-; CHECK-NEXT:    and 3, 3, 8
-; CHECK-NEXT:    and 10, 11, 8
-; CHECK-NEXT:  .LBB1_6: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB1_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    lwarx 12, 0, 5
-; CHECK-NEXT:    and 11, 12, 8
-; CHECK-NEXT:    cmpw 11, 10
+; CHECK-NEXT:    lwarx 11, 0, 5
+; CHECK-NEXT:    and 10, 11, 7
+; CHECK-NEXT:    cmpw 10, 9
 ; CHECK-NEXT:    bne 0, .LBB1_1
-; CHECK-NEXT:  # %bb.7: # %atomicrmw.start
+; CHECK-NEXT:  # %bb.6: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    andc 12, 12, 8
-; CHECK-NEXT:    or 12, 12, 3
-; CHECK-NEXT:    stwcx. 12, 0, 5
-; CHECK-NEXT:    bne 0, .LBB1_6
+; CHECK-NEXT:    andc 11, 11, 7
+; CHECK-NEXT:    or 11, 11, 3
+; CHECK-NEXT:    stwcx. 11, 0, 5
+; CHECK-NEXT:    bne 0, .LBB1_5
 ; CHECK-NEXT:    b .LBB1_1
-; CHECK-NEXT:  .LBB1_8: # %atomicrmw.end
+; CHECK-NEXT:  .LBB1_7: # %atomicrmw.end
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    blr
   %result = atomicrmw uinc_wrap ptr %ptr, i16 %val seq_cst
@@ -125,39 +116,34 @@ define i32 @atomicrmw_uinc_wrap_i32(ptr %ptr, i32 %val) {
 ; CHECK-LABEL: atomicrmw_uinc_wrap_i32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    li 6, 0
-; CHECK-NEXT:    lwz 5, 0(3)
+; CHECK-NEXT:    lwz 6, 0(3)
 ; CHECK-NEXT:    b .LBB2_2
 ; CHECK-NEXT:  .LBB2_1: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    cmplw 5, 7
-; CHECK-NEXT:    beq 0, .LBB2_7
+; CHECK-NEXT:    cmplw 5, 6
+; CHECK-NEXT:    mr 6, 5
+; CHECK-NEXT:    beq 0, .LBB2_6
 ; CHECK-NEXT:  .LBB2_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
-; CHECK-NEXT:    # Child Loop BB2_5 Depth 2
-; CHECK-NEXT:    mr 7, 5
-; CHECK-NEXT:    addi 5, 5, 1
-; CHECK-NEXT:    cmplw 7, 4
-; CHECK-NEXT:    bc 12, 0, .LBB2_4
+; CHECK-NEXT:    # Child Loop BB2_4 Depth 2
+; CHECK-NEXT:    cmplw 6, 4
+; CHECK-NEXT:    li 7, 0
+; CHECK-NEXT:    bge 0, .LBB2_4
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 8, 6, 0
-; CHECK-NEXT:    b .LBB2_5
+; CHECK-NEXT:    addi 7, 6, 1
 ; CHECK-NEXT:  .LBB2_4: # %atomicrmw.start
-; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 8, 5, 0
-; CHECK-NEXT:  .LBB2_5: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB2_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
 ; CHECK-NEXT:    lwarx 5, 0, 3
-; CHECK-NEXT:    cmpw 5, 7
+; CHECK-NEXT:    cmpw 5, 6
 ; CHECK-NEXT:    bne 0, .LBB2_1
-; CHECK-NEXT:  # %bb.6: # %atomicrmw.start
+; CHECK-NEXT:  # %bb.5: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    stwcx. 8, 0, 3
-; CHECK-NEXT:    bne 0, .LBB2_5
+; CHECK-NEXT:    stwcx. 7, 0, 3
+; CHECK-NEXT:    bne 0, .LBB2_4
 ; CHECK-NEXT:    b .LBB2_1
-; CHECK-NEXT:  .LBB2_7: # %atomicrmw.end
+; CHECK-NEXT:  .LBB2_6: # %atomicrmw.end
 ; CHECK-NEXT:    mr 3, 5
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    blr
@@ -169,39 +155,34 @@ define i64 @atomicrmw_uinc_wrap_i64(ptr %ptr, i64 %val) {
 ; CHECK-LABEL: atomicrmw_uinc_wrap_i64:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    ld 5, 0(3)
-; CHECK-NEXT:    li 6, 0
+; CHECK-NEXT:    ld 6, 0(3)
 ; CHECK-NEXT:    b .LBB3_2
 ; CHECK-NEXT:  .LBB3_1: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    cmpld 5, 7
-; CHECK-NEXT:    beq 0, .LBB3_7
+; CHECK-NEXT:    cmpld 5, 6
+; CHECK-NEXT:    mr 6, 5
+; CHECK-NEXT:    beq 0, .LBB3_6
 ; CHECK-NEXT:  .LBB3_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
-; CHECK-NEXT:    # Child Loop BB3_5 Depth 2
-; CHECK-NEXT:    mr 7, 5
-; CHECK-NEXT:    addi 5, 5, 1
-; CHECK-NEXT:    cmpld 7, 4
-; CHECK-NEXT:    bc 12, 0, .LBB3_4
+; CHECK-NEXT:    # Child Loop BB3_4 Depth 2
+; CHECK-NEXT:    cmpld 6, 4
+; CHECK-NEXT:    li 7, 0
+; CHECK-NEXT:    bge 0, .LBB3_4
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 8, 6, 0
-; CHECK-NEXT:    b .LBB3_5
+; CHECK-NEXT:    addi 7, 6, 1
 ; CHECK-NEXT:  .LBB3_4: # %atomicrmw.start
-; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 8, 5, 0
-; CHECK-NEXT:  .LBB3_5: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB3_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
 ; CHECK-NEXT:    ldarx 5, 0, 3
-; CHECK-NEXT:    cmpd 5, 7
+; CHECK-NEXT:    cmpd 5, 6
 ; CHECK-NEXT:    bne 0, .LBB3_1
-; CHECK-NEXT:  # %bb.6: # %atomicrmw.start
+; CHECK-NEXT:  # %bb.5: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    stdcx. 8, 0, 3
-; CHECK-NEXT:    bne 0, .LBB3_5
+; CHECK-NEXT:    stdcx. 7, 0, 3
+; CHECK-NEXT:    bne 0, .LBB3_4
 ; CHECK-NEXT:    b .LBB3_1
-; CHECK-NEXT:  .LBB3_7: # %atomicrmw.end
+; CHECK-NEXT:  .LBB3_6: # %atomicrmw.end
 ; CHECK-NEXT:    mr 3, 5
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    blr
@@ -226,43 +207,39 @@ define i8 @atomicrmw_udec_wrap_i8(ptr %ptr, i8 %val) {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    srw 3, 11, 7
 ; CHECK-NEXT:    cmplw 3, 9
-; CHECK-NEXT:    beq 0, .LBB4_8
+; CHECK-NEXT:    beq 0, .LBB4_7
 ; CHECK-NEXT:  .LBB4_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
-; CHECK-NEXT:    # Child Loop BB4_6 Depth 2
+; CHECK-NEXT:    # Child Loop BB4_5 Depth 2
 ; CHECK-NEXT:    andi. 9, 3, 255
 ; CHECK-NEXT:    cmplw 1, 9, 6
-; CHECK-NEXT:    addi 10, 3, -1
 ; CHECK-NEXT:    cror 20, 2, 5
+; CHECK-NEXT:    mr 10, 4
 ; CHECK-NEXT:    bc 12, 20, .LBB4_4
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 3, 10, 0
-; CHECK-NEXT:    b .LBB4_5
+; CHECK-NEXT:    addi 10, 3, -1
 ; CHECK-NEXT:  .LBB4_4: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 3, 4, 0
-; CHECK-NEXT:  .LBB4_5: # %atomicrmw.start
-; CHECK-NEXT:    #
-; CHECK-NEXT:    slw 11, 9, 7
-; CHECK-NEXT:    slw 3, 3, 7
+; CHECK-NEXT:    slw 3, 10, 7
+; CHECK-NEXT:    slw 10, 9, 7
 ; CHECK-NEXT:    and 3, 3, 8
-; CHECK-NEXT:    and 10, 11, 8
-; CHECK-NEXT:  .LBB4_6: # %atomicrmw.start
+; CHECK-NEXT:    and 10, 10, 8
+; CHECK-NEXT:  .LBB4_5: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB4_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
 ; CHECK-NEXT:    lwarx 12, 0, 5
 ; CHECK-NEXT:    and 11, 12, 8
 ; CHECK-NEXT:    cmpw 11, 10
 ; CHECK-NEXT:    bne 0, .LBB4_1
-; CHECK-NEXT:  # %bb.7: # %atomicrmw.start
+; CHECK-NEXT:  # %bb.6: # %atomicrmw.start
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    andc 12, 12, 8
 ; CHECK-NEXT:    or 12, 12, 3
 ; CHECK-NEXT:    stwcx. 12, 0, 5
-; CHECK-NEXT:    bne 0, .LBB4_6
+; CHECK-NEXT:    bne 0, .LBB4_5
 ; CHECK-NEXT:    b .LBB4_1
-; CHECK-NEXT:  .LBB4_8: # %atomicrmw.end
+; CHECK-NEXT:  .LBB4_7: # %atomicrmw.end
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    blr
   %result = atomicrmw udec_wrap ptr %ptr, i8 %val seq_cst
@@ -287,43 +264,39 @@ define i16 @atomicrmw_udec_wrap_i16(ptr %ptr, i16 %val) {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    srw 3, 11, 7
 ; CHECK-NEXT:    cmplw 3, 9
-; CHECK-NEXT:    beq 0, .LBB5_8
+; CHECK-NEXT:    beq 0, .LBB5_7
 ; CHECK-NEXT:  .LBB5_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
-; CHECK-NEXT:    # Child Loop BB5_6 Depth 2
+; CHECK-NEXT:    # Child Loop BB5_5 Depth 2
 ; CHECK-NEXT:    andi. 9, 3, 65535
 ; CHECK-NEXT:    cmplw 1, 9, 6
-; CHECK-NEXT:    addi 10, 3, -1
 ; CHECK-NEXT:    cror 20, 2, 5
+; CHECK-NEXT:    mr 10, 4
 ; CHECK-NEXT:    bc 12, 20, .LBB5_4
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 3, 10, 0
-; CHECK-NEXT:    b .LBB5_5
+; CHECK-NEXT:    addi 10, 3, -1
 ; CHECK-NEXT:  .LBB5_4: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 3, 4, 0
-; CHECK-NEXT:  .LBB5_5: # %atomicrmw.start
-; CHECK-NEXT:    #
-; CHECK-NEXT:    slw 11, 9, 7
-; CHECK-NEXT:    slw 3, 3, 7
+; CHECK-NEXT:    slw 3, 10, 7
+; CHECK-NEXT:    slw 10, 9, 7
 ; CHECK-NEXT:    and 3, 3, 8
-; CHECK-NEXT:    and 10, 11, 8
-; CHECK-NEXT:  .LBB5_6: # %atomicrmw.start
+; CHECK-NEXT:    and 10, 10, 8
+; CHECK-NEXT:  .LBB5_5: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB5_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
 ; CHECK-NEXT:    lwarx 12, 0, 5
 ; CHECK-NEXT:    and 11, 12, 8
 ; CHECK-NEXT:    cmpw 11, 10
 ; CHECK-NEXT:    bne 0, .LBB5_1
-; CHECK-NEXT:  # %bb.7: # %atomicrmw.start
+; CHECK-NEXT:  # %bb.6: # %atomicrmw.start
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    andc 12, 12, 8
 ; CHECK-NEXT:    or 12, 12, 3
 ; CHECK-NEXT:    stwcx. 12, 0, 5
-; CHECK-NEXT:    bne 0, .LBB5_6
+; CHECK-NEXT:    bne 0, .LBB5_5
 ; CHECK-NEXT:    b .LBB5_1
-; CHECK-NEXT:  .LBB5_8: # %atomicrmw.end
+; CHECK-NEXT:  .LBB5_7: # %atomicrmw.end
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    blr
   %result = atomicrmw udec_wrap ptr %ptr, i16 %val seq_cst
@@ -334,28 +307,27 @@ define i32 @atomicrmw_udec_wrap_i32(ptr %ptr, i32 %val) {
 ; CHECK-LABEL: atomicrmw_udec_wrap_i32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    lwz 5, 0(3)
+; CHECK-NEXT:    lwz 6, 0(3)
 ; CHECK-NEXT:    b .LBB6_2
 ; CHECK-NEXT:  .LBB6_1: # %atomicrmw.start
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    cmplw 5, 6
+; CHECK-NEXT:    mr 6, 5
 ; CHECK-NEXT:    beq 0, .LBB6_7
 ; CHECK-NEXT:  .LBB6_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
 ; CHECK-NEXT:    # Child Loop BB6_5 Depth 2
-; CHECK-NEXT:    mr 6, 5
 ; CHECK-NEXT:    cmpwi 6, 0
-; CHECK-NEXT:    cmplw 1, 6, 4
-; CHECK-NEXT:    addi 5, 5, -1
-; CHECK-NEXT:    cror 20, 2, 5
-; CHECK-NEXT:    bc 12, 20, .LBB6_4
+; CHECK-NEXT:    mr 7, 4
+; CHECK-NEXT:    bc 12, 2, .LBB6_5
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 7, 5, 0
-; CHECK-NEXT:    b .LBB6_5
-; CHECK-NEXT:  .LBB6_4: # %atomicrmw.start
+; CHECK-NEXT:    cmplw 6, 4
+; CHECK-NEXT:    mr 7, 4
+; CHECK-NEXT:    bc 12, 1, .LBB6_5
+; CHECK-NEXT:  # %bb.4: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 7, 4, 0
+; CHECK-NEXT:    addi 7, 6, -1
 ; CHECK-NEXT:  .LBB6_5: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB6_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
@@ -379,27 +351,27 @@ define i64 @atomicrmw_udec_wrap_i64(ptr %ptr, i64 %val) {
 ; CHECK-LABEL: atomicrmw_udec_wrap_i64:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    ld 5, 0(3)
+; CHECK-NEXT:    ld 6, 0(3)
 ; CHECK-NEXT:    b .LBB7_2
 ; CHECK-NEXT:  .LBB7_1: # %atomicrmw.start
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    cmpld 5, 6
+; CHECK-NEXT:    mr 6, 5
 ; CHECK-NEXT:    beq 0, .LBB7_7
 ; CHECK-NEXT:  .LBB7_2: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Loop Header: Depth=1
 ; CHECK-NEXT:    # Child Loop BB7_5 Depth 2
-; CHECK-NEXT:    mr. 6, 5
-; CHECK-NEXT:    cmpld 1, 6, 4
-; CHECK-NEXT:    addi 5, 5, -1
-; CHECK-NEXT:    cror 20, 2, 5
-; CHECK-NEXT:    bc 12, 20, .LBB7_4
+; CHECK-NEXT:    cmpdi 6, 0
+; CHECK-NEXT:    mr 7, 4
+; CHECK-NEXT:    bc 12, 2, .LBB7_5
 ; CHECK-NEXT:  # %bb.3: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ori 7, 5, 0
-; CHECK-NEXT:    b .LBB7_5
-; CHECK-NEXT:  .LBB7_4: # %atomicrmw.start
+; CHECK-NEXT:    cmpld 6, 4
+; CHECK-NEXT:    mr 7, 4
+; CHECK-NEXT:    bc 12, 1, .LBB7_5
+; CHECK-NEXT:  # %bb.4: # %atomicrmw.start
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    addi 7, 4, 0
+; CHECK-NEXT:    addi 7, 6, -1
 ; CHECK-NEXT:  .LBB7_5: # %atomicrmw.start
 ; CHECK-NEXT:    # Parent Loop BB7_2 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2

--- a/llvm/test/CodeGen/PowerPC/ctrloops-pseudo.ll
+++ b/llvm/test/CodeGen/PowerPC/ctrloops-pseudo.ll
@@ -370,7 +370,6 @@ define i32 @test4(i32 %inp) {
   ; AIX64-NEXT: bb.3.entry:
   ; AIX64-NEXT:   successors: %bb.4(0x80000000)
   ; AIX64-NEXT: {{  $}}
-  ; AIX64-NEXT: {{  $}}
   ; AIX64-NEXT: bb.4.entry:
   ; AIX64-NEXT:   successors: %bb.1(0x80000000)
   ; AIX64-NEXT: {{  $}}
@@ -412,7 +411,6 @@ define i32 @test4(i32 %inp) {
   ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT: bb.3.entry:
   ; AIX32-NEXT:   successors: %bb.4(0x80000000)
-  ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT: bb.4.entry:
   ; AIX32-NEXT:   successors: %bb.1(0x80000000)

--- a/llvm/test/CodeGen/PowerPC/ctrloops-pseudo.ll
+++ b/llvm/test/CodeGen/PowerPC/ctrloops-pseudo.ll
@@ -35,6 +35,7 @@ define void @test1(i32 %c) nounwind {
   ; AIX64-NEXT: {{  $}}
   ; AIX64-NEXT: bb.2.for.end:
   ; AIX64-NEXT:   BLR8 implicit $lr8, implicit $rm
+  ;
   ; AIX32-LABEL: name: test1
   ; AIX32: bb.0.entry:
   ; AIX32-NEXT:   successors: %bb.1(0x80000000)
@@ -57,6 +58,7 @@ define void @test1(i32 %c) nounwind {
   ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT: bb.2.for.end:
   ; AIX32-NEXT:   BLR implicit $lr, implicit $rm
+  ;
   ; LE64-LABEL: name: test1
   ; LE64: bb.0.entry:
   ; LE64-NEXT:   successors: %bb.1(0x80000000)
@@ -134,6 +136,7 @@ define void @test2(i32 %c, i32 %d) nounwind {
   ; AIX64-NEXT: {{  $}}
   ; AIX64-NEXT: bb.3.for.end:
   ; AIX64-NEXT:   BLR8 implicit $lr8, implicit $rm
+  ;
   ; AIX32-LABEL: name: test2
   ; AIX32: bb.0.entry:
   ; AIX32-NEXT:   successors: %bb.1(0x50000000), %bb.3(0x30000000)
@@ -163,6 +166,7 @@ define void @test2(i32 %c, i32 %d) nounwind {
   ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT: bb.3.for.end:
   ; AIX32-NEXT:   BLR implicit $lr, implicit $rm
+  ;
   ; LE64-LABEL: name: test2
   ; LE64: bb.0.entry:
   ; LE64-NEXT:   successors: %bb.1(0x50000000), %bb.3(0x30000000)
@@ -257,6 +261,7 @@ define void @test3(i32 %c, i32 %d) nounwind {
   ; AIX64-NEXT: {{  $}}
   ; AIX64-NEXT: bb.3.for.end:
   ; AIX64-NEXT:   BLR8 implicit $lr8, implicit $rm
+  ;
   ; AIX32-LABEL: name: test3
   ; AIX32: bb.0.entry:
   ; AIX32-NEXT:   successors: %bb.1(0x50000000), %bb.3(0x30000000)
@@ -289,6 +294,7 @@ define void @test3(i32 %c, i32 %d) nounwind {
   ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT: bb.3.for.end:
   ; AIX32-NEXT:   BLR implicit $lr, implicit $rm
+  ;
   ; LE64-LABEL: name: test3
   ; LE64: bb.0.entry:
   ; LE64-NEXT:   successors: %bb.1(0x50000000), %bb.3(0x30000000)
@@ -352,15 +358,24 @@ for.end:                                          ; preds = %for.body, %entry
 define i32 @test4(i32 %inp) {
   ; AIX64-LABEL: name: test4
   ; AIX64: bb.0.entry:
-  ; AIX64-NEXT:   successors: %bb.1(0x80000000)
+  ; AIX64-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
   ; AIX64-NEXT:   liveins: $x3
   ; AIX64-NEXT: {{  $}}
   ; AIX64-NEXT:   [[COPY:%[0-9]+]]:g8rc = COPY $x3
   ; AIX64-NEXT:   [[COPY1:%[0-9]+]]:gprc_and_gprc_nor0 = COPY [[COPY]].sub_32
   ; AIX64-NEXT:   [[CMPWI:%[0-9]+]]:crrc = CMPWI [[COPY1]], 1
   ; AIX64-NEXT:   [[LI:%[0-9]+]]:gprc_and_gprc_nor0 = LI 1
-  ; AIX64-NEXT:   [[ISEL:%[0-9]+]]:gprc = ISEL [[COPY1]], [[LI]], [[CMPWI]].sub_lt
-  ; AIX64-NEXT:   [[SUBF:%[0-9]+]]:gprc = SUBF [[ISEL]], [[COPY1]]
+  ; AIX64-NEXT:   BCC 12, [[CMPWI]], %bb.4
+  ; AIX64-NEXT: {{  $}}
+  ; AIX64-NEXT: bb.3.entry:
+  ; AIX64-NEXT:   successors: %bb.4(0x80000000)
+  ; AIX64-NEXT: {{  $}}
+  ; AIX64-NEXT: {{  $}}
+  ; AIX64-NEXT: bb.4.entry:
+  ; AIX64-NEXT:   successors: %bb.1(0x80000000)
+  ; AIX64-NEXT: {{  $}}
+  ; AIX64-NEXT:   [[PHI:%[0-9]+]]:gprc = PHI [[LI]], %bb.3, [[COPY1]], %bb.0
+  ; AIX64-NEXT:   [[SUBF:%[0-9]+]]:gprc = SUBF [[PHI]], [[COPY1]]
   ; AIX64-NEXT:   [[DEF:%[0-9]+]]:g8rc = IMPLICIT_DEF
   ; AIX64-NEXT:   [[INSERT_SUBREG:%[0-9]+]]:g8rc = INSERT_SUBREG [[DEF]], killed [[SUBF]], %subreg.sub_32
   ; AIX64-NEXT:   [[RLDICL:%[0-9]+]]:g8rc_and_g8rc_nox0 = RLDICL killed [[INSERT_SUBREG]], 0, 32
@@ -379,21 +394,31 @@ define i32 @test4(i32 %inp) {
   ; AIX64-NEXT:   [[LDtoc1:%[0-9]+]]:g8rc = LDtoc target-flags(ppc-tlsgd) @tls_var, $x2 :: (load (s64) from got)
   ; AIX64-NEXT:   [[TLSGDAIX8_:%[0-9]+]]:g8rc = TLSGDAIX8 killed [[LDtoc1]], killed [[LDtoc]]
   ; AIX64-NEXT:   [[COPY2:%[0-9]+]]:gprc = COPY [[TLSGDAIX8_]].sub_32
-  ; AIX64-NEXT:   [[ADD4_:%[0-9]+]]:gprc = ADD4 killed [[COPY2]], [[ISEL]]
+  ; AIX64-NEXT:   [[ADD4_:%[0-9]+]]:gprc = ADD4 killed [[COPY2]], [[PHI]]
   ; AIX64-NEXT:   [[DEF1:%[0-9]+]]:g8rc = IMPLICIT_DEF
   ; AIX64-NEXT:   [[INSERT_SUBREG1:%[0-9]+]]:g8rc = INSERT_SUBREG [[DEF1]], killed [[ADD4_]], %subreg.sub_32
   ; AIX64-NEXT:   $x3 = COPY [[INSERT_SUBREG1]]
   ; AIX64-NEXT:   BLR8 implicit $lr8, implicit $rm, implicit $x3
+  ;
   ; AIX32-LABEL: name: test4
   ; AIX32: bb.0.entry:
-  ; AIX32-NEXT:   successors: %bb.1(0x80000000)
+  ; AIX32-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
   ; AIX32-NEXT:   liveins: $r3
   ; AIX32-NEXT: {{  $}}
   ; AIX32-NEXT:   [[COPY:%[0-9]+]]:gprc_and_gprc_nor0 = COPY $r3
   ; AIX32-NEXT:   [[CMPWI:%[0-9]+]]:crrc = CMPWI [[COPY]], 1
   ; AIX32-NEXT:   [[LI:%[0-9]+]]:gprc_and_gprc_nor0 = LI 1
-  ; AIX32-NEXT:   [[ISEL:%[0-9]+]]:gprc = ISEL [[COPY]], [[LI]], [[CMPWI]].sub_lt
-  ; AIX32-NEXT:   [[SUBF:%[0-9]+]]:gprc_and_gprc_nor0 = SUBF [[ISEL]], [[COPY]]
+  ; AIX32-NEXT:   BCC 12, [[CMPWI]], %bb.4
+  ; AIX32-NEXT: {{  $}}
+  ; AIX32-NEXT: bb.3.entry:
+  ; AIX32-NEXT:   successors: %bb.4(0x80000000)
+  ; AIX32-NEXT: {{  $}}
+  ; AIX32-NEXT: {{  $}}
+  ; AIX32-NEXT: bb.4.entry:
+  ; AIX32-NEXT:   successors: %bb.1(0x80000000)
+  ; AIX32-NEXT: {{  $}}
+  ; AIX32-NEXT:   [[PHI:%[0-9]+]]:gprc = PHI [[LI]], %bb.3, [[COPY]], %bb.0
+  ; AIX32-NEXT:   [[SUBF:%[0-9]+]]:gprc_and_gprc_nor0 = SUBF [[PHI]], [[COPY]]
   ; AIX32-NEXT:   [[ADDI:%[0-9]+]]:gprc = ADDI killed [[SUBF]], 1
   ; AIX32-NEXT:   MTCTRloop killed [[ADDI]], implicit-def dead $ctr
   ; AIX32-NEXT: {{  $}}
@@ -408,9 +433,10 @@ define i32 @test4(i32 %inp) {
   ; AIX32-NEXT:   [[LWZtoc:%[0-9]+]]:gprc = LWZtoc target-flags(ppc-tlsgdm) @tls_var, $r2 :: (load (s32) from got)
   ; AIX32-NEXT:   [[LWZtoc1:%[0-9]+]]:gprc = LWZtoc target-flags(ppc-tlsgd) @tls_var, $r2 :: (load (s32) from got)
   ; AIX32-NEXT:   [[TLSGDAIX:%[0-9]+]]:gprc = TLSGDAIX killed [[LWZtoc1]], killed [[LWZtoc]]
-  ; AIX32-NEXT:   [[ADD4_:%[0-9]+]]:gprc = ADD4 killed [[TLSGDAIX]], [[ISEL]]
+  ; AIX32-NEXT:   [[ADD4_:%[0-9]+]]:gprc = ADD4 killed [[TLSGDAIX]], [[PHI]]
   ; AIX32-NEXT:   $r3 = COPY [[ADD4_]]
   ; AIX32-NEXT:   BLR implicit $lr, implicit $rm, implicit $r3
+  ;
   ; LE64-LABEL: name: test4
   ; LE64: bb.0.entry:
   ; LE64-NEXT:   successors: %bb.1(0x80000000)

--- a/llvm/test/CodeGen/PowerPC/expand-isel-to-branch.ll
+++ b/llvm/test/CodeGen/PowerPC/expand-isel-to-branch.ll
@@ -6,13 +6,13 @@ define noundef signext i32 @ham(ptr nocapture noundef %arg) #0 {
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    lwz 4, 0(3)
 ; CHECK-NEXT:    cmpwi 4, 750
-; CHECK-NEXT:    addi 5, 4, 1
+; CHECK-NEXT:    blt 0, L..BB0_2
+; CHECK-NEXT:  # %bb.1: # %bb
 ; CHECK-NEXT:    li 4, 1
-; CHECK-NEXT:    bc 12, 0, L..BB0_1
-; CHECK-NEXT:    b L..BB0_2
-; CHECK-NEXT:  L..BB0_1: # %bb
-; CHECK-NEXT:    addi 4, 5, 0
-; CHECK-NEXT:  L..BB0_2: # %bb
+; CHECK-NEXT:    b L..BB0_3
+; CHECK-NEXT:  L..BB0_2:
+; CHECK-NEXT:    addi 4, 4, 1
+; CHECK-NEXT:  L..BB0_3: # %bb
 ; CHECK-NEXT:    stw 4, 0(3)
 ; CHECK-NEXT:    li 3, 0
 ; CHECK-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/fp-strict-fcmp-spe.ll
+++ b/llvm/test/CodeGen/PowerPC/fp-strict-fcmp-spe.ll
@@ -7,7 +7,7 @@ define i32 @test_f32_oeq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-NEXT:    efscmpeq cr0, r5, r6
 ; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"oeq", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -20,7 +20,7 @@ define i32 @test_f32_ogt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-NEXT:    efscmpgt cr0, r5, r6
 ; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"ogt", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -31,13 +31,15 @@ define i32 @test_f32_oge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_oge_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpeq cr0, r6, r6
-; SPE-NEXT:    efscmpeq cr1, r5, r5
-; SPE-NEXT:    crand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    efscmplt cr0, r5, r6
-; SPE-NEXT:    crandc 4*cr5+lt, 4*cr5+lt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bc 4, gt, .LBB2_3
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efscmpeq cr0, r5, r5
+; SPE-NEXT:    bc 4, gt, .LBB2_3
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efscmplt cr0, r5, r6
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  .LBB2_3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"oge", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -50,7 +52,7 @@ define i32 @test_f32_olt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-NEXT:    efscmplt cr0, r5, r6
 ; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"olt", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -61,13 +63,15 @@ define i32 @test_f32_ole_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_ole_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpeq cr0, r6, r6
-; SPE-NEXT:    efscmpeq cr1, r5, r5
-; SPE-NEXT:    crand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    efscmpgt cr0, r5, r6
-; SPE-NEXT:    crandc 4*cr5+lt, 4*cr5+lt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bc 4, gt, .LBB4_3
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efscmpeq cr0, r5, r5
+; SPE-NEXT:    bc 4, gt, .LBB4_3
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efscmpgt cr0, r5, r6
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  .LBB4_3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"ole", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -78,11 +82,12 @@ define i32 @test_f32_one_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_one_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmplt cr0, r5, r6
-; SPE-NEXT:    efscmpgt cr1, r5, r6
-; SPE-NEXT:    cror 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efscmpgt cr0, r5, r6
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"one", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -93,11 +98,12 @@ define i32 @test_f32_ord_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_ord_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpeq cr0, r6, r6
-; SPE-NEXT:    efscmpeq cr1, r5, r5
-; SPE-NEXT:    crand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bc 4, gt, .LBB6_2
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efscmpeq cr0, r5, r5
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  .LBB6_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"ord", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -108,12 +114,14 @@ define i32 @test_f32_ueq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_ueq_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmplt cr0, r5, r6
-; SPE-NEXT:    efscmpgt cr1, r5, r6
-; SPE-NEXT:    cror 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bc 12, 4*cr5+lt, .LBB7_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB7_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB7_3
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    efscmpgt cr0, r5, r6
+; SPE-NEXT:    bc 12, gt, .LBB7_3
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB7_3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"ueq", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -124,13 +132,15 @@ define i32 @test_f32_ugt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_ugt_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpeq cr0, r5, r5
-; SPE-NEXT:    efscmpeq cr1, r6, r6
-; SPE-NEXT:    crnand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    efscmpgt cr0, r5, r6
-; SPE-NEXT:    cror 4*cr5+lt, gt, 4*cr5+lt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 4, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efscmpeq cr0, r6, r6
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efscmpgt cr0, r5, r6
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  # %bb.3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"ugt", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -141,10 +151,11 @@ define i32 @test_f32_uge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_uge_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmplt cr0, r5, r6
-; SPE-NEXT:    bc 12, gt, .LBB9_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB9_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB9_2
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB9_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"uge", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -155,13 +166,15 @@ define i32 @test_f32_ult_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_ult_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpeq cr0, r5, r5
-; SPE-NEXT:    efscmpeq cr1, r6, r6
-; SPE-NEXT:    crnand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    efscmplt cr0, r5, r6
-; SPE-NEXT:    cror 4*cr5+lt, gt, 4*cr5+lt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 4, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efscmpeq cr0, r6, r6
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efscmplt cr0, r5, r6
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  # %bb.3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"ult", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -172,10 +185,11 @@ define i32 @test_f32_ule_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_ule_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpgt cr0, r5, r6
-; SPE-NEXT:    bc 12, gt, .LBB11_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB11_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB11_2
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB11_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"ule", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -186,10 +200,11 @@ define i32 @test_f32_une_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_une_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpeq cr0, r5, r6
-; SPE-NEXT:    bc 12, gt, .LBB12_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB12_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB12_2
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB12_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"une", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -200,11 +215,12 @@ define i32 @test_f32_uno_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
 ; SPE-LABEL: test_f32_uno_s:
 ; SPE:       # %bb.0:
 ; SPE-NEXT:    efscmpeq cr0, r5, r5
-; SPE-NEXT:    efscmpeq cr1, r6, r6
-; SPE-NEXT:    crnand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 4, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efscmpeq cr0, r6, r6
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(float %f1, float %f2, metadata !"uno", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -219,7 +235,7 @@ define i32 @test_f64_oeq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    efdcmpeq cr0, r5, r7
 ; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"oeq", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -234,7 +250,7 @@ define i32 @test_f64_ogt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    efdcmpgt cr0, r5, r7
 ; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"ogt", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -247,13 +263,15 @@ define i32 @test_f64_oge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    evmergelo r6, r7, r8
 ; SPE-NEXT:    efdcmpeq cr0, r6, r6
-; SPE-NEXT:    efdcmpeq cr1, r5, r5
-; SPE-NEXT:    efdcmplt cr5, r5, r6
-; SPE-NEXT:    crand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    crandc 4*cr5+lt, 4*cr5+lt, 4*cr5+gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bc 4, gt, .LBB16_3
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efdcmpeq cr0, r5, r5
+; SPE-NEXT:    bc 4, gt, .LBB16_3
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efdcmplt cr0, r5, r6
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  .LBB16_3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"oge", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -268,7 +286,7 @@ define i32 @test_f64_olt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    efdcmplt cr0, r5, r7
 ; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"olt", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -281,13 +299,15 @@ define i32 @test_f64_ole_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    evmergelo r6, r7, r8
 ; SPE-NEXT:    efdcmpeq cr0, r6, r6
-; SPE-NEXT:    efdcmpeq cr1, r5, r5
-; SPE-NEXT:    efdcmpgt cr5, r5, r6
-; SPE-NEXT:    crand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    crandc 4*cr5+lt, 4*cr5+lt, 4*cr5+gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bc 4, gt, .LBB18_3
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efdcmpeq cr0, r5, r5
+; SPE-NEXT:    bc 4, gt, .LBB18_3
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efdcmpgt cr0, r5, r6
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  .LBB18_3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"ole", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -300,11 +320,12 @@ define i32 @test_f64_one_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmplt cr0, r5, r7
-; SPE-NEXT:    efdcmpgt cr1, r5, r7
-; SPE-NEXT:    cror 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 12, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efdcmpgt cr0, r5, r7
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"one", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -317,11 +338,12 @@ define i32 @test_f64_ord_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    evmergelo r6, r7, r8
 ; SPE-NEXT:    efdcmpeq cr0, r6, r6
-; SPE-NEXT:    efdcmpeq cr1, r5, r5
-; SPE-NEXT:    crand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bc 4, gt, .LBB20_2
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efdcmpeq cr0, r5, r5
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  .LBB20_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"ord", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -334,12 +356,14 @@ define i32 @test_f64_ueq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmplt cr0, r5, r7
-; SPE-NEXT:    efdcmpgt cr1, r5, r7
-; SPE-NEXT:    cror 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bc 12, 4*cr5+lt, .LBB21_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB21_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB21_3
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    efdcmpgt cr0, r5, r7
+; SPE-NEXT:    bc 12, gt, .LBB21_3
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB21_3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"ueq", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -352,13 +376,15 @@ define i32 @test_f64_ugt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmpeq cr0, r5, r5
-; SPE-NEXT:    efdcmpeq cr1, r7, r7
-; SPE-NEXT:    efdcmpgt cr5, r5, r7
-; SPE-NEXT:    crnand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    cror 4*cr5+lt, 4*cr5+gt, 4*cr5+lt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 4, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efdcmpeq cr0, r7, r7
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efdcmpgt cr0, r5, r7
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  # %bb.3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"ugt", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -371,10 +397,11 @@ define i32 @test_f64_uge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmplt cr0, r5, r7
-; SPE-NEXT:    bc 12, gt, .LBB23_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB23_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB23_2
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB23_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"uge", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -387,13 +414,15 @@ define i32 @test_f64_ult_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmpeq cr0, r5, r5
-; SPE-NEXT:    efdcmpeq cr1, r7, r7
-; SPE-NEXT:    efdcmplt cr5, r5, r7
-; SPE-NEXT:    crnand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    cror 4*cr5+lt, 4*cr5+gt, 4*cr5+lt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 4, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efdcmpeq cr0, r7, r7
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    efdcmplt cr0, r5, r7
+; SPE-NEXT:    bclr 12, gt, 0
+; SPE-NEXT:  # %bb.3:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"ult", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -406,10 +435,11 @@ define i32 @test_f64_ule_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmpgt cr0, r5, r7
-; SPE-NEXT:    bc 12, gt, .LBB25_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB25_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB25_2
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB25_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"ule", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -422,10 +452,11 @@ define i32 @test_f64_une_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmpeq cr0, r5, r7
-; SPE-NEXT:    bc 12, gt, .LBB26_1
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB26_1:
-; SPE-NEXT:    addi r3, r4, 0
+; SPE-NEXT:    bc 12, gt, .LBB26_2
+; SPE-NEXT:  # %bb.1:
+; SPE-NEXT:    mr r4, r3
+; SPE-NEXT:  .LBB26_2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"une", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b
@@ -438,11 +469,12 @@ define i32 @test_f64_uno_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
 ; SPE-NEXT:    evmergelo r7, r7, r8
 ; SPE-NEXT:    evmergelo r5, r5, r6
 ; SPE-NEXT:    efdcmpeq cr0, r5, r5
-; SPE-NEXT:    efdcmpeq cr1, r7, r7
-; SPE-NEXT:    crnand 4*cr5+lt, 4*cr1+gt, gt
-; SPE-NEXT:    bclr 12, 4*cr5+lt, 0
+; SPE-NEXT:    bclr 4, gt, 0
 ; SPE-NEXT:  # %bb.1:
-; SPE-NEXT:    ori r3, r4, 0
+; SPE-NEXT:    efdcmpeq cr0, r7, r7
+; SPE-NEXT:    bclr 4, gt, 0
+; SPE-NEXT:  # %bb.2:
+; SPE-NEXT:    mr r3, r4
 ; SPE-NEXT:    blr
   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(double %f1, double %f2, metadata !"uno", metadata !"fpexcept.strict") #0
   %res = select i1 %cond, i32 %a, i32 %b

--- a/llvm/test/CodeGen/PowerPC/fp-to-int-to-fp.ll
+++ b/llvm/test/CodeGen/PowerPC/fp-to-int-to-fp.ll
@@ -66,61 +66,60 @@ define float @fooul(float %X) #0 {
 ; PPC64-LABEL: fooul:
 ; PPC64:       # %bb.0: # %entry
 ; PPC64-NEXT:    addis 3, 2, .LCPI2_0@toc@ha
-; PPC64-NEXT:    li 4, 1
 ; PPC64-NEXT:    lfs 0, .LCPI2_0@toc@l(3)
-; PPC64-NEXT:    rldic 4, 4, 63, 0
 ; PPC64-NEXT:    fsubs 2, 1, 0
 ; PPC64-NEXT:    fcmpu 0, 1, 0
 ; PPC64-NEXT:    fctidz 2, 2
 ; PPC64-NEXT:    stfd 2, -8(1)
 ; PPC64-NEXT:    fctidz 2, 1
 ; PPC64-NEXT:    stfd 2, -16(1)
+; PPC64-NEXT:    blt 0, .LBB2_2
+; PPC64-NEXT:  # %bb.1: # %entry
 ; PPC64-NEXT:    ld 3, -8(1)
-; PPC64-NEXT:    ld 5, -16(1)
+; PPC64-NEXT:    li 4, 1
+; PPC64-NEXT:    rldic 4, 4, 63, 0
 ; PPC64-NEXT:    xor 3, 3, 4
-; PPC64-NEXT:    bc 12, 0, .LBB2_1
-; PPC64-NEXT:    b .LBB2_2
-; PPC64-NEXT:  .LBB2_1: # %entry
-; PPC64-NEXT:    addi 3, 5, 0
-; PPC64-NEXT:  .LBB2_2: # %entry
+; PPC64-NEXT:    b .LBB2_3
+; PPC64-NEXT:  .LBB2_2:
+; PPC64-NEXT:    ld 3, -16(1)
+; PPC64-NEXT:  .LBB2_3: # %entry
 ; PPC64-NEXT:    sradi 4, 3, 53
-; PPC64-NEXT:    rldicl 5, 3, 63, 1
 ; PPC64-NEXT:    addi 4, 4, 1
-; PPC64-NEXT:    clrldi 6, 3, 63
 ; PPC64-NEXT:    cmpldi 4, 1
-; PPC64-NEXT:    clrldi 4, 3, 53
-; PPC64-NEXT:    or 6, 6, 5
-; PPC64-NEXT:    clrldi 7, 6, 53
-; PPC64-NEXT:    addi 4, 4, 2047
-; PPC64-NEXT:    addi 7, 7, 2047
-; PPC64-NEXT:    or 4, 4, 3
-; PPC64-NEXT:    or 5, 7, 5
-; PPC64-NEXT:    rldicl 7, 3, 10, 54
-; PPC64-NEXT:    rldicr 4, 4, 0, 52
-; PPC64-NEXT:    addi 7, 7, 1
-; PPC64-NEXT:    bc 12, 1, .LBB2_4
-; PPC64-NEXT:  # %bb.3: # %entry
-; PPC64-NEXT:    ori 4, 3, 0
-; PPC64-NEXT:    b .LBB2_4
-; PPC64-NEXT:  .LBB2_4: # %entry
-; PPC64-NEXT:    rldicl 5, 5, 53, 11
-; PPC64-NEXT:    std 4, -32(1)
-; PPC64-NEXT:    rldicl 4, 5, 11, 1
-; PPC64-NEXT:    cmpldi 7, 1
-; PPC64-NEXT:    bc 12, 1, .LBB2_6
-; PPC64-NEXT:  # %bb.5: # %entry
-; PPC64-NEXT:    ori 4, 6, 0
+; PPC64-NEXT:    bgt 0, .LBB2_5
+; PPC64-NEXT:  # %bb.4: # %entry
+; PPC64-NEXT:    mr 4, 3
 ; PPC64-NEXT:    b .LBB2_6
+; PPC64-NEXT:  .LBB2_5:
+; PPC64-NEXT:    clrldi 4, 3, 53
+; PPC64-NEXT:    addi 4, 4, 2047
+; PPC64-NEXT:    or 4, 4, 3
+; PPC64-NEXT:    rldicr 4, 4, 0, 52
 ; PPC64-NEXT:  .LBB2_6: # %entry
+; PPC64-NEXT:    rldicl 5, 3, 10, 54
+; PPC64-NEXT:    clrldi 6, 3, 63
+; PPC64-NEXT:    std 4, -32(1)
+; PPC64-NEXT:    addi 5, 5, 1
+; PPC64-NEXT:    cmpldi 5, 1
+; PPC64-NEXT:    rldicl 5, 3, 63, 1
+; PPC64-NEXT:    or 4, 6, 5
+; PPC64-NEXT:    ble 0, .LBB2_8
+; PPC64-NEXT:  # %bb.7:
+; PPC64-NEXT:    clrldi 4, 4, 53
+; PPC64-NEXT:    addi 4, 4, 2047
+; PPC64-NEXT:    or 4, 4, 5
+; PPC64-NEXT:    rldicl 4, 4, 53, 11
+; PPC64-NEXT:    rldicl 4, 4, 11, 1
+; PPC64-NEXT:  .LBB2_8: # %entry
 ; PPC64-NEXT:    cmpdi 3, 0
 ; PPC64-NEXT:    std 4, -24(1)
-; PPC64-NEXT:    bc 12, 0, .LBB2_8
-; PPC64-NEXT:  # %bb.7: # %entry
+; PPC64-NEXT:    bc 12, 0, .LBB2_10
+; PPC64-NEXT:  # %bb.9: # %entry
 ; PPC64-NEXT:    lfd 0, -32(1)
 ; PPC64-NEXT:    fcfid 0, 0
 ; PPC64-NEXT:    frsp 1, 0
 ; PPC64-NEXT:    blr
-; PPC64-NEXT:  .LBB2_8:
+; PPC64-NEXT:  .LBB2_10:
 ; PPC64-NEXT:    lfd 0, -24(1)
 ; PPC64-NEXT:    fcfid 0, 0
 ; PPC64-NEXT:    frsp 0, 0
@@ -148,34 +147,34 @@ define double @fooudl(double %X) #0 {
 ; PPC64-LABEL: fooudl:
 ; PPC64:       # %bb.0: # %entry
 ; PPC64-NEXT:    addis 3, 2, .LCPI3_0@toc@ha
-; PPC64-NEXT:    li 4, 1
 ; PPC64-NEXT:    lfs 0, .LCPI3_0@toc@l(3)
-; PPC64-NEXT:    rldic 4, 4, 63, 0
 ; PPC64-NEXT:    fsub 2, 1, 0
 ; PPC64-NEXT:    fcmpu 0, 1, 0
 ; PPC64-NEXT:    fctidz 2, 2
 ; PPC64-NEXT:    stfd 2, -8(1)
 ; PPC64-NEXT:    fctidz 2, 1
 ; PPC64-NEXT:    stfd 2, -16(1)
+; PPC64-NEXT:    blt 0, .LBB3_2
+; PPC64-NEXT:  # %bb.1: # %entry
 ; PPC64-NEXT:    ld 3, -8(1)
-; PPC64-NEXT:    ld 5, -16(1)
+; PPC64-NEXT:    li 4, 1
+; PPC64-NEXT:    rldic 4, 4, 63, 0
 ; PPC64-NEXT:    xor 3, 3, 4
-; PPC64-NEXT:    li 4, 1107
-; PPC64-NEXT:    rldic 4, 4, 52, 1
-; PPC64-NEXT:    bc 12, 0, .LBB3_1
-; PPC64-NEXT:    b .LBB3_2
-; PPC64-NEXT:  .LBB3_1: # %entry
-; PPC64-NEXT:    addi 3, 5, 0
-; PPC64-NEXT:  .LBB3_2: # %entry
-; PPC64-NEXT:    rldicl 5, 3, 32, 32
+; PPC64-NEXT:    b .LBB3_3
+; PPC64-NEXT:  .LBB3_2:
+; PPC64-NEXT:    ld 3, -16(1)
+; PPC64-NEXT:  .LBB3_3: # %entry
+; PPC64-NEXT:    li 5, 1107
+; PPC64-NEXT:    rldicl 4, 3, 32, 32
+; PPC64-NEXT:    rldic 5, 5, 52, 1
 ; PPC64-NEXT:    clrldi 3, 3, 32
-; PPC64-NEXT:    or 4, 5, 4
-; PPC64-NEXT:    addis 5, 2, .LCPI3_1@toc@ha
+; PPC64-NEXT:    or 4, 4, 5
+; PPC64-NEXT:    li 5, 1075
 ; PPC64-NEXT:    std 4, -24(1)
-; PPC64-NEXT:    li 4, 1075
-; PPC64-NEXT:    rldic 4, 4, 52, 1
+; PPC64-NEXT:    addis 4, 2, .LCPI3_1@toc@ha
+; PPC64-NEXT:    lfd 0, .LCPI3_1@toc@l(4)
+; PPC64-NEXT:    rldic 4, 5, 52, 1
 ; PPC64-NEXT:    or 3, 3, 4
-; PPC64-NEXT:    lfd 0, .LCPI3_1@toc@l(5)
 ; PPC64-NEXT:    std 3, -32(1)
 ; PPC64-NEXT:    lfd 1, -24(1)
 ; PPC64-NEXT:    lfd 2, -32(1)
@@ -269,12 +268,10 @@ define double @si1_to_f64(i1 %X) #0 {
 ; PPC64-LABEL: si1_to_f64:
 ; PPC64:       # %bb.0: # %entry
 ; PPC64-NEXT:    andi. 3, 3, 1
-; PPC64-NEXT:    li 4, -1
+; PPC64-NEXT:    li 3, -1
+; PPC64-NEXT:    bc 12, 1, .LBB6_2
+; PPC64-NEXT:  # %bb.1: # %entry
 ; PPC64-NEXT:    li 3, 0
-; PPC64-NEXT:    bc 12, 1, .LBB6_1
-; PPC64-NEXT:    b .LBB6_2
-; PPC64-NEXT:  .LBB6_1: # %entry
-; PPC64-NEXT:    addi 3, 4, 0
 ; PPC64-NEXT:  .LBB6_2: # %entry
 ; PPC64-NEXT:    std 3, -8(1)
 ; PPC64-NEXT:    lfd 0, -8(1)

--- a/llvm/test/CodeGen/PowerPC/fptoui-be-crash.ll
+++ b/llvm/test/CodeGen/PowerPC/fptoui-be-crash.ll
@@ -5,67 +5,65 @@ define dso_local void @calc_buffer() local_unnamed_addr #0 {
 ; CHECK-LABEL: calc_buffer:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    ld r3, 0(r3)
-; CHECK-NEXT:    sradi r5, r3, 53
-; CHECK-NEXT:    rldicl r6, r3, 63, 1
-; CHECK-NEXT:    clrldi r7, r3, 63
-; CHECK-NEXT:    clrldi r4, r3, 53
-; CHECK-NEXT:    addi r5, r5, 1
-; CHECK-NEXT:    or r7, r7, r6
-; CHECK-NEXT:    cmpldi r5, 1
-; CHECK-NEXT:    clrldi r5, r7, 53
-; CHECK-NEXT:    addi r4, r4, 2047
-; CHECK-NEXT:    addi r5, r5, 2047
-; CHECK-NEXT:    or r5, r5, r6
-; CHECK-NEXT:    rldicl r6, r3, 10, 54
-; CHECK-NEXT:    or r4, r4, r3
-; CHECK-NEXT:    addi r6, r6, 1
-; CHECK-NEXT:    rldicl r5, r5, 53, 11
-; CHECK-NEXT:    cmpldi cr1, r6, 1
-; CHECK-NEXT:    rldicr r4, r4, 0, 52
-; CHECK-NEXT:    rldicl r5, r5, 11, 1
-; CHECK-NEXT:    bc 12, gt, .LBB0_2
+; CHECK-NEXT:    sradi r4, r3, 53
+; CHECK-NEXT:    addi r4, r4, 1
+; CHECK-NEXT:    cmpldi r4, 1
+; CHECK-NEXT:    bgt cr0, .LBB0_2
 ; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    ori r4, r3, 0
-; CHECK-NEXT:    b .LBB0_2
+; CHECK-NEXT:    mr r4, r3
+; CHECK-NEXT:    b .LBB0_3
 ; CHECK-NEXT:  .LBB0_2:
-; CHECK-NEXT:    bc 12, 4*cr1+gt, .LBB0_4
-; CHECK-NEXT:  # %bb.3:
-; CHECK-NEXT:    ori r5, r7, 0
-; CHECK-NEXT:    b .LBB0_4
-; CHECK-NEXT:  .LBB0_4:
-; CHECK-NEXT:    cmpdi r3, 0
+; CHECK-NEXT:    clrldi r4, r3, 53
+; CHECK-NEXT:    addi r4, r4, 2047
+; CHECK-NEXT:    or r4, r4, r3
+; CHECK-NEXT:    rldicr r4, r4, 0, 52
+; CHECK-NEXT:  .LBB0_3:
+; CHECK-NEXT:    rldicl r6, r3, 10, 54
 ; CHECK-NEXT:    std r4, -32(r1)
-; CHECK-NEXT:    std r5, -24(r1)
-; CHECK-NEXT:    bc 12, lt, .LBB0_6
-; CHECK-NEXT:  # %bb.5:
+; CHECK-NEXT:    rldicl r5, r3, 63, 1
+; CHECK-NEXT:    clrldi r4, r3, 63
+; CHECK-NEXT:    addi r6, r6, 1
+; CHECK-NEXT:    cmpldi r6, 1
+; CHECK-NEXT:    or r4, r4, r5
+; CHECK-NEXT:    ble cr0, .LBB0_5
+; CHECK-NEXT:  # %bb.4:
+; CHECK-NEXT:    clrldi r4, r4, 53
+; CHECK-NEXT:    addi r4, r4, 2047
+; CHECK-NEXT:    or r4, r4, r5
+; CHECK-NEXT:    rldicl r4, r4, 53, 11
+; CHECK-NEXT:    rldicl r4, r4, 11, 1
+; CHECK-NEXT:  .LBB0_5:
+; CHECK-NEXT:    cmpdi r3, 0
+; CHECK-NEXT:    std r4, -24(r1)
+; CHECK-NEXT:    bc 12, lt, .LBB0_7
+; CHECK-NEXT:  # %bb.6:
 ; CHECK-NEXT:    lfd f0, -32(r1)
 ; CHECK-NEXT:    fcfid f0, f0
 ; CHECK-NEXT:    frsp f0, f0
-; CHECK-NEXT:    b .LBB0_7
-; CHECK-NEXT:  .LBB0_6:
+; CHECK-NEXT:    b .LBB0_8
+; CHECK-NEXT:  .LBB0_7:
 ; CHECK-NEXT:    lfd f0, -24(r1)
 ; CHECK-NEXT:    fcfid f0, f0
 ; CHECK-NEXT:    frsp f0, f0
 ; CHECK-NEXT:    fadds f0, f0, f0
-; CHECK-NEXT:  .LBB0_7:
+; CHECK-NEXT:  .LBB0_8:
 ; CHECK-NEXT:    addis r3, r2, .LCPI0_0@toc@ha
-; CHECK-NEXT:    li r4, 1
 ; CHECK-NEXT:    lfs f1, .LCPI0_0@toc@l(r3)
-; CHECK-NEXT:    rldic r4, r4, 63, 0
 ; CHECK-NEXT:    fsubs f2, f0, f1
 ; CHECK-NEXT:    fctidz f2, f2
 ; CHECK-NEXT:    stfd f2, -8(r1)
 ; CHECK-NEXT:    fctidz f2, f0
-; CHECK-NEXT:    stfd f2, -16(r1)
-; CHECK-NEXT:    ld r3, -8(r1)
-; CHECK-NEXT:    ld r5, -16(r1)
 ; CHECK-NEXT:    fcmpu cr0, f0, f1
+; CHECK-NEXT:    stfd f2, -16(r1)
+; CHECK-NEXT:    blt cr0, .LBB0_10
+; CHECK-NEXT:  # %bb.9:
+; CHECK-NEXT:    ld r3, -8(r1)
+; CHECK-NEXT:    li r4, 1
+; CHECK-NEXT:    rldic r4, r4, 63, 0
 ; CHECK-NEXT:    xor r3, r3, r4
-; CHECK-NEXT:    bc 12, lt, .LBB0_8
-; CHECK-NEXT:    b .LBB0_9
-; CHECK-NEXT:  .LBB0_8:
-; CHECK-NEXT:    addi r3, r5, 0
-; CHECK-NEXT:  .LBB0_9:
+; CHECK-NEXT:    std r3, 0(r3)
+; CHECK-NEXT:  .LBB0_10:
+; CHECK-NEXT:    ld r3, -16(r1)
 ; CHECK-NEXT:    std r3, 0(r3)
   %load_initial = load i64, ptr poison, align 8
   %conv39 = uitofp i64 %load_initial to float

--- a/llvm/test/CodeGen/PowerPC/funnel-shift-rot.ll
+++ b/llvm/test/CodeGen/PowerPC/funnel-shift-rot.ll
@@ -74,47 +74,27 @@ define i32 @rotl_i32(i32 %x, i32 %z) {
 }
 
 define i64 @rotl_i64(i64 %x, i64 %z) {
-; CHECK32_32-LABEL: rotl_i64:
-; CHECK32_32:       # %bb.0:
-; CHECK32_32-NEXT:    andi. 5, 6, 32
-; CHECK32_32-NEXT:    clrlwi 5, 6, 27
-; CHECK32_32-NEXT:    subfic 6, 5, 32
-; CHECK32_32-NEXT:    bc 12, 2, .LBB4_2
-; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    ori 7, 3, 0
-; CHECK32_32-NEXT:    ori 3, 4, 0
-; CHECK32_32-NEXT:    b .LBB4_3
-; CHECK32_32-NEXT:  .LBB4_2:
-; CHECK32_32-NEXT:    addi 7, 4, 0
-; CHECK32_32-NEXT:  .LBB4_3:
-; CHECK32_32-NEXT:    srw 4, 7, 6
-; CHECK32_32-NEXT:    slw 8, 3, 5
-; CHECK32_32-NEXT:    srw 6, 3, 6
-; CHECK32_32-NEXT:    slw 5, 7, 5
-; CHECK32_32-NEXT:    or 3, 8, 4
-; CHECK32_32-NEXT:    or 4, 5, 6
-; CHECK32_32-NEXT:    blr
-;
-; CHECK32_64-LABEL: rotl_i64:
-; CHECK32_64:       # %bb.0:
-; CHECK32_64-NEXT:    andi. 5, 6, 32
-; CHECK32_64-NEXT:    clrlwi 5, 6, 27
-; CHECK32_64-NEXT:    bc 12, 2, .LBB4_2
-; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    ori 7, 3, 0
-; CHECK32_64-NEXT:    ori 3, 4, 0
-; CHECK32_64-NEXT:    b .LBB4_3
-; CHECK32_64-NEXT:  .LBB4_2:
-; CHECK32_64-NEXT:    addi 7, 4, 0
-; CHECK32_64-NEXT:  .LBB4_3:
-; CHECK32_64-NEXT:    subfic 6, 5, 32
-; CHECK32_64-NEXT:    srw 4, 7, 6
-; CHECK32_64-NEXT:    slw 8, 3, 5
-; CHECK32_64-NEXT:    srw 6, 3, 6
-; CHECK32_64-NEXT:    slw 5, 7, 5
-; CHECK32_64-NEXT:    or 3, 8, 4
-; CHECK32_64-NEXT:    or 4, 5, 6
-; CHECK32_64-NEXT:    blr
+; CHECK32-LABEL: rotl_i64:
+; CHECK32:       # %bb.0:
+; CHECK32-NEXT:    andi. 5, 6, 32
+; CHECK32-NEXT:    mr 5, 3
+; CHECK32-NEXT:    bne 0, .LBB4_2
+; CHECK32-NEXT:  # %bb.1:
+; CHECK32-NEXT:    mr 5, 4
+; CHECK32-NEXT:  .LBB4_2:
+; CHECK32-NEXT:    clrlwi 6, 6, 27
+; CHECK32-NEXT:    subfic 8, 6, 32
+; CHECK32-NEXT:    srw 7, 5, 8
+; CHECK32-NEXT:    bne 0, .LBB4_4
+; CHECK32-NEXT:  # %bb.3:
+; CHECK32-NEXT:    mr 4, 3
+; CHECK32-NEXT:  .LBB4_4:
+; CHECK32-NEXT:    slw 3, 4, 6
+; CHECK32-NEXT:    srw 4, 4, 8
+; CHECK32-NEXT:    slw 5, 5, 6
+; CHECK32-NEXT:    or 3, 3, 7
+; CHECK32-NEXT:    or 4, 5, 4
+; CHECK32-NEXT:    blr
 ;
 ; CHECK64-LABEL: rotl_i64:
 ; CHECK64:       # %bb.0:
@@ -224,47 +204,27 @@ define i32 @rotr_i32(i32 %x, i32 %z) {
 }
 
 define i64 @rotr_i64(i64 %x, i64 %z) {
-; CHECK32_32-LABEL: rotr_i64:
-; CHECK32_32:       # %bb.0:
-; CHECK32_32-NEXT:    andi. 5, 6, 32
-; CHECK32_32-NEXT:    clrlwi 5, 6, 27
-; CHECK32_32-NEXT:    subfic 6, 5, 32
-; CHECK32_32-NEXT:    bc 12, 2, .LBB11_2
-; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    ori 7, 4, 0
-; CHECK32_32-NEXT:    b .LBB11_3
-; CHECK32_32-NEXT:  .LBB11_2:
-; CHECK32_32-NEXT:    addi 7, 3, 0
-; CHECK32_32-NEXT:    addi 3, 4, 0
-; CHECK32_32-NEXT:  .LBB11_3:
-; CHECK32_32-NEXT:    srw 4, 7, 5
-; CHECK32_32-NEXT:    slw 8, 3, 6
-; CHECK32_32-NEXT:    srw 5, 3, 5
-; CHECK32_32-NEXT:    slw 6, 7, 6
-; CHECK32_32-NEXT:    or 3, 8, 4
-; CHECK32_32-NEXT:    or 4, 6, 5
-; CHECK32_32-NEXT:    blr
-;
-; CHECK32_64-LABEL: rotr_i64:
-; CHECK32_64:       # %bb.0:
-; CHECK32_64-NEXT:    andi. 5, 6, 32
-; CHECK32_64-NEXT:    clrlwi 5, 6, 27
-; CHECK32_64-NEXT:    bc 12, 2, .LBB11_2
-; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    ori 7, 4, 0
-; CHECK32_64-NEXT:    b .LBB11_3
-; CHECK32_64-NEXT:  .LBB11_2:
-; CHECK32_64-NEXT:    addi 7, 3, 0
-; CHECK32_64-NEXT:    addi 3, 4, 0
-; CHECK32_64-NEXT:  .LBB11_3:
-; CHECK32_64-NEXT:    subfic 6, 5, 32
-; CHECK32_64-NEXT:    srw 4, 7, 5
-; CHECK32_64-NEXT:    slw 8, 3, 6
-; CHECK32_64-NEXT:    srw 5, 3, 5
-; CHECK32_64-NEXT:    slw 6, 7, 6
-; CHECK32_64-NEXT:    or 3, 8, 4
-; CHECK32_64-NEXT:    or 4, 6, 5
-; CHECK32_64-NEXT:    blr
+; CHECK32-LABEL: rotr_i64:
+; CHECK32:       # %bb.0:
+; CHECK32-NEXT:    andi. 5, 6, 32
+; CHECK32-NEXT:    mr 5, 3
+; CHECK32-NEXT:    beq 0, .LBB11_2
+; CHECK32-NEXT:  # %bb.1:
+; CHECK32-NEXT:    mr 5, 4
+; CHECK32-NEXT:  .LBB11_2:
+; CHECK32-NEXT:    clrlwi 7, 6, 27
+; CHECK32-NEXT:    srw 6, 5, 7
+; CHECK32-NEXT:    beq 0, .LBB11_4
+; CHECK32-NEXT:  # %bb.3:
+; CHECK32-NEXT:    mr 4, 3
+; CHECK32-NEXT:  .LBB11_4:
+; CHECK32-NEXT:    subfic 3, 7, 32
+; CHECK32-NEXT:    srw 7, 4, 7
+; CHECK32-NEXT:    slw 4, 4, 3
+; CHECK32-NEXT:    slw 5, 5, 3
+; CHECK32-NEXT:    or 3, 4, 6
+; CHECK32-NEXT:    or 4, 5, 7
+; CHECK32-NEXT:    blr
 ;
 ; CHECK64-LABEL: rotr_i64:
 ; CHECK64:       # %bb.0:

--- a/llvm/test/CodeGen/PowerPC/funnel-shift.ll
+++ b/llvm/test/CodeGen/PowerPC/funnel-shift.ll
@@ -32,50 +32,31 @@ define i32 @fshl_i32(i32 %x, i32 %y, i32 %z) {
 }
 
 define i64 @fshl_i64(i64 %x, i64 %y, i64 %z) {
-; CHECK32_32-LABEL: fshl_i64:
-; CHECK32_32:       # %bb.0:
-; CHECK32_32-NEXT:    andi. 7, 8, 32
-; CHECK32_32-NEXT:    clrlwi 7, 8, 27
-; CHECK32_32-NEXT:    subfic 8, 7, 32
-; CHECK32_32-NEXT:    bc 12, 2, .LBB1_2
-; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    ori 9, 5, 0
-; CHECK32_32-NEXT:    ori 3, 4, 0
-; CHECK32_32-NEXT:    ori 4, 6, 0
-; CHECK32_32-NEXT:    b .LBB1_3
-; CHECK32_32-NEXT:  .LBB1_2:
-; CHECK32_32-NEXT:    addi 9, 4, 0
-; CHECK32_32-NEXT:    addi 4, 5, 0
-; CHECK32_32-NEXT:  .LBB1_3:
-; CHECK32_32-NEXT:    srw 5, 9, 8
-; CHECK32_32-NEXT:    slw 3, 3, 7
-; CHECK32_32-NEXT:    srw 4, 4, 8
-; CHECK32_32-NEXT:    slw 6, 9, 7
-; CHECK32_32-NEXT:    or 3, 3, 5
-; CHECK32_32-NEXT:    or 4, 6, 4
-; CHECK32_32-NEXT:    blr
-;
-; CHECK32_64-LABEL: fshl_i64:
-; CHECK32_64:       # %bb.0:
-; CHECK32_64-NEXT:    andi. 7, 8, 32
-; CHECK32_64-NEXT:    clrlwi 7, 8, 27
-; CHECK32_64-NEXT:    bc 12, 2, .LBB1_2
-; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    ori 9, 5, 0
-; CHECK32_64-NEXT:    ori 3, 4, 0
-; CHECK32_64-NEXT:    ori 5, 6, 0
-; CHECK32_64-NEXT:    b .LBB1_3
-; CHECK32_64-NEXT:  .LBB1_2:
-; CHECK32_64-NEXT:    addi 9, 4, 0
-; CHECK32_64-NEXT:  .LBB1_3:
-; CHECK32_64-NEXT:    subfic 8, 7, 32
-; CHECK32_64-NEXT:    srw 4, 9, 8
-; CHECK32_64-NEXT:    slw 3, 3, 7
-; CHECK32_64-NEXT:    srw 5, 5, 8
-; CHECK32_64-NEXT:    slw 6, 9, 7
-; CHECK32_64-NEXT:    or 3, 3, 4
-; CHECK32_64-NEXT:    or 4, 6, 5
-; CHECK32_64-NEXT:    blr
+; CHECK32-LABEL: fshl_i64:
+; CHECK32:       # %bb.0:
+; CHECK32-NEXT:    andi. 7, 8, 32
+; CHECK32-NEXT:    mr 7, 5
+; CHECK32-NEXT:    bne 0, .LBB1_2
+; CHECK32-NEXT:  # %bb.1:
+; CHECK32-NEXT:    mr 7, 4
+; CHECK32-NEXT:  .LBB1_2:
+; CHECK32-NEXT:    clrlwi 8, 8, 27
+; CHECK32-NEXT:    subfic 9, 8, 32
+; CHECK32-NEXT:    srw 10, 7, 9
+; CHECK32-NEXT:    bne 0, .LBB1_4
+; CHECK32-NEXT:  # %bb.3:
+; CHECK32-NEXT:    mr 4, 3
+; CHECK32-NEXT:  .LBB1_4:
+; CHECK32-NEXT:    slw 3, 4, 8
+; CHECK32-NEXT:    or 3, 3, 10
+; CHECK32-NEXT:    bne 0, .LBB1_6
+; CHECK32-NEXT:  # %bb.5:
+; CHECK32-NEXT:    mr 6, 5
+; CHECK32-NEXT:  .LBB1_6:
+; CHECK32-NEXT:    srw 4, 6, 9
+; CHECK32-NEXT:    slw 5, 7, 8
+; CHECK32-NEXT:    or 4, 5, 4
+; CHECK32-NEXT:    blr
 ;
 ; CHECK64-LABEL: fshl_i64:
 ; CHECK64:       # %bb.0:
@@ -92,113 +73,177 @@ define i64 @fshl_i64(i64 %x, i64 %y, i64 %z) {
 define i128 @fshl_i128(i128 %x, i128 %y, i128 %z) nounwind {
 ; CHECK32_32-LABEL: fshl_i128:
 ; CHECK32_32:       # %bb.0:
-; CHECK32_32-NEXT:    lwz 11, 20(1)
-; CHECK32_32-NEXT:    andi. 12, 11, 64
+; CHECK32_32-NEXT:    stwu 1, -32(1)
+; CHECK32_32-NEXT:    lwz 12, 52(1)
+; CHECK32_32-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
+; CHECK32_32-NEXT:    andi. 11, 12, 64
 ; CHECK32_32-NEXT:    mcrf 1, 0
-; CHECK32_32-NEXT:    andi. 12, 11, 32
-; CHECK32_32-NEXT:    clrlwi 11, 11, 27
-; CHECK32_32-NEXT:    bc 12, 6, .LBB2_2
+; CHECK32_32-NEXT:    mr 11, 6
+; CHECK32_32-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
+; CHECK32_32-NEXT:    bne 0, .LBB2_2
 ; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    ori 4, 6, 0
-; CHECK32_32-NEXT:    ori 12, 7, 0
-; CHECK32_32-NEXT:    ori 3, 5, 0
-; CHECK32_32-NEXT:    ori 5, 8, 0
-; CHECK32_32-NEXT:    ori 6, 9, 0
-; CHECK32_32-NEXT:    ori 7, 10, 0
-; CHECK32_32-NEXT:    b .LBB2_3
+; CHECK32_32-NEXT:    mr 11, 4
 ; CHECK32_32-NEXT:  .LBB2_2:
-; CHECK32_32-NEXT:    addi 12, 5, 0
-; CHECK32_32-NEXT:    addi 5, 6, 0
-; CHECK32_32-NEXT:    addi 6, 7, 0
-; CHECK32_32-NEXT:    addi 7, 8, 0
-; CHECK32_32-NEXT:  .LBB2_3:
-; CHECK32_32-NEXT:    subfic 8, 11, 32
-; CHECK32_32-NEXT:    bc 12, 2, .LBB2_5
-; CHECK32_32-NEXT:  # %bb.4:
-; CHECK32_32-NEXT:    ori 9, 12, 0
-; CHECK32_32-NEXT:    ori 3, 4, 0
-; CHECK32_32-NEXT:    ori 4, 5, 0
-; CHECK32_32-NEXT:    ori 5, 6, 0
-; CHECK32_32-NEXT:    ori 6, 7, 0
-; CHECK32_32-NEXT:    b .LBB2_6
-; CHECK32_32-NEXT:  .LBB2_5:
-; CHECK32_32-NEXT:    addi 9, 4, 0
-; CHECK32_32-NEXT:    addi 4, 12, 0
+; CHECK32_32-NEXT:    mr 30, 7
+; CHECK32_32-NEXT:    bne 1, .LBB2_4
+; CHECK32_32-NEXT:  # %bb.3:
+; CHECK32_32-NEXT:    mr 30, 5
+; CHECK32_32-NEXT:  .LBB2_4:
+; CHECK32_32-NEXT:    andi. 4, 12, 32
+; CHECK32_32-NEXT:    mr 4, 30
+; CHECK32_32-NEXT:    beq 0, .LBB2_18
+; CHECK32_32-NEXT:  # %bb.5:
+; CHECK32_32-NEXT:    beq 1, .LBB2_19
 ; CHECK32_32-NEXT:  .LBB2_6:
-; CHECK32_32-NEXT:    srw 7, 9, 8
-; CHECK32_32-NEXT:    slw 3, 3, 11
-; CHECK32_32-NEXT:    srw 10, 4, 8
-; CHECK32_32-NEXT:    slw 9, 9, 11
-; CHECK32_32-NEXT:    srw 12, 5, 8
-; CHECK32_32-NEXT:    slw 0, 4, 11
-; CHECK32_32-NEXT:    srw 6, 6, 8
-; CHECK32_32-NEXT:    slw 8, 5, 11
-; CHECK32_32-NEXT:    or 3, 3, 7
-; CHECK32_32-NEXT:    or 4, 9, 10
-; CHECK32_32-NEXT:    or 5, 0, 12
-; CHECK32_32-NEXT:    or 6, 8, 6
+; CHECK32_32-NEXT:    beq 0, .LBB2_20
+; CHECK32_32-NEXT:  .LBB2_7:
+; CHECK32_32-NEXT:    mr 5, 8
+; CHECK32_32-NEXT:    beq 1, .LBB2_21
+; CHECK32_32-NEXT:  .LBB2_8:
+; CHECK32_32-NEXT:    mr 3, 5
+; CHECK32_32-NEXT:    beq 0, .LBB2_22
+; CHECK32_32-NEXT:  .LBB2_9:
+; CHECK32_32-NEXT:    clrlwi 6, 12, 27
+; CHECK32_32-NEXT:    bne 1, .LBB2_11
+; CHECK32_32-NEXT:  .LBB2_10:
+; CHECK32_32-NEXT:    mr 9, 7
+; CHECK32_32-NEXT:  .LBB2_11:
+; CHECK32_32-NEXT:    subfic 7, 6, 32
+; CHECK32_32-NEXT:    mr 12, 9
+; CHECK32_32-NEXT:    bne 0, .LBB2_13
+; CHECK32_32-NEXT:  # %bb.12:
+; CHECK32_32-NEXT:    mr 12, 5
+; CHECK32_32-NEXT:  .LBB2_13:
+; CHECK32_32-NEXT:    srw 5, 4, 7
+; CHECK32_32-NEXT:    slw 11, 11, 6
+; CHECK32_32-NEXT:    srw 0, 3, 7
+; CHECK32_32-NEXT:    slw 4, 4, 6
+; CHECK32_32-NEXT:    srw 30, 12, 7
+; CHECK32_32-NEXT:    slw 29, 3, 6
+; CHECK32_32-NEXT:    bne 1, .LBB2_15
+; CHECK32_32-NEXT:  # %bb.14:
+; CHECK32_32-NEXT:    mr 10, 8
+; CHECK32_32-NEXT:  .LBB2_15:
+; CHECK32_32-NEXT:    or 3, 11, 5
+; CHECK32_32-NEXT:    or 4, 4, 0
+; CHECK32_32-NEXT:    or 5, 29, 30
+; CHECK32_32-NEXT:    bne 0, .LBB2_17
+; CHECK32_32-NEXT:  # %bb.16:
+; CHECK32_32-NEXT:    mr 10, 9
+; CHECK32_32-NEXT:  .LBB2_17:
+; CHECK32_32-NEXT:    srw 7, 10, 7
+; CHECK32_32-NEXT:    slw 6, 12, 6
+; CHECK32_32-NEXT:    or 6, 6, 7
+; CHECK32_32-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
+; CHECK32_32-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
+; CHECK32_32-NEXT:    addi 1, 1, 32
 ; CHECK32_32-NEXT:    blr
+; CHECK32_32-NEXT:  .LBB2_18:
+; CHECK32_32-NEXT:    mr 4, 11
+; CHECK32_32-NEXT:    bne 1, .LBB2_6
+; CHECK32_32-NEXT:  .LBB2_19:
+; CHECK32_32-NEXT:    mr 5, 3
+; CHECK32_32-NEXT:    bne 0, .LBB2_7
+; CHECK32_32-NEXT:  .LBB2_20:
+; CHECK32_32-NEXT:    mr 11, 5
+; CHECK32_32-NEXT:    mr 5, 8
+; CHECK32_32-NEXT:    bne 1, .LBB2_8
+; CHECK32_32-NEXT:  .LBB2_21:
+; CHECK32_32-NEXT:    mr 5, 6
+; CHECK32_32-NEXT:    mr 3, 5
+; CHECK32_32-NEXT:    bne 0, .LBB2_9
+; CHECK32_32-NEXT:  .LBB2_22:
+; CHECK32_32-NEXT:    mr 3, 30
+; CHECK32_32-NEXT:    clrlwi 6, 12, 27
+; CHECK32_32-NEXT:    beq 1, .LBB2_10
+; CHECK32_32-NEXT:    b .LBB2_11
 ;
 ; CHECK32_64-LABEL: fshl_i128:
 ; CHECK32_64:       # %bb.0:
-; CHECK32_64-NEXT:    stwu 1, -16(1)
-; CHECK32_64-NEXT:    lwz 11, 36(1)
-; CHECK32_64-NEXT:    andi. 12, 11, 64
-; CHECK32_64-NEXT:    stw 30, 8(1) # 4-byte Folded Spill
+; CHECK32_64-NEXT:    stwu 1, -32(1)
+; CHECK32_64-NEXT:    lwz 12, 52(1)
+; CHECK32_64-NEXT:    andi. 11, 12, 64
+; CHECK32_64-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
 ; CHECK32_64-NEXT:    mcrf 1, 0
-; CHECK32_64-NEXT:    clrlwi 12, 11, 27
-; CHECK32_64-NEXT:    andi. 11, 11, 32
-; CHECK32_64-NEXT:    bc 12, 6, .LBB2_2
+; CHECK32_64-NEXT:    mr 11, 6
+; CHECK32_64-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
+; CHECK32_64-NEXT:    bne 0, .LBB2_2
 ; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    ori 4, 6, 0
-; CHECK32_64-NEXT:    ori 30, 7, 0
-; CHECK32_64-NEXT:    ori 3, 5, 0
-; CHECK32_64-NEXT:    ori 7, 9, 0
-; CHECK32_64-NEXT:    b .LBB2_3
+; CHECK32_64-NEXT:    mr 11, 4
 ; CHECK32_64-NEXT:  .LBB2_2:
-; CHECK32_64-NEXT:    addi 30, 5, 0
-; CHECK32_64-NEXT:  .LBB2_3:
-; CHECK32_64-NEXT:    bc 12, 2, .LBB2_5
-; CHECK32_64-NEXT:  # %bb.4:
-; CHECK32_64-NEXT:    ori 5, 30, 0
-; CHECK32_64-NEXT:    ori 3, 4, 0
-; CHECK32_64-NEXT:    b .LBB2_6
-; CHECK32_64-NEXT:  .LBB2_5:
-; CHECK32_64-NEXT:    addi 5, 4, 0
+; CHECK32_64-NEXT:    mr 30, 7
+; CHECK32_64-NEXT:    bne 1, .LBB2_4
+; CHECK32_64-NEXT:  # %bb.3:
+; CHECK32_64-NEXT:    mr 30, 5
+; CHECK32_64-NEXT:  .LBB2_4:
+; CHECK32_64-NEXT:    andi. 4, 12, 32
+; CHECK32_64-NEXT:    mr 4, 30
+; CHECK32_64-NEXT:    beq 0, .LBB2_18
+; CHECK32_64-NEXT:  # %bb.5:
+; CHECK32_64-NEXT:    beq 1, .LBB2_19
 ; CHECK32_64-NEXT:  .LBB2_6:
-; CHECK32_64-NEXT:    bc 12, 6, .LBB2_8
-; CHECK32_64-NEXT:  # %bb.7:
-; CHECK32_64-NEXT:    ori 4, 8, 0
-; CHECK32_64-NEXT:    ori 8, 10, 0
-; CHECK32_64-NEXT:    b .LBB2_9
+; CHECK32_64-NEXT:    beq 0, .LBB2_20
+; CHECK32_64-NEXT:  .LBB2_7:
+; CHECK32_64-NEXT:    mr 5, 8
+; CHECK32_64-NEXT:    beq 1, .LBB2_21
 ; CHECK32_64-NEXT:  .LBB2_8:
-; CHECK32_64-NEXT:    addi 4, 6, 0
+; CHECK32_64-NEXT:    mr 3, 5
+; CHECK32_64-NEXT:    beq 0, .LBB2_22
 ; CHECK32_64-NEXT:  .LBB2_9:
-; CHECK32_64-NEXT:    subfic 11, 12, 32
-; CHECK32_64-NEXT:    bc 12, 2, .LBB2_11
-; CHECK32_64-NEXT:  # %bb.10:
-; CHECK32_64-NEXT:    ori 0, 4, 0
-; CHECK32_64-NEXT:    ori 4, 7, 0
-; CHECK32_64-NEXT:    ori 7, 8, 0
-; CHECK32_64-NEXT:    b .LBB2_12
+; CHECK32_64-NEXT:    clrlwi 6, 12, 27
+; CHECK32_64-NEXT:    bne 1, .LBB2_11
+; CHECK32_64-NEXT:  .LBB2_10:
+; CHECK32_64-NEXT:    mr 9, 7
 ; CHECK32_64-NEXT:  .LBB2_11:
-; CHECK32_64-NEXT:    addi 0, 30, 0
-; CHECK32_64-NEXT:  .LBB2_12:
-; CHECK32_64-NEXT:    srw 6, 5, 11
-; CHECK32_64-NEXT:    lwz 30, 8(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    slw 3, 3, 12
-; CHECK32_64-NEXT:    srw 9, 0, 11
-; CHECK32_64-NEXT:    slw 5, 5, 12
-; CHECK32_64-NEXT:    srw 10, 4, 11
-; CHECK32_64-NEXT:    slw 0, 0, 12
-; CHECK32_64-NEXT:    srw 7, 7, 11
-; CHECK32_64-NEXT:    slw 8, 4, 12
-; CHECK32_64-NEXT:    or 3, 3, 6
-; CHECK32_64-NEXT:    or 4, 5, 9
-; CHECK32_64-NEXT:    or 5, 0, 10
-; CHECK32_64-NEXT:    or 6, 8, 7
-; CHECK32_64-NEXT:    addi 1, 1, 16
+; CHECK32_64-NEXT:    subfic 7, 6, 32
+; CHECK32_64-NEXT:    mr 12, 9
+; CHECK32_64-NEXT:    bne 0, .LBB2_13
+; CHECK32_64-NEXT:  # %bb.12:
+; CHECK32_64-NEXT:    mr 12, 5
+; CHECK32_64-NEXT:  .LBB2_13:
+; CHECK32_64-NEXT:    srw 5, 4, 7
+; CHECK32_64-NEXT:    slw 11, 11, 6
+; CHECK32_64-NEXT:    srw 0, 3, 7
+; CHECK32_64-NEXT:    slw 4, 4, 6
+; CHECK32_64-NEXT:    srw 30, 12, 7
+; CHECK32_64-NEXT:    slw 29, 3, 6
+; CHECK32_64-NEXT:    bne 1, .LBB2_15
+; CHECK32_64-NEXT:  # %bb.14:
+; CHECK32_64-NEXT:    mr 10, 8
+; CHECK32_64-NEXT:  .LBB2_15:
+; CHECK32_64-NEXT:    or 3, 11, 5
+; CHECK32_64-NEXT:    or 4, 4, 0
+; CHECK32_64-NEXT:    or 5, 29, 30
+; CHECK32_64-NEXT:    bne 0, .LBB2_17
+; CHECK32_64-NEXT:  # %bb.16:
+; CHECK32_64-NEXT:    mr 10, 9
+; CHECK32_64-NEXT:  .LBB2_17:
+; CHECK32_64-NEXT:    srw 7, 10, 7
+; CHECK32_64-NEXT:    slw 6, 12, 6
+; CHECK32_64-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
+; CHECK32_64-NEXT:    or 6, 6, 7
+; CHECK32_64-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
+; CHECK32_64-NEXT:    addi 1, 1, 32
 ; CHECK32_64-NEXT:    blr
+; CHECK32_64-NEXT:  .LBB2_18:
+; CHECK32_64-NEXT:    mr 4, 11
+; CHECK32_64-NEXT:    bne 1, .LBB2_6
+; CHECK32_64-NEXT:  .LBB2_19:
+; CHECK32_64-NEXT:    mr 5, 3
+; CHECK32_64-NEXT:    bne 0, .LBB2_7
+; CHECK32_64-NEXT:  .LBB2_20:
+; CHECK32_64-NEXT:    mr 11, 5
+; CHECK32_64-NEXT:    mr 5, 8
+; CHECK32_64-NEXT:    bne 1, .LBB2_8
+; CHECK32_64-NEXT:  .LBB2_21:
+; CHECK32_64-NEXT:    mr 5, 6
+; CHECK32_64-NEXT:    mr 3, 5
+; CHECK32_64-NEXT:    bne 0, .LBB2_9
+; CHECK32_64-NEXT:  .LBB2_22:
+; CHECK32_64-NEXT:    mr 3, 30
+; CHECK32_64-NEXT:    clrlwi 6, 12, 27
+; CHECK32_64-NEXT:    beq 1, .LBB2_10
+; CHECK32_64-NEXT:    b .LBB2_11
 ;
 ; CHECK64-LABEL: fshl_i128:
 ; CHECK64:       # %bb.0:
@@ -235,11 +280,11 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-NEXT:    .cfi_offset r29, -12
 ; CHECK32_32-NEXT:    .cfi_offset r30, -8
 ; CHECK32_32-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 27, 3
+; CHECK32_32-NEXT:    mr 27, 5
 ; CHECK32_32-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 28, 4
+; CHECK32_32-NEXT:    mr 28, 3
 ; CHECK32_32-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 29, 5
+; CHECK32_32-NEXT:    mr 29, 4
 ; CHECK32_32-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
 ; CHECK32_32-NEXT:    mr 30, 6
 ; CHECK32_32-NEXT:    clrlwi 3, 7, 27
@@ -247,29 +292,31 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-NEXT:    li 5, 0
 ; CHECK32_32-NEXT:    li 6, 37
 ; CHECK32_32-NEXT:    bl __umoddi3
-; CHECK32_32-NEXT:    rotlwi 3, 30, 27
-; CHECK32_32-NEXT:    slwi 5, 30, 27
-; CHECK32_32-NEXT:    andi. 6, 4, 32
-; CHECK32_32-NEXT:    rlwimi 3, 29, 27, 0, 4
-; CHECK32_32-NEXT:    clrlwi 4, 4, 27
-; CHECK32_32-NEXT:    subfic 6, 4, 32
-; CHECK32_32-NEXT:    bc 12, 2, .LBB3_2
+; CHECK32_32-NEXT:    rotlwi 5, 30, 27
+; CHECK32_32-NEXT:    rlwimi 5, 27, 27, 0, 4
+; CHECK32_32-NEXT:    andi. 3, 4, 32
+; CHECK32_32-NEXT:    mr 6, 5
+; CHECK32_32-NEXT:    bne 0, .LBB3_2
 ; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    ori 7, 3, 0
-; CHECK32_32-NEXT:    ori 8, 28, 0
-; CHECK32_32-NEXT:    ori 3, 5, 0
-; CHECK32_32-NEXT:    b .LBB3_3
+; CHECK32_32-NEXT:    mr 6, 29
 ; CHECK32_32-NEXT:  .LBB3_2:
-; CHECK32_32-NEXT:    addi 7, 28, 0
-; CHECK32_32-NEXT:    addi 8, 27, 0
-; CHECK32_32-NEXT:  .LBB3_3:
+; CHECK32_32-NEXT:    clrlwi 4, 4, 27
+; CHECK32_32-NEXT:    subfic 7, 4, 32
+; CHECK32_32-NEXT:    srw 3, 6, 7
+; CHECK32_32-NEXT:    bne 0, .LBB3_4
+; CHECK32_32-NEXT:  # %bb.3:
+; CHECK32_32-NEXT:    mr 29, 28
+; CHECK32_32-NEXT:  .LBB3_4:
+; CHECK32_32-NEXT:    slw 8, 29, 4
+; CHECK32_32-NEXT:    or 3, 8, 3
+; CHECK32_32-NEXT:    beq 0, .LBB3_6
+; CHECK32_32-NEXT:  # %bb.5:
+; CHECK32_32-NEXT:    slwi 5, 30, 27
+; CHECK32_32-NEXT:  .LBB3_6:
+; CHECK32_32-NEXT:    srw 5, 5, 7
+; CHECK32_32-NEXT:    slw 4, 6, 4
+; CHECK32_32-NEXT:    or 4, 4, 5
 ; CHECK32_32-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    srw 5, 7, 6
-; CHECK32_32-NEXT:    slw 8, 8, 4
-; CHECK32_32-NEXT:    srw 6, 3, 6
-; CHECK32_32-NEXT:    slw 4, 7, 4
-; CHECK32_32-NEXT:    or 3, 8, 5
-; CHECK32_32-NEXT:    or 4, 4, 6
 ; CHECK32_32-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
 ; CHECK32_32-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
 ; CHECK32_32-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
@@ -290,53 +337,46 @@ define i37 @fshl_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_64-NEXT:    .cfi_offset r29, -12
 ; CHECK32_64-NEXT:    .cfi_offset r30, -8
 ; CHECK32_64-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 27, 3
-; CHECK32_64-NEXT:    clrlwi 3, 7, 27
-; CHECK32_64-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 28, 4
-; CHECK32_64-NEXT:    mr 4, 8
-; CHECK32_64-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 29, 5
+; CHECK32_64-NEXT:    mr 27, 5
 ; CHECK32_64-NEXT:    li 5, 0
+; CHECK32_64-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
+; CHECK32_64-NEXT:    mr 28, 3
+; CHECK32_64-NEXT:    clrlwi 3, 7, 27
+; CHECK32_64-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
+; CHECK32_64-NEXT:    mr 29, 4
+; CHECK32_64-NEXT:    mr 4, 8
 ; CHECK32_64-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
 ; CHECK32_64-NEXT:    mr 30, 6
 ; CHECK32_64-NEXT:    li 6, 37
 ; CHECK32_64-NEXT:    bl __umoddi3
-; CHECK32_64-NEXT:    rotlwi 3, 30, 27
-; CHECK32_64-NEXT:    andi. 5, 4, 32
-; CHECK32_64-NEXT:    bc 12, 2, .LBB3_2
+; CHECK32_64-NEXT:    rotlwi 5, 30, 27
+; CHECK32_64-NEXT:    andi. 3, 4, 32
+; CHECK32_64-NEXT:    rlwimi 5, 27, 27, 0, 4
+; CHECK32_64-NEXT:    mr 6, 5
+; CHECK32_64-NEXT:    bne 0, .LBB3_2
 ; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    ori 8, 28, 0
-; CHECK32_64-NEXT:    b .LBB3_3
+; CHECK32_64-NEXT:    mr 6, 29
 ; CHECK32_64-NEXT:  .LBB3_2:
-; CHECK32_64-NEXT:    addi 8, 27, 0
-; CHECK32_64-NEXT:  .LBB3_3:
-; CHECK32_64-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    rlwimi 3, 29, 27, 0, 4
 ; CHECK32_64-NEXT:    clrlwi 4, 4, 27
-; CHECK32_64-NEXT:    bc 12, 2, .LBB3_5
-; CHECK32_64-NEXT:  # %bb.4:
-; CHECK32_64-NEXT:    ori 7, 3, 0
-; CHECK32_64-NEXT:    b .LBB3_6
-; CHECK32_64-NEXT:  .LBB3_5:
-; CHECK32_64-NEXT:    addi 7, 28, 0
-; CHECK32_64-NEXT:  .LBB3_6:
+; CHECK32_64-NEXT:    subfic 7, 4, 32
+; CHECK32_64-NEXT:    srw 3, 6, 7
+; CHECK32_64-NEXT:    bne 0, .LBB3_4
+; CHECK32_64-NEXT:  # %bb.3:
+; CHECK32_64-NEXT:    mr 29, 28
+; CHECK32_64-NEXT:  .LBB3_4:
+; CHECK32_64-NEXT:    slw 8, 29, 4
+; CHECK32_64-NEXT:    or 3, 8, 3
+; CHECK32_64-NEXT:    beq 0, .LBB3_6
+; CHECK32_64-NEXT:  # %bb.5:
 ; CHECK32_64-NEXT:    slwi 5, 30, 27
+; CHECK32_64-NEXT:  .LBB3_6:
+; CHECK32_64-NEXT:    srw 5, 5, 7
+; CHECK32_64-NEXT:    slw 4, 6, 4
 ; CHECK32_64-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    bc 12, 2, .LBB3_8
-; CHECK32_64-NEXT:  # %bb.7:
-; CHECK32_64-NEXT:    ori 3, 5, 0
-; CHECK32_64-NEXT:    b .LBB3_8
-; CHECK32_64-NEXT:  .LBB3_8:
-; CHECK32_64-NEXT:    subfic 6, 4, 32
-; CHECK32_64-NEXT:    slw 8, 8, 4
-; CHECK32_64-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    srw 9, 7, 6
-; CHECK32_64-NEXT:    srw 5, 3, 6
-; CHECK32_64-NEXT:    slw 4, 7, 4
-; CHECK32_64-NEXT:    or 3, 8, 9
-; CHECK32_64-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
 ; CHECK32_64-NEXT:    or 4, 4, 5
+; CHECK32_64-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
+; CHECK32_64-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
+; CHECK32_64-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
 ; CHECK32_64-NEXT:    lwz 0, 36(1)
 ; CHECK32_64-NEXT:    addi 1, 1, 32
 ; CHECK32_64-NEXT:    mtlr 0
@@ -453,50 +493,31 @@ define i32 @fshr_i32(i32 %x, i32 %y, i32 %z) {
 }
 
 define i64 @fshr_i64(i64 %x, i64 %y, i64 %z) {
-; CHECK32_32-LABEL: fshr_i64:
-; CHECK32_32:       # %bb.0:
-; CHECK32_32-NEXT:    andi. 7, 8, 32
-; CHECK32_32-NEXT:    clrlwi 7, 8, 27
-; CHECK32_32-NEXT:    subfic 8, 7, 32
-; CHECK32_32-NEXT:    bc 12, 2, .LBB10_2
-; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    ori 9, 4, 0
-; CHECK32_32-NEXT:    ori 4, 5, 0
-; CHECK32_32-NEXT:    b .LBB10_3
-; CHECK32_32-NEXT:  .LBB10_2:
-; CHECK32_32-NEXT:    addi 9, 5, 0
-; CHECK32_32-NEXT:    addi 3, 4, 0
-; CHECK32_32-NEXT:    addi 4, 6, 0
-; CHECK32_32-NEXT:  .LBB10_3:
-; CHECK32_32-NEXT:    srw 5, 9, 7
-; CHECK32_32-NEXT:    slw 3, 3, 8
-; CHECK32_32-NEXT:    srw 4, 4, 7
-; CHECK32_32-NEXT:    slw 6, 9, 8
-; CHECK32_32-NEXT:    or 3, 3, 5
-; CHECK32_32-NEXT:    or 4, 6, 4
-; CHECK32_32-NEXT:    blr
-;
-; CHECK32_64-LABEL: fshr_i64:
-; CHECK32_64:       # %bb.0:
-; CHECK32_64-NEXT:    andi. 7, 8, 32
-; CHECK32_64-NEXT:    clrlwi 7, 8, 27
-; CHECK32_64-NEXT:    bc 12, 2, .LBB10_2
-; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    ori 9, 4, 0
-; CHECK32_64-NEXT:    b .LBB10_3
-; CHECK32_64-NEXT:  .LBB10_2:
-; CHECK32_64-NEXT:    addi 9, 5, 0
-; CHECK32_64-NEXT:    addi 3, 4, 0
-; CHECK32_64-NEXT:    addi 5, 6, 0
-; CHECK32_64-NEXT:  .LBB10_3:
-; CHECK32_64-NEXT:    subfic 8, 7, 32
-; CHECK32_64-NEXT:    srw 4, 9, 7
-; CHECK32_64-NEXT:    slw 3, 3, 8
-; CHECK32_64-NEXT:    srw 5, 5, 7
-; CHECK32_64-NEXT:    slw 6, 9, 8
-; CHECK32_64-NEXT:    or 3, 3, 4
-; CHECK32_64-NEXT:    or 4, 6, 5
-; CHECK32_64-NEXT:    blr
+; CHECK32-LABEL: fshr_i64:
+; CHECK32:       # %bb.0:
+; CHECK32-NEXT:    andi. 7, 8, 32
+; CHECK32-NEXT:    mr 7, 5
+; CHECK32-NEXT:    beq 0, .LBB10_2
+; CHECK32-NEXT:  # %bb.1:
+; CHECK32-NEXT:    mr 7, 4
+; CHECK32-NEXT:  .LBB10_2:
+; CHECK32-NEXT:    clrlwi 8, 8, 27
+; CHECK32-NEXT:    srw 10, 7, 8
+; CHECK32-NEXT:    beq 0, .LBB10_4
+; CHECK32-NEXT:  # %bb.3:
+; CHECK32-NEXT:    mr 4, 3
+; CHECK32-NEXT:  .LBB10_4:
+; CHECK32-NEXT:    subfic 9, 8, 32
+; CHECK32-NEXT:    slw 3, 4, 9
+; CHECK32-NEXT:    or 3, 3, 10
+; CHECK32-NEXT:    beq 0, .LBB10_6
+; CHECK32-NEXT:  # %bb.5:
+; CHECK32-NEXT:    mr 6, 5
+; CHECK32-NEXT:  .LBB10_6:
+; CHECK32-NEXT:    srw 4, 6, 8
+; CHECK32-NEXT:    slw 5, 7, 9
+; CHECK32-NEXT:    or 4, 5, 4
+; CHECK32-NEXT:    blr
 ;
 ; CHECK64-LABEL: fshr_i64:
 ; CHECK64:       # %bb.0:
@@ -525,11 +546,11 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-NEXT:    .cfi_offset r29, -12
 ; CHECK32_32-NEXT:    .cfi_offset r30, -8
 ; CHECK32_32-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 27, 3
+; CHECK32_32-NEXT:    mr 27, 5
 ; CHECK32_32-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 28, 4
+; CHECK32_32-NEXT:    mr 28, 3
 ; CHECK32_32-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_32-NEXT:    mr 29, 5
+; CHECK32_32-NEXT:    mr 29, 4
 ; CHECK32_32-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
 ; CHECK32_32-NEXT:    mr 30, 6
 ; CHECK32_32-NEXT:    clrlwi 3, 7, 27
@@ -537,30 +558,32 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_32-NEXT:    li 5, 0
 ; CHECK32_32-NEXT:    li 6, 37
 ; CHECK32_32-NEXT:    bl __umoddi3
-; CHECK32_32-NEXT:    rotlwi 3, 30, 27
-; CHECK32_32-NEXT:    addi 4, 4, 27
-; CHECK32_32-NEXT:    slwi 5, 30, 27
-; CHECK32_32-NEXT:    rlwimi 3, 29, 27, 0, 4
-; CHECK32_32-NEXT:    andi. 6, 4, 32
-; CHECK32_32-NEXT:    clrlwi 4, 4, 27
-; CHECK32_32-NEXT:    subfic 6, 4, 32
-; CHECK32_32-NEXT:    bc 12, 2, .LBB11_2
+; CHECK32_32-NEXT:    rotlwi 5, 30, 27
+; CHECK32_32-NEXT:    addi 3, 4, 27
+; CHECK32_32-NEXT:    andi. 4, 3, 32
+; CHECK32_32-NEXT:    rlwimi 5, 27, 27, 0, 4
+; CHECK32_32-NEXT:    mr 4, 5
+; CHECK32_32-NEXT:    beq 0, .LBB11_2
 ; CHECK32_32-NEXT:  # %bb.1:
-; CHECK32_32-NEXT:    ori 7, 28, 0
-; CHECK32_32-NEXT:    ori 8, 27, 0
-; CHECK32_32-NEXT:    b .LBB11_3
+; CHECK32_32-NEXT:    mr 4, 29
 ; CHECK32_32-NEXT:  .LBB11_2:
-; CHECK32_32-NEXT:    addi 7, 3, 0
-; CHECK32_32-NEXT:    addi 8, 28, 0
-; CHECK32_32-NEXT:    addi 3, 5, 0
-; CHECK32_32-NEXT:  .LBB11_3:
+; CHECK32_32-NEXT:    clrlwi 6, 3, 27
+; CHECK32_32-NEXT:    srw 3, 4, 6
+; CHECK32_32-NEXT:    beq 0, .LBB11_4
+; CHECK32_32-NEXT:  # %bb.3:
+; CHECK32_32-NEXT:    mr 29, 28
+; CHECK32_32-NEXT:  .LBB11_4:
+; CHECK32_32-NEXT:    subfic 7, 6, 32
+; CHECK32_32-NEXT:    slw 8, 29, 7
+; CHECK32_32-NEXT:    or 3, 8, 3
+; CHECK32_32-NEXT:    bne 0, .LBB11_6
+; CHECK32_32-NEXT:  # %bb.5:
+; CHECK32_32-NEXT:    slwi 5, 30, 27
+; CHECK32_32-NEXT:  .LBB11_6:
+; CHECK32_32-NEXT:    srw 5, 5, 6
+; CHECK32_32-NEXT:    slw 4, 4, 7
+; CHECK32_32-NEXT:    or 4, 4, 5
 ; CHECK32_32-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_32-NEXT:    srw 5, 7, 4
-; CHECK32_32-NEXT:    slw 8, 8, 6
-; CHECK32_32-NEXT:    srw 4, 3, 4
-; CHECK32_32-NEXT:    slw 6, 7, 6
-; CHECK32_32-NEXT:    or 3, 8, 5
-; CHECK32_32-NEXT:    or 4, 6, 4
 ; CHECK32_32-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
 ; CHECK32_32-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
 ; CHECK32_32-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
@@ -581,49 +604,47 @@ define i37 @fshr_i37(i37 %x, i37 %y, i37 %z) {
 ; CHECK32_64-NEXT:    .cfi_offset r29, -12
 ; CHECK32_64-NEXT:    .cfi_offset r30, -8
 ; CHECK32_64-NEXT:    stw 27, 12(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 27, 3
-; CHECK32_64-NEXT:    clrlwi 3, 7, 27
-; CHECK32_64-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 28, 4
-; CHECK32_64-NEXT:    mr 4, 8
-; CHECK32_64-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
-; CHECK32_64-NEXT:    mr 29, 5
+; CHECK32_64-NEXT:    mr 27, 5
 ; CHECK32_64-NEXT:    li 5, 0
+; CHECK32_64-NEXT:    stw 28, 16(1) # 4-byte Folded Spill
+; CHECK32_64-NEXT:    mr 28, 3
+; CHECK32_64-NEXT:    clrlwi 3, 7, 27
+; CHECK32_64-NEXT:    stw 29, 20(1) # 4-byte Folded Spill
+; CHECK32_64-NEXT:    mr 29, 4
+; CHECK32_64-NEXT:    mr 4, 8
 ; CHECK32_64-NEXT:    stw 30, 24(1) # 4-byte Folded Spill
 ; CHECK32_64-NEXT:    mr 30, 6
 ; CHECK32_64-NEXT:    li 6, 37
 ; CHECK32_64-NEXT:    bl __umoddi3
-; CHECK32_64-NEXT:    addi 4, 4, 27
-; CHECK32_64-NEXT:    rotlwi 3, 30, 27
-; CHECK32_64-NEXT:    andi. 5, 4, 32
-; CHECK32_64-NEXT:    rlwimi 3, 29, 27, 0, 4
-; CHECK32_64-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    bc 12, 2, .LBB11_2
+; CHECK32_64-NEXT:    rotlwi 5, 30, 27
+; CHECK32_64-NEXT:    addi 3, 4, 27
+; CHECK32_64-NEXT:    andi. 4, 3, 32
+; CHECK32_64-NEXT:    rlwimi 5, 27, 27, 0, 4
+; CHECK32_64-NEXT:    mr 4, 5
+; CHECK32_64-NEXT:    beq 0, .LBB11_2
 ; CHECK32_64-NEXT:  # %bb.1:
-; CHECK32_64-NEXT:    ori 7, 28, 0
-; CHECK32_64-NEXT:    ori 8, 27, 0
-; CHECK32_64-NEXT:    b .LBB11_3
+; CHECK32_64-NEXT:    mr 4, 29
 ; CHECK32_64-NEXT:  .LBB11_2:
-; CHECK32_64-NEXT:    addi 7, 3, 0
-; CHECK32_64-NEXT:    addi 8, 28, 0
-; CHECK32_64-NEXT:  .LBB11_3:
-; CHECK32_64-NEXT:    clrlwi 4, 4, 27
-; CHECK32_64-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    slwi 5, 30, 27
-; CHECK32_64-NEXT:    subfic 6, 4, 32
-; CHECK32_64-NEXT:    bc 12, 2, .LBB11_4
-; CHECK32_64-NEXT:    b .LBB11_5
+; CHECK32_64-NEXT:    clrlwi 6, 3, 27
+; CHECK32_64-NEXT:    srw 3, 4, 6
+; CHECK32_64-NEXT:    beq 0, .LBB11_4
+; CHECK32_64-NEXT:  # %bb.3:
+; CHECK32_64-NEXT:    mr 29, 28
 ; CHECK32_64-NEXT:  .LBB11_4:
-; CHECK32_64-NEXT:    addi 3, 5, 0
-; CHECK32_64-NEXT:  .LBB11_5:
-; CHECK32_64-NEXT:    srw 9, 7, 4
-; CHECK32_64-NEXT:    slw 8, 8, 6
+; CHECK32_64-NEXT:    subfic 7, 6, 32
+; CHECK32_64-NEXT:    slw 8, 29, 7
+; CHECK32_64-NEXT:    or 3, 8, 3
+; CHECK32_64-NEXT:    bne 0, .LBB11_6
+; CHECK32_64-NEXT:  # %bb.5:
+; CHECK32_64-NEXT:    slwi 5, 30, 27
+; CHECK32_64-NEXT:  .LBB11_6:
+; CHECK32_64-NEXT:    srw 5, 5, 6
+; CHECK32_64-NEXT:    slw 4, 4, 7
 ; CHECK32_64-NEXT:    lwz 30, 24(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    srw 4, 3, 4
-; CHECK32_64-NEXT:    slw 5, 7, 6
+; CHECK32_64-NEXT:    or 4, 4, 5
+; CHECK32_64-NEXT:    lwz 29, 20(1) # 4-byte Folded Reload
+; CHECK32_64-NEXT:    lwz 28, 16(1) # 4-byte Folded Reload
 ; CHECK32_64-NEXT:    lwz 27, 12(1) # 4-byte Folded Reload
-; CHECK32_64-NEXT:    or 3, 8, 9
-; CHECK32_64-NEXT:    or 4, 5, 4
 ; CHECK32_64-NEXT:    lwz 0, 36(1)
 ; CHECK32_64-NEXT:    addi 1, 1, 32
 ; CHECK32_64-NEXT:    mtlr 0

--- a/llvm/test/CodeGen/PowerPC/i1-to-double.ll
+++ b/llvm/test/CodeGen/PowerPC/i1-to-double.ll
@@ -4,16 +4,16 @@
 define double @test(i1 %X) {
 ; CHECK-LABEL: test:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    li 4, .LCPI0_0@l
 ; CHECK-NEXT:    andi. 3, 3, 1
-; CHECK-NEXT:    addis 3, 4, .LCPI0_0@ha
-; CHECK-NEXT:    li 4, .LCPI0_1@l
-; CHECK-NEXT:    addis 4, 4, .LCPI0_1@ha
-; CHECK-NEXT:    bc 12, 1, .LBB0_1
-; CHECK-NEXT:    b .LBB0_2
-; CHECK-NEXT:  .LBB0_1:
-; CHECK-NEXT:    addi 3, 4, 0
+; CHECK-NEXT:    bc 12, 1, .LBB0_2
+; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    li 3, .LCPI0_0@l
+; CHECK-NEXT:    addis 3, 3, .LCPI0_0@ha
+; CHECK-NEXT:    lfs 1, 0(3)
+; CHECK-NEXT:    blr
 ; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:    li 3, .LCPI0_1@l
+; CHECK-NEXT:    addis 3, 3, .LCPI0_1@ha
 ; CHECK-NEXT:    lfs 1, 0(3)
 ; CHECK-NEXT:    blr
   %Y = uitofp i1 %X to double
@@ -27,17 +27,17 @@ define double @test(i1 %X) {
 define double @u1tofp(i1 %i, double %d) #0 {
 ; CHECK-LABEL: u1tofp:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    li 4, .LCPI1_0@l
 ; CHECK-NEXT:    andi. 3, 3, 1
-; CHECK-NEXT:    addis 3, 4, .LCPI1_0@ha
-; CHECK-NEXT:    li 4, .LCPI1_1@l
-; CHECK-NEXT:    addis 4, 4, .LCPI1_1@ha
-; CHECK-NEXT:    bc 12, 1, .LBB1_1
-; CHECK-NEXT:    b .LBB1_2
-; CHECK-NEXT:  .LBB1_1: # %entry
-; CHECK-NEXT:    addi 3, 4, 0
-; CHECK-NEXT:  .LBB1_2: # %entry
 ; CHECK-NEXT:    fmr 0, 1
+; CHECK-NEXT:    bc 12, 1, .LBB1_2
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    li 3, .LCPI1_0@l
+; CHECK-NEXT:    addis 3, 3, .LCPI1_0@ha
+; CHECK-NEXT:    b .LBB1_3
+; CHECK-NEXT:  .LBB1_2:
+; CHECK-NEXT:    li 3, .LCPI1_1@l
+; CHECK-NEXT:    addis 3, 3, .LCPI1_1@ha
+; CHECK-NEXT:  .LBB1_3: # %entry
 ; CHECK-NEXT:    lfs 1, 0(3)
 ; CHECK-NEXT:    lis 3, foo@ha
 ; CHECK-NEXT:    stfd 0, foo@l(3)
@@ -51,17 +51,17 @@ entry:
 define double @s1tofp(i1 %i, double %d) #0 {
 ; CHECK-LABEL: s1tofp:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    li 4, .LCPI2_0@l
 ; CHECK-NEXT:    andi. 3, 3, 1
-; CHECK-NEXT:    addis 3, 4, .LCPI2_0@ha
-; CHECK-NEXT:    li 4, .LCPI2_1@l
-; CHECK-NEXT:    addis 4, 4, .LCPI2_1@ha
-; CHECK-NEXT:    bc 12, 1, .LBB2_1
-; CHECK-NEXT:    b .LBB2_2
-; CHECK-NEXT:  .LBB2_1: # %entry
-; CHECK-NEXT:    addi 3, 4, 0
-; CHECK-NEXT:  .LBB2_2: # %entry
 ; CHECK-NEXT:    fmr 0, 1
+; CHECK-NEXT:    bc 12, 1, .LBB2_2
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    li 3, .LCPI2_0@l
+; CHECK-NEXT:    addis 3, 3, .LCPI2_0@ha
+; CHECK-NEXT:    b .LBB2_3
+; CHECK-NEXT:  .LBB2_2:
+; CHECK-NEXT:    li 3, .LCPI2_1@l
+; CHECK-NEXT:    addis 3, 3, .LCPI2_1@ha
+; CHECK-NEXT:  .LBB2_3: # %entry
 ; CHECK-NEXT:    lfs 1, 0(3)
 ; CHECK-NEXT:    lis 3, foo@ha
 ; CHECK-NEXT:    stfd 0, foo@l(3)

--- a/llvm/test/CodeGen/PowerPC/ppcf128-constrained-fp-intrinsics.ll
+++ b/llvm/test/CodeGen/PowerPC/ppcf128-constrained-fp-intrinsics.ll
@@ -1383,19 +1383,18 @@ define i32 @test_fptoui_ppc_i32_ppc_fp128(ppc_fp128 %first) #0 {
 ; PC64-NEXT:    nop
 ; PC64-NEXT:    mffs 0
 ; PC64-NEXT:    mtfsb1 31
-; PC64-NEXT:    lis 4, -32768
-; PC64-NEXT:    bc 12, 8, .LBB31_3
-; PC64-NEXT:    b .LBB31_4
-; PC64-NEXT:  .LBB31_3: # %entry
-; PC64-NEXT:    li 4, 0
-; PC64-NEXT:  .LBB31_4: # %entry
+; PC64-NEXT:    li 3, 0
 ; PC64-NEXT:    mtfsb0 30
 ; PC64-NEXT:    fadd 1, 2, 1
 ; PC64-NEXT:    mtfsf 1, 0
 ; PC64-NEXT:    fctiwz 0, 1
 ; PC64-NEXT:    stfd 0, 120(1)
-; PC64-NEXT:    lwz 3, 124(1)
-; PC64-NEXT:    xor 3, 3, 4
+; PC64-NEXT:    bc 12, 8, .LBB31_4
+; PC64-NEXT:  # %bb.3: # %entry
+; PC64-NEXT:    lis 3, -32768
+; PC64-NEXT:  .LBB31_4: # %entry
+; PC64-NEXT:    lwz 4, 124(1)
+; PC64-NEXT:    xor 3, 4, 3
 ; PC64-NEXT:    addi 1, 1, 128
 ; PC64-NEXT:    ld 0, 16(1)
 ; PC64-NEXT:    lwz 12, 8(1)

--- a/llvm/test/CodeGen/PowerPC/pr43976.ll
+++ b/llvm/test/CodeGen/PowerPC/pr43976.ll
@@ -10,25 +10,25 @@ define dso_local signext i32 @b() local_unnamed_addr #0 {
 ; CHECK-NEXT:    stdu r1, -144(r1)
 ; CHECK-NEXT:    std r0, 160(r1)
 ; CHECK-NEXT:    addis r3, r2, a@toc@ha
-; CHECK-NEXT:    li r4, 1
 ; CHECK-NEXT:    lfd f0, a@toc@l(r3)
 ; CHECK-NEXT:    addis r3, r2, .LCPI0_0@toc@ha
-; CHECK-NEXT:    rldic r4, r4, 63, 0
 ; CHECK-NEXT:    lfs f1, .LCPI0_0@toc@l(r3)
 ; CHECK-NEXT:    fsub f2, f0, f1
 ; CHECK-NEXT:    fctidz f2, f2
 ; CHECK-NEXT:    stfd f2, 128(r1)
 ; CHECK-NEXT:    fctidz f2, f0
-; CHECK-NEXT:    stfd f2, 120(r1)
-; CHECK-NEXT:    ld r3, 128(r1)
-; CHECK-NEXT:    ld r5, 120(r1)
 ; CHECK-NEXT:    fcmpu cr0, f0, f1
+; CHECK-NEXT:    stfd f2, 120(r1)
+; CHECK-NEXT:    blt cr0, .LBB0_2
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    ld r3, 128(r1)
+; CHECK-NEXT:    li r4, 1
+; CHECK-NEXT:    rldic r4, r4, 63, 0
 ; CHECK-NEXT:    xor r3, r3, r4
-; CHECK-NEXT:    bc 12, lt, .LBB0_1
-; CHECK-NEXT:    b .LBB0_2
-; CHECK-NEXT:  .LBB0_1: # %entry
-; CHECK-NEXT:    addi r3, r5, 0
-; CHECK-NEXT:  .LBB0_2: # %entry
+; CHECK-NEXT:    b .LBB0_3
+; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:    ld r3, 120(r1)
+; CHECK-NEXT:  .LBB0_3: # %entry
 ; CHECK-NEXT:    std r3, 112(r1)
 ; CHECK-NEXT:    addis r3, r2, .LCPI0_1@toc@ha
 ; CHECK-NEXT:    lfd f0, 112(r1)

--- a/llvm/test/CodeGen/PowerPC/pr49509.ll
+++ b/llvm/test/CodeGen/PowerPC/pr49509.ll
@@ -23,32 +23,23 @@ define void @test() {
 ; CHECK-NEXT:    lbz 3, 0(3)
 ; CHECK-NEXT:    and 5, 5, 6
 ; CHECK-NEXT:    and 4, 4, 7
-; CHECK-NEXT:    and 4, 4, 5
+; CHECK-NEXT:    and 5, 4, 5
 ; CHECK-NEXT:    cmpwi 3, 0
-; CHECK-NEXT:    lis 3, 256
-; CHECK-NEXT:    lis 7, 512
-; CHECK-NEXT:    bc 12, 2, .LBB0_4
-; CHECK-NEXT:    b .LBB0_5
-; CHECK-NEXT:  .LBB0_4: # %bb66
 ; CHECK-NEXT:    li 3, 0
+; CHECK-NEXT:    cmpwi 1, 5, -1
+; CHECK-NEXT:    li 4, 0
+; CHECK-NEXT:    bc 12, 2, .LBB0_5
+; CHECK-NEXT:  # %bb.4: # %bb66
+; CHECK-NEXT:    lis 4, 256
 ; CHECK-NEXT:  .LBB0_5: # %bb66
-; CHECK-NEXT:    cmpwi 1, 4, -1
-; CHECK-NEXT:    cmpwi 5, 4, -1
-; CHECK-NEXT:    li 6, 0
-; CHECK-NEXT:    bc 12, 6, .LBB0_6
-; CHECK-NEXT:    b .LBB0_7
-; CHECK-NEXT:  .LBB0_6: # %bb66
-; CHECK-NEXT:    addi 3, 7, 0
+; CHECK-NEXT:    cmpwi 5, 5, -1
+; CHECK-NEXT:    lis 5, 512
+; CHECK-NEXT:    beq 5, .LBB0_7
+; CHECK-NEXT:  # %bb.6: # %bb66
+; CHECK-NEXT:    mr 5, 4
 ; CHECK-NEXT:  .LBB0_7: # %bb66
-; CHECK-NEXT:    cror 20, 22, 2
-; CHECK-NEXT:    stw 3, 0(3)
-; CHECK-NEXT:    bc 12, 20, .LBB0_9
-; CHECK-NEXT:  # %bb.8: # %bb66
-; CHECK-NEXT:    ori 3, 6, 0
-; CHECK-NEXT:    b .LBB0_10
-; CHECK-NEXT:  .LBB0_9: # %bb66
-; CHECK-NEXT:    li 3, 0
-; CHECK-NEXT:  .LBB0_10: # %bb66
+; CHECK-NEXT:    cror 20, 6, 2
+; CHECK-NEXT:    stw 5, 0(3)
 ; CHECK-NEXT:    stw 3, 0(3)
 ; CHECK-NEXT:    blr
 bb:

--- a/llvm/test/CodeGen/PowerPC/save-crbp-ppc32svr4.ll
+++ b/llvm/test/CodeGen/PowerPC/save-crbp-ppc32svr4.ll
@@ -13,7 +13,7 @@
 ; CHECK: addic 29, 0, 20
 ; Save CR through R12 using R29 as the stack pointer (aligned base pointer).
 ; CHECK: mfcr 12
-; CHECK: stw 12, -24(29)
+; CHECK: stw 12, -28(29)
 
 target datalayout = "E-m:e-p:32:32-i64:64-n32"
 target triple = "powerpc-unknown-freebsd"

--- a/llvm/test/CodeGen/PowerPC/select-cc-no-isel.ll
+++ b/llvm/test/CodeGen/PowerPC/select-cc-no-isel.ll
@@ -7,6 +7,7 @@
 define signext i32 @foo(ptr nocapture noundef %dummy) #0 {
   ; CHECK-LABEL: name: foo
   ; CHECK: bb.0.entry:
+  ; CHECK-NEXT:   successors: %bb.1, %bb.2
   ; CHECK-NEXT:   liveins: $x3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:g8rc_and_g8rc_nox0 = COPY $x3
@@ -14,14 +15,20 @@ define signext i32 @foo(ptr nocapture noundef %dummy) #0 {
   ; CHECK-NEXT:   [[ADDI:%[0-9]+]]:gprc_and_gprc_nor0 = nsw ADDI [[LWZ]], 1
   ; CHECK-NEXT:   [[CMPWI:%[0-9]+]]:crrc = CMPWI [[LWZ]], 750
   ; CHECK-NEXT:   [[LI:%[0-9]+]]:gprc_and_gprc_nor0 = LI 1
-  ; CHECK-NEXT:   [[ISEL:%[0-9]+]]:gprc = ISEL [[ADDI]], [[LI]], [[CMPWI]].sub_lt
-  ; CHECK-NEXT:   STW killed [[ISEL]], 0, [[COPY]] :: (store (s32) into %ir.dummy)
+  ; CHECK-NEXT:   BCC 12, [[CMPWI]], %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1.entry:
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2.entry:
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:gprc = PHI [[LI]], %bb.1, [[ADDI]], %bb.0
+  ; CHECK-NEXT:   STW killed [[PHI]], 0, [[COPY]] :: (store (s32) into %ir.dummy)
   ; CHECK-NEXT:   [[LI8_:%[0-9]+]]:g8rc = LI8 0
   ; CHECK-NEXT:   $x3 = COPY [[LI8_]]
   ; CHECK-NEXT:   BLR8 implicit $lr8, implicit $rm, implicit $x3
   ;
   ; CHECK-32-LABEL: name: foo
   ; CHECK-32: bb.0.entry:
+  ; CHECK-32-NEXT:   successors: %bb.1, %bb.2
   ; CHECK-32-NEXT:   liveins: $r3
   ; CHECK-32-NEXT: {{  $}}
   ; CHECK-32-NEXT:   [[COPY:%[0-9]+]]:gprc_and_gprc_nor0 = COPY $r3
@@ -29,8 +36,13 @@ define signext i32 @foo(ptr nocapture noundef %dummy) #0 {
   ; CHECK-32-NEXT:   [[ADDI:%[0-9]+]]:gprc_and_gprc_nor0 = nsw ADDI [[LWZ]], 1
   ; CHECK-32-NEXT:   [[CMPWI:%[0-9]+]]:crrc = CMPWI [[LWZ]], 750
   ; CHECK-32-NEXT:   [[LI:%[0-9]+]]:gprc_and_gprc_nor0 = LI 1
-  ; CHECK-32-NEXT:   [[ISEL:%[0-9]+]]:gprc = ISEL [[ADDI]], [[LI]], [[CMPWI]].sub_lt
-  ; CHECK-32-NEXT:   STW killed [[ISEL]], 0, [[COPY]] :: (store (s32) into %ir.dummy)
+  ; CHECK-32-NEXT:   BCC 12, [[CMPWI]], %bb.2
+  ; CHECK-32-NEXT: {{  $}}
+  ; CHECK-32-NEXT: bb.1.entry:
+  ; CHECK-32-NEXT: {{  $}}
+  ; CHECK-32-NEXT: bb.2.entry:
+  ; CHECK-32-NEXT:   [[PHI:%[0-9]+]]:gprc = PHI [[LI]], %bb.1, [[ADDI]], %bb.0
+  ; CHECK-32-NEXT:   STW killed [[PHI]], 0, [[COPY]] :: (store (s32) into %ir.dummy)
   ; CHECK-32-NEXT:   [[LI1:%[0-9]+]]:gprc = LI 0
   ; CHECK-32-NEXT:   $r3 = COPY [[LI1]]
   ; CHECK-32-NEXT:   BLR implicit $lr, implicit $rm, implicit $r3

--- a/llvm/test/CodeGen/PowerPC/select.ll
+++ b/llvm/test/CodeGen/PowerPC/select.ll
@@ -17,13 +17,11 @@ define i64 @f0(i64 %x) {
 ;
 ; CHECK-32-LABEL: f0:
 ; CHECK-32:       # %bb.0:
-; CHECK-32-NEXT:    li r4, 125
-; CHECK-32-NEXT:    li r5, -3
 ; CHECK-32-NEXT:    cmpwi r3, 0
-; CHECK-32-NEXT:    bc 12, lt, .LBB0_1
-; CHECK-32-NEXT:    b .LBB0_2
-; CHECK-32-NEXT:  .LBB0_1:
-; CHECK-32-NEXT:    addi r4, r5, 0
+; CHECK-32-NEXT:    li r4, -3
+; CHECK-32-NEXT:    blt cr0, .LBB0_2
+; CHECK-32-NEXT:  # %bb.1:
+; CHECK-32-NEXT:    li r4, 125
 ; CHECK-32-NEXT:  .LBB0_2:
 ; CHECK-32-NEXT:    srawi r3, r3, 31
 ; CHECK-32-NEXT:    blr
@@ -43,13 +41,11 @@ define i64 @f1(i64 %x) {
 ;
 ; CHECK-32-LABEL: f1:
 ; CHECK-32:       # %bb.0:
-; CHECK-32-NEXT:    li r4, 512
 ; CHECK-32-NEXT:    cmpwi r3, 0
-; CHECK-32-NEXT:    li r3, 64
-; CHECK-32-NEXT:    bc 12, lt, .LBB1_1
-; CHECK-32-NEXT:    b .LBB1_2
-; CHECK-32-NEXT:  .LBB1_1:
-; CHECK-32-NEXT:    addi r4, r3, 0
+; CHECK-32-NEXT:    li r4, 64
+; CHECK-32-NEXT:    blt cr0, .LBB1_2
+; CHECK-32-NEXT:  # %bb.1:
+; CHECK-32-NEXT:    li r4, 512
 ; CHECK-32-NEXT:  .LBB1_2:
 ; CHECK-32-NEXT:    li r3, 0
 ; CHECK-32-NEXT:    blr
@@ -69,14 +65,11 @@ define i64 @f2(i64 %x) {
 ; CHECK-32-LABEL: f2:
 ; CHECK-32:       # %bb.0:
 ; CHECK-32-NEXT:    or. r3, r4, r3
-; CHECK-32-NEXT:    li r3, 1024
+; CHECK-32-NEXT:    li r4, 0
 ; CHECK-32-NEXT:    bc 12, eq, .LBB2_2
 ; CHECK-32-NEXT:  # %bb.1:
-; CHECK-32-NEXT:    ori r4, r3, 0
-; CHECK-32-NEXT:    b .LBB2_3
+; CHECK-32-NEXT:    li r4, 1024
 ; CHECK-32-NEXT:  .LBB2_2:
-; CHECK-32-NEXT:    li r4, 0
-; CHECK-32-NEXT:  .LBB2_3:
 ; CHECK-32-NEXT:    li r3, 0
 ; CHECK-32-NEXT:    blr
   %c = icmp eq i64 %x, 0
@@ -93,15 +86,17 @@ define i64 @f3(i64 %x, i64 %y) {
 ;
 ; CHECK-32-LABEL: f3:
 ; CHECK-32:       # %bb.0:
-; CHECK-32-NEXT:    or. r3, r4, r3
-; CHECK-32-NEXT:    bc 12, eq, .LBB3_2
-; CHECK-32-NEXT:  # %bb.1:
-; CHECK-32-NEXT:    ori r3, r5, 0
-; CHECK-32-NEXT:    ori r4, r6, 0
-; CHECK-32-NEXT:    blr
-; CHECK-32-NEXT:  .LBB3_2:
-; CHECK-32-NEXT:    li r3, 0
+; CHECK-32-NEXT:    mr r7, r4
+; CHECK-32-NEXT:    or. r3, r7, r3
 ; CHECK-32-NEXT:    li r4, 0
+; CHECK-32-NEXT:    li r3, 0
+; CHECK-32-NEXT:    beq cr0, .LBB3_2
+; CHECK-32-NEXT:  # %bb.1:
+; CHECK-32-NEXT:    mr r3, r5
+; CHECK-32-NEXT:  .LBB3_2:
+; CHECK-32-NEXT:    beqlr cr0
+; CHECK-32-NEXT:  # %bb.3:
+; CHECK-32-NEXT:    mr r4, r6
 ; CHECK-32-NEXT:    blr
   %c = icmp eq i64 %x, 0
   %r = select i1 %c, i64 0, i64 %y
@@ -140,14 +135,18 @@ define i64 @f4_sge_0(i64 %x) {
 ;
 ; CHECK-32-LABEL: f4_sge_0:
 ; CHECK-32:       # %bb.0:
-; CHECK-32-NEXT:    subfic r5, r4, 0
-; CHECK-32-NEXT:    subfze r6, r3
+; CHECK-32-NEXT:    mr r5, r4
+; CHECK-32-NEXT:    subfic r4, r4, 0
+; CHECK-32-NEXT:    mr r6, r3
 ; CHECK-32-NEXT:    cmpwi r3, -1
-; CHECK-32-NEXT:    bc 12, gt, .LBB5_1
-; CHECK-32-NEXT:    blr
-; CHECK-32-NEXT:  .LBB5_1:
-; CHECK-32-NEXT:    addi r3, r6, 0
-; CHECK-32-NEXT:    addi r4, r5, 0
+; CHECK-32-NEXT:    subfze r3, r3
+; CHECK-32-NEXT:    bgt cr0, .LBB5_2
+; CHECK-32-NEXT:  # %bb.1:
+; CHECK-32-NEXT:    mr r3, r6
+; CHECK-32-NEXT:  .LBB5_2:
+; CHECK-32-NEXT:    bgtlr cr0
+; CHECK-32-NEXT:  # %bb.3:
+; CHECK-32-NEXT:    mr r4, r5
 ; CHECK-32-NEXT:    blr
   %c = icmp sge i64 %x, 0
   %x.neg = sub i64 0, %x
@@ -191,14 +190,17 @@ define i64 @f4_sle_0(i64 %x) {
 ; CHECK-32-NEXT:    cmpwi cr1, r3, 0
 ; CHECK-32-NEXT:    crandc 4*cr5+lt, 4*cr1+lt, eq
 ; CHECK-32-NEXT:    cmpwi cr1, r4, 0
-; CHECK-32-NEXT:    subfic r5, r4, 0
 ; CHECK-32-NEXT:    crand 4*cr5+gt, eq, 4*cr1+eq
+; CHECK-32-NEXT:    subfic r5, r4, 0
 ; CHECK-32-NEXT:    cror 4*cr5+lt, 4*cr5+gt, 4*cr5+lt
 ; CHECK-32-NEXT:    subfze r6, r3
-; CHECK-32-NEXT:    bclr 12, 4*cr5+lt, 0
+; CHECK-32-NEXT:    bc 12, 4*cr5+lt, .LBB7_2
 ; CHECK-32-NEXT:  # %bb.1:
-; CHECK-32-NEXT:    ori r3, r6, 0
-; CHECK-32-NEXT:    ori r4, r5, 0
+; CHECK-32-NEXT:    mr r3, r6
+; CHECK-32-NEXT:  .LBB7_2:
+; CHECK-32-NEXT:    bclr 12, 4*cr5+lt, 0
+; CHECK-32-NEXT:  # %bb.3:
+; CHECK-32-NEXT:    mr r4, r5
 ; CHECK-32-NEXT:    blr
   %c = icmp sle i64 %x, 0
   %x.neg = sub i64 0, %x
@@ -238,16 +240,20 @@ define i64 @f5(i64 %x, i64 %y) {
 ;
 ; CHECK-32-LABEL: f5:
 ; CHECK-32:       # %bb.0:
-; CHECK-32-NEXT:    li r7, 0
 ; CHECK-32-NEXT:    or. r3, r4, r3
-; CHECK-32-NEXT:    bc 12, eq, .LBB9_2
+; CHECK-32-NEXT:    mr r3, r5
+; CHECK-32-NEXT:    bne cr0, .LBB9_3
 ; CHECK-32-NEXT:  # %bb.1:
-; CHECK-32-NEXT:    ori r3, r7, 0
-; CHECK-32-NEXT:    ori r4, r7, 0
-; CHECK-32-NEXT:    blr
+; CHECK-32-NEXT:    bne cr0, .LBB9_4
 ; CHECK-32-NEXT:  .LBB9_2:
-; CHECK-32-NEXT:    addi r3, r5, 0
-; CHECK-32-NEXT:    addi r4, r6, 0
+; CHECK-32-NEXT:    mr r4, r6
+; CHECK-32-NEXT:    blr
+; CHECK-32-NEXT:  .LBB9_3:
+; CHECK-32-NEXT:    li r3, 0
+; CHECK-32-NEXT:    beq cr0, .LBB9_2
+; CHECK-32-NEXT:  .LBB9_4:
+; CHECK-32-NEXT:    li r6, 0
+; CHECK-32-NEXT:    mr r4, r6
 ; CHECK-32-NEXT:    blr
   %c = icmp eq i64 %x, 0
   %r = select i1 %c, i64 %y, i64 0
@@ -264,14 +270,11 @@ define i32 @f5_i32(i32 %x, i32 %y) {
 ;
 ; CHECK-32-LABEL: f5_i32:
 ; CHECK-32:       # %bb.0:
-; CHECK-32-NEXT:    li r5, 0
 ; CHECK-32-NEXT:    cmplwi r3, 0
-; CHECK-32-NEXT:    bc 12, eq, .LBB10_2
+; CHECK-32-NEXT:    mr r3, r4
+; CHECK-32-NEXT:    beqlr cr0
 ; CHECK-32-NEXT:  # %bb.1:
-; CHECK-32-NEXT:    ori r3, r5, 0
-; CHECK-32-NEXT:    blr
-; CHECK-32-NEXT:  .LBB10_2:
-; CHECK-32-NEXT:    addi r3, r4, 0
+; CHECK-32-NEXT:    li r3, 0
 ; CHECK-32-NEXT:    blr
   %c = icmp eq i32 %x, 0
   %r = select i1 %c, i32 %y, i32 0

--- a/llvm/test/CodeGen/PowerPC/select_const.ll
+++ b/llvm/test/CodeGen/PowerPC/select_const.ll
@@ -198,12 +198,10 @@ define i32 @select_C1_C2(i1 %cond) {
 ; NO_ISEL-LABEL: select_C1_C2:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 421
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 42
-; NO_ISEL-NEXT:    li 4, 421
-; NO_ISEL-NEXT:    bc 12, 1, .LBB18_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB18_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i32 421, i32 42
   ret i32 %sel
@@ -221,12 +219,10 @@ define i32 @select_C1_C2_zeroext(i1 zeroext %cond) {
 ; NO_ISEL-LABEL: select_C1_C2_zeroext:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 421
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 42
-; NO_ISEL-NEXT:    li 4, 421
-; NO_ISEL-NEXT:    bc 12, 1, .LBB19_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB19_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i32 421, i32 42
   ret i32 %sel
@@ -244,12 +240,10 @@ define i32 @select_C1_C2_signext(i1 signext %cond) {
 ; NO_ISEL-LABEL: select_C1_C2_signext:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 421
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 42
-; NO_ISEL-NEXT:    li 4, 421
-; NO_ISEL-NEXT:    bc 12, 1, .LBB20_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB20_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i32 421, i32 42
   ret i32 %sel
@@ -269,12 +263,10 @@ define i8 @sel_constants_add_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_add_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 1
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 28
-; NO_ISEL-NEXT:    li 4, 1
-; NO_ISEL-NEXT:    bc 12, 1, .LBB21_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB21_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = add i8 %sel, 5
@@ -293,12 +285,10 @@ define i8 @sel_constants_sub_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_sub_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, -9
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 18
-; NO_ISEL-NEXT:    li 4, -9
-; NO_ISEL-NEXT:    bc 12, 1, .LBB22_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB22_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = sub i8 %sel, 5
@@ -317,12 +307,10 @@ define i8 @sel_constants_sub_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_sub_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 9
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 2
-; NO_ISEL-NEXT:    li 4, 9
-; NO_ISEL-NEXT:    bc 12, 1, .LBB23_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB23_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 3
   %bo = sub i8 5, %sel
@@ -341,12 +329,10 @@ define i8 @sel_constants_mul_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_mul_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, -20
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 115
-; NO_ISEL-NEXT:    li 4, -20
-; NO_ISEL-NEXT:    bc 12, 1, .LBB24_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB24_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = mul i8 %sel, 5
@@ -364,11 +350,10 @@ define i8 @sel_constants_sdiv_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_sdiv_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
-; NO_ISEL-NEXT:    li 3, 4
-; NO_ISEL-NEXT:    bc 12, 1, .LBB25_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB25_1:
 ; NO_ISEL-NEXT:    li 3, 0
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
+; NO_ISEL-NEXT:    li 3, 4
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = sdiv i8 %sel, 5
@@ -386,11 +371,10 @@ define i8 @sdiv_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: sdiv_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
-; NO_ISEL-NEXT:    li 3, 5
-; NO_ISEL-NEXT:    bc 12, 1, .LBB26_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB26_1:
 ; NO_ISEL-NEXT:    li 3, 0
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
+; NO_ISEL-NEXT:    li 3, 5
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 121, i8 23
   %bo = sdiv i8 120, %sel
@@ -409,12 +393,10 @@ define i8 @sel_constants_udiv_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_udiv_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 50
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 4
-; NO_ISEL-NEXT:    li 4, 50
-; NO_ISEL-NEXT:    bc 12, 1, .LBB27_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB27_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = udiv i8 %sel, 5
@@ -432,11 +414,10 @@ define i8 @udiv_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: udiv_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
-; NO_ISEL-NEXT:    li 3, 5
-; NO_ISEL-NEXT:    bc 12, 1, .LBB28_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB28_1:
 ; NO_ISEL-NEXT:    li 3, 0
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
+; NO_ISEL-NEXT:    li 3, 5
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = udiv i8 120, %sel
@@ -455,12 +436,10 @@ define i8 @sel_constants_srem_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_srem_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, -4
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 3
-; NO_ISEL-NEXT:    li 4, -4
-; NO_ISEL-NEXT:    bc 12, 1, .LBB29_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB29_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = srem i8 %sel, 5
@@ -479,12 +458,10 @@ define i8 @srem_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: srem_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 120
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 5
-; NO_ISEL-NEXT:    li 4, 120
-; NO_ISEL-NEXT:    bc 12, 1, .LBB30_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB30_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 121, i8 23
   %bo = srem i8 120, %sel
@@ -514,12 +491,10 @@ define i8 @urem_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: urem_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 120
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 5
-; NO_ISEL-NEXT:    li 4, 120
-; NO_ISEL-NEXT:    bc 12, 1, .LBB32_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB32_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = urem i8 120, %sel
@@ -549,12 +524,10 @@ define i8 @sel_constants_or_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_or_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, -3
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 23
-; NO_ISEL-NEXT:    li 4, -3
-; NO_ISEL-NEXT:    bc 12, 1, .LBB34_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB34_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = or i8 %sel, 5
@@ -573,12 +546,10 @@ define i8 @sel_constants_xor_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_xor_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, -7
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 18
-; NO_ISEL-NEXT:    li 4, -7
-; NO_ISEL-NEXT:    bc 12, 1, .LBB35_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB35_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = xor i8 %sel, 5
@@ -597,12 +568,10 @@ define i8 @sel_constants_shl_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_shl_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, -128
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, -32
-; NO_ISEL-NEXT:    li 4, -128
-; NO_ISEL-NEXT:    bc 12, 1, .LBB36_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB36_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = shl i8 %sel, 5
@@ -634,12 +603,10 @@ define i8 @sel_constants_lshr_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_lshr_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    li 3, 7
+; NO_ISEL-NEXT:    bclr 12, 1, 0
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    li 3, 0
-; NO_ISEL-NEXT:    li 4, 7
-; NO_ISEL-NEXT:    bc 12, 1, .LBB38_1
-; NO_ISEL-NEXT:    blr
-; NO_ISEL-NEXT:  .LBB38_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, i8 -4, i8 23
   %bo = lshr i8 %sel, 5
@@ -699,15 +666,15 @@ define double @sel_constants_fadd_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_fadd_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    bc 12, 1, .LBB42_2
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    addis 3, 2, .LCPI42_0@toc@ha
-; NO_ISEL-NEXT:    addis 4, 2, .LCPI42_1@toc@ha
 ; NO_ISEL-NEXT:    addi 3, 3, .LCPI42_0@toc@l
-; NO_ISEL-NEXT:    addi 4, 4, .LCPI42_1@toc@l
-; NO_ISEL-NEXT:    bc 12, 1, .LBB42_1
-; NO_ISEL-NEXT:    b .LBB42_2
-; NO_ISEL-NEXT:  .LBB42_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
+; NO_ISEL-NEXT:    lfd 1, 0(3)
+; NO_ISEL-NEXT:    blr
 ; NO_ISEL-NEXT:  .LBB42_2:
+; NO_ISEL-NEXT:    addis 3, 2, .LCPI42_1@toc@ha
+; NO_ISEL-NEXT:    addi 3, 3, .LCPI42_1@toc@l
 ; NO_ISEL-NEXT:    lfd 1, 0(3)
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, double -4.0, double 23.3
@@ -730,15 +697,15 @@ define double @sel_constants_fsub_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_fsub_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    bc 12, 1, .LBB43_2
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    addis 3, 2, .LCPI43_0@toc@ha
-; NO_ISEL-NEXT:    addis 4, 2, .LCPI43_1@toc@ha
 ; NO_ISEL-NEXT:    addi 3, 3, .LCPI43_0@toc@l
-; NO_ISEL-NEXT:    addi 4, 4, .LCPI43_1@toc@l
-; NO_ISEL-NEXT:    bc 12, 1, .LBB43_1
-; NO_ISEL-NEXT:    b .LBB43_2
-; NO_ISEL-NEXT:  .LBB43_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
+; NO_ISEL-NEXT:    lfd 1, 0(3)
+; NO_ISEL-NEXT:    blr
 ; NO_ISEL-NEXT:  .LBB43_2:
+; NO_ISEL-NEXT:    addis 3, 2, .LCPI43_1@toc@ha
+; NO_ISEL-NEXT:    addi 3, 3, .LCPI43_1@toc@l
 ; NO_ISEL-NEXT:    lfd 1, 0(3)
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, double -4.0, double 23.3
@@ -761,15 +728,15 @@ define double @fsub_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: fsub_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    bc 12, 1, .LBB44_2
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    addis 3, 2, .LCPI44_0@toc@ha
-; NO_ISEL-NEXT:    addis 4, 2, .LCPI44_1@toc@ha
 ; NO_ISEL-NEXT:    addi 3, 3, .LCPI44_0@toc@l
-; NO_ISEL-NEXT:    addi 4, 4, .LCPI44_1@toc@l
-; NO_ISEL-NEXT:    bc 12, 1, .LBB44_1
-; NO_ISEL-NEXT:    b .LBB44_2
-; NO_ISEL-NEXT:  .LBB44_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
+; NO_ISEL-NEXT:    lfd 1, 0(3)
+; NO_ISEL-NEXT:    blr
 ; NO_ISEL-NEXT:  .LBB44_2:
+; NO_ISEL-NEXT:    addis 3, 2, .LCPI44_1@toc@ha
+; NO_ISEL-NEXT:    addi 3, 3, .LCPI44_1@toc@l
 ; NO_ISEL-NEXT:    lfd 1, 0(3)
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, double -4.0, double 23.3
@@ -792,15 +759,15 @@ define double @sel_constants_fmul_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_fmul_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    bc 12, 1, .LBB45_2
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    addis 3, 2, .LCPI45_0@toc@ha
-; NO_ISEL-NEXT:    addis 4, 2, .LCPI45_1@toc@ha
 ; NO_ISEL-NEXT:    addi 3, 3, .LCPI45_0@toc@l
-; NO_ISEL-NEXT:    addi 4, 4, .LCPI45_1@toc@l
-; NO_ISEL-NEXT:    bc 12, 1, .LBB45_1
-; NO_ISEL-NEXT:    b .LBB45_2
-; NO_ISEL-NEXT:  .LBB45_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
+; NO_ISEL-NEXT:    lfd 1, 0(3)
+; NO_ISEL-NEXT:    blr
 ; NO_ISEL-NEXT:  .LBB45_2:
+; NO_ISEL-NEXT:    addis 3, 2, .LCPI45_1@toc@ha
+; NO_ISEL-NEXT:    addi 3, 3, .LCPI45_1@toc@l
 ; NO_ISEL-NEXT:    lfd 1, 0(3)
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, double -4.0, double 23.3
@@ -823,15 +790,15 @@ define double @sel_constants_fdiv_constant(i1 %cond) {
 ; NO_ISEL-LABEL: sel_constants_fdiv_constant:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    bc 12, 1, .LBB46_2
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    addis 3, 2, .LCPI46_0@toc@ha
-; NO_ISEL-NEXT:    addis 4, 2, .LCPI46_1@toc@ha
 ; NO_ISEL-NEXT:    addi 3, 3, .LCPI46_0@toc@l
-; NO_ISEL-NEXT:    addi 4, 4, .LCPI46_1@toc@l
-; NO_ISEL-NEXT:    bc 12, 1, .LBB46_1
-; NO_ISEL-NEXT:    b .LBB46_2
-; NO_ISEL-NEXT:  .LBB46_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
+; NO_ISEL-NEXT:    lfd 1, 0(3)
+; NO_ISEL-NEXT:    blr
 ; NO_ISEL-NEXT:  .LBB46_2:
+; NO_ISEL-NEXT:    addis 3, 2, .LCPI46_1@toc@ha
+; NO_ISEL-NEXT:    addi 3, 3, .LCPI46_1@toc@l
 ; NO_ISEL-NEXT:    lfd 1, 0(3)
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, double -4.0, double 23.3
@@ -854,15 +821,15 @@ define double @fdiv_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: fdiv_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    bc 12, 1, .LBB47_2
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    addis 3, 2, .LCPI47_0@toc@ha
-; NO_ISEL-NEXT:    addis 4, 2, .LCPI47_1@toc@ha
 ; NO_ISEL-NEXT:    addi 3, 3, .LCPI47_0@toc@l
-; NO_ISEL-NEXT:    addi 4, 4, .LCPI47_1@toc@l
-; NO_ISEL-NEXT:    bc 12, 1, .LBB47_1
-; NO_ISEL-NEXT:    b .LBB47_2
-; NO_ISEL-NEXT:  .LBB47_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
+; NO_ISEL-NEXT:    lfd 1, 0(3)
+; NO_ISEL-NEXT:    blr
 ; NO_ISEL-NEXT:  .LBB47_2:
+; NO_ISEL-NEXT:    addis 3, 2, .LCPI47_1@toc@ha
+; NO_ISEL-NEXT:    addi 3, 3, .LCPI47_1@toc@l
 ; NO_ISEL-NEXT:    lfd 1, 0(3)
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, double -4.0, double 23.3
@@ -905,15 +872,15 @@ define double @frem_constant_sel_constants(i1 %cond) {
 ; NO_ISEL-LABEL: frem_constant_sel_constants:
 ; NO_ISEL:       # %bb.0:
 ; NO_ISEL-NEXT:    andi. 3, 3, 1
+; NO_ISEL-NEXT:    bc 12, 1, .LBB49_2
+; NO_ISEL-NEXT:  # %bb.1:
 ; NO_ISEL-NEXT:    addis 3, 2, .LCPI49_0@toc@ha
-; NO_ISEL-NEXT:    addis 4, 2, .LCPI49_1@toc@ha
 ; NO_ISEL-NEXT:    addi 3, 3, .LCPI49_0@toc@l
-; NO_ISEL-NEXT:    addi 4, 4, .LCPI49_1@toc@l
-; NO_ISEL-NEXT:    bc 12, 1, .LBB49_1
-; NO_ISEL-NEXT:    b .LBB49_2
-; NO_ISEL-NEXT:  .LBB49_1:
-; NO_ISEL-NEXT:    addi 3, 4, 0
+; NO_ISEL-NEXT:    lfd 1, 0(3)
+; NO_ISEL-NEXT:    blr
 ; NO_ISEL-NEXT:  .LBB49_2:
+; NO_ISEL-NEXT:    addis 3, 2, .LCPI49_1@toc@ha
+; NO_ISEL-NEXT:    addi 3, 3, .LCPI49_1@toc@l
 ; NO_ISEL-NEXT:    lfd 1, 0(3)
 ; NO_ISEL-NEXT:    blr
   %sel = select i1 %cond, double -4.0, double 23.3

--- a/llvm/test/CodeGen/PowerPC/smulfixsat.ll
+++ b/llvm/test/CodeGen/PowerPC/smulfixsat.ll
@@ -10,12 +10,11 @@ define i32 @func1(i32 %x, i32 %y) nounwind {
 ; CHECK-NEXT:    mullw 3, 3, 4
 ; CHECK-NEXT:    srawi 4, 3, 31
 ; CHECK-NEXT:    cmplw 5, 4
-; CHECK-NEXT:    srawi 4, 5, 31
-; CHECK-NEXT:    xori 4, 4, 65535
-; CHECK-NEXT:    xoris 4, 4, 32767
-; CHECK-NEXT:    bclr 12, 2, 0
+; CHECK-NEXT:    beqlr 0
 ; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    ori 3, 4, 0
+; CHECK-NEXT:    srawi 3, 5, 31
+; CHECK-NEXT:    xori 3, 3, 65535
+; CHECK-NEXT:    xoris 3, 3, 32767
 ; CHECK-NEXT:    blr
   %tmp = call i32 @llvm.smul.fix.sat.i32(i32 %x, i32 %y, i32 0)
   ret i32 %tmp
@@ -24,23 +23,22 @@ define i32 @func1(i32 %x, i32 %y) nounwind {
 define i32 @func2(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: func2:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mulhw. 6, 3, 4
-; CHECK-NEXT:    lis 5, 32767
+; CHECK-NEXT:    mulhw. 5, 3, 4
+; CHECK-NEXT:    bgt 0, .LBB1_2
+; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mullw 3, 3, 4
-; CHECK-NEXT:    rotlwi 3, 3, 31
-; CHECK-NEXT:    ori 4, 5, 65535
-; CHECK-NEXT:    rlwimi 3, 6, 31, 0, 0
-; CHECK-NEXT:    bc 12, 1, .LBB1_1
-; CHECK-NEXT:    b .LBB1_2
-; CHECK-NEXT:  .LBB1_1:
-; CHECK-NEXT:    addi 3, 4, 0
+; CHECK-NEXT:    rotlwi 4, 3, 31
+; CHECK-NEXT:    rlwimi 4, 5, 31, 0, 0
+; CHECK-NEXT:    b .LBB1_3
 ; CHECK-NEXT:  .LBB1_2:
-; CHECK-NEXT:    cmpwi 6, -1
-; CHECK-NEXT:    lis 4, -32768
-; CHECK-NEXT:    bc 12, 0, .LBB1_3
-; CHECK-NEXT:    blr
+; CHECK-NEXT:    lis 3, 32767
+; CHECK-NEXT:    ori 4, 3, 65535
 ; CHECK-NEXT:  .LBB1_3:
-; CHECK-NEXT:    addi 3, 4, 0
+; CHECK-NEXT:    cmpwi 5, -1
+; CHECK-NEXT:    lis 3, -32768
+; CHECK-NEXT:    bltlr 0
+; CHECK-NEXT:  # %bb.4:
+; CHECK-NEXT:    mr 3, 4
 ; CHECK-NEXT:    blr
   %tmp = call i32 @llvm.smul.fix.sat.i32(i32 %x, i32 %y, i32 1)
   ret i32 %tmp

--- a/llvm/test/CodeGen/PowerPC/spe.ll
+++ b/llvm/test/CodeGen/PowerPC/spe.ll
@@ -252,15 +252,13 @@ define i1 @test_fcmpuno(float %a, float %b) #0 {
 ; CHECK-LABEL: test_fcmpuno:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    efscmpeq 0, 3, 3
-; CHECK-NEXT:    efscmpeq 1, 4, 4
-; CHECK-NEXT:    li 5, 1
-; CHECK-NEXT:    crand 20, 5, 1
-; CHECK-NEXT:    bc 12, 20, .LBB12_2
-; CHECK-NEXT:  # %bb.1: # %entry
-; CHECK-NEXT:    ori 3, 5, 0
-; CHECK-NEXT:    blr
-; CHECK-NEXT:  .LBB12_2: # %entry
 ; CHECK-NEXT:    li 3, 0
+; CHECK-NEXT:    bc 4, 1, .LBB12_2
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    efscmpeq 0, 4, 4
+; CHECK-NEXT:    bclr 12, 1, 0
+; CHECK-NEXT:  .LBB12_2: # %entry
+; CHECK-NEXT:    li 3, 1
 ; CHECK-NEXT:    blr
   entry:
   %r = fcmp uno float %a, %b
@@ -270,16 +268,15 @@ define i1 @test_fcmpuno(float %a, float %b) #0 {
 define i1 @test_fcmpord(float %a, float %b) #0 {
 ; CHECK-LABEL: test_fcmpord:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mr 5, 3
 ; CHECK-NEXT:    efscmpeq 0, 4, 4
-; CHECK-NEXT:    efscmpeq 1, 3, 3
-; CHECK-NEXT:    li 5, 1
-; CHECK-NEXT:    crnand 20, 5, 1
-; CHECK-NEXT:    bc 12, 20, .LBB13_2
-; CHECK-NEXT:  # %bb.1: # %entry
-; CHECK-NEXT:    ori 3, 5, 0
-; CHECK-NEXT:    blr
-; CHECK-NEXT:  .LBB13_2: # %entry
 ; CHECK-NEXT:    li 3, 0
+; CHECK-NEXT:    bclr 4, 1, 0
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    efscmpeq 0, 5, 5
+; CHECK-NEXT:    bclr 4, 1, 0
+; CHECK-NEXT:  # %bb.2: # %entry
+; CHECK-NEXT:    li 3, 1
 ; CHECK-NEXT:    blr
   entry:
   %r = fcmp ord float %a, %b
@@ -289,16 +286,15 @@ define i1 @test_fcmpord(float %a, float %b) #0 {
 define i1 @test_fcmpueq(float %a, float %b) #0 {
 ; CHECK-LABEL: test_fcmpueq:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mr 5, 3
 ; CHECK-NEXT:    efscmpgt 0, 3, 4
-; CHECK-NEXT:    efscmplt 1, 3, 4
-; CHECK-NEXT:    li 5, 1
-; CHECK-NEXT:    cror 20, 5, 1
-; CHECK-NEXT:    bc 12, 20, .LBB14_2
-; CHECK-NEXT:  # %bb.1: # %entry
-; CHECK-NEXT:    ori 3, 5, 0
-; CHECK-NEXT:    blr
-; CHECK-NEXT:  .LBB14_2: # %entry
 ; CHECK-NEXT:    li 3, 0
+; CHECK-NEXT:    bclr 12, 1, 0
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    efscmplt 0, 5, 4
+; CHECK-NEXT:    bclr 12, 1, 0
+; CHECK-NEXT:  # %bb.2: # %entry
+; CHECK-NEXT:    li 3, 1
 ; CHECK-NEXT:    blr
   entry:
   %r = fcmp ueq float %a, %b
@@ -308,16 +304,15 @@ define i1 @test_fcmpueq(float %a, float %b) #0 {
 define i1 @test_fcmpne(float %a, float %b) #0 {
 ; CHECK-LABEL: test_fcmpne:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mr 5, 3
 ; CHECK-NEXT:    efscmplt 0, 3, 4
-; CHECK-NEXT:    efscmpgt 1, 3, 4
-; CHECK-NEXT:    li 5, 1
-; CHECK-NEXT:    crnor 20, 5, 1
-; CHECK-NEXT:    bc 12, 20, .LBB15_2
-; CHECK-NEXT:  # %bb.1: # %entry
-; CHECK-NEXT:    ori 3, 5, 0
-; CHECK-NEXT:    blr
-; CHECK-NEXT:  .LBB15_2: # %entry
 ; CHECK-NEXT:    li 3, 0
+; CHECK-NEXT:    bc 12, 1, .LBB15_2
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    efscmpgt 0, 5, 4
+; CHECK-NEXT:    bclr 4, 1, 0
+; CHECK-NEXT:  .LBB15_2: # %entry
+; CHECK-NEXT:    li 3, 1
 ; CHECK-NEXT:    blr
   entry:
   %r = fcmp one float %a, %b
@@ -389,18 +384,18 @@ ret:
 define i1 @test_fcmpult(float %a, float %b) #0 {
 ; CHECK-LABEL: test_fcmpult:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mr 5, 3
 ; CHECK-NEXT:    efscmpeq 0, 3, 3
-; CHECK-NEXT:    efscmpeq 1, 4, 4
-; CHECK-NEXT:    crnand 20, 5, 1
-; CHECK-NEXT:    efscmplt 0, 3, 4
-; CHECK-NEXT:    li 5, 1
-; CHECK-NEXT:    crnor 20, 1, 20
-; CHECK-NEXT:    bc 12, 20, .LBB18_2
-; CHECK-NEXT:  # %bb.1: # %entry
-; CHECK-NEXT:    ori 3, 5, 0
-; CHECK-NEXT:    blr
-; CHECK-NEXT:  .LBB18_2: # %entry
 ; CHECK-NEXT:    li 3, 0
+; CHECK-NEXT:    bc 4, 1, .LBB18_3
+; CHECK-NEXT:  # %bb.1: # %entry
+; CHECK-NEXT:    efscmpeq 0, 4, 4
+; CHECK-NEXT:    bc 4, 1, .LBB18_3
+; CHECK-NEXT:  # %bb.2: # %entry
+; CHECK-NEXT:    efscmplt 0, 5, 4
+; CHECK-NEXT:    bclr 4, 1, 0
+; CHECK-NEXT:  .LBB18_3: # %entry
+; CHECK-NEXT:    li 3, 1
 ; CHECK-NEXT:    blr
   entry:
   %r = fcmp ult float %a, %b
@@ -747,16 +742,14 @@ define i1 @test_dcmpuno(double %a, double %b) #0 {
 ; SPE:       # %bb.0: # %entry
 ; SPE-NEXT:    evmergelo 5, 5, 6
 ; SPE-NEXT:    evmergelo 3, 3, 4
-; SPE-NEXT:    li 7, 1
 ; SPE-NEXT:    efdcmpeq 0, 3, 3
-; SPE-NEXT:    efdcmpeq 1, 5, 5
-; SPE-NEXT:    crand 20, 5, 1
-; SPE-NEXT:    bc 12, 20, .LBB35_2
-; SPE-NEXT:  # %bb.1: # %entry
-; SPE-NEXT:    ori 3, 7, 0
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB35_2: # %entry
 ; SPE-NEXT:    li 3, 0
+; SPE-NEXT:    bc 4, 1, .LBB35_2
+; SPE-NEXT:  # %bb.1: # %entry
+; SPE-NEXT:    efdcmpeq 0, 5, 5
+; SPE-NEXT:    bclr 12, 1, 0
+; SPE-NEXT:  .LBB35_2: # %entry
+; SPE-NEXT:    li 3, 1
 ; SPE-NEXT:    blr
 ;
 ; EFPU2-LABEL: test_dcmpuno:
@@ -780,18 +773,16 @@ define i1 @test_dcmpuno(double %a, double %b) #0 {
 define i1 @test_dcmpord(double %a, double %b) #0 {
 ; SPE-LABEL: test_dcmpord:
 ; SPE:       # %bb.0: # %entry
-; SPE-NEXT:    evmergelo 3, 3, 4
-; SPE-NEXT:    evmergelo 4, 5, 6
-; SPE-NEXT:    li 7, 1
-; SPE-NEXT:    efdcmpeq 0, 4, 4
-; SPE-NEXT:    efdcmpeq 1, 3, 3
-; SPE-NEXT:    crnand 20, 5, 1
-; SPE-NEXT:    bc 12, 20, .LBB36_2
-; SPE-NEXT:  # %bb.1: # %entry
-; SPE-NEXT:    ori 3, 7, 0
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB36_2: # %entry
+; SPE-NEXT:    evmergelo 4, 3, 4
+; SPE-NEXT:    evmergelo 3, 5, 6
+; SPE-NEXT:    efdcmpeq 0, 3, 3
 ; SPE-NEXT:    li 3, 0
+; SPE-NEXT:    bclr 4, 1, 0
+; SPE-NEXT:  # %bb.1: # %entry
+; SPE-NEXT:    efdcmpeq 0, 4, 4
+; SPE-NEXT:    bclr 4, 1, 0
+; SPE-NEXT:  # %bb.2: # %entry
+; SPE-NEXT:    li 3, 1
 ; SPE-NEXT:    blr
 ;
 ; EFPU2-LABEL: test_dcmpord:
@@ -1173,17 +1164,15 @@ define i1 @test_dcmpne(double %a, double %b) #0 {
 ; SPE-LABEL: test_dcmpne:
 ; SPE:       # %bb.0: # %entry
 ; SPE-NEXT:    evmergelo 5, 5, 6
-; SPE-NEXT:    evmergelo 3, 3, 4
-; SPE-NEXT:    li 7, 1
-; SPE-NEXT:    efdcmplt 0, 3, 5
-; SPE-NEXT:    efdcmpgt 1, 3, 5
-; SPE-NEXT:    crnor 20, 5, 1
-; SPE-NEXT:    bc 12, 20, .LBB43_2
-; SPE-NEXT:  # %bb.1: # %entry
-; SPE-NEXT:    ori 3, 7, 0
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB43_2: # %entry
+; SPE-NEXT:    evmergelo 4, 3, 4
 ; SPE-NEXT:    li 3, 0
+; SPE-NEXT:    efdcmplt 0, 4, 5
+; SPE-NEXT:    bc 12, 1, .LBB43_2
+; SPE-NEXT:  # %bb.1: # %entry
+; SPE-NEXT:    efdcmpgt 0, 4, 5
+; SPE-NEXT:    bclr 4, 1, 0
+; SPE-NEXT:  .LBB43_2: # %entry
+; SPE-NEXT:    li 3, 1
 ; SPE-NEXT:    blr
 ;
 ; EFPU2-LABEL: test_dcmpne:
@@ -1208,20 +1197,19 @@ define i1 @test_dcmpne(double %a, double %b) #0 {
 ; EFPU2-NEXT:    mr 5, 29
 ; EFPU2-NEXT:    mr 6, 30
 ; EFPU2-NEXT:    bl __eqdf2
-; EFPU2-NEXT:    lwz 30, 40(1) # 4-byte Folded Reload
-; EFPU2-NEXT:    cmpwi 3, 0
-; EFPU2-NEXT:    lwz 29, 36(1) # 4-byte Folded Reload
-; EFPU2-NEXT:    li 4, 1
-; EFPU2-NEXT:    lwz 28, 32(1) # 4-byte Folded Reload
-; EFPU2-NEXT:    crorc 20, 2, 10
-; EFPU2-NEXT:    lwz 12, 24(1)
-; EFPU2-NEXT:    bc 12, 20, .LBB43_2
-; EFPU2-NEXT:  # %bb.1: # %entry
-; EFPU2-NEXT:    ori 3, 4, 0
-; EFPU2-NEXT:    b .LBB43_3
-; EFPU2-NEXT:  .LBB43_2: # %entry
+; EFPU2-NEXT:    mr 4, 3
 ; EFPU2-NEXT:    li 3, 0
+; EFPU2-NEXT:    bc 4, 10, .LBB43_3
+; EFPU2-NEXT:  # %bb.1: # %entry
+; EFPU2-NEXT:    cmpwi 4, 0
+; EFPU2-NEXT:    bc 12, 2, .LBB43_3
+; EFPU2-NEXT:  # %bb.2: # %entry
+; EFPU2-NEXT:    li 3, 1
 ; EFPU2-NEXT:  .LBB43_3: # %entry
+; EFPU2-NEXT:    lwz 30, 40(1) # 4-byte Folded Reload
+; EFPU2-NEXT:    lwz 29, 36(1) # 4-byte Folded Reload
+; EFPU2-NEXT:    lwz 28, 32(1) # 4-byte Folded Reload
+; EFPU2-NEXT:    lwz 12, 24(1)
 ; EFPU2-NEXT:    lwz 27, 28(1) # 4-byte Folded Reload
 ; EFPU2-NEXT:    mtcrf 32, 12 # cr2
 ; EFPU2-NEXT:    lwz 0, 52(1)
@@ -1404,20 +1392,19 @@ ret:
 define i1 @test_dcmpge(double %a, double %b) #0 {
 ; SPE-LABEL: test_dcmpge:
 ; SPE:       # %bb.0: # %entry
-; SPE-NEXT:    evmergelo 3, 3, 4
-; SPE-NEXT:    evmergelo 4, 5, 6
-; SPE-NEXT:    li 7, 1
-; SPE-NEXT:    efdcmpeq 0, 4, 4
-; SPE-NEXT:    efdcmpeq 1, 3, 3
-; SPE-NEXT:    efdcmplt 5, 3, 4
-; SPE-NEXT:    crand 20, 5, 1
-; SPE-NEXT:    crorc 20, 21, 20
-; SPE-NEXT:    bc 12, 20, .LBB47_2
-; SPE-NEXT:  # %bb.1: # %entry
-; SPE-NEXT:    ori 3, 7, 0
-; SPE-NEXT:    blr
-; SPE-NEXT:  .LBB47_2: # %entry
+; SPE-NEXT:    evmergelo 4, 3, 4
+; SPE-NEXT:    evmergelo 5, 5, 6
 ; SPE-NEXT:    li 3, 0
+; SPE-NEXT:    efdcmpeq 0, 5, 5
+; SPE-NEXT:    bclr 4, 1, 0
+; SPE-NEXT:  # %bb.1: # %entry
+; SPE-NEXT:    efdcmpeq 0, 4, 4
+; SPE-NEXT:    bclr 4, 1, 0
+; SPE-NEXT:  # %bb.2: # %entry
+; SPE-NEXT:    efdcmplt 0, 4, 5
+; SPE-NEXT:    bclr 12, 1, 0
+; SPE-NEXT:  # %bb.3: # %entry
+; SPE-NEXT:    li 3, 1
 ; SPE-NEXT:    blr
 ;
 ; EFPU2-LABEL: test_dcmpge:
@@ -1507,10 +1494,13 @@ define double @test_dselect(double %a, double %b, i1 %c) #0 {
 ; EFPU2-LABEL: test_dselect:
 ; EFPU2:       # %bb.0: # %entry
 ; EFPU2-NEXT:    andi. 7, 7, 1
-; EFPU2-NEXT:    bclr 12, 1, 0
+; EFPU2-NEXT:    bc 12, 1, .LBB49_2
 ; EFPU2-NEXT:  # %bb.1: # %entry
-; EFPU2-NEXT:    ori 3, 5, 0
-; EFPU2-NEXT:    ori 4, 6, 0
+; EFPU2-NEXT:    mr 3, 5
+; EFPU2-NEXT:  .LBB49_2: # %entry
+; EFPU2-NEXT:    bclr 12, 1, 0
+; EFPU2-NEXT:  # %bb.3: # %entry
+; EFPU2-NEXT:    mr 4, 6
 ; EFPU2-NEXT:    blr
 entry:
   %r = select i1 %c, double %a, double %b

--- a/llvm/test/CodeGen/PowerPC/srem-seteq-illegal-types.ll
+++ b/llvm/test/CodeGen/PowerPC/srem-seteq-illegal-types.ll
@@ -11,15 +11,13 @@ define i1 @test_srem_odd(i29 %X) nounwind {
 ; PPC-NEXT:    addi 3, 3, 24493
 ; PPC-NEXT:    lis 4, 82
 ; PPC-NEXT:    addis 3, 3, 41
-; PPC-NEXT:    ori 4, 4, 48987
 ; PPC-NEXT:    clrlwi 3, 3, 3
+; PPC-NEXT:    ori 4, 4, 48987
 ; PPC-NEXT:    cmplw 3, 4
+; PPC-NEXT:    li 3, 1
+; PPC-NEXT:    bclr 12, 0, 0
+; PPC-NEXT:  # %bb.1:
 ; PPC-NEXT:    li 3, 0
-; PPC-NEXT:    li 4, 1
-; PPC-NEXT:    bc 12, 0, .LBB0_1
-; PPC-NEXT:    blr
-; PPC-NEXT:  .LBB0_1:
-; PPC-NEXT:    addi 3, 4, 0
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_srem_odd:
@@ -45,21 +43,20 @@ define i1 @test_srem_odd(i29 %X) nounwind {
 define i1 @test_srem_even(i4 %X) nounwind {
 ; PPC-LABEL: test_srem_even:
 ; PPC:       # %bb.0:
-; PPC-NEXT:    slwi 5, 3, 28
-; PPC-NEXT:    srawi 5, 5, 28
-; PPC-NEXT:    mulli 5, 5, 3
-; PPC-NEXT:    rlwinm 6, 5, 25, 31, 31
-; PPC-NEXT:    srwi 5, 5, 4
-; PPC-NEXT:    add 5, 5, 6
-; PPC-NEXT:    mulli 5, 5, 6
-; PPC-NEXT:    sub 3, 3, 5
+; PPC-NEXT:    slwi 4, 3, 28
+; PPC-NEXT:    srawi 4, 4, 28
+; PPC-NEXT:    mulli 4, 4, 3
+; PPC-NEXT:    rlwinm 5, 4, 25, 31, 31
+; PPC-NEXT:    srwi 4, 4, 4
+; PPC-NEXT:    add 4, 4, 5
+; PPC-NEXT:    mulli 4, 4, 6
+; PPC-NEXT:    sub 3, 3, 4
 ; PPC-NEXT:    clrlwi 3, 3, 28
-; PPC-NEXT:    li 4, 0
 ; PPC-NEXT:    cmpwi 3, 1
 ; PPC-NEXT:    li 3, 1
 ; PPC-NEXT:    bclr 12, 2, 0
 ; PPC-NEXT:  # %bb.1:
-; PPC-NEXT:    ori 3, 4, 0
+; PPC-NEXT:    li 3, 0
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_srem_even:

--- a/llvm/test/CodeGen/PowerPC/umulfixsat.ll
+++ b/llvm/test/CodeGen/PowerPC/umulfixsat.ll
@@ -6,12 +6,13 @@ declare  i32 @llvm.umul.fix.sat.i32(i32, i32, i32)
 define i32 @func1(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: func1:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    mulhwu. 5, 3, 4
 ; CHECK-NEXT:    li 5, -1
-; CHECK-NEXT:    mulhwu. 6, 3, 4
-; CHECK-NEXT:    mullw 3, 3, 4
-; CHECK-NEXT:    bclr 12, 2, 0
+; CHECK-NEXT:    bne 0, .LBB0_2
 ; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    ori 3, 5, 0
+; CHECK-NEXT:    mullw 5, 3, 4
+; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:    mr 3, 5
 ; CHECK-NEXT:    blr
   %tmp = call i32 @llvm.umul.fix.sat.i32(i32 %x, i32 %y, i32 0)
   ret i32 %tmp
@@ -21,15 +22,14 @@ define i32 @func2(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: func2:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mulhwu 6, 3, 4
-; CHECK-NEXT:    li 5, -1
+; CHECK-NEXT:    mr 5, 3
 ; CHECK-NEXT:    cmplwi 6, 1
-; CHECK-NEXT:    mullw 3, 3, 4
+; CHECK-NEXT:    li 3, -1
+; CHECK-NEXT:    bgtlr 0
+; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    mullw 3, 5, 4
 ; CHECK-NEXT:    rotlwi 3, 3, 31
 ; CHECK-NEXT:    rlwimi 3, 6, 31, 0, 0
-; CHECK-NEXT:    bc 12, 1, .LBB1_1
-; CHECK-NEXT:    blr
-; CHECK-NEXT:  .LBB1_1:
-; CHECK-NEXT:    addi 3, 5, 0
 ; CHECK-NEXT:    blr
   %tmp = call i32 @llvm.umul.fix.sat.i32(i32 %x, i32 %y, i32 1)
   ret i32 %tmp

--- a/llvm/test/CodeGen/PowerPC/umulo-128-legalisation-lowering.ll
+++ b/llvm/test/CodeGen/PowerPC/umulo-128-legalisation-lowering.ll
@@ -32,102 +32,110 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
 ;
 ; PPC32-LABEL: muloti_test:
 ; PPC32:       # %bb.0: # %start
-; PPC32-NEXT:    stwu 1, -64(1)
-; PPC32-NEXT:    stw 26, 40(1) # 4-byte Folded Spill
-; PPC32-NEXT:    mulhwu. 26, 7, 6
-; PPC32-NEXT:    mcrf 1, 0
-; PPC32-NEXT:    stw 30, 56(1) # 4-byte Folded Spill
+; PPC32-NEXT:    stwu 1, -80(1)
+; PPC32-NEXT:    mr 11, 7
+; PPC32-NEXT:    stw 26, 56(1) # 4-byte Folded Spill
+; PPC32-NEXT:    mulhwu. 26, 11, 6
+; PPC32-NEXT:    stw 24, 48(1) # 4-byte Folded Spill
 ; PPC32-NEXT:    mfcr 12
-; PPC32-NEXT:    cmpwi 7, 5, 0
-; PPC32-NEXT:    cmpwi 2, 7, 0
-; PPC32-NEXT:    mulhwu. 26, 5, 8
-; PPC32-NEXT:    mcrf 5, 0
-; PPC32-NEXT:    stw 22, 24(1) # 4-byte Folded Spill
-; PPC32-NEXT:    crnor 20, 30, 10
-; PPC32-NEXT:    stw 23, 28(1) # 4-byte Folded Spill
-; PPC32-NEXT:    cmpwi 7, 9, 0
-; PPC32-NEXT:    mulhwu. 26, 3, 10
-; PPC32-NEXT:    mcrf 6, 0
-; PPC32-NEXT:    stw 29, 52(1) # 4-byte Folded Spill
-; PPC32-NEXT:    cmpwi 2, 3, 0
-; PPC32-NEXT:    stw 24, 32(1) # 4-byte Folded Spill
-; PPC32-NEXT:    crnor 21, 30, 10
-; PPC32-NEXT:    mulhwu. 26, 9, 4
-; PPC32-NEXT:    stw 25, 36(1) # 4-byte Folded Spill
-; PPC32-NEXT:    crorc 20, 20, 6
-; PPC32-NEXT:    stw 27, 44(1) # 4-byte Folded Spill
-; PPC32-NEXT:    crorc 21, 21, 26
-; PPC32-NEXT:    stw 28, 48(1) # 4-byte Folded Spill
-; PPC32-NEXT:    mulhwu 30, 6, 10
-; PPC32-NEXT:    stw 12, 20(1)
-; PPC32-NEXT:    crorc 20, 20, 22
-; PPC32-NEXT:    crorc 21, 21, 2
-; PPC32-NEXT:    li 11, 0
-; PPC32-NEXT:    mullw 26, 5, 10
-; PPC32-NEXT:    addc 30, 26, 30
-; PPC32-NEXT:    mulhwu 29, 5, 10
-; PPC32-NEXT:    addze 29, 29
-; PPC32-NEXT:    mullw 23, 5, 8
-; PPC32-NEXT:    mullw 22, 7, 6
-; PPC32-NEXT:    mulhwu 0, 6, 9
-; PPC32-NEXT:    mulhwu 12, 5, 9
-; PPC32-NEXT:    mulhwu 27, 8, 6
-; PPC32-NEXT:    mullw 25, 6, 9
-; PPC32-NEXT:    mullw 24, 5, 9
-; PPC32-NEXT:    mullw 5, 9, 4
-; PPC32-NEXT:    add 9, 22, 23
-; PPC32-NEXT:    add 9, 27, 9
-; PPC32-NEXT:    cmplw 1, 9, 27
-; PPC32-NEXT:    cror 20, 20, 4
-; PPC32-NEXT:    mullw 23, 3, 10
-; PPC32-NEXT:    add 26, 23, 5
-; PPC32-NEXT:    addc 5, 25, 30
-; PPC32-NEXT:    addze 0, 0
-; PPC32-NEXT:    or. 3, 4, 3
-; PPC32-NEXT:    mulhwu 28, 4, 10
+; PPC32-NEXT:    stw 27, 60(1) # 4-byte Folded Spill
 ; PPC32-NEXT:    mcrf 1, 0
-; PPC32-NEXT:    addc 3, 29, 0
-; PPC32-NEXT:    add 26, 28, 26
-; PPC32-NEXT:    cmplw 6, 26, 28
-; PPC32-NEXT:    cror 21, 21, 24
-; PPC32-NEXT:    mullw 30, 4, 10
-; PPC32-NEXT:    or. 4, 8, 7
-; PPC32-NEXT:    addze 4, 11
-; PPC32-NEXT:    addc 7, 24, 3
-; PPC32-NEXT:    crnor 22, 2, 6
-; PPC32-NEXT:    mullw 27, 8, 6
-; PPC32-NEXT:    adde 8, 12, 4
-; PPC32-NEXT:    addc 3, 30, 27
-; PPC32-NEXT:    adde 9, 26, 9
-; PPC32-NEXT:    addc 4, 7, 3
-; PPC32-NEXT:    adde 3, 8, 9
-; PPC32-NEXT:    cror 21, 22, 21
-; PPC32-NEXT:    cmplw 4, 7
-; PPC32-NEXT:    cmplw 1, 3, 8
-; PPC32-NEXT:    lwz 12, 20(1)
-; PPC32-NEXT:    cror 20, 21, 20
-; PPC32-NEXT:    crandc 21, 4, 6
-; PPC32-NEXT:    crand 22, 6, 0
-; PPC32-NEXT:    cror 21, 22, 21
-; PPC32-NEXT:    crnor 20, 20, 21
-; PPC32-NEXT:    li 7, 1
-; PPC32-NEXT:    mullw 6, 6, 10
-; PPC32-NEXT:    bc 12, 20, .LBB0_1
-; PPC32-NEXT:    b .LBB0_2
-; PPC32-NEXT:  .LBB0_1: # %start
+; PPC32-NEXT:    stw 19, 28(1) # 4-byte Folded Spill
+; PPC32-NEXT:    mulhwu 27, 6, 10
+; PPC32-NEXT:    stw 20, 32(1) # 4-byte Folded Spill
+; PPC32-NEXT:    cmpwi 6, 11, 0
+; PPC32-NEXT:    stw 21, 36(1) # 4-byte Folded Spill
 ; PPC32-NEXT:    li 7, 0
-; PPC32-NEXT:  .LBB0_2: # %start
+; PPC32-NEXT:    stw 22, 40(1) # 4-byte Folded Spill
+; PPC32-NEXT:    mulhwu. 26, 5, 8
+; PPC32-NEXT:    stw 23, 44(1) # 4-byte Folded Spill
+; PPC32-NEXT:    mcrf 5, 0
+; PPC32-NEXT:    stw 25, 52(1) # 4-byte Folded Spill
+; PPC32-NEXT:    cmpwi 5, 0
+; PPC32-NEXT:    stw 28, 64(1) # 4-byte Folded Spill
+; PPC32-NEXT:    mullw 24, 5, 10
+; PPC32-NEXT:    stw 29, 68(1) # 4-byte Folded Spill
+; PPC32-NEXT:    crnor 20, 2, 26
+; PPC32-NEXT:    stw 30, 72(1) # 4-byte Folded Spill
+; PPC32-NEXT:    cmpwi 3, 0
+; PPC32-NEXT:    stw 12, 24(1)
+; PPC32-NEXT:    mulhwu 30, 5, 10
+; PPC32-NEXT:    cmpwi 6, 9, 0
+; PPC32-NEXT:    crnor 21, 26, 2
+; PPC32-NEXT:    crorc 20, 20, 6
+; PPC32-NEXT:    crorc 20, 20, 22
+; PPC32-NEXT:    mulhwu 12, 5, 9
+; PPC32-NEXT:    mullw 26, 5, 9
+; PPC32-NEXT:    mullw 22, 5, 8
+; PPC32-NEXT:    addc 5, 24, 27
+; PPC32-NEXT:    addze 30, 30
+; PPC32-NEXT:    mullw 23, 6, 9
+; PPC32-NEXT:    addc 5, 23, 5
+; PPC32-NEXT:    mullw 21, 11, 6
+; PPC32-NEXT:    add 27, 21, 22
+; PPC32-NEXT:    mulhwu 28, 8, 6
+; PPC32-NEXT:    add 27, 28, 27
+; PPC32-NEXT:    cmplw 7, 27, 28
+; PPC32-NEXT:    mulhwu. 23, 3, 10
+; PPC32-NEXT:    mcrf 6, 0
+; PPC32-NEXT:    cror 24, 20, 28
+; PPC32-NEXT:    crorc 25, 21, 26
+; PPC32-NEXT:    mulhwu 0, 6, 9
+; PPC32-NEXT:    mullw 20, 9, 4
+; PPC32-NEXT:    mulhwu. 9, 9, 4
+; PPC32-NEXT:    mcrf 1, 0
+; PPC32-NEXT:    addze 9, 0
+; PPC32-NEXT:    mullw 19, 3, 10
+; PPC32-NEXT:    or. 3, 4, 3
+; PPC32-NEXT:    mcrf 5, 0
+; PPC32-NEXT:    addc 3, 30, 9
+; PPC32-NEXT:    add 24, 19, 20
+; PPC32-NEXT:    mulhwu 29, 4, 10
+; PPC32-NEXT:    add 28, 29, 24
+; PPC32-NEXT:    cmplw 2, 28, 29
+; PPC32-NEXT:    crorc 20, 25, 6
+; PPC32-NEXT:    cror 20, 20, 8
+; PPC32-NEXT:    mullw 22, 4, 10
+; PPC32-NEXT:    or. 4, 8, 11
+; PPC32-NEXT:    addze 4, 7
+; PPC32-NEXT:    crnor 21, 2, 22
+; PPC32-NEXT:    cror 20, 21, 20
+; PPC32-NEXT:    mullw 25, 8, 6
+; PPC32-NEXT:    addc 8, 26, 3
+; PPC32-NEXT:    adde 9, 12, 4
+; PPC32-NEXT:    addc 3, 22, 25
+; PPC32-NEXT:    adde 11, 28, 27
+; PPC32-NEXT:    addc 4, 8, 3
+; PPC32-NEXT:    adde 3, 9, 11
+; PPC32-NEXT:    cmplw 1, 3, 9
+; PPC32-NEXT:    cmplw 4, 8
+; PPC32-NEXT:    crandc 22, 4, 6
+; PPC32-NEXT:    mullw 6, 6, 10
+; PPC32-NEXT:    bc 12, 22, .LBB0_3
+; PPC32-NEXT:  # %bb.1: # %start
+; PPC32-NEXT:    crand 21, 6, 0
+; PPC32-NEXT:    bc 12, 21, .LBB0_3
+; PPC32-NEXT:  # %bb.2: # %start
+; PPC32-NEXT:    cror 20, 20, 24
+; PPC32-NEXT:    bc 4, 20, .LBB0_4
+; PPC32-NEXT:  .LBB0_3: # %start
+; PPC32-NEXT:    li 7, 1
+; PPC32-NEXT:  .LBB0_4: # %start
+; PPC32-NEXT:    lwz 12, 24(1)
+; PPC32-NEXT:    lwz 30, 72(1) # 4-byte Folded Reload
 ; PPC32-NEXT:    mtcrf 32, 12 # cr2
-; PPC32-NEXT:    lwz 30, 56(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 29, 52(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 28, 48(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 27, 44(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 26, 40(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 25, 36(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 24, 32(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 23, 28(1) # 4-byte Folded Reload
-; PPC32-NEXT:    lwz 22, 24(1) # 4-byte Folded Reload
-; PPC32-NEXT:    addi 1, 1, 64
+; PPC32-NEXT:    lwz 29, 68(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 28, 64(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 27, 60(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 26, 56(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 25, 52(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 24, 48(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 23, 44(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 22, 40(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 21, 36(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 20, 32(1) # 4-byte Folded Reload
+; PPC32-NEXT:    lwz 19, 28(1) # 4-byte Folded Reload
+; PPC32-NEXT:    addi 1, 1, 80
 ; PPC32-NEXT:    blr
 start:
   %0 = tail call { i128, i1 } @llvm.umul.with.overflow.i128(i128 %l, i128 %r) #2

--- a/llvm/test/CodeGen/PowerPC/urem-seteq-illegal-types.ll
+++ b/llvm/test/CodeGen/PowerPC/urem-seteq-illegal-types.ll
@@ -7,12 +7,11 @@ define i1 @test_urem_odd(i13 %X) nounwind {
 ; PPC:       # %bb.0:
 ; PPC-NEXT:    mulli 3, 3, 3277
 ; PPC-NEXT:    clrlwi 3, 3, 19
-; PPC-NEXT:    li 4, 0
 ; PPC-NEXT:    cmplwi 3, 1639
 ; PPC-NEXT:    li 3, 1
 ; PPC-NEXT:    bclr 12, 0, 0
 ; PPC-NEXT:  # %bb.1:
-; PPC-NEXT:    ori 3, 4, 0
+; PPC-NEXT:    li 3, 0
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_urem_odd:
@@ -40,12 +39,10 @@ define i1 @test_urem_even(i27 %X) nounwind {
 ; PPC-NEXT:    lis 3, 146
 ; PPC-NEXT:    ori 3, 3, 18725
 ; PPC-NEXT:    cmplw 4, 3
+; PPC-NEXT:    li 3, 1
+; PPC-NEXT:    bclr 12, 0, 0
+; PPC-NEXT:  # %bb.1:
 ; PPC-NEXT:    li 3, 0
-; PPC-NEXT:    li 4, 1
-; PPC-NEXT:    bc 12, 0, .LBB1_1
-; PPC-NEXT:    blr
-; PPC-NEXT:  .LBB1_1:
-; PPC-NEXT:    addi 3, 4, 0
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_urem_even:
@@ -72,12 +69,11 @@ define i1 @test_urem_odd_setne(i4 %X) nounwind {
 ; PPC:       # %bb.0:
 ; PPC-NEXT:    mulli 3, 3, 13
 ; PPC-NEXT:    clrlwi 3, 3, 28
-; PPC-NEXT:    li 4, 0
 ; PPC-NEXT:    cmplwi 3, 3
 ; PPC-NEXT:    li 3, 1
 ; PPC-NEXT:    bclr 12, 1, 0
 ; PPC-NEXT:  # %bb.1:
-; PPC-NEXT:    ori 3, 4, 0
+; PPC-NEXT:    li 3, 0
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_urem_odd_setne:
@@ -101,12 +97,11 @@ define i1 @test_urem_negative_odd(i9 %X) nounwind {
 ; PPC:       # %bb.0:
 ; PPC-NEXT:    mulli 3, 3, 307
 ; PPC-NEXT:    clrlwi 3, 3, 23
-; PPC-NEXT:    li 4, 0
 ; PPC-NEXT:    cmplwi 3, 1
 ; PPC-NEXT:    li 3, 1
 ; PPC-NEXT:    bclr 12, 1, 0
 ; PPC-NEXT:  # %bb.1:
-; PPC-NEXT:    ori 3, 4, 0
+; PPC-NEXT:    li 3, 0
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_urem_negative_odd:
@@ -126,37 +121,33 @@ define i1 @test_urem_negative_odd(i9 %X) nounwind {
 define <3 x i1> @test_urem_vec(<3 x i11> %X) nounwind {
 ; PPC-LABEL: test_urem_vec:
 ; PPC:       # %bb.0:
-; PPC-NEXT:    mulli 3, 3, 683
-; PPC-NEXT:    rlwinm 7, 3, 31, 22, 31
-; PPC-NEXT:    rlwimi 7, 3, 10, 21, 21
+; PPC-NEXT:    mr 6, 3
+; PPC-NEXT:    mulli 6, 6, 683
+; PPC-NEXT:    rlwinm 7, 6, 31, 22, 31
+; PPC-NEXT:    rlwimi 7, 6, 10, 21, 21
 ; PPC-NEXT:    mulli 5, 5, 819
-; PPC-NEXT:    li 6, 0
-; PPC-NEXT:    cmplwi 7, 341
-; PPC-NEXT:    mulli 3, 4, 1463
-; PPC-NEXT:    addi 4, 5, -1638
-; PPC-NEXT:    addi 3, 3, -1463
+; PPC-NEXT:    addi 5, 5, -1638
+; PPC-NEXT:    clrlwi 5, 5, 21
+; PPC-NEXT:    mulli 4, 4, 1463
+; PPC-NEXT:    addi 4, 4, -1463
 ; PPC-NEXT:    clrlwi 4, 4, 21
-; PPC-NEXT:    clrlwi 3, 3, 21
-; PPC-NEXT:    cmplwi 1, 4, 1
-; PPC-NEXT:    cmplwi 5, 3, 292
 ; PPC-NEXT:    li 3, 1
+; PPC-NEXT:    cmplwi 7, 341
+; PPC-NEXT:    cmplwi 1, 5, 1
+; PPC-NEXT:    cmplwi 5, 4, 292
+; PPC-NEXT:    li 4, 1
 ; PPC-NEXT:    bc 12, 21, .LBB4_2
 ; PPC-NEXT:  # %bb.1:
-; PPC-NEXT:    ori 4, 6, 0
-; PPC-NEXT:    b .LBB4_3
+; PPC-NEXT:    li 4, 0
 ; PPC-NEXT:  .LBB4_2:
-; PPC-NEXT:    addi 4, 3, 0
-; PPC-NEXT:  .LBB4_3:
-; PPC-NEXT:    bc 12, 5, .LBB4_5
-; PPC-NEXT:  # %bb.4:
-; PPC-NEXT:    ori 5, 6, 0
-; PPC-NEXT:    b .LBB4_6
-; PPC-NEXT:  .LBB4_5:
-; PPC-NEXT:    addi 5, 3, 0
-; PPC-NEXT:  .LBB4_6:
+; PPC-NEXT:    li 5, 1
+; PPC-NEXT:    bc 12, 5, .LBB4_4
+; PPC-NEXT:  # %bb.3:
+; PPC-NEXT:    li 5, 0
+; PPC-NEXT:  .LBB4_4:
 ; PPC-NEXT:    bclr 12, 1, 0
-; PPC-NEXT:  # %bb.7:
-; PPC-NEXT:    ori 3, 6, 0
+; PPC-NEXT:  # %bb.5:
+; PPC-NEXT:    li 3, 0
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_urem_vec:
@@ -244,16 +235,15 @@ define i1 @test_urem_oversized(i66 %X) nounwind {
 ; PPC-NEXT:    cmplw 5, 11
 ; PPC-NEXT:    cmplwi 1, 10, 13
 ; PPC-NEXT:    rlwinm 3, 3, 31, 31, 31
-; PPC-NEXT:    crand 20, 6, 0
-; PPC-NEXT:    crandc 21, 4, 6
+; PPC-NEXT:    crandc 20, 4, 6
+; PPC-NEXT:    crand 21, 6, 0
 ; PPC-NEXT:    rlwimi. 3, 6, 1, 30, 30
-; PPC-NEXT:    cror 20, 20, 21
+; PPC-NEXT:    cror 20, 21, 20
 ; PPC-NEXT:    crnand 20, 2, 20
-; PPC-NEXT:    li 3, 1
-; PPC-NEXT:    bc 12, 20, .LBB5_1
-; PPC-NEXT:    blr
-; PPC-NEXT:  .LBB5_1:
 ; PPC-NEXT:    li 3, 0
+; PPC-NEXT:    bclr 12, 20, 0
+; PPC-NEXT:  # %bb.1:
+; PPC-NEXT:    li 3, 1
 ; PPC-NEXT:    blr
 ;
 ; PPC64LE-LABEL: test_urem_oversized:

--- a/llvm/test/CodeGen/PowerPC/varargs.ll
+++ b/llvm/test/CodeGen/PowerPC/varargs.ll
@@ -7,31 +7,28 @@
 define ptr @test1(ptr %foo) nounwind {
 ; P32-LABEL: test1:
 ; P32:       # %bb.0:
-; P32-NEXT:    lbz r4, 0(r3)
-; P32-NEXT:    lwz r5, 4(r3)
-; P32-NEXT:    lwz r6, 8(r3)
-; P32-NEXT:    addi r7, r4, 1
-; P32-NEXT:    stb r7, 0(r3)
-; P32-NEXT:    addi r7, r5, 4
-; P32-NEXT:    cmpwi r4, 8
-; P32-NEXT:    slwi r4, r4, 2
-; P32-NEXT:    add r4, r6, r4
-; P32-NEXT:    bc 12, lt, .LBB0_2
+; P32-NEXT:    lbz r5, 0(r3)
+; P32-NEXT:    lwz r4, 4(r3)
+; P32-NEXT:    addi r6, r5, 1
+; P32-NEXT:    cmpwi r5, 8
+; P32-NEXT:    stb r6, 0(r3)
+; P32-NEXT:    mr r6, r4
+; P32-NEXT:    bge cr0, .LBB0_3
 ; P32-NEXT:  # %bb.1:
-; P32-NEXT:    ori r6, r7, 0
-; P32-NEXT:    b .LBB0_3
-; P32-NEXT:  .LBB0_2:
-; P32-NEXT:    addi r6, r5, 0
-; P32-NEXT:  .LBB0_3:
 ; P32-NEXT:    stw r6, 4(r3)
-; P32-NEXT:    bc 12, lt, .LBB0_5
-; P32-NEXT:  # %bb.4:
-; P32-NEXT:    ori r3, r5, 0
-; P32-NEXT:    b .LBB0_6
-; P32-NEXT:  .LBB0_5:
-; P32-NEXT:    addi r3, r4, 0
-; P32-NEXT:  .LBB0_6:
-; P32-NEXT:    lwz r3, 0(r3)
+; P32-NEXT:    blt cr0, .LBB0_4
+; P32-NEXT:  .LBB0_2:
+; P32-NEXT:    lwz r3, 0(r4)
+; P32-NEXT:    blr
+; P32-NEXT:  .LBB0_3:
+; P32-NEXT:    addi r6, r4, 4
+; P32-NEXT:    stw r6, 4(r3)
+; P32-NEXT:    bge cr0, .LBB0_2
+; P32-NEXT:  .LBB0_4:
+; P32-NEXT:    lwz r3, 8(r3)
+; P32-NEXT:    slwi r4, r5, 2
+; P32-NEXT:    add r4, r3, r4
+; P32-NEXT:    lwz r3, 0(r4)
 ; P32-NEXT:    blr
 ;
 ; P64-LABEL: test1:

--- a/llvm/test/CodeGen/PowerPC/wide-scalar-shift-by-byte-multiple-legalization.ll
+++ b/llvm/test/CodeGen/PowerPC/wide-scalar-shift-by-byte-multiple-legalization.ll
@@ -160,22 +160,22 @@ define void @ashr_8bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; LE-32BIT-LABEL: ashr_8bytes:
 ; LE-32BIT:       # %bb.0:
 ; LE-32BIT-NEXT:    lwz 4, 4(4)
-; LE-32BIT-NEXT:    lwz 6, 4(3)
-; LE-32BIT-NEXT:    lwz 3, 0(3)
+; LE-32BIT-NEXT:    lwz 6, 0(3)
 ; LE-32BIT-NEXT:    slwi 4, 4, 3
-; LE-32BIT-NEXT:    subfic 7, 4, 32
-; LE-32BIT-NEXT:    srw 6, 6, 4
-; LE-32BIT-NEXT:    addi 8, 4, -32
-; LE-32BIT-NEXT:    slw 7, 3, 7
-; LE-32BIT-NEXT:    sraw 4, 3, 4
-; LE-32BIT-NEXT:    sraw 3, 3, 8
-; LE-32BIT-NEXT:    cmpwi 8, 1
-; LE-32BIT-NEXT:    or 6, 6, 7
-; LE-32BIT-NEXT:    bc 12, 0, .LBB5_1
-; LE-32BIT-NEXT:    b .LBB5_2
-; LE-32BIT-NEXT:  .LBB5_1:
-; LE-32BIT-NEXT:    addi 3, 6, 0
+; LE-32BIT-NEXT:    addi 7, 4, -32
+; LE-32BIT-NEXT:    cmpwi 7, 0
+; LE-32BIT-NEXT:    ble 0, .LBB5_2
+; LE-32BIT-NEXT:  # %bb.1:
+; LE-32BIT-NEXT:    sraw 3, 6, 7
+; LE-32BIT-NEXT:    b .LBB5_3
 ; LE-32BIT-NEXT:  .LBB5_2:
+; LE-32BIT-NEXT:    lwz 3, 4(3)
+; LE-32BIT-NEXT:    subfic 7, 4, 32
+; LE-32BIT-NEXT:    slw 7, 6, 7
+; LE-32BIT-NEXT:    srw 3, 3, 4
+; LE-32BIT-NEXT:    or 3, 3, 7
+; LE-32BIT-NEXT:  .LBB5_3:
+; LE-32BIT-NEXT:    sraw 4, 6, 4
 ; LE-32BIT-NEXT:    stw 4, 0(5)
 ; LE-32BIT-NEXT:    stw 3, 4(5)
 ; LE-32BIT-NEXT:    blr
@@ -357,24 +357,24 @@ define void @ashr_16bytes(ptr %src.ptr, ptr %byteOff.ptr, ptr %dst) nounwind {
 ; BE-LABEL: ashr_16bytes:
 ; BE:       # %bb.0:
 ; BE-NEXT:    lwz 4, 12(4)
-; BE-NEXT:    ld 6, 8(3)
-; BE-NEXT:    ld 3, 0(3)
+; BE-NEXT:    ld 6, 0(3)
 ; BE-NEXT:    slwi 4, 4, 3
-; BE-NEXT:    subfic 7, 4, 64
-; BE-NEXT:    srd 6, 6, 4
-; BE-NEXT:    addi 8, 4, -64
-; BE-NEXT:    sld 7, 3, 7
-; BE-NEXT:    cmpwi 8, 1
-; BE-NEXT:    or 6, 6, 7
-; BE-NEXT:    srad 7, 3, 8
-; BE-NEXT:    srad 3, 3, 4
-; BE-NEXT:    bc 12, 0, .LBB8_2
+; BE-NEXT:    addi 7, 4, -64
+; BE-NEXT:    cmpwi 7, 1
+; BE-NEXT:    blt 0, .LBB8_2
 ; BE-NEXT:  # %bb.1:
-; BE-NEXT:    ori 6, 7, 0
-; BE-NEXT:    b .LBB8_2
+; BE-NEXT:    srad 3, 6, 7
+; BE-NEXT:    b .LBB8_3
 ; BE-NEXT:  .LBB8_2:
-; BE-NEXT:    std 3, 0(5)
-; BE-NEXT:    std 6, 8(5)
+; BE-NEXT:    ld 3, 8(3)
+; BE-NEXT:    subfic 7, 4, 64
+; BE-NEXT:    sld 7, 6, 7
+; BE-NEXT:    srd 3, 3, 4
+; BE-NEXT:    or 3, 3, 7
+; BE-NEXT:  .LBB8_3:
+; BE-NEXT:    srad 4, 6, 4
+; BE-NEXT:    std 3, 8(5)
+; BE-NEXT:    std 4, 0(5)
 ; BE-NEXT:    blr
 ;
 ; LE-32BIT-LABEL: ashr_16bytes:

--- a/llvm/test/CodeGen/PowerPC/wide-scalar-shift-legalization.ll
+++ b/llvm/test/CodeGen/PowerPC/wide-scalar-shift-legalization.ll
@@ -144,21 +144,21 @@ define void @ashr_8bytes(ptr %src.ptr, ptr %bitOff.ptr, ptr %dst) nounwind {
 ; LE-32BIT-LABEL: ashr_8bytes:
 ; LE-32BIT:       # %bb.0:
 ; LE-32BIT-NEXT:    lwz 4, 4(4)
-; LE-32BIT-NEXT:    lwz 6, 4(3)
-; LE-32BIT-NEXT:    lwz 3, 0(3)
-; LE-32BIT-NEXT:    subfic 7, 4, 32
-; LE-32BIT-NEXT:    srw 6, 6, 4
-; LE-32BIT-NEXT:    addi 8, 4, -32
-; LE-32BIT-NEXT:    slw 7, 3, 7
-; LE-32BIT-NEXT:    sraw 4, 3, 4
-; LE-32BIT-NEXT:    sraw 3, 3, 8
-; LE-32BIT-NEXT:    cmpwi 8, 1
-; LE-32BIT-NEXT:    or 6, 6, 7
-; LE-32BIT-NEXT:    bc 12, 0, .LBB5_1
-; LE-32BIT-NEXT:    b .LBB5_2
-; LE-32BIT-NEXT:  .LBB5_1:
-; LE-32BIT-NEXT:    addi 3, 6, 0
+; LE-32BIT-NEXT:    lwz 6, 0(3)
+; LE-32BIT-NEXT:    addi 7, 4, -32
+; LE-32BIT-NEXT:    cmpwi 7, 0
+; LE-32BIT-NEXT:    ble 0, .LBB5_2
+; LE-32BIT-NEXT:  # %bb.1:
+; LE-32BIT-NEXT:    sraw 3, 6, 7
+; LE-32BIT-NEXT:    b .LBB5_3
 ; LE-32BIT-NEXT:  .LBB5_2:
+; LE-32BIT-NEXT:    lwz 3, 4(3)
+; LE-32BIT-NEXT:    subfic 7, 4, 32
+; LE-32BIT-NEXT:    slw 7, 6, 7
+; LE-32BIT-NEXT:    srw 3, 3, 4
+; LE-32BIT-NEXT:    or 3, 3, 7
+; LE-32BIT-NEXT:  .LBB5_3:
+; LE-32BIT-NEXT:    sraw 4, 6, 4
 ; LE-32BIT-NEXT:    stw 4, 0(5)
 ; LE-32BIT-NEXT:    stw 3, 4(5)
 ; LE-32BIT-NEXT:    blr
@@ -364,23 +364,23 @@ define void @ashr_16bytes(ptr %src.ptr, ptr %bitOff.ptr, ptr %dst) nounwind {
 ; BE-LABEL: ashr_16bytes:
 ; BE:       # %bb.0:
 ; BE-NEXT:    lwz 4, 12(4)
-; BE-NEXT:    ld 6, 8(3)
-; BE-NEXT:    ld 3, 0(3)
-; BE-NEXT:    subfic 7, 4, 64
-; BE-NEXT:    srd 6, 6, 4
-; BE-NEXT:    addi 8, 4, -64
-; BE-NEXT:    sld 7, 3, 7
-; BE-NEXT:    cmpwi 8, 1
-; BE-NEXT:    or 6, 6, 7
-; BE-NEXT:    srad 7, 3, 8
-; BE-NEXT:    srad 3, 3, 4
-; BE-NEXT:    bc 12, 0, .LBB8_2
+; BE-NEXT:    ld 6, 0(3)
+; BE-NEXT:    addi 7, 4, -64
+; BE-NEXT:    cmpwi 7, 1
+; BE-NEXT:    blt 0, .LBB8_2
 ; BE-NEXT:  # %bb.1:
-; BE-NEXT:    ori 6, 7, 0
-; BE-NEXT:    b .LBB8_2
+; BE-NEXT:    srad 3, 6, 7
+; BE-NEXT:    b .LBB8_3
 ; BE-NEXT:  .LBB8_2:
-; BE-NEXT:    std 3, 0(5)
-; BE-NEXT:    std 6, 8(5)
+; BE-NEXT:    ld 3, 8(3)
+; BE-NEXT:    subfic 7, 4, 64
+; BE-NEXT:    sld 7, 6, 7
+; BE-NEXT:    srd 3, 3, 4
+; BE-NEXT:    or 3, 3, 7
+; BE-NEXT:  .LBB8_3:
+; BE-NEXT:    srad 4, 6, 4
+; BE-NEXT:    std 3, 8(5)
+; BE-NEXT:    std 4, 0(5)
 ; BE-NEXT:    blr
 ;
 ; LE-32BIT-LABEL: ashr_16bytes:


### PR DESCRIPTION
When expand `select_cc` in finalize-isel, we should not generate `isel` for targets not feature it.