### PR TITLE
[OpenMP][NFC] Move debug declares into CMAKE out of "private.h"

### DIFF
--- a/openmp/libomptarget/src/CMakeLists.txt
+++ b/openmp/libomptarget/src/CMakeLists.txt
@@ -44,6 +44,12 @@ if (LIBOMP_HAVE_VERSION_SCRIPT_FLAG)
     "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")
 endif()
 
+# Define the TARGET_NAME and DEBUG_PREFIX.
+target_compile_definitions(omptarget PRIVATE
+  TARGET_NAME=omptarget
+  DEBUG_PREFIX="omptarget"
+)
+
 # libomptarget.so needs to be aware of where the plugins live as they
 # are now separated in the build directory.
 set_target_properties(omptarget PROPERTIES

--- a/openmp/libomptarget/src/private.h
+++ b/openmp/libomptarget/src/private.h
@@ -257,11 +257,6 @@ struct TargetMemsetArgsTy {
 }
 #endif
 
-#define TARGET_NAME Libomptarget
-#ifndef DEBUG_PREFIX
-#define DEBUG_PREFIX GETNAME(TARGET_NAME)
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 /// dump a table of all the host-target pointer pairs on failure
 static inline void dumpTargetPointerMappings(const ident_t *Loc,

--- a/openmp/libomptarget/test/env/omp_target_debug.c
+++ b/openmp/libomptarget/test/env/omp_target_debug.c
@@ -8,6 +8,6 @@ int main(void) {
   return 0;
 }
 
-// DEBUG: Libomptarget
-// NDEBUG-NOT: Libomptarget
+// DEBUG: omptarget
+// NDEBUG-NOT: omptarget
 // NDEBUG-NOT: Target

--- a/openmp/libomptarget/test/mapping/alloc_fail.c
+++ b/openmp/libomptarget/test/mapping/alloc_fail.c
@@ -2,9 +2,9 @@
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
 
-// CHECK: Libomptarget message: explicit extension not allowed: host address specified is 0x{{.*}} (8 bytes), but device allocation maps to host at 0x{{.*}} (8 bytes)
-// CHECK: Libomptarget error: Call to getTargetPointer returned null pointer (device failure or illegal mapping).
-// CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: omptarget message: explicit extension not allowed: host address specified is 0x{{.*}} (8 bytes), but device allocation maps to host at 0x{{.*}} (8 bytes)
+// CHECK: omptarget error: Call to getTargetPointer returned null pointer (device failure or illegal mapping).
+// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 
 int main() {
   int arr[4] = {0, 1, 2, 3};

--- a/openmp/libomptarget/test/mapping/ompx_hold/omp_target_disassociate_ptr.c
+++ b/openmp/libomptarget/test/mapping/ompx_hold/omp_target_disassociate_ptr.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
 #pragma omp target data map(ompx_hold, alloc : X)
 #endif
   {
-    //      CHECK: Libomptarget error: Trying to disassociate a pointer with a
+    //      CHECK: omptarget error: Trying to disassociate a pointer with a
     // CHECK-SAME: non-zero hold reference count
     // CHECK-NEXT: omp_target_disassociate_ptr failed
     if (omp_target_disassociate_ptr(&X, DevNum)) {

--- a/openmp/libomptarget/test/mapping/padding_not_mapped.c
+++ b/openmp/libomptarget/test/mapping/padding_not_mapped.c
@@ -34,9 +34,9 @@ int main() {
   #pragma omp target update from(s.x) // should have no effect
   fprintf(stderr, "s.x = %d\n", s.x);
 
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: Libomptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
   #pragma omp target enter data map(present, alloc: s.x)
 
   return 0;

--- a/openmp/libomptarget/test/mapping/present/target.c
+++ b/openmp/libomptarget/test/mapping/present/target.c
@@ -10,7 +10,7 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
   fprintf(stderr, "addr=%p, size=%ld\n", &i, sizeof i);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : i)
 #pragma omp target map(present, alloc : i)
   ;
@@ -18,11 +18,11 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: Libomptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: Libomptarget error: Call to targetDataBegin failed, abort target.
-  // CHECK: Libomptarget error: Failed to process data before launching the kernel.
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
+  // CHECK: omptarget error: Failed to process data before launching the kernel.
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target map(present, alloc : i)
   ;
 

--- a/openmp/libomptarget/test/mapping/present/target_array_extension.c
+++ b/openmp/libomptarget/test/mapping/present/target_array_extension.c
@@ -60,7 +60,7 @@ int main() {
   fprintf(stderr, "addr=%p, size=%ld\n", &arr[LARGE_BEG],
           LARGE_SIZE * sizeof arr[0]);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : arr[LARGE])
   {
 #pragma omp target map(present, tofrom : arr[SMALL])
@@ -70,12 +70,12 @@ int main() {
   // CHECK: arr is present
   fprintf(stderr, "arr is present\n");
 
-  // CHECK: Libomptarget message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
-  // CHECK: Libomptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: Libomptarget error: Call to targetDataBegin failed, abort target.
-  // CHECK: Libomptarget error: Failed to process data before launching the kernel.
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
+  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
+  // CHECK: omptarget error: Failed to process data before launching the kernel.
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[SMALL])
   {
 #pragma omp target map(present, tofrom : arr[LARGE])

--- a/openmp/libomptarget/test/mapping/present/target_data.c
+++ b/openmp/libomptarget/test/mapping/present/target_data.c
@@ -10,7 +10,7 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
   fprintf(stderr, "addr=%p, size=%ld\n", &i, sizeof i);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : i)
 #pragma omp target data map(present, alloc : i)
   ;
@@ -18,8 +18,8 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(present, alloc : i)
   ;
 

--- a/openmp/libomptarget/test/mapping/present/target_data_array_extension.c
+++ b/openmp/libomptarget/test/mapping/present/target_data_array_extension.c
@@ -60,7 +60,7 @@ int main() {
   fprintf(stderr, "addr=%p, size=%ld\n", &arr[LARGE_BEG],
           LARGE_SIZE * sizeof arr[0]);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : arr[LARGE])
   {
 #pragma omp target data map(present, tofrom : arr[SMALL])
@@ -70,10 +70,10 @@ int main() {
   // CHECK: arr is present
   fprintf(stderr, "arr is present\n");
 
-  // CHECK: Libomptarget message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
-  // CHECK: Libomptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
+  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[SMALL])
   {
 #pragma omp target data map(present, tofrom : arr[LARGE])

--- a/openmp/libomptarget/test/mapping/present/target_data_at_exit.c
+++ b/openmp/libomptarget/test/mapping/present/target_data_at_exit.c
@@ -16,9 +16,9 @@ int main() {
 #pragma omp target exit data map(delete : i)
   }
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
   // CHECK: success
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
   fprintf(stderr, "success\n");
 
   return 0;

--- a/openmp/libomptarget/test/mapping/present/target_enter_data.c
+++ b/openmp/libomptarget/test/mapping/present/target_enter_data.c
@@ -10,7 +10,7 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
   fprintf(stderr, "addr=%p, size=%ld\n", &i, sizeof i);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target enter data map(alloc : i)
 #pragma omp target enter data map(present, alloc : i)
 #pragma omp target exit data map(delete : i)
@@ -18,9 +18,9 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: Libomptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target enter data map(present, alloc : i)
 
   // CHECK-NOT: i is present

--- a/openmp/libomptarget/test/mapping/present/target_exit_data_delete.c
+++ b/openmp/libomptarget/test/mapping/present/target_exit_data_delete.c
@@ -10,15 +10,15 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
   fprintf(stderr, "addr=%p, size=%ld\n", &i, sizeof i);
 
-// CHECK-NOT: Libomptarget
+// CHECK-NOT: omptarget
 #pragma omp target enter data map(alloc : i)
 #pragma omp target exit data map(present, delete : i)
 
   // CHECK: i was present
   fprintf(stderr, "i was present\n");
 
-// CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-// CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target exit data map(present, delete : i)
 
   // CHECK-NOT: i was present

--- a/openmp/libomptarget/test/mapping/present/target_exit_data_release.c
+++ b/openmp/libomptarget/test/mapping/present/target_exit_data_release.c
@@ -10,15 +10,15 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
   fprintf(stderr, "addr=%p, size=%ld\n", &i, sizeof i);
 
-// CHECK-NOT: Libomptarget
+// CHECK-NOT: omptarget
 #pragma omp target enter data map(alloc : i)
 #pragma omp target exit data map(present, release : i)
 
   // CHECK: i was present
   fprintf(stderr, "i was present\n");
 
-// CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-// CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target exit data map(present, release : i)
 
   // CHECK-NOT: i was present

--- a/openmp/libomptarget/test/mapping/present/target_update.c
+++ b/openmp/libomptarget/test/mapping/present/target_update.c
@@ -24,7 +24,7 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
   fprintf(stderr, "addr=%p, size=%ld\n", &i, sizeof i);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target enter data map(alloc : i)
 #pragma omp target update CLAUSE(present : i)
 #pragma omp target exit data map(delete : i)
@@ -32,8 +32,8 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: Libomptarget message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target update CLAUSE(present : i)
 
   // CHECK-NOT: i is present

--- a/openmp/libomptarget/test/mapping/present/target_update_array_extension.c
+++ b/openmp/libomptarget/test/mapping/present/target_update_array_extension.c
@@ -57,7 +57,7 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
   fprintf(stderr, "addr=%p, size=%ld\n", arr, sizeof arr);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : arr[LARGE])
   {
 #pragma omp target update CLAUSE(present : arr[SMALL])
@@ -66,8 +66,8 @@ int main() {
   // CHECK: arr is present
   fprintf(stderr, "arr is present\n");
 
-  // CHECK: Libomptarget message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[SMALL])
   {
 #pragma omp target update CLAUSE(present : arr[LARGE])

--- a/openmp/libomptarget/test/mapping/present/unified_shared_memory.c
+++ b/openmp/libomptarget/test/mapping/present/unified_shared_memory.c
@@ -12,7 +12,7 @@
 int main() {
   int i;
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : i)
 #pragma omp target map(present, alloc : i)
   ;
@@ -20,7 +20,7 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target map(present, alloc : i)
   ;
 

--- a/openmp/libomptarget/test/mapping/present/zero_length_array_section.c
+++ b/openmp/libomptarget/test/mapping/present/zero_length_array_section.c
@@ -10,7 +10,7 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]]
   fprintf(stderr, "addr=%p\n", arr);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : arr[0 : 5])
 #pragma omp target map(present, alloc : arr[0 : 0])
   ;
@@ -20,11 +20,11 @@ int main() {
 
   // arr[0:0] doesn't create an actual mapping in the first directive.
   //
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
-  // CHECK: Libomptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: Libomptarget error: Call to targetDataBegin failed, abort target.
-  // CHECK: Libomptarget error: Failed to process data before launching the kernel.
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
+  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
+  // CHECK: omptarget error: Failed to process data before launching the kernel.
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[0 : 0])
 #pragma omp target map(present, alloc : arr[0 : 0])
   ;

--- a/openmp/libomptarget/test/mapping/present/zero_length_array_section_exit.c
+++ b/openmp/libomptarget/test/mapping/present/zero_length_array_section_exit.c
@@ -10,7 +10,7 @@ int main() {
   // CHECK: addr=0x[[#%x,HOST_ADDR:]]
   fprintf(stderr, "addr=%p\n", arr);
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target enter data map(alloc : arr[0 : 5])
 #pragma omp target exit data map(present, release : arr[0 : 0])
 
@@ -19,8 +19,8 @@ int main() {
 
   // arr[0:0] doesn't create an actual mapping in the first directive.
   //
-  // CHECK: Libomptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
-  // CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target enter data map(alloc : arr[0 : 0])
 #pragma omp target exit data map(present, release : arr[0 : 0])
 

--- a/openmp/libomptarget/test/mapping/target_data_array_extension_at_exit.c
+++ b/openmp/libomptarget/test/mapping/target_data_array_extension_at_exit.c
@@ -66,7 +66,7 @@ void check_not_present() {
       arr[i] = 88;
   }
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
   // CHECK-NOT: error
   for (int i = 0; i < SIZE; ++i) {
     if (arr[i] != 99)
@@ -95,7 +95,7 @@ void check_is_present() {
       arr[i] = 88;
   }
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
   // CHECK-NOT: error
   for (int i = 0; i < SIZE; ++i) {
     if (SMALL_BEG <= i && i < SMALL_END) {

--- a/openmp/libomptarget/test/mapping/target_update_array_extension.c
+++ b/openmp/libomptarget/test/mapping/target_update_array_extension.c
@@ -54,7 +54,7 @@
 int main() {
   int arr[5];
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : arr[LARGE])
   {
 #pragma omp target update CLAUSE(arr[SMALL])
@@ -63,7 +63,7 @@ int main() {
   // CHECK: success
   fprintf(stderr, "success\n");
 
-  // CHECK-NOT: Libomptarget
+  // CHECK-NOT: omptarget
 #pragma omp target data map(alloc : arr[SMALL])
   {
 #pragma omp target update CLAUSE(arr[LARGE])

--- a/openmp/libomptarget/test/mapping/target_wrong_use_device_addr.c
+++ b/openmp/libomptarget/test/mapping/target_wrong_use_device_addr.c
@@ -13,7 +13,7 @@ int main() {
 
 #pragma omp target data map(to : x [0:10])
   {
-// CHECK: Libomptarget device 0 info: variable x does not have a valid device
+// CHECK: omptarget device 0 info: variable x does not have a valid device
 // counterpart
 #pragma omp target data use_device_addr(x)
     {

--- a/openmp/libomptarget/test/offloading/info.c
+++ b/openmp/libomptarget/test/offloading/info.c
@@ -64,7 +64,7 @@ int main() {
   { val = 1; }
 
   __tgt_set_info_flag(0x0);
-// INFO-NOT: Libomptarget device 0 info: {{.*}}
+// INFO-NOT: omptarget device 0 info: {{.*}}
 #pragma omp target
   {}
 

--- a/openmp/libomptarget/test/offloading/mandatory_but_no_devices.c
+++ b/openmp/libomptarget/test/offloading/mandatory_but_no_devices.c
@@ -47,7 +47,7 @@
 #include <omp.h>
 #include <stdio.h>
 
-// CHECK: Libomptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
 int main(void) {
   int X;
 #pragma omp DIR device(omp_get_initial_device())


### PR DESCRIPTION
Everywhere else we define this in the CMakeLists.txt and "private.h" needs to go. Rename "Libomptarget" into "omptarget", no benefit from "lib".