### PR TITLE
[flang] Fix test ctofortran

### DIFF
--- a/flang/test/Driver/ctofortran.f90
+++ b/flang/test/Driver/ctofortran.f90
@@ -5,6 +5,15 @@
 ! RUN: %t/runtest.sh %t %flang $t/ffile.f90 $t/cfile.c
 
 !--- ffile.f90
+program fmain
+  interface
+    subroutine csub() bind(c)
+    end subroutine
+  end interface
+
+  call csub()
+end program fmain
+
 subroutine foo(a) bind(c)
   integer :: a(:)
   if (lbound(a, 1) .ne. 1) then
@@ -37,7 +46,7 @@ void foo(CFI_cdesc_t*);
 
 int a[10];
 
-int main() {
+void csub() {
   int i, res;
   static CFI_CDESC_T(1) r1;
   CFI_cdesc_t *desc = (CFI_cdesc_t*)&r1;
@@ -55,7 +64,7 @@ int main() {
   }
 
   foo(desc);
-  return 0;
+  return;
 }
 !--- runtest.sh
 #!/bin/bash


### PR DESCRIPTION
After merge request #73124, the flang test Driver/ctofortran started failing because both the C and the Fortran code had main programs.  This update fixes that by eliminating the C main program in the test.