### PR TITLE
[DebugInfo][RemoveDIs] Emulate inserting insts in dbg.value sequences

### DIFF
--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -141,6 +141,14 @@ public:
   /// move such DPValues back to the right place (ahead of the terminator).
   void flushTerminatorDbgValues();
 
+  /// In rare circumstances instructions can be speculatively removed from
+  /// blocks, and then be re-inserted back into that position later. When this
+  /// happens in RemoveDIs debug-info mode, some special patching-up needs to
+  /// occur: inserting into the middle of a sequence of dbg.value intrinsics
+  /// does not have an equivalent with DPValues.
+  void reinsertInstInDPValues(Instruction *I,
+                              std::optional<DPValue::self_iterator> Pos);
+
 private:
   void setParent(Function *parent);
 

--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -308,6 +308,11 @@ public:
   /// Transfer any DPValues from \p Src into this DPMarker. If \p InsertAtHead
   /// is true, place them before existing DPValues, otherwise afterwards.
   void absorbDebugValues(DPMarker &Src, bool InsertAtHead);
+  /// Transfer the DPValues in \p Range from \p Src into this DPMarker. If
+  /// \p InsertAtHead is true, place them before existing DPValues, otherwise
+  // afterwards.
+  void absorbDebugValues(iterator_range<DPValue::self_iterator> Range,
+                         DPMarker &Src, bool InsertAtHead);
   /// Insert a DPValue into this DPMarker, at the end of the list. If
   /// \p InsertAtHead is true, at the start.
   void insertDPValue(DPValue *New, bool InsertAtHead);
@@ -327,6 +332,11 @@ public:
   /// never erase an assignment in this way, but it's the equivalent to
   /// erasing a dbg.value from a block.
   void dropOneDPValue(DPValue *DPV);
+
+  /// Return an iterator to the position of the "Next" DPValue after this
+  /// marker, or std::nullopt. This is the position to pass to
+  /// BasicBlock::reinsertInstInDPValues when re-inserting an instruction.
+  std::optional<DPValue::self_iterator> getReinsertionPosition();
 
   /// We generally act like all llvm Instructions have a range of DPValues
   /// attached to them, but in reality sometimes we don't allocate the DPMarker

--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -333,11 +333,6 @@ public:
   /// erasing a dbg.value from a block.
   void dropOneDPValue(DPValue *DPV);
 
-  /// Return an iterator to the position of the "Next" DPValue after this
-  /// marker, or std::nullopt. This is the position to pass to
-  /// BasicBlock::reinsertInstInDPValues when re-inserting an instruction.
-  std::optional<DPValue::self_iterator> getReinsertionPosition();
-
   /// We generally act like all llvm Instructions have a range of DPValues
   /// attached to them, but in reality sometimes we don't allocate the DPMarker
   /// to save time and memory, but still have to return ranges of DPValues. When

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -78,6 +78,11 @@ public:
   /// Return a range over the DPValues attached to this instruction.
   iterator_range<simple_ilist<DPValue>::iterator> getDbgValueRange() const;
 
+  /// Return an iterator to the position of the "Next" DPValue after this
+  /// instruction, or std::nullopt. This is the position to pass to
+  /// BasicBlock::reinsertInstInDPValues when re-inserting an instruction.
+  std::optional<simple_ilist<DPValue>::iterator> getDbgReinsertionPosition();
+
   /// Returns true if any DPValues are attached to this instruction.
   bool hasDbgValues() const;
 

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -1013,6 +1013,55 @@ DPMarker *BasicBlock::getMarker(InstListType::iterator It) {
   return It->DbgMarker;
 }
 
