### PR TITLE
[libc] fix getchar_unlocked

### DIFF
--- a/libc/src/stdio/generic/CMakeLists.txt
+++ b/libc/src/stdio/generic/CMakeLists.txt
@@ -321,7 +321,7 @@ add_entrypoint_object(
   SRCS
     getchar_unlocked.cpp
   HDRS
-    ../getc_unlocked.h
+    ../getchar_unlocked.h
   DEPENDS
     libc.src.errno.errno
     libc.include.stdio

--- a/libc/src/stdio/generic/CMakeLists.txt
+++ b/libc/src/stdio/generic/CMakeLists.txt
@@ -319,7 +319,7 @@ add_entrypoint_object(
 add_entrypoint_object(
   getchar_unlocked
   SRCS
-    getc_unlocked.cpp
+    getchar_unlocked.cpp
   HDRS
     ../getc_unlocked.h
   DEPENDS


### PR DESCRIPTION
A typo was leading to getc_unlocked.cpp.o being included into libc.a twice.

I only noticed because I was trying to convert libc.a to a shared object via

$ ld.lld -o libc.so --whole-archive libc.a

which errored since getc_unlocked was being defined twice.
