### PR TITLE
[BinaryFormat][LoongArch] Define psABI v2.20 relocs

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELFRelocs/LoongArch.def
+++ b/llvm/include/llvm/BinaryFormat/ELFRelocs/LoongArch.def
@@ -109,12 +109,20 @@ ELF_RELOC(R_LARCH_RELAX,            100)
 //
 // Spec addition: https://github.com/loongson/la-abi-specs/pull/1
 // Binutils commit 57a930e3bfe4b2c7fd6463ed39311e1938513138
-ELF_RELOC(R_LARCH_DELETE,      101)
+// Note that the 101 and 104 relocation numbers are defined as R_LARCH_DELETE
+// and R_LARCH_CFA respectively in psABI 2.10. But they are marked as reserved
+// in psABI v2.20 because they were proved not necessary to be exposed outside
+// of the linker.
 ELF_RELOC(R_LARCH_ALIGN,       102)
 ELF_RELOC(R_LARCH_PCREL20_S2,  103)
-ELF_RELOC(R_LARCH_CFA,         104)
 ELF_RELOC(R_LARCH_ADD6,        105)
 ELF_RELOC(R_LARCH_SUB6,        106)
 ELF_RELOC(R_LARCH_ADD_ULEB128, 107)
 ELF_RELOC(R_LARCH_SUB_ULEB128, 108)
 ELF_RELOC(R_LARCH_64_PCREL,    109)
+
+// Relocs added in ELF for the LoongArch™ Architecture v20231102, part of the
+// v2.20 LoongArch ABI specs.
+//
+// Spec addition: https://github.com/loongson/la-abi-specs/pull/4
+ELF_RELOC(R_LARCH_CALL36, 110)

--- a/llvm/test/tools/llvm-readobj/ELF/reloc-types-loongarch64.test
+++ b/llvm/test/tools/llvm-readobj/ELF/reloc-types-loongarch64.test
@@ -93,15 +93,14 @@
 # CHECK: Type: R_LARCH_TLS_GD_HI20 (98)
 # CHECK: Type: R_LARCH_32_PCREL (99)
 # CHECK: Type: R_LARCH_RELAX (100)
-# CHECK: Type: R_LARCH_DELETE (101)
 # CHECK: Type: R_LARCH_ALIGN (102)
 # CHECK: Type: R_LARCH_PCREL20_S2 (103)
-# CHECK: Type: R_LARCH_CFA (104)
 # CHECK: Type: R_LARCH_ADD6 (105)
 # CHECK: Type: R_LARCH_SUB6 (106)
 # CHECK: Type: R_LARCH_ADD_ULEB128 (107)
 # CHECK: Type: R_LARCH_SUB_ULEB128 (108)
 # CHECK: Type: R_LARCH_64_PCREL (109)
+# CHECK: Type: R_LARCH_CALL36 (110)
 
 --- !ELF
 FileHeader:
@@ -202,12 +201,11 @@ Sections:
       - Type: R_LARCH_TLS_GD_HI20
       - Type: R_LARCH_32_PCREL
       - Type: R_LARCH_RELAX
-      - Type: R_LARCH_DELETE
       - Type: R_LARCH_ALIGN
       - Type: R_LARCH_PCREL20_S2
-      - Type: R_LARCH_CFA
       - Type: R_LARCH_ADD6
       - Type: R_LARCH_SUB6
       - Type: R_LARCH_ADD_ULEB128
       - Type: R_LARCH_SUB_ULEB128
       - Type: R_LARCH_64_PCREL
+      - Type: R_LARCH_CALL36

--- a/llvm/unittests/Object/ELFTest.cpp
+++ b/llvm/unittests/Object/ELFTest.cpp
@@ -233,14 +233,10 @@ TEST(ELFTest, getELFRelocationTypeNameForLoongArch) {
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_32_PCREL));
   EXPECT_EQ("R_LARCH_RELAX",
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_RELAX));
-  EXPECT_EQ("R_LARCH_DELETE",
-            getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_DELETE));
   EXPECT_EQ("R_LARCH_ALIGN",
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_ALIGN));
   EXPECT_EQ("R_LARCH_PCREL20_S2",
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_PCREL20_S2));
-  EXPECT_EQ("R_LARCH_CFA",
-            getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_CFA));
   EXPECT_EQ("R_LARCH_ADD6",
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_ADD6));
   EXPECT_EQ("R_LARCH_SUB6",
@@ -251,6 +247,8 @@ TEST(ELFTest, getELFRelocationTypeNameForLoongArch) {
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_SUB_ULEB128));
   EXPECT_EQ("R_LARCH_64_PCREL",
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_64_PCREL));
+  EXPECT_EQ("R_LARCH_CALL36",
+            getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_CALL36));
 }
 
 TEST(ELFTest, getELFRelativeRelocationType) {


### PR DESCRIPTION
psABI v2.20 added R_LARCH_CALL36 and removed R_LARCH_DELETE / R_LARCH_CFA.

R_LARCH_CALL36 was designed for function call on medium code model where the 2 instructions (pcaddu18i + jirl) must be adjacent.