### PR TITLE
[mlir] Workaround for export lib generation on Windows for `mlir_arm_sme_abi_stubs`

### DIFF
--- a/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
+++ b/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
@@ -10,6 +10,20 @@
 #include <cstdint>
 #include <iostream>
 
+#ifdef _WIN32
+#ifndef MLIR_RUNNERUTILS_EXPORT
+#ifdef mlir_arm_sme_abi_stubs_EXPORTS
+// We are building this library
+#define MLIR_ARNSMEABISTUBS_EXPORT __declspec(dllexport)
+#else
+// We are using this library
+#define MLIR_ARNSMEABISTUBS_EXPORT __declspec(dllimport)
+#endif // mlir_runner_utils_EXPORTS
+#endif // MLIR_RUNNERUTILS_EXPORT
+#else
+#define MLIR_ARNSMEABISTUBS_EXPORT LLVM_ATTRIBUTE_WEAK
+#endif // _WIN32
+
 // The actual implementation of these routines is in:
 // compiler-rt/lib/builtins/aarch64/sme-abi.S. These stubs allow the current
 // ArmSME tests to run without depending on compiler-rt. This works as we don't
@@ -19,7 +33,7 @@
 
 extern "C" {
 
-bool LLVM_ATTRIBUTE_WEAK __aarch64_sme_accessible() {
+bool MLIR_ARNSMEABISTUBS_EXPORT __aarch64_sme_accessible() {
   // The ArmSME tests are run within an emulator so we assume SME is available.
   return true;
 }
@@ -29,20 +43,20 @@ struct sme_state {
   int64_t x1;
 };
 
-sme_state LLVM_ATTRIBUTE_WEAK __arm_sme_state() {
+sme_state MLIR_ARNSMEABISTUBS_EXPORT __arm_sme_state() {
   std::cerr << "[warning] __arm_sme_state() stubbed!\n";
   return sme_state{};
 }
 
-void LLVM_ATTRIBUTE_WEAK __arm_tpidr2_restore() {
+void MLIR_ARNSMEABISTUBS_EXPORT __arm_tpidr2_restore() {
   std::cerr << "[warning] __arm_tpidr2_restore() stubbed!\n";
 }
 
-void LLVM_ATTRIBUTE_WEAK __arm_tpidr2_save() {
+void MLIR_ARNSMEABISTUBS_EXPORT __arm_tpidr2_save() {
   std::cerr << "[warning] __arm_tpidr2_save() stubbed!\n";
 }
 
-void LLVM_ATTRIBUTE_WEAK __arm_za_disable() {
+void MLIR_ARNSMEABISTUBS_EXPORT __arm_za_disable() {
   std::cerr << "[warning] __arm_za_disable() stubbed!\n";
 }
 }

--- a/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
+++ b/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
@@ -10,19 +10,19 @@
 #include <cstdint>
 #include <iostream>
 
-#ifdef _WIN32
-#ifndef MLIR_ARMSMEABISTUBS_EXPORT
+#if (defined(_WIN32) || defined(__CYGWIN__))
+#ifndef MLIR_ARMSMEABISTUBS_EXPORTED
 #ifdef mlir_arm_sme_abi_stubs_EXPORTS
 // We are building this library
-#define MLIR_ARMSMEABISTUBS_EXPORT __declspec(dllexport)
+#define MLIR_ARMSMEABISTUBS_EXPORTED __declspec(dllexport)
 #else
 // We are using this library
-#define MLIR_ARMSMEABISTUBS_EXPORT __declspec(dllimport)
+#define MLIR_ARMSMEABISTUBS_EXPORTED __declspec(dllimport)
 #endif // mlir_arm_sme_abi_stubs_EXPORTS
-#endif // MLIR_ARMSMEABISTUBS_EXPORT
+#endif // MLIR_ARMSMEABISTUBS_EXPORTED
 #else
-#define MLIR_ARMSMEABISTUBS_EXPORT LLVM_ATTRIBUTE_WEAK
-#endif // _WIN32
+#define MLIR_ARMSMEABISTUBS_EXPORTED __attribute__((visibility("default")) LLVM_ATTRIBUTE_WEAK
+#endif // (defined(_WIN32) || defined(__CYGWIN__))
 
 // The actual implementation of these routines is in:
 // compiler-rt/lib/builtins/aarch64/sme-abi.S. These stubs allow the current
@@ -33,7 +33,7 @@
 
 extern "C" {
 
-bool MLIR_ARMSMEABISTUBS_EXPORT __aarch64_sme_accessible() {
+bool MLIR_ARMSMEABISTUBS_EXPORTED __aarch64_sme_accessible() {
   // The ArmSME tests are run within an emulator so we assume SME is available.
   return true;
 }
@@ -43,20 +43,20 @@ struct sme_state {
   int64_t x1;
 };
 
-sme_state MLIR_ARMSMEABISTUBS_EXPORT __arm_sme_state() {
+sme_state MLIR_ARMSMEABISTUBS_EXPORTED __arm_sme_state() {
   std::cerr << "[warning] __arm_sme_state() stubbed!\n";
   return sme_state{};
 }
 
-void MLIR_ARMSMEABISTUBS_EXPORT __arm_tpidr2_restore() {
+void MLIR_ARMSMEABISTUBS_EXPORTED __arm_tpidr2_restore() {
   std::cerr << "[warning] __arm_tpidr2_restore() stubbed!\n";
 }
 
-void MLIR_ARMSMEABISTUBS_EXPORT __arm_tpidr2_save() {
+void MLIR_ARMSMEABISTUBS_EXPORTED __arm_tpidr2_save() {
   std::cerr << "[warning] __arm_tpidr2_save() stubbed!\n";
 }
 
-void MLIR_ARMSMEABISTUBS_EXPORT __arm_za_disable() {
+void MLIR_ARMSMEABISTUBS_EXPORTED __arm_za_disable() {
   std::cerr << "[warning] __arm_za_disable() stubbed!\n";
 }
 }

--- a/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
+++ b/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
@@ -11,17 +11,17 @@
 #include <iostream>
 
 #ifdef _WIN32
-#ifndef MLIR_RUNNERUTILS_EXPORT
+#ifndef MLIR_ARMSMEABISTUBS_EXPORT
 #ifdef mlir_arm_sme_abi_stubs_EXPORTS
 // We are building this library
-#define MLIR_ARNSMEABISTUBS_EXPORT __declspec(dllexport)
+#define MLIR_ARMSMEABISTUBS_EXPORT __declspec(dllexport)
 #else
 // We are using this library
-#define MLIR_ARNSMEABISTUBS_EXPORT __declspec(dllimport)
-#endif // mlir_runner_utils_EXPORTS
-#endif // MLIR_RUNNERUTILS_EXPORT
+#define MLIR_ARMSMEABISTUBS_EXPORT __declspec(dllimport)
+#endif // mlir_arm_sme_abi_stubs_EXPORTS
+#endif // MLIR_ARMSMEABISTUBS_EXPORT
 #else
-#define MLIR_ARNSMEABISTUBS_EXPORT LLVM_ATTRIBUTE_WEAK
+#define MLIR_ARMSMEABISTUBS_EXPORT LLVM_ATTRIBUTE_WEAK
 #endif // _WIN32
 
 // The actual implementation of these routines is in:
@@ -33,7 +33,7 @@
 
 extern "C" {
 
-bool MLIR_ARNSMEABISTUBS_EXPORT __aarch64_sme_accessible() {
+bool MLIR_ARMSMEABISTUBS_EXPORT __aarch64_sme_accessible() {
   // The ArmSME tests are run within an emulator so we assume SME is available.
   return true;
 }
@@ -43,20 +43,20 @@ struct sme_state {
   int64_t x1;
 };
 
-sme_state MLIR_ARNSMEABISTUBS_EXPORT __arm_sme_state() {
+sme_state MLIR_ARMSMEABISTUBS_EXPORT __arm_sme_state() {
   std::cerr << "[warning] __arm_sme_state() stubbed!\n";
   return sme_state{};
 }
 
-void MLIR_ARNSMEABISTUBS_EXPORT __arm_tpidr2_restore() {
+void MLIR_ARMSMEABISTUBS_EXPORT __arm_tpidr2_restore() {
   std::cerr << "[warning] __arm_tpidr2_restore() stubbed!\n";
 }
 
-void MLIR_ARNSMEABISTUBS_EXPORT __arm_tpidr2_save() {
+void MLIR_ARMSMEABISTUBS_EXPORT __arm_tpidr2_save() {
   std::cerr << "[warning] __arm_tpidr2_save() stubbed!\n";
 }
 
-void MLIR_ARNSMEABISTUBS_EXPORT __arm_za_disable() {
+void MLIR_ARMSMEABISTUBS_EXPORT __arm_za_disable() {
   std::cerr << "[warning] __arm_za_disable() stubbed!\n";
 }
 }

--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -181,6 +181,7 @@ if(LLVM_ENABLE_PIC)
   add_mlir_library(mlir_arm_sme_abi_stubs
     SHARED
     ArmSMEStubs.cpp)
+  target_compile_definitions(mlir_arm_sme_abi_stubs PRIVATE mlir_arm_sme_abi_stubs_EXPORTS)
 
   if(MLIR_ENABLE_CUDA_RUNNER)
     # Configure CUDA support. Using check_language first allows us to give a


### PR DESCRIPTION
Using mlir cmake in downstream project fails with error
```
CMake Error at D:/projs/llvm/llvm-install/lib/cmake/mlir/MLIRTargets.cmake:2537 (message):
  The imported target "mlir_arm_sme_abi_stubs" references the file

     "D:/projs/llvm/llvm-install/lib/mlir_arm_sme_abi_stubs.lib"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "D:/projs/llvm/llvm-install/lib/cmake/mlir/MLIRTargets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  D:/projs/llvm/llvm-install/lib/cmake/mlir/MLIRConfig.cmake:37 (include)
  mlir/CMakeLists.txt:5 (find_package)
```

Windows cmake needs export libaries but it seems they are only being generated if you have at least one exported symbol.
Add export attributes to symbols.

Not sure what the best approach to fix this (probably we should just disable this lib on windows entirely), but it fixed things for me locally.