### PR TITLE
[BOLT][NFC] Refactor function state check

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4144,7 +4144,7 @@ void BinaryFunction::updateOutputValues(const BOLTLinker &Linker) {
     return;
 
   // Output ranges should match the input if the body hasn't changed.
-  if (!isSimple() && !BC.HasRelocations)
+  if (!isEmitted())
     return;
 
   // AArch64 may have functions that only contains a constant island (no code).

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4143,10 +4143,6 @@ void BinaryFunction::updateOutputValues(const BOLTLinker &Linker) {
   if (!requiresAddressMap())
     return;
 
-  // Output ranges should match the input if the body hasn't changed.
-  if (!isEmitted())
-    return;
-
   // AArch64 may have functions that only contains a constant island (no code).
   if (getLayout().block_empty())
     return;


### PR DESCRIPTION
Remove redundant check in updateOutputValues().