### PR TITLE
[libc] fix build on aarch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -130,14 +130,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     #libc.src.stdio.scanf
     #libc.src.stdio.fscanf
 
-    # search.h entrypoints
-    libc.src.search.hcreate
-    libc.src.search.hcreate_r
-    libc.src.search.hsearch
-    libc.src.search.hsearch_r
-    libc.src.search.hdestroy
-    libc.src.search.hdestroy_r
-
     # sys/mman.h entrypoints
     libc.src.sys.mman.madvise
     libc.src.sys.mman.mmap
@@ -458,6 +450,14 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.signal.sigprocmask
     libc.src.signal.sigfillset
     libc.src.signal.signal
+
+    # search.h entrypoints
+    libc.src.search.hcreate
+    libc.src.search.hcreate_r
+    libc.src.search.hsearch
+    libc.src.search.hsearch_r
+    libc.src.search.hdestroy
+    libc.src.search.hdestroy_r
 
     # threads.h entrypoints
     libc.src.threads.call_once

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -88,15 +88,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.strtoll
     libc.src.stdlib.strtoul
     libc.src.stdlib.strtoull
-
-    # search.h entrypoints
-    libc.src.search.hcreate
-    libc.src.search.hcreate_r
-    libc.src.search.hsearch
-    libc.src.search.hsearch_r
-    libc.src.search.hdestroy
-    libc.src.search.hdestroy_r
-
+    
     # sys/mman.h entrypoints
     libc.src.sys.mman.mmap
     libc.src.sys.mman.munmap

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -136,14 +136,6 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.scanf
     libc.src.stdio.fscanf
 
-    # search.h entrypoints
-    libc.src.search.hcreate
-    libc.src.search.hcreate_r
-    libc.src.search.hsearch
-    libc.src.search.hsearch_r
-    libc.src.search.hdestroy
-    libc.src.search.hdestroy_r
-
     # sys/mman.h entrypoints
     libc.src.sys.mman.madvise
     libc.src.sys.mman.mmap
@@ -491,6 +483,14 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.spawn.posix_spawn_file_actions_addopen
     libc.src.spawn.posix_spawn_file_actions_destroy
     libc.src.spawn.posix_spawn_file_actions_init
+
+    # search.h entrypoints
+    libc.src.search.hcreate
+    libc.src.search.hcreate_r
+    libc.src.search.hsearch
+    libc.src.search.hsearch_r
+    libc.src.search.hdestroy
+    libc.src.search.hdestroy_r
 
     # threads.h entrypoints
     libc.src.threads.call_once

--- a/libc/src/__support/bit.h
+++ b/libc/src/__support/bit.h
@@ -31,11 +31,11 @@ template <typename T> LIBC_INLINE int constexpr correct_zero(T val, int bits) {
 template <typename T> LIBC_INLINE constexpr int clz(T val);
 template <> LIBC_INLINE int clz<unsigned char>(unsigned char val) {
   return __builtin_clz(static_cast<unsigned int>(val)) -
-         8 * (sizeof(unsigned int) - sizeof(unsigned char));
+         8 * static_cast<int>(sizeof(unsigned int) - sizeof(unsigned char));
 }
 template <> LIBC_INLINE int clz<unsigned short>(unsigned short val) {
   return __builtin_clz(static_cast<unsigned int>(val)) -
-         8 * (sizeof(unsigned int) - sizeof(unsigned short));
+         8 * static_cast<int>(sizeof(unsigned int) - sizeof(unsigned short));
 }
 template <> LIBC_INLINE int clz<unsigned int>(unsigned int val) {
   return __builtin_clz(val);

--- a/libc/test/src/__support/hash_test.cpp
+++ b/libc/test/src/__support/hash_test.cpp
@@ -29,7 +29,7 @@ template <class T> struct AlignedMemory {
 };
 
 size_t sizes[] = {0, 1, 23, 59, 1024, 5261};
-char values[] = {0, 1, 23, 59, 102, -1};
+uint8_t values[] = {0, 1, 23, 59, 102, 255};
 
 // Hash value should not change with different alignments.
 TEST(LlvmLibcHashTest, SanityCheck) {


### PR DESCRIPTION
* avoid implicit narrowing conversion
* move hsearch entrypoints to FULL_BUILD