### PR TITLE
[BOLT] Extend calculateEmittedSize() for block size calculation

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -1230,6 +1230,9 @@ public:
   ///
   /// Return the pair where the first size is for the main part, and the second
   /// size is for the cold one.
+  /// Modify BinaryBasicBlock::OutputAddressRange for each basic block in the
+  /// function in place so that BB.OutputAddressRange.second less
+  /// BB.OutputAddressRange.first gives the emitted size of BB.
   std::pair<size_t, size_t> calculateEmittedSize(BinaryFunction &BF,
                                                  bool FixBranches = true);
 

--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -1231,8 +1231,8 @@ public:
   /// Return the pair where the first size is for the main part, and the second
   /// size is for the cold one.
   /// Modify BinaryBasicBlock::OutputAddressRange for each basic block in the
-  /// function in place so that BB.OutputAddressRange.second less
-  /// BB.OutputAddressRange.first gives the emitted size of BB.
+  /// function in place so that BinaryBasicBlock::getOutputSize() gives the
+  /// emitted size of the basic block.
   std::pair<size_t, size_t> calculateEmittedSize(BinaryFunction &BF,
                                                  bool FixBranches = true);
 

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2331,14 +2331,37 @@ BinaryContext::calculateEmittedSize(BinaryFunction &BF, bool FixBranches) {
   MCAsmLayout Layout(Assembler);
   Assembler.layout(Layout);
 
+  // Obtain fragment sizes.
+  std::vector<uint64_t> FragmentSizes;
+  // Main fragment size.
   const uint64_t HotSize =
       Layout.getSymbolOffset(*EndLabel) - Layout.getSymbolOffset(*StartLabel);
-  const uint64_t ColdSize =
-      std::accumulate(SplitLabels.begin(), SplitLabels.end(), 0ULL,
-                      [&](const uint64_t Accu, const LabelRange &Labels) {
-                        return Accu + Layout.getSymbolOffset(*Labels.second) -
-                               Layout.getSymbolOffset(*Labels.first);
-                      });
+  FragmentSizes.push_back(HotSize);
+  // Split fragment sizes.
+  uint64_t ColdSize = 0;
+  for (const auto &Labels : SplitLabels) {
+    uint64_t Size = Layout.getSymbolOffset(*Labels.second) -
+                    Layout.getSymbolOffset(*Labels.first);
+    FragmentSizes.push_back(Size);
+    ColdSize += Size;
+  }
+
+  // Populate new start and end offsets of each basic block.
+  BinaryBasicBlock *PrevBB = nullptr;
+  uint64_t FragmentIndex = 0;
+  for (FunctionFragment &FF : BF.getLayout().fragments()) {
+    for (BinaryBasicBlock *BB : FF) {
+      const uint64_t BBStartOffset = Layout.getSymbolOffset(*(BB->getLabel()));
+      BB->setOutputStartAddress(BBStartOffset);
+      if (PrevBB)
+        PrevBB->setOutputEndAddress(BBStartOffset);
+      PrevBB = BB;
+    }
+    if (PrevBB)
+      PrevBB->setOutputEndAddress(FragmentSizes[FragmentIndex]);
+    FragmentIndex++;
+    PrevBB = nullptr;
+  }
 
   // Clean-up the effect of the code emission.
   for (const MCSymbol &Symbol : Assembler.symbols()) {

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2347,9 +2347,9 @@ BinaryContext::calculateEmittedSize(BinaryFunction &BF, bool FixBranches) {
   }
 
   // Populate new start and end offsets of each basic block.
-  BinaryBasicBlock *PrevBB = nullptr;
   uint64_t FragmentIndex = 0;
   for (FunctionFragment &FF : BF.getLayout().fragments()) {
+    BinaryBasicBlock *PrevBB = nullptr;
     for (BinaryBasicBlock *BB : FF) {
       const uint64_t BBStartOffset = Layout.getSymbolOffset(*(BB->getLabel()));
       BB->setOutputStartAddress(BBStartOffset);
@@ -2360,7 +2360,6 @@ BinaryContext::calculateEmittedSize(BinaryFunction &BF, bool FixBranches) {
     if (PrevBB)
       PrevBB->setOutputEndAddress(FragmentSizes[FragmentIndex]);
     FragmentIndex++;
-    PrevBB = nullptr;
   }
 
   // Clean-up the effect of the code emission.

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -518,10 +518,12 @@ void BinaryFunction::print(raw_ostream &OS, std::string Annotation) {
          << " instructions, align : " << BB->getAlignment() << ")\n";
 
       if (opts::PrintOutputAddressRange)
-        OS << "  Output Start Address: " << BB->getOutputAddressRange().first
-           << "\n"
-           << "  Output End Address: " << BB->getOutputAddressRange().second
-           << "\n";
+        OS << "  Output Address Range: ["
+           << "0x" << Twine::utohexstr(BB->getOutputAddressRange().first)
+           << ", "
+           << "0x" << Twine::utohexstr(BB->getOutputAddressRange().second)
+           << ") "
+           << "(" << BB->getOutputSize() << " bytes)\n";
 
       if (isEntryPoint(*BB)) {
         if (MCSymbol *EntrySymbol = getSecondaryEntryPointSymbol(*BB))

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -108,6 +108,13 @@ cl::opt<bool>
                             cl::desc("try to preserve basic block alignment"),
                             cl::cat(BoltOptCategory));
 
+static cl::opt<bool> PrintOutputAddressRange(
+    "print-output-address-range",
+    cl::desc(
+        "print output address range for each basic block in the function when"
+        "BinaryFunction::print is called"),
+    cl::Hidden, cl::cat(BoltOptCategory));
+
 cl::opt<bool>
 PrintDynoStats("dyno-stats",
   cl::desc("print execution info based on profile"),
@@ -509,6 +516,12 @@ void BinaryFunction::print(raw_ostream &OS, std::string Annotation) {
     for (const BinaryBasicBlock *BB : FF) {
       OS << BB->getName() << " (" << BB->size()
          << " instructions, align : " << BB->getAlignment() << ")\n";
+
+      if (opts::PrintOutputAddressRange)
+        OS << "  Output Start Address: " << BB->getOutputAddressRange().first
+           << "\n"
+           << "  Output End Address: " << BB->getOutputAddressRange().second
+           << "\n";
 
       if (isEntryPoint(*BB)) {
         if (MCSymbol *EntrySymbol = getSecondaryEntryPointSymbol(*BB))

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -518,12 +518,9 @@ void BinaryFunction::print(raw_ostream &OS, std::string Annotation) {
          << " instructions, align : " << BB->getAlignment() << ")\n";
 
       if (opts::PrintOutputAddressRange)
-        OS << "  Output Address Range: ["
-           << "0x" << Twine::utohexstr(BB->getOutputAddressRange().first)
-           << ", "
-           << "0x" << Twine::utohexstr(BB->getOutputAddressRange().second)
-           << ") "
-           << "(" << BB->getOutputSize() << " bytes)\n";
+        OS << formatv("  Output Address Range: [{0:x}, {1:x}) ({2} bytes)\n",
+                      BB->getOutputAddressRange().first,
+                      BB->getOutputAddressRange().second, BB->getOutputSize());
 
       if (isEntryPoint(*BB)) {
         if (MCSymbol *EntrySymbol = getSecondaryEntryPointSymbol(*BB))

--- a/bolt/test/X86/calculate-emitted-block-size.s
+++ b/bolt/test/X86/calculate-emitted-block-size.s
@@ -1,0 +1,114 @@
+# Test BinaryContext::calculateEmittedSize's functionality to update
+# BinaryBasicBlock::OutputAddressRange in place so that the emitted size
+# of each basic block is given by BinaryBasicBlock::getOutputSize()
+
+# RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %s -o %t.o
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: llvm-strip --strip-unneeded %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --split-strategy=all \
+# RUN:         --print-split --print-only=chain --print-output-address-range \
+# RUN:         --data=%t.fdata --reorder-blocks=ext-tsp \
+# RUN:     2>&1 | FileCheck --check-prefix=SPLITALL %s
+# RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %s -o %t.o
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: llvm-strip --strip-unneeded %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --print-split \
+# RUN:         --print-only=chain --print-output-address-range \
+# RUN:         --data=%t.fdata --reorder-blocks=ext-tsp \
+# RUN:     2>&1 | FileCheck --check-prefix=SPLITHOTCOLD %s
+
+# SPLITALL: Binary Function "chain" after split-functions
+# SPLITALL: {{^\.LBB00}}
+# SPLITALL: Output Start Address: 0
+# SPLITALL: Output End Address: 18
+# SPLITALL: {{^\.LFT0}}
+# SPLITALL: Output Start Address: 0
+# SPLITALL: Output End Address: 10
+# SPLITALL: {{^\.Ltmp1}}
+# SPLITALL: Output Start Address: 0
+# SPLITALL: Output End Address: 2
+# SPLITALL: {{^\.Ltmp0}}
+# SPLITALL: Output Start Address: 0
+# SPLITALL: Output End Address: 16
+# SPLITALL: {{^\.Ltmp2}}
+# SPLITALL: Output Start Address: 0
+# SPLITALL: Output End Address: 8
+# SPLITALL: {{^\.LFT1}}
+# SPLITALL: Output Start Address: 0
+# SPLITALL: Output End Address: 8
+
+# SPLITHOTCOLD: {{^\.LBB00}}
+# SPLITHOTCOLD: Output Start Address: 0
+# SPLITHOTCOLD: Output End Address: 9
+# SPLITHOTCOLD: {{^\.LFT0}}
+# SPLITHOTCOLD: Output Start Address: 9
+# SPLITHOTCOLD: Output End Address: 14
+# SPLITHOTCOLD: {{^\.Ltmp1}}
+# SPLITHOTCOLD: Output Start Address: 14
+# SPLITHOTCOLD: Output End Address: 16
+# SPLITHOTCOLD: {{^\.Ltmp0}}
+# SPLITHOTCOLD: Output Start Address: 16
+# SPLITHOTCOLD: Output End Address: 27
+# SPLITHOTCOLD: {{^\.Ltmp2}}
+# SPLITHOTCOLD: Output Start Address: 27
+# SPLITHOTCOLD: Output End Address: 32
+# SPLITHOTCOLD: {{^\.LFT1}}
+# SPLITHOTCOLD: Output Start Address: 0
+# SPLITHOTCOLD: Output End Address: 8
+
+        .text
+        .globl  chain
+        .type   chain, @function
+chain:
+        pushq   %rbp
+        movq    %rsp, %rbp
+        cmpl    $2, %edi
+LLentry_LLchain_start:
+        jge     LLchain_start
+# FDATA: 1 chain #LLentry_LLchain_start# 1 chain #LLchain_start# 0 10
+# FDATA: 1 chain #LLentry_LLchain_start# 1 chain #LLfast# 0 500
+LLfast:
+        movl    $5, %eax
+LLfast_LLexit:
+        jmp     LLexit
+# FDATA: 1 chain #LLfast_LLexit# 1 chain #LLexit# 0 500
+LLchain_start:
+        movl    $10, %eax
+LLchain_start_LLchain1:
+        jge     LLchain1
+# FDATA: 1 chain #LLchain_start_LLchain1# 1 chain #LLchain1# 0 10
+# FDATA: 1 chain #LLchain_start_LLchain1# 1 chain #LLcold# 0 0
+LLcold:
+        addl    $1, %eax
+LLchain1:
+        addl    $1, %eax
+LLchain1_LLexit:
+        jmp     LLexit
+# FDATA: 1 chain #LLchain1_LLexit# 1 chain #LLexit# 0 10
+LLexit:
+        popq    %rbp
+        ret
+LLchain_end:
+        .size   chain, LLchain_end-chain
+
+
+        .globl  main
+        .type   main, @function
+main:
+        pushq   %rbp
+        movq    %rsp, %rbp
+        movl    $1, %edi
+LLmain_chain1:
+        call    chain
+# FDATA: 1 main #LLmain_chain1# 1 chain 0 0 500
+        movl    $4, %edi
+LLmain_chain2:
+        call    chain
+# FDATA: 1 main #LLmain_chain2# 1 chain 0 0 10
+        xorl    %eax, %eax
+        popq    %rbp
+        retq
+.Lmain_end:
+        .size   main, .Lmain_end-main

--- a/bolt/test/X86/calculate-emitted-block-size.s
+++ b/bolt/test/X86/calculate-emitted-block-size.s
@@ -19,44 +19,31 @@
 # RUN:         --data=%t.fdata --reorder-blocks=ext-tsp \
 # RUN:     2>&1 | FileCheck --check-prefix=SPLITHOTCOLD %s
 
-# SPLITALL: Binary Function "chain" after split-functions
 # SPLITALL: {{^\.LBB00}}
-# SPLITALL: Output Start Address: 0
-# SPLITALL: Output End Address: 18
+# SPLITALL: Output Address Range: [0x0, 0x12) (18 bytes)
 # SPLITALL: {{^\.LFT0}}
-# SPLITALL: Output Start Address: 0
-# SPLITALL: Output End Address: 10
+# SPLITALL: Output Address Range: [0x0, 0xa) (10 bytes)
 # SPLITALL: {{^\.Ltmp1}}
-# SPLITALL: Output Start Address: 0
-# SPLITALL: Output End Address: 2
+# SPLITALL: Output Address Range: [0x0, 0x2) (2 bytes)
 # SPLITALL: {{^\.Ltmp0}}
-# SPLITALL: Output Start Address: 0
-# SPLITALL: Output End Address: 16
+# SPLITALL: Output Address Range: [0x0, 0x10) (16 bytes)
 # SPLITALL: {{^\.Ltmp2}}
-# SPLITALL: Output Start Address: 0
-# SPLITALL: Output End Address: 8
+# SPLITALL: Output Address Range: [0x0, 0x8) (8 bytes)
 # SPLITALL: {{^\.LFT1}}
-# SPLITALL: Output Start Address: 0
-# SPLITALL: Output End Address: 8
+# SPLITALL: Output Address Range: [0x0, 0x8) (8 bytes)
 
 # SPLITHOTCOLD: {{^\.LBB00}}
-# SPLITHOTCOLD: Output Start Address: 0
-# SPLITHOTCOLD: Output End Address: 9
+# SPLITHOTCOLD: Output Address Range: [0x0, 0x9) (9 bytes)
 # SPLITHOTCOLD: {{^\.LFT0}}
-# SPLITHOTCOLD: Output Start Address: 9
-# SPLITHOTCOLD: Output End Address: 14
+# SPLITHOTCOLD: Output Address Range: [0x9, 0xe) (5 bytes)
 # SPLITHOTCOLD: {{^\.Ltmp1}}
-# SPLITHOTCOLD: Output Start Address: 14
-# SPLITHOTCOLD: Output End Address: 16
+# SPLITHOTCOLD: Output Address Range: [0xe, 0x10) (2 bytes)
 # SPLITHOTCOLD: {{^\.Ltmp0}}
-# SPLITHOTCOLD: Output Start Address: 16
-# SPLITHOTCOLD: Output End Address: 27
+# SPLITHOTCOLD: Output Address Range: [0x10, 0x1b) (11 bytes)
 # SPLITHOTCOLD: {{^\.Ltmp2}}
-# SPLITHOTCOLD: Output Start Address: 27
-# SPLITHOTCOLD: Output End Address: 32
+# SPLITHOTCOLD: Output Address Range: [0x1b, 0x20) (5 bytes)
 # SPLITHOTCOLD: {{^\.LFT1}}
-# SPLITHOTCOLD: Output Start Address: 0
-# SPLITHOTCOLD: Output End Address: 8
+# SPLITHOTCOLD: Output Address Range: [0x0, 0x8) (8 bytes)
 
         .text
         .globl  chain


### PR DESCRIPTION
This commit modifies BinaryContext::calculateEmittedSize to update the BinaryBasicBlock::OutputAddressRange for each basic block in the input BF. The modification is done in place, where BinaryBasicBlock::getOutputSize() now gives the emitted size of the basic block.