### PR TITLE
Allow lldb to load .dwp files with large .debug_info or .debug_types.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFContext.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFContext.cpp
@@ -142,7 +142,10 @@ llvm::DWARFContext &DWARFContext::GetAsLLVM() {
     AddSection("debug_line_str", getOrLoadLineStrData());
     AddSection("debug_cu_index", getOrLoadCuIndexData());
     AddSection("debug_tu_index", getOrLoadTuIndexData());
-
+    if (isDwo()) {
+      AddSection("debug_info.dwo", getOrLoadDebugInfoData());
+      AddSection("debug_types.dwo", getOrLoadDebugTypesData());
+    }
     m_llvm_context = llvm::DWARFContext::create(section_map, addr_size);
   }
   return *m_llvm_context;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -76,7 +76,7 @@ public:
     return m_unit_type == llvm::dwarf::DW_UT_type ||
            m_unit_type == llvm::dwarf::DW_UT_split_type;
   }
-  uint32_t GetNextUnitOffset() const { return m_offset + m_length + 4; }
+  dw_offset_t GetNextUnitOffset() const { return m_offset + m_length + 4; }
 
   llvm::Error ApplyIndexEntry(const llvm::DWARFUnitIndex::Entry *index_entry);
 
@@ -157,7 +157,7 @@ public:
   // Size of the CU data (without initial length and without header).
   size_t GetDebugInfoSize() const;
   // Size of the CU data incl. header but without initial length.
-  uint32_t GetLength() const { return m_header.GetLength(); }
+  dw_offset_t GetLength() const { return m_header.GetLength(); }
   uint16_t GetVersion() const { return m_header.GetVersion(); }
   const llvm::DWARFAbbreviationDeclarationSet *GetAbbreviations() const;
   dw_offset_t GetAbbrevOffset() const;


### PR DESCRIPTION
A previous patch to llvm allowed the DWARFUnitIndex class to handle .debug_info.dwo and .debug_types.dwo sections to go over 4GB by checking for this case and fixing up the DWARFUnitIndex. LLDB's DWARF parser tries to use the llvm's DWARF parser when it can, and LLDB's DWARF parser uses the llvm::DWARFUnitIndex which should allow us to load large .dwp files, but there were a few things missing on the LLDB front:
- support for parsing DWARFUnit objects when the offset exceeds 4GB due to a 32 bit truncation issue
- not populating the required DWARF sections when we call DWARFContext::GetAsLLVM() which didn't allow the fixups to happen as the data was missing.

This patch fixes these issues and now allows LLDB to parse large .dwp files without issues. The issue was discovered when running the "target modules dump separate-debug-info" command on one of these binaries that used a large .dwp file.

This is unfortunately hard to test without creating a huge .dwp file, so there are currently no tests for this that I can think of adding that wouldn't cause disk space constraints or making testing times longer by producing a huge .dwp file.