### PR TITLE
[flang] Fix Funderscoring TC failure on AIX [NFC]

### DIFF
--- a/flang/test/Driver/underscoring.f90
+++ b/flang/test/Driver/underscoring.f90
@@ -21,4 +21,4 @@ end
 ! NO-UNDERSCORING-NOT: ext_sub_
 ! NO-UNDERSCORING: {{ext_sub[^_]*$}}
 ! NO-UNDERSCORING-NOT: comblk_
-! NO-UNDERSCORING: comblk,
+! NO-UNDERSCORING: {{comblk[^_]*$}}


### PR DESCRIPTION
Change fundersoring test with a more accurate regex to ensure the lack of a trailing underscore, current TC is failing on AIX