### PR TITLE
Revert "[mlir] Fix a warning"

### DIFF
--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -373,7 +373,7 @@ llvm::cl::OptionValue<OpPassManager>::operator=(
   return *this;
 }
 
-llvm::cl::OptionValue<OpPassManager>::~OptionValue<OpPassManager>() = default;
+llvm::cl::OptionValue<OpPassManager>::~OptionValue() = default;
 
 void llvm::cl::OptionValue<OpPassManager>::setValue(
     const OpPassManager &newValue) {


### PR DESCRIPTION
Revert patch 6318dd82732c583fcfa12fe5b8d837e048dbb571 "[mlir] Fix a warning"

Template ID is not allowed in destructor names starting with C++ 20: https://eel.is/c++draft/diff.cpp17.class#2