### PR TITLE
[BOLT][test] Replace /dev/null with temp file

### DIFF
--- a/bolt/test/AArch64/got-ld64-relaxation.test
+++ b/bolt/test/AArch64/got-ld64-relaxation.test
@@ -2,7 +2,7 @@
 // to the ADR+ADD sequence is properly recognized and handled by bolt
 
 // RUN: yaml2obj %p/Inputs/got-ld64-relaxation.yaml &> %t.exe
-// RUN: llvm-bolt %t.exe -o /dev/null --print-fix-relaxations \
+// RUN: llvm-bolt %t.exe -o %t.null --print-fix-relaxations \
 // RUN:   --print-only=main | FileCheck %s
 
 // CHECK: adrp x0, foo

--- a/bolt/test/AArch64/skip-got-rel.test
+++ b/bolt/test/AArch64/skip-got-rel.test
@@ -3,6 +3,6 @@
 // normally.
 
 RUN: yaml2obj %p/Inputs/skip-got-rel.yaml &> %t.exe
-RUN: llvm-bolt %t.exe -o /dev/null --print-cfg --print-only=_start | FileCheck %s
+RUN: llvm-bolt %t.exe -o %t.null --print-cfg --print-only=_start | FileCheck %s
 
 CHECK: adr	x0, foo2

--- a/bolt/test/RISCV/branch-no-secondary-entry.s
+++ b/bolt/test/RISCV/branch-no-secondary-entry.s
@@ -1,7 +1,7 @@
 /// Test that no secondary entry points are created for basic block labels used
 /// by branches.
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt -print-cfg -o /dev/null %t 2>&1 | FileCheck %s
+// RUN: llvm-bolt -print-cfg -o %t.null %t 2>&1 | FileCheck %s
 
 // CHECK: Binary Function "_start" after building cfg {
 // CHECK: IsMultiEntry: 0

--- a/bolt/test/RISCV/call-annotations.s
+++ b/bolt/test/RISCV/call-annotations.s
@@ -4,7 +4,7 @@
 // RUN: llvm-mc -triple riscv64 -mattr=+c -filetype obj -o %t.o %s
 // RUN: ld.lld --emit-relocs -o %t %t.o
 // RUN: llvm-bolt --enable-bat --print-cfg --print-fix-riscv-calls \
-// RUN:     -o /dev/null %t | FileCheck %s
+// RUN:     -o %t.null %t | FileCheck %s
 
   .text
   .option norvc

--- a/bolt/test/RISCV/load-store.s
+++ b/bolt/test/RISCV/load-store.s
@@ -1,6 +1,6 @@
 // RUN: %clang %cflags -o %t %s
 // RUN: link_fdata --no-lbr %s %t %t.fdata
-// RUN: llvm-bolt %t -o /dev/null --data=%t.fdata --dyno-stats | FileCheck %s
+// RUN: llvm-bolt %t -o %t.null --data=%t.fdata --dyno-stats | FileCheck %s
 
 // CHECK: BOLT-INFO: program-wide dynostats after all optimizations before SCTC and FOP (no change):
 // CHECK: 3000 : executed instructions

--- a/bolt/test/RISCV/reloc-abs.s
+++ b/bolt/test/RISCV/reloc-abs.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -Wl,--defsym='__global_pointer$'=0x2800 -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .data

--- a/bolt/test/RISCV/reloc-bb-split.s
+++ b/bolt/test/RISCV/reloc-bb-split.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .data

--- a/bolt/test/RISCV/reloc-branch.s
+++ b/bolt/test/RISCV/reloc-branch.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .text

--- a/bolt/test/RISCV/reloc-call.s
+++ b/bolt/test/RISCV/reloc-call.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-fix-riscv-calls --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-fix-riscv-calls --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .text

--- a/bolt/test/RISCV/reloc-got.s
+++ b/bolt/test/RISCV/reloc-got.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .data

--- a/bolt/test/RISCV/reloc-jal.s
+++ b/bolt/test/RISCV/reloc-jal.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .text

--- a/bolt/test/RISCV/reloc-lohi.s
+++ b/bolt/test/RISCV/reloc-lohi.s
@@ -1,6 +1,6 @@
 // RUN: llvm-mc -triple riscv64 -filetype=obj -o %t.o %s
 // RUN: ld.lld -q -o %t %t.o
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .data

