### PR TITLE
feat libcxx: avoid defining std::nullptr_t in terms of ::nullptr_t

### DIFF
--- a/libcxx/include/cstddef
+++ b/libcxx/include/cstddef
@@ -56,7 +56,7 @@ Types:
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-using ::nullptr_t;
+using nullptr_t = decltype(nullptr);
 using ::ptrdiff_t _LIBCPP_USING_IF_EXISTS;
 using ::size_t _LIBCPP_USING_IF_EXISTS;
 


### PR DESCRIPTION
Before this PR, `<cstddef>` did

```cpp
using nullptr_t = ::nullptr_t;
```

`::nullptr_t` comes from `<stddef.h>` (of libc++). `<stddef.h>` of libc++ also uses `#include_next` to make the compiler look into glibc's `<stddef.h>`, which, notably, does not contain a definition of `::nullptr_t`.

Such behavior confused some editors, notably CLion Nova, into thinking that `std::nullptr_t` does not exist, which turned off essentially all intellisense features.

There exists a bug report against the C++ standard that `<stddef.h>` should not expose `::nullptr_t`. Consequently, `std::nullptr_t` should not rely on `::nullptr_t`, so that future glibc can remove the `::nullptr_t` definition:
https://timsong-cpp.github.io/lwg-issues/3484

Fixes: #73443