### PR TITLE
[libc][NFC] Move float macro into its own header / add target os detection

### DIFF
--- a/libc/cmake/modules/compiler_features/check_float128.cpp
+++ b/libc/cmake/modules/compiler_features/check_float128.cpp
@@ -1,4 +1,4 @@
-#include "src/__support/macros/properties/compiler.h"
+#include "src/__support/macros/properties/float.h"
 
 #ifndef LIBC_COMPILER_HAS_FLOAT128
 #error unsupported

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -43,13 +43,13 @@ We define two kinds of macros:
 
      * ``architectures.h`` - Target architecture properties.
        e.g., ``LIBC_TARGET_ARCH_IS_ARM``.
-     * ``os.h`` - Target architecture properties.
+     * ``os.h`` - Target os properties.
        e.g., ``LIBC_TARGET_OS_IS_LINUX``.
      * ``cpu_features.h`` - Target cpu feature availability.
        e.g., ``LIBC_TARGET_CPU_HAS_AVX2``.
      * ``compiler.h`` - Host compiler properties.
        e.g., ``LIBC_COMPILER_IS_CLANG``.
-     * ``float.h`` - Float type compiler support.
+     * ``float.h`` - Floating point type properties and availability.
        e.g., ``LIBC_COMPILER_HAS_FLOAT128``.
 
    * ``src/__support/macros/config.h`` - Important compiler and platform

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -43,14 +43,14 @@ We define two kinds of macros:
 
      * ``architectures.h`` - Target architecture properties.
        e.g., ``LIBC_TARGET_ARCH_IS_ARM``.
-     * ``os.h`` - Target os properties.
-       e.g., ``LIBC_TARGET_OS_IS_LINUX``.
-     * ``cpu_features.h`` - Target cpu feature availability.
-       e.g., ``LIBC_TARGET_CPU_HAS_AVX2``.
      * ``compiler.h`` - Host compiler properties.
        e.g., ``LIBC_COMPILER_IS_CLANG``.
+     * ``cpu_features.h`` - Target cpu feature availability.
+       e.g., ``LIBC_TARGET_CPU_HAS_AVX2``.
      * ``float.h`` - Floating point type properties and availability.
        e.g., ``LIBC_COMPILER_HAS_FLOAT128``.
+     * ``os.h`` - Target os properties.
+       e.g., ``LIBC_TARGET_OS_IS_LINUX``.
 
    * ``src/__support/macros/config.h`` - Important compiler and platform
      features. Such macros can be used to produce portable code by

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -43,10 +43,14 @@ We define two kinds of macros:
 
      * ``architectures.h`` - Target architecture properties.
        e.g., ``LIBC_TARGET_ARCH_IS_ARM``.
+     * ``os.h`` - Target architecture properties.
+       e.g., ``LIBC_TARGET_OS_IS_LINUX``.
+     * ``cpu_features.h`` - Target cpu feature availability.
+       e.g., ``LIBC_TARGET_CPU_HAS_AVX2``.
      * ``compiler.h`` - Host compiler properties.
        e.g., ``LIBC_COMPILER_IS_CLANG``.
