### PR TITLE
[lldb][progress] Always report progress upon Progress object destruction

### DIFF
--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -30,9 +30,8 @@ Progress::~Progress() {
   // Make sure to always report progress completed when this object is
   // destructed so it indicates the progress dialog/activity should go away.
   std::lock_guard<std::mutex> guard(m_mutex);
-  if (!m_completed) {
+  if (!m_completed)
     m_completed = m_total;
-  }
   ReportProgress();
 }
 

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -32,8 +32,8 @@ Progress::~Progress() {
   std::lock_guard<std::mutex> guard(m_mutex);
   if (!m_completed) {
     m_completed = m_total;
-    ReportProgress();
   }
+  ReportProgress();
 }
 
 void Progress::Increment(uint64_t amount, std::string update) {


### PR DESCRIPTION
This commit allows a final progress report upon the destruction of the `Progress` object to happen at all times as opposed to when the progress was not completed.