### PR TITLE
 [MachineSink] Some more preserving of debug location when rematerialising an instruction to replace a COPY

### DIFF
--- a/llvm/lib/CodeGen/MachineSink.cpp
+++ b/llvm/lib/CodeGen/MachineSink.cpp
@@ -506,7 +506,7 @@ bool MachineSinking::PerformSinkAndFold(MachineInstr &MI,
     MRI->clearKillFlags(UsedRegB);
 
   for (auto &[SinkDst, MaybeAM] : SinkInto) {
-    [[maybe_unused]] MachineInstr *New = nullptr;
+    MachineInstr *New = nullptr;
     LLVM_DEBUG(dbgs() << "Sinking copy of"; MI.dump(); dbgs() << "into";
                SinkDst->dump());
     if (SinkDst->isCopy()) {
@@ -525,6 +525,8 @@ bool MachineSinking::PerformSinkAndFold(MachineInstr &MI,
       Register DstReg = SinkDst->getOperand(0).getReg();
       TII->reMaterialize(*SinkDst->getParent(), InsertPt, DstReg, 0, MI, *TRI);
       New = &*std::prev(InsertPt);
+      if (!New->getDebugLoc())
+        New->setDebugLoc(SinkDst->getDebugLoc());
     } else {
       // Fold instruction into the addressing mode of a memory instruction.
       New = TII->emitLdStWithAddr(*SinkDst, MaybeAM);

--- a/llvm/test/DebugInfo/AArch64/constant-dbgloc.ll
+++ b/llvm/test/DebugInfo/AArch64/constant-dbgloc.ll
@@ -1,4 +1,4 @@
-; RUN: llc -filetype=asm %s -o - | FileCheck %s
+; RUN: llc -filetype=asm --aarch64-enable-sink-fold=true %s -o - | FileCheck %s
 
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "aarch64--linux-gnueabihf"


### PR DESCRIPTION
Somewhet similar to ef9bcace834e63f25bbbc5e8e2b615f89d85fb2f
([MachineSink][AArch64] Preserve debug location when rematerialising
an instruction to replace a COPY (#72685))
reuse the debug location of the COPY, iff the rematerialised instruction
did not have a location.

Fixes a regression in `DebugInfo/AArch64/constant-dbgloc.ll` after enabling sinj-and-fold.