### PR TITLE
[NFC][libc++] Refactors the time.cal tests.

### DIFF
--- a/libcxx/test/std/time/time.cal/euclidian.h
+++ b/libcxx/test/std/time/time.cal/euclidian.h
@@ -12,13 +12,12 @@
 //  Assumption: minValue <= lhs <= maxValue
 //  Assumption: minValue >= 0
 template <typename T, T minValue, T maxValue>
-T euclidian_addition(T rhs, T lhs)
-{
-    const T modulus = maxValue - minValue + 1;
-    T ret = rhs + lhs;
-    if (ret > maxValue)
-        ret -= modulus;
-    return ret;
+constexpr T euclidian_addition(T rhs, T lhs) {
+  const T modulus = maxValue - minValue + 1;
+  T ret           = rhs + lhs;
+  if (ret > maxValue)
+    ret -= modulus;
+  return ret;
 }
 
 //  Assumption: minValue < maxValue
@@ -26,13 +25,12 @@ T euclidian_addition(T rhs, T lhs)
 //  Assumption: minValue <= lhs <= maxValue
 //  Assumption: minValue >= 0
 template <typename T, T minValue, T maxValue>
-T euclidian_subtraction(T lhs, T rhs)
-{
-    const T modulus = maxValue - minValue + 1;
-    T ret = lhs - rhs;
-    if (ret < minValue)
-        ret += modulus;
-    if (ret > maxValue)     // this can happen if T is unsigned
-        ret += modulus;
-    return ret;
+constexpr T euclidian_subtraction(T lhs, T rhs) {
+  const T modulus = maxValue - minValue + 1;
+  T ret           = lhs - rhs;
+  if (ret < minValue)
+    ret += modulus;
+  if (ret > maxValue) // this can happen if T is unsigned
+    ret += modulus;
+  return ret;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.members/decrement.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.members/decrement.pass.cpp
@@ -13,41 +13,33 @@
 //  constexpr day& operator--() noexcept;
 //  constexpr day operator--(int) noexcept;
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename D>
-constexpr bool testConstexpr()
-{
-    D d1{10};
-    if (static_cast<unsigned>(--d1) != 9) return false;
-    if (static_cast<unsigned>(d1--) != 9) return false;
-    if (static_cast<unsigned>(d1)   != 8) return false;
-    return true;
+using day = std::chrono::day;
+
+constexpr bool test() {
+  for (unsigned i = 10; i <= 20; ++i) {
+    day d(i);
+    assert(static_cast<unsigned>(--d) == i - 1);
+    assert(static_cast<unsigned>(d--) == i - 1);
+    assert(static_cast<unsigned>(d) == i - 2);
+  }
+  return true;
 }
 
-int main(int, char**)
-{
-    using day = std::chrono::day;
-    ASSERT_NOEXCEPT(--(std::declval<day&>())  );
-    ASSERT_NOEXCEPT(  (std::declval<day&>())--);
+int main(int, char**) {
+  ASSERT_NOEXCEPT(--(std::declval<day&>()));
+  ASSERT_NOEXCEPT((std::declval<day&>())--);
 
-    ASSERT_SAME_TYPE(day , decltype(  std::declval<day&>()--));
-    ASSERT_SAME_TYPE(day&, decltype(--std::declval<day&>()  ));
+  ASSERT_SAME_TYPE(day, decltype(std::declval<day&>()--));
+  ASSERT_SAME_TYPE(day&, decltype(--std::declval<day&>()));
 
-    static_assert(testConstexpr<day>(), "");
-
-    for (unsigned i = 10; i <= 20; ++i)
-    {
-        day d(i);
-        assert(static_cast<unsigned>(--d) == i - 1);
-        assert(static_cast<unsigned>(d--) == i - 1);
-        assert(static_cast<unsigned>(d)   == i - 2);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.members/increment.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.members/increment.pass.cpp
@@ -13,41 +13,34 @@
 //  constexpr day& operator++() noexcept;
 //  constexpr day operator++(int) noexcept;
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename D>
-constexpr bool testConstexpr()
-{
-    D d1{1};
-    if (static_cast<unsigned>(++d1) != 2) return false;
-    if (static_cast<unsigned>(d1++) != 2) return false;
-    if (static_cast<unsigned>(d1)   != 3) return false;
-    return true;
+using day = std::chrono::day;
+
+constexpr bool test() {
+  for (unsigned i = 10; i <= 20; ++i) {
+    day d(i);
+    assert(static_cast<unsigned>(++d) == i + 1);
+    assert(static_cast<unsigned>(d++) == i + 1);
+    assert(static_cast<unsigned>(d) == i + 2);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using day = std::chrono::day;
-    ASSERT_NOEXCEPT(++(std::declval<day&>())  );
-    ASSERT_NOEXCEPT(  (std::declval<day&>())++);
+int main(int, char**) {
+  ASSERT_NOEXCEPT(++(std::declval<day&>()));
+  ASSERT_NOEXCEPT((std::declval<day&>())++);
 
-    ASSERT_SAME_TYPE(day , decltype(  std::declval<day&>()++));
-    ASSERT_SAME_TYPE(day&, decltype(++std::declval<day&>()  ));
+  ASSERT_SAME_TYPE(day, decltype(std::declval<day&>()++));
+  ASSERT_SAME_TYPE(day&, decltype(++std::declval<day&>()));
 
-    static_assert(testConstexpr<day>(), "");
-
-    for (unsigned i = 10; i <= 20; ++i)
-    {
-        day d(i);
-        assert(static_cast<unsigned>(++d) == i + 1);
-        assert(static_cast<unsigned>(d++) == i + 1);
-        assert(static_cast<unsigned>(d)   == i + 2);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
@@ -19,40 +19,30 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr()
-{
-    D d1{1};
-    if (static_cast<unsigned>(d1 += Ds{ 1}) !=  2) return false;
-    if (static_cast<unsigned>(d1 += Ds{ 2}) !=  4) return false;
-    if (static_cast<unsigned>(d1 += Ds{22}) != 26) return false;
-    if (static_cast<unsigned>(d1 -= Ds{ 1}) != 25) return false;
-    if (static_cast<unsigned>(d1 -= Ds{ 2}) != 23) return false;
-    if (static_cast<unsigned>(d1 -= Ds{22}) !=  1) return false;
-    return true;
+using day  = std::chrono::day;
+using days = std::chrono::days;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 10; ++i) {
+    day d(i);
+    assert(static_cast<unsigned>(d += days{22}) == i + 22);
+    assert(static_cast<unsigned>(d) == i + 22);
+    assert(static_cast<unsigned>(d -= days{12}) == i + 10);
+    assert(static_cast<unsigned>(d) == i + 10);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using day  = std::chrono::day;
-    using days = std::chrono::days;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<day&>() += std::declval<days>());
+  ASSERT_NOEXCEPT(std::declval<day&>() -= std::declval<days>());
 
-    ASSERT_NOEXCEPT(std::declval<day&>() += std::declval<days>());
-    ASSERT_NOEXCEPT(std::declval<day&>() -= std::declval<days>());
+  ASSERT_SAME_TYPE(day&, decltype(std::declval<day&>() += std::declval<days>()));
+  ASSERT_SAME_TYPE(day&, decltype(std::declval<day&>() -= std::declval<days>()));
 
-    ASSERT_SAME_TYPE(day&, decltype(std::declval<day&>() += std::declval<days>()));
-    ASSERT_SAME_TYPE(day&, decltype(std::declval<day&>() -= std::declval<days>()));
-
-    static_assert(testConstexpr<day, days>(), "");
-
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        day d(i);
-        assert(static_cast<unsigned>(d += days{22}) == i + 22);
-        assert(static_cast<unsigned>(d)             == i + 22);
-        assert(static_cast<unsigned>(d -= days{12}) == i + 10);
-        assert(static_cast<unsigned>(d)             == i + 10);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
@@ -16,44 +16,36 @@
 // constexpr days operator-(const day& x, const day& y) noexcept;
 //   Returns: days{int(unsigned{x}) - int(unsigned{y}).
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr()
-{
-    D d{23};
-    Ds offset{6};
-    if (d - offset != D{17}) return false;
-    if (d - D{17} != offset) return false;
-    return true;
+using day  = std::chrono::day;
+using days = std::chrono::days;
+
+constexpr bool test() {
+  day dy{12};
+  for (unsigned i = 0; i <= 10; ++i) {
+    day d1   = dy - days{i};
+    days off = dy - day{i};
+    assert(static_cast<unsigned>(d1) == 12 - i);
+    assert(off.count() == static_cast<int>(12 - i)); // days is signed
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using day  = std::chrono::day;
-    using days = std::chrono::days;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<day>() - std::declval<days>());
+  ASSERT_NOEXCEPT(std::declval<day>() - std::declval<day>());
 
-    ASSERT_NOEXCEPT(std::declval<day>() - std::declval<days>());
-    ASSERT_NOEXCEPT(std::declval<day>() - std::declval<day>());
+  ASSERT_SAME_TYPE(day, decltype(std::declval<day>() - std::declval<days>()));
+  ASSERT_SAME_TYPE(days, decltype(std::declval<day>() - std::declval<day>()));
 
-    ASSERT_SAME_TYPE(day,  decltype(std::declval<day>() - std::declval<days>()));
-    ASSERT_SAME_TYPE(days, decltype(std::declval<day>() - std::declval<day>()));
-
-    static_assert(testConstexpr<day, days>(), "");
-
-    day dy{12};
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        day d1   = dy - days{i};
-        days off = dy - day {i};
-        assert(static_cast<unsigned>(d1) == 12 - i);
-        assert(off.count() == static_cast<int>(12 - i)); // days is signed
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.nonmembers/plus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.nonmembers/plus.pass.cpp
@@ -16,45 +16,37 @@
 // constexpr day operator+(const days& x, const day& y) noexcept;
 //   Returns: y + x.
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr()
-{
-    D d{1};
-    Ds offset{23};
-    if (d + offset != D{24}) return false;
-    if (offset + d != D{24}) return false;
-    return true;
+using day  = std::chrono::day;
+using days = std::chrono::days;
+
+constexpr bool test() {
+  day dy{12};
+  for (unsigned i = 0; i <= 10; ++i) {
+    day d1 = dy + days{i};
+    day d2 = days{i} + dy;
+    assert(d1 == d2);
+    assert(static_cast<unsigned>(d1) == i + 12);
+    assert(static_cast<unsigned>(d2) == i + 12);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using day  = std::chrono::day;
-    using days = std::chrono::days;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<day>() + std::declval<days>());
+  ASSERT_NOEXCEPT(std::declval<days>() + std::declval<day>());
 
-    ASSERT_NOEXCEPT(std::declval<day>() + std::declval<days>());
-    ASSERT_NOEXCEPT(std::declval<days>() + std::declval<day>());
+  ASSERT_SAME_TYPE(day, decltype(std::declval<day>() + std::declval<days>()));
+  ASSERT_SAME_TYPE(day, decltype(std::declval<days>() + std::declval<day>()));
 
-    ASSERT_SAME_TYPE(day, decltype(std::declval<day>() + std::declval<days>()));
-    ASSERT_SAME_TYPE(day, decltype(std::declval<days>() + std::declval<day>()));
-
-    static_assert(testConstexpr<day, days>(), "");
-
-    day dy{12};
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        day d1 = dy + days{i};
-        day d2 = days{i} + dy;
-        assert(d1 == d2);
-        assert(static_cast<unsigned>(d1) == i + 12);
-        assert(static_cast<unsigned>(d2) == i + 12);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
@@ -25,45 +25,35 @@
 
 #include "test_macros.h"
 
-template <typename M, typename Ms>
-constexpr bool testConstexpr()
-{
-    {
-    M m{5};
-    Ms offset{3};
-    assert(m - offset == M{2});
-    assert(m - M{2} == offset);
-    }
+using month  = std::chrono::month;
+using months = std::chrono::months;
 
-    //  Check the example
-    assert(M{1} - M{2} == Ms{11});
+constexpr bool test() {
+  month m{6};
+  for (unsigned i = 1; i <= 12; ++i) {
+    month m1 = m - months{i};
+    assert(m1.ok());
+    int exp = 6 - i;
+    if (exp < 1)
+      exp += 12;
+    assert(static_cast<unsigned>(m1) == static_cast<unsigned>(exp));
+  }
 
-    return true;
+  //  Check the example
+  assert(month{1} - month{2} == months{11});
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using month  = std::chrono::month;
-    using months = std::chrono::months;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<month>() - std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<month>() - std::declval<month>());
 
-    ASSERT_NOEXCEPT(std::declval<month>() - std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<month>() - std::declval<month>());
+  ASSERT_SAME_TYPE(month, decltype(std::declval<month>() - std::declval<months>()));
+  ASSERT_SAME_TYPE(months, decltype(std::declval<month>() - std::declval<month>()));
 
-    ASSERT_SAME_TYPE(month , decltype(std::declval<month>() - std::declval<months>()));
-    ASSERT_SAME_TYPE(months, decltype(std::declval<month>() - std::declval<month> ()));
-
-    static_assert(testConstexpr<month, months>(), "");
-
-    month m{6};
-    for (unsigned i = 1; i <= 12; ++i)
-    {
-        month m1   = m - months{i};
-        assert(m1.ok());
-        int exp = 6 - i;
-        if (exp < 1)
-            exp += 12;
-        assert(static_cast<unsigned>(m1) == static_cast<unsigned>(exp));
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/c_encoding.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/c_encoding.pass.cpp
@@ -12,34 +12,29 @@
 
 //  constexpr unsigned c_encoding() const noexcept;
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename WD>
-constexpr bool testConstexpr()
-{
-    WD wd{5};
-    return wd.c_encoding() == 5;
+using weekday = std::chrono::weekday;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 10; ++i) {
+    weekday wd(i);
+    assert(wd.c_encoding() == (i == 7 ? 0 : i));
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using weekday = std::chrono::weekday;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<weekday&>().c_encoding());
+  ASSERT_SAME_TYPE(unsigned, decltype(std::declval<weekday&>().c_encoding()));
 
-    ASSERT_NOEXCEPT(                    std::declval<weekday&>().c_encoding());
-    ASSERT_SAME_TYPE(unsigned, decltype(std::declval<weekday&>().c_encoding()));
-
-    static_assert(testConstexpr<weekday>(), "");
-
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        weekday wd(i);
-        assert(wd.c_encoding() == (i == 7 ? 0 : i));
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/decrement.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/decrement.pass.cpp
@@ -13,7 +13,6 @@
 //  constexpr weekday& operator--() noexcept;
 //  constexpr weekday operator--(int) noexcept;
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
@@ -21,34 +20,28 @@
 #include "test_macros.h"
 #include "../../euclidian.h"
 
-template <typename WD>
-constexpr bool testConstexpr()
-{
-    WD wd{1};
-    if ((--wd).c_encoding() != 0) return false;
-    if ((wd--).c_encoding() != 0) return false;
-    if ((wd).c_encoding()   != 6) return false;
-    return true;
+using weekday = std::chrono::weekday;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 6; ++i) {
+    weekday wd(i);
+    assert(((--wd).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 1)));
+    assert(((wd--).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 1)));
+    assert(((wd).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 2)));
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using weekday = std::chrono::weekday;
-    ASSERT_NOEXCEPT(--(std::declval<weekday&>())  );
-    ASSERT_NOEXCEPT(  (std::declval<weekday&>())--);
+int main(int, char**) {
+  ASSERT_NOEXCEPT(--(std::declval<weekday&>()));
+  ASSERT_NOEXCEPT((std::declval<weekday&>())--);
 
-    ASSERT_SAME_TYPE(weekday , decltype(  std::declval<weekday&>()--));
-    ASSERT_SAME_TYPE(weekday&, decltype(--std::declval<weekday&>()  ));
+  ASSERT_SAME_TYPE(weekday, decltype(std::declval<weekday&>()--));
+  ASSERT_SAME_TYPE(weekday&, decltype(--std::declval<weekday&>()));
 
-    static_assert(testConstexpr<weekday>(), "");
-
-    for (unsigned i = 0; i <= 6; ++i)
-    {
-        weekday wd(i);
-        assert(((--wd).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 1)));
-        assert(((wd--).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 1)));
-        assert(((wd)  .c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 2)));
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/increment.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/increment.pass.cpp
@@ -13,7 +13,6 @@
 //  constexpr weekday& operator++() noexcept;
 //  constexpr weekday operator++(int) noexcept;
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
@@ -21,34 +20,28 @@
 #include "test_macros.h"
 #include "../../euclidian.h"
 
-template <typename WD>
-constexpr bool testConstexpr()
-{
-    WD wd{5};
-    if ((++wd).c_encoding() != 6) return false;
-    if ((wd++).c_encoding() != 6) return false;
-    if ((wd)  .c_encoding() != 0) return false;
-    return true;
+using weekday = std::chrono::weekday;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 6; ++i) {
+    weekday wd(i);
+    assert(((++wd).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 1)));
+    assert(((wd++).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 1)));
+    assert(((wd).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 2)));
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using weekday = std::chrono::weekday;
-    ASSERT_NOEXCEPT(++(std::declval<weekday&>())  );
-    ASSERT_NOEXCEPT(  (std::declval<weekday&>())++);
+int main(int, char**) {
+  ASSERT_NOEXCEPT(++(std::declval<weekday&>()));
+  ASSERT_NOEXCEPT((std::declval<weekday&>())++);
 
-    ASSERT_SAME_TYPE(weekday , decltype(  std::declval<weekday&>()++));
-    ASSERT_SAME_TYPE(weekday&, decltype(++std::declval<weekday&>()  ));
+  ASSERT_SAME_TYPE(weekday, decltype(std::declval<weekday&>()++));
+  ASSERT_SAME_TYPE(weekday&, decltype(++std::declval<weekday&>()));
 
-    static_assert(testConstexpr<weekday>(), "");
-
-    for (unsigned i = 0; i <= 6; ++i)
-    {
-        weekday wd(i);
-        assert(((++wd).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 1)));
-        assert(((wd++).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 1)));
-        assert(((wd)  .c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 2)));
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/iso_encoding.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/iso_encoding.pass.cpp
@@ -20,29 +20,25 @@
 
 #include "test_macros.h"
 
-template <typename WD>
-constexpr bool testConstexpr()
-{
-    WD wd{5};
-    return wd.c_encoding() == 5;
+using weekday = std::chrono::weekday;
+
+constexpr bool test() {
+  //  This is different than all the other tests, because the '7' gets converted to
+  //  a zero in the constructor, but then back to '7' by iso_encoding().
+  for (unsigned i = 0; i <= 10; ++i) {
+    weekday wd(i);
+    assert(wd.iso_encoding() == (i == 0 ? 7 : i));
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using weekday = std::chrono::weekday;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<weekday&>().iso_encoding());
+  ASSERT_SAME_TYPE(unsigned, decltype(std::declval<weekday&>().iso_encoding()));
 
-    ASSERT_NOEXCEPT(                    std::declval<weekday&>().iso_encoding());
-    ASSERT_SAME_TYPE(unsigned, decltype(std::declval<weekday&>().iso_encoding()));
+  test();
+  static_assert(test());
 
-    static_assert(testConstexpr<weekday>(), "");
-
-    //  This is different than all the other tests, because the '7' gets converted to
-    //  a zero in the constructor, but then back to '7' by iso_encoding().
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        weekday wd(i);
-        assert(wd.iso_encoding() == (i == 0 ? 7 : i));
-    }
-
-    return 0;
+  return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/plus_minus_equal.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.members/plus_minus_equal.pass.cpp
@@ -20,45 +20,34 @@
 #include "test_macros.h"
 #include "../../euclidian.h"
 
-template <typename M, typename Ms>
-constexpr bool testConstexpr()
-{
-    M m1{1};
-    if ((m1 += Ms{ 1}).c_encoding() !=  2) return false;
-    if ((m1 += Ms{ 2}).c_encoding() !=  4) return false;
-    if ((m1 += Ms{ 4}).c_encoding() !=  1) return false;
-    if ((m1 -= Ms{ 1}).c_encoding() !=  0) return false;
-    if ((m1 -= Ms{ 2}).c_encoding() !=  5) return false;
-    if ((m1 -= Ms{ 4}).c_encoding() !=  1) return false;
-    return true;
+using weekday = std::chrono::weekday;
+using days    = std::chrono::days;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 6; ++i) {
+    weekday wd(i);
+    assert(((wd += days{3}).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 3)));
+    assert(((wd).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 3)));
+  }
+
+  for (unsigned i = 0; i <= 6; ++i) {
+    weekday wd(i);
+    assert(((wd -= days{4}).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 4)));
+    assert(((wd).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 4)));
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using weekday = std::chrono::weekday;
-    using days    = std::chrono::days;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<weekday&>() += std::declval<days&>());
+  ASSERT_SAME_TYPE(weekday&, decltype(std::declval<weekday&>() += std::declval<days&>()));
 
-    ASSERT_NOEXCEPT(                    std::declval<weekday&>() += std::declval<days&>());
-    ASSERT_SAME_TYPE(weekday&, decltype(std::declval<weekday&>() += std::declval<days&>()));
+  ASSERT_NOEXCEPT(std::declval<weekday&>() -= std::declval<days&>());
+  ASSERT_SAME_TYPE(weekday&, decltype(std::declval<weekday&>() -= std::declval<days&>()));
 
-    ASSERT_NOEXCEPT(                    std::declval<weekday&>() -= std::declval<days&>());
-    ASSERT_SAME_TYPE(weekday&, decltype(std::declval<weekday&>() -= std::declval<days&>()));
-
-    static_assert(testConstexpr<weekday, days>(), "");
-
-    for (unsigned i = 0; i <= 6; ++i)
-    {
-        weekday wd(i);
-        assert(((wd += days{3}).c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 3)));
-        assert(((wd)           .c_encoding() == euclidian_addition<unsigned, 0, 6>(i, 3)));
-    }
-
-    for (unsigned i = 0; i <= 6; ++i)
-    {
-        weekday wd(i);
-        assert(((wd -= days{4}).c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 4)));
-        assert(((wd)           .c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, 4)));
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp
@@ -26,50 +26,38 @@
 #include "test_macros.h"
 #include "../../euclidian.h"
 
-template <typename WD, typename Ds>
-constexpr bool testConstexpr()
-{
-    {
-    WD wd{5};
-    Ds offset{3};
-    assert(wd - offset == WD{2});
-    assert(wd - WD{2} == offset);
+using weekday = std::chrono::weekday;
+using days    = std::chrono::days;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 6; ++i)
+    for (unsigned j = 0; j <= 6; ++j) {
+      weekday wd = weekday{i} - days{j};
+      assert(wd + days{j} == weekday{i});
+      assert((wd.c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, j)));
     }
 
-    //  Check the example
-    assert(WD{0} - WD{1} == Ds{6});
+  for (unsigned i = 0; i <= 6; ++i)
+    for (unsigned j = 0; j <= 6; ++j) {
+      days d = weekday{j} - weekday{i};
+      assert(weekday{i} + d == weekday{j});
+    }
 
-    return true;
+  //  Check the example
+  assert(weekday{0} - weekday{1} == days{6});
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using weekday  = std::chrono::weekday;
-    using days     = std::chrono::days;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<weekday>() - std::declval<days>());
+  ASSERT_SAME_TYPE(weekday, decltype(std::declval<weekday>() - std::declval<days>()));
 
-    ASSERT_NOEXCEPT(                   std::declval<weekday>() - std::declval<days>());
-    ASSERT_SAME_TYPE(weekday, decltype(std::declval<weekday>() - std::declval<days>()));
+  ASSERT_NOEXCEPT(std::declval<weekday>() - std::declval<weekday>());
+  ASSERT_SAME_TYPE(days, decltype(std::declval<weekday>() - std::declval<weekday>()));
 
-    ASSERT_NOEXCEPT(                   std::declval<weekday>() - std::declval<weekday>());
-    ASSERT_SAME_TYPE(days,    decltype(std::declval<weekday>() - std::declval<weekday>()));
-
-    static_assert(testConstexpr<weekday, days>(), "");
-
-    for (unsigned i = 0; i <= 6; ++i)
-        for (unsigned j = 0; j <= 6; ++j)
-        {
-            weekday wd = weekday{i} - days{j};
-            assert(wd + days{j} == weekday{i});
-            assert((wd.c_encoding() == euclidian_subtraction<unsigned, 0, 6>(i, j)));
-        }
-
-    for (unsigned i = 0; i <= 6; ++i)
-        for (unsigned j = 0; j <= 6; ++j)
-        {
-            days d = weekday{j} - weekday{i};
-            assert(weekday{i} + d == weekday{j});
-        }
-
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/plus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/plus.pass.cpp
@@ -30,40 +30,33 @@
 #include "test_macros.h"
 #include "../../euclidian.h"
 
-template <typename M, typename Ms>
-constexpr bool testConstexpr()
-{
-    M m{1};
-    Ms offset{4};
-    assert(m + offset == M{5});
-    assert(offset + m == M{5});
-    //  Check the example
-    assert(M{1} + Ms{6} == M{0});
-    return true;
+using weekday = std::chrono::weekday;
+using days    = std::chrono::days;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 6; ++i)
+    for (unsigned j = 0; j <= 6; ++j) {
+      weekday wd1 = weekday{i} + days{j};
+      weekday wd2 = days{j} + weekday{i};
+      assert(wd1 == wd2);
+      assert((wd1.c_encoding() == euclidian_addition<unsigned, 0, 6>(i, j)));
+      assert((wd2.c_encoding() == euclidian_addition<unsigned, 0, 6>(i, j)));
+    }
+
+  //  Check the example
+  assert(weekday{1} + days{6} == weekday{0});
+  return true;
 }
 
-int main(int, char**)
-{
-    using weekday = std::chrono::weekday;
-    using days    = std::chrono::days;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<weekday>() + std::declval<days>());
+  ASSERT_SAME_TYPE(weekday, decltype(std::declval<weekday>() + std::declval<days>()));
 
-    ASSERT_NOEXCEPT(                   std::declval<weekday>() + std::declval<days>());
-    ASSERT_SAME_TYPE(weekday, decltype(std::declval<weekday>() + std::declval<days>()));
+  ASSERT_NOEXCEPT(std::declval<days>() + std::declval<weekday>());
+  ASSERT_SAME_TYPE(weekday, decltype(std::declval<days>() + std::declval<weekday>()));
 
-    ASSERT_NOEXCEPT(                   std::declval<days>() + std::declval<weekday>());
-    ASSERT_SAME_TYPE(weekday, decltype(std::declval<days>() + std::declval<weekday>()));
+  test();
+  static_assert(test());
 
-    static_assert(testConstexpr<weekday, days>(), "");
-
-    for (unsigned i = 0; i <= 6; ++i)
-        for (unsigned j = 0; j <= 6; ++j)
-        {
-            weekday wd1 = weekday{i} + days{j};
-            weekday wd2 = days{j} + weekday{i};
-            assert(wd1 == wd2);
-            assert((wd1.c_encoding() == euclidian_addition<unsigned, 0, 6>(i, j)));
-            assert((wd2.c_encoding() == euclidian_addition<unsigned, 0, 6>(i, j)));
-        }
-
-    return 0;
+  return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/decrement.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/decrement.pass.cpp
@@ -13,41 +13,34 @@
 //  constexpr year& operator--() noexcept;
 //  constexpr year operator--(int) noexcept;
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename Y>
-constexpr bool testConstexpr()
-{
-    Y y1{10};
-    if (static_cast<int>(--y1) != 9) return false;
-    if (static_cast<int>(y1--) != 9) return false;
-    if (static_cast<int>(y1)   != 8) return false;
-    return true;
+using year = std::chrono::year;
+
+constexpr bool test() {
+  for (int i = 11000; i <= 11020; ++i) {
+    year yr(i);
+    assert(static_cast<int>(--yr) == i - 1);
+    assert(static_cast<int>(yr--) == i - 1);
+    assert(static_cast<int>(yr) == i - 2);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year = std::chrono::year;
-    ASSERT_NOEXCEPT(--(std::declval<year&>())  );
-    ASSERT_NOEXCEPT(  (std::declval<year&>())--);
+int main(int, char**) {
+  ASSERT_NOEXCEPT(--(std::declval<year&>()));
+  ASSERT_NOEXCEPT((std::declval<year&>())--);
 
-    ASSERT_SAME_TYPE(year , decltype(  std::declval<year&>()--));
-    ASSERT_SAME_TYPE(year&, decltype(--std::declval<year&>()  ));
+  ASSERT_SAME_TYPE(year, decltype(std::declval<year&>()--));
+  ASSERT_SAME_TYPE(year&, decltype(--std::declval<year&>()));
 
-    static_assert(testConstexpr<year>(), "");
-
-    for (int i = 11000; i <= 11020; ++i)
-    {
-        year yr(i);
-        assert(static_cast<int>(--yr) == i - 1);
-        assert(static_cast<int>(yr--) == i - 1);
-        assert(static_cast<int>(yr)   == i - 2);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/increment.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/increment.pass.cpp
@@ -13,41 +13,34 @@
 //  constexpr year& operator++() noexcept;
 //  constexpr year operator++(int) noexcept;
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename Y>
-constexpr bool testConstexpr()
-{
-    Y y1{10};
-    if (static_cast<int>(++y1) != 11) return false;
-    if (static_cast<int>(y1++) != 11) return false;
-    if (static_cast<int>(y1)   != 12) return false;
-    return true;
+using year = std::chrono::year;
+
+constexpr bool test() {
+  for (int i = 11000; i <= 11020; ++i) {
+    year yr(i);
+    assert(static_cast<int>(++yr) == i + 1);
+    assert(static_cast<int>(yr++) == i + 1);
+    assert(static_cast<int>(yr) == i + 2);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year = std::chrono::year;
-    ASSERT_NOEXCEPT(++(std::declval<year&>())  );
-    ASSERT_NOEXCEPT(  (std::declval<year&>())++);
+int main(int, char**) {
+  ASSERT_NOEXCEPT(++(std::declval<year&>()));
+  ASSERT_NOEXCEPT((std::declval<year&>())++);
 
-    ASSERT_SAME_TYPE(year , decltype(  std::declval<year&>()++));
-    ASSERT_SAME_TYPE(year&, decltype(++std::declval<year&>()  ));
+  ASSERT_SAME_TYPE(year, decltype(std::declval<year&>()++));
+  ASSERT_SAME_TYPE(year&, decltype(++std::declval<year&>()));
 
-    static_assert(testConstexpr<year>(), "");
-
-    for (int i = 11000; i <= 11020; ++i)
-    {
-        year yr(i);
-        assert(static_cast<int>(++yr) == i + 1);
-        assert(static_cast<int>(yr++) == i + 1);
-        assert(static_cast<int>(yr)   == i + 2);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/plus_minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/plus_minus.pass.cpp
@@ -19,33 +19,27 @@
 
 #include "test_macros.h"
 
-template <typename Y>
-constexpr bool testConstexpr()
-{
-    Y y1{1};
-    if (static_cast<int>(+y1) !=  1) return false;
-    if (static_cast<int>(-y1) != -1) return false;
-    return true;
+using year = std::chrono::year;
+
+constexpr bool test() {
+  for (int i = 10000; i <= 10020; ++i) {
+    year yr(i);
+    assert(static_cast<int>(+yr) == i);
+    assert(static_cast<int>(-yr) == -i);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year  = std::chrono::year;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(+std::declval<year>());
+  ASSERT_NOEXCEPT(-std::declval<year>());
 
-    ASSERT_NOEXCEPT(+std::declval<year>());
-    ASSERT_NOEXCEPT(-std::declval<year>());
+  ASSERT_SAME_TYPE(year, decltype(+std::declval<year>()));
+  ASSERT_SAME_TYPE(year, decltype(-std::declval<year>()));
 
-    ASSERT_SAME_TYPE(year, decltype(+std::declval<year>()));
-    ASSERT_SAME_TYPE(year, decltype(-std::declval<year>()));
-
-    static_assert(testConstexpr<year>(), "");
-
-    for (int i = 10000; i <= 10020; ++i)
-    {
-        year yr(i);
-        assert(static_cast<int>(+yr) ==  i);
-        assert(static_cast<int>(-yr) == -i);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/plus_minus_equal.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.members/plus_minus_equal.pass.cpp
@@ -19,40 +19,30 @@
 
 #include "test_macros.h"
 
-template <typename Y, typename Ys>
-constexpr bool testConstexpr()
-{
-    Y y1{1};
-    if (static_cast<int>(y1 += Ys{ 1}) !=  2) return false;
-    if (static_cast<int>(y1 += Ys{ 2}) !=  4) return false;
-    if (static_cast<int>(y1 += Ys{ 8}) != 12) return false;
-    if (static_cast<int>(y1 -= Ys{ 1}) != 11) return false;
-    if (static_cast<int>(y1 -= Ys{ 2}) !=  9) return false;
-    if (static_cast<int>(y1 -= Ys{ 8}) !=  1) return false;
-    return true;
+using year  = std::chrono::year;
+using years = std::chrono::years;
+
+constexpr bool test() {
+  for (int i = 10000; i <= 10020; ++i) {
+    year yr(i);
+    assert(static_cast<int>(yr += years{10}) == i + 10);
+    assert(static_cast<int>(yr) == i + 10);
+    assert(static_cast<int>(yr -= years{9}) == i + 1);
+    assert(static_cast<int>(yr) == i + 1);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year  = std::chrono::year;
-    using years = std::chrono::years;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year&>() += std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<year&>() -= std::declval<years>());
 
-    ASSERT_NOEXCEPT(std::declval<year&>() += std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<year&>() -= std::declval<years>());
+  ASSERT_SAME_TYPE(year&, decltype(std::declval<year&>() += std::declval<years>()));
+  ASSERT_SAME_TYPE(year&, decltype(std::declval<year&>() -= std::declval<years>()));
 
-    ASSERT_SAME_TYPE(year&, decltype(std::declval<year&>() += std::declval<years>()));
-    ASSERT_SAME_TYPE(year&, decltype(std::declval<year&>() -= std::declval<years>()));
-
-    static_assert(testConstexpr<year, years>(), "");
-
-    for (int i = 10000; i <= 10020; ++i)
-    {
-        year yr(i);
-        assert(static_cast<int>(yr += years{10}) == i + 10);
-        assert(static_cast<int>(yr)              == i + 10);
-        assert(static_cast<int>(yr -= years{ 9}) == i +  1);
-        assert(static_cast<int>(yr)              == i +  1);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.nonmembers/minus.pass.cpp
@@ -25,37 +25,30 @@
 
 #include "test_macros.h"
 
-template <typename Y, typename Ys>
-constexpr bool testConstexpr()
-{
-    Y y{2313};
-    Ys offset{1006};
-    if (y - offset != Y{1307}) return false;
-    if (y - Y{1307} != offset) return false;
-    return true;
+using year  = std::chrono::year;
+using years = std::chrono::years;
+
+constexpr bool test() {
+  year y{1223};
+  for (int i = 1100; i <= 1110; ++i) {
+    year y1   = y - years{i};
+    years ys1 = y - year{i};
+    assert(static_cast<int>(y1) == 1223 - i);
+    assert(ys1.count() == 1223 - i);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year  = std::chrono::year;
-    using years = std::chrono::years;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year>() - std::declval<years>());
+  ASSERT_SAME_TYPE(year, decltype(std::declval<year>() - std::declval<years>()));
 
-    ASSERT_NOEXCEPT(                 std::declval<year>() - std::declval<years>());
-    ASSERT_SAME_TYPE(year , decltype(std::declval<year>() - std::declval<years>()));
+  ASSERT_NOEXCEPT(std::declval<year>() - std::declval<year>());
+  ASSERT_SAME_TYPE(years, decltype(std::declval<year>() - std::declval<year>()));
 
-    ASSERT_NOEXCEPT(                 std::declval<year>() - std::declval<year>());
-    ASSERT_SAME_TYPE(years, decltype(std::declval<year>() - std::declval<year>()));
-
-    static_assert(testConstexpr<year, years>(), "");
-
-    year y{1223};
-    for (int i = 1100; i <= 1110; ++i)
-    {
-        year  y1 = y - years{i};
-        years ys1 = y - year{i};
-        assert(static_cast<int>(y1) == 1223 - i);
-        assert(ys1.count()          == 1223 - i);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.nonmembers/plus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.nonmembers/plus.pass.cpp
@@ -16,45 +16,37 @@
 // constexpr year operator+(const years& x, const year& y) noexcept;
 //   Returns: y + x
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-template <typename Y, typename Ys>
-constexpr bool testConstexpr()
-{
-    Y y{1001};
-    Ys offset{23};
-    if (y + offset != Y{1024}) return false;
-    if (offset + y != Y{1024}) return false;
-    return true;
+using year  = std::chrono::year;
+using years = std::chrono::years;
+
+constexpr bool test() {
+  year y{1223};
+  for (int i = 1100; i <= 1110; ++i) {
+    year y1 = y + years{i};
+    year y2 = years{i} + y;
+    assert(y1 == y2);
+    assert(static_cast<int>(y1) == i + 1223);
+    assert(static_cast<int>(y2) == i + 1223);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year  = std::chrono::year;
-    using years = std::chrono::years;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year>() + std::declval<years>());
+  ASSERT_SAME_TYPE(year, decltype(std::declval<year>() + std::declval<years>()));
 
-    ASSERT_NOEXCEPT(                std::declval<year>() + std::declval<years>());
-    ASSERT_SAME_TYPE(year, decltype(std::declval<year>() + std::declval<years>()));
+  ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year>());
+  ASSERT_SAME_TYPE(year, decltype(std::declval<years>() + std::declval<year>()));
 
-    ASSERT_NOEXCEPT(                std::declval<years>() + std::declval<year>());
-    ASSERT_SAME_TYPE(year, decltype(std::declval<years>() + std::declval<year>()));
-
-    static_assert(testConstexpr<year, years>(), "");
-
-    year y{1223};
-    for (int i = 1100; i <= 1110; ++i)
-    {
-        year y1 = y + years{i};
-        year y2 = years{i} + y;
-        assert(y1 == y2);
-        assert(static_cast<int>(y1) == i + 1223);
-        assert(static_cast<int>(y2) == i + 1223);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_month.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_month.pass.cpp
@@ -19,47 +19,37 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<unsigned>((d1          ).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 1}).month()) !=  2) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 2}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 += Ds{12}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 1}).month()) !=  3) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 2}).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 -= Ds{12}).month()) !=  1) return false;
-    return true;
+using month      = std::chrono::month;
+using months     = std::chrono::months;
+using year       = std::chrono::year;
+using year_month = std::chrono::year_month;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 10; ++i) {
+    year y{1234};
+    year_month ym(y, month{i});
+    assert(static_cast<unsigned>((ym += months{2}).month()) == i + 2);
+    assert(ym.year() == y);
+    assert(static_cast<unsigned>((ym).month()) == i + 2);
+    assert(ym.year() == y);
+    assert(static_cast<unsigned>((ym -= months{1}).month()) == i + 1);
+    assert(ym.year() == y);
+    assert(static_cast<unsigned>((ym).month()) == i + 1);
+    assert(ym.year() == y);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using month      = std::chrono::month;
-    using months     = std::chrono::months;
-    using year       = std::chrono::year;
-    using year_month = std::chrono::year_month;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month&>() += std::declval<months>());
+  ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() += std::declval<months>()));
 
-    ASSERT_NOEXCEPT(                       std::declval<year_month&>() += std::declval<months>());
-    ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() += std::declval<months>()));
+  ASSERT_NOEXCEPT(std::declval<year_month&>() -= std::declval<months>());
+  ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() -= std::declval<months>()));
 
-    ASSERT_NOEXCEPT(                       std::declval<year_month&>() -= std::declval<months>());
-    ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() -= std::declval<months>()));
-
-    static_assert(testConstexpr<year_month, months>(year_month{year{1234}, month{1}}), "");
-
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        year y{1234};
-        year_month ym(y, month{i});
-        assert(static_cast<unsigned>((ym += months{2}).month()) == i + 2);
-        assert(ym.year() == y);
-        assert(static_cast<unsigned>((ym             ).month()) == i + 2);
-        assert(ym.year() == y);
-        assert(static_cast<unsigned>((ym -= months{1}).month()) == i + 1);
-        assert(ym.year() == y);
-        assert(static_cast<unsigned>((ym             ).month()) == i + 1);
-        assert(ym.year() == y);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_year.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_year.pass.cpp
@@ -19,48 +19,37 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<int>((d1          ).year()) !=  1) return false;
-    if (static_cast<int>((d1 += Ds{ 1}).year()) !=  2) return false;
-    if (static_cast<int>((d1 += Ds{ 2}).year()) !=  4) return false;
-    if (static_cast<int>((d1 += Ds{12}).year()) != 16) return false;
-    if (static_cast<int>((d1 -= Ds{ 1}).year()) != 15) return false;
-    if (static_cast<int>((d1 -= Ds{ 2}).year()) != 13) return false;
-    if (static_cast<int>((d1 -= Ds{12}).year()) !=  1) return false;
-    return true;
+using month      = std::chrono::month;
+using year       = std::chrono::year;
+using years      = std::chrono::years;
+using year_month = std::chrono::year_month;
+
+constexpr bool test() {
+  for (int i = 1000; i <= 1010; ++i) {
+    month m{2};
+    year_month ym(year{i}, m);
+    assert(static_cast<int>((ym += years{2}).year()) == i + 2);
+    assert(ym.month() == m);
+    assert(static_cast<int>((ym).year()) == i + 2);
+    assert(ym.month() == m);
+    assert(static_cast<int>((ym -= years{1}).year()) == i + 1);
+    assert(ym.month() == m);
+    assert(static_cast<int>((ym).year()) == i + 1);
+    assert(ym.month() == m);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using month      = std::chrono::month;
-    using year       = std::chrono::year;
-    using years      = std::chrono::years;
-    using year_month = std::chrono::year_month;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month&>() += std::declval<years>());
+  ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() += std::declval<years>()));
 
+  ASSERT_NOEXCEPT(std::declval<year_month&>() -= std::declval<years>());
+  ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() -= std::declval<years>()));
 
-    ASSERT_NOEXCEPT(                       std::declval<year_month&>() += std::declval<years>());
-    ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() += std::declval<years>()));
-
-    ASSERT_NOEXCEPT(                       std::declval<year_month&>() -= std::declval<years>());
-    ASSERT_SAME_TYPE(year_month&, decltype(std::declval<year_month&>() -= std::declval<years>()));
-
-    static_assert(testConstexpr<year_month, years>(year_month{year{1}, month{1}}), "");
-
-    for (int i = 1000; i <= 1010; ++i)
-    {
-        month m{2};
-        year_month ym(year{i}, m);
-        assert(static_cast<int>((ym += years{2}).year()) == i + 2);
-        assert(ym.month() == m);
-        assert(static_cast<int>((ym            ).year()) == i + 2);
-        assert(ym.month() == m);
-        assert(static_cast<int>((ym -= years{1}).year()) == i + 1);
-        assert(ym.month() == m);
-        assert(static_cast<int>((ym            ).year()) == i + 1);
-        assert(ym.month() == m);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/minus.pass.cpp
@@ -20,69 +20,70 @@
 // Returns: x.year() - y.year() + months{static_cast<int>(unsigned{x.month()}) -
 //                                       static_cast<int>(unsigned{y.month()})}
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    using year       = std::chrono::year;
-    using years      = std::chrono::years;
-    using month      = std::chrono::month;
-    using months     = std::chrono::months;
-    using year_month = std::chrono::year_month;
+using year       = std::chrono::year;
+using years      = std::chrono::years;
+using month      = std::chrono::month;
+using months     = std::chrono::months;
+using year_month = std::chrono::year_month;
 
-    {   // year_month - years
-    ASSERT_NOEXCEPT(                      std::declval<year_month>() - std::declval<years>());
-    ASSERT_SAME_TYPE(year_month, decltype(std::declval<year_month>() - std::declval<years>()));
-
-    // static_assert(testConstexprYears (year_month{year{1}, month{1}}), "");
+constexpr bool test() {
+  { // year_month - years
 
     year_month ym{year{1234}, std::chrono::January};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month ym1 = ym - years{i};
-        assert(static_cast<int>(ym1.year()) == 1234 - i);
-        assert(ym1.month() == std::chrono::January);
+    for (int i = 0; i <= 10; ++i) {
+      year_month ym1 = ym - years{i};
+      assert(static_cast<int>(ym1.year()) == 1234 - i);
+      assert(ym1.month() == std::chrono::January);
     }
-    }
+  }
 
-    {   // year_month - months
-    ASSERT_NOEXCEPT(                      std::declval<year_month>() - std::declval<months>());
-    ASSERT_SAME_TYPE(year_month, decltype(std::declval<year_month>() - std::declval<months>()));
-
-    // static_assert(testConstexprMonths(year_month{year{1}, month{1}}), "");
+  { // year_month - months
 
     year_month ym{year{1234}, std::chrono::November};
-    for (int i = 0; i <= 10; ++i)  // TODO test wrap-around
+    for (int i = 0; i <= 10; ++i) // TODO test wrap-around
     {
-        year_month ym1 = ym - months{i};
-        assert(static_cast<int>(ym1.year()) == 1234);
-        assert(ym1.month() == month(11 - i));
+      year_month ym1 = ym - months{i};
+      assert(static_cast<int>(ym1.year()) == 1234);
+      assert(ym1.month() == month(11 - i));
     }
-    }
+  }
 
-    {   // year_month - year_month
-    ASSERT_NOEXCEPT(                  std::declval<year_month>() - std::declval<year_month>());
-    ASSERT_SAME_TYPE(months, decltype(std::declval<year_month>() - std::declval<year_month>()));
-
-    // static_assert(testConstexprMonths(year_month{year{1}, month{1}}), "");
+  { // year_month - year_month
 
     //  Same year
     year y{2345};
     for (int i = 1; i <= 12; ++i)
-        for (int j = 1; j <= 12; ++j)
-    {
+      for (int j = 1; j <= 12; ++j) {
         months diff = year_month{y, month(i)} - year_month{y, month(j)};
         assert(diff.count() == i - j);
-    }
+      }
 
     // TODO: different year
+  }
+  return true;
+}
 
-    }
+int main(int, char**) {
+  // year_month - years
+  ASSERT_NOEXCEPT(std::declval<year_month>() - std::declval<years>());
+  ASSERT_SAME_TYPE(year_month, decltype(std::declval<year_month>() - std::declval<years>()));
 
-    return 0;
+  // year_month - months
+  ASSERT_NOEXCEPT(std::declval<year_month>() - std::declval<months>());
+  ASSERT_SAME_TYPE(year_month, decltype(std::declval<year_month>() - std::declval<months>()));
+
+  // year_month - year_month
+  ASSERT_NOEXCEPT(std::declval<year_month>() - std::declval<year_month>());
+  ASSERT_SAME_TYPE(months, decltype(std::declval<year_month>() - std::declval<year_month>()));
+
+  test();
+  static_assert(test());
+
+  return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_month.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_month.pass.cpp
@@ -19,53 +19,41 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<unsigned>((d1          ).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 1}).month()) !=  2) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 2}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 += Ds{12}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 1}).month()) !=  3) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 2}).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 -= Ds{12}).month()) !=  1) return false;
-    return true;
+using year           = std::chrono::year;
+using month          = std::chrono::month;
+using day            = std::chrono::day;
+using year_month_day = std::chrono::year_month_day;
+using months         = std::chrono::months;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 10; ++i) {
+    year y{1234};
+    day d{23};
+    year_month_day ymd(y, month{i}, d);
+
+    ymd += months{2};
+    assert(ymd.year() == y);
+    assert(ymd.day() == d);
+    assert(static_cast<unsigned>((ymd).month()) == i + 2);
+
+    ymd -= months{1};
+    assert(ymd.year() == y);
+    assert(ymd.day() == d);
+    assert(static_cast<unsigned>((ymd).month()) == i + 1);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year           = std::chrono::year;
-    using month          = std::chrono::month;
-    using day            = std::chrono::day;
-    using year_month_day = std::chrono::year_month_day;
-    using months         = std::chrono::months;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_day&>() += std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<year_month_day&>() -= std::declval<months>());
 
