### PR TITLE
[libc++][test] Use `LIBCPP_STATIC_ASSERT` for `std::__mdspan_detail`

### DIFF
--- a/libcxx/test/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
@@ -87,7 +87,7 @@
 template <class M, size_t... Idxs>
 void test_mapping_requirements(std::index_sequence<Idxs...>) {
   using E = typename M::extents_type;
-  static_assert(std::__mdspan_detail::__is_extents_v<E>);
+  LIBCPP_STATIC_ASSERT(std::__mdspan_detail::__is_extents_v<E>);
   static_assert(std::is_copy_constructible_v<M>);
   static_assert(std::is_nothrow_move_constructible_v<M>);
   static_assert(std::is_nothrow_move_assignable_v<M>);

--- a/libcxx/test/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
@@ -87,7 +87,7 @@
 template <class M, size_t... Idxs>
 void test_mapping_requirements(std::index_sequence<Idxs...>) {
   using E = typename M::extents_type;
-  static_assert(std::__mdspan_detail::__is_extents_v<E>);
+  LIBCPP_STATIC_ASSERT(std::__mdspan_detail::__is_extents_v<E>);
   static_assert(std::is_copy_constructible_v<M>);
   static_assert(std::is_nothrow_move_constructible_v<M>);
   static_assert(std::is_nothrow_move_assignable_v<M>);

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
@@ -87,7 +87,7 @@
 template <class M, size_t... Idxs>
 void test_mapping_requirements(std::index_sequence<Idxs...>) {
   using E = typename M::extents_type;
-  static_assert(std::__mdspan_detail::__is_extents_v<E>);
+  LIBCPP_STATIC_ASSERT(std::__mdspan_detail::__is_extents_v<E>);
   static_assert(std::is_copy_constructible_v<M>);
   static_assert(std::is_nothrow_move_constructible_v<M>);
   static_assert(std::is_nothrow_move_assignable_v<M>);


### PR DESCRIPTION
Found while running libc++'s test suite against MSVC's STL.

`libcxx/test/std` should be portable, so these lines checking `std::__mdspan_detail` machinery should be using `LIBCPP_STATIC_ASSERT`.

I checked for other occurrences and these appear to be the only ones which have appeared since our last libc++ test suite update.