### PR TITLE
[llvm] Disable HandleLLVMOptions in runtimes mode

### DIFF
--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -151,9 +151,7 @@ endif()
 # Avoid checking whether the compiler is working.
 set(LLVM_COMPILER_CHECKED ON)
 
-# Handle common options used by all runtimes.
 include(AddLLVM)
-include(HandleLLVMOptions)
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 


### PR DESCRIPTION
Summary:
There are a few default options that LLVM adds that can be problematic
for runtimes builds. These options are generally intended to handle
building LLVM itself, but are also added when building in a runtimes
mode. One such issue I've run into is that in `libc` we deliberately use
`--target` to use a different device toolchain, which doesn't support
some linker arguments passed via `-Wl`. This is observed in
https://github.com/llvm/llvm-project/pull/73030 when attempting to use
these options.

This patch completely removes these default arguments.

The consensus is that any issues created by this patch should ultimately be solved on a per-runtime basis.