### PR TITLE
[mlir] Re-Add mlirTranslateModuleToLLVMIR to MLIR-C

### DIFF
--- a/mlir/include/mlir-c/Target/LLVMIR.h
+++ b/mlir/include/mlir-c/Target/LLVMIR.h
@@ -1,0 +1,35 @@
+//===- LLVMIR.h - C Interface for MLIR LLVMIR Target -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header declares the C interface to target LLVMIR with MLIR.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_C_TARGET_LLVMIR_H
+#define MLIR_C_TARGET_LLVMIR_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+#include "llvm-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Translate operation that satisfies LLVM dialect module requirements into an
+// LLVM IR module living in the given context. This translates operations from
+// any dilalect that has a registered implementation of
+// LLVMTranslationDialectInterface.
+MLIR_CAPI_EXPORTED LLVMModuleRef
+mlirTranslateModuleToLLVMIR(MlirOperation module, LLVMContextRef context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MLIR_C_TARGET_LLVMIR_H

--- a/mlir/include/mlir-c/Target/LLVMIR.h
+++ b/mlir/include/mlir-c/Target/LLVMIR.h
@@ -29,8 +29,8 @@ extern "C" {
 ///
 /// \returns the generated LLVM IR Module from the translated MLIR module, it is
 /// owned by the caller.
-MLIR_CAPI_EXPORTED LLVMModuleRef mlirTranslateModuleToLLVMIR(
-    MlirOperation module, LLVMContextRef context, MlirStringRef llvmModuleName);
+MLIR_CAPI_EXPORTED LLVMModuleRef
+mlirTranslateModuleToLLVMIR(MlirOperation module, LLVMContextRef context);
 
 #ifdef __cplusplus
 }

--- a/mlir/include/mlir-c/Target/LLVMIR.h
+++ b/mlir/include/mlir-c/Target/LLVMIR.h
@@ -1,6 +1,7 @@
-//===- LLVMIR.h - C Interface for MLIR LLVMIR Target -------------------===//
+//===-- LLVMIR.h - C Interface for MLIR LLVMIR Target -------------*- C -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
@@ -21,12 +22,15 @@
 extern "C" {
 #endif
 
-// Translate operation that satisfies LLVM dialect module requirements into an
-// LLVM IR module living in the given context. This translates operations from
-// any dilalect that has a registered implementation of
-// LLVMTranslationDialectInterface.
-MLIR_CAPI_EXPORTED LLVMModuleRef
-mlirTranslateModuleToLLVMIR(MlirOperation module, LLVMContextRef context);
+/// Translate operation that satisfies LLVM dialect module requirements into an
+/// LLVM IR module living in the given context. This translates operations from
+/// any dilalect that has a registered implementation of
+/// LLVMTranslationDialectInterface.
+///
+/// \returns the generated LLVM IR Module from the translated MLIR module, it is
+/// owned by the caller.
+MLIR_CAPI_EXPORTED LLVMModuleRef mlirTranslateModuleToLLVMIR(
+    MlirOperation module, LLVMContextRef context, MlirStringRef llvmModuleName);
 
 #ifdef __cplusplus
 }

--- a/mlir/lib/CAPI/CMakeLists.txt
+++ b/mlir/lib/CAPI/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(Interfaces)
 add_subdirectory(IR)
 add_subdirectory(RegisterEverything)
 add_subdirectory(Transforms)
+add_subdirectory(Target)
 
 if(MLIR_ENABLE_EXECUTION_ENGINE)
   add_subdirectory(ExecutionEngine)
@@ -36,4 +37,3 @@ if(MLIR_BUILD_MLIR_C_DYLIB)
     endif()
   endif()
 endif()
-

--- a/mlir/lib/CAPI/Target/CMakeLists.txt
+++ b/mlir/lib/CAPI/Target/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_mlir_upstream_c_api_library(MLIRCAPITarget
+  LLVMIR.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRToLLVMIRTranslationRegistration
+  MLIRCAPIIR
+  MLIRLLVMToLLVMIRTranslation
+  MLIRSupport
+)

--- a/mlir/lib/CAPI/Target/CMakeLists.txt
+++ b/mlir/lib/CAPI/Target/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_mlir_upstream_c_api_library(MLIRCAPITarget
   LLVMIR.cpp
 
+  LINK_COMPONENTS
+  Core
+
   LINK_LIBS PUBLIC
   MLIRToLLVMIRTranslationRegistration
   MLIRCAPIIR

--- a/mlir/lib/CAPI/Target/LLVMIR.cpp
+++ b/mlir/lib/CAPI/Target/LLVMIR.cpp
@@ -1,6 +1,7 @@
-//===- LLVMIR.cpp - C Interface for MLIR LLVMIR Target -------------------===//
+//===-- LLVMIR.h - C Interface for MLIR LLVMIR Target ---------------------===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
@@ -20,12 +21,15 @@
 using namespace mlir;
 
 LLVMModuleRef mlirTranslateModuleToLLVMIR(MlirOperation module,
-                                          LLVMContextRef context) {
+                                          LLVMContextRef context,
+                                          MlirStringRef llvmModuleName) {
   Operation *moduleOp = unwrap(module);
 
   llvm::LLVMContext *ctx = reinterpret_cast<llvm::LLVMContext *>(context);
 
-  auto llvmModule = mlir::translateModuleToLLVMIR(moduleOp, *ctx);
+  std::unique_ptr<llvm::Module> llvmModule = mlir::translateModuleToLLVMIR(
+      moduleOp, *ctx,
+      llvm::StringRef(llvmModuleName.data, llvmModuleName.length));
 
   LLVMModuleRef moduleRef = reinterpret_cast<LLVMModuleRef>(
       const_cast<llvm::Module *>(llvmModule.release()));

--- a/mlir/lib/CAPI/Target/LLVMIR.cpp
+++ b/mlir/lib/CAPI/Target/LLVMIR.cpp
@@ -11,6 +11,7 @@
 #include "llvm-c/Support.h"
 
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
 #include <memory>
 
 #include "mlir/CAPI/IR.h"
@@ -25,14 +26,13 @@ LLVMModuleRef mlirTranslateModuleToLLVMIR(MlirOperation module,
                                           MlirStringRef llvmModuleName) {
   Operation *moduleOp = unwrap(module);
 
-  llvm::LLVMContext *ctx = reinterpret_cast<llvm::LLVMContext *>(context);
+  llvm::LLVMContext *ctx = llvm::unwrap(context);
 
   std::unique_ptr<llvm::Module> llvmModule = mlir::translateModuleToLLVMIR(
       moduleOp, *ctx,
       llvm::StringRef(llvmModuleName.data, llvmModuleName.length));
 
-  LLVMModuleRef moduleRef = reinterpret_cast<LLVMModuleRef>(
-      const_cast<llvm::Module *>(llvmModule.release()));
+  LLVMModuleRef moduleRef = llvm::wrap(llvmModule.release());
 
   return moduleRef;
 }

--- a/mlir/lib/CAPI/Target/LLVMIR.cpp
+++ b/mlir/lib/CAPI/Target/LLVMIR.cpp
@@ -1,0 +1,34 @@
+//===- LLVMIR.cpp - C Interface for MLIR LLVMIR Target -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir-c/Target/LLVMIR.h"
+#include "llvm-c/Support.h"
+
+#include "llvm/IR/LLVMContext.h"
+#include <memory>
+
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+#include "mlir/CAPI/Wrap.h"
+#include "mlir/Target/LLVMIR/ModuleTranslation.h"
+
+using namespace mlir;
+
+LLVMModuleRef mlirTranslateModuleToLLVMIR(MlirOperation module,
+                                          LLVMContextRef context) {
+  Operation *moduleOp = unwrap(module);
+
+  llvm::LLVMContext *ctx = reinterpret_cast<llvm::LLVMContext *>(context);
+
+  auto llvmModule = mlir::translateModuleToLLVMIR(moduleOp, *ctx);
+
+  LLVMModuleRef moduleRef = reinterpret_cast<LLVMModuleRef>(
+      const_cast<llvm::Module *>(llvmModule.release()));
+
+  return moduleRef;
+}

--- a/mlir/lib/CAPI/Target/LLVMIR.cpp
+++ b/mlir/lib/CAPI/Target/LLVMIR.cpp
@@ -22,15 +22,13 @@
 using namespace mlir;
 
 LLVMModuleRef mlirTranslateModuleToLLVMIR(MlirOperation module,
-                                          LLVMContextRef context,
-                                          MlirStringRef llvmModuleName) {
+                                          LLVMContextRef context) {
   Operation *moduleOp = unwrap(module);
 
   llvm::LLVMContext *ctx = llvm::unwrap(context);
 
-  std::unique_ptr<llvm::Module> llvmModule = mlir::translateModuleToLLVMIR(
-      moduleOp, *ctx,
-      llvm::StringRef(llvmModuleName.data, llvmModuleName.length));
+  std::unique_ptr<llvm::Module> llvmModule =
+      mlir::translateModuleToLLVMIR(moduleOp, *ctx);
 
   LLVMModuleRef moduleRef = llvm::wrap(llvmModule.release());
 

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -43,6 +43,7 @@ _add_capi_test_executable(mlir-capi-llvm-test
     MLIRCAPIIR
     MLIRCAPILLVM
     MLIRCAPIRegisterEverything
+    MLIRCAPITarget
 )
 
 _add_capi_test_executable(mlir-capi-pass-test

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -43,7 +43,6 @@ _add_capi_test_executable(mlir-capi-llvm-test
     MLIRCAPIIR
     MLIRCAPILLVM
     MLIRCAPIRegisterEverything
-    MLIRCAPITarget
 )
 
 _add_capi_test_executable(mlir-capi-pass-test
@@ -85,4 +84,13 @@ _add_capi_test_executable(mlir-capi-transform-test
     MLIRCAPIIR
     MLIRCAPIRegisterEverything
     MLIRCAPITransformDialect
+)
+
+_add_capi_test_executable(mlir-capi-translation-test
+  translation.c
+  LINK_LIBS PRIVATE
+    MLIRCAPIIR
+    MLIRCAPILLVM
+    MLIRCAPIRegisterEverything
+    MLIRCAPITarget
 )

--- a/mlir/test/CAPI/llvm.c
+++ b/mlir/test/CAPI/llvm.c
@@ -9,9 +9,15 @@
 
 // RUN: mlir-capi-llvm-test 2>&1 | FileCheck %s
 
-#include "mlir-c/Dialect/LLVM.h"
+#include "llvm-c/Core.h"
+#include "llvm-c/Support.h"
+#include "llvm-c/Types.h"
+
 #include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/Dialect/LLVM.h"
 #include "mlir-c/IR.h"
+#include "mlir-c/RegisterEverything.h"
+#include "mlir-c/Target/LLVMIR.h"
 
 #include <assert.h>
 #include <math.h>
@@ -73,11 +79,47 @@ static void testTypeCreation(MlirContext ctx) {
           mlirTypeEqual(i32_i64_s, i32_i64_s_ref));
 }
 
+// CHECK-LABEL: testToLLVMIR()
+static void testToLLVMIR(MlirContext ctx) {
+  fprintf(stderr, "testToLLVMIR()\n");
+  LLVMContextRef llvmCtx = LLVMContextCreate();
+
+  const char *moduleString = "llvm.func @add(%arg0: i64, %arg1: i64) -> i64 { \
+                                %0 = llvm.add %arg0, %arg1  : i64 \
+                                llvm.return %0 : i64 \
+                             }";
+
+  mlirRegisterAllLLVMTranslations(ctx);
+
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleString));
+
+  MlirOperation operation = mlirModuleGetOperation(module);
+
+  LLVMModuleRef llvmModule = mlirTranslateModuleToLLVMIR(operation, llvmCtx);
+
+  // clang-format off
+  // CHECK: ; ModuleID = 'LLVMDialectModule'
+  // CHECK-NEXT: source_filename = "LLVMDialectModule"
+  // CHECK: declare ptr @malloc(i64 %0)
+  // CHECK: declare void @free(ptr %0)
+  // CHECK: define i64 @add(i64 %0, i64 %1) {
+  // CHECK-NEXT:   %3 = add i64 %0, %1
+  // CHECK-NEXT:   ret i64 %3
+  // CHECK-NEXT: }
+  // clang-format on
+  LLVMDumpModule(llvmModule);
+
+  LLVMDisposeModule(llvmModule);
+  mlirModuleDestroy(module);
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirDialectHandleRegisterDialect(mlirGetDialectHandle__llvm__(), ctx);
   mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("llvm"));
   testTypeCreation(ctx);
+  testToLLVMIR(ctx);
   mlirContextDestroy(ctx);
   return 0;
 }

--- a/mlir/test/CAPI/translation.c
+++ b/mlir/test/CAPI/translation.c
@@ -46,8 +46,6 @@ static void testToLLVMIR(MlirContext ctx) {
   LLVMModuleRef llvmModule = mlirTranslateModuleToLLVMIR(operation, llvmCtx);
 
   // clang-format off
-  // CHECK: declare ptr @malloc(i64 %{{.*}})
-  // CHECK: declare void @free(ptr %{{.*}})
   // CHECK: define i64 @add(i64 %[[arg1:.*]], i64 %[[arg2:.*]]) {
   // CHECK-NEXT:   %[[arg3:.*]] = add i64 %[[arg1]], %[[arg2]]
   // CHECK-NEXT:   ret i64 %[[arg3]]

--- a/mlir/test/CAPI/translation.c
+++ b/mlir/test/CAPI/translation.c
@@ -1,0 +1,72 @@
+//===- translation.c - Test MLIR Target translations ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: mlir-capi-translation-test 2>&1 | FileCheck %s
+
+#include "llvm-c/Core.h"
+#include "llvm-c/Support.h"
+#include "llvm-c/Types.h"
+
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/Dialect/LLVM.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/RegisterEverything.h"
+#include "mlir-c/Support.h"
+#include "mlir-c/Target/LLVMIR.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// CHECK-LABEL: testToLLVMIR()
+static void testToLLVMIR(MlirContext ctx) {
+  fprintf(stderr, "testToLLVMIR()\n");
+  LLVMContextRef llvmCtx = LLVMContextCreate();
+
+  const char *moduleString = "llvm.func @add(%arg0: i64, %arg1: i64) -> i64 { \
+                                %0 = llvm.add %arg0, %arg1  : i64 \
+                                llvm.return %0 : i64 \
+                             }";
+
+  mlirRegisterAllLLVMTranslations(ctx);
+
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleString));
+
+  MlirOperation operation = mlirModuleGetOperation(module);
+
+  MlirStringRef name = mlirStringRefCreateFromCString("LLVMDialectModule");
+
+  LLVMModuleRef llvmModule =
+      mlirTranslateModuleToLLVMIR(operation, llvmCtx, name);
+
+  // clang-format off
+  // CHECK: declare ptr @malloc(i64 %{{.*}})
+  // CHECK: declare void @free(ptr %{{.*}})
+  // CHECK: define i64 @add(i64 %[[arg1:.*]], i64 %[[arg2:.*]]) {
+  // CHECK-NEXT:   %[[arg3:.*]] = add i64 %[[arg1]], %[[arg2]]
+  // CHECK-NEXT:   ret i64 %[[arg3]]
+  // CHECK-NEXT: }
+  // clang-format on
+  LLVMDumpModule(llvmModule);
+
+  LLVMDisposeModule(llvmModule);
+  mlirModuleDestroy(module);
+}
+
+int main(void) {
+  MlirContext ctx = mlirContextCreate();
+  mlirDialectHandleRegisterDialect(mlirGetDialectHandle__llvm__(), ctx);
+  mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("llvm"));
+  testToLLVMIR(ctx);
+  mlirContextDestroy(ctx);
+  return 0;
+}

