### PR TITLE
[libc++][test] Cleanup typos and unnecessary semicolons

### DIFF
--- a/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_nontrivial.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_nontrivial.pass.cpp
@@ -302,10 +302,10 @@ constexpr bool test() {
   // Copying from `bool` to `char` will invoke the optimization, so only check one direction.
   test_copy_and_move<char, bool>();
 
-  // Copying between different structs with the same represenation (there is no way to guarantee the representation is
+  // Copying between different structs with the same representation (there is no way to guarantee the representation is
   // the same).
   test_copy_and_move<S1, S2>();
-  // Copying between different unions with the same represenation.
+  // Copying between different unions with the same representation.
   test_copy_and_move<U1, U2>();
 
   // Copying from a regular pointer to a void pointer (these are not considered trivially copyable).

--- a/libcxx/test/libcxx/algorithms/pstl.robust_against_customization_points_not_working.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/pstl.robust_against_customization_points_not_working.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++03, c++11, c++14
 // UNSUPPORTED: libcpp-has-no-incomplete-pstl
 
-// Having a customization point outside the module doesn't work, so this test is inherintly module-hostile.
+// Having a customization point outside the module doesn't work, so this test is inherently module-hostile.
 // UNSUPPORTED: clang-modules-build
 
 // Make sure that the customization points get called properly when overloaded

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_stride/assert.conversion.pass.cpp
@@ -101,7 +101,7 @@ int main(int, char**) {
         ([=] { std::layout_stride::template mapping<std::extents<signed char, D, 10>> m(arg); }()),
         "layout_stride::mapping converting ctor: other.required_span_size() must be representable as index_type.");
   }
-  // base offset must be 0 (i.e. mapping(0,...,0)==0) for a strided layout with positiv strides
+  // base offset must be 0 (i.e. mapping(0,...,0)==0) for a strided layout with positive strides
   {
     always_convertible_layout::mapping<std::dextents<int, 2>> offset_map(std::dextents<int, 2>{10, 10}, 3);
     TEST_LIBCPP_ASSERT_FAILURE(

--- a/libcxx/test/libcxx/diagnostics/bit.nodiscard_extensions.compile.pass.cpp
+++ b/libcxx/test/libcxx/diagnostics/bit.nodiscard_extensions.compile.pass.cpp
@@ -11,7 +11,7 @@
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_NODISCARD_EXT
 
 // Check that <bit> functions aren't marked [[nodiscard]] when
-// _LIBCPP_DISBALE_NODISCARD_EXT is defined
+// _LIBCPP_DISABLE_NODISCARD_EXT is defined
 
 #include <bit>
 

--- a/libcxx/test/libcxx/diagnostics/chrono.nodiscard_extensions.compile.pass.cpp
+++ b/libcxx/test/libcxx/diagnostics/chrono.nodiscard_extensions.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Check that format functions aren't marked [[nodiscard]] when
-// _LIBCPP_DISBALE_NODISCARD_EXT is defined
+// _LIBCPP_DISABLE_NODISCARD_EXT is defined
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-filesystem, no-localization, no-tzdb

--- a/libcxx/test/libcxx/diagnostics/format.nodiscard_extensions.compile.pass.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.nodiscard_extensions.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Check that format functions aren't marked [[nodiscard]] when
-// _LIBCPP_DISBALE_NODISCARD_EXT is defined
+// _LIBCPP_DISABLE_NODISCARD_EXT is defined
 
 // TODO FMT This test should not require std::to_chars(floating-point)
 // XFAIL: availability-fp_to_chars-missing

--- a/libcxx/test/libcxx/diagnostics/pstl.nodiscard_extensions.compile.pass.cpp
+++ b/libcxx/test/libcxx/diagnostics/pstl.nodiscard_extensions.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Check that PSTL algorithms aren't marked [[nodiscard]] when
-// _LIBCPP_DISBALE_NODISCARD_EXT is defined
+// _LIBCPP_DISABLE_NODISCARD_EXT is defined
 
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_NODISCARD_EXT
 

--- a/libcxx/test/libcxx/diagnostics/ranges.nodiscard_extensions.compile.pass.cpp
+++ b/libcxx/test/libcxx/diagnostics/ranges.nodiscard_extensions.compile.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Check that ranges algorithms aren't marked [[nodiscard]] when
-// _LIBCPP_DISBALE_NODISCARD_EXT is defined
+// _LIBCPP_DISABLE_NODISCARD_EXT is defined
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 

--- a/libcxx/test/libcxx/experimental/memory/memory.polymorphic.allocator.class/memory.polymorphic.allocator.mem/construct_piecewise_pair.pass.cpp
+++ b/libcxx/test/libcxx/experimental/memory/memory.polymorphic.allocator.class/memory.polymorphic.allocator.mem/construct_piecewise_pair.pass.cpp
@@ -21,7 +21,7 @@
 // void polymorphic_allocator<T>::construct(pair<T1, T2>*, piecewise_construct_t
 //                                          tuple<Args1...> x, tuple<Args2...>)
 
-// The stardard specifiers a tranformation to uses-allocator construction as
+// The standard specifies a transformation to uses-allocator construction as
 // follows:
 //  - If uses_allocator_v<T1,memory_resource*> is false and
 //      is_constructible_v<T,Args1...> is true, then xprime is x.
@@ -36,7 +36,7 @@
 //
 // The use of "xprime = tuple_cat(..., std::move(x), ...)" causes all of the
 // objects in 'x' to be copied into 'xprime'. If 'x' contains any types which
-// are stored by value this causes an unessary copy to occur. To prevent this
+// are stored by value this causes an unnecessary copy to occur. To prevent this
 //  libc++ changes this call into
 // "xprime = forward_as_tuple(..., std::get<Idx>(std::move(x))..., ...)".
 // 'xprime' contains references to the values in 'x' instead of copying them.

--- a/libcxx/test/libcxx/utilities/meta/stress_tests/stress_test_variant_overloads_impl.sh.cpp
+++ b/libcxx/test/libcxx/utilities/meta/stress_tests/stress_test_variant_overloads_impl.sh.cpp
@@ -99,7 +99,7 @@ using Overloads = Overload<Types...>;
 namespace variant_impl {
   template <class ...Types>
   using Overloads = std::__variant_detail::_MakeOverloads<Types...>;
-} // namespace variant_impl
+  } // namespace variant_impl
 
 #ifndef TEST_NS
 #error TEST_NS must be defined

--- a/libcxx/test/libcxx/utilities/meta/stress_tests/stress_test_variant_overloads_impl.sh.cpp
+++ b/libcxx/test/libcxx/utilities/meta/stress_tests/stress_test_variant_overloads_impl.sh.cpp
@@ -99,7 +99,7 @@ using Overloads = Overload<Types...>;
 namespace variant_impl {
   template <class ...Types>
   using Overloads = std::__variant_detail::_MakeOverloads<Types...>;
-} // naamespace variant_impl
+} // namespace variant_impl
 
 #ifndef TEST_NS
 #error TEST_NS must be defined

--- a/libcxx/test/libcxx/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
@@ -21,7 +21,7 @@
 // void polymorphic_allocator<T>::construct(pair<T1, T2>*, piecewise_construct_t
 //                                          tuple<Args1...> x, tuple<Args2...>)
 
-// The stardard specifiers a tranformation to uses-allocator construction as
+// The standard specifies a transformation to uses-allocator construction as
 // follows:
 //  - If uses_allocator_v<T1,memory_resource*> is false and
 //      is_constructible_v<T,Args1...> is true, then xprime is x.
@@ -36,7 +36,7 @@
 //
 // The use of "xprime = tuple_cat(..., std::move(x), ...)" causes all of the
 // objects in 'x' to be copied into 'xprime'. If 'x' contains any types which
-// are stored by value this causes an unessary copy to occur. To prevent this
+// are stored by value this causes an unnecessary copy to occur. To prevent this
 //  libc++ changes this call into
 // "xprime = forward_as_tuple(..., std::get<Idx>(std::move(x))..., ...)".
 // 'xprime' contains references to the values in 'x' instead of copying them.

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges.remove.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.remove/ranges.remove.pass.cpp
@@ -35,7 +35,7 @@ static_assert(!HasRemoveIt<PermutableNotForwardIterator>);
 static_assert(!HasRemoveIt<PermutableNotSwappable>);
 static_assert(!HasRemoveIt<int*, SentinelForNotSemiregular>);
 static_assert(!HasRemoveIt<int*, SentinelForNotWeaklyEqualityComparableWith>);
-static_assert(!HasRemoveIt<int**>); // not indirect_binary_prediacte
+static_assert(!HasRemoveIt<int**>); // not indirect_binary_predicate
 
 template <class Range>
 concept HasRemoveR = requires(Range range) { std::ranges::remove(range, 0); };
@@ -45,7 +45,7 @@ static_assert(!HasRemoveR<PermutableRangeNotForwardIterator>);
 static_assert(!HasRemoveR<PermutableRangeNotSwappable>);
 static_assert(!HasRemoveR<SentinelForNotSemiregular>);
 static_assert(!HasRemoveR<SentinelForNotWeaklyEqualityComparableWith>);
