### PR TITLE
[BasicAA] Don't use MinAbsVarIndex = 1.

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1230,9 +1230,6 @@ AliasResult BasicAAResult::aliasGEP(
     const VariableGEPIndex &Var = DecompGEP1.VarIndices[0];
     if (Var.Val.TruncBits == 0 &&
         isKnownNonZero(Var.Val.V, DL, 0, &AC, Var.CxtI, DT)) {
-      // If V != 0, then abs(VarIndex) > 0.
-      MinAbsVarIndex = APInt(Var.Scale.getBitWidth(), 1);
-
       // Check if abs(V*Scale) >= abs(Scale) holds in the presence of
       // potentially wrapping math.
       auto MultiplyByScaleNoWrap = [](const VariableGEPIndex &Var) {

--- a/llvm/test/Analysis/BasicAA/gep-modulo.ll
+++ b/llvm/test/Analysis/BasicAA/gep-modulo.ll
@@ -362,7 +362,6 @@ define i8 @mul_nsw_var_nonzero_minabsvarindex_one_index(ptr %arr, i8 %x, i64 %v)
   ret i8 %l
 }
 
-; FIXME: %gep and %p can alias.
 define i8 @test_pr72831_may_wrap(i64 %off) {
 ; CHECK-LABEL: Function: test_pr72831_may_wrap: 2 pointers, 0 call sites
 ; CHECK-NEXT:  MayAlias:    i8* %gep, i8* %p

--- a/llvm/test/Analysis/BasicAA/gep-modulo.ll
+++ b/llvm/test/Analysis/BasicAA/gep-modulo.ll
@@ -326,7 +326,7 @@ define i8 @mul_may_overflow_var_nonzero_minabsvarindex_one_index(ptr %arr, i8 %x
 ; CHECK-NEXT:  PartialAlias (off 917): [2000 x i8]* %arr, i8* %gep.917
 ; CHECK-NEXT:  MayAlias: i8* %gep.917, i8* %gep.idx
 ; CHECK-NEXT:  MustAlias: [2000 x i8]* %arr, i8* %gep.0
-; CHECK-NEXT:  NoAlias: i8* %gep.0, i8* %gep.idx
+; CHECK-NEXT:  MayAlias: i8* %gep.0, i8* %gep.idx
 ; CHECK-NEXT:  NoAlias: i8* %gep.0, i8* %gep.917
 ;
   load [2000 x i8], ptr %arr
@@ -365,7 +365,7 @@ define i8 @mul_nsw_var_nonzero_minabsvarindex_one_index(ptr %arr, i8 %x, i64 %v)
 ; FIXME: %gep and %p can alias.
 define i8 @test_pr72831_may_wrap(i64 %off) {
 ; CHECK-LABEL: Function: test_pr72831_may_wrap: 2 pointers, 0 call sites
-; CHECK-NEXT:  NoAlias:    i8* %gep, i8* %p
+; CHECK-NEXT:  MayAlias:    i8* %gep, i8* %p
 entry:
   %p = alloca [2 x i8], align 1
   %ext = zext i1 false to i64


### PR DESCRIPTION
The current code incorrectly assumed that the absolute variable index needs to be at least 1, if the variable is != 0. This is incorrect, in case multiplying with Scale wraps.

The code below already checks for wrapping properly, so just remove the incorrect assignment.

Fixes https://github.com/llvm/llvm-project/issues/72831.