### PR TITLE
Fix command escape bug in lldb-dap

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -731,7 +731,7 @@ class DebugCommunication(object):
         postRunCommands=None,
         enableAutoVariableSummaries=False,
         enableSyntheticChildDebugging=False,
-        commandEscapePrefix="`",
+        commandEscapePrefix=None,
         customFrameFormat=None,
         customThreadFormat=None,
     ):

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -354,7 +354,7 @@ class DAPTestCaseBase(TestBase):
         postRunCommands=None,
         enableAutoVariableSummaries=False,
         enableSyntheticChildDebugging=False,
-        commandEscapePrefix="`",
+        commandEscapePrefix=None,
         customFrameFormat=None,
         customThreadFormat=None,
     ):
@@ -434,7 +434,7 @@ class DAPTestCaseBase(TestBase):
         lldbDAPEnv=None,
         enableAutoVariableSummaries=False,
         enableSyntheticChildDebugging=False,
-        commandEscapePrefix="`",
+        commandEscapePrefix=None,
         customFrameFormat=None,
         customThreadFormat=None,
     ):

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -57,7 +57,7 @@ llvm::StringRef GetString(const llvm::json::Object *obj, llvm::StringRef key,
                           llvm::StringRef defaultValue) {
   if (obj == nullptr)
     return defaultValue;
-  return GetString(*obj, key);
+  return GetString(*obj, key, defaultValue);
 }
 
 // Gets an unsigned integer from a JSON object using the key, or returns the


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/69238 caused breakage in VSCode debug console usage -- the user's input is always treated as commands instead of expressions (the same behavior as if empty command escape prefix is specified). 

The bug is in one overload of `GetString()` which did not respect the default value of "\`". But more important, I am puzzled to find out why the regression is not caught by lldb test (testdap_evaluate). Turns out https://github.com/llvm/llvm-project/pull/69238 specifies commandEscapePrefix default value in test framework to be "\`" while VSCode will default not specify any commandEscapePrefix at all. Changing it to None will fail `testdap_evaluate`. We should align the default behavior between DAP client and testcase. 

This patches fixes the bug in `GetString()` and changed the default value of commandEscapePrefix in testcases to be None (be consistent with IDE). 