### PR TITLE
[mlir][spirv][doc] Remove duplicate syntax formats

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVArithmeticOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVArithmeticOps.td
@@ -88,18 +88,11 @@ def SPIRV_FAddOp : SPIRV_ArithmeticBinaryOp<"FAdd", SPIRV_Float, [Commutative]> 
   let description = [{
     Result Type must be a scalar or vector of floating-point type.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
-                          `:` float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -117,19 +110,11 @@ def SPIRV_FDivOp : SPIRV_ArithmeticBinaryOp<"FDiv", SPIRV_Float, []> {
   let description = [{
     Result Type must be a scalar or vector of floating-point type.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.
-
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
-                          `:` float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -150,21 +135,14 @@ def SPIRV_FModOp : SPIRV_ArithmeticBinaryOp<"FMod", SPIRV_Float, []> {
   let description = [{
     Result Type must be a scalar or vector of floating-point type.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.  Otherwise, the result is the remainder r of Operand
     1 divided by Operand 2 where if r ≠ 0, the sign of r is the same as the
     sign of Operand 2.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
-                          `:` float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -182,19 +160,10 @@ def SPIRV_FMulOp : SPIRV_ArithmeticBinaryOp<"FMul", SPIRV_Float, [Commutative]> 
   let description = [{
     Result Type must be a scalar or vector of floating-point type.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fmul-op ::= `spirv.FMul` ssa-use, ssa-use
-                          `:` float-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -218,17 +187,9 @@ def SPIRV_FNegateOp : SPIRV_ArithmeticUnaryOp<"FNegate", SPIRV_Float, []> {
   let description = [{
     Result Type must be a scalar or vector of floating-point type.
 
-     The type of Operand must be the same as Result Type.
+    The type of Operand must be the same as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -249,21 +210,13 @@ def SPIRV_FRemOp : SPIRV_ArithmeticBinaryOp<"FRem", SPIRV_Float, []> {
   let description = [{
     Result Type must be a scalar or vector of floating-point type.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.  Otherwise, the result is the remainder r of Operand
     1 divided by Operand 2 where if r ≠ 0, the sign of r is the same as the
     sign of Operand 1.
-
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
-                          `:` float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -282,18 +235,10 @@ def SPIRV_FSubOp : SPIRV_ArithmeticBinaryOp<"FSub", SPIRV_Float, []> {
   let description = [{
     Result Type must be a scalar or vector of floating-point type.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
-                          `:` float-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -314,7 +259,7 @@ def SPIRV_IAddOp : SPIRV_ArithmeticBinaryOp<"IAdd",
   let description = [{
     Result Type must be a scalar or vector of integer type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same number of components as Result
     Type. They must have the same component width as Result Type.
 
@@ -322,15 +267,7 @@ def SPIRV_IAddOp : SPIRV_ArithmeticBinaryOp<"IAdd",
     result R, where N is the component width and R is computed with enough
     precision to avoid overflow and underflow.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
-                          `:` integer-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -391,7 +328,7 @@ def SPIRV_IMulOp : SPIRV_ArithmeticBinaryOp<"IMul",
   let description = [{
     Result Type must be a scalar or vector of integer type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same number of components as Result
     Type. They must have the same component width as Result Type.
 
@@ -399,15 +336,7 @@ def SPIRV_IMulOp : SPIRV_ArithmeticBinaryOp<"IMul",
     result R, where N is the component width and R is computed with enough
     precision to avoid overflow and underflow.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
-                          `:` integer-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -431,7 +360,7 @@ def SPIRV_ISubOp : SPIRV_ArithmeticBinaryOp<"ISub",
   let description = [{
     Result Type must be a scalar or vector of integer type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same number of components as Result
     Type. They must have the same component width as Result Type.
 
@@ -439,15 +368,7 @@ def SPIRV_ISubOp : SPIRV_ArithmeticBinaryOp<"ISub",
     result R, where N is the component width and R is computed with enough
     precision to avoid overflow and underflow.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    isub-op ::= `spirv.ISub` ssa-use, ssa-use
-                          `:` integer-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -511,20 +432,12 @@ def SPIRV_SDivOp : SPIRV_ArithmeticBinaryOp<"SDiv",
   let description = [{
     Result Type must be a scalar or vector of integer type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same number of components as Result
     Type. They must have the same component width as Result Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.
-
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
-                           `:` integer-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -549,22 +462,15 @@ def SPIRV_SModOp : SPIRV_ArithmeticBinaryOp<"SMod",
   let description = [{
     Result Type must be a scalar or vector of integer type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same number of components as Result
     Type. They must have the same component width as Result Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.  Otherwise, the result is the remainder r of Operand
     1 divided by Operand 2 where if r ≠ 0, the sign of r is the same as the
     sign of Operand 2.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
-                           `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -649,22 +555,15 @@ def SPIRV_SRemOp : SPIRV_ArithmeticBinaryOp<"SRem",
   let description = [{
     Result Type must be a scalar or vector of integer type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same number of components as Result
     Type. They must have the same component width as Result Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.  Otherwise, the result is the remainder r of Operand
     1 divided by Operand 2 where if r ≠ 0, the sign of r is the same as the
     sign of Operand 1.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
-                           `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -686,25 +585,17 @@ def SPIRV_UDivOp : SPIRV_ArithmeticBinaryOp<"UDiv",
     Result Type must be a scalar or vector of integer type, whose Signedness
     operand is 0.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
-                           `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.UDiv %0, %1 : i32
     %5 = spirv.UDiv %2, %3 : vector<4xi32>
-
     ```
   }];
 }
@@ -789,25 +680,17 @@ def SPIRV_UModOp : SPIRV_ArithmeticBinaryOp<"UMod",
     Result Type must be a scalar or vector of integer type, whose Signedness
     operand is 0.
 
-     The types of Operand 1 and Operand 2 both must be the same as Result
+    The types of Operand 1 and Operand 2 both must be the same as Result
     Type.
 
-     Results are computed per component.  The resulting value is undefined
+    Results are computed per component.  The resulting value is undefined
     if Operand 2 is 0.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
-                           `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.UMod %0, %1 : i32
     %5 = spirv.UMod %2, %3 : vector<4xi32>
-
     ```
   }];
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBarrierOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBarrierOps.td
@@ -51,21 +51,10 @@ def SPIRV_ControlBarrierOp : SPIRV_Op<"ControlBarrier", []> {
     OpControlBarrier will be visible to any other invocation after return
     from that OpControlBarrier.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"CrossDevice"` | `"Device"` | `"Workgroup"` | ...
-
-    memory-semantics ::= `"None"` | `"Acquire"` | "Release"` | ...
-
-    control-barrier-op ::= `spirv.ControlBarrier` scope, scope, memory-semantics
-    ```
-
     #### Example:
 
     ```mlir
     spirv.ControlBarrier "Workgroup", "Device", "Acquire|UniformMemory"
-
     ```
   }];
 
@@ -102,21 +91,10 @@ def SPIRV_MemoryBarrierOp : SPIRV_Op<"MemoryBarrier", []> {
     To execute both a memory barrier and a control barrier, see
     OpControlBarrier.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"CrossDevice"` | `"Device"` | `"Workgroup"` | ...
-
-    memory-semantics ::= `"None"` | `"Acquire"` | `"Release"` | ...
-
-    memory-barrier-op ::= `spirv.MemoryBarrier` scope, memory-semantics
-    ```
-
     #### Example:
 
     ```mlir
     spirv.MemoryBarrier "Device", "Acquire|UniformMemory"
-
     ```
   }];
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBitOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBitOps.td
@@ -80,15 +80,6 @@ def SPIRV_BitCountOp : SPIRV_BitUnaryOp<"BitCount", []> {
     The result is the unsigned value that is the number of bits in Base that
     are 1.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    bitcount-op ::= ssa-id `=` `spirv.BitCount` ssa-use
-                               `:` integer-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -129,17 +120,6 @@ def SPIRV_BitFieldInsertOp : SPIRV_Op<"BitFieldInsert",
 
     The resulting value is undefined if Count or Offset or their sum is
     greater than the number of bits in the result.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    bitfield-insert-op ::= ssa-id `=` `spirv.BitFieldInsert` ssa-use `,` ssa-use
-                                      `,` ssa-use `,` ssa-use
-                                      `:` integer-scalar-vector-type
-                                      `,` integer-type `,` integer-type
-    ```
 
     #### Example:
 
@@ -202,17 +182,6 @@ def SPIRV_BitFieldSExtractOp : SPIRV_BitFieldExtractOp<"BitFieldSExtract",
     The resulting value is undefined if Count or Offset or their sum is
     greater than the number of bits in the result.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    bitfield-extract-s-op ::= ssa-id `=` `spirv.BitFieldSExtract` ssa-use
-                                         `,` ssa-use `,` ssa-use
-                                         `:` integer-scalar-vector-type
-                                         `,` integer-type `,` integer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -238,17 +207,6 @@ def SPIRV_BitFieldUExtractOp : SPIRV_BitFieldExtractOp<"BitFieldUExtract",
     The semantics are the same as with OpBitFieldSExtract with the exception
     that there is no sign extension. The remaining bits of the result will
     all be 0.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
-                                         `,` ssa-use `,` ssa-use
-                                         `:` integer-scalar-vector-type
-                                         `,` integer-type `,` integer-type
-    ```
 
     #### Example:
 
@@ -279,15 +237,6 @@ def SPIRV_BitReverseOp : SPIRV_BitUnaryOp<"BitReverse", []> {
 
     The bit-number n of the result will be taken from bit-number Width - 1 -
     n of Base, where Width is the OpTypeInt operand of the Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    bitreverse-op ::= ssa-id `=` `spirv.BitReverse` ssa-use
-                                 `:` integer-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -322,15 +271,6 @@ def SPIRV_BitwiseAndOp : SPIRV_BitBinaryOp<"BitwiseAnd",
     They must have the same number of components as Result Type. They must
     have the same component width as Result Type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    bitwise-and-op ::= ssa-id `=` `spirv.BitwiseAnd` ssa-use, ssa-use
-                                  `:` integer-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -359,15 +299,6 @@ def SPIRV_BitwiseOrOp : SPIRV_BitBinaryOp<"BitwiseOr",
     They must have the same number of components as Result Type. They must
     have the same component width as Result Type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    bitwise-or-op ::= ssa-id `=` `spirv.BitwiseOr` ssa-use, ssa-use
-                                  `:` integer-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -395,15 +326,6 @@ def SPIRV_BitwiseXorOp : SPIRV_BitBinaryOp<"BitwiseXor",
     Operand 1 and Operand 2  must be a scalar or vector of integer type.
     They must have the same number of components as Result Type. They must
     have the same component width as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    bitwise-xor-op ::= ssa-id `=` `spirv.BitwiseXor` ssa-use, ssa-use
-                                  `:` integer-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -437,18 +359,7 @@ def SPIRV_ShiftLeftLogicalOp : SPIRV_ShiftOp<"ShiftLeftLogical",
     The number of components and bit width of Result Type must match those
     Base type. All types must be integer types.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
-                                          ssa-use `,` ssa-use `:`
-                                          integer-scalar-vector-type `,`
-                                          integer-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -480,17 +391,6 @@ def SPIRV_ShiftRightArithmeticOp : SPIRV_ShiftOp<"ShiftRightArithmetic",
     greater than or equal to the bit width of the components of Base.
 
     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
-                                              ssa-use `,` ssa-use `:`
-                                              integer-scalar-vector-type `,`
-                                              integer-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -524,17 +424,6 @@ def SPIRV_ShiftRightLogicalOp : SPIRV_ShiftOp<"ShiftRightLogical",
 
     Results are computed per component.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
-                                           ssa-use `,` ssa-use `:`
-                                           integer-scalar-vector-type `,`
-                                           integer-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -557,14 +446,6 @@ def SPIRV_NotOp : SPIRV_BitUnaryOp<"Not", [UsableInSpecConstantOp]> {
     Operand's type  must be a scalar or vector of integer type.  It must
     have the same number of components as Result Type.  The component width
     must equal the component width in Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                  `vector<` integer-literal `x` integer-type `>`
-    not-op ::= ssa-id `=` `spirv.BitNot` ssa-use `:` integer-scalar-vector-type
-    ```
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCLOps.td
@@ -125,14 +125,6 @@ def SPIRV_CLAtan2Op : SPIRV_CLBinaryArithmeticOp<"atan2", 7, SPIRV_Float > {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-        ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    atan2-op ::= ssa-id `=` `spirv.CL.atan2` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -155,15 +147,6 @@ def SPIRV_CLAcosOp : SPIRV_CLUnaryArithmeticOp<"acos", 0, SPIRV_Float > {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    acos-op ::= ssa-id `=` `spirv.CL.acos` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -188,15 +171,6 @@ def SPIRV_CLAcoshOp : SPIRV_CLUnaryArithmeticOp<"acosh", 1, SPIRV_Float > {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    acosh-op ::= ssa-id `=` `spirv.CL.acosh` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -219,15 +193,6 @@ def SPIRV_CLAsinOp : SPIRV_CLUnaryArithmeticOp<"asin", 3, SPIRV_Float > {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    asin-op ::= ssa-id `=` `spirv.CL.asin` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -252,15 +217,6 @@ def SPIRV_CLAsinhOp : SPIRV_CLUnaryArithmeticOp<"asinh", 4, SPIRV_Float > {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    asinh-op ::= ssa-id `=` `spirv.CL.asinh` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -284,15 +240,6 @@ def SPIRV_CLAtanOp : SPIRV_CLUnaryArithmeticOp<"atan", 6, SPIRV_Float > {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    atan-op ::= ssa-id `=` `spirv.CL.atan` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -315,15 +262,6 @@ def SPIRV_CLAtanhOp : SPIRV_CLUnaryArithmeticOp<"atanh", 8, SPIRV_Float > {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    atanh-op ::= ssa-id `=` `spirv.CL.atanh` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -349,15 +287,6 @@ def SPIRV_CLCeilOp : SPIRV_CLUnaryArithmeticOp<"ceil", 12, SPIRV_Float> {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -379,15 +308,6 @@ def SPIRV_CLCosOp : SPIRV_CLUnaryArithmeticOp<"cos", 14, SPIRV_Float> {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -408,15 +328,6 @@ def SPIRV_CLCoshOp : SPIRV_CLUnaryArithmeticOp<"cosh", 15, SPIRV_Float > {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    cosh-op ::= ssa-id `=` `spirv.CL.cosh` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -441,15 +352,6 @@ def SPIRV_CLErfOp : SPIRV_CLUnaryArithmeticOp<"erf", 18, SPIRV_Float> {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -473,13 +375,6 @@ def SPIRV_CLExpOp : SPIRV_CLUnaryArithmeticOp<"exp", 19, SPIRV_Float> {
     All of the operands, including the Result Type operand,
     must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
-               float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -503,13 +398,6 @@ def SPIRV_CLFAbsOp : SPIRV_CLUnaryArithmeticOp<"fabs", 23, SPIRV_Float> {
     All of the operands, including the Result Type operand,
     must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
-               float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -534,13 +422,6 @@ def SPIRV_CLFMaxOp : SPIRV_CLBinaryArithmeticOp<"fmax", 27, SPIRV_Float> {
     All of the operands, including the Result Type operand,
     must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -563,14 +444,6 @@ def SPIRV_CLFMinOp : SPIRV_CLBinaryArithmeticOp<"fmin", 28, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the same type.
 
-
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -594,15 +467,6 @@ def SPIRV_CLFloorOp : SPIRV_CLUnaryArithmeticOp<"floor", 25, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -630,13 +494,6 @@ def SPIRV_CLFmaOp : SPIRV_CLTernaryArithmeticOp<"fma", 26, SPIRV_Float> {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -657,15 +514,6 @@ def SPIRV_CLLogOp : SPIRV_CLUnaryArithmeticOp<"log", 37, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -691,13 +539,6 @@ def SPIRV_CLMixOp : SPIRV_CLTernaryArithmeticOp<"mix", 99, SPIRV_Float> {
     Note: This instruction can be implemented using contractions such as mad
     or fma.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    mix-op ::= ssa-id `=` `spirv.CL.mix` ssa-use, ssa-use, ssa-use `:`
-           float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -719,16 +560,6 @@ def SPIRV_CLPowOp : SPIRV_CLBinaryArithmeticOp<"pow", 48, SPIRV_Float> {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
-               restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -752,15 +583,6 @@ def SPIRV_CLRintOp : SPIRV_CLUnaryArithmeticOp<"rint", 53, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -786,14 +608,6 @@ def SPIRV_CLRoundOp : SPIRV_CLUnaryArithmeticOp<"round", 55, SPIRV_Float> {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
-               float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -814,15 +628,6 @@ def SPIRV_CLRsqrtOp : SPIRV_CLUnaryArithmeticOp<"rsqrt", 56, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -847,13 +652,6 @@ def SPIRV_CLSAbsOp : SPIRV_CLUnaryArithmeticOp<"s_abs", 141, SPIRV_Integer> {
     All of the operands, including the Result Type operand,
     must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
-               integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -875,14 +673,8 @@ def SPIRV_CLSMaxOp : SPIRV_CLBinaryArithmeticOp<"s_max", 156, SPIRV_Integer> {
 
     All of the operands, including the Result Type operand, must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
+
     ```mlir
     %2 = spirv.CL.s_max %0, %1 : i32
     %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
@@ -902,14 +694,8 @@ def SPIRV_CLSMinOp : SPIRV_CLBinaryArithmeticOp<"s_min", 158, SPIRV_Integer> {
 
     All of the operands, including the Result Type operand, must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
+
     ```mlir
     %2 = spirv.CL.s_min %0, %1 : i32
     %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
@@ -928,15 +714,6 @@ def SPIRV_CLSinOp : SPIRV_CLUnaryArithmeticOp<"sin", 57, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -959,15 +736,6 @@ def SPIRV_CLSinhOp : SPIRV_CLUnaryArithmeticOp<"sinh", 59, SPIRV_Float > {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    sinh-op ::= ssa-id `=` `spirv.CL.sinh` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -988,15 +756,6 @@ def SPIRV_CLSqrtOp : SPIRV_CLUnaryArithmeticOp<"sqrt", 61, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -1019,15 +778,6 @@ def SPIRV_CLTanOp : SPIRV_CLUnaryArithmeticOp<"tan", 62, SPIRV_Float > {
     All of the operands, including the Result Type operand, must be of the
     same type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    tan-op ::= ssa-id `=` `spirv.CL.tan` ssa-use `:`
-               float-scalar-vector-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -1048,15 +798,6 @@ def SPIRV_CLTanhOp : SPIRV_CLUnaryArithmeticOp<"tanh", 63, SPIRV_Float> {
 
     All of the operands, including the Result Type operand, must be of the
     same type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
-               float-scalar-vector-type
-    ```
 
     #### Example:
 
@@ -1079,14 +820,8 @@ def SPIRV_CLUMaxOp : SPIRV_CLBinaryArithmeticOp<"u_max", 157, SPIRV_Integer> {
 
     All of the operands, including the Result Type operand, must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
+
     ```mlir
     %2 = spirv.CL.u_max %0, %1 : i32
     %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
@@ -1106,14 +841,8 @@ def SPIRV_CLUMinOp : SPIRV_CLBinaryArithmeticOp<"u_min", 159, SPIRV_Integer> {
 
     All of the operands, including the Result Type operand, must be of the same type.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
+
     ```mlir
     %2 = spirv.CL.u_min %0, %1 : i32
     %3 = spirv.CL.u_min %0, %1 : vector<3xi16>

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCastOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCastOps.td
@@ -61,13 +61,6 @@ def SPIRV_BitcastOp : SPIRV_Op<"Bitcast", [Pure]> {
     component of S (mapping to multiple components of L) maps its lower-
     ordered bits to the lower-numbered components of L.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
-                   `:` operand-type `to` result-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -105,14 +98,7 @@ def SPIRV_ConvertFToSOp : SPIRV_CastOp<"ConvertFToS", SPIRV_Integer, SPIRV_Float
     Float Value must be a scalar or vector of floating-point type.  It must
     have the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
-                          `:` operand-type `to` result-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -138,14 +124,7 @@ def SPIRV_ConvertFToUOp : SPIRV_CastOp<"ConvertFToU", SPIRV_Integer, SPIRV_Float
     Float Value must be a scalar or vector of floating-point type.  It must
     have the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
-                          `:` operand-type `to` result-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -172,14 +151,7 @@ def SPIRV_ConvertSToFOp : SPIRV_CastOp<"ConvertSToF",
     Signed Value must be a scalar or vector of integer type.  It must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
-                          `:` operand-type `to` result-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -206,14 +178,7 @@ def SPIRV_ConvertUToFOp : SPIRV_CastOp<"ConvertUToF",
     Unsigned Value must be a scalar or vector of integer type.  It must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
-                          `:` operand-type `to` result-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -242,14 +207,7 @@ def SPIRV_FConvertOp : SPIRV_CastOp<"FConvert",
     have the same number of components as Result Type.  The component width
     cannot equal the component width in Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
-                     `:` operand-type `to` result-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -277,14 +235,7 @@ def SPIRV_SConvertOp : SPIRV_CastOp<"SConvert",
     the same number of components as Result Type.  The component width
     cannot equal the component width in Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
-                     `:` operand-type `to` result-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -313,14 +264,7 @@ def SPIRV_UConvertOp : SPIRV_CastOp<"UConvert",
     the same number of components as Result Type.  The component width
     cannot equal the component width in Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
-                 `:` operand-type `to` result-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -348,13 +292,6 @@ def SPIRV_ConvertPtrToUOp : SPIRV_Op<"ConvertPtrToU", []> {
     the conversion truncates Pointer.
 
     For same bit width Pointer and Result Type, this is the same as OpBitcast.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    ptr-to-u-convert-op ::= ssa-id `=` `spirv.ConvertPtrToUOp` ssa-use
-                 `:` operand-type `to` result-type
-    ```
 
     #### Example:
 
@@ -404,13 +341,6 @@ def SPIRV_ConvertUToPtrOp : SPIRV_Op<"ConvertUToPtr", [UnsignedOp]> {
     the conversion truncates Integer Value.
 
     For same-width Integer Value and Result Type, this is the same as OpBitcast.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    u-to-ptr-convert-op ::= ssa-id `=` `spirv.ConvertUToPtr` ssa-use
-                 `:` operand-type `to` result-type
-    ```
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCompositeOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCompositeOps.td
@@ -43,13 +43,6 @@ def SPIRV_CompositeConstructOp : SPIRV_Op<"CompositeConstruct", [Pure]> {
     type of the result. When constructing a vector, there must be at least
     two Constituent operands.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
-                               (ssa-use (`,` ssa-use)* )? `:` composite-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -257,16 +250,6 @@ def SPIRV_VectorInsertDynamicOp : SPIRV_Op<"VectorInsertDynamic", [
 
     Behavior is undefined if Index's value is less than zero or greater than
     or equal to the number of components in Vector.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scalar-type ::= integer-type | float-type | boolean-type
-    vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
-                                  ssa-use `[` ssa-use `]`
-                                  `:` `vector<` integer-literal `x` scalar-type `>` `,`
-                                  integer-type
-    ```
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
@@ -29,14 +29,6 @@ def SPIRV_BranchOp : SPIRV_Op<"Branch", [
   let description = [{
     This instruction must be the last instruction in a block.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    branch-op ::= `spirv.Branch` successor
-    successor ::= bb-id branch-use-list?
-    branch-use-list ::= `(` ssa-use-list `:` type-list-no-parens `)`
-    ```
-
     #### Example:
 
     ```mlir
@@ -212,13 +204,6 @@ def SPIRV_FunctionCallOp : SPIRV_Op<"FunctionCall", [
     information: Result Type must match the Return Type of the function, and
     the calling argument types must match the formal parameter types.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    function-call-op ::= `spirv.FunctionCall` function-id `(` ssa-use-list `)`
-                     `:` function-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -344,10 +329,10 @@ def SPIRV_ReturnOp : SPIRV_Op<"Return", [InFunctionScope, Pure,
   let description = [{
     This instruction must be the last instruction in a block.
 
-    <!-- End of AutoGen section -->
+    #### Example:
 
-    ```
-    return-op ::= `spirv.Return`
+    ```mlir
+    spirv.Return
     ```
   }];
 
@@ -365,12 +350,6 @@ def SPIRV_UnreachableOp : SPIRV_Op<"Unreachable", [InFunctionScope, Terminator]>
 
   let description = [{
     This instruction must be the last instruction in a block.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    unreachable-op ::= `spirv.Unreachable`
-    ```
   }];
 
   let arguments = (ins);
@@ -392,12 +371,6 @@ def SPIRV_ReturnValueOp : SPIRV_Op<"ReturnValue", [InFunctionScope, Pure,
     instruction is in.
 
     This instruction must be the last instruction in a block.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    return-value-op ::= `spirv.ReturnValue` ssa-use `:` spirv-type
-    ```
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCooperativeMatrixOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVCooperativeMatrixOps.td
@@ -32,11 +32,6 @@ def SPIRV_KHRCooperativeMatrixLengthOp :
 
     The type attribute must be a cooperative matrix type.
 
-    ``` {.ebnf}
-    cooperative-matrix-length-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLength
-                                    ` : ` cooperative-matrix-type
-    ```
-
     #### Example:
 
     ```
@@ -99,14 +94,6 @@ def SPIRV_KHRCooperativeMatrixLoadOp : SPIRV_KhrVendorOp<"CooperativeMatrixLoad"
     (where the scope is the scope the cooperative matrix type was created with).
     All invocations in a given scope instance must be active or all must be
     inactive.
-
-    ``` {.ebnf}
-    cooperative-matrix-load-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLoad`
-                              ssa-use `,` ssa-use `,`
-                              `<` cooperative-matrix-layout `>`
-                              (`,` `<` memory-operand `>`)? `:`
-                                pointer-type `,` stride-type `->` cooperative-matrix-type
-    ```
 
     TODO: In the SPIR-V spec, `stride` is an optional argument. We should also
     support this optionality in the SPIR-V dialect.
@@ -191,14 +178,6 @@ def SPIRV_KHRCooperativeMatrixStoreOp : SPIRV_KhrVendorOp<"CooperativeMatrixStor
     (where the scope is the scope the cooperative matrix type was created with).
     All invocations in a given scope instance must be active or all must be
     inactive.
-
-    ``` {.ebnf}
-     coop-matrix-store-op ::= `spirv.KHR.CooperativeMatrixStore`
-                              ssa-use `,` ssa-use `,`
-                              ssa-use `,` `<` cooperative-matrix-layout `>`
-                              (`,` `<` memory-operand `>`)? `:`
-                              pointer-type `,` coop-matrix-type `,` stride-type
-    ```
 
     TODO: In the SPIR-V spec, `stride` is an optional argument. We should also
     support this optionality in the SPIR-V dialect.
@@ -377,12 +356,7 @@ def SPIRV_NVCooperativeMatrixLengthOp : SPIRV_NvVendorOp<"CooperativeMatrixLengt
 
     Type is a cooperative matrix type.
 
-    ``` {.ebnf}
-    cooperative-matrix-length-op ::= ssa-id `=` `spirv.NV.CooperativeMatrixLength
-                                    ` : ` cooperative-matrix-type
-    ```
-
-    For example:
+    #### Example:
 
     ```
     %0 = spirv.NV.CooperativeMatrixLength : !spirv.NV.coopmatrix<8x16xi32, Subgroup>
@@ -456,7 +430,7 @@ def SPIRV_NVCooperativeMatrixLoadOp : SPIRV_NvVendorOp<"CooperativeMatrixLoad", 
                               cooperative-matrix-type
     ```
 
-    For example:
+    #### Example:
 
     ```
     %0 = spirv.NV.CooperativeMatrixLoad %ptr, %stride, %colMajor
@@ -520,14 +494,7 @@ def SPIRV_NVCooperativeMatrixMulAddOp : SPIRV_NvVendorOp<"CooperativeMatrixMulAd
     scope instance must be active or all must be inactive (where the scope is
     the scope of the operation).
 
-    ``` {.ebnf}
-    cooperative-matrixmuladd-op ::= ssa-id `=` `spirv.NV.CooperativeMatrixMulAdd`
-                              ssa-use `,` ssa-use `,` ssa-use ` : `
-                              a-cooperative-matrix-type,
-                              b-cooperative-matrix-type ->
-                              result-cooperative-matrix-type
-    ```
-    For example:
+    #### Example:
 
     ```
     %0 = spirv.NV.CooperativeMatrixMulAdd %arg0, %arg1, %arg2,  :
@@ -592,7 +559,7 @@ def SPIRV_NVCooperativeMatrixStoreOp : SPIRV_NvVendorOp<"CooperativeMatrixStore"
                               pointer-type `,` coop-matrix-type
     ```
 
-    For example:
+    #### Example:
 
     ```
       spirv.NV.CooperativeMatrixStore %arg0, %arg2, %arg1, %arg3 :

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGLOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGLOps.td
@@ -116,13 +116,6 @@ def SPIRV_GLFAbsOp : SPIRV_GLUnaryArithmeticOp<"FAbs", 4, SPIRV_Float> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
-               float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -145,13 +138,6 @@ def SPIRV_GLSAbsOp : SPIRV_GLUnaryArithmeticOp<"SAbs", 5, SPIRV_Integer> {
     types. Result Type and operand types must have the same number of components
     with the same component width. Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
-               integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -176,13 +162,6 @@ def SPIRV_GLCeilOp : SPIRV_GLUnaryArithmeticOp<"Ceil", 9, SPIRV_Float> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -206,15 +185,6 @@ def SPIRV_GLCosOp : SPIRV_GLUnaryArithmeticOp<"Cos", 14, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
-               restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -238,15 +208,6 @@ def SPIRV_GLSinOp : SPIRV_GLUnaryArithmeticOp<"Sin", 13, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
-               restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -270,15 +231,6 @@ def SPIRV_GLTanOp : SPIRV_GLUnaryArithmeticOp<"Tan", 15, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
-               restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -304,15 +256,7 @@ def SPIRV_GLAsinOp : SPIRV_GLUnaryArithmeticOp<"Asin", 16, SPIRV_Float16or32> {
 
     Result Type and the type of x must be the same type. Results are computed
     per component.
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
-                restricted-float-scalar-vector-type
-    ```
+
     #### Example:
 
     ```mlir
@@ -338,15 +282,7 @@ def SPIRV_GLAcosOp : SPIRV_GLUnaryArithmeticOp<"Acos", 17, SPIRV_Float16or32> {
 
     Result Type and the type of x must be the same type. Results are computed
     per component.
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
-                restricted-float-scalar-vector-type
-    ```
+
     #### Example:
 
     ```mlir
@@ -372,15 +308,7 @@ def SPIRV_GLAtanOp : SPIRV_GLUnaryArithmeticOp<"Atan", 18, SPIRV_Float16or32> {
 
     Result Type and the type of x must be the same type. Results are computed
     per component.
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
-                restricted-float-scalar-vector-type
-    ```
+
     #### Example:
 
     ```mlir
@@ -404,15 +332,6 @@ def SPIRV_GLExpOp : SPIRV_GLUnaryArithmeticOp<"Exp", 27, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are
     computed per component.";
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
-               restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -437,13 +356,6 @@ def SPIRV_GLFloorOp : SPIRV_GLUnaryArithmeticOp<"Floor", 8, SPIRV_Float> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -470,13 +382,6 @@ def SPIRV_GLRoundOp: SPIRV_GLUnaryArithmeticOp<"Round", 1, SPIRV_Float> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -502,13 +407,6 @@ def SPIRV_GLRoundEvenOp: SPIRV_GLUnaryArithmeticOp<"RoundEven", 2, SPIRV_Float> 
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -532,13 +430,6 @@ def SPIRV_GLInverseSqrtOp : SPIRV_GLUnaryArithmeticOp<"InverseSqrt", 32, SPIRV_F
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
-                 float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -563,15 +454,6 @@ def SPIRV_GLLogOp : SPIRV_GLUnaryArithmeticOp<"Log", 28, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
-               restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -596,13 +478,6 @@ def SPIRV_GLFMaxOp : SPIRV_GLBinaryArithmeticOp<"FMax", 40, SPIRV_Float> {
     Result Type and the type of all operands must be the same
     type. Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -626,13 +501,6 @@ def SPIRV_GLUMaxOp : SPIRV_GLBinaryArithmeticOp<"UMax", 41, SPIRV_Integer> {
     components with the same component width. Results are computed per
     component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -656,13 +524,6 @@ def SPIRV_GLSMaxOp : SPIRV_GLBinaryArithmeticOp<"SMax", 42, SPIRV_Integer> {
     components with the same component width. Results are computed per
     component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -687,13 +548,6 @@ def SPIRV_GLFMinOp : SPIRV_GLBinaryArithmeticOp<"FMin", 37, SPIRV_Float> {
     Result Type and the type of all operands must be the same type. Results are
     computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -717,13 +571,6 @@ def SPIRV_GLUMinOp : SPIRV_GLBinaryArithmeticOp<"UMin", 38, SPIRV_Integer> {
     components with the same component width. Results are computed per
     component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -747,13 +594,6 @@ def SPIRV_GLSMinOp : SPIRV_GLBinaryArithmeticOp<"SMin", 39, SPIRV_Integer> {
     components with the same component width. Results are computed per
     component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -779,15 +619,6 @@ def SPIRV_GLPowOp : SPIRV_GLBinaryArithmeticOp<"Pow", 26, SPIRV_Float16or32> {
     Result Type and the type of all operands must be the same type. Results are
     computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
-               restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -811,13 +642,6 @@ def SPIRV_GLFSignOp : SPIRV_GLUnaryArithmeticOp<"FSign", 6, SPIRV_Float> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -840,13 +664,6 @@ def SPIRV_GLSSignOp : SPIRV_GLUnaryArithmeticOp<"SSign", 7, SPIRV_Integer> {
     types. Result Type and operand types must have the same number of components
     with the same component width. Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                   `vector<` integer-literal `x` integer-type `>`
-    sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
-                integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -870,13 +687,6 @@ def SPIRV_GLSqrtOp : SPIRV_GLUnaryArithmeticOp<"Sqrt", 31, SPIRV_Float> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
-                float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -900,15 +710,6 @@ def SPIRV_GLSinhOp : SPIRV_GLUnaryArithmeticOp<"Sinh", 19, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
-                restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -932,15 +733,6 @@ def SPIRV_GLCoshOp : SPIRV_GLUnaryArithmeticOp<"Cosh", 20, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
-                restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -964,15 +756,6 @@ def SPIRV_GLTanhOp : SPIRV_GLUnaryArithmeticOp<"Tanh", 21, SPIRV_Float16or32> {
     Result Type and the type of x must be the same type. Results are computed
     per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    restricted-float-scalar-type ::=  `f16` | `f32`
-    restricted-float-scalar-vector-type ::=
-      restricted-float-scalar-type |
-      `vector<` integer-literal `x` restricted-float-scalar-type `>`
-    tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
-                restricted-float-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -1134,16 +917,6 @@ def SPIRV_GLFrexpStructOp : SPIRV_GLOp<"FrexpStruct", 52, [Pure]> {
     The operand x must be a scalar or vector whose component type is
     floating-point.
 
-    <!-- End of AutoGen section -->
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
-                                  `!spirv.struct<` float-scalar-vector-type `,`
-                                                  integer-scalar-vector-type `>`
-    ```
     #### Example:
 
     ```mlir

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGroupOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGroupOps.td
@@ -40,15 +40,6 @@ def SPIRV_GroupFMulKHROp : SPIRV_KhrVendorOp<"GroupFMul", [Pure,
     The type of 'X' must be the same as 'Result Type'.
 
 
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
-                            `:` float-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -100,24 +91,11 @@ def SPIRV_GroupBroadcastOp : SPIRV_Op<"GroupBroadcast",
 
     Execution must be Workgroup or Subgroup Scope.
 
-     The type of Value must be the same as Result Type.
+    The type of Value must be the same as Result Type.
 
     LocalId must be an integer datatype. It can be a scalar, or a vector
     with 2 components or a vector with 3 components. LocalId must be the
     same for all invocations in the group.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    integer-float-scalar-vector-type ::= integer-type | float-type |
-                               `vector<` integer-literal `x` integer-type `>` |
-                               `vector<` integer-literal `x` float-type `>`
-    localid-type ::= integer-type |
-                   `vector<` integer-literal `x` integer-type `>`
-    group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
-                   ssa_use `:` integer-float-scalar-vector-type `,` localid-type
-    ```
 
     #### Example:
 
@@ -176,16 +154,7 @@ def SPIRV_GroupFAddOp : SPIRV_Op<"GroupFAdd", [Pure,
 
     The identity I for Operation is 0.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
-                            `:` float-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 
@@ -238,16 +207,7 @@ def SPIRV_GroupFMaxOp : SPIRV_Op<"GroupFMax", [Pure,
 
     The identity I for Operation is -INF.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
-                            `:` float-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 
@@ -300,16 +260,7 @@ def SPIRV_GroupFMinOp : SPIRV_Op<"GroupFMin", [Pure,
 
     The identity I for Operation is +INF.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
-                            `:` float-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 
@@ -362,16 +313,7 @@ def SPIRV_GroupIAddOp : SPIRV_Op<"GroupIAdd", [Pure,
 
     The identity I for Operation is 0.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
-                            `:` integer-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 
@@ -426,16 +368,6 @@ def SPIRV_GroupIMulKHROp : SPIRV_KhrVendorOp<"GroupIMul", [Pure,
 
     The type of 'X' must be the same as 'Result Type'.
 
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
-                            `:` integer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -488,16 +420,7 @@ def SPIRV_GroupSMaxOp : SPIRV_Op<"GroupSMax", [Pure,
     The identity I for Operation is INT_MIN when X is 32 bits wide and
     LONG_MIN when X is 64 bits wide.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
-                            `:` integer-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 
@@ -551,16 +474,7 @@ def SPIRV_GroupSMinOp : SPIRV_Op<"GroupSMin", [Pure,
     The identity I for Operation is INT_MAX when X is 32 bits wide and
     LONG_MAX when X is 64 bits wide.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
-                            `:` integer-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 
@@ -613,16 +527,7 @@ def SPIRV_GroupUMaxOp : SPIRV_Op<"GroupUMax", [Pure,
 
     The identity I for Operation is 0.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
-                            `:` integer-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 
@@ -676,16 +581,7 @@ def SPIRV_GroupUMinOp : SPIRV_Op<"GroupUMin", [Pure,
     The identity I for Operation is UINT_MAX when X is 32 bits wide and
     ULONG_MAX when X is 64 bits wide.
 
-     The type of X must be the same as Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    operation ::= `"Reduce"` | `"InclusiveScan"` | `"ExclusiveScan"`
-    op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
-                            `:` integer-type
-    ```
+    The type of X must be the same as Result Type.
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVImageOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVImageOps.td
@@ -41,15 +41,7 @@ def SPIRV_ImageDrefGatherOp : SPIRV_Op<"ImageDrefGather", [Pure]> {
 
     Image Operands encodes what operands follow, as per Image Operands.
 
-    <!-- End of AutoGen section -->
-    ```
-    image-operands ::= `"None"` | `"Bias"` | `"Lod"` | `"Grad"`
-                      | `"ConstOffset"` | `"Offser"` | `"ConstOffsets"`
-                      | `"Sample"` | `"MinLod"` | `"MakeTexelAvailable"`
-                      | `"MakeTexelVisible"` | `"NonPrivateTexel"`
-                      | `"VolatileTexel"` | `"SignExtend"` | `"ZeroExtend"`
     #### Example:
-    ```
 
     ```mlir
     %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 -> vector<4xi32>

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVIntelExtOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVIntelExtOps.td
@@ -34,11 +34,6 @@ def SPIRV_INTELConvertFToBF16Op : SPIRV_IntelVendorOp<"ConvertFToBF16", []> {
 
     Results are computed per component.
 
-    ```
-    convert-f-to-bf16-op ::= ssa-id `=` `spirv.INTEL.ConvertFToBF16` ssa-use
-                          `:` operand-type `to` result-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -84,11 +79,6 @@ def SPIRV_INTELConvertBF16ToFOp : SPIRV_IntelVendorOp<"ConvertBF16ToF", []> {
     The type must have the same number of components as the Result Type. The component width must be 16 bits.
 
     Results are computed per component.
-
-    ```
-    convert-bf16-to-f-op ::= ssa-id `=` `spirv.INTEL.ConvertBF16ToF` ssa-use
-                          `:` operand-type `to` result-type
-    ```
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVJointMatrixOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVJointMatrixOps.td
@@ -27,12 +27,7 @@ def SPIRV_INTELJointMatrixWorkItemLengthOp : SPIRV_IntelVendorOp<"JointMatrixWor
 
     Type is a joint matrix type.
 
-    ``` {.ebnf}
-    joint-matrix-length-op ::= ssa-id `=` `spirv.INTEL.JointMatrixWorkItemLength
-                                    ` : ` joint-matrix-type
-    ```
-
-    For example:
+    #### Example:
 
     ```
     %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVLogicalOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVLogicalOps.td
@@ -54,19 +54,11 @@ def SPIRV_FOrdEqualOp : SPIRV_LogicalBinaryOp<"FOrdEqual", SPIRV_Float, [Commuta
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -88,19 +80,11 @@ def SPIRV_FOrdGreaterThanOp : SPIRV_LogicalBinaryOp<"FOrdGreaterThan", SPIRV_Flo
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -122,19 +106,11 @@ def SPIRV_FOrdGreaterThanEqualOp : SPIRV_LogicalBinaryOp<"FOrdGreaterThanEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -156,19 +132,11 @@ def SPIRV_FOrdLessThanOp : SPIRV_LogicalBinaryOp<"FOrdLessThan", SPIRV_Float, []
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -190,19 +158,11 @@ def SPIRV_FOrdLessThanEqualOp : SPIRV_LogicalBinaryOp<"FOrdLessThanEqual", SPIRV
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -221,19 +181,11 @@ def SPIRV_FOrdNotEqualOp : SPIRV_LogicalBinaryOp<"FOrdNotEqual", SPIRV_Float, [C
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -252,19 +204,11 @@ def SPIRV_FUnordEqualOp : SPIRV_LogicalBinaryOp<"FUnordEqual", SPIRV_Float, [Com
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -286,19 +230,11 @@ def SPIRV_FUnordGreaterThanOp : SPIRV_LogicalBinaryOp<"FUnordGreaterThan", SPIRV
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -320,19 +256,11 @@ def SPIRV_FUnordGreaterThanEqualOp : SPIRV_LogicalBinaryOp<"FUnordGreaterThanEqu
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -354,19 +282,11 @@ def SPIRV_FUnordLessThanOp : SPIRV_LogicalBinaryOp<"FUnordLessThan", SPIRV_Float
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -388,19 +308,11 @@ def SPIRV_FUnordLessThanEqualOp : SPIRV_LogicalBinaryOp<"FUnordLessThanEqual", S
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -419,19 +331,11 @@ def SPIRV_FUnordNotEqualOp : SPIRV_LogicalBinaryOp<"FUnordNotEqual", SPIRV_Float
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     floating-point type.  They must have the same type, and they must have
     the same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -452,25 +356,17 @@ def SPIRV_IEqualOp : SPIRV_LogicalBinaryOp<"IEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
-                             `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.IEqual %0, %1 : i32
     %5 = spirv.IEqual %2, %3 : vector<4xi32>
-
     ```
   }];
 }
@@ -485,19 +381,12 @@ def SPIRV_INotEqualOp : SPIRV_LogicalBinaryOp<"INotEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
-                                 `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -519,16 +408,7 @@ def SPIRV_IsInfOp : SPIRV_LogicalUnaryOp<"IsInf", SPIRV_Float, []> {
     x must be a scalar or vector of floating-point type.  It must have the
     same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
-                            `:` float-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -552,16 +432,7 @@ def SPIRV_IsNanOp : SPIRV_LogicalUnaryOp<"IsNan", SPIRV_Float, []> {
     x must be a scalar or vector of floating-point type.  It must have the
     same number of components as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
-                            `:` float-scalar-vector-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -586,18 +457,11 @@ def SPIRV_LogicalAndOp : SPIRV_LogicalBinaryOp<"LogicalAnd",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 must be the same as Result Type.
+    The type of Operand 1 must be the same as Result Type.
 
-     The type of Operand 2 must be the same as Result Type.
+    The type of Operand 2 must be the same as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
-                    `:` operand-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -624,18 +488,11 @@ def SPIRV_LogicalEqualOp : SPIRV_LogicalBinaryOp<"LogicalEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 must be the same as Result Type.
+    The type of Operand 1 must be the same as Result Type.
 
-     The type of Operand 2 must be the same as Result Type.
+    The type of Operand 2 must be the same as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
-                      `:` operand-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -658,15 +515,9 @@ def SPIRV_LogicalNotOp : SPIRV_LogicalUnaryOp<"LogicalNot",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand must be the same as Result Type.
+    The type of Operand must be the same as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -693,18 +544,11 @@ def SPIRV_LogicalNotEqualOp : SPIRV_LogicalBinaryOp<"LogicalNotEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 must be the same as Result Type.
+    The type of Operand 1 must be the same as Result Type.
 
-     The type of Operand 2 must be the same as Result Type.
+    The type of Operand 2 must be the same as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
-                          `:` operand-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -730,18 +574,11 @@ def SPIRV_LogicalOrOp : SPIRV_LogicalBinaryOp<"LogicalOr",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 must be the same as Result Type.
+    The type of Operand 1 must be the same as Result Type.
 
-     The type of Operand 2 must be the same as Result Type.
+    The type of Operand 2 must be the same as Result Type.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
-                    `:` operand-type
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -770,15 +607,7 @@ def SPIRV_OrderedOp : SPIRV_LogicalBinaryOp<"Ordered", SPIRV_Float, [Commutative
 
     y must have the same type as x.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -808,19 +637,12 @@ def SPIRV_SGreaterThanOp : SPIRV_LogicalBinaryOp<"SGreaterThan",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
-                                    `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -845,25 +667,17 @@ def SPIRV_SGreaterThanEqualOp : SPIRV_LogicalBinaryOp<"SGreaterThanEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
-                                          `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.SGreaterThanEqual %0, %1 : i32
     %5 = spirv.SGreaterThanEqual %2, %3 : vector<4xi32>
-
     ```
   }];
 }
@@ -880,19 +694,12 @@ def SPIRV_SLessThanOp : SPIRV_LogicalBinaryOp<"SLessThan",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
-                                 `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
@@ -917,25 +724,17 @@ def SPIRV_SLessThanEqualOp : SPIRV_LogicalBinaryOp<"SLessThanEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
-                                       `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.SLessThanEqual %0, %1 : i32
     %5 = spirv.SLessThanEqual %2, %3 : vector<4xi32>
-
     ```
   }];
 }
@@ -954,7 +753,7 @@ def SPIRV_SelectOp : SPIRV_Op<"Select",
   let description = [{
     Before version 1.4, Result Type must be a pointer, scalar, or vector.
 
-     The types of Object 1 and Object 2 must be the same as Result Type.
+    The types of Object 1 and Object 2 must be the same as Result Type.
 
     Condition must be a scalar or vector of Boolean type.
 
@@ -966,19 +765,6 @@ def SPIRV_SelectOp : SPIRV_Op<"Select",
     and Object 2: When a component of Condition is true, the corresponding
     component in the result is taken from Object 1, otherwise it is taken
     from Object 2.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scalar-type ::= integer-type | float-type | boolean-type
-    select-object-type ::= scalar-type
-                           | `vector<` integer-literal `x` scalar-type `>`
-                           | pointer-type
-    select-condition-type ::= boolean-type
-                              | `vector<` integer-literal `x` boolean-type `>`
-    select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
-                  `:` select-condition-type `,` select-object-type
-    ```
 
     #### Example:
 
@@ -1021,25 +807,17 @@ def SPIRV_UGreaterThanOp : SPIRV_LogicalBinaryOp<"UGreaterThan",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
-                                    `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.UGreaterThan %0, %1 : i32
     %5 = spirv.UGreaterThan %2, %3 : vector<4xi32>
-
     ```
   }];
 }
@@ -1058,25 +836,17 @@ def SPIRV_UGreaterThanEqualOp : SPIRV_LogicalBinaryOp<"UGreaterThanEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
-                                          `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.UGreaterThanEqual %0, %1 : i32
     %5 = spirv.UGreaterThanEqual %2, %3 : vector<4xi32>
-
     ```
   }];
 }
@@ -1093,25 +863,17 @@ def SPIRV_ULessThanOp : SPIRV_LogicalBinaryOp<"ULessThan",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
-                                 `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.ULessThan %0, %1 : i32
     %5 = spirv.ULessThan %2, %3 : vector<4xi32>
-
     ```
   }];
 }
@@ -1132,15 +894,7 @@ def SPIRV_UnorderedOp : SPIRV_LogicalBinaryOp<"Unordered", SPIRV_Float, [Commuta
 
     y must have the same type as x.
 
-     Results are computed per component.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    float-scalar-vector-type ::= float-type |
-                                 `vector<` integer-literal `x` float-type `>`
-    unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
-    ```
+    Results are computed per component.
 
     #### Example:
 
@@ -1172,25 +926,17 @@ def SPIRV_ULessThanEqualOp : SPIRV_LogicalBinaryOp<"ULessThanEqual",
   let description = [{
     Result Type must be a scalar or vector of Boolean type.
 
-     The type of Operand 1 and Operand 2  must be a scalar or vector of
+    The type of Operand 1 and Operand 2  must be a scalar or vector of
     integer type.  They must have the same component width, and they must
     have the same number of components as Result Type.
 
-     Results are computed per component.
+    Results are computed per component.
 
-    <!-- End of AutoGen section -->
-    ```
-    integer-scalar-vector-type ::= integer-type |
-                                 `vector<` integer-literal `x` integer-type `>`
-    uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
-                                       `:` integer-scalar-vector-type
-    ```
     #### Example:
 
     ```mlir
     %4 = spirv.ULessThanEqual %0, %1 : i32
     %5 = spirv.ULessThanEqual %2, %3 : vector<4xi32>
-
     ```
   }];
 }

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMatrixOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMatrixOps.td
@@ -31,13 +31,6 @@ def SPIRV_MatrixTimesMatrixOp : SPIRV_Op<"MatrixTimesMatrix", [Pure]> {
     number of columns in Result Type. Its columns must have the same number
     of components as the number of columns in LeftMatrix.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    matrix-times-matrix-op ::= ssa-id `=` `spirv.MatrixTimesMatrix` ssa-use,
-    ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -81,14 +74,6 @@ def SPIRV_MatrixTimesScalarOp : SPIRV_Op<
     each column in Matrix is multiplied by Scalar.
 
     Scalar must have the same type as the Component Type in Result Type.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    matrix-times-scalar-op ::= ssa-id `=` `spirv.MatrixTimesScalar` ssa-use,
-    ssa-use `:` matrix-type `,` float-type `->` matrix-type
-
-    ```
 
     #### Example:
 
@@ -142,20 +127,11 @@ def SPIRV_TransposeOp : SPIRV_Op<"Transpose", [Pure]> {
 
     Matrix must have of type of OpTypeMatrix.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    transpose-op ::= ssa-id `=` `spirv.Transpose` ssa-use `:` matrix-type `->`
-    matrix-type
-    ```
-
-
     #### Example:
 
     ```mlir
     %0 = spirv.Transpose %matrix: !spirv.matrix<2 x vector<3xf32>> ->
     !spirv.matrix<3 x vector<2xf32>>
-
     ```
   }];
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMiscOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMiscOps.td
@@ -66,12 +66,6 @@ def SPIRV_UndefOp : SPIRV_Op<"Undef", [Pure]> {
     bit pattern or abstract value resulting in possibly different concrete,
     abstract, or opaque values.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    undef-op ::= `spirv.Undef` `:` spirv-type
-    ```
-
     #### Example:
 
     ```mlir

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVNonUniformOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVNonUniformOps.td
@@ -53,14 +53,6 @@ def SPIRV_GroupNonUniformBallotOp : SPIRV_Op<"GroupNonUniformBallot", []> {
 
     Predicate must be a Boolean type.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
-                              ssa-use `:` `vector` `<` 4 `x` `integer-type` `>`
-    ```
-
     #### Example:
 
     ```mlir
@@ -104,7 +96,7 @@ def SPIRV_GroupNonUniformBroadcastOp : SPIRV_Op<"GroupNonUniformBroadcast",
 
     Execution must be Workgroup or Subgroup Scope.
 
-     The type of Value must be the same as Result Type.
+    The type of Value must be the same as Result Type.
 
     Id  must be a scalar of integer type, whose Signedness operand is 0.
 
@@ -113,18 +105,6 @@ def SPIRV_GroupNonUniformBroadcastOp : SPIRV_Op<"GroupNonUniformBroadcast",
 
     The resulting value is undefined if Id is an inactive invocation, or is
     greater than or equal to the size of the group.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    integer-float-scalar-vector-type ::= integer-type | float-type |
-                               `vector<` integer-literal `x` integer-type `>` |
-                               `vector<` integer-literal `x` float-type `>`
-    group-non-uniform-broadcast-op ::= ssa-id `=`
-        `spirv.GroupNonUniformBroadcast` scope ssa_use, ssa_use
-        `:` integer-float-scalar-vector-type `,` integer-type
-    ```
 
     #### Example:
 
@@ -172,14 +152,6 @@ def SPIRV_GroupNonUniformElectOp : SPIRV_Op<"GroupNonUniformElect", []> {
     Result Type must be a Boolean type.
 
     Execution must be Workgroup or Subgroup Scope.
-
-    <!-- End of AutoGen section -->
-
-    ```
-    scope ::= `"Workgroup"` | `"Subgroup"`
-    non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
-                             `:` `i1`
-    ```
 
     #### Example:
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVStructureOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVStructureOps.td
@@ -40,13 +40,6 @@ def SPIRV_AddressOfOp : SPIRV_Op<"mlir.addressof",
     type, this op returns a pointer type as well, and the type is the same as
     the variable referenced.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
-                                     `:` spirv-pointer-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -543,13 +536,6 @@ def SPIRV_ReferenceOfOp : SPIRV_Op<"mlir.referenceof", [Pure]> {
     for modelling purpose in the SPIR-V dialect. This op's return type is
     the same as the specialization constant.
 
-    <!-- End of AutoGen section -->
-
-    ```
-    spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
-                                       `:` spirv-scalar-type
-    ```
-
     #### Example:
 
     ```mlir
@@ -785,11 +771,8 @@ def SPIRV_YieldOp : SPIRV_Op<"mlir.yield", [
     in its parent block (see SPIRV_SpecConstantOperation for further
     details). This op has no corresponding SPIR-V instruction.
 
-    ```
-    spirv.mlir.yield ::= `spirv.mlir.yield` ssa-id : spirv-type
-    ```
-
     #### Example:
+
     ```mlir
     %0 = ... (some op supported by SPIR-V OpSpecConstantOp)
     spirv.mlir.yield %0


### PR DESCRIPTION
Some operations defined their syntax both in the documentation and via `assemblyFormat`. This leads to two syntax descriptions in the documentation for SPIR-V, see for example the documentation for [`spirv.mlir.yield`](https://mlir.llvm.org/docs/Dialects/SPIR-V/#spirvmliryield-spirvyieldop). Since the `assemblyFormat` is used to generate the actual parsers and printer implementations, this PR removes the manual syntax descriptions. (Similar to https://github.com/llvm/llvm-project/pull/73343.)

The strategy that I used to find the duplicates was pretty uncomplicated. I scrolled through the [SPIR-V Dialect](https://mlir.llvm.org/docs/Dialects/SPIR-V) to find all duplicates and then remove the duplicate text from the `td` file.

Note that the `Syntax:` block in the docs is a good proxy for whether `assemblyFormat` is defined because it will only be generated if the op has defined `assemblyFormat` (`op.hasAssemblyFormat()`):

https://github.com/llvm/llvm-project/blob/e970652776bd07dbe42be557bf98722749230653/mlir/tools/mlir-tblgen/OpDocGen.cpp#L108-L124

https://github.com/llvm/llvm-project/blob/e970652776bd07dbe42be557bf98722749230653/mlir/tools/mlir-tblgen/OpDocGen.cpp#L197-L199

Related issue https://github.com/llvm/llvm-project/issues/73359.