### PR TITLE
[libc++] Diagnoses insufficiently aligned pointers for std::assume_aligned during constant evaluation

### DIFF
--- a/libcxx/include/__memory/assume_aligned.h
+++ b/libcxx/include/__memory/assume_aligned.h
@@ -27,6 +27,7 @@ _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __ass
   static_assert(_Np != 0 && (_Np & (_Np - 1)) == 0, "std::assume_aligned<N>(p) requires N to be a power of two");
 
   if (__libcpp_is_constant_evaluated()) {
+    (void)__builtin_assume_aligned(__ptr, _Np);
     return __ptr;
   } else {
     _LIBCPP_ASSERT_UNCATEGORIZED(reinterpret_cast<uintptr_t>(__ptr) % _Np == 0, "Alignment assumption is violated");

--- a/libcxx/test/libcxx/utilities/memory/ptr.align/assume_aligned.const_eval.verify.cpp
+++ b/libcxx/test/libcxx/utilities/memory/ptr.align/assume_aligned.const_eval.verify.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// template<size_t N, class T>
+// [[nodiscard]] constexpr T* assume_aligned(T* ptr);
+
+#include <memory>
+#include <cstddef>
+
+template <size_t Size>
+constexpr bool test() {
+  char data[1];
+
+  [[maybe_unused]] auto data1 = std::assume_aligned<Size>(data);
+
+  return true;
+}
+
+static_assert(test<2>());
+// expected-error@-1 {{static assertion expression is not an integral constant expression}}
+// expected-note@* {{alignment of the base pointee object (1 byte) is less than the asserted 2 bytes}}
+
+static_assert(test<4>());
+// expected-error@-1 {{static assertion expression is not an integral constant expression}}
+// expected-note@* {{alignment of the base pointee object (1 byte) is less than the asserted 4 bytes}}
+
+static_assert(test<8>());
+// expected-error@-1 {{static assertion expression is not an integral constant expression}}
+// expected-note@* {{alignment of the base pointee object (1 byte) is less than the asserted 8 bytes}}
+
+static_assert(test<16>());
+// expected-error@-1 {{static assertion expression is not an integral constant expression}}
+// expected-note@* {{alignment of the base pointee object (1 byte) is less than the asserted 16 bytes}}
+
+static_assert(test<32>());
+// expected-error@-1 {{static assertion expression is not an integral constant expression}}
+// expected-note@* {{alignment of the base pointee object (1 byte) is less than the asserted 32 bytes}}
+
+static_assert(test<64>());
+// expected-error@-1 {{static assertion expression is not an integral constant expression}}
+// expected-note@* {{alignment of the base pointee object (1 byte) is less than the asserted 64 bytes}}


### PR DESCRIPTION
This is a `libc++` enhancement when violating alignment assumption for `__builtin_assume_aligned`.

Fixes #64078