### PR TITLE
[llvm-special-case-list-fuzzer] fix off-by-one read

### DIFF
--- a/llvm/tools/llvm-special-case-list-fuzzer/special-case-list-fuzzer.cpp
+++ b/llvm/tools/llvm-special-case-list-fuzzer/special-case-list-fuzzer.cpp
@@ -12,8 +12,9 @@
 #include <cstdlib>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-  std::unique_ptr<llvm::MemoryBuffer> Buf = llvm::MemoryBuffer::getMemBuffer(
-      llvm::StringRef(reinterpret_cast<const char *>(Data), Size), "", false);
+  std::string Payload(reinterpret_cast<const char *>(Data), Size);
+  std::unique_ptr<llvm::MemoryBuffer> Buf =
+      llvm::MemoryBuffer::getMemBuffer(Payload);
 
   if (!Buf)
     return 0;


### PR DESCRIPTION
The current fuzzer relies on MemoryBuffer to hold the fuzz data. However, the fuzzer runs into an OOB instantly because the MemoryBuffer interface guarantees that "In addition to basic access to the characters in the file, this interface guarantees you can read one character past the end of the file, and that this character will read as '\0'." [ref](https://llvm.org/doxygen/classllvm_1_1MemoryBuffer.html#details), which the fuzzer fails to satisfy. As such, it runs into an OOB on [this line](https://github.com/llvm/llvm-project/blob/c57ef2c69846a3f69c9d1db61055ea3b7b5100c3/llvm/lib/Support/LineIterator.cpp#L48).

Consequently, the OSS-Fuzz set up is not running since the build is declared failing as the fuzzer fails on the first run. See here for links to build logs https://introspector.oss-fuzz.com/project-profile?project=llvm and specifically at the bottom of [this build log](https://oss-fuzz-build-logs.storage.googleapis.com/log-aecaad16-9581-48fe-af4a-a7be4dd947db.txt).

This change fixes the fuzzer and should solve the OSS-Fuzz build as well.

CC @mmdriley