### PR TITLE
[CVP] Don't try to fold load/store operands to constant

### DIFF
--- a/llvm/test/Transforms/CorrelatedValuePropagation/basic.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/basic.ll
@@ -63,7 +63,7 @@ define i8 @test3(ptr %a) nounwind {
 ; CHECK:       bb:
 ; CHECK-NEXT:    ret i8 0
 ; CHECK:       bb2:
-; CHECK-NEXT:    [[SHOULD_BE_CONST:%.*]] = load i8, ptr @gv, align 1
+; CHECK-NEXT:    [[SHOULD_BE_CONST:%.*]] = load i8, ptr [[A]], align 1
 ; CHECK-NEXT:    ret i8 [[SHOULD_BE_CONST]]
 ;
 entry:


### PR DESCRIPTION
CVP currently tries to fold load/store pointer operands to constants using LVI. If there is a dominating condition of the form `icmp eq ptr %p, @g`, then `%p` will be replaced with `@g`.

LVI is geared towards range-based optimizations, and is *very* inefficient at handling simple pointer equality conditions. We have other passes that can handle this optimization in a more efficient way, such as IPSCCP and GVN.

Removing this optimization gives a geomean 0.4-1.2% compile-time improvement depending on configuration: http://llvm-compile-time-tracker.com/compare.php?from=7eeedc124f9901a65573668bc504a45111a3f837&to=4769e20ad4d5f35db561bf14b00e91cec325039a&stat=instructions:u Especially notable is a 4% improvement on tramp3d-v4 with ThinLTO. At the same time, there is no impact on codegen.