### PR TITLE
[Clang] Eagerly instantiate used constexpr function upon definition.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -793,6 +793,11 @@ Bug Fixes to C++ Support
 - Fix crash when parsing nested requirement. Fixes:
   (`#73112 <https://github.com/llvm/llvm-project/issues/73112>`_)
 
+- Clang now immediately instantiates function template specializations
+  at the end of the definition of the corresponding function template
+  when the definition appears after the first point of instantiation.
+  (`#73232 <https://github.com/llvm/llvm-project/issues/73232>`_)
+
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed an import failure of recursive friend class template.

--- a/clang/include/clang/Sema/ExternalSemaSource.h
+++ b/clang/include/clang/Sema/ExternalSemaSource.h
@@ -181,7 +181,7 @@ public:
                  SmallVectorImpl<std::pair<ValueDecl *,
                                            SourceLocation> > &Pending) {}
 
-  virtual void ReadPendingOfInstantiationsForConstexprEntity(
+  virtual void ReadPendingInstantiationsOfConstexprEntity(
       const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls){};
 
   /// Read the set of late parsed template functions for this source.

--- a/clang/include/clang/Sema/ExternalSemaSource.h
+++ b/clang/include/clang/Sema/ExternalSemaSource.h
@@ -181,6 +181,9 @@ public:
                  SmallVectorImpl<std::pair<ValueDecl *,
                                            SourceLocation> > &Pending) {}
 
+  virtual void ReadPendingOfInstantiationsForConstexprEntity(
+      const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls){};
+
   /// Read the set of late parsed template functions for this source.
   ///
   /// The external source should insert its own late parsed template functions

--- a/clang/include/clang/Sema/MultiplexExternalSemaSource.h
+++ b/clang/include/clang/Sema/MultiplexExternalSemaSource.h
@@ -319,6 +319,9 @@ public:
   void ReadPendingInstantiations(
      SmallVectorImpl<std::pair<ValueDecl*, SourceLocation> >& Pending) override;
 
+  virtual void ReadPendingOfInstantiationsForConstexprEntity(
+      const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) override;
+
   /// Read the set of late parsed template functions for this source.
   ///
   /// The external source should insert its own late parsed template functions

--- a/clang/include/clang/Sema/MultiplexExternalSemaSource.h
+++ b/clang/include/clang/Sema/MultiplexExternalSemaSource.h
@@ -319,7 +319,7 @@ public:
   void ReadPendingInstantiations(
      SmallVectorImpl<std::pair<ValueDecl*, SourceLocation> >& Pending) override;
 
-  virtual void ReadPendingOfInstantiationsForConstexprEntity(
+  virtual void ReadPendingInstantiationsOfConstexprEntity(
       const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) override;
 
   /// Read the set of late parsed template functions for this source.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -59,6 +59,7 @@
 #include "clang/Sema/TypoCorrection.h"
 #include "clang/Sema/Weak.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -10087,6 +10088,12 @@ public:
   /// but have not yet been performed.
   std::deque<PendingImplicitInstantiation> PendingInstantiations;
 
+  /// Track constexpr functions referenced before they are (lexically) defined.
+  /// The key is the pattern, associated with a list of specialisations that
+  /// need to be instantiated when the pattern is defined.
+  llvm::DenseMap<NamedDecl *, SmallVector<NamedDecl *>>
+      PendingInstantiationsOfConstexprEntities;
+
   /// Queue of implicit template instantiations that cannot be performed
   /// eagerly.
   SmallVector<PendingImplicitInstantiation, 1> LateParsedInstantiations;
@@ -10405,6 +10412,10 @@ public:
                                      bool Recursive = false,
                                      bool DefinitionRequired = false,
                                      bool AtEndOfTU = false);
+
+  void InstantiateFunctionTemplateSpecializations(
+      SourceLocation PointOfInstantiation, FunctionDecl *Template);
+
   VarTemplateSpecializationDecl *BuildVarTemplateInstantiation(
       VarTemplateDecl *VarTemplate, VarDecl *FromVar,
       const TemplateArgumentList &TemplateArgList,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10413,8 +10413,7 @@ public:
                                      bool DefinitionRequired = false,
                                      bool AtEndOfTU = false);
 