--- a/bolt/test/RISCV/reloc-pcrel.s
+++ b/bolt/test/RISCV/reloc-pcrel.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .data

--- a/bolt/test/RISCV/reloc-rvc-branch.s
+++ b/bolt/test/RISCV/reloc-rvc-branch.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .text

--- a/bolt/test/RISCV/reloc-rvc-jump.s
+++ b/bolt/test/RISCV/reloc-rvc-jump.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -o %t %s
-// RUN: llvm-bolt --print-cfg --print-only=_start -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=_start -o %t.null %t \
 // RUN:    | FileCheck %s
 
   .text

--- a/bolt/test/RISCV/reloc-tls.s
+++ b/bolt/test/RISCV/reloc-tls.s
@@ -1,6 +1,6 @@
 // RUN: llvm-mc -triple riscv64 -filetype obj -o %t.o %s
 // RUN: ld.lld --emit-relocs -o %t %t.o
-// RUN: llvm-bolt --print-cfg --print-only=tls_le,tls_ie -o /dev/null %t \
+// RUN: llvm-bolt --print-cfg --print-only=tls_le,tls_ie -o %t.null %t \
 // RUN:    | FileCheck %s
 
 // CHECK-LABEL: Binary Function "tls_le{{.*}}" after building cfg {

--- a/bolt/test/X86/block-reordering.test
+++ b/bolt/test/X86/block-reordering.test
@@ -2,7 +2,7 @@
 # according to the new function layout.
 
 RUN: yaml2obj %p/Inputs/blarge.yaml &> %t.exe
-RUN: llvm-bolt %t.exe -o /dev/null --data %p/Inputs/blarge.fdata \
+RUN: llvm-bolt %t.exe -o %t.null --data %p/Inputs/blarge.fdata \
 RUN:   --reorder-blocks=normal --print-finalized  2>&1 | FileCheck %s \
 RUN:   --check-prefix=CHECK
 

--- a/bolt/test/X86/branch-data.test
+++ b/bolt/test/X86/branch-data.test
@@ -3,7 +3,7 @@
 # Also checks that llvm-bolt disassembler and CFG builder is working properly.
 
 RUN: yaml2obj %p/Inputs/blarge.yaml &> %t.exe
-RUN: llvm-bolt %t.exe -o /dev/null --data %p/Inputs/blarge.fdata --print-cfg | FileCheck %s
+RUN: llvm-bolt %t.exe -o %t.null --data %p/Inputs/blarge.fdata --print-cfg | FileCheck %s
 
 CHECK:    Binary Function "usqrt"
 CHECK:      State       : CFG constructed

--- a/bolt/test/X86/bug-function-layout-execount.s
+++ b/bolt/test/X86/bug-function-layout-execount.s
@@ -6,7 +6,7 @@
 # RUN: link_fdata %s %t.o %t.fdata
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
 # RUN: llvm-bolt %t.exe --data %t.fdata --lite --reorder-functions=exec-count \
-# RUN:   -v=2 --debug-only=hfsort -o /dev/null 2>&1 | FileCheck %s
+# RUN:   -v=2 --debug-only=hfsort -o %t.null 2>&1 | FileCheck %s
 
 # CHECK: Starting pass: reorder-functions
 # CHECK-NEXT: hot func func2 (1500)

--- a/bolt/test/X86/call-zero.s
+++ b/bolt/test/X86/call-zero.s
@@ -2,7 +2,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags %t.o -o %t.exe
-# RUN: llvm-bolt %t.exe -o /dev/null -v=2 2>&1 | FileCheck %s
+# RUN: llvm-bolt %t.exe -o %t.null -v=2 2>&1 | FileCheck %s
 # CHECK: Function main has a call to address zero.
 
         .text

--- a/bolt/test/X86/cfi-instrs-count.s
+++ b/bolt/test/X86/cfi-instrs-count.s
@@ -3,7 +3,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags %t.o -o %t.exe
-# RUN: llvm-bolt %t.exe -o /dev/null --print-cfg 2>&1 | FileCheck %s
+# RUN: llvm-bolt %t.exe -o %t.null --print-cfg 2>&1 | FileCheck %s
 # 
 # CHECK:  Binary Function "_Z7catchitv" after building cfg {
 # CHECK:    CFI Instrs  : 6

