### PR TITLE
[VFABI] Improve VFABI unit tests

### DIFF
--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -22,10 +22,8 @@ namespace {
 ///    given by the string FunctionType.
 /// 3. The number of vector parameters and their types match the values
 ///    specified in the test.
-///    On masked functions, when the VFISAKind is SVE or AdvancedSIMD (NEON) it
-///    also checks that the last parameter is a mask (ie, GlobalPredicate).
-///    TODO: Other VFISAKinds must add such checks according to their ABI
-///    specification.
+///    On masked functions it also checks that the last parameter is a mask (ie,
+///    GlobalPredicate).
 /// 4. The function is correctly found to have a mask.
 ///
 class VFABIParserTest : public ::testing::Test {

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -21,14 +21,14 @@ private:
   // Parser output.
   VFInfo Info;
   // Reset the data needed for the test.
-  void reset(const StringRef SFunTy) {
+  void reset(const StringRef ScalarFTyStr) {
     M = parseAssemblyString("declare void @dummy()", Err, Ctx);
     EXPECT_NE(M.get(), nullptr) << "Loading an invalid module.\n "
                                 << Err.getMessage() << "\n";
-    Type *Ty = parseType(SFunTy, Err, *(M.get()));
+    Type *Ty = parseType(ScalarFTyStr, Err, *(M.get()));
     ScalarFTy = dyn_cast<FunctionType>(Ty);
     EXPECT_NE(ScalarFTy, nullptr)
-        << "Invalid function type string: " << SFunTy << "\n"
+        << "Invalid function type string: " << ScalarFTyStr << "\n"
         << Err.getMessage() << "\n";
     // Reset the VFInfo
     Info = VFInfo();

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -18,13 +18,13 @@ namespace {
 /// Perform tests against VFABI Rules. `invokeParser` creates a VFInfo object
 /// and a scalar FunctionType, which are used by tests to check that:
 /// 1. The scalar and vector names are correct.
-/// 2. The parameter number from the parsed mangled name matches the scalar ones
-///    given by the string FunctionType.
+/// 2. The number of parameters from the parsed mangled name matches the number
+///    of arguments in the scalar function passed as FunctionType string.
 /// 3. The number of vector parameters and their types match the values
 ///    specified in the test.
 ///    On masked functions it also checks that the last parameter is a mask (ie,
 ///    GlobalPredicate).
-/// 4. The function is correctly found to have a mask.
+/// 4. The vector function is correctly found to have a mask.
 ///
 class VFABIParserTest : public ::testing::Test {
 private:
@@ -64,10 +64,10 @@ protected:
   ///
   /// \p MangledName string the parser has to demangle.
   ///
-  /// \p ScalarFTyStr FunctionType string to be used to get the signature of
-  /// the scalar function. Used by `tryDemangleForVFABI` to check for the number
-  /// of arguments on scalable vectors, and by `matchParameters` to perform
-  /// some additional checking in the tests in this file.
+  /// \p ScalarFTyStr FunctionType string to get the signature of the scalar
+  /// function, which is used by `tryDemangleForVFABI` to check for the number
+  /// of arguments on scalable vectors, and by `matchParameters` to perform some
+  /// additional checking in the tests in this file.
   bool invokeParser(const StringRef MangledName,
                     const StringRef ScalarFTyStr = "void()") {
     // Reset the VFInfo to be able to call `invokeParser` multiple times in
@@ -81,10 +81,10 @@ protected:
     return OptInfo.has_value();
   }
 
-  /// Returns whether the parsed function contains a mask
+  /// Returns whether the parsed function contains a mask.
   bool isMasked() const { return Info.isMasked(); }
 
-  /// Check the number of vectorized parameters matches the scalar ones. This
+  /// Check if the number of vectorized parameters matches the scalar ones. This
   /// requires a correct scalar FunctionType string to be fed to the
   /// 'invokeParser'. Mask parameters that are only required by the vector
   /// function call are ignored.

--- a/llvm/unittests/Analysis/VectorFunctionABITest.cpp
+++ b/llvm/unittests/Analysis/VectorFunctionABITest.cpp
@@ -27,9 +27,9 @@ private:
                                 << Err.getMessage() << "\n";
     Type *Ty = parseType(SFunTy, Err, *(M.get()));
     ScalarFTy = dyn_cast<FunctionType>(Ty);
-    EXPECT_NE(ScalarFTy, nullptr) << "Invalid function type string: " << SFunTy
-                            << "\n"
-                            << Err.getMessage() << "\n";
+    EXPECT_NE(ScalarFTy, nullptr)
+        << "Invalid function type string: " << SFunTy << "\n"
+        << Err.getMessage() << "\n";
     // Reset the VFInfo
     Info = VFInfo();
     ScalarFuncParametersNum = 0;
@@ -135,8 +135,8 @@ TEST_F(VFABIParserTest, OnlyValidNames) {
 }
 
 TEST_F(VFABIParserTest, ParamListParsing) {
-  EXPECT_TRUE(invokeParser("_ZGVnN2vl16Ls32R3l_foo",
-                           "void(i32, i32, i32, ptr, i32)"));
+  EXPECT_TRUE(
+      invokeParser("_ZGVnN2vl16Ls32R3l_foo", "void(i32, i32, i32, ptr, i32)"));
   EXPECT_TRUE(matchScalarParamNum()) << "Different number of Scalar parameters";
   EXPECT_EQ(VecFuncParameters.size(), (unsigned)5);
   EXPECT_EQ(VecFuncParameters[0], VFParameter({0, VFParamKind::Vector}));


### PR DESCRIPTION
Do checks for scalar parameter counts for all mappings with `matchScalarParametersNum`. It is not part of `invokeParser` so it can be selectively applied only to tests that supply valid mangled names.

Also, minor reformatting and typo fixes.