-    ASSERT_NOEXCEPT(std::declval<year_month_day&>() += std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<year_month_day&>() -= std::declval<months>());
+  ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() += std::declval<months>()));
+  ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() -= std::declval<months>()));
 
-    ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() += std::declval<months>()));
-    ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() -= std::declval<months>()));
-
-    static_assert(testConstexpr<year_month_day, months>(year_month_day{year{1234}, month{1}, day{1}}), "");
-
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        year y{1234};
-        day   d{23};
-        year_month_day ym(y, month{i}, d);
-        assert(static_cast<unsigned>((ym += months{2}).month()) == i + 2);
-        assert(ym.year() == y);
-        assert(ym.day()  == d);
-        assert(static_cast<unsigned>((ym             ).month()) == i + 2);
-        assert(ym.year() == y);
-        assert(ym.day()  == d);
-        assert(static_cast<unsigned>((ym -= months{1}).month()) == i + 1);
-        assert(ym.year() == y);
-        assert(ym.day()  == d);
-        assert(static_cast<unsigned>((ym             ).month()) == i + 1);
-        assert(ym.year() == y);
-        assert(ym.day()  == d);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_year.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_year.pass.cpp
@@ -19,53 +19,43 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<int>((d1          ).year()) !=  1) return false;
-    if (static_cast<int>((d1 += Ds{ 1}).year()) !=  2) return false;
-    if (static_cast<int>((d1 += Ds{ 2}).year()) !=  4) return false;
-    if (static_cast<int>((d1 += Ds{12}).year()) != 16) return false;
-    if (static_cast<int>((d1 -= Ds{ 1}).year()) != 15) return false;
-    if (static_cast<int>((d1 -= Ds{ 2}).year()) != 13) return false;
-    if (static_cast<int>((d1 -= Ds{12}).year()) !=  1) return false;
-    return true;
+using year           = std::chrono::year;
+using month          = std::chrono::month;
+using day            = std::chrono::day;
+using year_month_day = std::chrono::year_month_day;
+using years          = std::chrono::years;
+
+constexpr bool test() {
+  for (int i = 1000; i <= 1010; ++i) {
+    month m{2};
+    day d{23};
+    year_month_day ym(year{i}, m, d);
+    assert(static_cast<int>((ym += years{2}).year()) == i + 2);
+    assert(ym.month() == m);
+    assert(ym.day() == d);
+    assert(static_cast<int>((ym).year()) == i + 2);
+    assert(ym.month() == m);
+    assert(ym.day() == d);
+    assert(static_cast<int>((ym -= years{1}).year()) == i + 1);
+    assert(ym.month() == m);
+    assert(ym.day() == d);
+    assert(static_cast<int>((ym).year()) == i + 1);
+    assert(ym.month() == m);
+    assert(ym.day() == d);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year           = std::chrono::year;
-    using month          = std::chrono::month;
-    using day            = std::chrono::day;
-    using year_month_day = std::chrono::year_month_day;
-    using years          = std::chrono::years;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_day&>() += std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<year_month_day&>() -= std::declval<years>());
 
-    ASSERT_NOEXCEPT(std::declval<year_month_day&>() += std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<year_month_day&>() -= std::declval<years>());
+  ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() += std::declval<years>()));
+  ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() -= std::declval<years>()));
 