--- a/bolt/test/X86/checkvma-large-section.test
+++ b/bolt/test/X86/checkvma-large-section.test
@@ -2,7 +2,7 @@
 REQUIRES: asserts
 RUN: split-file %s %t
 RUN: yaml2obj %t/yaml -o %t.exe --max-size=0
-RUN: llvm-bolt %t.exe -o /dev/null --allow-stripped
+RUN: llvm-bolt %t.exe -o %t.null --allow-stripped
 #--- yaml
 --- !ELF
 FileHeader:

--- a/bolt/test/X86/data-to-data-pcrel.s
+++ b/bolt/test/X86/data-to-data-pcrel.s
@@ -4,7 +4,7 @@
 # RUN: llvm-strip --strip-unneeded %t.o
 # RUN: ld.lld %t.o -o %t.exe -q --unresolved-symbols=ignore-all
 # RUN: llvm-readelf -Wr %t.exe | FileCheck %s
-# RUN: llvm-bolt --strict %t.exe --relocs -o /dev/null
+# RUN: llvm-bolt --strict %t.exe --relocs -o %t.null
 
   .text
   .globl _start

--- a/bolt/test/X86/double-rel.s
+++ b/bolt/test/X86/double-rel.s
@@ -6,7 +6,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
 # RUN: ld.lld %t.o -o %t.exe -q --Tdata=0x80000
-# RUN: llvm-bolt %t.exe --relocs -o /dev/null --print-only=_start --print-disasm \
+# RUN: llvm-bolt %t.exe --relocs -o %t.null --print-only=_start --print-disasm \
 # RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
 # RUN: llvm-objdump -d --print-imm-hex %t.exe \
 # RUN:   | FileCheck %s --check-prefix=CHECK-OBJDUMP

--- a/bolt/test/X86/exceptions-args.test
+++ b/bolt/test/X86/exceptions-args.test
@@ -3,7 +3,7 @@
 
 RUN: %clang %cflags %p/../Inputs/stub.c -fPIC -pie -shared -o %t.so
 RUN: %clangxx %cxxflags -no-pie %p/Inputs/exc_args.s -o %t %t.so -Wl,-z,notext
-RUN: llvm-bolt %t -o /dev/null --print-finalized --print-only=main | FileCheck %s
+RUN: llvm-bolt %t -o %t.null --print-finalized --print-only=main | FileCheck %s
 
 CHECK: Binary Function "main" after finalize-functions
 CHECK:      callq	_Z3fooiiiiiiii {{.*}} GNU_args_size = 16

--- a/bolt/test/X86/fptr-addend-pcrel.s
+++ b/bolt/test/X86/fptr-addend-pcrel.s
@@ -6,7 +6,7 @@
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
 # RUN: llvm-strip --strip-unneeded %t.o
 # RUN: ld.lld %t.o -o %t.exe -q
-# RUN: llvm-bolt %t.exe --relocs -o /dev/null --print-only=foo --print-disasm \
+# RUN: llvm-bolt %t.exe --relocs -o %t.null --print-only=foo --print-disasm \
 # RUN:   | FileCheck %s
 
   .text

--- a/bolt/test/X86/gotpcrelx.s
+++ b/bolt/test/X86/gotpcrelx.s
@@ -12,9 +12,9 @@
 # RUN: ld.lld %t.o -o %t.no-relax.exe -q --no-relax
 # RUN: llvm-bolt %t.exe --relocs -o %t.out --print-cfg --print-only=_start \
 # RUN:   |& FileCheck --check-prefix=BOLT %s
-# RUN: llvm-bolt %t.pie.exe -o /dev/null --print-cfg --print-only=_start \
+# RUN: llvm-bolt %t.pie.exe -o %t.null --print-cfg --print-only=_start \
 # RUN:   |& FileCheck --check-prefix=PIE-BOLT %s
