### PR TITLE
[clang] Fix sorting module headers

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -2509,9 +2509,11 @@ void ModuleMapParser::parseHeaderDecl(MMToken::TokenKind LeadingToken,
       << FixItHint::CreateReplacement(CurrModuleDeclLoc, "framework module");
 }
 
-static int compareModuleHeaders(const Module::Header *A,
-                                const Module::Header *B) {
-  return A->NameAsWritten.compare(B->NameAsWritten);
+static bool compareModuleHeaders(const Module::Header &A,
+                                const Module::Header &B) {
+  return A.NameAsWritten < B.NameAsWritten ||
+    (A.NameAsWritten == B.NameAsWritten &&
+     A.PathRelativeToRootModuleDirectory < B.PathRelativeToRootModuleDirectory);
 }
 
 /// Parse an umbrella directory declaration.
@@ -2574,7 +2576,7 @@ void ModuleMapParser::parseUmbrellaDirDecl(SourceLocation UmbrellaLoc) {
     }
 
     // Sort header paths so that the pcm doesn't depend on iteration order.
-    llvm::array_pod_sort(Headers.begin(), Headers.end(), compareModuleHeaders);
+    std::stable_sort(Headers.begin(), Headers.end(), compareModuleHeaders);
 
     for (auto &Header : Headers)
       Map.addHeader(ActiveModule, std::move(Header), ModuleMap::TextualHeader);

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -2511,10 +2511,7 @@ void ModuleMapParser::parseHeaderDecl(MMToken::TokenKind LeadingToken,
 
 static bool compareModuleHeaders(const Module::Header &A,
                                  const Module::Header &B) {
-  return A.NameAsWritten < B.NameAsWritten ||
-         (A.NameAsWritten == B.NameAsWritten &&
-          A.PathRelativeToRootModuleDirectory <
-              B.PathRelativeToRootModuleDirectory);
+  return A.NameAsWritten < B.NameAsWritten;
 }
 
 /// Parse an umbrella directory declaration.

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -2510,10 +2510,11 @@ void ModuleMapParser::parseHeaderDecl(MMToken::TokenKind LeadingToken,
 }
 
 static bool compareModuleHeaders(const Module::Header &A,
-                                const Module::Header &B) {
+                                 const Module::Header &B) {
   return A.NameAsWritten < B.NameAsWritten ||
-    (A.NameAsWritten == B.NameAsWritten &&
-     A.PathRelativeToRootModuleDirectory < B.PathRelativeToRootModuleDirectory);
+         (A.NameAsWritten == B.NameAsWritten &&
+          A.PathRelativeToRootModuleDirectory <
+              B.PathRelativeToRootModuleDirectory);
 }
 
 /// Parse an umbrella directory declaration.


### PR DESCRIPTION
Struct Module::Header is not a POD type. As such, qsort() and llvm::array_pod_sort() must not be used to sort it. This became an issue with the new implementation of qsort() in glibc 2.39 that is not guaranteed to be a stable sort, causing Headers to be re-ordered and corrupted.

Replace the usage of llvm::array_pod_sort() with std::stable_sort() in order to fix this issue.  The signature of compareModuleHeaders() has to be modified.

Fixes #73145.