### PR TITLE
[OpenMP][NFC] Move Utils.h and Debug.h into a "Shared" include folder

### DIFF
--- a/openmp/libomptarget/include/OmptConnector.h
+++ b/openmp/libomptarget/include/OmptConnector.h
@@ -23,9 +23,9 @@
 #include <string>
 
 #include "omp-tools.h"
-
-#include "Debug.h"
 #include "omptarget.h"
+
+#include "Shared/Debug.h"
 
 #pragma push_macro("DEBUG_PREFIX")
 #undef DEBUG_PREFIX

--- a/openmp/libomptarget/include/Shared/Debug.h
+++ b/openmp/libomptarget/include/Shared/Debug.h
@@ -1,4 +1,4 @@
-//===------- Debug.h - Target independent OpenMP target RTL -- C++ --------===//
+//===-- Shared/Debug.h - Target independent OpenMP target RTL -- C++ ------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -34,8 +34,9 @@
 //   (uintptr_t) ptr);
 //
 //===----------------------------------------------------------------------===//
-#ifndef _OMPTARGET_DEBUG_H
-#define _OMPTARGET_DEBUG_H
+
+#ifndef OMPTARGET_SHARED_DEBUG_H
+#define OMPTARGET_SHARED_DEBUG_H
 
 #include <atomic>
 #include <mutex>
@@ -185,4 +186,4 @@ inline uint32_t getDebugLevel() {
     }                                                                          \
   } while (false)
 
-#endif // _OMPTARGET_DEBUG_H
+#endif // OMPTARGET_SHARED_DEBUG_H

--- a/openmp/libomptarget/include/Shared/Utils.h
+++ b/openmp/libomptarget/include/Shared/Utils.h
@@ -1,4 +1,4 @@
-//===------- Utilities.h - Target independent OpenMP target RTL -- C++ ----===//
+//===-- Shared/Utils.h - Target independent OpenMP target RTL -- C++ ------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef OPENMP_LIBOMPTARGET_INCLUDE_UTILITIES_H
-#define OPENMP_LIBOMPTARGET_INCLUDE_UTILITIES_H
+#ifndef OMPTARGET_SHARED_UTILS_H
+#define OMPTARGET_SHARED_UTILS_H
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
@@ -262,4 +262,4 @@ template <typename Ty> inline Ty roundUp(Ty V, Ty Boundary) {
 } // namespace omp
 } // namespace llvm
 
-#endif // OPENMP_LIBOMPTARGET_INCLUDE_UTILITIES_H
+#endif // OMPTARGET_SHARED_UTILS_H

--- a/openmp/libomptarget/plugins-nextgen/amdgpu/dynamic_hsa/hsa.cpp
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/dynamic_hsa/hsa.cpp
@@ -13,7 +13,8 @@
 
 #include "llvm/Support/DynamicLibrary.h"
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+
 #include "dlwrap.h"
 #include "hsa.h"
 #include "hsa_ext_amd.h"

--- a/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -20,12 +20,13 @@
 #include <unistd.h>
 #include <unordered_map>
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+#include "Shared/Utils.h"
+
 #include "Environment.h"
 #include "GlobalHandler.h"
 #include "OmptCallback.h"
 #include "PluginInterface.h"
-#include "Utilities.h"
 #include "UtilitiesRTL.h"
 #include "omptarget.h"
 

--- a/openmp/libomptarget/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/utils/UtilitiesRTL.h
@@ -12,7 +12,8 @@
 
 #include <cstdint>
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+
 #include "omptarget.h"
 
 #include "llvm/ADT/StringMap.h"
@@ -23,8 +24,8 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 #include "llvm/Support/MemoryBufferRef.h"
-
 #include "llvm/Support/YAMLTraits.h"
