### PR TITLE
[NFC] Add unit tests for TypeSize:isXBitVector

### DIFF
--- a/llvm/lib/CodeGen/ValueTypes.cpp
+++ b/llvm/lib/CodeGen/ValueTypes.cpp
@@ -79,35 +79,43 @@ bool EVT::isExtendedVector() const {
 }
 
 bool EVT::isExtended16BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 16;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(16);
 }
 
 bool EVT::isExtended32BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 32;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(32);
 }
 
 bool EVT::isExtended64BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 64;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(64);
 }
 
 bool EVT::isExtended128BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 128;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(128);
 }
 
 bool EVT::isExtended256BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 256;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(256);
 }
 
 bool EVT::isExtended512BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 512;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(512);
 }
 
 bool EVT::isExtended1024BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 1024;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(1024);
 }
 
 bool EVT::isExtended2048BitVector() const {
-  return isExtendedVector() && getExtendedSizeInBits() == 2048;
+  return isExtendedVector() &&
+         getExtendedSizeInBits() == TypeSize::getFixed(2048);
 }
 
 bool EVT::isExtendedFixedLengthVector() const {

--- a/llvm/unittests/CodeGen/ScalableVectorMVTsTest.cpp
+++ b/llvm/unittests/CodeGen/ScalableVectorMVTsTest.cpp
@@ -135,6 +135,16 @@ TEST(ScalableVectorMVTsTest, SizeQueries) {
   EVT v2i64 = EVT::getVectorVT(Ctx, MVT::i64, 2);
   EVT v2f64 = EVT::getVectorVT(Ctx, MVT::f64, 2);
 
+  EVT nxv5i32 = EVT::getVectorVT(Ctx, MVT::i32, 5, /*Scalable=*/ true);
+  ASSERT_FALSE(nxv5i32.is16BitVector());
+  ASSERT_FALSE(nxv5i32.is32BitVector());
+  ASSERT_FALSE(nxv5i32.is64BitVector());
+  ASSERT_FALSE(nxv5i32.is128BitVector());
+  ASSERT_FALSE(nxv5i32.is256BitVector());
+  ASSERT_FALSE(nxv5i32.is512BitVector());
+  ASSERT_FALSE(nxv5i32.is1024BitVector());
+  ASSERT_FALSE(nxv5i32.is2048BitVector());
+
   // Check equivalence and ordering on scalable types.
   EXPECT_EQ(nxv4i32.getSizeInBits(), nxv2i64.getSizeInBits());
   EXPECT_EQ(nxv2f64.getSizeInBits(), nxv2i64.getSizeInBits());

--- a/llvm/unittests/CodeGen/ScalableVectorMVTsTest.cpp
+++ b/llvm/unittests/CodeGen/ScalableVectorMVTsTest.cpp
@@ -135,7 +135,7 @@ TEST(ScalableVectorMVTsTest, SizeQueries) {
   EVT v2i64 = EVT::getVectorVT(Ctx, MVT::i64, 2);
   EVT v2f64 = EVT::getVectorVT(Ctx, MVT::f64, 2);
 
-  EVT nxv5i32 = EVT::getVectorVT(Ctx, MVT::i32, 5, /*Scalable=*/ true);
+  EVT nxv5i32 = EVT::getVectorVT(Ctx, MVT::i32, 5, /*Scalable=*/true);
   ASSERT_FALSE(nxv5i32.is16BitVector());
   ASSERT_FALSE(nxv5i32.is32BitVector());
   ASSERT_FALSE(nxv5i32.is64BitVector());


### PR DESCRIPTION
The tests are showing that the current behaviour isn't correct.