### PR TITLE
[Driver] Remove support for FreeBSD 11.x

### DIFF
--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -400,13 +400,6 @@ FreeBSD::FreeBSD(const Driver &D, const llvm::Triple &Triple,
     getFilePaths().push_back(concat(getDriver().SysRoot, "/usr/lib"));
 }
 
-unsigned FreeBSD::GetDefaultDwarfVersion() const {
-  unsigned Major = getTriple().getOSMajorVersion();
-  if (Major >= 12 || Major == 0)
-    return 4;
-  return 2;
-}
-
 void FreeBSD::AddClangSystemIncludeArgs(
     const llvm::opt::ArgList &DriverArgs,
     llvm::opt::ArgStringList &CC1Args) const {
@@ -509,14 +502,4 @@ SanitizerMask FreeBSD::getSupportedSanitizers() const {
     Res |= SanitizerKind::Memory;
   }
   return Res;
-}
-
-void FreeBSD::addClangTargetOptions(const ArgList &DriverArgs,
-                                    ArgStringList &CC1Args,
-                                    Action::OffloadKind) const {
-  unsigned Major = getTriple().getOSMajorVersion();
-  if (!DriverArgs.hasFlag(options::OPT_fuse_init_array,
-                          options::OPT_fno_use_init_array,
-                          (Major >= 12 || Major == 0)))
-    CC1Args.push_back("-fno-use-init-array");
 }

--- a/clang/lib/Driver/ToolChains/FreeBSD.h
+++ b/clang/lib/Driver/ToolChains/FreeBSD.h
@@ -82,14 +82,10 @@ public:
   getDefaultUnwindTableLevel(const llvm::opt::ArgList &Args) const override;
   bool isPIEDefault(const llvm::opt::ArgList &Args) const override;
   SanitizerMask getSupportedSanitizers() const override;
-  unsigned GetDefaultDwarfVersion() const override;
+  unsigned GetDefaultDwarfVersion() const override { return 4; }
   // Until dtrace (via CTF) and LLDB can deal with distributed debug info,
   // FreeBSD defaults to standalone/full debug info.
   bool GetDefaultStandaloneDebug() const override { return true; }
-  void
-  addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
-                        llvm::opt::ArgStringList &CC1Args,
-                        Action::OffloadKind DeviceOffloadKind) const override;
 
 protected:
   Tool *buildAssembler() const override;

--- a/clang/test/Driver/clang-g-opts.c
+++ b/clang/test/Driver/clang-g-opts.c
@@ -7,8 +7,8 @@
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF2 %s
 // RUN: %clang -### -S %s -g -target i686-pc-openbsd 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF2 %s
-// RUN: %clang -### -S %s -g -target x86_64-pc-freebsd10.0 2>&1 \
-// RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF2 %s
+// RUN: %clang -### -S %s -g -target x86_64-pc-freebsd 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF4 %s
 // RUN: %clang -### -S %s -g --target=x86_64-unknown-haiku 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF4 %s
 
@@ -27,8 +27,8 @@
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G-STANDALONE %s
 // RUN: %clang -### -S %s -g0 -g -target i686-pc-openbsd 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF2 %s
-// RUN: %clang -### -S %s -g0 -g -target x86_64-pc-freebsd10.0 2>&1 \
-// RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF2 %s
+// RUN: %clang -### -S %s -g0 -g -target x86_64-pc-freebsd 2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF4 %s
 // RUN: %clang -### -S %s -g0 -g --target=x86_64-unknown-haiku 2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF4 %s
 // RUN: %clang -### -S %s -g0 -g --target=i386-pc-solaris 2>&1 \

--- a/clang/test/Driver/constructors.c
+++ b/clang/test/Driver/constructors.c
@@ -76,10 +76,6 @@
 // RUN:   | FileCheck --check-prefix=CHECK-INIT-ARRAY %s
 
 // RUN: %clang -### %s -fsyntax-only 2>&1       \
