### PR TITLE
[flang] match the actual data size with the KIND (NFC)

### DIFF
--- a/flang/unittests/Runtime/MatmulTranspose.cpp
+++ b/flang/unittests/Runtime/MatmulTranspose.cpp
@@ -206,7 +206,7 @@ TEST(MatmulTranspose, Basic) {
   auto yLog{MakeArray<TypeCategory::Logical, 2>(std::vector<int>{3, 2},
       std::vector<std::uint16_t>{false, false, false, true, true, false})};
   auto vLog{MakeArray<TypeCategory::Logical, 1>(
-      std::vector<int>{3}, std::vector<std::uint16_t>{true, false, true})};
+      std::vector<int>{3}, std::vector<std::uint8_t>{true, false, true})};
   RTNAME(MatmulTranspose)(result, *xLog, *yLog, __FILE__, __LINE__);
   ASSERT_EQ(result.rank(), 2);
   EXPECT_EQ(result.GetDimension(0).LowerBound(), 1);


### PR DESCRIPTION
I think the intent is `uint8_t` instead of `uint16_t` to match `logical(1)`. Otherwise it needs to swap byte for the big endian environment.

I have a question regarding this test. What will the corresponding Fortran construct look like for `MatmulTranspose(result, *yLog, *vLog, ...)`? It seems that we are doing 
```
transpose(matrix( 3 by 2 )) * matrix( 1 by 3 )
```