### PR TITLE
[llvm][PowerPC] Correct handling of spill slots for SPE when EXPENSIVE_CHECKS is enabled

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -2334,24 +2334,16 @@ bool PPCFrameLowering::assignCalleeSavedSpillSlots(
     // In case of SPE we only have SuperRegs and CRs
     // in our CalleSaveInfo vector.
 
-    unsigned Idx = 0;
     for (auto &CalleeSaveReg : CSI) {
       const MCPhysReg &Reg = CalleeSaveReg.getReg();
       const MCPhysReg &Lower = RegInfo->getSubReg(Reg, 1);
       const MCPhysReg &Higher = RegInfo->getSubReg(Reg, 2);
 
-      // Check only for SuperRegs.
-      if (Lower) {
-        if (MRI.isPhysRegModified(Higher)) {
-          Idx++;
-          continue;
-        } else {
+      if ( // Check only for SuperRegs.
+          Lower &&
           // Replace Reg if only lower-32 bits modified
-          CSI.erase(CSI.begin() + Idx);
-          CSI.insert(CSI.begin() + Idx, CalleeSavedInfo(Lower));
-        }
-      }
-      Idx++;
+          !MRI.isPhysRegModified(Higher))
+        CalleeSaveReg = CalleeSavedInfo(Lower);
     }
   }
 

--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -2335,9 +2335,9 @@ bool PPCFrameLowering::assignCalleeSavedSpillSlots(
     // in our CalleSaveInfo vector.
 
     for (auto &CalleeSaveReg : CSI) {
-      const MCPhysReg &Reg = CalleeSaveReg.getReg();
-      const MCPhysReg &Lower = RegInfo->getSubReg(Reg, 1);
-      const MCPhysReg &Higher = RegInfo->getSubReg(Reg, 2);
+      MCPhysReg Reg = CalleeSaveReg.getReg();
+      MCPhysReg Lower = RegInfo->getSubReg(Reg, 1);
+      MCPhysReg Higher = RegInfo->getSubReg(Reg, 2);
 
       if ( // Check only for SuperRegs.
           Lower &&


### PR DESCRIPTION
This was modifying a container as it iterated it, which tripped a check in libstdc++'s debug checks.

Instead, just assign to the item via the reference we already have.

This fixes the following expensive checks failures on my machine:
  LLVM :: CodeGen/PowerPC/fp-strict.ll
  LLVM :: CodeGen/PowerPC/pr55463.ll
  LLVM :: CodeGen/PowerPC/register-pressure.ll
  LLVM :: CodeGen/PowerPC/spe.ll

Which are some of the tests noted by #68594.