### PR TITLE
[FIX] Fix undefined-behaviour in regex engine.

### DIFF
--- a/llvm/lib/Support/Regex.cpp
+++ b/llvm/lib/Support/Regex.cpp
@@ -92,6 +92,10 @@ bool Regex::match(StringRef String, SmallVectorImpl<StringRef> *Matches,
 
   unsigned nmatch = Matches ? preg->re_nsub+1 : 0;
 
+  // Update null string to empty string.
+  if (String.data() == nullptr)
+    String = "";
+
   // pmatch needs to have at least one element.
   SmallVector<llvm_regmatch_t, 8> pm;
   pm.resize(nmatch > 0 ? nmatch : 1);

--- a/llvm/unittests/Support/RegexTest.cpp
+++ b/llvm/unittests/Support/RegexTest.cpp
@@ -225,3 +225,10 @@ TEST_F(RegexTest, OssFuzz3727Regression) {
 }
 
 }
+
+TEST_F(RegexTest, NullStringInput) {
+  Regex r("^$");
+  // String data points to nullptr in default constructor
+  StringRef String;
+  EXPECT_TRUE(r.match(String));
+}


### PR DESCRIPTION
Running the `mlir-text-parser-fuzzer` on a random corpus discovers a path that causes application of offset to a null pointer (UB) in the regex engine.

This patch adds a check.

Input:
Binary input, generated by fuzzer.

Output:
```
/Users/tsachan/Documents/llvm-project/llvm/lib/Support/regengine.inc:152:18: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/tsachan/Documents/llvm-project/llvm/lib/Support/regengine.inc:152:18 in
==35858== ERROR: libFuzzer: deadly signal
    #0 0x10424236c in __sanitizer_print_stack_trace+0x28 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x5e36c)
    #1 0x1030c1ce0 in fuzzer::PrintStackTrace()+0x2c (mlir-text-parser-fuzzer:arm64+0x100b4dce0)
    #2 0x1030b43b4 in fuzzer::Fuzzer::CrashCallback()+0x54 (mlir-text-parser-fuzzer:arm64+0x100b403b4)
    #3 0x1940aaa20 in _sigtramp+0x34 (libsystem_platform.dylib:arm64+0x3a20)
    #4 0xeb4900019407bc24  (<unknown module>)
    #5 0x6b3b000193f89ae4  (<unknown module>)
    #6 0x824c80010425c834  (<unknown module>)
    #7 0x10425bfa0 in __sanitizer::Die()+0xcc (libclang_rt.asan_osx_dynamic.dylib:arm64+0x77fa0)
    #8 0x104271334 in __ubsan_handle_pointer_overflow_abort+0x24 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x8d334)
    #9 0x102be79c8 in llvm_regexec+0x4df8 (mlir-text-parser-fuzzer:arm64+0x1006739c8)
    #10 0x102bf98a8 in llvm::Regex::match(llvm::StringRef, llvm::SmallVectorImpl<llvm::StringRef>*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*) const+0x608 (mlir-text-parser-fuzzer:arm64+0x1006858a8)
    #11 0x102c31880 in mlir::Dialect::isValidNamespace(llvm::StringRef)+0xf0 (mlir-text-parser-fuzzer:arm64+0x1006bd880)
    #12 0x102b7d748 in mlir::OpaqueType::verify(llvm::function_ref<mlir::InFlightDiagnostic ()>, mlir::StringAttr, llvm::StringRef)+0x13c (mlir-text-parser-fuzzer:arm64+0x100609748)
    #13 0x102b76280 in mlir::OpaqueType::getChecked(llvm::function_ref<mlir::InFlightDiagnostic ()>, mlir::StringAttr, llvm::StringRef)+0x158 (mlir-text-parser-fuzzer:arm64+0x100602280)
    #14 0x102f91368 in mlir::detail::Parser::parseExtendedType()+0xe00 (mlir-text-parser-fuzzer:arm64+0x100a1d368)
    #15 0x10300ea00 in mlir::detail::Parser::parseNonFunctionType()+0x420 (mlir-text-parser-fuzzer:arm64+0x100a9aa00)
    #16 0x102fb6944 in mlir::parseAsmSourceFile(llvm::SourceMgr const&, mlir::Block*, mlir::ParserConfig const&, mlir::AsmParserState*, mlir::AsmParserCodeCompleteContext*)+0x1668 (mlir-text-parser-fuzzer:arm64+0x100a42944)
    #17 0x102ebe8e8 in mlir::parseSourceFile(llvm::SourceMgr const&, mlir::Block*, mlir::ParserConfig const&, mlir::LocationAttr*)+0x2b0 (mlir-text-parser-fuzzer:arm64+0x10094a8e8)
    #18 0x102ec0144 in mlir::parseSourceString(llvm::StringRef, mlir::Block*, mlir::ParserConfig const&, llvm::StringRef, mlir::LocationAttr*)+0x258 (mlir-text-parser-fuzzer:arm64+0x10094c144)
    #19 0x1025773e4 in mlir::OwningOpRef<mlir::ModuleOp> mlir::parseSourceString<mlir::ModuleOp>(llvm::StringRef, mlir::ParserConfig const&, llvm::StringRef)+0x160 (mlir-text-parser-fuzzer:arm64+0x1000033e4)
    #20 0x102576ed4 in LLVMFuzzerTestOneInput+0x578 (mlir-text-parser-fuzzer:arm64+0x100002ed4)
    #21 0x1030b57ec in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)+0x138 (mlir-text-parser-fuzzer:arm64+0x100b417ec)
    #22 0x1030a6558 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)+0xd0 (mlir-text-parser-fuzzer:arm64+0x100b32558)
    #23 0x1030ab974 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))+0x1a98 (mlir-text-parser-fuzzer:arm64+0x100b37974)
    #24 0x1030c25d4 in main+0x24 (mlir-text-parser-fuzzer:arm64+0x100b4e5d4)
    #25 0x193d23f24  (<unknown module>)
    #26 0x121afffffffffffc  (<unknown module>)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
```