### PR TITLE
[NFC] Change FindDbgDeclareUsers interface to match findDbgUsers/values

### DIFF
--- a/llvm/include/llvm/IR/DebugInfo.h
+++ b/llvm/include/llvm/IR/DebugInfo.h
@@ -40,7 +40,7 @@ class Module;
 
 /// Finds dbg.declare intrinsics declaring local variables as living in the
 /// memory that 'V' points to.
-TinyPtrVector<DbgDeclareInst *> FindDbgDeclareUses(Value *V);
+void findDbgDeclares(SmallVectorImpl<DbgDeclareInst *> &DbgUsers, Value *V);
 
 /// Finds the llvm.dbg.value intrinsics describing a value.
 void findDbgValues(SmallVectorImpl<DbgValueInst *> &DbgValues,

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -44,25 +44,24 @@ using namespace llvm;
 using namespace llvm::at;
 using namespace llvm::dwarf;
 
-TinyPtrVector<DbgDeclareInst *> llvm::FindDbgDeclareUses(Value *V) {
+void llvm::findDbgDeclares(SmallVectorImpl<DbgDeclareInst *> &DbgUsers,
+                           Value *V) {
   // This function is hot. Check whether the value has any metadata to avoid a
   // DenseMap lookup.
   if (!V->isUsedByMetadata())
-    return {};
+    return;
   auto *L = LocalAsMetadata::getIfExists(V);
   if (!L)
-    return {};
+    return;
   auto *MDV = MetadataAsValue::getIfExists(V->getContext(), L);
   if (!MDV)
-    return {};
+    return;
 
   TinyPtrVector<DbgDeclareInst *> Declares;
   for (User *U : MDV->users()) {
     if (auto *DDI = dyn_cast<DbgDeclareInst>(U))
       Declares.push_back(DDI);
   }
-
-  return Declares;
 }
 
 template <typename IntrinsicT>

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -57,10 +57,9 @@ void llvm::findDbgDeclares(SmallVectorImpl<DbgDeclareInst *> &DbgUsers,
   if (!MDV)
     return;
 
-  TinyPtrVector<DbgDeclareInst *> Declares;
   for (User *U : MDV->users()) {
     if (auto *DDI = dyn_cast<DbgDeclareInst>(U))
-      Declares.push_back(DDI);
+      DbgUsers.push_back(DDI);
   }
 }
 

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -963,7 +963,8 @@ static void cacheDIVar(FrameDataInfo &FrameData,
     if (DIVarCache.contains(V))
       continue;
 
-    auto DDIs = FindDbgDeclareUses(V);
+    SmallVector<DbgDeclareInst *> DDIs;
+    findDbgDeclares(DDIs, V);
     auto *I = llvm::find_if(DDIs, [](DbgDeclareInst *DDI) {
       return DDI->getExpression()->getNumElements() == 0;
     });
@@ -1119,7 +1120,8 @@ static void buildFrameDebugInfo(Function &F, coro::Shape &Shape,
   assert(PromiseAlloca &&
          "Coroutine with switch ABI should own Promise alloca");
 
-  TinyPtrVector<DbgDeclareInst *> DIs = FindDbgDeclareUses(PromiseAlloca);
+  SmallVector<DbgDeclareInst *> DIs;
+  findDbgDeclares(DIs, PromiseAlloca);
   if (DIs.empty())
     return;
 
@@ -1840,7 +1842,8 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
               FrameTy->getElementType(FrameData.getFieldIndex(E.first)), GEP,
               SpillAlignment, E.first->getName() + Twine(".reload"));
 
-        TinyPtrVector<DbgDeclareInst *> DIs = FindDbgDeclareUses(Def);
+        SmallVector<DbgDeclareInst *> DIs;
+        findDbgDeclares(DIs, Def);
         // Try best to find dbg.declare. If the spill is a temp, there may not
         // be a direct dbg.declare. Walk up the load chain to find one from an
         // alias.
@@ -1854,7 +1857,8 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
             CurDef = LdInst->getPointerOperand();
             if (!isa<AllocaInst, LoadInst>(CurDef))
               break;
-            DIs = FindDbgDeclareUses(CurDef);
+            DIs.clear();
+            findDbgDeclares(DIs, CurDef);
           }
         }
 

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -963,7 +963,7 @@ static void cacheDIVar(FrameDataInfo &FrameData,
     if (DIVarCache.contains(V))
       continue;
 
-    SmallVector<DbgDeclareInst *> DDIs;
+    SmallVector<DbgDeclareInst *, 1> DDIs;
     findDbgDeclares(DDIs, V);
     auto *I = llvm::find_if(DDIs, [](DbgDeclareInst *DDI) {
       return DDI->getExpression()->getNumElements() == 0;
@@ -1120,7 +1120,7 @@ static void buildFrameDebugInfo(Function &F, coro::Shape &Shape,
   assert(PromiseAlloca &&
          "Coroutine with switch ABI should own Promise alloca");
 
-  SmallVector<DbgDeclareInst *> DIs;
+  SmallVector<DbgDeclareInst *, 1> DIs;
   findDbgDeclares(DIs, PromiseAlloca);
   if (DIs.empty())
     return;
@@ -1842,7 +1842,7 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
               FrameTy->getElementType(FrameData.getFieldIndex(E.first)), GEP,
               SpillAlignment, E.first->getName() + Twine(".reload"));
 
-        SmallVector<DbgDeclareInst *> DIs;
+        SmallVector<DbgDeclareInst *, 1> DIs;
         findDbgDeclares(DIs, Def);
         // Try best to find dbg.declare. If the spill is a temp, there may not
         // be a direct dbg.declare. Walk up the load chain to find one from an

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -4940,10 +4940,13 @@ bool SROA::splitAlloca(AllocaInst &AI, AllocaSlices &AS) {
   // Migrate debug information from the old alloca to the new alloca(s)
   // and the individual partitions.
   TinyPtrVector<DbgVariableIntrinsic *> DbgVariables;
-  for (auto *DbgDeclare : FindDbgDeclareUses(&AI))
+  SmallVector<DbgDeclareInst *> DbgDeclares;
+  findDbgDeclares(DbgDeclares, &AI);
+  for (auto *DbgDeclare : DbgDeclares)
     DbgVariables.push_back(DbgDeclare);
   for (auto *DbgAssign : at::getAssignmentMarkers(&AI))
     DbgVariables.push_back(DbgAssign);
+
   for (DbgVariableIntrinsic *DbgVariable : DbgVariables) {
     auto *Expr = DbgVariable->getExpression();
     DIBuilder DIB(*AI.getModule(), /*AllowUnresolved*/ false);
@@ -4997,7 +5000,9 @@ bool SROA::splitAlloca(AllocaInst &AI, AllocaSlices &AS) {
 
       // Remove any existing intrinsics on the new alloca describing
       // the variable fragment.
-      for (DbgDeclareInst *OldDII : FindDbgDeclareUses(Fragment.Alloca)) {
+      SmallVector<DbgDeclareInst *> FragDbgDeclares;
+      findDbgDeclares(FragDbgDeclares, Fragment.Alloca);
+      for (DbgDeclareInst *OldDII : FragDbgDeclares) {
         auto SameVariableFragment = [](const DbgVariableIntrinsic *LHS,
                                        const DbgVariableIntrinsic *RHS) {
           return LHS->getVariable() == RHS->getVariable() &&
@@ -5147,7 +5152,9 @@ bool SROA::deleteDeadInstructions(
     // not be able to find it.
     if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) {
       DeletedAllocas.insert(AI);
-      for (DbgDeclareInst *OldDII : FindDbgDeclareUses(AI))
+      SmallVector<DbgDeclareInst *> DbgDeclares;
+      findDbgDeclares(DbgDeclares, AI);
+      for (DbgDeclareInst *OldDII : DbgDeclares)
         OldDII->eraseFromParent();
     }
 

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -4940,7 +4940,7 @@ bool SROA::splitAlloca(AllocaInst &AI, AllocaSlices &AS) {
   // Migrate debug information from the old alloca to the new alloca(s)
   // and the individual partitions.
   TinyPtrVector<DbgVariableIntrinsic *> DbgVariables;
-  SmallVector<DbgDeclareInst *> DbgDeclares;
+  SmallVector<DbgDeclareInst *, 1> DbgDeclares;
   findDbgDeclares(DbgDeclares, &AI);
   for (auto *DbgDeclare : DbgDeclares)
     DbgVariables.push_back(DbgDeclare);
@@ -5000,7 +5000,7 @@ bool SROA::splitAlloca(AllocaInst &AI, AllocaSlices &AS) {
 
       // Remove any existing intrinsics on the new alloca describing
       // the variable fragment.
-      SmallVector<DbgDeclareInst *> FragDbgDeclares;
+      SmallVector<DbgDeclareInst *, 1> FragDbgDeclares;
       findDbgDeclares(FragDbgDeclares, Fragment.Alloca);
       for (DbgDeclareInst *OldDII : FragDbgDeclares) {
         auto SameVariableFragment = [](const DbgVariableIntrinsic *LHS,
@@ -5152,7 +5152,7 @@ bool SROA::deleteDeadInstructions(
     // not be able to find it.
     if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) {
       DeletedAllocas.insert(AI);
-      SmallVector<DbgDeclareInst *> DbgDeclares;
+      SmallVector<DbgDeclareInst *, 1> DbgDeclares;
       findDbgDeclares(DbgDeclares, AI);
       for (DbgDeclareInst *OldDII : DbgDeclares)
         OldDII->eraseFromParent();

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -2103,7 +2103,8 @@ void llvm::insertDebugValuesForPHIs(BasicBlock *BB,
 bool llvm::replaceDbgDeclare(Value *Address, Value *NewAddress,
                              DIBuilder &Builder, uint8_t DIExprFlags,
                              int Offset) {
-  auto DbgDeclares = FindDbgDeclareUses(Address);
+  SmallVector<DbgDeclareInst *> DbgDeclares;
+  findDbgDeclares(DbgDeclares, Address);
   for (DbgVariableIntrinsic *DII : DbgDeclares) {
     const DebugLoc &Loc = DII->getDebugLoc();
     auto *DIVar = DII->getVariable();

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -2103,7 +2103,7 @@ void llvm::insertDebugValuesForPHIs(BasicBlock *BB,
 bool llvm::replaceDbgDeclare(Value *Address, Value *NewAddress,
                              DIBuilder &Builder, uint8_t DIExprFlags,
                              int Offset) {
-  SmallVector<DbgDeclareInst *> DbgDeclares;
+  SmallVector<DbgDeclareInst *, 1> DbgDeclares;
   findDbgDeclares(DbgDeclares, Address);
   for (DbgVariableIntrinsic *DII : DbgDeclares) {
     const DebugLoc &Loc = DII->getDebugLoc();

--- a/llvm/lib/Transforms/Utils/MemoryOpRemark.cpp
+++ b/llvm/lib/Transforms/Utils/MemoryOpRemark.cpp
@@ -321,8 +321,9 @@ void MemoryOpRemark::visitVariable(const Value *V,
   bool FoundDI = false;
   // Try to get an llvm.dbg.declare, which has a DILocalVariable giving us the
   // real debug info name and size of the variable.
-  for (const DbgVariableIntrinsic *DVI :
-       FindDbgDeclareUses(const_cast<Value *>(V))) {
+  SmallVector<DbgDeclareInst *> DbgDeclares;
+  findDbgDeclares(DbgDeclares, const_cast<Value *>(V));
+  for (const DbgVariableIntrinsic *DVI : DbgDeclares) {
     if (DILocalVariable *DILV = DVI->getVariable()) {
       std::optional<uint64_t> DISize = getSizeInBytes(DILV->getSizeInBits());
       VariableInfo Var{DILV->getName(), DISize};

--- a/llvm/lib/Transforms/Utils/MemoryOpRemark.cpp
+++ b/llvm/lib/Transforms/Utils/MemoryOpRemark.cpp
@@ -321,7 +321,7 @@ void MemoryOpRemark::visitVariable(const Value *V,
   bool FoundDI = false;
   // Try to get an llvm.dbg.declare, which has a DILocalVariable giving us the
   // real debug info name and size of the variable.
-  SmallVector<DbgDeclareInst *> DbgDeclares;
+  SmallVector<DbgDeclareInst *, 1> DbgDeclares;
   findDbgDeclares(DbgDeclares, const_cast<Value *>(V));
   for (const DbgVariableIntrinsic *DVI : DbgDeclares) {
     if (DILocalVariable *DILV = DVI->getVariable()) {


### PR DESCRIPTION
This simplifies an upcoming patch to support the RemoveDIs project (tracking variable locations without using intrinsics).

---

In the next patch we'll be adding another out-parameter, so the ugliness is worth it.