### PR TITLE
piper export cl 583969847

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysis.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowAnalysis.h
@@ -234,6 +234,22 @@ runDataflowAnalysis(
   return std::move(BlockStates);
 }
 
+// Create an analysis class that is derived from `DataflowAnalysis`. This is an
+// SFINAE adapter that allows us to call two different variants of constructor
+// (either with or without the optional `Environment` parameter).
+// FIXME: Make all classes derived from `DataflowAnalysis` take an `Environment`
+// parameter in their constructor so that we can get rid of this abomination.
+template <typename AnalysisT>
+auto createAnalysis(ASTContext &ASTCtx, Environment &Env)
+    -> decltype(AnalysisT(ASTCtx, Env)) {
+  return AnalysisT(ASTCtx, Env);
+}
+template <typename AnalysisT>
+auto createAnalysis(ASTContext &ASTCtx, Environment &Env)
+    -> decltype(AnalysisT(ASTCtx)) {
+  return AnalysisT(ASTCtx);
+}
+
 /// Runs a dataflow analysis over the given function and then runs `Diagnoser`
 /// over the results. Returns a list of diagnostics for `FuncDecl` or an
 /// error. Currently, errors can occur (at least) because the analysis requires
@@ -262,7 +278,7 @@ llvm::Expected<llvm::SmallVector<Diagnostic>> diagnoseFunction(
   const WatchedLiteralsSolver *Solver = OwnedSolver.get();
   DataflowAnalysisContext AnalysisContext(std::move(OwnedSolver));
   Environment Env(AnalysisContext, FuncDecl);
-  AnalysisT Analysis(ASTCtx);
+  AnalysisT Analysis = createAnalysis<AnalysisT>(ASTCtx, Env);
   llvm::SmallVector<Diagnostic> Diagnostics;
   if (llvm::Error Err =
           runTypeErasedDataflowAnalysis(

--- a/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
@@ -166,6 +166,10 @@ public:
   /// with a symbolic representation of the `this` pointee.
   Environment(DataflowAnalysisContext &DACtx, const DeclContext &DeclCtx);
 
+  /// Assigns storage locations and values to all global variables, fields
+  /// and functions referenced in `FuncDecl`. `FuncDecl` must have a body.
+  void initFieldsGlobalsAndFuncs(const FunctionDecl *FuncDecl);
+
   /// Returns a new environment that is a copy of this one.
   ///
   /// The state of the program is initially the same, but can be mutated without
@@ -283,7 +287,15 @@ public:
   /// Returns the storage location assigned to the `this` pointee in the
   /// environment or null if the `this` pointee has no assigned storage location
   /// in the environment.
-  RecordStorageLocation *getThisPointeeStorageLocation() const;
+  RecordStorageLocation *getThisPointeeStorageLocation() const {
+    return ThisPointeeLoc;
+  }
+
+  /// Sets the storage location assigned to the `this` pointee in the
+  /// environment.
+  void setThisPointeeStorageLocation(RecordStorageLocation &Loc) {
+    ThisPointeeLoc = &Loc;
+  }
 
   /// Returns the location of the result object for a record-type prvalue.
   ///
@@ -570,6 +582,9 @@ public:
     return dyn_cast<FunctionDecl>(getDeclCtx());
   }
 
+  /// Returns the size of the call stack.
+  size_t callStackSize() const { return CallStack.size(); }
+
   /// Returns whether this `Environment` can be extended to analyze the given
   /// `Callee` (i.e. if `pushCall` can be used), with recursion disallowed and a
   /// given `MaxDepth`.
@@ -629,10 +644,7 @@ private:
   void pushCallInternal(const FunctionDecl *FuncDecl,
                         ArrayRef<const Expr *> Args);
 
-  /// Assigns storage locations and values to all global variables, fields
-  /// and functions referenced in `FuncDecl`. `FuncDecl` must have a body.
-  void initFieldsGlobalsAndFuncs(const FunctionDecl *FuncDecl);
-
+private:
   // `DACtx` is not null and not owned by this object.
   DataflowAnalysisContext *DACtx;
 

--- a/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
@@ -379,7 +379,8 @@ public:
   /// storage locations and values for indirections until it finds a
   /// non-pointer/non-reference type.
   ///
-  /// If `Type` is a class, struct, or union type, calls `setValue()` to
+  /// If `Type` is a class, struct, or union type, creates values for all
+  /// modeled fields (including synthetic fields) and calls `setValue()` to
   /// associate the `RecordValue` with its storage location
   /// (`RecordValue::getLoc()`).
   ///

--- a/clang/include/clang/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.h
+++ b/clang/include/clang/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.h
@@ -45,7 +45,7 @@ struct UncheckedOptionalAccessModelOptions {
 class UncheckedOptionalAccessModel
     : public DataflowAnalysis<UncheckedOptionalAccessModel, NoopLattice> {
 public:
-  UncheckedOptionalAccessModel(ASTContext &Ctx);
+  UncheckedOptionalAccessModel(ASTContext &Ctx, dataflow::Environment &Env);
 
   /// Returns a matcher for the optional classes covered by this model.
   static ast_matchers::DeclarationMatcher optionalClassDecl();
@@ -53,17 +53,6 @@ public:
   static NoopLattice initialElement() { return {}; }
 
   void transfer(const CFGElement &Elt, NoopLattice &L, Environment &Env);
-
-  ComparisonResult compare(QualType Type, const Value &Val1,
-                           const Environment &Env1, const Value &Val2,
-                           const Environment &Env2) override;
-
-  bool merge(QualType Type, const Value &Val1, const Environment &Env1,
-             const Value &Val2, const Environment &Env2, Value &MergedVal,
-             Environment &MergedEnv) override;
-
-  Value *widen(QualType Type, Value &Prev, const Environment &PrevEnv,
-               Value &Current, Environment &CurrentEnv) override;
 
 private:
   CFGMatchSwitch<TransferState<NoopLattice>> TransferMatchSwitch;

--- a/clang/include/clang/Analysis/FlowSensitive/RecordOps.h
+++ b/clang/include/clang/Analysis/FlowSensitive/RecordOps.h
@@ -21,10 +21,10 @@ namespace dataflow {
 
 /// Copies a record (struct, class, or union) from `Src` to `Dst`.
 ///
-/// This performs a deep copy, i.e. it copies every field and recurses on
-/// fields of record type. It also copies properties from the `RecordValue`
-/// associated with `Src` to the `RecordValue` associated with `Dst` (if these
-/// `RecordValue`s exist).
+/// This performs a deep copy, i.e. it copies every field (including synthetic
+/// fields) and recurses on fields of record type. It also copies properties
+/// from the `RecordValue` associated with `Src` to the `RecordValue` associated
+/// with `Dst` (if these `RecordValue`s exist).
 ///
 /// If there is a `RecordValue` associated with `Dst` in the environment, this
 /// function creates a new `RecordValue` and associates it with `Dst`; clients
@@ -47,10 +47,11 @@ void copyRecord(RecordStorageLocation &Src, RecordStorageLocation &Dst,
 /// retrieved from `Env2`. A convenience overload retrieves values for `Loc1`
 /// and `Loc2` from the same environment.
 ///
-/// This performs a deep comparison, i.e. it compares every field and recurses
-/// on fields of record type. Fields of reference type compare equal if they
-/// refer to the same storage location. If `RecordValue`s are associated with
-/// `Loc1` and `Loc2`, it also compares the properties on those `RecordValue`s.
+/// This performs a deep comparison, i.e. it compares every field (including
+/// synthetic fields) and recurses on fields of record type. Fields of reference
+/// type compare equal if they refer to the same storage location. If
+/// `RecordValue`s are associated with `Loc1` and Loc2`, it also compares the
+/// properties on those `RecordValue`s.
 ///
 /// Note on how to interpret the result:
 /// - If this returns true, the records are guaranteed to be equal at runtime.

--- a/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
+++ b/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
@@ -73,7 +73,13 @@ public:
 ///
 /// Contains storage locations for all modeled fields of the record (also
 /// referred to as "children"). The child map is flat, so accessible members of
-/// the base class are directly accesible as children of this location.
+/// the base class are directly accessible as children of this location.
+///
+/// Record storage locations may also contain so-called synthetic fields. These
+/// are typically used to the internal state of a class (e.g. the value stored
+/// in a `std::optional`) without having to depend on that class's
+/// implementation details. All `RecordStorageLocation`s of a given type should
+/// have the same synthetic fields.
 ///
 /// The storage location for a field of reference type may be null. This
 /// typically occurs in one of two situations:
@@ -88,12 +94,12 @@ public:
 class RecordStorageLocation final : public StorageLocation {
 public:
   using FieldToLoc = llvm::DenseMap<const ValueDecl *, StorageLocation *>;
+  using SyntheticFieldMap = llvm::StringMap<StorageLocation *>;
 
-  explicit RecordStorageLocation(QualType Type)
-      : RecordStorageLocation(Type, FieldToLoc()) {}
-
-  RecordStorageLocation(QualType Type, FieldToLoc TheChildren)
-      : StorageLocation(Kind::Record, Type), Children(std::move(TheChildren)) {
+  RecordStorageLocation(QualType Type, FieldToLoc TheChildren,
+                        SyntheticFieldMap TheSyntheticFields)
+      : StorageLocation(Kind::Record, Type), Children(std::move(TheChildren)),
+        SyntheticFields(std::move(TheSyntheticFields)) {
     assert(!Type.isNull());
     assert(Type->isRecordType());
     assert([this] {
@@ -133,6 +139,19 @@ public:
     return It->second;
   }
 
+  /// Returns the storage location for the synthetic field `Name`.
+  /// The synthetic field must exist.
+  StorageLocation &getSyntheticField(llvm::StringRef Name) const {
+    StorageLocation *Loc = SyntheticFields.lookup(Name);
+    assert(Loc != nullptr);
+    return *Loc;
+  }
+
+  llvm::iterator_range<SyntheticFieldMap::const_iterator>
+  synthetic_fields() const {
+    return {SyntheticFields.begin(), SyntheticFields.end()};
+  }
+
   /// Changes the child storage location for a field `D` of reference type.
   /// All other fields cannot change their storage location and always retain
   /// the storage location passed to the `RecordStorageLocation` constructor.
@@ -151,6 +170,7 @@ public:
 
 private:
   FieldToLoc Children;
+  SyntheticFieldMap SyntheticFields;
 };
 
 } // namespace dataflow

--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -367,6 +367,16 @@ getFieldsGlobalsAndFuncs(const Stmt &S, FieldSet &Fields,
   }
 }
 
+Environment::Environment(DataflowAnalysisContext &DACtx)
+    : DACtx(&DACtx),
+      FlowConditionToken(DACtx.arena().makeFlowConditionToken()) {}
+
+Environment::Environment(DataflowAnalysisContext &DACtx,
+                         const DeclContext &DeclCtx)
+    : Environment(DACtx) {
+  CallStack.push_back(&DeclCtx);
+}
+
 // FIXME: Add support for resetting globals after function calls to enable
 // the implementation of sound analyses.
 void Environment::initFieldsGlobalsAndFuncs(const FunctionDecl *FuncDecl) {
@@ -416,57 +426,10 @@ void Environment::initFieldsGlobalsAndFuncs(const FunctionDecl *FuncDecl) {
   }
 }
 
-Environment::Environment(DataflowAnalysisContext &DACtx)
-    : DACtx(&DACtx),
-      FlowConditionToken(DACtx.arena().makeFlowConditionToken()) {}
-
 Environment Environment::fork() const {
   Environment Copy(*this);
   Copy.FlowConditionToken = DACtx->forkFlowCondition(FlowConditionToken);
   return Copy;
-}
-
-Environment::Environment(DataflowAnalysisContext &DACtx,
-                         const DeclContext &DeclCtx)
-    : Environment(DACtx) {
-  CallStack.push_back(&DeclCtx);
-
-  if (const auto *FuncDecl = dyn_cast<FunctionDecl>(&DeclCtx)) {
-    assert(FuncDecl->getBody() != nullptr);
-
-    initFieldsGlobalsAndFuncs(FuncDecl);
-
-    for (const auto *ParamDecl : FuncDecl->parameters()) {
-      assert(ParamDecl != nullptr);
-      setStorageLocation(*ParamDecl, createObject(*ParamDecl, nullptr));
-    }
-  }
-
-  if (const auto *MethodDecl = dyn_cast<CXXMethodDecl>(&DeclCtx)) {
-    auto *Parent = MethodDecl->getParent();
-    assert(Parent != nullptr);
-
-    if (Parent->isLambda()) {
-      for (auto Capture : Parent->captures()) {
-        if (Capture.capturesVariable()) {
-          const auto *VarDecl = Capture.getCapturedVar();
-          assert(VarDecl != nullptr);
-          setStorageLocation(*VarDecl, createObject(*VarDecl, nullptr));
-        } else if (Capture.capturesThis()) {
-          const auto *SurroundingMethodDecl =
-              cast<CXXMethodDecl>(DeclCtx.getNonClosureAncestor());
-          QualType ThisPointeeType =
-              SurroundingMethodDecl->getFunctionObjectParameterType();
-          ThisPointeeLoc =
-              &cast<RecordValue>(createValue(ThisPointeeType))->getLoc();
-        }
-      }
-    } else if (MethodDecl->isImplicitObjectMemberFunction()) {
-      QualType ThisPointeeType = MethodDecl->getFunctionObjectParameterType();
-      ThisPointeeLoc =
-          &cast<RecordValue>(createValue(ThisPointeeType))->getLoc();
-    }
-  }
 }
 
 bool Environment::canDescend(unsigned MaxDepth,
@@ -725,10 +688,6 @@ StorageLocation *Environment::getStorageLocation(const Expr &E) const {
   assert(E.isGLValue() ||
          E.getType()->isSpecificBuiltinType(BuiltinType::BuiltinFn));
   return getStorageLocationInternal(E);
-}
-
-RecordStorageLocation *Environment::getThisPointeeStorageLocation() const {
-  return ThisPointeeLoc;
 }
 
 RecordStorageLocation &

--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -811,8 +811,16 @@ Value *Environment::createValueUnlessSelfReferential(
                                           CreatedValuesCount)});
     }
 
-    RecordStorageLocation &Loc =
-        arena().create<RecordStorageLocation>(Type, std::move(FieldLocs));
+    RecordStorageLocation::SyntheticFieldMap SyntheticFieldLocs;
+    for (const auto &Entry : DACtx->getSyntheticFields(Type)) {
+      SyntheticFieldLocs.insert(
+          {Entry.getKey(),
+           &createLocAndMaybeValue(Entry.getValue(), Visited, Depth + 1,
+                                   CreatedValuesCount)});
+    }
+
+    RecordStorageLocation &Loc = DACtx->createRecordStorageLocation(
+        Type, std::move(FieldLocs), std::move(SyntheticFieldLocs));
     RecordValue &RecordVal = create<RecordValue>(Loc);
 
     // As we already have a storage location for the `RecordValue`, we can and

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
@@ -136,6 +136,10 @@ public:
             if (Value *Val = Env.getValue(*Child.second))
               dump(*Val);
         });
+
+      for (const auto &Prop : RLoc->synthetic_fields())
+        JOS.attributeObject(("sf:" + Prop.first()).str(),
+                            [&] { dump(*Prop.second); });
     }
   }
 

--- a/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
@@ -122,12 +122,6 @@ auto nulloptTypeDecl() {
 
 auto hasNulloptType() { return hasType(nulloptTypeDecl()); }
 
-// `optional` or `nullopt_t`
-auto hasAnyOptionalType() {
-  return hasType(hasUnqualifiedDesugaredType(
-      recordType(hasDeclaration(anyOf(nulloptTypeDecl(), optionalClass())))));
-}
-
 auto inPlaceClass() {
   return recordDecl(hasAnyName("std::in_place_t", "absl::in_place_t",
                                "base::in_place_t", "folly::in_place_t"));
@@ -160,11 +154,6 @@ auto isOptionalValueOrConversionAssignment() {
       unless(hasDeclaration(cxxMethodDecl(
           anyOf(isCopyAssignmentOperator(), isMoveAssignmentOperator())))),
       argumentCountIs(2), hasArgument(1, unless(hasNulloptType())));
-}
-
-auto isNulloptConstructor() {
-  return cxxConstructExpr(hasNulloptType(), argumentCountIs(1),
-                          hasArgument(0, hasNulloptType()));
 }
 
 auto isOptionalNulloptAssignment() {
@@ -246,10 +235,19 @@ const Formula &forceBoolValue(Environment &Env, const Expr &Expr) {
   return Value->formula();
 }
 
+StorageLocation &locForHasValue(const RecordStorageLocation &OptionalLoc) {
+  return OptionalLoc.getSyntheticField("has_value");
+}
+
+StorageLocation &locForValue(const RecordStorageLocation &OptionalLoc) {
+  return OptionalLoc.getSyntheticField("value");
+}
+
 /// Sets `HasValueVal` as the symbolic value that represents the "has_value"
-/// property of the optional value `OptionalVal`.
-void setHasValue(Value &OptionalVal, BoolValue &HasValueVal) {
-  OptionalVal.setProperty("has_value", HasValueVal);
+/// property of the optional at `OptionalLoc`.
+void setHasValue(RecordStorageLocation &OptionalLoc, BoolValue &HasValueVal,
+                 Environment &Env) {
+  Env.setValue(locForHasValue(OptionalLoc), HasValueVal);
 }
 
 /// Creates a symbolic value for an `optional` value at an existing storage
@@ -259,23 +257,22 @@ RecordValue &createOptionalValue(RecordStorageLocation &Loc,
                                  BoolValue &HasValueVal, Environment &Env) {
   auto &OptionalVal = Env.create<RecordValue>(Loc);
   Env.setValue(Loc, OptionalVal);
-  setHasValue(OptionalVal, HasValueVal);
+  setHasValue(Loc, HasValueVal, Env);
   return OptionalVal;
 }
 
 /// Returns the symbolic value that represents the "has_value" property of the
-/// optional value `OptionalVal`. Returns null if `OptionalVal` is null.
-BoolValue *getHasValue(Environment &Env, Value *OptionalVal) {
-  if (OptionalVal != nullptr) {
-    auto *HasValueVal =
-        cast_or_null<BoolValue>(OptionalVal->getProperty("has_value"));
-    if (HasValueVal == nullptr) {
-      HasValueVal = &Env.makeAtomicBoolValue();
-      OptionalVal->setProperty("has_value", *HasValueVal);
-    }
-    return HasValueVal;
+/// optional at `OptionalLoc`. Returns null if `OptionalLoc` is null.
+BoolValue *getHasValue(Environment &Env, RecordStorageLocation *OptionalLoc) {
+  if (OptionalLoc == nullptr)
+    return nullptr;
+  StorageLocation &HasValueLoc = locForHasValue(*OptionalLoc);
+  auto *HasValueVal = cast_or_null<BoolValue>(Env.getValue(HasValueLoc));
+  if (HasValueVal == nullptr) {
+    HasValueVal = &Env.makeAtomicBoolValue();
+    Env.setValue(HasValueLoc, *HasValueVal);
   }
-  return nullptr;
+  return HasValueVal;
 }
 
 /// Returns true if and only if `Type` is an optional type.
@@ -302,155 +299,31 @@ int countOptionalWrappers(const ASTContext &ASTCtx, QualType Type) {
                      .getDesugaredType(ASTCtx));
 }
 
-/// Tries to initialize the `optional`'s value (that is, contents), and return
-/// its location. Returns nullptr if the value can't be represented.
-StorageLocation *maybeInitializeOptionalValueMember(QualType Q,
-                                                    Value &OptionalVal,
-                                                    Environment &Env) {
-  // The "value" property represents a synthetic field. As such, it needs
-  // `StorageLocation`, like normal fields (and other variables). So, we model
-  // it with a `PointerValue`, since that includes a storage location.  Once
-  // the property is set, it will be shared by all environments that access the
-  // `Value` representing the optional (here, `OptionalVal`).
-  if (auto *ValueProp = OptionalVal.getProperty("value")) {
-    auto *ValuePtr = clang::cast<PointerValue>(ValueProp);
-    auto &ValueLoc = ValuePtr->getPointeeLoc();
-    if (Env.getValue(ValueLoc) != nullptr)
-      return &ValueLoc;
-
-    // The property was previously set, but the value has been lost. This can
-    // happen in various situations, for example:
-    // - Because of an environment merge (where the two environments mapped the
-    //   property to different values, which resulted in them both being
-    //   discarded).
-    // - When two blocks in the CFG, with neither a dominator of the other,
-    //   visit the same optional value. (FIXME: This is something we can and
-    //   should fix -- see also the lengthy FIXME below.)
-    // - Or even when a block is revisited during testing to collect
-    //   per-statement state.
-    // FIXME: This situation means that the optional contents are not shared
-    // between branches and the like. Practically, this lack of sharing
-    // reduces the precision of the model when the contents are relevant to
-    // the check, like another optional or a boolean that influences control
-    // flow.
-    if (ValueLoc.getType()->isRecordType()) {
-      refreshRecordValue(cast<RecordStorageLocation>(ValueLoc), Env);
-      return &ValueLoc;
-    } else {
-      auto *ValueVal = Env.createValue(ValueLoc.getType());
-      if (ValueVal == nullptr)
-        return nullptr;
-      Env.setValue(ValueLoc, *ValueVal);
-      return &ValueLoc;
-    }
+StorageLocation *getLocBehindPossiblePointer(const Expr &E,
+                                             const Environment &Env) {
+  if (E.isPRValue()) {
+    if (auto *PointerVal = dyn_cast_or_null<PointerValue>(Env.getValue(E)))
+      return &PointerVal->getPointeeLoc();
+    return nullptr;
   }
-
-  auto Ty = Q.getNonReferenceType();
-  auto &ValueLoc = Env.createObject(Ty);
-  auto &ValuePtr = Env.create<PointerValue>(ValueLoc);
-  // FIXME:
-  // The change we make to the `value` property below may become visible to
-  // other blocks that aren't successors of the current block and therefore
-  // don't see the change we made above mapping `ValueLoc` to `ValueVal`. For
-  // example:
-  //
-  //   void target(optional<int> oo, bool b) {
-  //     // `oo` is associated with a `RecordValue` here, which we will call
-  //     // `OptionalVal`.
-  //
-  //     // The `has_value` property is set on `OptionalVal` (but not the
-  //     // `value` property yet).
-  //     if (!oo.has_value()) return;
-  //
-  //     if (b) {
-  //       // Let's assume we transfer the `if` branch first.
-  //       //
-  //       // This causes us to call `maybeInitializeOptionalValueMember()`,
-  //       // which causes us to set the `value` property on `OptionalVal`
-  //       // (which had not been set until this point). This `value` property
-  //       // refers to a `PointerValue`, which in turn refers to a
-  //       // StorageLocation` that is associated to an `IntegerValue`.
-  //       oo.value();
-  //     } else {
-  //       // Let's assume we transfer the `else` branch after the `if` branch.
-  //       //
-  //       // We see the `value` property that the `if` branch set on
-  //       // `OptionalVal`, but in the environment for this block, the
-  //       // `StorageLocation` in the `PointerValue` is not associated with any
-  //       // `Value`.
-  //       oo.value();
-  //     }
-  //   }
-  //
-  // This situation is currently "saved" by the code above that checks whether
-  // the `value` property is already set, and if, the `ValueLoc` is not
-  // associated with a `ValueVal`, creates a new `ValueVal`.
-  //
-  // However, what we should really do is to make sure that the change to the
-  // `value` property does not "leak" to other blocks that are not successors
-  // of this block. To do this, instead of simply setting the `value` property
-  // on the existing `OptionalVal`, we should create a new `Value` for the
-  // optional, set the property on that, and associate the storage location that
-  // is currently associated with the existing `OptionalVal` with the newly
-  // created `Value` instead.
-  OptionalVal.setProperty("value", ValuePtr);
-  return &ValueLoc;
-}
-
-void initializeOptionalReference(const Expr *OptionalExpr,
-                                 const MatchFinder::MatchResult &,
-                                 LatticeTransferState &State) {
-  if (auto *OptionalVal = State.Env.getValue(*OptionalExpr)) {
-    if (OptionalVal->getProperty("has_value") == nullptr) {
-      setHasValue(*OptionalVal, State.Env.makeAtomicBoolValue());
-    }
-  }
-}
-
-/// Returns true if and only if `OptionalVal` is initialized and known to be
-/// empty in `Env`.
-bool isEmptyOptional(const Value &OptionalVal, const Environment &Env) {
-  auto *HasValueVal =
-      cast_or_null<BoolValue>(OptionalVal.getProperty("has_value"));
-  return HasValueVal != nullptr &&
-         Env.proves(Env.arena().makeNot(HasValueVal->formula()));
-}
-
-/// Returns true if and only if `OptionalVal` is initialized and known to be
-/// non-empty in `Env`.
-bool isNonEmptyOptional(const Value &OptionalVal, const Environment &Env) {
-  auto *HasValueVal =
-      cast_or_null<BoolValue>(OptionalVal.getProperty("has_value"));
-  return HasValueVal != nullptr && Env.proves(HasValueVal->formula());
-}
-
-Value *getValueBehindPossiblePointer(const Expr &E, const Environment &Env) {
-  Value *Val = Env.getValue(E);
-  if (auto *PointerVal = dyn_cast_or_null<PointerValue>(Val))
-    return Env.getValue(PointerVal->getPointeeLoc());
-  return Val;
+  return Env.getStorageLocation(E);
 }
 
 void transferUnwrapCall(const Expr *UnwrapExpr, const Expr *ObjectExpr,
                         LatticeTransferState &State) {
-  if (auto *OptionalVal =
-          getValueBehindPossiblePointer(*ObjectExpr, State.Env)) {
+  if (auto *OptionalLoc = cast_or_null<RecordStorageLocation>(
+          getLocBehindPossiblePointer(*ObjectExpr, State.Env))) {
     if (State.Env.getStorageLocation(*UnwrapExpr) == nullptr)
-      if (auto *Loc = maybeInitializeOptionalValueMember(
-              UnwrapExpr->getType(), *OptionalVal, State.Env))
-        State.Env.setStorageLocation(*UnwrapExpr, *Loc);
+      State.Env.setStorageLocation(*UnwrapExpr, locForValue(*OptionalLoc));
   }
 }
 
 void transferArrowOpCall(const Expr *UnwrapExpr, const Expr *ObjectExpr,
                          LatticeTransferState &State) {
-  if (auto *OptionalVal =
-          getValueBehindPossiblePointer(*ObjectExpr, State.Env)) {
-    if (auto *Loc = maybeInitializeOptionalValueMember(
-            UnwrapExpr->getType()->getPointeeType(), *OptionalVal, State.Env)) {
-      State.Env.setValue(*UnwrapExpr, State.Env.create<PointerValue>(*Loc));
-    }
-  }
+  if (auto *OptionalLoc = cast_or_null<RecordStorageLocation>(
+          getLocBehindPossiblePointer(*ObjectExpr, State.Env)))
+    State.Env.setValue(
+        *UnwrapExpr, State.Env.create<PointerValue>(locForValue(*OptionalLoc)));
 }
 
 void transferMakeOptionalCall(const CallExpr *E,
@@ -465,8 +338,7 @@ void transferOptionalHasValueCall(const CXXMemberCallExpr *CallExpr,
                                   const MatchFinder::MatchResult &,
                                   LatticeTransferState &State) {
   if (auto *HasValueVal = getHasValue(
-          State.Env, getValueBehindPossiblePointer(
-                         *CallExpr->getImplicitObjectArgument(), State.Env))) {
+          State.Env, getImplicitObjectLocation(*CallExpr, State.Env))) {
     State.Env.setValue(*CallExpr, *HasValueVal);
   }
 }
@@ -480,12 +352,11 @@ void transferValueOrImpl(
                                 const Formula &HasValueVal)) {
   auto &Env = State.Env;
 
-  const auto *ObjectArgumentExpr =
-      Result.Nodes.getNodeAs<clang::CXXMemberCallExpr>(ValueOrCallID)
-          ->getImplicitObjectArgument();
+  const auto *MCE =
+      Result.Nodes.getNodeAs<clang::CXXMemberCallExpr>(ValueOrCallID);
 
-  auto *HasValueVal = getHasValue(
-      State.Env, getValueBehindPossiblePointer(*ObjectArgumentExpr, State.Env));
+  auto *HasValueVal =
+      getHasValue(State.Env, getImplicitObjectLocation(*MCE, State.Env));
   if (HasValueVal == nullptr)
     return;
 
@@ -578,7 +449,9 @@ BoolValue &valueOrConversionHasValue(const FunctionDecl &F, const Expr &E,
 
   // This is a constructor/assignment call for `optional<T>` with argument of
   // type `optional<U>` such that `T` is constructible from `U`.
-  if (auto *HasValueVal = getHasValue(State.Env, State.Env.getValue(E)))
+  auto *Loc =
+      cast_or_null<RecordStorageLocation>(State.Env.getStorageLocation(E));
+  if (auto *HasValueVal = getHasValue(State.Env, Loc))
     return *HasValueVal;
   return State.Env.makeAtomicBoolValue();
 }
@@ -645,11 +518,11 @@ void transferSwap(RecordStorageLocation *Loc1, RecordStorageLocation *Loc2,
   // allows for local reasoning about the value. To avoid the above, we would
   // need *lazy* value allocation.
   // FIXME: allocate values lazily, instead of just creating a fresh value.
-  BoolValue *BoolVal1 = getHasValue(Env, Env.getValue(*Loc1));
+  BoolValue *BoolVal1 = getHasValue(Env, Loc1);
   if (BoolVal1 == nullptr)
     BoolVal1 = &Env.makeAtomicBoolValue();
 
-  BoolValue *BoolVal2 = getHasValue(Env, Env.getValue(*Loc2));
+  BoolValue *BoolVal2 = getHasValue(Env, Loc2);
   if (BoolVal2 == nullptr)
     BoolVal2 = &Env.makeAtomicBoolValue();
 
@@ -712,24 +585,43 @@ void transferOptionalAndOptionalCmp(const clang::CXXOperatorCallExpr *CmpExpr,
   Environment &Env = State.Env;
   auto &A = Env.arena();
   auto *CmpValue = &forceBoolValue(Env, *CmpExpr);
-  if (auto *LHasVal = getHasValue(Env, Env.getValue(*CmpExpr->getArg(0))))
-    if (auto *RHasVal = getHasValue(Env, Env.getValue(*CmpExpr->getArg(1)))) {
+  auto *Arg0Loc = cast_or_null<RecordStorageLocation>(
+      Env.getStorageLocation(*CmpExpr->getArg(0)));
+  if (auto *LHasVal = getHasValue(Env, Arg0Loc)) {
+    auto *Arg1Loc = cast_or_null<RecordStorageLocation>(
+        Env.getStorageLocation(*CmpExpr->getArg(1)));
+    if (auto *RHasVal = getHasValue(Env, Arg1Loc)) {
       if (CmpExpr->getOperator() == clang::OO_ExclaimEqual)
         CmpValue = &A.makeNot(*CmpValue);
       Env.assume(evaluateEquality(A, *CmpValue, LHasVal->formula(),
                                   RHasVal->formula()));
     }
+  }
 }
 
 void transferOptionalAndValueCmp(const clang::CXXOperatorCallExpr *CmpExpr,
                                  const clang::Expr *E, Environment &Env) {
   auto &A = Env.arena();
   auto *CmpValue = &forceBoolValue(Env, *CmpExpr);
-  if (auto *HasVal = getHasValue(Env, Env.getValue(*E))) {
+  auto *Loc = cast_or_null<RecordStorageLocation>(Env.getStorageLocation(*E));
+  if (auto *HasVal = getHasValue(Env, Loc)) {
     if (CmpExpr->getOperator() == clang::OO_ExclaimEqual)
       CmpValue = &A.makeNot(*CmpValue);
     Env.assume(
         evaluateEquality(A, *CmpValue, HasVal->formula(), A.makeLiteral(true)));
+  }
+}
+
+void transferOptionalAndNulloptCmp(const clang::CXXOperatorCallExpr *CmpExpr,
+                                   const clang::Expr *E, Environment &Env) {
+  auto &A = Env.arena();
+  auto *CmpValue = &forceBoolValue(Env, *CmpExpr);
+  auto *Loc = cast_or_null<RecordStorageLocation>(Env.getStorageLocation(*E));
+  if (auto *HasVal = getHasValue(Env, Loc)) {
+    if (CmpExpr->getOperator() == clang::OO_ExclaimEqual)
+      CmpValue = &A.makeNot(*CmpValue);
+    Env.assume(evaluateEquality(A, *CmpValue, HasVal->formula(),
+                                A.makeLiteral(false)));
   }
 }
 
@@ -762,12 +654,6 @@ auto buildTransferMatchSwitch() {
   // lot of duplicated work (e.g. string comparisons), consider providing APIs
   // that avoid it through memoization.
   return CFGMatchSwitchBuilder<LatticeTransferState>()
-      // Attach a symbolic "has_value" state to optional values that we see for
-      // the first time.
-      .CaseOfCFGStmt<Expr>(
-          expr(anyOf(declRefExpr(), memberExpr()), hasOptionalType()),
-          initializeOptionalReference)
-
       // make_optional
       .CaseOfCFGStmt<CallExpr>(isMakeOptionalCall(), transferMakeOptionalCall)
 
@@ -778,14 +664,6 @@ auto buildTransferMatchSwitch() {
              LatticeTransferState &State) {
             constructOptionalValue(*E, State.Env,
                                    State.Env.getBoolLiteralValue(true));
-          })
-      // nullopt_t::nullopt_t
-      .CaseOfCFGStmt<CXXConstructExpr>(
-          isNulloptConstructor(),
-          [](const CXXConstructExpr *E, const MatchFinder::MatchResult &,
-             LatticeTransferState &State) {
-            constructOptionalValue(*E, State.Env,
-                                   State.Env.getBoolLiteralValue(false));
           })
       // optional::optional(nullopt_t)
       .CaseOfCFGStmt<CXXConstructExpr>(
@@ -887,18 +765,32 @@ auto buildTransferMatchSwitch() {
 
       // Comparisons (==, !=):
       .CaseOfCFGStmt<CXXOperatorCallExpr>(
-          isComparisonOperatorCall(hasAnyOptionalType(), hasAnyOptionalType()),
+          isComparisonOperatorCall(hasOptionalType(), hasOptionalType()),
           transferOptionalAndOptionalCmp)
       .CaseOfCFGStmt<CXXOperatorCallExpr>(
-          isComparisonOperatorCall(hasOptionalType(),
-                                   unless(hasAnyOptionalType())),
+          isComparisonOperatorCall(hasOptionalType(), hasNulloptType()),
+          [](const clang::CXXOperatorCallExpr *Cmp,
+             const MatchFinder::MatchResult &, LatticeTransferState &State) {
+            transferOptionalAndNulloptCmp(Cmp, Cmp->getArg(0), State.Env);
+          })
+      .CaseOfCFGStmt<CXXOperatorCallExpr>(
+          isComparisonOperatorCall(hasNulloptType(), hasOptionalType()),
+          [](const clang::CXXOperatorCallExpr *Cmp,
+             const MatchFinder::MatchResult &, LatticeTransferState &State) {
+            transferOptionalAndNulloptCmp(Cmp, Cmp->getArg(1), State.Env);
+          })
+      .CaseOfCFGStmt<CXXOperatorCallExpr>(
+          isComparisonOperatorCall(
+              hasOptionalType(),
+              unless(anyOf(hasOptionalType(), hasNulloptType()))),
           [](const clang::CXXOperatorCallExpr *Cmp,
              const MatchFinder::MatchResult &, LatticeTransferState &State) {
             transferOptionalAndValueCmp(Cmp, Cmp->getArg(0), State.Env);
           })
       .CaseOfCFGStmt<CXXOperatorCallExpr>(
-          isComparisonOperatorCall(unless(hasAnyOptionalType()),
-                                   hasOptionalType()),
+          isComparisonOperatorCall(
+              unless(anyOf(hasOptionalType(), hasNulloptType())),
+              hasOptionalType()),
           [](const clang::CXXOperatorCallExpr *Cmp,
              const MatchFinder::MatchResult &, LatticeTransferState &State) {
             transferOptionalAndValueCmp(Cmp, Cmp->getArg(1), State.Env);
@@ -913,8 +805,9 @@ auto buildTransferMatchSwitch() {
 
 llvm::SmallVector<SourceLocation> diagnoseUnwrapCall(const Expr *ObjectExpr,
                                                      const Environment &Env) {
-  if (auto *OptionalVal = getValueBehindPossiblePointer(*ObjectExpr, Env)) {
-    auto *Prop = OptionalVal->getProperty("has_value");
+  if (auto *OptionalLoc = cast_or_null<RecordStorageLocation>(
+          getLocBehindPossiblePointer(*ObjectExpr, Env))) {
+    auto *Prop = Env.getValue(locForHasValue(*OptionalLoc));
     if (auto *HasValueVal = cast_or_null<BoolValue>(Prop)) {
       if (Env.proves(HasValueVal->formula()))
         return {};
@@ -960,84 +853,29 @@ UncheckedOptionalAccessModel::optionalClassDecl() {
   return optionalClass();
 }
 
-UncheckedOptionalAccessModel::UncheckedOptionalAccessModel(ASTContext &Ctx)
+static QualType valueTypeFromOptionalType(QualType OptionalTy) {
+  auto *CTSD =
+      cast<ClassTemplateSpecializationDecl>(OptionalTy->getAsCXXRecordDecl());
+  return CTSD->getTemplateArgs()[0].getAsType();
+}
+
+UncheckedOptionalAccessModel::UncheckedOptionalAccessModel(ASTContext &Ctx,
+                                                           Environment &Env)
     : DataflowAnalysis<UncheckedOptionalAccessModel, NoopLattice>(Ctx),
-      TransferMatchSwitch(buildTransferMatchSwitch()) {}
+      TransferMatchSwitch(buildTransferMatchSwitch()) {
+  Env.getDataflowAnalysisContext().setSyntheticFieldCallback(
+      [&Ctx](QualType Ty) -> llvm::StringMap<QualType> {
+        if (!isOptionalType(Ty))
+          return {};
+        return {{"value", valueTypeFromOptionalType(Ty)},
+                {"has_value", Ctx.BoolTy}};
+      });
+}
 
 void UncheckedOptionalAccessModel::transfer(const CFGElement &Elt,
                                             NoopLattice &L, Environment &Env) {
   LatticeTransferState State(L, Env);
   TransferMatchSwitch(Elt, getASTContext(), State);
-}
-
-ComparisonResult UncheckedOptionalAccessModel::compare(
-    QualType Type, const Value &Val1, const Environment &Env1,
-    const Value &Val2, const Environment &Env2) {
-  if (!isOptionalType(Type))
-    return ComparisonResult::Unknown;
-  bool MustNonEmpty1 = isNonEmptyOptional(Val1, Env1);
-  bool MustNonEmpty2 = isNonEmptyOptional(Val2, Env2);
-  if (MustNonEmpty1 && MustNonEmpty2)
-    return ComparisonResult::Same;
-  // If exactly one is true, then they're different, no reason to check whether
-  // they're definitely empty.
-  if (MustNonEmpty1 || MustNonEmpty2)
-    return ComparisonResult::Different;
-  // Check if they're both definitely empty.
-  return (isEmptyOptional(Val1, Env1) && isEmptyOptional(Val2, Env2))
-             ? ComparisonResult::Same
-             : ComparisonResult::Different;
-}
-
-bool UncheckedOptionalAccessModel::merge(QualType Type, const Value &Val1,
-                                         const Environment &Env1,
-                                         const Value &Val2,
-                                         const Environment &Env2,
-                                         Value &MergedVal,
-                                         Environment &MergedEnv) {
-  if (!isOptionalType(Type))
-    return true;
-  // FIXME: uses same approach as join for `BoolValues`. Requires non-const
-  // values, though, so will require updating the interface.
-  auto &HasValueVal = MergedEnv.makeAtomicBoolValue();
-  bool MustNonEmpty1 = isNonEmptyOptional(Val1, Env1);
-  bool MustNonEmpty2 = isNonEmptyOptional(Val2, Env2);
-  if (MustNonEmpty1 && MustNonEmpty2)
-    MergedEnv.assume(HasValueVal.formula());
-  else if (
-      // Only make the costly calls to `isEmptyOptional` if we got "unknown"
-      // (false) for both calls to `isNonEmptyOptional`.
-      !MustNonEmpty1 && !MustNonEmpty2 && isEmptyOptional(Val1, Env1) &&
-      isEmptyOptional(Val2, Env2))
-    MergedEnv.assume(MergedEnv.arena().makeNot(HasValueVal.formula()));
-  setHasValue(MergedVal, HasValueVal);
-  return true;
-}
-
-Value *UncheckedOptionalAccessModel::widen(QualType Type, Value &Prev,
-                                           const Environment &PrevEnv,
-                                           Value &Current,
-                                           Environment &CurrentEnv) {
-  switch (compare(Type, Prev, PrevEnv, Current, CurrentEnv)) {
-  case ComparisonResult::Same:
-    return &Prev;
-  case ComparisonResult::Different:
-    if (auto *PrevHasVal =
-            cast_or_null<BoolValue>(Prev.getProperty("has_value"))) {
-      if (isa<TopBoolValue>(PrevHasVal))
-        return &Prev;
-    }
-    if (auto *CurrentHasVal =
-            cast_or_null<BoolValue>(Current.getProperty("has_value"))) {
-      if (isa<TopBoolValue>(CurrentHasVal))
-        return &Current;
-    }
-    return &createOptionalValue(cast<RecordValue>(Current).getLoc(),
-                                CurrentEnv.makeTopBoolValue(), CurrentEnv);
-  case ComparisonResult::Unknown:
-    return nullptr;
-  }
-  llvm_unreachable("all cases covered in switch");
 }
 
 UncheckedOptionalAccessDiagnoser::UncheckedOptionalAccessDiagnoser(

--- a/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
+++ b/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
@@ -492,6 +492,56 @@ transferCFGBlock(const CFGBlock &Block, AnalysisContext &AC,
   return State;
 }
 
+static Environment initializeEnvironment(const Environment &InitEnv) {
+  Environment ResultEnv = InitEnv.fork();
+
+  const DeclContext *DeclCtx = ResultEnv.getDeclCtx();
+  if (DeclCtx == nullptr)
+    return ResultEnv;
+
+  if (const auto *FuncDecl = dyn_cast<FunctionDecl>(DeclCtx)) {
+    assert(FuncDecl->getBody() != nullptr);
+
+    ResultEnv.initFieldsGlobalsAndFuncs(FuncDecl);
+
+    for (const auto *ParamDecl : FuncDecl->parameters()) {
+      assert(ParamDecl != nullptr);
+      ResultEnv.setStorageLocation(*ParamDecl,
+                                   ResultEnv.createObject(*ParamDecl, nullptr));
+    }
+  }
+
+  if (const auto *MethodDecl = dyn_cast<CXXMethodDecl>(DeclCtx)) {
+    auto *Parent = MethodDecl->getParent();
+    assert(Parent != nullptr);
+
+    if (Parent->isLambda()) {
+      for (auto Capture : Parent->captures()) {
+        if (Capture.capturesVariable()) {
+          const auto *VarDecl = Capture.getCapturedVar();
+          assert(VarDecl != nullptr);
+          ResultEnv.setStorageLocation(
+              *VarDecl, ResultEnv.createObject(*VarDecl, nullptr));
+        } else if (Capture.capturesThis()) {
+          const auto *SurroundingMethodDecl =
+              cast<CXXMethodDecl>(DeclCtx->getNonClosureAncestor());
+          QualType ThisPointeeType =
+              SurroundingMethodDecl->getFunctionObjectParameterType();
+          ResultEnv.setThisPointeeStorageLocation(
+              cast<RecordValue>(ResultEnv.createValue(ThisPointeeType))
+                  ->getLoc());
+        }
+      }
+    } else if (MethodDecl->isImplicitObjectMemberFunction()) {
+      QualType ThisPointeeType = MethodDecl->getFunctionObjectParameterType();
+      ResultEnv.setThisPointeeStorageLocation(
+          cast<RecordValue>(ResultEnv.createValue(ThisPointeeType))->getLoc());
+    }
+  }
+
+  return ResultEnv;
+}
+
 llvm::Expected<std::vector<std::optional<TypeErasedDataflowAnalysisState>>>
 runTypeErasedDataflowAnalysis(
     const ControlFlowContext &CFCtx, TypeErasedDataflowAnalysis &Analysis,
@@ -500,6 +550,13 @@ runTypeErasedDataflowAnalysis(
                        const TypeErasedDataflowAnalysisState &)>
         PostVisitCFG) {
   PrettyStackTraceAnalysis CrashInfo(CFCtx, "runTypeErasedDataflowAnalysis");
+
+  auto MaybeStartingEnv =
+      InitEnv.callStackSize() == 1
+          ? std::make_optional<Environment>(initializeEnvironment(InitEnv))
+          : std::nullopt;
+  const Environment &StartingEnv =
+      MaybeStartingEnv ? *MaybeStartingEnv : InitEnv;
 
   const clang::CFG &CFG = CFCtx.getCFG();
   PostOrderCFGView POV(&CFG);
@@ -511,10 +568,10 @@ runTypeErasedDataflowAnalysis(
   // The entry basic block doesn't contain statements so it can be skipped.
   const CFGBlock &Entry = CFG.getEntry();
   BlockStates[Entry.getBlockID()] = {Analysis.typeErasedInitialElement(),
-                                     InitEnv.fork()};
+                                     StartingEnv.fork()};
   Worklist.enqueueSuccessors(&Entry);
 
-  AnalysisContext AC(CFCtx, Analysis, InitEnv, BlockStates);
+  AnalysisContext AC(CFCtx, Analysis, StartingEnv, BlockStates);
 
   // Bugs in lattices and transfer functions can prevent the analysis from
   // converging. To limit the damage (infinite loops) that these bugs can cause,

--- a/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
@@ -96,6 +96,7 @@ TEST_F(EnvironmentTest, CreateValueRecursiveType) {
   // Verify that the struct and the field (`R`) with first appearance of the
   // type is created successfully.
   Environment Env(DAContext, *Fun);
+  Env.initFieldsGlobalsAndFuncs(Fun);
   auto &SLoc = cast<RecordStorageLocation>(Env.createObject(Ty));
   PointerValue *PV = cast_or_null<PointerValue>(getFieldValue(&SLoc, *R, Env));
   EXPECT_THAT(PV, NotNull());
@@ -175,6 +176,7 @@ TEST_F(EnvironmentTest, InitGlobalVarsFun) {
 
   // Verify the global variable is populated when we analyze `Target`.
   Environment Env(DAContext, *Fun);
+  Env.initFieldsGlobalsAndFuncs(Fun);
   EXPECT_THAT(Env.getValue(*Var), NotNull());
 }
 
@@ -225,6 +227,7 @@ TEST_F(EnvironmentTest, IncludeFieldsFromDefaultInitializers) {
   // Verify that the `X` field of `S` is populated when analyzing the
   // constructor, even though it is not referenced directly in the constructor.
   Environment Env(DAContext, *Constructor);
+  Env.initFieldsGlobalsAndFuncs(Constructor);
   auto &Loc = cast<RecordStorageLocation>(Env.createObject(QTy));
   EXPECT_THAT(getFieldValue(&Loc, *XDecl, Env), NotNull());
 }
@@ -268,6 +271,7 @@ TEST_F(EnvironmentTest, InitGlobalVarsFieldFun) {
 
   // Verify the global variable is populated when we analyze `Target`.
   Environment Env(DAContext, *Fun);
+  Env.initFieldsGlobalsAndFuncs(Fun);
   const auto *GlobalLoc =
       cast<RecordStorageLocation>(Env.getStorageLocation(*GlobalDecl));
   auto *BarVal = getFieldValue(GlobalLoc, *BarDecl, Env);
@@ -303,6 +307,7 @@ TEST_F(EnvironmentTest, InitGlobalVarsConstructor) {
 
   // Verify the global variable is populated when we analyze `Target`.
   Environment Env(DAContext, *Ctor);
+  Env.initFieldsGlobalsAndFuncs(Ctor);
   EXPECT_THAT(Env.getValue(*Var), NotNull());
 }
 

--- a/clang/unittests/Analysis/FlowSensitive/TestingSupport.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TestingSupport.cpp
@@ -173,7 +173,8 @@ llvm::Error test::checkDataflowWithNoopAnalysis(
         void(const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &,
              ASTContext &)>
         VerifyResults,
-    DataflowAnalysisOptions Options, LangStandard::Kind Std) {
+    DataflowAnalysisOptions Options, LangStandard::Kind Std,
+    std::function<llvm::StringMap<QualType>(QualType)> SyntheticFieldCallback) {
   llvm::SmallVector<std::string, 3> ASTBuildArgs = {
       // -fnodelayed-template-parsing is the default everywhere but on Windows.
       // Set it explicitly so that tests behave the same on Windows as on other
@@ -183,8 +184,10 @@ llvm::Error test::checkDataflowWithNoopAnalysis(
           std::string(LangStandard::getLangStandardForKind(Std).getName())};
   AnalysisInputs<NoopAnalysis> AI(
       Code, TargetFuncMatcher,
-      [UseBuiltinModel = Options.BuiltinOpts.has_value()](ASTContext &C,
-                                                          Environment &Env) {
+      [UseBuiltinModel = Options.BuiltinOpts.has_value(),
+       &SyntheticFieldCallback](ASTContext &C, Environment &Env) {
+        Env.getDataflowAnalysisContext().setSyntheticFieldCallback(
+            std::move(SyntheticFieldCallback));
         return NoopAnalysis(
             C,
             DataflowAnalysisOptions{

--- a/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
+++ b/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
@@ -420,7 +420,9 @@ llvm::Error checkDataflowWithNoopAnalysis(
              ASTContext &)>
         VerifyResults = [](const auto &, auto &) {},
     DataflowAnalysisOptions Options = {BuiltinOptions()},
-    LangStandard::Kind Std = LangStandard::lang_cxx17);
+    LangStandard::Kind Std = LangStandard::lang_cxx17,
+    std::function<llvm::StringMap<QualType>(QualType)> SyntheticFieldCallback =
+        {});
 
 /// Returns the `ValueDecl` for the given identifier.
 ///

--- a/clang/unittests/Analysis/FlowSensitive/UncheckedOptionalAccessModelTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/UncheckedOptionalAccessModelTest.cpp
@@ -1319,8 +1319,8 @@ protected:
     llvm::Error Error = checkDataflow<UncheckedOptionalAccessModel>(
         AnalysisInputs<UncheckedOptionalAccessModel>(
             SourceCode, std::move(FuncMatcher),
-            [](ASTContext &Ctx, Environment &) {
-              return UncheckedOptionalAccessModel(Ctx);
+            [](ASTContext &Ctx, Environment &Env) {
+              return UncheckedOptionalAccessModel(Ctx, Env);
             })
             .withPostVisitCFG(
                 [&Diagnostics,


### PR DESCRIPTION
- [clang][dataflow] Strengthen widening of boolean values.
- [clang][dataflow] Defer initialization of `Environment`.
- [clang][dataflow] Add synthetic fields to `RecordStorageLocation`.
- [clang][dataflow] Make UncheckedOptionalAccessModel use synthetic fields.
