### PR TITLE
[libc] Provide compiler version properties

### DIFF
--- a/libc/src/__support/macros/properties/compiler.h
+++ b/libc/src/__support/macros/properties/compiler.h
@@ -9,16 +9,35 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_COMPILER_H
 #define LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_COMPILER_H
 
+// Example usage of compiler version checks
+// #if defined(LIBC_COMPILER_CLANG_VER)
+// #  if LIBC_COMPILER_CLANG_VER < 1500
+// #    warning "Libc only supports Clang 15 and later"
+// #  endif
+// #elif defined(LIBC_COMPILER_GCC_VER)
+// #  if LIBC_COMPILER_GCC_VER < 1500
+// #    warning "Libc only supports GCC 15 and later"
+// #  endif
+// #elif defined(LIBC_COMPILER_MSC_VER)
+// #  if LIBC_COMPILER_MSC_VER < 1930
+// #    warning "Libc only supports Visual Studio 2022 RTW (17.0) and later"
+// #  endif
+// #endif
+
 #if defined(__clang__)
 #define LIBC_COMPILER_IS_CLANG
+#define LIBC_COMPILER_CLANG_VER (__clang_major__ * 100 + __clang_minor__)
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)
 #define LIBC_COMPILER_IS_GCC
+#define LIBC_COMPILER_GCC_VER (__GNUC__ * 100 + __GNUC_MINOR__)
 #endif
 
 #if defined(_MSC_VER)
 #define LIBC_COMPILER_IS_MSC
+// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+#define LIBC_COMPILER_MSC_VER (_MSC_VER)
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_COMPILER_H


### PR DESCRIPTION
This will be used to support conditional compilation based on compiler version.
We adopt the same convention as [libc++](https://github.com/llvm/llvm-project/blob/main/libcxx/include/__config) - thx @legrosbuffle for the suggestion!
Usage:
```
#if defined(LIBC_COMPILER_CLANG_VER)
#  if LIBC_COMPILER_CLANG_VER < 1500
#    warning "Libc only supports Clang 15 and later"
#  endif
#elif defined(LIBC_COMPILER_GCC_VER)
#  if LIBC_COMPILER_GCC_VER < 1500
#    warning "Libc only supports GCC 15 and later"
#  endif
#elif defined(LIBC_COMPILER_MSC_VER)
#  if LIBC_COMPILER_MSC_VER < 1930
#    warning "Libc only supports Visual Studio 2022 RTW (17.0) and later"
#  endif
#endif
```