### PR TITLE
[flang][openacc][NFC] Remove run line for FIR only checks

### DIFF
--- a/flang/test/Lower/OpenACC/acc-fixed-form.f
+++ b/flang/test/Lower/OpenACC/acc-fixed-form.f
@@ -1,4 +1,3 @@
-! RUN: bbc -ffixed-form -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -ffixed-form -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
       subroutine sub1()

--- a/flang/test/Lower/OpenACC/acc-init.f90
+++ b/flang/test/Lower/OpenACC/acc-init.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC init directive.
 
-! RUN: bbc -fopenacc -emit-fir -hlfir=false %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 subroutine acc_init

--- a/flang/test/Lower/OpenACC/acc-routine-named.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-named.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC routine directive.
 
-! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 module acc_routines

--- a/flang/test/Lower/OpenACC/acc-routine.f90
+++ b/flang/test/Lower/OpenACC/acc-routine.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC routine directive.
 
-! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 

--- a/flang/test/Lower/OpenACC/acc-routine02.f90
+++ b/flang/test/Lower/OpenACC/acc-routine02.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC routine directive.
 
-! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 subroutine sub1(a, n)

--- a/flang/test/Lower/OpenACC/acc-routine03.f90
+++ b/flang/test/Lower/OpenACC/acc-routine03.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC routine directive in interfaces.
 
-! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 

--- a/flang/test/Lower/OpenACC/acc-routine04.f90
+++ b/flang/test/Lower/OpenACC/acc-routine04.f90
@@ -1,7 +1,6 @@
 ! This test checks correct lowering when OpenACC routine directive is placed
 ! before implicit none.
 
-! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 module dummy_mod

--- a/flang/test/Lower/OpenACC/acc-set.f90
+++ b/flang/test/Lower/OpenACC/acc-set.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC set directive.
 
-! RUN: bbc -fopenacc -emit-fir -hlfir=false %s -o - | FileCheck %s --check-prefixes=CHECK,FIR
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK,HLFIR
 
 program test_acc_set

--- a/flang/test/Lower/OpenACC/acc-shutdown.f90
+++ b/flang/test/Lower/OpenACC/acc-shutdown.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC shutdown directive.
 
-! RUN: bbc -fopenacc -emit-fir -hlfir=false %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 subroutine acc_shutdown

--- a/flang/test/Lower/OpenACC/acc-unstructured.f90
+++ b/flang/test/Lower/OpenACC/acc-unstructured.f90
@@ -1,4 +1,3 @@
-! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 subroutine test_unstructured1(a, b, c)

--- a/flang/test/Lower/OpenACC/acc-wait.f90
+++ b/flang/test/Lower/OpenACC/acc-wait.f90
@@ -1,6 +1,5 @@
 ! This test checks lowering of OpenACC wait directive.
 
-! RUN: bbc -fopenacc -emit-fir -hlfir=false %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 subroutine acc_update

--- a/flang/test/Lower/OpenACC/locations.f90
+++ b/flang/test/Lower/OpenACC/locations.f90
@@ -1,7 +1,7 @@
 ! This test checks correct propagation of location information in OpenACC
 ! operations.
 
-! RUN: bbc -fopenacc -emit-fir --mlir-print-debuginfo --mlir-print-local-scope %s -o - | FileCheck %s
+
 ! RUN: bbc -fopenacc -emit-hlfir --mlir-print-debuginfo --mlir-print-local-scope %s -o - | FileCheck %s
 module acc_locations
   implicit none

--- a/flang/test/Lower/OpenACC/stop-stmt-in-region.f90
+++ b/flang/test/Lower/OpenACC/stop-stmt-in-region.f90
@@ -1,8 +1,6 @@
 ! This test checks lowering of stop statement in OpenACC region.
 
-! RUN: bbc -fopenacc -emit-fir -hlfir=false %s -o - | FileCheck %s
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-fir -flang-deprecated-no-hlfir -fopenacc %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-hlfir -fopenacc %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPtest_stop_in_region1() {


### PR DESCRIPTION
Remove the run lines that check for the FIR lowering. HLFIR lowering produce the same check lines. 