### PR TITLE
[clang-tidy] Add check hicpp-ignored-remove-result

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -136,7 +136,17 @@ UnusedReturnValueCheck::UnusedReturnValueCheck(llvm::StringRef Name,
 UnusedReturnValueCheck::UnusedReturnValueCheck(llvm::StringRef Name,
                                                ClangTidyContext *Context,
                                                std::string CheckedFunctions)
-    : ClangTidyCheck(Name, Context), CheckedFunctions(CheckedFunctions) {}
+    : UnusedReturnValueCheck(Name, Context, std::move(CheckedFunctions), {},
+                             false) {}
+
+UnusedReturnValueCheck::UnusedReturnValueCheck(
+    llvm::StringRef Name, ClangTidyContext *Context,
+    std::string CheckedFunctions, std::vector<StringRef> CheckedReturnTypes,
+    bool AllowCastToVoid)
+    : ClangTidyCheck(Name, Context),
+      CheckedFunctions(std::move(CheckedFunctions)),
+      CheckedReturnTypes(std::move(CheckedReturnTypes)),
+      AllowCastToVoid(AllowCastToVoid) {}
 
 void UnusedReturnValueCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "CheckedFunctions", CheckedFunctions);

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -133,6 +133,11 @@ UnusedReturnValueCheck::UnusedReturnValueCheck(llvm::StringRef Name,
                                             "::boost::system::error_code"))),
       AllowCastToVoid(Options.get("AllowCastToVoid", false)) {}
 
+UnusedReturnValueCheck::UnusedReturnValueCheck(llvm::StringRef Name,
+                                               ClangTidyContext *Context,
+                                               std::string CheckedFunctions)
+    : ClangTidyCheck(Name, Context), CheckedFunctions(CheckedFunctions) {}
+
 void UnusedReturnValueCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "CheckedFunctions", CheckedFunctions);
   Options.store(Opts, "CheckedReturnTypes",

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.h
@@ -28,10 +28,12 @@ public:
     return TK_IgnoreUnlessSpelledInSource;
   }
 
-private:
+protected:
+  UnusedReturnValueCheck(StringRef Name, ClangTidyContext *Context,
+                         std::string CheckedFunctions);
   std::string CheckedFunctions;
   const std::vector<StringRef> CheckedReturnTypes;
-  const bool AllowCastToVoid;
+  bool AllowCastToVoid;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.h
@@ -28,11 +28,17 @@ public:
     return TK_IgnoreUnlessSpelledInSource;
   }
 
+private:
+  std::string CheckedFunctions;
+  const std::vector<StringRef> CheckedReturnTypes;
+
 protected:
   UnusedReturnValueCheck(StringRef Name, ClangTidyContext *Context,
                          std::string CheckedFunctions);
-  std::string CheckedFunctions;
-  const std::vector<StringRef> CheckedReturnTypes;
+  UnusedReturnValueCheck(StringRef Name, ClangTidyContext *Context,
+                         std::string CheckedFunctions,
+                         std::vector<StringRef> CheckedReturnTypes,
+                         bool AllowCastToVoid);
   bool AllowCastToVoid;
 };
 

