### PR TITLE
[libc][NFC] Fix missing dep in bazel

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -594,6 +594,7 @@ libc_support_library(
     name = "__support_bit",
     hdrs = ["src/__support/bit.h"],
     deps = [
+        ":__support_cpp_type_traits",
         ":__support_macros_attributes",
     ],
 )


### PR DESCRIPTION
Patch #73469 added a dependency from __support/bit.h to
__support/CPP/type_traits.h, but didn't add a dependency in the bazel.
This caused downstream build failures. This patch fixes the missing
dependency.

