### PR TITLE
[libc++][test][msan] Refine XFAIL after #67799

### DIFF
--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
@@ -9,8 +9,7 @@
 // UNSUPPORTED: target={{.+}}-windows-gnu
 // Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: tsan
-// Hangs with msan.
-// UNSUPPORTED: msan
+// XFAIL: target={{x86_64-.*}} && msan
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
 
 //  T exchange(T, memory_order = memory_order::seq_cst) volatile noexcept;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
@@ -9,8 +9,7 @@
 // XFAIL: availability-synchronization_library-missing
 // Clang's support for atomic operations on long double is broken. See https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: tsan
-// Hangs with msan.
-// UNSUPPORTED: msan
+// XFAIL: target={{x86_64-.*}} && msan
 // ADDITIONAL_COMPILE_FLAGS(has-latomic): -latomic
 
 // void wait(T old, memory_order order = memory_order::seq_cst) const volatile noexcept;


### PR DESCRIPTION
Undo a part of #73152.

These test do not hang, but unexpectedlty pass on aarch64
https://lab.llvm.org/buildbot/#/builders/74/builds/23708

Tests work on aarch64 and probably any platform without fp80.
