### PR TITLE
[AIX] In assembly file, create a dummy text renamed to an empty string

### DIFF
--- a/llvm/include/llvm/MC/MCSectionXCOFF.h
+++ b/llvm/include/llvm/MC/MCSectionXCOFF.h
@@ -115,6 +115,7 @@ public:
   bool useCodeAlign() const override;
   bool isVirtualSection() const override;
   StringRef getSymbolTableName() const { return SymbolTableName; }
+  void setSymbolTableName(StringRef STN) { SymbolTableName = STN; }
   bool isMultiSymbolsAllowed() const { return MultiSymbolsAllowed; }
   bool isCsect() const { return CsectProp.has_value(); }
   bool isDwarfSect() const { return DwarfSubtypeFlags.has_value(); }

--- a/llvm/include/llvm/MC/MCSymbolXCOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolXCOFF.h
@@ -52,9 +52,12 @@ public:
 
   XCOFF::VisibilityType getVisibilityType() const { return VisibilityType; }
 
-  bool hasRename() const { return !SymbolTableName.empty(); }
+  bool hasRename() const { return HasRename; }
 
-  void setSymbolTableName(StringRef STN) { SymbolTableName = STN; }
+  void setSymbolTableName(StringRef STN) {
+    SymbolTableName = STN;
+    HasRename = true;
+  }
 
   StringRef getSymbolTableName() const {
     if (hasRename())
@@ -67,6 +70,7 @@ private:
   MCSectionXCOFF *RepresentedCsect = nullptr;
   XCOFF::VisibilityType VisibilityType = XCOFF::SYM_V_UNSPECIFIED;
   StringRef SymbolTableName;
+  bool HasRename = false;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCXCOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCXCOFFStreamer.h
@@ -32,7 +32,8 @@ public:
                                             MCSymbolAttr Linkage,
                                             MCSymbolAttr Visibility) override;
   void emitXCOFFRefDirective(const MCSymbol *Symbol) override;
-  void emitXCOFFRenameDirective(const MCSymbol *Name, StringRef Rename) override;
+  void emitXCOFFRenameDirective(const MCSymbol *Name,
+                                 StringRef Rename) override;
   void emitXCOFFExceptDirective(const MCSymbol *Symbol, const MCSymbol *Trap,
                                 unsigned Lang, unsigned Reason,
                                 unsigned FunctionSize, bool hasDebug) override;

--- a/llvm/include/llvm/MC/MCXCOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCXCOFFStreamer.h
@@ -32,11 +32,7 @@ public:
                                             MCSymbolAttr Linkage,
                                             MCSymbolAttr Visibility) override;
   void emitXCOFFRefDirective(const MCSymbol *Symbol) override;
-  void emitXCOFFRenameDirective(const MCSymbol *Name,
-                                StringRef Rename) override {
-    report_fatal_error("emitXCOFFRenameDirective is not implemented yet on "
-                       "object generation path");
-  }
+  void emitXCOFFRenameDirective(const MCSymbol *Name, StringRef Rename) override;
   void emitXCOFFExceptDirective(const MCSymbol *Symbol, const MCSymbol *Trap,
                                 unsigned Lang, unsigned Reason,
                                 unsigned FunctionSize, bool hasDebug) override;

--- a/llvm/include/llvm/MC/MCXCOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCXCOFFStreamer.h
@@ -33,7 +33,7 @@ public:
                                             MCSymbolAttr Visibility) override;
   void emitXCOFFRefDirective(const MCSymbol *Symbol) override;
   void emitXCOFFRenameDirective(const MCSymbol *Name,
-                                 StringRef Rename) override;
+                                StringRef Rename) override;
   void emitXCOFFExceptDirective(const MCSymbol *Symbol, const MCSymbol *Trap,
                                 unsigned Lang, unsigned Reason,
                                 unsigned FunctionSize, bool hasDebug) override;

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -91,9 +91,9 @@
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCSection.h"
 #include "llvm/MC/MCSectionCOFF.h"
