### PR TITLE
[AArch64] Emit ST<OP> instruction when the return value has no use. 

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrAtomics.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrAtomics.td
@@ -525,22 +525,22 @@ def CMP_SWAP_128_MONOTONIC : cmp_swap_128;
 
 // v8.1 Atomic instructions:
 let Predicates = [HasLSE] in {
-  defm : LDOPregister_patterns<"LDADD", "atomic_load_add">;
-  defm : LDOPregister_patterns<"LDSET", "atomic_load_or">;
-  defm : LDOPregister_patterns<"LDEOR", "atomic_load_xor">;
-  defm : LDOPregister_patterns<"LDCLR", "atomic_load_clr">;
-  defm : LDOPregister_patterns<"LDSMAX", "atomic_load_max">;
-  defm : LDOPregister_patterns<"LDSMIN", "atomic_load_min">;
-  defm : LDOPregister_patterns<"LDUMAX", "atomic_load_umax">;
-  defm : LDOPregister_patterns<"LDUMIN", "atomic_load_umin">;
-  defm : LDOPregister_patterns<"SWP", "atomic_swap">;
+  defm : STLDOPregister_patterns<"ADD", "atomic_load_add">;
+  defm : STLDOPregister_patterns<"SET", "atomic_load_or">;
+  defm : STLDOPregister_patterns<"EOR", "atomic_load_xor">;
+  defm : STLDOPregister_patterns<"CLR", "atomic_load_clr">;
+  defm : STLDOPregister_patterns<"SMAX", "atomic_load_max">;
+  defm : STLDOPregister_patterns<"SMIN", "atomic_load_min">;
+  defm : STLDOPregister_patterns<"UMAX", "atomic_load_umax">;
+  defm : STLDOPregister_patterns<"UMIN", "atomic_load_umin">;
+  defm : SWPregister_patterns<"SWP", "atomic_swap">;
   defm : CASregister_patterns<"CAS", "atomic_cmp_swap">;
 
   // These two patterns are only needed for global isel, selection dag isel
   // converts atomic load-sub into a sub and atomic load-add, and likewise for
   // and -> clr.
-  defm : LDOPregister_patterns_mod<"LDADD", "atomic_load_sub", "SUB">;
-  defm : LDOPregister_patterns_mod<"LDCLR", "atomic_load_and", "ORN">;
+  defm : LDOPregister_patterns_mod<"ADD", "atomic_load_sub", "SUB">;
+  defm : LDOPregister_patterns_mod<"CLR", "atomic_load_and", "ORN">;
 }
 
 // v8.9a/v9.4a FEAT_LRCPC patterns

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -11737,10 +11737,36 @@ multiclass Swap<bits<1> Acq, bits<1> Rel, string order> {
   let Sz = 0b11, Acq = Acq, Rel = Rel in def X : BaseSWP<order, "", GPR64>;
 }
 
