### PR TITLE
[flang] Make the length size matched in comparison (NFC)

### DIFF
--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -171,7 +171,7 @@ protected:
     std::string spaces(value->ElementBytes(), ' ');
     CheckDescriptorEqStr(value.get(), spaces);
 
-    CheckDescriptorEqInt(length.get(), 0);
+    CheckDescriptorEqInt<std::int64_t>(length.get(), 0);
 
     if (errStr) {
       std::string paddedErrStr(GetPaddedStr(errStr, err->ElementBytes()));
@@ -193,7 +193,7 @@ protected:
     std::string spaces(value->ElementBytes(), ' ');
     CheckDescriptorEqStr(value.get(), spaces);
 
-    CheckDescriptorEqInt(length.get(), 0);
+    CheckDescriptorEqInt<std::int64_t>(length.get(), 0);
 
     if (errStr) {
       std::string paddedErrStr(GetPaddedStr(errStr, err->ElementBytes()));
@@ -294,7 +294,7 @@ TEST_F(SeveralArguments, ArgValueTooShort) {
       RTNAME(GetCommandArgument)(1, tooShort.get(), length.get(), errMsg.get()),
       -1);
 
-  CheckDescriptorEqInt(length.get(), 16);
+  CheckDescriptorEqInt<std::int64_t>(length.get(), 16);
   std::string expectedErrMsg{
       GetPaddedStr("Value too short", errMsg->ElementBytes())};
   CheckDescriptorEqStr(errMsg.get(), expectedErrMsg);
@@ -320,7 +320,7 @@ TEST_F(SeveralArguments, CommandErrMsgTooShort) {
 
   std::string spaces(value->ElementBytes(), ' ');
   CheckDescriptorEqStr(value.get(), spaces);
-  CheckDescriptorEqInt(length.get(), 0);
+  CheckDescriptorEqInt<std::int64_t>(length.get(), 0);
   CheckDescriptorEqStr(errMsg.get(), "Mis");
 }
 
@@ -351,7 +351,7 @@ TEST_F(OnlyValidArguments, CommandValueTooShort) {
 
   CheckDescriptorEqStr(
       tooShort.get(), "aProgram -f has/a/few/slashes has\\a\\few\\backslashe");
-  CheckDescriptorEqInt(length.get(), 51);
+  CheckDescriptorEqInt<std::int64_t>(length.get(), 51);
 
   OwningPtr<Descriptor> errMsg{CreateEmptyCharDescriptor()};
   ASSERT_NE(errMsg, nullptr);
@@ -377,7 +377,7 @@ TEST_F(OnlyValidArguments, GetCommandCanTakeNull) {
           value->ElementBytes()));
 
   EXPECT_EQ(0, RTNAME(GetCommand)(nullptr, length.get(), nullptr));
-  CheckDescriptorEqInt(length.get(), 51);
+  CheckDescriptorEqInt<std::int64_t>(length.get(), 51);
 }
 
 TEST_F(OnlyValidArguments, GetCommandShortLength) {


### PR DESCRIPTION
The template function call `CheckDescriptorEqInt(length.get(), 16)` is deduced to have `INT_T` equal to `std::int32_t` instead of `std::int64_t`, but the length descriptor points to a 64-byte storage. The comparison does not work in a big endian.