### PR TITLE
[mlir][docs] Add missing .md into Transform and Passes docs(NFC)

### DIFF
--- a/mlir/docs/Dialects/Transform.md
+++ b/mlir/docs/Dialects/Transform.md
@@ -431,6 +431,10 @@ ops rather than having the methods directly act on the payload IR.
 
 [include "Dialects/GPUTransformOps.md"]
 
+## Loop (extension) Transform Operations
+
+[include "Dialects/LoopExtensionOps.md"]
+
 ## Loop (SCF) Transform Operations
 
 [include "Dialects/SCFLoopTransformOps.md"]

--- a/mlir/docs/Passes.md
+++ b/mlir/docs/Passes.md
@@ -64,6 +64,10 @@ This document describes the available MLIR passes and their contracts.
 
 [include "MemRefPasses.md"]
 
+## 'mesh' Dialect Passes
+
+[include "MeshPasses.md"]
+
 ## 'ml\_program' Dialect Passes
 
 [include "MLProgramPasses.md"]


### PR DESCRIPTION
Fix broken docs for MeshDialect's pass and Transform dialect's loop extension.