-# RUN: llvm-bolt %t.no-relax.exe -o /dev/null --print-cfg --print-only=_start \
+# RUN: llvm-bolt %t.no-relax.exe -o %t.null --print-cfg --print-only=_start \
 # RUN:   |& FileCheck --check-prefix=NO-RELAX-BOLT %s
 # RUN: llvm-objdump -d --no-show-raw-insn --print-imm-hex \
 # RUN:   %t.out | FileCheck --check-prefix=DISASM %s

--- a/bolt/test/X86/icp-inline.s
+++ b/bolt/test/X86/icp-inline.s
@@ -20,7 +20,7 @@
 
 # Without -icp-inline option, ICP is performed
 # RUN: llvm-bolt %t.exe --icp=calls --icp-calls-topn=1 --inline-small-functions\
-# RUN:   -o /dev/null --lite=0 \
+# RUN:   -o %t.null --lite=0 \
 # RUN:   --inline-small-functions-bytes=4 --print-icp --data %t.fdata \
 # RUN:   | FileCheck %s --check-prefix=CHECK-NO-ICP-INLINE
 # CHECK-NO-ICP-INLINE: Binary Function "main" after indirect-call-promotion
@@ -29,7 +29,7 @@
 
 # With -icp-inline option, ICP is not performed (size of bar > inline threshold)
 # RUN: llvm-bolt %t.exe --icp=calls --icp-calls-topn=1 --inline-small-functions\
-# RUN:   -o /dev/null --lite=0 \
+# RUN:   -o %t.null --lite=0 \
 # RUN:   --inline-small-functions-bytes=4 --icp-inline --print-icp \
 # RUN:   --data %t.fdata | FileCheck %s --check-prefix=CHECK-ICP-INLINE
 # CHECK-ICP-INLINE:     Binary Function "main" after indirect-call-promotion

--- a/bolt/test/X86/indirect-goto.test
+++ b/bolt/test/X86/indirect-goto.test
@@ -1,6 +1,6 @@
 # Check llvm-bolt processes binaries compiled from sources that use indirect goto.
 RUN: %clang %cflags -no-pie %S/Inputs/indirect_goto.c -Wl,-q -o %t
-RUN: llvm-bolt %t -o /dev/null --relocs=1 --print-cfg --print-only=main \
+RUN: llvm-bolt %t -o %t.null --relocs=1 --print-cfg --print-only=main \
 RUN:   --strict \
 RUN:   2>&1 | FileCheck %s
 

--- a/bolt/test/X86/is-strip.s
+++ b/bolt/test/X86/is-strip.s
@@ -4,7 +4,7 @@
 # RUN: llvm-bolt %t -o %t.out 2>&1 | FileCheck %s -check-prefix=CHECK-NOSTRIP
 # RUN: cp %t %t.stripped
 # RUN: llvm-strip -s %t.stripped
-# RUN: not llvm-bolt %t.stripped -o /dev/null 2>&1 | FileCheck %s -check-prefix=CHECK-STRIP
+# RUN: not llvm-bolt %t.stripped -o %t.null 2>&1 | FileCheck %s -check-prefix=CHECK-STRIP
 # RUN: llvm-bolt %t.stripped -o %t.out --allow-stripped 2>&1 | FileCheck %s -check-prefix=CHECK-NOSTRIP
 
 # CHECK-NOSTRIP-NOT: BOLT-ERROR: stripped binaries are not supported.

--- a/bolt/test/X86/jmpjmp.test
+++ b/bolt/test/X86/jmpjmp.test
@@ -3,7 +3,7 @@
 
 RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %S/Inputs/jmpjmp.s -o %t.o
 RUN: %clang %cflags %t.o -o %t.exe
-RUN: llvm-bolt %t.exe -o /dev/null --print-cfg 2>&1 | FileCheck %s
+RUN: llvm-bolt %t.exe -o %t.null --print-cfg 2>&1 | FileCheck %s
 
 CHECK:  Binary Function "testfunc"
 CHECK:    State       : CFG constructed

--- a/bolt/test/X86/jump-table-footprint-reduction.test
+++ b/bolt/test/X86/jump-table-footprint-reduction.test
@@ -6,7 +6,7 @@ RUN:   %S/Inputs/jump_table_footprint_reduction.s -o %t.o
 RUN: link_fdata %S/Inputs/jump_table_footprint_reduction.s %t.o %t.fdata --nmtool llvm-nm
 RUN: llvm-strip --strip-unneeded %t.o
 RUN: %clang %cflags -no-pie %t.o -o %t.exe -Wl,-q
