### PR TITLE
[libc++][test] Change forbidden `extents<char>` to `extents<signed char>`

### DIFF
--- a/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
+++ b/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
@@ -17,7 +17,6 @@ struct IntType {
   constexpr bool operator==(const IntType& rhs) const { return val == rhs.val; }
   constexpr operator int() const noexcept { return val; }
   constexpr operator unsigned char() const { return val; }
-  constexpr operator char() const noexcept { return val; }
   constexpr operator signed char() const noexcept { return val; }
 };
 

--- a/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
+++ b/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
@@ -18,6 +18,7 @@ struct IntType {
   constexpr operator int() const noexcept { return val; }
   constexpr operator unsigned char() const { return val; }
   constexpr operator char() const noexcept { return val; }
+  constexpr operator signed char() const noexcept { return val; }
 };
 
 // only non-const convertible

--- a/libcxx/test/std/containers/views/mdspan/extents/CtorTestCombinations.h
+++ b/libcxx/test/std/containers/views/mdspan/extents/CtorTestCombinations.h
@@ -89,11 +89,11 @@ constexpr bool test_index_type_combo() {
   test<int, int, Test>();
   test<int, size_t, Test>();
   test<unsigned, int, Test>();
-  test<char, size_t, Test>();
+  test<signed char, size_t, Test>();
   test<long long, unsigned, Test>();
   test<size_t, int, Test>();
   test<size_t, size_t, Test>();
   test<int, IntType, Test>();
-  test<char, IntType, Test>();
+  test<signed char, IntType, Test>();
   return true;
 }