-    ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() += std::declval<years>()));
-    ASSERT_SAME_TYPE(year_month_day&, decltype(std::declval<year_month_day&>() -= std::declval<years>()));
-
-    static_assert(testConstexpr<year_month_day, years>(year_month_day{year{1}, month{1}, day{1}}), "");
-
-    for (int i = 1000; i <= 1010; ++i)
-    {
-        month m{2};
-        day   d{23};
-        year_month_day ym(year{i}, m, d);
-        assert(static_cast<int>((ym += years{2}).year()) == i + 2);
-        assert(ym.month() == m);
-        assert(ym.day()   == d);
-        assert(static_cast<int>((ym            ).year()) == i + 2);
-        assert(ym.month() == m);
-        assert(ym.day()   == d);
-        assert(static_cast<int>((ym -= years{1}).year()) == i + 1);
-        assert(ym.month() == m);
-        assert(ym.day()   == d);
-        assert(static_cast<int>((ym            ).year()) == i + 1);
-        assert(ym.month() == m);
-        assert(ym.day()   == d);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/plus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/plus.pass.cpp
@@ -23,91 +23,71 @@
 // constexpr year_month_day operator+(const years& dy, const year_month_day& ymd) noexcept;
 //   Returns: ym + dm.
 
-
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-constexpr bool testConstexprYears(std::chrono::year_month_day ym)
-{
-    std::chrono::years offset{23};
-    if (static_cast<int>((ym         ).year()) !=  1) return false;
-    if (static_cast<int>((ym + offset).year()) != 24) return false;
-    if (static_cast<int>((offset + ym).year()) != 24) return false;
-    return true;
+using day            = std::chrono::day;
+using year           = std::chrono::year;
+using years          = std::chrono::years;
+using month          = std::chrono::month;
+using months         = std::chrono::months;
+using year_month_day = std::chrono::year_month_day;
+
+constexpr bool test() {
+  { // year_month_day + months
+    year_month_day ym{year{1234}, std::chrono::January, day{12}};
+    for (int i = 0; i <= 10; ++i) // TODO test wrap-around
+    {
+      year_month_day ym1 = ym + months{i};
+      year_month_day ym2 = months{i} + ym;
+      assert(static_cast<int>(ym1.year()) == 1234);
+      assert(static_cast<int>(ym2.year()) == 1234);
+      assert(ym1.month() == month(1 + i));
+      assert(ym2.month() == month(1 + i));
+      assert(ym1.day() == day{12});
+      assert(ym2.day() == day{12});
+      assert(ym1 == ym2);
+    }
+  }
+
+  { // year_month_day + years
+    year_month_day ym{year{1234}, std::chrono::January, day{12}};
+    for (int i = 0; i <= 10; ++i) {
+      year_month_day ym1 = ym + years{i};
+      year_month_day ym2 = years{i} + ym;
+      assert(static_cast<int>(ym1.year()) == i + 1234);
+      assert(static_cast<int>(ym2.year()) == i + 1234);
+      assert(ym1.month() == std::chrono::January);
+      assert(ym2.month() == std::chrono::January);
+      assert(ym1.day() == day{12});
+      assert(ym2.day() == day{12});
+      assert(ym1 == ym2);
+    }
+  }
+
+  return true;
 }
 
+int main(int, char**) {
+  // year_month_day + months
+  ASSERT_NOEXCEPT(std::declval<year_month_day>() + std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_day>());
 
-constexpr bool testConstexprMonths(std::chrono::year_month_day ym)
-{
-    std::chrono::months offset{6};
-    if (static_cast<unsigned>((ym         ).month()) !=  1) return false;
-    if (static_cast<unsigned>((ym + offset).month()) !=  7) return false;
-    if (static_cast<unsigned>((offset + ym).month()) !=  7) return false;
-    return true;
-}
+  ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<year_month_day>() + std::declval<months>()));
+  ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<months>() + std::declval<year_month_day>()));
 