-RUN: llvm-bolt %t.exe --data %t.fdata -o /dev/null \
+RUN: llvm-bolt %t.exe --data %t.fdata -o %t.null \
 RUN:   --jump-tables=move --jt-footprint-reduction --assume-abi --relocs \
 RUN:   | FileCheck %s
 

--- a/bolt/test/X86/jump-table-pic-order.test
+++ b/bolt/test/X86/jump-table-pic-order.test
@@ -2,7 +2,7 @@
 # in the same order as they appear in the input code.
 
 RUN: %clang %cflags %S/Inputs/jump-table-pic.s -o %t.exe -Wl,-q
-RUN: llvm-bolt %t.exe --strict --print-cfg --print-only=main -o /dev/null \
+RUN: llvm-bolt %t.exe --strict --print-cfg --print-only=main -o %t.null \
 RUN:   | FileCheck %s
 
 CHECK:      BB Layout   : {{.*, .*, .*,}} [[BB4to6:.*, .*, .*]]

--- a/bolt/test/X86/jump-table-reference.test
+++ b/bolt/test/X86/jump-table-reference.test
@@ -1,6 +1,6 @@
 # Verifies that BOLT detects fixed destination of indirect jump
 
 RUN: %clang %cflags -no-pie %S/Inputs/jump_table_reference.s -Wl,-q -o %t
-RUN: llvm-bolt %t --relocs -o /dev/null 2>&1 | FileCheck %s
+RUN: llvm-bolt %t --relocs -o %t.null 2>&1 | FileCheck %s
 
 CHECK: BOLT-INFO: fixed indirect branch detected in main

--- a/bolt/test/X86/layout-heuristic.test
+++ b/bolt/test/X86/layout-heuristic.test
@@ -5,7 +5,7 @@
 # Also checks that llvm-bolt disassembler and CFG builder is working properly.
 
 RUN: yaml2obj %p/Inputs/blarge.yaml &> %t.exe
-RUN: llvm-bolt %t.exe -o /dev/null --data %p/Inputs/blarge.fdata \
+RUN: llvm-bolt %t.exe -o %t.null --data %p/Inputs/blarge.fdata \
 RUN:   --reorder-blocks=normal --print-cfg --print-reordered \
 RUN:   --funcs=main,SolveCubic,usqrt --sequential-disassembly \
 RUN:   2>&1 | FileCheck %s

--- a/bolt/test/X86/line-number.test
+++ b/bolt/test/X86/line-number.test
@@ -1,7 +1,7 @@
 # Verifies that the extraction of DWARF line number information is correct.
 
 RUN: %clangxx %cxxflags %S/Inputs/linenumber.cpp -g -o %t
-RUN: llvm-bolt %t -o /dev/null --print-reordered --update-debug-sections \
+RUN: llvm-bolt %t -o %t.null --print-reordered --update-debug-sections \
 RUN:   --print-debug-info --reorder-blocks=reverse --sequential-disassembly \
 RUN:   2>&1 | FileCheck %s
 

--- a/bolt/test/X86/lto-name-match.s
+++ b/bolt/test/X86/lto-name-match.s
@@ -2,7 +2,7 @@
 # RUN: link_fdata %s %t.o %t.fdata
 # RUN: llvm-strip --strip-unneeded %t.o
 # RUN: %clang %cflags %t.o -o %t.exe
-# RUN: llvm-bolt %t.exe --data %t.fdata -o /dev/null | FileCheck %s
+# RUN: llvm-bolt %t.exe --data %t.fdata -o %t.null | FileCheck %s
 
 ## Check that profile is correctly matched by functions with variable suffixes.
 ## E.g., LTO-generated name foo.llvm.123 should match foo.llvm.*.

--- a/bolt/test/X86/no-entry-reordering.test
+++ b/bolt/test/X86/no-entry-reordering.test
@@ -5,7 +5,7 @@ RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %S/Inputs/entry.s -o %
 RUN: link_fdata %S/Inputs/entry.s %t.o %t.fdata --nmtool llvm-nm
 RUN: llvm-strip --strip-unneeded %t.o
 RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
