### PR TITLE
[llvm-c] Expose debug support for LLJIT in Orc C-API bindings

### DIFF
--- a/llvm/include/llvm-c/LLJIT.h
+++ b/llvm/include/llvm-c/LLJIT.h
@@ -1,4 +1,4 @@
-/*===----------- llvm-c/LLJIT.h - OrcV2 LLJIT C bindings --------*- C++ -*-===*\
+/*===----------- llvm-c/LLJIT.h - OrcV2 LLJIT C bindings ----------*- C -*-===*\
 |*                                                                            *|
 |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
 |* Exceptions.                                                                *|

--- a/llvm/include/llvm-c/LLJIT.h
+++ b/llvm/include/llvm-c/LLJIT.h
@@ -243,12 +243,6 @@ LLVMOrcIRTransformLayerRef LLVMOrcLLJITGetIRTransformLayer(LLVMOrcLLJITRef J);
 const char *LLVMOrcLLJITGetDataLayoutStr(LLVMOrcLLJITRef J);
 
 /**
- * Install the plugin that submits debug objects to the executor. Executors must
- * expose the llvm_orc_registerJITLoaderGDBWrapper symbol.
- */
-LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J);
-
-/**
  * @}
  */
 

--- a/llvm/include/llvm-c/LLJIT.h
+++ b/llvm/include/llvm-c/LLJIT.h
@@ -243,6 +243,12 @@ LLVMOrcIRTransformLayerRef LLVMOrcLLJITGetIRTransformLayer(LLVMOrcLLJITRef J);
 const char *LLVMOrcLLJITGetDataLayoutStr(LLVMOrcLLJITRef J);
 
 /**
+ * Install the plugin that submits debug objects to the executor. Executors must
+ * expose the llvm_orc_registerJITLoaderGDBWrapper symbol.
+ */
+LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J);
+
+/**
  * @}
  */
 

--- a/llvm/include/llvm-c/LLJITUtils.h
+++ b/llvm/include/llvm-c/LLJITUtils.h
@@ -1,4 +1,4 @@
-/*===--- llvm-c/LLJITUtils.h - OrcV2 LLJIT Utilities C bindings -*- C++ -*-===*\
+/*===------- llvm-c/LLJITUtils.h - Advanced LLJIT features --------*- C -*-===*\
 |*                                                                            *|
 |* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
 |* Exceptions.                                                                *|

--- a/llvm/include/llvm-c/LLJITUtils.h
+++ b/llvm/include/llvm-c/LLJITUtils.h
@@ -38,11 +38,6 @@ LLVM_C_EXTERN_C_BEGIN
  */
 
 /**
- * A reference to an orc::LLJIT instance.
- */
-typedef struct LLVMOrcOpaqueLLJIT *LLVMOrcLLJITRef;
-
-/**
  * Install the plugin that submits debug objects to the executor. Executors must
  * expose the llvm_orc_registerJITLoaderGDBWrapper symbol.
  */

