### PR TITLE
[mlir][Vector] Add fold transpose(shape_cast) -> shape_cast

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -5558,7 +5558,8 @@ class FoldTransposeShapeCast : public OpRewritePattern<TransposeOp> {
     Value transposeSrc = transpOp.getVector();
     auto shapeCastOp = transposeSrc.getDefiningOp<vector::ShapeCastOp>();
     if (!shapeCastOp)
-      return failure();
+      return rewriter.notifyMatchFailure(
+          transpOp, "TransposeOp source is not ShapeCastOp");
 
     auto sourceType = transpOp.getSourceVectorType();
     auto resultType = transpOp.getResultVectorType();
@@ -5580,7 +5581,8 @@ class FoldTransposeShapeCast : public OpRewritePattern<TransposeOp> {
     for (auto [srcDim, resDim] :
          llvm::zip_equal(sourceWithoutUnitDims, resultWithoutUnitDims)) {
       if (srcDim != resDim)
-        return failure();
+        return rewriter.notifyMatchFailure(transpOp,
+                                           "TransposeOp permutes non-unit dim");
     }
 
     rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(transpOp, resultType,

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -5567,8 +5567,8 @@ class FoldTransposeShapeCast : public OpRewritePattern<TransposeOp> {
       return llvm::make_filter_range(
           llvm::zip_equal(type.getShape(), type.getScalableDims()),
           [&](auto dim) {
-            auto [size, isScalble] = dim;
-            return size != 1 || isScalble;
+            auto [size, isScalable] = dim;
+            return size != 1 || isScalable;
           });
     };
 

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -67,6 +67,18 @@ func.func @create_mask_transpose_to_transposed_create_mask(
 
 // -----
 
+// CHECK-LABEL: transposed_unit_dim_shape_cast_to_shape_cast
+//  CHECK-SAME: %[[VEC:.*]]: vector<[4]xf32>
+func.func @transposed_unit_dim_shape_cast_to_shape_cast(%vec: vector<[4]xf32>) -> vector<1x[4]xf32> {
+  //     CHECK: vector.shape_cast %[[VEC]] : vector<[4]xf32> to vector<1x[4]xf32>
+  // CHECK-NOT: vector.transpose
+  %0 = vector.shape_cast %vec : vector<[4]xf32> to vector<[4]x1xf32>
+  %1 = vector.transpose %0, [1, 0] : vector<[4]x1xf32> to vector<1x[4]xf32>
+  return %1 : vector<1x[4]xf32>
+}
+
+// -----
+
 // CHECK-LABEL: extract_from_create_mask
 //  CHECK-SAME: %[[DIM0:.*]]: index, %[[DIM1:.*]]: index
 func.func @extract_from_create_mask(%dim0: index, %dim1: index) -> vector<[4]x[4]xi1> {


### PR DESCRIPTION
This folds transpose(shape_cast) into a new shape_cast, when the transpose just permutes a unit dim from the result of the shape_cast.

Example:

```
%0 = vector.shape_cast %vec : vector<[4]xf32> to vector<[4]x1xf32>
%1 = vector.transpose %0, [1, 0] : vector<[4]x1xf32> to vector<1x[4]xf32>
```

Folds to:
```
%0 = vector.shape_cast %vec : vector<[4]xf32> to vector<1x[4]xf32>
```

This is an (alternate) fix for lowering matmuls to ArmSME.