### PR TITLE
Reland "[clang][Sema] Use original template pattern when declaring implicit deduction guides for nested template classes"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -734,6 +734,11 @@ Bug Fixes to C++ Support
   declaration definition. Fixes:
   (`#61763 <https://github.com/llvm/llvm-project/issues/61763>`_)
 
+- Fix a bug where implicit deduction guides are not correctly generated for nested template
+  classes. Fixes:
+  (`#46200 <https://github.com/llvm/llvm-project/issues/46200>`_)
+  (`#57812 <https://github.com/llvm/llvm-project/issues/57812>`_)
+
 - Diagnose use of a variable-length array in a coroutine. The design of
   coroutines is such that it is not possible to support VLA use. Fixes:
   (`#65858 <https://github.com/llvm/llvm-project/issues/65858>`_)

--- a/clang/test/SemaTemplate/nested-deduction-guides.cpp
+++ b/clang/test/SemaTemplate/nested-deduction-guides.cpp
@@ -4,10 +4,15 @@
 template<typename T> struct A {
   template<typename U> struct B {
     B(...);
+    B(const B &) = default;
   };
   template<typename U> B(U) -> B<U>;
 };
 A<void>::B b = 123;
+A<void>::B copy = b;
 
 using T = decltype(b);
 using T = A<void>::B<int>;
+
+using Copy = decltype(copy);
+using Copy = A<void>::B<int>;

--- a/clang/test/SemaTemplate/nested-implicit-deduction-guides.cpp
+++ b/clang/test/SemaTemplate/nested-implicit-deduction-guides.cpp
@@ -1,0 +1,60 @@
+// RUN: %clang_cc1 -std=c++20 -verify %s
+// expected-no-diagnostics
+
+template<class T> struct S {
+    template<class U> struct N {
+        N(T) {}
+        N(T, U) {}
+        template<class V> N(V, U) {}
+    };
+};
+
+S<int>::N x{"a", 1};
+using T = decltype(x);
+using T = S<int>::N<int>;
+
+template<class X> struct default_ftd_argument {
+    template<class Y> struct B {
+        template<class W = X, class Z = Y, class V = Z, int I = 0> B(Y);
+    };
+};
+
+default_ftd_argument<int>::B default_arg("a");
+using DefaultArg = decltype(default_arg);
+using DefaultArg = default_ftd_argument<int>::B<const char *>;
+
+template<bool> struct test;
+template<class X> struct non_type_param {
+    template<class Y> struct B {
+        B(Y);
+        template<class Z, test<Z::value> = 0> B(Z);
+    };
+};
+
+non_type_param<int>::B ntp = 5;
+using NonTypeParam = decltype(ntp);
+using NonTypeParam = non_type_param<int>::B<int>;
+
+template<typename A, typename T>
+concept C = (sizeof(T) == sizeof(A));
+
+template<class X> struct concepts {
+    template<class Y> struct B {
+        template<class K = X, C<K> Z> B(Y, Z);
+    };
+};
+
+concepts<int>::B cc(1, 3);
+using Concepts = decltype(cc);
+using Concepts = concepts<int>::B<int>;
+
+template<class X> struct requires_clause {
+    template<class Y> struct B {
+        template<class Z> requires (sizeof(Z) == sizeof(X))
+            B(Y, Z);
+    };
+};
+
+requires_clause<int>::B req(1, 2);
+using RC = decltype(req);
+using RC = requires_clause<int>::B<int>;


### PR DESCRIPTION
Reland of f418319730341e9d41ce8ead6fbfe5603c343985 with proper handling of template constructors

When a nested template is instantiated, the template pattern of the inner class is not copied into the outer class
ClassTemplateSpecializationDecl. The specialization contains a ClassTemplateDecl with an empty record that points to the original template pattern instead.

As a result, when looking up the constructors of the inner class, no results are returned. This patch finds the original template pattern and uses that for the lookup instead.

Based on CWG2471 we must also substitute the known outer template arguments when creating deduction guides for the inner class.

Changes from last iteration:

1. In template constructors, arguments are first rewritten to depth - 1 relative to the constructor as compared to depth 0 originally. These arguments are needed for substitution into constraint expressions.
2. Outer arguments are then applied with the template instantiator to produce a template argument at depth zero for use in the deduction guide. This substitution does not evaluate constraints, which preserves constraint arguments at the correct depth for later evaluation.
3. Tests are added that cover template constructors within nested deduction guides for all special substitution cases.
4. Computation of the template pattern and outer instantiation arguments are pulled into the constructor of `ConvertConstructorToDeductionGuideTransform`.