### PR TITLE
[clang-format] Don't skip stringizing when determining brace kind

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -496,7 +496,7 @@ void UnwrappedLineParser::calculateBraceTypes(bool ExpectClassBody) {
     do {
       NextTok = Tokens->getNextToken();
     } while (NextTok->is(tok::comment));
-    while (NextTok->is(tok::hash) && !Line->InPPDirective) {
+    while (NextTok->is(tok::hash) && !Line->InMacroBody) {
       NextTok = Tokens->getNextToken();
       do {
         NextTok = Tokens->getNextToken();

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -496,7 +496,7 @@ void UnwrappedLineParser::calculateBraceTypes(bool ExpectClassBody) {
     do {
       NextTok = Tokens->getNextToken();
     } while (NextTok->is(tok::comment));
-    while (NextTok->is(tok::hash)) {
+    while (NextTok->is(tok::hash) && !Line->InPPDirective) {
       NextTok = Tokens->getNextToken();
       do {
         NextTok = Tokens->getNextToken();

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1855,13 +1855,13 @@ TEST_F(TokenAnnotatorTest, UnderstandHashInMacro) {
   auto Tokens = annotate("#define Foo(Bar) \\\n"
                          "  { \\\n"
                          "    #Bar \\\n"
-                         "  }\n");
+                         "  }");
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;
   EXPECT_BRACE_KIND(Tokens[6], BK_Block);
   EXPECT_BRACE_KIND(Tokens[9], BK_Block);
 
   Tokens = annotate("#define Foo(Bar) \\\n"
-                    "  { #Bar }\n");
+                    "  { #Bar }");
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;
   EXPECT_BRACE_KIND(Tokens[6], BK_Block);
   EXPECT_BRACE_KIND(Tokens[9], BK_Block);

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1851,6 +1851,22 @@ TEST_F(TokenAnnotatorTest, UnderstandsTrailingReturnArrow) {
   EXPECT_TOKEN(Tokens[13], tok::arrow, TT_Unknown);
 }
 
+TEST_F(TokenAnnotatorTest, UnderstandHashInMacro) {
+  auto Tokens = annotate("#define Foo(Bar) \\\n"
+                         "  { \\\n"
+                         "    #Bar \\\n"
+                         "  }\n");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_BRACE_KIND(Tokens[6], BK_Block);
+  EXPECT_BRACE_KIND(Tokens[9], BK_Block);
+
+  Tokens = annotate("#define Foo(Bar) \\\n"
+                    "  { #Bar }\n");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_BRACE_KIND(Tokens[6], BK_Block);
+  EXPECT_BRACE_KIND(Tokens[9], BK_Block);
+}
+
 TEST_F(TokenAnnotatorTest, UnderstandsAttributeMacros) {
   // '__attribute__' has special handling.
   auto Tokens = annotate("__attribute__(X) void Foo(void);");


### PR DESCRIPTION
PR #69473 introduced skipping PP directives when determining the brace kind of an lbrace. However, it did so by skipping to the end of the line when encountering a hash character. This means it also skipped to the end of line when encountering a macro stringizing operator, which, unlike PP directives, don't have effect until the end of line.

This led to cases where the rbrace could be completely skipped if it was on the same line as a stringizing operator.

This patch skips hash characters if we're already in a PP directive, as you can't define a macro inside of a macro

Fixes https://github.com/llvm/llvm-project/issues/72662