### PR TITLE
[libc++] Refactor atomic_{unsigned,signed}_lock_free

### DIFF
--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -448,6 +448,9 @@ typedef atomic<ptrdiff_t> atomic_ptrdiff_t;
 typedef atomic<intmax_t>  atomic_intmax_t;
 typedef atomic<uintmax_t> atomic_uintmax_t;
 
+typedef see-below         atomic_signed_lock_free;   // since C++20
+typedef see-below         atomic_unsigned_lock_free; // since C++20
+
 // flag type and operations
 
 typedef struct atomic_flag

--- a/libcxx/test/std/atomics/types.pass.cpp
+++ b/libcxx/test/std/atomics/types.pass.cpp
@@ -175,7 +175,12 @@ int main(int, char**)
 
 #if TEST_STD_VER >= 20
     test<std::atomic_signed_lock_free::value_type>();
+    static_assert(std::is_signed_v<std::atomic_signed_lock_free::value_type>);
+    static_assert(std::is_integral_v<std::atomic_signed_lock_free::value_type>);
+
     test<std::atomic_unsigned_lock_free::value_type>();
+    static_assert(std::is_unsigned_v<std::atomic_unsigned_lock_free::value_type>);
+    static_assert(std::is_integral_v<std::atomic_unsigned_lock_free::value_type>);
 /*
     test<std::shared_ptr<int>>();
 */


### PR DESCRIPTION
Their definition was a bit roundabout and it was actually wrong since atomic_unsigned_lock_free would be a signed type whenever __cxx_contention_t is lock free, which is most of the time.

Fixes #72968