--- a/clang-tools-extra/clang-tidy/hicpp/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/hicpp/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
 add_clang_library(clangTidyHICPPModule
   ExceptionBaseclassCheck.cpp
   HICPPTidyModule.cpp
+  IgnoredRemoveResultCheck.cpp
   MultiwayPathsCoveredCheck.cpp
   NoAssemblerCheck.cpp
   SignedBitwiseCheck.cpp

--- a/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
@@ -10,6 +10,7 @@
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
 #include "../bugprone/UndelegatedConstructorCheck.h"
+#include "../bugprone/UnusedReturnValueCheck.h"
 #include "../bugprone/UseAfterMoveCheck.h"
 #include "../cppcoreguidelines/AvoidGotoCheck.h"
 #include "../cppcoreguidelines/NoMallocCheck.h"
@@ -41,6 +42,15 @@
 #include "NoAssemblerCheck.h"
 #include "SignedBitwiseCheck.h"
 
+namespace {
+
+// Checked functions for hicpp-ignored-remove-result.
+const llvm::StringRef CheckedFunctions = "::std::remove;"
+                                         "::std::remove_if;"
+                                         "::std::unique;";
+
+} // namespace
+
 namespace clang::tidy {
 namespace hicpp {
 
@@ -64,6 +74,8 @@ public:
         "hicpp-explicit-conversions");
     CheckFactories.registerCheck<readability::FunctionSizeCheck>(
         "hicpp-function-size");
+    CheckFactories.registerCheck<bugprone::UnusedReturnValueCheck>(
+        "hicpp-ignored-remove-result");
     CheckFactories.registerCheck<readability::NamedParameterCheck>(
         "hicpp-named-parameter");
     CheckFactories.registerCheck<bugprone::UseAfterMoveCheck>(
@@ -106,6 +118,14 @@ public:
         "hicpp-uppercase-literal-suffix");
     CheckFactories.registerCheck<cppcoreguidelines::ProTypeVarargCheck>(
         "hicpp-vararg");
+  }
+
+  ClangTidyOptions getModuleOptions() override {
+    ClangTidyOptions Options;
+    ClangTidyOptions::OptionMap &Opts = Options.CheckOptions;
+    Opts["hicpp-ignored-remove-result.CheckedFunctions"] = CheckedFunctions;
+    Opts["hicpp-ignored-remove-result.AllowCastToVoid"] = "true";
+    return Options;
   }
 };
 

--- a/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
@@ -10,7 +10,6 @@
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
 #include "../bugprone/UndelegatedConstructorCheck.h"
-#include "../bugprone/UnusedReturnValueCheck.h"
 #include "../bugprone/UseAfterMoveCheck.h"
 #include "../cppcoreguidelines/AvoidGotoCheck.h"
 #include "../cppcoreguidelines/NoMallocCheck.h"
@@ -38,18 +37,10 @@
 #include "../readability/NamedParameterCheck.h"
 #include "../readability/UppercaseLiteralSuffixCheck.h"
 #include "ExceptionBaseclassCheck.h"
+#include "IgnoredRemoveResultCheck.h"
 #include "MultiwayPathsCoveredCheck.h"
 #include "NoAssemblerCheck.h"
 #include "SignedBitwiseCheck.h"
-
-namespace {
-
-// Checked functions for hicpp-ignored-remove-result.
-const llvm::StringRef CheckedFunctions = "::std::remove;"
-                                         "::std::remove_if;"
-                                         "::std::unique;";
-
-} // namespace
 
 namespace clang::tidy {
 namespace hicpp {
@@ -67,6 +58,8 @@ public:
         "hicpp-deprecated-headers");
     CheckFactories.registerCheck<ExceptionBaseclassCheck>(
         "hicpp-exception-baseclass");
+    CheckFactories.registerCheck<IgnoredRemoveResultCheck>(
+        "hicpp-ignored-remove-result");
     CheckFactories.registerCheck<MultiwayPathsCoveredCheck>(
         "hicpp-multiway-paths-covered");
     CheckFactories.registerCheck<SignedBitwiseCheck>("hicpp-signed-bitwise");
@@ -74,8 +67,6 @@ public:
         "hicpp-explicit-conversions");
     CheckFactories.registerCheck<readability::FunctionSizeCheck>(
         "hicpp-function-size");
-    CheckFactories.registerCheck<bugprone::UnusedReturnValueCheck>(
-        "hicpp-ignored-remove-result");
     CheckFactories.registerCheck<readability::NamedParameterCheck>(
         "hicpp-named-parameter");
     CheckFactories.registerCheck<bugprone::UseAfterMoveCheck>(
@@ -118,14 +109,6 @@ public:
         "hicpp-uppercase-literal-suffix");
     CheckFactories.registerCheck<cppcoreguidelines::ProTypeVarargCheck>(
         "hicpp-vararg");
-  }
-
-  ClangTidyOptions getModuleOptions() override {
-    ClangTidyOptions Options;
-    ClangTidyOptions::OptionMap &Opts = Options.CheckOptions;
-    Opts["hicpp-ignored-remove-result.CheckedFunctions"] = CheckedFunctions;
-    Opts["hicpp-ignored-remove-result.AllowCastToVoid"] = "true";
-    return Options;
   }
 };
 

