### PR TITLE
[llvm][TypeSize] Consider TypeSize of '0' to be fixed/scalable-agnostic.

### DIFF
--- a/llvm/include/llvm/Support/TypeSize.h
+++ b/llvm/include/llvm/Support/TypeSize.h
@@ -97,16 +97,14 @@ protected:
 
   constexpr FixedOrScalableQuantity() = default;
   constexpr FixedOrScalableQuantity(ScalarTy Quantity, bool Scalable)
-      : Quantity(Quantity), Scalable(Quantity ? Scalable : false) {}
+      : Quantity(Quantity), Scalable(Scalable) {}
 
   friend constexpr LeafTy &operator+=(LeafTy &LHS, const LeafTy &RHS) {
     assert((LHS.Quantity == 0 || RHS.Quantity == 0 ||
             LHS.Scalable == RHS.Scalable) &&
            "Incompatible types");
     LHS.Quantity += RHS.Quantity;
-    if (!LHS.Quantity)
-      LHS.Scalable = false;
-    else if (RHS.Quantity)
+    if (!RHS.isZero())
       LHS.Scalable = RHS.Scalable;
     return LHS;
   }
@@ -116,9 +114,7 @@ protected:
             LHS.Scalable == RHS.Scalable) &&
            "Incompatible types");
     LHS.Quantity -= RHS.Quantity;
-    if (!LHS.Quantity)
-      LHS.Scalable = false;
-    else if (RHS.Quantity)
+    if (!RHS.isZero())
       LHS.Scalable = RHS.Scalable;
     return LHS;
   }

--- a/llvm/include/llvm/Support/TypeSize.h
+++ b/llvm/include/llvm/Support/TypeSize.h
@@ -97,17 +97,29 @@ protected:
 
   constexpr FixedOrScalableQuantity() = default;
   constexpr FixedOrScalableQuantity(ScalarTy Quantity, bool Scalable)
-      : Quantity(Quantity), Scalable(Scalable) {}
+      : Quantity(Quantity), Scalable(Quantity ? Scalable : false) {}
 
   friend constexpr LeafTy &operator+=(LeafTy &LHS, const LeafTy &RHS) {
-    assert(LHS.Scalable == RHS.Scalable && "Incompatible types");
+    assert((LHS.Quantity == 0 || RHS.Quantity == 0 ||
+            LHS.Scalable == RHS.Scalable) &&
+           "Incompatible types");
     LHS.Quantity += RHS.Quantity;
+    if (!LHS.Quantity)
+      LHS.Scalable = false;
+    else if (RHS.Quantity)
+      LHS.Scalable = RHS.Scalable;
     return LHS;
   }
 
   friend constexpr LeafTy &operator-=(LeafTy &LHS, const LeafTy &RHS) {
-    assert(LHS.Scalable == RHS.Scalable && "Incompatible types");
+    assert((LHS.Quantity == 0 || RHS.Quantity == 0 ||
+            LHS.Scalable == RHS.Scalable) &&
+           "Incompatible types");
     LHS.Quantity -= RHS.Quantity;
+    if (!LHS.Quantity)
+      LHS.Scalable = false;
+    else if (RHS.Quantity)
+      LHS.Scalable = RHS.Scalable;
     return LHS;
   }
 
