### PR TITLE
[InstCombine] Add one-use limitation to box multiply fold

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1405,7 +1405,6 @@ static Instruction *foldBoxMultiply(BinaryOperator &I) {
   // ResLo = (CrossSum << HalfBits) + (YLo * XLo)
   Value *XLo, *YLo;
   Value *CrossSum;
-  
   // Require one-use on the multiply to avoid increasing the number of
   // multiplications.
   if (!match(&I, m_c_Add(m_Shl(m_Value(CrossSum), m_SpecificInt(HalfBits)),

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1405,6 +1405,14 @@ static Instruction *foldBoxMultiply(BinaryOperator &I) {
   // ResLo = (CrossSum << HalfBits) + (YLo * XLo)
   Value *XLo, *YLo;
   Value *CrossSum;
+  
+  // Checking the operands of I is used in no more than one place,
+  // which can not be deleted, cause a mul instruction has far more weight than
+  // add and shl instruction in IR, thus this method cannot achieve the goal of
+  // simplifying instructions, just return null.
+  if ((!I.getOperand(0)->hasOneUser() || !I.getOperand(1)->hasOneUser()))
+    return nullptr;
+
   if (!match(&I, m_c_Add(m_Shl(m_Value(CrossSum), m_SpecificInt(HalfBits)),
                          m_Mul(m_Value(YLo), m_Value(XLo)))))
     return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1406,10 +1406,8 @@ static Instruction *foldBoxMultiply(BinaryOperator &I) {
   Value *XLo, *YLo;
   Value *CrossSum;
   
-  // Checking the operands of I is used in no more than one place,
-  // which can not be deleted, cause a mul instruction has far more weight than
-  // add and shl instruction in IR, thus this method cannot achieve the goal of
-  // simplifying instructions, just return null.
+  // Require one-use on the multiply to avoid increasing the number of
+  // multiplications.
   if (!match(&I, m_c_Add(m_Shl(m_Value(CrossSum), m_SpecificInt(HalfBits)),
                          m_OneUse(m_Mul(m_Value(YLo), m_Value(XLo))))))
     return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1410,11 +1410,8 @@ static Instruction *foldBoxMultiply(BinaryOperator &I) {
   // which can not be deleted, cause a mul instruction has far more weight than
   // add and shl instruction in IR, thus this method cannot achieve the goal of
   // simplifying instructions, just return null.
-  if ((!I.getOperand(0)->hasOneUser() || !I.getOperand(1)->hasOneUser()))
-    return nullptr;
-
   if (!match(&I, m_c_Add(m_Shl(m_Value(CrossSum), m_SpecificInt(HalfBits)),
-                         m_Mul(m_Value(YLo), m_Value(XLo)))))
+                         m_OneUse(m_Mul(m_Value(YLo), m_Value(XLo))))))
     return nullptr;
 
   // XLo = X & HalfMask

--- a/llvm/test/Transforms/InstCombine/mul_full_64.ll
+++ b/llvm/test/Transforms/InstCombine/mul_full_64.ll
@@ -177,6 +177,7 @@ define i64 @mul_full_64_variant2(i64 %a, i64 %b, ptr nocapture %rhi) {
   ret i64 %add27
 }
 
+; Negative test case for mul_fold function: MUL7 is used in more than one place
 define i64 @mul_full_64_variant3(i64 %a, i64 %b, ptr nocapture %rhi) {
 ; CHECK-LABEL: @mul_full_64_variant3(
 ; CHECK-NEXT:    [[CONV:%.*]] = and i64 [[A:%.*]], 4294967295
@@ -196,7 +197,9 @@ define i64 @mul_full_64_variant3(i64 %a, i64 %b, ptr nocapture %rhi) {
 ; CHECK-NEXT:    [[SHR_I:%.*]] = lshr i64 [[ADD15]], 32
 ; CHECK-NEXT:    [[ADD17:%.*]] = add i64 [[ADD10]], [[SHR_I]]
 ; CHECK-NEXT:    store i64 [[ADD17]], ptr [[RHI:%.*]], align 8
-; CHECK-NEXT:    [[ADD19:%.*]] = mul i64 [[A]], [[B]]
+; CHECK-NEXT:    [[ADD18:%.*]] = add i64 [[MUL6]], [[MUL5]]
+; CHECK-NEXT:    [[SHL:%.*]] = shl i64 [[ADD18]], 32
+; CHECK-NEXT:    [[ADD19:%.*]] = add i64 [[SHL]], [[MUL7]]
 ; CHECK-NEXT:    ret i64 [[ADD19]]
 ;
   %conv = and i64 %a, 4294967295


### PR DESCRIPTION
Check the operands of I are used in no more than one place, which can not be deleted, cause a mul instruction has far more weight than add and shl instruction in IR, thus this method cannot achieve the goal of simplifying instructions, just return null.