-#include "llvm/MC/MCSectionXCOFF.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCSectionMachO.h"
+#include "llvm/MC/MCSectionXCOFF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCSymbol.h"
@@ -504,10 +504,10 @@ bool AsmPrinter::doInitialization(Module &M) {
     // a rename for the default text-section symbol name.  This call has
     // no effect when generating object code directly.
     MCSection *TextSection =
-      OutStreamer->getContext().getObjectFileInfo()->getTextSection();
+        OutStreamer->getContext().getObjectFileInfo()->getTextSection();
     MCSymbolXCOFF *XSym =
-      static_cast<MCSectionXCOFF *>(TextSection)->getQualNameSymbol();
-    if (XSym->hasRename()) 
+        static_cast<MCSectionXCOFF *>(TextSection)->getQualNameSymbol();
+    if (XSym->hasRename())
       OutStreamer->emitXCOFFRenameDirective(XSym, XSym->getSymbolTableName());
   }
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -91,6 +91,7 @@
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCSection.h"
 #include "llvm/MC/MCSectionCOFF.h"
+#include "llvm/MC/MCSectionXCOFF.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCSectionMachO.h"
 #include "llvm/MC/MCStreamer.h"
@@ -444,7 +445,7 @@ bool AsmPrinter::doInitialization(Module &M) {
       .getModuleMetadata(M);
 
   // On AIX, we delay emitting any section information until
-  // after emitting the .file pseudo-op.  This allows additional
+  // after emitting the .file pseudo-op. This allows additional
   // information (such as the embedded command line) to be associated
   // with all sections in the object file rather than a single section.
   if (!TM.getTargetTriple().isOSBinFormatXCOFF())
@@ -496,8 +497,18 @@ bool AsmPrinter::doInitialization(Module &M) {
   // C_INFO symbol is preserved if any csect is kept by the linker.
   if (TM.getTargetTriple().isOSBinFormatXCOFF()) {
     emitModuleCommandLines(M);
-    // Now we can generate section information
+    // Now we can generate section information.
     OutStreamer->initSections(false, *TM.getMCSubtargetInfo());
+
+    // To work around an AIX assembler and/or linker bug, generate
+    // a rename for the default text-section symbol name.  This call has
+    // no effect when generating object code directly.
+    MCSection *TextSection =
+      OutStreamer->getContext().getObjectFileInfo()->getTextSection();
+    MCSymbolXCOFF *XSym =
+      static_cast<MCSectionXCOFF *>(TextSection)->getQualNameSymbol();
+    if (XSym->hasRename()) 
+      OutStreamer->emitXCOFFRenameDirective(XSym, XSym->getSymbolTableName());
   }
 
   GCModuleInfo *MI = getAnalysisIfAvailable<GCModuleInfo>();

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -928,9 +928,15 @@ void MCObjectFileInfo::initXCOFFMCObjectFileInfo(const Triple &T) {
   // the ABI or object file format, but various tools rely on the section
   // name being empty (considering named symbols to be "user symbol names").
   TextSection = Ctx->getXCOFFSection(
-      "", SectionKind::getText(),
+      "..text..", // Use a non-null name to work around an AIX assembler bug...
+      SectionKind::getText(),
       XCOFF::CsectProperties(XCOFF::StorageMappingClass::XMC_PR, XCOFF::XTY_SD),
       /* MultiSymbolsAllowed*/ true);
+
+  // ... but use a null name when generating the symbol table.
+  MCSectionXCOFF *TS = static_cast<MCSectionXCOFF *>(TextSection);
+  TS->getQualNameSymbol()->setSymbolTableName("");
+  TS->setSymbolTableName("");
 
   DataSection = Ctx->getXCOFFSection(
       ".data", SectionKind::getData(),

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -1190,7 +1190,7 @@ void MCStreamer::emitXCOFFSymbolLinkageWithVisibility(MCSymbol *Symbol,
 }
 
 void MCStreamer::emitXCOFFRenameDirective(const MCSymbol *Name,
-                                          StringRef Rename) { }
+                                          StringRef Rename) {}
 
 void MCStreamer::emitXCOFFRefDirective(const MCSymbol *Symbol) {
   llvm_unreachable("emitXCOFFRefDirective is only supported on XCOFF targets");

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -1190,10 +1190,7 @@ void MCStreamer::emitXCOFFSymbolLinkageWithVisibility(MCSymbol *Symbol,
 }
 
 void MCStreamer::emitXCOFFRenameDirective(const MCSymbol *Name,
-                                          StringRef Rename) {
-  llvm_unreachable("emitXCOFFRenameDirective is only supported on "
-                   "XCOFF targets");
-}
+                                          StringRef Rename) { }
 
 void MCStreamer::emitXCOFFRefDirective(const MCSymbol *Symbol) {
   llvm_unreachable("emitXCOFFRefDirective is only supported on XCOFF targets");

--- a/llvm/lib/MC/MCXCOFFStreamer.cpp
+++ b/llvm/lib/MC/MCXCOFFStreamer.cpp
@@ -96,6 +96,13 @@ void MCXCOFFStreamer::emitXCOFFRefDirective(const MCSymbol *Symbol) {
   DF->getFixups().push_back(Fixup);
 }
 
+void MCXCOFFStreamer::emitXCOFFRenameDirective(const MCSymbol *Name,
+                                               StringRef Rename) {
+  const MCSymbolXCOFF *Symbol = cast<const MCSymbolXCOFF>(Name);
+  if (!Symbol->hasRename())
+    report_fatal_error("Only explicit .rename is supported for XCOFF.");
+}
+
 void MCXCOFFStreamer::emitXCOFFExceptDirective(const MCSymbol *Symbol,
                                                const MCSymbol *Trap,
                                                unsigned Lang, unsigned Reason,

--- a/llvm/test/CodeGen/PowerPC/aix-alias.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-alias.ll
@@ -55,7 +55,7 @@ entry:
 ; ASM-NEXT:    .csect fun[DS]
 ; ASM-NEXT:  fun_weak:                               # @fun
 ; ASM-NEXT:  fun_hidden:
-; ASM:         .csect [PR],5
+; ASM:         .csect ..text..[PR],5
 ; ASM-NEXT:  .fun:
 ; ASM-NEXT:  .fun_weak:
 ; ASM-NEXT:  .fun_hidden:
@@ -63,7 +63,7 @@ entry:
 ; ASM-NEXT:    li 3, 0
 ; ASM-NEXT:    blr
 ; ASM-NEXT:                                          # -- End function
-; ASM:       .csect [PR],5
+; ASM:       .csect ..text..[PR],5
 ; ASM-NEXT:  .test:
 ; ASM-NEXT:  # %bb.0:                                # %entry
 ; ASM:         bl .fun

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
@@ -99,7 +99,7 @@ entry:
 ; COMMON-NEXT:  .align  2
 ; COMMON-NEXT:  .vbyte  4, 0
 ; COMMON-NEXT:  .vbyte  4, 0
-; CHECK-ASM-NEXT:   .csect [PR],5
+; CHECK-ASM-NEXT:   .csect ..text..[PR],5
 ; CHECK-FUNC-NEXT:  .csect .foov[PR],5
 ; COMMON-NEXT:                                         # -- End function
 ; COMMON:       .toc

--- a/llvm/test/CodeGen/PowerPC/aix-extern-weak.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-extern-weak.ll
@@ -41,7 +41,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; BIT64-NEXT:     .vbyte	8, .main                   # @main
 ; BIT64-NEXT:     .vbyte	8, TOC[TC0]
 ; BIT64-NEXT:     .vbyte	8, 0
-; COMMON-NEXT:    .csect  [PR]
+; COMMON-NEXT:    .csect  ..text..[PR]
 ; COMMON-NEXT:    .main:
 
 ; COMMON:         .csect  .data[RW]

--- a/llvm/test/CodeGen/PowerPC/aix-extern.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-extern.ll
@@ -51,7 +51,7 @@ declare i32 @bar_extern(ptr)
 ; BIT64-NEXT:       .vbyte	8, .foo                    # @foo
 ; BIT64-NEXT:       .vbyte	8, TOC[TC0]
 ; BIT64-NEXT:       .vbyte	8, 0
-; COMMON-NEXT:      .csect [PR]
+; COMMON-NEXT:      .csect ..text..[PR]
 ; COMMON-NEXT: .foo:
 
 ; COMMON:           .globl	main[DS]                # -- Begin function main
@@ -64,7 +64,7 @@ declare i32 @bar_extern(ptr)
 ; BIT64-NEXT:       .vbyte	8, .main                   # @main
 ; BIT64-NEXT:       .vbyte	8, TOC[TC0]
 ; BIT64-NEXT:       .vbyte	8, 0
-; COMMON-NEXT:      .csect [PR]
+; COMMON-NEXT:      .csect ..text..[PR]
 ; COMMON-NEXT: .main:
 
 ; COMMON:           .csect .data[RW]

--- a/llvm/test/CodeGen/PowerPC/aix-func-align.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-func-align.ll
@@ -23,10 +23,10 @@ entry:
   ret i32 0
 }
 
-; CHECK:      .csect [PR],6
+; CHECK:      .csect ..text..[PR],6
 ; CHECK-NEXT: .foo:
 
-; CHECK:      .csect [PR],6
+; CHECK:      .csect ..text..[PR],6
 ; CHECK-NEXT: .bar:
 
 ; SYMS:       Symbol {{[{][[:space:]] *}}Index: [[#INDX:]]{{[[:space:]] *Name: $}}

--- a/llvm/test/CodeGen/PowerPC/aix-personality-alias.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-personality-alias.ll
@@ -56,7 +56,7 @@ declare void @_Z3barv()
 ; SYM64:  	.vbyte	8, .__gxx_personality_v0
 ; SYM64:  	.vbyte	8, TOC[TC0]
 ; SYM64:  	.vbyte	8, 0
-;   SYM:  	.csect [PR],5
+;   SYM:  	.csect ..text..[PR],5
 ;   SYM:  .__gxx_personality_v0:
 ;   SYM:  .__xlcxx_personality_v1:
 ;   SYM:  # %bb.0:                                # %entry

--- a/llvm/test/CodeGen/PowerPC/aix-weak.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-weak.ll
@@ -50,7 +50,7 @@ entry:
 ; BIT64-NEXT:           .vbyte	8, .foo_weak               # @foo_weak
 ; BIT64-NEXT:           .vbyte	8, TOC[TC0]
 ; BIT64-NEXT:           .vbyte	8, 0
-; COMMON-NEXT:          .csect [PR]
+; COMMON-NEXT:          .csect ..text..[PR]
 ; COMMON-NEXT:  .foo_weak:
 
 ; COMMON:               .weak   foo_ref_weak[DS]        # -- Begin function foo_ref_weak
@@ -63,7 +63,7 @@ entry:
 ; BIT64-NEXT:           .vbyte	8, .foo_ref_weak           # @foo_ref_weak
 ; BIT64-NEXT:           .vbyte	8, TOC[TC0]
 ; BIT64-NEXT:           .vbyte	8, 0
-; COMMON-NEXT:          .csect [PR]
+; COMMON-NEXT:          .csect ..text..[PR]
 ; COMMON-NEXT:  .foo_ref_weak:
 
 ; COMMON:               .globl  main[DS]                # -- Begin function main
@@ -76,7 +76,7 @@ entry:
 ; BIT64-NEXT:           .vbyte	8, .main                   # @main
 ; BIT64-NEXT:           .vbyte	8, TOC[TC0]
 ; BIT64-NEXT:           .vbyte	8, 0
-; COMMON-NEXT:          .csect [PR]
+; COMMON-NEXT:          .csect ..text..[PR]
 ; COMMON-NEXT:  .main:
 
 ; COMMON:     	        .csect .data[RW]

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-data.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-data.ll
@@ -46,7 +46,7 @@
 ; CHECK-NOT: .toc
 
 ; CHECK:  .file
-; CHECK-NEXT:      .csect [PR],5
+; CHECK-NEXT:      .csect ..text..[PR],5
 
 ; CHECK:      .csect .data[RW],5
 ; CHECK-NEXT: .globl  ivar

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
@@ -50,6 +50,8 @@ entry:
   ret void
 }
 
+; ASM:        .csect ..text..[PR],5
+; ASM-NEXT:   .rename ..text..[PR],""
 ; ASM:        .csect .foo[PR],5
 ; ASM-NEXT:  	.globl	foo[DS]                         # -- Begin function foo
 ; ASM-NEXT:  	.globl	.foo[PR]

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-symbol-rename.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-symbol-rename.ll
@@ -54,7 +54,7 @@ declare i32 @"f\40o"(...)
 ; ASM-NEXT:    .vbyte  4, ._Renamed..24f_o     # @"f$o"
 ; ASM-NEXT:    .vbyte  4, TOC[TC0]
 ; ASM-NEXT:    .vbyte  4, 0
-; ASM-NEXT:    .csect [PR],5
+; ASM-NEXT:    .csect ..text..[PR],5
 ; ASM-NEXT:  ._Renamed..24f_o:
 ; ASM:         bl ._Renamed..40f_o[PR]
 ; ASM-NEXT:    nop
@@ -67,7 +67,7 @@ declare i32 @"f\40o"(...)
 ; ASM-NEXT:    .vbyte  4, ._Renamed..26f_o     # @"f&o"
 ; ASM-NEXT:    .vbyte  4, TOC[TC0]
 ; ASM-NEXT:    .vbyte  4, 0
-; ASM-NEXT:    .csect [PR],5
+; ASM-NEXT:    .csect ..text..[PR],5
 ; ASM-NEXT:  ._Renamed..26f_o:
 ; ASM:         bl ._Renamed..24f_o
 ; ASM:         .globl  _Renamed..265ff__o[DS] # -- Begin function f&_o
@@ -79,7 +79,7 @@ declare i32 @"f\40o"(...)
 ; ASM-NEXT:    .vbyte  4, ._Renamed..265ff__o  # @"f&_o"
 ; ASM-NEXT:    .vbyte  4, TOC[TC0]
 ; ASM-NEXT:    .vbyte  4, 0
-; ASM-NEXT:    .csect [PR],5
+; ASM-NEXT:    .csect ..text..[PR],5
 ; ASM-NEXT:  ._Renamed..265ff__o:
 ; ASM:         .csect .data[RW],2
 ; ASM-NEXT:    .globl  _Renamed..60f_o

--- a/llvm/test/CodeGen/PowerPC/test_func_desc.ll
+++ b/llvm/test/CodeGen/PowerPC/test_func_desc.ll
@@ -37,7 +37,7 @@ entry:
 ; 64BIT-NEXT: .vbyte	8, .foo
 ; 64BIT-NEXT: .vbyte	8, TOC[TC0]
 ; 64BIT-NEXT: .vbyte	8, 0
-; CHECK-NEXT: .csect [PR],5
+; CHECK-NEXT: .csect ..text..[PR],5
 ; CHECK-LABEL: .foo:
 
 ; CHECK: .globl main[DS]
@@ -50,7 +50,7 @@ entry:
 ; 64BIT-NEXT: .vbyte	8, .main
 ; 64BIT-NEXT: .vbyte	8, TOC[TC0]
 ; 64BIT-NEXT: .vbyte	8, 0
-; CHECK-NEXT: .csect [PR],5
+; CHECK-NEXT: .csect ..text..[PR],5
 ; CHECK-LABEL: .main:
 ; CHECK: bl .foo
 ; CHECK: bl .extern_foo
@@ -66,7 +66,7 @@ entry:
 ; 64BIT-NEXT: .vbyte	8, .static_foo
 ; 64BIT-NEXT: .vbyte	8, TOC[TC0]
 ; 64BIT-NEXT: .vbyte	8, 0
-; CHECK-NEXT: .csect [PR],5
+; CHECK-NEXT: .csect ..text..[PR],5
 ; CHECK-LABEL: .static_foo:
 
 ; CHECK-NOT: .csect extern_foo

--- a/llvm/test/DebugInfo/XCOFF/empty.ll
+++ b/llvm/test/DebugInfo/XCOFF/empty.ll
@@ -36,7 +36,8 @@ entry:
 !12 = !DILocation(line: 3, column: 3, scope: !8)
 
 ; ASM32:               .file   "1.c"
-; ASM32-NEXT:          .csect [PR],5
+; ASM32-NEXT:          .csect ..text..[PR],5
+; ASM32-NEXT:          .rename ..text..[PR],""
 ; ASM32-NEXT:          .globl  main[DS]                        # -- Begin function main
 ; ASM32-NEXT:          .globl  .main
 ; ASM32-NEXT:          .align  2
@@ -44,7 +45,7 @@ entry:
 ; ASM32-NEXT:          .vbyte  4, .main                        # @main
 ; ASM32-NEXT:          .vbyte  4, TOC[TC0]
 ; ASM32-NEXT:          .vbyte  4, 0
-; ASM32-NEXT:          .csect [PR],5
+; ASM32-NEXT:          .csect ..text..[PR],5
 ; ASM32-NEXT:  .main:
 ; ASM32-NEXT:  L..func_begin0:
 ; ASM32-NEXT:  # %bb.0:                                # %entry
@@ -237,7 +238,8 @@ entry:
 ; ASM32-NEXT:  L..debug_line_end0:
 
 ; ASM64:               .file   "1.c"
-; ASM64-NEXT:          .csect [PR],5
+; ASM64-NEXT:          .csect ..text..[PR],5
+; ASM64-NEXT:          .rename ..text..[PR],""
 ; ASM64-NEXT:          .globl  main[DS]                        # -- Begin function main
 ; ASM64-NEXT:          .globl  .main
 ; ASM64-NEXT:          .align  2
@@ -245,7 +247,7 @@ entry:
 ; ASM64-NEXT:          .vbyte  8, .main                        # @main
 ; ASM64-NEXT:          .vbyte  8, TOC[TC0]
 ; ASM64-NEXT:          .vbyte  8, 0
-; ASM64-NEXT:          .csect [PR],5
+; ASM64-NEXT:          .csect ..text..[PR],5
 ; ASM64-NEXT:  .main:
 ; ASM64-NEXT:  L..func_begin0:
 ; ASM64-NEXT:  # %bb.0:                                # %entry

--- a/llvm/test/DebugInfo/XCOFF/explicit-section.ll
+++ b/llvm/test/DebugInfo/XCOFF/explicit-section.ll
@@ -43,7 +43,8 @@ entry:
 !16 = !DILocation(line: 3, column: 3, scope: !14)
 
 ; CHECK:               .file   "2.c"
-; CHECK-NEXT:          .csect [PR],5
+; CHECK-NEXT:          .csect ..text..[PR],5
+; CHECK-NEXT:          .rename ..text..[PR],""
 ; CHECK-NEXT:          .globl  bar[DS]                         # -- Begin function bar
 ; CHECK-NEXT:          .globl  .bar
 ; CHECK-NEXT:          .align  2
@@ -51,7 +52,7 @@ entry:
 ; CHECK-NEXT:          .vbyte  4, .bar                         # @bar
 ; CHECK-NEXT:          .vbyte  4, TOC[TC0]
 ; CHECK-NEXT:          .vbyte  4, 0
-; CHECK-NEXT:          .csect [PR],5
+; CHECK-NEXT:          .csect ..text..[PR],5
 ; CHECK-NEXT:  .bar:
 ; CHECK-NEXT:  L..func_begin0:
 ; CHECK-NEXT:  # %bb.0:                                # %entry

--- a/llvm/test/DebugInfo/XCOFF/function-sections.ll
+++ b/llvm/test/DebugInfo/XCOFF/function-sections.ll
@@ -38,7 +38,8 @@ entry:
 !14 = !DILocation(line: 8, column: 3, scope: !13)
 
 ; CHECK:               .file   "1.c"
-; CHECK-NEXT:          .csect [PR],5
+; CHECK-NEXT:          .csect ..text..[PR],5
+; CHECK-NEXT:          .rename ..text..[PR],""
 ; CHECK-NEXT:          .csect .foo[PR],5
 ; CHECK-NEXT:          .globl  foo[DS]                         # -- Begin function foo
 ; CHECK-NEXT:          .globl  .foo[PR]


### PR DESCRIPTION
This works around an AIX assembler and linker bug. If the -fno-integrated-as and -frecord-command-line options are used but there's no actual code in the source file, the assembler creates an object file with only an .info section.  The AIX linker rejects such an object file. 