### PR TITLE
[mlir][doc] Remove duplicate syntax formats

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -838,12 +838,6 @@ def Arith_SubFOp : Arith_FloatBinaryOp<"subf"> {
 def Arith_MaximumFOp : Arith_FloatBinaryOp<"maximumf", [Commutative]> {
   let summary = "floating-point maximum operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `arith.maximumf` ssa-use `,` ssa-use `:` type
-    ```
-
     Returns the maximum of the two arguments, treating -0.0 as less than +0.0.
     If one of the arguments is NaN, then the result is also NaN.
 
@@ -864,12 +858,6 @@ def Arith_MaximumFOp : Arith_FloatBinaryOp<"maximumf", [Commutative]> {
 def Arith_MaxNumFOp : Arith_FloatBinaryOp<"maxnumf", [Commutative]> {
   let summary = "floating-point maximum operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `arith.maxnumf` ssa-use `,` ssa-use `:` type
-    ```
-
     Returns the maximum of the two arguments.
     If the arguments are -0.0 and +0.0, then the result is either of them.
     If one of the arguments is NaN, then the result is the other argument.
@@ -910,12 +898,6 @@ def Arith_MaxUIOp : Arith_TotalIntBinaryOp<"maxui", [Commutative]> {
 def Arith_MinimumFOp : Arith_FloatBinaryOp<"minimumf", [Commutative]> {
   let summary = "floating-point minimum operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `arith.minimumf` ssa-use `,` ssa-use `:` type
-    ```
-
     Returns the minimum of the two arguments, treating -0.0 as less than +0.0.
     If one of the arguments is NaN, then the result is also NaN.
 
@@ -936,12 +918,6 @@ def Arith_MinimumFOp : Arith_FloatBinaryOp<"minimumf", [Commutative]> {
 def Arith_MinNumFOp : Arith_FloatBinaryOp<"minnumf", [Commutative]> {
   let summary = "floating-point minimum operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `arith.minnumf` ssa-use `,` ssa-use `:` type
-    ```
-
     Returns the minimum of the two arguments.
     If the arguments are -0.0 and +0.0, then the result is either of them.
     If one of the arguments is NaN, then the result is the other argument.

--- a/mlir/include/mlir/Dialect/Complex/IR/ComplexOps.td
+++ b/mlir/include/mlir/Dialect/Complex/IR/ComplexOps.td
@@ -280,12 +280,6 @@ def ExpOp : ComplexUnaryOp<"exp", [SameOperandsAndResultType]> {
 def Expm1Op : ComplexUnaryOp<"expm1", [SameOperandsAndResultType]> {
   let summary = "computes exponential of a complex number minus 1";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `complex.expm1` ssa-use `:` type
-    ```
-
     complex.expm1(x) := complex.exp(x) - 1
 
     Example:

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -447,12 +447,6 @@ def MemRef_CastOp : MemRef_Op<"cast", [
     ]> {
   let summary = "memref cast operation";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `memref.cast` ssa-use `:` type `to` type
-    ```
-
     The `memref.cast` operation converts a memref from one type to an equivalent
     type with a compatible shape. The source and destination types are
     compatible if:

--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2203,12 +2203,6 @@ def Vector_TypeCastOp :
     super-vectorization operational. It can be seen as a special case of the
     `view` operation but scoped in the super-vectorization context.
 
-    Syntax:
-
-    ```
-    operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
-    ```
-
     Example:
 
     ```mlir


### PR DESCRIPTION
Some operations defined their syntax both in the documentation and via `assemblyFormat`. This leads to two `Syntax:` subheadings in the documentation, see for example the documentation for [`arith.maximumf`](https://mlir.llvm.org/docs/Dialects/ArithOps/#arithmaximumf-arithmaximumfop). Since the `assemblyFormat` is used to generate the actual parsers and printer implementations, this PR suggest to remove the manual syntax descriptions.