-RUN: llvm-bolt %t.exe --data %t.fdata -o /dev/null --reorder-blocks=normal \
+RUN: llvm-bolt %t.exe --data %t.fdata -o %t.null --reorder-blocks=normal \
 RUN:   --funcs=_start --print-reordered --sequential-disassembly | FileCheck %s
 
 CHECK:  BB Layout : .LBB00, {{.*}}

--- a/bolt/test/X86/pt_gnu_relro.s
+++ b/bolt/test/X86/pt_gnu_relro.s
@@ -21,7 +21,7 @@
 # READELF: Section to Segment mapping:
 # READELF: 04 .got
 
-# RUN: llvm-bolt %t.exe --relocs -o /dev/null -v=1 \
+# RUN: llvm-bolt %t.exe --relocs -o %t.null -v=1 \
 # RUN:   |& FileCheck --check-prefix=BOLT %s
 # BOLT: BOLT-INFO: marking .got as GNU_RELRO
 

--- a/bolt/test/X86/reader-stale-yaml.test
+++ b/bolt/test/X86/reader-stale-yaml.test
@@ -3,11 +3,11 @@
 
 RUN: yaml2obj %p/Inputs/blarge.yaml &> %t.exe
 # Testing "usqrt"
-RUN: llvm-bolt %t.exe -o /dev/null --b %p/Inputs/blarge_profile_stale.yaml \
+RUN: llvm-bolt %t.exe -o %t.null --b %p/Inputs/blarge_profile_stale.yaml \
 RUN:   --print-cfg --print-only=usqrt --infer-stale-profile=1 \
 RUN:   --profile-ignore-hash=1 --profile-use-dfs=0 2>&1 | FileCheck %s -check-prefix=CHECK1
 # Testing "SolveCubic"
-RUN: llvm-bolt %t.exe -o /dev/null --b %p/Inputs/blarge_profile_stale.yaml \
+RUN: llvm-bolt %t.exe -o %t.null --b %p/Inputs/blarge_profile_stale.yaml \
 RUN:   --print-cfg --print-only=SolveCubic --infer-stale-profile=1 \
 RUN:   --profile-ignore-hash=1 --profile-use-dfs=0 2>&1 | FileCheck %s -check-prefix=CHECK2
 

--- a/bolt/test/X86/reader.test
+++ b/bolt/test/X86/reader.test
@@ -1,7 +1,7 @@
 # This script checks that DataReader in llvm-bolt is reading data correctly
 
 RUN: yaml2obj %p/Inputs/blarge.yaml &> %t.exe
-RUN: llvm-bolt %t.exe -o /dev/null --data %p/Inputs/blarge.fdata --dump-data \
+RUN: llvm-bolt %t.exe -o %t.null --data %p/Inputs/blarge.fdata --dump-data \
 RUN:   2>&1 | sort | FileCheck %s -check-prefix=CHECK
 
 CHECK:  main 1105 SolveCubic 0 0 151

--- a/bolt/test/X86/sctc-bug.test
+++ b/bolt/test/X86/sctc-bug.test
@@ -1,7 +1,7 @@
 # Check that we don't accidentally optimize out a tail call.
 
 RUN: %clang %cflags %S/Inputs/sctc_bug.s -o %t
-RUN: llvm-bolt %t -o /dev/null --funcs=main --print-after-lowering \
+RUN: llvm-bolt %t -o %t.null --funcs=main --print-after-lowering \
 RUN:   2>&1 | FileCheck %s
 
 CHECK:   jp      .L{{.*}}

--- a/bolt/test/X86/sctc-bug2.test
+++ b/bolt/test/X86/sctc-bug2.test
@@ -1,7 +1,7 @@
 # Check that conditional tail call is not treated as a regular tail call by SCTC.
 
 RUN: %clang %cflags %S/Inputs/sctc_bug2.s -o %t
-RUN: llvm-bolt %t -o /dev/null --funcs=main --print-after-lowering \
+RUN: llvm-bolt %t -o %t.null --funcs=main --print-after-lowering \
 RUN:   --sequential-disassembly 2>&1 | FileCheck %s
 
 CHECK: .LFT1

