### PR TITLE
[NFC][NVPTX] Add a simpler test case for 0b80288e9e0b

### DIFF
--- a/llvm/test/CodeGen/NVPTX/vector-stores.ll
+++ b/llvm/test/CodeGen/NVPTX/vector-stores.ll
@@ -1,31 +1,39 @@
 ; RUN: llc < %s -march=nvptx64 -mcpu=sm_20 | FileCheck %s
 ; RUN: %if ptxas %{ llc < %s -march=nvptx64 -mcpu=sm_20 | %ptxas-verify %}
 
-; CHECK: .visible .func foo1
+; CHECK-LABEL: .visible .func foo1
 ; CHECK: st.v2.f32
 define void @foo1(<2 x float> %val, ptr %ptr) {
   store <2 x float> %val, ptr %ptr
   ret void
 }
 
-; CHECK: .visible .func foo2
+; CHECK-LABEL: .visible .func foo2
 ; CHECK: st.v4.f32
 define void @foo2(<4 x float> %val, ptr %ptr) {
   store <4 x float> %val, ptr %ptr
   ret void
 }
 
-; CHECK: .visible .func foo3
+; CHECK-LABEL: .visible .func foo3
 ; CHECK: st.v2.u32
 define void @foo3(<2 x i32> %val, ptr %ptr) {
   store <2 x i32> %val, ptr %ptr
   ret void
 }
 
-; CHECK: .visible .func foo4
+; CHECK-LABEL: .visible .func foo4
 ; CHECK: st.v4.u32
 define void @foo4(<4 x i32> %val, ptr %ptr) {
   store <4 x i32> %val, ptr %ptr
   ret void
 }
 
+; CHECK-LABEL: .visible .func v16i8
+define void @v16i8(ptr %a, ptr %b) {
+; CHECK: ld.v4.u32
+; CHECK: st.v4.u32
+  %v = load <16 x i8>, ptr %a
+  store <16 x i8> %v, ptr %b
+  ret void
+}


### PR DESCRIPTION
While 0b80288e9e0b allowed more efficient lowering for 16xi8 loads, its
test case was closer to an "integration" one. Add a much simpler unit
test case that exercises it.