--- a/llvm/include/llvm-c/LLJITUtils.h
+++ b/llvm/include/llvm-c/LLJITUtils.h
@@ -1,0 +1,57 @@
+/*===--- llvm-c/LLJITUtils.h - OrcV2 LLJIT Utilities C bindings -*- C++ -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* This header declares the C interface for extra utilities to be used with   *|
+|* the LLJIT class from the llvm-c/LLJIT.h header. It requires to following   *|
+|* link libraries in addition to libLLVMOrcJIT.a:                             *|
+|*  - libLLVMOrcDebugging.a                                                   *|
+|*                                                                            *|
+|* Many exotic languages can interoperate with C code but have a harder time  *|
+|* with C++ due to name mangling. So in addition to C, this interface enables *|
+|* tools written in such languages.                                           *|
+|*                                                                            *|
+|* Note: This interface is experimental. It is *NOT* stable, and may be       *|
+|*       changed without warning. Only C API usage documentation is           *|
+|*       provided. See the C++ documentation for all higher level ORC API     *|
+|*       details.                                                             *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef LLVM_C_LLJITUTILS_H
+#define LLVM_C_LLJITUTILS_H
+
+#include "llvm-c/LLJIT.h"
+
+LLVM_C_EXTERN_C_BEGIN
+
+/**
+ * @defgroup LLVMCExecutionEngineLLJITUtils LLJIT Utilities
+ * @ingroup LLVMCExecutionEngineLLJIT
+ *
+ * @{
+ */
+
+/**
+ * A reference to an orc::LLJIT instance.
+ */
+typedef struct LLVMOrcOpaqueLLJIT *LLVMOrcLLJITRef;
+
+/**
+ * Install the plugin that submits debug objects to the executor. Executors must
+ * expose the llvm_orc_registerJITLoaderGDBWrapper symbol.
+ */
+LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J);
+
+/**
+ * @}
+ */
+
+LLVM_C_EXTERN_C_END
+
+#endif /* LLVM_C_LLJITUTILS_H */

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_component_library(LLVMOrcDebugging
   DebugInfoSupport.cpp
   DebuggerSupport.cpp
   DebuggerSupportPlugin.cpp
+  LLJITUtilsCBindings.cpp
   PerfSupportPlugin.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
@@ -39,7 +39,7 @@ Error enableDebuggerSupport(LLJIT &J) {
     if (!Registrar)
       return Registrar.takeError();
     ObjLinkingLayer->addPlugin(std::make_unique<DebugObjectManagerPlugin>(
-        ES, std::move(*Registrar), true, true));
+        ES, std::move(*Registrar), false, true));
     return Error::success();
   }
   case Triple::MachO: {

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp
@@ -1,4 +1,4 @@
-//===--------------- OrcV2CBindings.cpp - C bindings OrcV2 APIs -----------===//
+//===--------- LLJITUtilsCBindings.cpp - Advanced LLJIT features ----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp
@@ -1,0 +1,22 @@
+//===--------------- OrcV2CBindings.cpp - C bindings OrcV2 APIs -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm-c/LLJIT.h"
+#include "llvm-c/LLJITUtils.h"
+
+#include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+
+using namespace llvm;
+using namespace llvm::orc;
+
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLJIT, LLVMOrcLLJITRef)
+
+LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J) {
+  return wrap(llvm::orc::enableDebuggerSupport(*unwrap(J)));
+}

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -11,7 +11,6 @@
 #include "llvm-c/OrcEE.h"
 #include "llvm-c/TargetMachine.h"
 
-#include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/ExecutionEngine/Orc/ObjectTransformLayer.h"

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -11,6 +11,7 @@
 #include "llvm-c/OrcEE.h"
 #include "llvm-c/TargetMachine.h"
 
+#include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/ExecutionEngine/Orc/ObjectTransformLayer.h"
@@ -1178,4 +1179,8 @@ LLVMErrorRef LLVMOrcCreateLocalLazyCallThroughManager(
 void LLVMOrcDisposeLazyCallThroughManager(
     LLVMOrcLazyCallThroughManagerRef LCM) {
   std::unique_ptr<LazyCallThroughManager> TmpLCM(unwrap(LCM));
+}
+
+LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J) {
+  return wrap(llvm::orc::enableDebuggerSupport(*unwrap(J)));
 }

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -1180,7 +1180,3 @@ void LLVMOrcDisposeLazyCallThroughManager(
     LLVMOrcLazyCallThroughManagerRef LCM) {
   std::unique_ptr<LazyCallThroughManager> TmpLCM(unwrap(LCM));
 }
-
-LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J) {
-  return wrap(llvm::orc::enableDebuggerSupport(*unwrap(J)));
-}

--- a/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
   IRReader
   JITLink
   Object
+  OrcDebugging
   OrcJIT
   OrcShared
   OrcTargetProcess

--- a/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
@@ -9,6 +9,7 @@
 #include "llvm-c/Core.h"
 #include "llvm-c/Error.h"
 #include "llvm-c/LLJIT.h"
+#include "llvm-c/LLJITUtils.h"
 #include "llvm-c/Orc.h"
 #include "gtest/gtest.h"
 

--- a/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcCAPITest.cpp
@@ -532,7 +532,7 @@ static void *findLastDebugDescriptorEntryPtr() {
 }
 }
 
-#if defined(_AIX) or (not defined(__ELF__) and not defined(__MACH__))
+#if defined(_AIX) or not defined(__ELF__)
 TEST_F(OrcCAPITestBase, DISABLED_EnableDebugSupport) {
 #else
 TEST_F(OrcCAPITestBase, EnableDebugSupport) {


### PR DESCRIPTION
Allow C-API users to debug their JITed code. The new API function `LLVMOrcObjectLayerRegisterPluginJITLoaderGDB()` adds the required plugin to provide GDB JIT Interface support. This initial patch covers the ELF use-case by installing the DebugObjectManagerPlugin. It should be easy to add support for other object formats later on.