### PR TITLE
[Flang] Shift the data from lower to higher order bits in the big endian environment

### DIFF
--- a/flang/include/flang/Common/uint128.h
+++ b/flang/include/flang/Common/uint128.h
@@ -23,6 +23,16 @@
 #include <cstdint>
 #include <type_traits>
 
+#if FLANG_LITTLE_ENDIAN
+#define SWAP(a, i, b, j) \
+  a{i}, b { j }
+#elif FLANG_BIG_ENDIAN
+#define SWAP(a, i, b, j) \
+  b{j}, a { i }
+#else
+#error host endianness is not known
+#endif
+
 namespace Fortran::common {
 
 template <bool IS_SIGNED = false> class Int128 {
@@ -34,14 +44,14 @@ public:
   constexpr Int128(unsigned long n) : low_{n} {}
   constexpr Int128(unsigned long long n) : low_{n} {}
   constexpr Int128(int n)
-      : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(
-                                                 n < 0)} {}
+      : SWAP(low_, static_cast<std::uint64_t>(n), high_,
+            -static_cast<std::uint64_t>(n < 0)) {}
   constexpr Int128(long n)
-      : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(
-                                                 n < 0)} {}
+      : SWAP(low_, static_cast<std::uint64_t>(n), high_,
+            -static_cast<std::uint64_t>(n < 0)) {}
   constexpr Int128(long long n)
-      : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(
-                                                 n < 0)} {}
+      : SWAP(low_, static_cast<std::uint64_t>(n), high_,
+            -static_cast<std::uint64_t>(n < 0)) {}
   constexpr Int128(const Int128 &) = default;
   constexpr Int128(Int128 &&) = default;
   constexpr Int128 &operator=(const Int128 &) = default;
@@ -246,7 +256,8 @@ public:
   }
 
 private:
-  constexpr Int128(std::uint64_t hi, std::uint64_t lo) : low_{lo}, high_{hi} {}
+  constexpr Int128(std::uint64_t hi, std::uint64_t lo)
+      : SWAP(low_, lo, high_, hi) {}
   constexpr int LeadingZeroes() const {
     if (high_ == 0) {
       return 64 + LeadingZeroBitCount(low_);
@@ -255,7 +266,7 @@ private:
     }
   }
   static constexpr std::uint64_t topBit{std::uint64_t{1} << 63};
-  std::uint64_t low_{0}, high_{0};
+  std::uint64_t SWAP(low_, 0, high_, 0);
 };
 
 using UnsignedInt128 = Int128<false>;
@@ -288,4 +299,7 @@ template <int BITS>
 using HostSignedIntType = typename HostSignedIntTypeHelper<BITS>::type;
 
 } // namespace Fortran::common
+
+#undef SWAP
+
 #endif

--- a/flang/runtime/edit-input.cpp
+++ b/flang/runtime/edit-input.cpp
@@ -244,11 +244,11 @@ bool EditIntegerInput(
     value = -value;
   }
   if (any || !io.GetConnectionState().IsAtEOF()) {
-    // For integer kind <= 4, the value is stored in the lower order bits on
-    // the big endian platform. When memcpy the value, shift the value, shift
-    // the value to the higher order bit.
-    if (!isHostLittleEndian && kind <= 4) {
-      auto l{value.low() << (8 * (sizeof(value.low()) - kind))};
+    // The value is stored in the lower order bits on big endian platform.
+    // When memcpy, shift the value to the higher order bit.
+    auto shft{static_cast<int>(sizeof(value.low())) - kind};
+    if (!isHostLittleEndian && shft >= 0) {
+      auto l{value.low() << (8 * shft)};
       std::memcpy(n, &l, kind);
     } else {
       std::memcpy(n, &value, kind); // a blank field means zero

--- a/flang/runtime/edit-input.cpp
+++ b/flang/runtime/edit-input.cpp
@@ -244,7 +244,15 @@ bool EditIntegerInput(
     value = -value;
   }
   if (any || !io.GetConnectionState().IsAtEOF()) {
-    std::memcpy(n, &value, kind); // a blank field means zero
+    // For integer kind <= 4, the value is stored in the lower order bits on
+    // the big endian platform. When memcpy the value, shift the value, shift
+    // the value to the higher order bit.
+    if (!isHostLittleEndian && kind <= 4) {
+      auto l{value.low() << (8 * (sizeof(value.low()) - kind))};
+      std::memcpy(n, &l, kind);
+    } else {
+      std::memcpy(n, &value, kind); // a blank field means zero
+    }
   }
   return any;
 }

--- a/flang/runtime/edit-input.cpp
+++ b/flang/runtime/edit-input.cpp
@@ -247,6 +247,7 @@ bool EditIntegerInput(
     // The value is stored in the lower order bits on big endian platform.
     // When memcpy, shift the value to the higher order bit.
     auto shft{static_cast<int>(sizeof(value.low())) - kind};
+    // For kind==8 (i.e. shft==0), the value is stored in low_ in big endian.
     if (!isHostLittleEndian && shft >= 0) {
       auto l{value.low() << (8 * shft)};
       std::memcpy(n, &l, kind);


### PR DESCRIPTION
Shift the data from lower to higher order bits when memcpy the value in the namelist in the big endian environment
