### PR TITLE
[Flang] malloc(1) on AIX as malloc(0) returns nullptr

### DIFF
--- a/flang/runtime/ISO_Fortran_binding.cpp
+++ b/flang/runtime/ISO_Fortran_binding.cpp
@@ -75,7 +75,7 @@ RT_API_ATTRS int CFI_allocate(CFI_cdesc_t *descriptor,
     dim->sm = byteSize;
     byteSize *= extent;
   }
-  void *p = byteSize ? std::malloc(byteSize) : std::malloc(1);
+  void *p{byteSize ? std::malloc(byteSize) : std::malloc(1)};
   if (!p && byteSize) {
     return CFI_ERROR_MEM_ALLOCATION;
   }

--- a/flang/runtime/ISO_Fortran_binding.cpp
+++ b/flang/runtime/ISO_Fortran_binding.cpp
@@ -75,7 +75,14 @@ RT_API_ATTRS int CFI_allocate(CFI_cdesc_t *descriptor,
     dim->sm = byteSize;
     byteSize *= extent;
   }
+#ifdef _AIX
+  if (!byteSize)
+    void *p{std::malloc(1)};
+  else
+    void *p{std::malloc(byteSize)};
+#else
   void *p{std::malloc(byteSize)};
+#endif
   if (!p && byteSize) {
     return CFI_ERROR_MEM_ALLOCATION;
   }

--- a/flang/runtime/ISO_Fortran_binding.cpp
+++ b/flang/runtime/ISO_Fortran_binding.cpp
@@ -75,14 +75,7 @@ RT_API_ATTRS int CFI_allocate(CFI_cdesc_t *descriptor,
     dim->sm = byteSize;
     byteSize *= extent;
   }
-#ifdef _AIX
-  if (!byteSize)
-    void *p{std::malloc(1)};
-  else
-    void *p{std::malloc(byteSize)};
-#else
-  void *p{std::malloc(byteSize)};
-#endif
+  void *p = byteSize ? std::malloc(byteSize) : std::malloc(1);
   if (!p && byteSize) {
     return CFI_ERROR_MEM_ALLOCATION;
   }


### PR DESCRIPTION
On AIX malloc(0) reutrns nullptr, which fails test case `Evaluate/ISO-Fortran-binding.test`, using malloc(1) in AIX for consistent behaviour