### PR TITLE
[Flang] Fix a test case that depends on stderr output of nullptr.

### DIFF
--- a/flang/unittests/Runtime/RuntimeCrashTest.cpp
+++ b/flang/unittests/Runtime/RuntimeCrashTest.cpp
@@ -43,9 +43,9 @@ TEST(TestTerminator, CheckFailedLocationTest) {
 }
 
 TEST(TestTerminator, CheckFailedTest) {
-  static Fortran::runtime::Terminator t;
+  static Fortran::runtime::Terminator t("someFileName");
   ASSERT_DEATH(t.CheckFailed("predicate"),
-      "RUNTIME_CHECK\\(predicate\\) failed at \\(null\\)\\(0\\)");
+      "RUNTIME_CHECK\\(predicate\\) failed at someFileName\\(0\\)");
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This test case depends on the stderr output of a `nullptr` being "(null)". However, it is empty string on AIX.
This PR is to initialize the `sourceFileName_` to be a specific string to avoid that.

