### PR TITLE
[flang][openacc] Keep CYCLE check for compute and data construct

### DIFF
--- a/flang/lib/Semantics/check-directive-structure.h
+++ b/flang/lib/Semantics/check-directive-structure.h
@@ -79,7 +79,17 @@ public:
           break;
         }
       } else if constexpr (std::is_same_v<D, llvm::acc::Directive>) {
-        return; // OpenACC construct do not need check for unlabelled CYCLES
+        switch ((llvm::acc::Directive)currentDirective_) {
+        // exclude loop directives which do not need a check for unlabelled
+        // CYCLES
+        case llvm::acc::Directive::ACCD_loop:
+        case llvm::acc::Directive::ACCD_kernels_loop:
+        case llvm::acc::Directive::ACCD_parallel_loop:
+        case llvm::acc::Directive::ACCD_serial_loop:
+          return;
+        default:
+          break;
+        }
       }
       CheckConstructNameBranching("CYCLE");
     }

--- a/flang/test/Semantics/OpenACC/acc-data.f90
+++ b/flang/test/Semantics/OpenACC/acc-data.f90
@@ -187,6 +187,19 @@ program openacc_data_validity
   !$acc data copy(aa) device_type(default) wait
   !$acc end data
 
+  do i = 1, 100
+    !$acc data copy(aa)
+    !ERROR: CYCLE to construct outside of DATA construct is not allowed
+    if (i == 10) cycle
+    !$acc end data
+  end do
+
+  !$acc data copy(aa)
+  do i = 1, 100
+    if (i == 10) cycle
+  end do
+  !$acc end data
+
 end program openacc_data_validity
 
 module mod1

--- a/flang/test/Semantics/OpenACC/acc-kernels.f90
+++ b/flang/test/Semantics/OpenACC/acc-kernels.f90
@@ -144,4 +144,17 @@ program openacc_kernels_validity
   end do
   !$acc end kernels
 
+  do i = 1, 100
+    !$acc kernels
+    !ERROR: CYCLE to construct outside of KERNELS construct is not allowed
+    if (i == 10) cycle
+    !$acc end kernels
+  end do
+
+  !$acc kernels
+  do i = 1, 100
+    if (i == 10) cycle
+  end do
+  !$acc end kernels
+
 end program openacc_kernels_validity

--- a/flang/test/Semantics/OpenACC/acc-parallel.f90
+++ b/flang/test/Semantics/OpenACC/acc-parallel.f90
@@ -142,4 +142,17 @@ program openacc_parallel_validity
   end do
   !$acc end parallel
 
+  do i = 1, 100
+    !$acc parallel
+    !ERROR: CYCLE to construct outside of PARALLEL construct is not allowed
+    if (i == 10) cycle
+    !$acc end parallel
+  end do
+
+  !$acc parallel
+  do i = 1, 100
+    if (i == 10) cycle
+  end do
+  !$acc end parallel
+
 end program openacc_parallel_validity

--- a/flang/test/Semantics/OpenACC/acc-serial.f90
+++ b/flang/test/Semantics/OpenACC/acc-serial.f90
@@ -166,4 +166,17 @@ program openacc_serial_validity
   end do
   !$acc end serial
 
+  do i = 1, 100
+    !$acc serial
+    !ERROR: CYCLE to construct outside of SERIAL construct is not allowed
+    if (i == 10) cycle
+    !$acc end serial
+  end do
+
+  !$acc serial
+  do i = 1, 100
+    if (i == 10) cycle
+  end do
+  !$acc end serial
+
 end program openacc_serial_validity


### PR DESCRIPTION
Unlike mentioned in #73839, some OpenACC construct still need the cycle branching check to be performed. This patch adds a list of construct where the check is not needed (loop and combined construct) and add tests to check where it is still needed. 