--- a/clang-tools-extra/clang-tidy/hicpp/IgnoredRemoveResultCheck.cpp
+++ b/clang-tools-extra/clang-tidy/hicpp/IgnoredRemoveResultCheck.cpp
@@ -15,7 +15,7 @@ IgnoredRemoveResultCheck::IgnoredRemoveResultCheck(llvm::StringRef Name,
     : UnusedReturnValueCheck(Name, Context,
                              "::std::remove;"
                              "::std::remove_if;"
-                             "::std::unique;") {
+                             "::std::unique") {
   // The constructor for ClangTidyCheck needs to have been called
   // before we can access options via Options.get().
   AllowCastToVoid = Options.get("AllowCastToVoid", true);

--- a/clang-tools-extra/clang-tidy/hicpp/IgnoredRemoveResultCheck.cpp
+++ b/clang-tools-extra/clang-tidy/hicpp/IgnoredRemoveResultCheck.cpp
@@ -1,0 +1,28 @@
+//===--- IgnoredRemoveResultCheck.cpp - clang-tidy ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "IgnoredRemoveResultCheck.h"
+
+namespace clang::tidy::hicpp {
+
+IgnoredRemoveResultCheck::IgnoredRemoveResultCheck(llvm::StringRef Name,
+                                                   ClangTidyContext *Context)
+    : UnusedReturnValueCheck(Name, Context,
+                             "::std::remove;"
+                             "::std::remove_if;"
+                             "::std::unique;") {
+  // The constructor for ClangTidyCheck needs to have been called
+  // before we can access options via Options.get().
+  AllowCastToVoid = Options.get("AllowCastToVoid", true);
+}
+
+void IgnoredRemoveResultCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "AllowCastToVoid", AllowCastToVoid);
+}
+
+} // namespace clang::tidy::hicpp

--- a/clang-tools-extra/clang-tidy/hicpp/IgnoredRemoveResultCheck.h
+++ b/clang-tools-extra/clang-tidy/hicpp/IgnoredRemoveResultCheck.h
@@ -1,0 +1,29 @@
+//===--- IgnoredRemoveResultCheck.h - clang-tidy ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_HICPP_IGNOREDREMOVERESULTCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_HICPP_IGNOREDREMOVERESULTCHECK_H
+
+#include "../bugprone/UnusedReturnValueCheck.h"
+
+namespace clang::tidy::hicpp {
+
+/// Ensure that the result of std::remove, std::remove_if and std::unique
+/// are not ignored according to rule 17.5.1.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/hicpp/ignored-remove-result.html
+class IgnoredRemoveResultCheck : public bugprone::UnusedReturnValueCheck {
+public:
+  IgnoredRemoveResultCheck(StringRef Name, ClangTidyContext *Context);
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+};
+
+} // namespace clang::tidy::hicpp
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_HICPP_IGNOREDREMOVERESULTCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -174,6 +174,12 @@ New checks
   Flags coroutines that suspend while a lock guard is in scope at the
   suspension point.
 
+- New :doc:`hicpp-ignored-remove-result
+  <clang-tidy/checks/hicpp/ignored-remove-result>` check.
+
+  Ensure that the result of ``std::remove``, ``std::remove_if`` and
+  ``std::unique`` are not ignored according to rule 17.5.1.
+
 - New :doc:`misc-coroutine-hostile-raii
   <clang-tidy/checks/misc/coroutine-hostile-raii>` check.
 
@@ -204,10 +210,6 @@ New check aliases
 - New alias :doc:`cppcoreguidelines-macro-to-enum
   <clang-tidy/checks/cppcoreguidelines/macro-to-enum>` to :doc:`modernize-macro-to-enum
   <clang-tidy/checks/modernize/macro-to-enum>` was added.
