### PR TITLE
[cross-project-tests] Fix struct-dse example so that it fails again

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
@@ -10,7 +10,9 @@
 //// Check debug-info for the escaped struct variable num is reasonable.
 
 #include <stdio.h>
-struct Nums { int a, b, c, d, e, f, g, h, i, j; };
+struct Nums {
+  int a, b, c, d, e, f, g, h, i, j;
+};
 struct Nums glob;
 __attribute__((__noinline__))
 void esc(struct Nums* nums) {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
@@ -10,7 +10,7 @@
 //// Check debug-info for the escaped struct variable num is reasonable.
 
 #include <stdio.h>
-struct Nums { int a, b, c; };
+struct Nums { int a, b, c, d, e, f, g, h, i, j; };
 struct Nums glob;
 __attribute__((__noinline__))
 void esc(struct Nums* nums) {


### PR DESCRIPTION
The purpose of this example is to provide a case where the debugger / debug info experience could be improved. A recent commit by clang (0d2860b795879f4dd152963b52f969b53b136899) changed codegen such that it changes how "small structs" are initialized, in a way that the debugger is now able to correctly display the variable being targeted by this test.

In order to keep the example relevant, i.e. failing, this commit makes it so that the struct is now "big enough" to not trigger the new codegen.