### PR TITLE
[libc++][test] Fix unused and nodiscard warnings

### DIFF
--- a/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/complexity.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.heap.operations/sort.heap/complexity.pass.cpp
@@ -61,6 +61,7 @@ int main(int, char**) {
     const int debug_elements = std::min(100, n);
     // Multiplier 2 because of comp(a,b) comp(b, a) checks.
     const int debug_comparisons = 2 * (debug_elements + 1) * debug_elements;
+    (void)debug_comparisons;
     std::shuffle(first, last, g);
     std::make_heap(first, last);
     // The exact stats of our current implementation are recorded here.
@@ -70,7 +71,6 @@ int main(int, char**) {
     LIBCPP_ASSERT(stats.moved <= 2 * n + n * logn);
 #if _LIBCPP_HARDENING_MODE != _LIBCPP_HARDENING_MODE_DEBUG
     LIBCPP_ASSERT(stats.compared <= n * logn);
-    (void)debug_comparisons;
 #else
     LIBCPP_ASSERT(stats.compared <= 2 * n * logn + debug_comparisons);
 #endif

--- a/libcxx/test/std/containers/sequences/deque/deque.cons/from_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.cons/from_range.pass.cpp
@@ -19,7 +19,7 @@
 
 int main(int, char**) {
   for_all_iterators_and_allocators<int>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_container<std::deque, int, Iter, Sent, Alloc>([](const auto& c) {
+    test_sequence_container<std::deque, int, Iter, Sent, Alloc>([]([[maybe_unused]] const auto& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/append_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/append_range.pass.cpp
@@ -26,7 +26,7 @@ int main(int, char**) {
   static_assert(test_constraints_append_range<std::deque, int, double>());
 
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_append_range<std::deque<int, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_append_range<std::deque<int, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/assign_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/assign_range.pass.cpp
@@ -25,7 +25,7 @@ int main(int, char**) {
   static_assert(test_constraints_assign_range<std::deque, int, double>());
 
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_assign_range<std::deque<int, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_assign_range<std::deque<int, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_range.pass.cpp
@@ -26,7 +26,7 @@ int main(int, char**) {
   static_assert(test_constraints_insert_range<std::deque, int, double>());
 
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_insert_range<std::deque<int, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_insert_range<std::deque<int, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/prepend_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/prepend_range.pass.cpp
@@ -26,7 +26,7 @@ int main(int, char**) {
   static_assert(test_constraints_prepend_range<std::deque, int, double>());
 
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_prepend_range<std::deque<int, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_prepend_range<std::deque<int, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/containers/sequences/vector.bool/append_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/append_range.pass.cpp
@@ -25,7 +25,7 @@ constexpr bool test() {
   static_assert(test_constraints_append_range<std::vector, bool, char>());
 
   for_all_iterators_and_allocators<bool, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_append_range<std::vector<bool, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_append_range<std::vector<bool, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
       // `is_contiguous_container_asan_correct` doesn't work on `vector<bool>`.
     });

--- a/libcxx/test/std/containers/sequences/vector.bool/assign_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/assign_range.pass.cpp
@@ -25,7 +25,7 @@ constexpr bool test() {
   static_assert(test_constraints_assign_range<std::vector, bool, char>());
 
   for_all_iterators_and_allocators<bool, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_assign_range<std::vector<bool, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_assign_range<std::vector<bool, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
       // `is_contiguous_container_asan_correct` doesn't work on `vector<bool>`.
     });

--- a/libcxx/test/std/containers/sequences/vector.bool/construct_from_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/construct_from_range.pass.cpp
@@ -18,7 +18,7 @@
 
 constexpr bool test() {
   for_all_iterators_and_allocators<bool>([]<class Iter, class Sent, class Alloc>() {
-    test_vector_bool<Iter, Sent, Alloc>([](const auto& c) {
+    test_vector_bool<Iter, Sent, Alloc>([]([[maybe_unused]] const auto& c) {
       LIBCPP_ASSERT(c.__invariants());
       // `is_contiguous_container_asan_correct` doesn't work on `vector<bool>`.
     });

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_range.pass.cpp
@@ -25,7 +25,7 @@ constexpr bool test() {
   static_assert(test_constraints_insert_range<std::vector, bool, char>());
 
   for_all_iterators_and_allocators<bool, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_insert_range<std::vector<bool, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_insert_range<std::vector<bool, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
       // `is_contiguous_container_asan_correct` doesn't work on `vector<bool>`.
     });

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/construct_from_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/construct_from_range.pass.cpp
@@ -19,7 +19,7 @@
 
 constexpr bool test() {
   for_all_iterators_and_allocators<int>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_container<std::vector, int, Iter, Sent, Alloc>([](const auto& c) {
+    test_sequence_container<std::vector, int, Iter, Sent, Alloc>([]([[maybe_unused]] const auto& c) {
       LIBCPP_ASSERT(c.__invariants());
       LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
     });

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range.pass.cpp
@@ -27,7 +27,7 @@ constexpr bool test() {
   static_assert(test_constraints_append_range<std::vector, int, double>());
 
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_append_range<std::vector<int, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_append_range<std::vector<int, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
       LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
     });

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/assign_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/assign_range.pass.cpp
@@ -27,7 +27,7 @@ constexpr bool test() {
   static_assert(test_constraints_assign_range<std::vector, int, double>());
 
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_assign_range<std::vector<int, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_assign_range<std::vector<int, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
       LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
     });

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range.pass.cpp
@@ -26,7 +26,7 @@
 
 constexpr bool test() {
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_insert_range<std::vector<int, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_insert_range<std::vector<int, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
       LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
     });

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_append/append_range.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_append/append_range.pass.cpp
@@ -23,9 +23,8 @@
 
 constexpr bool test_constexpr() {
   for_all_iterators_and_allocators_constexpr<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
-      LIBCPP_ASSERT(c.__invariants());
-    });
+    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>(
+        []([[maybe_unused]] auto&& c) { LIBCPP_ASSERT(c.__invariants()); });
   });
 
   return true;
@@ -35,9 +34,8 @@ int main(int, char**) {
   static_assert(test_constraints_append_range<std::basic_string, char, int>());
 
   for_all_iterators_and_allocators<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
-      LIBCPP_ASSERT(c.__invariants());
-    });
+    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>(
+        []([[maybe_unused]] auto&& c) { LIBCPP_ASSERT(c.__invariants()); });
   });
   static_assert(test_constexpr());
 

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_append/append_range.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_append/append_range.pass.cpp
@@ -23,7 +23,7 @@
 
 constexpr bool test_constexpr() {
   for_all_iterators_and_allocators_constexpr<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });
@@ -35,7 +35,7 @@ int main(int, char**) {
   static_assert(test_constraints_append_range<std::basic_string, char, int>());
 
   for_all_iterators_and_allocators<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_append_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/assign_range.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/assign_range.pass.cpp
@@ -23,9 +23,8 @@
 
 constexpr bool test_constexpr() {
   for_all_iterators_and_allocators_constexpr<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
-      LIBCPP_ASSERT(c.__invariants());
-    });
+    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>(
+        []([[maybe_unused]] auto&& c) { LIBCPP_ASSERT(c.__invariants()); });
   });
 
   return true;
@@ -35,9 +34,8 @@ int main(int, char**) {
   static_assert(test_constraints_assign_range<std::basic_string, char, int>());
 
   for_all_iterators_and_allocators<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
-      LIBCPP_ASSERT(c.__invariants());
-    });
+    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>(
+        []([[maybe_unused]] auto&& c) { LIBCPP_ASSERT(c.__invariants()); });
   });
   static_assert(test_constexpr());
 

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/assign_range.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/assign_range.pass.cpp
@@ -23,7 +23,7 @@
 
 constexpr bool test_constexpr() {
   for_all_iterators_and_allocators_constexpr<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });
