### PR TITLE
Reland [mlir] Workaround for export lib generation on Windows for mlir_arm_sme_abi_stubs #73147 

### DIFF
--- a/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
+++ b/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
@@ -10,6 +10,20 @@
 #include <cstdint>
 #include <iostream>
 
+#if (defined(_WIN32) || defined(__CYGWIN__))
+#ifndef MLIR_ARMSMEABISTUBS_EXPORTED
+#ifdef mlir_arm_sme_abi_stubs_EXPORTS
+// We are building this library
+#define MLIR_ARMSMEABISTUBS_EXPORTED __declspec(dllexport)
+#else
+// We are using this library
+#define MLIR_ARMSMEABISTUBS_EXPORTED __declspec(dllimport)
+#endif // mlir_arm_sme_abi_stubs_EXPORTS
+#endif // MLIR_ARMSMEABISTUBS_EXPORTED
+#else
+#define MLIR_ARMSMEABISTUBS_EXPORTED __attribute__((visibility("default")) LLVM_ATTRIBUTE_WEAK
+#endif // (defined(_WIN32) || defined(__CYGWIN__))
+
 // The actual implementation of these routines is in:
 // compiler-rt/lib/builtins/aarch64/sme-abi.S. These stubs allow the current
 // ArmSME tests to run without depending on compiler-rt. This works as we don't
@@ -19,7 +33,7 @@
 
 extern "C" {
 
-bool LLVM_ATTRIBUTE_WEAK __aarch64_sme_accessible() {
+bool MLIR_ARMSMEABISTUBS_EXPORTED __aarch64_sme_accessible() {
   // The ArmSME tests are run within an emulator so we assume SME is available.
   return true;
 }
@@ -29,20 +43,20 @@ struct sme_state {
   int64_t x1;
 };
 
-sme_state LLVM_ATTRIBUTE_WEAK __arm_sme_state() {
+sme_state MLIR_ARMSMEABISTUBS_EXPORTED __arm_sme_state() {
   std::cerr << "[warning] __arm_sme_state() stubbed!\n";
   return sme_state{};
 }
 
-void LLVM_ATTRIBUTE_WEAK __arm_tpidr2_restore() {
+void MLIR_ARMSMEABISTUBS_EXPORTED __arm_tpidr2_restore() {
   std::cerr << "[warning] __arm_tpidr2_restore() stubbed!\n";
 }
 
-void LLVM_ATTRIBUTE_WEAK __arm_tpidr2_save() {
+void MLIR_ARMSMEABISTUBS_EXPORTED __arm_tpidr2_save() {
   std::cerr << "[warning] __arm_tpidr2_save() stubbed!\n";
 }
 
-void LLVM_ATTRIBUTE_WEAK __arm_za_disable() {
+void MLIR_ARMSMEABISTUBS_EXPORTED __arm_za_disable() {
   std::cerr << "[warning] __arm_za_disable() stubbed!\n";
 }
 }

--- a/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
+++ b/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
@@ -21,7 +21,7 @@
 #endif // mlir_arm_sme_abi_stubs_EXPORTS
 #endif // MLIR_ARMSMEABISTUBS_EXPORTED
 #else
-#define MLIR_ARMSMEABISTUBS_EXPORTED __attribute__((visibility("default")) LLVM_ATTRIBUTE_WEAK
+#define MLIR_ARMSMEABISTUBS_EXPORTED LLVM_ATTRIBUTE_WEAK
 #endif // (defined(_WIN32) || defined(__CYGWIN__))
 
 // The actual implementation of these routines is in:

--- a/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
+++ b/mlir/lib/ExecutionEngine/ArmSMEStubs.cpp
@@ -21,7 +21,8 @@
 #endif // mlir_arm_sme_abi_stubs_EXPORTS
 #endif // MLIR_ARMSMEABISTUBS_EXPORTED
 #else
-#define MLIR_ARMSMEABISTUBS_EXPORTED LLVM_ATTRIBUTE_WEAK
+#define MLIR_ARMSMEABISTUBS_EXPORTED                                           \
+  __attribute__((visibility("default"))) LLVM_ATTRIBUTE_WEAK
 #endif // (defined(_WIN32) || defined(__CYGWIN__))
 
 // The actual implementation of these routines is in:

--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -181,6 +181,7 @@ if(LLVM_ENABLE_PIC)
   add_mlir_library(mlir_arm_sme_abi_stubs
     SHARED
     ArmSMEStubs.cpp)
+  target_compile_definitions(mlir_arm_sme_abi_stubs PRIVATE mlir_arm_sme_abi_stubs_EXPORTS)
 
   if(MLIR_ENABLE_CUDA_RUNNER)
     # Configure CUDA support. Using check_language first allows us to give a


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/73147

Fixed the visibility macro