### PR TITLE
[clang] report inlining decisions with -Wattribute-{warning|error}

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -93,6 +93,8 @@ def err_fe_backend_error_attr :
 def warn_fe_backend_warning_attr :
   Warning<"call to '%0' declared with 'warning' attribute: %1">, BackendInfo,
   InGroup<BackendWarningAttributes>;
+def note_fe_backend_in : Note<"called by function '%0'">;
+def note_fe_backend_inlined : Note<"inlined by function '%0'">;
 
 def err_fe_invalid_code_complete_file : Error<
     "cannot locate code-completion file %0">, DefaultFatal;

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -52,6 +52,8 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 
 #include <optional>
+#include <string>
+
 using namespace clang;
 using namespace llvm;
 
@@ -794,6 +796,14 @@ void BackendConsumer::DontCallDiagHandler(const DiagnosticInfoDontCall &D) {
                               ? diag::err_fe_backend_error_attr
                               : diag::warn_fe_backend_warning_attr)
       << llvm::demangle(D.getFunctionName()) << D.getNote();
+
+  SmallVector<std::string, 4> InliningDecisions;
+  D.getInliningDecisions(InliningDecisions);
+  InliningDecisions.push_back(D.getCaller().str());
+  for (auto Dec : llvm::enumerate(InliningDecisions))
+    Diags.Report(Dec.index() ? diag::note_fe_backend_inlined
+                             : diag::note_fe_backend_in)
+        << llvm::demangle(Dec.value());
 }
 
 void BackendConsumer::MisExpectDiagHandler(

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -797,8 +797,8 @@ void BackendConsumer::DontCallDiagHandler(const DiagnosticInfoDontCall &D) {
                               : diag::warn_fe_backend_warning_attr)
       << llvm::demangle(D.getFunctionName()) << D.getNote();
 
-  SmallVector<std::string> InliningDecisions = D.getInliningDecisions();
-  InliningDecisions.push_back(D.getCaller().str());
+  SmallVector<StringRef> InliningDecisions = D.getInliningDecisions();
+  InliningDecisions.push_back(D.getCaller());
   for (const auto &[index, value] : llvm::enumerate(InliningDecisions))
     Diags.Report(LocCookie, index ? diag::note_fe_backend_inlined
                                   : diag::note_fe_backend_in)

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -799,8 +799,8 @@ void BackendConsumer::DontCallDiagHandler(const DiagnosticInfoDontCall &D) {
   SmallVector<StringRef> InliningDecisions = D.getInliningDecisions();
   InliningDecisions.push_back(D.getCaller());
   for (const auto &[index, value] : llvm::enumerate(InliningDecisions))
-    Diags.Report(LocCookie, index ? diag::note_fe_backend_inlined
-                                  : diag::note_fe_backend_in)
+    Diags.Report(index ? diag::note_fe_backend_inlined
+                       : diag::note_fe_backend_in)
         << llvm::demangle(value);
 }
 

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -800,10 +800,10 @@ void BackendConsumer::DontCallDiagHandler(const DiagnosticInfoDontCall &D) {
   SmallVector<std::string, 4> InliningDecisions;
   D.getInliningDecisions(InliningDecisions);
   InliningDecisions.push_back(D.getCaller().str());
-  for (auto Dec : llvm::enumerate(InliningDecisions))
-    Diags.Report(Dec.index() ? diag::note_fe_backend_inlined
-                             : diag::note_fe_backend_in)
-        << llvm::demangle(Dec.value());
+  for (auto [index, value] : llvm::enumerate(InliningDecisions))
+    Diags.Report(index ? diag::note_fe_backend_inlined
+                       : diag::note_fe_backend_in)
+        << llvm::demangle(value);
 }
 
 void BackendConsumer::MisExpectDiagHandler(

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -799,7 +799,7 @@ void BackendConsumer::DontCallDiagHandler(const DiagnosticInfoDontCall &D) {
 
   SmallVector<std::string> InliningDecisions = D.getInliningDecisions();
   InliningDecisions.push_back(D.getCaller().str());
-  for (auto [index, value] : llvm::enumerate(InliningDecisions))
+  for (const auto &[index, value] : llvm::enumerate(InliningDecisions))
     Diags.Report(LocCookie, index ? diag::note_fe_backend_inlined
                                   : diag::note_fe_backend_in)
         << llvm::demangle(value);

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -801,8 +801,8 @@ void BackendConsumer::DontCallDiagHandler(const DiagnosticInfoDontCall &D) {
   D.getInliningDecisions(InliningDecisions);
   InliningDecisions.push_back(D.getCaller().str());
   for (auto [index, value] : llvm::enumerate(InliningDecisions))
-    Diags.Report(index ? diag::note_fe_backend_inlined
-                       : diag::note_fe_backend_in)
+    Diags.Report(LocCookie, index ? diag::note_fe_backend_inlined
+                                  : diag::note_fe_backend_in)
         << llvm::demangle(value);
 }
 

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -797,8 +797,7 @@ void BackendConsumer::DontCallDiagHandler(const DiagnosticInfoDontCall &D) {
                               : diag::warn_fe_backend_warning_attr)
       << llvm::demangle(D.getFunctionName()) << D.getNote();
 
-  SmallVector<std::string, 4> InliningDecisions;
-  D.getInliningDecisions(InliningDecisions);
+  SmallVector<std::string> InliningDecisions = D.getInliningDecisions();
   InliningDecisions.push_back(D.getCaller().str());
   for (auto [index, value] : llvm::enumerate(InliningDecisions))
     Diags.Report(LocCookie, index ? diag::note_fe_backend_inlined

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -52,7 +52,6 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 
 #include <optional>
-#include <string>
 
 using namespace clang;
 using namespace llvm;

--- a/clang/test/Frontend/backend-attribute-error-warning-optimize.c
+++ b/clang/test/Frontend/backend-attribute-error-warning-optimize.c
@@ -9,6 +9,7 @@ int x(void) {
 }
 void baz(void) {
   foo(); // expected-error {{call to 'foo' declared with 'error' attribute: oh no foo}}
+         // expected-note@* {{called by function 'baz'}}
   if (x())
     bar();
 }
@@ -19,4 +20,24 @@ void (*quux)(void);
 void indirect(void) {
   quux = foo;
   quux();
+}
+
+static inline void a(int x) {
+    if (x == 10)
+        foo(); // expected-error {{call to 'foo' declared with 'error' attribute: oh no foo}}
+               // expected-note@* {{called by function 'a'}}
+               // expected-note@* {{inlined by function 'b'}}
+               // expected-note@* {{inlined by function 'd'}}
+}
+
+static inline void b() {
+    a(10);
+}
+
+void c() {
+    a(9);
+}
+
+void d() {
+  b();
 }

--- a/clang/test/Frontend/backend-attribute-error-warning-optimize.c
+++ b/clang/test/Frontend/backend-attribute-error-warning-optimize.c
@@ -23,19 +23,19 @@ void indirect(void) {
 }
 
 static inline void a(int x) {
-    if (x == 10)
-        foo(); // expected-error {{call to 'foo' declared with 'error' attribute: oh no foo}}
-               // expected-note@* {{called by function 'a'}}
-               // expected-note@* {{inlined by function 'b'}}
-               // expected-note@* {{inlined by function 'd'}}
+  if (x == 10)
+    foo(); // expected-error {{call to 'foo' declared with 'error' attribute: oh no foo}}
+           // expected-note@* {{called by function 'a'}}
+           // expected-note@* {{inlined by function 'b'}}
+           // expected-note@* {{inlined by function 'd'}}
 }
 
 static inline void b() {
-    a(10);
+  a(10);
 }
 
 void c() {
-    a(9);
+  a(9);
 }
 
 void d() {

--- a/clang/test/Frontend/backend-attribute-error-warning.c
+++ b/clang/test/Frontend/backend-attribute-error-warning.c
@@ -23,11 +23,17 @@ duplicate_warnings(void);
 
 void baz(void) {
   foo(); // expected-error {{call to 'foo' declared with 'error' attribute: oh no foo}}
+         // expected-note@* {{called by function 'baz'}}
   if (x())
     bar(); // expected-error {{call to 'bar' declared with 'error' attribute: oh no bar}}
+           // expected-note@* {{called by function 'baz'}}
 
   quux();                     // enabled-warning {{call to 'quux' declared with 'warning' attribute: oh no quux}}
+                              // enabled-note@* {{called by function 'baz'}}
   __compiletime_assert_455(); // expected-error {{call to '__compiletime_assert_455' declared with 'error' attribute: demangle me}}
+                              // expected-note@* {{called by function 'baz'}}
   duplicate_errors();         // expected-error {{call to 'duplicate_errors' declared with 'error' attribute: two}}
+                              // expected-note@* {{called by function 'baz'}}
   duplicate_warnings();       // enabled-warning {{call to 'duplicate_warnings' declared with 'warning' attribute: two}}
+                              // enabled-note@* {{called by function 'baz'}}
 }

--- a/clang/test/Frontend/backend-attribute-error-warning.cpp
+++ b/clang/test/Frontend/backend-attribute-error-warning.cpp
@@ -24,13 +24,19 @@ duplicate_warnings(void);
 
 void baz(void) {
   foo(); // expected-error {{call to 'foo()' declared with 'error' attribute: oh no foo}}
+         // expected-note@* {{called by function 'baz()'}}
   if (x())
     bar(); // expected-error {{call to 'bar()' declared with 'error' attribute: oh no bar}}
+           // expected-note@* {{called by function 'baz()'}}
 
   quux();                     // enabled-warning {{call to 'quux()' declared with 'warning' attribute: oh no quux}}
+                              // enabled-note@* {{called by function 'baz()'}}
   __compiletime_assert_455(); // expected-error {{call to '__compiletime_assert_455()' declared with 'error' attribute: demangle me}}
+                              // expected-note@* {{called by function 'baz()'}}
   duplicate_errors();         // expected-error {{call to 'duplicate_errors()' declared with 'error' attribute: two}}
+                              // expected-note@* {{called by function 'baz()'}}
   duplicate_warnings();       // enabled-warning {{call to 'duplicate_warnings()' declared with 'warning' attribute: two}}
+                              // enabled-note@* {{called by function 'baz()'}}
 }
 
 #ifdef __cplusplus
@@ -46,15 +52,21 @@ struct Widget {
 
 void baz_cpp(void) {
   foo(); // expected-error {{call to 'foo()' declared with 'error' attribute: oh no foo}}
+         // expected-note@* {{called by function 'baz_cpp()'}}
   if (x())
     bar(); // expected-error {{call to 'bar()' declared with 'error' attribute: oh no bar}}
+           // expected-note@* {{called by function 'baz_cpp()'}}
   quux();  // enabled-warning {{call to 'quux()' declared with 'warning' attribute: oh no quux}}
+           // enabled-note@* {{called by function 'baz_cpp()'}}
 
   // Test that we demangle correctly in the diagnostic for C++.
   __compiletime_assert_455(); // expected-error {{call to '__compiletime_assert_455()' declared with 'error' attribute: demangle me}}
+                              // expected-note@* {{called by function 'baz_cpp()'}}
   nocall<int>(42);            // expected-error {{call to 'int nocall<int>(int)' declared with 'error' attribute: demangle me, too}}
+                              // expected-note@* {{called by function 'baz_cpp()'}}
 
   Widget W;
   int w = W; // enabled-warning {{call to 'Widget::operator int()' declared with 'warning' attribute: don't call me!}}
+             // enabled-note@* {{called by function 'baz_cpp()'}}
 }
 #endif

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1803,13 +1803,17 @@ example:
     call of a function with this attribute is not eliminated via optimization.
     Front ends can provide optional ``srcloc`` metadata nodes on call sites of
     such callees to attach information about where in the source language such a
-    call came from. A string value can be provided as a note.
+    call came from. A string value can be provided as a note. The optimizer may
+    add the optional ``inlined.from`` metadata to call sites which front ends
+    might consume to display more precise diagnostics.
 ``"dontcall-warn"``
     This attribute denotes that a warning diagnostic should be emitted when a
     call of a function with this attribute is not eliminated via optimization.
     Front ends can provide optional ``srcloc`` metadata nodes on call sites of
     such callees to attach information about where in the source language such a
-    call came from. A string value can be provided as a note.
+    call came from. A string value can be provided as a note. The optimizer may
+    add the optional ``inlined.from`` metadata to call sites which front ends
+    might consume to display more precise diagnostics.
 ``fn_ret_thunk_extern``
     This attribute tells the code generator that returns from functions should
     be replaced with jumps to externally-defined architecture-specific symbols.

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -1119,8 +1119,7 @@ public:
   static bool classof(const DiagnosticInfo *DI) {
     return DI->getKind() == DK_DontCall;
   }
-  void
-  getInliningDecisions(SmallVectorImpl<std::string> &InliningDecisions) const;
+  SmallVector<std::string> getInliningDecisions() const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -29,7 +29,6 @@
 #include <functional>
 #include <iterator>
 #include <optional>
-#include <string>
 
 namespace llvm {
 
@@ -1119,7 +1118,7 @@ public:
   static bool classof(const DiagnosticInfo *DI) {
     return DI->getKind() == DK_DontCall;
   }
-  SmallVector<std::string> getInliningDecisions() const;
+  SmallVector<StringRef> getInliningDecisions() const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -1099,15 +1099,19 @@ public:
 void diagnoseDontCall(const CallInst &CI);
 
 class DiagnosticInfoDontCall : public DiagnosticInfo {
+  StringRef CallerName;
   StringRef CalleeName;
   StringRef Note;
   unsigned LocCookie;
+  MDNode *MDN;
 
 public:
-  DiagnosticInfoDontCall(StringRef CalleeName, StringRef Note,
-                         DiagnosticSeverity DS, unsigned LocCookie)
-      : DiagnosticInfo(DK_DontCall, DS), CalleeName(CalleeName), Note(Note),
-        LocCookie(LocCookie) {}
+  DiagnosticInfoDontCall(StringRef CallerName, StringRef CalleeName,
+                         StringRef Note, DiagnosticSeverity DS,
+                         unsigned LocCookie, MDNode *MDN)
+      : DiagnosticInfo(DK_DontCall, DS), CallerName(CallerName),
+        CalleeName(CalleeName), Note(Note), LocCookie(LocCookie), MDN(MDN) {}
+  StringRef getCaller() const { return CallerName; }
   StringRef getFunctionName() const { return CalleeName; }
   StringRef getNote() const { return Note; }
   unsigned getLocCookie() const { return LocCookie; }
@@ -1115,6 +1119,8 @@ public:
   static bool classof(const DiagnosticInfo *DI) {
     return DI->getKind() == DK_DontCall;
   }
+  void
+  getInliningDecisions(SmallVectorImpl<std::string> &InliningDecisions) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -455,18 +455,11 @@ void DiagnosticInfoDontCall::print(DiagnosticPrinter &DP) const {
 SmallVector<std::string> DiagnosticInfoDontCall::getInliningDecisions() const {
   SmallVector<std::string> InliningDecisions;
 
-  if (MDN) {
-    const MDOperand &MO = MDN->getOperand(0);
-    if (auto *MDT = dyn_cast<MDTuple>(MO)) {
-      for (const MDOperand &MO : MDT->operands()) {
-        if (auto *S = dyn_cast<MDString>(MO)) {
+  if (MDN)
+    if (auto *MDT = dyn_cast<MDTuple>(MDN->getOperand(0)))
+      for (const MDOperand &MO : MDT->operands())
+        if (auto *S = dyn_cast<MDString>(MO))
           InliningDecisions.push_back(S->getString().str());
-        }
-      }
-    } else if (auto *S = dyn_cast<MDString>(MO)) {
-      InliningDecisions.push_back(S->getString().str());
-    }
-  }
 
   return InliningDecisions;
 }

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -455,11 +455,18 @@ void DiagnosticInfoDontCall::print(DiagnosticPrinter &DP) const {
 SmallVector<StringRef> DiagnosticInfoDontCall::getInliningDecisions() const {
   SmallVector<StringRef> InliningDecisions;
 
-  if (MDN)
-    if (auto *MDT = dyn_cast<MDTuple>(MDN->getOperand(0)))
-      for (const MDOperand &MO : MDT->operands())
-        if (auto *S = dyn_cast<MDString>(MO))
+  if (MDN) {
+    const MDOperand &MO = MDN->getOperand(0);
+    if (auto *MDT = dyn_cast<MDTuple>(MO)) {
+      for (const MDOperand &MO : MDT->operands()) {
+        if (auto *S = dyn_cast<MDString>(MO)) {
           InliningDecisions.push_back(S->getString());
+        }
+      }
+    } else if (auto *S = dyn_cast<MDString>(MO)) {
+      InliningDecisions.push_back(S->getString());
+    }
+  }
 
   return InliningDecisions;
 }

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -452,14 +452,14 @@ void DiagnosticInfoDontCall::print(DiagnosticPrinter &DP) const {
     DP << ": " << getNote();
 }
 
-SmallVector<std::string> DiagnosticInfoDontCall::getInliningDecisions() const {
-  SmallVector<std::string> InliningDecisions;
+SmallVector<StringRef> DiagnosticInfoDontCall::getInliningDecisions() const {
+  SmallVector<StringRef> InliningDecisions;
 
   if (MDN)
     if (auto *MDT = dyn_cast<MDTuple>(MDN->getOperand(0)))
       for (const MDOperand &MO : MDT->operands())
         if (auto *S = dyn_cast<MDString>(MO))
-          InliningDecisions.push_back(S->getString().str());
+          InliningDecisions.push_back(S->getString());
 
   return InliningDecisions;
 }

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -452,19 +452,21 @@ void DiagnosticInfoDontCall::print(DiagnosticPrinter &DP) const {
     DP << ": " << getNote();
 }
 
-void DiagnosticInfoDontCall::getInliningDecisions(
-    SmallVectorImpl<std::string> &InliningDecisions) const {
-  if (!MDN)
-    return;
+SmallVector<std::string> DiagnosticInfoDontCall::getInliningDecisions() const {
+  SmallVector<std::string> InliningDecisions;
 
-  const MDOperand &MO = MDN->getOperand(0);
-  if (auto *MDT = dyn_cast<MDTuple>(MO)) {
-    for (const MDOperand &MO : MDT->operands()) {
-      if (auto *S = dyn_cast<MDString>(MO)) {
-        InliningDecisions.push_back(S->getString().str());
+  if (MDN) {
+    const MDOperand &MO = MDN->getOperand(0);
+    if (auto *MDT = dyn_cast<MDTuple>(MO)) {
+      for (const MDOperand &MO : MDT->operands()) {
+        if (auto *S = dyn_cast<MDString>(MO)) {
+          InliningDecisions.push_back(S->getString().str());
+        }
       }
+    } else if (auto *S = dyn_cast<MDString>(MO)) {
+      InliningDecisions.push_back(S->getString().str());
     }
-  } else if (auto *S = dyn_cast<MDString>(MO)) {
-    InliningDecisions.push_back(S->getString().str());
   }
+
+  return InliningDecisions;
 }

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -2520,6 +2520,19 @@ llvm::InlineResult llvm::InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
         // inlining, commonly when the callee is an intrinsic.
         if (MarkNoUnwind && !CI->doesNotThrow())
           CI->setDoesNotThrow();
+
+        const Function *Callee = CI->getCalledFunction();
+        if (Callee && (Callee->hasFnAttribute("dontcall-error") ||
+                       Callee->hasFnAttribute("dontcall-warn"))) {
+          Metadata *MD = MDString::get(CI->getContext(), CalledFunc->getName());
+          if (MDNode *N = CI->getMetadata("inlined.from")) {
+            TempMDTuple Temp = cast<MDTuple>(N)->clone();
+            Temp->push_back(MD);
+            MD = MDNode::replaceWithUniqued(std::move(Temp));
+          }
+          MDTuple *MDT = MDNode::get(CI->getContext(), {MD});
+          CI->setMetadata("inlined.from", MDT);
+        }
       }
     }
   }

--- a/llvm/test/Transforms/Inline/dontcall-attributes.ll
+++ b/llvm/test/Transforms/Inline/dontcall-attributes.ll
@@ -23,7 +23,7 @@ define void @quux() {
 
 ; Test that @baz's call to @foo has metadata with inlining info.
 define void @baz() {
-; CHECK-LABEL: @baz(
+; CHECK-LABEL: define {{[^@]+}}@baz(
 ; CHECK-NEXT:    call void @foo(), !inlined.from !0
 ;
   call void @bar(i32 10)
@@ -32,7 +32,7 @@ define void @baz() {
 
 ; Test that @zing's call to @foo has unique metadata from @baz's call to @foo.
 define void @zing() {
-; CHECK-LABEL: @zing(
+; CHECK-LABEL: define {{[^@]+}}@zing(
 ; CHECK-NEXT:    call void @foo(), !inlined.from !1
 ;
   call void @baz()
@@ -58,14 +58,14 @@ define void @always_callee() alwaysinline {
   ret void
 }
 define void @always_caller() alwaysinline {
-; CHECK-BOTH-LABEL: @always_caller(
+; CHECK-BOTH-LABEL: define {{[^@]+}}@always_caller(
 ; CHECK-NEXT: call void @fof(), !inlined.from !4
 ; CHECK-ALWAYS-NEXT: call void @fof(), !inlined.from !0
   call void @always_callee()
   ret void
 }
 define void @always_caller2() alwaysinline {
-; CHECK-BOTH-LABEL: @always_caller2(
+; CHECK-BOTH-LABEL: define {{[^@]+}}@always_caller2(
 ; CHECK-NEXT: call void @fof(), !inlined.from !5
 ; CHECK-ALWAYS-NEXT: call void @fof(), !inlined.from !1
   call void @always_caller()

--- a/llvm/test/Transforms/Inline/dontcall-attributes.ll
+++ b/llvm/test/Transforms/Inline/dontcall-attributes.ll
@@ -25,7 +25,6 @@ define void @quux() {
 define void @baz() {
 ; CHECK-LABEL: define {{[^@]+}}@baz(
 ; CHECK-NEXT:    call void @foo(), !inlined.from !0
-;
   call void @bar(i32 10)
   ret void
 }
@@ -34,7 +33,6 @@ define void @baz() {
 define void @zing() {
 ; CHECK-LABEL: define {{[^@]+}}@zing(
 ; CHECK-NEXT:    call void @foo(), !inlined.from !1
-;
   call void @baz()
   ret void
 }

--- a/llvm/test/Transforms/Inline/dontcall-attributes.ll
+++ b/llvm/test/Transforms/Inline/dontcall-attributes.ll
@@ -39,14 +39,14 @@ define void @zing() {
 
 ; Same test but @fof has fn attr "dontcall-error"="..." rather than
 ; "dontcall-warn"="...".
-define void @a() {
+define void @_Z1av() {
   call void @fof()
   ret void
 }
-define void @b() {
-; CHECK-LABEL: @b(
+define void @_Z1bv() {
+; CHECK-LABEL: define {{[^@]+}}@_Z1bv(
 ; CHECK-NEXT: call void @fof(), !inlined.from !3
-  call void @a()
+  call void @_Z1av()
   ret void
 }
 
@@ -73,7 +73,7 @@ define void @always_caller2() alwaysinline {
 ; CHECK: !0 = !{!"bar"}
 ; CHECK-NEXT: !1 = !{!2}
 ; CHECK-NEXT: !2 = !{!"bar", !"baz"}
-; CHECK-NEXT: !3 = !{!"a"}
+; CHECK-NEXT: !3 = !{!"_Z1av"}
 ; CHECK-NEXT: !4 = !{!"always_callee"}
 ; CHECK-ALWAYS: !0 = !{!"always_callee"}
 ; CHECK-ALWAYS-NEXT: !1 = !{!2}

--- a/llvm/test/Transforms/Inline/dontcall-attributes.ll
+++ b/llvm/test/Transforms/Inline/dontcall-attributes.ll
@@ -1,0 +1,84 @@
+; RUN: opt -S -o - -passes=inline %s \
+; RUN:  | FileCheck %s --check-prefixes=CHECK-BOTH,CHECK
+; RUN: opt -S -o - -passes=always-inline %s \
+; RUN:  | FileCheck %s --check-prefixes=CHECK-BOTH,CHECK-ALWAYS
+
+declare void @foo() "dontcall-warn"="oh no"
+declare void @fof() "dontcall-error"="oh no"
+
+define void @bar(i32 %x) {
+  %cmp = icmp eq i32 %x, 10
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:
+  call void @foo()
+  br label %if.end
+
+if.end:
+  ret void
+}
+
+define void @quux() {
+  call void @bar(i32 9)
+  ret void
+}
+
+; Test that @baz's call to @foo has metadata with inlining info.
+define void @baz() {
+; CHECK-LABEL: @baz(
+; CHECK-NEXT:    call void @foo(), !inlined.from !0
+;
+  call void @bar(i32 10)
+  ret void
+}
+
+; Test that @zing's call to @foo has unique metadata from @baz's call to @foo.
+define void @zing() {
+; CHECK-LABEL: @zing(
+; CHECK-NEXT:    call void @foo(), !inlined.from !1
+;
+  call void @baz()
+  ret void
+}
+
+; Same test but @fof has fn attr "dontcall-error"="..." rather than
+; "dontcall-warn"="...".
+define void @a() {
+  call void @fof()
+  ret void
+}
+define void @b() {
+; CHECK-LABEL: @b(
+; CHECK-NEXT: call void @fof(), !inlined.from !3
+  call void @a()
+  ret void
+}
+
+; Add some tests for alwaysinline.
+define void @always_callee() alwaysinline {
+  call void @fof()
+  ret void
+}
+define void @always_caller() alwaysinline {
+; CHECK-BOTH-LABEL: @always_caller(
+; CHECK-NEXT: call void @fof(), !inlined.from !4
+; CHECK-ALWAYS-NEXT: call void @fof(), !inlined.from !0
+  call void @always_callee()
+  ret void
+}
+define void @always_caller2() alwaysinline {
+; CHECK-BOTH-LABEL: @always_caller2(
+; CHECK-NEXT: call void @fof(), !inlined.from !5
+; CHECK-ALWAYS-NEXT: call void @fof(), !inlined.from !1
+  call void @always_caller()
+  ret void
+}
+
+; CHECK: !0 = !{!"bar"}
+; CHECK-NEXT: !1 = !{!2}
+; CHECK-NEXT: !2 = !{!"bar", !"baz"}
+; CHECK-NEXT: !3 = !{!"a"}
+; CHECK-NEXT: !4 = !{!"always_callee"}
+; CHECK-ALWAYS: !0 = !{!"always_callee"}
+; CHECK-ALWAYS-NEXT: !1 = !{!2}
+; CHECK-ALWAYS-NEXT: !2 = !{!"always_callee", !"always_caller"}

--- a/llvm/test/Transforms/Inline/dontcall-attributes.ll
+++ b/llvm/test/Transforms/Inline/dontcall-attributes.ll
@@ -1,7 +1,5 @@
-; RUN: opt -S -o - -passes=inline %s \
-; RUN:  | FileCheck %s --check-prefixes=CHECK-BOTH,CHECK
-; RUN: opt -S -o - -passes=always-inline %s \
-; RUN:  | FileCheck %s --check-prefixes=CHECK-BOTH,CHECK-ALWAYS
+; RUN: opt -S -passes=inline < %s | FileCheck %s --check-prefixes=CHECK-BOTH,CHECK
+; RUN: opt -S -passes=always-inline < %s | FileCheck %s --check-prefixes=CHECK-BOTH,CHECK-ALWAYS
 
 declare void @foo() "dontcall-warn"="oh no"
 declare void @fof() "dontcall-error"="oh no"


### PR DESCRIPTION
Due to inlining, descovering which specific call site to a function with
the attribute "warning" or "error" is painful.

In the IR record inlining decisions in a new metadata tuple "inlined.from" when inlining a callee
that itself contains a call to a dontcall-error or dontcall-warn fn.

Print this info so that it's clearer which call site is problematic.

There's still some limitations with this approach; macro expansion is
not recorded.

Fixes: https://github.com/ClangBuiltLinux/linux/issues/1571

Differential Revision: https://reviews.llvm.org/D141451