@@ -315,6 +327,8 @@ class TypeSize : public details::FixedOrScalableQuantity<TypeSize, uint64_t> {
       : FixedOrScalableQuantity(V) {}
 
 public:
+  constexpr TypeSize() : FixedOrScalableQuantity(0, false) {}
+
   constexpr TypeSize(ScalarTy Quantity, bool Scalable)
       : FixedOrScalableQuantity(Quantity, Scalable) {}
 

--- a/llvm/unittests/Support/TypeSizeTest.cpp
+++ b/llvm/unittests/Support/TypeSizeTest.cpp
@@ -97,6 +97,10 @@ static_assert(TypeSize::getFixed(8) + TypeSize::getScalable(0) ==
               TypeSize::getFixed(8));
 static_assert(TypeSize::getScalable(0) + TypeSize::getFixed(8) ==
               TypeSize::getFixed(8));
+static_assert(TypeSize::getScalable(8) - TypeSize::getFixed(0) ==
+              TypeSize::getScalable(8));
+static_assert(TypeSize::getFixed(8) - TypeSize::getScalable(0) ==
+              TypeSize::getFixed(8));
 
 TEST(TypeSize, FailIncompatibleTypes) {
   EXPECT_DEBUG_DEATH(TypeSize::getFixed(8) + TypeSize::getScalable(8),

--- a/llvm/unittests/Support/TypeSizeTest.cpp
+++ b/llvm/unittests/Support/TypeSizeTest.cpp
@@ -82,11 +82,13 @@ static_assert(UINT64_C(2) * TSFixed32 == TypeSize::getFixed(64));
 static_assert(alignTo(TypeSize::getFixed(7), 8) == TypeSize::getFixed(8));
 
 static_assert(TypeSize() == TypeSize::getFixed(0));
-static_assert(TypeSize() == TypeSize::getScalable(0));
-static_assert(TypeSize::getFixed(0) == TypeSize::getScalable(0));
+static_assert(TypeSize::getFixed(0) != TypeSize::getScalable(0));
+static_assert(TypeSize::getFixed(0).isZero());
+static_assert(TypeSize::getScalable(0).isZero());
 static_assert(TypeSize::getFixed(0) ==
+              (TypeSize::getFixed(4) - TypeSize::getFixed(4)));
+static_assert(TypeSize::getScalable(0) ==
               (TypeSize::getScalable(4) - TypeSize::getScalable(4)));
-static_assert(!TypeSize().isScalable());
 static_assert(TypeSize::getFixed(0) + TypeSize::getScalable(8) ==
               TypeSize::getScalable(8));
 static_assert(TypeSize::getScalable(8) + TypeSize::getFixed(0) ==

--- a/llvm/unittests/Support/TypeSizeTest.cpp
+++ b/llvm/unittests/Support/TypeSizeTest.cpp
@@ -81,6 +81,21 @@ static_assert(INT64_C(2) * TSFixed32 == TypeSize::getFixed(64));
 static_assert(UINT64_C(2) * TSFixed32 == TypeSize::getFixed(64));
 static_assert(alignTo(TypeSize::getFixed(7), 8) == TypeSize::getFixed(8));
 
+static_assert(TypeSize() == TypeSize::getFixed(0));
+static_assert(TypeSize() == TypeSize::getScalable(0));
+static_assert(TypeSize::getFixed(0) == TypeSize::getScalable(0));
+static_assert(TypeSize::getFixed(0) ==
+              (TypeSize::getScalable(4) - TypeSize::getScalable(4)));
+static_assert(!TypeSize().isScalable());
+static_assert(TypeSize::getFixed(0) + TypeSize::getScalable(8) ==
+              TypeSize::getScalable(8));
+static_assert(TypeSize::getScalable(8) + TypeSize::getFixed(0) ==
+              TypeSize::getScalable(8));
+static_assert(TypeSize::getFixed(8) + TypeSize::getScalable(0) ==
+              TypeSize::getFixed(8));
+static_assert(TypeSize::getScalable(0) + TypeSize::getFixed(8) ==
+              TypeSize::getFixed(8));
+
 TEST(TypeSize, FailIncompatibleTypes) {
   EXPECT_DEBUG_DEATH(TypeSize::getFixed(8) + TypeSize::getScalable(8),
                      "Incompatible types");


### PR DESCRIPTION
This patch allows adding any quantity to a zero-initialized TypeSize, such
that e.g.:

  TypeSize::Scalable(0) + TypeSize::Fixed(4) == TypeSize::Fixed(4)
  TypeSize::Fixed(0) + TypeSize::Scalable(4) == TypeSize::Scalable(4)

This makes it easier to implement add-reductions using TypeSize where
the 'scalable' flag is not yet known before starting the reduction.

(this PR follows on from #72979)