+let Predicates = [HasLSE] in
+multiclass SWPpatterns<string inst, string suffix, string op, string size, dag SrcRHS, dag DstRHS> {
+  def : Pat<(!cast<PatFrag>(op#"_"#size#"_monotonic") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(inst # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#size#"_acquire") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(inst # "A" # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#size#"_release") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(inst # "L" # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#size#"_acq_rel") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(inst # "AL" # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#size#"_seq_cst") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(inst # "AL" # suffix) DstRHS, GPR64sp:$Rn)>;
+}
+
+multiclass SWPregister_patterns_ord<string inst, string suffix, string op,
+                                     string size, dag RHS> {
+  defm : SWPpatterns<inst, suffix, op, size, RHS, RHS>;
+}
+
+multiclass SWPregister_patterns<string inst, string op> {
+  defm : SWPregister_patterns_ord<inst, "X", op, "64", (i64 GPR64:$Rm)>;
+  defm : SWPregister_patterns_ord<inst, "W", op, "32", (i32 GPR32:$Rm)>;
+  defm : SWPregister_patterns_ord<inst, "H", op, "16", (i32 GPR32:$Rm)>;
+  defm : SWPregister_patterns_ord<inst, "B", op, "8",  (i32 GPR32:$Rm)>;
+}
+
+
 let Predicates = [HasLSE], mayLoad = 1, mayStore = 1, hasSideEffects = 1 in
-class BaseLDOPregister<string op, string order, string size, RegisterClass RC>
-      : I<(outs RC:$Rt),(ins RC:$Rs, GPR64sp:$Rn), "ld" # op # order # size,
-          "\t$Rs, $Rt, [$Rn]","",[]>,
+class BaseSTLDOPregister<string op, string order, string size, RegisterClass RC, string prefix, string operand>
+      : I<(outs RC:$Rt),(ins RC:$Rs, GPR64sp:$Rn), !strconcat(prefix, op, order, size), operand,"",[]>,
         Sched<[WriteAtomic]> {
   bits<2> Sz;
   bit Acq;
@@ -11763,38 +11789,80 @@ class BaseLDOPregister<string op, string order, string size, RegisterClass RC>
   let Predicates = [HasLSE];
 }
 
-multiclass LDOPregister<bits<3> opc, string op, bits<1> Acq, bits<1> Rel,
+
+multiclass STOPregister<bits<3> opc, string op, bits<1> Acq, bits<1> Rel, string order> {
+  let Rt = 0b11111, Acq = Acq, Rel = Rel, opc = opc in {
+    let Sz = 0b00 in def B : BaseSTLDOPregister<op, order, "b", GPR32, "st", "\t$Rs, [$Rn]">;
+    let Sz = 0b01 in def H : BaseSTLDOPregister<op, order, "h", GPR32, "st", "\t$Rs, [$Rn]">;
+    let Sz = 0b10 in def W : BaseSTLDOPregister<op, order, "", GPR32, "st", "\t$Rs, [$Rn]">;
+    let Sz = 0b11 in def X : BaseSTLDOPregister<op, order, "", GPR64, "st", "\t$Rs, [$Rn]">;
+  }
+}
+
+multiclass LDOPregister<bits<3> opc, string op, bits<1> Acq, bits<1> Rel, string order> {
+  let Acq = Acq, Rel = Rel, opc = opc in {
+    let Sz = 0b00 in def B : BaseSTLDOPregister<op, order, "b", GPR32, "ld", "\t$Rs, $Rt, [$Rn]">;
+    let Sz = 0b01 in def H : BaseSTLDOPregister<op, order, "h", GPR32, "ld", "\t$Rs, $Rt, [$Rn]">;
+    let Sz = 0b10 in def W : BaseSTLDOPregister<op, order, "", GPR32, "ld", "\t$Rs, $Rt, [$Rn]">;
+    let Sz = 0b11 in def X : BaseSTLDOPregister<op, order, "", GPR64, "ld", "\t$Rs, $Rt, [$Rn]">;
+  }
+}
+
+multiclass STLDOPregister<bits<3> opc, string op, bits<1> Acq, bits<1> Rel,
                         string order> {
-  let Sz = 0b00, Acq = Acq, Rel = Rel, opc = opc in
-    def B : BaseLDOPregister<op, order, "b", GPR32>;
-  let Sz = 0b01, Acq = Acq, Rel = Rel, opc = opc in
-    def H : BaseLDOPregister<op, order, "h", GPR32>;
-  let Sz = 0b10, Acq = Acq, Rel = Rel, opc = opc in
-    def W : BaseLDOPregister<op, order, "", GPR32>;
-  let Sz = 0b11, Acq = Acq, Rel = Rel, opc = opc in
-    def X : BaseLDOPregister<op, order, "", GPR64>;
+  defm "LD"#NAME : LDOPregister<opc, op, Acq, Rel, order>;
+  defm "ST"#NAME : STOPregister<opc, op, Acq, Rel, order>;
+}
+
+multiclass binary_atomic_op_noret<SDNode atomic_op> {
+  defm "_ret" : binary_atomic_op<atomic_op>;
+  let HasNoUse = true in
+  defm "_noret"  : binary_atomic_op<atomic_op>;
+}
+
+defm atomic_load_add : binary_atomic_op_noret<atomic_load_add>;
+defm atomic_load_and : binary_atomic_op_noret<atomic_load_and>;
+defm atomic_load_max : binary_atomic_op_noret<atomic_load_max>;
+defm atomic_load_min : binary_atomic_op_noret<atomic_load_min>;
+defm atomic_load_clr : binary_atomic_op_noret<atomic_load_clr>;
+defm atomic_load_or : binary_atomic_op_noret<atomic_load_or>;
+defm atomic_load_sub : binary_atomic_op_noret<atomic_load_sub>;
+defm atomic_load_umax : binary_atomic_op_noret<atomic_load_umax>;
+defm atomic_load_umin : binary_atomic_op_noret<atomic_load_umin>;
+defm atomic_load_xor : binary_atomic_op_noret<atomic_load_xor>;
+
+let Predicates = [HasLSE] in
+multiclass STLDpatterns<string inst, string prefix, string suffix, string op, string ret,
+                                         string size, dag SrcRHS, dag DstRHS> {
+  def : Pat<(!cast<PatFrag>(op#"_"#ret#"_"#size#"_monotonic") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(prefix # inst # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#ret#"_"#size#"_acquire") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(prefix # inst # "A" # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#ret#"_"#size#"_release") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(prefix # inst # "L" # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#ret#"_"#size#"_acq_rel") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(prefix # inst # "AL" # suffix) DstRHS, GPR64sp:$Rn)>;
+  def : Pat<(!cast<PatFrag>(op#"_"#ret#"_"#size#"_seq_cst") GPR64sp:$Rn, SrcRHS),
+              (!cast<Instruction>(prefix # inst # "AL" # suffix) DstRHS, GPR64sp:$Rn)>;
 }
 
 // Differing SrcRHS and DstRHS allow you to cover CLR & SUB by giving a more
 // complex DAG for DstRHS.
-let Predicates = [HasLSE] in
-multiclass LDOPregister_patterns_ord_dag<string inst, string suffix, string op,
+multiclass STLDOPregister_patterns_ord_dag<string inst, string suffix, string op,
                                          string size, dag SrcRHS, dag DstRHS> {
-  def : Pat<(!cast<PatFrag>(op#"_"#size#"_monotonic") GPR64sp:$Rn, SrcRHS),
-            (!cast<Instruction>(inst # suffix) DstRHS, GPR64sp:$Rn)>;
-  def : Pat<(!cast<PatFrag>(op#"_"#size#"_acquire") GPR64sp:$Rn, SrcRHS),
-            (!cast<Instruction>(inst # "A" # suffix) DstRHS, GPR64sp:$Rn)>;
-  def : Pat<(!cast<PatFrag>(op#"_"#size#"_release") GPR64sp:$Rn, SrcRHS),
-            (!cast<Instruction>(inst # "L" # suffix) DstRHS, GPR64sp:$Rn)>;
-  def : Pat<(!cast<PatFrag>(op#"_"#size#"_acq_rel") GPR64sp:$Rn, SrcRHS),
-            (!cast<Instruction>(inst # "AL" # suffix) DstRHS, GPR64sp:$Rn)>;
-  def : Pat<(!cast<PatFrag>(op#"_"#size#"_seq_cst") GPR64sp:$Rn, SrcRHS),
-            (!cast<Instruction>(inst # "AL" # suffix) DstRHS, GPR64sp:$Rn)>;
+
+  defm : STLDpatterns<inst, "ST", suffix, op, "noret", size, SrcRHS, DstRHS>;
+  defm : STLDpatterns<inst, "LD", suffix, op, "ret", size, SrcRHS, DstRHS>;
 }
 
-multiclass LDOPregister_patterns_ord<string inst, string suffix, string op,
+multiclass LDOPregister_patterns_ord_dag<string inst, string suffix, string op,
+                                         string size, dag SrcRHS, dag DstRHS> {
+  defm : STLDpatterns<inst, "LD", suffix, op, "ret", size, SrcRHS, DstRHS>;
+}
+
+multiclass STLDOPregister_patterns_ord<string inst, string suffix, string op,
                                      string size, dag RHS> {
-  defm : LDOPregister_patterns_ord_dag<inst, suffix, op, size, RHS, RHS>;
+  defm : STLDOPregister_patterns_ord_dag<inst, suffix, op, size, RHS, RHS>;
 }
 
 multiclass LDOPregister_patterns_ord_mod<string inst, string suffix, string op,
@@ -11802,11 +11870,11 @@ multiclass LDOPregister_patterns_ord_mod<string inst, string suffix, string op,
   defm : LDOPregister_patterns_ord_dag<inst, suffix, op, size, LHS, RHS>;
 }
 
-multiclass LDOPregister_patterns<string inst, string op> {
-  defm : LDOPregister_patterns_ord<inst, "X", op, "64", (i64 GPR64:$Rm)>;
-  defm : LDOPregister_patterns_ord<inst, "W", op, "32", (i32 GPR32:$Rm)>;
-  defm : LDOPregister_patterns_ord<inst, "H", op, "16", (i32 GPR32:$Rm)>;
-  defm : LDOPregister_patterns_ord<inst, "B", op, "8",  (i32 GPR32:$Rm)>;
+multiclass STLDOPregister_patterns<string inst, string op> {
+  defm : STLDOPregister_patterns_ord<inst, "X", op, "64", (i64 GPR64:$Rm)>;
+  defm : STLDOPregister_patterns_ord<inst, "W", op, "32", (i32 GPR32:$Rm)>;
+  defm : STLDOPregister_patterns_ord<inst, "H", op, "16", (i32 GPR32:$Rm)>;
+  defm : STLDOPregister_patterns_ord<inst, "B", op, "8",  (i32 GPR32:$Rm)>;
 }
 
 multiclass LDOPregister_patterns_mod<string inst, string op, string mod> {
@@ -11853,30 +11921,6 @@ multiclass CASregister_patterns<string inst, string op> {
                         (i32 GPR32:$Rold), (i32 GPR32:$Rnew)>;
   defm : CASregister_patterns_ord<inst, "B", op, "8",
                         (i32 GPR32:$Rold), (i32 GPR32:$Rnew)>;
-}
-
-let Predicates = [HasLSE] in
-class BaseSTOPregister<string asm, RegisterClass OP, Register Reg,
-                        Instruction inst> :
-      InstAlias<asm # "\t$Rs, [$Rn]", (inst Reg, OP:$Rs, GPR64sp:$Rn)>;
-
-multiclass STOPregister<string asm, string instr> {
-  def : BaseSTOPregister<asm # "lb", GPR32, WZR,
-                    !cast<Instruction>(instr # "LB")>;
-  def : BaseSTOPregister<asm # "lh", GPR32, WZR,
-                    !cast<Instruction>(instr # "LH")>;
-  def : BaseSTOPregister<asm # "l",  GPR32, WZR,
-                    !cast<Instruction>(instr # "LW")>;
-  def : BaseSTOPregister<asm # "l",  GPR64, XZR,
-                    !cast<Instruction>(instr # "LX")>;
-  def : BaseSTOPregister<asm # "b",  GPR32, WZR,
-                    !cast<Instruction>(instr # "B")>;
-  def : BaseSTOPregister<asm # "h",  GPR32, WZR,
-                    !cast<Instruction>(instr # "H")>;
-  def : BaseSTOPregister<asm,        GPR32, WZR,
-                    !cast<Instruction>(instr # "W")>;
-  def : BaseSTOPregister<asm,        GPR64, XZR,
-                    !cast<Instruction>(instr # "X")>;
 }
 
 class LoadStore64B_base<bits<3> opc, string asm_inst, string asm_ops,

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -2188,56 +2188,46 @@ defm SWPA  : Swap<1, 0, "a">;
 defm SWPL  : Swap<0, 1, "l">;
 defm SWPAL : Swap<1, 1, "al">;
 
-// v8.1 atomic LD<OP>(register). Performs load and then ST<OP>(register)
-defm LDADD   : LDOPregister<0b000, "add", 0, 0, "">;
-defm LDADDA  : LDOPregister<0b000, "add", 1, 0, "a">;
-defm LDADDL  : LDOPregister<0b000, "add", 0, 1, "l">;
-defm LDADDAL : LDOPregister<0b000, "add", 1, 1, "al">;
+// v8.1 atomic (ST|LD)<OP>(register).
+defm ADD   : STLDOPregister<0b000, "add", 0, 0, "">;
+defm ADDA  : STLDOPregister<0b000, "add", 1, 0, "a">;
+defm ADDL  : STLDOPregister<0b000, "add", 0, 1, "l">;
+defm ADDAL : STLDOPregister<0b000, "add", 1, 1, "al">;
 
-defm LDCLR   : LDOPregister<0b001, "clr", 0, 0, "">;
-defm LDCLRA  : LDOPregister<0b001, "clr", 1, 0, "a">;
-defm LDCLRL  : LDOPregister<0b001, "clr", 0, 1, "l">;
-defm LDCLRAL : LDOPregister<0b001, "clr", 1, 1, "al">;
+defm CLR   : STLDOPregister<0b001, "clr", 0, 0, "">;
+defm CLRA  : STLDOPregister<0b001, "clr", 1, 0, "a">;
+defm CLRL  : STLDOPregister<0b001, "clr", 0, 1, "l">;
+defm CLRAL : STLDOPregister<0b001, "clr", 1, 1, "al">;
 
-defm LDEOR   : LDOPregister<0b010, "eor", 0, 0, "">;
-defm LDEORA  : LDOPregister<0b010, "eor", 1, 0, "a">;
-defm LDEORL  : LDOPregister<0b010, "eor", 0, 1, "l">;
-defm LDEORAL : LDOPregister<0b010, "eor", 1, 1, "al">;
+defm EOR   : STLDOPregister<0b010, "eor", 0, 0, "">;
+defm EORA  : STLDOPregister<0b010, "eor", 1, 0, "a">;
+defm EORL  : STLDOPregister<0b010, "eor", 0, 1, "l">;
+defm EORAL : STLDOPregister<0b010, "eor", 1, 1, "al">;
 
-defm LDSET   : LDOPregister<0b011, "set", 0, 0, "">;
-defm LDSETA  : LDOPregister<0b011, "set", 1, 0, "a">;
-defm LDSETL  : LDOPregister<0b011, "set", 0, 1, "l">;
-defm LDSETAL : LDOPregister<0b011, "set", 1, 1, "al">;
+defm SET   : STLDOPregister<0b011, "set", 0, 0, "">;
+defm SETA  : STLDOPregister<0b011, "set", 1, 0, "a">;
+defm SETL  : STLDOPregister<0b011, "set", 0, 1, "l">;
+defm SETAL : STLDOPregister<0b011, "set", 1, 1, "al">;
 
-defm LDSMAX   : LDOPregister<0b100, "smax", 0, 0, "">;
-defm LDSMAXA  : LDOPregister<0b100, "smax", 1, 0, "a">;
-defm LDSMAXL  : LDOPregister<0b100, "smax", 0, 1, "l">;
-defm LDSMAXAL : LDOPregister<0b100, "smax", 1, 1, "al">;
+defm SMAX   : STLDOPregister<0b100, "smax", 0, 0, "">;
+defm SMAXA  : STLDOPregister<0b100, "smax", 1, 0, "a">;
+defm SMAXL  : STLDOPregister<0b100, "smax", 0, 1, "l">;
+defm SMAXAL : STLDOPregister<0b100, "smax", 1, 1, "al">;
 
-defm LDSMIN   : LDOPregister<0b101, "smin", 0, 0, "">;
-defm LDSMINA  : LDOPregister<0b101, "smin", 1, 0, "a">;
-defm LDSMINL  : LDOPregister<0b101, "smin", 0, 1, "l">;
-defm LDSMINAL : LDOPregister<0b101, "smin", 1, 1, "al">;
+defm SMIN   : STLDOPregister<0b101, "smin", 0, 0, "">;
+defm SMINA  : STLDOPregister<0b101, "smin", 1, 0, "a">;
+defm SMINL  : STLDOPregister<0b101, "smin", 0, 1, "l">;
+defm SMINAL : STLDOPregister<0b101, "smin", 1, 1, "al">;
 
-defm LDUMAX   : LDOPregister<0b110, "umax", 0, 0, "">;
-defm LDUMAXA  : LDOPregister<0b110, "umax", 1, 0, "a">;
-defm LDUMAXL  : LDOPregister<0b110, "umax", 0, 1, "l">;
-defm LDUMAXAL : LDOPregister<0b110, "umax", 1, 1, "al">;
+defm UMAX   : STLDOPregister<0b110, "umax", 0, 0, "">;
+defm UMAXA  : STLDOPregister<0b110, "umax", 1, 0, "a">;
+defm UMAXL  : STLDOPregister<0b110, "umax", 0, 1, "l">;
+defm UMAXAL : STLDOPregister<0b110, "umax", 1, 1, "al">;
 
-defm LDUMIN   : LDOPregister<0b111, "umin", 0, 0, "">;
-defm LDUMINA  : LDOPregister<0b111, "umin", 1, 0, "a">;
-defm LDUMINL  : LDOPregister<0b111, "umin", 0, 1, "l">;
-defm LDUMINAL : LDOPregister<0b111, "umin", 1, 1, "al">;
-
-// v8.1 atomic ST<OP>(register) as aliases to "LD<OP>(register) when Rt=xZR"
-defm : STOPregister<"stadd","LDADD">; // STADDx
-defm : STOPregister<"stclr","LDCLR">; // STCLRx
-defm : STOPregister<"steor","LDEOR">; // STEORx
-defm : STOPregister<"stset","LDSET">; // STSETx
-defm : STOPregister<"stsmax","LDSMAX">;// STSMAXx
-defm : STOPregister<"stsmin","LDSMIN">;// STSMINx
-defm : STOPregister<"stumax","LDUMAX">;// STUMAXx
-defm : STOPregister<"stumin","LDUMIN">;// STUMINx
+defm UMIN   : STLDOPregister<0b111, "umin", 0, 0, "">;
+defm UMINA  : STLDOPregister<0b111, "umin", 1, 0, "a">;
+defm UMINL  : STLDOPregister<0b111, "umin", 0, 1, "l">;
+defm UMINAL : STLDOPregister<0b111, "umin", 1, 1, "al">;
 
 // v8.5 Memory Tagging Extension
 let Predicates = [HasMTE] in {

--- a/llvm/test/CodeGen/AArch64/atomic-ops-lse.ll
+++ b/llvm/test/CodeGen/AArch64/atomic-ops-lse.ll
@@ -114,7 +114,7 @@ define dso_local void @test_atomic_load_add_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -134,7 +134,7 @@ define dso_local void @test_atomic_load_add_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -238,7 +238,7 @@ define dso_local void @test_atomic_load_or_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsetal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsetal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -258,7 +258,7 @@ define dso_local void @test_atomic_load_or_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsetal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsetal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -362,7 +362,7 @@ define dso_local void @test_atomic_load_xor_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldeoral w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steoral w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -382,7 +382,7 @@ define dso_local void @test_atomic_load_xor_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldeoral x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steoral x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -517,7 +517,7 @@ define dso_local void @test_atomic_load_min_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsminal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -542,7 +542,7 @@ define dso_local void @test_atomic_load_min_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsminal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -677,7 +677,7 @@ define dso_local void @test_atomic_load_umin_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: lduminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stuminal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -702,7 +702,7 @@ define dso_local void @test_atomic_load_umin_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: lduminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stuminal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -837,7 +837,7 @@ define dso_local void @test_atomic_load_max_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -862,7 +862,7 @@ define dso_local void @test_atomic_load_max_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -997,7 +997,7 @@ define dso_local void @test_atomic_load_umax_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -1022,7 +1022,7 @@ define dso_local void @test_atomic_load_umax_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -1499,7 +1499,7 @@ define dso_local void @test_atomic_load_sub_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddal w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal w[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -1522,7 +1522,7 @@ define dso_local void @test_atomic_load_sub_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddal x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal x[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -1977,7 +1977,7 @@ define dso_local void @test_atomic_load_and_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldclral w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclral w[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -1999,7 +1999,7 @@ define dso_local void @test_atomic_load_and_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldclral x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclral x[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2103,7 +2103,7 @@ define dso_local void @test_atomic_load_add_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2123,7 +2123,7 @@ define dso_local void @test_atomic_load_add_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2227,7 +2227,7 @@ define dso_local void @test_atomic_load_add_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldadda w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stadda w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2247,7 +2247,7 @@ define dso_local void @test_atomic_load_add_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldadda x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stadda x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2351,7 +2351,7 @@ define dso_local void @test_atomic_load_add_i32_noret_monotonic(i32 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldadd w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stadd w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2371,7 +2371,7 @@ define dso_local void @test_atomic_load_add_i64_noret_monotonic(i64 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldadd x{{[0-9]}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stadd x{{[0-9]}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2475,7 +2475,7 @@ define dso_local void @test_atomic_load_add_i32_noret_release(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddl w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: staddl w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2495,7 +2495,7 @@ define dso_local void @test_atomic_load_add_i64_noret_release(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddl x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: staddl x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2599,7 +2599,7 @@ define dso_local void @test_atomic_load_add_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2619,7 +2619,7 @@ define dso_local void @test_atomic_load_add_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2729,7 +2729,7 @@ define dso_local void @test_atomic_load_and_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldclral w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclral w[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2751,7 +2751,7 @@ define dso_local void @test_atomic_load_and_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldclral x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclral x[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2861,7 +2861,7 @@ define dso_local void @test_atomic_load_and_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldclra w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclra w[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2883,7 +2883,7 @@ define dso_local void @test_atomic_load_and_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldclra x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclra x[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2993,7 +2993,7 @@ define dso_local void @test_atomic_load_and_i32_noret_monotonic(i32 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldclr w{{[0-9]+}}, w[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: stclr w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3015,7 +3015,7 @@ define dso_local void @test_atomic_load_and_i64_noret_monotonic(i64 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldclr x{{[0-9]+}}, x[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: stclr x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3125,7 +3125,7 @@ define dso_local void @test_atomic_load_and_i32_noret_release(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldclrl w{{[0-9]*}}, w[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: stclrl w{{[0-9]*}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3147,7 +3147,7 @@ define dso_local void @test_atomic_load_and_i64_noret_release(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldclrl x{{[0-9]*}}, x[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: stclrl x{{[0-9]*}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3257,7 +3257,7 @@ define dso_local void @test_atomic_load_and_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldclral w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclral w[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3279,7 +3279,7 @@ define dso_local void @test_atomic_load_and_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldclral x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stclral x[[NOT]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3805,7 +3805,7 @@ define dso_local void @test_atomic_load_max_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3830,7 +3830,7 @@ define dso_local void @test_atomic_load_max_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3965,7 +3965,7 @@ define dso_local void @test_atomic_load_max_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmaxa w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxa w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3990,7 +3990,7 @@ define dso_local void @test_atomic_load_max_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmaxa x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxa x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4125,7 +4125,7 @@ define dso_local void @test_atomic_load_max_i32_noret_monotonic(i32 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmax w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsmax w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4150,7 +4150,7 @@ define dso_local void @test_atomic_load_max_i64_noret_monotonic(i64 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmax x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsmax x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4285,7 +4285,7 @@ define dso_local void @test_atomic_load_max_i32_noret_release(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmaxl w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsmaxl w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4310,7 +4310,7 @@ define dso_local void @test_atomic_load_max_i64_noret_release(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmaxl x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsmaxl x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4445,7 +4445,7 @@ define dso_local void @test_atomic_load_max_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4470,7 +4470,7 @@ define dso_local void @test_atomic_load_max_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmaxal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4605,7 +4605,7 @@ define dso_local void @test_atomic_load_min_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsminal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4630,7 +4630,7 @@ define dso_local void @test_atomic_load_min_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsminal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4765,7 +4765,7 @@ define dso_local void @test_atomic_load_min_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmina w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmina w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4790,7 +4790,7 @@ define dso_local void @test_atomic_load_min_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmina x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsmina x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4925,7 +4925,7 @@ define dso_local void @test_atomic_load_min_i32_noret_monotonic(i32 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsmin w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsmin w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4950,7 +4950,7 @@ define dso_local void @test_atomic_load_min_i64_noret_monotonic(i64 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsmin x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsmin x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5085,7 +5085,7 @@ define dso_local void @test_atomic_load_min_i32_noret_release(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsminl w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsminl w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5110,7 +5110,7 @@ define dso_local void @test_atomic_load_min_i64_noret_release(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsminl x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsminl x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5245,7 +5245,7 @@ define dso_local void @test_atomic_load_min_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsminal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5270,7 +5270,7 @@ define dso_local void @test_atomic_load_min_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsminal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5374,7 +5374,7 @@ define dso_local void @test_atomic_load_or_i32_noret_acq_rel(i32 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsetal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsetal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5394,7 +5394,7 @@ define dso_local void @test_atomic_load_or_i64_noret_acq_rel(i64 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsetal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsetal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5498,7 +5498,7 @@ define dso_local void @test_atomic_load_or_i32_noret_acquire(i32 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldseta w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stseta w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5518,7 +5518,7 @@ define dso_local void @test_atomic_load_or_i64_noret_acquire(i64 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldseta x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stseta x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5622,7 +5622,7 @@ define dso_local void @test_atomic_load_or_i32_noret_monotonic(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldset w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stset w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5642,7 +5642,7 @@ define dso_local void @test_atomic_load_or_i64_noret_monotonic(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldset x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stset x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5746,7 +5746,7 @@ define dso_local void @test_atomic_load_or_i32_noret_release(i32 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsetl w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsetl w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5766,7 +5766,7 @@ define dso_local void @test_atomic_load_or_i64_noret_release(i64 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsetl x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stsetl x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5870,7 +5870,7 @@ define dso_local void @test_atomic_load_or_i32_noret_seq_cst(i32 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldsetal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsetal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5890,7 +5890,7 @@ define dso_local void @test_atomic_load_or_i64_noret_seq_cst(i64 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldsetal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stsetal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -6004,7 +6004,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddal w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal w[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6027,7 +6027,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddal x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal x[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6142,7 +6142,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldadda w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stadda w[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6165,7 +6165,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldadda x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stadda x[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6280,7 +6280,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_monotonic(i32 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldadd w{{[0-9]+}}, w[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: stadd w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6303,7 +6303,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_monotonic(i64 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldadd x{{[0-9]+}}, x[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: stadd x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6418,7 +6418,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_release(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddl w{{[0-9]*}}, w[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: staddl w{{[0-9]*}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6441,7 +6441,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_release(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddl x{{[0-9]*}}, x[[NEW:[1-9][0-9]*]], [x[[ADDR]]]
+; CHECK: staddl x{{[0-9]*}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6556,7 +6556,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldaddal w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal w[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6579,7 +6579,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldaddal x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: staddal x[[NEG]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -7345,7 +7345,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_acq_rel(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7370,7 +7370,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_acq_rel(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7505,7 +7505,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_acquire(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumaxa w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxa w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7530,7 +7530,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_acquire(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumaxa x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxa x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7665,7 +7665,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_monotonic(i32 %offset) no
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumax w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stumax w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7690,7 +7690,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_monotonic(i64 %offset) no
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumax x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stumax x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7825,7 +7825,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_release(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumaxl w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stumaxl w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7850,7 +7850,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_release(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumaxl x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stumaxl x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7985,7 +7985,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_seq_cst(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8010,7 +8010,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_seq_cst(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumaxal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8145,7 +8145,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_acq_rel(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: lduminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stuminal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8170,7 +8170,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_acq_rel(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: lduminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stuminal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8305,7 +8305,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_acquire(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumina w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumina w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8330,7 +8330,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_acquire(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumina x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stumina x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8465,7 +8465,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_monotonic(i32 %offset) no
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldumin w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stumin w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8490,7 +8490,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_monotonic(i64 %offset) no
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldumin x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stumin x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8625,7 +8625,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_release(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: lduminl w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stuminl w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8650,7 +8650,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_release(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: lduminl x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: stuminl x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8785,7 +8785,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_seq_cst(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: lduminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stuminal w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8810,7 +8810,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_seq_cst(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: lduminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: stuminal x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8914,7 +8914,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldeoral w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steoral w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8934,7 +8934,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldeoral x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steoral x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9038,7 +9038,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldeora w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steora w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9058,7 +9058,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldeora x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steora x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9162,7 +9162,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_monotonic(i32 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldeor w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: steor w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9182,7 +9182,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_monotonic(i64 %offset) nou
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldeor x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: steor x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9286,7 +9286,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_release(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldeorl w{{[0-9]+}}, w{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: steorl w{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9306,7 +9306,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_release(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldeorl x{{[0-9]+}}, x{{[1-9][0-9]*}}, [x[[ADDR]]]
+; CHECK: steorl x{{[0-9]+}}, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9410,7 +9410,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: ldeoral w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steoral w0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9430,7 +9430,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: ldeoral x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
+; CHECK: steoral x0, [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }

--- a/llvm/test/CodeGen/AArch64/atomic-ops-lse.ll
+++ b/llvm/test/CodeGen/AArch64/atomic-ops-lse.ll
@@ -114,7 +114,7 @@ define dso_local void @test_atomic_load_add_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: staddal w0, [x[[ADDR]]]
+; CHECK: ldaddal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -134,7 +134,7 @@ define dso_local void @test_atomic_load_add_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: staddal x0, [x[[ADDR]]]
+; CHECK: ldaddal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -238,7 +238,7 @@ define dso_local void @test_atomic_load_or_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsetal w0, [x[[ADDR]]]
+; CHECK: ldsetal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -258,7 +258,7 @@ define dso_local void @test_atomic_load_or_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsetal x0, [x[[ADDR]]]
+; CHECK: ldsetal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -362,7 +362,7 @@ define dso_local void @test_atomic_load_xor_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: steoral w0, [x[[ADDR]]]
+; CHECK: ldeoral w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -382,7 +382,7 @@ define dso_local void @test_atomic_load_xor_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: steoral x0, [x[[ADDR]]]
+; CHECK: ldeoral x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -517,7 +517,7 @@ define dso_local void @test_atomic_load_min_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsminal w0, [x[[ADDR]]]
+; CHECK: ldsminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -542,7 +542,7 @@ define dso_local void @test_atomic_load_min_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsminal x0, [x[[ADDR]]]
+; CHECK: ldsminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -677,7 +677,7 @@ define dso_local void @test_atomic_load_umin_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stuminal w0, [x[[ADDR]]]
+; CHECK: lduminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -702,7 +702,7 @@ define dso_local void @test_atomic_load_umin_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stuminal x0, [x[[ADDR]]]
+; CHECK: lduminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -837,7 +837,7 @@ define dso_local void @test_atomic_load_max_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsmaxal w0, [x[[ADDR]]]
+; CHECK: ldsmaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -862,7 +862,7 @@ define dso_local void @test_atomic_load_max_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsmaxal x0, [x[[ADDR]]]
+; CHECK: ldsmaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -997,7 +997,7 @@ define dso_local void @test_atomic_load_umax_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stumaxal w0, [x[[ADDR]]]
+; CHECK: ldumaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -1022,7 +1022,7 @@ define dso_local void @test_atomic_load_umax_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stumaxal x0, [x[[ADDR]]]
+; CHECK: ldumaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -1499,7 +1499,7 @@ define dso_local void @test_atomic_load_sub_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: staddal w[[NEG]], [x[[ADDR]]]
+; CHECK: ldaddal w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -1522,7 +1522,7 @@ define dso_local void @test_atomic_load_sub_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: staddal x[[NEG]], [x[[ADDR]]]
+; CHECK: ldaddal x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -1977,7 +1977,7 @@ define dso_local void @test_atomic_load_and_i32_noret(i32 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stclral w[[NOT]], [x[[ADDR]]]
+; CHECK: ldclral w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -1999,7 +1999,7 @@ define dso_local void @test_atomic_load_and_i64_noret(i64 %offset) nounwind {
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stclral x[[NOT]], [x[[ADDR]]]
+; CHECK: ldclral x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2103,7 +2103,7 @@ define dso_local void @test_atomic_load_add_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: staddal w0, [x[[ADDR]]]
+; CHECK: ldaddal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2123,7 +2123,7 @@ define dso_local void @test_atomic_load_add_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: staddal x0, [x[[ADDR]]]
+; CHECK: ldaddal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2227,7 +2227,7 @@ define dso_local void @test_atomic_load_add_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stadda w0, [x[[ADDR]]]
+; CHECK: ldadda w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2247,7 +2247,7 @@ define dso_local void @test_atomic_load_add_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stadda x0, [x[[ADDR]]]
+; CHECK: ldadda x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2619,7 +2619,7 @@ define dso_local void @test_atomic_load_add_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: staddal x0, [x[[ADDR]]]
+; CHECK: ldaddal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2729,7 +2729,7 @@ define dso_local void @test_atomic_load_and_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stclral w[[NOT]], [x[[ADDR]]]
+; CHECK: ldclral w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2751,7 +2751,7 @@ define dso_local void @test_atomic_load_and_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stclral x[[NOT]], [x[[ADDR]]]
+; CHECK: ldclral x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2861,7 +2861,7 @@ define dso_local void @test_atomic_load_and_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stclra w[[NOT]], [x[[ADDR]]]
+; CHECK: ldclra w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -2883,7 +2883,7 @@ define dso_local void @test_atomic_load_and_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stclra x[[NOT]], [x[[ADDR]]]
+; CHECK: ldclra x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3257,7 +3257,7 @@ define dso_local void @test_atomic_load_and_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stclral w[[NOT]], [x[[ADDR]]]
+; CHECK: ldclral w[[NOT]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3279,7 +3279,7 @@ define dso_local void @test_atomic_load_and_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stclral x[[NOT]], [x[[ADDR]]]
+; CHECK: ldclral x[[NOT]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3805,7 +3805,7 @@ define dso_local void @test_atomic_load_max_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsmaxal w0, [x[[ADDR]]]
+; CHECK: ldsmaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3830,7 +3830,7 @@ define dso_local void @test_atomic_load_max_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsmaxal x0, [x[[ADDR]]]
+; CHECK: ldsmaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3965,7 +3965,7 @@ define dso_local void @test_atomic_load_max_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsmaxa w0, [x[[ADDR]]]
+; CHECK: ldsmaxa w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -3990,7 +3990,7 @@ define dso_local void @test_atomic_load_max_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsmaxa x0, [x[[ADDR]]]
+; CHECK: ldsmaxa x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4445,7 +4445,7 @@ define dso_local void @test_atomic_load_max_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsmaxal w0, [x[[ADDR]]]
+; CHECK: ldsmaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4470,7 +4470,7 @@ define dso_local void @test_atomic_load_max_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsmaxal x0, [x[[ADDR]]]
+; CHECK: ldsmaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4605,7 +4605,7 @@ define dso_local void @test_atomic_load_min_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsminal w0, [x[[ADDR]]]
+; CHECK: ldsminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4630,7 +4630,7 @@ define dso_local void @test_atomic_load_min_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsminal x0, [x[[ADDR]]]
+; CHECK: ldsminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4765,7 +4765,7 @@ define dso_local void @test_atomic_load_min_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsmina w0, [x[[ADDR]]]
+; CHECK: ldsmina w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -4790,7 +4790,7 @@ define dso_local void @test_atomic_load_min_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsmina x0, [x[[ADDR]]]
+; CHECK: ldsmina x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5245,7 +5245,7 @@ define dso_local void @test_atomic_load_min_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsminal w0, [x[[ADDR]]]
+; CHECK: ldsminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5270,7 +5270,7 @@ define dso_local void @test_atomic_load_min_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsminal x0, [x[[ADDR]]]
+; CHECK: ldsminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5374,7 +5374,7 @@ define dso_local void @test_atomic_load_or_i32_noret_acq_rel(i32 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsetal w0, [x[[ADDR]]]
+; CHECK: ldsetal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5394,7 +5394,7 @@ define dso_local void @test_atomic_load_or_i64_noret_acq_rel(i64 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsetal x0, [x[[ADDR]]]
+; CHECK: ldsetal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5498,7 +5498,7 @@ define dso_local void @test_atomic_load_or_i32_noret_acquire(i32 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stseta w0, [x[[ADDR]]]
+; CHECK: ldseta w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5518,7 +5518,7 @@ define dso_local void @test_atomic_load_or_i64_noret_acquire(i64 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stseta x0, [x[[ADDR]]]
+; CHECK: ldseta x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5870,7 +5870,7 @@ define dso_local void @test_atomic_load_or_i32_noret_seq_cst(i32 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stsetal w0, [x[[ADDR]]]
+; CHECK: ldsetal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -5890,7 +5890,7 @@ define dso_local void @test_atomic_load_or_i64_noret_seq_cst(i64 %offset) nounwi
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stsetal x0, [x[[ADDR]]]
+; CHECK: ldsetal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -6004,7 +6004,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: staddal w[[NEG]], [x[[ADDR]]]
+; CHECK: ldaddal w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6027,7 +6027,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: staddal x[[NEG]], [x[[ADDR]]]
+; CHECK: ldaddal x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6142,7 +6142,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stadda w[[NEG]], [x[[ADDR]]]
+; CHECK: ldadda w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6165,7 +6165,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stadda x[[NEG]], [x[[ADDR]]]
+; CHECK: ldadda x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6556,7 +6556,7 @@ define dso_local void @test_atomic_load_sub_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: staddal w[[NEG]], [x[[ADDR]]]
+; CHECK: ldaddal w[[NEG]], w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -6579,7 +6579,7 @@ define dso_local void @test_atomic_load_sub_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: staddal x[[NEG]], [x[[ADDR]]]
+; CHECK: ldaddal x[[NEG]], x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
 
   ret void
@@ -7345,7 +7345,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_acq_rel(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stumaxal w0, [x[[ADDR]]]
+; CHECK: ldumaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7370,7 +7370,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_acq_rel(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stumaxal x0, [x[[ADDR]]]
+; CHECK: ldumaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7505,7 +7505,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_acquire(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stumaxa w0, [x[[ADDR]]]
+; CHECK: ldumaxa w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7530,7 +7530,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_acquire(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stumaxa x0, [x[[ADDR]]]
+; CHECK: ldumaxa x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -7985,7 +7985,7 @@ define dso_local void @test_atomic_load_umax_i32_noret_seq_cst(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stumaxal w0, [x[[ADDR]]]
+; CHECK: ldumaxal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8010,7 +8010,7 @@ define dso_local void @test_atomic_load_umax_i64_noret_seq_cst(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stumaxal x0, [x[[ADDR]]]
+; CHECK: ldumaxal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8145,7 +8145,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_acq_rel(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stuminal w0, [x[[ADDR]]]
+; CHECK: lduminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8170,7 +8170,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_acq_rel(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stuminal x0, [x[[ADDR]]]
+; CHECK: lduminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8305,7 +8305,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_acquire(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stumina w0, [x[[ADDR]]]
+; CHECK: ldumina w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8330,7 +8330,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_acquire(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stumina x0, [x[[ADDR]]]
+; CHECK: ldumina x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8785,7 +8785,7 @@ define dso_local void @test_atomic_load_umin_i32_noret_seq_cst(i32 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: stuminal w0, [x[[ADDR]]]
+; CHECK: lduminal w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8810,7 +8810,7 @@ define dso_local void @test_atomic_load_umin_i64_noret_seq_cst(i64 %offset) noun
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: stuminal x0, [x[[ADDR]]]
+; CHECK: lduminal x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8914,7 +8914,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_acq_rel(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: steoral w0, [x[[ADDR]]]
+; CHECK: ldeoral w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -8934,7 +8934,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_acq_rel(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: steoral x0, [x[[ADDR]]]
+; CHECK: ldeoral x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9038,7 +9038,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_acquire(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: steora w0, [x[[ADDR]]]
+; CHECK: ldeora w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9058,7 +9058,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_acquire(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: steora x0, [x[[ADDR]]]
+; CHECK: ldeora x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9410,7 +9410,7 @@ define dso_local void @test_atomic_load_xor_i32_noret_seq_cst(i32 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var32
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var32
 
-; CHECK: steoral w0, [x[[ADDR]]]
+; CHECK: ldeoral w0, w[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }
@@ -9430,7 +9430,7 @@ define dso_local void @test_atomic_load_xor_i64_noret_seq_cst(i64 %offset) nounw
 ; CHECK: adrp [[TMPADDR:x[0-9]+]], var64
 ; CHECK: add x[[ADDR:[0-9]+]], [[TMPADDR]], {{#?}}:lo12:var64
 
-; CHECK: steoral x0, [x[[ADDR]]]
+; CHECK: ldeoral x0, x[[NEW:[0-9]+]], [x[[ADDR]]]
 ; CHECK-NOT: dmb
   ret void
 }


### PR DESCRIPTION
This PR fixed #69503. 

The original implementation consider `ST<OP>` as `InstAlias` of `LD<OP>`, however this method could not cover the case in the #69503. 

This PR instead create a new pattern match, utilizing the `HasNoUse` field of the`PatFrags`