+  // year_month_day + years
+  ASSERT_NOEXCEPT(std::declval<year_month_day>() + std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_day>());
 
-int main(int, char**)
-{
-    using day        = std::chrono::day;
-    using year       = std::chrono::year;
-    using years      = std::chrono::years;
-    using month      = std::chrono::month;
-    using months     = std::chrono::months;
-    using year_month_day = std::chrono::year_month_day;
+  ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<year_month_day>() + std::declval<years>()));
+  ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<years>() + std::declval<year_month_day>()));
 
-    {   // year_month_day + months
-    ASSERT_NOEXCEPT(std::declval<year_month_day>() + std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_day>());
-
-    ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<year_month_day>() + std::declval<months>()));
-    ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<months>() + std::declval<year_month_day>()));
-
-    static_assert(testConstexprMonths(year_month_day{year{1}, month{1}, day{1}}), "");
-
-    year_month_day ym{year{1234}, std::chrono::January, day{12}};
-    for (int i = 0; i <= 10; ++i)  // TODO test wrap-around
-    {
-        year_month_day ym1 = ym + months{i};
-        year_month_day ym2 = months{i} + ym;
-        assert(static_cast<int>(ym1.year()) == 1234);
-        assert(static_cast<int>(ym2.year()) == 1234);
-        assert(ym1.month() == month(1 + i));
-        assert(ym2.month() == month(1 + i));
-        assert(ym1.day()   == day{12});
-        assert(ym2.day()   == day{12});
-        assert(ym1 == ym2);
-    }
-    }
-
-    {   // year_month_day + years
-    ASSERT_NOEXCEPT(std::declval<year_month_day>() + std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_day>());
-
-    ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<year_month_day>() + std::declval<years>()));
-    ASSERT_SAME_TYPE(year_month_day, decltype(std::declval<years>() + std::declval<year_month_day>()));
-
-    static_assert(testConstexprYears (year_month_day{year{1}, month{1}, day{1}}), "");
-
-    year_month_day ym{year{1234}, std::chrono::January, day{12}};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month_day ym1 = ym + years{i};
-        year_month_day ym2 = years{i} + ym;
-        assert(static_cast<int>(ym1.year()) == i + 1234);
-        assert(static_cast<int>(ym2.year()) == i + 1234);
-        assert(ym1.month() == std::chrono::January);
-        assert(ym2.month() == std::chrono::January);
-        assert(ym1.day()   == day{12});
-        assert(ym2.day()   == day{12});
-        assert(ym1 == ym2);
-    }
-    }
-
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_month.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_month.pass.cpp
@@ -19,49 +19,39 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<unsigned>((d1          ).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 1}).month()) !=  2) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 2}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 += Ds{12}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 1}).month()) !=  3) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 2}).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 -= Ds{12}).month()) !=  1) return false;
-    return true;
+using year                = std::chrono::year;
+using month               = std::chrono::month;
+using month_day_last      = std::chrono::month_day_last;
+using year_month_day_last = std::chrono::year_month_day_last;
+using months              = std::chrono::months;
+
+constexpr bool test() {
+  for (unsigned i = 0; i <= 10; ++i) {
+    year y{1234};
+    month_day_last mdl{month{i}};
+    year_month_day_last ym(y, mdl);
+    assert(static_cast<unsigned>((ym += months{2}).month()) == i + 2);
+    assert(ym.year() == y);
+    assert(static_cast<unsigned>((ym).month()) == i + 2);
+    assert(ym.year() == y);
+    assert(static_cast<unsigned>((ym -= months{1}).month()) == i + 1);
+    assert(ym.year() == y);
+    assert(static_cast<unsigned>((ym).month()) == i + 1);
+    assert(ym.year() == y);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year                = std::chrono::year;
-    using month               = std::chrono::month;
-    using month_day_last      = std::chrono::month_day_last;
-    using year_month_day_last = std::chrono::year_month_day_last;
-    using months              = std::chrono::months;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() += std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() -= std::declval<months>());
 
-    ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() += std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() -= std::declval<months>());
+  ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() += std::declval<months>()));
+  ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() -= std::declval<months>()));
 
