### PR TITLE
[lldb][dap] always add column field in StackFrame body

### DIFF
--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -817,8 +817,7 @@ llvm::json::Value CreateStackFrame(lldb::SBFrame &frame) {
     if (line && line != LLDB_INVALID_LINE_NUMBER)
       object.try_emplace("line", line);
     auto column = line_entry.GetColumn();
-    if (column && column != LLDB_INVALID_COLUMN_NUMBER)
-      object.try_emplace("column", column);
+    object.try_emplace("column", column);
   } else {
     object.try_emplace("line", 0);
     object.try_emplace("column", 0);

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -816,6 +816,8 @@ llvm::json::Value CreateStackFrame(lldb::SBFrame &frame) {
     auto line = line_entry.GetLine();
     if (line && line != LLDB_INVALID_LINE_NUMBER)
       object.try_emplace("line", line);
+    else
+      object.try_emplace("line", 0);
     auto column = line_entry.GetColumn();
     object.try_emplace("column", column);
   } else {


### PR DESCRIPTION
The `column` field is mandatory in StackTraceResponse, otherwise the debugger client may raise error (e.g. VSCode can't correctly open an editor without the column field) 