### PR TITLE
Remove `__cdecl` from _ReturnAddress

### DIFF
--- a/compiler-rt/include/sanitizer/common_interface_defs.h
+++ b/compiler-rt/include/sanitizer/common_interface_defs.h
@@ -293,7 +293,7 @@ void SANITIZER_CDECL __sanitizer_symbolize_global(void *data_ptr,
 #define __sanitizer_return_address()                                           \
   __builtin_extract_return_addr(__builtin_return_address(0))
 #else
-void *SANITIZER_CDECL _ReturnAddress(void);
+void *_ReturnAddress(void);
 #pragma intrinsic(_ReturnAddress)
 #define __sanitizer_return_address() _ReturnAddress()
 #endif

--- a/compiler-rt/test/asan/TestCases/Windows/msvc/gz.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/msvc/gz.cpp
@@ -1,0 +1,15 @@
+// Make sure that ASan works with non-cdecl default calling conventions.
+// Many x86 projects pass `/Gz` to their compiles, so that __stdcall is the default,
+// but LLVM is built with __cdecl.
+//
+// RUN: %clang_cl_asan -Gz %Od %s %Fe%t
+
+// includes a declaration of `_ReturnAddress`
+#include <intrin.h>
+
+#include <sanitizer/asan_interface.h>
+
+int main() {
+  __alignas(8) char buffer[8];
+  __asan_poison_memory_region(buffer, sizeof buffer);
+}

--- a/compiler-rt/test/asan/TestCases/Windows/msvc/gz.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/msvc/gz.cpp
@@ -10,6 +10,6 @@
 #include <sanitizer/asan_interface.h>
 
 int main() {
-  __alignas(8) char buffer[8];
+  alignas(8) char buffer[8];
   __asan_poison_memory_region(buffer, sizeof buffer);
 }


### PR DESCRIPTION
As an intrinsic, `_ReturnAddress` does not need it; additionally,
if someone else declares `_ReturnAddress` without `__cdecl` (for
example, `<intrin.h>`)

Additionally, actually add a test for this change. I've tested it locally with both LLVM and MSVC.