### PR TITLE
[FIX] Fix the function 'isctype' failed in arm64-big-endian

### DIFF
--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -384,7 +384,7 @@ public:
     static const mask punct  = _ISpunct;
     static const mask xdigit = _ISxdigit;
     static const mask blank  = _ISblank;
-#if defined(__mips__)
+#if defined(__mips__) || defined(__BIG_ENDIAN__)
     static const mask __regex_word = static_cast<mask>(_ISbit(15));
 #else
     static const mask __regex_word = 0x80;


### PR DESCRIPTION
 Thefunction `isctype` fails in `arm64-big-endian` while succeeds in `arm64-little-endian`. Because big-endian or little-endian determines the byte order of the character mask obtained by isctype, while __regex_word of the corresponding obtained type mask does not change accordingly.
 I found the relevant changes:[D17132](https://reviews.llvm.org/D17132l), In this changes, the value of __regex_word is determined by whether the GLIBC is defined to determine whether the value is big-endian. However, GLIBC now is defined in arm64-little-endian and arm64-big-endian, but mips is not defined. This results in __regex_word being the same in the both sides. So I added a macro after mips to judge.
