### PR TITLE
[runtimes] Add missing test dependencies to check-all

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1249,6 +1249,7 @@ if( LLVM_INCLUDE_TESTS )
   add_custom_target(test-depends
       DEPENDS ${LLVM_ALL_LIT_DEPENDS} ${LLVM_ALL_ADDITIONAL_TEST_DEPENDS})
   set_target_properties(test-depends PROPERTIES FOLDER "Tests")
+  add_dependencies(check-all test-depends)
 endif()
 
 if (LLVM_INCLUDE_DOCS)


### PR DESCRIPTION
The test-depends target contained all the dependencies needed to run the runtimes tests, but it was never added as a dependency of check-all. This caused some of the tsan tests to fail, since the custom libcxx build the tests were looking for was never built.  Besides the tsan failures, this fixes all the other test failures I was seeing with:
cmake -G Ninja -B release-build -S llvm \
        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
        -DCMAKE_BUILD_TYPE=Release \
        -DLLVM_ENABLE_ASSERTIONS=OFF \
        -DLLVM_ENABLE_PROJECTS="clang;lld" \
        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;compiler-rt"

This is the same configuration the test-release.sh script uses, so I'm hoping this will also fix all the test failures we've been seeing when building the releases.

Fixes #58680