### PR TITLE
[UTC] Support arm64-apple-macosx in update_llc_test_checks.py.

### DIFF
--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_function_name.ll
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_function_name.ll
@@ -2,6 +2,7 @@
 
 ; RUN: llc -mtriple=aarch64-unknown-linux < %s | FileCheck --check-prefix=LINUX %s
 ; RUN: llc -mtriple=aarch64-apple-darwin < %s | FileCheck --check-prefix=DARWIN %s
+; RUN: llc -mtriple=arm64-apple-macosx < %s | FileCheck --check-prefix=DARWIN %s
 
 define hidden i32 @"_Z54bar$ompvariant$bar"() {
 entry:

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_function_name.ll.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_function_name.ll.expected
@@ -3,6 +3,7 @@
 
 ; RUN: llc -mtriple=aarch64-unknown-linux < %s | FileCheck --check-prefix=LINUX %s
 ; RUN: llc -mtriple=aarch64-apple-darwin < %s | FileCheck --check-prefix=DARWIN %s
+; RUN: llc -mtriple=arm64-apple-macosx < %s | FileCheck --check-prefix=DARWIN %s
 
 define hidden i32 @"_Z54bar$ompvariant$bar"() {
 ; LINUX-LABEL: _Z54bar$ompvariant$bar:

--- a/llvm/utils/UpdateTestChecks/asm.py
+++ b/llvm/utils/UpdateTestChecks/asm.py
@@ -552,6 +552,7 @@ def get_run_handler(triple):
         "arm64e": (scrub_asm_arm_eabi, ASM_FUNCTION_AARCH64_DARWIN_RE),
         "arm64ec": (scrub_asm_arm_eabi, ASM_FUNCTION_AARCH64_RE),
         "arm64-apple-ios": (scrub_asm_arm_eabi, ASM_FUNCTION_AARCH64_DARWIN_RE),
+        "arm64-apple-macosx": (scrub_asm_arm_eabi, ASM_FUNCTION_AARCH64_DARWIN_RE),
         "armv7-apple-ios": (scrub_asm_arm_eabi, ASM_FUNCTION_ARM_IOS_RE),
         "armv7-apple-darwin": (scrub_asm_arm_eabi, ASM_FUNCTION_ARM_DARWIN_RE),
         "thumb": (scrub_asm_arm_eabi, ASM_FUNCTION_ARM_RE),


### PR DESCRIPTION
arm64-apple-macosx is the default triple (usually with the macOS version number) on arm64 macOS. Support it in update_llc_test_checks.py.