### PR TITLE
[libc++][test] Avoid preprocessor directives in macro argument lists

### DIFF
--- a/libcxx/test/std/input.output/iostream.format/print.fun/print.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/print.file.pass.cpp
@@ -94,11 +94,8 @@ static void test_read_only() {
   TEST_VALIDATE_EXCEPTION(
       std::system_error,
       [&]([[maybe_unused]] const std::system_error& e) {
-#ifdef _AIX
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Broken pipe"};
-#else
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Operation not permitted"};
-#endif
+        [[maybe_unused]] std::string_view what{
+            "failed to write formatted output: " TEST_IF_AIX("Broken pipe", "Operation not permitted")};
         TEST_LIBCPP_REQUIRE(
             e.what() == what,
             TEST_WRITE_CONCATENATED("\nExpected exception ", what, "\nActual exception   ", e.what(), '\n'));

--- a/libcxx/test/std/input.output/iostream.format/print.fun/println.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/println.file.pass.cpp
@@ -97,11 +97,8 @@ static void test_read_only() {
   TEST_VALIDATE_EXCEPTION(
       std::system_error,
       [&]([[maybe_unused]] const std::system_error& e) {
-#ifdef _AIX
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Broken pipe"};
-#else
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Operation not permitted"};
-#endif
+        [[maybe_unused]] std::string_view what{
+            "failed to write formatted output: " TEST_IF_AIX("Broken pipe", "Operation not permitted")};
         TEST_LIBCPP_REQUIRE(
             e.what() == what,
             TEST_WRITE_CONCATENATED("\nExpected exception ", what, "\nActual exception   ", e.what(), '\n'));

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.file.pass.cpp
@@ -103,11 +103,8 @@ static void test_read_only() {
   TEST_VALIDATE_EXCEPTION(
       std::system_error,
       [&]([[maybe_unused]] const std::system_error& e) {
-#ifdef _AIX
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Broken pipe"};
-#else
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Operation not permitted"};
-#endif
+        [[maybe_unused]] std::string_view what{
+            "failed to write formatted output: " TEST_IF_AIX("Broken pipe", "Operation not permitted")};
         TEST_LIBCPP_REQUIRE(
             e.what() == what,
             TEST_WRITE_CONCATENATED("\nExpected exception ", what, "\nActual exception   ", e.what(), '\n'));

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.file.pass.cpp
@@ -110,11 +110,8 @@ static void test_read_only() {
   TEST_VALIDATE_EXCEPTION(
       std::system_error,
       [&]([[maybe_unused]] const std::system_error& e) {
-#ifdef _AIX
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Broken pipe"};
-#else
-        [[maybe_unused]] std::string_view what{"failed to write formatted output: Operation not permitted"};
-#endif
+        [[maybe_unused]] std::string_view what{
+            "failed to write formatted output: " TEST_IF_AIX("Broken pipe", "Operation not permitted")};
         TEST_LIBCPP_REQUIRE(
             e.what() == what,
             TEST_WRITE_CONCATENATED("\nExpected exception ", what, "\nActual exception   ", e.what(), '\n'));

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -443,4 +443,10 @@ inline void DoNotOptimize(Tp const& value) {
 #  define TEST_WORKAROUND_BUG_109234844_WEAK /* nothing */
 #endif
 
+#ifdef _AIX
+#  define TEST_IF_AIX(arg_true, arg_false) arg_true
+#else
+#  define TEST_IF_AIX(arg_true, arg_false) arg_false
+#endif
+
 #endif // SUPPORT_TEST_MACROS_HPP


### PR DESCRIPTION
Found while running libc++'s test suite with MSVC's STL.

MSVC has a level 1 "warning C5101: use of preprocessor directive in function-like macro argument list is undefined behavior". I don't know why Clang doesn't complain about this.

There are some formatting tests which densely interleave preprocessor directives within function-like macros, and they would need invasive changes. For now, I'm just skipping those tests.

However, a few tests were only slightly affected, and I was able to add a new test macro `TEST_IF_AIX` to make them portable.