### PR TITLE
Remove dependence on <ciso646>

### DIFF
--- a/llvm/include/llvm/Support/Threading.h
+++ b/llvm/include/llvm/Support/Threading.h
@@ -18,8 +18,8 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/Support/Compiler.h"
-#include <ciso646> // So we can check the C++ standard lib macros.
 #include <optional>
+#include <version>
 
 #if defined(_MSC_VER)
 // MSVC's call_once implementation worked since VS 2015, which is the minimum

--- a/llvm/lib/DebugInfo/GSYM/LookupResult.cpp
+++ b/llvm/lib/DebugInfo/GSYM/LookupResult.cpp
@@ -12,7 +12,6 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
-#include <ciso646>
 
 using namespace llvm;
 using namespace gsym;


### PR DESCRIPTION
C++23 removed `<ciso646>` from the standard library. The header is used in two places: Once in order to pull in standard library macros. Since this file also includes `<optional>`, that use of `<ciso646>` is technically redundant, but should probably be left in in case a future change ever removes the include of `<optional>`. A second use of `<ciso646>` appears to have been introduced in da650094b187ee3c8017d74f63c885663faca1d8, but seems unnecessary (the file doesn't seem to use anything from that header, and it seems to build just fine on MSVC here without it). The new `<version>` header should be supported by all supported implementations. This change replaces uses of `<ciso646>` with the `<version>` header, or removes them entirely where unnecessary.