### PR TITLE
Compile MSAN/TSAN failing test with -O1

### DIFF
--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp
@@ -10,7 +10,8 @@
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
 // This test chokes on the sanitizers during CI runs. It appears we can address most of this by simply enabling optimizations.
-// ADDITIONAL_COMPILE_FLAGS: -O1
+// ADDITIONAL_COMPILE_FLAGS(msan): -O1
+// ADDITIONAL_COMPILE_FLAGS(tsan): -O1
 
 // <deque>
 

--- a/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp
@@ -9,6 +9,9 @@
 // REQUIRES: long_tests
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
+// This test chokes on the sanitizers during CI runs. It appears we can address most of this by simply enabling optimizations.
+// ADDITIONAL_COMPILE_FLAGS: -O1
+
 // <deque>
 
 // template <class InputIterator>

--- a/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.negbin/eval.pass.cpp
+++ b/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.negbin/eval.pass.cpp
@@ -8,7 +8,8 @@
 //
 // REQUIRES: long_tests
 
-// This test chokes on the sanitizers during CI runs. It appears we can address most of this by simply enabling optimizations.
+// This test is super slow, in particular with msan or tsan. In order to avoid timeouts and to
+// spend less time waiting for this particular test to complete we compile with optimizations.
 // ADDITIONAL_COMPILE_FLAGS: -O1
 
 // <random>

--- a/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.negbin/eval.pass.cpp
+++ b/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.negbin/eval.pass.cpp
@@ -8,6 +8,9 @@
 //
 // REQUIRES: long_tests
 
+// This test chokes on the sanitizers during CI runs. It appears we can address most of this by simply enabling optimizations.
+// ADDITIONAL_COMPILE_FLAGS: -O1
+
 // <random>
 
 // template<class IntType = int>


### PR DESCRIPTION
This attempts to fix flakes on the bots where the modified test times out while running under sanitizers.

Turning on the optimizer for just this test appears to mostly fix the issue.