### PR TITLE
[llvm] Specialize 'NoCFIValue::getType()'

### DIFF
--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -975,6 +975,11 @@ public:
     return cast<GlobalValue>(Op<0>().get());
   }
 
+  /// NoCFIValue is always a pointer.
+  inline PointerType *getType() const {
+    return cast<PointerType>(Value::getType());
+  }
+
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const Value *V) {
     return V->getValueID() == NoCFIValueVal;

--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -976,7 +976,7 @@ public:
   }
 
   /// NoCFIValue is always a pointer.
-  inline PointerType *getType() const {
+  PointerType *getType() const {
     return cast<PointerType>(Value::getType());
   }
 


### PR DESCRIPTION
Specialize `NoCFIValue::getType()` to give a more detailed type hint to clients.