### PR TITLE
[clang] Use the materialized temporary's type while creating the APValue

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -691,6 +691,9 @@ Bug Fixes to C++ Support
   Fixes:
   (`#68769 <https://github.com/llvm/llvm-project/issues/68769>`_)
 
+- Fixed a crash for C++98/03 while checking an ill-formed ``_Static_assert`` expression.
+  Fixes: (`#72025 <https://github.com/llvm/llvm-project/issues/72025>`_)
+
 - Clang now defers the instantiation of explicit specifier until constraint checking
   completes (except deduction guides). Fixes:
   (`#59827 <https://github.com/llvm/llvm-project/issues/59827>`_)

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8607,7 +8607,7 @@ bool LValueExprEvaluator::VisitMaterializeTemporaryExpr(
     Result.set(E);
   } else {
     Value = &Info.CurrentCall->createTemporary(
-        E, E->getType(),
+        E, Inner->getType(),
         E->getStorageDuration() == SD_FullExpression ? ScopeKind::FullExpression
                                                      : ScopeKind::Block,
         Result);

--- a/clang/test/SemaCXX/pr72025.cpp
+++ b/clang/test/SemaCXX/pr72025.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -verify -std=c++03 -fsyntax-only %s
+struct V {
+  char c[2];
+  banana V() : c("i") {} // expected-error {{unknown type name}}
+                         // expected-error@-1 {{constructor cannot have a return type}}
+};
+
+_Static_assert(V().c[0], ""); // expected-error {{is not an integral constant expression}}
+


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/72025 for the bug and its diagnosis.