### PR TITLE
Do not report -Wasm-operand-widths for Aarch64 ilp32 operands

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1362,6 +1362,10 @@ bool AArch64TargetInfo::validateAsmConstraint(
 bool AArch64TargetInfo::validateConstraintModifier(
     StringRef Constraint, char Modifier, unsigned Size,
     std::string &SuggestedModifier) const {
+  // Ignore in ILP32 since width of pointer type is 32 bits
+  // while memory instruction shall 'x' registers.
+  if (getTriple().getEnvironment() == llvm::Triple::GNUILP32)
+    return true;
   // Strip off constraint modifiers.
   while (Constraint[0] == '=' || Constraint[0] == '+' || Constraint[0] == '&')
     Constraint = Constraint.substr(1);


### PR DESCRIPTION
Since width of pointer type is 32 bits in ILP32 while memory instruction shall 'x' registers. msr/mrs likewise.

Now Wasm-operand-widths in ILP32 will warning below asm code with a WRONG massage. 
 
```
void atomicAdd32(int *ptr, int lIncr)
{
  int  result = 0;
  unsigned int tmp = 0;

  __asm__ volatile(
     "1: ldxr   %w0, [%2]        \n\t"
     "   add    %w0, %w0, %w3    \n\t"
     "   stxr   %w1, %w0, [%2]   \n\t"
     "   cbnz   %w1, 1b          \n\t"
     : "=&r"(result), "=&r"(tmp)
     : "r"(ptr), "Ir"(lIncr)
     :"memory","cc"
  );
}
```
The [%2]  shall be 'x' rregister for ldxr inst., not the %w2.
```
warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
        : "r"(ptr), "Ir"(lIncr)
              ^
: note: use constraint modifier "w"
        "1: ldxr   %w0, [%2]        \n\t"
                         ^~
                         %w2
```
