### PR TITLE
[libcxx] Remove unused Python imports

### DIFF
--- a/libcxx/test/libcxx/transitive_includes_to_csv.py
+++ b/libcxx/test/libcxx/transitive_includes_to_csv.py
@@ -7,7 +7,7 @@
 #
 # ===----------------------------------------------------------------------===##
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List  # Needed for python 3.8 compatibility.
 import argparse
 import pathlib

--- a/libcxx/utils/adb_run.py
+++ b/libcxx/utils/adb_run.py
@@ -18,7 +18,7 @@ import shlex
 import socket
 import subprocess
 import sys
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 
 # Sync a host file /path/to/dir/file to ${REMOTE_BASE_DIR}/run-${HASH}/dir/file.

--- a/libcxx/utils/gdb/libcxx/printers.py
+++ b/libcxx/utils/gdb/libcxx/printers.py
@@ -12,7 +12,6 @@ These should work for objects compiled with either the stable ABI or the unstabl
 
 from __future__ import print_function
 
-import math
 import re
 import gdb
 

--- a/libcxx/utils/generate_escaped_output_table.py
+++ b/libcxx/utils/generate_escaped_output_table.py
@@ -15,7 +15,7 @@
 
 from io import StringIO
 from pathlib import Path
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 import re
 import sys

--- a/libcxx/utils/generate_extended_grapheme_cluster_table.py
+++ b/libcxx/utils/generate_extended_grapheme_cluster_table.py
@@ -15,7 +15,7 @@
 
 from io import StringIO
 from pathlib import Path
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 import re
 import sys

--- a/libcxx/utils/generate_extended_grapheme_cluster_test.py
+++ b/libcxx/utils/generate_extended_grapheme_cluster_test.py
@@ -16,7 +16,6 @@
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional, TextIO
-from array import array
 import sys
 
 

--- a/libcxx/utils/generate_std_clang_module_header.py
+++ b/libcxx/utils/generate_std_clang_module_header.py
@@ -6,7 +6,6 @@
 #
 # ===----------------------------------------------------------------------===##
 
-import operator
 import os.path
 
 import libcxx.header_information

--- a/libcxx/utils/generate_std_cppm_in.py
+++ b/libcxx/utils/generate_std_cppm_in.py
@@ -6,7 +6,6 @@
 #
 # ===----------------------------------------------------------------------===##
 
-import operator
 import os.path
 
 from libcxx.header_information import module_headers

--- a/libcxx/utils/generate_width_estimation_table.py
+++ b/libcxx/utils/generate_width_estimation_table.py
@@ -15,7 +15,7 @@
 
 from io import StringIO
 from pathlib import Path
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 import re
 import sys

--- a/libcxx/utils/graph_header_deps.py
+++ b/libcxx/utils/graph_header_deps.py
@@ -8,7 +8,6 @@
 # ===----------------------------------------------------------------------===##
 
 import argparse
-import sys
 
 if __name__ == "__main__":
     """Converts a header dependency CSV file to Graphviz dot file.

--- a/libcxx/utils/libcxx/test/android.py
+++ b/libcxx/utils/libcxx/test/android.py
@@ -6,8 +6,6 @@
 #
 #===----------------------------------------------------------------------===##
 
-import atexit
-import os
 import re
 import select
 import socket

--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -10,9 +10,7 @@ import os
 import pickle
 import pipes
 import platform
-import re
 import shutil
-import subprocess
 import tempfile
 
 import libcxx.test.format

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -6,14 +6,10 @@
 #
 # ===----------------------------------------------------------------------===##
 
-import contextlib
-import io
 import lit
 import lit.formats
 import os
-import pipes
 import re
-import shutil
 
 
 def _getTempPaths(test):

--- a/libcxx/utils/qemu_baremetal.py
+++ b/libcxx/utils/qemu_baremetal.py
@@ -15,8 +15,6 @@ output (if the underlying baremetal enviroment supports QEMU semihosting).
 
 import argparse
 import os
-import platform
-import subprocess
 import sys
 
 


### PR DESCRIPTION
VSCode's Pylance extension informed me, and text searching confirmed, that these imports are unused. I believe we should be able to remove them harmlessly.