-static_assert(!HasRemoveR<UncheckedRange<int**>>); // not indirect_binary_prediacte
+static_assert(!HasRemoveR<UncheckedRange<int**>>); // not indirect_binary_predicate
 
 template <int N, int M>
 struct Data {

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp
@@ -19,7 +19,7 @@
 //     ranges::transform(I1 first1, S1 last1, I2 first2, S2 last2, O result,
 //                       F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
 
-// The range overloads are tested in ranges.tranform.binary.range.pass.cpp.
+// The range overloads are tested in ranges.transform.binary.range.pass.cpp.
 
 #include <algorithm>
 #include <array>

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
@@ -18,7 +18,7 @@
 //     ranges::transform(R1&& r1, R2&& r2, O result,
 //                       F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
 
-// The iterator overloads are tested in ranges.tranform.binary.iterator.pass.cpp.
+// The iterator overloads are tested in ranges.transform.binary.iterator.pass.cpp.
 
 #include <algorithm>
 #include <array>

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp
@@ -34,15 +34,15 @@ struct BinaryFunc {
 };
 
 template <class Range>
-concept HasTranformR = requires(Range r, int* out) { std::ranges::transform(r, r, out, BinaryFunc{}); };
+concept HasTransformR = requires(Range r, int* out) { std::ranges::transform(r, r, out, BinaryFunc{}); };
 
-static_assert(HasTranformR<std::array<int, 1>>);
-static_assert(!HasTranformR<int>);
-static_assert(!HasTranformR<InputRangeNotDerivedFrom>);
-static_assert(!HasTranformR<InputRangeNotIndirectlyReadable>);
-static_assert(!HasTranformR<InputRangeNotInputOrOutputIterator>);
-static_assert(!HasTranformR<InputRangeNotSentinelSemiregular>);
-static_assert(!HasTranformR<InputRangeNotSentinelEqualityComparableWith>);
+static_assert(HasTransformR<std::array<int, 1>>);
+static_assert(!HasTransformR<int>);
+static_assert(!HasTransformR<InputRangeNotDerivedFrom>);
+static_assert(!HasTransformR<InputRangeNotIndirectlyReadable>);
+static_assert(!HasTransformR<InputRangeNotInputOrOutputIterator>);
+static_assert(!HasTransformR<InputRangeNotSentinelSemiregular>);
+static_assert(!HasTransformR<InputRangeNotSentinelEqualityComparableWith>);
 
 template <class It>
 concept HasTransformOut = requires(int* it, int* sent, It out, std::array<int, 2> range) {

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.unary.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.unary.pass.cpp
@@ -31,15 +31,15 @@
 #include "almost_satisfies_types.h"
 
 template <class Range>
-concept HasTranformR = requires(Range r, int* out) { std::ranges::transform(r, out, std::identity{}); };
+concept HasTransformR = requires(Range r, int* out) { std::ranges::transform(r, out, std::identity{}); };
 
-static_assert(HasTranformR<std::array<int, 1>>);
-static_assert(!HasTranformR<int>);
-static_assert(!HasTranformR<InputRangeNotDerivedFrom>);
-static_assert(!HasTranformR<InputRangeNotIndirectlyReadable>);
-static_assert(!HasTranformR<InputRangeNotInputOrOutputIterator>);
-static_assert(!HasTranformR<InputRangeNotSentinelSemiregular>);
-static_assert(!HasTranformR<InputRangeNotSentinelEqualityComparableWith>);
+static_assert(HasTransformR<std::array<int, 1>>);
+static_assert(!HasTransformR<int>);
+static_assert(!HasTransformR<InputRangeNotDerivedFrom>);
+static_assert(!HasTransformR<InputRangeNotIndirectlyReadable>);
+static_assert(!HasTransformR<InputRangeNotInputOrOutputIterator>);
+static_assert(!HasTransformR<InputRangeNotSentinelSemiregular>);
+static_assert(!HasTransformR<InputRangeNotSentinelEqualityComparableWith>);
 
 template <class It, class Sent = It>
 concept HasTransformIt =

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -18,7 +18,7 @@
 //   constexpr bool     // constexpr after c++17
 //   equal(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2);
 
-// We test the cartesian product, so we somethimes compare differently signed types
+// We test the cartesian product, so we sometimes compare differently signed types
 // ADDITIONAL_COMPILE_FLAGS: -Wno-sign-compare
 
 #include <algorithm>

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.foreach/ranges.for_each_n.pass.cpp
@@ -57,7 +57,7 @@ constexpr void test_iterator() {
     assert(i == 4);
   }
 
-  { // check that an emptry range works
+  { // check that an empty range works
     int a[] = {};
     std::ranges::for_each_n(Iter(a), 0, [](auto&) { assert(false); });
   }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp
@@ -87,7 +87,7 @@ constexpr void test_iterators() {
     }
   }
 
-  { // check that it's partitoned if the predicate is true for all elements
+  { // check that it's partitioned if the predicate is true for all elements
     {
       int a[] = {1, 2, 3, 4};
       auto ret = std::ranges::is_partitioned(Iter(a), Sent(Iter(a + 4)), [](int) { return true; });

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp
@@ -190,7 +190,7 @@ test_pointer_sort()
 
 // test_adversarial_quicksort generates a vector with values arranged in such a
 // way that they would invoke O(N^2) behavior on any quick sort implementation
-// that satisifies certain conditions.  Details are available in the following
+// that satisfies certain conditions.  Details are available in the following
 // paper:
 // "A Killer Adversary for Quicksort", M. D. McIlroy, Software-Practice &
 // Experience Volume 29 Issue 4 April 10, 1999 pp 341-344.

--- a/libcxx/test/std/concepts/concepts.object/semiregular.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.object/semiregular.compile.pass.cpp
@@ -107,7 +107,7 @@ static_assert(!std::semiregular<has_rvalue_reference_member>);
 static_assert(!std::semiregular<has_function_ref_member>);
 static_assert(!std::semiregular<deleted_assignment_from_const_rvalue>);
 
-// Not default_initialzable
+// Not default_initializable
 static_assert(!std::semiregular<std::runtime_error>);
 static_assert(
     !std::semiregular<std::tuple<std::runtime_error, std::overflow_error> >);

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back_exception_safety.pass.cpp
@@ -17,7 +17,7 @@
 #include <cassert>
 
 // Flag that makes the copy constructor for CMyClass throw an exception
-static bool gCopyConstructorShouldThow = false;
+static bool gCopyConstructorShouldThrow = false;
 
 class CMyClass {
     public: CMyClass(int tag);
@@ -51,7 +51,7 @@ CMyClass::CMyClass(const CMyClass& iOther) :
     fMagicValue(kStartedConstructionMagicValue), fTag(iOther.fTag)
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
-    if (gCopyConstructorShouldThow) {
+    if (gCopyConstructorShouldThrow) {
         throw std::exception();
     }
     // Signal that the constructor has finished running
@@ -74,13 +74,13 @@ int main(int, char**)
     vec.push_back(instance);
     std::deque<CMyClass> vec2(vec);
 
-    gCopyConstructorShouldThow = true;
+    gCopyConstructorShouldThrow = true;
     try {
         vec.push_back(instance);
         assert(false);
     }
     catch (...) {
-        gCopyConstructorShouldThow = false;
+        gCopyConstructorShouldThrow = false;
         assert(vec==vec2);
     }
     }

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back_exception_safety.pass.cpp
@@ -52,7 +52,7 @@ CMyClass::CMyClass(const CMyClass& iOther) :
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
     if (gCopyConstructorShouldThrow) {
-        throw std::exception();
+      throw std::exception();
     }
     // Signal that the constructor has finished running
     fMagicValue = kFinishedConstructionMagicValue;
@@ -80,8 +80,8 @@ int main(int, char**)
         assert(false);
     }
     catch (...) {
-        gCopyConstructorShouldThrow = false;
-        assert(vec==vec2);
+      gCopyConstructorShouldThrow = false;
+      assert(vec == vec2);
     }
     }
 

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_front_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_front_exception_safety.pass.cpp
@@ -19,7 +19,6 @@
 // Flag that makes the copy constructor for CMyClass throw an exception
 static bool gCopyConstructorShouldThrow = false;
 
-
 class CMyClass {
     public: CMyClass(int tag);
     public: CMyClass(const CMyClass& iOther);
@@ -52,7 +51,7 @@ CMyClass::CMyClass(const CMyClass& iOther) :
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
     if (gCopyConstructorShouldThrow) {
-        throw std::exception();
+      throw std::exception();
     }
     // Signal that the constructor has finished running
     fMagicValue = kFinishedConstructionMagicValue;
@@ -80,8 +79,8 @@ int main(int, char**)
         assert(false);
     }
     catch (...) {
-        gCopyConstructorShouldThrow = false;
-        assert(vec==vec2);
+      gCopyConstructorShouldThrow = false;
+      assert(vec == vec2);
     }
     }
 

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_front_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_front_exception_safety.pass.cpp
@@ -17,7 +17,7 @@
 #include "test_allocator.h"
 
 // Flag that makes the copy constructor for CMyClass throw an exception
-static bool gCopyConstructorShouldThow = false;
+static bool gCopyConstructorShouldThrow = false;
 
 
 class CMyClass {
@@ -51,7 +51,7 @@ CMyClass::CMyClass(const CMyClass& iOther) :
     fMagicValue(kStartedConstructionMagicValue), fTag(iOther.fTag)
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
-    if (gCopyConstructorShouldThow) {
+    if (gCopyConstructorShouldThrow) {
         throw std::exception();
     }
     // Signal that the constructor has finished running
@@ -74,13 +74,13 @@ int main(int, char**)
     vec.push_front(instance);
     std::deque<CMyClass> vec2(vec);
 
-    gCopyConstructorShouldThow = true;
+    gCopyConstructorShouldThrow = true;
     try {
         vec.push_front(instance);
         assert(false);
     }
     catch (...) {
-        gCopyConstructorShouldThow = false;
+        gCopyConstructorShouldThrow = false;
         assert(vec==vec2);
     }
     }

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_exception_safety.pass.cpp
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 // Flag that makes the copy constructor for CMyClass throw an exception
-static bool gCopyConstructorShouldThow = false;
+static bool gCopyConstructorShouldThrow = false;
 
 
 class CMyClass {
@@ -48,7 +48,7 @@ CMyClass::CMyClass(const CMyClass& /*iOther*/) :
     fMagicValue(kStartedConstructionMagicValue)
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
-    if (gCopyConstructorShouldThow) {
+    if (gCopyConstructorShouldThrow) {
         throw std::exception();
     }
     // Signal that the constructor has finished running
@@ -67,7 +67,7 @@ int main(int, char**)
 
     vec.push_front(instance);
 
-    gCopyConstructorShouldThow = true;
+    gCopyConstructorShouldThrow = true;
     try {
         vec.push_front(instance);
     }

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.modifiers/push_front_exception_safety.pass.cpp
@@ -20,7 +20,6 @@
 // Flag that makes the copy constructor for CMyClass throw an exception
 static bool gCopyConstructorShouldThrow = false;
 
-
 class CMyClass {
     public: CMyClass();
     public: CMyClass(const CMyClass& iOther);
@@ -49,7 +48,7 @@ CMyClass::CMyClass(const CMyClass& /*iOther*/) :
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
     if (gCopyConstructorShouldThrow) {
-        throw std::exception();
+      throw std::exception();
     }
     // Signal that the constructor has finished running
     fMagicValue = kFinishedConstructionMagicValue;

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/remove_if.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/remove_if.pass.cpp
@@ -42,7 +42,7 @@ bool g(int i)
 }
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {};
+    PredLWG526 (int i) : i_(i) {}
     ~PredLWG526() { i_ = -32767; }
     bool operator() (const PredLWG526 &p) const { return p.i_ == i_; }
 

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/remove_if.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/remove_if.pass.cpp
@@ -42,12 +42,12 @@ bool g(int i)
 }
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {}
-    ~PredLWG526() { i_ = -32767; }
-    bool operator() (const PredLWG526 &p) const { return p.i_ == i_; }
+  PredLWG526(int i) : i_(i) {}
+  ~PredLWG526() { i_ = -32767; }
+  bool operator()(const PredLWG526& p) const { return p.i_ == i_; }
 
-    bool operator==(int i) const { return i == i_;}
-    int i_;
+  bool operator==(int i) const { return i == i_; }
+  int i_;
 };
 
 int main(int, char**)

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/unique_pred.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/unique_pred.pass.cpp
@@ -35,12 +35,12 @@ void do_unique(L &l, Predicate pred, typename L::size_type expected)
 
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {}
-    ~PredLWG526() { i_ = -32767; }
-    bool operator() (const PredLWG526 &lhs, const PredLWG526 &rhs) const { return lhs.i_ == rhs.i_; }
+  PredLWG526(int i) : i_(i) {}
+  ~PredLWG526() { i_ = -32767; }
+  bool operator()(const PredLWG526& lhs, const PredLWG526& rhs) const { return lhs.i_ == rhs.i_; }
 
-    bool operator==(int i) const { return i == i_;}
-    int i_;
+  bool operator==(int i) const { return i == i_; }
+  int i_;
 };
 
 

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/unique_pred.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.ops/unique_pred.pass.cpp
@@ -35,7 +35,7 @@ void do_unique(L &l, Predicate pred, typename L::size_type expected)
 
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {};
+    PredLWG526 (int i) : i_(i) {}
     ~PredLWG526() { i_ = -32767; }
     bool operator() (const PredLWG526 &lhs, const PredLWG526 &rhs) const { return lhs.i_ == rhs.i_; }
 

--- a/libcxx/test/std/containers/sequences/list/list.modifiers/push_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.modifiers/push_back_exception_safety.pass.cpp
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 // Flag that makes the copy constructor for CMyClass throw an exception
-static bool gCopyConstructorShouldThow = false;
+static bool gCopyConstructorShouldThrow = false;
 
 
 class CMyClass {
@@ -48,7 +48,7 @@ CMyClass::CMyClass(const CMyClass& /*iOther*/) :
     fMagicValue(kStartedConstructionMagicValue)
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
-    if (gCopyConstructorShouldThow) {
+    if (gCopyConstructorShouldThrow) {
         throw std::exception();
     }
     // Signal that the constructor has finished running
@@ -67,7 +67,7 @@ int main(int, char**)
 
     vec.push_back(instance);
 
-    gCopyConstructorShouldThow = true;
+    gCopyConstructorShouldThrow = true;
     try {
         vec.push_back(instance);
     }

--- a/libcxx/test/std/containers/sequences/list/list.modifiers/push_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.modifiers/push_back_exception_safety.pass.cpp
@@ -20,7 +20,6 @@
 // Flag that makes the copy constructor for CMyClass throw an exception
 static bool gCopyConstructorShouldThrow = false;
 
-
 class CMyClass {
     public: CMyClass();
     public: CMyClass(const CMyClass& iOther);
@@ -49,7 +48,7 @@ CMyClass::CMyClass(const CMyClass& /*iOther*/) :
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
     if (gCopyConstructorShouldThrow) {
-        throw std::exception();
+      throw std::exception();
     }
     // Signal that the constructor has finished running
     fMagicValue = kFinishedConstructionMagicValue;

--- a/libcxx/test/std/containers/sequences/list/list.modifiers/push_front_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.modifiers/push_front_exception_safety.pass.cpp
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 
 // Flag that makes the copy constructor for CMyClass throw an exception
-static bool gCopyConstructorShouldThow = false;
+static bool gCopyConstructorShouldThrow = false;
 
 
 class CMyClass {
@@ -48,7 +48,7 @@ CMyClass::CMyClass(const CMyClass& /*iOther*/) :
     fMagicValue(kStartedConstructionMagicValue)
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
-    if (gCopyConstructorShouldThow) {
+    if (gCopyConstructorShouldThrow) {
         throw std::exception();
     }
     // Signal that the constructor has finished running
@@ -67,7 +67,7 @@ int main(int, char**)
 
     vec.push_front(instance);
 
-    gCopyConstructorShouldThow = true;
+    gCopyConstructorShouldThrow = true;
     try {
         vec.push_front(instance);
     }

--- a/libcxx/test/std/containers/sequences/list/list.modifiers/push_front_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.modifiers/push_front_exception_safety.pass.cpp
@@ -20,7 +20,6 @@
 // Flag that makes the copy constructor for CMyClass throw an exception
 static bool gCopyConstructorShouldThrow = false;
 
-
 class CMyClass {
     public: CMyClass();
     public: CMyClass(const CMyClass& iOther);
@@ -49,7 +48,7 @@ CMyClass::CMyClass(const CMyClass& /*iOther*/) :
 {
     // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
     if (gCopyConstructorShouldThrow) {
-        throw std::exception();
+      throw std::exception();
     }
     // Signal that the constructor has finished running
     fMagicValue = kFinishedConstructionMagicValue;

--- a/libcxx/test/std/containers/sequences/list/list.ops/remove_if.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.ops/remove_if.pass.cpp
@@ -30,12 +30,12 @@ bool g(int i)
 }
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {}
-    ~PredLWG526() { i_ = -32767; }
-    bool operator() (const PredLWG526 &p) const { return p.i_ == i_; }
+  PredLWG526(int i) : i_(i) {}
+  ~PredLWG526() { i_ = -32767; }
+  bool operator()(const PredLWG526& p) const { return p.i_ == i_; }
 
-    bool operator==(int i) const { return i == i_;}
-    int i_;
+  bool operator==(int i) const { return i == i_; }
+  int i_;
 };
 
 typedef unary_counting_predicate<bool(*)(int), int> Predicate;

--- a/libcxx/test/std/containers/sequences/list/list.ops/remove_if.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.ops/remove_if.pass.cpp
@@ -30,7 +30,7 @@ bool g(int i)
 }
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {};
+    PredLWG526 (int i) : i_(i) {}
     ~PredLWG526() { i_ = -32767; }
     bool operator() (const PredLWG526 &p) const { return p.i_ == i_; }
 

--- a/libcxx/test/std/containers/sequences/list/list.ops/unique_pred.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.ops/unique_pred.pass.cpp
@@ -24,7 +24,7 @@ bool g(int x, int y)
 }
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {};
+    PredLWG526 (int i) : i_(i) {}
     ~PredLWG526() { i_ = -32767; }
     bool operator() (const PredLWG526 &lhs, const PredLWG526 &rhs) const { return lhs.i_ == rhs.i_; }
 

--- a/libcxx/test/std/containers/sequences/list/list.ops/unique_pred.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.ops/unique_pred.pass.cpp
@@ -24,12 +24,12 @@ bool g(int x, int y)
 }
 
 struct PredLWG526 {
-    PredLWG526 (int i) : i_(i) {}
-    ~PredLWG526() { i_ = -32767; }
-    bool operator() (const PredLWG526 &lhs, const PredLWG526 &rhs) const { return lhs.i_ == rhs.i_; }
+  PredLWG526(int i) : i_(i) {}
+  ~PredLWG526() { i_ = -32767; }
+  bool operator()(const PredLWG526& lhs, const PredLWG526& rhs) const { return lhs.i_ == rhs.i_; }
 
-    bool operator==(int i) const { return i == i_;}
-    int i_;
+  bool operator==(int i) const { return i == i_; }
+  int i_;
 };
 
 int main(int, char**)

--- a/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
+++ b/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
@@ -12,7 +12,7 @@
 struct IntType {
   int val;
   constexpr IntType() = default;
-  constexpr IntType(int v) noexcept : val(v){};
+  constexpr IntType(int v) noexcept : val(v){}
 
   constexpr bool operator==(const IntType& rhs) const { return val == rhs.val; }
   constexpr operator int() const noexcept { return val; }
@@ -24,7 +24,7 @@ struct IntType {
 struct IntTypeNC {
   int val;
   constexpr IntTypeNC() = default;
-  constexpr IntTypeNC(int v) noexcept : val(v){};
+  constexpr IntTypeNC(int v) noexcept : val(v){}
 
   constexpr bool operator==(const IntType& rhs) const { return val == rhs.val; }
   constexpr operator int() noexcept { return val; }

--- a/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
+++ b/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
@@ -12,7 +12,7 @@
 struct IntType {
   int val;
   constexpr IntType() = default;
-  constexpr IntType(int v) noexcept : val(v){}
+  constexpr IntType(int v) noexcept : val(v) {}
 
   constexpr bool operator==(const IntType& rhs) const { return val == rhs.val; }
   constexpr operator int() const noexcept { return val; }
@@ -24,7 +24,7 @@ struct IntType {
 struct IntTypeNC {
   int val;
   constexpr IntTypeNC() = default;
-  constexpr IntTypeNC(int v) noexcept : val(v){}
+  constexpr IntTypeNC(int v) noexcept : val(v) {}
 
   constexpr bool operator==(const IntType& rhs) const { return val == rhs.val; }
   constexpr operator int() noexcept { return val; }

--- a/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
+++ b/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
@@ -35,7 +35,7 @@
 // - is_strided and is_unique are true if all extents are smaller than Wrap
 // - not default constructible
 // - not extents constructible
-// - not trivally copyable
+// - not trivially copyable
 // - does not check dynamic to static extent conversion in converting ctor
 // - check via side-effects that mdspan::swap calls mappings swap via ADL
 

--- a/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
+++ b/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
@@ -76,7 +76,7 @@ private:
 
 public:
   constexpr mapping() noexcept = delete;
-  constexpr mapping(const mapping& other) noexcept : extents_(other.extents()){};
+  constexpr mapping(const mapping& other) noexcept : extents_(other.extents()){}
   constexpr mapping(extents_type&& ext) noexcept
     requires(Wrap == 8)
       : extents_(ext) {}
@@ -240,9 +240,9 @@ private:
 public:
   constexpr mapping() noexcept = delete;
   constexpr mapping(const mapping& other) noexcept
-      : extents_(other.extents_), offset_(other.offset_), scaling_(other.scaling_){};
+      : extents_(other.extents_), offset_(other.offset_), scaling_(other.scaling_){}
   constexpr mapping(const extents_type& ext, index_type offset = 0, index_type scaling = 1) noexcept
-      : extents_(ext), offset_(offset), scaling_(scaling){};
+      : extents_(ext), offset_(offset), scaling_(scaling){}
 
   template <class OtherExtents>
   constexpr mapping(const mapping<OtherExtents>& other) noexcept {

--- a/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
+++ b/libcxx/test/std/containers/views/mdspan/CustomTestLayouts.h
@@ -76,7 +76,7 @@ private:
 
 public:
   constexpr mapping() noexcept = delete;
-  constexpr mapping(const mapping& other) noexcept : extents_(other.extents()){}
+  constexpr mapping(const mapping& other) noexcept : extents_(other.extents()) {}
   constexpr mapping(extents_type&& ext) noexcept
     requires(Wrap == 8)
       : extents_(ext) {}
@@ -240,9 +240,9 @@ private:
 public:
   constexpr mapping() noexcept = delete;
   constexpr mapping(const mapping& other) noexcept
-      : extents_(other.extents_), offset_(other.offset_), scaling_(other.scaling_){}
+      : extents_(other.extents_), offset_(other.offset_), scaling_(other.scaling_) {}
   constexpr mapping(const extents_type& ext, index_type offset = 0, index_type scaling = 1) noexcept
-      : extents_(ext), offset_(offset), scaling_(scaling){}
+      : extents_(ext), offset_(offset), scaling_(scaling) {}
 
   template <class OtherExtents>
   constexpr mapping(const mapping<OtherExtents>& other) noexcept {

--- a/libcxx/test/std/containers/views/mdspan/extents/CtorTestCombinations.h
+++ b/libcxx/test/std/containers/views/mdspan/extents/CtorTestCombinations.h
@@ -17,7 +17,7 @@
 #include "../ConvertibleToIntegral.h"
 #include "test_macros.h"
 
-// Helper file to implement combinatorical testing of extents constructor
+// Helper file to implement combinatorial testing of extents constructor
 //
 // std::extents can be constructed from just indices, a std::array, or a std::span
 // In each of those cases one can either provide all extents, or just the dynamic ones

--- a/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
@@ -24,7 +24,7 @@
 struct NoDefaultCtorIndex {
   size_t value;
   constexpr NoDefaultCtorIndex() = delete;
-  constexpr NoDefaultCtorIndex(size_t val) : value(val){};
+  constexpr NoDefaultCtorIndex(size_t val) : value(val){}
   constexpr operator size_t() const noexcept { return value; }
 };
 

--- a/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctad.pass.cpp
@@ -24,7 +24,7 @@
 struct NoDefaultCtorIndex {
   size_t value;
   constexpr NoDefaultCtorIndex() = delete;
-  constexpr NoDefaultCtorIndex(size_t val) : value(val){}
+  constexpr NoDefaultCtorIndex(size_t val) : value(val) {}
   constexpr operator size_t() const noexcept { return value; }
 };
 

--- a/libcxx/test/std/containers/views/mdspan/extents/ctor_default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctor_default.pass.cpp
@@ -14,7 +14,7 @@
 // constexpr extents() noexcept = default;
 //
 // Remarks: since the standard uses an exposition only array member, dynamic extents
-// need to be zero intialized!
+// need to be zero initialized!
 
 #include <mdspan>
 #include <cassert>

--- a/libcxx/test/std/containers/views/mdspan/extents/ctor_from_array.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctor_from_array.pass.cpp
@@ -74,7 +74,7 @@ int main(int, char**) {
   std::array a5{3, 4, 5, 6, 7};
   // check that explicit construction works, i.e. no error
   static_assert(std::is_constructible_v< std::extents<int, D, D, 5, D, D>, decltype(a5)>,
-                "extents unexpectectly not constructible");
+                "extents unexpectedly not constructible");
   // check that implicit construction doesn't work
   assert((implicit_construction<std::extents<int, D, D, 5, D, D>>(a5).value == false));
 

--- a/libcxx/test/std/containers/views/mdspan/extents/ctor_from_span.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctor_from_span.pass.cpp
@@ -76,7 +76,7 @@ int main(int, char**) {
   std::span<int, 5> s5(a5.data(), 5);
   // check that explicit construction works, i.e. no error
   static_assert(std::is_constructible_v< std::extents<int, D, D, 5, D, D>, decltype(s5)>,
-                "extents unexpectectly not constructible");
+                "extents unexpectedly not constructible");
   // check that implicit construction doesn't work
   assert((implicit_construction<std::extents<int, D, D, 5, D, D>>(s5).value == false));
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/CustomTestAccessors.h
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/CustomTestAccessors.h
@@ -50,7 +50,7 @@ struct move_counted_handle {
   constexpr move_counted_handle(const move_counted_handle&) = default;
   template <class OtherT>
     requires(std::is_constructible_v<T*, OtherT*>)
-  constexpr move_counted_handle(const move_counted_handle<OtherT>& other) : ptr(other.ptr){};
+  constexpr move_counted_handle(const move_counted_handle<OtherT>& other) : ptr(other.ptr){}
   constexpr move_counted_handle(move_counted_handle&& other) {
     ptr = other.ptr;
     if !consteval {

--- a/libcxx/test/std/containers/views/mdspan/mdspan/CustomTestAccessors.h
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/CustomTestAccessors.h
@@ -50,7 +50,7 @@ struct move_counted_handle {
   constexpr move_counted_handle(const move_counted_handle&) = default;
   template <class OtherT>
     requires(std::is_constructible_v<T*, OtherT*>)
-  constexpr move_counted_handle(const move_counted_handle<OtherT>& other) : ptr(other.ptr){}
+  constexpr move_counted_handle(const move_counted_handle<OtherT>& other) : ptr(other.ptr) {}
   constexpr move_counted_handle(move_counted_handle&& other) {
     ptr = other.ptr;
     if !consteval {

--- a/libcxx/test/std/containers/views/mdspan/mdspan/types.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/types.pass.cpp
@@ -39,7 +39,7 @@
 #include "../CustomTestLayouts.h"
 
 // Calculated expected size of an mdspan
-// Note this expectes that only default_accessor is empty
+// Note this expects that only default_accessor is empty
 template<class MDS>
 constexpr size_t expected_size() {
   size_t sizeof_dht = sizeof(typename MDS::data_handle_type);

--- a/libcxx/test/std/experimental/simd/simd.class/simd_ctor_default.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.class/simd_ctor_default.pass.cpp
@@ -19,7 +19,7 @@
 namespace ex = std::experimental::parallelism_v2;
 
 // See https://www.open-std.org/jtc1/sc22/WG21/docs/papers/2019/n4808.pdf
-// Default intialization performs no initialization of the elements; value-initialization initializes each element with T().
+// Default initialization performs no initialization of the elements; value-initialization initializes each element with T().
 // Thus, default initialization leaves the elements in an indeterminate state.
 template <class T, std::size_t>
 struct CheckSimdDefaultCtor {

--- a/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_ctor_default.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_ctor_default.pass.cpp
@@ -19,7 +19,7 @@
 namespace ex = std::experimental::parallelism_v2;
 
 // See https://www.open-std.org/jtc1/sc22/WG21/docs/papers/2019/n4808.pdf
-// Default intialization performs no initialization of the elements; value-initialization initializes each element with T().
+// Default initialization performs no initialization of the elements; value-initialization initializes each element with T().
 // Thus, default initialization leaves the elements in an indeterminate state.
 template <class T, std::size_t>
 struct CheckSimdMaskDefaultCtor {

--- a/libcxx/test/std/input.output/filesystems/class.file_status/file_status.status.eq.ops.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.file_status/file_status.status.eq.ops.cpp
@@ -22,26 +22,26 @@
 
 void test() {
   {
-    std::fileystem::file_status f1;
-    std::fileystem::file_status f2;
+    std::filesystem::file_status f1;
+    std::filesystem::file_status f2;
 
     assert(testEquality(f1, f2, true));
   }
   {
-    std::fileystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
-    std::fileystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::filesystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::filesystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
 
     assert(testEquality(f1, f2, true));
   }
   {
-    std::fileystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
-    std::fileystem::file_status f2{std::filesystem::file_type::none, std::filesystem::perms::owner_read};
+    std::filesystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::filesystem::file_status f2{std::filesystem::file_type::none, std::filesystem::perms::owner_read};
 
     assert(testEquality(f1, f2, false));
   }
   {
-    std::fileystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
-    std::fileystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_write};
+    std::filesystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::filesystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_write};
 
     assert(testEquality(f1, f2, false));
   }

--- a/libcxx/test/std/input.output/filesystems/class.file_status/file_status.status.eq.ops.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.file_status/file_status.status.eq.ops.cpp
@@ -22,26 +22,26 @@
 
 void test() {
   {
-    std::filesystem::file_status f1;
-    std::filesystem::file_status f2;
+    std::fileystem::file_status f1;
+    std::fileystem::file_status f2;
 
     assert(testEquality(f1, f2, true));
   }
   {
-    std::filesystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
-    std::filesystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::fileystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::fileystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
 
     assert(testEquality(f1, f2, true));
   }
   {
-    std::filesystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
-    std::filesystem::file_status f2{std::filesystem::file_type::none, std::filesystem::perms::owner_read};
+    std::fileystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::fileystem::file_status f2{std::filesystem::file_type::none, std::filesystem::perms::owner_read};
 
     assert(testEquality(f1, f2, false));
   }
   {
-    std::filesystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
-    std::filesystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_write};
+    std::fileystem::file_status f1{std::filesystem::file_type::regular, std::filesystem::perms::owner_read};
+    std::fileystem::file_status f2{std::filesystem::file_type::regular, std::filesystem::perms::owner_write};
 
     assert(testEquality(f1, f2, false));
   }

--- a/libcxx/test/std/input.output/syncstream/syncbuf/sputc.pass.cpp
+++ b/libcxx/test/std/input.output/syncstream/syncbuf/sputc.pass.cpp
@@ -67,7 +67,7 @@ void test() {
         typename SyncBuf::int_type ret = sync_buf.sputc(c);
         assert(ret == typename SyncBuf::int_type(c));
       }
-      // The synchchronization happens upon destruction of sync_buf.
+      // The synchronization happens upon destruction of sync_buf.
       assert(buf.str().empty());
       assert(stats.allocated_size >= 1024);
     }
@@ -92,7 +92,7 @@ void test() {
         ret = new_sync_buf.sputc(c);
         assert(ret == typename SyncBuf::int_type(c));
 
-        // The synchchronization happens upon destruction of new_sync_buf.
+        // The synchronization happens upon destruction of new_sync_buf.
         assert(buf.str().empty());
         assert(stats.allocated_size >= 2);
       }
@@ -129,7 +129,7 @@ void test() {
         ret = new_sync_buf.sputc(c);
         assert(ret == typename SyncBuf::int_type(c));
 
-        // The synchchronization happens upon destruction of new_sync_buf.
+        // The synchronization happens upon destruction of new_sync_buf.
         assert(buf.str().empty());
       }
       assert(buf.str().size() == 2);

--- a/libcxx/test/std/input.output/syncstream/syncbuf/sputn.pass.cpp
+++ b/libcxx/test/std/input.output/syncstream/syncbuf/sputn.pass.cpp
@@ -66,7 +66,7 @@ void test() {
       std::streamsize ret = sync_buf.sputn(expected.data(), expected.size());
       assert(ret == 1024);
 
-      // The synchchronization happens upon destruction of sync_buf.
+      // The synchronization happens upon destruction of sync_buf.
       assert(buf.str().empty());
       assert(stats.allocated_size >= 1024);
     }
@@ -87,7 +87,7 @@ void test() {
         ret = new_sync_buf.sputn(expected.data(), expected.size());
         assert(ret == 1024);
 
-        // The synchchronization happens upon destruction of new_sync_buf.
+        // The synchronization happens upon destruction of new_sync_buf.
         assert(buf.str().empty());
         assert(stats.allocated_size >= 2048);
       }
@@ -116,7 +116,7 @@ void test() {
         ret = new_sync_buf.sputn(expected.data(), expected.size());
         assert(ret == 1024);
 
-        // The synchchronization happens upon destruction of new_sync_buf.
+        // The synchronization happens upon destruction of new_sync_buf.
         assert(buf.str().empty());
       }
       assert(buf.str() == expected + expected);

--- a/libcxx/test/std/input.output/syncstream/syncbuf/syncstream.syncbuf.assign/assign.pass.cpp
+++ b/libcxx/test/std/input.output/syncstream/syncbuf/syncstream.syncbuf.assign/assign.pass.cpp
@@ -70,7 +70,7 @@ public:
 
 // Helper wrapper to inspect the internal state of the basic_syncbuf
 //
-// This is used the valiate some standard requirements and libc++
+// This is used to validate some standard requirements and libc++
 // implementation details.
 template <class CharT, class Traits, class Allocator>
 class syncbuf_inspector : public std::basic_syncbuf<CharT, Traits, Allocator> {

--- a/libcxx/test/std/numerics/numarray/class.gslice/gslice.cons/default.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/class.gslice/gslice.cons/default.pass.cpp
@@ -8,7 +8,7 @@
 
 // <valarray>
 
-// class glice;
+// class gslice;
 
 // gslice();
 

--- a/libcxx/test/std/numerics/numarray/class.gslice/gslice.cons/start_size_stride.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/class.gslice/gslice.cons/start_size_stride.pass.cpp
@@ -8,7 +8,7 @@
 
 // <valarray>
 
-// class glice;
+// class gslice;
 
 // gslice(size_t start, const valarray<size_t>& size,
 //                      const valarray<size_t>& stride);

--- a/libcxx/test/std/ranges/range.adaptors/range.drop/dangling.cache.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.drop/dangling.cache.pass.cpp
@@ -48,10 +48,10 @@ struct ZeroOnDestroy : std::ranges::view_base {
 };
 
 int main(int, char**) {
-  auto noDanlingCache = ZeroOnDestroy::dropFirstFour();
+  auto noDanglingCache = ZeroOnDestroy::dropFirstFour();
   // If we use the cached version, it will reference the copied-from view.
   // Worst case this is a segfault, best case it's an assertion fired.
-  assert(*noDanlingCache.begin() == 5);
+  assert(*noDanglingCache.begin() == 5);
 
   return 0;
 }

--- a/libcxx/test/std/ranges/range.adaptors/range.join.view/sentinel/ctor.other.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.join.view/sentinel/ctor.other.pass.cpp
@@ -32,7 +32,7 @@ struct convertible_sentinel_wrapper {
   T it_;
 };
 
-struct ConstConveritbleView : BufferView<BufferView<int*>*> {
+struct ConstConvertibleView : BufferView<BufferView<int*>*> {
   using BufferView<BufferView<int*>*>::BufferView;
 
   using sentinel = convertible_sentinel_wrapper<BufferView<int*>*>;
@@ -43,16 +43,16 @@ struct ConstConveritbleView : BufferView<BufferView<int*>*> {
   constexpr sentinel end() { return sentinel(data_ + size_); }
   constexpr const_sentinel end() const { return const_sentinel(data_ + size_); }
 };
-static_assert(!std::ranges::common_range<ConstConveritbleView>);
-static_assert(std::convertible_to<std::ranges::sentinel_t<ConstConveritbleView>,
-                                  std::ranges::sentinel_t<ConstConveritbleView const>>);
-LIBCPP_STATIC_ASSERT(!std::ranges::__simple_view<ConstConveritbleView>);
+static_assert(!std::ranges::common_range<ConstConvertibleView>);
+static_assert(std::convertible_to<std::ranges::sentinel_t<ConstConvertibleView>,
+                                  std::ranges::sentinel_t<ConstConvertibleView const>>);
+LIBCPP_STATIC_ASSERT(!std::ranges::__simple_view<ConstConvertibleView>);
 
 constexpr bool test() {
   int buffer[4][4] = {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}};
   {
     BufferView<int*> inners[] = {buffer[0], buffer[1], buffer[2]};
-    ConstConveritbleView outer(inners);
+    ConstConvertibleView outer(inners);
     std::ranges::join_view jv(outer);
     auto sent1 = jv.end();
     std::ranges::sentinel_t<const decltype(jv)> sent2 = sent1;

--- a/libcxx/test/std/ranges/range.adaptors/range.reverse/begin.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.reverse/begin.pass.cpp
@@ -115,7 +115,7 @@ constexpr bool test() {
     ASSERT_SAME_TYPE(decltype(std::move(rev).begin()), std::reverse_iterator<bidirectional_iterator<int*>>);
   }
   // Non-common random access range.
-  // Note: const overload invalid for non-common ranges, though it would not be imposible
+  // Note: const overload invalid for non-common ranges, though it would not be impossible
   // to implement for random access ranges.
   {
     auto rev = std::ranges::reverse_view(RASentRange{buffer, buffer + 8});

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/end.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/end.pass.cpp
@@ -154,14 +154,14 @@ constexpr bool test() {
   }
   {
     // test ID 13
-    std::ranges::zip_view v{SimpleNonCommonRandomAcessSized(buffer1)};
+    std::ranges::zip_view v{SimpleNonCommonRandomAccessSized(buffer1)};
     static_assert(std::ranges::common_range<decltype(v)>);
     assert(v.begin() + 5 == v.end());
     static_assert(std::is_same_v<decltype(v.end()), decltype(std::as_const(v).end())>);
   }
   {
     // test ID 14
-    std::ranges::zip_view v{SimpleNonCommonRandomAcessSized(buffer1), SimpleNonCommonRandomAcessSized(buffer2)};
+    std::ranges::zip_view v{SimpleNonCommonRandomAccessSized(buffer1), SimpleNonCommonRandomAccessSized(buffer2)};
     static_assert(std::ranges::common_range<decltype(v)>);
     assert(v.begin() + 1 == v.end());
     static_assert(std::is_same_v<decltype(v.end()), decltype(std::as_const(v).end())>);
@@ -308,14 +308,14 @@ constexpr bool test() {
   }
   {
     // test ID 35
-    std::ranges::zip_view v{NonSimpleNonCommonRandomAcessSized(buffer1)};
+    std::ranges::zip_view v{NonSimpleNonCommonRandomAccessSized(buffer1)};
     static_assert(std::ranges::common_range<decltype(v)>);
     assert(v.begin() + 5 == v.end());
     static_assert(!std::is_same_v<decltype(v.end()), decltype(std::as_const(v).end())>);
   }
   {
     // test ID 36
-    std::ranges::zip_view v{NonSimpleNonCommonRandomAcessSized(buffer1), NonSimpleNonCommonRandomAcessSized(buffer2)};
+    std::ranges::zip_view v{NonSimpleNonCommonRandomAccessSized(buffer1), NonSimpleNonCommonRandomAccessSized(buffer2)};
     static_assert(std::ranges::common_range<decltype(v)>);
     assert(v.begin() + 1 == v.end());
     static_assert(!std::is_same_v<decltype(v.end()), decltype(std::as_const(v).end())>);

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_move.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_move.pass.cpp
@@ -20,7 +20,7 @@
 
 struct ThrowingMove {
   ThrowingMove() = default;
-  ThrowingMove(ThrowingMove&&){};
+  ThrowingMove(ThrowingMove&&){}
 };
 
 constexpr bool test() {

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_move.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_move.pass.cpp
@@ -20,7 +20,7 @@
 
 struct ThrowingMove {
   ThrowingMove() = default;
-  ThrowingMove(ThrowingMove&&){}
+  ThrowingMove(ThrowingMove&&) {}
 };
 
 constexpr bool test() {

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_swap.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_swap.pass.cpp
@@ -19,7 +19,7 @@
 
 struct ThrowingMove {
   ThrowingMove() = default;
-  ThrowingMove(ThrowingMove&&){};
+  ThrowingMove(ThrowingMove&&){}
   ThrowingMove& operator=(ThrowingMove&&){return *this;}
 };
 

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_swap.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/iterator/iter_swap.pass.cpp
@@ -19,7 +19,7 @@
 
 struct ThrowingMove {
   ThrowingMove() = default;
-  ThrowingMove(ThrowingMove&&){}
+  ThrowingMove(ThrowingMove&&) {}
   ThrowingMove& operator=(ThrowingMove&&){return *this;}
 };
 

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/sentinel/minus.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/sentinel/minus.pass.cpp
@@ -154,9 +154,9 @@ constexpr bool test() {
   }
 
   {
-    // const imcompatible:
-    // underlying const sentinels cannot substract underlying iterators
-    // underlying sentinels cannot substract underlying const iterators
+    // const incompatible:
+    // underlying const sentinels cannot subtract underlying iterators
+    // underlying sentinels cannot subtract underlying const iterators
     std::ranges::zip_view v(NonSimpleForwardSizedNonCommon{buffer1});
     static_assert(!std::ranges::common_range<decltype(v)>);
     LIBCPP_STATIC_ASSERT(!std::ranges::__simple_view<decltype(v)>);

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/types.h
@@ -127,9 +127,9 @@ struct NonCommonSized : IntBufferView {
 };
 
 using SimpleNonCommonSized = NonCommonSized<true>;
-using SimpleNonCommonRandomAcessSized = SimpleNonCommonSized;
+using SimpleNonCommonRandomAccessSized = SimpleNonCommonSized;
 using NonSimpleNonCommonSized = NonCommonSized<false>;
-using NonSimpleNonCommonRandomAcessSized = NonSimpleNonCommonSized;
+using NonSimpleNonCommonRandomAccessSized = NonSimpleNonCommonSized;
 
 static_assert(!std::ranges::common_range<SimpleNonCommonSized>);
 static_assert(std::ranges::random_access_range<SimpleNonCommonSized>);

--- a/libcxx/test/std/ranges/range.adaptors/range.zip/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.zip/types.h
@@ -127,7 +127,7 @@ struct NonCommonSized : IntBufferView {
 };
 
 using SimpleNonCommonSized = NonCommonSized<true>;
-using SimpleNonCommonRandomAccessSized = SimpleNonCommonSized;
+using SimpleNonCommonRandomAccessSized    = SimpleNonCommonSized;
 using NonSimpleNonCommonSized = NonCommonSized<false>;
 using NonSimpleNonCommonRandomAccessSized = NonSimpleNonCommonSized;
 

--- a/libcxx/test/std/ranges/range.factories/range.repeat.view/views_repeat.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.repeat.view/views_repeat.pass.cpp
@@ -11,7 +11,7 @@
 // template <class T>
 // views::repeat(T &&) requires constructible_from<ranges::repeat_view<T>, T>;
 
-// templaye <class T, class Bound>
+// template <class T, class Bound>
 // views::repeat(T &&, Bound &&) requires constructible_from<ranges::repeat_view<T, Bound>, T, Bound>;
 
 #include <cassert>

--- a/libcxx/test/std/re/re.const/re.matchflag/match_flag_type.pass.cpp
+++ b/libcxx/test/std/re/re.const/re.matchflag/match_flag_type.pass.cpp
@@ -11,7 +11,7 @@
 // namespace regex_constants
 // {
 //
-// emum match_flag_type  // bitmask type
+// enum match_flag_type  // bitmask type
 // {
 //     match_default     = 0,
 //     match_not_bol     = unspecified,

--- a/libcxx/test/std/re/re.const/re.synopt/syntax_option_type.pass.cpp
+++ b/libcxx/test/std/re/re.const/re.synopt/syntax_option_type.pass.cpp
@@ -11,7 +11,7 @@
 // namespace regex_constants
 // {
 //
-// emum syntax_option_type  // bitmask type
+// enum syntax_option_type  // bitmask type
 // {
 //     icase      = unspecified,
 //     nosubs     = unspecified,

--- a/libcxx/test/std/strings/string.view/string.view.comparison/common_type_specialization.pass.cpp
+++ b/libcxx/test/std/strings/string.view/string.view.comparison/common_type_specialization.pass.cpp
@@ -10,7 +10,7 @@
 
 // During the review D130295 it was noticed libc++'s implementation uses
 // std::common_type. When users specialize this template for their own types the
-// comparisions would fail. This tests with a specialized std::common_type.
+// comparisons would fail. This tests with a specialized std::common_type.
 
 // <string_view>
 

--- a/libcxx/test/std/thread/futures/futures.async/async.pass.cpp
+++ b/libcxx/test/std/thread/futures/futures.async/async.pass.cpp
@@ -78,8 +78,8 @@ void f5(int j)
     TEST_THROW(j);
 }
 
-template <class Ret, class CheckLamdba, class ...Args>
-void test(CheckLamdba&& getAndCheckFn, bool IsDeferred, Args&&... args) {
+template <class Ret, class CheckLambda, class ...Args>
+void test(CheckLambda&& getAndCheckFn, bool IsDeferred, Args&&... args) {
     // Reset global state.
     invoked = false;
 

--- a/libcxx/test/std/thread/futures/futures.async/async.pass.cpp
+++ b/libcxx/test/std/thread/futures/futures.async/async.pass.cpp
@@ -78,31 +78,31 @@ void f5(int j)
     TEST_THROW(j);
 }
 
-template <class Ret, class CheckLambda, class ...Args>
+template <class Ret, class CheckLambda, class... Args>
 void test(CheckLambda&& getAndCheckFn, bool IsDeferred, Args&&... args) {
-    // Reset global state.
-    invoked = false;
+  // Reset global state.
+  invoked = false;
 
-    // Create the future and wait
-    std::future<Ret> f = std::async(std::forward<Args>(args)...);
-    std::this_thread::sleep_for(ms(300));
+  // Create the future and wait
+  std::future<Ret> f = std::async(std::forward<Args>(args)...);
+  std::this_thread::sleep_for(ms(300));
 
-    // Check that deferred async's have not invoked the function.
-    assert(invoked == !IsDeferred);
+  // Check that deferred async's have not invoked the function.
+  assert(invoked == !IsDeferred);
 
-    // Time the call to f.get() and check that the returned value matches
-    // what is expected.
-    Clock::time_point t0 = Clock::now();
-    assert(getAndCheckFn(f));
-    Clock::time_point t1 = Clock::now();
+  // Time the call to f.get() and check that the returned value matches
+  // what is expected.
+  Clock::time_point t0 = Clock::now();
+  assert(getAndCheckFn(f));
+  Clock::time_point t1 = Clock::now();
 
-    // If the async is deferred it should take more than 100ms, otherwise
-    // it should take less than 100ms.
-    if (IsDeferred) {
-        assert(t1-t0 > ms(100));
-    } else {
-        assert(t1-t0 < ms(100));
-    }
+  // If the async is deferred it should take more than 100ms, otherwise
+  // it should take less than 100ms.
+  if (IsDeferred) {
+    assert(t1 - t0 > ms(100));
+  } else {
+    assert(t1 - t0 < ms(100));
+  }
 }
 
 int main(int, char**)

--- a/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_duration.pass.cpp
+++ b/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_duration.pass.cpp
@@ -46,9 +46,9 @@ std::atomic<unsigned> CountDown(Threads);
 void f1()
 {
   // Preemptive scheduling means that one cannot make assumptions about when
-  // code executes and therefore we cannot assume anthing about when the mutex
+  // code executes and therefore we cannot assume anything about when the mutex
   // starts waiting relative to code in the main thread. We can however prove
-  // that a timeout occured and that implies that this code is waiting.
+  // that a timeout occurred and that implies that this code is waiting.
   // See f2() below.
   //
   // Nevertheless, we should at least try to ensure that the mutex waits and

--- a/libcxx/test/std/time/time.syn/formatter.file_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.file_time.pass.cpp
@@ -901,7 +901,7 @@ static void test_valid_values_date_time() {
 template <class CharT>
 static void test_valid_values_time_zone() {
 // The Apple CI gives %z='-0700'	%Ez='-0700'	%Oz='-0700'	%Z='UTC'
-// -0700 looks like the local time where the CI happens to recide, therefore
+// -0700 looks like the local time where the CI happens to reside, therefore
 // omit this test on Apple.
 // The Windows CI gives %z='-0000', but on local machines set to a different
 // timezone, it gives e.g. %z='+0200'.

--- a/libcxx/test/std/time/time.syn/formatter.sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.sys_time.pass.cpp
@@ -897,7 +897,7 @@ static void test_valid_values_date_time() {
 template <class CharT>
 static void test_valid_values_time_zone() {
 // The Apple CI gives %z='-0700'	%Ez='-0700'	%Oz='-0700'	%Z='UTC'
-// -0700 looks like the local time where the CI happens to recide, therefore
+// -0700 looks like the local time where the CI happens to reside, therefore
 // omit this test on Apple.
 // The Windows CI gives %z='-0000', but on local machines set to a different
 // timezone, it gives e.g. %z='+0200'.

--- a/libcxx/test/std/time/time.zone/time.zone.db/time.zone.db.list/erase_after.compile.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.db/time.zone.db.list/erase_after.compile.pass.cpp
@@ -22,7 +22,7 @@
 //   Preconditions: The iterator following p is dereferenceable.
 //
 // Since there is no Standard way to create a second entry it's not
-// possible to fullfill this precondition. This is tested in a libc++
+// possible to fulfill this precondition. This is tested in a libc++
 // specific test.
 
 #include <chrono>

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/assign.U.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/assign.U.pass.cpp
@@ -52,7 +52,7 @@ static_assert(std::is_assignable_v<std::expected<int, int>&, int>);
 static_assert(std::is_assignable_v<std::expected<int, int>&, std::expected<int, int>>);
 
 // remove_cvref_t<U> is a specialization of unexpected
-// it is true because it covered the unepxected overload
+// it is true because it covered the unexpected overload
 static_assert(std::is_assignable_v<std::expected<int, int>&, std::unexpected<int>>);
 
 // !is_constructible_v<T, U>

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.intializer_list.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/emplace.intializer_list.pass.cpp
@@ -36,15 +36,15 @@ concept CanEmplace = requires(T t, Args&&... args) { t.emplace(std::forward<Args
 static_assert(CanEmplace<std::expected<int, int>, int>);
 
 template <bool Noexcept>
-struct CtorFromInitalizerList {
-  CtorFromInitalizerList(std::initializer_list<int>&) noexcept(Noexcept);
-  CtorFromInitalizerList(std::initializer_list<int>&, int) noexcept(Noexcept);
+struct CtorFromInitializerList {
+  CtorFromInitializerList(std::initializer_list<int>&) noexcept(Noexcept);
+  CtorFromInitializerList(std::initializer_list<int>&, int) noexcept(Noexcept);
 };
 
-static_assert(CanEmplace<std::expected<CtorFromInitalizerList<true>, int>, std::initializer_list<int>&>);
-static_assert(!CanEmplace<std::expected<CtorFromInitalizerList<false>, int>, std::initializer_list<int>&>);
-static_assert(CanEmplace<std::expected<CtorFromInitalizerList<true>, int>, std::initializer_list<int>&, int>);
-static_assert(!CanEmplace<std::expected<CtorFromInitalizerList<false>, int>, std::initializer_list<int>&, int>);
+static_assert(CanEmplace<std::expected<CtorFromInitializerList<true>, int>, std::initializer_list<int>&>);
+static_assert(!CanEmplace<std::expected<CtorFromInitializerList<false>, int>, std::initializer_list<int>&>);
+static_assert(CanEmplace<std::expected<CtorFromInitializerList<true>, int>, std::initializer_list<int>&, int>);
+static_assert(!CanEmplace<std::expected<CtorFromInitializerList<false>, int>, std::initializer_list<int>&, int>);
 
 struct Data {
   std::initializer_list<int> il;

--- a/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/swap/free.swap.pass.cpp
@@ -31,16 +31,16 @@ static_assert(!std::is_swappable_v<std::expected<NotSwappable, int>>);
 // !is_swappable_v<E>
 static_assert(!std::is_swappable_v<std::expected<int, NotSwappable>>);
 
-struct NotMoveContructible {
-  NotMoveContructible(NotMoveContructible&&) = delete;
-  friend void swap(NotMoveContructible&, NotMoveContructible&) {}
+struct NotMoveConstructible {
+  NotMoveConstructible(NotMoveConstructible&&) = delete;
+  friend void swap(NotMoveConstructible&, NotMoveConstructible&) {}
 };
 
 // !is_move_constructible_v<T>
-static_assert(!std::is_swappable_v<std::expected<NotMoveContructible, int>>);
+static_assert(!std::is_swappable_v<std::expected<NotMoveConstructible, int>>);
 
 // !is_move_constructible_v<E>
-static_assert(!std::is_swappable_v<std::expected<int, NotMoveContructible>>);
+static_assert(!std::is_swappable_v<std::expected<int, NotMoveConstructible>>);
 
 struct MoveMayThrow {
   MoveMayThrow(MoveMayThrow&&) noexcept(false);

--- a/libcxx/test/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/swap/member.swap.pass.cpp
@@ -43,16 +43,16 @@ static_assert(!HasMemberSwap<NotSwappable, int>);
 // !is_swappable_v<E>
 static_assert(!HasMemberSwap<int, NotSwappable>);
 
-struct NotMoveContructible {
-  NotMoveContructible(NotMoveContructible&&) = delete;
-  friend void swap(NotMoveContructible&, NotMoveContructible&) {}
+struct NotMoveConstructible {
+  NotMoveConstructible(NotMoveConstructible&&) = delete;
+  friend void swap(NotMoveConstructible&, NotMoveConstructible&) {}
 };
 
 // !is_move_constructible_v<T>
-static_assert(!HasMemberSwap<NotMoveContructible, int>);
+static_assert(!HasMemberSwap<NotMoveConstructible, int>);
 
 // !is_move_constructible_v<E>
-static_assert(!HasMemberSwap<int, NotMoveContructible>);
+static_assert(!HasMemberSwap<int, NotMoveConstructible>);
 
 struct MoveMayThrow {
   MoveMayThrow(MoveMayThrow&&) noexcept(false);

--- a/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/free.swap.pass.cpp
@@ -28,13 +28,13 @@ void swap(NotSwappable&, NotSwappable&) = delete;
 // !is_swappable_v<E>
 static_assert(!std::is_swappable_v<std::expected<void, NotSwappable>>);
 
-struct NotMoveContructible {
-  NotMoveContructible(NotMoveContructible&&) = delete;
-  friend void swap(NotMoveContructible&, NotMoveContructible&) {}
+struct NotMoveConstructible {
+  NotMoveConstructible(NotMoveConstructible&&) = delete;
+  friend void swap(NotMoveConstructible&, NotMoveConstructible&) {}
 };
 
 // !is_move_constructible_v<E>
-static_assert(!std::is_swappable_v<std::expected<void, NotMoveContructible>>);
+static_assert(!std::is_swappable_v<std::expected<void, NotMoveConstructible>>);
 
 // Test noexcept
 struct MoveMayThrow {

--- a/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/swap/member.swap.pass.cpp
@@ -37,13 +37,13 @@ void swap(NotSwappable&, NotSwappable&) = delete;
 // !is_swappable_v<E>
 static_assert(!HasMemberSwap<NotSwappable>);
 
-struct NotMoveContructible {
-  NotMoveContructible(NotMoveContructible&&) = delete;
-  friend void swap(NotMoveContructible&, NotMoveContructible&) {}
+struct NotMoveConstructible {
+  NotMoveConstructible(NotMoveConstructible&&) = delete;
+  friend void swap(NotMoveConstructible&, NotMoveConstructible&) {}
 };
 
 // !is_move_constructible_v<E>
-static_assert(!HasMemberSwap<NotMoveContructible>);
+static_assert(!HasMemberSwap<NotMoveConstructible>);
 
 // Test noexcept
 struct MoveMayThrow {

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -175,7 +175,7 @@ struct TailClobberer {
 
   friend constexpr bool operator==(const TailClobberer&, const TailClobberer&) = default;
 
-  friend constexpr void swap(TailClobberer&, TailClobberer&){};
+  friend constexpr void swap(TailClobberer&, TailClobberer&){}
 
 private:
   alignas(2) bool b;

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -175,7 +175,7 @@ struct TailClobberer {
 
   friend constexpr bool operator==(const TailClobberer&, const TailClobberer&) = default;
 
-  friend constexpr void swap(TailClobberer&, TailClobberer&){}
+  friend constexpr void swap(TailClobberer&, TailClobberer&) {}
 
 private:
   alignas(2) bool b;

--- a/libcxx/test/std/utilities/format/format.formattable/concept.formattable.compile.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formattable/concept.formattable.compile.pass.cpp
@@ -254,7 +254,7 @@ void test_P2286() {
   test_P2286_vector_bool<CharT, std::vector<bool, min_allocator<bool>>>();
 }
 
-// Tests volatile quified objects are no longer formattable.
+// Tests volatile qualified objects are no longer formattable.
 template <class CharT>
 void test_LWG3631() {
   assert_is_not_formattable<volatile CharT, CharT>();

--- a/libcxx/test/std/utilities/format/format.formatter/format.context/format.context/ctor.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.context/format.context/ctor.pass.cpp
@@ -14,7 +14,7 @@
 
 // <format>
 
-// The Standard does not specifiy a constructor
+// The Standard does not specify a constructor
 // basic_format_context(Out out,
 //                      basic_format_args<basic_format_context> args,
 //                      std::optional<std::::locale>&& loc = std::nullopt);
@@ -38,7 +38,7 @@ template <class OutIt, class CharT>
 void test() {
   std::basic_string<CharT> string = MAKE_STRING(CharT, "string");
   // The type of the object is an exposition only type. The temporary is needed
-  // to extend the lifetype of the object since args stores a pointer to the
+  // to extend the lifetime of the object since args stores a pointer to the
   // data in this object.
   auto format_arg_store = std::make_format_args<std::basic_format_context<OutIt, CharT>>(true, CharT('a'), 42, string);
   std::basic_format_args args = format_arg_store;

--- a/libcxx/test/std/utilities/format/format.formatter/format.context/format.context/locale.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.context/format.context/locale.pass.cpp
@@ -32,7 +32,7 @@ void test() {
   std::locale fr_FR{LOCALE_fr_FR_UTF_8};
   std::basic_string<CharT> string = MAKE_STRING(CharT, "string");
   // The type of the object is an exposition only type. The temporary is needed
-  // to extend the lifetype of the object since args stores a pointer to the
+  // to extend the lifetime of the object since args stores a pointer to the
   // data in this object.
   auto format_arg_store = std::make_format_args<std::basic_format_context<OutIt, CharT>>(true, CharT('a'), 42, string);
   std::basic_format_args args = format_arg_store;

--- a/libcxx/test/std/utilities/format/format.functions/escaped_output.ascii.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/escaped_output.ascii.pass.cpp
@@ -150,7 +150,7 @@ void test_char() {
   // *** P2286 examples ***
   test_format(SV("['\\'', '\"']"), SV("[{:?}, {:?}]"), CharT('\''), CharT('"'));
 
-  // *** Specical cases ***
+  // *** Special cases ***
   test_format(SV("'\\t'"), SV("{:?}"), CharT('\t'));
   test_format(SV("'\\n'"), SV("{:?}"), CharT('\n'));
   test_format(SV("'\\r'"), SV("{:?}"), CharT('\r'));
@@ -282,7 +282,7 @@ void test_string() {
 
   test_format(SV("[\"🤷🏻\u200d♂\ufe0f\"]"), SV("[{:?}]"), SV("🤷🏻‍♂️"));
 
-  // *** Specical cases ***
+  // *** Special cases ***
   test_format(SV(R"("\t\n\r\\'\" ")"), SV("{:?}"), SV("\t\n\r\\'\" "));
 
   // *** Printable ***

--- a/libcxx/test/std/utilities/format/format.functions/escaped_output.unicode.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/escaped_output.unicode.pass.cpp
@@ -155,7 +155,7 @@ void test_char() {
   // *** P2286 examples ***
   test_format(SV("['\\'', '\"']"), SV("[{:?}, {:?}]"), CharT('\''), CharT('"'));
 
-  // *** Specical cases ***
+  // *** Special cases ***
   test_format(SV("'\\t'"), SV("{:?}"), CharT('\t'));
   test_format(SV("'\\n'"), SV("{:?}"), CharT('\n'));
   test_format(SV("'\\r'"), SV("{:?}"), CharT('\r'));
@@ -324,7 +324,7 @@ void test_string() {
 
   test_format(SV(R"(["🤷🏻\u{200d}♂\u{fe0f}"])"), SV("[{:?}]"), SV("🤷🏻‍♂️"));
 
-  // *** Specical cases ***
+  // *** Special cases ***
   test_format(SV(R"("\t\n\r\\'\" ")"), SV("{:?}"), SV("\t\n\r\\'\" "));
 
   // *** Printable ***

--- a/libcxx/test/std/utilities/format/format.functions/format_tests.h
+++ b/libcxx/test/std/utilities/format/format.functions/format_tests.h
@@ -2990,7 +2990,7 @@ void format_test_pointer(TestFunction check, ExceptionTest check_exception) {
 
 template <class CharT, class TestFunction, class ExceptionTest>
 void format_test_handle(TestFunction check, ExceptionTest check_exception) {
-  // *** Valid permuatations ***
+  // *** Valid permutations ***
   check(SV("answer is '0xaaaa'"), SV("answer is '{}'"), status::foo);
   check(SV("answer is '0xaaaa'"), SV("answer is '{:x}'"), status::foo);
   check(SV("answer is '0XAAAA'"), SV("answer is '{:X}'"), status::foo);
@@ -3239,7 +3239,7 @@ void format_tests(TestFunction check, ExceptionTest check_exception) {
   if constexpr (modus == execution_modus::full)
     format_test_floating_point<CharT>(check, check_exception);
 
-  // *** Test pointer formater argument ***
+  // *** Test pointer formatter argument ***
   check(SV("hello 0x0"), SV("hello {}"), nullptr);
   check(SV("hello 0x42"), SV("hello {}"), reinterpret_cast<void*>(0x42));
   check(SV("hello 0x42"), SV("hello {}"), reinterpret_cast<const void*>(0x42));
@@ -3249,7 +3249,7 @@ void format_tests(TestFunction check, ExceptionTest check_exception) {
   // *** Test handle formatter argument ***
   format_test_handle<CharT>(check, check_exception);
 
-  // *** Test the interal buffer optimizations ***
+  // *** Test the internal buffer optimizations ***
   if constexpr (modus == execution_modus::full)
     format_test_buffer_optimizations<CharT>(check);
 }

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.enab/enable_shared_from_this.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.enab/enable_shared_from_this.pass.cpp
@@ -18,7 +18,7 @@
 //     shared_ptr<T> shared_from_this();
 //     shared_ptr<T const> shared_from_this() const;
 //     weak_ptr<T> weak_from_this() noexcept;                         // C++17
-//     weak_ptr<T const> weak_from_this() const noexecpt;             // C++17
+//     weak_ptr<T const> weak_from_this() const noexcept;             // C++17
 // };
 
 #include <memory>

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter.pass.cpp
@@ -53,11 +53,11 @@ class MoveDeleter
     MoveDeleter();
     MoveDeleter(MoveDeleter const&);
 public:
-    MoveDeleter(MoveDeleter&&) {}
+  MoveDeleter(MoveDeleter&&) {}
 
-    explicit MoveDeleter(int) {}
+  explicit MoveDeleter(int) {}
 
-    void operator()(T *ptr) { delete ptr; }
+  void operator()(T* ptr) { delete ptr; }
 };
 
 // https://llvm.org/PR60258

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter.pass.cpp
@@ -53,7 +53,7 @@ class MoveDeleter
     MoveDeleter();
     MoveDeleter(MoveDeleter const&);
 public:
-    MoveDeleter(MoveDeleter&&) {};
+    MoveDeleter(MoveDeleter&&) {}
 
     explicit MoveDeleter(int) {}
 

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter_allocator.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter_allocator.pass.cpp
@@ -53,11 +53,11 @@ class MoveDeleter
     MoveDeleter();
     MoveDeleter(MoveDeleter const&);
 public:
-    MoveDeleter(MoveDeleter&&) {}
+  MoveDeleter(MoveDeleter&&) {}
 
-    explicit MoveDeleter(int) {}
+  explicit MoveDeleter(int) {}
 
-    void operator()(T *ptr) { delete ptr; }
+  void operator()(T* ptr) { delete ptr; }
 };
 
 // https://llvm.org/PR60258

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter_allocator.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter_allocator.pass.cpp
@@ -53,7 +53,7 @@ class MoveDeleter
     MoveDeleter();
     MoveDeleter(MoveDeleter const&);
 public:
-    MoveDeleter(MoveDeleter&&) {};
+    MoveDeleter(MoveDeleter&&) {}
 
     explicit MoveDeleter(int) {}
 

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.lwg2070.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.lwg2070.pass.cpp
@@ -43,7 +43,7 @@ public:
   MyAllocator(int i) : id(i) {}
 
   template <class U>
-  MyAllocator(MyAllocator<U> const& other) : id(other.id){}
+  MyAllocator(MyAllocator<U> const& other) : id(other.id) {}
 
   pointer allocate(std::ptrdiff_t n) {
     return pointer(static_cast<T*>(::operator new(n * sizeof(T))));

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.lwg2070.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.lwg2070.pass.cpp
@@ -43,7 +43,7 @@ public:
   MyAllocator(int i) : id(i) {}
 
   template <class U>
-  MyAllocator(MyAllocator<U> const& other) : id(other.id){};
+  MyAllocator(MyAllocator<U> const& other) : id(other.id){}
 
   pointer allocate(std::ptrdiff_t n) {
     return pointer(static_cast<T*>(::operator new(n * sizeof(T))));

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.private.compile.fail.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.private.compile.fail.cpp
@@ -20,7 +20,7 @@
 
 struct S {
 private:
-   S () {};  // ctor is private
+   S () {}  // ctor is private
 };
 
 int main(int, char**)

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.private.compile.fail.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.private.compile.fail.cpp
@@ -20,7 +20,7 @@
 
 struct S {
 private:
-   S () {}  // ctor is private
+  S() {} // ctor is private
 };
 
 int main(int, char**)

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.obs/op_bool.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.obs/op_bool.pass.cpp
@@ -20,7 +20,7 @@
 
 struct A {
   int a;
-  virtual ~A(){};
+  virtual ~A(){}
 };
 struct B : A {};
 

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.obs/op_bool.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.obs/op_bool.pass.cpp
@@ -20,7 +20,7 @@
 
 struct A {
   int a;
-  virtual ~A(){}
+  virtual ~A() {}
 };
 struct B : A {};
 

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03
 
-// Self assignement post-conditions are tested.
+// Self assignment post-conditions are tested.
 // ADDITIONAL_COMPILE_FLAGS: -Wno-self-move
 
 // <memory>

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
@@ -40,8 +40,8 @@ struct DerivedFromAllocArgT : std::allocator_arg_t {};
 
 
 // Make sure the _Up... constructor SFINAEs out when the number of initializers
-// is less that the number of elements in the tuple. Previously libc++ would
-// offer these constructers as an extension but they broke conforming code.
+// is less than the number of elements in the tuple. Previously libc++ would
+// offer these constructors as an extension but they broke conforming code.
 void test_uses_allocator_sfinae_evaluation()
 {
      using BadDefault = DefaultCtorBlowsUp<>;

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
@@ -38,7 +38,6 @@ struct DefaultCtorBlowsUp {
 
 struct DerivedFromAllocArgT : std::allocator_arg_t {};
 
-
 // Make sure the _Up... constructor SFINAEs out when the number of initializers
 // is less than the number of elements in the tuple. Previously libc++ would
 // offer these constructors as an extension but they broke conforming code.

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.verify.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.verify.cpp
@@ -31,7 +31,7 @@ std::tuple<ExplicitCopy> const_explicit_copy_test() {
 }
 
 std::tuple<ExplicitCopy> non_const_explicit_copy_test() {
-    ExplicitCopy e(42);
-    return {std::allocator_arg, std::allocator<int>{}, e};
-    // expected-error@-1 {{chosen constructor is explicit in copy-initialization}}
+  ExplicitCopy e(42);
+  return {std::allocator_arg, std::allocator<int>{}, e};
+  // expected-error@-1 {{chosen constructor is explicit in copy-initialization}}
 }

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.verify.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.verify.cpp
@@ -30,7 +30,7 @@ std::tuple<ExplicitCopy> const_explicit_copy_test() {
     // expected-error@-1 {{chosen constructor is explicit in copy-initialization}}
 }
 
-std::tuple<ExplicitCopy> non_const_explicity_copy_test() {
+std::tuple<ExplicitCopy> non_const_explicit_copy_test() {
     ExplicitCopy e(42);
     return {std::allocator_arg, std::allocator<int>{}, e};
     // expected-error@-1 {{chosen constructor is explicit in copy-initialization}}

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/tracking_mem_res.h
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/tracking_mem_res.h
@@ -14,7 +14,8 @@
 
 class TrackingMemRes : public std::pmr::memory_resource {
 public:
-  TrackingMemRes(std::size_t* last_size, size_t* last_alignment) : last_size_(last_size), last_alignment_(last_alignment) {}
+  TrackingMemRes(std::size_t* last_size, size_t* last_alignment)
+      : last_size_(last_size), last_alignment_(last_alignment) {}
 
 private:
   std::size_t* last_size_;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/tracking_mem_res.h
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/tracking_mem_res.h
@@ -14,21 +14,21 @@
 
 class TrackingMemRes : public std::pmr::memory_resource {
 public:
-  TrackingMemRes(std::size_t* last_size, size_t* last_alginment) : last_size_(last_size), last_alginment_(last_alginment) {}
+  TrackingMemRes(std::size_t* last_size, size_t* last_alignment) : last_size_(last_size), last_alignment_(last_alignment) {}
 
 private:
   std::size_t* last_size_;
-  std::size_t* last_alginment_;
+  std::size_t* last_alignment_;
   void* do_allocate(std::size_t size, size_t alignment) override {
     *last_size_      = size;
-    *last_alginment_ = alignment;
+    *last_alignment_ = alignment;
 
     return std::pmr::new_delete_resource()->allocate(size, alignment);
   }
 
   void do_deallocate(void* ptr, std::size_t size, size_t alignment) override {
     *last_size_      = size;
-    *last_alginment_ = alignment;
+    *last_alignment_ = alignment;
     std::pmr::new_delete_resource()->deallocate(ptr, size, alignment);
   }
 

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
@@ -23,13 +23,13 @@
 
 struct Derived : ConstexprTestTypes::MoveOnly {
   Derived() = default;
-  TEST_CONSTEXPR_CXX20 Derived(ConstexprTestTypes::MoveOnly&&){}
+  TEST_CONSTEXPR_CXX20 Derived(ConstexprTestTypes::MoveOnly&&) {}
 };
 struct CountAssign {
   int copied = 0;
   int moved = 0;
   TEST_CONSTEXPR_CXX20 CountAssign() = default;
-  TEST_CONSTEXPR_CXX20 CountAssign(const int){}
+  TEST_CONSTEXPR_CXX20 CountAssign(const int) {}
   TEST_CONSTEXPR_CXX20 CountAssign& operator=(CountAssign const&) {
     ++copied;
     return *this;

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp
@@ -23,13 +23,13 @@
 
 struct Derived : ConstexprTestTypes::MoveOnly {
   Derived() = default;
-  TEST_CONSTEXPR_CXX20 Derived(ConstexprTestTypes::MoveOnly&&){};
+  TEST_CONSTEXPR_CXX20 Derived(ConstexprTestTypes::MoveOnly&&){}
 };
 struct CountAssign {
   int copied = 0;
   int moved = 0;
   TEST_CONSTEXPR_CXX20 CountAssign() = default;
-  TEST_CONSTEXPR_CXX20 CountAssign(const int){};
+  TEST_CONSTEXPR_CXX20 CountAssign(const int){}
   TEST_CONSTEXPR_CXX20 CountAssign& operator=(CountAssign const&) {
     ++copied;
     return *this;

--- a/libcxx/test/support/assert_macros.h
+++ b/libcxx/test/support/assert_macros.h
@@ -66,7 +66,7 @@ void test_require(bool condition, const char* condition_str, const char* file, i
 
 // assert(false) replacement
 // The ARG is either a
-// - c-ctring or std::string, in which case the string is printed to stderr,
+// - c-string or std::string, in which case the string is printed to stderr,
 // - an invocable object, which will be invoked.
 #define TEST_FAIL(ARG) ::test_fail(__FILE__, __LINE__, ARG)
 

--- a/libcxx/test/support/boolean_testable.h
+++ b/libcxx/test/support/boolean_testable.h
@@ -48,7 +48,7 @@ template <class T>
 struct StrictComparable {
   StrictComparable() = default;
 
-  // this shouldn't be explicit to make it easier to initlaize inside arrays (which it almost always is)
+  // this shouldn't be explicit to make it easier to initialize inside arrays (which it almost always is)
   constexpr StrictComparable(T value) : value_{value} {}
 
   friend constexpr BooleanTestable const& operator==(StrictComparable const& a, StrictComparable const& b) {

--- a/libcxx/test/support/concat_macros.h
+++ b/libcxx/test/support/concat_macros.h
@@ -27,7 +27,7 @@ concept test_char_streamable = requires(T&& value) { std::stringstream{} << std:
 #  endif
 
 // If possible concatenates message for the assertion function, else returns a
-// default message. Not being able to stream is not considered and error. For
+// default message. Not being able to stream is not considered an error. For
 // example, streaming to std::wcerr doesn't work properly in the CI. Therefore
 // the formatting tests should only stream to std::string.
 //

--- a/libcxx/test/support/copy_move_types.h
+++ b/libcxx/test/support/copy_move_types.h
@@ -173,14 +173,14 @@ struct TracedCopyMove {
 template <>
 struct std::uses_allocator<TracedCopyMove, test_allocator<int>> : std::true_type {};
 
-// If the constructor tuple(tuple<UTyles...>&) is not available,
+// If the constructor tuple(tuple<UTypes...>&) is not available,
 // the fallback call to `tuple(const tuple&) = default;` or any other
 // constructor that takes const ref would increment the constCopy.
 inline constexpr bool nonConstCopyCtrCalled(const TracedCopyMove& obj) {
   return obj.nonConstCopy == 1 && obj.constCopy == 0 && obj.constMove == 0 && obj.nonConstMove == 0;
 }
 
-// If the constructor tuple(const tuple<UTyles...>&&) is not available,
+// If the constructor tuple(const tuple<UTypes...>&&) is not available,
 // the fallback call to `tuple(const tuple&) = default;` or any other
 // constructor that takes const ref would increment the constCopy.
 inline constexpr bool constMoveCtrCalled(const TracedCopyMove& obj) {

--- a/libcxx/test/support/iterator_traits_cpp17_iterators.h
+++ b/libcxx/test/support/iterator_traits_cpp17_iterators.h
@@ -19,7 +19,7 @@ struct iterator_traits_cpp17_proxy_iterator {
   int operator*();
   iterator_traits_cpp17_proxy_iterator& operator++();
 
-  // this returns legcay_iterator, not iterator_traits_cpp17_proxy_iterator
+  // this returns legacy_iterator, not iterator_traits_cpp17_proxy_iterator
   iterator_traits_cpp17_iterator operator++(int);
 };
 
@@ -41,7 +41,7 @@ struct iterator_traits_cpp17_proxy_input_iterator {
   int operator*();
   iterator_traits_cpp17_proxy_input_iterator& operator++();
 
-  // this returns legcay_input_iterator, not iterator_traits_cpp17_proxy_input_iterator
+  // this returns legacy_input_iterator, not iterator_traits_cpp17_proxy_input_iterator
   iterator_traits_cpp17_input_iterator operator++(int);
 
   bool operator==(iterator_traits_cpp17_proxy_input_iterator const&) const;

--- a/libcxx/test/support/test_container_comparisons.h
+++ b/libcxx/test/support/test_container_comparisons.h
@@ -361,7 +361,7 @@ constexpr void test_ordered_set_spaceship_with_type(Compare comp) {
     }
   }
   if constexpr (std::is_same_v< Container<Elem>, std::set<PartialOrder>>) {
-    // Unodered values are not supported for `set`
+    // Unordered values are not supported for `set`
     if constexpr (std::is_same_v<Elem, PartialOrder> && std::is_same_v<Compare, decltype(std::less{})>) {
       Container<Elem, Compare> l1{{1, std::numeric_limits<int>::min()}, comp};
       Container<Elem, Compare> l2{{1, 2}, comp};

--- a/libcxx/test/support/test_iterators.h
+++ b/libcxx/test/support/test_iterators.h
@@ -1430,11 +1430,11 @@ class iterator_wrapper {
   using iter_traits = std::iterator_traits<Iter>;
 
 public:
-  using iterator_cateory = typename iter_traits::iterator_category;
-  using value_type       = typename iter_traits::value_type;
-  using difference_type  = typename iter_traits::difference_type;
-  using pointer          = typename iter_traits::pointer;
-  using reference        = typename iter_traits::reference;
+  using iterator_category = typename iter_traits::iterator_category;
+  using value_type        = typename iter_traits::value_type;
+  using difference_type   = typename iter_traits::difference_type;
+  using pointer           = typename iter_traits::pointer;
+  using reference         = typename iter_traits::reference;
 
   constexpr iterator_wrapper() : iter_() {}
   constexpr explicit iterator_wrapper(Iter iter) : iter_(iter) {}
@@ -1506,7 +1506,7 @@ class throw_on_move_iterator : public iterator_wrapper<throw_on_move_iterator<It
 public:
   using difference_type   = typename base::difference_type;
   using value_type        = typename base::value_type;
-  using iterator_category = typename base::iterator_cateory;
+  using iterator_category = typename base::iterator_category;
 
   throw_on_move_iterator() = default;
   throw_on_move_iterator(Iter iter, int moves_until_throw)


### PR DESCRIPTION
I've structured this into a series of commits for even easier reviewing, if that helps. I could easily split this up into separate PRs if desired, but as this is low-risk with simple edits, I thought one PR would be easiest.

* Drop unnecessary semicolons after function definitions.
* Cleanup comment typos.
* Cleanup `static_assert` typos.
* Cleanup test code typos.
  + There should be no functional changes, assuming I've changed all occurrences.
* ~~Fix massive test code typos.~~
  + This was a real problem, but needed more surgery. I reverted those changes here, and @philnik777 is fixing this properly with #73444.
* clang-formatting as requested by the CI.
