### PR TITLE
[AArch64] Assembly support for Armv9.5-A Debug/PMU Extensions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -738,6 +738,7 @@ def : ROSysReg<"ID_AA64PFR1_EL1",     0b11, 0b000, 0b0000, 0b0100, 0b001>;
 def : ROSysReg<"ID_AA64PFR2_EL1",     0b11, 0b000, 0b0000, 0b0100, 0b010>;
 def : ROSysReg<"ID_AA64DFR0_EL1",     0b11, 0b000, 0b0000, 0b0101, 0b000>;
 def : ROSysReg<"ID_AA64DFR1_EL1",     0b11, 0b000, 0b0000, 0b0101, 0b001>;
+def : ROSysReg<"ID_AA64DFR2_EL1",     0b11, 0b000, 0b0000, 0b0101, 0b010>;
 def : ROSysReg<"ID_AA64AFR0_EL1",     0b11, 0b000, 0b0000, 0b0101, 0b100>;
 def : ROSysReg<"ID_AA64AFR1_EL1",     0b11, 0b000, 0b0000, 0b0101, 0b101>;
 def : ROSysReg<"ID_AA64ISAR0_EL1",    0b11, 0b000, 0b0000, 0b0110, 0b000>;
@@ -1937,3 +1938,11 @@ let Requires = [{ {AArch64::FeatureFPMR} }] in {
 def : ROSysReg<"ID_AA64FPFR0_EL1", 0b11, 0b000, 0b0000, 0b0100, 0b111>;
 def : RWSysReg<"FPMR",             0b11, 0b011, 0b0100, 0b0100, 0b010>;
 }
+
+// v9.5a Software Stepping Enhancements (FEAT_STEP2)
+//                                  Op0   Op1    CRn     CRm     Op2
+def : RWSysReg<"MDSTEPOP_EL1",      0b10, 0b000, 0b0000, 0b0101, 0b010>;
+
+// v9.5a System PMU zero register (FEAT_SPMU2)
+//                                  Op0   Op1    CRn     CRm     Op2
+def : WOSysReg<"SPMZR_EL0",         0b10, 0b011, 0b1001, 0b1100, 0b100>;

--- a/llvm/test/MC/AArch64/armv9.5a-spmu2-error.s
+++ b/llvm/test/MC/AArch64/armv9.5a-spmu2-error.s
@@ -1,0 +1,4 @@
+// RUN: not llvm-mc -triple aarch64 -show-encoding < %s 2>&1 | FileCheck %s
+
+mrs x0, SPMZR_EL0
+// CHECK: [[@LINE-1]]:9: error: expected readable system register

--- a/llvm/test/MC/AArch64/armv9.5a-spmu2.s
+++ b/llvm/test/MC/AArch64/armv9.5a-spmu2.s
@@ -1,0 +1,4 @@
+// RUN: llvm-mc -triple aarch64 -show-encoding < %s | FileCheck %s
+
+msr SPMZR_EL0, x0
+// CHECK: msr SPMZR_EL0, x0                  // encoding: [0x80,0x9c,0x13,0xd5]

--- a/llvm/test/MC/AArch64/armv9.5a-step2.s
+++ b/llvm/test/MC/AArch64/armv9.5a-step2.s
@@ -1,0 +1,7 @@
+// RUN: llvm-mc -triple aarch64 -show-encoding < %s | FileCheck %s
+
+mrs x0, MDSTEPOP_EL1
+// CHECK: mrs x0, MDSTEPOP_EL1                  // encoding: [0x40,0x05,0x30,0xd5]
+
+msr MDSTEPOP_EL1, x0
+// CHECK: msr MDSTEPOP_EL1, x0                  // encoding: [0x40,0x05,0x10,0xd5]

--- a/llvm/test/MC/AArch64/basic-a64-diagnostics.s
+++ b/llvm/test/MC/AArch64/basic-a64-diagnostics.s
@@ -3599,6 +3599,7 @@
         msr ID_AA64PFR2_EL1, x12
         msr ID_AA64DFR0_EL1, x12
         msr ID_AA64DFR1_EL1, x12
+        msr ID_AA64DFR2_EL1, x12
         msr ID_AA64AFR0_EL1, x12
         msr ID_AA64AFR1_EL1, x12
         msr ID_AA64ISAR0_EL1, x12
@@ -3735,6 +3736,9 @@
 // CHECK-ERROR-NEXT:             ^
 // CHECK-ERROR-NEXT: error: expected writable system register or pstate
 // CHECK-ERROR-NEXT:         msr ID_AA64DFR1_EL1, x12
+// CHECK-ERROR-NEXT:             ^
+// CHECK-ERROR-NEXT: error: expected writable system register or pstate
+// CHECK-ERROR-NEXT:         msr ID_AA64DFR2_EL1, x12
 // CHECK-ERROR-NEXT:             ^
 // CHECK-ERROR-NEXT: error: expected writable system register or pstate
 // CHECK-ERROR-NEXT:         msr ID_AA64AFR0_EL1, x12

