### PR TITLE
[flang] Pass Argv0 to getIntriniscDir and getOpenMPHeadersDir

### DIFF
--- a/flang/include/flang/Frontend/CompilerInvocation.h
+++ b/flang/include/flang/Frontend/CompilerInvocation.h
@@ -98,6 +98,8 @@ class CompilerInvocation : public CompilerInvocationBase {
 
   bool warnAsErr = false;
 
+  const char *argv0;
+
   /// This flag controls the unparsing and is used to decide whether to print
   /// out the semantically analyzed version of an object or expression or the
   /// plain version that does not include any information from semantic
@@ -184,6 +186,8 @@ public:
     return enableConformanceChecks;
   }
 
+  const char *getArgv0() { return argv0; }
+
   bool &getEnableUsageChecks() { return enableUsageChecks; }
   const bool &getEnableUsageChecks() const { return enableUsageChecks; }
 
@@ -217,6 +221,8 @@ public:
   void setEnableUsageChecks() { enableUsageChecks = true; }
 
   /// Useful setters
+  void setArgv0(const char *dir) { argv0 = dir; }
+
   void setModuleDir(std::string &dir) { moduleDir = dir; }
 
   void setModuleFileSuffix(const char *suffix) {

--- a/flang/include/flang/Frontend/CompilerInvocation.h
+++ b/flang/include/flang/Frontend/CompilerInvocation.h
@@ -98,6 +98,7 @@ class CompilerInvocation : public CompilerInvocationBase {
 
   bool warnAsErr = false;
 
+  // Executable name
   const char *argv0;
 
   /// This flag controls the unparsing and is used to decide whether to print

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -700,19 +700,19 @@ static bool parseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
 }
 
 // Generate the path to look for intrinsic modules
-static std::string getIntrinsicDir() {
+static std::string getIntrinsicDir(const char *argv) {
   // TODO: Find a system independent API
   llvm::SmallString<128> driverPath;
-  driverPath.assign(llvm::sys::fs::getMainExecutable(nullptr, nullptr));
+  driverPath.assign(llvm::sys::fs::getMainExecutable(argv, nullptr));
   llvm::sys::path::remove_filename(driverPath);
   driverPath.append("/../include/flang/");
   return std::string(driverPath);
 }
 
 // Generate the path to look for OpenMP headers
-static std::string getOpenMPHeadersDir() {
+static std::string getOpenMPHeadersDir(const char *argv) {
   llvm::SmallString<128> includePath;
-  includePath.assign(llvm::sys::fs::getMainExecutable(nullptr, nullptr));
+  includePath.assign(llvm::sys::fs::getMainExecutable(argv, nullptr));
   llvm::sys::path::remove_filename(includePath);
   includePath.append("/../include/flang/OpenMP/");
   return std::string(includePath);
@@ -1216,6 +1216,8 @@ bool CompilerInvocation::createFromArgs(
     }
   }
 
+  res.setArgv0(argv0);
+
   return success;
 }
 
@@ -1258,7 +1260,8 @@ void CompilerInvocation::setDefaultFortranOpts() {
 
   // Add the location of omp_lib.h to the search directories. Currently this is
   // identical to the modules' directory.
-  fortranOptions.searchDirectories.emplace_back(getOpenMPHeadersDir());
+  fortranOptions.searchDirectories.emplace_back(
+      getOpenMPHeadersDir(getArgv0()));
 
   fortranOptions.isFixedForm = false;
 }
@@ -1323,7 +1326,8 @@ void CompilerInvocation::setFortranOpts() {
       preprocessorOptions.searchDirectoriesFromIntrModPath.end());
 
   //  Add the default intrinsic module directory
-  fortranOptions.intrinsicModuleDirectories.emplace_back(getIntrinsicDir());
+  fortranOptions.intrinsicModuleDirectories.emplace_back(
+      getIntrinsicDir(getArgv0()));
 
   // Add the directory supplied through -J/-module-dir to the list of search
   // directories


### PR DESCRIPTION
The `llvm::sys::fs::getMainExecutable(nullptr, nullptr)` is not able to obtain the correct executable path on AIX without Argv0 due to the lack of a current process on AIX's  `proc` filesystem. This causes a build failure on AIX as intrinsic module directory is missing. 