### PR TITLE
[flang] Move internal Fortran::ISO namespace out of user-facing ISO_F…

### DIFF
--- a/flang/include/flang/ISO_Fortran_binding.h
+++ b/flang/include/flang/ISO_Fortran_binding.h
@@ -10,7 +10,14 @@
 #ifndef CFI_ISO_FORTRAN_BINDING_H_
 #define CFI_ISO_FORTRAN_BINDING_H_
 
+/* When this header is included into the compiler and runtime implementations,
+ * it does so by means of a wrapper header that establishes namespaces and
+ * a macro for extra function attributes (RT_API_ATTRS).
+ */
+#ifndef FORTRAN_ISO_FORTRAN_BINDING_WRAPPER_H_
 #include <stddef.h>
+#define FORTRAN_ISO_NAMESPACE_
+#endif
 
 /* Standard interface to Fortran from C and C++.
  * These interfaces are named in subclause 18.5 of the Fortran 2018
@@ -20,12 +27,6 @@
 
 #ifndef RT_API_ATTRS
 #define RT_API_ATTRS
-#endif
-
-#ifdef __cplusplus
-namespace Fortran {
-namespace ISO {
-inline namespace Fortran_2018 {
 #endif
 
 /* 18.5.4 */
@@ -169,7 +170,8 @@ template <int r> struct CdescStorage : public CFI_cdesc_t {
 template <> struct CdescStorage<1> : public CFI_cdesc_t {};
 template <> struct CdescStorage<0> : public CFI_cdesc_t {};
 } // namespace cfi_internal
-#define CFI_CDESC_T(rank) ::Fortran::ISO::cfi_internal::CdescStorage<rank>
+#define CFI_CDESC_T(rank) \
+  FORTRAN_ISO_NAMESPACE_::cfi_internal::CdescStorage<rank>
 #else
 #define CFI_CDESC_T(_RANK) \
   struct { \
@@ -199,9 +201,6 @@ RT_API_ATTRS int CFI_setpointer(
     CFI_cdesc_t *, const CFI_cdesc_t *source, const CFI_index_t lower_bounds[]);
 #ifdef __cplusplus
 } // extern "C"
-} // inline namespace Fortran_2018
-} // namespace ISO
-} // namespace Fortran
 #endif
 
 #endif /* CFI_ISO_FORTRAN_BINDING_H_ */

--- a/flang/include/flang/ISO_Fortran_binding_wrapper.h
+++ b/flang/include/flang/ISO_Fortran_binding_wrapper.h
@@ -22,8 +22,18 @@
  */
 
 /* clang-format off */
+#include <stddef.h>
 #include "Runtime/api-attrs.h"
+#ifdef __cplusplus
+namespace Fortran {
+namespace ISO {
+#define FORTRAN_ISO_NAMESPACE_ ::Fortran::ISO
+#endif /* __cplusplus */
 #include "ISO_Fortran_binding.h"
+#ifdef __cplusplus
+} // namespace ISO
+} // namespace Fortran
+#endif /* __cplusplus */
 /* clang-format on */
 
 #endif /* FORTRAN_ISO_FORTRAN_BINDING_WRAPPER_H_ */

--- a/flang/lib/Optimizer/CodeGen/DescriptorModel.h
+++ b/flang/lib/Optimizer/CodeGen/DescriptorModel.h
@@ -113,7 +113,7 @@ getModel<Fortran::ISO::cfi_internal::FlexibleArray<Fortran::ISO::CFI_dim_t>>() {
 /// Get the type model of the field number `Field` in an ISO CFI descriptor.
 template <int Field>
 static constexpr TypeBuilderFunc getDescFieldTypeModel() {
-  Fortran::ISO::Fortran_2018::CFI_cdesc_t dummyDesc{};
+  Fortran::ISO::CFI_cdesc_t dummyDesc{};
   // check that the descriptor is exactly 8 fields as specified in CFI_cdesc_t
   // in flang/include/flang/ISO_Fortran_binding.h.
   auto [a, b, c, d, e, f, g, h] = dummyDesc;


### PR DESCRIPTION
…ortran_binding.h

... and into the ISO_Fortran_binding_wrapper.h header, through which the compiler and runtime access its contents.  This change ensures that user code that #includes ISO_Fortran_binding.h within 'extern "C" {' doesn't encounter mysterious namespace errors.