### PR TITLE
[libc][bazel] Add copts to libc_support_library

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -47,8 +47,10 @@ def _libc_library(name, hidden, copts = [], deps = [], **kwargs):
 # A convenience function which should be used to list all libc support libraries.
 # Any library which does not define a public function should be listed with
 # libc_support_library.
-def libc_support_library(name, **kwargs):
-    _libc_library(name = name, hidden = False, **kwargs)
+def libc_support_library(name, copts = None, **kwargs):
+    copts = copts or []
+    copts = copts + ["-O3", "-fno-builtin", "-fno-lax-vector-conversions"]
+    _libc_library(name = name, copts = copts, hidden = False, **kwargs)
 
 def libc_function(
         name,


### PR DESCRIPTION
Most libc_support_library calls are for header-only libraries, but there
are a few that have .cpp files. This patch adds the same base copts to
these that libc_function already has.
