### PR TITLE
[libc] Mark operator== const to avoid ambiguity in C++20.

### DIFF
--- a/libc/src/__support/CPP/bitset.h
+++ b/libc/src/__support/CPP/bitset.h
@@ -65,7 +65,8 @@ template <size_t NumberOfBits> struct bitset {
     }
   }
 
-  LIBC_INLINE constexpr bool operator==(const bitset<NumberOfBits> &other) {
+  LIBC_INLINE constexpr bool
+  operator==(const bitset<NumberOfBits> &other) const {
     for (size_t i = 0; i < NUMBER_OF_UNITS; ++i) {
       if (Data[i] != other.Data[i])
         return false;


### PR DESCRIPTION
C++20 will automatically generate an operator== with reversed operand order, which is ambiguous with the written operator== when one argument is marked const and the other isn't.

This operator currently triggers -Wambiguous-reversed-operator at several usage sites in libc/test/src/__support/CPP/bitset_test.cpp, starting with line 153.