### PR TITLE
[llvm][MC][ARM][Assembly] Emit relocations for LDRs

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -76,7 +76,8 @@ const MCFixupKindInfo &ARMAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
       // Name                      Offset (bits) Size (bits)     Flags
       {"fixup_arm_ldst_pcrel_12", 0, 32, MCFixupKindInfo::FKF_IsPCRel},
       {"fixup_t2_ldst_pcrel_12", 0, 32,
-       MCFixupKindInfo::FKF_IsPCRel | MCFixupKindInfo::FKF_IsAlignedDownTo32Bits},
+       MCFixupKindInfo::FKF_IsPCRel |
+           MCFixupKindInfo::FKF_IsAlignedDownTo32Bits},
       {"fixup_arm_pcrel_10_unscaled", 0, 32, MCFixupKindInfo::FKF_IsPCRel},
       {"fixup_arm_pcrel_10", 0, 32, IsPCRelConstant},
       {"fixup_t2_pcrel_10", 0, 32,

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -74,10 +74,10 @@ const MCFixupKindInfo &ARMAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
       // ARMFixupKinds.h.
       //
       // Name                      Offset (bits) Size (bits)     Flags
-      {"fixup_arm_ldst_pcrel_12", 0, 32, IsPCRelConstant},
+      {"fixup_arm_ldst_pcrel_12", 0, 32, MCFixupKindInfo::FKF_IsPCRel},
       {"fixup_t2_ldst_pcrel_12", 0, 32,
-       IsPCRelConstant | MCFixupKindInfo::FKF_IsAlignedDownTo32Bits},
-      {"fixup_arm_pcrel_10_unscaled", 0, 32, IsPCRelConstant},
+       MCFixupKindInfo::FKF_IsPCRel | MCFixupKindInfo::FKF_IsAlignedDownTo32Bits},
+      {"fixup_arm_pcrel_10_unscaled", 0, 32, MCFixupKindInfo::FKF_IsPCRel},
       {"fixup_arm_pcrel_10", 0, 32, IsPCRelConstant},
       {"fixup_t2_pcrel_10", 0, 32,
        MCFixupKindInfo::FKF_IsPCRel |

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
@@ -158,6 +158,12 @@ unsigned ARMELFObjectWriter::GetRelocTypeInner(const MCValue &Target,
       default:
         return ELF::R_ARM_THM_CALL;
       }
+    case ARM::fixup_arm_ldst_pcrel_12:
+      return ELF::R_ARM_LDR_PC_G0;
+    case ARM::fixup_arm_pcrel_10_unscaled:
+      return ELF::R_ARM_LDRS_PC_G0;
+    case ARM::fixup_t2_ldst_pcrel_12:
+      return ELF::R_ARM_THM_PC12;
     case ARM::fixup_bf_target:
       return ELF::R_ARM_THM_BF16;
     case ARM::fixup_bfc_target:

--- a/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
@@ -1,0 +1,39 @@
+@ RUN: llvm-mc -filetype=obj -triple=armv7 %s -o %t
+@ RUN: llvm-readelf -r %t | FileCheck %s --check-prefix=ARM
+@ RUN: llvm-objdump -d --triple=armv7 %t | FileCheck %s --check-prefix=ARM_ADDEND
+
+@ ARM: R_ARM_LDRS_PC_G0
+@ ARM: foo1
+@ ARM: R_ARM_LDRS_PC_G0
+@ ARM: foo2
+@ ARM: R_ARM_LDRS_PC_G0
+@ ARM: foo3
+
+// Value is decimal at the moment but hex in other cases (things could change)
+@ ARM_ADDEND: r0, [pc, #-
+@ ARM_ADDEND 8]
+@ ARM_ADDEND: r0, [pc, #-
+@ ARM_ADDEND 8]
+@ ARM_ADDEND: r0, [pc, #-
+@ ARM_ADDEND 8]
+
+    .arm
+    .section .text.bar, "ax"
+    .balign 4
+    .global bar
+    .type bar, %function
+bar:
+    ldrh r0, foo1
+    ldrsb r0, foo2
+    ldrsh r0, foo3
+    bx lr
+
+    .section .data.foo, "a", %progbits
+    .balign 4
+    .global foo1
+    .global foo2
+    .global foo3
+foo1:
+foo2:
+foo3:
+    .word 0x11223344, 0x55667788

--- a/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
@@ -12,16 +12,11 @@
 // The value format is decimal in these specific cases, but it's hex for other
 // ldr instructions. These checks are valid for both formats.
 
-@ ARM_ADDEND: r0, [pc, #-
-@ ARM_ADDEND 8]
-@ ARM_ADDEND: r0, [pc, #-
-@ ARM_ADDEND 8]
-@ ARM_ADDEND: r0, [pc, #-
-@ ARM_ADDEND 8]
-@ ARM_ADDEND: r0, [pc, #-
-@ ARM_ADDEND 16]
-@ ARM_ADDEND: r0, [pc, #-
-@ ARM_ADDEND 16]
+@ ARM_ADDEND: r0, [pc, #-{{(0x)?}}8]
+@ ARM_ADDEND: r0, [pc, #-{{(0x)?}}8]
+@ ARM_ADDEND: r0, [pc, #-{{(0x)?}}8]
+@ ARM_ADDEND: r0, [pc, #-{{16|0x10}}]
+@ ARM_ADDEND: r0, [pc, #-{{16|0x10}}]
 @ ARM_ADDEND: r0, [pc]
 
     .arm

--- a/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
@@ -9,7 +9,9 @@
 @ ARM: R_ARM_LDRS_PC_G0
 @ ARM: foo3
 
-// Value is decimal at the moment but hex in other cases (things could change)
+// The value format is decimal in these specific cases, but it's hex for other
+// ldr instructions. These checks are valid for both formats.
+
 @ ARM_ADDEND: r0, [pc, #-
 @ ARM_ADDEND 8]
 @ ARM_ADDEND: r0, [pc, #-

--- a/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-arm-ldr-imm8-relocs.s
@@ -3,11 +3,11 @@
 @ RUN: llvm-objdump -d --triple=armv7 %t | FileCheck %s --check-prefix=ARM_ADDEND
 
 @ ARM: R_ARM_LDRS_PC_G0
-@ ARM: foo1
 @ ARM: R_ARM_LDRS_PC_G0
-@ ARM: foo2
 @ ARM: R_ARM_LDRS_PC_G0
-@ ARM: foo3
+@ ARM: R_ARM_LDRS_PC_G0
+@ ARM: R_ARM_LDRS_PC_G0
+@ ARM: R_ARM_LDRS_PC_G0
 
 // The value format is decimal in these specific cases, but it's hex for other
 // ldr instructions. These checks are valid for both formats.
@@ -18,6 +18,11 @@
 @ ARM_ADDEND 8]
 @ ARM_ADDEND: r0, [pc, #-
 @ ARM_ADDEND 8]
+@ ARM_ADDEND: r0, [pc, #-
+@ ARM_ADDEND 16]
+@ ARM_ADDEND: r0, [pc, #-
+@ ARM_ADDEND 16]
+@ ARM_ADDEND: r0, [pc]
 
     .arm
     .section .text.bar, "ax"
@@ -25,17 +30,18 @@
     .global bar
     .type bar, %function
 bar:
-    ldrh r0, foo1
-    ldrsb r0, foo2
-    ldrsh r0, foo3
+    ldrh r0, foo
+    ldrsb r0, foo
+    ldrsh r0, foo
+    ldrh r0, just_after-8
+    ldrsb r0, just_after-8
+    ldrsh r0, foo+8
     bx lr
 
     .section .data.foo, "a", %progbits
     .balign 4
-    .global foo1
-    .global foo2
-    .global foo3
-foo1:
-foo2:
-foo3:
+    .global foo
+foo:
     .word 0x11223344, 0x55667788
+just_after:
+    .word 0x9900aabb, 0xccddeeff

--- a/llvm/test/MC/ARM/pcrel-global.s
+++ b/llvm/test/MC/ARM/pcrel-global.s
@@ -9,10 +9,9 @@
 @ DISASM-LABEL: <bar>:
 @ DISASM-NEXT:    adr.w   r0, #-4
 @ DISASM-NEXT:    adr.w   r0, #-8
-@ DISASM-NEXT:    ldr.w   pc, [pc, #-0xc]         @ 0x10 <bar>
-@ DISASM-NEXT:    ldr     r0, [pc, #0x0]          @ 0x20 <bar+0x10>
+@ DISASM-NEXT:    ldr     r0, [pc, #0x0]          @ 0x14 <bar+0xc>
 @ DISASM-NEXT:    add     r0, pc
-@ DISASM-NEXT:   .word   0xffffffef
+@ DISASM-NEXT:   .word   0xfffffff3
 @@ GNU assembler creates an R_ARM_REL32 referencing bar.
 @ DISASM-NOT:    {{.}}
 
@@ -20,10 +19,8 @@
 
 .globl foo
 foo:
-ldrd r0, r1, foo @ arm_pcrel_10_unscaled
 vldr d0, foo     @ arm_pcrel_10
 adr r2, foo      @ arm_adr_pcrel_12
-ldr r0, foo      @ arm_ldst_pcrel_12
 
 .thumb
 .thumb_func
@@ -32,7 +29,6 @@ ldr r0, foo      @ arm_ldst_pcrel_12
 bar:
 adr r0, bar      @ thumb_adr_pcrel_10
 adr.w r0, bar    @ t2_adr_pcrel_12
-ldr.w pc, bar    @ t2_ldst_pcrel_12
 
   ldr r0, .LCPI
 .LPC0_1:

--- a/llvm/test/MC/ARM/pcrel-ldr-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-ldr-relocs.s
@@ -6,22 +6,24 @@
 @ RUN: llvm-objdump -d --triple=thumbv7 %t | FileCheck %s --check-prefix=THUMB_ADDEND
 
 @ ARM: R_ARM_LDR_PC_G0
-@ ARM: foo1
 @ ARM: R_ARM_LDR_PC_G0
-@ ARM: foo2
+@ ARM: R_ARM_LDR_PC_G0
+@ ARM: R_ARM_LDR_PC_G0
 
 @ ARM_ADDEND: r0, [pc, #-0x8]
 @ ARM_ADDEND: r0, [pc, #-0x8]
 @ ARM_ADDEND: r0, [pc, #-0x10]
+@ ARM_ADDEND: r0, [pc]
 
 @ THUMB: R_ARM_THM_PC12
-@ THUMB: foo1
 @ THUMB: R_ARM_THM_PC12
-@ THUMB: foo2
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: R_ARM_THM_PC12
 
 @ THUMB_ADDEND: r0, [pc, #-0x4]
 @ THUMB_ADDEND: r0, [pc, #-0x4]
 @ THUMB_ADDEND: r0, [pc, #-0xc]
+@ THUMB_ADDEND: r0, [pc, #0x4]
 
     .section .text.bar, "ax"
     .balign 4
@@ -29,17 +31,16 @@
     .type bar, %function
 bar:
     ldr r0, foo1
-    ldrb r0, foo2
-    ldr r0, foo3-8
+    ldrb r0, foo1
+    ldr r0, foo2-8
+    ldrb r0, foo1+8
     bx lr
 
     .section .data.foo, "a", %progbits
     .balign 4
     .global foo1
     .global foo2
-    .global foo3
 foo1:
-foo2:
     .word 0x11223344, 0x55667788
-foo3:
+foo2:
     .word 0x99aabbcc, 0xddeeff00

--- a/llvm/test/MC/ARM/pcrel-ldr-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-ldr-relocs.s
@@ -1,0 +1,45 @@
+@ RUN: llvm-mc -filetype=obj -triple=armv7 %s -o %t
+@ RUN: llvm-readelf -r %t | FileCheck %s --check-prefix=ARM
+@ RUN: llvm-objdump -d --triple=armv7 %t | FileCheck %s --check-prefix=ARM_ADDEND
+@ RUN: llvm-mc -filetype=obj -triple=thumbv7 %s -o %t
+@ RUN: llvm-readelf -r %t | FileCheck %s --check-prefix=THUMB
+@ RUN: llvm-objdump -d --triple=thumbv7 %t | FileCheck %s --check-prefix=THUMB_ADDEND
+
+@ ARM: R_ARM_LDR_PC_G0
+@ ARM: foo1
+@ ARM: R_ARM_LDR_PC_G0
+@ ARM: foo2
+
+@ ARM_ADDEND: r0, [pc, #-0x8]
+@ ARM_ADDEND: r0, [pc, #-0x8]
+@ ARM_ADDEND: r0, [pc, #-0x10]
+
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: foo1
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: foo2
+
+@ THUMB_ADDEND: r0, [pc, #-0x4]
+@ THUMB_ADDEND: r0, [pc, #-0x4]
+@ THUMB_ADDEND: r0, [pc, #-0xc]
+
+    .section .text.bar, "ax"
+    .balign 4
+    .global bar
+    .type bar, %function
+bar:
+    ldr r0, foo1
+    ldrb r0, foo2
+    ldr r0, foo3-8
+    bx lr
+
+    .section .data.foo, "a", %progbits
+    .balign 4
+    .global foo1
+    .global foo2
+    .global foo3
+foo1:
+foo2:
+    .word 0x11223344, 0x55667788
+foo3:
+    .word 0x99aabbcc, 0xddeeff00

--- a/llvm/test/MC/ARM/pcrel-thumb-ldr2-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-thumb-ldr2-relocs.s
@@ -1,0 +1,36 @@
+@ RUN: llvm-mc -filetype=obj -triple=thumbv7 %s -o %t
+@ RUN: llvm-readelf -r %t | FileCheck %s --check-prefix=THUMB
+@ RUN: llvm-objdump -d --triple=thumbv7 %t | FileCheck %s --check-prefix=THUMB_ADDEND
+
+@ All the ldr variants produce a relocation
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: foo3
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: foo4
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: foo5
+
+@ THUMB_ADDEND: r0, [pc, #-0x4]
+@ THUMB_ADDEND: r0, [pc, #-0x4]
+@ THUMB_ADDEND: r0, [pc, #-0x4]
+
+    .thumb
+    .section .text.bar, "ax"
+    .balign 4
+    .global bar
+    .type bar, %function
+bar:
+    ldrh r0, foo3
+    ldrsb r0, foo4
+    ldrsh r0, foo5
+    bx lr
+
+    .section .data.foo, "a", %progbits
+    .balign 4
+    .global foo3
+    .global foo4
+    .global foo5
+foo3:
+foo4:
+foo5:
+    .word 0x11223344, 0x55667788

--- a/llvm/test/MC/ARM/pcrel-thumb-ldr2-relocs.s
+++ b/llvm/test/MC/ARM/pcrel-thumb-ldr2-relocs.s
@@ -4,15 +4,18 @@
 
 @ All the ldr variants produce a relocation
 @ THUMB: R_ARM_THM_PC12
-@ THUMB: foo3
 @ THUMB: R_ARM_THM_PC12
-@ THUMB: foo4
 @ THUMB: R_ARM_THM_PC12
-@ THUMB: foo5
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: R_ARM_THM_PC12
+@ THUMB: R_ARM_THM_PC12
 
 @ THUMB_ADDEND: r0, [pc, #-0x4]
 @ THUMB_ADDEND: r0, [pc, #-0x4]
 @ THUMB_ADDEND: r0, [pc, #-0x4]
+@ THUMB_ADDEND: r0, [pc, #0x4]
+@ THUMB_ADDEND: r0, [pc, #-0xc]
+@ THUMB_ADDEND: r0, [pc, #0x4]
 
     .thumb
     .section .text.bar, "ax"
@@ -20,17 +23,19 @@
     .global bar
     .type bar, %function
 bar:
-    ldrh r0, foo3
-    ldrsb r0, foo4
-    ldrsh r0, foo5
+    ldrh r0, foo1
+    ldrsb r0, foo1
+    ldrsh r0, foo1
+    ldrh r0, foo1+8
+    ldrsb r0, foo2-8
+    ldrsh r0, foo1+8
     bx lr
 
     .section .data.foo, "a", %progbits
     .balign 4
-    .global foo3
-    .global foo4
-    .global foo5
-foo3:
-foo4:
-foo5:
+    .global foo1
+    .global foo2
+foo1:
     .word 0x11223344, 0x55667788
+foo2:
+    .word 0x9900aabb, 0xccddeeff

--- a/llvm/test/MC/ARM/thumb1-relax-ldrlit.s
+++ b/llvm/test/MC/ARM/thumb1-relax-ldrlit.s
@@ -1,6 +1,5 @@
 @ RUN: not llvm-mc -triple thumbv6m-none-macho -filetype=obj -o /dev/null %s 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
 @ RUN: not llvm-mc -triple thumbv7m-none-macho -filetype=obj -o /dev/null %s 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
-@ RUN: not llvm-mc -triple thumbv7m-none-eabi -filetype=obj -o /dev/null %s 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
 
         .global func1
 _func1:


### PR DESCRIPTION
It's possible (though inadvisable) to use LDR and refer to labels in different
sections. In the Arm state, the assembler resolves the LDR instruction without
emitting a relocation. That's incorrect because the assembler cannot make any
assumptions about the relative position of the sections and the compiler output
is therefore wrong.

This patch ensures relocations are generated for all `LDR <Rt...>, label`
instructions in the Arm state (little endian). This is not necessary when the
label is in the same section but the relocation is now generated regardless.
Instructions that now generate relocations have been removed from the
pcrel-global.s test.

Fortunately, LLD already implements the generated relocations and can fix LDR
instructions when the symbol is in a different section, or report an error if
the offset is too large for the immediate field in the particular LDR's
encoding.

The patch to address this problem for big endian targets will follow, as well
as a fix for ADR that exhibits a similar behavior.
