### PR TITLE
[flang] Address case of under-processed array symbol

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -7708,7 +7708,6 @@ void ResolveNamesVisitor::HandleProcedureName(
   } else if (CheckUseError(name)) {
     // error was reported
   } else {
-    auto &nonUltimateSymbol{*symbol};
     symbol = &Resolve(name, symbol)->GetUltimate();
     CheckEntryDummyUse(name.source, symbol);
     bool convertedToProcEntity{ConvertToProcEntity(*symbol)};
@@ -7733,9 +7732,7 @@ void ResolveNamesVisitor::HandleProcedureName(
       // is created for the current scope.
       // Operate on non ultimate symbol so that HostAssocDetails are also
       // created for symbols used associated in the host procedure.
-      if (IsUplevelReference(nonUltimateSymbol)) {
-        MakeHostAssocSymbol(name, nonUltimateSymbol);
-      }
+      ResolveName(name);
     } else if (symbol->test(Symbol::Flag::Implicit)) {
       Say(name,
           "Use of '%s' as a procedure conflicts with its implicit definition"_err_en_US);

--- a/flang/test/Semantics/symbol33.f90
+++ b/flang/test/Semantics/symbol33.f90
@@ -1,0 +1,11 @@
+! RUN: %python %S/test_symbols.py %s %flang_fc1
+! Ensure that a misparsed function reference that turns out to be an
+! array element reference still applies implicit typing, &c.
+!DEF: /subr (Subroutine) Subprogram
+subroutine subr
+  !DEF: /subr/moo (Implicit) ObjectEntity INTEGER(4)
+  common //moo(1)
+  !DEF: /subr/a ObjectEntity REAL(4)
+  !REF: /subr/moo
+  real a(moo(1))
+end subroutine


### PR DESCRIPTION
Array element references are frequently parsed as function references due to the ambiguous syntax of Fortran, and the parse tree is repaired by semantics once the relevant symbol table entries are in hand. This patch fixes a case in which the correction takes a path that leaves the type of a symbol undetermined, leading to later spurious errors in expression analysis.

Fixes https://github.com/llvm/llvm-project/issues/68652.