### PR TITLE
[PowerPC] Move __ehinfo TOC entries to the end of the TOC section

### DIFF
--- a/llvm/include/llvm/MC/MCSymbolXCOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolXCOFF.h
@@ -17,6 +17,9 @@ namespace llvm {
 class MCSectionXCOFF;
 
 class MCSymbolXCOFF : public MCSymbol {
+
+  enum XCOFFSymbolFlags : uint16_t { SF_EHInfo = 0x0001 };
+
 public:
   MCSymbolXCOFF(const StringMapEntry<bool> *Name, bool isTemporary)
       : MCSymbol(SymbolKindXCOFF, Name, isTemporary) {}
@@ -64,6 +67,10 @@ public:
       return SymbolTableName;
     return getUnqualifiedName();
   }
+
+  bool isEHInfo() const { return getFlags() & SF_EHInfo; }
+
+  void setEHInfo() const { modifyFlags(SF_EHInfo, SF_EHInfo); }
 
 private:
   std::optional<XCOFF::StorageClass> StorageClass;

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2644,12 +2644,16 @@ MCSection *TargetLoweringObjectFileXCOFF::getSectionForFunctionDescriptor(
 MCSection *TargetLoweringObjectFileXCOFF::getSectionForTOCEntry(
     const MCSymbol *Sym, const TargetMachine &TM) const {
   // Use TE storage-mapping class when large code model is enabled so that
-  // the chance of needing -bbigtoc is decreased.
+  // the chance of needing -bbigtoc is decreased. Also, the toc-entry for
+  // EH info is never referenced directly using instructions so it can be
+  // allocated with TE storage-mapping class.
   return getContext().getXCOFFSection(
       cast<MCSymbolXCOFF>(Sym)->getSymbolTableName(), SectionKind::getData(),
-      XCOFF::CsectProperties(
-          TM.getCodeModel() == CodeModel::Large ? XCOFF::XMC_TE : XCOFF::XMC_TC,
-          XCOFF::XTY_SD));
+      XCOFF::CsectProperties((TM.getCodeModel() == CodeModel::Large ||
+                              cast<MCSymbolXCOFF>(Sym)->isEHInfo())
+                                 ? XCOFF::XMC_TE
+                                 : XCOFF::XMC_TC,
+                             XCOFF::XTY_SD));
 }
 
 MCSection *TargetLoweringObjectFileXCOFF::getSectionForLSDA(

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2310,8 +2310,10 @@ bool TargetLoweringObjectFileXCOFF::ShouldSetSSPCanaryBitInTB(
 
 MCSymbol *
 TargetLoweringObjectFileXCOFF::getEHInfoTableSymbol(const MachineFunction *MF) {
-  return MF->getMMI().getContext().getOrCreateSymbol(
+  MCSymbol *EHInfoSym = MF->getMMI().getContext().getOrCreateSymbol(
       "__ehinfo." + Twine(MF->getFunctionNumber()));
+  cast<MCSymbolXCOFF>(EHInfoSym)->setEHInfo();
+  return EHInfoSym;
 }
 
 MCSymbol *

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -2450,7 +2450,6 @@ void PPCAIXAsmPrinter::emitTracebackTable() {
     auto &Ctx = OutStreamer->getContext();
     MCSymbol *EHInfoSym =
         TargetLoweringObjectFileXCOFF::getEHInfoTableSymbol(MF);
-    cast<MCSymbolXCOFF>(EHInfoSym)->setEHInfo();
     MCSymbol *TOCEntry = lookUpOrCreateTOCEntry(EHInfoSym, TOCType_EHBlock);
     const MCSymbol *TOCBaseSym =
         cast<MCSectionXCOFF>(getObjFileLowering().getTOCBaseSection())

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -2450,6 +2450,7 @@ void PPCAIXAsmPrinter::emitTracebackTable() {
     auto &Ctx = OutStreamer->getContext();
     MCSymbol *EHInfoSym =
         TargetLoweringObjectFileXCOFF::getEHInfoTableSymbol(MF);
+    cast<MCSymbolXCOFF>(EHInfoSym)->setEHInfo();
     MCSymbol *TOCEntry = lookUpOrCreateTOCEntry(EHInfoSym, TOCType_EHBlock);
     const MCSymbol *TOCBaseSym =
         cast<MCSectionXCOFF>(getObjFileLowering().getTOCBaseSection())

--- a/llvm/test/CodeGen/PowerPC/aix-ehinfo-sym.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ehinfo-sym.ll
@@ -47,4 +47,4 @@ attributes #0 = { nounwind }
 attributes #1 = { mustprogress noinline optnone }
 
 ; CHECK: __ehinfo.0:
-; CHECK: .tc __ehinfo.0[TC],__ehinfo.0
+; CHECK: .tc __ehinfo.0[TE],__ehinfo.0

--- a/llvm/test/CodeGen/PowerPC/aix-ehinfo-sym.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ehinfo-sym.ll
@@ -4,6 +4,10 @@
 ; RUN: llc -mtriple powerpc64-ibm-aix -fast-isel -verify-machineinstrs < %s | \
 ; RUN:  FileCheck %s
 
+; RUN: llc -mtriple powerpc64-ibm-aix -verify-machineinstrs  -filetype=obj \
+; RUN:   -o %t.o < %s
+; RUN: llvm-readobj --syms %t.o | FileCheck --check-prefix=SYM %s
+
 ; Function Attrs: nounwind
 declare i32 @func1() #0
 
@@ -48,3 +52,10 @@ attributes #1 = { mustprogress noinline optnone }
 
 ; CHECK: __ehinfo.0:
 ; CHECK: .tc __ehinfo.0[TE],__ehinfo.0
+
+; SYM:    Symbol {
+; SYM:      Name: __ehinfo.0
+; SYM:      CSECT Auxiliary Entry {
+; SYM:        StorageMappingClass: XMC_TE (0x16)
+; SYM:      }
+; SYM:    }

--- a/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-emit-tracebacktable-clobber-register.ll
@@ -104,7 +104,7 @@ entry:
 ; COMMON-NEXT:                                         # -- End function
 ; COMMON:       .toc
 ; COMMON:      L..C2:
-; COMMON-NEXT:  .tc __ehinfo.1[TC],__ehinfo.1
+; COMMON-NEXT:  .tc __ehinfo.1[TE],__ehinfo.1
 
 
 ; OBJ-DIS:      9c: 00 00 00 00  	# Traceback table start

--- a/llvm/test/CodeGen/PowerPC/aix-exception.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-exception.ll
@@ -180,7 +180,7 @@ eh.resume:                                        ; preds = %catch.dispatch
 ; ASM:  L..C0:
 ; ASM:    .tc _ZTIi[TC],_ZTIi[UA]
 ; ASM:  L..C1:
-; ASM:    .tc __ehinfo.1[TC],__ehinfo.1
+; ASM:    .tc __ehinfo.1[TE],__ehinfo.1
 
 declare ptr @__cxa_allocate_exception(i32)
 declare void @__cxa_throw(ptr, ptr, ptr)


### PR DESCRIPTION
On AIX, the __ehinfo toc-entry is never referenced directly using instructions, therefore we can allocate them with the TE storage mapping class to move them to the end of TOC.