@@ -35,7 +35,7 @@ int main(int, char**) {
   static_assert(test_constraints_assign_range<std::basic_string, char, int>());
 
   for_all_iterators_and_allocators<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_assign_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/insert_range.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/insert_range.pass.cpp
@@ -23,7 +23,7 @@
 
 constexpr bool test_constexpr() {
   for_all_iterators_and_allocators_constexpr<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });
@@ -35,7 +35,7 @@ int main(int, char**) {
   static_assert(test_constraints_insert_range<std::basic_string, char, int>());
 
   for_all_iterators_and_allocators<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([](auto&& c) {
+    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
       LIBCPP_ASSERT(c.__invariants());
     });
   });

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/insert_range.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/insert_range.pass.cpp
@@ -23,9 +23,8 @@
 
 constexpr bool test_constexpr() {
   for_all_iterators_and_allocators_constexpr<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
-      LIBCPP_ASSERT(c.__invariants());
-    });
+    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>(
+        []([[maybe_unused]] auto&& c) { LIBCPP_ASSERT(c.__invariants()); });
   });
 
   return true;
@@ -35,9 +34,8 @@ int main(int, char**) {
   static_assert(test_constraints_insert_range<std::basic_string, char, int>());
 
   for_all_iterators_and_allocators<char, const char*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>([]([[maybe_unused]] auto&& c) {
-      LIBCPP_ASSERT(c.__invariants());
-    });
+    test_sequence_insert_range<std::basic_string<char, std::char_traits<char>, Alloc>, Iter, Sent>(
+        []([[maybe_unused]] auto&& c) { LIBCPP_ASSERT(c.__invariants()); });
   });
   static_assert(test_constexpr());
 

