### PR TITLE
[OpenMP][libomptarget][RFC] extend libomptarget with mechanism to execute fill memory on the target

### DIFF
--- a/openmp/libomptarget/include/device.h
+++ b/openmp/libomptarget/include/device.h
@@ -528,6 +528,10 @@ struct DeviceTy {
   int32_t dataExchange(void *SrcPtr, DeviceTy &DstDev, void *DstPtr,
                        int64_t Size, AsyncInfoTy &AsyncInfo);
 
+  /// Fill memory on the target device (aka memset)
+  int32_t fillMemory(void *Ptr, int32_t Val, uint64_t NumValues,
+                     AsyncInfoTy &AsyncInfo);
+
   /// Notify the plugin about a new mapping starting at the host address
   /// \p HstPtr and \p Size bytes.
   int32_t notifyDataMapped(void *HstPtr, int64_t Size);

--- a/openmp/libomptarget/include/omptargetplugin.h
+++ b/openmp/libomptarget/include/omptargetplugin.h
@@ -109,6 +109,17 @@ int32_t __tgt_rtl_data_exchange_async(int32_t SrcID, void *SrcPtr,
                                       int32_t DesID, void *DstPtr, int64_t Size,
                                       __tgt_async_info *AsyncInfo);
 
+// Perform a memory fill operation on the target device (aka "memset") by
+// calling a native driver operation.  In case of success, return zero.
+// Otherwise, return an error code.
+int32_t __tgt_rtl_fill_memory(int32_t DevID, void *Ptr, int32_t ByteVal,
+                              int64_t NumBytes);
+
+// Asynchronous version of __tgt_rtl_fill_memory
+int32_t __tgt_rtl_fill_memory_async(int32_t DevID, void *Ptr, int32_t Val,
+                                    int64_t NumValues,
+                                    __tgt_async_info *AsyncInfo);
+
 // De-allocate the data referenced by target ptr on the device. In case of
 // success, return zero. Otherwise, return an error code. Kind dictates what
 // allocator to use (e.g. shared, host, device).

--- a/openmp/libomptarget/include/rtl.h
+++ b/openmp/libomptarget/include/rtl.h
@@ -48,6 +48,9 @@ struct RTLInfoTy {
   typedef int32_t(data_exchange_ty)(int32_t, void *, int32_t, void *, int64_t);
   typedef int32_t(data_exchange_async_ty)(int32_t, void *, int32_t, void *,
                                           int64_t, __tgt_async_info *);
+  typedef int32_t(fill_memory_ty)(int32_t, void *, int32_t, uint64_t);
+  typedef int32_t(fill_memory_async_ty)(int32_t, void *, int32_t, uint64_t,
+                                        __tgt_async_info *);
   typedef int32_t(data_delete_ty)(int32_t, void *, int32_t);
   typedef int32_t(launch_kernel_ty)(int32_t, void *, void **, ptrdiff_t *,
                                     const KernelArgsTy *, __tgt_async_info *);
@@ -101,6 +104,8 @@ struct RTLInfoTy {
   data_retrieve_async_ty *data_retrieve_async = nullptr;
   data_exchange_ty *data_exchange = nullptr;
   data_exchange_async_ty *data_exchange_async = nullptr;
+  fill_memory_ty *fill_memory = nullptr;
+  fill_memory_async_ty *fill_memory_async = nullptr;
   data_delete_ty *data_delete = nullptr;
   launch_kernel_ty *launch_kernel = nullptr;
   init_requires_ty *init_requires = nullptr;

--- a/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2357,6 +2357,14 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
                                           getAgent(), (uint64_t)Size);
   }
 
+  /// Fill memory on the target device (aka memset)
+  Error fillMemoryImpl(void *Ptr, int32_t Val, uint64_t NumValues,
+                       AsyncInfoWrapperTy &AsyncInfoWrapperTy) override {
+    hsa_status_t Status =
+        hsa_amd_memory_fill(const_cast<void *>(Ptr), Val, NumValues);
+    return Plugin::check(Status, "Error in hsa_amd_memory_fill: %s");
+  }
+
   /// Initialize the async info for interoperability purposes.
   Error initAsyncInfoImpl(AsyncInfoWrapperTy &AsyncInfoWrapper) override {
     // TODO: Implement this function.

--- a/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.h
+++ b/openmp/libomptarget/plugins-nextgen/common/PluginInterface/PluginInterface.h
@@ -775,6 +775,12 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
                                  void *DstPtr, int64_t Size,
                                  AsyncInfoWrapperTy &AsyncInfoWrapper) = 0;
 
+  /// Fill memory on the target device (aka memset).
+  Error fillMemory(void *Ptr, int32_t Val, uint64_t NumValues,
+                   __tgt_async_info *AsyncInfo);
+  virtual Error fillMemoryImpl(void *Ptr, int32_t Val, uint64_t NumValue,
+                               AsyncInfoWrapperTy &AsyncInfo) = 0;
+
   /// Run the kernel associated with \p EntryPtr
   Error launchKernel(void *EntryPtr, void **ArgPtrs, ptrdiff_t *ArgOffsets,
                      KernelArgsTy &KernelArgs, __tgt_async_info *AsyncInfo);

--- a/openmp/libomptarget/plugins-nextgen/generic-elf-64bit/src/rtl.cpp
+++ b/openmp/libomptarget/plugins-nextgen/generic-elf-64bit/src/rtl.cpp
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <ffi.h>
 #include <string>
 #include <unordered_map>
@@ -265,6 +266,14 @@ struct GenELF64DeviceTy : public GenericDeviceTy {
     // This function should never be called because the function
     // GenELF64PluginTy::isDataExchangable() returns false.
     return Plugin::error("dataExchangeImpl not supported");
+  }
+
+  /// Fill memory on the target device (aka memset).
+  Error fillMemoryImpl(void *Ptr, int32_t Val, uint64_t NumValues,
+                       AsyncInfoWrapperTy &AsyncInfoWrapperTy) override {
+    (void)std::memset(Ptr, Val,
+                      static_cast<size_t>(NumValues) * sizeof(int32_t));
+    return Plugin::success();
   }
 
   /// All functions are already synchronous. No need to do anything on this

--- a/openmp/libomptarget/src/device.cpp
+++ b/openmp/libomptarget/src/device.cpp
@@ -672,6 +672,16 @@ int32_t DeviceTy::dataExchange(void *SrcPtr, DeviceTy &DstDev, void *DstPtr,
                                   DstPtr, Size, AsyncInfo);
 }
 
