### PR TITLE
[libc][math] Add unit tests for raising excepts in nextafter

### DIFF
--- a/libc/test/UnitTest/FPMatcher.h
+++ b/libc/test/UnitTest/FPMatcher.h
@@ -143,7 +143,8 @@ template <typename T> struct FPTest : public Test {
 #define EXPECT_FP_EXCEPTION(expected)                                          \
   do {                                                                         \
     if (math_errhandling & MATH_ERREXCEPT) {                                   \
-      EXPECT_GE(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) & expected, \
+      EXPECT_GE(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) &           \
+                    (expected),                                                \
                 expected);                                                     \
     }                                                                          \
   } while (0)
@@ -151,7 +152,8 @@ template <typename T> struct FPTest : public Test {
 #define ASSERT_FP_EXCEPTION(expected)                                          \
   do {                                                                         \
     if (math_errhandling & MATH_ERREXCEPT) {                                   \
-      ASSERT_GE(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) & expected, \
+      ASSERT_GE(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) &           \
+                    (expected),                                                \
                 expected);                                                     \
     }                                                                          \
   } while (0)
@@ -162,7 +164,7 @@ template <typename T> struct FPTest : public Test {
     EXPECT_FP_EQ(expected_val, actual_val);                                    \
     if (math_errhandling & MATH_ERREXCEPT) {                                   \
       EXPECT_GE(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) &           \
-                    expected_except,                                           \
+                    (expected_except),                                         \
                 expected_except);                                              \
       LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                     \
     }                                                                          \
@@ -174,7 +176,7 @@ template <typename T> struct FPTest : public Test {
     EXPECT_FP_IS_NAN(actual_val);                                              \
     if (math_errhandling & MATH_ERREXCEPT) {                                   \
       EXPECT_GE(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) &           \
-                    expected_except,                                           \
+                    (expected_except),                                         \
                 expected_except);                                              \
       LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                     \
     }                                                                          \


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/72763#discussion_r1398277962. 

### Summary
- Add unit tests for raising excepts in `nextafter`. 
- Fixed a bug in testing code for `nexttoward`.  

cc: @lntue 

