### PR TITLE
[OpenMP][NFC] Rename OmptCallback.cpp into OpenMP/OMPT/Callback.cpp

### DIFF
--- a/openmp/libomptarget/src/CMakeLists.txt
+++ b/openmp/libomptarget/src/CMakeLists.txt
@@ -19,10 +19,10 @@ add_llvm_library(omptarget
   device.cpp
   interface.cpp
   omptarget.cpp
-  OmptCallback.cpp
   rtl.cpp
   LegacyAPI.cpp
   OpenMP/InteropAPI.cpp
+  OpenMP/OMPT/Callback.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LIBOMPTARGET_INCLUDE_DIR}

--- a/openmp/libomptarget/src/OpenMP/OMPT/Callback.cpp
+++ b/openmp/libomptarget/src/OpenMP/OMPT/Callback.cpp
@@ -1,4 +1,4 @@
-//===-- OmptCallback.cpp - Target independent OpenMP target RTL --- C++ -*-===//
+//===-- OpenMP/OMPT/Callback.cpp - OpenMP Tooling Callback implementation -===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,9 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifdef OMPT_SUPPORT
+#ifndef OMPT_SUPPORT
 
-#include "llvm/Support/DynamicLibrary.h"
+extern "C" {
+/// Dummy definition when OMPT is disabled
+void ompt_libomptarget_connect() {}
+}
+
+#else // OMPT_SUPPORT is set
 
 #include <cstdlib>
 #include <cstring>
@@ -23,6 +28,8 @@
 #include "OpenMP/OMPT/Callback.h"
 #include "OpenMP/OMPT/Connector.h"
 #include "OpenMP/OMPT/Interface.h"
+
+#include "llvm/Support/DynamicLibrary.h"
 
 #undef DEBUG_PREFIX
 #define DEBUG_PREFIX "OMPT"
@@ -490,10 +497,5 @@ void ompt_libomptarget_connect(ompt_start_tool_result_t *result) {
   }
   DP("Leave ompt_libomptarget_connect\n");
 }
-}
-#else
-extern "C" {
-/// Dummy definition when OMPT is disabled
-void ompt_libomptarget_connect() {}
 }
 #endif // OMPT_SUPPORT


### PR DESCRIPTION
Also revert the ifdef OMPT_SUPPORT order to have the short fallback first and not after 400 lines.