--- a/bolt/test/X86/sctc-bug3.test
+++ b/bolt/test/X86/sctc-bug3.test
@@ -1,7 +1,7 @@
 # Check that we don't accidentally optimize out a tail call.
 
 RUN: %clang %cflags %S/Inputs/sctc_bug3.s -o %t
-RUN: llvm-bolt %t -o /dev/null --funcs=main --print-after-lowering \
+RUN: llvm-bolt %t -o %t.null --funcs=main --print-after-lowering \
 RUN:   --sequential-disassembly 2>&1 | FileCheck %s
 
 CHECK: .LBB00 (1 instructions, align : 1)

--- a/bolt/test/X86/sctc-bug4.test
+++ b/bolt/test/X86/sctc-bug4.test
@@ -1,7 +1,7 @@
 # Check that fallthrough blocks are handled properly.
 
 RUN: %clang %cflags %S/Inputs/sctc_bug4.s -o %t
-RUN: llvm-bolt %t -o /dev/null \
+RUN: llvm-bolt %t -o %t.null \
 RUN:   -funcs=test_func -print-sctc -sequential-disassembly 2>&1 | FileCheck %s
 
 CHECK:      .Ltmp2 (3 instructions, align : 1)

--- a/bolt/test/X86/section-end-sym.s
+++ b/bolt/test/X86/section-end-sym.s
@@ -5,7 +5,7 @@
 
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %s -o %t.o
 # RUN: ld.lld %t.o -o %t.exe -q
-# RUN: llvm-bolt %t.exe -o /dev/null --print-cfg --debug-only=bolt 2>&1 \
+# RUN: llvm-bolt %t.exe -o %t.null --print-cfg --debug-only=bolt 2>&1 \
 # RUN:   | FileCheck %s
 
 # CHECK: considering symbol etext for function

--- a/bolt/test/X86/tailcall.test
+++ b/bolt/test/X86/tailcall.test
@@ -2,7 +2,7 @@
 # in control flow graph.
 
 RUN: %clang %cflags %S/Inputs/tailcall.s -o %t.exe
-RUN: llvm-bolt %t.exe -o /dev/null --print-cfg 2>&1 | FileCheck %s
+RUN: llvm-bolt %t.exe -o %t.null --print-cfg 2>&1 | FileCheck %s
 
 CHECK:  Binary Function "foo"
 CHECK:    jmp     bar # TAILCALL

--- a/bolt/test/X86/vararg.test
+++ b/bolt/test/X86/vararg.test
@@ -5,7 +5,7 @@
 REQUIRES: x86_64-linux
 
 RUN: %clangxx %cxxflags -no-pie %p/../Inputs/vararg.s -o %t -Wl,-q
-RUN: llvm-bolt %t -o /dev/null --print-cfg --print-only=.*printf.* |& FileCheck %s
+RUN: llvm-bolt %t -o %t.null --print-cfg --print-only=.*printf.* |& FileCheck %s
 
 CHECK: IsSimple    : 0
 CHECK: Entry Point

--- a/bolt/test/X86/yaml-multiple-profiles.test
+++ b/bolt/test/X86/yaml-multiple-profiles.test
@@ -5,7 +5,7 @@
 # RUN: split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %t/main.s -o %t.o
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
-# RUN: llvm-bolt %t.exe -o /dev/null --data %t/profile.yaml \
+# RUN: llvm-bolt %t.exe -o %t.null --data %t/profile.yaml \
 # RUN:   --profile-ignore-hash -v=1 2>&1 | FileCheck %s
 # CHECK: BOLT-WARNING: dropping duplicate profile for main_alias(*2)
 #--- main.s

--- a/bolt/test/bad-exe.test
+++ b/bolt/test/bad-exe.test
@@ -7,6 +7,6 @@ REQUIRES: system-linux
 
 RUN: %clang %cflags %S/Inputs/icf-jump-tables.c -g -o %t
 RUN: llvm-objcopy --only-keep-debug %t %t.debuginfo
-RUN: not llvm-bolt %t.debuginfo -o /dev/null 2>&1 | FileCheck %s
+RUN: not llvm-bolt %t.debuginfo -o %t.null 2>&1 | FileCheck %s
 
 CHECK: input binary is not a valid ELF executable

