### PR TITLE
[mlir] Fix two `CHECK:` typos

### DIFF
--- a/mlir/test/Dialect/Affine/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Affine/value-bounds-op-interface-impl.mlir
@@ -6,7 +6,7 @@
 //  CHECK-SAME:     %[[a:.*]]: index, %[[b:.*]]: index
 //       CHECK:   %[[apply:.*]] = affine.apply #[[$map]]()[%[[a]], %[[b]]]
 //       CHECK:   %[[apply:.*]] = affine.apply #[[$map]]()[%[[a]], %[[b]]]
-//       CHECL:   return %[[apply]]
+//       CHECK:   return %[[apply]]
 func.func @affine_apply(%a: index, %b: index) -> index {
   %0 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%a, %b]
   %1 = "test.reify_bound"(%0) : (index) -> (index)

--- a/mlir/test/Dialect/NVGPU/transform-pipeline-shared.mlir
+++ b/mlir/test/Dialect/NVGPU/transform-pipeline-shared.mlir
@@ -165,7 +165,7 @@ func.func @async_depth_2_peeled(%global: memref<?xf32>) {
   // CHECK:   nvgpu.device_async_copy
   // CHECK:   scf.yield
   // CHECK: nvgpu.device_async_wait %{{.*}} {numGroups = 1
-  // CHEKC: nvgpu.device_async_wait %{{.*}} {numGroups = 0
+  // CHECK: nvgpu.device_async_wait %{{.*}} {numGroups = 0
   scf.for %i = %c0 to %c98 step %c4 {
     %c96 = arith.constant 96 : index
     %cond = arith.cmpi slt, %i, %c96 : index


### PR DESCRIPTION
Out of curiosity, I ran [typos](https://github.com/crate-ci/typos) against MLIR. It found two `CHECK:` typos (and many minor typos; which I'm not gonna work on today).