### PR TITLE
[GlobalISel] Remove dead VRegs after instruction selection

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -788,6 +788,11 @@ public:
   /// clearVirtRegs - Remove all virtual registers (after physreg assignment).
   void clearVirtRegs();
 
+  /// clearDeadVirtRegs - Remove virtual registers without a definition and
+  /// uses. Since virtual registers are linear and can be removed only from the
+  /// end, register ids will be shuffled.
+  void clearDeadVirtRegs();
+
   /// setRegAllocationHint - Specify a register allocation hint for the
   /// specified virtual register. This is typically used by target, and in case
   /// of an earlier hint it will be overwritten.

--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -326,6 +326,9 @@ bool InstructionSelect::runOnMachineFunction(MachineFunction &MF) {
   // types after us (otherwise MIRPrinter would need them). Make sure the types
   // disappear.
   MRI.clearVirtRegTypes();
+  // We need to remove dead virtual registers as no register class has been
+  // assigned to them.
+  MRI.clearDeadVirtRegs();
 
   // FIXME: Should we accurately track changes?
   return true;

--- a/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic-128.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic-128.ll
@@ -9,22 +9,22 @@ define void @val_compare_and_swap(ptr %p, i128 %oldval, i128 %newval) {
 ; CHECK-LLSC-O1-LABEL: val_compare_and_swap:
 ; CHECK-LLSC-O1:       // %bb.0:
 ; CHECK-LLSC-O1-NEXT:  .LBB0_1: // =>This Inner Loop Header: Depth=1
-; CHECK-LLSC-O1-NEXT:    ldaxp x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cmp x8, x2
-; CHECK-LLSC-O1-NEXT:    cset w10, ne
-; CHECK-LLSC-O1-NEXT:    cmp x9, x3
-; CHECK-LLSC-O1-NEXT:    cinc w10, w10, ne
-; CHECK-LLSC-O1-NEXT:    cbz w10, .LBB0_3
+; CHECK-LLSC-O1-NEXT:    ldaxp x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cmp x9, x2
+; CHECK-LLSC-O1-NEXT:    cset w8, ne
+; CHECK-LLSC-O1-NEXT:    cmp x10, x3
+; CHECK-LLSC-O1-NEXT:    cinc w8, w8, ne
+; CHECK-LLSC-O1-NEXT:    cbz w8, .LBB0_3
 ; CHECK-LLSC-O1-NEXT:  // %bb.2: // in Loop: Header=BB0_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stxp w10, x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB0_1
+; CHECK-LLSC-O1-NEXT:    stxp w8, x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB0_1
 ; CHECK-LLSC-O1-NEXT:    b .LBB0_4
 ; CHECK-LLSC-O1-NEXT:  .LBB0_3: // in Loop: Header=BB0_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stxp w10, x4, x5, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB0_1
+; CHECK-LLSC-O1-NEXT:    stxp w8, x4, x5, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB0_1
 ; CHECK-LLSC-O1-NEXT:  .LBB0_4:
-; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x8
-; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x10
 ; CHECK-LLSC-O1-NEXT:    str q0, [x0]
 ; CHECK-LLSC-O1-NEXT:    ret
 ;
@@ -94,22 +94,22 @@ define void @val_compare_and_swap_monotonic_seqcst(ptr %p, i128 %oldval, i128 %n
 ; CHECK-LLSC-O1-LABEL: val_compare_and_swap_monotonic_seqcst:
 ; CHECK-LLSC-O1:       // %bb.0:
 ; CHECK-LLSC-O1-NEXT:  .LBB1_1: // =>This Inner Loop Header: Depth=1
-; CHECK-LLSC-O1-NEXT:    ldaxp x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cmp x8, x2
-; CHECK-LLSC-O1-NEXT:    cset w10, ne
-; CHECK-LLSC-O1-NEXT:    cmp x9, x3
-; CHECK-LLSC-O1-NEXT:    cinc w10, w10, ne
-; CHECK-LLSC-O1-NEXT:    cbz w10, .LBB1_3
+; CHECK-LLSC-O1-NEXT:    ldaxp x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cmp x9, x2
+; CHECK-LLSC-O1-NEXT:    cset w8, ne
+; CHECK-LLSC-O1-NEXT:    cmp x10, x3
+; CHECK-LLSC-O1-NEXT:    cinc w8, w8, ne
+; CHECK-LLSC-O1-NEXT:    cbz w8, .LBB1_3
 ; CHECK-LLSC-O1-NEXT:  // %bb.2: // in Loop: Header=BB1_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stlxp w10, x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB1_1
+; CHECK-LLSC-O1-NEXT:    stlxp w8, x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB1_1
 ; CHECK-LLSC-O1-NEXT:    b .LBB1_4
 ; CHECK-LLSC-O1-NEXT:  .LBB1_3: // in Loop: Header=BB1_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stlxp w10, x4, x5, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB1_1
+; CHECK-LLSC-O1-NEXT:    stlxp w8, x4, x5, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB1_1
 ; CHECK-LLSC-O1-NEXT:  .LBB1_4:
-; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x8
-; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x10
 ; CHECK-LLSC-O1-NEXT:    str q0, [x0]
 ; CHECK-LLSC-O1-NEXT:    ret
 ;
@@ -179,22 +179,22 @@ define void @val_compare_and_swap_release_acquire(ptr %p, i128 %oldval, i128 %ne
 ; CHECK-LLSC-O1-LABEL: val_compare_and_swap_release_acquire:
 ; CHECK-LLSC-O1:       // %bb.0:
 ; CHECK-LLSC-O1-NEXT:  .LBB2_1: // =>This Inner Loop Header: Depth=1
-; CHECK-LLSC-O1-NEXT:    ldaxp x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cmp x8, x2
-; CHECK-LLSC-O1-NEXT:    cset w10, ne
-; CHECK-LLSC-O1-NEXT:    cmp x9, x3
-; CHECK-LLSC-O1-NEXT:    cinc w10, w10, ne
-; CHECK-LLSC-O1-NEXT:    cbz w10, .LBB2_3
+; CHECK-LLSC-O1-NEXT:    ldaxp x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cmp x9, x2
+; CHECK-LLSC-O1-NEXT:    cset w8, ne
+; CHECK-LLSC-O1-NEXT:    cmp x10, x3
+; CHECK-LLSC-O1-NEXT:    cinc w8, w8, ne
+; CHECK-LLSC-O1-NEXT:    cbz w8, .LBB2_3
 ; CHECK-LLSC-O1-NEXT:  // %bb.2: // in Loop: Header=BB2_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stlxp w10, x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB2_1
+; CHECK-LLSC-O1-NEXT:    stlxp w8, x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB2_1
 ; CHECK-LLSC-O1-NEXT:    b .LBB2_4
 ; CHECK-LLSC-O1-NEXT:  .LBB2_3: // in Loop: Header=BB2_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stlxp w10, x4, x5, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB2_1
+; CHECK-LLSC-O1-NEXT:    stlxp w8, x4, x5, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB2_1
 ; CHECK-LLSC-O1-NEXT:  .LBB2_4:
-; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x8
-; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x10
 ; CHECK-LLSC-O1-NEXT:    str q0, [x0]
 ; CHECK-LLSC-O1-NEXT:    ret
 ;
@@ -264,22 +264,22 @@ define void @val_compare_and_swap_monotonic(ptr %p, i128 %oldval, i128 %newval) 
 ; CHECK-LLSC-O1-LABEL: val_compare_and_swap_monotonic:
 ; CHECK-LLSC-O1:       // %bb.0:
 ; CHECK-LLSC-O1-NEXT:  .LBB3_1: // =>This Inner Loop Header: Depth=1
-; CHECK-LLSC-O1-NEXT:    ldaxp x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cmp x8, x2
-; CHECK-LLSC-O1-NEXT:    cset w10, ne
-; CHECK-LLSC-O1-NEXT:    cmp x9, x3
-; CHECK-LLSC-O1-NEXT:    cinc w10, w10, ne
-; CHECK-LLSC-O1-NEXT:    cbz w10, .LBB3_3
+; CHECK-LLSC-O1-NEXT:    ldaxp x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cmp x9, x2
+; CHECK-LLSC-O1-NEXT:    cset w8, ne
+; CHECK-LLSC-O1-NEXT:    cmp x10, x3
+; CHECK-LLSC-O1-NEXT:    cinc w8, w8, ne
+; CHECK-LLSC-O1-NEXT:    cbz w8, .LBB3_3
 ; CHECK-LLSC-O1-NEXT:  // %bb.2: // in Loop: Header=BB3_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stlxp w10, x8, x9, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB3_1
+; CHECK-LLSC-O1-NEXT:    stlxp w8, x9, x10, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB3_1
 ; CHECK-LLSC-O1-NEXT:    b .LBB3_4
 ; CHECK-LLSC-O1-NEXT:  .LBB3_3: // in Loop: Header=BB3_1 Depth=1
-; CHECK-LLSC-O1-NEXT:    stlxp w10, x4, x5, [x0]
-; CHECK-LLSC-O1-NEXT:    cbnz w10, .LBB3_1
+; CHECK-LLSC-O1-NEXT:    stlxp w8, x4, x5, [x0]
+; CHECK-LLSC-O1-NEXT:    cbnz w8, .LBB3_1
 ; CHECK-LLSC-O1-NEXT:  .LBB3_4:
-; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x8
-; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[0], x9
+; CHECK-LLSC-O1-NEXT:    mov v0.d[1], x10
 ; CHECK-LLSC-O1-NEXT:    str q0, [x0]
 ; CHECK-LLSC-O1-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-hoisted-constants.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-hoisted-constants.ll
@@ -26,14 +26,14 @@ define i32 @test(i32 %a, i1 %c) {
   ; TRANSLATED-NEXT:   G_BR %bb.2
   ; TRANSLATED-NEXT: {{  $}}
   ; TRANSLATED-NEXT: bb.2.common.ret:
-  ; TRANSLATED-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %7(s32), %bb.3, [[C1]](s32), %bb.1
+  ; TRANSLATED-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI [[ADD:%[0-9]+]](s32), %bb.3, [[C1]](s32), %bb.1
   ; TRANSLATED-NEXT:   $w0 = COPY [[PHI]](s32)
   ; TRANSLATED-NEXT:   RET_ReallyLR implicit $w0
   ; TRANSLATED-NEXT: {{  $}}
   ; TRANSLATED-NEXT: bb.3.cont:
   ; TRANSLATED-NEXT:   successors: %bb.2(0x80000000)
   ; TRANSLATED-NEXT: {{  $}}
-  ; TRANSLATED-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[COPY]], [[CONSTANT_FOLD_BARRIER]]
+  ; TRANSLATED-NEXT:   [[ADD]]:_(s32) = G_ADD [[COPY]], [[CONSTANT_FOLD_BARRIER]]
   ; TRANSLATED-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
   ; TRANSLATED-NEXT:   BL @callee, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp
   ; TRANSLATED-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
@@ -58,14 +58,14 @@ define i32 @test(i32 %a, i1 %c) {
   ; PRESELECTION-NEXT:   G_BR %bb.2
   ; PRESELECTION-NEXT: {{  $}}
   ; PRESELECTION-NEXT: bb.2.common.ret:
-  ; PRESELECTION-NEXT:   [[PHI:%[0-9]+]]:gpr(s32) = G_PHI %7(s32), %bb.3, [[C]](s32), %bb.1
+  ; PRESELECTION-NEXT:   [[PHI:%[0-9]+]]:gpr(s32) = G_PHI [[ADD:%[0-9]+]](s32), %bb.3, [[C]](s32), %bb.1
   ; PRESELECTION-NEXT:   $w0 = COPY [[PHI]](s32)
   ; PRESELECTION-NEXT:   RET_ReallyLR implicit $w0
   ; PRESELECTION-NEXT: {{  $}}
   ; PRESELECTION-NEXT: bb.3.cont:
   ; PRESELECTION-NEXT:   successors: %bb.2(0x80000000)
   ; PRESELECTION-NEXT: {{  $}}
-  ; PRESELECTION-NEXT:   [[ADD:%[0-9]+]]:gpr(s32) = G_ADD [[COPY]], [[CONSTANT_FOLD_BARRIER]]
+  ; PRESELECTION-NEXT:   [[ADD]]:gpr(s32) = G_ADD [[COPY]], [[CONSTANT_FOLD_BARRIER]]
   ; PRESELECTION-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
   ; PRESELECTION-NEXT:   BL @callee, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp
   ; PRESELECTION-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
@@ -84,14 +84,14 @@ define i32 @test(i32 %a, i1 %c) {
   ; POSTSELECTION-NEXT:   B %bb.2
   ; POSTSELECTION-NEXT: {{  $}}
   ; POSTSELECTION-NEXT: bb.2.common.ret:
-  ; POSTSELECTION-NEXT:   [[PHI:%[0-9]+]]:gpr32 = PHI %7, %bb.3, [[COPY2]], %bb.1
+  ; POSTSELECTION-NEXT:   [[PHI:%[0-9]+]]:gpr32 = PHI [[ADDWrr:%[0-9]+]], %bb.3, [[COPY2]], %bb.1
   ; POSTSELECTION-NEXT:   $w0 = COPY [[PHI]]
   ; POSTSELECTION-NEXT:   RET_ReallyLR implicit $w0
   ; POSTSELECTION-NEXT: {{  $}}
   ; POSTSELECTION-NEXT: bb.3.cont:
   ; POSTSELECTION-NEXT:   successors: %bb.2(0x80000000)
   ; POSTSELECTION-NEXT: {{  $}}
-  ; POSTSELECTION-NEXT:   [[ADDWrr:%[0-9]+]]:gpr32 = ADDWrr [[COPY]], [[MOVi32imm]]
+  ; POSTSELECTION-NEXT:   [[ADDWrr]]:gpr32 = ADDWrr [[COPY]], [[MOVi32imm]]
   ; POSTSELECTION-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
   ; POSTSELECTION-NEXT:   BL @callee, csr_darwin_aarch64_aapcs, implicit-def $lr, implicit $sp
   ; POSTSELECTION-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-br.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-br.mir
@@ -37,7 +37,7 @@ registers:
 
 # CHECK:  body:
 # CHECK:   bb.0:
-# CHECK:    TBNZW %1, 0, %bb.1
+# CHECK:    TBNZW %{{[0-9]+}}, 0, %bb.1
 # CHECK:    B %bb.0
 body:             |
   bb.0:
@@ -60,7 +60,7 @@ registers:
 
 # CHECK:  body:
 # CHECK:   bb.0:
-# CHECK:    %0:gpr64 = COPY $x0
+# CHECK:    %{{[0-9]+}}:gpr64 = COPY $x0
 # CHECK:    BR %0
 body:             |
   bb.0:

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-dbg-value.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-dbg-value.mir
@@ -65,7 +65,7 @@ body: |
     ; CHECK-LABEL: name: test_dbg_value_dead
     ; CHECK: liveins: $w0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: DBG_VALUE %1:gpr64, $noreg, !7, !DIExpression(), debug-location !9
+    ; CHECK-NEXT: DBG_VALUE %{{[0-9]+}}:gpr64, $noreg, !7, !DIExpression(), debug-location !9
     %0:gpr(s32) = COPY $w0
     %1:gpr(s64) = G_ZEXT %0:gpr(s32)
     DBG_VALUE %1(s64), $noreg, !7, !DIExpression(), debug-location !9

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-intrinsic-aarch64-hint.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-intrinsic-aarch64-hint.mir
@@ -13,8 +13,7 @@ name:            hint
 legalized:       true
 regBankSelected: true
 
-# CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
+# CHECK:      registers:       []
 registers:
   - { id: 0, class: gpr }
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-jump-table-brjt.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-jump-table-brjt.mir
@@ -70,9 +70,9 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32 = COPY $wzr
   ; CHECK-NEXT:   [[MOVaddrJT:%[0-9]+]]:gpr64common = MOVaddrJT target-flags(aarch64-page) %jump-table.0, target-flags(aarch64-pageoff, aarch64-nc) %jump-table.0
-  ; CHECK-NEXT:   early-clobber %17:gpr64, early-clobber %18:gpr64sp = JumpTableDest32 [[MOVaddrJT]], [[SUBREG_TO_REG]], %jump-table.0
+  ; CHECK-NEXT:   early-clobber [[BADDR:%[0-9]+]]:gpr64, early-clobber %{{[0-9]+}}:gpr64sp = JumpTableDest32 [[MOVaddrJT]], [[SUBREG_TO_REG]], %jump-table.0
   ; CHECK-NEXT:   JUMP_TABLE_DEBUG_INFO 0
-  ; CHECK-NEXT:   BR %17
+  ; CHECK-NEXT:   BR [[BADDR]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.sw.bb:
   ; CHECK-NEXT:   successors: %bb.4(0x80000000)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-static.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-static.mir
@@ -55,7 +55,7 @@ legalized:       true
 regBankSelected: true
 
 # CHECK:  body:
-# CHECK: %2:gpr64sp = ANDXri %0, 8060
+# CHECK: %1:gpr64sp = ANDXri %0, 8060
 body:             |
   bb.0:
       liveins: $x0
@@ -203,9 +203,8 @@ tracksRegLiveness: true
 
 # CHECK:      registers:
 # CHECK-NEXT:  - { id: 0, class: fpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '' }
 # CHECK-NEXT:  - { id: 2, class: fpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '' }
 registers:
   - { id: 0, class: fpr }
   - { id: 1, class: gpr }

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-stlxr-intrin.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-stlxr-intrin.mir
@@ -27,8 +27,8 @@ body:             |
     ; CHECK: liveins: $w0, $x1, $x2
     ; CHECK: [[COPY:%[0-9]+]]:gpr64 = COPY $x1
     ; CHECK: [[COPY1:%[0-9]+]]:gpr64sp = COPY $x2
-    ; CHECK: early-clobber %2:gpr32 = STLXRX [[COPY]], [[COPY1]] :: (volatile store (s64) into %ir.addr)
-    ; CHECK: $w0 = COPY %2
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STLXRX [[COPY]], [[COPY1]] :: (volatile store (s64) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %1:gpr(s64) = COPY $x1
     %2:gpr(p0) = COPY $x2
@@ -50,8 +50,8 @@ body:             |
     ; CHECK: liveins: $w0, $w1, $x2
     ; CHECK: [[COPY:%[0-9]+]]:gpr32 = COPY $w1
     ; CHECK: [[COPY1:%[0-9]+]]:gpr64sp = COPY $x2
-    ; CHECK: early-clobber %3:gpr32 = STLXRW [[COPY]], [[COPY1]] :: (volatile store (s32) into %ir.addr)
-    ; CHECK: $w0 = COPY %3
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STLXRW [[COPY]], [[COPY1]] :: (volatile store (s32) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %1:gpr(s32) = COPY $w1
     %2:gpr(p0) = COPY $x2
@@ -78,8 +78,8 @@ body:             |
     ; CHECK: [[DEF:%[0-9]+]]:gpr64all = IMPLICIT_DEF
     ; CHECK: [[INSERT_SUBREG:%[0-9]+]]:gpr64 = INSERT_SUBREG [[DEF]], [[COPY]], %subreg.sub_32
     ; CHECK: [[COPY2:%[0-9]+]]:gpr32 = COPY [[INSERT_SUBREG]].sub_32
-    ; CHECK: early-clobber %5:gpr32 = STLXRB [[COPY2]], [[COPY1]] :: (volatile store (s8) into %ir.addr)
-    ; CHECK: $w0 = COPY %5
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STLXRB [[COPY2]], [[COPY1]] :: (volatile store (s8) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %3:gpr(s32) = COPY $w1
     %2:gpr(p0) = COPY $x2
@@ -108,8 +108,8 @@ body:             |
     ; CHECK: [[DEF:%[0-9]+]]:gpr64all = IMPLICIT_DEF
     ; CHECK: [[INSERT_SUBREG:%[0-9]+]]:gpr64 = INSERT_SUBREG [[DEF]], [[COPY]], %subreg.sub_32
     ; CHECK: [[COPY2:%[0-9]+]]:gpr32 = COPY [[INSERT_SUBREG]].sub_32
-    ; CHECK: early-clobber %5:gpr32 = STLXRH [[COPY2]], [[COPY1]] :: (volatile store (s16) into %ir.addr)
-    ; CHECK: $w0 = COPY %5
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STLXRH [[COPY2]], [[COPY1]] :: (volatile store (s16) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %3:gpr(s32) = COPY $w1
     %2:gpr(p0) = COPY $x2

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-stx.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-stx.mir
@@ -25,8 +25,8 @@ body:             |
     ; CHECK: [[DEF:%[0-9]+]]:gpr64all = IMPLICIT_DEF
     ; CHECK: [[INSERT_SUBREG:%[0-9]+]]:gpr64 = INSERT_SUBREG [[DEF]], [[COPY]], %subreg.sub_32
     ; CHECK: [[COPY2:%[0-9]+]]:gpr32 = COPY [[INSERT_SUBREG]].sub_32
-    ; CHECK: early-clobber %5:gpr32 = STXRB [[COPY2]], [[COPY1]] :: (volatile store (s8) into %ir.addr)
-    ; CHECK: $w0 = COPY %5
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STXRB [[COPY2]], [[COPY1]] :: (volatile store (s8) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %3:gpr(s32) = COPY $w1
     %2:gpr(p0) = COPY $x2
@@ -56,8 +56,8 @@ body:             |
     ; CHECK: [[DEF:%[0-9]+]]:gpr64all = IMPLICIT_DEF
     ; CHECK: [[INSERT_SUBREG:%[0-9]+]]:gpr64 = INSERT_SUBREG [[DEF]], [[COPY]], %subreg.sub_32
     ; CHECK: [[COPY2:%[0-9]+]]:gpr32 = COPY [[INSERT_SUBREG]].sub_32
-    ; CHECK: early-clobber %5:gpr32 = STXRH [[COPY2]], [[COPY1]] :: (volatile store (s16) into %ir.addr)
-    ; CHECK: $w0 = COPY %5
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STXRH [[COPY2]], [[COPY1]] :: (volatile store (s16) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %3:gpr(s32) = COPY $w1
     %2:gpr(p0) = COPY $x2
@@ -84,8 +84,8 @@ body:             |
     ; CHECK: liveins: $w0, $w1, $x2
     ; CHECK: [[COPY:%[0-9]+]]:gpr32 = COPY $w1
     ; CHECK: [[COPY1:%[0-9]+]]:gpr64sp = COPY $x2
-    ; CHECK: early-clobber %3:gpr32 = STXRW [[COPY]], [[COPY1]] :: (volatile store (s32) into %ir.addr)
-    ; CHECK: $w0 = COPY %3
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STXRW [[COPY]], [[COPY1]] :: (volatile store (s32) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %1:gpr(s32) = COPY $w1
     %2:gpr(p0) = COPY $x2
@@ -110,8 +110,8 @@ body:             |
     ; CHECK: liveins: $w0, $x1, $x2
     ; CHECK: [[COPY:%[0-9]+]]:gpr64 = COPY $x1
     ; CHECK: [[COPY1:%[0-9]+]]:gpr64sp = COPY $x2
-    ; CHECK: early-clobber %2:gpr32 = STXRX [[COPY]], [[COPY1]] :: (volatile store (s64) into %ir.addr)
-    ; CHECK: $w0 = COPY %2
+    ; CHECK: early-clobber [[STATUS:%[0-9]+]]:gpr32 = STXRX [[COPY]], [[COPY1]] :: (volatile store (s64) into %ir.addr)
+    ; CHECK: $w0 = COPY [[STATUS]]
     ; CHECK: RET_ReallyLR implicit $w0
     %1:gpr(s64) = COPY $x1
     %2:gpr(p0) = COPY $x2

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select.mir
@@ -56,7 +56,7 @@ legalized:       true
 regBankSelected: true
 
 # CHECK:  body:
-# CHECK: %2:gpr64sp = ANDXri %0, 8060
+# CHECK: %1:gpr64sp = ANDXri %0, 8060
 body:             |
   bb.0:
       liveins: $x0
@@ -220,9 +220,8 @@ tracksRegLiveness: true
 
 # CHECK:      registers:
 # CHECK-NEXT:  - { id: 0, class: fpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '' }
 # CHECK-NEXT:  - { id: 2, class: fpr32, preferred-register: '' }
-# CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '' }
 registers:
   - { id: 0, class: fpr }
   - { id: 1, class: gpr }
@@ -257,7 +256,7 @@ regBankSelected: true
 tracksRegLiveness: true
 
 # CHECK:      registers:
-# CHECK-NEXT:  - { id: 0, class: gpr, preferred-register: '' }
+# CHECK-NEXT:  - { id: 0, class: gpr32, preferred-register: '' }
 # CHECK-NEXT:  - { id: 1, class: gpr32, preferred-register: '' }
 # CHECK-NEXT:  - { id: 2, class: gpr32, preferred-register: '' }
 # CHECK-NEXT:  - { id: 3, class: gpr32, preferred-register: '' }

--- a/llvm/test/CodeGen/AArch64/fexplog.ll
+++ b/llvm/test/CodeGen/AArch64/fexplog.ll
@@ -684,12 +684,12 @@ define <7 x half> @exp_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    fcvt s1, h9
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    fcvt s1, h10
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    fcvt s1, h11
@@ -707,18 +707,19 @@ define <7 x half> @exp_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    str q0, [sp] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl expf
-; CHECK-GI-NEXT:    ldp q2, q1, [sp, #64] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q3, q2, [sp, #48] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    fcvt h0, s0
+; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #128] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #112] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[1], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp, #32] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[1], v3.h[0]
 ; CHECK-GI-NEXT:    ldp d13, d12, [sp, #96] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[2], v3.h[0]
-; CHECK-GI-NEXT:    mov v1.h[3], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp] // 32-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[4], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[2], v2.h[0]
+; CHECK-GI-NEXT:    ldp q2, q3, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[3], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[4], v2.h[0]
+; CHECK-GI-NEXT:    ldr q2, [sp] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[7], v0.h[0]
@@ -1162,7 +1163,7 @@ define <16 x half> @exp_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    fcvt s1, h8
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    fcvt s1, h9
@@ -1187,7 +1188,7 @@ define <16 x half> @exp_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    fcvt s1, h13
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
@@ -1238,7 +1239,7 @@ define <16 x half> @exp_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl expf
 ; CHECK-GI-NEXT:    ldr q3, [sp, #192] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr q2, [sp, #128] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #112] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp x29, x30, [sp, #304] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[1], v2.h[0]
 ; CHECK-GI-NEXT:    ldp q1, q2, [sp] // 32-byte Folded Reload
@@ -1264,7 +1265,7 @@ define <16 x half> @exp_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    ldr q2, [sp, #96] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    fcvt h2, s0
-; CHECK-GI-NEXT:    ldr q0, [sp, #112] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q0, [sp, #128] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    ldr q0, [sp, #160] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
@@ -1961,12 +1962,12 @@ define <7 x half> @exp2_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    fcvt s1, h9
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    fcvt s1, h10
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    fcvt s1, h11
@@ -1984,18 +1985,19 @@ define <7 x half> @exp2_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    str q0, [sp] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl exp2f
-; CHECK-GI-NEXT:    ldp q2, q1, [sp, #64] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q3, q2, [sp, #48] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    fcvt h0, s0
+; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #128] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #112] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[1], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp, #32] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[1], v3.h[0]
 ; CHECK-GI-NEXT:    ldp d13, d12, [sp, #96] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[2], v3.h[0]
-; CHECK-GI-NEXT:    mov v1.h[3], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp] // 32-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[4], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[2], v2.h[0]
+; CHECK-GI-NEXT:    ldp q2, q3, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[3], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[4], v2.h[0]
+; CHECK-GI-NEXT:    ldr q2, [sp] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[7], v0.h[0]
@@ -2439,7 +2441,7 @@ define <16 x half> @exp2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    fcvt s1, h8
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    fcvt s1, h9
@@ -2464,7 +2466,7 @@ define <16 x half> @exp2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    fcvt s1, h13
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
@@ -2515,7 +2517,7 @@ define <16 x half> @exp2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl exp2f
 ; CHECK-GI-NEXT:    ldr q3, [sp, #192] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr q2, [sp, #128] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #112] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp x29, x30, [sp, #304] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[1], v2.h[0]
 ; CHECK-GI-NEXT:    ldp q1, q2, [sp] // 32-byte Folded Reload
@@ -2541,7 +2543,7 @@ define <16 x half> @exp2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    ldr q2, [sp, #96] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    fcvt h2, s0
-; CHECK-GI-NEXT:    ldr q0, [sp, #112] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q0, [sp, #128] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    ldr q0, [sp, #160] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
@@ -3238,12 +3240,12 @@ define <7 x half> @log_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    fcvt s1, h9
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    fcvt s1, h10
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    fcvt s1, h11
@@ -3261,18 +3263,19 @@ define <7 x half> @log_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    str q0, [sp] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl logf
-; CHECK-GI-NEXT:    ldp q2, q1, [sp, #64] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q3, q2, [sp, #48] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    fcvt h0, s0
+; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #128] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #112] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[1], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp, #32] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[1], v3.h[0]
 ; CHECK-GI-NEXT:    ldp d13, d12, [sp, #96] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[2], v3.h[0]
-; CHECK-GI-NEXT:    mov v1.h[3], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp] // 32-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[4], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[2], v2.h[0]
+; CHECK-GI-NEXT:    ldp q2, q3, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[3], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[4], v2.h[0]
+; CHECK-GI-NEXT:    ldr q2, [sp] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[7], v0.h[0]
@@ -3716,7 +3719,7 @@ define <16 x half> @log_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    fcvt s1, h8
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    fcvt s1, h9
@@ -3741,7 +3744,7 @@ define <16 x half> @log_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    fcvt s1, h13
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
@@ -3792,7 +3795,7 @@ define <16 x half> @log_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl logf
 ; CHECK-GI-NEXT:    ldr q3, [sp, #192] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr q2, [sp, #128] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #112] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp x29, x30, [sp, #304] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[1], v2.h[0]
 ; CHECK-GI-NEXT:    ldp q1, q2, [sp] // 32-byte Folded Reload
@@ -3818,7 +3821,7 @@ define <16 x half> @log_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    ldr q2, [sp, #96] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    fcvt h2, s0
-; CHECK-GI-NEXT:    ldr q0, [sp, #112] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q0, [sp, #128] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    ldr q0, [sp, #160] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
@@ -4515,12 +4518,12 @@ define <7 x half> @log2_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    fcvt s1, h9
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    fcvt s1, h10
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    fcvt s1, h11
@@ -4538,18 +4541,19 @@ define <7 x half> @log2_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    str q0, [sp] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log2f
-; CHECK-GI-NEXT:    ldp q2, q1, [sp, #64] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q3, q2, [sp, #48] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    fcvt h0, s0
+; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #128] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #112] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[1], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp, #32] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[1], v3.h[0]
 ; CHECK-GI-NEXT:    ldp d13, d12, [sp, #96] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[2], v3.h[0]
-; CHECK-GI-NEXT:    mov v1.h[3], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp] // 32-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[4], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[2], v2.h[0]
+; CHECK-GI-NEXT:    ldp q2, q3, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[3], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[4], v2.h[0]
+; CHECK-GI-NEXT:    ldr q2, [sp] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[7], v0.h[0]
@@ -4993,7 +4997,7 @@ define <16 x half> @log2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    fcvt s1, h8
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    fcvt s1, h9
@@ -5018,7 +5022,7 @@ define <16 x half> @log2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    fcvt s1, h13
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
@@ -5069,7 +5073,7 @@ define <16 x half> @log2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log2f
 ; CHECK-GI-NEXT:    ldr q3, [sp, #192] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr q2, [sp, #128] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #112] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp x29, x30, [sp, #304] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[1], v2.h[0]
 ; CHECK-GI-NEXT:    ldp q1, q2, [sp] // 32-byte Folded Reload
@@ -5095,7 +5099,7 @@ define <16 x half> @log2_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    ldr q2, [sp, #96] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    fcvt h2, s0
-; CHECK-GI-NEXT:    ldr q0, [sp, #112] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q0, [sp, #128] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    ldr q0, [sp, #160] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
@@ -5792,12 +5796,12 @@ define <7 x half> @log10_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    fcvt s1, h9
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    fcvt s1, h10
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    fcvt s1, h11
@@ -5815,18 +5819,19 @@ define <7 x half> @log10_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    str q0, [sp] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log10f
-; CHECK-GI-NEXT:    ldp q2, q1, [sp, #64] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q3, q2, [sp, #48] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    fcvt h0, s0
+; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #128] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #112] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[1], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp, #32] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[1], v3.h[0]
 ; CHECK-GI-NEXT:    ldp d13, d12, [sp, #96] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[2], v3.h[0]
-; CHECK-GI-NEXT:    mov v1.h[3], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp] // 32-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[4], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[2], v2.h[0]
+; CHECK-GI-NEXT:    ldp q2, q3, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[3], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[4], v2.h[0]
+; CHECK-GI-NEXT:    ldr q2, [sp] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[7], v0.h[0]
@@ -6270,7 +6275,7 @@ define <16 x half> @log10_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    fcvt s1, h8
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    fcvt s1, h9
@@ -6295,7 +6300,7 @@ define <16 x half> @log10_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    fcvt s1, h13
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
@@ -6346,7 +6351,7 @@ define <16 x half> @log10_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl log10f
 ; CHECK-GI-NEXT:    ldr q3, [sp, #192] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr q2, [sp, #128] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #112] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp x29, x30, [sp, #304] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[1], v2.h[0]
 ; CHECK-GI-NEXT:    ldp q1, q2, [sp] // 32-byte Folded Reload
@@ -6372,7 +6377,7 @@ define <16 x half> @log10_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    ldr q2, [sp, #96] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    fcvt h2, s0
-; CHECK-GI-NEXT:    ldr q0, [sp, #112] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q0, [sp, #128] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    ldr q0, [sp, #160] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]

--- a/llvm/test/CodeGen/AArch64/fpow.ll
+++ b/llvm/test/CodeGen/AArch64/fpow.ll
@@ -267,15 +267,15 @@ define <4 x double> @pow_v4f64(<4 x double> %a, <4 x double> %b) {
 ; CHECK-GI-NEXT:    fmov d1, d11
 ; CHECK-GI-NEXT:    fmov d0, d9
 ; CHECK-GI-NEXT:    bl pow
-; CHECK-GI-NEXT:    ldp q3, q1, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q1, q3, [sp, #32] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-GI-NEXT:    ldr q2, [sp, #48] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #16] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldr x30, [sp, #96] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #64] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v2.d[1], v3.d[0]
+; CHECK-GI-NEXT:    mov v3.d[1], v2.d[0]
 ; CHECK-GI-NEXT:    mov v1.d[1], v0.d[0]
-; CHECK-GI-NEXT:    mov v0.16b, v2.16b
+; CHECK-GI-NEXT:    mov v0.16b, v3.16b
 ; CHECK-GI-NEXT:    add sp, sp, #112
 ; CHECK-GI-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/AArch64/frem.ll
+++ b/llvm/test/CodeGen/AArch64/frem.ll
@@ -269,15 +269,15 @@ define <4 x double> @frem_v4f64(<4 x double> %a, <4 x double> %b) {
 ; CHECK-GI-NEXT:    fmov d1, d11
 ; CHECK-GI-NEXT:    fmov d0, d9
 ; CHECK-GI-NEXT:    bl fmod
-; CHECK-GI-NEXT:    ldp q3, q1, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q1, q3, [sp, #32] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-GI-NEXT:    ldr q2, [sp, #48] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #16] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldr x30, [sp, #96] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #64] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v2.d[1], v3.d[0]
+; CHECK-GI-NEXT:    mov v3.d[1], v2.d[0]
 ; CHECK-GI-NEXT:    mov v1.d[1], v0.d[0]
-; CHECK-GI-NEXT:    mov v0.16b, v2.16b
+; CHECK-GI-NEXT:    mov v0.16b, v3.16b
 ; CHECK-GI-NEXT:    add sp, sp, #112
 ; CHECK-GI-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/AArch64/fsincos.ll
+++ b/llvm/test/CodeGen/AArch64/fsincos.ll
@@ -684,12 +684,12 @@ define <7 x half> @sin_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    fcvt s1, h9
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    fcvt s1, h10
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    fcvt s1, h11
@@ -707,18 +707,19 @@ define <7 x half> @sin_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    str q0, [sp] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl sinf
-; CHECK-GI-NEXT:    ldp q2, q1, [sp, #64] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q3, q2, [sp, #48] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    fcvt h0, s0
+; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #128] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #112] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[1], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp, #32] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[1], v3.h[0]
 ; CHECK-GI-NEXT:    ldp d13, d12, [sp, #96] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[2], v3.h[0]
-; CHECK-GI-NEXT:    mov v1.h[3], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp] // 32-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[4], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[2], v2.h[0]
+; CHECK-GI-NEXT:    ldp q2, q3, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[3], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[4], v2.h[0]
+; CHECK-GI-NEXT:    ldr q2, [sp] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[7], v0.h[0]
@@ -1162,7 +1163,7 @@ define <16 x half> @sin_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    fcvt s1, h8
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    fcvt s1, h9
@@ -1187,7 +1188,7 @@ define <16 x half> @sin_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    fcvt s1, h13
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
@@ -1238,7 +1239,7 @@ define <16 x half> @sin_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl sinf
 ; CHECK-GI-NEXT:    ldr q3, [sp, #192] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr q2, [sp, #128] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #112] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp x29, x30, [sp, #304] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[1], v2.h[0]
 ; CHECK-GI-NEXT:    ldp q1, q2, [sp] // 32-byte Folded Reload
@@ -1264,7 +1265,7 @@ define <16 x half> @sin_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    ldr q2, [sp, #96] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    fcvt h2, s0
-; CHECK-GI-NEXT:    ldr q0, [sp, #112] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q0, [sp, #128] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    ldr q0, [sp, #160] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
@@ -1961,12 +1962,12 @@ define <7 x half> @cos_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    fcvt s1, h9
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    fcvt s1, h10
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #48] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #64] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    fcvt s1, h11
@@ -1984,18 +1985,19 @@ define <7 x half> @cos_v7f16(<7 x half> %a) {
 ; CHECK-GI-NEXT:    str q0, [sp] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl cosf
-; CHECK-GI-NEXT:    ldp q2, q1, [sp, #64] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldp q3, q2, [sp, #48] // 32-byte Folded Reload
 ; CHECK-GI-NEXT:    fcvt h0, s0
+; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d9, d8, [sp, #128] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp d11, d10, [sp, #112] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[1], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp, #32] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    ldr x30, [sp, #144] // 8-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[1], v3.h[0]
 ; CHECK-GI-NEXT:    ldp d13, d12, [sp, #96] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[2], v3.h[0]
-; CHECK-GI-NEXT:    mov v1.h[3], v2.h[0]
-; CHECK-GI-NEXT:    ldp q2, q3, [sp] // 32-byte Folded Reload
-; CHECK-GI-NEXT:    mov v1.h[4], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[2], v2.h[0]
+; CHECK-GI-NEXT:    ldp q2, q3, [sp, #16] // 32-byte Folded Reload
+; CHECK-GI-NEXT:    mov v1.h[3], v3.h[0]
+; CHECK-GI-NEXT:    mov v1.h[4], v2.h[0]
+; CHECK-GI-NEXT:    ldr q2, [sp] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    mov v1.h[7], v0.h[0]
@@ -2439,7 +2441,7 @@ define <16 x half> @cos_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    fcvt s1, h8
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    fcvt s1, h9
@@ -2464,7 +2466,7 @@ define <16 x half> @cos_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    fcvt s1, h13
 ; CHECK-GI-NEXT:    fcvt h0, s0
-; CHECK-GI-NEXT:    str q0, [sp, #112] // 16-byte Folded Spill
+; CHECK-GI-NEXT:    str q0, [sp, #128] // 16-byte Folded Spill
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    ldr q1, [sp, #80] // 16-byte Folded Reload
@@ -2515,7 +2517,7 @@ define <16 x half> @cos_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    fmov s0, s1
 ; CHECK-GI-NEXT:    bl cosf
 ; CHECK-GI-NEXT:    ldr q3, [sp, #192] // 16-byte Folded Reload
-; CHECK-GI-NEXT:    ldr q2, [sp, #128] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q2, [sp, #112] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    ldp x29, x30, [sp, #304] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[1], v2.h[0]
 ; CHECK-GI-NEXT:    ldp q1, q2, [sp] // 32-byte Folded Reload
@@ -2541,7 +2543,7 @@ define <16 x half> @cos_v16f16(<16 x half> %a) {
 ; CHECK-GI-NEXT:    ldr q2, [sp, #96] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[5], v2.h[0]
 ; CHECK-GI-NEXT:    fcvt h2, s0
-; CHECK-GI-NEXT:    ldr q0, [sp, #112] // 16-byte Folded Reload
+; CHECK-GI-NEXT:    ldr q0, [sp, #128] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v3.h[6], v0.h[0]
 ; CHECK-GI-NEXT:    ldr q0, [sp, #160] // 16-byte Folded Reload
 ; CHECK-GI-NEXT:    mov v1.h[6], v0.h[0]

--- a/llvm/test/CodeGen/AArch64/itofp.ll
+++ b/llvm/test/CodeGen/AArch64/itofp.ll
@@ -4442,20 +4442,20 @@ define <32 x half> @stofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    scvtf v18.2d, v4.2d
 ; CHECK-GI-FP16-NEXT:    scvtf v17.2d, v6.2d
 ; CHECK-GI-FP16-NEXT:    scvtf v4.2d, v1.2d
-; CHECK-GI-FP16-NEXT:    scvtf v3.2d, v3.2d
-; CHECK-GI-FP16-NEXT:    ldp q1, q23, [sp]
-; CHECK-GI-FP16-NEXT:    scvtf v5.2d, v5.2d
 ; CHECK-GI-FP16-NEXT:    scvtf v6.2d, v7.2d
+; CHECK-GI-FP16-NEXT:    ldp q1, q23, [sp]
+; CHECK-GI-FP16-NEXT:    scvtf v3.2d, v3.2d
+; CHECK-GI-FP16-NEXT:    scvtf v5.2d, v5.2d
 ; CHECK-GI-FP16-NEXT:    mov d20, v16.d[1]
 ; CHECK-GI-FP16-NEXT:    mov d19, v0.d[1]
 ; CHECK-GI-FP16-NEXT:    mov d21, v18.d[1]
 ; CHECK-GI-FP16-NEXT:    mov d22, v17.d[1]
-; CHECK-GI-FP16-NEXT:    fcvt h16, d16
+; CHECK-GI-FP16-NEXT:    fcvt h7, d16
 ; CHECK-GI-FP16-NEXT:    scvtf v2.2d, v1.2d
 ; CHECK-GI-FP16-NEXT:    fcvt h0, d0
 ; CHECK-GI-FP16-NEXT:    fcvt h1, d18
 ; CHECK-GI-FP16-NEXT:    ldr q18, [sp, #32]
-; CHECK-GI-FP16-NEXT:    fcvt h7, d17
+; CHECK-GI-FP16-NEXT:    fcvt h16, d17
 ; CHECK-GI-FP16-NEXT:    ldp q25, q17, [sp, #48]
 ; CHECK-GI-FP16-NEXT:    fcvt h20, d20
 ; CHECK-GI-FP16-NEXT:    fcvt h24, d19
@@ -4469,18 +4469,18 @@ define <32 x half> @stofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    scvtf v23.2d, v23.2d
 ; CHECK-GI-FP16-NEXT:    scvtf v25.2d, v25.2d
 ; CHECK-GI-FP16-NEXT:    mov d4, v4.d[1]
-; CHECK-GI-FP16-NEXT:    mov v16.h[1], v20.h[0]
+; CHECK-GI-FP16-NEXT:    mov v7.h[1], v20.h[0]
 ; CHECK-GI-FP16-NEXT:    ldp q19, q20, [sp, #80]
 ; CHECK-GI-FP16-NEXT:    mov v0.h[1], v24.h[0]
 ; CHECK-GI-FP16-NEXT:    fcvt h24, d5
 ; CHECK-GI-FP16-NEXT:    mov v1.h[1], v21.h[0]
 ; CHECK-GI-FP16-NEXT:    ldr q21, [sp, #112]
-; CHECK-GI-FP16-NEXT:    mov v7.h[1], v22.h[0]
+; CHECK-GI-FP16-NEXT:    mov v16.h[1], v22.h[0]
 ; CHECK-GI-FP16-NEXT:    mov d22, v2.d[1]
 ; CHECK-GI-FP16-NEXT:    scvtf v20.2d, v20.2d
 ; CHECK-GI-FP16-NEXT:    fcvt h2, d2
 ; CHECK-GI-FP16-NEXT:    scvtf v19.2d, v19.2d
-; CHECK-GI-FP16-NEXT:    mov v16.h[2], v27.h[0]
+; CHECK-GI-FP16-NEXT:    mov v7.h[2], v27.h[0]
 ; CHECK-GI-FP16-NEXT:    scvtf v21.2d, v21.2d
 ; CHECK-GI-FP16-NEXT:    mov d5, v5.d[1]
 ; CHECK-GI-FP16-NEXT:    mov v0.h[2], v26.h[0]
@@ -4488,7 +4488,7 @@ define <32 x half> @stofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    mov v1.h[2], v24.h[0]
 ; CHECK-GI-FP16-NEXT:    mov d24, v17.d[1]
 ; CHECK-GI-FP16-NEXT:    fcvt h22, d22
-; CHECK-GI-FP16-NEXT:    mov v7.h[2], v28.h[0]
+; CHECK-GI-FP16-NEXT:    mov v16.h[2], v28.h[0]
 ; CHECK-GI-FP16-NEXT:    mov d27, v20.d[1]
 ; CHECK-GI-FP16-NEXT:    fcvt h18, d18
 ; CHECK-GI-FP16-NEXT:    mov d28, v3.d[1]
@@ -4524,14 +4524,14 @@ define <32 x half> @stofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    mov v1.h[3], v5.h[0]
 ; CHECK-GI-FP16-NEXT:    fcvt h19, d22
 ; CHECK-GI-FP16-NEXT:    mov v20.h[2], v21.h[0]
-; CHECK-GI-FP16-NEXT:    mov v7.h[3], v6.h[0]
-; CHECK-GI-FP16-NEXT:    mov v16.h[3], v24.h[0]
+; CHECK-GI-FP16-NEXT:    mov v16.h[3], v6.h[0]
+; CHECK-GI-FP16-NEXT:    mov v7.h[3], v24.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v2.h[3], v23.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v18.h[3], v25.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v3.h[3], v17.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v20.h[3], v19.h[0]
-; CHECK-GI-FP16-NEXT:    mov v1.d[1], v7.d[0]
-; CHECK-GI-FP16-NEXT:    mov v0.d[1], v16.d[0]
+; CHECK-GI-FP16-NEXT:    mov v1.d[1], v16.d[0]
+; CHECK-GI-FP16-NEXT:    mov v0.d[1], v7.d[0]
 ; CHECK-GI-FP16-NEXT:    mov v2.d[1], v18.d[0]
 ; CHECK-GI-FP16-NEXT:    mov v3.d[1], v20.d[0]
 ; CHECK-GI-FP16-NEXT:    ret
@@ -4644,20 +4644,20 @@ define <32 x half> @utofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    ucvtf v18.2d, v4.2d
 ; CHECK-GI-FP16-NEXT:    ucvtf v17.2d, v6.2d
 ; CHECK-GI-FP16-NEXT:    ucvtf v4.2d, v1.2d
-; CHECK-GI-FP16-NEXT:    ucvtf v3.2d, v3.2d
-; CHECK-GI-FP16-NEXT:    ldp q1, q23, [sp]
-; CHECK-GI-FP16-NEXT:    ucvtf v5.2d, v5.2d
 ; CHECK-GI-FP16-NEXT:    ucvtf v6.2d, v7.2d
+; CHECK-GI-FP16-NEXT:    ldp q1, q23, [sp]
+; CHECK-GI-FP16-NEXT:    ucvtf v3.2d, v3.2d
+; CHECK-GI-FP16-NEXT:    ucvtf v5.2d, v5.2d
 ; CHECK-GI-FP16-NEXT:    mov d20, v16.d[1]
 ; CHECK-GI-FP16-NEXT:    mov d19, v0.d[1]
 ; CHECK-GI-FP16-NEXT:    mov d21, v18.d[1]
 ; CHECK-GI-FP16-NEXT:    mov d22, v17.d[1]
-; CHECK-GI-FP16-NEXT:    fcvt h16, d16
+; CHECK-GI-FP16-NEXT:    fcvt h7, d16
 ; CHECK-GI-FP16-NEXT:    ucvtf v2.2d, v1.2d
 ; CHECK-GI-FP16-NEXT:    fcvt h0, d0
 ; CHECK-GI-FP16-NEXT:    fcvt h1, d18
 ; CHECK-GI-FP16-NEXT:    ldr q18, [sp, #32]
-; CHECK-GI-FP16-NEXT:    fcvt h7, d17
+; CHECK-GI-FP16-NEXT:    fcvt h16, d17
 ; CHECK-GI-FP16-NEXT:    ldp q25, q17, [sp, #48]
 ; CHECK-GI-FP16-NEXT:    fcvt h20, d20
 ; CHECK-GI-FP16-NEXT:    fcvt h24, d19
@@ -4671,18 +4671,18 @@ define <32 x half> @utofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    ucvtf v23.2d, v23.2d
 ; CHECK-GI-FP16-NEXT:    ucvtf v25.2d, v25.2d
 ; CHECK-GI-FP16-NEXT:    mov d4, v4.d[1]
-; CHECK-GI-FP16-NEXT:    mov v16.h[1], v20.h[0]
+; CHECK-GI-FP16-NEXT:    mov v7.h[1], v20.h[0]
 ; CHECK-GI-FP16-NEXT:    ldp q19, q20, [sp, #80]
 ; CHECK-GI-FP16-NEXT:    mov v0.h[1], v24.h[0]
 ; CHECK-GI-FP16-NEXT:    fcvt h24, d5
 ; CHECK-GI-FP16-NEXT:    mov v1.h[1], v21.h[0]
 ; CHECK-GI-FP16-NEXT:    ldr q21, [sp, #112]
-; CHECK-GI-FP16-NEXT:    mov v7.h[1], v22.h[0]
+; CHECK-GI-FP16-NEXT:    mov v16.h[1], v22.h[0]
 ; CHECK-GI-FP16-NEXT:    mov d22, v2.d[1]
 ; CHECK-GI-FP16-NEXT:    ucvtf v20.2d, v20.2d
 ; CHECK-GI-FP16-NEXT:    fcvt h2, d2
 ; CHECK-GI-FP16-NEXT:    ucvtf v19.2d, v19.2d
-; CHECK-GI-FP16-NEXT:    mov v16.h[2], v27.h[0]
+; CHECK-GI-FP16-NEXT:    mov v7.h[2], v27.h[0]
 ; CHECK-GI-FP16-NEXT:    ucvtf v21.2d, v21.2d
 ; CHECK-GI-FP16-NEXT:    mov d5, v5.d[1]
 ; CHECK-GI-FP16-NEXT:    mov v0.h[2], v26.h[0]
@@ -4690,7 +4690,7 @@ define <32 x half> @utofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    mov v1.h[2], v24.h[0]
 ; CHECK-GI-FP16-NEXT:    mov d24, v17.d[1]
 ; CHECK-GI-FP16-NEXT:    fcvt h22, d22
-; CHECK-GI-FP16-NEXT:    mov v7.h[2], v28.h[0]
+; CHECK-GI-FP16-NEXT:    mov v16.h[2], v28.h[0]
 ; CHECK-GI-FP16-NEXT:    mov d27, v20.d[1]
 ; CHECK-GI-FP16-NEXT:    fcvt h18, d18
 ; CHECK-GI-FP16-NEXT:    mov d28, v3.d[1]
@@ -4726,14 +4726,14 @@ define <32 x half> @utofp_v32i64_v32f16(<32 x i64> %a) {
 ; CHECK-GI-FP16-NEXT:    mov v1.h[3], v5.h[0]
 ; CHECK-GI-FP16-NEXT:    fcvt h19, d22
 ; CHECK-GI-FP16-NEXT:    mov v20.h[2], v21.h[0]
-; CHECK-GI-FP16-NEXT:    mov v7.h[3], v6.h[0]
-; CHECK-GI-FP16-NEXT:    mov v16.h[3], v24.h[0]
+; CHECK-GI-FP16-NEXT:    mov v16.h[3], v6.h[0]
+; CHECK-GI-FP16-NEXT:    mov v7.h[3], v24.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v2.h[3], v23.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v18.h[3], v25.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v3.h[3], v17.h[0]
 ; CHECK-GI-FP16-NEXT:    mov v20.h[3], v19.h[0]
-; CHECK-GI-FP16-NEXT:    mov v1.d[1], v7.d[0]
-; CHECK-GI-FP16-NEXT:    mov v0.d[1], v16.d[0]
+; CHECK-GI-FP16-NEXT:    mov v1.d[1], v16.d[0]
+; CHECK-GI-FP16-NEXT:    mov v0.d[1], v7.d[0]
 ; CHECK-GI-FP16-NEXT:    mov v2.d[1], v18.d[0]
 ; CHECK-GI-FP16-NEXT:    mov v3.d[1], v20.d[0]
 ; CHECK-GI-FP16-NEXT:    ret

--- a/llvm/test/CodeGen/X86/GlobalISel/select-inc.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-inc.mir
@@ -14,16 +14,14 @@ legalized:       true
 regBankSelected: true
 # ALL:      registers:
 # ALL-NEXT:  - { id: 0, class: gr8, preferred-register: '' }
-# INC-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# ADD-NEXT:  - { id: 1, class: gpr, preferred-register: '' }
-# ALL-NEXT:  - { id: 2, class: gr8, preferred-register: '' }
+# ALL-NEXT:  - { id: 1, class: gr8, preferred-register: '' }
 registers:
   - { id: 0, class: gpr }
   - { id: 1, class: gpr }
   - { id: 2, class: gpr }
 # ALL:      %0:gr8 = COPY $al
-# INC-NEXT: %2:gr8 = INC8r %0
-# ADD-NEXT: %2:gr8 = ADD8ri %0, 1
+# INC-NEXT: %1:gr8 = INC8r %0
+# ADD-NEXT: %1:gr8 = ADD8ri %0, 1
 body:             |
   bb.1 (%ir-block.0):
     liveins: $al

--- a/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec256.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec256.mir
@@ -60,14 +60,14 @@ registers:
   - { id: 0, class: vecr }
   - { id: 1, class: vecr }
   - { id: 2, class: vecr }
-# AVX:               %1:vr128 = COPY $xmm1
-# AVX-NEXT:          undef %2.sub_xmm:vr256 = COPY %1
-# AVX-NEXT:          $ymm0 = COPY %2
+# AVX:               [[COPY:%[0-9]+]]:vr128 = COPY $xmm1
+# AVX-NEXT:          undef [[COPY1:%[0-9]+]].sub_xmm:vr256 = COPY [[COPY]]
+# AVX-NEXT:          $ymm0 = COPY [[COPY1]]
 # AVX-NEXT:          RET 0, implicit $ymm0
 #
-# AVX512VL:          %1:vr128x = COPY $xmm1
-# AVX512VL-NEXT:     undef %2.sub_xmm:vr256x = COPY %1
-# AVX512VL-NEXT:     $ymm0 = COPY %2
+# AVX512VL:          [[COPY:%[0-9]+]]:vr128x = COPY $xmm1
+# AVX512VL-NEXT:     undef [[COPY1:%[0-9]+]].sub_xmm:vr256x = COPY [[COPY]]
+# AVX512VL-NEXT:     $ymm0 = COPY [[COPY1]]
 # AVX512VL-NEXT:     RET 0, implicit $ymm0
 body:             |
   bb.1 (%ir-block.0):

--- a/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec512.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/select-insert-vec512.mir
@@ -76,8 +76,8 @@ body:             |
 
     ; ALL-LABEL: name: test_insert_128_idx0_undef
     ; ALL: [[COPY:%[0-9]+]]:vr128x = COPY $xmm1
-    ; ALL: undef %2.sub_xmm:vr512 = COPY [[COPY]]
-    ; ALL: $zmm0 = COPY %2
+    ; ALL: undef [[COPY1:%[0-9]+]].sub_xmm:vr512 = COPY [[COPY]]
+    ; ALL: $zmm0 = COPY [[COPY1]]
     ; ALL: RET 0, implicit $ymm0
     %0(<16 x s32>) = IMPLICIT_DEF
     %1(<4 x s32>) = COPY $xmm1
@@ -177,8 +177,8 @@ body:             |
 
     ; ALL-LABEL: name: test_insert_256_idx0_undef
     ; ALL: [[COPY:%[0-9]+]]:vr256x = COPY $ymm1
-    ; ALL: undef %2.sub_ymm:vr512 = COPY [[COPY]]
-    ; ALL: $zmm0 = COPY %2
+    ; ALL: undef [[COPY1:%[0-9]+]].sub_ymm:vr512 = COPY [[COPY]]
+    ; ALL: $zmm0 = COPY [[COPY1]]
     ; ALL: RET 0, implicit $ymm0
     %0(<16 x s32>) = IMPLICIT_DEF
     %1(<8 x s32>) = COPY $ymm1

--- a/llvm/test/CodeGen/X86/switch-bit-test-unreachable-default.ll
+++ b/llvm/test/CodeGen/X86/switch-bit-test-unreachable-default.ll
@@ -39,20 +39,20 @@ define i32 @baz(i32 %0) {
 ; CHECK-GISEL:   liveins: $edi
 ; CHECK-GISEL:   %0:gr32 = COPY $edi
 ; CHECK-GISEL:   %10:gr32 = MOV32ri 1
-; CHECK-GISEL:   %11:gr32 = MOV32r0 implicit-def dead $eflags
+; CHECK-GISEL:   %8:gr32 = MOV32r0 implicit-def dead $eflags
 ; CHECK-GISEL:   %2:gr32 = SUB32ri %0:gr32(tied-def 0), 0, implicit-def dead $eflags
 ; CHECK-GISEL: bb.5 (%ir-block.1):
 ; CHECK-GISEL: ; predecessors: %bb.1
 ; CHECK-GISEL:   successors: %bb.4(0x55555555), %bb.2(0x2aaaaaab); %bb.4(66.67%), %bb.2(33.33%)
 ; CHECK-GISEL:   %3:gr32 = MOV32ri 1
-; CHECK-GISEL:   %13:gr8 = COPY %2.sub_8bit:gr32
-; CHECK-GISEL:   $cl = COPY %13:gr8
+; CHECK-GISEL:   %1:gr8 = COPY %2.sub_8bit:gr32
+; CHECK-GISEL:   $cl = COPY %1:gr8
 ; CHECK-GISEL:   %4:gr32 = SHL32rCL %3:gr32(tied-def 0), implicit-def dead $eflags, implicit $cl
 ; CHECK-GISEL:   %6:gr32 = AND32ri %4:gr32(tied-def 0), 13056, implicit-def dead $eflags
 ; CHECK-GISEL:   %7:gr32 = MOV32r0 implicit-def dead $eflags
 ; CHECK-GISEL:   CMP32rr %6:gr32, %7:gr32, implicit-def $eflags
-; CHECK-GISEL:   %12:gr8 = SETCCr 5, implicit $eflags
-; CHECK-GISEL:   TEST8ri %12:gr8, 1, implicit-def $eflags
+; CHECK-GISEL:   %5:gr8 = SETCCr 5, implicit $eflags
+; CHECK-GISEL:   TEST8ri %5:gr8, 1, implicit-def $eflags
 ; CHECK-GISEL:   JCC_1 %bb.4, 5, implicit $eflags
 ; CHECK-GISEL:   JMP_1 %bb.2
 ; CHECK-GISEL: bb.6 (%ir-block.1):
@@ -63,7 +63,7 @@ define i32 @baz(i32 %0) {
 ; CHECK-GISEL: bb.3.if.then.unreachabledefault:
 ; CHECK-GISEL: bb.4.return:
 ; CHECK-GISEL: ; predecessors: %bb.5, %bb.2
-; CHECK-GISEL:   %9:gr32 = PHI %10:gr32, %bb.2, %11:gr32, %bb.5
+; CHECK-GISEL:   %9:gr32 = PHI %10:gr32, %bb.2, %8:gr32, %bb.5
 ; CHECK-GISEL:   $eax = COPY %9:gr32
 ; CHECK-GISEL:   RET 0, implicit $eax
 

--- a/llvm/test/DebugInfo/AArch64/debug-reg-bank.ll
+++ b/llvm/test/DebugInfo/AArch64/debug-reg-bank.ll
@@ -6,7 +6,7 @@ define void @foo(i32 %n) !dbg !7 {
   ; CHECK: bb.1.entry:
   ; CHECK-NEXT:   liveins: $w0
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   DBG_VALUE %2:gpr32, $noreg, !12, !DIExpression(), debug-location !19
+  ; CHECK-NEXT:   DBG_VALUE %{{[0-9]+}}:gpr32, $noreg, !12, !DIExpression(), debug-location !19
   ; CHECK-NEXT:   RET_ReallyLR debug-location !20
 entry:
   %m = mul i32 %n, 13

--- a/llvm/test/DebugInfo/X86/debug-reg-bank.ll
+++ b/llvm/test/DebugInfo/X86/debug-reg-bank.ll
@@ -6,7 +6,7 @@ define void @foo(i32 %n) !dbg !7 {
   ; CHECK: bb.1.entry:
   ; CHECK-NEXT:   liveins: $edi
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   DBG_VALUE %2:gr32, $noreg, !12, !DIExpression(), debug-location !19
+  ; CHECK-NEXT:   DBG_VALUE %{{[0-9]+}}:gr32, $noreg, !12, !DIExpression(), debug-location !19
   ; CHECK-NEXT:   RET 0, debug-location !20
 entry:
   %m = mul i32 %n, 13


### PR DESCRIPTION
Such VRegs may appear almost at all stages of the GlobalISel pipeline. These VRegs will not obtain a RegClass because it is assigned during instruction selection but since we don't have any uses, these VRegs remain without a class. Such representation is not valid in terms of MIR.

We swap dead VRegs with alive VRegs from the end of VRegs range. So, we are able to shrink all the structures from the end.