### PR TITLE
[flang] Make .exe extension of the linker optional (NFC)

### DIFF
--- a/flang/test/Driver/dynamic-linker.f90
+++ b/flang/test/Driver/dynamic-linker.f90
@@ -15,6 +15,6 @@
 ! GNU-LINKER-OPTIONS-SAME: "-rpath" "/path/to/dir"
 
 ! For MSVC, adding -static does not add any additional linker options.
-! MSVC-LINKER-OPTIONS: "{{.*}}link.exe"
+! MSVC-LINKER-OPTIONS: "{{.*}}link{{(.exe)?}}"
 ! MSVC-LINKER-OPTIONS-SAME: "-dll"
 ! MSVC-LINKER-OPTIONS-SAME: "-rpath" "/path/to/dir"


### PR DESCRIPTION
The change in https://github.com/llvm/llvm-project/commit/34e4e5eb70818 breaks our local build that uses `-DCLANG_DEFAULT_LINKER=lld`. Although there is an open issue (https://github.com/llvm/llvm-project/issues/73153) related to `CLANG_DEFAULT_LINKER` and `FLANG_DEFAULT_LINKER`, the name of the linker may not have the `.exe` extension.