### PR TITLE
[flang][openacc][NFC] Check only HLFIR lowering for declare tests

### DIFF
--- a/flang/test/Lower/OpenACC/acc-declare-globals.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-globals.f90
@@ -1,7 +1,6 @@
 ! This test checks lowering of OpenACC declare directive in module specification
 ! part.
 
-! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 module acc_declare_test


### PR DESCRIPTION
HLFIR lowering as been set by default now and FIR lowering support will be removed in the near future. This patch removes the specific FIR check lines on declare tests.