### PR TITLE
[OpenMP][NFC] Create an "OpenMP" folder in the include folder

### DIFF
--- a/openmp/libomptarget/include/OpenMP/InternalTypes.h
+++ b/openmp/libomptarget/include/OpenMP/InternalTypes.h
@@ -1,0 +1,36 @@
+//===-- OpenMP/InternalTypes.h -- Internal OpenMP Types ------------- C++ -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Private type declarations and helper macros for OpenMP.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OMPTARGET_OPENMP_INTERNAL_TYPES_H
+#define OMPTARGET_OPENMP_INTERNAL_TYPES_H
+
+#include <cstddef>
+#include <cstdint>
+
+typedef intptr_t kmp_intptr_t;
+
+extern "C" {
+
+// Compiler sends us this info:
+typedef struct kmp_depend_info {
+  kmp_intptr_t base_addr;
+  size_t len;
+  struct {
+    bool in : 1;
+    bool out : 1;
+    bool mtx : 1;
+  } flags;
+} kmp_depend_info_t;
+
+} // extern "C"
+
+#endif // OMPTARGET_OPENMP_INTERNAL_TYPES_H

--- a/openmp/libomptarget/include/OpenMP/InteropAPI.h
+++ b/openmp/libomptarget/include/OpenMP/InteropAPI.h
@@ -1,0 +1,43 @@
+//===-- OpenMP/InteropAPI.h - OpenMP interoperability types and API - C++ -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OMPTARGET_OPENMP_INTEROP_API_H
+#define OMPTARGET_OPENMP_INTEROP_API_H
+
+#include "omp.h"
+
+#include "omptarget.h"
+
+extern "C" {
+
+typedef enum kmp_interop_type_t {
+  kmp_interop_type_unknown = -1,
+  kmp_interop_type_platform,
+  kmp_interop_type_device,
+  kmp_interop_type_tasksync,
+} kmp_interop_type_t;
+
+/// The interop value type, aka. the interop object.
+typedef struct omp_interop_val_t {
+  /// Device and interop-type are determined at construction time and fix.
+  omp_interop_val_t(intptr_t device_id, kmp_interop_type_t interop_type)
+      : interop_type(interop_type), device_id(device_id) {}
+  const char *err_str = nullptr;
+  __tgt_async_info *async_info = nullptr;
+  __tgt_device_info device_info;
+  const kmp_interop_type_t interop_type;
+  const intptr_t device_id;
+  const omp_foreign_runtime_ids_t vendor_id = cuda;
+  const intptr_t backend_type_id = omp_interop_backend_type_cuda_1;
+} omp_interop_val_t;
+
+} // extern "C"
+
+#endif // OMPTARGET_OPENMP_INTEROP_API_H

--- a/openmp/libomptarget/include/OpenMP/omp.h
+++ b/openmp/libomptarget/include/OpenMP/omp.h
@@ -1,16 +1,20 @@
-//===----------------------------------------------------------------------===//
+//===-- OpenMP/omp.h - Copies of OpenMP user facing types and APIs - C++ -===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// This copies some OpenMP user facing types and APIs for easy reach within the
+// implementation.
+//
+//===----------------------------------------------------------------------===//
 
-#ifndef _INTEROP_H_
-#define _INTEROP_H_
+#ifndef OMPTARGET_OPENMP_OMP_H
+#define OMPTARGET_OPENMP_OMP_H
 
-#include "omptarget.h"
-#include <assert.h>
+#include <cstdint>
 
 #if defined(_WIN32)
 #define __KAI_KMPC_CONVENTION __cdecl
@@ -24,9 +28,13 @@
 #endif
 #endif
 