+
 using namespace llvm::ELF;
 
 namespace llvm {

--- a/openmp/libomptarget/plugins-nextgen/common/OMPT/OmptCallback.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/OMPT/OmptCallback.cpp
@@ -18,7 +18,8 @@
 #include <cstring>
 #include <memory>
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+
 #include "OmptCallback.h"
 #include "OmptConnector.h"
 

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/GlobalHandler.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/GlobalHandler.cpp
@@ -12,8 +12,9 @@
 
 #include "GlobalHandler.h"
 #include "PluginInterface.h"
-#include "Utilities.h"
 #include "Utils/ELF.h"
+
+#include "Shared/Utils.h"
 
 #include <cstring>
 

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/GlobalHandler.h
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/GlobalHandler.h
@@ -18,8 +18,9 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Object/ELFObjectFile.h"
 
-#include "Debug.h"
-#include "Utilities.h"
+#include "Shared/Debug.h"
+#include "Shared/Utils.h"
+
 #include "omptarget.h"
 
 namespace llvm {

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/JIT.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/JIT.cpp
@@ -9,10 +9,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "JIT.h"
-#include "Debug.h"
+
+#include "Shared/Debug.h"
+#include "Shared/Utils.h"
 
 #include "PluginInterface.h"
-#include "Utilities.h"
 #include "omptarget.h"
 
 #include "llvm/ADT/SmallVector.h"

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/JIT.h
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/JIT.h
@@ -11,7 +11,7 @@
 #ifndef OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_COMMON_JIT_H
 #define OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_COMMON_JIT_H
 
-#include "Utilities.h"
+#include "Shared/Utils.h"
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/MemoryManager.h
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/MemoryManager.h
@@ -21,8 +21,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Debug.h"
-#include "Utilities.h"
+#include "Shared/Debug.h"
+#include "Shared/Utils.h"
 #include "omptarget.h"
 
 /// Base class of per-device allocator.

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.cpp
@@ -9,7 +9,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "PluginInterface.h"
-#include "Debug.h"
+
+#include "Shared/Debug.h"
+
 #include "Environment.h"
 #include "GlobalHandler.h"
 #include "JIT.h"

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.h
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.h
@@ -19,13 +19,14 @@
 #include <shared_mutex>
 #include <vector>
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+#include "Shared/Utils.h"
+
 #include "Environment.h"
 #include "GlobalHandler.h"
 #include "JIT.h"
 #include "MemoryManager.h"
 #include "RPC.h"
-#include "Utilities.h"
 #include "omptarget.h"
 
 #ifdef OMPT_SUPPORT

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/RPC.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/RPC.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "RPC.h"
-#include "Debug.h"
+
+#include "Shared/Debug.h"
+
 #include "PluginInterface.h"
 
 // This header file may be present in-tree or from an LLVM installation. The

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/Utils/ELF.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/Utils/ELF.cpp
@@ -11,7 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "ELF.h"
-#include "Debug.h"
+
+#include "Shared/Debug.h"
 
 #include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Object/Binary.h"

--- a/openmp/libomptarget/plugins-nextgen/cuda/dynamic_cuda/cuda.cpp
+++ b/openmp/libomptarget/plugins-nextgen/cuda/dynamic_cuda/cuda.cpp
@@ -13,7 +13,8 @@
 
 #include "llvm/Support/DynamicLibrary.h"
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+
 #include "cuda.h"
 #include "dlwrap.h"
 

--- a/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/cuda/src/rtl.cpp
@@ -16,7 +16,8 @@
 #include <string>
 #include <unordered_map>
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+
 #include "Environment.h"
 #include "GlobalHandler.h"
 #include "OmptCallback.h"

--- a/openmp/libomptarget/plugins-nextgen/generic-elf-64bit/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/generic-elf-64bit/src/rtl.cpp
@@ -16,7 +16,8 @@
 #include <string>
 #include <unordered_map>
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+
 #include "Environment.h"
 #include "GlobalHandler.h"
 #include "OmptCallback.h"

--- a/openmp/libomptarget/src/OmptCallback.cpp
+++ b/openmp/libomptarget/src/OmptCallback.cpp
@@ -18,7 +18,8 @@
 #include <cstring>
 #include <memory>
 
-#include "Debug.h"
+#include "Shared/Debug.h"
+
 #include "OmptCallback.h"
 #include "OmptConnector.h"
 #include "OmptInterface.h"

--- a/openmp/libomptarget/src/device.cpp
+++ b/openmp/libomptarget/src/device.cpp
@@ -17,7 +17,7 @@
 #include "private.h"
 #include "rtl.h"
 
-#include "Utilities.h"
+#include "Shared/Utils.h"
 
 #include <cassert>
 #include <climits>

--- a/openmp/libomptarget/src/interface.cpp
+++ b/openmp/libomptarget/src/interface.cpp
@@ -18,7 +18,7 @@
 #include "private.h"
 #include "rtl.h"
 
-#include "Utilities.h"
+#include "Shared/Utils.h"
 
 #include <cassert>
 #include <cstdint>

--- a/openmp/libomptarget/src/private.h
+++ b/openmp/libomptarget/src/private.h
@@ -13,10 +13,11 @@
 #ifndef _OMPTARGET_PRIVATE_H
 #define _OMPTARGET_PRIVATE_H
 
+#include "Shared/Debug.h"
+
+#include "SourceInfo.h"
 #include "device.h"
-#include <Debug.h>
-#include <SourceInfo.h>
-#include <omptarget.h>
+#include "omptarget.h"
 
 #include <cstdint>
 

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -17,7 +17,7 @@
 #include "private.h"
 #include "rtl.h"
 
-#include "Utilities.h"
+#include "Shared/Utils.h"
 
 #include <cassert>
 #include <cstdlib>


### PR DESCRIPTION
Headers used throughout the different runtimes are different from the internal headers. This is a first step to bring structure in into the include folder.