### PR TITLE
[mlir][vector] Fix a `target-rank=0` unrolling

### DIFF
--- a/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
+++ b/mlir/lib/Conversion/VectorToSCF/VectorToSCF.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/IR/Builders.h"
@@ -1212,11 +1213,6 @@ struct UnrollTransferWriteConversion
     if (inputVectorTy.getRank() <= options.targetRank)
       return failure();
 
-    // When target-rank=0, unrolling would cause the vector input argument
-    // into `transfer_write` to become a scalar.
-    if (inputVectorTy.getRank() == 1)
-      return failure();
-
     if (isTensorOp(xferOp) && !options.lowerTensors)
       return failure();
     // Transfer ops that modify the element type are not supported atm.
@@ -1256,8 +1252,18 @@ struct UnrollTransferWriteConversion
             auto extracted =
                 b.create<vector::ExtractOp>(loc, vec, extractionIndices);
             auto inBoundsAttr = dropFirstElem(b, xferOp.getInBoundsAttr());
+            Value xferVec;
+            if (inputVectorTy.getRank() == 1) {
+              // When target-rank=0, unrolling would causes the vector input
+              // argument into `transfer_write` to become a scalar. We solve
+              // this by broadcasting the scalar to a 0D vector.
+              xferVec = b.create<vector::BroadcastOp>(
+                  loc, VectorType::get({}, extracted.getType()), extracted);
+            } else {
+              xferVec = extracted;
+            }
             auto newXferOp = b.create<vector::TransferWriteOp>(
-                loc, sourceType, extracted, source, xferIndices,
+                loc, sourceType, xferVec, source, xferIndices,
                 AffineMapAttr::get(unpackedPermutationMap(b, xferOp)), Value(),
                 inBoundsAttr);
 