-    ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() += std::declval<months>()));
-    ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() -= std::declval<months>()));
-
-    static_assert(testConstexpr<year_month_day_last, months>(year_month_day_last{year{1234}, month_day_last{month{1}}}), "");
-
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        year y{1234};
-        month_day_last   mdl{month{i}};
-        year_month_day_last ym(y, mdl);
-        assert(static_cast<unsigned>((ym += months{2}).month()) == i + 2);
-        assert(ym.year() == y);
-        assert(static_cast<unsigned>((ym             ).month()) == i + 2);
-        assert(ym.year() == y);
-        assert(static_cast<unsigned>((ym -= months{1}).month()) == i + 1);
-        assert(ym.year() == y);
-        assert(static_cast<unsigned>((ym             ).month()) == i + 1);
-        assert(ym.year() == y);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_year.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_year.pass.cpp
@@ -19,48 +19,38 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<int>((d1          ).year()) !=  1) return false;
-    if (static_cast<int>((d1 += Ds{ 1}).year()) !=  2) return false;
-    if (static_cast<int>((d1 += Ds{ 2}).year()) !=  4) return false;
-    if (static_cast<int>((d1 += Ds{12}).year()) != 16) return false;
-    if (static_cast<int>((d1 -= Ds{ 1}).year()) != 15) return false;
-    if (static_cast<int>((d1 -= Ds{ 2}).year()) != 13) return false;
-    if (static_cast<int>((d1 -= Ds{12}).year()) !=  1) return false;
-    return true;
+using year                = std::chrono::year;
+using month               = std::chrono::month;
+using month_day_last      = std::chrono::month_day_last;
+using year_month_day_last = std::chrono::year_month_day_last;
+using years               = std::chrono::years;
+
+constexpr bool test() {
+  for (int i = 1000; i <= 1010; ++i) {
+    month_day_last mdl{month{2}};
+    year_month_day_last ymdl(year{i}, mdl);
+    assert(static_cast<int>((ymdl += years{2}).year()) == i + 2);
+    assert(ymdl.month_day_last() == mdl);
+    assert(static_cast<int>((ymdl).year()) == i + 2);
+    assert(ymdl.month_day_last() == mdl);
+    assert(static_cast<int>((ymdl -= years{1}).year()) == i + 1);
+    assert(ymdl.month_day_last() == mdl);
+    assert(static_cast<int>((ymdl).year()) == i + 1);
+    assert(ymdl.month_day_last() == mdl);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year                = std::chrono::year;
-    using month               = std::chrono::month;
-    using month_day_last      = std::chrono::month_day_last;
-    using year_month_day_last = std::chrono::year_month_day_last;
-    using years               = std::chrono::years;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() += std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() -= std::declval<years>());
 
-    ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() += std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<year_month_day_last&>() -= std::declval<years>());
+  ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() += std::declval<years>()));
+  ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() -= std::declval<years>()));
 
-    ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() += std::declval<years>()));
-    ASSERT_SAME_TYPE(year_month_day_last&, decltype(std::declval<year_month_day_last&>() -= std::declval<years>()));
-
-    static_assert(testConstexpr<year_month_day_last, years>(year_month_day_last{year{1}, month_day_last{month{1}}}), "");
-
-    for (int i = 1000; i <= 1010; ++i)
-    {
-        month_day_last mdl{month{2}};
-        year_month_day_last ymdl(year{i}, mdl);
-        assert(static_cast<int>((ymdl += years{2}).year()) == i + 2);
-        assert(ymdl.month_day_last() == mdl);
-        assert(static_cast<int>((ymdl            ).year()) == i + 2);
-        assert(ymdl.month_day_last() == mdl);
-        assert(static_cast<int>((ymdl -= years{1}).year()) == i + 1);
-        assert(ymdl.month_day_last() == mdl);
-        assert(static_cast<int>((ymdl            ).year()) == i + 1);
-        assert(ymdl.month_day_last() == mdl);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/minus.pass.cpp
@@ -20,71 +20,57 @@
 //
 //   Returns: ymdl + (-dy).
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-constexpr bool testConstexprYears (std::chrono::year_month_day_last ymdl)
-{
-    std::chrono::year_month_day_last ym1 = ymdl - std::chrono::years{10};
-    return
-        ym1.year()  == std::chrono::year{static_cast<int>(ymdl.year()) - 10}
-     && ym1.month() == ymdl.month()
-        ;
-}
+using year                = std::chrono::year;
+using month               = std::chrono::month;
+using month_day_last      = std::chrono::month_day_last;
+using year_month_day_last = std::chrono::year_month_day_last;
+using months              = std::chrono::months;
+using years               = std::chrono::years;
 
-constexpr bool testConstexprMonths (std::chrono::year_month_day_last ymdl)
-{
-    std::chrono::year_month_day_last ym1 = ymdl - std::chrono::months{6};
-    return
-        ym1.year()  == ymdl.year()
-     && ym1.month() == std::chrono::month{static_cast<unsigned>(ymdl.month()) - 6}
-        ;
-}
+constexpr bool test() {
+  constexpr month December = std::chrono::December;
 
-int main(int, char**)
-{
-    using year                = std::chrono::year;
-    using month               = std::chrono::month;
-    using month_day_last      = std::chrono::month_day_last;
-    using year_month_day_last = std::chrono::year_month_day_last;
-    using months              = std::chrono::months;
-    using years               = std::chrono::years;
+  { // year_month_day_last - years
 
-    constexpr month December = std::chrono::December;
-
-    { // year_month_day_last - years
-    ASSERT_NOEXCEPT(                               std::declval<year_month_day_last>() - std::declval<years>());
-    ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() - std::declval<years>()));
-
-    static_assert(testConstexprYears(year_month_day_last{year{1234}, month_day_last{December}}), "");
     year_month_day_last ym{year{1234}, month_day_last{December}};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month_day_last ym1 = ym - years{i};
-        assert(static_cast<int>(ym1.year()) == 1234 - i);
-        assert(ym1.month() == December);
+    for (int i = 0; i <= 10; ++i) {
+      year_month_day_last ym1 = ym - years{i};
+      assert(static_cast<int>(ym1.year()) == 1234 - i);
+      assert(ym1.month() == December);
     }
-    }
+  }
 
-    { // year_month_day_last - months
-    ASSERT_NOEXCEPT(                               std::declval<year_month_day_last>() - std::declval<months>());
-    ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() - std::declval<months>()));
+  { // year_month_day_last - months
 
-    static_assert(testConstexprMonths(year_month_day_last{year{1234}, month_day_last{December}}), "");
     // TODO test wrapping
     year_month_day_last ym{year{1234}, month_day_last{December}};
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        year_month_day_last ym1 = ym - months{i};
-        assert(static_cast<int>(ym1.year()) == 1234);
-        assert(static_cast<unsigned>(ym1.month()) == 12U-i);
+    for (unsigned i = 0; i <= 10; ++i) {
+      year_month_day_last ym1 = ym - months{i};
+      assert(static_cast<int>(ym1.year()) == 1234);
+      assert(static_cast<unsigned>(ym1.month()) == 12U - i);
     }
-    }
+  }
 
