### PR TITLE
[LLD] [COFF] Don't preserve unnecessary __imp_ prefixed symbols

### DIFF
--- a/lld/test/COFF/lto-imp-prefix.ll
+++ b/lld/test/COFF/lto-imp-prefix.ll
@@ -8,13 +8,9 @@
 
 ; RUN: lld-link /entry:entry %t.main.obj %t.other1.obj /out:%t1.exe /subsystem:console /debug:symtab
 
-;; The current implementation for handling __imp_ symbols retains all of them.
-;; Observe that this currently produces __imp_unusedFunc even if nothing
-;; references unusedFunc in any form.
-
+;; Check that we don't retain __imp_ prefixed symbols we don't need.
 ; RUN: llvm-nm %t1.exe | FileCheck %s
-
-; CHECK: __imp_unusedFunc
+; CHECK-NOT: __imp_unusedFunc
 
 ; RUN: lld-link /entry:entry %t.main.obj %t.other2.obj /out:%t2.exe /subsystem:console
 


### PR DESCRIPTION
This redoes the fix from 3ab6209a3f93bdbeec8e9b9fcc00a9a4980915ff differently, without the unwanted effect of preserving unnecessary `__imp_` prefixed symbols.

If the referencing object is a regular object, the `__imp_` symbol will have `isUsedInRegularObj` set on it from that already. If the referencing object is an LTO object, we set `isUsedInRegularObj` for any symbol starting with `__imp_`.

If the object file defining the `__imp_` symbol is a regular object, the `isUsedInRegularObj` flag has no effect. If it is an LTO object, it causes the symbol to be preserved.