### PR TITLE
[clang-tidy] performance-unnecessary-copy-init: Add a hook...

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.cpp
@@ -318,7 +318,7 @@ void UnnecessaryCopyInitialization::handleCopyFromMethodReturn(
       !isInitializingVariableImmutable(*ObjectArg, Ctx.BlockStmt, Ctx.ASTCtx,
                                        ExcludedContainerTypes))
     return;
-  diagnoseCopyFromMethodReturn(Ctx, ObjectArg);
+  diagnoseCopyFromMethodReturn(Ctx);
 }
 
 void UnnecessaryCopyInitialization::handleCopyFromLocalVar(
@@ -331,7 +331,7 @@ void UnnecessaryCopyInitialization::handleCopyFromLocalVar(
 }
 
 void UnnecessaryCopyInitialization::diagnoseCopyFromMethodReturn(
-    const CheckContext &Ctx, const VarDecl *ObjectArg) {
+    const CheckContext &Ctx) {
   auto Diagnostic =
       diag(Ctx.Var.getLocation(),
            "the %select{|const qualified }0variable %1 is "
@@ -342,6 +342,7 @@ void UnnecessaryCopyInitialization::diagnoseCopyFromMethodReturn(
       << Ctx.Var.getType().isConstQualified() << &Ctx.Var << Ctx.IsVarUnused;
   maybeIssueFixes(Ctx, Diagnostic);
 }
+
 void UnnecessaryCopyInitialization::diagnoseCopyFromLocalVar(
     const CheckContext &Ctx, const VarDecl &OldVar) {
   auto Diagnostic =

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
@@ -32,6 +32,12 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 
+protected:
+  // This is virtual so that derived classes can implement additional behavior.
+  virtual void makeDiagnostic(DiagnosticBuilder Diagnostic, const VarDecl &Var,
+                              const Stmt &BlockStmt, const DeclStmt &Stmt,
+                              ASTContext &Context, bool IssueFix);
+
 private:
   void handleCopyFromMethodReturn(const VarDecl &Var, const Stmt &BlockStmt,
                                   const DeclStmt &Stmt, bool IssueFix,
@@ -40,6 +46,7 @@ private:
   void handleCopyFromLocalVar(const VarDecl &NewVar, const VarDecl &OldVar,
                               const Stmt &BlockStmt, const DeclStmt &Stmt,
                               bool IssueFix, ASTContext &Context);
+
   const std::vector<StringRef> AllowedTypes;
   const std::vector<StringRef> ExcludedContainerTypes;
 };

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
@@ -48,8 +48,7 @@ protected:
 
   // Create diagnostics. These are virtual so that derived classes can change
   // behaviour.
-  virtual void diagnoseCopyFromMethodReturn(const CheckContext &Ctx,
-                                            const VarDecl *ObjectArg);
+  virtual void diagnoseCopyFromMethodReturn(const CheckContext &Ctx);
   virtual void diagnoseCopyFromLocalVar(const CheckContext &Ctx,
                                         const VarDecl &OldVar);
 

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
@@ -36,7 +36,6 @@ protected:
   // A helper to manipulate the state common to
   // `CopyFromMethodReturn` and `CopyFromLocalVar`.
   struct CheckContext {
-    CheckContext(const ast_matchers::MatchFinder::MatchResult &Result);
     const VarDecl &Var;
     const Stmt &BlockStmt;
     const DeclStmt &VarDeclStmt;


### PR DESCRIPTION
... so that derived checks can derived checks can observe for which variables a warning has been emitted. Does nothing by default, which makes this  an NFC.