### PR TITLE
[MsgPack] Handle Expected<T> errors in document reader

### DIFF
--- a/llvm/include/llvm/BinaryFormat/MsgPackReader.h
+++ b/llvm/include/llvm/BinaryFormat/MsgPackReader.h
@@ -18,7 +18,12 @@
 ///  msgpack::Reader MPReader(input);
 ///  msgpack::Object Obj;
 ///
-///  while (MPReader.read(Obj)) {
+///  while (true) {
+///    Expected<bool> ReadObj = MPReader.read(&Obj);
+///    if (!ReadObj)
+///      // Handle error...
+///    if (!ReadObj.get())
+///      break; // Reached end of input
 ///    switch (Obj.Kind) {
 ///    case msgpack::Type::Int:
 //       // Use Obj.Int

--- a/llvm/lib/BinaryFormat/MsgPackDocument.cpp
+++ b/llvm/lib/BinaryFormat/MsgPackDocument.cpp
@@ -143,7 +143,13 @@ bool Document::readFromBlob(
     // On to next element (or key if doing a map key next).
     // Read the value.
     Object Obj;
-    if (!MPReader.read(Obj)) {
+    Expected<bool> ReadObj = MPReader.read(Obj);
+    if (!ReadObj) {
+      // FIXME: Propagate the Error to the caller.
+      consumeError(ReadObj.takeError());
+      return false;
+    }
+    if (!ReadObj.get()) {
       if (Multi && Stack.size() == 1) {
         // OK to finish here as we've just done a top-level element with Multi
         break;

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUPALMetadata.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUPALMetadata.cpp
@@ -83,7 +83,6 @@ bool AMDGPUPALMetadata::setFromLegacyBlob(StringRef Blob) {
 
 // Set PAL metadata from msgpack blob.
 bool AMDGPUPALMetadata::setFromMsgPackBlob(StringRef Blob) {
-  msgpack::Reader Reader(Blob);
   return MsgPackDoc.readFromBlob(Blob, /*Multi=*/false);
 }
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
@@ -9,16 +9,15 @@
 # LLVM-NEXT:    NoteSection {
 # LLVM-NEXT:      Name: .note.nt_amdgpu_metadata
 # LLVM-NEXT:      Offset: 0x40
-# LLVM-NEXT:      Size: 0x28
+# LLVM-NEXT:      Size: 0x38
 # LLVM-NEXT:      Note {
 # LLVM-NEXT:        Owner: AMDGPU
-# LLVM-NEXT:        Data size: 0x11
+# LLVM-NEXT:        Data size: 0x24
 # LLVM-NEXT:        Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
 # LLVM-NEXT:        AMDGPU Metadata: Invalid AMDGPU Metadata
 # LLVM-NEXT:  ---
-# LLVM-NEXT:  0:               0
-# LLVM-NEXT:  amdhsa.kernels:
-# LLVM-NEXT:    - 0
+# LLVM-NEXT: amdhsa.kernels:
+# LLVM-NEXT:  - .name:           test_kernel
 # LLVM-NEXT:  ...
 # LLVM-EMPTY:
 # LLVM-NEXT:      }
@@ -27,13 +26,12 @@
 
 # GNU:      Displaying notes found in: .note.nt_amdgpu_metadata
 # GNU-NEXT:   Owner                Data size        Description
-# GNU-NEXT:   AMDGPU               0x00000011       NT_AMDGPU_METADATA (AMDGPU Metadata)
+# GNU-NEXT:   AMDGPU               0x00000024       NT_AMDGPU_METADATA (AMDGPU Metadata)
 # GNU-NEXT:     AMDGPU Metadata:
 # GNU-NEXT:         Invalid AMDGPU Metadata
 # GNU-NEXT: ---
-# GNU-NEXT: 0:               0
 # GNU-NEXT: amdhsa.kernels:
-# GNU-NEXT:   - 0
+# GNU-NEXT:  - .name:           test_kernel
 # GNU-NEXT: ...
 
 --- !ELF
@@ -48,4 +46,4 @@ Sections:
       - Name: AMDGPU
         Type: NT_AMDGPU_METADATA
         ## Desc contains 'amdhsa.kernels' without valid entries.
-        Desc: '82ae616d646873612e6b65726e656c7391'
+        Desc: '81ae616d646873612e6b65726e656c739181a52e6e616d65ab746573745f6b65726e656c'

--- a/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
@@ -26,6 +26,8 @@
 # GNU-NEXT:   Owner                Data size 	Description
 # GNU-NEXT:   AMDGPU               0x00000003	NT_AMDGPU_METADATA (AMDGPU Metadata)
 # GNU-NEXT:    description data: 12 34 56
+# GNU-NEXT:   AMDGPU               0x00000003	NT_AMDGPU_METADATA (AMDGPU Metadata)
+# GNU-NEXT:    description data: ab cd ef
 # GNU-EMPTY:
 
 # LLVM:      Notes [
@@ -57,13 +59,21 @@
 # LLVM-NEXT:  NoteSection {
 # LLVM-NEXT:    Name: .note.bar
 # LLVM-NEXT:    Offset: 0x128
-# LLVM-NEXT:    Size: 0x18
+# LLVM-NEXT:    Size: 0x30
 # LLVM-NEXT:    Note {
 # LLVM-NEXT:      Owner: AMDGPU
 # LLVM-NEXT:      Data size: 0x3
 # LLVM-NEXT:      Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
 # LLVM-NEXT:      Description data (
 # LLVM-NEXT:        0000: 123456                               |.4V|
+# LLVM-NEXT:      )
+# LLVM-NEXT:    }
+# LLVM-NEXT:    Note {
+# LLVM-NEXT:      Owner: AMDGPU
+# LLVM-NEXT:      Data size: 0x3
+# LLVM-NEXT:      Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
+# LLVM-NEXT:      Description data (
+# LLVM-NEXT:        0000: ABCDEF                               |...|
 # LLVM-NEXT:      )
 # LLVM-NEXT:    }
 # LLVM-NEXT:  }
@@ -87,7 +97,6 @@ Sections:
       - Name: AMDGPU
         Type: NT_AMDGPU_METADATA
         Desc: '123456'
-      # TODO: https://bugs.llvm.org/show_bug.cgi?id=49034
-      # - Name: AMDGPU
-      #   Type: NT_AMDGPU_METADATA
-      #    Desc: 'abcdef'
+      - Name: AMDGPU
+        Type: NT_AMDGPU_METADATA
+        Desc: 'abcdef'


### PR DESCRIPTION
This was causing an assert on invalid in the modified test case.

Fixes this Issue: https://github.com/llvm/llvm-project/issues/48378

Thanks for taking a look!