+// Run a "fill memory" operation (aka "memset") on the target device
+int32_t DeviceTy::fillMemory(void *Ptr, int32_t Val, uint64_t NumValues,
+                             AsyncInfoTy &AsyncInfo) {
+  if (!AsyncInfo || !RTL->fill_memory_async || !RTL->synchronize) {
+    assert(RTL->fill_memory && "RTL->fill_memory is nullptr");
+    return RTL->fill_memory(RTLDeviceID, Ptr, Val, NumValues);
+  }
+  return RTL->fill_memory_async(RTLDeviceID, Ptr, Val, NumValues, AsyncInfo);
+}
+
 int32_t DeviceTy::notifyDataMapped(void *HstPtr, int64_t Size) {
   if (!RTL->data_notify_mapped)
     return OFFLOAD_SUCCESS;

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -209,6 +209,10 @@ bool RTLsTy::attemptLoadRTL(const std::string &RTLName, RTLInfoTy &RTL) {
       DynLibrary->getAddressOfSymbol("__tgt_rtl_data_exchange");
   *((void **)&RTL.data_exchange_async) =
       DynLibrary->getAddressOfSymbol("__tgt_rtl_data_exchange_async");
+  *((void **)&RTL.fill_memory) =
+      DynLibrary->getAddressOfSymbol("__tgt_rtl_fill_memory");
+  *((void **)&RTL.fill_memory_async) =
+      DynLibrary->getAddressOfSymbol("__tgt_rtl_fill_memory_async");
   *((void **)&RTL.is_data_exchangable) =
       DynLibrary->getAddressOfSymbol("__tgt_rtl_is_data_exchangable");
   *((void **)&RTL.supports_empty_images) =


### PR DESCRIPTION
This PR extends libomptarget with a new plugin entry point to use a plugin's backend implementation for memory fill operations (e.g., `hsa_amd_fill_memory` or `cuMemsetD32`) to implement `omp_target_memset()` and `omp_target_memset_async()`.

*This PR is not yet ready to merge, but should serve a place for having a discussion how to deal with this also for future cases.*