### PR TITLE
[libc++] Remove dependence on <ciso646>

### DIFF
--- a/libcxx/test/support/container_debug_tests.h
+++ b/libcxx/test/support/container_debug_tests.h
@@ -9,7 +9,8 @@
 #ifndef TEST_SUPPORT_CONTAINER_DEBUG_TESTS_H
 #define TEST_SUPPORT_CONTAINER_DEBUG_TESTS_H
 
-#include <ciso646>
+#include "test_macros.h"
+
 #ifndef _LIBCPP_VERSION
 #error This header may only be used for libc++ tests
 #endif
@@ -25,7 +26,6 @@
 
 #include "check_assertion.h"
 #include "test_allocator.h"
-#include "test_macros.h"
 
 // These test make use of 'if constexpr'.
 #if TEST_STD_VER <= 14

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -10,17 +10,14 @@
 #ifndef SUPPORT_TEST_MACROS_HPP
 #define SUPPORT_TEST_MACROS_HPP
 
-// Attempt to get STL specific macros like _LIBCPP_VERSION using the most
-// minimal header possible. If we're testing libc++, we should use `<__config>`.
-// If <__config> isn't available, fall back to <ciso646>.
 #ifdef __has_include
-# if __has_include("<__config>")
-#   include <__config>
-#   define TEST_IMP_INCLUDED_HEADER
-# endif
-#endif
-#ifndef TEST_IMP_INCLUDED_HEADER
-#include <ciso646>
+#  if __has_include("<version>")
+#    include <version>
+#  else
+#    include <ciso646>
+#  endif
+#else
+#  include <ciso646>
 #endif
 
 #define TEST_STRINGIZE_IMPL(...) #__VA_ARGS__

--- a/libcxxabi/src/demangle/DemangleConfig.h
+++ b/libcxxabi/src/demangle/DemangleConfig.h
@@ -19,7 +19,7 @@
 #include "../abort_message.h"
 #endif
 
-#include <ciso646>
+#include <version>
 
 #ifdef _MSC_VER
 // snprintf is implemented in VS 2015


### PR DESCRIPTION
C++23 removed `<ciso646>` from the standard library. The header is used in a few places in order to pull in implementation-specific and feature test macros. The new way of doing that is `<version>`, which should be supported by all supported implementations. This change replaces all those uses of `<ciso646>` with `<version>`.