--- a/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
+++ b/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
@@ -752,11 +752,11 @@ func.func @cannot_fully_unroll_transfer_write_of_nd_scalable_vector(%vec: vector
 
 //  -----
 
-// TARGET-RANK-ZERO-LABEL: func @cannot_further_unroll_transfer_write
-func.func @cannot_further_unroll_transfer_write(%vec : vector<2xi32>) {
-  // TARGET-RANK-ZERO-NOT: vector.extract
-  // TARGET-RANK-ZERO: vector.transfer_write
-  // TARGET-RANK-ZERO-NOT: vector.extract
+// TARGET-RANK-ZERO-LABEL: func @unroll_transfer_write_target_rank_zero
+func.func @unroll_transfer_write_target_rank_zero(%vec : vector<2xi32>) {
+  // TARGET-RANK-ZERO: %[[EXTRACTED:.*]] = vector.extract
+  // TARGET-RANK-ZERO: %[[BROADCASTED:.*]] = vector.broadcast %[[EXTRACTED]]
+  // TARGET-RANK-ZERO: vector.transfer_write %[[BROADCASTED]]
   %alloc = memref.alloc() : memref<4xi32>
   %c0 = arith.constant 0 : index
   vector.transfer_write %vec, %alloc[%c0] : vector<2xi32>, memref<4xi32>

--- a/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
+++ b/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
@@ -754,11 +754,15 @@ func.func @cannot_fully_unroll_transfer_write_of_nd_scalable_vector(%vec: vector
 
 // TARGET-RANK-ZERO-LABEL: func @unroll_transfer_write_target_rank_zero
 func.func @unroll_transfer_write_target_rank_zero(%vec : vector<2xi32>) {
-  // TARGET-RANK-ZERO: %[[EXTRACTED:.*]] = vector.extract
-  // TARGET-RANK-ZERO: %[[BROADCASTED:.*]] = vector.broadcast %[[EXTRACTED]]
-  // TARGET-RANK-ZERO: vector.transfer_write %[[BROADCASTED]]
   %alloc = memref.alloc() : memref<4xi32>
   %c0 = arith.constant 0 : index
   vector.transfer_write %vec, %alloc[%c0] : vector<2xi32>, memref<4xi32>
   return
 }
+// TARGET-RANK-ZERO: %[[ALLOC:.*]] = memref.alloc() : memref<4xi32>
+// TARGET-RANK-ZERO: %[[EXTRACTED1:.*]] = vector.extract {{.*}} : i32 from vector<2xi32>
+// TARGET-RANK-ZERO: %[[BROADCASTED1:.*]] = vector.broadcast %[[EXTRACTED1]] : i32 to vector<i32>
+// TARGET-RANK-ZERO: vector.transfer_write %[[BROADCASTED1]], %[[ALLOC]]{{.*}} : vector<i32>, memref<4xi32>
+// TARGET-RANK-ZERO: %[[EXTRACTED2:.*]] = vector.extract {{.*}} : i32 from vector<2xi32>
+// TARGET-RANK-ZERO: %[[BROADCASTED2:.*]] = vector.broadcast %[[EXTRACTED2]] : i32 to vector<i32>
+// TARGET-RANK-ZERO: vector.transfer_write %[[BROADCASTED2]], %[[ALLOC]]{{.*}} : vector<i32>, memref<4xi32>

--- a/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
+++ b/mlir/test/Conversion/VectorToSCF/vector-to-scf.mlir
@@ -754,9 +754,9 @@ func.func @cannot_fully_unroll_transfer_write_of_nd_scalable_vector(%vec: vector
 
 // TARGET-RANK-ZERO-LABEL: func @cannot_further_unroll_transfer_write
 func.func @cannot_further_unroll_transfer_write(%vec : vector<2xi32>) {
-  // FULL-UNROLL-NOT: vector.extract
-  // FULL-UNROLL: vector.transfer_write
-  // FULL-UNROLL-NOT: vector.extract
+  // TARGET-RANK-ZERO-NOT: vector.extract
+  // TARGET-RANK-ZERO: vector.transfer_write
+  // TARGET-RANK-ZERO-NOT: vector.extract
   %alloc = memref.alloc() : memref<4xi32>
   %c0 = arith.constant 0 : index
   vector.transfer_write %vec, %alloc[%c0] : vector<2xi32>, memref<4xi32>


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/64269.

With this patch, calling `mlir-opt "-convert-vector-to-scf=full-unroll target-rank=0"` on
```mlir
func.func @main(%vec : vector<2xi32>) {
  %alloc = memref.alloc() : memref<4xi32>
  %c0 = arith.constant 0 : index
  vector.transfer_write %vec, %alloc[%c0] : vector<2xi32>, memref<4xi32>
  return
}
```
will result in
```mlir
module {
  func.func @main(%arg0: vector<2xi32>) {
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %alloc = memref.alloc() : memref<4xi32>
    %0 = vector.extract %arg0[0] : i32 from vector<2xi32>
    %1 = vector.broadcast %0 : i32 to vector<i32>
    vector.transfer_write %1, %alloc[%c0] : vector<i32>, memref<4xi32>
    %2 = vector.extract %arg0[1] : i32 from vector<2xi32>
    %3 = vector.broadcast %2 : i32 to vector<i32>
    vector.transfer_write %3, %alloc[%c1] : vector<i32>, memref<4xi32>
    return
  }
}
```

I've also tried to proactively find other `target-rank=0` bugs, but couldn't find any. `options.targetRank` is only used 8 times throughout the `mlir` folder, all inside `VectorToSCF.cpp`. None of the other uses look like they could cause a crash. I've also tried

```mlir
func.func @main(%vec : vector<2xi32>) -> vector<2xi32> {
  %alloc = memref.alloc() : memref<4xindex>
  %c0 = arith.constant 0 : index
  %out = vector.transfer_read %alloc[%c0], %c0 : memref<4xindex>, vector<2xi32>
  return %out : vector<2xi32>
}
```
with `"--convert-vector-to-scf=full-unroll target-rank=0"` and that also didn't crash. (Maybe obvious. I have to admit that I'm not very familiar with these ops.)