### PR TITLE
[flang] Suppress error meant to prevent discontiguous association whe…

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -529,17 +529,18 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
               dummyName);
         }
         if (actualIsArrayElement && actualLastSymbol &&
-            IsPointer(*actualLastSymbol)) {
-          basicError = true;
-          messages.Say(
-              "Element of pointer array may not be associated with a %s array"_err_en_US,
-              dummyName);
-        }
-        if (actualLastSymbol && IsAssumedShape(*actualLastSymbol)) {
-          basicError = true;
-          messages.Say(
-              "Element of assumed-shape array may not be associated with a %s array"_err_en_US,
-              dummyName);
+            !evaluate::IsContiguous(*actualLastSymbol, foldingContext)) {
+          if (IsPointer(*actualLastSymbol)) {
+            basicError = true;
+            messages.Say(
+                "Element of pointer array may not be associated with a %s array"_err_en_US,
+                dummyName);
+          } else if (IsAssumedShape(*actualLastSymbol)) {
+            basicError = true;
+            messages.Say(
+                "Element of assumed-shape array may not be associated with a %s array"_err_en_US,
+                dummyName);
+          }
         }
       }
     }


### PR DESCRIPTION
…n actual argument is contiguous

When an element of a contiguous pointer array or assumed-shape array is associated as an actual argument with an assumed-size dummy array, don't flag the usage as an error.