### PR TITLE
[lldb][test] TestConstStaticIntegralMember: relax assertion on number of global variables

### DIFF
--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -118,7 +118,7 @@ class TestCase(TestBase):
 
     def check_global_var(self, name: str, expect_type, expect_val):
         var_list = self.target().FindGlobalVariables(name, lldb.UINT32_MAX)
-        self.assertEqual(len(var_list), 1)
+        self.assertGreaterEqual(len(var_list), 1)
         varobj = var_list[0]
         self.assertEqual(varobj.type.name, expect_type)
         self.assertEqual(varobj.value, expect_val)


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/73626 we started attaching `DW_AT_const_value`s on a static data-member's declaration again. In DWARFv5, those static members are represented with a `DW_TAG_variable`. When LLDB builds the `ManualDWARFIndex`, it simply iterates over all DIEs in a CU and puts *any* `DW_TAG_variable` with a constant or location into the index. So when using the manual index, we can end up having 2 entries for a static data member in the index, one for the declaration and one for the definition.

This caused a test failure on Linux (where DWARFv5 is the default and the tests use the manual index).

This patch loosens the restriction that we find exactly 1 variable.