### PR TITLE
[libc++abi] Introduce LIBCXXABI_ENABLE_DEMANGLER

### DIFF
--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -40,6 +40,9 @@ include(CMakeDependentOption)
 include(HandleCompilerRT)
 
 # Define options.
+option(LIBCXXABI_ENABLE_DEMANGLER
+  "Provide support for demangling in the runtime.
+   When disabled, libc++abi does not support the name demangler API." ON)
 option(LIBCXXABI_ENABLE_EXCEPTIONS
   "Provide support for exceptions in the runtime.
   When disabled, libc++abi does not support stack unwinding and other exceptions-related features." ON)
@@ -385,7 +388,7 @@ if (LIBCXXABI_SILENT_TERMINATE)
   add_definitions(-DLIBCXXABI_SILENT_TERMINATE)
 endif()
 
-if (LIBCXXABI_NON_DEMANGLING_TERMINATE)
+if (LIBCXXABI_NON_DEMANGLING_TERMINATE OR NOT LIBCXXABI_ENABLE_DEMANGLER)
   add_definitions(-DLIBCXXABI_NON_DEMANGLING_TERMINATE)
 endif()
 

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -3,7 +3,6 @@ set(LIBCXXABI_SOURCES
   # C++ABI files
   cxa_aux_runtime.cpp
   cxa_default_handlers.cpp
-  cxa_demangle.cpp
   cxa_exception_storage.cpp
   cxa_guard.cpp
   cxa_handlers.cpp
@@ -18,6 +17,12 @@ set(LIBCXXABI_SOURCES
   fallback_malloc.cpp
   private_typeinfo.cpp
 )
+
+if (LIBCXXABI_ENABLE_DEMANGLER)
+  list(APPEND LIBCXXABI_SOURCES
+    cxa_demangle.cpp
+  )
+endif()
 
 if (LIBCXXABI_ENABLE_NEW_DELETE_DEFINITIONS)
   list(APPEND LIBCXXABI_SOURCES


### PR DESCRIPTION
This change introduces a `LIBCXXABI_ENABLE_DEMANGLER` CMake option that allows turning off the demangler API from being included in the build. This can be useful when trying to build a minimal version of libc++abi, e.g., for a baremetal target. The demangler is quite heavy in dependencies on libraries that are not easily available on such a target, and is not an essential component.