### PR TITLE
[LLD] dtNeeded name should consistent with soNames

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1439,7 +1439,7 @@ template <class ELFT> void SharedFile::parse() {
       uint64_t val = dyn.getVal();
       if (val >= this->stringTable.size())
         fatal(toString(this) + ": invalid DT_NEEDED entry");
-      dtNeeded.push_back(this->stringTable.data() + val);
+      dtNeeded.push_back(path::filename(this->stringTable.data() + val));
     } else if (dyn.d_tag == DT_SONAME) {
       uint64_t val = dyn.getVal();
       if (val >= this->stringTable.size())
@@ -1451,8 +1451,8 @@ template <class ELFT> void SharedFile::parse() {
   // DSOs are uniquified not by filename but by soname.
   DenseMap<CachedHashStringRef, SharedFile *>::iterator it;
   bool wasInserted;
-  std::tie(it, wasInserted) =
-      symtab.soNames.try_emplace(CachedHashStringRef(soName), this);
+  std::tie(it, wasInserted) = symtab.soNames.try_emplace(
+      CachedHashStringRef(path::filename(soName)), this);
 
   // If a DSO appears more than once on the command line with and without
   // --as-needed, --no-as-needed takes precedence over --as-needed because a

--- a/lld/test/ELF/dtNeeded-soName-undefined.s
+++ b/lld/test/ELF/dtNeeded-soName-undefined.s
@@ -1,0 +1,24 @@
+# REQUIRES: aarch64
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=aarch64 main.s -o main.o
+# RUN: llvm-mc -filetype=obj -triple=aarch64 def.s -o def.o && ld.lld -shared def.o -o def.so
+# RUN: llvm-mc -filetype=obj -triple=aarch64 ref.s -o ref.o && ld.lld -shared ref.o -o ref.so ./def.so
+
+# RUN: not ld.lld main.o ref.so def.so -o /dev/null 2>&1 | FileCheck %s
+
+# CHECK-NOT:  error:
+# CHECK:      error: undefined reference due to --no-allow-shlib-undefined: foo
+# CHECK-NEXT: >>> referenced by ref.so
+
+
+#--- def.s
+
+#--- ref.s
+.globl fun
+fun:
+  bl foo@PLT
+#--- main.s
+.globl _start
+_start:
+  bl fun@PLT


### PR DESCRIPTION
If dtNeeded name is inconsistent with soNames, lld can not report error right.
### demo
```
#--- def.s

#--- ref.s
.globl fun
fun:
  bl foo@PLT

#--- main.s
.globl _start
_start:
  bl fun@PLT


$ llvm-mc -filetype=obj -triple=aarch64 main.s -o main.o
$ llvm-mc -filetype=obj -triple=aarch64 def.s -o def.o && ld.lld -shared def.o -o def.so
$ llvm-mc -filetype=obj -triple=aarch64 ref.s -o ref.o && ld.lld -shared ref.o -o ref.so ./def.so
```

### can report error
$ ld.lld main.o ref.so ./def.so
```
ld.lld: error: undefined reference due to --no-allow-shlib-undefined: foo
>>> referenced by ref.so
```
dtNeeded name = `./def.so`, soName = `./def.so`, consistent.
### can not report error
$ ld.lld main.o ref.so def.so
dtNeeded name = `./def.so`, soName = `def.so`, inconsistent.

We can see that if dtNeeded name is inconsistent with soNames, lld can not report error right.
https://github.com/llvm/llvm-project/blob/4594d5bb3ac6772bb20e429bbb04842ef6eaea35/lld/ELF/Writer.cpp#L2019-L2036