-     * ``cpu_features.h`` - Target cpu apu feature availability.
-       e.g., ``LIBC_TARGET_CPU_HAS_AVX2``.
+     * ``float.h`` - Float type compiler support.
+       e.g., ``LIBC_COMPILER_HAS_FLOAT128``.
 
    * ``src/__support/macros/config.h`` - Important compiler and platform
      features. Such macros can be used to produce portable code by

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -42,7 +42,7 @@ add_header_library(
     .named_pair
     libc.src.__support.CPP.type_traits
     libc.src.__support.macros.attributes
-    libc.src.__support.macros.properties.compiler
+    libc.src.__support.macros.config
 )
 
 add_header_library(

--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -147,6 +147,8 @@ add_header_library(
     type_traits/true_type.h
     type_traits/type_identity.h
     type_traits/void_t.h
+  DEPENDS
+    libc.src.__support.macros.properties.float
 )
 
 add_header_library(

--- a/libc/src/__support/CPP/type_traits/is_floating_point.h
+++ b/libc/src/__support/CPP/type_traits/is_floating_point.h
@@ -11,7 +11,7 @@
 #include "src/__support/CPP/type_traits/is_same.h"
 #include "src/__support/CPP/type_traits/remove_cv.h"
 #include "src/__support/macros/attributes.h"
-#include "src/__support/macros/properties/compiler.h"
+#include "src/__support/macros/properties/float.h"
 
 namespace LIBC_NAMESPACE::cpp {
 

--- a/libc/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/src/__support/FPUtil/CMakeLists.txt
@@ -28,6 +28,7 @@ add_header_library(
   HDRS
     FloatProperties.h
   DEPENDS
+    libc.src.__support.macros.properties.float
     libc.src.__support.uint128
 )
 

--- a/libc/src/__support/FPUtil/FloatProperties.h
+++ b/libc/src/__support/FPUtil/FloatProperties.h
@@ -10,21 +10,9 @@
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOATPROPERTIES_H
 
 #include "src/__support/UInt128.h"
-#include "src/__support/macros/properties/architectures.h" // LIBC_TARGET_ARCH_XXX
+#include "src/__support/macros/properties/float.h" // LIBC_COMPILER_HAS_FLOAT128
 
 #include <stdint.h>
-
-// https://developer.arm.com/documentation/dui0491/i/C-and-C---Implementation-Details/Basic-data-types
-// https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
-// https://docs.amd.com/bundle/HIP-Programming-Guide-v5.1/page/Programming_with_HIP.html
-#if defined(_WIN32) || defined(__arm__) || defined(__NVPTX__) ||               \
-    defined(__AMDGPU__) || (defined(__APPLE__) && defined(__aarch64__))
-#define LONG_DOUBLE_IS_DOUBLE
-#endif
-
-#if !defined(LONG_DOUBLE_IS_DOUBLE) && defined(LIBC_TARGET_ARCH_IS_X86)
-#define SPECIAL_X86_LONG_DOUBLE
-#endif
 
 namespace LIBC_NAMESPACE {
 namespace fputil {

--- a/libc/src/__support/macros/properties/CMakeLists.txt
+++ b/libc/src/__support/macros/properties/CMakeLists.txt
@@ -11,9 +11,25 @@ add_header_library(
 )
 
 add_header_library(
+  os
+  HDRS
+    os.h
+)
+
+add_header_library(
   cpu_features
   HDRS
     cpu_features.h
   DEPENDS
     .architectures
+)
+
+add_header_library(
+  float
+  HDRS
+    float.h
+  DEPENDS
+    .architectures
+    .compiler
+    .os
 )

--- a/libc/src/__support/macros/properties/compiler.h
+++ b/libc/src/__support/macros/properties/compiler.h
@@ -21,25 +21,4 @@
 #define LIBC_COMPILER_IS_MSC
 #endif
 
-// Check compiler features
-#if defined(FLT128_MANT_DIG)
-// C23 _Float128 type is available.
-#define LIBC_COMPILER_HAS_FLOAT128
-#define LIBC_FLOAT128_IS_C23
-using float128 = _Float128;
-
-#elif defined(__SIZEOF_FLOAT128__)
-// Builtin __float128 is available.
-#define LIBC_COMPILER_HAS_FLOAT128
-#define LIBC_FLOAT128_IS_BUILTIN
-using float128 = __float128;
-
-#elif (defined(__linux__) && defined(__aarch64__))
-// long double on Linux aarch64 is 128-bit floating point.
-#define LIBC_COMPILER_HAS_FLOAT128
-#define LIBC_FLOAT128_IS_LONG_DOUBLE
-using float128 = long double;
-
-#endif
-
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_COMPILER_H

--- a/libc/src/__support/macros/properties/float.h
+++ b/libc/src/__support/macros/properties/float.h
@@ -1,0 +1,46 @@
+//===-- Float type support --------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Floating point properties are a combination of compiler support, target OS
+// and target architecture.
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_FLOAT_H
+#define LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_FLOAT_H
+
+#include "src/__support/macros/properties/architectures.h"
+#include "src/__support/macros/properties/compiler.h"
+#include "src/__support/macros/properties/os.h"
+
+// https://developer.arm.com/documentation/dui0491/i/C-and-C---Implementation-Details/Basic-data-types
+// https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+// https://docs.amd.com/bundle/HIP-Programming-Guide-v5.1/page/Programming_with_HIP.html
+#if defined(LIBC_TARGET_OS_IS_WINDOWS) ||                                      \
+    (defined(LIBC_TARGET_OS_IS_MACOS) &&                                       \
+     defined(LIBC_TARGET_ARCH_IS_AARCH64)) ||                                  \
+    defined(LIBC_TARGET_ARCH_IS_ARM) || defined(LIBC_TARGET_ARCH_IS_NVPTX) ||  \
+    defined(LIBC_TARGET_ARCH_IS_AMDGPU)
+#define LONG_DOUBLE_IS_DOUBLE
+#endif
+
+#if !defined(LONG_DOUBLE_IS_DOUBLE) && defined(LIBC_TARGET_ARCH_IS_X86)
+#define SPECIAL_X86_LONG_DOUBLE
+#endif
+
+// Check compiler features
+#if defined(FLT128_MANT_DIG)
+#define LIBC_COMPILER_HAS_FLOAT128
+using float128 = _Float128;
+#elif defined(__SIZEOF_FLOAT128__)
+#define LIBC_COMPILER_HAS_FLOAT128
+using float128 = __float128;
+#elif (defined(__linux__) && defined(__aarch64__))
+#define LIBC_COMPILER_HAS_FLOAT128
+#define LIBC_FLOAT128_IS_LONG_DOUBLE
+using float128 = long double;
+#endif
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_FLOAT_H

--- a/libc/src/__support/macros/properties/os.h
+++ b/libc/src/__support/macros/properties/os.h
@@ -1,0 +1,40 @@
+//===-- Target OS detection -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_OS_H
+#define LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_OS_H
+
+#if (defined(__freebsd__) || defined(__FreeBSD__))
+#define LIBC_TARGET_OS_IS_FREEBSD
+#endif
+
+#if defined(__ANDROID__)
+#define LIBC_TARGET_OS_IS_ANDROID
+#endif
+
+#if defined(__linux__) && !defined(LIBC_TARGET_OS_IS_FREEBSD) &&               \
+    !defined(LIBC_TARGET_OS_IS_ANDROID)
+#define LIBC_TARGET_OS_IS_LINUX
+#endif
+
+#if (defined(_WIN64) || defined(_WIN32))
+#define LIBC_TARGET_OS_IS_WINDOWS
+#endif
+
+#if (defined(__apple__) || defined(__APPLE__) || defined(__MACH__))
+// From https://stackoverflow.com/a/49560690
+#include "TargetConditionals.h"
+#if defined(TARGET_OS_OSX)
+#define LIBC_TARGET_OS_IS_MACOS
+#endif
+#if defined(TARGET_OS_IPHONE)
+// This is set for any non-Mac Apple products (IOS, TV, WATCH)
+#define LIBC_TARGET_OS_IS_IPHONE
+#endif
+#endif
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_OS_H

--- a/libc/src/math/copysignf128.h
+++ b/libc/src/math/copysignf128.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_MATH_COPYSIGNF128_H
 #define LLVM_LIBC_SRC_MATH_COPYSIGNF128_H
 
-#include "src/__support/macros/properties/compiler.h"
+#include "src/__support/macros/properties/float.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/math/generic/copysignf128.cpp
+++ b/libc/src/math/generic/copysignf128.cpp
@@ -9,7 +9,6 @@
 #include "src/math/copysignf128.h"
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "src/__support/common.h"
-#include "src/__support/macros/properties/compiler.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -76,6 +76,21 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_macros_properties_os",
+    hdrs = ["src/__support/macros/properties/os.h"],
+)
+
+libc_support_library(
+    name = "__support_macros_properties_float",
+    hdrs = ["src/__support/macros/properties/float.h"],
+    deps = [
+        ":__support_macros_properties_architectures",
+        ":__support_macros_properties_compiler",
+        ":__support_macros_properties_os",
+    ],
+)
+
+libc_support_library(
     name = "__support_macros_properties_cpu_features",
     hdrs = ["src/__support/macros/properties/cpu_features.h"],
     deps = [
@@ -308,7 +323,7 @@ libc_support_library(
     deps = [
         ":__support_macros_attributes",
         ":__support_macros_config",
-        ":__support_macros_properties_compiler",
+        ":__support_macros_properties_float",
     ],
 )
 
@@ -657,6 +672,7 @@ libc_support_library(
     name = "__support_fputil_float_properties",
     hdrs = ["src/__support/FPUtil/FloatProperties.h"],
     deps = [
+        ":__support_macros_properties_float",
         ":__support_uint128",
     ],
 )


### PR DESCRIPTION
Floating point properties are a combination of target OS, target architecture and compiler support.
 - Adding target OS detection,
 - Moving floating point type detection to its own file.

This is in preparation of adding support for `_Float16` which requires testing compiler **version** and target architecture.