+  return true;
+}
 
-    return 0;
+int main(int, char**) {
+  // year_month_day_last - years
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last>() - std::declval<years>());
+  ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() - std::declval<years>()));
+
+  // year_month_day_last - months
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last>() - std::declval<months>());
+  ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() - std::declval<months>()));
+
+  test();
+  static_assert(test());
+
+  return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/plus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/plus.pass.cpp
@@ -31,93 +31,70 @@
 //
 //   Returns: ymdl + dy
 
-
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-constexpr bool testConstexprYears(std::chrono::year_month_day_last ymdl)
-{
-    std::chrono::years offset{23};
-    if (static_cast<int>((ymdl         ).year()) !=  1)           return false;
-    if (static_cast<int>((ymdl + offset).year()) != 24)           return false;
-    if (                 (ymdl + offset).month() != ymdl.month()) return false;
-    if (static_cast<int>((offset + ymdl).year()) != 24)           return false;
-    if (                 (offset + ymdl).month() != ymdl.month()) return false;
-    return true;
-}
+using year                = std::chrono::year;
+using month               = std::chrono::month;
+using month_day_last      = std::chrono::month_day_last;
+using year_month_day_last = std::chrono::year_month_day_last;
+using months              = std::chrono::months;
+using years               = std::chrono::years;
 
+constexpr bool test() {
+  constexpr month January = std::chrono::January;
 
-constexpr bool testConstexprMonths(std::chrono::year_month_day_last ymdl)
-{
-    std::chrono::months offset{6};
-    if (static_cast<unsigned>((ymdl         ).month()) !=  1)          return false;
-    if (                      (ymdl + offset).year()   != ymdl.year()) return false;
-    if (static_cast<unsigned>((ymdl + offset).month()) !=  7)          return false;
-    if (static_cast<unsigned>((offset + ymdl).month()) !=  7)          return false;
-    if (                      (offset + ymdl).year()   != ymdl.year()) return false;
-    return true;
-}
+  { // year_month_day_last + months
+    year_month_day_last ym{year{1234}, month_day_last{January}};
+    for (int i = 0; i <= 10; ++i) // TODO test wrap-around
+    {
+      year_month_day_last ym1 = ym + months{i};
+      year_month_day_last ym2 = months{i} + ym;
+      assert(static_cast<int>(ym1.year()) == 1234);
+      assert(static_cast<int>(ym2.year()) == 1234);
+      assert(ym1.month() == month(1 + i));
+      assert(ym2.month() == month(1 + i));
+      assert(ym1 == ym2);
+    }
+  }
 
-
-int main(int, char**)
-{
-    using year                = std::chrono::year;
-    using month               = std::chrono::month;
-    using month_day_last      = std::chrono::month_day_last;
-    using year_month_day_last = std::chrono::year_month_day_last;
-    using months              = std::chrono::months;
-    using years               = std::chrono::years;
-
-    constexpr month January = std::chrono::January;
-
-    {   // year_month_day_last + months
-    ASSERT_NOEXCEPT(std::declval<year_month_day_last>() + std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_day_last>());
-
-    ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() + std::declval<months>()));
-    ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<months>() + std::declval<year_month_day_last>()));
-
-    static_assert(testConstexprMonths(year_month_day_last{year{1}, month_day_last{January}}), "");
+  { // year_month_day_last + years
 
     year_month_day_last ym{year{1234}, month_day_last{January}};
-    for (int i = 0; i <= 10; ++i)  // TODO test wrap-around
-    {
-        year_month_day_last ym1 = ym + months{i};
-        year_month_day_last ym2 = months{i} + ym;
-        assert(static_cast<int>(ym1.year()) == 1234);
-        assert(static_cast<int>(ym2.year()) == 1234);
-        assert(ym1.month() == month(1 + i));
-        assert(ym2.month() == month(1 + i));
-        assert(ym1 == ym2);
+    for (int i = 0; i <= 10; ++i) {
+      year_month_day_last ym1 = ym + years{i};
+      year_month_day_last ym2 = years{i} + ym;
+      assert(static_cast<int>(ym1.year()) == i + 1234);
+      assert(static_cast<int>(ym2.year()) == i + 1234);
+      assert(ym1.month() == std::chrono::January);
+      assert(ym2.month() == std::chrono::January);
+      assert(ym1 == ym2);
     }
-    }
+  }
 
-    {   // year_month_day_last + years
-    ASSERT_NOEXCEPT(std::declval<year_month_day_last>() + std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_day_last>());
+  return true;
+}
 
-    ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() + std::declval<years>()));
-    ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<years>() + std::declval<year_month_day_last>()));
+int main(int, char**) {
+  // year_month_day_last + months
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last>() + std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_day_last>());
 
-    static_assert(testConstexprYears(year_month_day_last{year{1}, month_day_last{January}}), "");
+  ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() + std::declval<months>()));
+  ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<months>() + std::declval<year_month_day_last>()));
 
-    year_month_day_last ym{year{1234}, month_day_last{January}};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month_day_last ym1 = ym + years{i};
-        year_month_day_last ym2 = years{i} + ym;
-        assert(static_cast<int>(ym1.year()) == i + 1234);
-        assert(static_cast<int>(ym2.year()) == i + 1234);
-        assert(ym1.month() == std::chrono::January);
-        assert(ym2.month() == std::chrono::January);
-        assert(ym1 == ym2);
-    }
-    }
+  // year_month_day_last + years
+  ASSERT_NOEXCEPT(std::declval<year_month_day_last>() + std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_day_last>());
 
+  ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<year_month_day_last>() + std::declval<years>()));
+  ASSERT_SAME_TYPE(year_month_day_last, decltype(std::declval<years>() + std::declval<year_month_day_last>()));
+
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_month.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_month.pass.cpp
@@ -19,63 +19,53 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<unsigned>((d1          ).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 1}).month()) !=  2) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 2}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 += Ds{12}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 1}).month()) !=  3) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 2}).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 -= Ds{12}).month()) !=  1) return false;
-    return true;
+using year               = std::chrono::year;
+using month              = std::chrono::month;
+using weekday            = std::chrono::weekday;
+using weekday_indexed    = std::chrono::weekday_indexed;
+using year_month_weekday = std::chrono::year_month_weekday;
+using months             = std::chrono::months;
+
+constexpr bool test() {
+  constexpr weekday Tuesday = std::chrono::Tuesday;
+
+  for (unsigned i = 0; i <= 10; ++i) {
+    year y{1234};
+    year_month_weekday ymwd(y, month{i}, weekday_indexed{Tuesday, 2});
+
+    assert(static_cast<unsigned>((ymwd += months{2}).month()) == i + 2);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+
+    assert(static_cast<unsigned>((ymwd).month()) == i + 2);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+
+    assert(static_cast<unsigned>((ymwd -= months{1}).month()) == i + 1);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+
+    assert(static_cast<unsigned>((ymwd).month()) == i + 1);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year               = std::chrono::year;
-    using month              = std::chrono::month;
-    using weekday            = std::chrono::weekday;
-    using weekday_indexed    = std::chrono::weekday_indexed;
-    using year_month_weekday = std::chrono::year_month_weekday;
-    using months             = std::chrono::months;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday&>() += std::declval<months>());
+  ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() += std::declval<months>()));
 
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday&>() -= std::declval<months>());
+  ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() -= std::declval<months>()));
 
-    ASSERT_NOEXCEPT(                               std::declval<year_month_weekday&>() += std::declval<months>());
-    ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() += std::declval<months>()));
-
-    ASSERT_NOEXCEPT(                               std::declval<year_month_weekday&>() -= std::declval<months>());
-    ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() -= std::declval<months>()));
-
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-    static_assert(testConstexpr<year_month_weekday, months>(year_month_weekday{year{1234}, month{1}, weekday_indexed{Tuesday, 2}}), "");
-
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        year y{1234};
-        year_month_weekday ymwd(y, month{i}, weekday_indexed{Tuesday, 2});
-
-        assert(static_cast<unsigned>((ymwd += months{2}).month()) == i + 2);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-
-        assert(static_cast<unsigned>((ymwd             ).month()) == i + 2);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-
-        assert(static_cast<unsigned>((ymwd -= months{1}).month()) == i + 1);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-
-        assert(static_cast<unsigned>((ymwd             ).month()) == i + 1);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_year.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_year.pass.cpp
@@ -19,63 +19,52 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<int>((d1          ).year()) !=  1) return false;
-    if (static_cast<int>((d1 += Ds{ 1}).year()) !=  2) return false;
-    if (static_cast<int>((d1 += Ds{ 2}).year()) !=  4) return false;
-    if (static_cast<int>((d1 += Ds{12}).year()) != 16) return false;
-    if (static_cast<int>((d1 -= Ds{ 1}).year()) != 15) return false;
-    if (static_cast<int>((d1 -= Ds{ 2}).year()) != 13) return false;
-    if (static_cast<int>((d1 -= Ds{12}).year()) !=  1) return false;
-    return true;
+using year               = std::chrono::year;
+using month              = std::chrono::month;
+using weekday            = std::chrono::weekday;
+using weekday_indexed    = std::chrono::weekday_indexed;
+using year_month_weekday = std::chrono::year_month_weekday;
+using years              = std::chrono::years;
+
+constexpr bool test() {
+  constexpr weekday Tuesday = std::chrono::Tuesday;
+  constexpr month January   = std::chrono::January;
+
+  for (int i = 1000; i <= 1010; ++i) {
+    year_month_weekday ymwd(year{i}, January, weekday_indexed{Tuesday, 2});
+
+    assert(static_cast<int>((ymwd += years{2}).year()) == i + 2);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+
+    assert(static_cast<int>((ymwd).year()) == i + 2);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+
+    assert(static_cast<int>((ymwd -= years{1}).year()) == i + 1);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+
+    assert(static_cast<int>((ymwd).year()) == i + 1);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+    assert(ymwd.index() == 2);
+  }
+  return true;
 }
 
-int main(int, char**)
-{
-    using year               = std::chrono::year;
-    using month              = std::chrono::month;
-    using weekday            = std::chrono::weekday;
-    using weekday_indexed    = std::chrono::weekday_indexed;
-    using year_month_weekday = std::chrono::year_month_weekday;
-    using years              = std::chrono::years;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday&>() += std::declval<years>());
+  ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() += std::declval<years>()));
 
-    ASSERT_NOEXCEPT(                               std::declval<year_month_weekday&>() += std::declval<years>());
-    ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() += std::declval<years>()));
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday&>() -= std::declval<years>());
+  ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() -= std::declval<years>()));
 
