### PR TITLE
[libc++] Simplify the conditions for generating a linker script

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -251,17 +251,18 @@ option(LIBCXX_STATICALLY_LINK_ABI_IN_SHARED_LIBRARY
 
 # Generate and install a linker script inplace of libc++.so. The linker script
 # will link libc++ to the correct ABI library. This option is on by default
-# on UNIX platforms other than Apple unless
-# 'LIBCXX_STATICALLY_LINK_ABI_IN_SHARED_LIBRARY' is on. This option is also
-# disabled when the ABI library is not specified or is specified to be "none".
-set(ENABLE_LINKER_SCRIPT_DEFAULT_VALUE OFF)
-if (LLVM_HAVE_LINK_VERSION_SCRIPT AND NOT LIBCXX_STATICALLY_LINK_ABI_IN_SHARED_LIBRARY
-      AND NOT LIBCXX_CXX_ABI STREQUAL "none"
-      AND Python3_EXECUTABLE
-      AND LIBCXX_ENABLE_SHARED)
-    set(ENABLE_LINKER_SCRIPT_DEFAULT_VALUE ON)
+# on UNIX platforms other than Apple unless we statically link libc++abi
+# inside libc++.so, we don't build libc++.so at all or we don't have any
+# ABI library.
+if (LIBCXX_STATICALLY_LINK_ABI_IN_SHARED_LIBRARY
+    OR NOT LIBCXX_ENABLE_SHARED
+    OR LIBCXX_CXX_ABI STREQUAL "none")
+  set(ENABLE_LINKER_SCRIPT_DEFAULT_VALUE OFF)
+elseif(UNIX AND NOT APPLE)
+  set(ENABLE_LINKER_SCRIPT_DEFAULT_VALUE ON)
+else()
+  set(ENABLE_LINKER_SCRIPT_DEFAULT_VALUE OFF)
 endif()
-
 option(LIBCXX_ENABLE_ABI_LINKER_SCRIPT
       "Use and install a linker script for the given ABI library"
       ${ENABLE_LINKER_SCRIPT_DEFAULT_VALUE})


### PR DESCRIPTION
We really shouldn't be depending on far away configuration options like LLVM_HAVE_LINK_VERSION_SCRIPT here. This patch simplifies the enablement of the linker scripts and as a result gets rid of an undesirable dependency on HandleLLVMOptions.cmake.

As a drive-by, the patch also stops taking into account whether Python3 is available. This should have no bearing on whether we generate a linker script or not, which is required for correctness. If someone tries to build libc++ and generate a linker script but Python3 is not available, they should get an error instead of silently getting an incorrect installation of the library.