--- a/bolt/test/no-relocs.test
+++ b/bolt/test/no-relocs.test
@@ -5,6 +5,6 @@
 REQUIRES: system-linux
 
 RUN: %clang %cflags %S/Inputs/icf-jump-tables.c -o %t
-RUN: not llvm-bolt %t -o /dev/null --relocs 2>&1 | FileCheck %s
+RUN: not llvm-bolt %t -o %t.null --relocs 2>&1 | FileCheck %s
 
 CHECK: BOLT-ERROR: relocations against code are missing from the input file.

--- a/bolt/test/pie.test
+++ b/bolt/test/pie.test
@@ -5,6 +5,6 @@
 REQUIRES: system-linux
 
 RUN: %clang %cflags -fPIC -pie %p/Inputs/jump_table_icp.cpp -o %t
-RUN: llvm-bolt %t -o /dev/null 2>&1 | FileCheck %s
+RUN: llvm-bolt %t -o %t.null 2>&1 | FileCheck %s
 
 CHECK: BOLT-INFO: shared object or position-independent executable detected

--- a/bolt/test/re-optimize.test
+++ b/bolt/test/re-optimize.test
@@ -5,7 +5,7 @@
 REQUIRES: system-linux
 
 RUN: %clang %cflags %S/Inputs/icf-jump-tables.c -o %t.exe
-RUN: llvm-bolt %t.exe -o %t 2>&1 > /dev/null
+RUN: llvm-bolt %t.exe -o %t 2>&1 > %t.null
 RUN: not llvm-bolt %t -o %t.bolt 2>&1 | FileCheck %s
 
 CHECK: BOLT-ERROR: input file was processed by BOLT. Cannot re-optimize.

--- a/bolt/test/runtime/X86/asm-dump.c
+++ b/bolt/test/runtime/X86/asm-dump.c
@@ -14,7 +14,7 @@
  * RUN: %t.instr > %t.result
  *
  * Run BOLT with asm-dump
- * RUN: llvm-bolt %t.exe -p %t.fdata --funcs=main --asm-dump=%t -o /dev/null \
+ * RUN: llvm-bolt %t.exe -p %t.fdata --funcs=main --asm-dump=%t -o %t.null \
  * RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
  *
  * Check asm file contents
@@ -42,7 +42,7 @@
  * RUN: %clang -fPIC %t.o -o %t.exe.reopt -Wl,-q
  *
  * Finally consume reoptimized file with reconstructed fdata
- * RUN: llvm-bolt %t.exe.reopt -p %t.fdata.reconst -o /dev/null \
+ * RUN: llvm-bolt %t.exe.reopt -p %t.fdata.reconst -o %t.null \
  * RUN:   | FileCheck %s --check-prefix=CHECK-REOPT
  *
  * CHECK-BOLT: BOLT-INFO: Dumping function assembly to {{.*}}/main.s

--- a/bolt/test/yaml-profile-kind.c
+++ b/bolt/test/yaml-profile-kind.c
@@ -1,10 +1,10 @@
 /* This test checks the handling of YAML profile with different block orders.
 # RUN: %clang %cflags %s -o %t.exe
 # RUN: link_fdata %s %t.exe %t.fdata
-# RUN: llvm-bolt %t.exe -o /dev/null -data %t.fdata -w %t.yaml
+# RUN: llvm-bolt %t.exe -o %t.null -data %t.fdata -w %t.yaml
 # RUN: FileCheck %s --input-file %t.yaml --check-prefix=CHECK-BINARY
 # CHECK-BINARY: dfs-order: false
-# RUN: llvm-bolt %t.exe -o /dev/null -data %t.fdata -w %t.yaml --profile-use-dfs
+# RUN: llvm-bolt %t.exe -o %t.null -data %t.fdata -w %t.yaml --profile-use-dfs
 # RUN: FileCheck %s --input-file %t.yaml --check-prefix=CHECK-DFS
 # CHECK-DFS: dfs-order: true
 


### PR DESCRIPTION
NFC processing time script identifies tests by output filename.
When `/dev/null` is used as output filename, we're unable to tell the
source test, and the reports are unhelpful.
Replace `/dev/null/ with `%t.null` which resolves the issue.
