### PR TITLE
[mlir] fix LLVM type converter for structs

### DIFF
--- a/mlir/docs/TargetLLVMIR.md
+++ b/mlir/docs/TargetLLVMIR.md
@@ -290,6 +290,21 @@ memref<2 x vector<4x8 x f32>
 Tensor types cannot be converted to the LLVM dialect. Operations on tensors must
 be [bufferized](Bufferization.md) before being converted.
 
+### Conversion of LLVM Container Types with Non-Compatible Element Types
+
+Progressive lowering may result in there existing LLVM container types, such
+as LLVM dialect structures, containing non-compatible types:
+`!llvm.struct<(index)>`. Such types are converted recursively using the rules
+described above.
+
+Identified structures are converted to _new_ structures that have their
+identifiers prefixed with `_Converted.` since the bodies of identified types
+cannot be updated once initialized. Such names are considered _reserved_ and
+must not appear in the input code (in practice, C reserves names starting with
+`_` and a capital, and `.` cannot appear in valid C types anyway). If they do
+and have a different body than the result of the conversion, the type conversion
+will stop.
+
 ### Calling Conventions
 
 Calling conventions provides a mechanism to customize the conversion of function

--- a/mlir/docs/TargetLLVMIR.md
+++ b/mlir/docs/TargetLLVMIR.md
@@ -292,7 +292,7 @@ be [bufferized](Bufferization.md) before being converted.
 
 ### Conversion of LLVM Container Types with Non-Compatible Element Types
 
-Progressive lowering may result in there existing LLVM container types, such
+Progressive lowering may result in there LLVM container types, such
 as LLVM dialect structures, containing non-compatible types:
 `!llvm.struct<(index)>`. Such types are converted recursively using the rules
 described above.

