### PR TITLE
[OpenACC] Implement Atomic construct variants

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1364,9 +1364,6 @@ def warn_pragma_acc_unimplemented_clause_parsing
 def err_acc_invalid_directive
     : Error<"invalid OpenACC directive '%select{%1|%1 %2}0'">;
 def err_acc_missing_directive : Error<"expected OpenACC directive">;
-def err_acc_invalid_atomic_clause
-    : Error<"%select{missing|invalid}0 OpenACC 'atomic-clause'%select{| "
-            "'%1'}0; expected 'read', 'write', 'update', or 'capture'">;
 
 // OpenMP support.
 def warn_pragma_omp_ignored : Warning<

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1364,6 +1364,9 @@ def warn_pragma_acc_unimplemented_clause_parsing
 def err_acc_invalid_directive
     : Error<"invalid OpenACC directive '%select{%1|%1 %2}0'">;
 def err_acc_missing_directive : Error<"expected OpenACC directive">;
+def err_acc_invalid_atomic_clause
+    : Error<"%select{missing|invalid}0 OpenACC 'atomic-clause'%select{| "
+            "'%1'}0; expected 'read', 'write', 'update', or 'capture'">;
 
 // OpenMP support.
 def warn_pragma_omp_ignored : Warning<

--- a/clang/include/clang/Basic/OpenACCKinds.h
+++ b/clang/include/clang/Basic/OpenACCKinds.h
@@ -41,13 +41,8 @@ enum class OpenACCDirectiveKind {
   SerialLoop,
   KernelsLoop,
 
-  // Atomic Construct.  The OpenACC standard considers these as a single
-  // construct, however the atomic-clause (read, write, update, capture) are
-  // important for legalization of the application of this to statements/blocks.
-  AtomicRead,
-  AtomicWrite,
-  AtomicUpdate,
-  AtomicCapture,
+  // Atomic Construct.
+  Atomic,
 
   // Declare Directive.
   Declare,
@@ -63,6 +58,14 @@ enum class OpenACCDirectiveKind {
   // FIXME: routine construct.
 
   // Invalid.
+  Invalid,
+};
+
+enum class OpenACCAtomicKind {
+  Read,
+  Write,
+  Update,
+  Capture,
   Invalid,
 };
 } // namespace clang

