### PR TITLE
[libc++][test] Avoid using `allocator<const T>`

### DIFF
--- a/libcxx/test/std/containers/views/mdspan/MinimalElementType.h
+++ b/libcxx/test/std/containers/views/mdspan/MinimalElementType.h
@@ -9,7 +9,8 @@
 #ifndef TEST_STD_CONTAINERS_VIEWS_MDSPAN_MINIMAL_ELEMENT_TYPE_H
 #define TEST_STD_CONTAINERS_VIEWS_MDSPAN_MINIMAL_ELEMENT_TYPE_H
 
-#include<memory>
+#include <memory>
+#include <type_traits>
 
 // Idiosyncratic element type for mdspan
 // Make sure we don't assume copyable, default constructible, movable etc.
@@ -25,7 +26,7 @@ struct MinimalElementType {
 template<class T, size_t N>
 struct ElementPool {
   constexpr ElementPool() {
-    ptr_ = std::allocator<T>().allocate(N);
+    ptr_ = std::allocator<std::remove_const_t<T>>().allocate(N);
     for (int i = 0; i != N; ++i)
       std::construct_at(ptr_ + i, 42);
   }
@@ -35,11 +36,11 @@ struct ElementPool {
   constexpr ~ElementPool() {
     for (int i = 0; i != N; ++i)
       std::destroy_at(ptr_ + i);
-    std::allocator<T>().deallocate(ptr_, N);
+    std::allocator<std::remove_const_t<T>>().deallocate(ptr_, N);
   }
 
 private:
-  T* ptr_;
+  std::remove_const_t<T>* ptr_;
 };
 
 #endif // TEST_STD_CONTAINERS_VIEWS_MDSPAN_MINIMAL_ELEMENT_TYPE_H


### PR DESCRIPTION
Found while running libc++'s test suite with MSVC's STL.

MSVC's STL rejects `allocator<const T>`. This may or may not be justified by the current Standardese (it was bogus in the C++03 era), but it's how we reject usage like `vector<const T>`.

A bunch of `mdspan` tests are failing for us because some centralized machinery is using `allocator<const T>`. Testing that `mdspan` and its associated types work properly with `const T` is good and necessary, but directly allocating `const T` is what's a problem for MSVC's STL. I'd like to ask for a very targeted change here that preserves all of the test coverage but changes how `ElementPool` interacts with `allocator`.

This intentionally leaves `ElementPool::get_ptr()` returning `T*` (pointer-to-possibly-const), so there's no externally visible difference.