-
-- New alias :doc:`hicpp-ignored-remove-result
-  <clang-tidy/checks/hicpp/ignored-remove-result>` to :doc:`bugprone-unused-return-value
-  <clang-tidy/checks/bugprone/unused-return-value>` was added.
 
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -205,6 +205,10 @@ New check aliases
   <clang-tidy/checks/cppcoreguidelines/macro-to-enum>` to :doc:`modernize-macro-to-enum
   <clang-tidy/checks/modernize/macro-to-enum>` was added.
 
+- New alias :doc:`hicpp-ignored-remove-result
+  <clang-tidy/checks/hicpp/ignored-remove-result>` to :doc:`bugprone-unused-return-value
+  <clang-tidy/checks/bugprone/unused-return-value>` was added.
+
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -11,7 +11,7 @@ The mutating algorithms ``std::remove``, ``std::remove_if`` and both overloads
 of ``std::unique`` operate by swapping or moving elements of the range they are
 operating over. On completion, they return an iterator to the last valid
 element. In the majority of cases the correct behavior is to use this result as
-the first operand in a call to std::erase.
+the first operand in a call to ``std::erase``.
 
 This check is an alias of check :doc:`bugprone-unused-return-value <../bugprone/unused-return-value>`
 with a fixed set of functions.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -1,0 +1,20 @@
+.. title:: clang-tidy - hicpp-ignored-remove-result
+
+hicpp-ignored-remove-result
+===========================
+
+Ensure that the result of ``std::remove``, ``std::remove_if`` and ``std::unique``
+are not ignored according to
+`rule 17.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library>`_.
+
+The mutating algorithms ``std::remove``, ``std::remove_if`` and both overloads
+of ``std::unique`` operate by swapping or moving elements of the range they are
+operating over. On completion, they return an iterator to the last valid
+element. In the majority of cases the correct behavior is to use this result as
+the first operand in a call to std::erase.
+
+This check is an alias of check :doc:`bugprone-unused-return-value <../bugprone/unused-return-value>`
+with a fixed set of functions.
+
+Suppressing issues by casting to ``void`` is enabled by default and can be
+disabled by setting `AllowCastToVoid` option to ``false``.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -13,8 +13,5 @@ operating over. On completion, they return an iterator to the last valid
 element. In the majority of cases the correct behavior is to use this result as
 the first operand in a call to ``std::erase``.
 
-This check is an alias of check :doc:`bugprone-unused-return-value <../bugprone/unused-return-value>`
-with a fixed set of functions.
-
 Suppressing issues by casting to ``void`` is enabled by default and can be
 disabled by setting `AllowCastToVoid` option to ``false``.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -13,6 +13,9 @@ operating over. On completion, they return an iterator to the last valid
 element. In the majority of cases the correct behavior is to use this result as
 the first operand in a call to ``std::erase``.
 
+This check is a subset of :doc:`bugprone-unused-return-value <../bugprone/unused-return-value>`
+and depending on used options it can be superfluous to enable both checks.
+
 Options
 -------
 

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -13,5 +13,9 @@ operating over. On completion, they return an iterator to the last valid
 element. In the majority of cases the correct behavior is to use this result as
 the first operand in a call to ``std::erase``.
 
-Suppressing issues by casting to ``void`` is enabled by default and can be
-disabled by setting `AllowCastToVoid` option to ``false``.
+Options
+-------
+
+.. option:: AllowCastToVoid
+
+   Controls whether casting return values to ``void`` is permitted. Default: `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -226,6 +226,7 @@ Clang-Tidy Checks
    :doc:`google-runtime-operator <google/runtime-operator>`,
    :doc:`google-upgrade-googletest-case <google/upgrade-googletest-case>`, "Yes"
    :doc:`hicpp-exception-baseclass <hicpp/exception-baseclass>`,
+   :doc:`hicpp-ignored-remove-result <hicpp/ignored-remove-result>`,
    :doc:`hicpp-multiway-paths-covered <hicpp/multiway-paths-covered>`,
    :doc:`hicpp-no-assembler <hicpp/no-assembler>`,
    :doc:`hicpp-signed-bitwise <hicpp/signed-bitwise>`,

