### PR TITLE
[BOLT][DWARF] Add support to create path

### DIFF
--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -679,6 +679,8 @@ void DWARFRewriter::updateDebugInfo() {
     assert(CompDirAttrInfo && "DW_AT_comp_dir is not in Skeleton CU.");
 
     if (!opts::DwarfOutputPath.empty()) {
+      if (!sys::fs::exists(opts::DwarfOutputPath))
+        sys::fs::create_directory(opts::DwarfOutputPath);
       addStringHelper(DIEBldr, UnitDIE, Unit, CompDirAttrInfo,
                       opts::DwarfOutputPath.c_str());
     }

--- a/bolt/test/X86/dwarf5-df-output-dir-same-name.test
+++ b/bolt/test/X86/dwarf5-df-output-dir-same-name.test
@@ -21,3 +21,19 @@
 ; BOLT: split.dwo1.dwo
 ; BOLT: DW_AT_dwo_name  ("split.dwo0.dwo")
 ; BOLT: DW_AT_dwo_name  ("split.dwo1.dwo")
+
+; Tests that when --dwarf-output-path is specified, but path do not exist BOLT creates it.
+
+; RUN: rm -rf dwo
+; RUN: llvm-bolt main.exe -o main.exe.bolt --update-debug-sections --dwarf-output-path=%t/dwo
+; RUN: ls -l %t/dwo > log
+; RUN: llvm-dwarfdump --debug-info main.exe.bolt >> log
+; RUN: cat log | FileCheck -check-prefix=BOLT1 %s
+
+; Tests that BOLT handles correctly writing out .dwo files to the same directory when input has input where part of path
+; is in DW_AT_dwo_name and the .dwo file names are the same.
+
+; BOLT1: split.dwo0.dwo
+; BOLT1: split.dwo1.dwo
+; BOLT1: DW_AT_dwo_name  ("split.dwo0.dwo")
+; BOLT1: DW_AT_dwo_name  ("split.dwo1.dwo")


### PR DESCRIPTION
When option --dwarf-output-path is specified, if the path does not exist BOLT will now create it. This is what also happens when --plugin-opt=dwo_dir=<value> is specified to LLD.