### PR TITLE
[libc++abi] Remove unnecessary dependency on std::unique_ptr

### DIFF
--- a/libcxxabi/src/cxa_default_handlers.cpp
+++ b/libcxxabi/src/cxa_default_handlers.cpp
@@ -10,8 +10,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <exception>
-#include <memory>
-#include <stdlib.h>
 #include "abort_message.h"
 #include "cxxabi.h"
 #include "cxa_handlers.h"
@@ -23,17 +21,7 @@
 
 static constinit const char* cause = "uncaught";
 
-#ifndef _LIBCXXABI_NO_EXCEPTIONS
-// Demangle the given string, or return the string as-is in case of an error.
-static std::unique_ptr<char const, void (*)(char const*)> demangle(char const* str)
-{
-#if !defined(LIBCXXABI_NON_DEMANGLING_TERMINATE)
-    if (const char* result = __cxxabiv1::__cxa_demangle(str, nullptr, nullptr, nullptr))
-        return {result, [](char const* p) { std::free(const_cast<char*>(p)); }};
-#endif
-    return {str, [](char const*) { /* nothing to free */ }};
-}
-
+#  ifndef _LIBCXXABI_NO_EXCEPTIONS
 __attribute__((noreturn))
 static void demangling_terminate_handler()
 {
@@ -61,7 +49,17 @@ static void demangling_terminate_handler()
             exception_header + 1;
     const __shim_type_info* thrown_type =
         static_cast<const __shim_type_info*>(exception_header->exceptionType);
-    auto name = demangle(thrown_type->name());
+
+    auto name = [str = thrown_type->name()] {
+#    ifndef LIBCXXABI_NON_DEMANGLING_TERMINATE
+      if (const char* result = __cxxabiv1::__cxa_demangle(str, nullptr, nullptr, nullptr))
+        // We're about to abort(), this memory can never be freed; so it's fine
+        // to just return a raw pointer
+        return result;
+#    endif
+      return str;
+    }();
+
     // If the uncaught exception can be caught with std::exception&
     const __shim_type_info* catch_type =
         static_cast<const __shim_type_info*>(&typeid(std::exception));
@@ -69,12 +67,12 @@ static void demangling_terminate_handler()
     {
         // Include the what() message from the exception
         const std::exception* e = static_cast<const std::exception*>(thrown_object);
-        abort_message("terminating due to %s exception of type %s: %s", cause, name.get(), e->what());
+        abort_message("terminating due to %s exception of type %s: %s", cause, name, e->what());
     }
     else
     {
         // Else just note that we're terminating due to an exception
-        abort_message("terminating due to %s exception of type %s", cause, name.get());
+        abort_message("terminating due to %s exception of type %s", cause, name);
     }
 }
 #else // !_LIBCXXABI_NO_EXCEPTIONS


### PR DESCRIPTION
The demangling terminate handler uses a function `demangle()` to perform the demangling. This function returns an `std::unique_ptr`, relying on custom deleter and `const_cast` hacks to deal with the facts that only one branch actually allocates, and that the pointer type needs to be `const char*`. However, the destructor of the returned `std::unique_ptr` will never actually run, because the sole place this function is ever called is right before the terminate handler aborts the program. So all this is unnecessary, and creates a dependency onto `<memory>`. This change removes the `demangle()` function and replaces the call with an immediately invoked lambda expression that simply returns a raw pointer in both cases, which should be fine because the memory can never be freed here anyways.