### PR TITLE
[libc++] Protect the libc++ implementation from CUDA SDK's `__noinline__` macro

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1211,6 +1211,9 @@ __sanitizer_verify_double_ended_contiguous_container(const void*, const void*, c
 // when compiling for CUDA we use the non-underscored version of the noinline
 // attribute.
 //
+// This is a temporary workaround and we still expect the CUDA SDK team to solve
+// this issue properly in the SDK headers.
+//
 // See https://github.com/llvm/llvm-project/pull/73838 for more details.
 #    define _LIBCPP_NOINLINE __attribute__((noinline))
 #  elif __has_attribute(__noinline__)

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1205,6 +1205,20 @@ __sanitizer_verify_double_ended_contiguous_container(const void*, const void*, c
 #    define _LIBCPP_NOINLINE
 #  endif
 
+#  if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)
+// The CUDA SDK contains an unfortunate definition for the __noinline__ macro,
+// which breaks the regular __attribute__((__noinline__)) syntax. Therefore,
+// when compiling for CUDA we use the non-underscored version of the noinline
+// attribute.
+//
+// See https://github.com/llvm/llvm-project/pull/73838 for more details.
+#    define _LIBCPP_NOINLINE __attribute__((noinline))
+#  elif __has_attribute(__noinline__)
+#    define _LIBCPP_NOINLINE __attribute__((__noinline__))
+#  else
+#    define _LIBCPP_NOINLINE
+#  endif
+
 // We often repeat things just for handling wide characters in the library.
 // When wide characters are disabled, it can be useful to have a quick way of
 // disabling it without having to resort to #if-#endif, which has a larger


### PR DESCRIPTION
The CUDA SDK contains an unfortunate definition for the `__noinline__`
macro. This patch works around it by using `__attribute__((noinline))`
instead of `__attribute__((__noinline__))` on CUDA. We are still waiting
for a long-term resolution to this issue in NVIDIA/cccl#1235.
