### PR TITLE
[clang] changes where a test writes its output

### DIFF
--- a/clang/test/OpenMP/dispatch_unsupported.c
+++ b/clang/test/OpenMP/dispatch_unsupported.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-llvm -fopenmp -disable-llvm-passes %s -o /dev/null -verify=expected
+// RUN: %clang_cc1 -emit-llvm -fopenmp -disable-llvm-passes %s -o %t -verify=expected
 
 // expected-error@+2 {{cannot compile this OpenMP dispatch directive yet}}
 void a(){


### PR DESCRIPTION
Writing directly to /dev/null has permission issues on some systems, so we've changed this to a temporary file instead.