### PR TITLE
[runtime] Have the runtime use the compiler builtin for alloca on NetBSD

### DIFF
--- a/openmp/runtime/src/kmp_safe_c_api.h
+++ b/openmp/runtime/src/kmp_safe_c_api.h
@@ -56,7 +56,11 @@ template <typename T> struct kmp_get_rmax_t<T, true> {
 
 // For now, these macros use the existing API.
 
+#if KMP_OS_NETBSD
+#define KMP_ALLOCA __builtin_alloca
+#else
 #define KMP_ALLOCA alloca
+#endif
 #define KMP_MEMCPY_S(dst, bsz, src, cnt) memcpy(dst, src, cnt)
 #define KMP_SNPRINTF snprintf
 #define KMP_SSCANF sscanf


### PR DESCRIPTION
Most of the tests were failing with the following in their logs..
```
| /usr/bin/ld: /home/brad/llvm-build/runtimes/runtimes-bins/openmp/runtime/src/libomp.so:
warning: Warning: reference to the libc supplied alloca(3); this most likely will not
work. Please use the compiler provided version of alloca(3), by supplying the appropriate
compiler flags (e.g. -std=gnu99).
```

By making use of __builtin_alloca..

before:

Total Discovered Tests: 353
  Unsupported:  59 (16.71%)
  Passed     :  51 (14.45%)
  Failed     : 243 (68.84%)

after:

Total Discovered Tests: 353
  Unsupported:  59 (16.71%)
  Passed     : 290 (82.15%)
  Failed     :   4 (1.13%)