### PR TITLE
[clang] Fix error in gcc 7.5. on arm32-linux

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17299,7 +17299,7 @@ bool Sema::EvaluateStaticAssertMessageAsString(Expr *Message,
                                     OverloadCandidateSet::CSK_Normal);
     if (MemberLookup.empty())
       return std::nullopt;
-    return std::move(MemberLookup);
+    return std::move(std::optional<LookupResult>(MemberLookup));
   };
 
   bool SizeNotFound, DataNotFound;


### PR DESCRIPTION
Apparently the gcc 7.5 compiler for arm32-linux fails to implicitly convert to std::optional; this inserts an explicit constructor to unbreak that compiler. [Injection from https://reviews.llvm.org/rG4142a64ae3ca4856e6a5ffae9e40014ef5cf9db5]