+void BasicBlock::reinsertInstInDPValues(
+    Instruction *I, std::optional<DPValue::self_iterator> Pos) {
+  // "I" was originally removed from a position where it was immediately in
+  // front of Pos. Any DPValues on that position then "fell down" onto Pos.
+  // "I" has been re-inserted after that wedge of DPValues, shuffle them around
+  // to represent the original positioning. To illustrate:
+  //
+  //   Instructions:  I1---I---I0
+  //       DPValues:    DDD DDD
+  //
+  // Instruction "I" removed,
+  //
+  //   Instructions:  I1------I0
+  //       DPValues:    DDDDDD
+  //                       ^Pos
+  //
+  // Instruction "I" re-inserted (now):
+  //
+  //   Instructions:  I1------I-I0
+  //       DPValues:    DDDDDD
+  //                       ^Pos
+  //
+  // After this method completes:
+  //
+  //   Instructions:  I1---I---I0
+  //       DPValues:    DDD DDD
+  //
+  // In a fantastic future we would a) ban passes from doing this at all, but
+  // in lieu of that b) we could have more fine grained control over how
+  // debug-info records coalesce together. This will probably happen if/when we
+  // address the matter of all debug-info records having to have a total order.
+
+  // If there were no DPValues on I0, Pos will be empty. We also don't need to
+  // do any further maintanence.
+  if (!Pos)
+    return;
+
+  // Construct the range of DPMarkers to move.
+  DPMarker *DPM = (*Pos)->getMarker();
+  auto Range = make_range(*Pos, DPM->StoredDPValues.end());
+  assert(Range.begin() != Range.end());
+
+  // These are DPValues that used to be attached to I0 but are now attached to I
+  // after the re-insertion. Move them back onto I0.
+  DPMarker *NextMarker = createMarker(std::next(I->getIterator()));
+  assert(NextMarker->StoredDPValues.empty());
+  NextMarker->absorbDebugValues(Range, *DPM, true);
+}
+
 #ifndef NDEBUG
 /// In asserts builds, this checks the numbering. In non-asserts builds, it
 /// is defined as a no-op inline function in BasicBlock.h.

--- a/llvm/lib/IR/DebugProgramInstruction.cpp
+++ b/llvm/lib/IR/DebugProgramInstruction.cpp
@@ -267,19 +267,6 @@ void DPMarker::dropOneDPValue(DPValue *DPV) {
   DPV->deleteInstr();
 }
 
-std::optional<DPValue::self_iterator> DPMarker::getReinsertionPosition() {
-  // Is there a marker on the next instruction?
-  DPMarker *NextMarker = getParent()->getNextMarker(MarkedInstr);
-  if (!NextMarker)
-    return std::nullopt;
-
-  // Are there any DPValues in the next marker?
-  if (NextMarker->StoredDPValues.empty())
-    return std::nullopt;
-
-  return NextMarker->StoredDPValues.begin();
-}
-
 const BasicBlock *DPMarker::getParent() const {
   return MarkedInstr->getParent();
 }

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -254,6 +254,19 @@ Instruction::getDbgValueRange() const {
   return DbgMarker->getDbgValueRange();
 }
 
+std::optional<DPValue::self_iterator> Instruction::getDbgReinsertionPosition() {
+  // Is there a marker on the next instruction?
+  DPMarker *NextMarker = getParent()->getNextMarker(this);
+  if (!NextMarker)
+    return std::nullopt;
+
+  // Are there any DPValues in the next marker?
+  if (NextMarker->StoredDPValues.empty())
+    return std::nullopt;
+
+  return NextMarker->StoredDPValues.begin();
+}
+
 bool Instruction::hasDbgValues() const { return !getDbgValueRange().empty(); }
 
 void Instruction::dropDbgValues() {

--- a/llvm/unittests/IR/BasicBlockDbgInfoTest.cpp
+++ b/llvm/unittests/IR/BasicBlockDbgInfoTest.cpp
@@ -1167,7 +1167,7 @@ TEST(BasicBlockDbgInfoTest, RemoveInstAndReinsert) {
   // The Supported (TM) code sequence for removing then reinserting insts
   // after another instruction:
   std::optional<DPValue::self_iterator> Pos =
-      AddInst->DbgMarker->getReinsertionPosition();
+      AddInst->getDbgReinsertionPosition();
   AddInst->removeFromParent();
 
   // We should have a re-insertion position.
@@ -1242,7 +1242,7 @@ TEST(BasicBlockDbgInfoTest, RemoveInstAndReinsertForOneDPValue) {
 
   // The Supported (TM) code sequence for removing then reinserting insts:
   std::optional<DPValue::self_iterator> Pos =
-      AddInst->DbgMarker->getReinsertionPosition();
+      AddInst->getDbgReinsertionPosition();
   AddInst->removeFromParent();
 
   // No re-insertion position as there were no DPValues on the ret.


### PR DESCRIPTION
Here's a problem for the RemoveDIs project to make debug-info not be stored in instructions -- in the following sequence:
    dbg.value(foo
    %bar = add i32 ...
    dbg.value(baz
It's possible for rare passes (only CodeGenPrepare) to remove the add instruction, and then re-insert it back in the same place. When debug-info is stored in instructions and there's a total order on "when" things happen this is easy, but by moving that information out of the instruction stream we start having to do manual maintenance.

This patch adds some utilities for re-inserting an instruction into a sequence of DPValue objects. Someday we hope to design this away, but for now it's necessary to support all the things you can do with dbg.values. The two unit tests show how DPValues get shuffled around using the relevant function calls. A follow-up patch adds instrumentation to CodeGenPrepare.