### PR TITLE
[mlir][linalg] Fix a DCE crash with memref<0x..> and the op has uses

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -2101,7 +2101,7 @@ struct EraseDeadLinalgOp : public OpInterfaceRewritePattern<LinalgOp> {
       auto mt = llvm::dyn_cast<MemRefType>(opOperand.get().getType());
       if (!mt)
         continue;
-      if (llvm::is_contained(op.getShape(&opOperand), 0)) {
+      if (llvm::is_contained(op.getShape(&opOperand), 0) && op->use_empty()) {
         rewriter.eraseOp(op);
         return success();
       }

--- a/mlir/test/Dialect/Linalg/canonicalize.mlir
+++ b/mlir/test/Dialect/Linalg/canonicalize.mlir
@@ -68,8 +68,6 @@ func.func @no_dce_zero_memref(%arg0 : memref<0xf32>, %arg1: tensor<0xf32>) -> te
 }
 
 // CHECK-LABEL: @no_dce_zero_memref
-//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<0xf32>
-//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<0xf32>
 //  CHECK-NEXT:   linalg.generic
 
 // -----


### PR DESCRIPTION
The DCE for LinalgOp when processing operands as `memref<0x..>` causes a crash if this op has uses. This PR addresses it.

Fixes https://github.com/llvm/llvm-project/issues/73547