### PR TITLE
[mlir][linalg] Edit the yieldOutputs method's builder

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -480,8 +480,8 @@ public:
     llvm_unreachable("unsupported type conversion function");
   }
 
-  void yieldOutputs(ValueRange values) {
-    OpBuilder builder = getBuilder();
+  void yieldOutputs(OpBuilder builder, ValueRange values) {
+    builder.setInsertionPointToEnd(&block);
     Location loc = builder.getUnknownLoc();
     builder.create<YieldOp>(loc, values);
   }

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorPasses.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorPasses.cpp
@@ -260,6 +260,7 @@ struct SparseTensorCodegenPass
     // The following operations and dialects may be introduced by the
     // codegen rules, and are therefore marked as legal.
     target.addLegalOp<linalg::FillOp>();
+    target.addLegalOp<linalg::YieldOp>();
     target.addLegalDialect<
         arith::ArithDialect, bufferization::BufferizationDialect,
         complex::ComplexDialect, memref::MemRefDialect, scf::SCFDialect>();

--- a/mlir/tools/mlir-linalg-ods-gen/mlir-linalg-ods-yaml-gen.cpp
+++ b/mlir/tools/mlir-linalg-ods-gen/mlir-linalg-ods-yaml-gen.cpp
@@ -1012,7 +1012,7 @@ void {0}::regionBuilder(ImplicitLocOpBuilder &b,
   SmallVector<Value> yields;
   {2}
   {3}
-  helper.yieldOutputs(yields);
+  helper.yieldOutputs(b, yields);
 }
 )FMT";
     auto &args = opConfig.structuredOp->args;


### PR DESCRIPTION
Passing the `RegionBuilder`'s builder to the `yieldOutputs` method, Instead of creating a new one within the `yieldOutputs` method. This change is being made since having memory leaks issues (when compiling with address sanitizer) when applying `RewritePattern` on `LinalgStructuredOp` (creating and erasing op within `matchAndRewrite` method would reproduce the issue).