-// RUN:     --target=i386-unknown-freebsd11 \
-// RUN:   | FileCheck --check-prefix=CHECK-NO-INIT-ARRAY %s
-//
-// RUN: %clang -### %s -fsyntax-only 2>&1       \
 // RUN:     --target=i386-unknown-freebsd \
 // RUN:   | FileCheck --check-prefix=CHECK-INIT-ARRAY %s
 //

--- a/clang/test/Driver/debug-options.c
+++ b/clang/test/Driver/debug-options.c
@@ -76,10 +76,7 @@
 // RUN:             | FileCheck -check-prefix=G_STANDALONE %s
 
 // FreeBSD.
-// RUN: %clang -### -c -g %s -target x86_64-pc-freebsd11.0 2>&1 \
-// RUN:             | FileCheck -check-prefix=G_GDB \
-// RUN:                         -check-prefix=G_DWARF2 %s
-// RUN: %clang -### -c -g %s -target x86_64-pc-freebsd12.0 2>&1 \
+// RUN: %clang -### -c -g %s -target x86_64-pc-freebsd 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_GDB \
 // RUN:                         -check-prefix=G_DWARF4 %s
 
@@ -188,15 +185,11 @@
 // RUN:             | FileCheck -check-prefix=GLTO_ONLY %s
 // RUN: %clang -### -c -gline-tables-only %s -target i686-pc-openbsd 2>&1 \
 // RUN:             | FileCheck -check-prefix=GLTO_ONLY_DWARF2 %s
-// RUN: %clang -### -c -gline-tables-only %s -target x86_64-pc-freebsd10.0 2>&1 \
-// RUN:             | FileCheck -check-prefix=GLTO_ONLY_DWARF2 %s
 // RUN: %clang -### -c -gline-tables-only -g %s -target x86_64-linux-gnu 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_ONLY %s
 // RUN: %clang -### -c -gline-tables-only -g %s -target x86_64-apple-darwin16 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_STANDALONE -check-prefix=G_DWARF4 %s
 // RUN: %clang -### -c -gline-tables-only -g %s -target i686-pc-openbsd 2>&1 \
-// RUN:             | FileCheck -check-prefix=G_ONLY_DWARF2 %s
-// RUN: %clang -### -c -gline-tables-only -g %s -target x86_64-pc-freebsd10.0 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_ONLY_DWARF2 %s
 // RUN: %clang -### -c -gline-tables-only -g %s --target=i386-pc-solaris 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_ONLY %s
@@ -207,15 +200,11 @@
 // RUN:             | FileCheck -check-prefix=GLIO_ONLY %s
 // RUN: %clang -### -c -gline-directives-only %s -target i686-pc-openbsd 2>&1 \
 // RUN:             | FileCheck -check-prefix=GLIO_ONLY_DWARF2 %s
-// RUN: %clang -### -c -gline-directives-only %s -target x86_64-pc-freebsd10.0 2>&1 \
-// RUN:             | FileCheck -check-prefix=GLIO_ONLY_DWARF2 %s
 // RUN: %clang -### -c -gline-directives-only -g %s -target x86_64-linux-gnu 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_ONLY %s
 // RUN: %clang -### -c -gline-directives-only -g %s -target x86_64-apple-darwin16 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_STANDALONE -check-prefix=G_DWARF4 %s
 // RUN: %clang -### -c -gline-directives-only -g %s -target i686-pc-openbsd 2>&1 \
-// RUN:             | FileCheck -check-prefix=G_ONLY_DWARF2 %s
-// RUN: %clang -### -c -gline-directives-only -g %s -target x86_64-pc-freebsd10.0 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_ONLY_DWARF2 %s
 // RUN: %clang -### -c -gline-directives-only -g %s --target=i386-pc-solaris 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_ONLY %s


### PR DESCRIPTION
Now that FreeBSD 14.0 has been released make the 12.x branch the oldest
supported releases. -fuse-init-array defaults to on. DWARF 4 is now the
default.