-#ifdef __cplusplus
 extern "C" {
-#endif
+
+int omp_get_default_device(void) __attribute__((weak));
+
+/// InteropAPI
+///
+///{
 
 /// TODO: Include the `omp.h` of the current build
 /* OpenMP 5.1 interop */
@@ -81,9 +89,8 @@ int __KAI_KMPC_CONVENTION omp_get_num_interop_properties(const omp_interop_t);
  * The `omp_get_interop_int` routine retrieves an integer property from an
  * `omp_interop_t` object.
  */
-omp_intptr_t __KAI_KMPC_CONVENTION omp_get_interop_int(const omp_interop_t,
-                                                       omp_interop_property_t,
-                                                       int *);
+omp_intptr_t __KAI_KMPC_CONVENTION
+omp_get_interop_int(const omp_interop_t, omp_interop_property_t, int *);
 /*!
  * The `omp_get_interop_ptr` routine retrieves a pointer property from an
  * `omp_interop_t` object.
@@ -94,9 +101,8 @@ void *__KAI_KMPC_CONVENTION omp_get_interop_ptr(const omp_interop_t,
  * The `omp_get_interop_str` routine retrieves a string property from an
  * `omp_interop_t` object.
  */
-const char *__KAI_KMPC_CONVENTION omp_get_interop_str(const omp_interop_t,
-                                                      omp_interop_property_t,
-                                                      int *);
+const char *__KAI_KMPC_CONVENTION
+omp_get_interop_str(const omp_interop_t, omp_interop_property_t, int *);
 /*!
  * The `omp_get_interop_name` routine retrieves a property name from an
  * `omp_interop_t` object.
@@ -121,13 +127,6 @@ typedef enum omp_interop_backend_type_t {
   omp_interop_backend_type_cuda_1 = 1,
 } omp_interop_backend_type_t;
 
-typedef enum kmp_interop_type_t {
-  kmp_interop_type_unknown = -1,
-  kmp_interop_type_platform,
-  kmp_interop_type_device,
-  kmp_interop_type_tasksync,
-} kmp_interop_type_t;
-
 typedef enum omp_foreign_runtime_ids {
   cuda = 1,
   cuda_driver = 2,
@@ -137,21 +136,8 @@ typedef enum omp_foreign_runtime_ids {
   level_zero = 6,
 } omp_foreign_runtime_ids_t;
 
-/// The interop value type, aka. the interop object.
-typedef struct omp_interop_val_t {
-  /// Device and interop-type are determined at construction time and fix.
-  omp_interop_val_t(intptr_t device_id, kmp_interop_type_t interop_type)
-      : interop_type(interop_type), device_id(device_id) {}
-  const char *err_str = nullptr;
-  __tgt_async_info *async_info = nullptr;
-  __tgt_device_info device_info;
-  const kmp_interop_type_t interop_type;
-  const intptr_t device_id;
-  const omp_foreign_runtime_ids_t vendor_id = cuda;
-  const intptr_t backend_type_id = omp_interop_backend_type_cuda_1;
-} omp_interop_val_t;
+///} InteropAPI
 
-#ifdef __cplusplus
-}
-#endif
-#endif
+} // extern "C"
+
+#endif // OMPTARGET_OPENMP_OMP_H

--- a/openmp/libomptarget/src/CMakeLists.txt
+++ b/openmp/libomptarget/src/CMakeLists.txt
@@ -18,11 +18,11 @@ add_llvm_library(omptarget
   api.cpp
   device.cpp
   interface.cpp
-  interop.cpp
   omptarget.cpp
   OmptCallback.cpp
   rtl.cpp
   LegacyAPI.cpp
+  OpenMP/InteropAPI.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LIBOMPTARGET_INCLUDE_DIR}

--- a/openmp/libomptarget/src/omptarget.cpp
+++ b/openmp/libomptarget/src/omptarget.cpp
@@ -18,6 +18,8 @@
 #include "private.h"
 #include "rtl.h"
 
+#include "OpenMP/omp.h"
+
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/bit.h"
 

--- a/openmp/libomptarget/src/private.h
+++ b/openmp/libomptarget/src/private.h
@@ -16,6 +16,8 @@
 #include "Shared/Debug.h"
 #include "Shared/SourceInfo.h"
 
+#include "OpenMP/InternalTypes.h"
+
 #include "device.h"
 #include "omptarget.h"
 
@@ -110,7 +112,6 @@ extern "C" {
  */
 typedef int kmp_int32;
 typedef int64_t kmp_int64;
-typedef intptr_t kmp_intptr_t;
 
 typedef void *omp_depend_t;
 struct kmp_task;
@@ -154,24 +155,8 @@ typedef struct kmp_tasking_flags { /* Total struct must be exactly 32 bits */
   unsigned reserved31 : 7; /* reserved for library use */
 } kmp_tasking_flags_t;
 
-// Compiler sends us this info:
-typedef struct kmp_depend_info {
-  kmp_intptr_t base_addr;
-  size_t len;
-  struct {
-    bool in : 1;
-    bool out : 1;
-    bool mtx : 1;
-  } flags;
-} kmp_depend_info_t;
-// functions that extract info from libomp; keep in sync
-int omp_get_default_device(void) __attribute__((weak));
 int32_t __kmpc_global_thread_num(void *) __attribute__((weak));
 int __kmpc_get_target_offload(void) __attribute__((weak));
-void __kmpc_omp_wait_deps(ident_t *loc_ref, kmp_int32 gtid, kmp_int32 ndeps,
-                          kmp_depend_info_t *dep_list, kmp_int32 ndeps_noalias,
-                          kmp_depend_info_t *noalias_dep_list)
-    __attribute__((weak));
 void **__kmpc_omp_get_target_async_handle_ptr(kmp_int32 gtid)
     __attribute__((weak));
 bool __kmpc_omp_has_task_team(kmp_int32 gtid) __attribute__((weak));


### PR DESCRIPTION
Not everything in libomptarget (include) is "OpenMP", but some things most certainly are. This commit moves some code around to start making this distinction without the intention to change functionality.