### PR TITLE
[flang][openacc] Enforce no branching out of compute region for combined construct

### DIFF
--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -218,6 +218,7 @@ void AccStructureChecker::Leave(const parser::OpenACCCombinedConstruct &x) {
   const auto &beginBlockDir{std::get<parser::AccBeginCombinedDirective>(x.t)};
   const auto &combinedDir{
       std::get<parser::AccCombinedDirective>(beginBlockDir.t)};
+  auto &doCons{std::get<std::optional<parser::DoConstruct>>(x.t)};
   switch (combinedDir.v) {
   case llvm::acc::Directive::ACCD_kernels_loop:
   case llvm::acc::Directive::ACCD_parallel_loop:
@@ -225,6 +226,10 @@ void AccStructureChecker::Leave(const parser::OpenACCCombinedConstruct &x) {
     // Restriction - line 1004-1005
     CheckOnlyAllowedAfter(llvm::acc::Clause::ACCC_device_type,
         computeConstructOnlyAllowedAfterDeviceTypeClauses);
+    if (doCons) {
+      const parser::Block &block{std::get<parser::Block>(doCons->t)};
+      CheckNoBranching(block, GetContext().directive, beginBlockDir.source);
+    }
     break;
   default:
     break;

--- a/flang/test/Parser/acc-unparse.f90
+++ b/flang/test/Parser/acc-unparse.f90
@@ -9,7 +9,7 @@ program bug47659
     !$acc parallel loop
     do j = 1, 10
       if (j == 2) then
-        exit label1
+        stop 1
       end if
     end do
   end do label1

--- a/flang/test/Semantics/OpenACC/acc-branch.f90
+++ b/flang/test/Semantics/OpenACC/acc-branch.f90
@@ -19,6 +19,27 @@ subroutine openacc_clause_validity
   end do
   !$acc end parallel
 
+  !$acc parallel loop
+  do i = 1, N
+    a(i) = 3.14
+    !ERROR: RETURN statement is not allowed in a PARALLEL LOOP construct
+    return
+  end do
+
+  !$acc serial loop
+  do i = 1, N
+    a(i) = 3.14
+    !ERROR: RETURN statement is not allowed in a SERIAL LOOP construct
+    return
+  end do
+
+  !$acc kernels loop
+  do i = 1, N
+    a(i) = 3.14
+    !ERROR: RETURN statement is not allowed in a KERNELS LOOP construct
+    return
+  end do
+
   !$acc parallel
   !$acc loop
   do i = 1, N


### PR DESCRIPTION
`A program may not branch into or out of a compute construct.` This restriction is also true for combined constructs. This patch enforce this rule. 