### PR TITLE
[libc++] Removes basic_string::reserve().

### DIFF
--- a/libcxx/docs/ReleaseNotes/18.rst
+++ b/libcxx/docs/ReleaseNotes/18.rst
@@ -52,6 +52,7 @@ Implemented Papers
 - P0020R6 - Floating Point Atomic
 - P2918R2 - Runtime format strings II
 - P2871R3 - Remove Deprecated Unicode Conversion Facets from C++26
+- P2870R3 - Remove basic_string::reserve()
 
 
 Improvements and New Features
@@ -74,6 +75,9 @@ Improvements and New Features
 
 - The ``_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT`` macro has been added to make
   the declarations in ``<codecvt>`` available.
+
+- The ``_LIBCPP_ENABLE_CXX26_REMOVED_STRING_RESERVE`` macro has been added to make
+  the function ``std::basic_string<...>::reserve()`` available.
 
 
 Deprecations and Removals

--- a/libcxx/docs/Status/Cxx2cPapers.csv
+++ b/libcxx/docs/Status/Cxx2cPapers.csv
@@ -37,7 +37,7 @@
 "`P2447R6 <https://wg21.link/P2447R6>`__","LWG","``std::span`` over an initializer list","Kona November 2023","","",""
 "`P2821R5 <https://wg21.link/P2821R5>`__","LWG","``span.at()``","Kona November 2023","","",""
 "`P2868R3 <https://wg21.link/P2868R3>`__","LWG","Remove Deprecated ``std::allocator`` Typedef From C++26","Kona November 2023","","",""
-"`P2870R3 <https://wg21.link/P2870R3>`__","LWG","Remove ``basic_string::reserve()`` From C++26","Kona November 2023","","",""
+"`P2870R3 <https://wg21.link/P2870R3>`__","LWG","Remove ``basic_string::reserve()`` From C++26","Kona November 2023","|Complete|","18.0",""
 "`P2871R3 <https://wg21.link/P2871R3>`__","LWG","Remove Deprecated Unicode Conversion Facets from C++26","Kona November 2023","|Complete|","18.0",""
 "`P2819R2 <https://wg21.link/P2819R2>`__","LWG","Add tuple protocol to complex","Kona November 2023","","",""
 "`P2937R0 <https://wg21.link/P2937R0>`__","LWG","Freestanding: Remove ``strtok``","Kona November 2023","","",""

--- a/libcxx/docs/UsingLibcxx.rst
+++ b/libcxx/docs/UsingLibcxx.rst
@@ -335,6 +335,9 @@ C++26 Specific Configuration Macros
 **_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT**:
   This macro is used to re-enable all named declarations in ``<codecvt>``.
 
+**_LIBCPP_ENABLE_CXX26_REMOVED_STRING_RESERVE**
+  This macro is used to re-enable the function
+  ``std::basic_string<...>::reserve()``.
 
 Libc++ Extensions
 =================

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -173,7 +173,7 @@ public:
     constexpr void resize_and_overwrite(size_type n, Operation op); // since C++23
 
     void reserve(size_type res_arg);                                                            // constexpr since C++20
-    void reserve(); // deprecated in C++20
+    void reserve();                                                                             // deprecated in C++20, removed in C++26
     void shrink_to_fit();                                                                       // constexpr since C++20
     void clear() noexcept;                                                                      // constexpr since C++20
     bool empty() const noexcept;                                                                // constexpr since C++20
@@ -1187,7 +1187,9 @@ public:
 
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __resize_default_init(size_type __n);
 
+#if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRING_RESERVE)
     _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI void reserve() _NOEXCEPT { shrink_to_fit(); }
+#endif
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void shrink_to_fit() _NOEXCEPT;
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void clear() _NOEXCEPT;
 

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/PR53170.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/PR53170.pass.cpp
@@ -11,7 +11,7 @@
 // void reserve(); // Deprecated in C++20.
 // void reserve(size_type);
 
-// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS -D_LIBCPP_ENABLE_CXX26_REMOVED_STRING_RESERVE
 
 // This test ensures that libc++ implements https://wg21.link/P0966R1 (reserve never shrinks)
 // even before C++20. This is required in order to avoid ODR violations because basic_string::reserve(size)

--- a/libcxx/test/std/strings/basic.string/string.capacity/reserve.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/reserve.pass.cpp
@@ -8,9 +8,9 @@
 
 // <string>
 
-// void reserve(); // Deprecated in C++20.
+// void reserve(); // Deprecated in C++20, removed in C++26.
 
-// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS -D_LIBCPP_ENABLE_CXX26_REMOVED_STRING_RESERVE
 
 #include <string>
 #include <stdexcept>

--- a/libcxx/test/std/strings/basic.string/string.capacity/reserve.removed_in_cxx26.verify.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/reserve.removed_in_cxx26.verify.cpp
@@ -8,13 +8,13 @@
 
 // <string>
 
-// void reserve(); // Deprecated in C++20
+// void reserve(); // Removed in C++26
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17, c++26
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
 
 #include <string>
 
 void f() {
   std::string s;
-  s.reserve(); // expected-warning {{'reserve' is deprecated}}
+  s.reserve(); // expected-error {{too few arguments to function call, single argument '__requested_capacity' was not specified}}
 }

--- a/libcxx/test/std/strings/basic.string/string.capacity/reserve.removed_in_cxx26.verify.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/reserve.removed_in_cxx26.verify.cpp
@@ -16,5 +16,5 @@
 
 void f() {
   std::string s;
-  s.reserve(); // expected-error {{too few arguments to function call, single argument '__requested_capacity' was not specified}}
+  s.reserve(); // expected-error {{too few arguments to function call}}
 }


### PR DESCRIPTION
Implements:
- P2870R3 Remove basic_string::reserve()