### PR TITLE
[JumpThreading] Remove LVI printer flag

### DIFF
--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -102,11 +102,6 @@ static cl::opt<unsigned> PhiDuplicateThreshold(
     cl::desc("Max PHIs in BB to duplicate for jump threading"), cl::init(76),
     cl::Hidden);
 
-static cl::opt<bool> PrintLVIAfterJumpThreading(
-    "print-lvi-after-jump-threading",
-    cl::desc("Print the LazyValueInfo cache after JumpThreading"), cl::init(false),
-    cl::Hidden);
-
 static cl::opt<bool> ThreadAcrossLoopHeaders(
     "jump-threading-across-loop-headers",
     cl::desc("Allow JumpThreading to thread across loop headers, for testing"),
@@ -256,11 +251,6 @@ PreservedAnalyses JumpThreadingPass::run(Function &F,
               std::make_unique<DomTreeUpdater>(
                   &DT, nullptr, DomTreeUpdater::UpdateStrategy::Lazy),
               std::nullopt, std::nullopt);
-
-  if (PrintLVIAfterJumpThreading) {
-    dbgs() << "LVI for function '" << F.getName() << "':\n";
-    LVI.printLVI(F, getDomTreeUpdater()->getDomTree(), dbgs());
-  }
 
   if (!Changed)
     return PreservedAnalyses::all();

--- a/llvm/test/Analysis/LazyValueAnalysis/lvi-after-jumpthreading.ll
+++ b/llvm/test/Analysis/LazyValueAnalysis/lvi-after-jumpthreading.ll
@@ -1,5 +1,4 @@
-; RUN: opt < %s -passes=jump-threading -print-lvi-after-jump-threading -disable-output 2>&1 | FileCheck %s
-; RUN: opt < %s -passes=jump-threading -print-lvi-after-jump-threading -disable-output 2>&1 | FileCheck %s
+; RUN: opt < %s -passes="jump-threading,print<lazy-value-info>" -disable-output 2>&1 | FileCheck %s
 
 ; Testing LVI cache after jump-threading
 


### PR DESCRIPTION
This patch removes the -print-lvi-after-jump-threading flag now that we can print everything in the LVI cache using the print<lazy-value-info> pass.