### PR TITLE
[Clang] Improve support for expression messages in `static_assert`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -635,9 +635,9 @@ Bug Fixes in This Version
 - Fix crash during code generation of C++ coroutine initial suspend when the return
   type of await_resume is not trivially destructible.
   Fixes (`#63803 <https://github.com/llvm/llvm-project/issues/63803>`_)
-- Fix crash when the object used as a ``static_asssert`` message has ``size`` or ``data`` members
+- Fix crash when the object used as a ``static_assert`` message has ``size`` or ``data`` members
   which are not member functions.
-- Support UDLs in ``static_asssert`` message.
+- Support UDLs in ``static_assert`` message.
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -635,6 +635,9 @@ Bug Fixes in This Version
 - Fix crash during code generation of C++ coroutine initial suspend when the return
   type of await_resume is not trivially destructible.
   Fixes (`#63803 <https://github.com/llvm/llvm-project/issues/63803>`_)
+- Fix crash when the object used as a ``static_asssert`` message has ``size`` or ``data`` members
+  which are not member functions.
+- Support UDLs in ``static_asssert`` message.
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1023,7 +1023,7 @@ Decl *Parser::ParseStaticAssertDeclaration(SourceLocation &DeclEnd) {
         const Token &T = GetLookAheadToken(I);
         if (T.is(tok::r_paren))
           break;
-        if (!tokenIsLikeStringLiteral(T, getLangOpts())) {
+        if (!tokenIsLikeStringLiteral(T, getLangOpts()) || T.hasUDSuffix()) {
           ParseAsExpression = true;
           break;
         }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17291,33 +17291,15 @@ bool Sema::EvaluateStaticAssertMessageAsString(Expr *Message,
 
   auto FindMember = [&](StringRef Member, bool &Empty,
                         bool Diag = false) -> std::optional<LookupResult> {
-    QualType ObjectType = Message->getType();
-    Expr::Classification ObjectClassification =
-        Message->Classify(getASTContext());
-
     DeclarationName DN = PP.getIdentifierInfo(Member);
     LookupResult MemberLookup(*this, DN, Loc, Sema::LookupMemberName);
     LookupQualifiedName(MemberLookup, RD);
     Empty = MemberLookup.empty();
     OverloadCandidateSet Candidates(MemberLookup.getNameLoc(),
                                     OverloadCandidateSet::CSK_Normal);
-    for (NamedDecl *D : MemberLookup) {
-      AddMethodCandidate(DeclAccessPair::make(D, D->getAccess()), ObjectType,
-                         ObjectClassification, /*Args=*/{}, Candidates);
-    }
-    OverloadCandidateSet::iterator Best;
-    switch (Candidates.BestViableFunction(*this, Loc, Best)) {
-    case OR_Success:
-      return std::move(MemberLookup);
-    default:
-      if (Diag)
-        Candidates.NoteCandidates(
-            PartialDiagnosticAt(
-                Loc, PDiag(diag::err_static_assert_invalid_mem_fn_ret_ty)
-                         << (Member == "data")),
-            *this, OCD_AllCandidates, /*Args=*/{});
-    }
-    return std::nullopt;
+    if (MemberLookup.empty())
+      return std::nullopt;
+    return MemberLookup;
   };
 
   bool SizeNotFound, DataNotFound;

--- a/clang/test/CXX/drs/dr27xx.cpp
+++ b/clang/test/CXX/drs/dr27xx.cpp
@@ -3,28 +3,22 @@
 namespace dr2798 { // dr2798: 17 drafting
 #if __cpp_static_assert >= 202306
 struct string {
-    constexpr string() {
-        data_ = new char[6]();
-        __builtin_memcpy(data_, "Hello", 5);
-        data_[5] = 0;
-    }
-    constexpr ~string() {
-        delete[] data_;
-    }
-    constexpr unsigned long size() const {
-        return 5;
-    };
-    constexpr const char* data() const {
-        return data_;
-    }
+  constexpr string() {
+    data_ = new char[6]();
+    __builtin_memcpy(data_, "Hello", 5);
+    data_[5] = 0;
+  }
+  constexpr ~string() { delete[] data_; }
+  constexpr unsigned long size() const { return 5; };
+  constexpr const char *data() const { return data_; }
 
-    char* data_;
+  char *data_;
 };
 struct X {
-    string s;
+  string s;
 };
 consteval X f() { return {}; }
 
 static_assert(false, f().s); // expected-error {{static assertion failed: Hello}}
 #endif
-}
+} // namespace dr2798

--- a/clang/test/CXX/drs/dr27xx.cpp
+++ b/clang/test/CXX/drs/dr27xx.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -std=c++2c -verify %s
+
+namespace dr2798 { // dr2798: 17 drafting
+#if __cpp_static_assert >= 202306
+struct string {
+    constexpr string() {
+        data_ = new char[6]();
+        __builtin_memcpy(data_, "Hello", 5);
+        data_[5] = 0;
+    }
+    constexpr ~string() {
+        delete[] data_;
+    }
+    constexpr unsigned long size() const {
+        return 5;
+    };
+    constexpr const char* data() const {
+        return data_;
+    }
+
+    char* data_;
+};
+struct X {
+    string s;
+};
+consteval X f() { return {}; }
+
+static_assert(false, f().s); // expected-error {{static assertion failed: Hello}}
+#endif
+}

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -7145,7 +7145,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1223.html">1223</a></td>
     <td>drafting</td>
     <td>Syntactic disambiguation and <I>trailing-return-type</I>s</td>
-    <td class="unreleased" align="center">Clang 17</td>
+    <td class="full" align="center">Clang 17</td>
   </tr>
   <tr id="1224">
     <td><a href="https://cplusplus.github.io/CWG/issues/1224.html">1224</a></td>


### PR DESCRIPTION
- Support non-member functions and callable objects for size and data(). We previously tried to (badly) pick the best overload ourselves, in a way that would only support member functions. We now leave clang construct an unresolved member expression and call that, properly performing overload resolution with callable objects and static functions, consistent with the logic for `get` calls for structured bindings.
- Support UDLs as message expression.
- Add tests and mark CWG2798 as resolved