### PR TITLE
[flang] pass true/false to EditLogicalOutput directly (NFC)

### DIFF
--- a/flang/runtime/edit-output.cpp
+++ b/flang/runtime/edit-output.cpp
@@ -140,7 +140,7 @@ bool EditIntegerOutput(IoStatementState &io, const DataEdit &edit,
     return EditBOZOutput<4>(
         io, edit, reinterpret_cast<const unsigned char *>(&n), KIND);
   case 'L':
-    return EditLogicalOutput(io, edit, n == 0 ? false : true);
+    return EditLogicalOutput(io, edit, n != 0 ? true : false);
   case 'A': // legacy extension
     return EditCharacterOutput(
         io, edit, reinterpret_cast<char *>(&n), sizeof n);

--- a/flang/runtime/edit-output.cpp
+++ b/flang/runtime/edit-output.cpp
@@ -140,7 +140,7 @@ bool EditIntegerOutput(IoStatementState &io, const DataEdit &edit,
     return EditBOZOutput<4>(
         io, edit, reinterpret_cast<const unsigned char *>(&n), KIND);
   case 'L':
-    return EditLogicalOutput(io, edit, *reinterpret_cast<const char *>(&n));
+    return EditLogicalOutput(io, edit, n == 0 ? false : true);
   case 'A': // legacy extension
     return EditCharacterOutput(
         io, edit, reinterpret_cast<char *>(&n), sizeof n);


### PR DESCRIPTION
Using `reinterpret_cast<const char *>(&n)` will cause issue in the big endian environment when `KIND > 1`.