--- a/mlir/test/CAPI/translation.c
+++ b/mlir/test/CAPI/translation.c
@@ -43,10 +43,7 @@ static void testToLLVMIR(MlirContext ctx) {
 
   MlirOperation operation = mlirModuleGetOperation(module);
 
-  MlirStringRef name = mlirStringRefCreateFromCString("LLVMDialectModule");
-
-  LLVMModuleRef llvmModule =
-      mlirTranslateModuleToLLVMIR(operation, llvmCtx, name);
+  LLVMModuleRef llvmModule = mlirTranslateModuleToLLVMIR(operation, llvmCtx);
 
   // clang-format off
   // CHECK: declare ptr @malloc(i64 %{{.*}})

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -45,10 +45,10 @@ if (MLIR_INCLUDE_INTEGRATION_TESTS)
     message(FATAL_ERROR "MLIR_INCLUDE_INTEGRATION_TESTS requires a native target")
   endif()
 
-  # When the Integration tests are requested via the MLIR_INCLUDE_INTEGRATION_TESTS 
-  # configuration flag, we automatically include sm80 tests when build for 
-  # cuSparse when the configuration flag MLIR_ENABLE_CUDA_CUSPARSE is set and 
-  # include sm80 lt tests when the MLIR_ENABLE_CUDA_CUSPARSELT is set in 
+  # When the Integration tests are requested via the MLIR_INCLUDE_INTEGRATION_TESTS
+  # configuration flag, we automatically include sm80 tests when build for
+  # cuSparse when the configuration flag MLIR_ENABLE_CUDA_CUSPARSE is set and
+  # include sm80 lt tests when the MLIR_ENABLE_CUDA_CUSPARSELT is set in
   # addition to those.
   if (MLIR_ENABLE_CUDA_CUSPARSE)
     set(MLIR_RUN_CUDA_SM80_TESTS ON)
@@ -101,6 +101,7 @@ set(MLIR_TEST_DEPENDS
   mlir-capi-quant-test
   mlir-capi-sparse-tensor-test
   mlir-capi-transform-test
+  mlir-capi-translation-test
   mlir-linalg-ods-yaml-gen
   mlir-lsp-server
   mlir-pdll-lsp-server

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -106,6 +106,7 @@ tools = [
     "mlir-capi-quant-test",
     "mlir-capi-sparse-tensor-test",
     "mlir-capi-transform-test",
+    "mlir-capi-translation-test",
     "mlir-cpu-runner",
     add_runtime("mlir_runner_utils"),
     add_runtime("mlir_c_runner_utils"),


### PR DESCRIPTION
The test was checking something unrelated to what it controlled so it failed after that part changed, i removed that.

See https://github.com/llvm/llvm-project/pull/73117