--- a/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
@@ -86,15 +86,7 @@ LLVMTypeConverter::LLVMTypeConverter(MLIRContext *ctx,
 
     if (type.isIdentified()) {
       auto convertedType = LLVM::LLVMStructType::getIdentified(
-          type.getContext(), ("_Converted_" + type.getName()).str());
-      unsigned counter = 1;
-      while (convertedType.isInitialized()) {
-        assert(counter != UINT_MAX &&
-               "about to overflow struct renaming counter in conversion");
-        convertedType = LLVM::LLVMStructType::getIdentified(
-            type.getContext(),
-            ("_Converted_" + std::to_string(counter) + type.getName()).str());
-      }
+          type.getContext(), ("_Converted." + type.getName()).str());
 
       SmallVectorImpl<Type> &recursiveStack = getCurrentThreadRecursiveStack();
       if (llvm::count(recursiveStack, type)) {
@@ -110,10 +102,26 @@ LLVMTypeConverter::LLVMTypeConverter(MLIRContext *ctx,
       if (failed(convertTypes(type.getBody(), convertedElemTypes)))
         return std::nullopt;
 
-      if (failed(convertedType.setBody(convertedElemTypes, type.isPacked())))
-        return failure();
-      results.push_back(convertedType);
-      return success();
+      // If the converted type has not been initialized yet, just set its body
+      // to be the converted arguments and return.
+      if (!convertedType.isInitialized()) {
+        if (failed(
+                convertedType.setBody(convertedElemTypes, type.isPacked()))) {
+          return failure();
+        }
+        results.push_back(convertedType);
+        return success();
+      }
+
+      // If it has been initialized and has the same body, just use it. This
+      // ensures that recursive structs keep being recursive rather than
+      // including a non-updated name.
+      if (TypeRange(convertedType.getBody()) == TypeRange(convertedElemTypes)) {
+        results.push_back(convertedType);
+        return success();
+      }
+
+      return failure();
     }
 
     SmallVector<Type> convertedSubtypes;

--- a/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
@@ -113,10 +113,11 @@ LLVMTypeConverter::LLVMTypeConverter(MLIRContext *ctx,
         return success();
       }
 
-      // If it has been initialized and has the same body, just use it. This
-      // ensures that recursive structs keep being recursive rather than
-      // including a non-updated name.
-      if (TypeRange(convertedType.getBody()) == TypeRange(convertedElemTypes)) {
+      // If it has been initialized, has the same body and packed bit, just use
+      // it. This ensures that recursive structs keep being recursive rather
+      // than including a non-updated name.
+      if (TypeRange(convertedType.getBody()) == TypeRange(convertedElemTypes) &&
+          convertedType.isPacked() == type.isPacked()) {
         results.push_back(convertedType);
         return success();
       }

--- a/mlir/test/Conversion/LLVMCommon/types.mlir
+++ b/mlir/test/Conversion/LLVMCommon/types.mlir
@@ -21,3 +21,15 @@ func.func private @create_clashes_on_conversion_recursive(!llvm.struct<"foo", (s
 // CHECK: @merge_on_conversion_recursive(!llvm.struct<"_Converted.foo", (struct<"_Converted.foo">, i64)>)
 func.func private @clashing_struct_name(!llvm.struct<"_Converted.foo", (struct<"_Converted.foo">, i64)>)
 func.func private @merge_on_conversion_recursive(!llvm.struct<"foo", (struct<"foo">, index)>)
+
+// -----
+
+// CHECK: @create_clashing_pack(!llvm.struct<"foo", packed (!llvm.struct<"foo">, index)>)
+func.func private @clashing_struct_name(!llvm.struct<"_Converted.foo", (struct<"_Converted.foo">, i64)>)
+func.func private @create_clashing_pack(!llvm.struct<"foo", packed (struct<"foo">, index)>)
+
+// -----
+
+// CHECK: @merge_on_conversion_pack(!llvm.struct<"_Converted.foo", packed (struct<"_Converted.foo">, i64)>)
+func.func private @clashing_struct_name(!llvm.struct<"_Converted.foo", packed (struct<"_Converted.foo">, i64)>)
+func.func private @merge_on_conversion_pack(!llvm.struct<"foo", packed (struct<"foo">, index)>)

--- a/mlir/test/Conversion/LLVMCommon/types.mlir
+++ b/mlir/test/Conversion/LLVMCommon/types.mlir
@@ -1,0 +1,23 @@
+// RUN: mlir-opt %s --convert-func-to-llvm --split-input-file | FileCheck %s
+
+// CHECK: @create_clashes_on_conversion(!llvm.struct<"foo", (index)>)
+func.func private @clashing_struct_name(!llvm.struct<"_Converted.foo", (f32)>)
+func.func private @create_clashes_on_conversion(!llvm.struct<"foo", (index)>)
+
+// -----
+
+// CHECK: @merge_on_conversion(!llvm.struct<"_Converted.foo", (i64)>) attributes {sym_visibility = "private"}
+func.func private @clashing_struct_name(!llvm.struct<"_Converted.foo", (i64)>)
+func.func private @merge_on_conversion(!llvm.struct<"foo", (index)>)
+
+// -----
+
+// CHECK: @create_clashes_on_conversion_recursive(!llvm.struct<"foo", (!llvm.struct<"foo">, index)>)
+func.func private @clashing_struct_name(!llvm.struct<"_Converted.foo", (struct<"_Converted.foo">, f32)>)
+func.func private @create_clashes_on_conversion_recursive(!llvm.struct<"foo", (struct<"foo">, index)>)
+
+// -----
+
+// CHECK: @merge_on_conversion_recursive(!llvm.struct<"_Converted.foo", (struct<"_Converted.foo">, i64)>)
+func.func private @clashing_struct_name(!llvm.struct<"_Converted.foo", (struct<"_Converted.foo">, i64)>)
+func.func private @merge_on_conversion_recursive(!llvm.struct<"foo", (struct<"foo">, index)>)


### PR DESCRIPTION
Existing implementation of the LLVM type converter for LLVM structs containing incompatible types was attempting to change identifiers of the struct in case of name clash post-conversion (all identified structs have different names post-conversion since one cannot change the body of the struct once initialized). Beyond a trivial error of not updating the counter in renaming, this approach was broken for recursive structs that can't be made aware of the renaming and would use the pre-existing struct with clashing name instead.

For example, given

`!llvm.struct<"_Converted.foo", (struct<"_Converted.foo">, f32)>`

the following type

`!llvm.struct<"foo", (struct<"foo", index>)>`

would incorrectly convert to

```
!llvm.struct<"_Converted_1.foo",
             (struct<"_Converted.foo",
	             (struct<"_Converted.foo">, f32)>)>
```

Remove this incorrect renaming and simply refuse to convert types if it would lead to identifier clashes for structs with different bodies. Document the expectation that such generated names are reserved and must not be present in the input IR of the converter. If we ever actually need to use handle such cases, this can be achieved by temporarily renaming structs with reserved identifiers to an unreserved name and back in a pre/post-processing pass that does _not_ use the type conversion infra.