### PR TITLE
[Driver] Default Generic_GCC aarch64_be to -fasynchronous-unwind-tables

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2937,6 +2937,7 @@ ToolChain::UnwindTableLevel
 Generic_GCC::getDefaultUnwindTableLevel(const ArgList &Args) const {
   switch (getArch()) {
   case llvm::Triple::aarch64:
+  case llvm::Triple::aarch64_be:
   case llvm::Triple::ppc:
   case llvm::Triple::ppcle:
   case llvm::Triple::ppc64:

--- a/clang/test/Driver/aarch64-features.c
+++ b/clang/test/Driver/aarch64-features.c
@@ -1,4 +1,5 @@
 // RUN: %clang --target=aarch64-none-linux-gnu -### %s -fsyntax-only 2>&1 | FileCheck %s
+// RUN: %clang --target=aarch64_be-none-linux-gnu -### %s -fsyntax-only 2>&1 | FileCheck %s
 // RUN: %clang --target=arm64-none-linux-gnu -### %s -fsyntax-only 2>&1 | FileCheck %s
 
 // CHECK: "-funwind-tables=2"


### PR DESCRIPTION
This patch defaults Generic_GCC aarch64_be to use -fasynchronous-unwind-tables and ensures consistent behavior with aarch64 little endian.