### PR TITLE
[DomTree] Fix root attachment in runDFS()

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/llvm/include/llvm/Support/GenericDomTreeConstruction.h
@@ -308,7 +308,7 @@ struct SemiNCAInfo {
     for (unsigned i = 2; i < NextDFSNum; ++i) {
       auto &WInfo = *NumToInfo[i];
       assert(WInfo.Semi != 0);
-      const unsigned SDomNum = NodeToInfo[NumToNode[WInfo.Semi]].DFSNum;
+      const unsigned SDomNum = NumToInfo[WInfo.Semi]->DFSNum;
       NodePtr WIDomCandidate = WInfo.IDom;
       while (NodeToInfo[WIDomCandidate].DFSNum > SDomNum)
         WIDomCandidate = NodeToInfo[WIDomCandidate].IDom;

--- a/llvm/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/llvm/include/llvm/Support/GenericDomTreeConstruction.h
@@ -181,7 +181,7 @@ struct SemiNCAInfo {
                   const NodeOrderMap *SuccOrder = nullptr) {
     assert(V);
     SmallVector<NodePtr, 64> WorkList = {V};
-    if (NodeToInfo.count(V) != 0) NodeToInfo[V].Parent = AttachToNum;
+    NodeToInfo[V].Parent = AttachToNum;
 
     while (!WorkList.empty()) {
       const NodePtr BB = WorkList.pop_back_val();
@@ -307,6 +307,7 @@ struct SemiNCAInfo {
     // during path compression in Eval.
     for (unsigned i = 2; i < NextDFSNum; ++i) {
       auto &WInfo = *NumToInfo[i];
+      assert(WInfo.Semi != 0);
       const unsigned SDomNum = NodeToInfo[NumToNode[WInfo.Semi]].DFSNum;
       NodePtr WIDomCandidate = WInfo.IDom;
       while (NodeToInfo[WIDomCandidate].DFSNum > SDomNum)
@@ -552,7 +553,7 @@ struct SemiNCAInfo {
 
     addVirtualRoot();
     unsigned Num = 1;
-    for (const NodePtr Root : DT.Roots) Num = runDFS(Root, Num, DC, 0);
+    for (const NodePtr Root : DT.Roots) Num = runDFS(Root, Num, DC, 1);
   }
 
   static void CalculateFromScratch(DomTreeT &DT, BatchUpdatePtr BUI) {


### PR DESCRIPTION
Currently, runDFS() only sets the Parent of the DFS root if it is already in the NodeToInfo map. This doesn't matter if we're running DFS on the DT root, which doesn't have a parent anyway. However, when running on PDT roots, this means we end up keeping the parent at 0, rather than setting it to 1 for the virtual PDT root. Because the virtual root (nullptr) has the same value as the dummy value in NumToNode (nullptr) this happens to work out by accident right now.

I believe we should always be setting the parent in runDFS(), and adjust AttachToNum in doFullDFSWalk() to be 1 (the virtual root) for PDTs.