### PR TITLE
[mlir][sparse] change dim level type -> level type

### DIFF
--- a/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
@@ -193,14 +193,14 @@ enum class LevelFormat : uint8_t {
 };
 
 /// This enum defines all the nondefault properties for storage formats.
-enum class LevelNondefaultProperty : uint8_t {
+enum class LevelPropertyNondefault : uint8_t {
   Nonunique = 1,  // 0b00000_01
   Nonordered = 2, // 0b00000_10
 };
 
 /// Returns string representation of the given dimension level type.
-constexpr const char *toMLIRString(DimLevelType dlt) {
-  switch (dlt) {
+constexpr const char *toMLIRString(DimLevelType lt) {
+  switch (lt) {
   case DimLevelType::Undef:
     return "undef";
   case DimLevelType::Dense:
@@ -236,9 +236,9 @@ constexpr const char *toMLIRString(DimLevelType dlt) {
 }
 
 /// Check that the `DimLevelType` contains a valid (possibly undefined) value.
-constexpr bool isValidDLT(DimLevelType dlt) {
-  const uint8_t formatBits = static_cast<uint8_t>(dlt) >> 2;
-  const uint8_t propertyBits = static_cast<uint8_t>(dlt) & 3;
+constexpr bool isValidLT(DimLevelType lt) {
+  const uint8_t formatBits = static_cast<uint8_t>(lt) >> 2;
+  const uint8_t propertyBits = static_cast<uint8_t>(lt) & 3;
   // If undefined or dense, then must be unique and ordered.
   // Otherwise, the format must be one of the known ones.
   return (formatBits <= 1 || formatBits == 16)
@@ -247,67 +247,67 @@ constexpr bool isValidDLT(DimLevelType dlt) {
 }
 
 /// Check if the `DimLevelType` is the special undefined value.
-constexpr bool isUndefDLT(DimLevelType dlt) {
-  return dlt == DimLevelType::Undef;
+constexpr bool isUndefLT(DimLevelType lt) {
+  return lt == DimLevelType::Undef;
 }
 
 /// Check if the `DimLevelType` is dense (regardless of properties).
-constexpr bool isDenseDLT(DimLevelType dlt) {
-  return (static_cast<uint8_t>(dlt) & ~3) ==
+constexpr bool isDenseLT(DimLevelType lt) {
+  return (static_cast<uint8_t>(lt) & ~3) ==
          static_cast<uint8_t>(DimLevelType::Dense);
 }
 
 /// Check if the `DimLevelType` is compressed (regardless of properties).
-constexpr bool isCompressedDLT(DimLevelType dlt) {
-  return (static_cast<uint8_t>(dlt) & ~3) ==
+constexpr bool isCompressedLT(DimLevelType lt) {
+  return (static_cast<uint8_t>(lt) & ~3) ==
          static_cast<uint8_t>(DimLevelType::Compressed);
 }
 
 /// Check if the `DimLevelType` is singleton (regardless of properties).
-constexpr bool isSingletonDLT(DimLevelType dlt) {
-  return (static_cast<uint8_t>(dlt) & ~3) ==
+constexpr bool isSingletonLT(DimLevelType lt) {
+  return (static_cast<uint8_t>(lt) & ~3) ==
          static_cast<uint8_t>(DimLevelType::Singleton);
 }
 
 /// Check if the `DimLevelType` is loose compressed (regardless of properties).
-constexpr bool isLooseCompressedDLT(DimLevelType dlt) {
-  return (static_cast<uint8_t>(dlt) & ~3) ==
+constexpr bool isLooseCompressedLT(DimLevelType lt) {
+  return (static_cast<uint8_t>(lt) & ~3) ==
          static_cast<uint8_t>(DimLevelType::LooseCompressed);
 }
 
 /// Check if the `DimLevelType` is 2OutOf4 (regardless of properties).
-constexpr bool is2OutOf4DLT(DimLevelType dlt) {
-  return (static_cast<uint8_t>(dlt) & ~3) ==
+constexpr bool is2OutOf4LT(DimLevelType lt) {
+  return (static_cast<uint8_t>(lt) & ~3) ==
          static_cast<uint8_t>(DimLevelType::TwoOutOfFour);
 }
 
 /// Check if the `DimLevelType` needs positions array.
-constexpr bool isWithPosDLT(DimLevelType dlt) {
-  return isCompressedDLT(dlt) || isLooseCompressedDLT(dlt);
+constexpr bool isWithPosLT(DimLevelType lt) {
+  return isCompressedLT(lt) || isLooseCompressedLT(lt);
 }
 
 /// Check if the `DimLevelType` needs coordinates array.
-constexpr bool isWithCrdDLT(DimLevelType dlt) {
-  return isCompressedDLT(dlt) || isSingletonDLT(dlt) ||
-         isLooseCompressedDLT(dlt) || is2OutOf4DLT(dlt);
+constexpr bool isWithCrdLT(DimLevelType lt) {
+  return isCompressedLT(lt) || isSingletonLT(lt) ||
+         isLooseCompressedLT(lt) || is2OutOf4LT(lt);
 }
 
 /// Check if the `DimLevelType` is ordered (regardless of storage format).
-constexpr bool isOrderedDLT(DimLevelType dlt) {
-  return !(static_cast<uint8_t>(dlt) & 2);
+constexpr bool isOrderedLT(DimLevelType lt) {
+  return !(static_cast<uint8_t>(lt) & 2);
 }
 
 /// Check if the `DimLevelType` is unique (regardless of storage format).
-constexpr bool isUniqueDLT(DimLevelType dlt) {
-  return !(static_cast<uint8_t>(dlt) & 1);
+constexpr bool isUniqueLT(DimLevelType lt) {
+  return !(static_cast<uint8_t>(lt) & 1);
 }
 
 /// Convert a DimLevelType to its corresponding LevelFormat.
-/// Returns std::nullopt when input dlt is Undef.
-constexpr std::optional<LevelFormat> getLevelFormat(DimLevelType dlt) {
-  if (dlt == DimLevelType::Undef)
+/// Returns std::nullopt when input lt is Undef.
+constexpr std::optional<LevelFormat> getLevelFormat(DimLevelType lt) {
+  if (lt == DimLevelType::Undef)
     return std::nullopt;
-  return static_cast<LevelFormat>(static_cast<uint8_t>(dlt) & ~3);
+  return static_cast<LevelFormat>(static_cast<uint8_t>(lt) & ~3);
 }
 
 /// Convert a LevelFormat to its corresponding DimLevelType with the given
@@ -315,9 +315,9 @@ constexpr std::optional<LevelFormat> getLevelFormat(DimLevelType dlt) {
 /// for the input level format.
 constexpr std::optional<DimLevelType>
 buildLevelType(LevelFormat lf, bool ordered, bool unique) {
-  auto dlt = static_cast<DimLevelType>(static_cast<uint8_t>(lf) |
+  auto lt = static_cast<DimLevelType>(static_cast<uint8_t>(lf) |
                                        (ordered ? 0 : 2) | (unique ? 0 : 1));
-  return isValidDLT(dlt) ? std::optional(dlt) : std::nullopt;
+  return isValidLT(lt) ? std::optional(lt) : std::nullopt;
 }
 
 //
@@ -382,134 +382,134 @@ static_assert(
          DimLevelType::TwoOutOfFour),
     "buildLevelType conversion is broken");
 
-static_assert((isValidDLT(DimLevelType::Undef) &&
-               isValidDLT(DimLevelType::Dense) &&
-               isValidDLT(DimLevelType::Compressed) &&
-               isValidDLT(DimLevelType::CompressedNu) &&
-               isValidDLT(DimLevelType::CompressedNo) &&
-               isValidDLT(DimLevelType::CompressedNuNo) &&
-               isValidDLT(DimLevelType::Singleton) &&
-               isValidDLT(DimLevelType::SingletonNu) &&
-               isValidDLT(DimLevelType::SingletonNo) &&
-               isValidDLT(DimLevelType::SingletonNuNo) &&
-               isValidDLT(DimLevelType::LooseCompressed) &&
-               isValidDLT(DimLevelType::LooseCompressedNu) &&
-               isValidDLT(DimLevelType::LooseCompressedNo) &&
-               isValidDLT(DimLevelType::LooseCompressedNuNo) &&
-               isValidDLT(DimLevelType::TwoOutOfFour)),
-              "isValidDLT definition is broken");
+static_assert((isValidLT(DimLevelType::Undef) &&
+               isValidLT(DimLevelType::Dense) &&
+               isValidLT(DimLevelType::Compressed) &&
+               isValidLT(DimLevelType::CompressedNu) &&
+               isValidLT(DimLevelType::CompressedNo) &&
+               isValidLT(DimLevelType::CompressedNuNo) &&
+               isValidLT(DimLevelType::Singleton) &&
+               isValidLT(DimLevelType::SingletonNu) &&
+               isValidLT(DimLevelType::SingletonNo) &&
+               isValidLT(DimLevelType::SingletonNuNo) &&
+               isValidLT(DimLevelType::LooseCompressed) &&
+               isValidLT(DimLevelType::LooseCompressedNu) &&
+               isValidLT(DimLevelType::LooseCompressedNo) &&
+               isValidLT(DimLevelType::LooseCompressedNuNo) &&
+               isValidLT(DimLevelType::TwoOutOfFour)),
+              "isValidLT definition is broken");
 
-static_assert((isDenseDLT(DimLevelType::Dense) &&
-               !isDenseDLT(DimLevelType::Compressed) &&
-               !isDenseDLT(DimLevelType::CompressedNu) &&
-               !isDenseDLT(DimLevelType::CompressedNo) &&
-               !isDenseDLT(DimLevelType::CompressedNuNo) &&
-               !isDenseDLT(DimLevelType::Singleton) &&
-               !isDenseDLT(DimLevelType::SingletonNu) &&
-               !isDenseDLT(DimLevelType::SingletonNo) &&
-               !isDenseDLT(DimLevelType::SingletonNuNo) &&
-               !isDenseDLT(DimLevelType::LooseCompressed) &&
-               !isDenseDLT(DimLevelType::LooseCompressedNu) &&
-               !isDenseDLT(DimLevelType::LooseCompressedNo) &&
-               !isDenseDLT(DimLevelType::LooseCompressedNuNo) &&
-               !isDenseDLT(DimLevelType::TwoOutOfFour)),
-              "isDenseDLT definition is broken");
+static_assert((isDenseLT(DimLevelType::Dense) &&
+               !isDenseLT(DimLevelType::Compressed) &&
+               !isDenseLT(DimLevelType::CompressedNu) &&
+               !isDenseLT(DimLevelType::CompressedNo) &&
+               !isDenseLT(DimLevelType::CompressedNuNo) &&
+               !isDenseLT(DimLevelType::Singleton) &&
+               !isDenseLT(DimLevelType::SingletonNu) &&
+               !isDenseLT(DimLevelType::SingletonNo) &&
+               !isDenseLT(DimLevelType::SingletonNuNo) &&
+               !isDenseLT(DimLevelType::LooseCompressed) &&
+               !isDenseLT(DimLevelType::LooseCompressedNu) &&
+               !isDenseLT(DimLevelType::LooseCompressedNo) &&
+               !isDenseLT(DimLevelType::LooseCompressedNuNo) &&
+               !isDenseLT(DimLevelType::TwoOutOfFour)),
+              "isDenseLT definition is broken");
 
-static_assert((!isCompressedDLT(DimLevelType::Dense) &&
-               isCompressedDLT(DimLevelType::Compressed) &&
-               isCompressedDLT(DimLevelType::CompressedNu) &&
-               isCompressedDLT(DimLevelType::CompressedNo) &&
-               isCompressedDLT(DimLevelType::CompressedNuNo) &&
-               !isCompressedDLT(DimLevelType::Singleton) &&
-               !isCompressedDLT(DimLevelType::SingletonNu) &&
-               !isCompressedDLT(DimLevelType::SingletonNo) &&
-               !isCompressedDLT(DimLevelType::SingletonNuNo) &&
-               !isCompressedDLT(DimLevelType::LooseCompressed) &&
-               !isCompressedDLT(DimLevelType::LooseCompressedNu) &&
-               !isCompressedDLT(DimLevelType::LooseCompressedNo) &&
-               !isCompressedDLT(DimLevelType::LooseCompressedNuNo) &&
-               !isCompressedDLT(DimLevelType::TwoOutOfFour)),
-              "isCompressedDLT definition is broken");
+static_assert((!isCompressedLT(DimLevelType::Dense) &&
+               isCompressedLT(DimLevelType::Compressed) &&
+               isCompressedLT(DimLevelType::CompressedNu) &&
+               isCompressedLT(DimLevelType::CompressedNo) &&
+               isCompressedLT(DimLevelType::CompressedNuNo) &&
+               !isCompressedLT(DimLevelType::Singleton) &&
+               !isCompressedLT(DimLevelType::SingletonNu) &&
+               !isCompressedLT(DimLevelType::SingletonNo) &&
+               !isCompressedLT(DimLevelType::SingletonNuNo) &&
+               !isCompressedLT(DimLevelType::LooseCompressed) &&
+               !isCompressedLT(DimLevelType::LooseCompressedNu) &&
+               !isCompressedLT(DimLevelType::LooseCompressedNo) &&
+               !isCompressedLT(DimLevelType::LooseCompressedNuNo) &&
+               !isCompressedLT(DimLevelType::TwoOutOfFour)),
+              "isCompressedLT definition is broken");
 
-static_assert((!isSingletonDLT(DimLevelType::Dense) &&
-               !isSingletonDLT(DimLevelType::Compressed) &&
-               !isSingletonDLT(DimLevelType::CompressedNu) &&
-               !isSingletonDLT(DimLevelType::CompressedNo) &&
-               !isSingletonDLT(DimLevelType::CompressedNuNo) &&
-               isSingletonDLT(DimLevelType::Singleton) &&
-               isSingletonDLT(DimLevelType::SingletonNu) &&
-               isSingletonDLT(DimLevelType::SingletonNo) &&
-               isSingletonDLT(DimLevelType::SingletonNuNo) &&
-               !isSingletonDLT(DimLevelType::LooseCompressed) &&
-               !isSingletonDLT(DimLevelType::LooseCompressedNu) &&
-               !isSingletonDLT(DimLevelType::LooseCompressedNo) &&
-               !isSingletonDLT(DimLevelType::LooseCompressedNuNo) &&
-               !isSingletonDLT(DimLevelType::TwoOutOfFour)),
-              "isSingletonDLT definition is broken");
+static_assert((!isSingletonLT(DimLevelType::Dense) &&
+               !isSingletonLT(DimLevelType::Compressed) &&
+               !isSingletonLT(DimLevelType::CompressedNu) &&
+               !isSingletonLT(DimLevelType::CompressedNo) &&
+               !isSingletonLT(DimLevelType::CompressedNuNo) &&
+               isSingletonLT(DimLevelType::Singleton) &&
+               isSingletonLT(DimLevelType::SingletonNu) &&
+               isSingletonLT(DimLevelType::SingletonNo) &&
+               isSingletonLT(DimLevelType::SingletonNuNo) &&
+               !isSingletonLT(DimLevelType::LooseCompressed) &&
+               !isSingletonLT(DimLevelType::LooseCompressedNu) &&
+               !isSingletonLT(DimLevelType::LooseCompressedNo) &&
+               !isSingletonLT(DimLevelType::LooseCompressedNuNo) &&
+               !isSingletonLT(DimLevelType::TwoOutOfFour)),
+              "isSingletonLT definition is broken");
 
-static_assert((!isLooseCompressedDLT(DimLevelType::Dense) &&
-               !isLooseCompressedDLT(DimLevelType::Compressed) &&
-               !isLooseCompressedDLT(DimLevelType::CompressedNu) &&
-               !isLooseCompressedDLT(DimLevelType::CompressedNo) &&
-               !isLooseCompressedDLT(DimLevelType::CompressedNuNo) &&
-               !isLooseCompressedDLT(DimLevelType::Singleton) &&
-               !isLooseCompressedDLT(DimLevelType::SingletonNu) &&
-               !isLooseCompressedDLT(DimLevelType::SingletonNo) &&
-               !isLooseCompressedDLT(DimLevelType::SingletonNuNo) &&
-               isLooseCompressedDLT(DimLevelType::LooseCompressed) &&
-               isLooseCompressedDLT(DimLevelType::LooseCompressedNu) &&
-               isLooseCompressedDLT(DimLevelType::LooseCompressedNo) &&
-               isLooseCompressedDLT(DimLevelType::LooseCompressedNuNo) &&
-               !isLooseCompressedDLT(DimLevelType::TwoOutOfFour)),
-              "isLooseCompressedDLT definition is broken");
+static_assert((!isLooseCompressedLT(DimLevelType::Dense) &&
+               !isLooseCompressedLT(DimLevelType::Compressed) &&
+               !isLooseCompressedLT(DimLevelType::CompressedNu) &&
+               !isLooseCompressedLT(DimLevelType::CompressedNo) &&
+               !isLooseCompressedLT(DimLevelType::CompressedNuNo) &&
+               !isLooseCompressedLT(DimLevelType::Singleton) &&
+               !isLooseCompressedLT(DimLevelType::SingletonNu) &&
+               !isLooseCompressedLT(DimLevelType::SingletonNo) &&
+               !isLooseCompressedLT(DimLevelType::SingletonNuNo) &&
+               isLooseCompressedLT(DimLevelType::LooseCompressed) &&
+               isLooseCompressedLT(DimLevelType::LooseCompressedNu) &&
+               isLooseCompressedLT(DimLevelType::LooseCompressedNo) &&
+               isLooseCompressedLT(DimLevelType::LooseCompressedNuNo) &&
+               !isLooseCompressedLT(DimLevelType::TwoOutOfFour)),
+              "isLooseCompressedLT definition is broken");
 
-static_assert((!is2OutOf4DLT(DimLevelType::Dense) &&
-               !is2OutOf4DLT(DimLevelType::Compressed) &&
-               !is2OutOf4DLT(DimLevelType::CompressedNu) &&
-               !is2OutOf4DLT(DimLevelType::CompressedNo) &&
-               !is2OutOf4DLT(DimLevelType::CompressedNuNo) &&
-               !is2OutOf4DLT(DimLevelType::Singleton) &&
-               !is2OutOf4DLT(DimLevelType::SingletonNu) &&
-               !is2OutOf4DLT(DimLevelType::SingletonNo) &&
-               !is2OutOf4DLT(DimLevelType::SingletonNuNo) &&
-               !is2OutOf4DLT(DimLevelType::LooseCompressed) &&
-               !is2OutOf4DLT(DimLevelType::LooseCompressedNu) &&
-               !is2OutOf4DLT(DimLevelType::LooseCompressedNo) &&
-               !is2OutOf4DLT(DimLevelType::LooseCompressedNuNo) &&
-               is2OutOf4DLT(DimLevelType::TwoOutOfFour)),
-              "is2OutOf4DLT definition is broken");
+static_assert((!is2OutOf4LT(DimLevelType::Dense) &&
+               !is2OutOf4LT(DimLevelType::Compressed) &&
+               !is2OutOf4LT(DimLevelType::CompressedNu) &&
+               !is2OutOf4LT(DimLevelType::CompressedNo) &&
+               !is2OutOf4LT(DimLevelType::CompressedNuNo) &&
+               !is2OutOf4LT(DimLevelType::Singleton) &&
+               !is2OutOf4LT(DimLevelType::SingletonNu) &&
+               !is2OutOf4LT(DimLevelType::SingletonNo) &&
+               !is2OutOf4LT(DimLevelType::SingletonNuNo) &&
+               !is2OutOf4LT(DimLevelType::LooseCompressed) &&
+               !is2OutOf4LT(DimLevelType::LooseCompressedNu) &&
+               !is2OutOf4LT(DimLevelType::LooseCompressedNo) &&
+               !is2OutOf4LT(DimLevelType::LooseCompressedNuNo) &&
+               is2OutOf4LT(DimLevelType::TwoOutOfFour)),
+              "is2OutOf4LT definition is broken");
 
-static_assert((isOrderedDLT(DimLevelType::Dense) &&
-               isOrderedDLT(DimLevelType::Compressed) &&
-               isOrderedDLT(DimLevelType::CompressedNu) &&
-               !isOrderedDLT(DimLevelType::CompressedNo) &&
-               !isOrderedDLT(DimLevelType::CompressedNuNo) &&
-               isOrderedDLT(DimLevelType::Singleton) &&
-               isOrderedDLT(DimLevelType::SingletonNu) &&
-               !isOrderedDLT(DimLevelType::SingletonNo) &&
-               !isOrderedDLT(DimLevelType::SingletonNuNo) &&
-               isOrderedDLT(DimLevelType::LooseCompressed) &&
-               isOrderedDLT(DimLevelType::LooseCompressedNu) &&
-               !isOrderedDLT(DimLevelType::LooseCompressedNo) &&
-               !isOrderedDLT(DimLevelType::LooseCompressedNuNo) &&
-               isOrderedDLT(DimLevelType::TwoOutOfFour)),
-              "isOrderedDLT definition is broken");
+static_assert((isOrderedLT(DimLevelType::Dense) &&
+               isOrderedLT(DimLevelType::Compressed) &&
+               isOrderedLT(DimLevelType::CompressedNu) &&
+               !isOrderedLT(DimLevelType::CompressedNo) &&
+               !isOrderedLT(DimLevelType::CompressedNuNo) &&
+               isOrderedLT(DimLevelType::Singleton) &&
+               isOrderedLT(DimLevelType::SingletonNu) &&
+               !isOrderedLT(DimLevelType::SingletonNo) &&
+               !isOrderedLT(DimLevelType::SingletonNuNo) &&
+               isOrderedLT(DimLevelType::LooseCompressed) &&
+               isOrderedLT(DimLevelType::LooseCompressedNu) &&
+               !isOrderedLT(DimLevelType::LooseCompressedNo) &&
+               !isOrderedLT(DimLevelType::LooseCompressedNuNo) &&
+               isOrderedLT(DimLevelType::TwoOutOfFour)),
+              "isOrderedLT definition is broken");
 
-static_assert((isUniqueDLT(DimLevelType::Dense) &&
-               isUniqueDLT(DimLevelType::Compressed) &&
-               !isUniqueDLT(DimLevelType::CompressedNu) &&
-               isUniqueDLT(DimLevelType::CompressedNo) &&
-               !isUniqueDLT(DimLevelType::CompressedNuNo) &&
-               isUniqueDLT(DimLevelType::Singleton) &&
-               !isUniqueDLT(DimLevelType::SingletonNu) &&
-               isUniqueDLT(DimLevelType::SingletonNo) &&
-               !isUniqueDLT(DimLevelType::SingletonNuNo) &&
-               isUniqueDLT(DimLevelType::LooseCompressed) &&
-               !isUniqueDLT(DimLevelType::LooseCompressedNu) &&
-               isUniqueDLT(DimLevelType::LooseCompressedNo) &&
-               !isUniqueDLT(DimLevelType::LooseCompressedNuNo) &&
-               isUniqueDLT(DimLevelType::TwoOutOfFour)),
-              "isUniqueDLT definition is broken");
+static_assert((isUniqueLT(DimLevelType::Dense) &&
+               isUniqueLT(DimLevelType::Compressed) &&
+               !isUniqueLT(DimLevelType::CompressedNu) &&
+               isUniqueLT(DimLevelType::CompressedNo) &&
+               !isUniqueLT(DimLevelType::CompressedNuNo) &&
+               isUniqueLT(DimLevelType::Singleton) &&
+               !isUniqueLT(DimLevelType::SingletonNu) &&
+               isUniqueLT(DimLevelType::SingletonNo) &&
+               !isUniqueLT(DimLevelType::SingletonNuNo) &&
+               isUniqueLT(DimLevelType::LooseCompressed) &&
+               !isUniqueLT(DimLevelType::LooseCompressedNu) &&
+               isUniqueLT(DimLevelType::LooseCompressedNo) &&
+               !isUniqueLT(DimLevelType::LooseCompressedNuNo) &&
+               isUniqueLT(DimLevelType::TwoOutOfFour)),
+              "isUniqueLT definition is broken");
 
 /// Bit manipulations for affine encoding.
 ///

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/Enums.h
@@ -247,9 +247,7 @@ constexpr bool isValidLT(DimLevelType lt) {
 }
 
 /// Check if the `DimLevelType` is the special undefined value.
-constexpr bool isUndefLT(DimLevelType lt) {
-  return lt == DimLevelType::Undef;
-}
+constexpr bool isUndefLT(DimLevelType lt) { return lt == DimLevelType::Undef; }
 
 /// Check if the `DimLevelType` is dense (regardless of properties).
 constexpr bool isDenseLT(DimLevelType lt) {
@@ -288,8 +286,8 @@ constexpr bool isWithPosLT(DimLevelType lt) {
 
 /// Check if the `DimLevelType` needs coordinates array.
 constexpr bool isWithCrdLT(DimLevelType lt) {
-  return isCompressedLT(lt) || isSingletonLT(lt) ||
-         isLooseCompressedLT(lt) || is2OutOf4LT(lt);
+  return isCompressedLT(lt) || isSingletonLT(lt) || isLooseCompressedLT(lt) ||
+         is2OutOf4LT(lt);
 }
 
 /// Check if the `DimLevelType` is ordered (regardless of storage format).
@@ -316,7 +314,7 @@ constexpr std::optional<LevelFormat> getLevelFormat(DimLevelType lt) {
 constexpr std::optional<DimLevelType>
 buildLevelType(LevelFormat lf, bool ordered, bool unique) {
   auto lt = static_cast<DimLevelType>(static_cast<uint8_t>(lf) |
-                                       (ordered ? 0 : 2) | (unique ? 0 : 1));
+                                      (ordered ? 0 : 2) | (unique ? 0 : 1));
   return isValidLT(lt) ? std::optional(lt) : std::nullopt;
 }
 

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.td
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorAttrDefs.td
@@ -370,13 +370,13 @@ def SparseTensorEncodingAttr : SparseTensor_Attr<"SparseTensorEncoding",
     /// are always all-dense.)
     ::mlir::sparse_tensor::DimLevelType getLvlType(::mlir::sparse_tensor::Level l) const;
 
-    bool isDenseLvl(::mlir::sparse_tensor::Level l) const { return isDenseDLT(getLvlType(l)); }
-    bool isCompressedLvl(::mlir::sparse_tensor::Level l) const { return isCompressedDLT(getLvlType(l)); }
-    bool isSingletonLvl(::mlir::sparse_tensor::Level l) const { return isSingletonDLT(getLvlType(l)); }
-    bool isLooseCompressedLvl(::mlir::sparse_tensor::Level l) const { return isLooseCompressedDLT(getLvlType(l)); }
-    bool isTwoOutOfFourLvl(::mlir::sparse_tensor::Level l) const { return is2OutOf4DLT(getLvlType(l)); }
-    bool isOrderedLvl(::mlir::sparse_tensor::Level l) const { return isOrderedDLT(getLvlType(l)); }
-    bool isUniqueLvl(::mlir::sparse_tensor::Level l) const { return isUniqueDLT(getLvlType(l)); }
+    bool isDenseLvl(::mlir::sparse_tensor::Level l) const { return isDenseLT(getLvlType(l)); }
+    bool isCompressedLvl(::mlir::sparse_tensor::Level l) const { return isCompressedLT(getLvlType(l)); }
+    bool isSingletonLvl(::mlir::sparse_tensor::Level l) const { return isSingletonLT(getLvlType(l)); }
+    bool isLooseCompressedLvl(::mlir::sparse_tensor::Level l) const { return isLooseCompressedLT(getLvlType(l)); }
+    bool isTwoOutOfFourLvl(::mlir::sparse_tensor::Level l) const { return is2OutOf4LT(getLvlType(l)); }
+    bool isOrderedLvl(::mlir::sparse_tensor::Level l) const { return isOrderedLT(getLvlType(l)); }
+    bool isUniqueLvl(::mlir::sparse_tensor::Level l) const { return isUniqueLT(getLvlType(l)); }
 
     /// Returns true if every level is dense.  Also returns true for
     /// the null encoding (since dense-tensors are always all-dense).

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorStorageLayout.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorStorageLayout.h
@@ -126,7 +126,7 @@ public:
   void foreachField(
       llvm::function_ref<bool(
           FieldIndex /*fieldIdx*/, SparseTensorFieldKind /*fieldKind*/,
-          Level /*lvl (if applicable)*/, DimLevelType /*DLT (if applicable)*/)>)
+          Level /*lvl (if applicable)*/, DimLevelType /*LT (if applicable)*/)>)
       const;
 
   /// Gets the field index for required field.

--- a/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorType.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/IR/SparseTensorType.h
@@ -293,17 +293,17 @@ public:
 
   // We can't just delegate these, since we want to use this class's
   // `getLvlType` method instead of STEA's.
-  bool isDenseLvl(Level l) const { return isDenseDLT(getLvlType(l)); }
-  bool isCompressedLvl(Level l) const { return isCompressedDLT(getLvlType(l)); }
+  bool isDenseLvl(Level l) const { return isDenseLT(getLvlType(l)); }
+  bool isCompressedLvl(Level l) const { return isCompressedLT(getLvlType(l)); }
   bool isLooseCompressedLvl(Level l) const {
-    return isLooseCompressedDLT(getLvlType(l));
+    return isLooseCompressedLT(getLvlType(l));
   }
-  bool isSingletonLvl(Level l) const { return isSingletonDLT(getLvlType(l)); }
-  bool is2OutOf4Lvl(Level l) const { return is2OutOf4DLT(getLvlType(l)); }
-  bool isOrderedLvl(Level l) const { return isOrderedDLT(getLvlType(l)); }
-  bool isUniqueLvl(Level l) const { return isUniqueDLT(getLvlType(l)); }
-  bool isWithPos(Level l) const { return isWithPosDLT(getLvlType(l)); }
-  bool isWithCrd(Level l) const { return isWithCrdDLT(getLvlType(l)); }
+  bool isSingletonLvl(Level l) const { return isSingletonLT(getLvlType(l)); }
+  bool is2OutOf4Lvl(Level l) const { return is2OutOf4LT(getLvlType(l)); }
+  bool isOrderedLvl(Level l) const { return isOrderedLT(getLvlType(l)); }
+  bool isUniqueLvl(Level l) const { return isUniqueLT(getLvlType(l)); }
+  bool isWithPos(Level l) const { return isWithPosLT(getLvlType(l)); }
+  bool isWithCrd(Level l) const { return isWithCrdLT(getLvlType(l)); }
 
   /// Returns the coordinate-overhead bitwidth, defaulting to zero.
   unsigned getCrdWidth() const { return enc ? enc.getCrdWidth() : 0; }

--- a/mlir/include/mlir/Dialect/SparseTensor/Utils/Merger.h
+++ b/mlir/include/mlir/Dialect/SparseTensor/Utils/Merger.h
@@ -57,7 +57,7 @@ using LatPointId = unsigned;
 using LatSetId = unsigned;
 
 /// A pair of level and its corresponding DimLevelType of a tensor.
-using LvlDLTPair = std::pair<Level, DimLevelType>;
+using LvlLTPair = std::pair<Level, DimLevelType>;
 
 /// A pair of loop id and its coefficients. E.g., for affine expression in the
 /// affine map `2 * d0`, loop id = 0, coefficient = 2.
@@ -422,9 +422,9 @@ public:
 
   /// Sets the level number and level-type of the `t`th tensor on
   /// `i`th loop.
-  void setLevelAndType(TensorId t, LoopId i, Level lvl, DimLevelType dlt) {
-    assert(isValidLevel(t, lvl) && isValidLoopId(i) && isValidDLT(dlt));
-    lvlTypes[t][i] = dlt;
+  void setLevelAndType(TensorId t, LoopId i, Level lvl, DimLevelType lt) {
+    assert(isValidLevel(t, lvl) && isValidLoopId(i) && isValidLT(lt));
+    lvlTypes[t][i] = lt;
     loopToLvl[t][i] = lvl;
     lvlToLoop[t][lvl] = i;
     // TODO: favor a constant loop bound when there are multiple choices.
@@ -467,12 +467,12 @@ public:
   /// Sets whether the output tensor is sparse or not.
   void setHasSparseOut(bool s) { hasSparseOut = s; }
 
-  /// Establishes the two-way map that i <-> <t, lvl, dlt>.
+  /// Establishes the two-way map that i <-> <t, lvl, lt>.
   void setLoopDependentTensorLevel(LoopId i, TensorId t, Level lvl,
-                                   DimLevelType dlt, unsigned coefficient) {
+                                   DimLevelType lt, unsigned coefficient) {
     assert(isValidLoopId(i) && isValidLevel(t, lvl));
     assert(!loopToUnresolvedLvls[i][t].has_value()); // must be the first def
-    loopToUnresolvedLvls[i][t] = std::make_pair(lvl, dlt);
+    loopToUnresolvedLvls[i][t] = std::make_pair(lvl, lt);
     levelToDependentLoop[t][lvl].emplace_back(i, coefficient);
   }
 
@@ -508,9 +508,9 @@ public:
   /// non-trivial index expression.
   bool isSparseLvlWithNonTrivialIdxExp(TensorLoopId b) const {
     if (isLvlWithNonTrivialIdxExp(b)) {
-      auto dlt = getLoopDependentLevelType(b);
-      return isCompressedDLT(dlt) || isSingletonDLT(dlt) ||
-             isLooseCompressedDLT(dlt) || is2OutOf4DLT(dlt);
+      auto lt = getLoopDependentLevelType(b);
+      return isCompressedLT(lt) || isSingletonLT(lt) ||
+             isLooseCompressedLT(lt) || is2OutOf4LT(lt);
     }
     return false;
   }
@@ -647,9 +647,9 @@ private:
   /// Map from a loop to its dependencies if any.
   /// The dependencies of a loop is a set of (tensor, level) pairs.
   /// It is currently only set for non-trivial index expressions.
-  /// E.g., A[i+j] => i and j will have dependencies {A0, dlt(A0)} to indicate
+  /// E.g., A[i+j] => i and j will have dependencies {A0, lt(A0)} to indicate
   /// that i and j are used in the non-trivial index expression on A0.
-  std::vector<std::vector<std::optional<LvlDLTPair>>> loopToUnresolvedLvls;
+  std::vector<std::vector<std::optional<LvlLTPair>>> loopToUnresolvedLvls;
 
   /// The inverse map of ldxToDependencies from tensor level -> dependent loop
   /// E.g., A[2i+j], we have A0 => {(2, i), (1, j)}, to indicate that A0 uses

--- a/mlir/include/mlir/ExecutionEngine/SparseTensor/Storage.h
+++ b/mlir/include/mlir/ExecutionEngine/SparseTensor/Storage.h
@@ -108,31 +108,31 @@ public:
   }
 
   /// Safely checks if the level uses dense storage.
-  bool isDenseLvl(uint64_t l) const { return isDenseDLT(getLvlType(l)); }
+  bool isDenseLvl(uint64_t l) const { return isDenseLT(getLvlType(l)); }
 
   /// Safely checks if the level uses compressed storage.
   bool isCompressedLvl(uint64_t l) const {
-    return isCompressedDLT(getLvlType(l));
+    return isCompressedLT(getLvlType(l));
   }
 
   /// Safely checks if the level uses loose compressed storage.
   bool isLooseCompressedLvl(uint64_t l) const {
-    return isLooseCompressedDLT(getLvlType(l));
+    return isLooseCompressedLT(getLvlType(l));
   }
 
   /// Safely checks if the level uses singleton storage.
   bool isSingletonLvl(uint64_t l) const {
-    return isSingletonDLT(getLvlType(l));
+    return isSingletonLT(getLvlType(l));
   }
 
   /// Safely checks if the level uses 2 out of 4 storage.
-  bool is2OutOf4Lvl(uint64_t l) const { return is2OutOf4DLT(getLvlType(l)); }
+  bool is2OutOf4Lvl(uint64_t l) const { return is2OutOf4LT(getLvlType(l)); }
 
   /// Safely checks if the level is ordered.
-  bool isOrderedLvl(uint64_t l) const { return isOrderedDLT(getLvlType(l)); }
+  bool isOrderedLvl(uint64_t l) const { return isOrderedLT(getLvlType(l)); }
 
   /// Safely checks if the level is unique.
-  bool isUniqueLvl(uint64_t l) const { return isUniqueDLT(getLvlType(l)); }
+  bool isUniqueLvl(uint64_t l) const { return isUniqueLT(getLvlType(l)); }
 
   /// Gets positions-overhead storage for the given level.
 #define DECL_GETPOSITIONS(PNAME, P)                                            \
@@ -296,7 +296,7 @@ public:
   void lexInsert(const uint64_t *lvlCoords, V val) final {
     assert(lvlCoords);
     bool allDense = std::all_of(getLvlTypes().begin(), getLvlTypes().end(),
-                                [](DimLevelType lt) { return isDenseDLT(lt); });
+                                [](DimLevelType lt) { return isDenseLT(lt); });
     if (allDense) {
       uint64_t lvlRank = getLvlRank();
       uint64_t valIdx = 0;

--- a/mlir/include/mlir/ExecutionEngine/SparseTensor/Storage.h
+++ b/mlir/include/mlir/ExecutionEngine/SparseTensor/Storage.h
@@ -121,9 +121,7 @@ public:
   }
 
   /// Safely checks if the level uses singleton storage.
-  bool isSingletonLvl(uint64_t l) const {
-    return isSingletonLT(getLvlType(l));
-  }
+  bool isSingletonLvl(uint64_t l) const { return isSingletonLT(getLvlType(l)); }
 
   /// Safely checks if the level uses 2 out of 4 storage.
   bool is2OutOf4Lvl(uint64_t l) const { return is2OutOf4LT(getLvlType(l)); }

--- a/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMap.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/Detail/DimLvlMap.cpp
@@ -65,7 +65,7 @@ bool DimSpec::isValid(Ranks const &ranks) const {
 LvlSpec::LvlSpec(LvlVar var, LvlExpr expr, DimLevelType type)
     : var(var), expr(expr), type(type) {
   assert(expr);
-  assert(isValidDLT(type) && !isUndefDLT(type));
+  assert(isValidLT(type) && !isUndefLT(type));
 }
 
 bool LvlSpec::isValid(Ranks const &ranks) const {

--- a/mlir/lib/Dialect/SparseTensor/IR/Detail/LvlTypeParser.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/Detail/LvlTypeParser.cpp
@@ -58,7 +58,7 @@ FailureOr<uint8_t> LvlTypeParser::parseLvlType(AsmParser &parser) const {
     return failure();
   }
 
-  ERROR_IF(!isValidDLT(static_cast<DimLevelType>(properties)),
+  ERROR_IF(!isValidLT(static_cast<DimLevelType>(properties)),
            "invalid level type: level format doesn't support the properties");
   return properties;
 }
@@ -70,9 +70,9 @@ ParseResult LvlTypeParser::parseProperty(AsmParser &parser,
   ERROR_IF(failed(parser.parseOptionalKeyword(&strVal)),
            "expected valid level property (e.g. nonordered, nonunique or high)")
   if (strVal.compare("nonunique") == 0) {
-    *properties |= static_cast<uint8_t>(LevelNondefaultProperty::Nonunique);
+    *properties |= static_cast<uint8_t>(LevelPropertyNondefault::Nonunique);
   } else if (strVal.compare("nonordered") == 0) {
-    *properties |= static_cast<uint8_t>(LevelNondefaultProperty::Nonordered);
+    *properties |= static_cast<uint8_t>(LevelPropertyNondefault::Nonordered);
   } else {
     parser.emitError(loc, "unknown level property: ") << strVal;
     return failure();

--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -71,13 +71,13 @@ void StorageLayout::foreachField(
   FieldIndex fieldIdx = kDataFieldStartingIdx;
   // Per-level storage.
   for (Level l = 0; l < end; l++) {
-    const auto dlt = lvlTypes[l];
-    if (isWithPosDLT(dlt)) {
-      if (!(callback(fieldIdx++, SparseTensorFieldKind::PosMemRef, l, dlt)))
+    const auto lt = lvlTypes[l];
+    if (isWithPosLT(lt)) {
+      if (!(callback(fieldIdx++, SparseTensorFieldKind::PosMemRef, l, lt)))
         return;
     }
-    if (isWithCrdDLT(dlt)) {
-      if (!(callback(fieldIdx++, SparseTensorFieldKind::CrdMemRef, l, dlt)))
+    if (isWithCrdLT(lt)) {
+      if (!(callback(fieldIdx++, SparseTensorFieldKind::CrdMemRef, l, lt)))
         return;
     }
   }
@@ -113,16 +113,16 @@ void sparse_tensor::foreachFieldAndTypeInSparseTensor(
   StorageLayout(stt).foreachField(
       [specType, posMemType, crdMemType, valMemType,
        callback](FieldIndex fieldIdx, SparseTensorFieldKind fieldKind,
-                 Level lvl, DimLevelType dlt) -> bool {
+                 Level lvl, DimLevelType lt) -> bool {
         switch (fieldKind) {
         case SparseTensorFieldKind::StorageSpec:
-          return callback(specType, fieldIdx, fieldKind, lvl, dlt);
+          return callback(specType, fieldIdx, fieldKind, lvl, lt);
         case SparseTensorFieldKind::PosMemRef:
-          return callback(posMemType, fieldIdx, fieldKind, lvl, dlt);
+          return callback(posMemType, fieldIdx, fieldKind, lvl, lt);
         case SparseTensorFieldKind::CrdMemRef:
-          return callback(crdMemType, fieldIdx, fieldKind, lvl, dlt);
+          return callback(crdMemType, fieldIdx, fieldKind, lvl, lt);
         case SparseTensorFieldKind::ValMemRef:
-          return callback(valMemType, fieldIdx, fieldKind, lvl, dlt);
+          return callback(valMemType, fieldIdx, fieldKind, lvl, lt);
         };
         llvm_unreachable("unrecognized field kind");
       });
@@ -167,7 +167,7 @@ StorageLayout::getFieldIndexAndStride(SparseTensorFieldKind kind,
   }
   foreachField([lvl, kind, &fieldIdx](FieldIndex fIdx,
                                       SparseTensorFieldKind fKind, Level fLvl,
-                                      DimLevelType dlt) -> bool {
+                                      DimLevelType lt) -> bool {
     if ((lvl && fLvl == lvl.value() && kind == fKind) ||
         (kind == fKind && fKind == SparseTensorFieldKind::ValMemRef)) {
       fieldIdx = fIdx;
@@ -313,7 +313,7 @@ SparseTensorEncodingAttr SparseTensorEncodingAttr::withoutDimSlices() const {
 }
 
 bool SparseTensorEncodingAttr::isAllDense() const {
-  return !getImpl() || llvm::all_of(getLvlTypes(), isDenseDLT);
+  return !getImpl() || llvm::all_of(getLvlTypes(), isDenseLT);
 }
 
 bool SparseTensorEncodingAttr::isCOO() const {
@@ -321,7 +321,7 @@ bool SparseTensorEncodingAttr::isCOO() const {
 }
 
 bool SparseTensorEncodingAttr::isAllOrdered() const {
-  return !getImpl() || llvm::all_of(getLvlTypes(), isOrderedDLT);
+  return !getImpl() || llvm::all_of(getLvlTypes(), isOrderedLT);
 }
 
 bool SparseTensorEncodingAttr::isIdentity() const {
@@ -645,14 +645,14 @@ SparseTensorEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     return emitError() << "unexpected position bitwidth: " << posWidth;
   if (!acceptBitWidth(crdWidth))
     return emitError() << "unexpected coordinate bitwidth: " << crdWidth;
-  if (auto it = std::find_if(lvlTypes.begin(), lvlTypes.end(), isSingletonDLT);
+  if (auto it = std::find_if(lvlTypes.begin(), lvlTypes.end(), isSingletonLT);
       it != std::end(lvlTypes)) {
     if (it == lvlTypes.begin() ||
-        (!isCompressedDLT(*(it - 1)) && !isLooseCompressedDLT(*(it - 1))))
+        (!isCompressedLT(*(it - 1)) && !isLooseCompressedLT(*(it - 1))))
       return emitError() << "expected compressed or loose_compressed level "
                             "before singleton level";
     if (!std::all_of(it, lvlTypes.end(),
-                     [](DimLevelType i) { return isSingletonDLT(i); }))
+                     [](DimLevelType i) { return isSingletonLT(i); }))
       return emitError() << "expected all singleton lvlTypes "
                             "following a singleton level";
   }
@@ -955,17 +955,17 @@ Level mlir::sparse_tensor::toStoredDim(SparseTensorEncodingAttr enc,
 }
 
 /// We normalized sparse tensor encoding attribute by always using
-/// ordered/unique DLT such that "compressed_nu_no" and "compressed_nu" (as well
+/// ordered/unique LT such that "compressed_nu_no" and "compressed_nu" (as well
 /// as other variants) lead to the same storage specifier type, and stripping
 /// irrelevant fields that do not alter the sparse tensor memory layout.
 static SparseTensorEncodingAttr
 getNormalizedEncodingForSpecifier(SparseTensorEncodingAttr enc) {
-  SmallVector<DimLevelType> dlts;
-  for (auto dlt : enc.getLvlTypes())
-    dlts.push_back(*buildLevelType(*getLevelFormat(dlt), true, true));
+  SmallVector<DimLevelType> lts;
+  for (auto lt : enc.getLvlTypes())
+    lts.push_back(*buildLevelType(*getLevelFormat(lt), true, true));
 
   return SparseTensorEncodingAttr::get(
-      enc.getContext(), dlts,
+      enc.getContext(), lts,
       AffineMap(), // dimToLvl (irrelevant to storage specifier)
       AffineMap(), // lvlToDim (irrelevant to storage specifier)
       // Always use `index` for memSize and lvlSize instead of reusing
@@ -1070,7 +1070,7 @@ static LogicalResult verifyPackUnPack(Operation *op, bool requiresStaticShape,
   bool misMatch = false;
   layout.foreachField([&idx, &misMatch, stt, valTp,
                        lvlTps](FieldIndex fid, SparseTensorFieldKind fKind,
-                               Level lvl, DimLevelType dlt) -> bool {
+                               Level lvl, DimLevelType lt) -> bool {
     if (fKind == SparseTensorFieldKind::StorageSpec)
       return true;
 
@@ -1078,7 +1078,7 @@ static LogicalResult verifyPackUnPack(Operation *op, bool requiresStaticShape,
     if (fKind == SparseTensorFieldKind::ValMemRef) {
       inputTp = valTp;
     } else {
-      assert(fid == idx && stt.getLvlType(lvl) == dlt);
+      assert(fid == idx && stt.getLvlType(lvl) == lt);
       inputTp = lvlTps[idx++];
     }
     // The input element type and expected element type should match.

--- a/mlir/lib/Dialect/SparseTensor/Transforms/CodegenEnv.h
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/CodegenEnv.h
@@ -77,10 +77,10 @@ public:
   const TensorExp &exp(ExprId e) const { return latticeMerger.exp(e); }
   const LatPoint &lat(LatPointId l) const { return latticeMerger.lat(l); }
   ArrayRef<LatPointId> set(LatSetId s) const { return latticeMerger.set(s); }
-  DimLevelType dlt(TensorId t, LoopId i) const {
+  DimLevelType lt(TensorId t, LoopId i) const {
     return latticeMerger.getLvlType(t, i);
   }
-  DimLevelType dlt(TensorLoopId b) const { return latticeMerger.getLvlType(b); }
+  DimLevelType lt(TensorLoopId b) const { return latticeMerger.getLvlType(b); }
 
   unsigned getLoopNum() const { return latticeMerger.getNumLoops(); }
 

--- a/mlir/lib/Dialect/SparseTensor/Transforms/CodegenUtils.h
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/CodegenUtils.h
@@ -429,8 +429,8 @@ inline Value constantPrimaryTypeEncoding(OpBuilder &builder, Location loc,
 
 /// Generates a constant of the internal dimension level type encoding.
 inline Value constantDimLevelTypeEncoding(OpBuilder &builder, Location loc,
-                                          DimLevelType dlt) {
-  return constantI8(builder, loc, static_cast<uint8_t>(dlt));
+                                          DimLevelType lt) {
+  return constantI8(builder, loc, static_cast<uint8_t>(lt));
 }
 
 inline bool isZeroRankedTensorOrScalar(Type type) {

--- a/mlir/lib/Dialect/SparseTensor/Transforms/LoopEmitter.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/LoopEmitter.cpp
@@ -434,18 +434,18 @@ void LoopEmitter::initializeLoopEmit(
              !highs[t][l]);
       const auto lvlTp = lvlTypes[t][l];
       // Handle sparse storage schemes.
-      if (isCompressedDLT(lvlTp) || isLooseCompressedDLT(lvlTp)) {
+      if (isCompressedLT(lvlTp) || isLooseCompressedLT(lvlTp)) {
         // Generate sparse primitives to obtain positions and coordinates.
         positionsBuffers[t][l] = genToPositions(builder, loc, tensor, l);
         coordinatesBuffers[t][l] =
             genToCoordinates(builder, loc, tensor, l, cooStart);
-      } else if (isSingletonDLT(lvlTp) || is2OutOf4DLT(lvlTp)) {
+      } else if (isSingletonLT(lvlTp) || is2OutOf4LT(lvlTp)) {
         // Singleton level, fetch coordinates.
         coordinatesBuffers[t][l] =
             genToCoordinates(builder, loc, tensor, l, cooStart);
       } else {
         // Dense level, nothing to fetch.
-        assert(isDenseDLT(lvlTp));
+        assert(isDenseLT(lvlTp));
       }
 
       // Find upper bound in current dimension.
@@ -529,12 +529,12 @@ void LoopEmitter::categorizeLoopCondition(
   for (auto [t, l] : unpackTensorLevelRange(tidLvls)) {
     assert(lvlTypes[t].size() > l); // Must be a valid tid, dim pair
     auto lvlType = lvlTypes[t][l];
-    // Must be a recognizable DLT.
-    assert(isDenseDLT(lvlType) || isCompressedDLT(lvlType) ||
-           isLooseCompressedDLT(lvlType) || isSingletonDLT(lvlType) ||
-           is2OutOf4DLT(lvlType));
+    // Must be a recognizable LT.
+    assert(isDenseLT(lvlType) || isCompressedLT(lvlType) ||
+           isLooseCompressedLT(lvlType) || isSingletonLT(lvlType) ||
+           is2OutOf4LT(lvlType));
 
-    bool isSparse = !isDenseDLT(lvlType);
+    bool isSparse = !isDenseLT(lvlType);
     bool isSlice = isSparseSlices[t];
     bool isAffine = !dependentLvlMap[t][l].empty();
     bool isUnRedu = false;
@@ -626,10 +626,10 @@ Value LoopEmitter::genAffine(OpBuilder &builder, Location loc, AffineExpr a) {
 std::pair<Operation *, Value> LoopEmitter::emitForLoopOverTensorAtLvl(
     OpBuilder &builder, Location loc, TensorId tid, Level lvl, Value lo,
     Value hi, MutableArrayRef<Value> reduc, bool isParallel) {
-  bool isSparseCond = isCompressedDLT(lvlTypes[tid][lvl]) ||
-                      isLooseCompressedDLT(lvlTypes[tid][lvl]) ||
-                      is2OutOf4DLT(lvlTypes[tid][lvl]) ||
-                      isSingletonDLT(lvlTypes[tid][lvl]);
+  bool isSparseCond = isCompressedLT(lvlTypes[tid][lvl]) ||
+                      isLooseCompressedLT(lvlTypes[tid][lvl]) ||
+                      is2OutOf4LT(lvlTypes[tid][lvl]) ||
+                      isSingletonLT(lvlTypes[tid][lvl]);
   // TODO: support dynamic slices.
   // Uses the first dimension here to build the loop bound (which is also the
   // biggest range).
@@ -891,8 +891,8 @@ std::pair<Operation *, Value> LoopEmitter::emitWhileLoopOverTensorsAtLvls(
     // Dense level are handled by the shared univeral index.
     assert(!isDenseCond(cKind));
     // Must be a recognizable sparse level.
-    assert(isCompressedDLT(lvlTp) || isLooseCompressedDLT(lvlTp) ||
-           isSingletonDLT(lvlTp));
+    assert(isCompressedLT(lvlTp) || isLooseCompressedLT(lvlTp) ||
+           isSingletonLT(lvlTp));
     (void)lvlTp;
 
     unsigned prevSz = ivs.size();
@@ -993,7 +993,7 @@ std::pair<Operation *, Value> LoopEmitter::emitWhileLoopOverTensorsAtLvls(
 
   for (auto [tid, lvl] : unpackTensorLevelFromCondRange(spConds)) {
     // Generates segment high for non-unique level.
-    if (!isUniqueDLT(lvlTypes[tid][lvl])) {
+    if (!isUniqueLT(lvlTypes[tid][lvl])) {
       segHi[tid][lvl] = genSegmentHigh(builder, loc, tid, lvl, posits[tid][lvl],
                                        highs[tid][lvl]);
     }
@@ -1009,8 +1009,8 @@ std::pair<Operation *, Value> LoopEmitter::emitWhileLoopOverTensorsAtLvls(
   if (!needsUniv) {
     for (auto [tid, lvl] : unpackTensorLevelFromCondRange(spConds)) {
       const auto lvlTp = lvlTypes[tid][lvl];
-      if (isCompressedDLT(lvlTp) || isSingletonDLT(lvlTp) ||
-          isLooseCompressedDLT(lvlTp)) {
+      if (isCompressedLT(lvlTp) || isSingletonLT(lvlTp) ||
+          isLooseCompressedLT(lvlTp)) {
         const auto crd = coords[tid][lvl];
         if (min) {
           Value cmp = CMPI(ult, coords[tid][lvl], min);
@@ -1043,7 +1043,7 @@ bool LoopEmitter::shouldIteratedByForLoop(ArrayRef<TensorLvlCond> sparseConds,
   if (sparseConds.size() == 1) {
     auto [tid, lvl] = unpackTensorLevel(sparseConds.back().first);
     return !isAffineIdxCond(sparseConds.back().second) &&
-           !(genDedup && !isUniqueDLT(lvlTypes[tid][lvl]));
+           !(genDedup && !isUniqueLT(lvlTypes[tid][lvl]));
   }
 
   return true;
@@ -1149,7 +1149,7 @@ Operation *LoopEmitter::enterFilterLoopOverTensorAtLvl(
     OpBuilder &builder, Location loc, TensorId tid, Level lvl,
     AffineExpr affine, MutableArrayRef<Value> reduc) {
   assert(isValidLevel(tid, lvl));
-  assert(!isa<AffineDimExpr>(affine) && !isDenseDLT(lvlTypes[tid][lvl]));
+  assert(!isa<AffineDimExpr>(affine) && !isDenseLT(lvlTypes[tid][lvl]));
   // We can not re-enter the same level.
   assert(!coords[tid][lvl]);
 
@@ -1216,7 +1216,7 @@ void LoopEmitter::genDenseAffineAddress(OpBuilder &builder, Location loc,
                                         TensorLevel tidLvl,
                                         AffineExpr lvlExpr) {
   auto [tid, lvl] = unpackTensorLevel(tidLvl);
-  assert(isDenseDLT(lvlTypes[tid][lvl]));
+  assert(isDenseLT(lvlTypes[tid][lvl]));
   // For dense levels, the vel-coordinate also serves as the position.
   Value lvlCrd = genAffine(builder, loc, lvlExpr);
   posits[tid][lvl] = genAddress(builder, loc, tid, lvl, lvlCrd);
@@ -1227,7 +1227,7 @@ void LoopEmitter::prepareLoopOverTensorAtLvl(OpBuilder &builder, Location loc,
   assert(isValidLevel(tid, lvl));
   const auto lvlTp = lvlTypes[tid][lvl];
 
-  if (isDenseDLT(lvlTp))
+  if (isDenseLT(lvlTp))
     return;
 
   const Value c0 = C_IDX(0);
@@ -1236,11 +1236,11 @@ void LoopEmitter::prepareLoopOverTensorAtLvl(OpBuilder &builder, Location loc,
   // Either the first level, or the previous level has been set.
   /// FIXME: See the [CLARIFY_POSITS_LVL] note in the header.
   assert(lvl == 0 || posits[tid][lvl - 1]);
-  if (isCompressedDLT(lvlTp) || isLooseCompressedDLT(lvlTp)) {
+  if (isCompressedLT(lvlTp) || isLooseCompressedLT(lvlTp)) {
     const Value mem = positionsBuffers[tid][lvl];
 
     Value pLo = lvl == 0 ? c0 : posits[tid][lvl - 1];
-    if (isLooseCompressedDLT(lvlTp))
+    if (isLooseCompressedLT(lvlTp))
       pLo = builder.create<arith::MulIOp>(loc, pLo, c2);
     posits[tid][lvl] = genIndexLoad(builder, loc, mem, pLo);
 
@@ -1248,7 +1248,7 @@ void LoopEmitter::prepareLoopOverTensorAtLvl(OpBuilder &builder, Location loc,
     highs[tid][lvl] = genIndexLoad(builder, loc, mem, pHi);
     return;
   }
-  if (isSingletonDLT(lvlTp)) {
+  if (isSingletonLT(lvlTp)) {
     const Value pLo = lvl == 0 ? c0 : posits[tid][lvl - 1];
     posits[tid][lvl] = pLo;
 
@@ -1259,12 +1259,12 @@ void LoopEmitter::prepareLoopOverTensorAtLvl(OpBuilder &builder, Location loc,
     // whenever coiterating, in order to improve code quality for the
     // non-coiterating cases.
     const auto parentSegHi = segHi[tid][lvl - 1];
-    highs[tid][lvl] = (!isUniqueDLT(lvlTypes[tid][lvl - 1]) && parentSegHi)
+    highs[tid][lvl] = (!isUniqueLT(lvlTypes[tid][lvl - 1]) && parentSegHi)
                           ? parentSegHi
                           : ADDI(pLo, c1);
     return;
   }
-  if (is2OutOf4DLT(lvlTp)) {
+  if (is2OutOf4LT(lvlTp)) {
     const Value pLo = lvl == 0 ? c0 : posits[tid][lvl - 1];
     // Each 2:4 block has exactly two specified elements.
     posits[tid][lvl] = MULI(pLo, c2);
@@ -1279,7 +1279,7 @@ void LoopEmitter::enterTensorsAtDenseLvls(
     SmallVectorImpl<SliceLoopInfo> &sliceInfo) {
   for (auto [dnTidLvl, denseLoopCond] : dnConds) {
     auto [tid, lvl] = unpackTensorLevel(dnTidLvl);
-    assert(isDenseDLT(lvlTypes[tid][lvl]));
+    assert(isDenseLT(lvlTypes[tid][lvl]));
 
     if (isAffineIdxCond(denseLoopCond)) {
       // Pushes sliced levels to build correct LoopInfo.
@@ -1330,7 +1330,7 @@ void LoopEmitter::exitForLoop(RewriterBase &rewriter, Location loc,
   for (auto [tid, lvl, reduced] : loopInfo.sliceDrivenInfo) {
     if (!reduced) {
       SliceInfo &info = sliceStack[tid].back();
-      assert(isDenseDLT(lvlTypes[tid][lvl]));
+      assert(isDenseLT(lvlTypes[tid][lvl]));
       assert(*info.slicedOnLvl == lvl);
       (void)reduced;
       // Resets slices pointers as the resolved slices are invalidated after we
@@ -1414,7 +1414,7 @@ void LoopEmitter::exitForLoop(RewriterBase &rewriter, Location loc,
     coords[tid][lvl] = Value();
     posits[tid][lvl] = Value();
     // Dense level, high is fixed.
-    if (!isDenseDLT(lvlTypes[tid][lvl]))
+    if (!isDenseLT(lvlTypes[tid][lvl]))
       highs[tid][lvl] = Value();
   }
 }
@@ -1435,7 +1435,7 @@ void LoopEmitter::forwardsReducedSliceLevelTreeIt(OpBuilder &builder,
 
   Level curLvl = rootLvl + 1;
   // Prunes all denses subtree.
-  while (curLvl < leafLvl && isDenseDLT(lvlTypes[tid][curLvl])) {
+  while (curLvl < leafLvl && isDenseLT(lvlTypes[tid][curLvl])) {
     // One step forward in parent level results in forwarding `slice.size` step
     // in child dense level.
     auto [size, stride] = sliceMeta[tid][curLvl].back();
@@ -1446,7 +1446,7 @@ void LoopEmitter::forwardsReducedSliceLevelTreeIt(OpBuilder &builder,
 
   Value nxPosPtr = nullptr;
   if (curLvl < leafLvl) {
-    assert(!isDenseDLT(lvlTypes[tid][curLvl]));
+    assert(!isDenseLT(lvlTypes[tid][curLvl]));
     // The first compressed level, setting up the position pointer for it.
     Value sPosBuf = slicePosBuffer[tid][curLvl].back();
     // One step forwards in the parent level result in forwarding one `segment`
@@ -1467,7 +1467,7 @@ void LoopEmitter::forwardsReducedSliceLevelTreeIt(OpBuilder &builder,
   // that the position pointer is not forwarded inside the loop.
   for (; curLvl < leafLvl; curLvl++) {
     assert(nxPosPtr);
-    if (!isDenseDLT(lvlTypes[tid][curLvl])) {
+    if (!isDenseLT(lvlTypes[tid][curLvl])) {
       nxPosPtr = MULI(nxPosPtr, C_IDX(kSliceIterWidth));
       Value sPosBuf = slicePosBuffer[tid][curLvl].back();
       updateSlicePosPtr(builder, loc, sPosBuf, nxPosPtr);
@@ -1493,7 +1493,7 @@ void LoopEmitter::exitWhileLoop(OpBuilder &builder, Location loc,
   unsigned delta = 0;
   for (auto [tid, lvl, resolved] : loopInfo.sliceDrivenInfo) {
     // TODO: handle dense.
-    assert(isCompressedDLT(lvlTypes[tid][lvl]));
+    assert(isCompressedLT(lvlTypes[tid][lvl]));
     levelReducedDep[tid][lvl]--;
     if (!resolved) {
       // TODO: support coiterating multiple slices
@@ -1541,8 +1541,8 @@ void LoopEmitter::exitWhileLoop(OpBuilder &builder, Location loc,
 
   for (auto [tid, lvl] : unpackTensorLevelRange(loopInfo.trivialTidLvls)) {
     const auto lvlTp = lvlTypes[tid][lvl];
-    if (isCompressedDLT(lvlTp) || isSingletonDLT(lvlTp) ||
-        isLooseCompressedDLT(lvlTp)) {
+    if (isCompressedLT(lvlTp) || isSingletonLT(lvlTp) ||
+        isLooseCompressedLT(lvlTp)) {
       const Value crd = coords[tid][lvl];
       const Value pos = posits[tid][lvl];
       Value cmp = CMPI(eq, crd, iv);
@@ -1550,7 +1550,7 @@ void LoopEmitter::exitWhileLoop(OpBuilder &builder, Location loc,
       // forward all the duplicated coords by setting the position to the
       // segment high.
       Value add =
-          !isUniqueDLT(lvlTypes[tid][lvl]) ? segHi[tid][lvl] : ADDI(pos, one);
+          !isUniqueLT(lvlTypes[tid][lvl]) ? segHi[tid][lvl] : ADDI(pos, one);
 
       operands.push_back(SELECT(cmp, add, pos));
       // Following loops continue iteration from the break point of the
@@ -1765,7 +1765,7 @@ ValueRange LoopEmitter::genUnResolvedSliceTreeTraverse(
     const SliceInfo &frontSlice = *unResLvls.back();
     Level firstLvl = *frontSlice.slicedOnLvl;
     if (!lvlFullyResolved(tid, firstLvl)) {
-      if (isCompressedDLT(lvlTypes[tid][firstLvl])) {
+      if (isCompressedLT(lvlTypes[tid][firstLvl])) {
         // An extra counter that tracks how many segments are there in the child
         // compressed level.
         innerArgs.push_back(c0);
@@ -1804,7 +1804,7 @@ ValueRange LoopEmitter::genUnResolvedSliceTreeTraverse(
                       .second;
               YIELD(itArgs);
             });
-      } else if (isDenseDLT(lvlTypes[tid][firstLvl])) {
+      } else if (isDenseLT(lvlTypes[tid][firstLvl])) {
         assert(firstLvl == 0); // This must be the first level.
         Value lb = frontSlice.offset;
         auto [sliceSz, stride] =
@@ -1831,7 +1831,7 @@ ValueRange LoopEmitter::genUnResolvedSliceTreeTraverse(
     SmallVector<Value> lbs, ubs, steps, lvlSzs;
     for (const SliceInfo *slice : llvm::reverse(unResLvls)) {
       Level sliceLvl = *slice->slicedOnLvl;
-      assert(isDenseDLT(lvlTypes[tid][sliceLvl]));
+      assert(isDenseLT(lvlTypes[tid][sliceLvl]));
       Value offset = slice->offset;
       auto [sliceSz, stride] = sliceMeta[tid][sliceLvl][slice->depth];
       assert(stride == 1 && "Not yet implemented");
@@ -1880,7 +1880,7 @@ void LoopEmitter::genResolvedSliceBegin(OpBuilder &builder, Location loc,
                                         TensorId tid, Level lvl) {
   Value c0 = C_IDX(0), c1 = C_IDX(1), c2 = C_IDX(2), c3 = C_IDX(3),
         c4 = C_IDX(4);
-  if (isDenseDLT(lvlTypes[tid][lvl])) {
+  if (isDenseLT(lvlTypes[tid][lvl])) {
     // Dense slice begin is trivial.
     sliceStack[tid].emplace_back(/*minCoord=*/c0, /*offset=*/c0,
                                  /*nonEmpty=*/constantI1(builder, loc, true),
@@ -1948,13 +1948,13 @@ void LoopEmitter::genUnResolvedSliceBegin(OpBuilder &builder, Location loc,
   // The remaining slice size after reduction.
   Value remSz = sliceMeta[tid][lvl][depth + 1].first;
   // Dense slice begin is trivial
-  if (isDenseDLT(lvlTypes[tid][lvl])) {
+  if (isDenseLT(lvlTypes[tid][lvl])) {
     sliceStack[tid].emplace_back(c0, c0, constantI1(builder, loc, false), lvl,
                                  depth + 1);
     return;
   }
 
-  assert(isCompressedDLT(lvlTypes[tid][lvl]));
+  assert(isCompressedLT(lvlTypes[tid][lvl]));
   // Unhandled Cases:
   //
   // 1st, lvl = prevSlicedLvl, i.e., t[d0 + d1 + d2,...] (more than one
@@ -1976,7 +1976,7 @@ void LoopEmitter::genUnResolvedSliceBegin(OpBuilder &builder, Location loc,
       break;
     }
     unResSlices.push_back(&getMostRecentSliceOnLvl(tid, prevLvl));
-    if (!isDenseDLT(lvlTypes[tid][prevLvl])) {
+    if (!isDenseLT(lvlTypes[tid][prevLvl])) {
       break;
     }
   }
@@ -2054,7 +2054,7 @@ bool LoopEmitter::genSliceBegin(OpBuilder &builder, Location loc, TensorId tid,
   if (depFullyReduced(tid, lvl)) {
     // Do not need to prepare for slice driven loop on dense level after it is
     // fully reduced.
-    if (isDenseDLT(lvlTypes[tid][lvl]))
+    if (isDenseLT(lvlTypes[tid][lvl]))
       return true;
     // If constraints on the tensor is fully resolved. We do not need to
     // generates slice begin any more, instead we fall back to TACO-based
@@ -2073,8 +2073,8 @@ bool LoopEmitter::genSliceBegin(OpBuilder &builder, Location loc, TensorId tid,
   // Only when the level is sorted, the next-non-empty slice can be computed
   // efficiently.
   const DimLevelType lvlType = lvlTypes[tid][lvl];
-  assert(isOrderedDLT(lvlType));
-  if (isSingletonDLT(lvlType)) {
+  assert(isOrderedLT(lvlType));
+  if (isSingletonLT(lvlType)) {
     llvm_unreachable("TODO: dense level should be easy to support, while "
                      "singleton level requires more efforts");
   }
@@ -2090,7 +2090,7 @@ bool LoopEmitter::genSliceBegin(OpBuilder &builder, Location loc, TensorId tid,
   // Generate caches required to fast compute next-non-empty slices with
   // increasing offset for slice-base loop.
   // We do not need cache for dense levels.
-  if (slicePosBuffer[tid][lvl][0] == nullptr && !isDenseDLT(lvlType)) {
+  if (slicePosBuffer[tid][lvl][0] == nullptr && !isDenseLT(lvlType)) {
     OpBuilder::InsertionGuard guard(builder);
     // The buffer can be reused, and the size is loop invariant: it only
     // depends on the iteration graph's toposort.
@@ -2139,7 +2139,7 @@ bool LoopEmitter::genSliceBegin(OpBuilder &builder, Location loc, TensorId tid,
 void LoopEmitter::invalidateSliceIterIdx(OpBuilder &builder, Location loc,
                                          TensorId tid, Level lvl) {
   for (unsigned i = 0; i <= lvl; i++) {
-    if (!isDenseDLT(lvlTypes[tid][i]) && !dependentLvlMap[tid][i].empty()) {
+    if (!isDenseLT(lvlTypes[tid][i]) && !dependentLvlMap[tid][i].empty()) {
       updateSlicePosPtr(builder, loc, slicePosBuffer[tid][i].back(), C_IDX(0));
     }
   }
@@ -2148,7 +2148,7 @@ void LoopEmitter::invalidateSliceIterIdx(OpBuilder &builder, Location loc,
 std::tuple<Value, Value, Value>
 LoopEmitter::genSliceNextInduction(OpBuilder &builder, Location loc,
                                    TensorId tid, Level lvl) {
-  if (!isCompressedDLT(lvlTypes[tid][lvl]))
+  if (!isCompressedLT(lvlTypes[tid][lvl]))
     llvm_unreachable("TODO");
 
   // else generate code to compute next non empty slice.

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
@@ -115,28 +115,28 @@ static void allocSchemeForRank(OpBuilder &builder, Location loc,
   Value linear = constantIndex(builder, loc, 1);
   const Level lvlRank = stt.getLvlRank();
   for (Level lvl = startLvl; lvl < lvlRank; lvl++) {
-    const auto dlt = stt.getLvlType(lvl);
-    if (isCompressedDLT(dlt) || isLooseCompressedDLT(dlt)) {
+    const auto lt = stt.getLvlType(lvl);
+    if (isCompressedLT(lt) || isLooseCompressedLT(lt)) {
       // Append linear x positions, initialized to zero. Since each compressed
       // dimension initially already has a single zero entry, this maintains
       // the desired "linear + 1" length property at all times. For loose
       // compression, we multiply linear by two in order to append both the
       // lo/hi positions.
       Value posZero = constantZero(builder, loc, stt.getPosType());
-      if (isLooseCompressedDLT(dlt)) {
+      if (isLooseCompressedLT(lt)) {
         Value two = constantIndex(builder, loc, 2);
         linear = builder.create<arith::MulIOp>(loc, linear, two);
       }
       createPushback(builder, loc, desc, SparseTensorFieldKind::PosMemRef, lvl,
                      /*value=*/posZero, /*repeat=*/linear);
       return;
-    } else if (isSingletonDLT(dlt) || is2OutOf4DLT(dlt)) {
+    } else if (isSingletonLT(lt) || is2OutOf4LT(lt)) {
       return; // nothing to do
     }
     // Keep compounding the size, but nothing needs to be initialized
     // at this level. We will eventually reach a compressed level or
     // otherwise the values array for the from-here "all-dense" case.
-    assert(isDenseDLT(dlt));
+    assert(isDenseLT(lt));
     Value size = desc.getLvlSize(builder, loc, lvl);
     linear = builder.create<arith::MulIOp>(loc, linear, size);
   }
@@ -216,7 +216,7 @@ static void createAllocFields(OpBuilder &builder, Location loc,
       stt,
       [&builder, &fields, stt, loc, posHeuristic, crdHeuristic, valHeuristic,
        enableInit](Type fType, FieldIndex fIdx, SparseTensorFieldKind fKind,
-                   Level /*lvl*/, DimLevelType /*dlt*/) -> bool {
+                   Level /*lvl*/, DimLevelType /*lt*/) -> bool {
         assert(fields.size() == fIdx);
         Value field;
         switch (fKind) {
@@ -248,8 +248,8 @@ static void createAllocFields(OpBuilder &builder, Location loc,
   Value posZero = constantZero(builder, loc, stt.getPosType());
   for (Level lvl = 0, lvlRank = stt.getLvlRank(); lvl < lvlRank; lvl++) {
     desc.setLvlSize(builder, loc, lvl, lvlSizesValues[lvl]);
-    const auto dlt = stt.getLvlType(lvl);
-    if (isCompressedDLT(dlt) || isLooseCompressedDLT(dlt))
+    const auto lt = stt.getLvlType(lvl);
+    if (isCompressedLT(lt) || isLooseCompressedLT(lt))
       createPushback(builder, loc, desc, SparseTensorFieldKind::PosMemRef, lvl,
                      /*value=*/posZero);
   }
@@ -373,8 +373,8 @@ static void genEndInsert(OpBuilder &builder, Location loc,
   const SparseTensorType stt(desc.getRankedTensorType());
   const Level lvlRank = stt.getLvlRank();
   for (Level lvl = 0; lvl < lvlRank; lvl++) {
-    const auto dlt = stt.getLvlType(lvl);
-    if (isCompressedDLT(dlt)) {
+    const auto lt = stt.getLvlType(lvl);
+    if (isCompressedLT(lt)) {
       // Compressed dimensions need a position cleanup for all entries
       // that were not visited during the insertion pass.
       //
@@ -408,8 +408,8 @@ static void genEndInsert(OpBuilder &builder, Location loc,
         builder.setInsertionPointAfter(loop);
       }
     } else {
-      assert(isDenseDLT(dlt) || isLooseCompressedDLT(dlt) ||
-             isSingletonDLT(dlt) || is2OutOf4DLT(dlt));
+      assert(isDenseLT(lt) || isLooseCompressedLT(lt) ||
+             isSingletonLT(lt) || is2OutOf4LT(lt));
     }
   }
 }
@@ -473,8 +473,8 @@ public:
     Value parentPos = constantZero(builder, loc, builder.getIndexType());
     // Generate code for every level.
     for (Level lvl = 0; lvl < lvlRank; lvl++) {
-      const auto dlt = stt.getLvlType(lvl);
-      if (isCompressedDLT(dlt) || isLooseCompressedDLT(dlt)) {
+      const auto lt = stt.getLvlType(lvl);
+      if (isCompressedLT(lt) || isLooseCompressedLT(lt)) {
         // Create:
         //   if (!present) {
         //     coordinates[lvl].push_back(coords[lvl])
@@ -482,13 +482,13 @@ public:
         //   }
         //   positions[lvl] = coordinates.size() - 1
         //   <insert @ positions[lvl] at next level lvl + 1>
-        if (isLooseCompressedDLT(dlt)) {
+        if (isLooseCompressedLT(lt)) {
           Value two = constantIndex(builder, loc, 2);
           parentPos = builder.create<arith::MulIOp>(loc, parentPos, two);
         }
         parentPos =
             genCompressed(builder, loc, desc, coords, value, parentPos, lvl);
-      } else if (isSingletonDLT(dlt) || is2OutOf4DLT(dlt)) {
+      } else if (isSingletonLT(lt) || is2OutOf4LT(lt)) {
         // Create:
         //   coordinates[lvl].push_back(coords[lvl])
         //   positions[lvl] = positions[lvl-1]
@@ -496,7 +496,7 @@ public:
         createPushback(builder, loc, desc, SparseTensorFieldKind::CrdMemRef,
                        lvl, /*value=*/coords[lvl]);
       } else {
-        assert(isDenseDLT(dlt));
+        assert(isDenseLT(lt));
         // Construct the new position as:
         //   positions[lvl] = size * positions[lvl-1] + coords[lvl]
         //   <insert @ positions[lvl] at next level lvl + 1>
@@ -516,7 +516,7 @@ public:
 
   std::string getMangledFuncName() {
     // The mangled name of the function has this format:
-    //   <namePrefix>_<DLT>_<shape>_<ordering>_<eltType>_<crdWidth>_<posWidth>
+    //   <namePrefix>_<LT>_<shape>_<ordering>_<eltType>_<crdWidth>_<posWidth>
     constexpr const char kInsertFuncNamePrefix[] = "_insert_";
     const SparseTensorType stt(llvm::cast<RankedTensorType>(rtp));
     SmallString<32> nameBuffer;
@@ -1155,7 +1155,7 @@ public:
         SparseTensorType(cast<RankedTensorType>(op.getResult().getType())),
         [&rewriter, &fields, srcDesc,
          loc](Type fTp, FieldIndex fIdx, SparseTensorFieldKind fKind, Level lvl,
-              DimLevelType /*dlt*/) -> bool {
+              DimLevelType /*lt*/) -> bool {
           // Simply reuses the storage specifier as it is an SSA value.
           if (fKind == SparseTensorFieldKind::StorageSpec) {
             fields.push_back(srcDesc.getSpecifier());
@@ -1284,7 +1284,7 @@ struct SparseAssembleOpConverter : public OpConversionPattern<AssembleOp> {
         stt,
         [&rewriter, &fields, &op, &stt,
          loc](Type fType, FieldIndex fIdx, SparseTensorFieldKind fKind,
-              Level /*lvl*/, DimLevelType dlt) -> bool {
+              Level /*lvl*/, DimLevelType lt) -> bool {
           assert(fields.size() == fIdx);
           if (fKind == SparseTensorFieldKind::StorageSpec) {
             fields.push_back(
@@ -1333,21 +1333,21 @@ struct SparseAssembleOpConverter : public OpConversionPattern<AssembleOp> {
         continue;
 
       // Sets up the memory size by reading the last value in position array.
-      DimLevelType dlt = stt.getLvlType(lvl);
+      DimLevelType lt = stt.getLvlType(lvl);
       // Simply forwards the position index when this is a dense level.
-      if (isDenseDLT(dlt)) {
+      if (isDenseLT(lt)) {
         memSize = rewriter.create<arith::MulIOp>(loc, lvlSize, memSize);
         posBack = rewriter.create<arith::SubIOp>(loc, memSize, c1);
         continue;
       }
 
-      if (isWithPosDLT(dlt)) {
-        assert(isCompressedDLT(dlt) || isLooseCompressedDLT(dlt));
-        if (isLooseCompressedDLT(dlt)) {
+      if (isWithPosLT(lt)) {
+        assert(isCompressedLT(lt) || isLooseCompressedLT(lt));
+        if (isLooseCompressedLT(lt)) {
           memSize = rewriter.create<arith::MulIOp>(loc, memSize, c2);
           posBack = rewriter.create<arith::SubIOp>(loc, memSize, c1);
         } else {
-          assert(isCompressedDLT(dlt));
+          assert(isCompressedLT(lt));
           posBack = memSize;
           memSize = rewriter.create<arith::AddIOp>(loc, memSize, c1);
         }
@@ -1356,7 +1356,7 @@ struct SparseAssembleOpConverter : public OpConversionPattern<AssembleOp> {
         memSize = genIndexLoad(rewriter, loc, desc.getPosMemRef(lvl), posBack);
         posBack = rewriter.create<arith::SubIOp>(loc, posBack, c1);
       }
-      assert(isWithCrdDLT(dlt) && lvl <= trailCOOStart);
+      assert(isWithCrdLT(lt) && lvl <= trailCOOStart);
       // FIXME: This seems to be unnecessarily complex, can we simplify it?
       if (lvl == trailCOOStart) {
         Value cooSz = rewriter.create<arith::MulIOp>(
@@ -1390,7 +1390,7 @@ struct SparseDisassembleOpConverter
     desc.getLayout().foreachField([desc, loc, &rewriter, &op, &retMem, &retLen](
                                       FieldIndex fid,
                                       SparseTensorFieldKind fKind, Level lvl,
-                                      DimLevelType dlt) -> bool {
+                                      DimLevelType lt) -> bool {
       if (fKind == SparseTensorFieldKind::StorageSpec)
         return true;
       SparseTensorType stt(desc.getRankedTensorType());

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
@@ -408,8 +408,8 @@ static void genEndInsert(OpBuilder &builder, Location loc,
         builder.setInsertionPointAfter(loop);
       }
     } else {
-      assert(isDenseLT(lt) || isLooseCompressedLT(lt) ||
-             isSingletonLT(lt) || is2OutOf4LT(lt));
+      assert(isDenseLT(lt) || isLooseCompressedLT(lt) || isSingletonLT(lt) ||
+             is2OutOf4LT(lt));
     }
   }
 }

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorConversion.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorConversion.cpp
@@ -145,8 +145,8 @@ static Value genLvlTypesBuffer(OpBuilder &builder, Location loc,
                                SparseTensorType stt) {
   SmallVector<Value> lvlTypes;
   lvlTypes.reserve(stt.getLvlRank());
-  for (const auto dlt : stt.getEncoding().getLvlTypes())
-    lvlTypes.push_back(constantDimLevelTypeEncoding(builder, loc, dlt));
+  for (const auto lt : stt.getEncoding().getLvlTypes())
+    lvlTypes.push_back(constantDimLevelTypeEncoding(builder, loc, lt));
   return allocaBuffer(builder, loc, lvlTypes);
 }
 

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorDescriptor.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorDescriptor.cpp
@@ -42,7 +42,7 @@ convertSparseTensorType(RankedTensorType rtp, SmallVectorImpl<Type> &fields) {
       stt,
       [&fields](Type fieldType, FieldIndex fieldIdx,
                 SparseTensorFieldKind /*fieldKind*/, Level /*lvl*/,
-                DimLevelType /*dlt*/) -> bool {
+                DimLevelType /*lt*/) -> bool {
         assert(fieldIdx == fields.size());
         fields.push_back(fieldType);
         return true;

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorRewriting.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorRewriting.cpp
@@ -45,8 +45,8 @@ static bool isZeroValue(Value val) {
 // Helper to detect a sparse tensor type operand.
 static bool isSparseTensor(Value v) {
   auto enc = getSparseTensorEncoding(v.getType());
-  return enc && !llvm::all_of(enc.getLvlTypes(), [](auto dlt) {
-           return dlt == DimLevelType::Dense;
+  return enc && !llvm::all_of(enc.getLvlTypes(), [](auto lt) {
+           return lt == DimLevelType::Dense;
          });
 }
 static bool isSparseTensor(OpOperand *op) { return isSparseTensor(op->get()); }

--- a/mlir/lib/Dialect/SparseTensor/Transforms/Sparsification.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Sparsification.cpp
@@ -981,8 +981,8 @@ static bool startLoopSeq(CodegenEnv &env, OpBuilder &builder, ExprId exp,
       }
       needsUniv = true;
     }
-    if (isCompressedLT(lt) || isSingletonLT(lt) ||
-        isLooseCompressedLT(lt) || is2OutOf4LT(lt) || isIdxReduc) {
+    if (isCompressedLT(lt) || isSingletonLT(lt) || isLooseCompressedLT(lt) ||
+        is2OutOf4LT(lt) || isIdxReduc) {
       // Only when this is a index reduction loop, can the lt be undefined.
       assert(!isUndefLT(lt) || isIdxReduc);
       // sparse/singleton levels, or a dense/sparse index reduction loop.

--- a/mlir/lib/Dialect/SparseTensor/Transforms/Sparsification.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Sparsification.cpp
@@ -79,28 +79,28 @@ static bool isInvariantAffine(AffineExpr a, unsigned loopDepth, LoopId ldx,
 /// same index is used more than once. Also rejects compound affine
 /// expressions in sparse dimensions.
 static bool findAffine(Merger &merger, TensorId tid, Level lvl, AffineExpr a,
-                       DimLevelType dlt, bool setLvlFormat = true) {
+                       DimLevelType lt, bool setLvlFormat = true) {
   switch (a.getKind()) {
   case AffineExprKind::DimId: {
     const LoopId idx = merger.makeLoopId(cast<AffineDimExpr>(a).getPosition());
-    if (!isUndefDLT(merger.getLvlType(tid, idx)))
+    if (!isUndefLT(merger.getLvlType(tid, idx)))
       return false; // used more than once
 
     if (setLvlFormat)
-      merger.setLevelAndType(tid, idx, lvl, dlt);
+      merger.setLevelAndType(tid, idx, lvl, lt);
     return true;
   }
   case AffineExprKind::Add:
   case AffineExprKind::Mul:
   case AffineExprKind::Constant: {
-    assert(isDenseDLT(dlt));
+    assert(isDenseLT(lt));
     if (auto binOp = dyn_cast<AffineBinaryOpExpr>(a)) {
       // We do not set dim level format for affine expression like d0 + d1 on
       // either loop index at d0 or d1.
       // We continue the recursion merely to check whether current affine is
       // admissible or not.
-      return findAffine(merger, tid, lvl, binOp.getLHS(), dlt, false) &&
-             findAffine(merger, tid, lvl, binOp.getRHS(), dlt, false);
+      return findAffine(merger, tid, lvl, binOp.getLHS(), lt, false) &&
+             findAffine(merger, tid, lvl, binOp.getRHS(), lt, false);
     }
     // Falls through when it is a constant Affine
     return true;
@@ -125,7 +125,7 @@ static bool findAffine(Merger &merger, TensorId tid, Level lvl, AffineExpr a,
 ///
 /// TODO: constant should be easy to handle.
 static bool findDepIdxSet(Merger &merger, TensorId tensor, Level lvl,
-                          AffineExpr a, DimLevelType dlt, bool isSubExp = false,
+                          AffineExpr a, DimLevelType lt, bool isSubExp = false,
                           int64_t coefficient = 1) {
   switch (a.getKind()) {
   case AffineExprKind::DimId: {
@@ -134,7 +134,7 @@ static bool findDepIdxSet(Merger &merger, TensorId tensor, Level lvl,
       return false;
 
     const LoopId ldx = merger.makeLoopId(cast<AffineDimExpr>(a).getPosition());
-    if (!isUndefDLT(merger.getLvlType(tensor, ldx)))
+    if (!isUndefLT(merger.getLvlType(tensor, ldx)))
       return false; // used more than once, e.g., A[i][i]
 
     // TODO: Generalizes the following two cases. A[i] (with trivial index
@@ -142,7 +142,7 @@ static bool findDepIdxSet(Merger &merger, TensorId tensor, Level lvl,
     // not necessarily need to differentiate them.
     if (!isSubExp) {
       assert(coefficient == 1);
-      merger.setLevelAndType(tensor, ldx, lvl, dlt);
+      merger.setLevelAndType(tensor, ldx, lvl, lt);
     }
 
     if (isSubExp) {
@@ -161,7 +161,7 @@ static bool findDepIdxSet(Merger &merger, TensorId tensor, Level lvl,
         // else increase min(d0_1, d0_2).
         return false;
       }
-      merger.setLoopDependentTensorLevel(ldx, tensor, lvl, dlt, coefficient);
+      merger.setLoopDependentTensorLevel(ldx, tensor, lvl, lt, coefficient);
     }
     return true;
   }
@@ -183,12 +183,12 @@ static bool findDepIdxSet(Merger &merger, TensorId tensor, Level lvl,
     // Must be in form of `constant * d`.
     assert(isa<AffineConstantExpr>(lhs) && isa<AffineDimExpr>(rhs));
     int64_t coefficient = cast<AffineConstantExpr>(lhs).getValue();
-    return findDepIdxSet(merger, tensor, lvl, rhs, dlt, isSubExp, coefficient);
+    return findDepIdxSet(merger, tensor, lvl, rhs, lt, isSubExp, coefficient);
   }
   case AffineExprKind::Add: {
     auto binOp = cast<AffineBinaryOpExpr>(a);
-    return findDepIdxSet(merger, tensor, lvl, binOp.getLHS(), dlt, true) &&
-           findDepIdxSet(merger, tensor, lvl, binOp.getRHS(), dlt, true);
+    return findDepIdxSet(merger, tensor, lvl, binOp.getLHS(), lt, true) &&
+           findDepIdxSet(merger, tensor, lvl, binOp.getRHS(), lt, true);
   }
   default:
     return false;
@@ -275,12 +275,12 @@ static bool findSparseAnnotations(CodegenEnv &env, bool idxReducBased) {
     // to be sliced.
     for (Level l = 0; l < lvlRank; l++) {
       const AffineExpr a = map.getResult(l);
-      const DimLevelType dlt = enc.getLvlType(l);
+      const DimLevelType lt = enc.getLvlType(l);
       if (idxReducBased && needIdxReduc) {
-        if (!findDepIdxSet(env.merger(), tid, l, a, dlt))
+        if (!findDepIdxSet(env.merger(), tid, l, a, lt))
           return false; // inadmissible affine expression
       } else {
-        if (!findAffine(env.merger(), tid, l, a, dlt))
+        if (!findAffine(env.merger(), tid, l, a, lt))
           return false; // inadmissible affine expression
       }
     }
@@ -800,11 +800,11 @@ static bool shouldTryParallize(CodegenEnv &env, LoopId ldx, bool isOuter,
   linalg::GenericOp op = env.op();
   auto iteratorTypes = op.getIteratorTypesArray();
   bool isSparse = llvm::any_of(tidLvls, [ldx, &env](TensorLevel tidLvl) {
-    // Queries the DLT based on the tensor id and loop idx, as requested by
-    // `CodegenEnv::dlt(TensorId, LoopIdx)`. The returned DLT from CodegenEnv
-    // should be consistent with the DLT indexed by <TensorId, Level>.
-    const auto dlt = env.dlt(env.unpackTensorLevel(tidLvl).first, ldx);
-    return isCompressedDLT(dlt) || isSingletonDLT(dlt);
+    // Queries the LT based on the tensor id and loop idx, as requested by
+    // `CodegenEnv::lt(TensorId, LoopIdx)`. The returned LT from CodegenEnv
+    // should be consistent with the LT indexed by <TensorId, Level>.
+    const auto lt = env.lt(env.unpackTensorLevel(tidLvl).first, ldx);
+    return isCompressedLT(lt) || isSingletonLT(lt);
   });
 
   return isParallelFor(env, isOuter, isSparse);
@@ -884,27 +884,27 @@ static scf::IfOp genIf(CodegenEnv &env, OpBuilder &builder, LoopId ldx,
   env.merger().foreachTensorLoopId(
       p, /*simple=*/true,
       [&](TensorLoopId b, TensorId tid, std::optional<Level> lvl,
-          DimLevelType dlt, bool isIdxRed) {
+          DimLevelType lt, bool isIdxRed) {
         if (isIdxRed) {
           // Since there is no 1:1 mapping from loop to level (multiple loops
           // are required to resolve one level with non-trivial index
           // expression), we need to reconstruct the tensor level types if this
           // loop requires index reduction condition.
-          assert(lvl.has_value() && isUndefDLT(dlt));
+          assert(lvl.has_value() && isUndefLT(lt));
           auto stt = getSparseTensorType(env.op().getInputs()[tid]);
-          dlt = stt.getLvlType(*lvl);
+          lt = stt.getLvlType(*lvl);
         }
         assert(ldx == env.merger().loop(b));
         Value clause;
-        if (isCompressedDLT(dlt) || isSingletonDLT(dlt) ||
-            isLooseCompressedDLT(dlt) || is2OutOf4DLT(dlt)) {
+        if (isCompressedLT(lt) || isSingletonLT(lt) ||
+            isLooseCompressedLT(lt) || is2OutOf4LT(lt)) {
           assert(lvl.has_value());
           const Value crd = env.emitter().getCoords()[tid][*lvl];
           const Value lvar = env.getLoopVar(ldx);
           clause = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
                                                  crd, lvar);
         } else {
-          assert(isDenseDLT(dlt) || isUndefDLT(dlt));
+          assert(isDenseLT(lt) || isUndefLT(lt));
           clause = constantI1(builder, loc, true);
         }
         cond = cond ? builder.create<arith::AndIOp>(loc, cond, clause) : clause;
@@ -970,9 +970,9 @@ static bool startLoopSeq(CodegenEnv &env, OpBuilder &builder, ExprId exp,
   SmallVector<TensorLevel> tidLvls;
   env.merger().foreachTensorLoopId(l0, [&](TensorLoopId b, TensorId tid,
                                            std::optional<Level> lvl,
-                                           DimLevelType dlt, bool isIdxReduc) {
+                                           DimLevelType lt, bool isIdxReduc) {
     assert(env.merger().loop(b) == idx);
-    if (isDenseDLT(dlt) || isUndefDLT(dlt)) {
+    if (isDenseLT(lt) || isUndefLT(lt)) {
       if (tid == env.merger().getSynTensorID()) {
         // Needs loop emitter to set up loop bounds for synthetic tensor too if
         // there is a loop condition imposed on the synthetic tensor.
@@ -981,10 +981,10 @@ static bool startLoopSeq(CodegenEnv &env, OpBuilder &builder, ExprId exp,
       }
       needsUniv = true;
     }
-    if (isCompressedDLT(dlt) || isSingletonDLT(dlt) ||
-        isLooseCompressedDLT(dlt) || is2OutOf4DLT(dlt) || isIdxReduc) {
-      // Only when this is a index reduction loop, can the dlt be undefined.
-      assert(!isUndefDLT(dlt) || isIdxReduc);
+    if (isCompressedLT(lt) || isSingletonLT(lt) ||
+        isLooseCompressedLT(lt) || is2OutOf4LT(lt) || isIdxReduc) {
+      // Only when this is a index reduction loop, can the lt be undefined.
+      assert(!isUndefLT(lt) || isIdxReduc);
       // sparse/singleton levels, or a dense/sparse index reduction loop.
       tidLvls.push_back(env.makeTensorLevel(tid, *lvl));
     }
@@ -1050,15 +1050,15 @@ static bool translateBitsToTidLvlPairs(
   bool hasNonUnique = false;
   env.merger().foreachTensorLoopId(
       li, [&, ldx](TensorLoopId b, TensorId tid, std::optional<Level> lvl,
-                   DimLevelType dlt, bool isIdxReduc) {
+                   DimLevelType lt, bool isIdxReduc) {
         if (simple[b]) {
           if (isIdxReduc) {
             tidLvls.push_back(env.makeTensorLevel(tid, *lvl));
             numloopCond++;
             return;
           }
-          if (isUndefDLT(dlt)) {
-            // An undefined dlt in the lattices, we probably mean to
+          if (isUndefLT(lt)) {
+            // An undefined lt in the lattices, we probably mean to
             // iterate based on the level of output tensor.  E.g., this
             // could be a synthetic tensor (for invariants and sparse
             // output tensor).
@@ -1083,13 +1083,13 @@ static bool translateBitsToTidLvlPairs(
                 return;
             }
           }
-          hasNonUnique = !isUniqueDLT(dlt) || hasNonUnique;
+          hasNonUnique = !isUniqueLT(lt) || hasNonUnique;
           tidLvls.push_back(env.makeTensorLevel(tid, *lvl));
           numloopCond++;
-        } else if (isDenseDLT(dlt) || isIdxReduc) {
+        } else if (isDenseLT(lt) || isIdxReduc) {
           tidLvls.push_back(env.makeTensorLevel(tid, *lvl));
         } else {
-          assert(isUndefDLT(dlt));
+          assert(isUndefLT(lt));
           linalg::GenericOp op = env.op();
           if (tid >= op.getNumDpsInputs())
             // We only handle affine expression on input tensors (for now).
@@ -1132,7 +1132,7 @@ static bool translateBitsToTidLvlPairs(
         }
       });
 
-  if (isDenseDLT(env.dlt(outTid, ldx))) {
+  if (isDenseLT(env.lt(outTid, ldx))) {
     // Note that we generate dense indices of the output tensor
     // unconditionally, since they may not appear in the lattice, but may be
     // needed for linearized env.

--- a/mlir/lib/Dialect/SparseTensor/Utils/Merger.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Utils/Merger.cpp
@@ -670,8 +670,8 @@ bool Merger::isSingleCondition(TensorId t, ExprId e) const {
 bool Merger::hasAnySparse(const BitVector &bits) const {
   for (TensorLoopId b : bits.set_bits()) {
     const auto lt = getLvlType(b);
-    if (isCompressedLT(lt) || isSingletonLT(lt) ||
-        isLooseCompressedLT(lt) || is2OutOf4LT(lt))
+    if (isCompressedLT(lt) || isSingletonLT(lt) || isLooseCompressedLT(lt) ||
+        is2OutOf4LT(lt))
       return true;
   }
   return hasSparseIdxReduction(bits);

--- a/mlir/lib/Dialect/SparseTensor/Utils/Merger.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Utils/Merger.cpp
@@ -232,7 +232,7 @@ Merger::Merger(unsigned numInputOutputTensors, unsigned numLoops,
                 std::vector<std::optional<Level>>(numLoops, std::nullopt)),
       lvlToLoop(numTensors,
                 std::vector<std::optional<LoopId>>(maxLvlRank, std::nullopt)),
-      loopToUnresolvedLvls(numLoops, std::vector<std::optional<LvlDLTPair>>(
+      loopToUnresolvedLvls(numLoops, std::vector<std::optional<LvlLTPair>>(
                                          numTensors, std::nullopt)),
       levelToDependentLoop(numTensors,
                            std::vector<std::vector<LoopCoeffPair>>(
@@ -476,7 +476,7 @@ BitVector Merger::simplifyCond(LatSetId s0, LatPointId p0) {
     // Starts resetting from a dense level, so that the first bit (if kept)
     // is not undefined level-type.
     for (unsigned b = 0; b < be; b++) {
-      if (simple[b] && isDenseDLT(getLvlType(TensorLoopId{b}))) {
+      if (simple[b] && isDenseLT(getLvlType(TensorLoopId{b}))) {
         offset = be - b - 1; // relative to the end
         break;
       }
@@ -488,9 +488,9 @@ BitVector Merger::simplifyCond(LatSetId s0, LatPointId p0) {
        b = b == 0 ? be - 1 : b - 1, i++) {
     // Slice on dense level has `locate` property as well, and can be optimized.
     if (simple[b] && !isSparseLvlWithNonTrivialIdxExp(b)) {
-      const auto dlt = getLvlType(b);
-      if (!isCompressedDLT(dlt) && !isSingletonDLT(dlt) &&
-          !isLooseCompressedDLT(dlt) && !is2OutOf4DLT(dlt)) {
+      const auto lt = getLvlType(b);
+      if (!isCompressedLT(lt) && !isSingletonLT(lt) &&
+          !isLooseCompressedLT(lt) && !is2OutOf4LT(lt)) {
         if (reset)
           simple.reset(b);
         reset = true;
@@ -669,9 +669,9 @@ bool Merger::isSingleCondition(TensorId t, ExprId e) const {
 
 bool Merger::hasAnySparse(const BitVector &bits) const {
   for (TensorLoopId b : bits.set_bits()) {
-    const auto dlt = getLvlType(b);
-    if (isCompressedDLT(dlt) || isSingletonDLT(dlt) ||
-        isLooseCompressedDLT(dlt) || is2OutOf4DLT(dlt))
+    const auto lt = getLvlType(b);
+    if (isCompressedLT(lt) || isSingletonLT(lt) ||
+        isLooseCompressedLT(lt) || is2OutOf4LT(lt))
       return true;
   }
   return hasSparseIdxReduction(bits);
@@ -919,11 +919,11 @@ void Merger::dumpBits(const BitVector &bits) const {
     if (bits[b]) {
       const TensorId t = tensor(b);
       const LoopId i = loop(b);
-      const auto dlt = lvlTypes[t][i];
+      const auto lt = lvlTypes[t][i];
       if (isLvlWithNonTrivialIdxExp(b))
         llvm::dbgs() << " DEP_" << t << "_" << i;
       else
-        llvm::dbgs() << " i_" << t << "_" << i << "_" << toMLIRString(dlt);
+        llvm::dbgs() << " i_" << t << "_" << i << "_" << toMLIRString(lt);
     }
   }
 }


### PR DESCRIPTION
The "dimension" before "level" does not really make sense Note that renaming the actual type DimLevelType to LevelType is still TBD, since this is an externally visible change (e.g. visible to Python API).