### PR TITLE
[BOLT] Refactor SplitFunctions for function reuse. NFC.

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1272,6 +1272,20 @@ public:
   /// otherwise processed.
   bool isPseudo() const { return IsPseudo; }
 
+  /// Return true if every block in the function has a valid execution count.
+  bool hasFullProfile() const {
+    return llvm::all_of(blocks(), [](const BinaryBasicBlock &BB) {
+      return BB.getExecutionCount() != BinaryBasicBlock::COUNT_NO_PROFILE;
+    });
+  }
+
+  /// Return true if every block in the function has a zero execution count.
+  bool allBlocksCold() const {
+    return llvm::all_of(blocks(), [](const BinaryBasicBlock &BB) {
+      return BB.getExecutionCount() == 0;
+    });
+  }
+
   /// Return true if the function contains explicit or implicit indirect branch
   /// to its split fragments, e.g., split jump table, landing pad in split
   /// fragment.

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1272,13 +1272,6 @@ public:
   /// otherwise processed.
   bool isPseudo() const { return IsPseudo; }
 
-  /// Return true if every block in the function has a valid execution count.
-  bool hasFullProfile() const {
-    return llvm::all_of(blocks(), [](const BinaryBasicBlock &BB) {
-      return BB.getExecutionCount() != BinaryBasicBlock::COUNT_NO_PROFILE;
-    });
-  }
-
   /// Return true if every block in the function has a zero execution count.
   bool allBlocksCold() const {
     return llvm::all_of(blocks(), [](const BinaryBasicBlock &BB) {

--- a/bolt/lib/Passes/SplitFunctions.cpp
+++ b/bolt/lib/Passes/SplitFunctions.cpp
@@ -109,9 +109,15 @@ static cl::opt<SplitFunctionsStrategy> SplitStrategy(
 } // namespace opts
 
 namespace {
+bool hasFullProfile(const BinaryFunction &BF) {
+  return llvm::all_of(BF.blocks(), [](const BinaryBasicBlock &BB) {
+    return BB.getExecutionCount() != BinaryBasicBlock::COUNT_NO_PROFILE;
+  });
+}
+
 struct SplitProfile2 final : public SplitStrategy {
   bool canSplit(const BinaryFunction &BF) override {
-    return BF.hasValidProfile() && BF.hasFullProfile() && !BF.allBlocksCold();
+    return BF.hasValidProfile() && hasFullProfile(BF) && !BF.allBlocksCold();
   }
 
   bool keepEmpty() override { return false; }


### PR DESCRIPTION
This commit updates SplitFunctions.h and SplitFunctions.cpp to enable
the reuse of createEHTrampolines, mergeEHTrampolines, allBlocksCold 
by a distinct function splitting pass (CDSplit). While the SplitFunctions 
pass happens before the function reordering pass because function 
reordering depends on the function splitting decisions, CDSplit will be 
implemented as a separate function splitting pass and called after the 
function reordering pass to make use of the fixed function ordering to 
achieve better function splitting decisions. 