### PR TITLE
[BOLT][test] Update perf2bolt/perf_test.test

### DIFF
--- a/bolt/test/perf2bolt/Inputs/perf_test.c
+++ b/bolt/test/perf2bolt/Inputs/perf_test.c
@@ -1,7 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-
 int add(int a, int b) { return a + b; }
 int minus(int a, int b) { return a - b; }
 int multiple(int a, int b) { return a * b; }
@@ -15,7 +11,7 @@ int main() {
   int a = 16;
   int b = 8;
 
-  for (int i = 1; i < 100000; i++) {
+  for (int i = 1; i < 1000000; i++) {
     add(a, b);
     minus(a, b);
     multiple(a, b);


### PR DESCRIPTION
perf_test keeps failing on bolt-aarch64-ubuntu-clang-shared:
https://lab.llvm.org/buildbot/#/builders/221/builds/20330

The reason is likely that there are no samples due to short test runtime.
Bump up the running time 10x and remove unneeded headers.

With the change that test passed on a buildbot host 10/10 times.
