### PR TITLE
[OpenMP] Support for `nothing` in `metadirective`

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2518,12 +2518,14 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
 
   switch (DKind) {
   case OMPD_nothing:
-    if ((StmtCtx & ParsedStmtContext::AllowStandaloneOpenMPDirectives) ==
-        ParsedStmtContext())
-      Diag(Tok, diag::err_omp_immediate_directive)
-        << getOpenMPDirectiveName(DKind) << 0;
     ConsumeToken();
-    skipUntilPragmaOpenMPEnd(DKind);
+    // If we are parsing the directive within a metadirective, the directive
+    // ends with a ')'.
+    if (ReadDirectiveWithinMetadirective && Tok.is(tok::r_paren))
+      while (Tok.isNot(tok::annot_pragma_openmp_end))
+        ConsumeAnyToken();
+    else
+      skipUntilPragmaOpenMPEnd(DKind);
     if (Tok.is(tok::annot_pragma_openmp_end))
       ConsumeAnnotationToken();
     break;

--- a/clang/test/OpenMP/metadirective_ast_print.c
+++ b/clang/test/OpenMP/metadirective_ast_print.c
@@ -67,6 +67,16 @@ void foo(void) {
                                 default(parallel for)
   for (int i = 0; i < 100; i++)
   ;
+
+#pragma omp metadirective when(implementation = {extension(match_all)} \
+                               : nothing) default(parallel for)
+  for (int i = 0; i < 16; i++)
+    ;
+
+#pragma omp metadirective when(implementation = {extension(match_any)} \
+                               : parallel) default(nothing)
+  for (int i = 0; i < 16; i++)
+    ;
 }
 
 // CHECK: void bar(void);
@@ -95,5 +105,7 @@ void foo(void) {
 // CHECK-NEXT: for (int j = 0; j < 16; j++)
 // CHECK-AMDGCN: #pragma omp teams distribute parallel for
 // CHECK-AMDGCN-NEXT: for (int i = 0; i < 100; i++)
+// CHECK: for (int i = 0; i < 16; i++)
+// CHECK: for (int i = 0; i < 16; i++)
 
 #endif

--- a/clang/test/OpenMP/metadirective_empty.cpp
+++ b/clang/test/OpenMP/metadirective_empty.cpp
@@ -14,11 +14,17 @@ void func() {
                                :) default(parallel for)
   for (int i = 0; i < N; i++)
     ;
+
+#pragma omp metadirective when(implementation = {vendor(llvm)} \
+                               :nothing) default(parallel for)
+  for (int i = 0; i < N; i++)
+    ;
 }
 
 // CHECK-LABEL: void @_Z4funcv()
 // CHECK: entry:
 // CHECK:   [[I:%.+]] = alloca i32,
+// CHECK:   [[I1:%.+]] = alloca i32,
 // CHECK:   store i32 0, ptr [[I]],
 // CHECK:   br label %[[FOR_COND:.+]]
 // CHECK: [[FOR_COND]]:
@@ -33,6 +39,20 @@ void func() {
 // CHECK:   store i32 [[INC]], ptr [[I]],
 // CHECK:   br label %[[FOR_COND]],
 // CHECK: [[FOR_END]]:
+// CHECK:   store i32 0, ptr [[I1]],
+// CHECK:   br label %[[FOR_COND1:.+]]
+// CHECK: [[FOR_COND1]]:
+// CHECK:   [[TWO:%.+]] = load i32, ptr [[I1]],
+// CHECK:   [[CMP1:%.+]] = icmp slt i32 [[TWO]], 1000
+// CHECK:   br i1 [[CMP1]], label %[[FOR_BODY1:.+]], label %[[FOR_END1:.+]]
+// CHECK: [[FOR_BODY1]]:
+// CHECK:   br label %[[FOR_INC1:.+]]
+// CHECK: [[FOR_INC1]]:
+// CHECK:   [[THREE:%.+]] = load i32, ptr [[I1]],
+// CHECK:   [[INC1:%.+]] = add nsw i32 [[THREE]], 1
+// CHECK:   store i32 [[INC1]], ptr [[I1]],
+// CHECK:   br label %[[FOR_COND1]],
+// CHECK: [[FOR_END1]]:
 // CHECK:   ret void
 // CHECK: }
 

--- a/clang/test/OpenMP/nothing_messages.cpp
+++ b/clang/test/OpenMP/nothing_messages.cpp
@@ -12,7 +12,6 @@ int mixed() {
     x=d;
   }
 
-// expected-error@+2 {{#pragma omp nothing' cannot be an immediate substatement}}
   if(!x)
 #pragma omp nothing
     x=d;


### PR DESCRIPTION
- Removed an unnecessary check that was preventing `nothing` to work properly inside `metadirective`.