### PR TITLE
[compiler-rt][sanitizer_common] Increase min user-map/freearray round…

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -641,11 +641,11 @@ class SizeClassAllocator64 {
   // kRegionSize must be <= 2^36, see CompactPtrT.
   COMPILER_CHECK((kRegionSize) <= (1ULL << (SANITIZER_WORDSIZE / 2 + 4)));
   // Call mmap for user memory with at least this size.
-  static const uptr kUserMapSize = 1 << 16;
+  static const uptr kUserMapSize = 1 << 18;
   // Call mmap for metadata memory with at least this size.
   static const uptr kMetaMapSize = 1 << 16;
   // Call mmap for free array memory with at least this size.
-  static const uptr kFreeArrayMapSize = 1 << 16;
+  static const uptr kFreeArrayMapSize = 1 << 18;
 
   atomic_sint32_t release_to_os_interval_ms_;
 


### PR DESCRIPTION
…ing size

About 90% of the time when running scudo tests on fuchsia+riscv with asan instrumentation, we will be unable to map the arena for scudo's primary allocator. We have enough space, but much of the existing allocations are fragmented enough such that we can't allocate that large enough contiguous space. This reduces fragmentation more by increase min allocation rounding for user-map and freearray in the primary allocator.

Note that changing these values doesn't have a functional effect on the actual size of the user-map or freearray portions of a region. Those are toggled by different constants. This will reduce the number of times mmap is called and reduce the number of fragments.

Locally, I've been able to run the scudo tests under asan-instrumentation on riscv 39-bit vma and haven't run into the `SCUDO ERROR: zx_vmar_map` error.