### PR TITLE
[flang][openacc] Do not check for unlabelled CYCLE branching

### DIFF
--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -15,7 +15,6 @@
 #include "flang/Common/enum-set.h"
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/tools.h"
-#include <type_traits>
 #include <unordered_map>
 
 namespace Fortran::semantics {

--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -15,6 +15,7 @@
 #include "flang/Common/enum-set.h"
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/tools.h"
+#include <type_traits>
 #include <unordered_map>
 
 namespace Fortran::semantics {
@@ -62,20 +63,24 @@ public:
     if (const auto &cycleName{cycleStmt.v}) {
       CheckConstructNameBranching("CYCLE", cycleName.value());
     } else {
-      switch ((llvm::omp::Directive)currentDirective_) {
-      // exclude directives which do not need a check for unlabelled CYCLES
-      case llvm::omp::Directive::OMPD_do:
-      case llvm::omp::Directive::OMPD_simd:
-      case llvm::omp::Directive::OMPD_parallel_do:
-      case llvm::omp::Directive::OMPD_parallel_do_simd:
-      case llvm::omp::Directive::OMPD_distribute_parallel_do:
-      case llvm::omp::Directive::OMPD_distribute_parallel_do_simd:
-      case llvm::omp::Directive::OMPD_distribute_parallel_for:
-      case llvm::omp::Directive::OMPD_distribute_simd:
-      case llvm::omp::Directive::OMPD_distribute_parallel_for_simd:
-        return;
-      default:
-        break;
+      if constexpr (std::is_same_v<D, llvm::omp::Directive>) {
+        switch ((llvm::omp::Directive)currentDirective_) {
+        // exclude directives which do not need a check for unlabelled CYCLES
+        case llvm::omp::Directive::OMPD_do:
+        case llvm::omp::Directive::OMPD_simd:
+        case llvm::omp::Directive::OMPD_parallel_do:
+        case llvm::omp::Directive::OMPD_parallel_do_simd:
+        case llvm::omp::Directive::OMPD_distribute_parallel_do:
+        case llvm::omp::Directive::OMPD_distribute_parallel_do_simd:
+        case llvm::omp::Directive::OMPD_distribute_parallel_for:
+        case llvm::omp::Directive::OMPD_distribute_simd:
+        case llvm::omp::Directive::OMPD_distribute_parallel_for_simd:
+          return;
+        default:
+          break;
+        }
+      } else if constexpr (std::is_same_v<D, llvm::acc::Directive>) {
+        return; // OpenACC construct do not need check for unlabelled CYCLES
       }
       CheckConstructNameBranching("CYCLE");
     }

--- a/flang/test/Semantics/OpenACC/acc-kernels-loop.f90
+++ b/flang/test/Semantics/OpenACC/acc-kernels-loop.f90
@@ -290,4 +290,9 @@ program openacc_kernels_loop_validity
     a(i) = 3.14
   end do
 
+  !$acc parallel loop
+  do i = 1, N
+    if(i == 10) cycle
+  end do
+
 end program openacc_kernels_loop_validity

--- a/flang/test/Semantics/OpenACC/acc-loop.f90
+++ b/flang/test/Semantics/OpenACC/acc-loop.f90
@@ -276,4 +276,11 @@ program openacc_loop_validity
     end do
   end do
 
+  !$acc parallel
+  !$acc loop
+  do i = 1, n
+    if(i == 10) cycle
+  end do
+  !$acc end parallel
+
 end program openacc_loop_validity

--- a/flang/test/Semantics/OpenACC/acc-parallel-loop-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-parallel-loop-validity.f90
@@ -136,4 +136,9 @@ program openacc_parallel_loop_validity
     reduction_l = d(i) .neqv. e(i)
   end do
 
+  !$acc parallel loop
+  do i = 1, N
+    if(i == 10) cycle
+  end do
+
 end program openacc_parallel_loop_validity

--- a/flang/test/Semantics/OpenACC/acc-serial-loop.f90
+++ b/flang/test/Semantics/OpenACC/acc-serial-loop.f90
@@ -106,4 +106,9 @@ program openacc_serial_loop_validity
   end do
   !$acc end serial
 
+  !$acc serial loop
+  do i = 1, n
+    if(i == 10) cycle
+  end do
+
 end program openacc_serial_loop_validity


### PR DESCRIPTION
There is no such restriction for any OpenACC construct. This patch adds a constexpr condition on the type of Directive. 