### PR TITLE
[llvm-jitlink] Support plain AArch32 range extension stubs in jitlink-check's stub_addr() expressions

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch32.h
@@ -295,7 +295,7 @@ public:
   StubsManager() = default;
 
   /// Name of the object file section that will contain all our stubs.
-  static StringRef getSectionName() { return "__llvm_jitlink_STUBS"; }
+  static StringRef getSectionName();
 
   /// Implements link-graph traversal via visitExistingEdges().
   bool visitEdge(LinkGraph &G, Block *B, Edge &E) {
@@ -344,6 +344,10 @@ private:
 /// Create a branch range extension stub with Thumb encoding for v7 CPUs.
 template <>
 Symbol &StubsManager<Thumbv7>::createEntry(LinkGraph &G, Symbol &Target);
+
+template <> inline StringRef StubsManager<Thumbv7>::getSectionName() {
+  return "__llvm_jitlink_aarch32_STUBS_Thumbv7";
+}
 
 } // namespace aarch32
 } // namespace jitlink

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_thumb_stubs.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_thumb_stubs.s
@@ -9,9 +9,10 @@
 	.text
 	.syntax unified
 
-# Check that calls/jumps to external functions trigger the generation of stubs
-# and GOT entries. The GOT entry contains the absolute address of the external
-# function. The stub loads it and branches there.
+# Check that calls/jumps to external functions trigger the generation of
+# branch-range extension stubs. These stubs don't follow the default PLT model
+# where the branch-target address is loaded from a GOT entry. Instead, they
+# hard-code it in the immediate field.
 #
 # jitlink-check: decode_operand(test_external_call, 2) = stub_addr(elf_stubs.o, external_func) - next_pc(test_external_call)
 # jitlink-check: decode_operand(test_external_jump, 0) = stub_addr(elf_stubs.o, external_func) - next_pc(test_external_jump)

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_thumb_stubs.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_thumb_stubs.s
@@ -1,0 +1,44 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=thumbv7-linux-gnueabi -arm-add-build-attributes \
+# RUN:         -filetype=obj -filetype=obj -o %t/elf_stubs.o %s
+# RUN: llvm-jitlink -noexec -slab-address 0x76ff0000 \
+# RUN:              -slab-allocate 10Kb -slab-page-size 4096 \
+# RUN:              -abs external_func=0x76bbe880 \
+# RUN:              -check %s %t/elf_stubs.o
+
+	.text
+	.syntax unified
+
+# Check that calls/jumps to external functions trigger the generation of stubs
+# and GOT entries. The GOT entry contains the absolute address of the external
+# function. The stub loads it and branches there.
+#
+# jitlink-check: decode_operand(test_external_call, 2) = stub_addr(elf_stubs.o, external_func) - next_pc(test_external_call)
+# jitlink-check: decode_operand(test_external_jump, 0) = stub_addr(elf_stubs.o, external_func) - next_pc(test_external_jump)
+	.globl  test_external_call
+	.type	test_external_call,%function
+	.p2align	1
+	.code	16
+	.thumb_func
+test_external_call:
+	bl	external_func
+	.size test_external_call, .-test_external_call
+
+	.globl  test_external_jump
+	.type	test_external_call,%function
+	.p2align	1
+	.code	16
+	.thumb_func
+test_external_jump:
+	b	external_func
+	.size test_external_jump, .-test_external_jump
+
+# Empty main function for jitlink to be happy
+	.globl	main
+	.type	main,%function
+	.p2align	1
+	.code	16
+	.thumb_func
+main:
+	bx	lr
+	.size	main,	.-main

--- a/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
@@ -68,8 +68,8 @@ static Expected<Symbol &> getELFStubTarget(LinkGraph &G, Block &B) {
   return getELFGOTTarget(G, GOTSym.getBlock());
 }
 
-static Expected<std::string>
-getELFAArch32StubTargetName(LinkGraph &G, Block &B) {
+static Expected<std::string> getELFAArch32StubTargetName(LinkGraph &G,
+                                                         Block &B) {
   auto E = getFirstRelocationEdge(G, B);
   if (!E)
     return E.takeError();

--- a/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
@@ -12,7 +12,6 @@
 
 #include "llvm-jitlink.h"
 
-#include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Path.h"
 
@@ -70,7 +69,7 @@ static Expected<Symbol &> getELFStubTarget(LinkGraph &G, Block &B) {
 }
 
 static Expected<std::string>
-getELFAArch32StubTargetName(LinkGraph &G, Block &B, orc::ExecutionSession &ES) {
+getELFAArch32StubTargetName(LinkGraph &G, Block &B) {
   auto E = getFirstRelocationEdge(G, B);
   if (!E)
     return E.takeError();
@@ -158,7 +157,7 @@ Error registerELFGraphInfo(Session &S, LinkGraph &G) {
           return make_error<StringError>("zero-fill atom in Stub section",
                                          inconvertibleErrorCode());
 
-        if (auto Name = getELFAArch32StubTargetName(G, Sym->getBlock(), S.ES))
+        if (auto Name = getELFAArch32StubTargetName(G, Sym->getBlock()))
           FileInfo.StubInfos[*Name] = {Sym->getSymbolContent(),
                                        Sym->getAddress().getValue(),
                                        Sym->getTargetFlags()};


### PR DESCRIPTION
We want to use regular `stub_addr()` expressions in `jitlink-check` lines to test the generation of stubs in AArch32, but we don't want this to require a standardized GOT-based PLT implementation. In terms of performance and binary size it doesn't seem beneficial. And in terms of patching, we should be able to handle range-extension- and interworking-stubs without a lot of extra logic.

This patch adds a separate path for AArch32 stubs in `llvm-jitlink-elf` to allow it. The relocations in our stubs are not pointing to the GOT, but to the external symbol directly. Thus, we have to avoid access to the block of the edge target. Instead we only return the symbol name. This is enough to use `stub_addr()` expressions in tests.

In order to allow decoding of stub target addresses in the future, we mention the stub flavor in the section name.