### PR TITLE
workflows/release-binaries: Add schedule to run job once per month

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -15,6 +15,9 @@ on:
         description: 'Tag to build'
         required: true
         type: string
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 8 1 * *'
 
 permissions:
   contents: read # Default everything to read-only
@@ -26,7 +29,7 @@ jobs:
     if: github.repository == 'llvm/llvm-project'
     outputs:
       release-version: ${{ steps.validate-tag.outputs.release-version }}
-      release: ${{ steps.validate-tag.outputs.release }}
+      flags: ${{ steps.validate-tag.outputs.flags }}
       build-dir: ${{ steps.validate-tag.outputs.build-dir }}
       rc-flags: ${{ steps.validate-tag.outputs.rc-flags }}
       ref: ${{ steps.validate-tag.outputs.ref }}
@@ -50,6 +53,11 @@ jobs:
         tag="${{ github.ref_name }}"
         trimmed=$(echo ${{ inputs.tag }} | xargs)
         [[ "$trimmed" != "" ]] && tag="$trimmed"
+        if [ "$tag" = "main" ]; then
+          # If tag is main, then we've been triggered by a scheduled so pass so
+          # use the head commit as the tag.
+          tag=`git rev-parse HEAD`
+        fi
         if [ -n "${{ inputs.upload }}" ]; then
           upload="${{ inputs.upload }}"
         else
@@ -71,7 +79,7 @@ jobs:
     - name: Checkout LLVM
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.tag || github.ref_name }}
+        ref: ${{ needs.prepare.outputs.ref }}
 
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
@@ -140,8 +148,7 @@ jobs:
     - name: Build and test release
       run: |
         ${{ needs.prepare.outputs.build-dir }}/llvm-project/llvm/utils/release/test-release.sh \
-        -release ${{ needs.prepare.outputs.release }} \
-        ${{ needs.prepare.outputs.rc-flags }} \
+        ${{ needs.prepare.outputs.flags }} \
         -triple ${{ matrix.target.triple }} \
         -use-ninja \
         -no-checkout \

--- a/.github/workflows/set-release-binary-outputs.sh
+++ b/.github/workflows/set-release-binary-outputs.sh
@@ -16,19 +16,32 @@ if [[ "$github_user" != "tstellar" && "$github_user" != "tru" ]]; then
   echo "ERROR: User not allowed: $github_user"
   exit 1
 fi
-pattern='^llvmorg-[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\)\?$'
-echo "$tag" | grep -e $pattern
-if [ $? != 0 ]; then
-  echo "ERROR: Tag '$tag' doesn't match pattern: $pattern"
-  exit 1
+
+if echo $tag | grep -e '^[0-9a-f]\+$'; then
+  # This is a plain commit.
+  # TODO: Don't hardcode this.
+  release_version="18"
+  build_dir="$tag"
+  upload='false'
+  ref="$tag"
+  flags="-git-ref $tag -test-asserts"
+
+else
+
+  pattern='^llvmorg-[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\)\?$'
+  echo "$tag" | grep -e $pattern
+  if [ $? != 0 ]; then
+    echo "ERROR: Tag '$tag' doesn't match pattern: $pattern"
+    exit 1
+  fi
+  release_version=`echo "$tag" | sed 's/llvmorg-//g'`
+  release=`echo "$release_version" | sed 's/-.*//g'`
+  build_dir=`echo "$release_version" | sed 's,^[^-]\+,final,' | sed 's,[^-]\+-rc\(.\+\),rc\1,'`
+  rc_flags=`echo "$release_version" | sed 's,^[^-]\+,-final,' | sed 's,[^-]\+-rc\(.\+\),-rc \1 -test-asserts,' | sed 's,--,-,'`
+  flags="-release $release $rc_flags"
 fi
-release_version=`echo "$tag" | sed 's/llvmorg-//g'`
-release=`echo "$release_version" | sed 's/-.*//g'`
-build_dir=`echo "$release_version" | sed 's,^[^-]\+,final,' | sed 's,[^-]\+-rc\(.\+\),rc\1,'`
-rc_flags=`echo "$release_version" | sed 's,^[^-]\+,-final,' | sed 's,[^-]\+-rc\(.\+\),-rc \1 -test-asserts,' | sed 's,--,-,'`
 echo "release-version=$release_version" >> $GITHUB_OUTPUT
-echo "release=$release" >> $GITHUB_OUTPUT
 echo "build-dir=$build_dir" >> $GITHUB_OUTPUT
-echo "rc-flags=$rc_flags" >> $GITHUB_OUTPUT
+echo "flags=$flags" >> $GITHUB_OUTPUT
 echo "upload=$upload" >> $GITHUB_OUTPUT
 echo "ref=$tag" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This will help catch any regressions introduced in the main branch before we start release testing.