### PR TITLE
[Rewrite] Fix offset computation in RemoveText

### DIFF
--- a/clang/include/clang/Rewrite/Core/RewriteBuffer.h
+++ b/clang/include/clang/Rewrite/Core/RewriteBuffer.h
@@ -58,7 +58,7 @@ public:
 
   /// RemoveText - Remove the specified text.
   void RemoveText(unsigned OrigOffset, unsigned Size,
-                  bool removeLineIfEmpty = false);
+                  bool removeLineIfEmpty = false, bool AfterInserts = true);
 
   /// InsertText - Insert some text at the specified point, where the offset in
   /// the buffer is specified relative to the original SourceBuffer.  The

--- a/clang/include/clang/Rewrite/Core/Rewriter.h
+++ b/clang/include/clang/Rewrite/Core/Rewriter.h
@@ -139,17 +139,20 @@ public:
 
   /// RemoveText - Remove the specified text region.
   bool RemoveText(SourceLocation Start, unsigned Length,
-                  RewriteOptions opts = RewriteOptions());
+                  RewriteOptions opts = RewriteOptions(),
+                  bool AfterInserts = true);
 
   /// Remove the specified text region.
   bool RemoveText(CharSourceRange range,
                   RewriteOptions opts = RewriteOptions()) {
-    return RemoveText(range.getBegin(), getRangeSize(range, opts), opts);
+    return RemoveText(range.getBegin(), getRangeSize(range, opts), opts,
+                      !opts.IncludeInsertsAtBeginOfRange);
   }
 
   /// Remove the specified text region.
   bool RemoveText(SourceRange range, RewriteOptions opts = RewriteOptions()) {
-    return RemoveText(range.getBegin(), getRangeSize(range, opts), opts);
+    return RemoveText(range.getBegin(), getRangeSize(range, opts), opts,
+                      !opts.IncludeInsertsAtBeginOfRange);
   }
 
   /// ReplaceText - This method replaces a range of characters in the input


### PR DESCRIPTION
When removing a source range from the RewriterBuffer, Clang needs to compute the size of the actual range in the RewriterBuffer (as new elements may have been inserted at any position of the original range). Once this is done, it then maps the original source location offset to real offsets into the RewriteBuffer, supposedly accounting for modifications of the RewriteBuffer (insertion/deletion of text). However, it actually does not account for modifications at the beginning of the range, which is inconsistent behavior as they are taken into account when computing the size of the range. This commit fixes this slightly-off behavior.