### PR TITLE
[bolt] Support arm64 FP register spills

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -314,6 +314,12 @@ public:
 
   bool isRegToRegMove(const MCInst &Inst, MCPhysReg &From,
                       MCPhysReg &To) const override {
+    if (Inst.getOpcode() == AArch64::FMOVDXr) {
+      From = Inst.getOperand(1).getReg();
+      To = Inst.getOperand(0).getReg();
+      return true;
+    }
+
     if (Inst.getOpcode() != AArch64::ORRXrs)
       return false;
     if (Inst.getOperand(1).getReg() != AArch64::XZR)

--- a/bolt/test/AArch64/fp-reg-spill.s
+++ b/bolt/test/AArch64/fp-reg-spill.s
@@ -1,0 +1,19 @@
+# Check that we correctly handle arm64 fp register spills in
+# bolt when we are processing jump tables.
+# REQUIRES: system-linux
+# RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t.o
+# RUN: ld.lld --emit-relocs %t.o -o %t.elf
+# RUN: llvm-bolt --jump-tables=move %t.elf -o %t.bolt
+
+.globl _foo, _start
+
+_foo:
+  ret
+
+_start:
+  adr x6, _foo
+  fmov d18,x6
+  fmov x5,d18
+  ldrb  w5, [x5, w1, uxtw]
+  add x5, x6, w5, sxtb #2
+  br x5


### PR DESCRIPTION
At the moment llvm-bolt fails when analyzing jump tables on aarch64 in case FP register spill/reload is used.