### PR TITLE
[Flang][OpenMP] Prevent ICE for certain constructs in unnamed programs

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -26,7 +26,7 @@
 template <typename T>
 static Fortran::semantics::Scope *GetScope(
     Fortran::semantics::SemanticsContext &context, const T &x) {
-  std::optional<Fortran::parser::CharBlock> source{GetSource(x)};
+  std::optional<Fortran::parser::CharBlock> source{GetLastSource(x)};
   return source ? &context.FindScope(*source) : nullptr;
 }
 

--- a/flang/test/Semantics/OpenMP/struct.f90
+++ b/flang/test/Semantics/OpenMP/struct.f90
@@ -1,0 +1,7 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+! Check OpenMP compatibility with the DEC STRUCTURE extension
+
+structure /s/
+end structure
+
+end


### PR DESCRIPTION
This patch fixes #72748 by modifying the processing of program units to search for a symbol to which OpenMP REQUIRES clauses can bind to. Rather than picking up the first PFT node with a source reference and getting its associated scope, it picks up the last one.

This avoids using the source from the first specification construct of an nameless program, which can sometimes not be associated to any scope, causing an ICE due to an invalid source location.