### PR TITLE
[mlir][transform] Do not maintain mappings for dead handles

### DIFF
--- a/mlir/test/Dialect/Transform/transform-state-extension.mlir
+++ b/mlir/test/Dialect/Transform/transform-state-extension.mlir
@@ -76,6 +76,9 @@ transform.sequence failures(propagate) {
   %dummy = test_remap_operand_to_self %arg0 : (!transform.any_op) -> !transform.any_op
   %valuehandle = transform.get_result %dummy[0] : (!transform.any_op) -> !transform.any_value
   test_remap_operand_to_self %dummy : (!transform.any_op) -> ()
+  // Use %valuehandle so that the SSA value is not dead. This prevents the
+  // transform dialect interpreter from discarding the handle.
+  test_print_number_of_associated_payload_ir_values %valuehandle : !transform.any_value
 }
 
 // -----


### PR DESCRIPTION
Do not maintain transform IR <-> payload IR mappings for dead handles, i.e., handles that do not have any further uses.

This change reduces the memory overhead of the transform dialect interpreter.