### PR TITLE
[libcxxabi][ItaniumDemangle] Demangle explicitly named object parameters

### DIFF
--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -901,7 +901,9 @@ class ExplicitObjectParameter final : public Node {
 
 public:
   ExplicitObjectParameter(Node *Base_)
-      : Node(KExplicitObjectParameter, Cache::Yes), Base(Base_) {}
+      : Node(KExplicitObjectParameter, Cache::Yes), Base(Base_) {
+    assert(Base != nullptr);
+  }
 
   template <typename Fn> void match(Fn F) const { F(Base); }
 

--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -901,13 +901,16 @@ class ExplicitObjectParameter final : public Node {
 
 public:
   ExplicitObjectParameter(Node *Base_)
-      : Node(KExplicitObjectParameter, Cache::Yes), Base(Base_) {
+      : Node(KExplicitObjectParameter), Base(Base_) {
     assert(Base != nullptr);
   }
 
   template <typename Fn> void match(Fn F) const { F(Base); }
 
-  void printLeft(OutputBuffer &OB) const override { OB += "this "; }
+  void printLeft(OutputBuffer &OB) const override {
+    OB += "this ";
+    Base->print(OB);
+  }
 
   void printRight(OutputBuffer &OB) const override { Base->print(OB); }
 };
@@ -5457,7 +5460,7 @@ Node *AbstractManglingParser<Derived, Alloc>::parseEncoding() {
       if (Ty == nullptr)
         return nullptr;
 
-      const bool IsFirstParam = (Names.size() - ParamsBegin) == 0;
+      const bool IsFirstParam = ParamsBegin == Names.size();
       if (NameInfo.HasExplicitObjectParameter && IsFirstParam)
         Ty = make<ExplicitObjectParameter>(Ty);
 

--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -911,8 +911,6 @@ public:
     OB += "this ";
     Base->print(OB);
   }
-
-  void printRight(OutputBuffer &OB) const override { Base->print(OB); }
 };
 
 class FunctionEncoding final : public Node {

--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -902,7 +902,9 @@ class ExplicitObjectParameter final : public Node {
 public:
   ExplicitObjectParameter(Node *Base_)
       : Node(KExplicitObjectParameter), Base(Base_) {
-    assert(Base != nullptr);
+    DEMANGLE_ASSERT(
+        Base != nullptr,
+        "Creating an ExplicitObjectParameter without a valid Base Node.");
   }
 
   template <typename Fn> void match(Fn F) const { F(Base); }

--- a/libcxxabi/src/demangle/ItaniumNodes.def
+++ b/libcxxabi/src/demangle/ItaniumNodes.def
@@ -99,5 +99,6 @@ NODE(RequiresExpr)
 NODE(ExprRequirement)
 NODE(TypeRequirement)
 NODE(NestedRequirement)
+NODE(ExplicitObjectParameter)
 
 #undef NODE

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -19,7 +19,6 @@
 #include "DemangleConfig.h"
 #include "StringViewExtras.h"
 #include "Utility.h"
-#include <__cxxabi_config.h>
 #include <algorithm>
 #include <cctype>
 #include <cstdio>

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -911,8 +911,6 @@ public:
     OB += "this ";
     Base->print(OB);
   }
-
-  void printRight(OutputBuffer &OB) const override { Base->print(OB); }
 };
 
 class FunctionEncoding final : public Node {

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -902,7 +902,9 @@ class ExplicitObjectParameter final : public Node {
 public:
   ExplicitObjectParameter(Node *Base_)
       : Node(KExplicitObjectParameter), Base(Base_) {
-    assert(Base != nullptr);
+    DEMANGLE_ASSERT(
+        Base != nullptr,
+        "Creating an ExplicitObjectParameter without a valid Base Node.");
   }
 
   template <typename Fn> void match(Fn F) const { F(Base); }

--- a/llvm/include/llvm/Demangle/ItaniumNodes.def
+++ b/llvm/include/llvm/Demangle/ItaniumNodes.def
@@ -99,5 +99,6 @@ NODE(RequiresExpr)
 NODE(ExprRequirement)
 NODE(TypeRequirement)
 NODE(NestedRequirement)
+NODE(ExplicitObjectParameter)
 
 #undef NODE


### PR DESCRIPTION
The mangling for an explicitly named object was introduced in https://reviews.llvm.org/D140828

See following discussion for why a new mangling had to be introduced: https://github.com/itanium-cxx-abi/cxx-abi/issues/148

Since clang started emitting names with the new mangling, this patch implements support for demangling such names.

The approach this patch takes is to add a new `ExplicitObjectParameter` node that will print the first parameter of a function declaration with a `this ` prefix, to reflect what was spelled out in source.

Example:
```
void MyClass::func(this MyClass const& self); // _ZNH7MyClass4funcERKS_
```
With this patch, the above demangles to:
```
_ZNH7MyClass4funcERKS_ -> MyClass::func(this MyClass const&)
```

Note that `func` is not marked as `const &`, since the function-qualifiers are now encoded as part of the explicit `this`. C++ doesn't allow specifying the function-qualifiers in the presence of an explicit object parameter, so this demangling is consistent with the source spelling.