### PR TITLE
[CUDA][Win32] Add `fma(long double,..)` to math forward declares.

### DIFF
--- a/clang/lib/Headers/__clang_cuda_math_forward_declares.h
+++ b/clang/lib/Headers/__clang_cuda_math_forward_declares.h
@@ -70,6 +70,9 @@ __DEVICE__ double floor(double);
 __DEVICE__ float floor(float);
 __DEVICE__ double fma(double, double, double);
 __DEVICE__ float fma(float, float, float);
+#ifdef _MSC_VER
+__DEVICE__ long double fma(long double, long double, long double);
+#endif
 __DEVICE__ double fmax(double, double);
 __DEVICE__ float fmax(float, float);
 __DEVICE__ double fmin(double, double);

--- a/clang/lib/Headers/__clang_cuda_math_forward_declares.h
+++ b/clang/lib/Headers/__clang_cuda_math_forward_declares.h
@@ -71,6 +71,8 @@ __DEVICE__ float floor(float);
 __DEVICE__ double fma(double, double, double);
 __DEVICE__ float fma(float, float, float);
 #ifdef _MSC_VER
+// long double fma variant is not actually supported by CUDA (PTX).
+// However, MS-STL requires that this is forward declared anyways.
 __DEVICE__ long double fma(long double, long double, long double);
 #endif
 __DEVICE__ double fmax(double, double);


### PR DESCRIPTION
As per https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1256 - we are missing the `fma` long double variant for Cpp20 compat with MS-STL.

See also #49853.
-> I'm wondering if we should include this for all long double variants as defined in https://github.com/microsoft/STL/blob/730af178f7c79bd75d414627f969550775e14994/stl/inc/cmath#L291 ?

CC @blinkfrog