### PR TITLE
AArch64: switch Apple CPUs (that support it) to v8.6a.

### DIFF
--- a/llvm/include/llvm/TargetParser/AArch64TargetParser.h
+++ b/llvm/include/llvm/TargetParser/AArch64TargetParser.h
@@ -593,25 +593,22 @@ inline constexpr CpuInfo CpuInfos[] = {
      (AArch64::ExtensionBitset(
          {AArch64::AEK_AES, AArch64::AEK_SHA2, AArch64::AEK_SHA3,
           AArch64::AEK_FP16, AArch64::AEK_FP16FML}))},
-    {"apple-a15", ARMV8_5A,
+    {"apple-a15", ARMV8_6A,
      (AArch64::ExtensionBitset(
          {AArch64::AEK_AES, AArch64::AEK_SHA2, AArch64::AEK_SHA3,
-          AArch64::AEK_FP16, AArch64::AEK_FP16FML,
-          AArch64::AEK_BF16, AArch64::AEK_I8MM}))},
-    {"apple-a16", ARMV8_5A,
+          AArch64::AEK_FP16, AArch64::AEK_FP16FML}))},
+    {"apple-a16", ARMV8_6A,
      (AArch64::ExtensionBitset(
          {AArch64::AEK_AES, AArch64::AEK_SHA2, AArch64::AEK_SHA3,
-          AArch64::AEK_FP16, AArch64::AEK_FP16FML,
-          AArch64::AEK_BF16, AArch64::AEK_I8MM}))},
+          AArch64::AEK_FP16, AArch64::AEK_FP16FML}))},
     {"apple-m1", ARMV8_5A,
      (AArch64::ExtensionBitset(
          {AArch64::AEK_AES, AArch64::AEK_SHA2, AArch64::AEK_SHA3,
           AArch64::AEK_FP16, AArch64::AEK_FP16FML}))},
-    {"apple-m2", ARMV8_5A,
+    {"apple-m2", ARMV8_6A,
      (AArch64::ExtensionBitset(
          {AArch64::AEK_AES, AArch64::AEK_SHA2, AArch64::AEK_SHA3,
-          AArch64::AEK_FP16, AArch64::AEK_FP16FML,
-          AArch64::AEK_BF16, AArch64::AEK_I8MM}))},
+          AArch64::AEK_FP16, AArch64::AEK_FP16FML}))},
     {"apple-s4", ARMV8_3A,
      (AArch64::ExtensionBitset(
          {AArch64::AEK_AES, AArch64::AEK_SHA2, AArch64::AEK_FP16}))},

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1389,7 +1389,7 @@ INSTANTIATE_TEST_SUITE_P(
                  AArch64::AEK_FP16FML, AArch64::AEK_SHA3})),
             "8.5-A"),
         ARMCPUTestParams<AArch64::ExtensionBitset>(
-            "apple-a15", "armv8.5-a", "crypto-neon-fp-armv8",
+            "apple-a15", "armv8.6-a", "crypto-neon-fp-armv8",
             (AArch64::ExtensionBitset(
                 {AArch64::AEK_CRC, AArch64::AEK_AES, AArch64::AEK_SHA2,
                  AArch64::AEK_SHA3, AArch64::AEK_FP, AArch64::AEK_SIMD,
@@ -1397,9 +1397,9 @@ INSTANTIATE_TEST_SUITE_P(
                  AArch64::AEK_RCPC, AArch64::AEK_DOTPROD, AArch64::AEK_FP16,
                  AArch64::AEK_FP16FML, AArch64::AEK_SHA3, AArch64::AEK_BF16,
                  AArch64::AEK_I8MM})),
-            "8.5-A"),
+            "8.6-A"),
         ARMCPUTestParams<AArch64::ExtensionBitset>(
-            "apple-a16", "armv8.5-a", "crypto-neon-fp-armv8",
+            "apple-a16", "armv8.6-a", "crypto-neon-fp-armv8",
             (AArch64::ExtensionBitset(
                 {AArch64::AEK_CRC, AArch64::AEK_AES, AArch64::AEK_SHA2,
                  AArch64::AEK_SHA3, AArch64::AEK_FP, AArch64::AEK_SIMD,
@@ -1407,7 +1407,7 @@ INSTANTIATE_TEST_SUITE_P(
                  AArch64::AEK_RCPC, AArch64::AEK_DOTPROD, AArch64::AEK_FP16,
                  AArch64::AEK_FP16FML, AArch64::AEK_SHA3, AArch64::AEK_BF16,
                  AArch64::AEK_I8MM})),
-            "8.5-A"),
+            "8.6-A"),
         ARMCPUTestParams<AArch64::ExtensionBitset>(
             "apple-m1", "armv8.5-a", "crypto-neon-fp-armv8",
             (AArch64::ExtensionBitset(
@@ -1418,7 +1418,7 @@ INSTANTIATE_TEST_SUITE_P(
                  AArch64::AEK_FP16FML, AArch64::AEK_SHA3})),
             "8.5-A"),
         ARMCPUTestParams<AArch64::ExtensionBitset>(
-            "apple-m2", "armv8.5-a", "crypto-neon-fp-armv8",
+            "apple-m2", "armv8.6-a", "crypto-neon-fp-armv8",
             (AArch64::ExtensionBitset(
                 {AArch64::AEK_CRC, AArch64::AEK_AES, AArch64::AEK_SHA2,
                  AArch64::AEK_SHA3, AArch64::AEK_FP, AArch64::AEK_SIMD,
@@ -1426,7 +1426,7 @@ INSTANTIATE_TEST_SUITE_P(
                  AArch64::AEK_RCPC, AArch64::AEK_DOTPROD, AArch64::AEK_FP16,
                  AArch64::AEK_FP16FML, AArch64::AEK_SHA3, AArch64::AEK_BF16,
                  AArch64::AEK_I8MM})),
-            "8.5-A"),
+            "8.6-A"),
         ARMCPUTestParams<AArch64::ExtensionBitset>(
             "apple-s4", "armv8.3-a", "crypto-neon-fp-armv8",
             (AArch64::ExtensionBitset(


### PR DESCRIPTION
We pretended they were v8.5a in the past because LLVM's modelling used to fold SM4 crypto support into v8.6a (which the CPUs don't actually have). That's changed in the last year so we can use the real value.

This is mostly a tidy-up commit before one that'll bring in A17 and M3.