### PR TITLE
[DebugInfo][RemoveDIs] Handle DPValues in LCSSA

### DIFF
--- a/llvm/test/Transforms/LCSSA/rewrite-existing-dbg-values.ll
+++ b/llvm/test/Transforms/LCSSA/rewrite-existing-dbg-values.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -S -passes=lcssa < %s | FileCheck %s
+; RUN: opt -S -passes=lcssa < %s --try-experimental-debuginfo-iterators | FileCheck %s
 
 ; Reproducer for PR39019.
 ;


### PR DESCRIPTION
LCSSA needs to manually update dbg.value intrinsic users of Values that are having LCSSA PHIs inserted -- instrument it to do the same for DPValues, the replacement for dbg.values.

This patch also contains an opportunistic fix replacing instruction-insertion with iterator-insertion, necessary for communicating debug-info in the future.