--- a/libcxx/test/std/thread/futures/futures.future_error/what.pass.cpp
+++ b/libcxx/test/std/thread/futures/futures.future_error/what.pass.cpp
@@ -38,24 +38,24 @@ int main(int, char**) {
 #if TEST_STD_VER >= 17
   {
     std::future_error const f(std::future_errc::broken_promise);
-    char const* what = f.what();
+    [[maybe_unused]] char const* what = f.what();
     LIBCPP_ASSERT(what == std::string_view{"The associated promise has been destructed prior "
                                            "to the associated state becoming ready."});
   }
   {
     std::future_error f(std::future_errc::future_already_retrieved);
-    char const* what = f.what();
+    [[maybe_unused]] char const* what = f.what();
     LIBCPP_ASSERT(what == std::string_view{"The future has already been retrieved from "
                                            "the promise or packaged_task."});
   }
   {
     std::future_error f(std::future_errc::promise_already_satisfied);
-    char const* what = f.what();
+    [[maybe_unused]] char const* what = f.what();
     LIBCPP_ASSERT(what == std::string_view{"The state of the promise has already been set."});
   }
   {
     std::future_error f(std::future_errc::no_state);
-    char const* what = f.what();
+    [[maybe_unused]] char const* what = f.what();
     LIBCPP_ASSERT(what == std::string_view{"Operation not permitted on an object without "
                                            "an associated state."});
   }

--- a/libcxx/test/std/utilities/function.objects/func.invoke/invoke_r.pass.cpp
+++ b/libcxx/test/std/utilities/function.objects/func.invoke/invoke_r.pass.cpp
@@ -91,7 +91,7 @@ constexpr bool test() {
         {
             bool was_called = false;
             auto f = [&](NonCopyable) -> int { was_called = true; return 0; };
-            std::invoke_r<int>(f, NonCopyable());
+            (void)std::invoke_r<int>(f, NonCopyable());
             assert(was_called);
         }
         // Forward function object, with void return
@@ -111,7 +111,7 @@ constexpr bool test() {
                 constexpr int operator()() && { was_called = true; return 0; }
             };
             bool was_called = false;
-            std::invoke_r<int>(MoveOnlyIntFunction{was_called});
+            (void)std::invoke_r<int>(MoveOnlyIntFunction{was_called});
             assert(was_called);
         }
     }

--- a/libcxx/test/support/deduction_guides_sfinae_checks.h
+++ b/libcxx/test/support/deduction_guides_sfinae_checks.h
@@ -116,10 +116,10 @@ constexpr void SequenceContainerDeductionGuidesSfinaeAway() {
 template<template<typename ...> class Container, typename InstantiatedContainer>
 constexpr void ContainerAdaptorDeductionGuidesSfinaeAway() {
   using T = typename InstantiatedContainer::value_type;
-  using Alloc = std::allocator<T>;
+  using Alloc [[maybe_unused]] = std::allocator<T>;
   using Iter = T*;
 
-  using BadIter = int;
+  using BadIter [[maybe_unused]] = int;
   using BadAlloc = Empty;
 
   // (container) -- no constraints.


### PR DESCRIPTION
Found while running libc++'s test suite with MSVC's STL.

This is structured into a series of commits for easier reviewing; I could also split this into smaller PRs if desired.

* Add void-casts for `invoke_r` calls to fix MSVC STL `[[nodiscard]]` warnings.
  + Our rationale is that if someone is calling `invoke_r<NonVoidType>`, it sure looks like they care about the return value.
* Add `[[maybe_unused]]` to silence `-Wunused-parameter` warnings.
  + This happens because the parameters are used within `LIBCPP_ASSERT`, which vanishes for MSVC's STL. This also motivates the following changes.
* Add `[[maybe_unused]]` to fix `-Wunused-variable` warnings.
* Always void-cast `debug_comparisons` to fix `-Wunused-variable` warnings.
  + As this was already unused with a void-cast in one `_LIBCPP_HARDENING_MODE` branch, I'm simply lifting it next to the variable definition.
* Add `[[maybe_unused]]` to fix `-Wunused-local-typedef` warnings.
