### PR TITLE
[Flang] Add new Integration tests directory to Flang

### DIFF
--- a/flang/test/Driver/OpenMP/host-ir-flag.f90
+++ b/flang/test/Driver/OpenMP/host-ir-flag.f90
@@ -1,6 +1,0 @@
-!RUN: %flang_fc1 -emit-llvm-bc -fopenmp -o %t.bc %s 2>&1
-!RUN: %flang_fc1 -emit-mlir -fopenmp -fopenmp-is-target-device -fopenmp-host-ir-file-path %t.bc -o - %s 2>&1 | FileCheck %s
-
-!CHECK: module attributes {{{.*}}, omp.host_ir_filepath = "{{.*}}.bc", omp.is_gpu = false, omp.is_target_device = true{{.*}}}
-subroutine omp_subroutine()
-end subroutine omp_subroutine

--- a/flang/test/Integration/OpenMP/host-ir-flag.f90
+++ b/flang/test/Integration/OpenMP/host-ir-flag.f90
@@ -1,0 +1,14 @@
+!===----------------------------------------------------------------------===!
+! This directory can be used to add Integration tests involving multiple
+! stages of the compiler (for eg. from Fortran to LLVM IR). It should not
+! contain executable tests. We should only add tests here sparingly and only
+! if there is no other way to test. Repeat this message in each test that is
+! added to this directory and sub-directories.
+!===----------------------------------------------------------------------===!
+
+!RUN: %flang_fc1 -emit-llvm-bc -fopenmp -o %t.bc %s 2>&1
+!RUN: %flang_fc1 -emit-mlir -fopenmp -fopenmp-is-target-device -fopenmp-host-ir-file-path %t.bc -o - %s 2>&1 | FileCheck %s
+
+!CHECK: module attributes {{{.*}}, omp.host_ir_filepath = "{{.*}}.bc", omp.is_gpu = false, omp.is_target_device = true{{.*}}}
+subroutine omp_subroutine()
+end subroutine omp_subroutine

--- a/flang/test/Integration/OpenMP/map-types-and-sizes.f90
+++ b/flang/test/Integration/OpenMP/map-types-and-sizes.f90
@@ -1,3 +1,11 @@
+!===----------------------------------------------------------------------===!
+! This directory can be used to add Integration tests involving multiple
+! stages of the compiler (for eg. from Fortran to LLVM IR). It should not
+! contain executable tests. We should only add tests here sparingly and only
+! if there is no other way to test. Repeat this message in each test that is
+! added to this directory and sub-directories.
+!===----------------------------------------------------------------------===!
+
 !RUN: %flang_fc1 -emit-llvm -fopenmp -flang-deprecated-no-hlfir %s -o - | FileCheck %s
 
 !===============================================================================

--- a/flang/test/Integration/OpenMP/target-filtering.f90
+++ b/flang/test/Integration/OpenMP/target-filtering.f90
@@ -1,0 +1,69 @@
+!===----------------------------------------------------------------------===!
+! This directory can be used to add Integration tests involving multiple
+! stages of the compiler (for eg. from Fortran to LLVM IR). It should not
+! contain executable tests. We should only add tests here sparingly and only
+! if there is no other way to test. Repeat this message in each test that is
+! added to this directory and sub-directories.
+!===----------------------------------------------------------------------===!
+
+!RUN: %flang_fc1 -emit-llvm -fopenmp %s -o - | FileCheck %s --check-prefixes HOST,ALL
+!RUN: %flang_fc1 -emit-llvm -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s --check-prefixes DEVICE,ALL
+
+!HOST: define {{.*}}@{{.*}}before{{.*}}(
+!DEVICE-NOT: define {{.*}}@before{{.*}}(
+!DEVICE-NOT: declare {{.*}}@before{{.*}}
+integer function before(x)
+   integer, intent(in) :: x
+   before = x + 200
+end function
+
+!ALL: define {{.*}}@{{.*}}main{{.*}}(
+program main
+   integer :: x, before, after
+   !$omp target map(tofrom : x)
+      x = 100
+   !$omp end target
+   !HOST: call {{.*}}@{{.*}}before{{.*}}(
+   !DEVICE-NOT: call {{.*}}@before{{.*}}(
+   !HOST: call {{.*}}@{{.*}}after{{.*}}(
+   !DEVICE-NOT: call {{.*}}@after{{.*}}(
+   x = x + before(x) + after(x)
+end program
+
+!HOST: define {{.*}}@{{.*}}after{{.*}}(
+!DEVICE-NOT: define {{.*}}@after{{.*}}(
+!DEVICE-NOT: declare {{.*}}@after{{.*}}
+integer function after(x)
+   integer, intent(in) :: x
+   after = x + 300
+end function
+
+!ALL: define {{.*}}@{{.*}}before_target{{.*}}(
+subroutine before_target(x)
+   integer, intent(out) :: x
+   !$omp target map(from: x)
+      x = 1
+   !$omp end target
+end subroutine
+
+!ALL: define {{.*}}@{{.*}}middle{{.*}}(
+subroutine middle()
+   integer :: x
+   !$omp target map(from: x)
+      x = 0
+   !$omp end target
+   !HOST: call {{.*}}@{{.*}}before_target{{.*}}(
+   !DEVICE-NOT: call {{.*}}@{{.*}}before_target{{.*}}(
+   !HOST: call {{.*}}@{{.*}}after_target{{.*}}(
+   !DEVICE-NOT: call {{.*}}@{{.*}}after_target{{.*}}(
+   call before_target(x)
+   call after_target(x)
+end subroutine
+
+!ALL: define {{.*}}@{{.*}}after_target{{.*}}(
+subroutine after_target(x)
+   integer, intent(out) :: x
+   !$omp target map(from:x)
+      x = 2
+   !$omp end target
+end subroutine

--- a/flang/test/Integration/README.md
+++ b/flang/test/Integration/README.md
@@ -1,0 +1,3 @@
+# Flang Integration Tests
+
+This directory can be used to add Integration tests involving multiple stages of the compiler (for eg. from Fortran to LLVM IR). It should not contain executable tests. We should only add tests here sparingly and only if there is no other way to test. Repeat this message in each test that is added to this directory and sub-directories.


### PR DESCRIPTION
As per the RFC: [https://discourse.llvm.org/t/rfc-flang-new-directory-for-adding-end-to-end-tests-for-lowering-to-llvm-ir-in-flang/74872/11](https://discourse.llvm.org/t/rfc-flang-new-directory-for-adding-end-to-end-tests-for-lowering-to-llvm-ir-in-flang/74872/11), this patch adds a new Integration test directory for OpenMP- `flang/test/Integration/OpenMP` and moves the existing OpenMP integration tests from `flang/test/Driver/OpenMP` to this directory.

**This directory can be used to add Integration tests involving multiple stages of the compiler (for eg. from Fortran to LLVM IR). It should not contain executable tests. We should only add tests here sparingly and only if there is no other way to test. Repeat this message in each test that is added to this directory and sub-directories.**