--- a/llvm/test/MC/AArch64/basic-a64-instructions.s
+++ b/llvm/test/MC/AArch64/basic-a64-instructions.s
@@ -4369,6 +4369,7 @@ _func:
 	mrs x9, ID_AA64PFR2_EL1
 	mrs x9, ID_AA64DFR0_EL1
 	mrs x9, ID_AA64DFR1_EL1
+	mrs x9, ID_AA64DFR2_EL1
 	mrs x9, ID_AA64AFR0_EL1
 	mrs x9, ID_AA64AFR1_EL1
 	mrs x9, ID_AA64ISAR0_EL1
@@ -4706,6 +4707,7 @@ _func:
 // CHECK: mrs      x9, {{id_aa64pfr2_el1|ID_AA64PFR2_EL1}}        // encoding: [0x49,0x04,0x38,0xd5]
 // CHECK: mrs      x9, {{id_aa64dfr0_el1|ID_AA64DFR0_EL1}}        // encoding: [0x09,0x05,0x38,0xd5]
 // CHECK: mrs      x9, {{id_aa64dfr1_el1|ID_AA64DFR1_EL1}}        // encoding: [0x29,0x05,0x38,0xd5]
+// CHECK: mrs      x9, {{id_aa64dfr2_el1|ID_AA64DFR2_EL1}}        // encoding: [0x49,0x05,0x38,0xd5]
 // CHECK: mrs      x9, {{id_aa64afr0_el1|ID_AA64AFR0_EL1}}        // encoding: [0x89,0x05,0x38,0xd5]
 // CHECK: mrs      x9, {{id_aa64afr1_el1|ID_AA64AFR1_EL1}}        // encoding: [0xa9,0x05,0x38,0xd5]
 // CHECK: mrs      x9, {{id_aa64isar0_el1|ID_AA64ISAR0_EL1}}       // encoding: [0x09,0x06,0x38,0xd5]

--- a/llvm/test/MC/Disassembler/AArch64/armv9.5a-spmu2.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.5a-spmu2.txt
@@ -1,0 +1,4 @@
+# RUN: llvm-mc -triple aarch64 -disassemble < %s | FileCheck %s
+
+[0x80,0x9c,0x13,0xd5]
+# CHECK: msr SPMZR_EL0, x0

--- a/llvm/test/MC/Disassembler/AArch64/armv9.5a-step2.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.5a-step2.txt
@@ -1,0 +1,7 @@
+# RUN: llvm-mc -triple aarch64 -disassemble < %s | FileCheck %s
+
+[0x40,0x05,0x30,0xd5]
+# CHECK: mrs x0, MDSTEPOP_EL1
+
+[0x40,0x05,0x10,0xd5]
+# CHECK: msr MDSTEPOP_EL1, x0

--- a/llvm/test/MC/Disassembler/AArch64/basic-a64-instructions.txt
+++ b/llvm/test/MC/Disassembler/AArch64/basic-a64-instructions.txt
@@ -3559,6 +3559,7 @@
 # CHECK: mrs      x9, {{id_aa64pfr2_el1|ID_AA64PFR2_EL1}}
 # CHECK: mrs      x9, {{id_aa64dfr0_el1|ID_AA64DFR0_EL1}}
 # CHECK: mrs      x9, {{id_aa64dfr1_el1|ID_AA64DFR1_EL1}}
+# CHECK: mrs      x9, {{id_aa64dfr2_el1|ID_AA64DFR2_EL1}}
 # CHECK: mrs      x9, {{id_aa64afr0_el1|ID_AA64AFR0_EL1}}
 # CHECK: mrs      x9, {{id_aa64afr1_el1|ID_AA64AFR1_EL1}}
 # CHECK: mrs      x9, {{id_aa64isar0_el1|ID_AA64ISAR0_EL1}}
@@ -4181,6 +4182,7 @@
 0x49 0x4 0x38 0xd5
 0x9 0x5 0x38 0xd5
 0x29 0x5 0x38 0xd5
+0x49 0x5 0x38 0xd5
 0x89 0x5 0x38 0xd5
 0xa9 0x5 0x38 0xd5
 0x9 0x6 0x38 0xd5


### PR DESCRIPTION
This implements assembly support for the Debug/PMU extensions introduced as part of the Armv9.5-A architecture version.
The changes include:
* New ID_AA64DFR2_EL1 ID system register
* New MDSTEPOP_EL1 and SPMZR_EL0 system registers

Mode details about these extensions can be found at:
* https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-a-profile-architecture-developments-2023
* https://developer.arm.com/documentation/ddi0602/2023-09/

Changes by me and @ostannard .