### PR TITLE
[Clang] Fix `-Wdocumentation` warning (NFC)

### DIFF
--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -7776,10 +7776,10 @@ public:
   /// \param MLoc Location of the modifier
   OMPOrderClause(OpenMPOrderClauseKind A, SourceLocation ALoc,
                  SourceLocation StartLoc, SourceLocation LParenLoc,
-                 SourceLocation EndLoc, OpenMPOrderClauseModifier M,
+                 SourceLocation EndLoc, OpenMPOrderClauseModifier Modifier,
                  SourceLocation MLoc)
       : OMPClause(llvm::omp::OMPC_order, StartLoc, EndLoc),
-        LParenLoc(LParenLoc), Kind(A), KindKwLoc(ALoc), Modifier(M),
+        LParenLoc(LParenLoc), Kind(A), KindKwLoc(ALoc), Modifier(Modifier),
         ModifierKwLoc(MLoc) {}
 
   /// Build an empty clause.


### PR DESCRIPTION
```
llvm-project/clang/include/clang/AST/OpenMPClause.h:7762:14: warning: parameter 'Modifier' not found in the function declaration [-Wdocumentation]
  /// \param Modifier The modifier applied to 'order' clause.
             ^~~~~~~~
llvm-project/clang/include/clang/AST/OpenMPClause.h:7762:14: note: did you mean 'M'?
  /// \param Modifier The modifier applied to 'order' clause.
```