### PR TITLE
[flang][OpenMP] Add semantic check for target construct

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -116,6 +116,8 @@ public:
   void Enter(const parser::OmpAtomicCapture &);
   void Leave(const parser::OmpAtomic &);
 
+  void Enter(const parser::Call &c);
+
 #define GEN_FLANG_CLAUSE_CHECK_ENTER
 #include "llvm/Frontend/OpenMP/OMP.inc"
 

--- a/flang/test/Semantics/OpenMP/target03.f90
+++ b/flang/test/Semantics/OpenMP/target03.f90
@@ -1,0 +1,17 @@
+! RUN: %flang_fc1 -fopenmp -fdebug-dump-parse-tree -pedantic %s 2>&1 | FileCheck %s
+
+program main
+  use omp_lib
+  integer :: x, y
+contains
+  subroutine foo()
+  !$omp target
+    !CHECK: portability: The result of an OMP_GET_DEFAULT_DEVICE routine called within a TARGET region is unspecified.
+    x = omp_get_default_device()
+    !CHECK: portability: The result of an OMP_GET_NUM_DEVICES routine called within a TARGET region is unspecified.
+    y = omp_get_num_devices()
+    !CHECK: portability: The result of an OMP_SET_DEFAULT_DEVICE routine called within a TARGET region is unspecified.
+    call omp_set_default_device(x)
+  !$omp end target
+  end subroutine
+end program


### PR DESCRIPTION
This patch adds the following semantic check for target construct

```
The result of an omp_set_default_device, omp_get_default_device, or
omp_get_num_devices routine called within a target region is
unspecified.
```