### PR TITLE
[Flang] Add multiline error message support to pass-plugin-not-found (NFC)

### DIFF
--- a/flang/test/Driver/pass-plugin-not-found.f90
+++ b/flang/test/Driver/pass-plugin-not-found.f90
@@ -6,4 +6,4 @@
 ! RUN: not %flang_fc1 -emit-llvm -o /dev/null -fpass-plugin=X.Y %s 2>&1 | FileCheck %s --check-prefix=ERROR
 
 ! The exact wording of the error message depends on the system dlerror.
-! ERROR: error: unable to load plugin 'X.Y': 'Could not load library 'X.Y': {{.*}}: {{.*}}{{[Nn]}}o such file{{.*}}'
+! ERROR: error: unable to load plugin 'X.Y': 'Could not load library 'X.Y': {{.*}}{{[[:space:]].*}}{{.*}}: {{.*}}{{[Nn]}}o such file{{.*}}'


### PR DESCRIPTION
The error message above has multiple lines on AIX, adding `{{[[:space:]].*}}` to match multiple lines