### PR TITLE
[workflows] Add top-level permissions for libcxx-build-and-test.yaml

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -23,6 +23,9 @@ on:
       - 'cmake/**'
       - '.github/workflows/libcxx-build-and-test.yaml'
 
+permissions:
+  contents: read # Default everything to read-only
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
This is the standard convention for our workflow files.