### PR TITLE
[libc++] Add a merge driver that can apply clang-format

### DIFF
--- a/libcxx/utils/clang-format-merge-driver.sh
+++ b/libcxx/utils/clang-format-merge-driver.sh
@@ -15,24 +15,24 @@
 # Many thanks to Nico Weber for paving the way here.
 
 # Path to the file's contents at the ancestor's version.
-base=$1
+base="$1"
 
 # Path to the file's contents at the current version.
-current=$2
+current="$2"
 
 # Path to the file's contents at the other branch's version (for nonlinear histories, there might be multiple other branches).
-other=$3
+other="$3"
 
 # The path of the file in the repository.
-path=$4
+path="$4"
 
-clang-format --style=file --assume-filename=$path < $base > $base.tmp
-mv $base.tmp $base
+clang-format --style=file --assume-filename="$path" < "$base" > "$base.tmp"
+mv "$base.tmp" "$base"
 
-clang-format --style=file --assume-filename=$path < $current > $current.tmp
-mv $current.tmp $current
+clang-format --style=file --assume-filename="$path" < "$current" > "$current.tmp"
+mv "$current.tmp" "$current"
 
-clang-format --style=file --assume-filename=$path < $other > $other.tmp
-mv $other.tmp $other
+clang-format --style=file --assume-filename="$path" < "$other" > "$other.tmp"
+mv "$other.tmp" "$other"
 
-git merge-file $current $base $other
+git merge-file -L "$current" -L "$base" -L "$other" "$current" "$base" "$other"

--- a/libcxx/utils/clang-format-merge-driver.sh
+++ b/libcxx/utils/clang-format-merge-driver.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This script can be installed in .git/config to allow rebasing old patches across
+# libc++'s clang-format of the whole tree. Most contributors should not require that
+# since they don't have many pre-clang-format patches lying around. This script is to
+# make it easier for contributors that do have such patches.
+#
+# The script is installed by running the following from the root of your repository:
+#
+#   $ git config merge.libcxx-reformat.name "Run clang-format when rebasing libc++ patches"
+#   $ git config merge.libcxx-reformat.driver "libcxx/utils/clang-format-merge-driver.sh %O %A %B %P"
+#   $ git config merge.libcxx-reformat.recursive binary
+#
+# This is based on https://github.com/nico/hack/blob/main/notes/auto_git_rebase_across_mechanical_changes.md.
+# Many thanks to Nico Weber for paving the way here.
+
+# Path to the file's contents at the ancestor's version.
+base=$1
+
+# Path to the file's contents at the current version.
+current=$2
+
+# Path to the file's contents at the other branch's version (for nonlinear histories, there might be multiple other branches).
+other=$3
+
+# The path of the file in the repository.
+path=$4
+
+clang-format --style=file --assume-filename=$path < $base > $base.tmp
+mv $base.tmp $base
+
+clang-format --style=file --assume-filename=$path < $current > $current.tmp
+mv $current.tmp $current
+
+clang-format --style=file --assume-filename=$path < $other > $other.tmp
+mv $other.tmp $other
+
+git merge-file $current $base $other

--- a/libcxx/utils/clang-format-merge-driver.sh
+++ b/libcxx/utils/clang-format-merge-driver.sh
@@ -34,4 +34,4 @@ mv "$current.tmp" "$current"
 clang-format --style=file --assume-filename="$path" < "$other" > "$other.tmp"
 mv "$other.tmp" "$other"
 
-git merge-file -L "$current" -L "$base" -L "$other" "$current" "$base" "$other"
+git merge-file -Lcurrent -Lbase -Lother "$current" "$base" "$other"

--- a/libcxx/utils/clang-format-merge-driver.sh
+++ b/libcxx/utils/clang-format-merge-driver.sh
@@ -9,7 +9,6 @@
 #
 #   $ git config merge.libcxx-reformat.name "Run clang-format when rebasing libc++ patches"
 #   $ git config merge.libcxx-reformat.driver "libcxx/utils/clang-format-merge-driver.sh %O %A %B %P"
-#   $ git config merge.libcxx-reformat.recursive binary
 #
 # This is based on https://github.com/nico/hack/blob/main/notes/auto_git_rebase_across_mechanical_changes.md.
 # Many thanks to Nico Weber for paving the way here.


### PR DESCRIPTION
In preparation for the moment when we'll clang-format the whole code base, this patch adds a script that can be used to rebase patches across clang-format changes mechanically, without requiring manual intervention.

See https://discourse.llvm.org/t/rfc-clang-formatting-all-of-libc-once-and-for-all.