### PR TITLE
[BPF] Add asm support for JSET insn

### DIFF
--- a/llvm/lib/Target/BPF/BPFInstrFormats.td
+++ b/llvm/lib/Target/BPF/BPFInstrFormats.td
@@ -63,6 +63,7 @@ def BPF_JA   : BPFJumpOp<0x0>;
 def BPF_JEQ  : BPFJumpOp<0x1>;
 def BPF_JGT  : BPFJumpOp<0x2>;
 def BPF_JGE  : BPFJumpOp<0x3>;
+def BPF_JSET : BPFJumpOp<0x4>;
 def BPF_JNE  : BPFJumpOp<0x5>;
 def BPF_JSGT : BPFJumpOp<0x6>;
 def BPF_JSGE : BPFJumpOp<0x7>;

--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -149,6 +149,7 @@ def BPF_CC_LTU_32 : PatLeaf<(i32 imm),
                          [{return (N->getZExtValue() == ISD::SETULT);}]>;
 def BPF_CC_LEU_32 : PatLeaf<(i32 imm),
                          [{return (N->getZExtValue() == ISD::SETULE);}]>;
+def NoCond : PatLeaf<(vt)> {}
 
 // For arithmetic and jump instructions the 8-bit 'code'
 // field is divided into three parts:
@@ -265,6 +266,7 @@ defm JULT : J<BPF_JLT, "<", BPF_CC_LTU, BPF_CC_LTU_32>;
 defm JULE : J<BPF_JLE, "<=", BPF_CC_LEU, BPF_CC_LEU_32>;
 defm JSLT : J<BPF_JSLT, "s<", BPF_CC_LT, BPF_CC_LT_32>;
 defm JSLE : J<BPF_JSLE, "s<=", BPF_CC_LE, BPF_CC_LE_32>;
+defm JSET : J<BPF_JSET, "&", NoCond, NoCond>;
 }
 
 // ALU instructions

--- a/llvm/test/MC/BPF/insn-unit-32.s
+++ b/llvm/test/MC/BPF/insn-unit-32.s
@@ -55,6 +55,11 @@
 // CHECK: b4 09 00 00 ff ff ff ff      w9 = -1
 // CHECK: c4 0a 00 00 40 00 00 00      w10 s>>= 64
 
+  if w1 & w2 goto Llabel0    // BPF_JSET | BPF_X
+  if w1 & 0xff goto Llabel0  // BPF_JSET | BPF_K
+// CHECK: 4e 21 0d 00 00 00 00 00      if w1 & w2 goto +13
+// CHECK: 46 01 0c 00 ff 00 00 00      if w1 & 255 goto +12
+
   if w0 == w1 goto Llabel0   // BPF_JEQ  | BPF_X
   if w3 != w4 goto Llabel0   // BPF_JNE  | BPF_X
 // CHECK: 1e 10 0b 00 00 00 00 00 	if w0 == w1 goto +11

--- a/llvm/test/MC/BPF/insn-unit.s
+++ b/llvm/test/MC/BPF/insn-unit.s
@@ -62,6 +62,11 @@
 // CHECK: db a3 e2 ff 00 00 00 00 	lock *(u64 *)(r3 - 30) += r10
 
 // ======== BPF_JMP Class ========
+  if r1 & r2 goto Llabel0    // BPF_JSET  | BPF_X
+  if r1 & 0xffff goto Llabel0    // BPF_JSET  | BPF_K
+// CHECK: 4d 21 1d 00 00 00 00 00 	if r1 & r2 goto +29
+// CHECK: 45 01 1c 00 ff ff 00 00 	if r1 & 65535 goto +28
+
   goto Llabel0               // BPF_JA
   call 1                     // BPF_CALL
   exit                       // BPF_EXIT


### PR DESCRIPTION
BPF upstream reported that JSET insn is not supported in inline asm ([1]). BPF_JSET insn is part of BPF ISA so let us add asm support for it now.

  [1] https://lore.kernel.org/bpf/2e8a1584-a289-4b2e-800c-8b463e734bcb@linux.dev/