### PR TITLE
[libc++] Remove linux Buildkite builders entirely

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -158,6 +158,10 @@ jobs:
           'generic-no-wide-characters',
           'generic-static',
           'generic-with_llvm_unwinder'
+          # TODO Find a better place for the benchmark and bootstrapping builds to live. They're either very expensive
+          # or don't provide much value since the benchmark run results are too noise on the bots.
+          'benchmarks',
+          'bootstrapping-build',
         ]
         machine: [ 'libcxx-runners-8' ]
         std_modules: [ 'OFF' ]

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -157,11 +157,11 @@ jobs:
           'generic-no-unicode',
           'generic-no-wide-characters',
           'generic-static',
-          'generic-with_llvm_unwinder'
+          'generic-with_llvm_unwinder',
           # TODO Find a better place for the benchmark and bootstrapping builds to live. They're either very expensive
           # or don't provide much value since the benchmark run results are too noise on the bots.
           'benchmarks',
-          'bootstrapping-build',
+          'bootstrapping-build'
         ]
         machine: [ 'libcxx-runners-8' ]
         std_modules: [ 'OFF' ]

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -101,20 +101,6 @@ environment_definitions:
 
 
 steps:
-- label: Bootstrapping build
-  command: libcxx/utils/ci/run-buildbot bootstrapping-build
-  env:
-    <<: *common_env
-  <<: *linux_agent
-  <<: *common
-
-- label: Benchmarks
-  command: libcxx/utils/ci/run-buildbot benchmarks
-  env:
-    <<: *common_env
-  <<: *linux_agent
-  <<: *common
-
 - group: ':windows: Windows'
   steps:
   - label: Clang-cl (DLL)

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -43,14 +43,9 @@ definitions:
 
 # Define agents using YAML anchors to reduce duplication
 agents_definitions:
-  _linux_agent: &linux_agent
-    agents:
-      queue: libcxx-builders
-      os: linux
   _windows_agent: &windows_agent
     agents:
       queue: windows
-
   # Mac OS Builders
   _mac_agent_x86: &mac_agent_x86
     agents:

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -46,6 +46,7 @@ agents_definitions:
   _windows_agent: &windows_agent
     agents:
       queue: windows
+
   # Mac OS Builders
   _mac_agent_x86: &mac_agent_x86
     agents:
@@ -206,6 +207,11 @@ steps:
   - label: Armv7 -fno-exceptions
     command: libcxx/utils/ci/run-buildbot armv7-no-exceptions
     <<: *arm_agent_armv8l
+    <<: *common
+
+  - label: Armv7-M picolibc
+    command: libcxx/utils/ci/run-buildbot armv7m-picolibc
+    <<: *arm_agent_aarch64
     <<: *common
 
 - group: AIX


### PR DESCRIPTION
This removes the Google hosted Linux buildkite builders. We have since moved all of them over to github actions.

Follow up changes will be sent for android.