### PR TITLE
Add a scheduled build for libc++

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -22,6 +22,9 @@ on:
       - 'runtimes/**'
       - 'cmake/**'
       - '.github/workflows/libcxx-build-and-test.yaml'
+  schedule:
+    # Run nightly at 8 AM UTC (or roughly 3 AM eastern)
+    - cron: '0 3 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
We had a scheduled build on buildkite, we probably want something testing head here as well.
[skip ci]