### PR TITLE
[MLIR][NFC] Fix build on recent GCC with C++20 enabled

### DIFF
--- a/mlir/lib/Conversion/ComplexToLibm/ComplexToLibm.cpp
+++ b/mlir/lib/Conversion/ComplexToLibm/ComplexToLibm.cpp
@@ -55,10 +55,8 @@ template <typename Op, typename TypeResolver = ComplexTypeResolver>
 struct ScalarOpToLibmCall : public OpRewritePattern<Op> {
 public:
   using OpRewritePattern<Op>::OpRewritePattern;
-  ScalarOpToLibmCall<Op, TypeResolver>(MLIRContext *context,
-                                       StringRef floatFunc,
-                                       StringRef doubleFunc,
-                                       PatternBenefit benefit)
+  ScalarOpToLibmCall(MLIRContext *context, StringRef floatFunc,
+                     StringRef doubleFunc, PatternBenefit benefit)
       : OpRewritePattern<Op>(context, benefit), floatFunc(floatFunc),
         doubleFunc(doubleFunc){};
 

--- a/mlir/lib/Conversion/MathToLibm/MathToLibm.cpp
+++ b/mlir/lib/Conversion/MathToLibm/MathToLibm.cpp
@@ -50,8 +50,8 @@ template <typename Op>
 struct ScalarOpToLibmCall : public OpRewritePattern<Op> {
 public:
   using OpRewritePattern<Op>::OpRewritePattern;
-  ScalarOpToLibmCall<Op>(MLIRContext *context, StringRef floatFunc,
-                         StringRef doubleFunc)
+  ScalarOpToLibmCall(MLIRContext *context, StringRef floatFunc,
+                     StringRef doubleFunc)
       : OpRewritePattern<Op>(context), floatFunc(floatFunc),
         doubleFunc(doubleFunc){};
 

--- a/mlir/lib/Conversion/SCFToSPIRV/SCFToSPIRV.cpp
+++ b/mlir/lib/Conversion/SCFToSPIRV/SCFToSPIRV.cpp
@@ -96,8 +96,8 @@ Region::iterator getBlockIt(Region &region, unsigned index) {
 template <typename OpTy>
 class SCFToSPIRVPattern : public OpConversionPattern<OpTy> {
 public:
-  SCFToSPIRVPattern<OpTy>(MLIRContext *context, SPIRVTypeConverter &converter,
-                          ScfToSPIRVContextImpl *scfToSPIRVContext)
+  SCFToSPIRVPattern(MLIRContext *context, SPIRVTypeConverter &converter,
+                    ScfToSPIRVContextImpl *scfToSPIRVContext)
       : OpConversionPattern<OpTy>::OpConversionPattern(converter, context),
         scfToSPIRVContext(scfToSPIRVContext), typeConverter(converter) {}
 

--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -373,7 +373,7 @@ llvm::cl::OptionValue<OpPassManager>::operator=(
   return *this;
 }
 
-llvm::cl::OptionValue<OpPassManager>::~OptionValue<OpPassManager>() = default;
+llvm::cl::OptionValue<OpPassManager>::~OptionValue() = default;
 
 void llvm::cl::OptionValue<OpPassManager>::setValue(
     const OpPassManager &newValue) {


### PR DESCRIPTION
The following pattern fails on recent GCC versions with -std=c++20 flag passed and succeeds with -std=c++17. Such behavior is not observed on Clang 16.0.

```
template <typename T>
struct Foo {
    Foo<T>(int a) {}
};
```

This patch removes template parameter from constructor in two occurences to make the following command complete successfully:
bazel build -c fastbuild --cxxopt=-std=c++20 --host_cxxopt=-std=c++20 @llvm-project//mlir/...

This patch is similar to https://reviews.llvm.org/D154782