--- a/clang/include/clang/Basic/OpenACCKinds.h
+++ b/clang/include/clang/Basic/OpenACCKinds.h
@@ -41,7 +41,13 @@ enum class OpenACCDirectiveKind {
   SerialLoop,
   KernelsLoop,
 
-  // FIXME: atomic Construct variants.
+  // Atomic Construct.  The OpenACC standard considers these as a single
+  // construct, however the atomic-clause (read, write, update, capture) are
+  // important for legalization of the application of this to statements/blocks.
+  AtomicRead,
+  AtomicWrite,
+  AtomicUpdate,
+  AtomicCapture,
 
   // Declare Directive.
   Declare,

--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -29,7 +29,8 @@ enum class OpenACCDirectiveKindEx {
   // 'enter data' and 'exit data'
   Enter,
   Exit,
-  // FIXME: Atomic Variants
+  // 'atomic read', 'atomic write', 'atomic update', and 'atomic capture'.
+  Atomic,
 };
 
 // Translate single-token string representations to the OpenACC Directive Kind.
@@ -59,7 +60,19 @@ OpenACCDirectiveKindEx getOpenACCDirectiveKind(StringRef Name) {
   return llvm::StringSwitch<OpenACCDirectiveKindEx>(Name)
       .Case("enter", OpenACCDirectiveKindEx::Enter)
       .Case("exit", OpenACCDirectiveKindEx::Exit)
+      .Case("atomic", OpenACCDirectiveKindEx::Atomic)
       .Default(OpenACCDirectiveKindEx::Invalid);
+}
+
+// Since 'atomic' is effectively a compound directive, this will decode the
+// second part of the directive.
+OpenACCDirectiveKind getOpenACCAtomicDirectiveKind(StringRef Name) {
+  return llvm::StringSwitch<OpenACCDirectiveKind>(Name)
+      .Case("read", OpenACCDirectiveKind::AtomicRead)
+      .Case("write", OpenACCDirectiveKind::AtomicWrite)
+      .Case("update", OpenACCDirectiveKind::AtomicUpdate)
+      .Case("capture", OpenACCDirectiveKind::AtomicCapture)
+      .Default(OpenACCDirectiveKind::Invalid);
 }
 
 bool isOpenACCDirectiveKind(OpenACCDirectiveKind Kind, StringRef Tok) {
@@ -82,6 +95,10 @@ bool isOpenACCDirectiveKind(OpenACCDirectiveKind Kind, StringRef Tok) {
   case OpenACCDirectiveKind::KernelsLoop:
   case OpenACCDirectiveKind::EnterData:
   case OpenACCDirectiveKind::ExitData:
+  case OpenACCDirectiveKind::AtomicRead:
+  case OpenACCDirectiveKind::AtomicWrite:
+  case OpenACCDirectiveKind::AtomicUpdate:
+  case OpenACCDirectiveKind::AtomicCapture:
     return false;
 
   case OpenACCDirectiveKind::Declare:
@@ -126,6 +143,28 @@ ParseOpenACCEnterExitDataDirective(Parser &P, Token FirstTok,
              : OpenACCDirectiveKind::ExitData;
 }
 
+OpenACCDirectiveKind ParseOpenACCAtomicDirective(Parser &P) {
+  Token AtomicClauseToken = P.getCurToken();
+
+  if (AtomicClauseToken.isAnnotation()) {
+    P.Diag(AtomicClauseToken, diag::err_acc_invalid_atomic_clause) << 0;
+    return OpenACCDirectiveKind::Invalid;
+  }
+
+  std::string AtomicClauseSpelling =
+      P.getPreprocessor().getSpelling(AtomicClauseToken);
+
+  OpenACCDirectiveKind DirKind =
+      getOpenACCAtomicDirectiveKind(AtomicClauseSpelling);
+
+  if (DirKind == OpenACCDirectiveKind::Invalid)
+    P.Diag(AtomicClauseToken, diag::err_acc_invalid_atomic_clause)
+        << 1 << AtomicClauseSpelling;
+
+  P.ConsumeToken();
+  return DirKind;
+}
+
 // Parse and consume the tokens for OpenACC Directive/Construct kinds.
 OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
   Token FirstTok = P.getCurToken();
@@ -158,6 +197,8 @@ OpenACCDirectiveKind ParseOpenACCDirectiveKind(Parser &P) {
     case OpenACCDirectiveKindEx::Exit:
       return ParseOpenACCEnterExitDataDirective(P, FirstTok, FirstTokSpelling,
                                                 ExDirKind);
+    case OpenACCDirectiveKindEx::Atomic:
+      return ParseOpenACCAtomicDirective(P);
     }
   }
 

--- a/clang/test/ParserOpenACC/parse-constructs.c
+++ b/clang/test/ParserOpenACC/parse-constructs.c
@@ -95,16 +95,14 @@ void func() {
   for(;;){}
 
   int i = 0, j = 0, k = 0;
-  // expected-error@+2{{missing OpenACC 'atomic-clause'; expected 'read', 'write', 'update', or 'capture'}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic
   i = j;
-  // expected-error@+2{{invalid OpenACC 'atomic-clause' 'garbage'; expected 'read', 'write', 'update', or 'capture'}}
+  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic garbage
   i = j;
-  // expected-warning@+3{{OpenACC clause parsing not yet implemented}}
-  // expected-error@+2{{invalid OpenACC 'atomic-clause' 'garbage'; expected 'read', 'write', 'update', or 'capture'}}
+  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc atomic garbage clause list
   i = j;

--- a/clang/test/ParserOpenACC/parse-constructs.c
+++ b/clang/test/ParserOpenACC/parse-constructs.c
@@ -94,6 +94,37 @@ void func() {
 #pragma acc kernels loop
   for(;;){}
 
+  int i = 0, j = 0, k = 0;
+  // expected-error@+2{{missing OpenACC 'atomic-clause'; expected 'read', 'write', 'update', or 'capture'}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc atomic
+  i = j;
+  // expected-error@+2{{invalid OpenACC 'atomic-clause' 'garbage'; expected 'read', 'write', 'update', or 'capture'}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc atomic garbage
+  i = j;
+  // expected-warning@+3{{OpenACC clause parsing not yet implemented}}
+  // expected-error@+2{{invalid OpenACC 'atomic-clause' 'garbage'; expected 'read', 'write', 'update', or 'capture'}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc atomic garbage clause list
+  i = j;
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc atomic read
+  i = j;
+  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc atomic write clause list
+  i = i + j;
+  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc atomic update clause list
+  i++;
+  // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
+  // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
+#pragma acc atomic capture clause list
+  i = j++;
+
+
   // expected-warning@+2{{OpenACC clause parsing not yet implemented}}
   // expected-warning@+1{{OpenACC directives not yet implemented, pragma ignored}}
 #pragma acc declare clause list


### PR DESCRIPTION
`atomic` is required to be followed by a special `atomic clause`, so this patch manages the parsing of that.  We are representing each of the variants of the atomic construct as separate kinds, because they have distinct rules/application/etc, and this should make it easier to check rules in the future.