### PR TITLE
[clang] Fix sanitizer bot failure after 14ca8d4

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -489,6 +489,7 @@ ParsedType Sema::getTypeName(const IdentifierInfo &II, SourceLocation NameLoc,
                                                 SS->getScopeRep(), &II);
       TypeLocBuilder TLB;
       DependentNameTypeLoc TL = TLB.push<DependentNameTypeLoc>(T);
+      TL.setElaboratedKeywordLoc(SourceLocation());
       TL.setQualifierLoc(SS->getWithLocInContext(Context));
       TL.setNameLoc(NameLoc);
       return CreateParsedType(T, TLB.getTypeSourceInfo(Context, T));


### PR DESCRIPTION
Initialize field so there is no use-of-uninitialized-value warning.