### PR TITLE
[LLVM][DWARF] Add support for .debug_names with split dwarf

### DIFF
--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -297,15 +297,15 @@ protected:
 };
 
 struct TypeUnitMetaInfo {
-  // Symbol for start of the TU section.
-  MCSymbol *Label;
+  // Symbol for start of the TU section or signature if this is SplitDwarf.
+  std::variant<MCSymbol *, uint64_t> LabelOrSignature;
   // Unique ID of Type Unit.
   unsigned UniqueID;
 };
 using TUVectorTy = SmallVector<TypeUnitMetaInfo, 1>;
 class DWARF5AccelTable : public AccelTable<DWARF5AccelTableData> {
   // Symbols to start of all the TU sections that were generated.
-  TUVectorTy TUSymbols;
+  TUVectorTy TUSymbolsOrHashes;
 
 public:
   struct UnitIndexAndEncoding {
@@ -313,9 +313,11 @@ public:
     DWARF5AccelTableData::AttributeEncoding Endoding;
   };
   /// Returns type units that were constructed.
-  const TUVectorTy &getTypeUnitsSymbols() { return TUSymbols; }
+  const TUVectorTy &getTypeUnitsSymbols() { return TUSymbolsOrHashes; }
   /// Add a type unit start symbol.
   void addTypeUnitSymbol(DwarfTypeUnit &U);
+  /// Add a type unit Signature.
+  void addTypeUnitSignature(DwarfTypeUnit &U);
   /// Convert DIE entries to explicit offset.
   /// Needs to be called after DIE offsets are computed.
   void convertDieToOffset() {

--- a/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AccelTable.cpp
@@ -201,9 +201,11 @@ class Dwarf5AccelTableWriter : public AccelTableWriter {
     char AugmentationString[8] = {'L', 'L', 'V', 'M', '0', '7', '0', '0'};
 
     Header(uint32_t CompUnitCount, uint32_t LocalTypeUnitCount,
-           uint32_t BucketCount, uint32_t NameCount)
+           uint32_t ForeignTypeUnitCount, uint32_t BucketCount,
+           uint32_t NameCount)
         : CompUnitCount(CompUnitCount), LocalTypeUnitCount(LocalTypeUnitCount),
-          BucketCount(BucketCount), NameCount(NameCount) {}
+          ForeignTypeUnitCount(ForeignTypeUnitCount), BucketCount(BucketCount),
+          NameCount(NameCount) {}
 
     void emit(Dwarf5AccelTableWriter &Ctx);
   };
@@ -220,6 +222,8 @@ class Dwarf5AccelTableWriter : public AccelTableWriter {
   MCSymbol *AbbrevStart = Asm->createTempSymbol("names_abbrev_start");
   MCSymbol *AbbrevEnd = Asm->createTempSymbol("names_abbrev_end");
   MCSymbol *EntryPool = Asm->createTempSymbol("names_entries");
+  // Indicates if this module is built with Split Dwarf enabled.
+  bool IsSplitDwarf = false;
 
   void populateAbbrevsMap();
 
@@ -238,7 +242,8 @@ public:
       ArrayRef<std::variant<MCSymbol *, uint64_t>> TypeUnits,
       llvm::function_ref<
           std::optional<DWARF5AccelTable::UnitIndexAndEncoding>(const DataT &)>
-          getIndexForEntry);
+          getIndexForEntry,
+      bool IsSplitDwarf);
 
   void emit();
 };
@@ -450,6 +455,8 @@ void Dwarf5AccelTableWriter<DataT>::emitTUList() const {
     Asm->OutStreamer->AddComment("Type unit " + Twine(TU.index()));
     if (std::holds_alternative<MCSymbol *>(TU.value()))
       Asm->emitDwarfSymbolReference(std::get<MCSymbol *>(TU.value()));
+    else if (IsSplitDwarf)
+      Asm->emitInt64(std::get<uint64_t>(TU.value()));
     else
       Asm->emitDwarfLengthOrOffset(std::get<uint64_t>(TU.value()));
   }
@@ -551,12 +558,15 @@ Dwarf5AccelTableWriter<DataT>::Dwarf5AccelTableWriter(
     ArrayRef<std::variant<MCSymbol *, uint64_t>> TypeUnits,
     llvm::function_ref<
         std::optional<DWARF5AccelTable::UnitIndexAndEncoding>(const DataT &)>
-        getIndexForEntry)
+        getIndexForEntry,
+    bool IsSplitDwarf)
     : AccelTableWriter(Asm, Contents, false),
