### PR TITLE
[lldb] Improve error message for script commands when there's no interpreter

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
@@ -26,17 +26,19 @@ ScriptInterpreterNone::ScriptInterpreterNone(Debugger &debugger)
 
 ScriptInterpreterNone::~ScriptInterpreterNone() = default;
 
+static const char *no_interpreter_err_msg =
+    "error: Embedded script interpreter unavailable. LLDB was built without "
+    "scripting language support.\n";
+
 bool ScriptInterpreterNone::ExecuteOneLine(llvm::StringRef command,
                                            CommandReturnObject *,
                                            const ExecuteScriptOptions &) {
-  m_debugger.GetErrorStream().PutCString(
-      "error: there is no embedded script interpreter in this mode.\n");
+  m_debugger.GetErrorStream().PutCString(no_interpreter_err_msg);
   return false;
 }
 
 void ScriptInterpreterNone::ExecuteInterpreterLoop() {
-  m_debugger.GetErrorStream().PutCString(
-      "error: there is no embedded script interpreter in this mode.\n");
+  m_debugger.GetErrorStream().PutCString(no_interpreter_err_msg);
 }
 
 void ScriptInterpreterNone::Initialize() {


### PR DESCRIPTION
It was:
```
error: there is no embedded script interpreter in this mode.
```

1. What does "mode" mean?
2. It implies there might be an embedded script interpreter for some other "mode", whatever that would be.

So I'm simplifying it and noting the most common reason for this which is that lldb wasn't built with a scripting language enabled in the first place.

There are other tips for dealing with this, but I'm not sure this message is the best place for them.