### PR TITLE
[AArch64] Fix predicates for FEAT_CPA's SVE-specific instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -4167,7 +4167,7 @@ let Predicates = [HasSVE2orSME2, HasLUT] in {
 //===----------------------------------------------------------------------===//
 // Checked Pointer Arithmetic (FEAT_CPA)
 //===----------------------------------------------------------------------===//
-let Predicates = [HasSVEorSME, HasCPA] in {
+let Predicates = [HasSVE, HasCPA] in {
   // Add/subtract (vectors, unpredicated)
   def ADD_ZZZ_CPA : sve_int_bin_cons_arit_0<0b11, 0b010, "addpt", ZPR64>;
   def SUB_ZZZ_CPA : sve_int_bin_cons_arit_0<0b11, 0b011, "subpt", ZPR64>;

--- a/llvm/test/MC/AArch64/SVE/armv9.5a-cpa.s
+++ b/llvm/test/MC/AArch64/SVE/armv9.5a-cpa.s
@@ -1,15 +1,15 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sve -mattr=+cpa < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme -mattr=+cpa < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme -mattr=+cpa < %s 2>&1 \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR-NO-SVE
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+cpa < %s 2>&1 \
-// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR-NO-SVESME
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR-NO-SVE
 // RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sve < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR-NO-CPA
 // RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme < %s 2>&1 \
-// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR-NO-CPA
+// RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sve -mattr=+cpa < %s \
 // RUN:        | llvm-objdump -d --mattr=+sve --mattr=+cpa - \
 // RUN:        | FileCheck %s --check-prefix=CHECK-INST
@@ -23,47 +23,47 @@
 addpt z23.d, z13.d, z8.d
 // CHECK-INST: addpt z23.d, z13.d, z8.d
 // CHECK-ENCODING: [0xb7,0x09,0xe8,0x04]
-// CHECK-ERROR: instruction requires: cpa sve or sme
-// CHECK-ERROR-NO-SVESME: instruction requires: sve or sme
+// CHECK-ERROR: instruction requires: cpa sve
+// CHECK-ERROR-NO-SVE: instruction requires: sve
 // CHECK-ERROR-NO-CPA: instruction requires: cpa
 // CHECK-UNKNOWN: 04e809b7 <unknown>
 
 addpt z23.d, p3/m, z23.d, z13.d
 // CHECK-INST: addpt z23.d, p3/m, z23.d, z13.d
 // CHECK-ENCODING: [0xb7,0x0d,0xc4,0x04]
-// CHECK-ERROR: instruction requires: cpa sve or sme
-// CHECK-ERROR-NO-SVESME: instruction requires: sve or sme
+// CHECK-ERROR: instruction requires: cpa sve
+// CHECK-ERROR-NO-SVE: instruction requires: sve
 // CHECK-ERROR-NO-CPA: instruction requires: cpa
 // CHECK-UNKNOWN: 04c40db7 <unknown>
 
 subpt z23.d, z13.d, z8.d
 // CHECK-INST: subpt z23.d, z13.d, z8.d
 // CHECK-ENCODING: [0xb7,0x0d,0xe8,0x04]
-// CHECK-ERROR: instruction requires: cpa sve or sme
-// CHECK-ERROR-NO-SVESME: instruction requires: sve or sme
+// CHECK-ERROR: instruction requires: cpa sve
+// CHECK-ERROR-NO-SVE: instruction requires: sve
 // CHECK-ERROR-NO-CPA: instruction requires: cpa
 // CHECK-UNKNOWN: 04e80db7 <unknown>
 
 subpt z23.d, p3/m, z23.d, z13.d
 // CHECK-INST: subpt z23.d, p3/m, z23.d, z13.d
 // CHECK-ENCODING: [0xb7,0x0d,0xc5,0x04]
-// CHECK-ERROR: instruction requires: cpa sve or sme
-// CHECK-ERROR-NO-SVESME: instruction requires: sve or sme
+// CHECK-ERROR: instruction requires: cpa sve
+// CHECK-ERROR-NO-SVE: instruction requires: sve
 // CHECK-ERROR-NO-CPA: instruction requires: cpa
 // CHECK-UNKNOWN: 04c50db7 <unknown>
 
 madpt z0.d, z1.d, z31.d
 // CHECK-INST: madpt z0.d, z1.d, z31.d
 // CHECK-ENCODING: [0xe0,0xdb,0xc1,0x44]
-// CHECK-ERROR: instruction requires: cpa sve or sme
-// CHECK-ERROR-NO-SVESME: instruction requires: sve or sme
+// CHECK-ERROR: instruction requires: cpa sve
+// CHECK-ERROR-NO-SVE: instruction requires: sve
 // CHECK-ERROR-NO-CPA: instruction requires: cpa
 // CHECK-UNKNOWN: 44c1dbe0 <unknown>
 
 mlapt z0.d, z1.d, z31.d
 // CHECK-INST: mlapt z0.d, z1.d, z31.d
 // CHECK-ENCODING: [0x20,0xd0,0xdf,0x44]
-// CHECK-ERROR: instruction requires: cpa sve or sme
-// CHECK-ERROR-NO-SVESME: instruction requires: sve or sme
+// CHECK-ERROR: instruction requires: cpa sve
+// CHECK-ERROR-NO-SVE: instruction requires: sve
 // CHECK-ERROR-NO-CPA: instruction requires: cpa
 // CHECK-UNKNOWN: 44dfd020 <unknown>


### PR DESCRIPTION
Following up on #73777, this fixes the predicate for the SVE-specific
FEAT_CPA instructions to require SVE instead of SVE or SME. These
instructions should not be availabe if only SME is enabled.
