### PR TITLE
[OpenMP][Tools] Have sort(1) not use long name parameters

### DIFF
--- a/openmp/tools/multiplex/tests/lit.cfg
+++ b/openmp/tools/multiplex/tests/lit.cfg
@@ -90,7 +90,7 @@ if 'Linux' in config.operating_system:
 
 # substitutions
 config.substitutions.append(("FileCheck", "tee %%t.out | %s" % config.test_filecheck))
-config.substitutions.append(("%sort-threads", "sort --numeric-sort --stable"))
+config.substitutions.append(("%sort-threads", "sort -n -s"))
 
 config.substitutions.append(("%libomp-compile-and-run", \
     "%libomp-compile && %libomp-run"))


### PR DESCRIPTION
I noticed a few tests were failing on NetBSD. NetBSD's sort(1) does not support long name parameters unlike GNU and FreeBSD/OpenBSD/DragonFly's sort(1).

```
executed command: sort --numeric-sort --stable

 .---command stderr------------
 | sort: unknown option -- -
 | usage: sort [-bdfHilmnrSsu] [-k kstart[,kend]] [-o output] [-R char] [-T dir]
 |              [-t char] [file ...]
 |    or: sort -C|-c [-bdfilnru] [-k kstart[,kend]] [-o output] [-R char]
 |              [-t char] [file]
 `-----------------------------
```