### PR TITLE
[code-format] Also include libc++ extensionless headers

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -127,7 +127,7 @@ class ClangFormatHelper(FormatHelper):
         return False
 
     def should_include_extensionless_file(self, path: str) -> bool:
-        return path.startswith('libcxx/include')
+        return path.startswith("libcxx/include")
 
     def filter_changed_files(self, changed_files: list[str]) -> list[str]:
         filtered_files = []

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -133,7 +133,7 @@ class ClangFormatHelper(FormatHelper):
         filtered_files = []
         for path in changed_files:
             _, ext = os.path.splitext(path)
-            if ext in (".cpp", ".c", ".h", ".hpp", ".hxx", ".cxx"):
+            if ext in (".cpp", ".c", ".h", ".hpp", ".hxx", ".cxx", ".inc", ".cppm"):
                 if not self.should_be_excluded(path):
                     filtered_files.append(path)
             elif ext == "" and self.should_include_extensionless_file(path):

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -126,6 +126,9 @@ class ClangFormatHelper(FormatHelper):
             return True
         return False
 
+    def should_include_extensionless_file(self, path: str) -> bool:
+        return path.startswith('libcxx/include')
+
     def filter_changed_files(self, changed_files: list[str]) -> list[str]:
         filtered_files = []
         for path in changed_files:
@@ -133,6 +136,8 @@ class ClangFormatHelper(FormatHelper):
             if ext in (".cpp", ".c", ".h", ".hpp", ".hxx", ".cxx"):
                 if not self.should_be_excluded(path):
                     filtered_files.append(path)
+            elif ext == "" and self.should_include_extensionless_file(path):
+                filtered_files.append(path)
         return filtered_files
 
     def format_run(


### PR DESCRIPTION
These headers were skipped by the job because they didn't have an extension. However, such headers are extremely common in libc++.

As a drive-by change, also include `.cppm` and `.inc` extensions since those are also common in libc++.