### PR TITLE
[clang] Fix lit test failure caused by https://github.com/llvm/llvm-project/pull/70762

### DIFF
--- a/clang/test/Sema/code_align.c
+++ b/clang/test/Sema/code_align.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify=expected,c-local -x c %s
-// RUN: %clang_cc1 -fsyntax-only -verify=expected,cpp-local -pedantic -x c++ -std=c++11 %s
+// RUN: %clang_cc1 -triple=x86_64-unknown-linux -fsyntax-only -verify=expected,c-local -x c %s
+// RUN: %clang_cc1 -triple=x86_64-unknown-linux -fsyntax-only -verify=expected,cpp-local -pedantic -x c++ -std=c++11 %s
 
 void foo() {
   int i;
@@ -75,7 +75,7 @@ void foo1(int A)
   [[clang::code_align(9223372036854775808)]]
   for(int I=0; I<256; ++I) { bar(I); }
 
-  // cpp-local-error@+1{{'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was (__int128_t)1311768467294899680ULL << 64}}
+  // expected-error@+1{{'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was (__int128_t)1311768467294899680ULL << 64}}
   [[clang::code_align((__int128_t)0x1234567890abcde0ULL << 64)]]
   for(int I=0; I<256; ++I) { bar(I); }
 
@@ -85,6 +85,7 @@ void foo1(int A)
 
   // cpp-local-error@+3{{expression is not an integral constant expression}}
   // cpp-local-note@+2{{left shift of negative value -1311768467294899680}}
+  // c-local-error@+1{{'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was -(__int128_t)1311768467294899680ULL << 64}}
   [[clang::code_align(-(__int128_t)0x1234567890abcde0ULL << 64)]]
   for(int I=0; I<256; ++I) { bar(I); }
 

--- a/clang/test/Sema/code_align.c
+++ b/clang/test/Sema/code_align.c
@@ -75,7 +75,7 @@ void foo1(int A)
   [[clang::code_align(9223372036854775808)]]
   for(int I=0; I<256; ++I) { bar(I); }
 
-  // expected-error@+1{{'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was (__int128_t)1311768467294899680ULL << 64}}
+  // cpp-local-error@+1{{'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was (__int128_t)1311768467294899680ULL << 64}}
   [[clang::code_align((__int128_t)0x1234567890abcde0ULL << 64)]]
   for(int I=0; I<256; ++I) { bar(I); }
 
@@ -85,7 +85,6 @@ void foo1(int A)
 
   // cpp-local-error@+3{{expression is not an integral constant expression}}
   // cpp-local-note@+2{{left shift of negative value -1311768467294899680}}
-  // c-local-error@+1{{'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was -(__int128_t)1311768467294899680ULL << 64}}
   [[clang::code_align(-(__int128_t)0x1234567890abcde0ULL << 64)]]
   for(int I=0; I<256; ++I) { bar(I); }
 
@@ -127,7 +126,7 @@ void code_align_dependent() {
   [[clang::code_align(A)]] // OK
   for(int I=0; I<128; ++I) { bar(I); }
 
-  [[clang::code_align(A)]] // expected-note{{previous attribute is here}}
+  [[clang::code_align(A)]] // cpp-local-note{{previous attribute is here}}
   [[clang::code_align(E)]] // cpp-local-error{{conflicting loop attribute 'code_align'}}
   for(int I=0; I<128; ++I) { bar(I); }
 
@@ -143,7 +142,7 @@ void code_align_dependent() {
 
 template<int ITMPL>
 void bar3() {
-  [[clang::code_align(8)]]      // expected-note{{previous attribute is here}}
+  [[clang::code_align(8)]]      // cpp-local-note{{previous attribute is here}}
   [[clang::code_align(ITMPL)]] // cpp-local-error{{conflicting loop attribute 'code_align'}} \
 	                       // cpp-local-note@#temp-instantiation{{in instantiation of function template specialization 'bar3<4>' requested here}}
   for(int I=0; I<128; ++I) { bar(I); }
@@ -151,7 +150,7 @@ void bar3() {
 
 template<int ITMPL1>
 void bar4() {
-  [[clang::code_align(ITMPL1)]] // expected-note{{previous attribute is here}}
+  [[clang::code_align(ITMPL1)]] // cpp-local-note{{previous attribute is here}}
   [[clang::code_align(32)]]    // cpp-local-error{{conflicting loop attribute 'code_align'}} \
 	                       // cpp-local-note@#temp-instantiation1{{in instantiation of function template specialization 'bar4<64>' requested here}}
   for(int I=0; I<128; ++I) { bar(I); }

--- a/clang/test/Sema/code_align.c
+++ b/clang/test/Sema/code_align.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple=x86_64-unknown-linux -fsyntax-only -verify=expected,c-local -x c %s
-// RUN: %clang_cc1 -triple=x86_64-unknown-linux -fsyntax-only -verify=expected,cpp-local -pedantic -x c++ -std=c++11 %s
+// RUN: %clang_cc1 -triple x86_64-pc-linux -fsyntax-only -verify=expected,c-local -x c %s
+// RUN: %clang_cc1 -triple x86_64-pc-linux -fsyntax-only -verify=expected,cpp-local -pedantic -x c++ -std=c++11 %s
 
 void foo() {
   int i;


### PR DESCRIPTION
Lit test generates different outputs for usage of __int128_t in clang-armv8-quick environment. This patch adds triple to fix the lit failure.

```
Step 5 (ninja check 1) failure: 1 unexpected failures 38623 expected passes 71 expected failures 36752 unsupported tests (failure)
******************** TEST 'Clang :: Sema/code_align.c' FAILED ******************** Exit Code: 1

Command Output (stderr):
--
RUN: at line 1: /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/bin/clang -cc1 -internal-isystem /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/lib/clang/18/include -nostdsysteminc -fsyntax-only -verify=expected,c-local -x c /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code_align.c
+ /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/bin/clang -cc1 
+ -internal-isystem 
+ /home/tcwg-buildbot/worker/clang-armv8-quick/stage1/lib/clang/18/inclu
+ de -nostdsysteminc -fsyntax-only -verify=expected,c-local -x c 
+ /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code
+ _align.c
error: 'c-local-error' diagnostics expected but not seen: 
  File /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code_align.c Line 79 (directive at /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code_align.c:78): 'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was (__int128_t)1311768467294899680ULL << 64
  File /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code_align.c Line 89 (directive at /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code_align.c:88): 'code_align' attribute requires an integer argument which is a constant power of two between 1 and 4096 inclusive; provided argument was -(__int128_t)1311768467294899680ULL << 64
error: 'c-local-error' diagnostics seen but not expected: 
  File /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code_align.c Line 79: use of undeclared identifier '__int128_t'
  File /home/tcwg-buildbot/worker/clang-armv8-quick/llvm/clang/test/Sema/code_align.c Line 89: use of undeclared identifier '__int128_t'
4 errors generated.

```