### PR TITLE
[clang] Fix sorting header paths

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -49,6 +49,7 @@
 #include <optional>
 #include <string>
 #include <system_error>
+#include <tuple>
 #include <utility>
 
 using namespace clang;
@@ -2511,7 +2512,8 @@ void ModuleMapParser::parseHeaderDecl(MMToken::TokenKind LeadingToken,
 
 static bool compareModuleHeaders(const Module::Header &A,
                                  const Module::Header &B) {
-  return A.NameAsWritten < B.NameAsWritten;
+  return std::tie(A.NameAsWritten, A.PathRelativeToRootModuleDirectory) <
+         std::tie(B.NameAsWritten, B.PathRelativeToRootModuleDirectory);
 }
 
 /// Parse an umbrella directory declaration.


### PR DESCRIPTION
This code was initially written in commit
7ff29148ac7883881e62dc9e1714057c68ad4436 with the intention of sorting headers according to their path. At the time, the path was saved in field NameAsWritten of Module::Header.

Later, commit e6830b6028ec5434ccf8dbebdd992918f67b1751 added field PathRelativeToRootModuleDirectory to Module::Header and modified ModuleMapParser::parseUmbrellaDirDecl() so that it started to save the header path in the new field and started setting NameAsWritten = "". It didn't modify compareModuleHeaders() in order to adapt it to the new field.

After this commit, the sorting stopped working because it continued comparing only NameAsWritten.

This commit fixes it by treating NameAsWritten and PathRelativeToRootModuleDirectory as a tuple when comparing Module::Header.