### PR TITLE
[lldb] correct inconsistent order of messages on process launch

### DIFF
--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -264,7 +264,6 @@ protected:
         // PushProcessIOHandler().
         process_sp->SyncIOHandler(0, std::chrono::seconds(2));
 
-        llvm::StringRef data = stream.GetString();
         // If we didn't have a local executable, then we wouldn't have had an
         // executable module before launch.
         if (!exe_module_sp)
@@ -280,6 +279,9 @@ protected:
               exe_module_sp->GetFileSpec().GetPath().c_str(), archname);
         }
         result.SetStatus(eReturnStatusSuccessFinishResult);
+        // This message will refer to an event that happened after the process
+        // launched.
+        llvm::StringRef data = stream.GetString();
         if (!data.empty())
           result.AppendMessage(data);
         result.SetDidChangeProcessState(true);

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -265,8 +265,6 @@ protected:
         process_sp->SyncIOHandler(0, std::chrono::seconds(2));
 
         llvm::StringRef data = stream.GetString();
-        if (!data.empty())
-          result.AppendMessage(data);
         // If we didn't have a local executable, then we wouldn't have had an
         // executable module before launch.
         if (!exe_module_sp)
@@ -282,6 +280,8 @@ protected:
               exe_module_sp->GetFileSpec().GetPath().c_str(), archname);
         }
         result.SetStatus(eReturnStatusSuccessFinishResult);
+        if (!data.empty())
+          result.AppendMessage(data);
         result.SetDidChangeProcessState(true);
       } else {
         result.AppendError(

--- a/lldb/test/Shell/Breakpoint/jit-loader_jitlink_elf.test
+++ b/lldb/test/Shell/Breakpoint/jit-loader_jitlink_elf.test
@@ -10,9 +10,9 @@
 
 # CHECK: Breakpoint 1: no locations (pending).
 # CHECK: (lldb) run {{.*}}
+# CHECK: Process {{.*}} launched: {{.*}}
 # CHECK: Process {{.*}} stopped
 # CHECK: JIT(0x{{.*}})`jitbp() at jitbp.cpp:1:15
 # CHECK: -> 1    int jitbp() { return 0; }
 # CHECK:                       ^
 # CHECK:    2    int main() { return jitbp(); }
-# CHECK: Process {{.*}} launched: {{.*}}

--- a/lldb/test/Shell/Breakpoint/jit-loader_rtdyld_elf.test
+++ b/lldb/test/Shell/Breakpoint/jit-loader_rtdyld_elf.test
@@ -14,9 +14,9 @@
 
 # CHECK: Breakpoint 1: no locations (pending).
 # CHECK: (lldb) run {{.*}}
+# CHECK: Process {{.*}} launched: {{.*}}
 # CHECK: Process {{.*}} stopped
 # CHECK: JIT(0x{{.*}})`jitbp() at jitbp.cpp:1:15
 # CHECK: -> 1    int jitbp() { return 0; }
 # CHECK:                       ^
 # CHECK:    2    int main() { return jitbp(); }
-# CHECK: Process {{.*}} launched: {{.*}}


### PR DESCRIPTION
Fixes [#68035](https://github.com/llvm/llvm-project/issues/68035), where an inconsistency in the order of "Process launched" and "Process stopped" messages occurs during `process launch`. 

The fix involves adjusting the message output sequence in `CommandObjectProcessLaunch::DoExecute` within `source/Commands/CommandObjectProcess.cpp`. This ensures "Process launched" consistently precedes "Process stopped" when executing commands with the '-o' flag, i.e., non-interactive mode.

Upon implementing this change, two tests failed: `lldb/test/Shell/Breakpoint/jit-loader_jitlink_elf.test` and `lldb/test/Shell/Breakpoint/jit-loader_rtdyld_elf.test`. These failures were expected as they relied on the previous, now-corrected message order. Updating these tests to align with the new message sequence is part of this PR's scope.