--- a/clang-tools-extra/test/clang-tidy/checkers/hicpp/ignored-remove-result.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/hicpp/ignored-remove-result.cpp
@@ -1,0 +1,47 @@
+// RUN: %check_clang_tidy %s hicpp-ignored-remove-result %t
+
+namespace std {
+
+template <typename ForwardIt, typename T>
+ForwardIt remove(ForwardIt, ForwardIt, const T &);
+
+template <typename ForwardIt, typename UnaryPredicate>
+ForwardIt remove_if(ForwardIt, ForwardIt, UnaryPredicate);
+
+template <typename ForwardIt>
+ForwardIt unique(ForwardIt, ForwardIt);
+
+template <class InputIt, class T>
+InputIt find(InputIt, InputIt, const T&);
+
+} // namespace std
+
+void warning() {
+  std::remove(nullptr, nullptr, 1);
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+  // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
+
+  std::remove_if(nullptr, nullptr, nullptr);
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+  // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
+
+  std::unique(nullptr, nullptr);
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+  // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
+}
+
+void noWarning() {
+
+  auto RemoveRetval = std::remove(nullptr, nullptr, 1);
+
+  auto RemoveIfRetval = std::remove_if(nullptr, nullptr, nullptr);
+
+  auto UniqueRetval = std::unique(nullptr, nullptr);
+
+  // cast to void should allow ignoring the return value
+  (void)std::remove(nullptr, nullptr, 1);
+
+  // no warning on std::find since the checker overrides
+  // bugprone-unused-return-value's checked functions.
+  std::find(nullptr, nullptr, 1);
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/hicpp/ignored-remove-result.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/hicpp/ignored-remove-result.cpp
@@ -1,4 +1,5 @@
 // RUN: %check_clang_tidy %s hicpp-ignored-remove-result %t
+// RUN: %check_clang_tidy -check-suffixes=NOCAST %s hicpp-ignored-remove-result %t -- -config='{CheckOptions: {hicpp-ignored-remove-result.AllowCastToVoid: false}}'
 
 namespace std {
 
@@ -14,20 +15,36 @@ ForwardIt unique(ForwardIt, ForwardIt);
 template <class InputIt, class T>
 InputIt find(InputIt, InputIt, const T&);
 
+class error_code {
+};
+
 } // namespace std
+
+std::error_code errorFunc() {
+  return std::error_code();
+}
 
 void warning() {
   std::remove(nullptr, nullptr, 1);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
   // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
+  // CHECK-MESSAGES-NOCAST: [[@LINE-3]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
 
   std::remove_if(nullptr, nullptr, nullptr);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
   // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
+  // CHECK-MESSAGES-NOCAST: [[@LINE-3]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
 
   std::unique(nullptr, nullptr);
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
   // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
+  // CHECK-MESSAGES-NOCAST: [[@LINE-3]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+}
+
+void optionalWarning() {
+  // No warning unless AllowCastToVoid=false
+  (void)std::remove(nullptr, nullptr, 1);
+  // CHECK-MESSAGES-NOCAST: [[@LINE-1]]:9: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
 }
 
 void noWarning() {
@@ -38,10 +55,12 @@ void noWarning() {
 
   auto UniqueRetval = std::unique(nullptr, nullptr);
 
-  // cast to void should allow ignoring the return value
-  (void)std::remove(nullptr, nullptr, 1);
-
-  // no warning on std::find since the checker overrides
-  // bugprone-unused-return-value's checked functions.
+  // Verify that other checks in the baseclass are not used.
+  // - no warning on std::find since the checker overrides
+  //   bugprone-unused-return-value's checked functions.
   std::find(nullptr, nullptr, 1);
+  // - no warning on return types since the checker disable
+  //   bugprone-unused-return-value's checked return types.
+  errorFunc();
+  (void) errorFunc();
 }


### PR DESCRIPTION
This check implements the [rule 17.5.1](https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library) of the HICPP standard which states:

- Do not ignore the result of std::remove, std::remove_if or std::unique

  The mutating algorithms std::remove, std::remove_if and both overloads of std::unique operate by swapping or moving elements of the range they are operating over. On completion, they return an iterator to the last valid element. In the majority of cases the correct behavior is to use this result as the first operand in a call to std::erase.

This check is based on `bugprone-unused-return-value` but with a fixed set of functions.

Suppressing issues by casting to `void` is enabled by default, but can be disabled by setting `AllowCastToVoid` option to `false`.