### PR TITLE
[LoongArch][MC] Support to get the FixupKind for BL

### DIFF
--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCCodeEmitter.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCCodeEmitter.cpp
@@ -259,6 +259,7 @@ LoongArchMCCodeEmitter::getExprOpValue(const MCInst &MI, const MCOperand &MO,
       FixupKind = LoongArch::fixup_loongarch_b21;
       break;
     case LoongArch::B:
+    case LoongArch::BL:
       FixupKind = LoongArch::fixup_loongarch_b26;
       break;
     }

--- a/llvm/test/CodeGen/LoongArch/test_bl_fixupkind.mir
+++ b/llvm/test/CodeGen/LoongArch/test_bl_fixupkind.mir
@@ -1,14 +1,10 @@
-## Tagged as "Expectedly Failed" until the following patch fix it
-# XFAIL: *
 # RUN: llc --mtriple=loongarch64 --filetype=obj %s -o - | \
 # RUN: llvm-objdump -d - | FileCheck %s
 
 # REQUIRES: asserts
 
-## Check that bl can get fixupkind correctly.
-## When BL has target-flags(loongarch-call), there is no error. But without
-## this flag, an assertion error will appear:
-## Assertion `FixupKind != LoongArch::fixup_loongarch_invalid && "Unhandled expression!"' failed.
+## Check that bl can get fixupkind correctly, whether BL contains
+## target-flags(loongarch-call) or not.
 
 --- |
   target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"


### PR DESCRIPTION
Previously, bolt could not get FixupKind for BL correctly, because bolt cannot get target-flags for BL. Here just add support in MCCodeEmitter.

Fixes https://github.com/llvm/llvm-project/pull/72826.