### PR TITLE
[nfc]Generalize PGOFuncName helper methods for general global objects

### DIFF
--- a/clang/lib/CodeGen/CodeGenPGO.cpp
+++ b/clang/lib/CodeGen/CodeGenPGO.cpp
@@ -34,7 +34,7 @@ using namespace CodeGen;
 void CodeGenPGO::setFuncName(StringRef Name,
                              llvm::GlobalValue::LinkageTypes Linkage) {
   llvm::IndexedInstrProfReader *PGOReader = CGM.getPGOReader();
-  FuncName = llvm::getPGOFuncName(
+  FuncName = llvm::getPGOObjectName(
       Name, Linkage, CGM.getCodeGenOpts().MainFileName,
       PGOReader ? PGOReader->getVersion() : llvm::IndexedInstrProf::Version);
 
@@ -45,8 +45,8 @@ void CodeGenPGO::setFuncName(StringRef Name,
 
 void CodeGenPGO::setFuncName(llvm::Function *Fn) {
   setFuncName(Fn->getName(), Fn->getLinkage());
-  // Create PGOFuncName meta data.
-  llvm::createPGOFuncNameMetadata(*Fn, FuncName);
+  // Create PGOName meta data.
+  llvm::createPGONameMetadata(*Fn, FuncName);
 }
 
 /// The version of the PGO hash algorithm.

--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -181,10 +181,10 @@ std::string getPGOFuncName(const Function &F, bool InLTO = false,
 /// used the key for profile lookup. The function's original
 /// name is \c RawFuncName and has linkage of type \c Linkage.
 /// The function is defined in module \c FileName.
-std::string getPGOFuncName(StringRef RawFuncName,
-                           GlobalValue::LinkageTypes Linkage,
-                           StringRef FileName,
-                           uint64_t Version = INSTR_PROF_INDEX_VERSION);
+std::string getPGOObjectName(StringRef RawFuncName,
+                             GlobalValue::LinkageTypes Linkage,
+                             StringRef FileName,
+                             uint64_t Version = INSTR_PROF_INDEX_VERSION);
 
 /// \return the modified name for function \c F suitable to be
 /// used as the key for IRPGO profile lookup. \c InLTO indicates if this is
@@ -279,15 +279,12 @@ bool getValueProfDataFromInst(const Instruction &Inst,
                               uint32_t &ActualNumValueData, uint64_t &TotalC,
                               bool GetNoICPValue = false);
 
-inline StringRef getPGOFuncNameMetadataName() { return "PGOFuncName"; }
+inline StringRef getPGONameMetadataName() { return "PGOName"; }
 
-/// Return the PGOFuncName meta data associated with a function.
-MDNode *getPGOFuncNameMetadata(const Function &F);
-
-/// Create the PGOFuncName meta data if PGOFuncName is different from
-/// function's raw name. This should only apply to internal linkage functions
-/// declared by users only.
-void createPGOFuncNameMetadata(Function &F, StringRef PGOFuncName);
+/// Create the PGOName meta data if PGOName is different from the object's raw
+/// name. This should only apply to internal linkage objects declared by users
+/// only (i.e., not internalized by LTO).
+void createPGONameMetadata(GlobalObject &GO, StringRef PGOName);
 
 /// Check if we can use Comdat for profile variables. This will eliminate
 /// the duplicated profile variables for Comdat functions.

--- a/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
@@ -1700,8 +1700,8 @@ void PGOUseFunc::annotateValueSites() {
   if (DisableValueProfiling)
     return;
 
-  // Create the PGOFuncName meta data.
-  createPGOFuncNameMetadata(F, FuncInfo.FuncName);
+  // Create the PGOName meta data.
+  createPGONameMetadata(F, FuncInfo.FuncName);
 
   for (uint32_t Kind = IPVK_First; Kind <= IPVK_Last; ++Kind)
     annotateValueSites(Kind);

--- a/llvm/test/Transforms/DeadArgElim/func_metadata.ll
+++ b/llvm/test/Transforms/DeadArgElim/func_metadata.ll
@@ -7,8 +7,8 @@ target triple = "x86_64-unknown-linux-gnu"
 
 @s = common dso_local local_unnamed_addr global i32 0, align 4
 
-define internal i32 @va_func(i32 %num, ...) !prof !28 !PGOFuncName !29{
-; CHECK: define internal void @va_func(i32 %num) !prof ![[ENTRYCOUNT:[0-9]+]] !PGOFuncName ![[PGOFUNCNAME1:[0-9]+]] {
+define internal i32 @va_func(i32 %num, ...) !prof !28 !PGOName !29{
+; CHECK: define internal void @va_func(i32 %num) !prof ![[ENTRYCOUNT:[0-9]+]] !PGOName ![[PGOName1:[0-9]+]] {
 entry:
   %0 = load i32, ptr @s, align 4, !tbaa !31
   %add = add nsw i32 %0, %num
@@ -16,8 +16,8 @@ entry:
   ret i32 0
 }
 
-define internal fastcc i32 @foo() unnamed_addr !prof !28 !PGOFuncName !30 {
-; CHECK: define internal fastcc void @foo() unnamed_addr !prof ![[ENTRYCOUNT:[0-9]+]] !PGOFuncName ![[PGOFUNCNAME2:[0-9]+]] {
+define internal fastcc i32 @foo() unnamed_addr !prof !28 !PGOName !30 {
+; CHECK: define internal fastcc void @foo() unnamed_addr !prof ![[ENTRYCOUNT:[0-9]+]] !PGOName ![[PGOName2:[0-9]+]] {
 entry:
   %0 = load i32, ptr @s, align 4, !tbaa !31
   %add = add nsw i32 %0, 8
@@ -58,9 +58,9 @@ entry:
 !28 = !{!"function_entry_count", i64 1}
 ; CHECK: ![[ENTRYCOUNT]] = !{!"function_entry_count", i64 1}
 !29 = !{!"foo.c:va_func"}
-; CHECK: ![[PGOFUNCNAME1]] = !{!"foo.c:va_func"}
+; CHECK: ![[PGOName1]] = !{!"foo.c:va_func"}
 !30 = !{!"foo.c:foo"}
-; CHECK: ![[PGOFUNCNAME2]] = !{!"foo.c:foo"}
+; CHECK: ![[PGOName2]] = !{!"foo.c:foo"}
 !31 = !{!32, !32, i64 0}
 !32 = !{!"int", !33, i64 0}
 !33 = !{!"omnipotent char", !34, i64 0}

--- a/llvm/test/Transforms/JumpThreading/thread-prob-1.ll
+++ b/llvm/test/Transforms/JumpThreading/thread-prob-1.ll
@@ -4,7 +4,7 @@
 ; Make sure that we set the branch probability for the newly created
 ; basic block.
 
-define void @foo(i1 %cond1, i1 %cond2) !prof !0 !PGOFuncName !1 {
+define void @foo(i1 %cond1, i1 %cond2) !prof !0 !PGOName !1 {
 entry:
   br i1 %cond1, label %bb.f1, label %bb.f2, !prof !2
 

--- a/llvm/test/Transforms/PGOProfile/Inputs/thinlto_cspgo_bar_gen.ll
+++ b/llvm/test/Transforms/PGOProfile/Inputs/thinlto_cspgo_bar_gen.ll
@@ -26,7 +26,7 @@ if.end:
   ret void
 }
 
-define internal fastcc i32 @cond(i32 %i) #1 !prof !29 !PGOFuncName !35 {
+define internal fastcc i32 @cond(i32 %i) #1 !prof !29 !PGOName !35 {
 entry:
   %rem = srem i32 %i, 2
   ret i32 %rem

--- a/llvm/test/Transforms/PGOProfile/Inputs/thinlto_cspgo_bar_use.ll
+++ b/llvm/test/Transforms/PGOProfile/Inputs/thinlto_cspgo_bar_use.ll
@@ -31,7 +31,7 @@ if.end:
 
 declare void @clobber()
 
-define internal fastcc i32 @cond(i32 %i) #1 !prof !29 !PGOFuncName !35 {
+define internal fastcc i32 @cond(i32 %i) #1 !prof !29 !PGOName !35 {
 entry:
   %rem = srem i32 %i, 2
   ret i32 %rem

--- a/llvm/test/Transforms/PGOProfile/Inputs/thinlto_indirect_call_promotion.ll
+++ b/llvm/test/Transforms/PGOProfile/Inputs/thinlto_indirect_call_promotion.ll
@@ -8,7 +8,7 @@ entry:
   ret void
 }
 
-define internal void @c() !PGOFuncName !1 {
+define internal void @c() !PGOName !1 {
 entry:
   ret void
 }

--- a/llvm/test/Transforms/PGOProfile/icp_invoke.ll
+++ b/llvm/test/Transforms/PGOProfile/icp_invoke.ll
@@ -6,12 +6,12 @@ target triple = "x86_64-unknown-linux-gnu"
 @foo2 = global ptr null, align 8
 @_ZTIi = external constant ptr
 
-define internal void @_ZL4bar1v() !PGOFuncName !0 {
+define internal void @_ZL4bar1v() !PGOName !0 {
 entry:
   ret void
 }
 
-define internal i32 @_ZL4bar2v() !PGOFuncName !1 {
+define internal i32 @_ZL4bar2v() !PGOName !1 {
 entry:
   ret i32 100
 }

--- a/llvm/test/Transforms/PGOProfile/icp_invoke_nouse.ll
+++ b/llvm/test/Transforms/PGOProfile/icp_invoke_nouse.ll
@@ -5,7 +5,7 @@ target triple = "x86_64-unknown-linux-gnu"
 @_ZTISt9exception = external constant ptr
 @pfptr = global ptr null, align 8
 
-define internal i32 @_ZL4bar1v() !PGOFuncName !0 {
+define internal i32 @_ZL4bar1v() !PGOName !0 {
 entry:
   ret i32 100 
 }

--- a/llvm/test/tools/gold/X86/Inputs/thinlto_cspgo_bar.ll
+++ b/llvm/test/tools/gold/X86/Inputs/thinlto_cspgo_bar.ll
@@ -63,7 +63,7 @@ for.inc.3:
   ret void
 }
 
-define internal fastcc i32 @cond(i32 %i) #1 !prof !29 !PGOFuncName !36 {
+define internal fastcc i32 @cond(i32 %i) #1 !prof !29 !PGOName !36 {
 entry:
   %rem = srem i32 %i, 2
   ret i32 %rem


### PR DESCRIPTION
- Rename `PGOFuncName` metadata to `PGOName`. Updated tests accordingly.
- Generalize existing helper functions (rename, change parameter type) so they could be used for GlobalObject.

This is a split of https://github.com/llvm/llvm-project/pull/66825 to use PGOName for vtables. In particular,  the old format is used. The difference of old and new format only matters in one scenario -- the instrPGO (not SamplePGO) for local functions when it comes to the import of (profiled) indirect functions or vtables.
1. ThinTLO computes the list of imported variables and functions using `GlobalValue::GUID`, which is computed using [global identifier](https://github.com/llvm/llvm-project/blob/39faf13dde5502cdba7aff1b967c51cd0a93bb71/llvm/include/llvm/IR/GlobalValue.h#L591). 
2. When merging raw profiles into indexed profiles, the profiled address is [mapped](https://github.com/llvm/llvm-project/blob/39faf13dde5502cdba7aff1b967c51cd0a93bb71/llvm/lib/ProfileData/InstrProf.cpp#L882) to the MD5 hash. For local linkage functions or global variables.  The MD5 is annotated in value profiles.
3. MD5 hash in the annotation and ThinLTO should be computed from the same name. For globals, the name is the same already. For local ones, old format uses `filename:name` but new format uses `filename;name`.
    - This applies to local functions for ICP as well. I have a patch to record `hash-of-new-format` and `hash-of-old-format` in the raw profiles, so the remap could remap (and annotate) old hash. Still needs some work to make it work.