-  void InstantiateFunctionTemplateSpecializations(
-      SourceLocation PointOfInstantiation, FunctionDecl *Template);
+  void PerformPendingInstantiationsOfConstexprFunctions(FunctionDecl *Template);
 
   VarTemplateSpecializationDecl *BuildVarTemplateInstantiation(
       VarTemplateDecl *VarTemplate, VarDecl *FromVar,

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -695,6 +695,10 @@ enum ASTRecordTypes {
   /// Record code for an unterminated \#pragma clang assume_nonnull begin
   /// recorded in a preamble.
   PP_ASSUME_NONNULL_LOC = 67,
+
+  /// Record code for constexpr templated entities that have been used but not
+  /// yet instantiated.
+  PENDING_INSTANTIATIONS_OF_CONSTEXPR_ENTITIES = 68,
 };
 
 /// Record types used within a source manager block.

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -814,6 +814,9 @@ private:
   /// is the instantiation location.
   SmallVector<serialization::DeclID, 64> PendingInstantiations;
 
+  llvm::DenseMap<serialization::DeclID, std::set<serialization::DeclID>>
+      PendingInstantiationsOfConstexprEntities;
+
   //@}
 
   /// \name DiagnosticsEngine-relevant special data
@@ -2100,6 +2103,9 @@ public:
   void ReadPendingInstantiations(
                   SmallVectorImpl<std::pair<ValueDecl *,
                                             SourceLocation>> &Pending) override;
+
+  virtual void ReadPendingOfInstantiationsForConstexprEntity(
+      const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) override;
 
   void ReadLateParsedTemplates(
       llvm::MapVector<const FunctionDecl *, std::unique_ptr<LateParsedTemplate>>

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -2104,7 +2104,7 @@ public:
                   SmallVectorImpl<std::pair<ValueDecl *,
                                             SourceLocation>> &Pending) override;
 
-  virtual void ReadPendingOfInstantiationsForConstexprEntity(
+  virtual void ReadPendingInstantiationsOfConstexprEntity(
       const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) override;
 
   void ReadLateParsedTemplates(

--- a/clang/lib/Sema/MultiplexExternalSemaSource.cpp
+++ b/clang/lib/Sema/MultiplexExternalSemaSource.cpp
@@ -310,6 +310,12 @@ void MultiplexExternalSemaSource::ReadPendingInstantiations(
     Sources[i]->ReadPendingInstantiations(Pending);
 }
 
+void MultiplexExternalSemaSource::ReadPendingOfInstantiationsForConstexprEntity(
+    const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) {
+  for (size_t i = 0; i < Sources.size(); ++i)
+    Sources[i]->ReadPendingOfInstantiationsForConstexprEntity(D, Decls);
+};
+
 void MultiplexExternalSemaSource::ReadLateParsedTemplates(
     llvm::MapVector<const FunctionDecl *, std::unique_ptr<LateParsedTemplate>>
         &LPTMap) {

--- a/clang/lib/Sema/MultiplexExternalSemaSource.cpp
+++ b/clang/lib/Sema/MultiplexExternalSemaSource.cpp
@@ -310,10 +310,10 @@ void MultiplexExternalSemaSource::ReadPendingInstantiations(
     Sources[i]->ReadPendingInstantiations(Pending);
 }
 
-void MultiplexExternalSemaSource::ReadPendingOfInstantiationsForConstexprEntity(
+void MultiplexExternalSemaSource::ReadPendingInstantiationsOfConstexprEntity(
     const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) {
   for (size_t i = 0; i < Sources.size(); ++i)
-    Sources[i]->ReadPendingOfInstantiationsForConstexprEntity(D, Decls);
+    Sources[i]->ReadPendingInstantiationsOfConstexprEntity(D, Decls);
 };
 
 void MultiplexExternalSemaSource::ReadLateParsedTemplates(

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16275,6 +16275,9 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
   if (FD && !FD->isDeleted())
     checkTypeSupport(FD->getType(), FD->getLocation(), FD);
 
+  if (FD && FD->isConstexpr() && FD->isTemplated())
+    InstantiateFunctionTemplateSpecializations(FD->getEndLoc(), FD);
+
   return dcl;
 }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16276,7 +16276,7 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
     checkTypeSupport(FD->getType(), FD->getLocation(), FD);
 
   if (FD && FD->isConstexpr() && FD->isTemplated())
-    InstantiateFunctionTemplateSpecializations(FD->getEndLoc(), FD);
+    PerformPendingInstantiationsOfConstexprFunctions(FD);
 
   return dcl;
 }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -19053,12 +19053,17 @@ void Sema::MarkFunctionReferenced(SourceLocation Loc, FunctionDecl *Func,
               CodeSynthesisContexts.size())
             PendingLocalImplicitInstantiations.push_back(
                 std::make_pair(Func, PointOfInstantiation));
-          else if (Func->isConstexpr())
+          else if (Func->isConstexpr()) {
             // Do not defer instantiations of constexpr functions, to avoid the
             // expression evaluator needing to call back into Sema if it sees a
             // call to such a function.
             InstantiateFunctionDefinition(PointOfInstantiation, Func);
-          else {
+            if (!Func->isDefined()) {
+              PendingInstantiationsOfConstexprEntities
+                  [Func->getTemplateInstantiationPattern()->getCanonicalDecl()]
+                      .push_back(Func);
+            }
+          } else {
             Func->setInstantiationIsPending(true);
             PendingInstantiations.push_back(
                 std::make_pair(Func, PointOfInstantiation));

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -8731,9 +8731,11 @@ void ASTReader::ReadPendingInstantiations(
   PendingInstantiations.clear();
 }
 
-void ASTReader::ReadPendingOfInstantiationsForConstexprEntity(
+void ASTReader::ReadPendingInstantiationsOfConstexprEntity(
     const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) {
   for (auto *Redecl : D->redecls()) {
+    if (!Redecl->isFromASTFile())
+      continue;
     DeclID Id = Redecl->getGlobalID();
     auto It = PendingInstantiationsOfConstexprEntities.find(Id);
     if (It == PendingInstantiationsOfConstexprEntities.end())

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -3709,6 +3709,19 @@ llvm::Error ASTReader::ReadASTBlock(ModuleFile &F,
       }
       break;
 
+    case PENDING_INSTANTIATIONS_OF_CONSTEXPR_ENTITIES:
+      if (Record.size() % 2 != 0)
+        return llvm::createStringError(
+            std::errc::illegal_byte_sequence,
+            "Invalid PENDING_INSTANTIATIONS_OF_CONSTEXPR_ENTITIES block");
+
+      for (unsigned I = 0, N = Record.size(); I != N; /* in loop */) {
+        DeclID Key = getGlobalDeclID(F, Record[I++]);
+        DeclID Value = getGlobalDeclID(F, Record[I++]);
+        PendingInstantiationsOfConstexprEntities[Key].insert(Value);
+      }
+      break;
+
     case SEMA_DECL_REFS:
       if (Record.size() != 3)
         return llvm::createStringError(std::errc::illegal_byte_sequence,
@@ -8716,6 +8729,18 @@ void ASTReader::ReadPendingInstantiations(
     Pending.push_back(std::make_pair(D, Loc));
   }
   PendingInstantiations.clear();
+}
+
+void ASTReader::ReadPendingOfInstantiationsForConstexprEntity(
+    const NamedDecl *D, llvm::SmallSetVector<NamedDecl *, 4> &Decls) {
+  for (auto *Redecl : D->redecls()) {
+    DeclID Id = Redecl->getGlobalID();
+    auto It = PendingInstantiationsOfConstexprEntities.find(Id);
+    if (It == PendingInstantiationsOfConstexprEntities.end())
+      continue;
+    for (DeclID InstantiationId : It->second)
+      Decls.insert(cast<NamedDecl>(GetDecl(InstantiationId)));
+  }
 }
 
 void ASTReader::ReadLateParsedTemplates(

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -4837,7 +4837,7 @@ ASTFileSignature ASTWriter::WriteASTCore(Sema &SemaRef, StringRef isysroot,
   assert(SemaRef.PendingLocalImplicitInstantiations.empty() &&
          "There are local ones at end of translation unit!");
 
-  // Build a record containing all of pending instantiations of constexpr
+  // Build a record containing all pending instantiations of constexpr
   // entities.
   RecordData PendingInstantiationsOfConstexprEntities;
   for (const auto &I : SemaRef.PendingInstantiationsOfConstexprEntities) {

--- a/clang/test/PCH/instantiate-used-constexpr-function.cpp
+++ b/clang/test/PCH/instantiate-used-constexpr-function.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -std=c++2a -emit-pch %s -o %t
+// RUN: %clang_cc1 -std=c++2a -include-pch %t -verify %s
+
+// expected-no-diagnostics
+
+#ifndef HEADER
+#define HEADER
+
+template<typename T> constexpr T f();
+constexpr int g() { return f<int>(); } // #1
+
+#else /*included pch*/
+
+template<typename T> constexpr T f() { return 123; }
+int k[g()];
+
+#endif // HEADER

--- a/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
+++ b/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
@@ -105,13 +105,15 @@ template <typename T>
 constexpr int f(T t);
 
 auto a = &f<char>;
-auto b = &f<int>; // expected-error {{immediate function 'f<int>' used before it is defined}} \
-                  // expected-note {{in instantiation of function template specialization}}
+auto b = &f<int>; // expected-error {{immediate function 'f<int>' used before it is defined}}
 
 template <typename T>
 constexpr int f(T t) { // expected-note {{'f<int>' defined here}}
     return id(t); // expected-note {{'f<int>' is an immediate function because its body contains a call to a consteval function 'id' and that call is not a constant expression}}
-}
+} // expected-note {{in instantiation of function template specialization}}
+
+
+
 }
 
 namespace constructors {

--- a/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
+++ b/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
@@ -105,12 +105,13 @@ template <typename T>
 constexpr int f(T t);
 
 auto a = &f<char>;
-auto b = &f<int>; // expected-error {{immediate function 'f<int>' used before it is defined}}
+auto b = &f<int>; // expected-error {{immediate function 'f<int>' used before it is defined}} \
+                  // expected-note {{in instantiation of function template specialization}}
 
 template <typename T>
 constexpr int f(T t) { // expected-note {{'f<int>' defined here}}
     return id(t); // expected-note {{'f<int>' is an immediate function because its body contains a call to a consteval function 'id' and that call is not a constant expression}}
-} // expected-note {{in instantiation of function template specialization}}
+}
 
 
 

--- a/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
+++ b/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
@@ -112,9 +112,6 @@ template <typename T>
 constexpr int f(T t) { // expected-note {{'f<int>' defined here}}
     return id(t); // expected-note {{'f<int>' is an immediate function because its body contains a call to a consteval function 'id' and that call is not a constant expression}}
 }
-
-
-
 }
 
 namespace constructors {

--- a/clang/test/SemaTemplate/instantiate-used-constexpr-function.cpp
+++ b/clang/test/SemaTemplate/instantiate-used-constexpr-function.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+namespace GH73232  {
+
+template <typename _CharT>
+struct basic_string {
+  constexpr void _M_construct();
+  constexpr basic_string() {
+    _M_construct();
+  }
+};
+
+basic_string<char> a;
+
+template <typename _CharT>
+constexpr void basic_string<_CharT>::_M_construct(){}
+constexpr basic_string<char> str{};
+
+template <typename T>
+constexpr void g(T);
+
+constexpr int f() { g(0); return 0; }
+
+template <typename T>
+constexpr void g(T) {}
+
+constexpr int z = f();
+
+}


### PR DESCRIPTION
Despite CWG2497 not being resolved, it is reasonable to expect the following code to compile (and which is supported by other compilers)

```cpp
  template<typename T> constexpr T f();
  constexpr int g() { return f<int>(); } // #1
  template<typename T> constexpr T f() { return 123; }
  int k[g()];
  // #2
```

To that end, we eagerly instantiate all referenced specializations of constexpr functions when they are defined.

We maintain a map of (pattern, [instantiations]) independant of `PendingInstantiations` to avoid having to iterate that list after each function definition.

We should apply the same logic to constexpr variables, but I wanted to keep the PR small.

Fixes #73232