### PR TITLE
[SPIR-V] Mark currently failing tests as XFAIL

### DIFF
--- a/llvm/test/CodeGen/SPIRV/EnqueueEmptyKernel.ll
+++ b/llvm/test/CodeGen/SPIRV/EnqueueEmptyKernel.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ;; This test checks that Invoke parameter of OpEnueueKernel instruction meet the
 ;; following specification requirements in case of enqueueing empty block:
 ;; "Invoke must be an OpFunction whose OpTypeFunction operand has:

--- a/llvm/test/CodeGen/SPIRV/half_no_extension.ll
+++ b/llvm/test/CodeGen/SPIRV/half_no_extension.ll
@@ -7,6 +7,9 @@
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ; CHECK-SPIRV:     OpCapability Float16Buffer
 ; CHECK-SPIRV-NOT: OpCapability Float16
 

--- a/llvm/test/CodeGen/SPIRV/linked-list.ll
+++ b/llvm/test/CodeGen/SPIRV/linked-list.ll
@@ -1,4 +1,7 @@
-; RUN: llc -O0 -opaque-pointers=0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
 
 %struct.Node = type { %struct.Node.0 addrspace(1)* }
 ; CHECK: %[[#]] = OpTypeOpaque "struct.Node.0"

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/vstore_private.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/vstore_private.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ; CHECK: %[[#i16_ty:]] = OpTypeInt 16 0
 ; CHECK: %[[#v4xi16_ty:]] = OpTypeVector %[[#i16_ty]] 4
 ; CHECK: %[[#pv4xi16_ty:]] = OpTypePointer Function %[[#v4xi16_ty]]

--- a/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ; CHECK: %[[#bool:]] = OpTypeBool
 ; CHECK: %[[#true:]] = OpConstantTrue %[[#bool]]
 ; CHECK: OpBranchConditional %[[#true]]

--- a/llvm/test/CodeGen/SPIRV/pstruct.ll
+++ b/llvm/test/CodeGen/SPIRV/pstruct.ll
@@ -1,4 +1,7 @@
-; RUN: llc -O0 -opaque-pointers=0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
 
 %struct.ST = type { i32, i32, i32 }
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/BuildNDRange_2.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/BuildNDRange_2.ll
@@ -20,6 +20,9 @@
 
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ; CHECK-SPIRV-DAG:     %[[#LEN2_ID:]] = OpConstant %[[#]] 2
 ; CHECK-SPIRV-DAG:     %[[#LEN3_ID:]] = OpConstant %[[#]] 3
 ; CHECK-SPIRV-DAG:     %[[#ARRAY_T2:]] = OpTypeArray %[[#]] %[[#LEN2_ID]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/block_w_struct_return.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/block_w_struct_return.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV1_4
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ;; TODO: We cannot check SPIR_V 1.1 and 1.4 simultaneously, implement additional
 ;;       run with CHECK-SPIRV1_1.
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/enqueue_kernel.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/enqueue_kernel.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ; CHECK-SPIRV: OpEntryPoint Kernel %[[#BlockKer1:]] "__device_side_enqueue_block_invoke_kernel"
 ; CHECK-SPIRV: OpEntryPoint Kernel %[[#BlockKer2:]] "__device_side_enqueue_block_invoke_2_kernel"
 ; CHECK-SPIRV: OpEntryPoint Kernel %[[#BlockKer3:]] "__device_side_enqueue_block_invoke_3_kernel"

--- a/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
@@ -1,4 +1,7 @@
-; RUN: llc -O0 -opaque-pointers=0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
 
 ;; Check 'LLVM ==> SPIR-V' conversion of extractvalue/insertvalue.
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/global_block.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/global_block.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV1_4
 
+; TODO(#60133): Requires updates following opaque pointer migration.
+; XFAIL: *
+
 ;; There are no blocks in SPIR-V. Therefore they are translated into regular
 ;; functions. An LLVM module which uses blocks, also contains some auxiliary
 ;; block-specific instructions, which are redundant in SPIR-V and should be


### PR DESCRIPTION
These tests are currently failing and their fix is being tracked in Issue #60133. Marking them as XFAIL for now will get the test suite to a passing state so we can work on adding a GitHub action to automatically run these tests on a PR bot to help keep the tree green.

Also removed the no-longer supported -opaque-pointers=0 flag from the couple tests where it was remaining.