### PR TITLE
Fix for building llvm-flang with gcc 7.5.0 (minimum LLVM required gcc version

### DIFF
--- a/flang/include/flang/Common/enum-class.h
+++ b/flang/include/flang/Common/enum-class.h
@@ -63,9 +63,8 @@ constexpr std::array<std::string_view, ITEMS> EnumNames(const char *p) {
   [[maybe_unused]] static constexpr std::size_t NAME##_enumSize{ \
       ::Fortran::common::CountEnumNames(#__VA_ARGS__)}; \
   [[maybe_unused]] static inline std::string_view EnumToString(NAME e) { \
-    static const constexpr char vaArgs[]{#__VA_ARGS__}; \
     static const constexpr auto names{ \
-        ::Fortran::common::EnumNames<NAME##_enumSize>(vaArgs)}; \
+        ::Fortran::common::EnumNames<NAME##_enumSize>(#__VA_ARGS__)}; \
     return names[static_cast<std::size_t>(e)]; \
   }
 


### PR DESCRIPTION
Fix for https://github.com/llvm/llvm-project/issues/68593