### PR TITLE
[libc++][test][msan] Fix bots after #67799

### DIFF
--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
@@ -8,7 +8,9 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: target={{.+}}-windows-gnu
 // Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
-// XFAIL: tsan, msan
+// XFAIL: tsan
+// Hangs with msan.
+// UNSUPPORTED: msan
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
 
 //  T exchange(T, memory_order = memory_order::seq_cst) volatile noexcept;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
@@ -10,6 +10,8 @@
 // XFAIL: LIBCXX-AIX-FIXME
 // Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: tsan
+// Hangs with msan.
+// UNSUPPORTED: msan
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
 
 // floating-point-type fetch_add(floating-point-type,

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
@@ -10,6 +10,8 @@
 // XFAIL: LIBCXX-AIX-FIXME
 // Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: tsan
+// Hangs with msan.
+// UNSUPPORTED: msan
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
 
 // floating-point-type fetch_sub(floating-point-type,

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: target={{.+}}-windows-gnu
 // XFAIL: LIBCXX-AIX-FIXME
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
+// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
+// Hangs with msan.
+// UNSUPPORTED: msan
 
 // floating-point-type operator-=(floating-point-type) volatile noexcept;
 // floating-point-type operator-=(floating-point-type) noexcept;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
@@ -9,7 +9,6 @@
 // UNSUPPORTED: target={{.+}}-windows-gnu
 // XFAIL: LIBCXX-AIX-FIXME
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // Hangs with msan.
 // UNSUPPORTED: msan
 

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
@@ -9,6 +9,9 @@
 // UNSUPPORTED: target={{.+}}-windows-gnu
 // XFAIL: LIBCXX-AIX-FIXME
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
+// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
+// Hangs with msan.
+// UNSUPPORTED: msan
 
 // floating-point-type operator+=(floating-point-type) volatile noexcept;
 // floating-point-type operator+=(floating-point-type) noexcept;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
@@ -9,7 +9,6 @@
 // UNSUPPORTED: target={{.+}}-windows-gnu
 // XFAIL: LIBCXX-AIX-FIXME
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
-// Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // Hangs with msan.
 // UNSUPPORTED: msan
 

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
@@ -8,7 +8,9 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: availability-synchronization_library-missing
 // Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
-// XFAIL: tsan, msan
+// XFAIL: tsan
+// Hangs with msan.
+// UNSUPPORTED: msan
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
 
 // void wait(T old, memory_order order = memory_order::seq_cst) const volatile noexcept;


### PR DESCRIPTION
Tests hangs on
https://lab.llvm.org/buildbot/#/builders/sanitizer-x86_64-linux-bootstrap-msan
https://lab.llvm.org/buildbot/#/builders/sanitizer-aarch64-linux-bootstrap-msan