-    ASSERT_NOEXCEPT(                               std::declval<year_month_weekday&>() -= std::declval<years>());
-    ASSERT_SAME_TYPE(year_month_weekday&, decltype(std::declval<year_month_weekday&>() -= std::declval<years>()));
-
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-    constexpr month January = std::chrono::January;
-
-    static_assert(testConstexpr<year_month_weekday, years>(year_month_weekday{year{1}, January, weekday_indexed{Tuesday, 2}}), "");
-
-    for (int i = 1000; i <= 1010; ++i)
-    {
-        year_month_weekday ymwd(year{i}, January, weekday_indexed{Tuesday, 2});
-
-        assert(static_cast<int>((ymwd += years{2}).year()) == i + 2);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-
-        assert(static_cast<int>((ymwd            ).year()) == i + 2);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-
-        assert(static_cast<int>((ymwd -= years{1}).year()) == i + 1);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-
-        assert(static_cast<int>((ymwd            ).year()) == i + 1);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-        assert(ymwd.index()    == 2);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/minus.pass.cpp
@@ -16,85 +16,60 @@
 // constexpr year_month_weekday operator-(const year_month_weekday& ymwd, const years& dy) noexcept;
 //   Returns: ymwd + (-dy).
 
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
+using year               = std::chrono::year;
+using month              = std::chrono::month;
+using weekday            = std::chrono::weekday;
+using weekday_indexed    = std::chrono::weekday_indexed;
+using year_month_weekday = std::chrono::year_month_weekday;
+using years              = std::chrono::years;
+using months             = std::chrono::months;
 
-constexpr bool testConstexprYears ()
-{
-    std::chrono::year_month_weekday ym0{std::chrono::year{1234}, std::chrono::January, std::chrono::weekday_indexed{std::chrono::Tuesday, 1}};
-    std::chrono::year_month_weekday ym1 = ym0 - std::chrono::years{10};
-    return
-        ym1.year()    == std::chrono::year{1234-10}
-     && ym1.month()   == std::chrono::January
-     && ym1.weekday() == std::chrono::Tuesday
-     && ym1.index()   == 1
-        ;
-}
+constexpr bool test() {
+  constexpr month November  = std::chrono::November;
+  constexpr weekday Tuesday = std::chrono::Tuesday;
 
-constexpr bool testConstexprMonths ()
-{
-    std::chrono::year_month_weekday ym0{std::chrono::year{1234}, std::chrono::November, std::chrono::weekday_indexed{std::chrono::Tuesday, 1}};
-    std::chrono::year_month_weekday ym1 = ym0 - std::chrono::months{6};
-    return
-        ym1.year()    == std::chrono::year{1234}
-     && ym1.month()   == std::chrono::May
-     && ym1.weekday() == std::chrono::Tuesday
-     && ym1.index()   == 1
-        ;
-}
-
-
-int main(int, char**)
-{
-    using year               = std::chrono::year;
-    using month              = std::chrono::month;
-    using weekday            = std::chrono::weekday;
-    using weekday_indexed    = std::chrono::weekday_indexed;
-    using year_month_weekday = std::chrono::year_month_weekday;
-    using years              = std::chrono::years;
-    using months             = std::chrono::months;
-
-    constexpr month November  = std::chrono::November;
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-
-    {  // year_month_weekday - years
-    ASSERT_NOEXCEPT(                              std::declval<year_month_weekday>() - std::declval<years>());
-    ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() - std::declval<years>()));
-
-    static_assert(testConstexprYears(), "");
-
+  { // year_month_weekday - years
     year_month_weekday ym{year{1234}, November, weekday_indexed{Tuesday, 1}};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month_weekday ym1 = ym - years{i};
-        assert(static_cast<int>(ym1.year()) == 1234 - i);
-        assert(ym1.month()   == November);
-        assert(ym1.weekday() == Tuesday);
-        assert(ym1.index()   == 1);
+    for (int i = 0; i <= 10; ++i) {
+      year_month_weekday ym1 = ym - years{i};
+      assert(static_cast<int>(ym1.year()) == 1234 - i);
+      assert(ym1.month() == November);
+      assert(ym1.weekday() == Tuesday);
+      assert(ym1.index() == 1);
     }
-    }
+  }
 
-    {  // year_month_weekday - months
-    ASSERT_NOEXCEPT(                              std::declval<year_month_weekday>() - std::declval<months>());
-    ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() - std::declval<months>()));
-
-    static_assert(testConstexprMonths(), "");
-
+  { // year_month_weekday - months
     year_month_weekday ym{year{1234}, November, weekday_indexed{Tuesday, 2}};
-    for (unsigned i = 1; i <= 10; ++i)
-    {
-        year_month_weekday ym1 = ym - months{i};
-        assert(ym1.year()    == year{1234});
-        assert(ym1.month()   == month{11-i});
-        assert(ym1.weekday() == Tuesday);
-        assert(ym1.index()   == 2);
+    for (unsigned i = 1; i <= 10; ++i) {
+      year_month_weekday ym1 = ym - months{i};
+      assert(ym1.year() == year{1234});
+      assert(ym1.month() == month{11 - i});
+      assert(ym1.weekday() == Tuesday);
+      assert(ym1.index() == 2);
     }
-    }
+  }
+
+  return true;
+}
+
+int main(int, char**) {
+  // year_month_weekday - years
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday>() - std::declval<years>());
+  ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() - std::declval<years>()));
+
+  // year_month_weekday - months
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday>() - std::declval<months>());
+  ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() - std::declval<months>()));
+
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/plus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/plus.pass.cpp
@@ -23,99 +23,79 @@
 // constexpr year_month_weekday operator+(const years& dy, const year_month_weekday& ymd) noexcept;
 //   Returns: ym + dm.
 
-
-
 #include <chrono>
 #include <type_traits>
 #include <cassert>
 
 #include "test_macros.h"
 
-constexpr bool testConstexprYears(std::chrono::year_month_weekday ym)
-{
-    std::chrono::years offset{23};
-    if (static_cast<int>((ym         ).year()) !=  1) return false;
-    if (static_cast<int>((ym + offset).year()) != 24) return false;
-    if (static_cast<int>((offset + ym).year()) != 24) return false;
-    return true;
-}
+using year               = std::chrono::year;
+using month              = std::chrono::month;
+using weekday            = std::chrono::weekday;
+using weekday_indexed    = std::chrono::weekday_indexed;
+using year_month_weekday = std::chrono::year_month_weekday;
+using years              = std::chrono::years;
+using months             = std::chrono::months;
 
+constexpr bool test() {
+  constexpr weekday Tuesday = std::chrono::Tuesday;
+  constexpr month January   = std::chrono::January;
 
-constexpr bool testConstexprMonths(std::chrono::year_month_weekday ym)
-{
-    std::chrono::months offset{6};
-    if (static_cast<unsigned>((ym         ).month()) !=  1) return false;
-    if (static_cast<unsigned>((ym + offset).month()) !=  7) return false;
-    if (static_cast<unsigned>((offset + ym).month()) !=  7) return false;
-    return true;
-}
-
-
-int main(int, char**)
-{
-    using year               = std::chrono::year;
-    using month              = std::chrono::month;
-    using weekday            = std::chrono::weekday;
-    using weekday_indexed    = std::chrono::weekday_indexed;
-    using year_month_weekday = std::chrono::year_month_weekday;
-    using years              = std::chrono::years;
-    using months             = std::chrono::months;
-
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-    constexpr month January = std::chrono::January;
-
-    {   // year_month_weekday + months (and switched)
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday>() + std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_weekday>());
-
-    ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() + std::declval<months>()));
-    ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<months>() + std::declval<year_month_weekday>()));
-
-    static_assert(testConstexprMonths(year_month_weekday{year{1}, January, weekday_indexed{Tuesday, 1}}), "");
-
+  { // year_month_weekday + months (and switched)
     year_month_weekday ym{year{1234}, January, weekday_indexed{Tuesday, 3}};
-    for (int i = 0; i <= 10; ++i)  // TODO test wrap-around
+    for (int i = 0; i <= 10; ++i) // TODO test wrap-around
     {
-        year_month_weekday ym1 = ym + months{i};
-        year_month_weekday ym2 = months{i} + ym;
-        assert(static_cast<int>(ym1.year()) == 1234);
-        assert(static_cast<int>(ym2.year()) == 1234);
-        assert(ym1.month()   == month(1 + i));
-        assert(ym2.month()   == month(1 + i));
-        assert(ym1.weekday() == Tuesday);
-        assert(ym2.weekday() == Tuesday);
-        assert(ym1.index()   == 3);
-        assert(ym2.index()   == 3);
-        assert(ym1 == ym2);
+      year_month_weekday ym1 = ym + months{i};
+      year_month_weekday ym2 = months{i} + ym;
+      assert(static_cast<int>(ym1.year()) == 1234);
+      assert(static_cast<int>(ym2.year()) == 1234);
+      assert(ym1.month() == month(1 + i));
+      assert(ym2.month() == month(1 + i));
+      assert(ym1.weekday() == Tuesday);
+      assert(ym2.weekday() == Tuesday);
+      assert(ym1.index() == 3);
+      assert(ym2.index() == 3);
+      assert(ym1 == ym2);
     }
-    }
+  }
 
-    {   // year_month_weekday + years (and switched)
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday>() + std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_weekday>());
-
-    ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() + std::declval<years>()));
-    ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<years>() + std::declval<year_month_weekday>()));
-
-    static_assert(testConstexprYears (year_month_weekday{year{1}, January, weekday_indexed{Tuesday, 1}}), "");
-
+  { // year_month_weekday + years (and switched)
     year_month_weekday ym{year{1234}, std::chrono::January, weekday_indexed{Tuesday, 3}};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month_weekday ym1 = ym + years{i};
-        year_month_weekday ym2 = years{i} + ym;
-        assert(static_cast<int>(ym1.year()) == i + 1234);
-        assert(static_cast<int>(ym2.year()) == i + 1234);
-        assert(ym1.month()   == January);
-        assert(ym2.month()   == January);
-        assert(ym1.weekday() == Tuesday);
-        assert(ym2.weekday() == Tuesday);
-        assert(ym1.index()   == 3);
-        assert(ym2.index()   == 3);
-        assert(ym1 == ym2);
+    for (int i = 0; i <= 10; ++i) {
+      year_month_weekday ym1 = ym + years{i};
+      year_month_weekday ym2 = years{i} + ym;
+      assert(static_cast<int>(ym1.year()) == i + 1234);
+      assert(static_cast<int>(ym2.year()) == i + 1234);
+      assert(ym1.month() == January);
+      assert(ym2.month() == January);
+      assert(ym1.weekday() == Tuesday);
+      assert(ym2.weekday() == Tuesday);
+      assert(ym1.index() == 3);
+      assert(ym2.index() == 3);
+      assert(ym1 == ym2);
     }
-    }
+  }
 
+  return true;
+}
+
+int main(int, char**) {
+  // year_month_weekday + months (and switched)
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday>() + std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_weekday>());
+
+  ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() + std::declval<months>()));
+  ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<months>() + std::declval<year_month_weekday>()));
+
+  // year_month_weekday + years (and switched)
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday>() + std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_weekday>());
+
+  ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<year_month_weekday>() + std::declval<years>()));
+  ASSERT_SAME_TYPE(year_month_weekday, decltype(std::declval<years>() + std::declval<year_month_weekday>()));
+
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_month.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_month.pass.cpp
@@ -19,58 +19,51 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<unsigned>((d1          ).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 1}).month()) !=  2) return false;
-    if (static_cast<unsigned>((d1 += Ds{ 2}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 += Ds{12}).month()) !=  4) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 1}).month()) !=  3) return false;
-    if (static_cast<unsigned>((d1 -= Ds{ 2}).month()) !=  1) return false;
-    if (static_cast<unsigned>((d1 -= Ds{12}).month()) !=  1) return false;
-    return true;
+using year                    = std::chrono::year;
+using month                   = std::chrono::month;
+using weekday                 = std::chrono::weekday;
+using weekday_last            = std::chrono::weekday_last;
+using year_month_weekday_last = std::chrono::year_month_weekday_last;
+using months                  = std::chrono::months;
+
+constexpr bool test() {
+  constexpr weekday Tuesday = std::chrono::Tuesday;
+
+  for (unsigned i = 0; i <= 10; ++i) {
+    year y{1234};
+    year_month_weekday_last ymwd(y, month{i}, weekday_last{Tuesday});
+
+    assert(static_cast<unsigned>((ymwd += months{2}).month()) == i + 2);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+
+    assert(static_cast<unsigned>((ymwd).month()) == i + 2);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+
+    assert(static_cast<unsigned>((ymwd -= months{1}).month()) == i + 1);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+
+    assert(static_cast<unsigned>((ymwd).month()) == i + 1);
+    assert(ymwd.year() == y);
+    assert(ymwd.weekday() == Tuesday);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year                    = std::chrono::year;
-    using month                   = std::chrono::month;
-    using weekday                 = std::chrono::weekday;
-    using weekday_last            = std::chrono::weekday_last;
-    using year_month_weekday_last = std::chrono::year_month_weekday_last;
-    using months                  = std::chrono::months;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() += std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() -= std::declval<months>());
 
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() += std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() -= std::declval<months>());
+  ASSERT_SAME_TYPE(
+      year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() += std::declval<months>()));
+  ASSERT_SAME_TYPE(
+      year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() -= std::declval<months>()));
 
-    ASSERT_SAME_TYPE(year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() += std::declval<months>()));
-    ASSERT_SAME_TYPE(year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() -= std::declval<months>()));
-
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-    static_assert(testConstexpr<year_month_weekday_last, months>(year_month_weekday_last{year{1234}, month{1}, weekday_last{Tuesday}}), "");
-
-    for (unsigned i = 0; i <= 10; ++i)
-    {
-        year y{1234};
-        year_month_weekday_last ymwd(y, month{i}, weekday_last{Tuesday});
-
-        assert(static_cast<unsigned>((ymwd += months{2}).month()) == i + 2);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-
-        assert(static_cast<unsigned>((ymwd             ).month()) == i + 2);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-
-        assert(static_cast<unsigned>((ymwd -= months{1}).month()) == i + 1);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-
-        assert(static_cast<unsigned>((ymwd             ).month()) == i + 1);
-        assert(ymwd.year()     == y);
-        assert(ymwd.weekday()  == Tuesday);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_year.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_year.pass.cpp
@@ -19,59 +19,51 @@
 
 #include "test_macros.h"
 
-template <typename D, typename Ds>
-constexpr bool testConstexpr(D d1)
-{
-    if (static_cast<int>((d1          ).year()) !=  1) return false;
-    if (static_cast<int>((d1 += Ds{ 1}).year()) !=  2) return false;
-    if (static_cast<int>((d1 += Ds{ 2}).year()) !=  4) return false;
-    if (static_cast<int>((d1 += Ds{12}).year()) != 16) return false;
-    if (static_cast<int>((d1 -= Ds{ 1}).year()) != 15) return false;
-    if (static_cast<int>((d1 -= Ds{ 2}).year()) != 13) return false;
-    if (static_cast<int>((d1 -= Ds{12}).year()) !=  1) return false;
-    return true;
+using year                    = std::chrono::year;
+using month                   = std::chrono::month;
+using weekday                 = std::chrono::weekday;
+using weekday_last            = std::chrono::weekday_last;
+using year_month_weekday_last = std::chrono::year_month_weekday_last;
+using years                   = std::chrono::years;
+
+constexpr bool test() {
+  constexpr weekday Tuesday = std::chrono::Tuesday;
+  constexpr month January   = std::chrono::January;
+
+  for (int i = 1000; i <= 1010; ++i) {
+    year_month_weekday_last ymwd(year{i}, January, weekday_last{Tuesday});
+
+    assert(static_cast<int>((ymwd += years{2}).year()) == i + 2);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+
+    assert(static_cast<int>((ymwd).year()) == i + 2);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+
+    assert(static_cast<int>((ymwd -= years{1}).year()) == i + 1);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+
+    assert(static_cast<int>((ymwd).year()) == i + 1);
+    assert(ymwd.month() == January);
+    assert(ymwd.weekday() == Tuesday);
+  }
+
+  return true;
 }
 
-int main(int, char**)
-{
-    using year                    = std::chrono::year;
-    using month                   = std::chrono::month;
-    using weekday                 = std::chrono::weekday;
-    using weekday_last            = std::chrono::weekday_last;
-    using year_month_weekday_last = std::chrono::year_month_weekday_last;
-    using years                   = std::chrono::years;
+int main(int, char**) {
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() += std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() -= std::declval<years>());
 
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() += std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday_last&>() -= std::declval<years>());
+  ASSERT_SAME_TYPE(
+      year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() += std::declval<years>()));
+  ASSERT_SAME_TYPE(
+      year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() -= std::declval<years>()));
 
