### PR TITLE
[flang][OpenMP] Fix the attribute setting for OmpCommonBlock

### DIFF
--- a/flang/test/Semantics/OpenMP/common-block.f90
+++ b/flang/test/Semantics/OpenMP/common-block.f90
@@ -4,7 +4,7 @@ program main
   !CHECK: a size=4 offset=0: ObjectEntity type: REAL(4)
   !CHECK: b size=8 offset=4: ObjectEntity type: INTEGER(4) shape: 1_8:2_8
   !CHECK: c size=4 offset=12: ObjectEntity type: REAL(4)
-  !CHECK: blk size=16 offset=0: CommonBlockDetails alignment=4: a b c
+  !CHECK: blk (OmpCommonBlock) size=16 offset=0: CommonBlockDetails alignment=4: a b c
   real :: a, c
   integer :: b(2)
   common /blk/ a, b, c

--- a/flang/test/Semantics/OpenMP/declare-target-common-block.f90
+++ b/flang/test/Semantics/OpenMP/declare-target-common-block.f90
@@ -3,7 +3,7 @@
 PROGRAM main
     !CHECK: one (OmpDeclareTarget) size=4 offset=0: ObjectEntity type: REAL(4)
     !CHECK: two (OmpDeclareTarget) size=4 offset=4: ObjectEntity type: REAL(4)
-    !CHECK: numbers size=8 offset=0: CommonBlockDetails alignment=4: one two
+    !CHECK: numbers (OmpCommonBlock) size=8 offset=0: CommonBlockDetails alignment=4: one two
     REAL :: one, two
     COMMON /numbers/ one, two
     !$omp declare target(/numbers/)

--- a/flang/test/Semantics/OpenMP/symbol01.f90
+++ b/flang/test/Semantics/OpenMP/symbol01.f90
@@ -20,7 +20,7 @@ end module md
 program mm
  !REF: /md
  use :: md
- !DEF: /mm/c CommonBlockDetails
+ !DEF: /mm/c (OmpCommonBlock) CommonBlockDetails
  !DEF: /mm/x ObjectEntity REAL(4)
  !DEF: /mm/y ObjectEntity REAL(4)
  common /c/x, y


### PR DESCRIPTION
This patch sets the `OmpCommonBlock` attribute everytime a common block object is resolved in openmp context. Also, removed the call to `CheckMultipleAppearances(.., OmpCommonBlock)` because that is simply not required - we need to check multiple apprearances for the directive or clause related flag and not for the the common block flag.