-      Header(CompUnits.size(), TypeUnits.size(), Contents.getBucketCount(),
+      Header(CompUnits.size(), IsSplitDwarf ? 0 : TypeUnits.size(),
+             IsSplitDwarf ? TypeUnits.size() : 0, Contents.getBucketCount(),
              Contents.getUniqueNameCount()),
       CompUnits(CompUnits), TypeUnits(TypeUnits),
-      getIndexForEntry(std::move(getIndexForEntry)) {
+      getIndexForEntry(std::move(getIndexForEntry)),
+      IsSplitDwarf(IsSplitDwarf) {
   populateAbbrevsMap();
 }
 
@@ -608,7 +618,10 @@ void llvm::emitDWARF5AccelTable(
 
   for (const auto &TU : TUSymbols) {
     TUIndex[TU.UniqueID] = TUCount++;
-    TypeUnits.push_back(TU.Label);
+    if (DD.useSplitDwarf())
+      TypeUnits.push_back(std::get<uint64_t>(TU.LabelOrSignature));
+    else
+      TypeUnits.push_back(std::get<MCSymbol *>(TU.LabelOrSignature));
   }
 
   if (CompUnits.empty())
@@ -633,12 +646,17 @@ void llvm::emitDWARF5AccelTable(
           return {{CUIndex[Entry.getUnitID()],
                    {dwarf::DW_IDX_compile_unit, CUIndexForm}}};
         return std::nullopt;
-      })
+      },
+      DD.useSplitDwarf())
       .emit();
 }
 
 void DWARF5AccelTable::addTypeUnitSymbol(DwarfTypeUnit &U) {
-  TUSymbols.push_back({U.getLabelBegin(), U.getUniqueID()});
+  TUSymbolsOrHashes.push_back({U.getLabelBegin(), U.getUniqueID()});
+}
+
+void DWARF5AccelTable::addTypeUnitSignature(DwarfTypeUnit &U) {
+  TUSymbolsOrHashes.push_back({U.getTypeSignature(), U.getUniqueID()});
 }
 
 void llvm::emitDWARF5AccelTable(
@@ -650,7 +668,7 @@ void llvm::emitDWARF5AccelTable(
   std::vector<std::variant<MCSymbol *, uint64_t>> TypeUnits;
   Contents.finalize(Asm, "names");
   Dwarf5AccelTableWriter<DWARF5AccelTableData>(Asm, Contents, CUs, TypeUnits,
-                                               getIndexForEntry)
+                                               getIndexForEntry, false)
       .emit();
 }
 

--- a/llvm/test/DebugInfo/X86/debug-names-types.ll
+++ b/llvm/test/DebugInfo/X86/debug-names-types.ll
@@ -1,14 +1,9 @@
 ; UNSUPPORTED: system-windows
-; This checks that .debug_names can be generated with monolithic -fdebug-type-sections, and does not generate when split-dwarf is enabled.
+; This checks that .debug_names can be generated with monolithic, and split-dwarf, when -fdebug-type-sections is enabled.
 ; Generated with: clang++ main.cpp   -g2 -gdwarf-5 -gpubnames -fdebug-types-section
 
 ; RUN: llc -mtriple=x86_64 -generate-type-units -dwarf-version=5 -filetype=obj %s -o %t
 ; RUN: llvm-dwarfdump -debug-info -debug-names %t | FileCheck %s
-
-; RUN: llc -mtriple=x86_64 -generate-type-units -dwarf-version=5 -filetype=obj -split-dwarf-file=%t.mainTypes.dwo --split-dwarf-output=%t.mainTypes.dwo %s -o %t
-; RUN: llvm-readelf --sections %t | FileCheck %s --check-prefixes=CHECK-SPLIT
-
-; CHECK-SPLIT-NOT: .debug_names
 
 ; CHECK:     .debug_info contents:
 ; CHECK:      DW_TAG_type_unit
@@ -116,6 +111,99 @@
 ; CHECK-NEXT:     }
 ; CHECK-NEXT:   ]
 ; CHECK-NEXT: }