-    ASSERT_SAME_TYPE(year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() += std::declval<years>()));
-    ASSERT_SAME_TYPE(year_month_weekday_last&, decltype(std::declval<year_month_weekday_last&>() -= std::declval<years>()));
-
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-    constexpr month January = std::chrono::January;
-
-    static_assert(testConstexpr<year_month_weekday_last, years>(year_month_weekday_last{year{1}, January, weekday_last{Tuesday}}), "");
-
-    for (int i = 1000; i <= 1010; ++i)
-    {
-        year_month_weekday_last ymwd(year{i}, January, weekday_last{Tuesday});
-
-        assert(static_cast<int>((ymwd += years{2}).year()) == i + 2);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-
-        assert(static_cast<int>((ymwd            ).year()) == i + 2);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-
-        assert(static_cast<int>((ymwd -= years{1}).year()) == i + 1);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-
-        assert(static_cast<int>((ymwd            ).year()) == i + 1);
-        assert(ymwd.month()    == January);
-        assert(ymwd.weekday()  == Tuesday);
-    }
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/minus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/minus.pass.cpp
@@ -22,72 +22,54 @@
 
 #include "test_macros.h"
 
+using year                    = std::chrono::year;
+using month                   = std::chrono::month;
+using weekday                 = std::chrono::weekday;
+using weekday_last            = std::chrono::weekday_last;
+using year_month_weekday_last = std::chrono::year_month_weekday_last;
+using years                   = std::chrono::years;
+using months                  = std::chrono::months;
 
-constexpr bool testConstexprYears(std::chrono::year_month_weekday_last ym)
-{
-    std::chrono::years offset{14};
-    if (static_cast<int>((ym         ).year()) != 66) return false;
-    if (static_cast<int>((ym - offset).year()) != 52) return false;
-    return true;
+constexpr bool test() {
+  constexpr month October   = std::chrono::October;
+  constexpr weekday Tuesday = std::chrono::Tuesday;
+
+  { // year_month_weekday_last - years
+    year_month_weekday_last ym{year{1234}, October, weekday_last{Tuesday}};
+    for (int i = 0; i <= 10; ++i) {
+      year_month_weekday_last ym1 = ym - years{i};
+      assert(ym1.year() == year{1234 - i});
+      assert(ym1.month() == October);
+      assert(ym1.weekday() == Tuesday);
+      assert(ym1.weekday_last() == weekday_last{Tuesday});
+    }
+  }
+
+  { // year_month_weekday_last - months
+    year_month_weekday_last ym{year{1234}, October, weekday_last{Tuesday}};
+    for (unsigned i = 0; i < 10; ++i) {
+      year_month_weekday_last ym1 = ym - months{i};
+      assert(ym1.year() == year{1234});
+      assert(ym1.month() == month{10 - i});
+      assert(ym1.weekday() == Tuesday);
+      assert(ym1.weekday_last() == weekday_last{Tuesday});
+    }
+  }
+
+  return true;
 }
 
-constexpr bool testConstexprMonths(std::chrono::year_month_weekday_last ym)
-{
-    std::chrono::months offset{6};
-    if (static_cast<unsigned>((ym         ).month()) != 10) return false;
-    if (static_cast<unsigned>((ym - offset).month()) !=  4) return false;
-    return true;
-}
+int main(int, char**) {
+  // year_month_weekday_last - years
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last>() - std::declval<years>());
+  ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() - std::declval<years>()));
 
-int main(int, char**)
-{
-    using year                    = std::chrono::year;
-    using month                   = std::chrono::month;
-    using weekday                 = std::chrono::weekday;
-    using weekday_last            = std::chrono::weekday_last;
-    using year_month_weekday_last = std::chrono::year_month_weekday_last;
-    using years                   = std::chrono::years;
-    using months                  = std::chrono::months;
+  // year_month_weekday_last - months
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last>() - std::declval<months>());
+  ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() - std::declval<months>()));
 
-    constexpr month October = std::chrono::October;
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-
-    { // year_month_weekday_last - years
-
-    ASSERT_NOEXCEPT(                                   std::declval<year_month_weekday_last>() - std::declval<years>());
-    ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() - std::declval<years>()));
-
-    static_assert(testConstexprYears(year_month_weekday_last{year{66}, October, weekday_last{Tuesday}}), "");
-
-    year_month_weekday_last ym{year{1234}, October, weekday_last{Tuesday}};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month_weekday_last ym1 = ym - years{i};
-        assert(ym1.year()         == year{1234 - i});
-        assert(ym1.month()        == October);
-        assert(ym1.weekday()      == Tuesday);
-        assert(ym1.weekday_last() == weekday_last{Tuesday});
-    }
-    }
-
-    { // year_month_weekday_last - months
-
-    ASSERT_NOEXCEPT(                                   std::declval<year_month_weekday_last>() - std::declval<months>());
-    ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() - std::declval<months>()));
-
-    static_assert(testConstexprMonths(year_month_weekday_last{year{66}, October, weekday_last{Tuesday}}), "");
-
-    year_month_weekday_last ym{year{1234}, October, weekday_last{Tuesday}};
-    for (unsigned i = 0; i < 10; ++i)
-    {
-        year_month_weekday_last ym1 = ym - months{i};
-        assert(ym1.year()         == year{1234});
-        assert(ym1.month()        == month{10 - i});
-        assert(ym1.weekday()      == Tuesday);
-        assert(ym1.weekday_last() == weekday_last{Tuesday});
-    }
-    }
-
+  test();
+  static_assert(test());
 
   return 0;
 }

--- a/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/plus.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/plus.pass.cpp
@@ -28,90 +28,73 @@
 
 #include "test_macros.h"
 
-constexpr bool testConstexprYears(std::chrono::year_month_weekday_last ym)
-{
-    std::chrono::years offset{23};
-    if (static_cast<int>((ym         ).year()) !=  1) return false;
-    if (static_cast<int>((ym + offset).year()) != 24) return false;
-    if (static_cast<int>((offset + ym).year()) != 24) return false;
-    return true;
-}
+using year                    = std::chrono::year;
+using month                   = std::chrono::month;
+using weekday                 = std::chrono::weekday;
+using weekday_last            = std::chrono::weekday_last;
+using year_month_weekday_last = std::chrono::year_month_weekday_last;
+using years                   = std::chrono::years;
+using months                  = std::chrono::months;
 
-constexpr bool testConstexprMonths(std::chrono::year_month_weekday_last ym)
-{
-    std::chrono::months offset{6};
-    if (static_cast<unsigned>((ym         ).month()) !=  1) return false;
-    if (static_cast<unsigned>((ym + offset).month()) !=  7) return false;
-    if (static_cast<unsigned>((offset + ym).month()) !=  7) return false;
-    return true;
-}
+constexpr bool test() {
+  constexpr weekday Tuesday = std::chrono::Tuesday;
+  constexpr month January   = std::chrono::January;
 
-
-int main(int, char**)
-{
-    using year                    = std::chrono::year;
-    using month                   = std::chrono::month;
-    using weekday                 = std::chrono::weekday;
-    using weekday_last            = std::chrono::weekday_last;
-    using year_month_weekday_last = std::chrono::year_month_weekday_last;
-    using years                   = std::chrono::years;
-    using months                  = std::chrono::months;
-
-    constexpr weekday Tuesday = std::chrono::Tuesday;
-    constexpr month January = std::chrono::January;
-
-    {   // year_month_weekday_last + months
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday_last>() + std::declval<months>());
-    ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_weekday_last>());
-
-    ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() + std::declval<months>()));
-    ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<months>() + std::declval<year_month_weekday_last>()));
-
-    static_assert(testConstexprMonths(year_month_weekday_last{year{1}, January, weekday_last{Tuesday}}), "");
-
+  { // year_month_weekday_last + months
     year_month_weekday_last ym{year{1234}, January, weekday_last{Tuesday}};
-    for (int i = 0; i <= 10; ++i)  // TODO test wrap-around
+    for (int i = 0; i <= 10; ++i) // TODO test wrap-around
     {
-        year_month_weekday_last ym1 = ym + months{i};
-        year_month_weekday_last ym2 = months{i} + ym;
-        assert(ym1.year()         == year(1234));
-        assert(ym2.year()         == year(1234));
-        assert(ym1.month()        == month(1 + i));
-        assert(ym2.month()        == month(1 + i));
-        assert(ym1.weekday()      == Tuesday);
-        assert(ym2.weekday()      == Tuesday);
-        assert(ym1.weekday_last() == weekday_last{Tuesday});
-        assert(ym2.weekday_last() == weekday_last{Tuesday});
-        assert(ym1 == ym2);
+      year_month_weekday_last ym1 = ym + months{i};
+      year_month_weekday_last ym2 = months{i} + ym;
+      assert(ym1.year() == year(1234));
+      assert(ym2.year() == year(1234));
+      assert(ym1.month() == month(1 + i));
+      assert(ym2.month() == month(1 + i));
+      assert(ym1.weekday() == Tuesday);
+      assert(ym2.weekday() == Tuesday);
+      assert(ym1.weekday_last() == weekday_last{Tuesday});
+      assert(ym2.weekday_last() == weekday_last{Tuesday});
+      assert(ym1 == ym2);
     }
-    }
+  }
 
-    {   // year_month_weekday_last + years
-    ASSERT_NOEXCEPT(std::declval<year_month_weekday_last>() + std::declval<years>());
-    ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_weekday_last>());
-
-    ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() + std::declval<years>()));
-    ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<years>() + std::declval<year_month_weekday_last>()));
-
-    static_assert(testConstexprYears (year_month_weekday_last{year{1}, January, weekday_last{Tuesday}}), "");
-
+  { // year_month_weekday_last + years
     year_month_weekday_last ym{year{1234}, std::chrono::January, weekday_last{Tuesday}};
-    for (int i = 0; i <= 10; ++i)
-    {
-        year_month_weekday_last ym1 = ym + years{i};
-        year_month_weekday_last ym2 = years{i} + ym;
-        assert(ym1.year()         == year(1234 + i));
-        assert(ym2.year()         == year(1234 + i));
-        assert(ym1.month()        == January);
-        assert(ym2.month()        == January);
-        assert(ym1.weekday()      == Tuesday);
-        assert(ym2.weekday()      == Tuesday);
-        assert(ym1.weekday_last() == weekday_last{Tuesday});
-        assert(ym2.weekday_last() == weekday_last{Tuesday});
-        assert(ym1 == ym2);
+    for (int i = 0; i <= 10; ++i) {
+      year_month_weekday_last ym1 = ym + years{i};
+      year_month_weekday_last ym2 = years{i} + ym;
+      assert(ym1.year() == year(1234 + i));
+      assert(ym2.year() == year(1234 + i));
+      assert(ym1.month() == January);
+      assert(ym2.month() == January);
+      assert(ym1.weekday() == Tuesday);
+      assert(ym2.weekday() == Tuesday);
+      assert(ym1.weekday_last() == weekday_last{Tuesday});
+      assert(ym2.weekday_last() == weekday_last{Tuesday});
+      assert(ym1 == ym2);
     }
-    }
+  }
 
+  return true;
+}
+
+int main(int, char**) {
+  // year_month_weekday_last + months
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last>() + std::declval<months>());
+  ASSERT_NOEXCEPT(std::declval<months>() + std::declval<year_month_weekday_last>());
+
+  ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() + std::declval<months>()));
+  ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<months>() + std::declval<year_month_weekday_last>()));
+
+  // year_month_weekday_last + years
+  ASSERT_NOEXCEPT(std::declval<year_month_weekday_last>() + std::declval<years>());
+  ASSERT_NOEXCEPT(std::declval<years>() + std::declval<year_month_weekday_last>());
+
+  ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<year_month_weekday_last>() + std::declval<years>()));
+  ASSERT_SAME_TYPE(year_month_weekday_last, decltype(std::declval<years>() + std::declval<year_month_weekday_last>()));
+
+  test();
+  static_assert(test());
 
   return 0;
 }


### PR DESCRIPTION
These tests use an old way to test code in constexpr context. This changes the code to the idomatic libc++ method.

This is a preparation for #73162.

Side changes
- Updated formatting
- Made some helper functions constexpr
- Some naming improvements