--- a/libcxx/test/std/containers/views/mdspan/extents/obs_static.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/obs_static.pass.cpp
@@ -81,7 +81,7 @@ void test() {
 int main(int, char**) {
   test<int>();
   test<unsigned>();
-  test<char>();
+  test<signed char>();
   test<long long>();
   test<size_t>();
   return 0;

--- a/libcxx/test/std/containers/views/mdspan/extents/types.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/types.pass.cpp
@@ -78,7 +78,7 @@ void test() {
 int main(int, char**) {
   test<int>();
   test<unsigned>();
-  test<char>();
+  test<signed char>();
   test<long long>();
   test<size_t>();
   return 0;

--- a/libcxx/test/std/containers/views/mdspan/layout_left/extents.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/extents.verify.cpp
@@ -29,5 +29,5 @@ void not_extents() {
 
 void representable() {
   // expected-error-re@*:* {{static assertion failed {{.*}}layout_left::mapping product of static extents must be representable as index_type.}}
-  [[maybe_unused]] std::layout_left::mapping<std::extents<char, 20, 20>> mapping;
+  [[maybe_unused]] std::layout_left::mapping<std::extents<signed char, 20, 20>> mapping;
 }

--- a/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
@@ -80,7 +80,7 @@ constexpr bool test() {
   test_iteration<std::extents<unsigned, D>>(7);
   test_iteration<std::extents<unsigned, 7>>();
   test_iteration<std::extents<unsigned, 7, 8>>();
-  test_iteration<std::extents<char, D, D, D, D>>(1, 1, 1, 1);
+  test_iteration<std::extents<signed char, D, D, D, D>>(1, 1, 1, 1);
 
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(std::layout_left::mapping<std::extents<int, D>>(std::extents<int, D>(1)), 0));

--- a/libcxx/test/std/containers/views/mdspan/layout_left/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/properties.pass.cpp
@@ -53,7 +53,7 @@ constexpr void test_layout_mapping_left() {
 constexpr bool test() {
   constexpr size_t D = std::dynamic_extent;
   test_layout_mapping_left<std::extents<int>>();
-  test_layout_mapping_left<std::extents<char, 4, 5>>();
+  test_layout_mapping_left<std::extents<signed char, 4, 5>>();
   test_layout_mapping_left<std::extents<unsigned, D, 4>>();
   test_layout_mapping_left<std::extents<size_t, D, D, D, D>>();
   return true;

--- a/libcxx/test/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
@@ -124,7 +124,7 @@ void test_layout_mapping_left() {
 int main(int, char**) {
   constexpr size_t D = std::dynamic_extent;
   test_layout_mapping_left<std::extents<int>>();
-  test_layout_mapping_left<std::extents<char, 4, 5>>();
+  test_layout_mapping_left<std::extents<signed char, 4, 5>>();
   test_layout_mapping_left<std::extents<unsigned, D, 4>>();
   test_layout_mapping_left<std::extents<size_t, D, D, D, D>>();
   return 0;

--- a/libcxx/test/std/containers/views/mdspan/layout_right/extents.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/extents.verify.cpp
@@ -29,5 +29,5 @@ void not_extents() {
 
 void representable() {
   // expected-error-re@*:* {{static assertion failed {{.*}}layout_right::mapping product of static extents must be representable as index_type.}}
-  [[maybe_unused]] std::layout_right::mapping<std::extents<char, 20, 20>> mapping;
+  [[maybe_unused]] std::layout_right::mapping<std::extents<signed char, 20, 20>> mapping;
 }

--- a/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
@@ -80,7 +80,7 @@ constexpr bool test() {
   test_iteration<std::extents<unsigned, D>>(7);
   test_iteration<std::extents<unsigned, 7>>();
   test_iteration<std::extents<unsigned, 7, 8>>();
-  test_iteration<std::extents<char, D, D, D, D>>(1, 1, 1, 1);
+  test_iteration<std::extents<signed char, D, D, D, D>>(1, 1, 1, 1);
 
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(std::layout_right::mapping<std::extents<int, D>>(std::extents<int, D>(1)), 0));

--- a/libcxx/test/std/containers/views/mdspan/layout_right/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/properties.pass.cpp
@@ -53,7 +53,7 @@ constexpr void test_layout_mapping_right() {
 constexpr bool test() {
   constexpr size_t D = std::dynamic_extent;
   test_layout_mapping_right<std::extents<int>>();
-  test_layout_mapping_right<std::extents<char, 4, 5>>();
+  test_layout_mapping_right<std::extents<signed char, 4, 5>>();
   test_layout_mapping_right<std::extents<unsigned, D, 4>>();
   test_layout_mapping_right<std::extents<size_t, D, D, D, D>>();
   return true;

--- a/libcxx/test/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
@@ -124,7 +124,7 @@ void test_layout_mapping_right() {
 int main(int, char**) {
   constexpr size_t D = std::dynamic_extent;
   test_layout_mapping_right<std::extents<int>>();
-  test_layout_mapping_right<std::extents<char, 4, 5>>();
+  test_layout_mapping_right<std::extents<signed char, 4, 5>>();
   test_layout_mapping_right<std::extents<unsigned, D, 4>>();
   test_layout_mapping_right<std::extents<size_t, D, D, D, D>>();
   return 0;

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/extents.verify.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/extents.verify.cpp
@@ -29,5 +29,5 @@ void not_extents() {
 
 void representable() {
   // expected-error-re@*:* {{static assertion failed {{.*}}layout_stride::mapping product of static extents must be representable as index_type.}}
-  [[maybe_unused]] std::layout_stride::mapping<std::extents<char, 20, 20>> mapping;
+  [[maybe_unused]] std::layout_stride::mapping<std::extents<signed char, 20, 20>> mapping;
 }

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
@@ -79,7 +79,7 @@ constexpr bool test() {
   test_iteration<std::extents<unsigned, D>>(std::array<int, 1>{3}, 7);
   test_iteration<std::extents<unsigned, 7>>(std::array<int, 1>{4});
   test_iteration<std::extents<unsigned, 7, 8>>(std::array<int, 2>{25, 3});
-  test_iteration<std::extents<char, D, D, D, D>>(std::array<int, 4>{1, 1, 1, 1}, 1, 1, 1, 1);
+  test_iteration<std::extents<signed char, D, D, D, D>>(std::array<int, 4>{1, 1, 1, 1}, 1, 1, 1, 1);
 
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/properties.pass.cpp
@@ -102,8 +102,8 @@ test_layout_mapping_stride(E ext, std::array<typename E::index_type, E::rank()> 
 constexpr bool test() {
   constexpr size_t D = std::dynamic_extent;
   test_layout_mapping_stride(std::extents<int>(), std::array<int, 0>{}, true);
-  test_layout_mapping_stride(std::extents<char, 4, 5>(), std::array<char, 2>{1, 4}, true);
-  test_layout_mapping_stride(std::extents<char, 4, 5>(), std::array<char, 2>{1, 5}, false);
+  test_layout_mapping_stride(std::extents<signed char, 4, 5>(), std::array<signed char, 2>{1, 4}, true);
+  test_layout_mapping_stride(std::extents<signed char, 4, 5>(), std::array<signed char, 2>{1, 5}, false);
   test_layout_mapping_stride(std::extents<unsigned, D, 4>(7), std::array<unsigned, 2>{20, 2}, false);
   test_layout_mapping_stride(std::extents<size_t, D, D, D, D>(3, 3, 3, 3), std::array<size_t, 4>{3, 1, 9, 27}, true);
   return true;

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
@@ -124,7 +124,7 @@ void test_layout_mapping_stride() {
 int main(int, char**) {
   constexpr size_t D = std::dynamic_extent;
   test_layout_mapping_stride<std::extents<int>>();
-  test_layout_mapping_stride<std::extents<char, 4, 5>>();
+  test_layout_mapping_stride<std::extents<signed char, 4, 5>>();
   test_layout_mapping_stride<std::extents<unsigned, D, 4>>();
   test_layout_mapping_stride<std::extents<size_t, D, D, D, D>>();
   return 0;

--- a/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -57,10 +57,10 @@ template <class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -47,10 +47,10 @@ template <class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
@@ -59,10 +59,10 @@ template <bool hc, bool mc, bool ac, class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<hc, mc, ac>(
       handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
@@ -75,7 +75,7 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
   // Use weird layout, make sure it has the properties we want to test
   constexpr size_t D = std::dynamic_extent;
   static_assert(
-      !std::is_default_constructible_v< typename layout_wrapping_integral<4>::template mapping<std::extents<char, D>>>);
+      !std::is_default_constructible_v< typename layout_wrapping_integral<4>::template mapping<std::extents<signed char, D>>>);
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
@@ -74,8 +74,8 @@ constexpr void mixin_layout(const H& handle, const A& acc) {
 
   // Use weird layout, make sure it has the properties we want to test
   constexpr size_t D = std::dynamic_extent;
-  static_assert(
-      !std::is_default_constructible_v< typename layout_wrapping_integral<4>::template mapping<std::extents<signed char, D>>>);
+  static_assert(!std::is_default_constructible_v<
+                typename layout_wrapping_integral<4>::template mapping<std::extents<signed char, D>>>);
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
@@ -105,10 +105,10 @@ template <bool mec, bool ac, class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
       handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
@@ -68,10 +68,10 @@ template <bool mec, bool ac, class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<mec, ac>(
       handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
@@ -84,17 +84,17 @@ constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   // construct from just dynamic extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<char, D>(7)), acc, 7);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc, 0, 3);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 3);
   test_mdspan_types<mec, ac>(
       handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 2, 3, 2);
 
   // construct from all extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 4, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc, 0, 7, 3);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 7, 3);
   test_mdspan_types<mec, ac>(
       handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 7, 2, 4, 3, 2);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
@@ -65,10 +65,10 @@ template <bool ac, class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
@@ -57,10 +57,10 @@ template <class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
@@ -105,10 +105,10 @@ template <bool mec, bool ac, class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
       handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -46,10 +46,10 @@ template <class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/deduction.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/deduction.pass.cpp
@@ -80,10 +80,10 @@ template <class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -120,7 +120,7 @@ constexpr void test_layout() {
   test_iteration(construct_mapping(Layout(), std::extents<unsigned, D>(7)));
   test_iteration(construct_mapping(Layout(), std::extents<unsigned, 7>()));
   test_iteration(construct_mapping(Layout(), std::extents<unsigned, 7, 8>()));
-  test_iteration(construct_mapping(Layout(), std::extents<char, D, D, D, D>(1, 1, 1, 1)));
+  test_iteration(construct_mapping(Layout(), std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
 // TODO enable for GCC 13, when the CI pipeline is switched, doesn't work with GCC 12
 #if defined(__clang_major__) && __clang_major__ >= 17

--- a/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -49,10 +49,10 @@ template <class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/properties.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/properties.pass.cpp
@@ -178,10 +178,10 @@ template <class H, class L, class A>
 constexpr void mixin_extents(const H& handle, const L& layout, const A& acc) {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcxx/test/std/containers/views/mdspan/mdspan/types.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/types.pass.cpp
@@ -136,9 +136,9 @@ template <class T, class L, class A>
 void mixin_extents() {
   constexpr size_t D = std::dynamic_extent;
   test_mdspan_types<T, std::extents<int>, L, A>();
-  test_mdspan_types<T, std::extents<char, D>, L, A>();
-  test_mdspan_types<T, std::dextents<char, 7>, L, A>();
-  test_mdspan_types<T, std::dextents<char, 9>, L, A>();
+  test_mdspan_types<T, std::extents<signed char, D>, L, A>();
+  test_mdspan_types<T, std::dextents<signed char, 7>, L, A>();
+  test_mdspan_types<T, std::dextents<signed char, 9>, L, A>();
   test_mdspan_types<T, std::extents<unsigned, 7>, L, A>();
   test_mdspan_types<T, std::extents<unsigned, D, D, D>, L, A>();
   test_mdspan_types<T, std::extents<size_t, D, 7, D>, L, A>();


### PR DESCRIPTION
Found while running libc++'s test suite with MSVC's STL.

[N4964](https://wg21.link/N4964) \[mdspan.extents.overview\]/1.1:

> ```cpp
> template<class IndexType, size_t... Extents>
> class extents {
> ```
> \[...\]
> *Mandates:*
> * `IndexType` is a signed or unsigned integer type \[...\]

This famously excludes `char`.

<details><summary>Click to expand citation, [basic.fundamental]/1, /2, /7:</summary>

> There are five *standard signed integer types*: "`signed char`", "`short int`", "`int`", "`long int`", and "`long long int`". \[...\] The standard and extended signed integer types are collectively called *signed integer types*.

> For each of the standard signed integer types, there exists a corresponding (but different) *standard unsigned integer type*: "`unsigned char`", "`unsigned short int`", "`unsigned int`", "`unsigned long int`", and "`unsigned long long int`". \[...\] The standard and extended unsigned integer types are collectively called *unsigned integer types*.

> Type `char` is a distinct type that has an implementation-defined choice of "`signed char`" or "`unsigned char`" as its underlying type.
</details>

MSVC's STL enforces the Mandates here, so this PR changes the relevant occurrences of `char` to `signed char`. To make this work, we also need to add an `operator signed char()` to the test helper type `IntType` so it remains unambiguously convertible, and then we can remove `operator char()`.

(libc++ should also enforce the Mandates, \[structure.specifications\]/3.2, but this PR doesn't attempt to make such a change. I'm not set up to build and test libc++ normally, I just have my exotic configuration.)