+
+; RUN: llc -mtriple=x86_64 -generate-type-units -dwarf-version=5 -filetype=obj -split-dwarf-file=%t.mainTypes.dwo --split-dwarf-output=%t.mainTypes.dwo %s -o %t
+; RUN: llvm-dwarfdump -debug-names %t | FileCheck %s --check-prefixes=CHECK-SPLIT
+
+; CHECK-SPLIT:          .debug_names contents
+; CHECK-SPLIT:          Foreign TU count: 1
+; CHECK-SPLIT-NEXT:     Bucket count: 4
+; CHECK-SPLIT-NEXT:     Name count: 4
+; CHECK-SPLIT-NEXT:     Abbreviations table size: 0x28
+; CHECK-SPLIT-NEXT:     Augmentation: 'LLVM0700'
+; CHECK-SPLIT-NEXT:   }
+; CHECK-SPLIT-NEXT:   Compilation Unit offsets [
+; CHECK-SPLIT-NEXT:     CU[0]: 0x00000000
+; CHECK-SPLIT-NEXT:   ]
+; CHECK-SPLIT-NEXT:   Foreign Type Unit signatures [
+; CHECK-SPLIT-NEXT:     ForeignTU[0]: 0x675d23e4f33235f2
+; CHECK-SPLIT-NEXT:   ]
+; CHECK-SPLIT-NEXT:   Abbreviations [
+; CHECK-SPLIT-NEXT:     Abbreviation [[ABBREV:0x[0-9a-f]*]] {
+; CHECK-SPLIT-NEXT:       Tag: DW_TAG_structure_type
+; CHECK-SPLIT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
+; CHECK-SPLIT-NEXT:       Tag: DW_TAG_structure_type
+; CHECK-SPLIT-NEXT:       DW_IDX_type_unit: DW_FORM_data1
+; CHECK-SPLIT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
+; CHECK-SPLIT-NEXT:       Tag: DW_TAG_base_type
+; CHECK-SPLIT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
+; CHECK-SPLIT-NEXT:       Tag: DW_TAG_subprogram
+; CHECK-SPLIT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:     Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
+; CHECK-SPLIT-NEXT:       Tag: DW_TAG_base_type
+; CHECK-SPLIT-NEXT:       DW_IDX_type_unit: DW_FORM_data1
+; CHECK-SPLIT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:   ]
+; CHECK-SPLIT-NEXT:   Bucket 0 [
+; CHECK-SPLIT-NEXT:     Name 1 {
+; CHECK-SPLIT-NEXT:       Hash: 0xB888030
+; CHECK-SPLIT-NEXT:       String: {{.+}} "int"
+; CHECK-SPLIT-NEXT:       Entry @ {{.+}} {
+; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV2]]
+; CHECK-SPLIT-NEXT:         Tag: DW_TAG_base_type
+; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x00000035
+; CHECK-SPLIT-NEXT:       }
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:   ]
+; CHECK-SPLIT-NEXT:   Bucket 1 [
+; CHECK-SPLIT-NEXT:     Name 2 {
+; CHECK-SPLIT-NEXT:       Hash: 0xB887389
+; CHECK-SPLIT-NEXT:       String: {{.+}} "Foo"
+; CHECK-SPLIT-NEXT:       Entry @ {{.+}} {
+; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV1]]
+; CHECK-SPLIT-NEXT:         Tag: DW_TAG_structure_type
+; CHECK-SPLIT-NEXT:         DW_IDX_type_unit: 0x00
+; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x0000001f
+; CHECK-SPLIT-NEXT:       }
+; CHECK-SPLIT-NEXT:       Entry @ 0xae {
+; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV]]
+; CHECK-SPLIT-NEXT:         Tag: DW_TAG_structure_type
+; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x00000039
+; CHECK-SPLIT-NEXT:       }
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:   ]
+; CHECK-SPLIT-NEXT:   Bucket 2 [
+; CHECK-SPLIT-NEXT:     Name 3 {
+; CHECK-SPLIT-NEXT:       Hash: 0x7C9A7F6A
+; CHECK-SPLIT-NEXT:       String: {{.+}} "main"
+; CHECK-SPLIT-NEXT:       Entry @ {{.+}} {
+; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV3]]
+; CHECK-SPLIT-NEXT:         Tag: DW_TAG_subprogram
+; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; CHECK-SPLIT-NEXT:       }
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:   ]
+; CHECK-SPLIT-NEXT:   Bucket 3 [
+; CHECK-SPLIT-NEXT:     Name 4 {
+; CHECK-SPLIT-NEXT:       Hash: 0x7C952063
+; CHECK-SPLIT-NEXT:       String: {{.+}} "char"
+; CHECK-SPLIT-NEXT:       Entry @ {{.+}} {
+; CHECK-SPLIT-NEXT:         Abbrev: [[ABBREV4]]
+; CHECK-SPLIT-NEXT:         Tag: DW_TAG_base_type
+; CHECK-SPLIT-NEXT:         DW_IDX_type_unit: 0x00
+; CHECK-SPLIT-NEXT:         DW_IDX_die_offset: 0x00000034
+; CHECK-SPLIT-NEXT:       }
+; CHECK-SPLIT-NEXT:     }
+; CHECK-SPLIT-NEXT:   ]
+; CHECK-SPLIT-NEXT: }
 
 
 ; ModuleID = 'main.cpp'


### PR DESCRIPTION
Enables Type Units with DWARF5 accelerator tables for split dwarf. It is still
under discussion what is the best way to implement support for de-duplication in
DWP. This will be in follow up PR.
