### PR TITLE
[FIX] Fix the function 'isctype' failed in arm64-be

### DIFF
--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -372,7 +372,7 @@ public:
 #else
     static const mask __regex_word = 1<<10;
 #endif // defined(__BIONIC__)
-#elif defined(__GLIBC__)
+#elif defined(__GLIBC__) || defined(__BIG_ENDIAN__)
     typedef unsigned short mask;
     static const mask space  = _ISspace;
     static const mask print  = _ISprint;


### PR DESCRIPTION
The function `isctype` fails in arm64-be while it succeeds in arm64-le. This is because the function does not use the big endian and small endian modes to distinguish the value of __regex_word.